### PR TITLE
add .gitignore for Go project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+
+# Output of go coverage
+*.out
+coverage.out
+coverage.html
+
+# Go workspace
+go.work
+go.work.sum
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment and secrets
+.env
+.env.*
+*.env
+configs/.local.env
+credentials.json
+serviceaccount.json
+*.pem
+*.key
+
+# Build output
+bin/
+dist/
+tmp/
+
+# Vendor (if not committed)
+# vendor/
+
+# Debug
+__debug_bin*


### PR DESCRIPTION
## Summary
- Add `.gitignore` with standard Go project entries
- Covers: binaries, test output, coverage files, IDE folders (.idea/, .vscode/), OS files (.DS_Store), env/secrets, build output, debug binaries