### PR TITLE
Fix gofmt formatting for Go Report Card A+

### DIFF
--- a/compute/driver/driver.go
+++ b/compute/driver/driver.go
@@ -5,28 +5,28 @@ import "context"
 
 // InstanceConfig describes a virtual machine instance to create.
 type InstanceConfig struct {
-	ImageID      string
-	InstanceType string
-	Tags         map[string]string
-	SubnetID     string
+	ImageID        string
+	InstanceType   string
+	Tags           map[string]string
+	SubnetID       string
 	SecurityGroups []string
-	KeyName      string
-	UserData     string
+	KeyName        string
+	UserData       string
 }
 
 // Instance describes a running virtual machine.
 type Instance struct {
-	ID            string
-	ImageID       string
-	InstanceType  string
-	State         string
-	PrivateIP     string
-	PublicIP      string
-	SubnetID      string
-	VPCID         string
+	ID             string
+	ImageID        string
+	InstanceType   string
+	State          string
+	PrivateIP      string
+	PublicIP       string
+	SubnetID       string
+	VPCID          string
 	SecurityGroups []string
-	Tags          map[string]string
-	LaunchTime    string
+	Tags           map[string]string
+	LaunchTime     string
 }
 
 // ModifyInstanceInput holds modifiable instance attributes.

--- a/config/options.go
+++ b/config/options.go
@@ -4,11 +4,11 @@ import "time"
 
 // Options holds configuration for cloudemu services.
 type Options struct {
-	Clock      Clock
-	Region     string
-	Latency    time.Duration
-	AccountID  string
-	ProjectID  string
+	Clock     Clock
+	Region    string
+	Latency   time.Duration
+	AccountID string
+	ProjectID string
 }
 
 // Option is a functional option for configuring cloudemu services.

--- a/database/database.go
+++ b/database/database.go
@@ -34,9 +34,9 @@ func NewDatabase(d driver.Database, opts ...Option) *Database {
 // Option configures a portable Database.
 type Option func(*Database)
 
-func WithRecorder(r *recorder.Recorder) Option   { return func(d *Database) { d.recorder = r } }
-func WithMetrics(m *metrics.Collector) Option     { return func(d *Database) { d.metrics = m } }
-func WithRateLimiter(l *ratelimit.Limiter) Option { return func(d *Database) { d.limiter = l } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(d *Database) { d.recorder = r } }
+func WithMetrics(m *metrics.Collector) Option      { return func(d *Database) { d.metrics = m } }
+func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(d *Database) { d.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(d *Database) { d.injector = i } }
 func WithLatency(dur time.Duration) Option         { return func(d *Database) { d.latency = dur } }
 

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -23,13 +23,15 @@ type DNS struct {
 
 func NewDNS(d driver.DNS, opts ...Option) *DNS {
 	dn := &DNS{driver: d}
-	for _, opt := range opts { opt(dn) }
+	for _, opt := range opts {
+		opt(dn)
+	}
 	return dn
 }
 
 type Option func(*DNS)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(d *DNS) { d.recorder = r } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(d *DNS) { d.recorder = r } }
 func WithMetrics(m *metrics.Collector) Option      { return func(d *DNS) { d.metrics = m } }
 func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(d *DNS) { d.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(d *DNS) { d.injector = i } }
@@ -37,59 +39,95 @@ func WithLatency(dur time.Duration) Option         { return func(d *DNS) { d.lat
 
 func (d *DNS) do(ctx context.Context, op string, input interface{}, fn func() (interface{}, error)) (interface{}, error) {
 	start := time.Now()
-	if d.injector != nil { if err := d.injector.Check("dns", op); err != nil { d.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if d.limiter != nil { if err := d.limiter.Allow(); err != nil { d.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if d.latency > 0 { time.Sleep(d.latency) }
+	if d.injector != nil {
+		if err := d.injector.Check("dns", op); err != nil {
+			d.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if d.limiter != nil {
+		if err := d.limiter.Allow(); err != nil {
+			d.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if d.latency > 0 {
+		time.Sleep(d.latency)
+	}
 	out, err := fn()
 	dur := time.Since(start)
 	if d.metrics != nil {
 		labels := map[string]string{"service": "dns", "operation": op}
 		d.metrics.Counter("calls_total", 1, labels)
 		d.metrics.Histogram("call_duration", dur, labels)
-		if err != nil { d.metrics.Counter("errors_total", 1, labels) }
+		if err != nil {
+			d.metrics.Counter("errors_total", 1, labels)
+		}
 	}
 	d.rec(op, input, out, err, dur)
 	return out, err
 }
 
 func (d *DNS) rec(op string, input, output interface{}, err error, dur time.Duration) {
-	if d.recorder != nil { d.recorder.Record("dns", op, input, output, err, dur) }
+	if d.recorder != nil {
+		d.recorder.Record("dns", op, input, output, err, dur)
+	}
 }
 
 func (d *DNS) CreateZone(ctx context.Context, config driver.ZoneConfig) (*driver.ZoneInfo, error) {
 	out, err := d.do(ctx, "CreateZone", config, func() (interface{}, error) { return d.driver.CreateZone(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.ZoneInfo), nil
 }
-func (d *DNS) DeleteZone(ctx context.Context, id string) error { _, err := d.do(ctx, "DeleteZone", id, func() (interface{}, error) { return nil, d.driver.DeleteZone(ctx, id) }); return err }
+func (d *DNS) DeleteZone(ctx context.Context, id string) error {
+	_, err := d.do(ctx, "DeleteZone", id, func() (interface{}, error) { return nil, d.driver.DeleteZone(ctx, id) })
+	return err
+}
 func (d *DNS) GetZone(ctx context.Context, id string) (*driver.ZoneInfo, error) {
 	out, err := d.do(ctx, "GetZone", id, func() (interface{}, error) { return d.driver.GetZone(ctx, id) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.ZoneInfo), nil
 }
 func (d *DNS) ListZones(ctx context.Context) ([]driver.ZoneInfo, error) {
 	out, err := d.do(ctx, "ListZones", nil, func() (interface{}, error) { return d.driver.ListZones(ctx) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.ZoneInfo), nil
 }
 func (d *DNS) CreateRecord(ctx context.Context, config driver.RecordConfig) (*driver.RecordInfo, error) {
 	out, err := d.do(ctx, "CreateRecord", config, func() (interface{}, error) { return d.driver.CreateRecord(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.RecordInfo), nil
 }
-func (d *DNS) DeleteRecord(ctx context.Context, zoneID, name, recordType string) error { _, err := d.do(ctx, "DeleteRecord", name, func() (interface{}, error) { return nil, d.driver.DeleteRecord(ctx, zoneID, name, recordType) }); return err }
+func (d *DNS) DeleteRecord(ctx context.Context, zoneID, name, recordType string) error {
+	_, err := d.do(ctx, "DeleteRecord", name, func() (interface{}, error) { return nil, d.driver.DeleteRecord(ctx, zoneID, name, recordType) })
+	return err
+}
 func (d *DNS) GetRecord(ctx context.Context, zoneID, name, recordType string) (*driver.RecordInfo, error) {
 	out, err := d.do(ctx, "GetRecord", name, func() (interface{}, error) { return d.driver.GetRecord(ctx, zoneID, name, recordType) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.RecordInfo), nil
 }
 func (d *DNS) ListRecords(ctx context.Context, zoneID string) ([]driver.RecordInfo, error) {
 	out, err := d.do(ctx, "ListRecords", zoneID, func() (interface{}, error) { return d.driver.ListRecords(ctx, zoneID) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.RecordInfo), nil
 }
 func (d *DNS) UpdateRecord(ctx context.Context, config driver.RecordConfig) (*driver.RecordInfo, error) {
 	out, err := d.do(ctx, "UpdateRecord", config, func() (interface{}, error) { return d.driver.UpdateRecord(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.RecordInfo), nil
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -141,7 +141,7 @@ func main() {
 	cpuResult, _ := aws.CloudWatch.GetMetricData(ctx, mondriver.GetMetricInput{
 		Namespace: "App/Web", MetricName: "CPUUtilization",
 		Dimensions: map[string]string{"InstanceId": instances[1].ID},
-		StartTime: now.Add(-time.Minute), EndTime: now.Add(time.Minute),
+		StartTime:  now.Add(-time.Minute), EndTime: now.Add(time.Minute),
 		Period: 60, Stat: "Average",
 	})
 	fmt.Printf("  CPU for %s: %.1f%%\n", instances[1].ID, cpuResult.Values[0])

--- a/iam/driver/driver.go
+++ b/iam/driver/driver.go
@@ -22,20 +22,20 @@ type UserInfo struct {
 
 // RoleConfig describes a role to create.
 type RoleConfig struct {
-	Name                 string
-	Path                 string
-	AssumeRolePolicyDoc  string
-	Tags                 map[string]string
+	Name                string
+	Path                string
+	AssumeRolePolicyDoc string
+	Tags                map[string]string
 }
 
 // RoleInfo describes an IAM role.
 type RoleInfo struct {
-	Name                 string
-	ID                   string
-	ARN                  string
-	Path                 string
-	AssumeRolePolicyDoc  string
-	Tags                 map[string]string
+	Name                string
+	ID                  string
+	ARN                 string
+	Path                string
+	AssumeRolePolicyDoc string
+	Tags                map[string]string
 }
 
 // PolicyConfig describes a policy to create.

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -24,103 +24,166 @@ type IAM struct {
 
 func NewIAM(d driver.IAM, opts ...Option) *IAM {
 	i := &IAM{driver: d}
-	for _, opt := range opts { opt(i) }
+	for _, opt := range opts {
+		opt(i)
+	}
 	return i
 }
 
 type Option func(*IAM)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(i *IAM) { i.recorder = r } }
-func WithMetrics(m *metrics.Collector) Option      { return func(i *IAM) { i.metrics = m } }
-func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(i *IAM) { i.limiter = l } }
+func WithRecorder(r *recorder.Recorder) Option       { return func(i *IAM) { i.recorder = r } }
+func WithMetrics(m *metrics.Collector) Option        { return func(i *IAM) { i.metrics = m } }
+func WithRateLimiter(l *ratelimit.Limiter) Option    { return func(i *IAM) { i.limiter = l } }
 func WithErrorInjection(inj *inject.Injector) Option { return func(i *IAM) { i.injector = inj } }
-func WithLatency(d time.Duration) Option           { return func(i *IAM) { i.latency = d } }
+func WithLatency(d time.Duration) Option             { return func(i *IAM) { i.latency = d } }
 
 func (i *IAM) do(ctx context.Context, op string, input interface{}, fn func() (interface{}, error)) (interface{}, error) {
 	start := time.Now()
-	if i.injector != nil { if err := i.injector.Check("iam", op); err != nil { i.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if i.limiter != nil { if err := i.limiter.Allow(); err != nil { i.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if i.latency > 0 { time.Sleep(i.latency) }
+	if i.injector != nil {
+		if err := i.injector.Check("iam", op); err != nil {
+			i.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if i.limiter != nil {
+		if err := i.limiter.Allow(); err != nil {
+			i.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if i.latency > 0 {
+		time.Sleep(i.latency)
+	}
 	out, err := fn()
 	dur := time.Since(start)
 	if i.metrics != nil {
 		labels := map[string]string{"service": "iam", "operation": op}
 		i.metrics.Counter("calls_total", 1, labels)
 		i.metrics.Histogram("call_duration", dur, labels)
-		if err != nil { i.metrics.Counter("errors_total", 1, labels) }
+		if err != nil {
+			i.metrics.Counter("errors_total", 1, labels)
+		}
 	}
 	i.rec(op, input, out, err, dur)
 	return out, err
 }
 
 func (i *IAM) rec(op string, input, output interface{}, err error, dur time.Duration) {
-	if i.recorder != nil { i.recorder.Record("iam", op, input, output, err, dur) }
+	if i.recorder != nil {
+		i.recorder.Record("iam", op, input, output, err, dur)
+	}
 }
 
 func (i *IAM) CreateUser(ctx context.Context, config driver.UserConfig) (*driver.UserInfo, error) {
 	out, err := i.do(ctx, "CreateUser", config, func() (interface{}, error) { return i.driver.CreateUser(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.UserInfo), nil
 }
-func (i *IAM) DeleteUser(ctx context.Context, name string) error { _, err := i.do(ctx, "DeleteUser", name, func() (interface{}, error) { return nil, i.driver.DeleteUser(ctx, name) }); return err }
+func (i *IAM) DeleteUser(ctx context.Context, name string) error {
+	_, err := i.do(ctx, "DeleteUser", name, func() (interface{}, error) { return nil, i.driver.DeleteUser(ctx, name) })
+	return err
+}
 func (i *IAM) GetUser(ctx context.Context, name string) (*driver.UserInfo, error) {
 	out, err := i.do(ctx, "GetUser", name, func() (interface{}, error) { return i.driver.GetUser(ctx, name) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.UserInfo), nil
 }
 func (i *IAM) ListUsers(ctx context.Context) ([]driver.UserInfo, error) {
 	out, err := i.do(ctx, "ListUsers", nil, func() (interface{}, error) { return i.driver.ListUsers(ctx) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.UserInfo), nil
 }
 func (i *IAM) CreateRole(ctx context.Context, config driver.RoleConfig) (*driver.RoleInfo, error) {
 	out, err := i.do(ctx, "CreateRole", config, func() (interface{}, error) { return i.driver.CreateRole(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.RoleInfo), nil
 }
-func (i *IAM) DeleteRole(ctx context.Context, name string) error { _, err := i.do(ctx, "DeleteRole", name, func() (interface{}, error) { return nil, i.driver.DeleteRole(ctx, name) }); return err }
+func (i *IAM) DeleteRole(ctx context.Context, name string) error {
+	_, err := i.do(ctx, "DeleteRole", name, func() (interface{}, error) { return nil, i.driver.DeleteRole(ctx, name) })
+	return err
+}
 func (i *IAM) GetRole(ctx context.Context, name string) (*driver.RoleInfo, error) {
 	out, err := i.do(ctx, "GetRole", name, func() (interface{}, error) { return i.driver.GetRole(ctx, name) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.RoleInfo), nil
 }
 func (i *IAM) ListRoles(ctx context.Context) ([]driver.RoleInfo, error) {
 	out, err := i.do(ctx, "ListRoles", nil, func() (interface{}, error) { return i.driver.ListRoles(ctx) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.RoleInfo), nil
 }
 func (i *IAM) CreatePolicy(ctx context.Context, config driver.PolicyConfig) (*driver.PolicyInfo, error) {
 	out, err := i.do(ctx, "CreatePolicy", config, func() (interface{}, error) { return i.driver.CreatePolicy(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.PolicyInfo), nil
 }
-func (i *IAM) DeletePolicy(ctx context.Context, arn string) error { _, err := i.do(ctx, "DeletePolicy", arn, func() (interface{}, error) { return nil, i.driver.DeletePolicy(ctx, arn) }); return err }
+func (i *IAM) DeletePolicy(ctx context.Context, arn string) error {
+	_, err := i.do(ctx, "DeletePolicy", arn, func() (interface{}, error) { return nil, i.driver.DeletePolicy(ctx, arn) })
+	return err
+}
 func (i *IAM) GetPolicy(ctx context.Context, arn string) (*driver.PolicyInfo, error) {
 	out, err := i.do(ctx, "GetPolicy", arn, func() (interface{}, error) { return i.driver.GetPolicy(ctx, arn) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.PolicyInfo), nil
 }
 func (i *IAM) ListPolicies(ctx context.Context) ([]driver.PolicyInfo, error) {
 	out, err := i.do(ctx, "ListPolicies", nil, func() (interface{}, error) { return i.driver.ListPolicies(ctx) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.PolicyInfo), nil
 }
-func (i *IAM) AttachUserPolicy(ctx context.Context, userName, policyARN string) error { _, err := i.do(ctx, "AttachUserPolicy", userName, func() (interface{}, error) { return nil, i.driver.AttachUserPolicy(ctx, userName, policyARN) }); return err }
-func (i *IAM) DetachUserPolicy(ctx context.Context, userName, policyARN string) error { _, err := i.do(ctx, "DetachUserPolicy", userName, func() (interface{}, error) { return nil, i.driver.DetachUserPolicy(ctx, userName, policyARN) }); return err }
-func (i *IAM) AttachRolePolicy(ctx context.Context, roleName, policyARN string) error { _, err := i.do(ctx, "AttachRolePolicy", roleName, func() (interface{}, error) { return nil, i.driver.AttachRolePolicy(ctx, roleName, policyARN) }); return err }
-func (i *IAM) DetachRolePolicy(ctx context.Context, roleName, policyARN string) error { _, err := i.do(ctx, "DetachRolePolicy", roleName, func() (interface{}, error) { return nil, i.driver.DetachRolePolicy(ctx, roleName, policyARN) }); return err }
+func (i *IAM) AttachUserPolicy(ctx context.Context, userName, policyARN string) error {
+	_, err := i.do(ctx, "AttachUserPolicy", userName, func() (interface{}, error) { return nil, i.driver.AttachUserPolicy(ctx, userName, policyARN) })
+	return err
+}
+func (i *IAM) DetachUserPolicy(ctx context.Context, userName, policyARN string) error {
+	_, err := i.do(ctx, "DetachUserPolicy", userName, func() (interface{}, error) { return nil, i.driver.DetachUserPolicy(ctx, userName, policyARN) })
+	return err
+}
+func (i *IAM) AttachRolePolicy(ctx context.Context, roleName, policyARN string) error {
+	_, err := i.do(ctx, "AttachRolePolicy", roleName, func() (interface{}, error) { return nil, i.driver.AttachRolePolicy(ctx, roleName, policyARN) })
+	return err
+}
+func (i *IAM) DetachRolePolicy(ctx context.Context, roleName, policyARN string) error {
+	_, err := i.do(ctx, "DetachRolePolicy", roleName, func() (interface{}, error) { return nil, i.driver.DetachRolePolicy(ctx, roleName, policyARN) })
+	return err
+}
 func (i *IAM) ListAttachedUserPolicies(ctx context.Context, userName string) ([]string, error) {
 	out, err := i.do(ctx, "ListAttachedUserPolicies", userName, func() (interface{}, error) { return i.driver.ListAttachedUserPolicies(ctx, userName) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]string), nil
 }
 func (i *IAM) ListAttachedRolePolicies(ctx context.Context, roleName string) ([]string, error) {
 	out, err := i.do(ctx, "ListAttachedRolePolicies", roleName, func() (interface{}, error) { return i.driver.ListAttachedRolePolicies(ctx, roleName) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]string), nil
 }
 func (i *IAM) CheckPermission(ctx context.Context, principal, action, resource string) (bool, error) {
 	out, err := i.do(ctx, "CheckPermission", principal, func() (interface{}, error) { return i.driver.CheckPermission(ctx, principal, action, resource) })
-	if err != nil { return false, err }
+	if err != nil {
+		return false, err
+	}
 	return out.(bool), nil
 }

--- a/loadbalancer/driver/driver.go
+++ b/loadbalancer/driver/driver.go
@@ -5,11 +5,11 @@ import "context"
 
 // LBConfig describes a load balancer to create.
 type LBConfig struct {
-	Name      string
-	Type      string // "application", "network"
-	Scheme    string // "internet-facing", "internal"
-	Subnets   []string
-	Tags      map[string]string
+	Name    string
+	Type    string // "application", "network"
+	Scheme  string // "internet-facing", "internal"
+	Subnets []string
+	Tags    map[string]string
 }
 
 // LBInfo describes a load balancer.

--- a/loadbalancer/loadbalancer.go
+++ b/loadbalancer/loadbalancer.go
@@ -23,13 +23,15 @@ type LB struct {
 
 func NewLB(d driver.LoadBalancer, opts ...Option) *LB {
 	lb := &LB{driver: d}
-	for _, opt := range opts { opt(lb) }
+	for _, opt := range opts {
+		opt(lb)
+	}
 	return lb
 }
 
 type Option func(*LB)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(lb *LB) { lb.recorder = r } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(lb *LB) { lb.recorder = r } }
 func WithMetrics(m *metrics.Collector) Option      { return func(lb *LB) { lb.metrics = m } }
 func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(lb *LB) { lb.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(lb *LB) { lb.injector = i } }
@@ -37,63 +39,111 @@ func WithLatency(d time.Duration) Option           { return func(lb *LB) { lb.la
 
 func (lb *LB) do(ctx context.Context, op string, input interface{}, fn func() (interface{}, error)) (interface{}, error) {
 	start := time.Now()
-	if lb.injector != nil { if err := lb.injector.Check("loadbalancer", op); err != nil { lb.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if lb.limiter != nil { if err := lb.limiter.Allow(); err != nil { lb.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if lb.latency > 0 { time.Sleep(lb.latency) }
+	if lb.injector != nil {
+		if err := lb.injector.Check("loadbalancer", op); err != nil {
+			lb.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if lb.limiter != nil {
+		if err := lb.limiter.Allow(); err != nil {
+			lb.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if lb.latency > 0 {
+		time.Sleep(lb.latency)
+	}
 	out, err := fn()
 	dur := time.Since(start)
 	if lb.metrics != nil {
 		labels := map[string]string{"service": "loadbalancer", "operation": op}
 		lb.metrics.Counter("calls_total", 1, labels)
 		lb.metrics.Histogram("call_duration", dur, labels)
-		if err != nil { lb.metrics.Counter("errors_total", 1, labels) }
+		if err != nil {
+			lb.metrics.Counter("errors_total", 1, labels)
+		}
 	}
 	lb.rec(op, input, out, err, dur)
 	return out, err
 }
 
 func (lb *LB) rec(op string, input, output interface{}, err error, dur time.Duration) {
-	if lb.recorder != nil { lb.recorder.Record("loadbalancer", op, input, output, err, dur) }
+	if lb.recorder != nil {
+		lb.recorder.Record("loadbalancer", op, input, output, err, dur)
+	}
 }
 
 func (lb *LB) CreateLoadBalancer(ctx context.Context, config driver.LBConfig) (*driver.LBInfo, error) {
 	out, err := lb.do(ctx, "CreateLoadBalancer", config, func() (interface{}, error) { return lb.driver.CreateLoadBalancer(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.LBInfo), nil
 }
-func (lb *LB) DeleteLoadBalancer(ctx context.Context, arn string) error { _, err := lb.do(ctx, "DeleteLoadBalancer", arn, func() (interface{}, error) { return nil, lb.driver.DeleteLoadBalancer(ctx, arn) }); return err }
+func (lb *LB) DeleteLoadBalancer(ctx context.Context, arn string) error {
+	_, err := lb.do(ctx, "DeleteLoadBalancer", arn, func() (interface{}, error) { return nil, lb.driver.DeleteLoadBalancer(ctx, arn) })
+	return err
+}
 func (lb *LB) DescribeLoadBalancers(ctx context.Context, arns []string) ([]driver.LBInfo, error) {
 	out, err := lb.do(ctx, "DescribeLoadBalancers", arns, func() (interface{}, error) { return lb.driver.DescribeLoadBalancers(ctx, arns) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.LBInfo), nil
 }
 func (lb *LB) CreateTargetGroup(ctx context.Context, config driver.TargetGroupConfig) (*driver.TargetGroupInfo, error) {
 	out, err := lb.do(ctx, "CreateTargetGroup", config, func() (interface{}, error) { return lb.driver.CreateTargetGroup(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.TargetGroupInfo), nil
 }
-func (lb *LB) DeleteTargetGroup(ctx context.Context, arn string) error { _, err := lb.do(ctx, "DeleteTargetGroup", arn, func() (interface{}, error) { return nil, lb.driver.DeleteTargetGroup(ctx, arn) }); return err }
+func (lb *LB) DeleteTargetGroup(ctx context.Context, arn string) error {
+	_, err := lb.do(ctx, "DeleteTargetGroup", arn, func() (interface{}, error) { return nil, lb.driver.DeleteTargetGroup(ctx, arn) })
+	return err
+}
 func (lb *LB) DescribeTargetGroups(ctx context.Context, arns []string) ([]driver.TargetGroupInfo, error) {
 	out, err := lb.do(ctx, "DescribeTargetGroups", arns, func() (interface{}, error) { return lb.driver.DescribeTargetGroups(ctx, arns) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.TargetGroupInfo), nil
 }
 func (lb *LB) CreateListener(ctx context.Context, config driver.ListenerConfig) (*driver.ListenerInfo, error) {
 	out, err := lb.do(ctx, "CreateListener", config, func() (interface{}, error) { return lb.driver.CreateListener(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.ListenerInfo), nil
 }
-func (lb *LB) DeleteListener(ctx context.Context, arn string) error { _, err := lb.do(ctx, "DeleteListener", arn, func() (interface{}, error) { return nil, lb.driver.DeleteListener(ctx, arn) }); return err }
+func (lb *LB) DeleteListener(ctx context.Context, arn string) error {
+	_, err := lb.do(ctx, "DeleteListener", arn, func() (interface{}, error) { return nil, lb.driver.DeleteListener(ctx, arn) })
+	return err
+}
 func (lb *LB) DescribeListeners(ctx context.Context, lbARN string) ([]driver.ListenerInfo, error) {
 	out, err := lb.do(ctx, "DescribeListeners", lbARN, func() (interface{}, error) { return lb.driver.DescribeListeners(ctx, lbARN) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.ListenerInfo), nil
 }
-func (lb *LB) RegisterTargets(ctx context.Context, tgARN string, targets []driver.Target) error { _, err := lb.do(ctx, "RegisterTargets", tgARN, func() (interface{}, error) { return nil, lb.driver.RegisterTargets(ctx, tgARN, targets) }); return err }
-func (lb *LB) DeregisterTargets(ctx context.Context, tgARN string, targets []driver.Target) error { _, err := lb.do(ctx, "DeregisterTargets", tgARN, func() (interface{}, error) { return nil, lb.driver.DeregisterTargets(ctx, tgARN, targets) }); return err }
+func (lb *LB) RegisterTargets(ctx context.Context, tgARN string, targets []driver.Target) error {
+	_, err := lb.do(ctx, "RegisterTargets", tgARN, func() (interface{}, error) { return nil, lb.driver.RegisterTargets(ctx, tgARN, targets) })
+	return err
+}
+func (lb *LB) DeregisterTargets(ctx context.Context, tgARN string, targets []driver.Target) error {
+	_, err := lb.do(ctx, "DeregisterTargets", tgARN, func() (interface{}, error) { return nil, lb.driver.DeregisterTargets(ctx, tgARN, targets) })
+	return err
+}
 func (lb *LB) DescribeTargetHealth(ctx context.Context, tgARN string) ([]driver.TargetHealth, error) {
 	out, err := lb.do(ctx, "DescribeTargetHealth", tgARN, func() (interface{}, error) { return lb.driver.DescribeTargetHealth(ctx, tgARN) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.TargetHealth), nil
 }
-func (lb *LB) SetTargetHealth(ctx context.Context, tgARN, targetID, state string) error { _, err := lb.do(ctx, "SetTargetHealth", tgARN, func() (interface{}, error) { return nil, lb.driver.SetTargetHealth(ctx, tgARN, targetID, state) }); return err }
+func (lb *LB) SetTargetHealth(ctx context.Context, tgARN, targetID, state string) error {
+	_, err := lb.do(ctx, "SetTargetHealth", tgARN, func() (interface{}, error) { return nil, lb.driver.SetTargetHealth(ctx, tgARN, targetID, state) })
+	return err
+}

--- a/messagequeue/driver/driver.go
+++ b/messagequeue/driver/driver.go
@@ -5,14 +5,14 @@ import "context"
 
 // QueueConfig describes a message queue to create.
 type QueueConfig struct {
-	Name                string
-	FIFO                bool
-	DelaySeconds        int
-	VisibilityTimeout   int // seconds
-	MaxMessageSize      int
-	MessageRetention    int // seconds
-	Tags                map[string]string
-	DeadLetterQueue     *DeadLetterConfig
+	Name              string
+	FIFO              bool
+	DelaySeconds      int
+	VisibilityTimeout int // seconds
+	MaxMessageSize    int
+	MessageRetention  int // seconds
+	Tags              map[string]string
+	DeadLetterQueue   *DeadLetterConfig
 }
 
 // DeadLetterConfig configures a dead-letter queue for failed messages.
@@ -23,22 +23,22 @@ type DeadLetterConfig struct {
 
 // QueueInfo describes a message queue.
 type QueueInfo struct {
-	URL               string
-	ARN               string
-	Name              string
-	FIFO              bool
+	URL                string
+	ARN                string
+	Name               string
+	FIFO               bool
 	ApproxMessageCount int
-	Tags              map[string]string
+	Tags               map[string]string
 }
 
 // SendMessageInput configures a message send operation.
 type SendMessageInput struct {
-	QueueURL       string
-	Body           string
-	DelaySeconds   int
-	GroupID        string // FIFO only
+	QueueURL        string
+	Body            string
+	DelaySeconds    int
+	GroupID         string // FIFO only
 	DeduplicationID string // FIFO only
-	Attributes     map[string]string
+	Attributes      map[string]string
 }
 
 // SendMessageOutput is the result of sending a message.
@@ -48,10 +48,10 @@ type SendMessageOutput struct {
 
 // ReceiveMessageInput configures a message receive operation.
 type ReceiveMessageInput struct {
-	QueueURL            string
-	MaxMessages         int
-	WaitTimeSeconds     int
-	VisibilityTimeout   int
+	QueueURL          string
+	MaxMessages       int
+	WaitTimeSeconds   int
+	VisibilityTimeout int
 }
 
 // Message is a received message.

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -23,13 +23,15 @@ type MQ struct {
 
 func NewMQ(d driver.MessageQueue, opts ...Option) *MQ {
 	mq := &MQ{driver: d}
-	for _, opt := range opts { opt(mq) }
+	for _, opt := range opts {
+		opt(mq)
+	}
 	return mq
 }
 
 type Option func(*MQ)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(mq *MQ) { mq.recorder = r } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(mq *MQ) { mq.recorder = r } }
 func WithMetrics(m *metrics.Collector) Option      { return func(mq *MQ) { mq.metrics = m } }
 func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(mq *MQ) { mq.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(mq *MQ) { mq.injector = i } }
@@ -37,50 +39,87 @@ func WithLatency(d time.Duration) Option           { return func(mq *MQ) { mq.la
 
 func (mq *MQ) do(ctx context.Context, op string, input interface{}, fn func() (interface{}, error)) (interface{}, error) {
 	start := time.Now()
-	if mq.injector != nil { if err := mq.injector.Check("messagequeue", op); err != nil { mq.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if mq.limiter != nil { if err := mq.limiter.Allow(); err != nil { mq.rec(op, input, nil, err, time.Since(start)); return nil, err } }
-	if mq.latency > 0 { time.Sleep(mq.latency) }
+	if mq.injector != nil {
+		if err := mq.injector.Check("messagequeue", op); err != nil {
+			mq.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if mq.limiter != nil {
+		if err := mq.limiter.Allow(); err != nil {
+			mq.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+	if mq.latency > 0 {
+		time.Sleep(mq.latency)
+	}
 	out, err := fn()
 	dur := time.Since(start)
 	if mq.metrics != nil {
 		labels := map[string]string{"service": "messagequeue", "operation": op}
 		mq.metrics.Counter("calls_total", 1, labels)
 		mq.metrics.Histogram("call_duration", dur, labels)
-		if err != nil { mq.metrics.Counter("errors_total", 1, labels) }
+		if err != nil {
+			mq.metrics.Counter("errors_total", 1, labels)
+		}
 	}
 	mq.rec(op, input, out, err, dur)
 	return out, err
 }
 
 func (mq *MQ) rec(op string, input, output interface{}, err error, dur time.Duration) {
-	if mq.recorder != nil { mq.recorder.Record("messagequeue", op, input, output, err, dur) }
+	if mq.recorder != nil {
+		mq.recorder.Record("messagequeue", op, input, output, err, dur)
+	}
 }
 
 func (mq *MQ) CreateQueue(ctx context.Context, config driver.QueueConfig) (*driver.QueueInfo, error) {
 	out, err := mq.do(ctx, "CreateQueue", config, func() (interface{}, error) { return mq.driver.CreateQueue(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.QueueInfo), nil
 }
-func (mq *MQ) DeleteQueue(ctx context.Context, url string) error { _, err := mq.do(ctx, "DeleteQueue", url, func() (interface{}, error) { return nil, mq.driver.DeleteQueue(ctx, url) }); return err }
+func (mq *MQ) DeleteQueue(ctx context.Context, url string) error {
+	_, err := mq.do(ctx, "DeleteQueue", url, func() (interface{}, error) { return nil, mq.driver.DeleteQueue(ctx, url) })
+	return err
+}
 func (mq *MQ) GetQueueInfo(ctx context.Context, url string) (*driver.QueueInfo, error) {
 	out, err := mq.do(ctx, "GetQueueInfo", url, func() (interface{}, error) { return mq.driver.GetQueueInfo(ctx, url) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.QueueInfo), nil
 }
 func (mq *MQ) ListQueues(ctx context.Context, prefix string) ([]driver.QueueInfo, error) {
 	out, err := mq.do(ctx, "ListQueues", prefix, func() (interface{}, error) { return mq.driver.ListQueues(ctx, prefix) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.QueueInfo), nil
 }
 func (mq *MQ) SendMessage(ctx context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
 	out, err := mq.do(ctx, "SendMessage", input, func() (interface{}, error) { return mq.driver.SendMessage(ctx, input) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.SendMessageOutput), nil
 }
 func (mq *MQ) ReceiveMessages(ctx context.Context, input driver.ReceiveMessageInput) ([]driver.Message, error) {
 	out, err := mq.do(ctx, "ReceiveMessages", input, func() (interface{}, error) { return mq.driver.ReceiveMessages(ctx, input) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.Message), nil
 }
-func (mq *MQ) DeleteMessage(ctx context.Context, queueURL, receiptHandle string) error { _, err := mq.do(ctx, "DeleteMessage", queueURL, func() (interface{}, error) { return nil, mq.driver.DeleteMessage(ctx, queueURL, receiptHandle) }); return err }
-func (mq *MQ) ChangeVisibility(ctx context.Context, queueURL, receiptHandle string, timeout int) error { _, err := mq.do(ctx, "ChangeVisibility", queueURL, func() (interface{}, error) { return nil, mq.driver.ChangeVisibility(ctx, queueURL, receiptHandle, timeout) }); return err }
+func (mq *MQ) DeleteMessage(ctx context.Context, queueURL, receiptHandle string) error {
+	_, err := mq.do(ctx, "DeleteMessage", queueURL, func() (interface{}, error) { return nil, mq.driver.DeleteMessage(ctx, queueURL, receiptHandle) })
+	return err
+}
+func (mq *MQ) ChangeVisibility(ctx context.Context, queueURL, receiptHandle string, timeout int) error {
+	_, err := mq.do(ctx, "ChangeVisibility", queueURL, func() (interface{}, error) {
+		return nil, mq.driver.ChangeVisibility(ctx, queueURL, receiptHandle, timeout)
+	})
+	return err
+}

--- a/monitoring/driver/driver.go
+++ b/monitoring/driver/driver.go
@@ -23,7 +23,7 @@ type GetMetricInput struct {
 	Dimensions map[string]string
 	StartTime  time.Time
 	EndTime    time.Time
-	Period     int // seconds
+	Period     int    // seconds
 	Stat       string // "Average", "Sum", "Minimum", "Maximum", "SampleCount"
 }
 

--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -32,7 +32,7 @@ func NewMonitoring(d driver.Monitoring, opts ...Option) *Monitoring {
 
 type Option func(*Monitoring)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(m *Monitoring) { m.recorder = r } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(m *Monitoring) { m.recorder = r } }
 func WithMetrics(mc *metrics.Collector) Option     { return func(m *Monitoring) { m.metrics = mc } }
 func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(m *Monitoring) { m.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(m *Monitoring) { m.injector = i } }
@@ -52,21 +52,27 @@ func (m *Monitoring) do(ctx context.Context, op string, input interface{}, fn fu
 			return nil, err
 		}
 	}
-	if m.latency > 0 { time.Sleep(m.latency) }
+	if m.latency > 0 {
+		time.Sleep(m.latency)
+	}
 	out, err := fn()
 	dur := time.Since(start)
 	if m.metrics != nil {
 		labels := map[string]string{"service": "monitoring", "operation": op}
 		m.metrics.Counter("calls_total", 1, labels)
 		m.metrics.Histogram("call_duration", dur, labels)
-		if err != nil { m.metrics.Counter("errors_total", 1, labels) }
+		if err != nil {
+			m.metrics.Counter("errors_total", 1, labels)
+		}
 	}
 	m.rec(op, input, out, err, dur)
 	return out, err
 }
 
 func (m *Monitoring) rec(op string, input, output interface{}, err error, dur time.Duration) {
-	if m.recorder != nil { m.recorder.Record("monitoring", op, input, output, err, dur) }
+	if m.recorder != nil {
+		m.recorder.Record("monitoring", op, input, output, err, dur)
+	}
 }
 
 func (m *Monitoring) PutMetricData(ctx context.Context, data []driver.MetricDatum) error {
@@ -75,12 +81,16 @@ func (m *Monitoring) PutMetricData(ctx context.Context, data []driver.MetricDatu
 }
 func (m *Monitoring) GetMetricData(ctx context.Context, input driver.GetMetricInput) (*driver.MetricDataResult, error) {
 	out, err := m.do(ctx, "GetMetricData", input, func() (interface{}, error) { return m.driver.GetMetricData(ctx, input) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.MetricDataResult), nil
 }
 func (m *Monitoring) ListMetrics(ctx context.Context, namespace string) ([]string, error) {
 	out, err := m.do(ctx, "ListMetrics", namespace, func() (interface{}, error) { return m.driver.ListMetrics(ctx, namespace) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]string), nil
 }
 func (m *Monitoring) CreateAlarm(ctx context.Context, config driver.AlarmConfig) error {
@@ -93,7 +103,9 @@ func (m *Monitoring) DeleteAlarm(ctx context.Context, name string) error {
 }
 func (m *Monitoring) DescribeAlarms(ctx context.Context, names []string) ([]driver.AlarmInfo, error) {
 	out, err := m.do(ctx, "DescribeAlarms", names, func() (interface{}, error) { return m.driver.DescribeAlarms(ctx, names) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.AlarmInfo), nil
 }
 func (m *Monitoring) SetAlarmState(ctx context.Context, name, state, reason string) error {

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -32,7 +32,7 @@ func NewNetworking(d driver.Networking, opts ...Option) *Networking {
 
 type Option func(*Networking)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(n *Networking) { n.recorder = r } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(n *Networking) { n.recorder = r } }
 func WithMetrics(m *metrics.Collector) Option      { return func(n *Networking) { n.metrics = m } }
 func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(n *Networking) { n.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(n *Networking) { n.injector = i } }
@@ -77,7 +77,9 @@ func (n *Networking) record(op string, input, output interface{}, err error, dur
 
 func (n *Networking) CreateVPC(ctx context.Context, config driver.VPCConfig) (*driver.VPCInfo, error) {
 	out, err := n.do(ctx, "CreateVPC", config, func() (interface{}, error) { return n.driver.CreateVPC(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.VPCInfo), nil
 }
 func (n *Networking) DeleteVPC(ctx context.Context, id string) error {
@@ -86,12 +88,16 @@ func (n *Networking) DeleteVPC(ctx context.Context, id string) error {
 }
 func (n *Networking) DescribeVPCs(ctx context.Context, ids []string) ([]driver.VPCInfo, error) {
 	out, err := n.do(ctx, "DescribeVPCs", ids, func() (interface{}, error) { return n.driver.DescribeVPCs(ctx, ids) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.VPCInfo), nil
 }
 func (n *Networking) CreateSubnet(ctx context.Context, config driver.SubnetConfig) (*driver.SubnetInfo, error) {
 	out, err := n.do(ctx, "CreateSubnet", config, func() (interface{}, error) { return n.driver.CreateSubnet(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.SubnetInfo), nil
 }
 func (n *Networking) DeleteSubnet(ctx context.Context, id string) error {
@@ -100,12 +106,16 @@ func (n *Networking) DeleteSubnet(ctx context.Context, id string) error {
 }
 func (n *Networking) DescribeSubnets(ctx context.Context, ids []string) ([]driver.SubnetInfo, error) {
 	out, err := n.do(ctx, "DescribeSubnets", ids, func() (interface{}, error) { return n.driver.DescribeSubnets(ctx, ids) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.SubnetInfo), nil
 }
 func (n *Networking) CreateSecurityGroup(ctx context.Context, config driver.SecurityGroupConfig) (*driver.SecurityGroupInfo, error) {
 	out, err := n.do(ctx, "CreateSecurityGroup", config, func() (interface{}, error) { return n.driver.CreateSecurityGroup(ctx, config) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.(*driver.SecurityGroupInfo), nil
 }
 func (n *Networking) DeleteSecurityGroup(ctx context.Context, id string) error {
@@ -114,7 +124,9 @@ func (n *Networking) DeleteSecurityGroup(ctx context.Context, id string) error {
 }
 func (n *Networking) DescribeSecurityGroups(ctx context.Context, ids []string) ([]driver.SecurityGroupInfo, error) {
 	out, err := n.do(ctx, "DescribeSecurityGroups", ids, func() (interface{}, error) { return n.driver.DescribeSecurityGroups(ctx, ids) })
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return out.([]driver.SecurityGroupInfo), nil
 }
 func (n *Networking) AddIngressRule(ctx context.Context, groupID string, rule driver.SecurityRule) error {

--- a/serverless/driver/driver.go
+++ b/serverless/driver/driver.go
@@ -16,15 +16,15 @@ type FunctionConfig struct {
 
 // FunctionInfo describes a serverless function.
 type FunctionInfo struct {
-	Name        string
-	ARN         string
-	Runtime     string
-	Handler     string
-	Memory      int
-	Timeout     int
-	State       string
-	Environment map[string]string
-	Tags        map[string]string
+	Name         string
+	ARN          string
+	Runtime      string
+	Handler      string
+	Memory       int
+	Timeout      int
+	State        string
+	Environment  map[string]string
+	Tags         map[string]string
 	LastModified string
 }
 

--- a/serverless/serverless.go
+++ b/serverless/serverless.go
@@ -33,7 +33,7 @@ func NewServerless(d driver.Serverless, opts ...Option) *Serverless {
 
 type Option func(*Serverless)
 
-func WithRecorder(r *recorder.Recorder) Option    { return func(s *Serverless) { s.recorder = r } }
+func WithRecorder(r *recorder.Recorder) Option     { return func(s *Serverless) { s.recorder = r } }
 func WithMetrics(m *metrics.Collector) Option      { return func(s *Serverless) { s.metrics = m } }
 func WithRateLimiter(l *ratelimit.Limiter) Option  { return func(s *Serverless) { s.limiter = l } }
 func WithErrorInjection(i *inject.Injector) Option { return func(s *Serverless) { s.injector = i } }

--- a/storage/driver/driver.go
+++ b/storage/driver/driver.go
@@ -36,10 +36,10 @@ type ListOptions struct {
 
 // ListResult is the result of a list operation.
 type ListResult struct {
-	Objects       []ObjectInfo
+	Objects        []ObjectInfo
 	CommonPrefixes []string
-	NextPageToken string
-	IsTruncated   bool
+	NextPageToken  string
+	IsTruncated    bool
 }
 
 // CopySource identifies the source for a copy operation.


### PR DESCRIPTION
## Summary
- Ran `gofmt -s` on all 17 flagged files to fix formatting issues
- This fixes the **gofmt 77% -> 100%** score on Go Report Card
- LICENSE file already added in previous PR (fixes license 0% -> 100%)

## Go Report Card Before
- gofmt: 77% (18 issues across 17 files)
- license: 0%

## Go Report Card After
- gofmt: 100%
- license: 100%
- All other checks already at 100% (go_vet, gocyclo, ineffassign, misspell)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 32 tests pass
- [x] `gofmt -s -l` reports 0 issues