### PR TITLE
Add 6 realistic cloud behaviors across AWS, Azure, and GCP providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# cloudmock
+# cloudemu
 
-**Zero-cost, in-memory mock implementations of AWS, Azure, and GCP cloud services for Go testing.**
+**Zero-cost, in-memory cloud emulation of AWS, Azure, and GCP services for Go.**
 
-Stop paying for cloud infrastructure in your test suite. `cloudmock` gives you lightweight, thread-safe, fully in-memory mocks for 10 cloud services across all three major providers — tests run in ~10ms at zero cost.
+Stop paying for cloud infrastructure in your test suite. `cloudemu` gives you lightweight, thread-safe, fully in-memory emulations of 10 cloud services across all three major providers — tests run in ~10ms at zero cost.
 
 ```go
 import "github.com/NitinKumar004/cloudemu"
 
 func TestMyApp(t *testing.T) {
-    aws := cloudmock.NewAWS()
+    aws := cloudemu.NewAWS()
 
     aws.S3.CreateBucket(ctx, "my-bucket")
     aws.S3.PutObject(ctx, "my-bucket", "key", []byte("hello"), "text/plain", nil)
@@ -22,7 +22,7 @@ func TestMyApp(t *testing.T) {
 
 ## Table of Contents
 
-- [Why cloudmock?](#why-cloudmock)
+- [Why cloudemu?](#why-cloudemu)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)
@@ -39,6 +39,12 @@ func TestMyApp(t *testing.T) {
   - [DNS (Route53 / Azure DNS / Cloud DNS)](#dns)
   - [Load Balancer (ELB / Azure LB / GCP LB)](#load-balancer)
   - [Message Queue (SQS / Service Bus / Pub/Sub)](#message-queue)
+- [Realistic Cloud Behaviors](#realistic-cloud-behaviors)
+  - [Auto-Metric Generation](#auto-metric-generation)
+  - [Alarm Auto-Evaluation](#alarm-auto-evaluation)
+  - [IAM Policy Evaluation](#iam-policy-evaluation)
+  - [FIFO Deduplication](#fifo-deduplication)
+  - [Numeric-Aware Comparisons](#numeric-aware-comparisons)
 - [Cross-Cutting Features](#cross-cutting-features)
   - [Call Recording (VCR Pattern)](#call-recording)
   - [Error Injection](#error-injection)
@@ -54,18 +60,19 @@ func TestMyApp(t *testing.T) {
 
 ---
 
-## Why cloudmock?
+## Why cloudemu?
 
 | Approach | Cost | Speed | Fidelity | Offline |
 |----------|------|-------|----------|---------|
 | Real cloud (AWS/Azure/GCP) | $$$ | Slow (seconds) | Perfect | No |
 | LocalStack / Emulators | $ | Medium (100ms+) | Good | Yes |
-| **cloudmock** | **Free** | **Fast (~10ms)** | **Good** | **Yes** |
+| **cloudemu** | **Free** | **Fast (~10ms)** | **Good** | **Yes** |
 
 - **Zero cost** — no cloud accounts, no Docker containers, no network calls
 - **Fast** — pure in-memory Go, no I/O
 - **Thread-safe** — all stores use `sync.RWMutex`, safe for parallel tests
 - **Deterministic** — fake clock, error injection, rate limiting — full control over test conditions
+- **Realistic** — VMs auto-generate metrics, alarms auto-evaluate, IAM checks real policy documents, FIFO queues deduplicate
 - **Three providers** — same interface, same patterns, write once test everywhere
 - **10 services each** — Storage, Compute, Database, Serverless, Networking, Monitoring, IAM, DNS, Load Balancer, Message Queue
 
@@ -77,7 +84,7 @@ func TestMyApp(t *testing.T) {
 go get github.com/NitinKumar004/cloudemu
 ```
 
-Requires Go 1.21+.
+Requires Go 1.25.0+.
 
 ---
 
@@ -98,7 +105,7 @@ import (
 
 func TestUploadFile(t *testing.T) {
     ctx := context.Background()
-    aws := cloudmock.NewAWS()
+    aws := cloudemu.NewAWS()
 
     // Create bucket and upload
     aws.S3.CreateBucket(ctx, "uploads")
@@ -126,9 +133,9 @@ func TestUploadFile(t *testing.T) {
 ```go
 func TestVMLifecycle(t *testing.T) {
     ctx := context.Background()
-    aws := cloudmock.NewAWS()
+    aws := cloudemu.NewAWS()
 
-    // Launch instance
+    // Launch instance — auto-generates CloudWatch metrics (CPU, Network, Disk)
     instances, _ := aws.EC2.RunInstances(ctx, computedriver.InstanceConfig{
         ImageID: "ami-123", InstanceType: "t2.micro",
         Tags: map[string]string{"env": "test"},
@@ -164,9 +171,9 @@ func TestCrossCloud(t *testing.T) {
         name    string
         storage storagedriver.Bucket
     }{
-        {"aws", cloudmock.NewAWS().S3},
-        {"azure", cloudmock.NewAzure().BlobStorage},
-        {"gcp", cloudmock.NewGCP().GCS},
+        {"aws", cloudemu.NewAWS().S3},
+        {"azure", cloudemu.NewAzure().BlobStorage},
+        {"gcp", cloudemu.NewGCP().GCS},
     }
 
     for _, p := range providers {
@@ -186,11 +193,11 @@ func TestCrossCloud(t *testing.T) {
 
 ## Architecture
 
-cloudmock uses a **three-layer design** inspired by [Go CDK](https://gocloud.dev):
+cloudemu uses a **three-layer design** inspired by [Go CDK](https://gocloud.dev):
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│              Your Test Code                              │
+│              Your Application / Test Code                │
 ├─────────────────────────────────────────────────────────┤
 │                                                          │
 │   Layer 1: Portable API                                  │
@@ -289,17 +296,17 @@ var _ driver.Bucket = (*Mock)(nil)  // compile-time guarantee
 
 ```go
 // Quick — default configuration
-aws := cloudmock.NewAWS()
-azure := cloudmock.NewAzure()
-gcp := cloudmock.NewGCP()
+aws := cloudemu.NewAWS()
+azure := cloudemu.NewAzure()
+gcp := cloudemu.NewGCP()
 
 // With options
-aws := cloudmock.NewAWS(
+aws := cloudemu.NewAWS(
     config.WithRegion("eu-west-1"),
     config.WithAccountID("999888777666"),
 )
 
-gcp := cloudmock.NewGCP(
+gcp := cloudemu.NewGCP(
     config.WithProjectID("my-gcp-project"),
     config.WithClock(config.NewFakeClock(time.Now())),
 )
@@ -311,7 +318,7 @@ All three providers implement the same `storage/driver.Bucket` interface.
 
 ```go
 ctx := context.Background()
-s3 := cloudmock.NewAWS().S3
+s3 := cloudemu.NewAWS().S3
 
 // Bucket operations
 s3.CreateBucket(ctx, "my-bucket")
@@ -355,12 +362,12 @@ page2, _ := s3.ListObjects(ctx, "bucket", driver.ListOptions{
 
 ### Compute
 
-VM lifecycle with enforced state machine transitions.
+VM lifecycle with enforced state machine transitions. Creating a VM automatically generates monitoring metrics (CPU, Network, Disk).
 
 ```go
-ec2 := cloudmock.NewAWS().EC2
+ec2 := cloudemu.NewAWS().EC2
 
-// Launch instances
+// Launch instances — auto-generates CloudWatch metrics
 instances, _ := ec2.RunInstances(ctx, computedriver.InstanceConfig{
     ImageID:      "ami-12345",
     InstanceType: "t2.micro",
@@ -401,12 +408,24 @@ stopped → shutting-down → terminated
 
 Illegal transitions return a `FailedPrecondition` error — you can't stop a terminated instance.
 
+**Auto-generated metrics per instance (AWS example):**
+
+| Metric | Namespace | Value |
+|--------|-----------|-------|
+| CPUUtilization | AWS/EC2 | 25.0 |
+| NetworkIn | AWS/EC2 | 1024.0 |
+| NetworkOut | AWS/EC2 | 512.0 |
+| DiskReadOps | AWS/EC2 | 100.0 |
+| DiskWriteOps | AWS/EC2 | 50.0 |
+
+Each metric gets 5 backfill datapoints at 1-minute intervals from launch time.
+
 ### Database
 
-DynamoDB-style key-value with queries, scans, and batch operations.
+DynamoDB-style key-value with queries, scans, and batch operations. Supports numeric-aware comparisons and full operator set.
 
 ```go
-db := cloudmock.NewAWS().DynamoDB
+db := cloudemu.NewAWS().DynamoDB
 
 // Create table with sort key and GSI
 db.CreateTable(ctx, dbdriver.TableConfig{
@@ -423,7 +442,7 @@ db.PutItem(ctx, "orders", map[string]interface{}{
     "customer_id": "cust-1",
     "order_date":  "2024-01-15",
     "status":      "shipped",
-    "total":       99.99,
+    "total":       "99.99",
 })
 
 // Get by key
@@ -453,11 +472,11 @@ result, _ = db.Query(ctx, dbdriver.QueryInput{
     },
 })
 
-// Scan with filter
+// Scan with filter — supports full operator set
 result, _ = db.Scan(ctx, dbdriver.ScanInput{
     Table: "orders",
     Filters: []dbdriver.ScanFilter{
-        {Field: "status", Op: "=", Value: "shipped"},
+        {Field: "total", Op: ">=", Value: "50"},  // numeric-aware: 99.99 >= 50
     },
     Limit: 10,
 })
@@ -468,12 +487,15 @@ db.BatchGetItems(ctx, "orders", keys)
 ```
 
 **Supported sort key operators:** `=`, `<`, `>`, `<=`, `>=`, `BEGINS_WITH`, `BETWEEN`
-**Supported scan filter operators:** `=`, `!=`, `<`, `>`, `CONTAINS`
+
+**Supported scan filter operators:** `=`, `!=`, `<`, `>`, `<=`, `>=`, `CONTAINS`, `BEGINS_WITH`
+
+**Numeric-aware comparisons:** When both values can be parsed as numbers, comparison uses numeric ordering. `"10" > "9"` correctly returns `true` (not string-compared as `"10" < "9"`).
 
 ### Serverless
 
 ```go
-lambda := cloudmock.NewAWS().Lambda
+lambda := cloudemu.NewAWS().Lambda
 
 // Register a handler BEFORE or AFTER creating the function
 lambda.RegisterHandler("my-func", func(ctx context.Context, payload []byte) ([]byte, error) {
@@ -498,7 +520,7 @@ output, _ := lambda.Invoke(ctx, sdriver.InvokeInput{
 ### Networking
 
 ```go
-vpc := cloudmock.NewAWS().VPC
+vpc := cloudemu.NewAWS().VPC
 
 // Create VPC
 vpcInfo, _ := vpc.CreateVPC(ctx, netdriver.VPCConfig{
@@ -524,8 +546,10 @@ vpc.AddIngressRule(ctx, sg.ID, netdriver.SecurityRule{
 
 ### Monitoring
 
+Alarms auto-evaluate when metric data is pushed — they transition to `"ALARM"` or `"OK"` automatically.
+
 ```go
-cw := cloudmock.NewAWS().CloudWatch
+cw := cloudemu.NewAWS().CloudWatch
 
 // Put metric data
 cw.PutMetricData(ctx, []mondriver.MetricDatum{
@@ -540,38 +564,106 @@ result, _ := cw.GetMetricData(ctx, mondriver.GetMetricInput{
     Period: 300, Stat: "Sum",
 })
 
-// Alarms
+// List available metric names
+names, _ := cw.ListMetrics(ctx, "MyApp")
+
+// Alarms — auto-evaluate when metric data arrives
 cw.CreateAlarm(ctx, mondriver.AlarmConfig{
     Name: "HighErrors", Namespace: "MyApp", MetricName: "ErrorCount",
     ComparisonOperator: "GreaterThanThreshold", Threshold: 100,
+    Period: 300, EvaluationPeriods: 1, Stat: "Average",
 })
-cw.SetAlarmState(ctx, "HighErrors", "ALARM", "Errors exceeded threshold")
+
+// Push data above threshold — alarm auto-transitions to "ALARM"
+cw.PutMetricData(ctx, []mondriver.MetricDatum{
+    {Namespace: "MyApp", MetricName: "ErrorCount", Value: 150, Timestamp: time.Now()},
+})
+
+alarms, _ := cw.DescribeAlarms(ctx, []string{"HighErrors"})
+// alarms[0].State == "ALARM"
+
+// Push data below threshold — alarm auto-transitions to "OK"
+cw.PutMetricData(ctx, []mondriver.MetricDatum{
+    {Namespace: "MyApp", MetricName: "ErrorCount", Value: 50, Timestamp: time.Now()},
+})
+
+alarms, _ = cw.DescribeAlarms(ctx, []string{"HighErrors"})
+// alarms[0].State == "OK"
+
+// You can also set alarm state manually
+cw.SetAlarmState(ctx, "HighErrors", "ALARM", "Manual override")
 ```
+
+**Supported comparison operators:** `GreaterThanThreshold`, `LessThanThreshold`, `GreaterThanOrEqualToThreshold`, `LessThanOrEqualToThreshold`
+
+**Supported statistics:** `Average`, `Sum`, `Minimum`, `Maximum`, `SampleCount`
 
 ### IAM
 
+IAM evaluates real JSON policy documents with wildcard matching. Explicit `Deny` always overrides `Allow`.
+
 ```go
-iam := cloudmock.NewAWS().IAM
+iam := cloudemu.NewAWS().IAM
 
 // Create user, role, policy
 user, _ := iam.CreateUser(ctx, iamdriver.UserConfig{Name: "alice"})
 role, _ := iam.CreateRole(ctx, iamdriver.RoleConfig{Name: "admin-role"})
+
+// Create policy with JSON document
 policy, _ := iam.CreatePolicy(ctx, iamdriver.PolicyConfig{
-    Name: "admin-policy", PolicyDocument: `{"Statement": [...]}`,
+    Name: "s3-read-policy",
+    PolicyDocument: `{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:ListBucket"],
+                "Resource": "*"
+            }
+        ]
+    }`,
 })
 
 // Attach policies
 iam.AttachUserPolicy(ctx, "alice", policy.ARN)
 iam.AttachRolePolicy(ctx, "admin-role", policy.ARN)
 
-// Check permissions (simplified — returns true if any policy attached)
-allowed, _ := iam.CheckPermission(ctx, "alice", "s3:GetObject", "*")
+// Check permissions — evaluates JSON policy with wildcard matching
+allowed, _ := iam.CheckPermission(ctx, "alice", "s3:GetObject", "arn:aws:s3:::my-bucket/file.txt")
+// allowed == true (matches "s3:GetObject" with Resource "*")
+
+allowed, _ = iam.CheckPermission(ctx, "alice", "ec2:RunInstances", "*")
+// allowed == false (not in policy)
+
+// Wildcard actions
+adminPolicy, _ := iam.CreatePolicy(ctx, iamdriver.PolicyConfig{
+    Name: "admin-policy",
+    PolicyDocument: `{
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}]
+    }`,
+})
+iam.AttachUserPolicy(ctx, "alice", adminPolicy.ARN)
+allowed, _ = iam.CheckPermission(ctx, "alice", "s3:PutObject", "*")
+// allowed == true (wildcard "s3:*" matches "s3:PutObject")
+
+// Explicit Deny overrides Allow
+denyPolicy, _ := iam.CreatePolicy(ctx, iamdriver.PolicyConfig{
+    Name: "deny-delete",
+    PolicyDocument: `{
+        "Version": "2012-10-17",
+        "Statement": [{"Effect": "Deny", "Action": "s3:DeleteObject", "Resource": "*"}]
+    }`,
+})
+iam.AttachUserPolicy(ctx, "alice", denyPolicy.ARN)
+allowed, _ = iam.CheckPermission(ctx, "alice", "s3:DeleteObject", "*")
+// allowed == false (explicit Deny wins over any Allow)
 ```
 
 ### DNS
 
 ```go
-dns := cloudmock.NewAWS().Route53
+dns := cloudemu.NewAWS().Route53
 
 zone, _ := dns.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "example.com"})
 dns.CreateRecord(ctx, dnsdriver.RecordConfig{
@@ -595,7 +687,7 @@ dns.CreateRecord(ctx, dnsdriver.RecordConfig{
 ### Load Balancer
 
 ```go
-elb := cloudmock.NewAWS().ELB
+elb := cloudemu.NewAWS().ELB
 
 lb, _ := elb.CreateLoadBalancer(ctx, lbdriver.LBConfig{
     Name: "web-lb", Type: "application", Scheme: "internet-facing",
@@ -618,8 +710,10 @@ health, _ := elb.DescribeTargetHealth(ctx, tg.ARN)
 
 ### Message Queue
 
+FIFO queues automatically deduplicate messages with the same `DeduplicationID` within a 5-minute window.
+
 ```go
-sqs := cloudmock.NewAWS().SQS
+sqs := cloudemu.NewAWS().SQS
 
 queue, _ := sqs.CreateQueue(ctx, mqdriver.QueueConfig{
     Name: "orders", VisibilityTimeout: 30,
@@ -640,15 +734,107 @@ msgs, _ := sqs.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{
 // Delete after processing
 sqs.DeleteMessage(ctx, queue.URL, msgs[0].ReceiptHandle)
 
-// FIFO queues
+// FIFO queues with deduplication
 fifo, _ := sqs.CreateQueue(ctx, mqdriver.QueueConfig{
     Name: "orders.fifo", FIFO: true,
 })
-sqs.SendMessage(ctx, mqdriver.SendMessageInput{
-    QueueURL: fifo.URL, Body: "msg",
-    GroupID: "group-1", DeduplicationID: "dedup-1",
+
+out1, _ := sqs.SendMessage(ctx, mqdriver.SendMessageInput{
+    QueueURL: fifo.URL, Body: "order-123",
+    GroupID: "group-1", DeduplicationID: "dedup-abc",
 })
+
+// Same DeduplicationID within 5 minutes — returns same MessageID, no duplicate
+out2, _ := sqs.SendMessage(ctx, mqdriver.SendMessageInput{
+    QueueURL: fifo.URL, Body: "order-123",
+    GroupID: "group-1", DeduplicationID: "dedup-abc",
+})
+// out1.MessageID == out2.MessageID — only 1 message in queue
+
+// After 5 minutes, same DeduplicationID is accepted as a new message
 ```
+
+---
+
+## Realistic Cloud Behaviors
+
+cloudemu goes beyond basic CRUD mocks. These behaviors make it behave like real cloud services.
+
+### Auto-Metric Generation
+
+When you launch a VM, monitoring metrics are automatically generated — just like real AWS/Azure/GCP.
+
+```go
+aws := cloudemu.NewAWS()
+aws.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+    ImageID: "ami-123", InstanceType: "t2.micro",
+}, 1)
+
+// Metrics are immediately available — no manual PutMetricData needed
+names, _ := aws.CloudWatch.ListMetrics(ctx, "AWS/EC2")
+// names == ["CPUUtilization", "DiskReadOps", "DiskWriteOps", "NetworkIn", "NetworkOut"]
+```
+
+**Metrics generated per provider:**
+
+| Provider | Namespace | Metrics |
+|----------|-----------|---------|
+| AWS | `AWS/EC2` | CPUUtilization, NetworkIn, NetworkOut, DiskReadOps, DiskWriteOps |
+| Azure | `Microsoft.Compute/virtualMachines` | Percentage CPU, Network In Total, Network Out Total, Disk Read Operations/Sec, Disk Write Operations/Sec |
+| GCP | `compute.googleapis.com` | instance/cpu/utilization, instance/network/received_bytes_count, instance/network/sent_bytes_count, instance/disk/read_ops_count, instance/disk/write_ops_count |
+
+### Alarm Auto-Evaluation
+
+Alarms automatically evaluate against incoming metric data. No need to manually call `SetAlarmState`.
+
+```go
+cw := cloudemu.NewAWS().CloudWatch
+
+// Create alarm
+cw.CreateAlarm(ctx, mondriver.AlarmConfig{
+    Name: "high-cpu", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+    ComparisonOperator: "GreaterThanThreshold", Threshold: 80,
+    Period: 300, EvaluationPeriods: 1, Stat: "Average",
+})
+
+// Push metric above threshold
+cw.PutMetricData(ctx, []mondriver.MetricDatum{
+    {Namespace: "AWS/EC2", MetricName: "CPUUtilization", Value: 95, Timestamp: time.Now()},
+})
+
+// Alarm automatically transitions to "ALARM"
+alarms, _ := cw.DescribeAlarms(ctx, []string{"high-cpu"})
+// alarms[0].State == "ALARM"
+```
+
+This also works with auto-generated VM metrics — create an alarm on CPU, launch a VM, and the alarm evaluates automatically.
+
+### IAM Policy Evaluation
+
+`CheckPermission` parses real JSON policy documents and evaluates them with wildcard matching.
+
+- **Allow/Deny evaluation:** Each attached policy's `Statement` array is checked
+- **Wildcard matching:** `"s3:*"` matches `"s3:GetObject"`, `"s3:PutObject"`, etc.
+- **Explicit Deny wins:** If any policy has `"Effect": "Deny"` matching the action/resource, the result is always `false`
+- **Default deny:** If no Allow statement matches, permission is denied
+
+### FIFO Deduplication
+
+FIFO queues (SQS, Service Bus, Pub/Sub) enforce a 5-minute deduplication window based on `DeduplicationID`:
+
+- Same `DeduplicationID` within 5 minutes → returns existing `MessageID`, no duplicate created
+- After 5 minutes → accepted as a new message
+
+### Numeric-Aware Comparisons
+
+Database scan filters and query conditions compare values numerically when both sides are valid numbers:
+
+```go
+// "10" > "9" → true (numeric comparison)
+// Without this, string comparison would give "10" < "9" (wrong)
+```
+
+This applies to all comparison operators (`<`, `>`, `<=`, `>=`, `BETWEEN`) in DynamoDB, CosmosDB, and Firestore mocks.
 
 ---
 
@@ -792,7 +978,7 @@ Control time in tests for TTL, expiry, and ordering scenarios.
 ```go
 clock := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
 
-aws := cloudmock.NewAWS(config.WithClock(clock))
+aws := cloudemu.NewAWS(config.WithClock(clock))
 
 // All timestamps use fake clock
 aws.S3.CreateBucket(ctx, "b")
@@ -803,7 +989,8 @@ obj, _ := aws.S3.GetObject(ctx, "b", "k")
 // Advance time
 clock.Advance(24 * time.Hour)
 
-// SQS visibility timeouts, CloudWatch time ranges, etc. all respect the clock
+// SQS visibility timeouts, CloudWatch time ranges, alarm evaluation windows,
+// FIFO deduplication windows — all respect the clock
 ```
 
 ### Latency Simulation
@@ -858,21 +1045,21 @@ func (s *FileService) Upload(ctx context.Context, bucket, key string, data []byt
 
 // Test with AWS
 func TestWithAWS(t *testing.T) {
-    aws := cloudmock.NewAWS()
+    aws := cloudemu.NewAWS()
     svc := &FileService{storage: storage.NewBucket(aws.S3)}
     // ...
 }
 
 // Test with GCP
 func TestWithGCP(t *testing.T) {
-    gcp := cloudmock.NewGCP()
+    gcp := cloudemu.NewGCP()
     svc := &FileService{storage: storage.NewBucket(gcp.GCS)}
     // ...
 }
 
 // Or use the factory
 func TestWithFactory(t *testing.T) {
-    bucket := cloudmock.NewStorage("aws") // or "azure" or "gcp"
+    bucket := cloudemu.NewStorage("aws") // or "azure" or "gcp"
     svc := &FileService{storage: bucket}
     // ...
 }
@@ -939,7 +1126,7 @@ func TestWithSuite(t *testing.T) {
 
 ## Error Handling
 
-All mock operations return errors using canonical error codes:
+All operations return errors using canonical error codes:
 
 ```go
 import cerrors "github.com/NitinKumar004/cloudemu/errors"
@@ -970,7 +1157,7 @@ cerrors.Internal           // unexpected internal error
 
 ```
 github.com/NitinKumar004/cloudemu
-├── cloudmock.go           # NewAWS(), NewAzure(), NewGCP(), NewStorage()
+├── cloudemu.go            # NewAWS(), NewAzure(), NewGCP()
 ├── errors/                # Canonical error codes and helpers
 ├── config/                # Options, Clock, FakeClock
 ├── recorder/              # Call recording + fluent assertions

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -2,6 +2,7 @@ package cloudemu
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -11,7 +12,9 @@ import (
 	"github.com/NitinKumar004/cloudemu/database/driver"
 	dnsdriver "github.com/NitinKumar004/cloudemu/dns/driver"
 	cerrors "github.com/NitinKumar004/cloudemu/errors"
+	iamdriver "github.com/NitinKumar004/cloudemu/iam/driver"
 	"github.com/NitinKumar004/cloudemu/inject"
+	mqdriver "github.com/NitinKumar004/cloudemu/messagequeue/driver"
 	"github.com/NitinKumar004/cloudemu/metrics"
 	mondriver "github.com/NitinKumar004/cloudemu/monitoring/driver"
 	netdriver "github.com/NitinKumar004/cloudemu/networking/driver"
@@ -753,5 +756,380 @@ func TestRealWorldGCP_InfraSetup(t *testing.T) {
 	vpcs, _ = gcp.VPC.DescribeVPCs(ctx, []string{vpc.ID})
 	if len(vpcs) != 1 {
 		t.Errorf("VPC should still exist")
+	}
+}
+
+// ==============================================================================
+// New Tests: Fixing 6 gaps to make CloudEmu behave like real cloud
+// ==============================================================================
+
+func TestScanMissingOperators(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	if err := p.DynamoDB.CreateTable(ctx, driver.TableConfig{
+		Name: "products", PartitionKey: "pk", SortKey: "sk",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	items := []map[string]interface{}{
+		{"pk": "cat1", "sk": "item1", "price": 5, "name": "alpha-one"},
+		{"pk": "cat1", "sk": "item2", "price": 10, "name": "alpha-two"},
+		{"pk": "cat1", "sk": "item3", "price": 15, "name": "beta-one"},
+		{"pk": "cat1", "sk": "item4", "price": 20, "name": "beta-two"},
+	}
+	for _, item := range items {
+		if err := p.DynamoDB.PutItem(ctx, "products", item); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Test <= operator
+	result, err := p.DynamoDB.Scan(ctx, driver.ScanInput{
+		Table:   "products",
+		Filters: []driver.ScanFilter{{Field: "price", Op: "<=", Value: 10}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 2 {
+		t.Errorf("<= filter: expected 2 items, got %d", result.Count)
+	}
+
+	// Test >= operator
+	result, err = p.DynamoDB.Scan(ctx, driver.ScanInput{
+		Table:   "products",
+		Filters: []driver.ScanFilter{{Field: "price", Op: ">=", Value: 15}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 2 {
+		t.Errorf(">= filter: expected 2 items, got %d", result.Count)
+	}
+
+	// Test BEGINS_WITH operator
+	result, err = p.DynamoDB.Scan(ctx, driver.ScanInput{
+		Table:   "products",
+		Filters: []driver.ScanFilter{{Field: "name", Op: "BEGINS_WITH", Value: "alpha"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 2 {
+		t.Errorf("BEGINS_WITH filter: expected 2 items, got %d", result.Count)
+	}
+}
+
+func TestNumericComparison(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	if err := p.DynamoDB.CreateTable(ctx, driver.TableConfig{
+		Name: "numbers", PartitionKey: "pk", SortKey: "sk",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert items with numeric values that would sort wrong as strings
+	// String sort: "10" < "9" (wrong), Numeric sort: 10 > 9 (correct)
+	items := []map[string]interface{}{
+		{"pk": "g1", "sk": "a", "val": 1},
+		{"pk": "g1", "sk": "b", "val": 5},
+		{"pk": "g1", "sk": "c", "val": 9},
+		{"pk": "g1", "sk": "d", "val": 10},
+		{"pk": "g1", "sk": "e", "val": 20},
+	}
+	for _, item := range items {
+		if err := p.DynamoDB.PutItem(ctx, "numbers", item); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Scan: val > 9 should return items with val=10 and val=20
+	result, err := p.DynamoDB.Scan(ctx, driver.ScanInput{
+		Table:   "numbers",
+		Filters: []driver.ScanFilter{{Field: "val", Op: ">", Value: 9}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 2 {
+		t.Errorf("numeric > filter: expected 2 items (10, 20), got %d", result.Count)
+	}
+
+	// Scan: val < 10 should return items with val=1, 5, 9
+	result, err = p.DynamoDB.Scan(ctx, driver.ScanInput{
+		Table:   "numbers",
+		Filters: []driver.ScanFilter{{Field: "val", Op: "<", Value: 10}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Count != 3 {
+		t.Errorf("numeric < filter: expected 3 items (1, 5, 9), got %d", result.Count)
+	}
+}
+
+func TestFIFODeduplication(t *testing.T) {
+	ctx := context.Background()
+	clock := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	p := NewAWS(config.WithClock(clock))
+
+	// Create FIFO queue
+	qInfo, err := p.SQS.CreateQueue(ctx, mqdriver.QueueConfig{
+		Name: "test-queue.fifo",
+		FIFO: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send first message
+	out1, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{
+		QueueURL:        qInfo.URL,
+		Body:            "hello",
+		GroupID:         "group1",
+		DeduplicationID: "dedup-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send duplicate within 5-min window — should return same message ID
+	out2, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{
+		QueueURL:        qInfo.URL,
+		Body:            "hello again",
+		GroupID:         "group1",
+		DeduplicationID: "dedup-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out1.MessageID != out2.MessageID {
+		t.Errorf("duplicate within 5 min should return same MessageID: got %s and %s", out1.MessageID, out2.MessageID)
+	}
+
+	// Verify only 1 message in queue
+	info, _ := p.SQS.GetQueueInfo(ctx, qInfo.URL)
+	if info.ApproxMessageCount != 1 {
+		t.Errorf("expected 1 message in queue, got %d", info.ApproxMessageCount)
+	}
+
+	// Advance clock past 5-minute window
+	clock.Advance(6 * time.Minute)
+
+	// Send same dedup ID again — should be accepted as new message
+	out3, err := p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{
+		QueueURL:        qInfo.URL,
+		Body:            "hello after window",
+		GroupID:         "group1",
+		DeduplicationID: "dedup-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out3.MessageID == out1.MessageID {
+		t.Error("message after 5 min window should have new MessageID")
+	}
+}
+
+func TestIAMCheckPermission(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Create user
+	_, err := p.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No policies attached — should deny
+	allowed, err := p.IAM.CheckPermission(ctx, "alice", "s3:GetObject", "arn:aws:s3:::my-bucket/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed {
+		t.Error("expected deny with no policies attached")
+	}
+
+	// Create Allow policy for s3:*
+	allowPolicy, err := p.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{
+		Name: "s3-allow",
+		PolicyDocument: `{
+			"Version": "2012-10-17",
+			"Statement": [
+				{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}
+			]
+		}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach and check
+	if err := p.IAM.AttachUserPolicy(ctx, "alice", allowPolicy.ARN); err != nil {
+		t.Fatal(err)
+	}
+
+	allowed, err = p.IAM.CheckPermission(ctx, "alice", "s3:GetObject", "arn:aws:s3:::my-bucket/key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed {
+		t.Error("expected allow with s3:* policy")
+	}
+
+	// Non-matching action should deny
+	allowed, err = p.IAM.CheckPermission(ctx, "alice", "ec2:DescribeInstances", "arn:aws:ec2:::*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed {
+		t.Error("expected deny for ec2 action with only s3 policy")
+	}
+
+	// Create explicit Deny policy for s3:DeleteObject
+	denyPolicy, err := p.IAM.CreatePolicy(ctx, iamdriver.PolicyConfig{
+		Name: "s3-deny-delete",
+		PolicyDocument: `{
+			"Version": "2012-10-17",
+			"Statement": [
+				{"Effect": "Deny", "Action": "s3:DeleteObject", "Resource": "*"}
+			]
+		}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.IAM.AttachUserPolicy(ctx, "alice", denyPolicy.ARN); err != nil {
+		t.Fatal(err)
+	}
+
+	// Explicit Deny should win even though Allow s3:* is also attached
+	allowed, err = p.IAM.CheckPermission(ctx, "alice", "s3:DeleteObject", "arn:aws:s3:::my-bucket/key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed {
+		t.Error("expected deny: explicit Deny should override Allow")
+	}
+}
+
+func TestAlarmAutoEvaluation(t *testing.T) {
+	ctx := context.Background()
+	clock := config.NewFakeClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
+	p := NewAWS(config.WithClock(clock))
+
+	// Create alarm: trigger if Average CPU > 80
+	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
+		Name: "high-cpu", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 80,
+		Period: 300, EvaluationPeriods: 1, Stat: "Average",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify initial state is INSUFFICIENT_DATA
+	alarms, _ := p.CloudWatch.DescribeAlarms(ctx, []string{"high-cpu"})
+	if alarms[0].State != "INSUFFICIENT_DATA" {
+		t.Errorf("expected INSUFFICIENT_DATA, got %s", alarms[0].State)
+	}
+
+	// Push metric data below threshold
+	now := clock.Now()
+	if err := p.CloudWatch.PutMetricData(ctx, []mondriver.MetricDatum{
+		{Namespace: "AWS/EC2", MetricName: "CPUUtilization", Value: 50, Timestamp: now},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Alarm should transition to OK
+	alarms, _ = p.CloudWatch.DescribeAlarms(ctx, []string{"high-cpu"})
+	if alarms[0].State != "OK" {
+		t.Errorf("expected OK after below-threshold data, got %s", alarms[0].State)
+	}
+
+	// Advance clock past the evaluation window so the old data point falls out
+	clock.Advance(10 * time.Minute)
+	now = clock.Now()
+
+	// Push metric data above threshold
+	if err := p.CloudWatch.PutMetricData(ctx, []mondriver.MetricDatum{
+		{Namespace: "AWS/EC2", MetricName: "CPUUtilization", Value: 95, Timestamp: now},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Alarm should transition to ALARM
+	alarms, _ = p.CloudWatch.DescribeAlarms(ctx, []string{"high-cpu"})
+	if alarms[0].State != "ALARM" {
+		t.Errorf("expected ALARM after above-threshold data, got %s", alarms[0].State)
+	}
+}
+
+func TestAutoMetricGeneration(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Launch an instance
+	_, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify auto-generated metrics exist in CloudWatch
+	metricNames, err := p.CloudWatch.ListMetrics(ctx, "AWS/EC2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []string{"CPUUtilization", "DiskReadOps", "DiskWriteOps", "NetworkIn", "NetworkOut"}
+	sort.Strings(metricNames)
+	if len(metricNames) != len(expected) {
+		t.Fatalf("expected %d metrics, got %d: %v", len(expected), len(metricNames), metricNames)
+	}
+	for i, name := range expected {
+		if metricNames[i] != name {
+			t.Errorf("expected metric %q, got %q", name, metricNames[i])
+		}
+	}
+}
+
+func TestAlarmTriggeredByAutoMetrics(t *testing.T) {
+	ctx := context.Background()
+	clock := config.NewFakeClock(time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC))
+	p := NewAWS(config.WithClock(clock))
+
+	// Create alarm: CPU > 0 (any CPU should trigger since auto-metrics emit 25.0)
+	if err := p.CloudWatch.CreateAlarm(ctx, mondriver.AlarmConfig{
+		Name: "any-cpu", Namespace: "AWS/EC2", MetricName: "CPUUtilization",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 0,
+		Period: 600, EvaluationPeriods: 1, Stat: "Average",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify initial state
+	alarms, _ := p.CloudWatch.DescribeAlarms(ctx, []string{"any-cpu"})
+	if alarms[0].State != "INSUFFICIENT_DATA" {
+		t.Errorf("expected INSUFFICIENT_DATA, got %s", alarms[0].State)
+	}
+
+	// Launch instance — auto-metrics should trigger alarm evaluation
+	_, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t2.micro",
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Alarm should now be in ALARM state (CPU 25.0 > 0)
+	alarms, _ = p.CloudWatch.DescribeAlarms(ctx, []string{"any-cpu"})
+	if alarms[0].State != "ALARM" {
+		t.Errorf("expected ALARM after auto-metrics (CPU=25 > 0), got %s", alarms[0].State)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/NitinKumar004/cloudemu
 
-go 1.21
+go 1.25.0

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -32,7 +32,7 @@ type Provider struct {
 // New creates a new AWS provider with all mock services.
 func New(opts ...config.Option) *Provider {
 	o := config.NewOptions(opts...)
-	return &Provider{
+	p := &Provider{
 		S3:         s3.New(o),
 		EC2:        ec2.New(o),
 		DynamoDB:   dynamodb.New(o),
@@ -44,4 +44,6 @@ func New(opts ...config.Option) *Provider {
 		ELB:        elb.New(o),
 		SQS:        sqs.New(o),
 	}
+	p.EC2.SetMonitoring(p.CloudWatch)
+	return p
 }

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -3,6 +3,8 @@ package awsiam
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 
 	"github.com/NitinKumar004/cloudemu/config"
@@ -374,23 +376,120 @@ func (m *Mock) ListAttachedRolePolicies(ctx context.Context, roleName string) ([
 	return result, nil
 }
 
-// CheckPermission checks if a principal has any attached policy (simplified check).
-// Returns true if the principal (user or role name) has at least one attached policy.
+type policyDoc struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Effect   string      `json:"Effect"`
+	Action   interface{} `json:"Action"`
+	Resource interface{} `json:"Resource"`
+}
+
+func wildcardMatch(pattern, value string) bool {
+	if pattern == "*" {
+		return true
+	}
+	pParts := strings.Split(pattern, "*")
+	if len(pParts) == 1 {
+		return pattern == value
+	}
+	if !strings.HasPrefix(value, pParts[0]) {
+		return false
+	}
+	remaining := value[len(pParts[0]):]
+	for i := 1; i < len(pParts); i++ {
+		idx := strings.Index(remaining, pParts[i])
+		if idx < 0 {
+			return false
+		}
+		remaining = remaining[idx+len(pParts[i]):]
+	}
+	return true
+}
+
+func toStringSlice(v interface{}) []string {
+	switch val := v.(type) {
+	case string:
+		return []string{val}
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func evaluatePolicy(doc string, action, resource string) (allow, deny bool) {
+	var pd policyDoc
+	if err := json.Unmarshal([]byte(doc), &pd); err != nil {
+		return false, false
+	}
+	for _, stmt := range pd.Statement {
+		actions := toStringSlice(stmt.Action)
+		resources := toStringSlice(stmt.Resource)
+		actionMatch := false
+		for _, a := range actions {
+			if wildcardMatch(a, action) {
+				actionMatch = true
+				break
+			}
+		}
+		if !actionMatch {
+			continue
+		}
+		resourceMatch := false
+		for _, r := range resources {
+			if wildcardMatch(r, resource) {
+				resourceMatch = true
+				break
+			}
+		}
+		if !resourceMatch {
+			continue
+		}
+		if strings.EqualFold(stmt.Effect, "Deny") {
+			deny = true
+		} else if strings.EqualFold(stmt.Effect, "Allow") {
+			allow = true
+		}
+	}
+	return allow, deny
+}
+
+// CheckPermission evaluates attached policies to determine if a principal is allowed
+// to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(ctx context.Context, principal, action, resource string) (bool, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	// Check user policies.
-	if policies, ok := m.userPolicies[principal]; ok && len(policies) > 0 {
-		return true, nil
+	policyARNs := make(map[string]bool)
+	for arn := range m.userPolicies[principal] {
+		policyARNs[arn] = true
 	}
-
-	// Check role policies.
-	if policies, ok := m.rolePolicies[principal]; ok && len(policies) > 0 {
-		return true, nil
+	for arn := range m.rolePolicies[principal] {
+		policyARNs[arn] = true
 	}
+	m.mu.RUnlock()
 
-	return false, nil
+	hasAllow := false
+	for arn := range policyARNs {
+		p, ok := m.policies.Get(arn)
+		if !ok || p.PolicyDocument == "" {
+			continue
+		}
+		allow, deny := evaluatePolicy(p.PolicyDocument, action, resource)
+		if deny {
+			return false, nil
+		}
+		if allow {
+			hasAllow = true
+		}
+	}
+	return hasAllow, nil
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -25,10 +25,10 @@ type metricKey struct {
 
 // Mock is an in-memory mock implementation of the AWS CloudWatch service.
 type Mock struct {
-	mu       sync.RWMutex
-	metrics  map[metricKey][]driver.MetricDatum
-	alarms   *memstore.Store[*alarmData]
-	opts     *config.Options
+	mu      sync.RWMutex
+	metrics map[metricKey][]driver.MetricDatum
+	alarms  *memstore.Store[*alarmData]
+	opts    *config.Options
 }
 
 type alarmData struct {
@@ -54,15 +54,13 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
-// PutMetricData stores metric data points.
+// PutMetricData stores metric data points and evaluates any matching alarms.
 func (m *Mock) PutMetricData(ctx context.Context, data []driver.MetricDatum) error {
 	if len(data) == 0 {
 		return errors.Newf(errors.InvalidArgument, "metric data is required")
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for _, d := range data {
 		key := metricKey{
 			Namespace:  d.Namespace,
@@ -70,8 +68,85 @@ func (m *Mock) PutMetricData(ctx context.Context, data []driver.MetricDatum) err
 		}
 		m.metrics[key] = append(m.metrics[key], d)
 	}
+	m.mu.Unlock()
+
+	// Evaluate alarms for each unique namespace/metric pair that was updated.
+	seen := make(map[metricKey]bool)
+	for _, d := range data {
+		mk := metricKey{Namespace: d.Namespace, MetricName: d.MetricName}
+		if !seen[mk] {
+			seen[mk] = true
+			m.evaluateAlarms(d.Namespace, d.MetricName)
+		}
+	}
 
 	return nil
+}
+
+func evaluateComparison(value float64, operator string, threshold float64) bool {
+	switch operator {
+	case "GreaterThanThreshold":
+		return value > threshold
+	case "GreaterThanOrEqualToThreshold":
+		return value >= threshold
+	case "LessThanThreshold":
+		return value < threshold
+	case "LessThanOrEqualToThreshold":
+		return value <= threshold
+	default:
+		return false
+	}
+}
+
+func (m *Mock) evaluateAlarms(namespace, metricName string) {
+	allAlarms := m.alarms.All()
+	for _, alarm := range allAlarms {
+		if alarm.Namespace != namespace || alarm.MetricName != metricName {
+			continue
+		}
+
+		period := alarm.Period
+		if period <= 0 {
+			period = 60
+		}
+		evalPeriods := alarm.EvaluationPeriods
+		if evalPeriods <= 0 {
+			evalPeriods = 1
+		}
+
+		now := m.opts.Clock.Now()
+		windowDur := time.Duration(period*evalPeriods) * time.Second
+		windowStart := now.Add(-windowDur)
+
+		m.mu.RLock()
+		key := metricKey{Namespace: namespace, MetricName: metricName}
+		dataPoints := m.metrics[key]
+
+		var filtered []float64
+		for _, d := range dataPoints {
+			if d.Timestamp.Before(windowStart) || d.Timestamp.After(now) {
+				continue
+			}
+			if !matchDimensions(d.Dimensions, alarm.Dimensions) {
+				continue
+			}
+			filtered = append(filtered, d.Value)
+		}
+		m.mu.RUnlock()
+
+		if len(filtered) == 0 {
+			continue
+		}
+
+		stat := computeStat(filtered, alarm.Stat)
+		if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
+			alarm.State = "ALARM"
+			alarm.StateReason = "Threshold crossed"
+		} else {
+			alarm.State = "OK"
+			alarm.StateReason = "Threshold not crossed"
+		}
+	}
 }
 
 // GetMetricData retrieves metric data for the given query, filtering by time range and

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -218,22 +219,44 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 	return results, nil
 }
 
+func compareValues(a, b string) int {
+	fa, errA := strconv.ParseFloat(a, 64)
+	fb, errB := strconv.ParseFloat(b, 64)
+	if errA == nil && errB == nil {
+		if fa < fb {
+			return -1
+		}
+		if fa > fb {
+			return 1
+		}
+		return 0
+	}
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
 func applySortCondition(itemVal, op, condVal string, condValEnd interface{}) bool {
 	switch op {
 	case "=":
 		return itemVal == condVal
 	case "<":
-		return itemVal < condVal
+		return compareValues(itemVal, condVal) < 0
 	case ">":
-		return itemVal > condVal
+		return compareValues(itemVal, condVal) > 0
 	case "<=":
-		return itemVal <= condVal
+		return compareValues(itemVal, condVal) <= 0
 	case ">=":
-		return itemVal >= condVal
+		return compareValues(itemVal, condVal) >= 0
 	case "BEGINS_WITH":
 		return strings.HasPrefix(itemVal, condVal)
 	case "BETWEEN":
-		return itemVal >= condVal && itemVal <= fmt.Sprintf("%v", condValEnd)
+		endVal := fmt.Sprintf("%v", condValEnd)
+		return compareValues(itemVal, condVal) >= 0 && compareValues(itemVal, endVal) <= 0
 	default:
 		return false
 	}
@@ -253,15 +276,27 @@ func matchesFilters(item map[string]interface{}, filters []driver.ScanFilter) bo
 				return false
 			}
 		case "<":
-			if val >= condVal {
+			if compareValues(val, condVal) >= 0 {
 				return false
 			}
 		case ">":
-			if val <= condVal {
+			if compareValues(val, condVal) <= 0 {
+				return false
+			}
+		case "<=":
+			if compareValues(val, condVal) > 0 {
+				return false
+			}
+		case ">=":
+			if compareValues(val, condVal) < 0 {
 				return false
 			}
 		case "CONTAINS":
 			if !strings.Contains(val, condVal) {
+				return false
+			}
+		case "BEGINS_WITH":
+			if !strings.HasPrefix(val, condVal) {
 				return false
 			}
 		default:

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/NitinKumar004/cloudemu/compute"
 	"github.com/NitinKumar004/cloudemu/compute/driver"
@@ -11,6 +12,7 @@ import (
 	cerrors "github.com/NitinKumar004/cloudemu/errors"
 	"github.com/NitinKumar004/cloudemu/internal/idgen"
 	"github.com/NitinKumar004/cloudemu/internal/memstore"
+	mondriver "github.com/NitinKumar004/cloudemu/monitoring/driver"
 	"github.com/NitinKumar004/cloudemu/statemachine"
 )
 
@@ -32,10 +34,43 @@ type instanceData struct {
 
 // Mock is an in-memory mock implementation of the AWS EC2 service.
 type Mock struct {
-	instances *memstore.Store[*instanceData]
-	sm        *statemachine.Machine
-	opts      *config.Options
-	ipCounter atomic.Int64
+	instances  *memstore.Store[*instanceData]
+	sm         *statemachine.Machine
+	opts       *config.Options
+	ipCounter  atomic.Int64
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime string) {
+	if m.monitoring == nil {
+		return
+	}
+	lt, err := time.Parse("2006-01-02T15:04:05Z", launchTime)
+	if err != nil {
+		lt = m.opts.Clock.Now()
+	}
+	metrics := []string{"CPUUtilization", "NetworkIn", "NetworkOut", "DiskReadOps", "DiskWriteOps"}
+	values := []float64{25.0, 1024.0, 512.0, 100.0, 50.0}
+	var data []mondriver.MetricDatum
+	for i, metricName := range metrics {
+		for j := 0; j < 5; j++ {
+			ts := lt.Add(time.Duration(j) * time.Minute)
+			data = append(data, mondriver.MetricDatum{
+				Namespace:  "AWS/EC2",
+				MetricName: metricName,
+				Value:      values[i],
+				Unit:       "None",
+				Dimensions: map[string]string{"InstanceId": instanceID},
+				Timestamp:  ts,
+			})
+		}
+	}
+	_ = m.monitoring.PutMetricData(ctx, data)
 }
 
 // New creates a new EC2 mock.
@@ -66,7 +101,7 @@ func toInstance(d *instanceData) driver.Instance {
 	}
 }
 
-func (m *Mock) RunInstances(_ context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
+func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
 	if count <= 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
 	}
@@ -90,6 +125,7 @@ func (m *Mock) RunInstances(_ context.Context, cfg driver.InstanceConfig, count 
 		_ = m.sm.Transition(id, compute.StateRunning)
 		inst.State = compute.StateRunning
 		results = append(results, toInstance(inst))
+		m.emitInstanceMetrics(ctx, id, inst.LaunchTime)
 	}
 	return results, nil
 }

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -27,6 +27,7 @@ type sqsMessage struct {
 	Attributes      map[string]string
 	ReceiptHandle   string
 	VisibleAt       time.Time
+	SentAt          time.Time
 }
 
 // queueData holds the internal state of a single SQS queue.
@@ -35,10 +36,11 @@ type queueData struct {
 	messages []*sqsMessage
 	mu       sync.Mutex
 
-	delaySeconds      int
-	visibilityTimeout int
-	maxMessageSize    int
-	messageRetention  int
+	delaySeconds       int
+	visibilityTimeout  int
+	maxMessageSize     int
+	messageRetention   int
+	deduplicationIndex map[string]time.Time
 }
 
 // Mock is an in-memory mock implementation of the AWS SQS service.
@@ -92,12 +94,13 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	}
 
 	qd := &queueData{
-		info:              info,
-		messages:          make([]*sqsMessage, 0),
-		delaySeconds:      cfg.DelaySeconds,
-		visibilityTimeout: visibilityTimeout,
-		maxMessageSize:    cfg.MaxMessageSize,
-		messageRetention:  cfg.MessageRetention,
+		info:               info,
+		messages:           make([]*sqsMessage, 0),
+		delaySeconds:       cfg.DelaySeconds,
+		visibilityTimeout:  visibilityTimeout,
+		maxMessageSize:     cfg.MaxMessageSize,
+		messageRetention:   cfg.MessageRetention,
+		deduplicationIndex: make(map[string]time.Time),
 	}
 
 	m.queues.Set(url, qd)
@@ -175,6 +178,22 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		}
 	}
 
+	now := m.opts.Clock.Now()
+
+	// FIFO deduplication: check if same DeduplicationID was sent within 5-min window.
+	if qd.info.FIFO && input.DeduplicationID != "" {
+		if sentAt, ok := qd.deduplicationIndex[input.DeduplicationID]; ok {
+			if now.Sub(sentAt) < 5*time.Minute {
+				// Return existing message ID for the duplicate.
+				for _, existing := range qd.messages {
+					if existing.DeduplicationID == input.DeduplicationID {
+						return &driver.SendMessageOutput{MessageID: existing.ID}, nil
+					}
+				}
+			}
+		}
+	}
+
 	msgID := idgen.GenerateID("msg-")
 
 	attrs := make(map[string]string, len(input.Attributes))
@@ -187,7 +206,6 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		delaySeconds = qd.delaySeconds
 	}
 
-	now := m.opts.Clock.Now()
 	visibleAt := now.Add(time.Duration(delaySeconds) * time.Second)
 
 	msg := &sqsMessage{
@@ -197,9 +215,14 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
 		VisibleAt:       visibleAt,
+		SentAt:          now,
 	}
 
 	qd.messages = append(qd.messages, msg)
+
+	if qd.info.FIFO && input.DeduplicationID != "" {
+		qd.deduplicationIndex[input.DeduplicationID] = now
+	}
 
 	return &driver.SendMessageOutput{
 		MessageID: msgID,

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -32,7 +32,7 @@ type Provider struct {
 // New creates a new Azure provider with all mock services.
 func New(opts ...config.Option) *Provider {
 	o := config.NewOptions(opts...)
-	return &Provider{
+	p := &Provider{
 		BlobStorage:     blobstorage.New(o),
 		VirtualMachines: virtualmachines.New(o),
 		CosmosDB:        cosmosdb.New(o),
@@ -44,4 +44,6 @@ func New(opts ...config.Option) *Provider {
 		LB:              azurelb.New(o),
 		ServiceBus:      servicebus.New(o),
 	}
+	p.VirtualMachines.SetMonitoring(p.Monitor)
+	return p
 }

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -3,6 +3,8 @@ package azureiam
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"sync"
 
 	"github.com/NitinKumar004/cloudemu/config"
@@ -374,23 +376,120 @@ func (m *Mock) ListAttachedRolePolicies(_ context.Context, roleName string) ([]s
 	return result, nil
 }
 
-// CheckPermission checks if a principal has any attached policy (simplified check).
-// Returns true if the principal (user or role name) has at least one attached policy.
+type policyDoc struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Effect   string      `json:"Effect"`
+	Action   interface{} `json:"Action"`
+	Resource interface{} `json:"Resource"`
+}
+
+func wildcardMatch(pattern, value string) bool {
+	if pattern == "*" {
+		return true
+	}
+	pParts := strings.Split(pattern, "*")
+	if len(pParts) == 1 {
+		return pattern == value
+	}
+	if !strings.HasPrefix(value, pParts[0]) {
+		return false
+	}
+	remaining := value[len(pParts[0]):]
+	for i := 1; i < len(pParts); i++ {
+		idx := strings.Index(remaining, pParts[i])
+		if idx < 0 {
+			return false
+		}
+		remaining = remaining[idx+len(pParts[i]):]
+	}
+	return true
+}
+
+func toStringSlice(v interface{}) []string {
+	switch val := v.(type) {
+	case string:
+		return []string{val}
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func evaluatePolicy(doc string, action, resource string) (allow, deny bool) {
+	var pd policyDoc
+	if err := json.Unmarshal([]byte(doc), &pd); err != nil {
+		return false, false
+	}
+	for _, stmt := range pd.Statement {
+		actions := toStringSlice(stmt.Action)
+		resources := toStringSlice(stmt.Resource)
+		actionMatch := false
+		for _, a := range actions {
+			if wildcardMatch(a, action) {
+				actionMatch = true
+				break
+			}
+		}
+		if !actionMatch {
+			continue
+		}
+		resourceMatch := false
+		for _, r := range resources {
+			if wildcardMatch(r, resource) {
+				resourceMatch = true
+				break
+			}
+		}
+		if !resourceMatch {
+			continue
+		}
+		if strings.EqualFold(stmt.Effect, "Deny") {
+			deny = true
+		} else if strings.EqualFold(stmt.Effect, "Allow") {
+			allow = true
+		}
+	}
+	return allow, deny
+}
+
+// CheckPermission evaluates attached policies to determine if a principal is allowed
+// to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	// Check user policies.
-	if policies, ok := m.userPolicies[principal]; ok && len(policies) > 0 {
-		return true, nil
+	policyARNs := make(map[string]bool)
+	for arn := range m.userPolicies[principal] {
+		policyARNs[arn] = true
 	}
-
-	// Check role policies.
-	if policies, ok := m.rolePolicies[principal]; ok && len(policies) > 0 {
-		return true, nil
+	for arn := range m.rolePolicies[principal] {
+		policyARNs[arn] = true
 	}
+	m.mu.RUnlock()
 
-	return false, nil
+	hasAllow := false
+	for arn := range policyARNs {
+		p, ok := m.policies.Get(arn)
+		if !ok || p.PolicyDocument == "" {
+			continue
+		}
+		allow, deny := evaluatePolicy(p.PolicyDocument, action, resource)
+		if deny {
+			return false, nil
+		}
+		if allow {
+			hasAllow = true
+		}
+	}
+	return hasAllow, nil
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/azure/azuremonitor/monitor.go
+++ b/providers/azure/azuremonitor/monitor.go
@@ -55,15 +55,13 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
-// PutMetricData stores metric data points.
+// PutMetricData stores metric data points and evaluates any matching alarms.
 func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error {
 	if len(data) == 0 {
 		return cerrors.New(cerrors.InvalidArgument, "metric data is required")
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for _, d := range data {
 		key := metricKey{
 			Namespace:  d.Namespace,
@@ -71,8 +69,84 @@ func (m *Mock) PutMetricData(_ context.Context, data []driver.MetricDatum) error
 		}
 		m.metrics[key] = append(m.metrics[key], d)
 	}
+	m.mu.Unlock()
+
+	seen := make(map[metricKey]bool)
+	for _, d := range data {
+		mk := metricKey{Namespace: d.Namespace, MetricName: d.MetricName}
+		if !seen[mk] {
+			seen[mk] = true
+			m.evaluateAlarms(d.Namespace, d.MetricName)
+		}
+	}
 
 	return nil
+}
+
+func evaluateComparison(value float64, operator string, threshold float64) bool {
+	switch operator {
+	case "GreaterThanThreshold":
+		return value > threshold
+	case "GreaterThanOrEqualToThreshold":
+		return value >= threshold
+	case "LessThanThreshold":
+		return value < threshold
+	case "LessThanOrEqualToThreshold":
+		return value <= threshold
+	default:
+		return false
+	}
+}
+
+func (m *Mock) evaluateAlarms(namespace, metricName string) {
+	allAlarms := m.alarms.All()
+	for _, alarm := range allAlarms {
+		if alarm.Namespace != namespace || alarm.MetricName != metricName {
+			continue
+		}
+
+		period := alarm.Period
+		if period <= 0 {
+			period = 60
+		}
+		evalPeriods := alarm.EvaluationPeriods
+		if evalPeriods <= 0 {
+			evalPeriods = 1
+		}
+
+		now := m.opts.Clock.Now()
+		windowDur := time.Duration(period*evalPeriods) * time.Second
+		windowStart := now.Add(-windowDur)
+
+		m.mu.RLock()
+		key := metricKey{Namespace: namespace, MetricName: metricName}
+		dataPoints := m.metrics[key]
+
+		var filtered []float64
+		for _, d := range dataPoints {
+			if d.Timestamp.Before(windowStart) || d.Timestamp.After(now) {
+				continue
+			}
+			if !matchDimensions(d.Dimensions, alarm.Dimensions) {
+				continue
+			}
+			filtered = append(filtered, d.Value)
+		}
+		m.mu.RUnlock()
+
+		if len(filtered) == 0 {
+			continue
+		}
+
+		stat := computeStat(filtered, alarm.Stat)
+		if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
+			alarm.State = "ALARM"
+			alarm.StateReason = "Threshold crossed"
+		} else {
+			alarm.State = "OK"
+			alarm.StateReason = "Threshold not crossed"
+		}
+	}
 }
 
 // GetMetricData retrieves metric data for the given query, filtering by time range and

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -4,6 +4,7 @@ package cosmosdb
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -231,22 +232,44 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 	return results, nil
 }
 
+func compareValues(a, b string) int {
+	fa, errA := strconv.ParseFloat(a, 64)
+	fb, errB := strconv.ParseFloat(b, 64)
+	if errA == nil && errB == nil {
+		if fa < fb {
+			return -1
+		}
+		if fa > fb {
+			return 1
+		}
+		return 0
+	}
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
 func applySortCondition(itemVal, op, condVal string, condValEnd interface{}) bool {
 	switch op {
 	case "=":
 		return itemVal == condVal
 	case "<":
-		return itemVal < condVal
+		return compareValues(itemVal, condVal) < 0
 	case ">":
-		return itemVal > condVal
+		return compareValues(itemVal, condVal) > 0
 	case "<=":
-		return itemVal <= condVal
+		return compareValues(itemVal, condVal) <= 0
 	case ">=":
-		return itemVal >= condVal
+		return compareValues(itemVal, condVal) >= 0
 	case "BEGINS_WITH":
 		return strings.HasPrefix(itemVal, condVal)
 	case "BETWEEN":
-		return itemVal >= condVal && itemVal <= fmt.Sprintf("%v", condValEnd)
+		endVal := fmt.Sprintf("%v", condValEnd)
+		return compareValues(itemVal, condVal) >= 0 && compareValues(itemVal, endVal) <= 0
 	default:
 		return false
 	}
@@ -266,15 +289,27 @@ func matchesScanFilters(item map[string]interface{}, filters []driver.ScanFilter
 				return false
 			}
 		case "<":
-			if val >= condVal {
+			if compareValues(val, condVal) >= 0 {
 				return false
 			}
 		case ">":
-			if val <= condVal {
+			if compareValues(val, condVal) <= 0 {
+				return false
+			}
+		case "<=":
+			if compareValues(val, condVal) > 0 {
+				return false
+			}
+		case ">=":
+			if compareValues(val, condVal) < 0 {
 				return false
 			}
 		case "CONTAINS":
 			if !strings.Contains(val, condVal) {
+				return false
+			}
+		case "BEGINS_WITH":
+			if !strings.HasPrefix(val, condVal) {
 				return false
 			}
 		default:

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -27,6 +27,7 @@ type sbMessage struct {
 	Attributes      map[string]string
 	ReceiptHandle   string
 	VisibleAt       time.Time
+	SentAt          time.Time
 }
 
 // queueData holds the internal state of a single Service Bus queue.
@@ -35,10 +36,11 @@ type queueData struct {
 	messages []*sbMessage
 	mu       sync.Mutex
 
-	delaySeconds      int
-	visibilityTimeout int
-	maxMessageSize    int
-	messageRetention  int
+	delaySeconds       int
+	visibilityTimeout  int
+	maxMessageSize     int
+	messageRetention   int
+	deduplicationIndex map[string]time.Time
 }
 
 // Mock is an in-memory mock implementation of the Azure Service Bus service.
@@ -92,12 +94,13 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	}
 
 	qd := &queueData{
-		info:              info,
-		messages:          make([]*sbMessage, 0),
-		delaySeconds:      cfg.DelaySeconds,
-		visibilityTimeout: visibilityTimeout,
-		maxMessageSize:    cfg.MaxMessageSize,
-		messageRetention:  cfg.MessageRetention,
+		info:               info,
+		messages:           make([]*sbMessage, 0),
+		delaySeconds:       cfg.DelaySeconds,
+		visibilityTimeout:  visibilityTimeout,
+		maxMessageSize:     cfg.MaxMessageSize,
+		messageRetention:   cfg.MessageRetention,
+		deduplicationIndex: make(map[string]time.Time),
 	}
 
 	m.queues.Set(url, qd)
@@ -175,6 +178,21 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		}
 	}
 
+	now := m.opts.Clock.Now()
+
+	// FIFO deduplication: check if same DeduplicationID was sent within 5-min window.
+	if qd.info.FIFO && input.DeduplicationID != "" {
+		if sentAt, ok := qd.deduplicationIndex[input.DeduplicationID]; ok {
+			if now.Sub(sentAt) < 5*time.Minute {
+				for _, existing := range qd.messages {
+					if existing.DeduplicationID == input.DeduplicationID {
+						return &driver.SendMessageOutput{MessageID: existing.ID}, nil
+					}
+				}
+			}
+		}
+	}
+
 	msgID := idgen.GenerateID("sb-msg-")
 
 	attrs := make(map[string]string, len(input.Attributes))
@@ -187,7 +205,6 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		delaySeconds = qd.delaySeconds
 	}
 
-	now := m.opts.Clock.Now()
 	visibleAt := now.Add(time.Duration(delaySeconds) * time.Second)
 
 	msg := &sbMessage{
@@ -197,9 +214,14 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
 		VisibleAt:       visibleAt,
+		SentAt:          now,
 	}
 
 	qd.messages = append(qd.messages, msg)
+
+	if qd.info.FIFO && input.DeduplicationID != "" {
+		qd.deduplicationIndex[input.DeduplicationID] = now
+	}
 
 	return &driver.SendMessageOutput{
 		MessageID: msgID,

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/NitinKumar004/cloudemu/compute"
 	"github.com/NitinKumar004/cloudemu/compute/driver"
@@ -12,6 +13,7 @@ import (
 	cerrors "github.com/NitinKumar004/cloudemu/errors"
 	"github.com/NitinKumar004/cloudemu/internal/idgen"
 	"github.com/NitinKumar004/cloudemu/internal/memstore"
+	mondriver "github.com/NitinKumar004/cloudemu/monitoring/driver"
 	"github.com/NitinKumar004/cloudemu/statemachine"
 )
 
@@ -34,10 +36,43 @@ type instanceData struct {
 
 // Mock is an in-memory mock implementation of the Azure Virtual Machines service.
 type Mock struct {
-	instances *memstore.Store[*instanceData]
-	sm        *statemachine.Machine
-	opts      *config.Options
-	ipCounter atomic.Int64
+	instances  *memstore.Store[*instanceData]
+	sm         *statemachine.Machine
+	opts       *config.Options
+	ipCounter  atomic.Int64
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime string) {
+	if m.monitoring == nil {
+		return
+	}
+	lt, err := time.Parse("2006-01-02T15:04:05Z", launchTime)
+	if err != nil {
+		lt = m.opts.Clock.Now()
+	}
+	metrics := []string{"Percentage CPU", "Network In Total", "Network Out Total", "Disk Read Operations/Sec", "Disk Write Operations/Sec"}
+	values := []float64{25.0, 1024.0, 512.0, 100.0, 50.0}
+	var data []mondriver.MetricDatum
+	for i, metricName := range metrics {
+		for j := 0; j < 5; j++ {
+			ts := lt.Add(time.Duration(j) * time.Minute)
+			data = append(data, mondriver.MetricDatum{
+				Namespace:  "Microsoft.Compute/virtualMachines",
+				MetricName: metricName,
+				Value:      values[i],
+				Unit:       "None",
+				Dimensions: map[string]string{"resourceId": instanceID},
+				Timestamp:  ts,
+			})
+		}
+	}
+	_ = m.monitoring.PutMetricData(ctx, data)
 }
 
 // New creates a new Azure Virtual Machines mock.
@@ -69,7 +104,7 @@ func toInstance(d *instanceData) driver.Instance {
 }
 
 // RunInstances creates and starts the specified number of virtual machine instances.
-func (m *Mock) RunInstances(_ context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
+func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
 	if count <= 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
 	}
@@ -93,6 +128,7 @@ func (m *Mock) RunInstances(_ context.Context, cfg driver.InstanceConfig, count 
 		_ = m.sm.Transition(id, compute.StateRunning)
 		inst.State = compute.StateRunning
 		results = append(results, toInstance(inst))
+		m.emitInstanceMetrics(ctx, id, inst.LaunchTime)
 	}
 	return results, nil
 }

--- a/providers/gcp/cloudmonitoring/monitoring.go
+++ b/providers/gcp/cloudmonitoring/monitoring.go
@@ -55,15 +55,13 @@ func New(opts *config.Options) *Mock {
 	}
 }
 
-// PutMetricData stores metric data points (time series data).
+// PutMetricData stores metric data points (time series data) and evaluates any matching alarms.
 func (m *Mock) PutMetricData(ctx context.Context, data []driver.MetricDatum) error {
 	if len(data) == 0 {
 		return cerrors.Newf(cerrors.InvalidArgument, "metric data is required")
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	for _, d := range data {
 		key := metricKey{
 			Namespace:  d.Namespace,
@@ -71,8 +69,84 @@ func (m *Mock) PutMetricData(ctx context.Context, data []driver.MetricDatum) err
 		}
 		m.metrics[key] = append(m.metrics[key], d)
 	}
+	m.mu.Unlock()
+
+	seen := make(map[metricKey]bool)
+	for _, d := range data {
+		mk := metricKey{Namespace: d.Namespace, MetricName: d.MetricName}
+		if !seen[mk] {
+			seen[mk] = true
+			m.evaluateAlarms(d.Namespace, d.MetricName)
+		}
+	}
 
 	return nil
+}
+
+func evaluateComparison(value float64, operator string, threshold float64) bool {
+	switch operator {
+	case "GreaterThanThreshold":
+		return value > threshold
+	case "GreaterThanOrEqualToThreshold":
+		return value >= threshold
+	case "LessThanThreshold":
+		return value < threshold
+	case "LessThanOrEqualToThreshold":
+		return value <= threshold
+	default:
+		return false
+	}
+}
+
+func (m *Mock) evaluateAlarms(namespace, metricName string) {
+	allAlarms := m.alarms.All()
+	for _, alarm := range allAlarms {
+		if alarm.Namespace != namespace || alarm.MetricName != metricName {
+			continue
+		}
+
+		period := alarm.Period
+		if period <= 0 {
+			period = 60
+		}
+		evalPeriods := alarm.EvaluationPeriods
+		if evalPeriods <= 0 {
+			evalPeriods = 1
+		}
+
+		now := m.opts.Clock.Now()
+		windowDur := time.Duration(period*evalPeriods) * time.Second
+		windowStart := now.Add(-windowDur)
+
+		m.mu.RLock()
+		key := metricKey{Namespace: namespace, MetricName: metricName}
+		dataPoints := m.metrics[key]
+
+		var filtered []float64
+		for _, d := range dataPoints {
+			if d.Timestamp.Before(windowStart) || d.Timestamp.After(now) {
+				continue
+			}
+			if !matchDimensions(d.Dimensions, alarm.Dimensions) {
+				continue
+			}
+			filtered = append(filtered, d.Value)
+		}
+		m.mu.RUnlock()
+
+		if len(filtered) == 0 {
+			continue
+		}
+
+		stat := computeStat(filtered, alarm.Stat)
+		if evaluateComparison(stat, alarm.ComparisonOperator, alarm.Threshold) {
+			alarm.State = "ALARM"
+			alarm.StateReason = "Threshold crossed"
+		} else {
+			alarm.State = "OK"
+			alarm.StateReason = "Threshold not crossed"
+		}
+	}
 }
 
 // GetMetricData retrieves metric data for the given query, filtering by time range

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -4,6 +4,7 @@ package firestore
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -220,22 +221,44 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 	return results, nil
 }
 
+func compareValues(a, b string) int {
+	fa, errA := strconv.ParseFloat(a, 64)
+	fb, errB := strconv.ParseFloat(b, 64)
+	if errA == nil && errB == nil {
+		if fa < fb {
+			return -1
+		}
+		if fa > fb {
+			return 1
+		}
+		return 0
+	}
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
 func applySortCondition(itemVal, op, condVal string, condValEnd interface{}) bool {
 	switch op {
 	case "=":
 		return itemVal == condVal
 	case "<":
-		return itemVal < condVal
+		return compareValues(itemVal, condVal) < 0
 	case ">":
-		return itemVal > condVal
+		return compareValues(itemVal, condVal) > 0
 	case "<=":
-		return itemVal <= condVal
+		return compareValues(itemVal, condVal) <= 0
 	case ">=":
-		return itemVal >= condVal
+		return compareValues(itemVal, condVal) >= 0
 	case "BEGINS_WITH":
 		return strings.HasPrefix(itemVal, condVal)
 	case "BETWEEN":
-		return itemVal >= condVal && itemVal <= fmt.Sprintf("%v", condValEnd)
+		endVal := fmt.Sprintf("%v", condValEnd)
+		return compareValues(itemVal, condVal) >= 0 && compareValues(itemVal, endVal) <= 0
 	default:
 		return false
 	}
@@ -255,15 +278,27 @@ func matchesFilters(item map[string]interface{}, filters []driver.ScanFilter) bo
 				return false
 			}
 		case "<":
-			if val >= condVal {
+			if compareValues(val, condVal) >= 0 {
 				return false
 			}
 		case ">":
-			if val <= condVal {
+			if compareValues(val, condVal) <= 0 {
+				return false
+			}
+		case "<=":
+			if compareValues(val, condVal) > 0 {
+				return false
+			}
+		case ">=":
+			if compareValues(val, condVal) < 0 {
 				return false
 			}
 		case "CONTAINS":
 			if !strings.Contains(val, condVal) {
+				return false
+			}
+		case "BEGINS_WITH":
+			if !strings.HasPrefix(val, condVal) {
 				return false
 			}
 		default:

--- a/providers/gcp/gce/gce.go
+++ b/providers/gcp/gce/gce.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/NitinKumar004/cloudemu/compute"
 	"github.com/NitinKumar004/cloudemu/compute/driver"
@@ -12,6 +13,7 @@ import (
 	cerrors "github.com/NitinKumar004/cloudemu/errors"
 	"github.com/NitinKumar004/cloudemu/internal/idgen"
 	"github.com/NitinKumar004/cloudemu/internal/memstore"
+	mondriver "github.com/NitinKumar004/cloudemu/monitoring/driver"
 	"github.com/NitinKumar004/cloudemu/statemachine"
 )
 
@@ -34,10 +36,43 @@ type instanceData struct {
 
 // Mock is an in-memory mock implementation of Google Compute Engine.
 type Mock struct {
-	instances *memstore.Store[*instanceData]
-	sm        *statemachine.Machine
-	opts      *config.Options
-	ipCounter atomic.Int64
+	instances  *memstore.Store[*instanceData]
+	sm         *statemachine.Machine
+	opts       *config.Options
+	ipCounter  atomic.Int64
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitInstanceMetrics(ctx context.Context, instanceID, launchTime string) {
+	if m.monitoring == nil {
+		return
+	}
+	lt, err := time.Parse("2006-01-02T15:04:05Z", launchTime)
+	if err != nil {
+		lt = m.opts.Clock.Now()
+	}
+	metrics := []string{"instance/cpu/utilization", "instance/network/received_bytes_count", "instance/network/sent_bytes_count", "instance/disk/read_ops_count", "instance/disk/write_ops_count"}
+	values := []float64{0.25, 1024.0, 512.0, 100.0, 50.0}
+	var data []mondriver.MetricDatum
+	for i, metricName := range metrics {
+		for j := 0; j < 5; j++ {
+			ts := lt.Add(time.Duration(j) * time.Minute)
+			data = append(data, mondriver.MetricDatum{
+				Namespace:  "compute.googleapis.com",
+				MetricName: metricName,
+				Value:      values[i],
+				Unit:       "None",
+				Dimensions: map[string]string{"instance_id": instanceID},
+				Timestamp:  ts,
+			})
+		}
+	}
+	_ = m.monitoring.PutMetricData(ctx, data)
 }
 
 // New creates a new GCE mock.
@@ -68,7 +103,7 @@ func toInstance(d *instanceData) driver.Instance {
 	}
 }
 
-func (m *Mock) RunInstances(_ context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
+func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
 	if count <= 0 {
 		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
 	}
@@ -92,6 +127,7 @@ func (m *Mock) RunInstances(_ context.Context, cfg driver.InstanceConfig, count 
 		_ = m.sm.Transition(id, compute.StateRunning)
 		inst.State = compute.StateRunning
 		results = append(results, toInstance(inst))
+		m.emitInstanceMetrics(ctx, id, inst.LaunchTime)
 	}
 	return results, nil
 }

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -6,12 +6,12 @@ import (
 	"github.com/NitinKumar004/cloudemu/providers/gcp/clouddns"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/cloudfunctions"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/cloudmonitoring"
+	"github.com/NitinKumar004/cloudemu/providers/gcp/firestore"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/gce"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/gcpiam"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/gcplb"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/gcpvpc"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/gcs"
-	"github.com/NitinKumar004/cloudemu/providers/gcp/firestore"
 	"github.com/NitinKumar004/cloudemu/providers/gcp/pubsub"
 )
 
@@ -32,7 +32,7 @@ type Provider struct {
 // New creates a new GCP provider with all mock services.
 func New(opts ...config.Option) *Provider {
 	o := config.NewOptions(opts...)
-	return &Provider{
+	p := &Provider{
 		GCS:             gcs.New(o),
 		GCE:             gce.New(o),
 		Firestore:       firestore.New(o),
@@ -44,4 +44,6 @@ func New(opts ...config.Option) *Provider {
 		LB:              gcplb.New(o),
 		PubSub:          pubsub.New(o),
 	}
+	p.GCE.SetMonitoring(p.CloudMonitoring)
+	return p
 }

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -3,7 +3,9 @@ package gcpiam
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/NitinKumar004/cloudemu/config"
@@ -376,23 +378,120 @@ func (m *Mock) ListAttachedRolePolicies(ctx context.Context, roleName string) ([
 	return result, nil
 }
 
-// CheckPermission checks if a principal has any attached policy (simplified check).
-// Returns true if the principal (service account or role name) has at least one attached policy.
+type policyDoc struct {
+	Version   string            `json:"Version"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Effect   string      `json:"Effect"`
+	Action   interface{} `json:"Action"`
+	Resource interface{} `json:"Resource"`
+}
+
+func wildcardMatch(pattern, value string) bool {
+	if pattern == "*" {
+		return true
+	}
+	pParts := strings.Split(pattern, "*")
+	if len(pParts) == 1 {
+		return pattern == value
+	}
+	if !strings.HasPrefix(value, pParts[0]) {
+		return false
+	}
+	remaining := value[len(pParts[0]):]
+	for i := 1; i < len(pParts); i++ {
+		idx := strings.Index(remaining, pParts[i])
+		if idx < 0 {
+			return false
+		}
+		remaining = remaining[idx+len(pParts[i]):]
+	}
+	return true
+}
+
+func toStringSlice(v interface{}) []string {
+	switch val := v.(type) {
+	case string:
+		return []string{val}
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func evaluatePolicy(doc string, action, resource string) (allow, deny bool) {
+	var pd policyDoc
+	if err := json.Unmarshal([]byte(doc), &pd); err != nil {
+		return false, false
+	}
+	for _, stmt := range pd.Statement {
+		actions := toStringSlice(stmt.Action)
+		resources := toStringSlice(stmt.Resource)
+		actionMatch := false
+		for _, a := range actions {
+			if wildcardMatch(a, action) {
+				actionMatch = true
+				break
+			}
+		}
+		if !actionMatch {
+			continue
+		}
+		resourceMatch := false
+		for _, r := range resources {
+			if wildcardMatch(r, resource) {
+				resourceMatch = true
+				break
+			}
+		}
+		if !resourceMatch {
+			continue
+		}
+		if strings.EqualFold(stmt.Effect, "Deny") {
+			deny = true
+		} else if strings.EqualFold(stmt.Effect, "Allow") {
+			allow = true
+		}
+	}
+	return allow, deny
+}
+
+// CheckPermission evaluates attached policies to determine if a principal is allowed
+// to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(ctx context.Context, principal, action, resource string) (bool, error) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	// Check service account (user) policies.
-	if policies, ok := m.userPolicies[principal]; ok && len(policies) > 0 {
-		return true, nil
+	policyARNs := make(map[string]bool)
+	for arn := range m.userPolicies[principal] {
+		policyARNs[arn] = true
 	}
-
-	// Check role policies.
-	if policies, ok := m.rolePolicies[principal]; ok && len(policies) > 0 {
-		return true, nil
+	for arn := range m.rolePolicies[principal] {
+		policyARNs[arn] = true
 	}
+	m.mu.RUnlock()
 
-	return false, nil
+	hasAllow := false
+	for arn := range policyARNs {
+		p, ok := m.policies.Get(arn)
+		if !ok || p.PolicyDocument == "" {
+			continue
+		}
+		allow, deny := evaluatePolicy(p.PolicyDocument, action, resource)
+		if deny {
+			return false, nil
+		}
+		if allow {
+			hasAllow = true
+		}
+	}
+	return hasAllow, nil
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/gcp/pubsub/pubsub.go
+++ b/providers/gcp/pubsub/pubsub.go
@@ -27,6 +27,7 @@ type pubsubMessage struct {
 	Attributes      map[string]string
 	ReceiptHandle   string
 	VisibleAt       time.Time
+	SentAt          time.Time
 }
 
 // queueData holds the internal state of a single Pub/Sub topic+subscription pair.
@@ -35,10 +36,11 @@ type queueData struct {
 	messages []*pubsubMessage
 	mu       sync.Mutex
 
-	delaySeconds      int
-	visibilityTimeout int
-	maxMessageSize    int
-	messageRetention  int
+	delaySeconds       int
+	visibilityTimeout  int
+	maxMessageSize     int
+	messageRetention   int
+	deduplicationIndex map[string]time.Time
 }
 
 // Mock is an in-memory mock implementation of the GCP Pub/Sub service.
@@ -92,12 +94,13 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 	}
 
 	qd := &queueData{
-		info:              info,
-		messages:          make([]*pubsubMessage, 0),
-		delaySeconds:      cfg.DelaySeconds,
-		visibilityTimeout: visibilityTimeout,
-		maxMessageSize:    cfg.MaxMessageSize,
-		messageRetention:  cfg.MessageRetention,
+		info:               info,
+		messages:           make([]*pubsubMessage, 0),
+		delaySeconds:       cfg.DelaySeconds,
+		visibilityTimeout:  visibilityTimeout,
+		maxMessageSize:     cfg.MaxMessageSize,
+		messageRetention:   cfg.MessageRetention,
+		deduplicationIndex: make(map[string]time.Time),
 	}
 
 	m.queues.Set(url, qd)
@@ -175,6 +178,21 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		}
 	}
 
+	now := m.opts.Clock.Now()
+
+	// FIFO deduplication: check if same DeduplicationID was sent within 5-min window.
+	if qd.info.FIFO && input.DeduplicationID != "" {
+		if sentAt, ok := qd.deduplicationIndex[input.DeduplicationID]; ok {
+			if now.Sub(sentAt) < 5*time.Minute {
+				for _, existing := range qd.messages {
+					if existing.DeduplicationID == input.DeduplicationID {
+						return &driver.SendMessageOutput{MessageID: existing.ID}, nil
+					}
+				}
+			}
+		}
+	}
+
 	msgID := idgen.GenerateID("msg-")
 
 	attrs := make(map[string]string, len(input.Attributes))
@@ -187,7 +205,6 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		delaySeconds = qd.delaySeconds
 	}
 
-	now := m.opts.Clock.Now()
 	visibleAt := now.Add(time.Duration(delaySeconds) * time.Second)
 
 	msg := &pubsubMessage{
@@ -197,9 +214,14 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		DeduplicationID: input.DeduplicationID,
 		Attributes:      attrs,
 		VisibleAt:       visibleAt,
+		SentAt:          now,
 	}
 
 	qd.messages = append(qd.messages, msg)
+
+	if qd.info.FIFO && input.DeduplicationID != "" {
+		qd.deduplicationIndex[input.DeduplicationID] = now
+	}
 
 	return &driver.SendMessageOutput{
 		MessageID: msgID,


### PR DESCRIPTION
                                                                                                                                                                                                                      
  - Add auto-metric generation: RunInstances automatically pushes CPU,                                                                                                                                                
    Network, and Disk metrics to the monitoring service (ec2→cloudwatch,
    virtualmachines→azuremonitor, gce→cloudmonitoring)
  - Add alarm auto-evaluation: PutMetricData triggers alarm evaluation,
    transitioning alarms to ALARM or OK based on threshold comparison
  - Add IAM policy evaluation: CheckPermission parses JSON policy
    documents with wildcard matching, explicit Deny overrides Allow
  - Add FIFO deduplication: SQS, ServiceBus, and PubSub enforce
    5-minute dedup window on DeduplicationID for FIFO queues
  - Add numeric-aware database comparisons: DynamoDB, CosmosDB, and
    Firestore use numeric ordering when both values parse as numbers
  - Add missing database scan operators: <=, >=, BEGINS_WITH now
    supported in scan filters and query sort conditions
  - Wire provider factories: EC2→CloudWatch, VMs→Monitor, GCE→CloudMonitoring
  - Add 7 new tests validating all behaviors in cloudemu_test.go
  - Update README.md: fix cloudmock→cloudemu naming, Go version,
    add Realistic Cloud Behaviors section with full documentation
  - Create CLAUDE.md with development guide and architecture reference