### PR TITLE
Add AWS Secrets Manager service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -22,6 +22,7 @@ import (
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/ratelimit"
 	"github.com/stackshy/cloudemu/recorder"
+	smdriver "github.com/stackshy/cloudemu/secretmanager/driver"
 	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
 	"github.com/stackshy/cloudemu/storage"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
@@ -1600,5 +1601,559 @@ func TestGCPCloudFunctionPubSubTrigger(t *testing.T) {
 
 	if len(received) != 3 {
 		t.Errorf("expected 3 triggered messages, got %d", len(received))
+	}
+}
+
+func TestAWSSecretsManagerOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Create a secret
+	info, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:        "db-password",
+		Value:       "hunter2",
+		Description: "Database password",
+		Tags:        map[string]string{"env": "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if info.Name != "db-password" {
+		t.Errorf("expected name 'db-password', got %q", info.Name)
+	}
+	if info.Version != 1 {
+		t.Errorf("expected version 1, got %d", info.Version)
+	}
+	if info.Description != "Database password" {
+		t.Errorf("expected description 'Database password', got %q", info.Description)
+	}
+	if info.Tags["env"] != "test" {
+		t.Errorf("expected tag env=test, got %q", info.Tags["env"])
+	}
+	if info.ARN == "" {
+		t.Error("expected non-empty ARN")
+	}
+
+	// Get secret
+	val, err := p.SecretsManager.GetSecret(ctx, "db-password")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if val.Value != "hunter2" {
+		t.Errorf("expected value 'hunter2', got %q", val.Value)
+	}
+	if val.Version != 1 {
+		t.Errorf("expected version 1, got %d", val.Version)
+	}
+
+	// Update secret — version should auto-increment
+	updated, err := p.SecretsManager.UpdateSecret(ctx, "db-password", "new-password-123")
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+	if updated.Version != 2 {
+		t.Errorf("expected version 2, got %d", updated.Version)
+	}
+
+	// Get should return latest version
+	val, err = p.SecretsManager.GetSecret(ctx, "db-password")
+	if err != nil {
+		t.Fatalf("GetSecret after update: %v", err)
+	}
+	if val.Value != "new-password-123" {
+		t.Errorf("expected 'new-password-123', got %q", val.Value)
+	}
+
+	// Get specific version — version 1
+	val, err = p.SecretsManager.GetSecretVersion(ctx, "db-password", 1)
+	if err != nil {
+		t.Fatalf("GetSecretVersion(1): %v", err)
+	}
+	if val.Value != "hunter2" {
+		t.Errorf("expected 'hunter2' for version 1, got %q", val.Value)
+	}
+
+	// Get specific version — version 2
+	val, err = p.SecretsManager.GetSecretVersion(ctx, "db-password", 2)
+	if err != nil {
+		t.Fatalf("GetSecretVersion(2): %v", err)
+	}
+	if val.Value != "new-password-123" {
+		t.Errorf("expected 'new-password-123' for version 2, got %q", val.Value)
+	}
+
+	// Get non-existent version
+	_, err = p.SecretsManager.GetSecretVersion(ctx, "db-password", 99)
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for version 99, got %v", err)
+	}
+
+	// List secrets
+	secrets, err := p.SecretsManager.ListSecrets(ctx)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(secrets) != 1 {
+		t.Errorf("expected 1 secret, got %d", len(secrets))
+	}
+
+	// Delete secret (scheduled deletion)
+	if err := p.SecretsManager.DeleteSecret(ctx, "db-password"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	// Get after delete should return FailedPrecondition (scheduled for deletion)
+	_, err = p.SecretsManager.GetSecret(ctx, "db-password")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("expected FailedPrecondition after delete, got %v", err)
+	}
+
+	// List should exclude deleted secrets
+	secrets, err = p.SecretsManager.ListSecrets(ctx)
+	if err != nil {
+		t.Fatalf("ListSecrets after delete: %v", err)
+	}
+	if len(secrets) != 0 {
+		t.Errorf("expected 0 secrets after delete, got %d", len(secrets))
+	}
+}
+
+func TestAWSSecretsManagerDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{Name: "my-secret", Value: "v1"})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	_, err = p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{Name: "my-secret", Value: "v2"})
+	if !cerrors.IsAlreadyExists(err) {
+		t.Errorf("expected AlreadyExists for duplicate name, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerNotFound(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.GetSecret(ctx, "non-existent")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+
+	_, err = p.SecretsManager.UpdateSecret(ctx, "non-existent", "value")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for update, got %v", err)
+	}
+
+	err = p.SecretsManager.DeleteSecret(ctx, "non-existent")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for delete, got %v", err)
+	}
+
+	_, err = p.SecretsManager.GetSecretVersion(ctx, "non-existent", 1)
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for GetSecretVersion, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerRotation(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "api-key",
+		Value: "original-key",
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Rotate secret with callback
+	rotated, err := p.SecretsManager.RotateSecret(ctx, "api-key", func(current string) (string, error) {
+		if current != "original-key" {
+			t.Errorf("rotation callback received %q, expected 'original-key'", current)
+		}
+		return "rotated-key-abc", nil
+	})
+	if err != nil {
+		t.Fatalf("RotateSecret: %v", err)
+	}
+	if rotated.Version != 2 {
+		t.Errorf("expected version 2 after rotation, got %d", rotated.Version)
+	}
+
+	// Verify current value is rotated
+	val, err := p.SecretsManager.GetSecret(ctx, "api-key")
+	if err != nil {
+		t.Fatalf("GetSecret after rotation: %v", err)
+	}
+	if val.Value != "rotated-key-abc" {
+		t.Errorf("expected 'rotated-key-abc', got %q", val.Value)
+	}
+
+	// Old version should still be accessible
+	val, err = p.SecretsManager.GetSecretVersion(ctx, "api-key", 1)
+	if err != nil {
+		t.Fatalf("GetSecretVersion(1) after rotation: %v", err)
+	}
+	if val.Value != "original-key" {
+		t.Errorf("expected 'original-key' for version 1, got %q", val.Value)
+	}
+
+	// Rotate again
+	_, err = p.SecretsManager.RotateSecret(ctx, "api-key", func(_ string) (string, error) {
+		return "rotated-key-xyz", nil
+	})
+	if err != nil {
+		t.Fatalf("RotateSecret (2nd): %v", err)
+	}
+
+	val, err = p.SecretsManager.GetSecret(ctx, "api-key")
+	if err != nil {
+		t.Fatalf("GetSecret after 2nd rotation: %v", err)
+	}
+	if val.Value != "rotated-key-xyz" {
+		t.Errorf("expected 'rotated-key-xyz', got %q", val.Value)
+	}
+	if val.Version != 3 {
+		t.Errorf("expected version 3, got %d", val.Version)
+	}
+}
+
+func TestAWSSecretsManagerRotationCallbackError(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "fail-secret",
+		Value: "original",
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Rotation with failing callback
+	_, err = p.SecretsManager.RotateSecret(ctx, "fail-secret", func(_ string) (string, error) {
+		return "", cerrors.New(cerrors.Internal, "rotation failed")
+	})
+	if err == nil {
+		t.Error("expected error from failing rotation callback")
+	}
+
+	// Value should remain unchanged
+	val, err := p.SecretsManager.GetSecret(ctx, "fail-secret")
+	if err != nil {
+		t.Fatalf("GetSecret after failed rotation: %v", err)
+	}
+	if val.Value != "original" {
+		t.Errorf("expected 'original' after failed rotation, got %q", val.Value)
+	}
+	if val.Version != 1 {
+		t.Errorf("expected version 1 after failed rotation, got %d", val.Version)
+	}
+}
+
+func TestAWSSecretsManagerEmptyName(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{Name: "", Value: "v"})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Errorf("expected InvalidArgument for empty name, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerDescribeSecret(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:        "describe-me",
+		Value:       "secret-val",
+		Description: "A test secret",
+		Tags:        map[string]string{"team": "backend"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Update to get version 2
+	_, err = p.SecretsManager.UpdateSecret(ctx, "describe-me", "updated-val")
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+
+	info, err := p.SecretsManager.DescribeSecret(ctx, "describe-me")
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+	if info.Name != "describe-me" {
+		t.Errorf("expected name 'describe-me', got %q", info.Name)
+	}
+	if info.Description != "A test secret" {
+		t.Errorf("expected description 'A test secret', got %q", info.Description)
+	}
+	if info.Version != 2 {
+		t.Errorf("expected version 2, got %d", info.Version)
+	}
+	if info.Tags["team"] != "backend" {
+		t.Errorf("expected tag team=backend, got %q", info.Tags["team"])
+	}
+	if info.DeletedAt != "" {
+		t.Errorf("expected empty DeletedAt, got %q", info.DeletedAt)
+	}
+
+	// DescribeSecret on non-existent
+	_, err = p.SecretsManager.DescribeSecret(ctx, "no-such-secret")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+
+	// DescribeSecret on deleted secret should still work (shows DeletedAt)
+	if err := p.SecretsManager.DeleteSecret(ctx, "describe-me"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	info, err = p.SecretsManager.DescribeSecret(ctx, "describe-me")
+	if err != nil {
+		t.Fatalf("DescribeSecret after delete: %v", err)
+	}
+	if info.DeletedAt == "" {
+		t.Error("expected non-empty DeletedAt after deletion")
+	}
+}
+
+func TestAWSSecretsManagerTagResource(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "tag-test",
+		Value: "v",
+		Tags:  map[string]string{"env": "dev"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Add new tags and update existing
+	err = p.SecretsManager.TagResource(ctx, "tag-test", map[string]string{"env": "prod", "team": "infra"})
+	if err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	info, err := p.SecretsManager.DescribeSecret(ctx, "tag-test")
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+	if info.Tags["env"] != "prod" {
+		t.Errorf("expected tag env=prod, got %q", info.Tags["env"])
+	}
+	if info.Tags["team"] != "infra" {
+		t.Errorf("expected tag team=infra, got %q", info.Tags["team"])
+	}
+
+	// TagResource on non-existent secret
+	err = p.SecretsManager.TagResource(ctx, "no-such", map[string]string{"a": "b"})
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerUntagResource(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "untag-test",
+		Value: "v",
+		Tags:  map[string]string{"env": "dev", "team": "infra", "cost": "free"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Remove two tags
+	err = p.SecretsManager.UntagResource(ctx, "untag-test", []string{"env", "cost"})
+	if err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	info, err := p.SecretsManager.DescribeSecret(ctx, "untag-test")
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+	if _, ok := info.Tags["env"]; ok {
+		t.Error("expected tag 'env' to be removed")
+	}
+	if _, ok := info.Tags["cost"]; ok {
+		t.Error("expected tag 'cost' to be removed")
+	}
+	if info.Tags["team"] != "infra" {
+		t.Errorf("expected tag team=infra to remain, got %q", info.Tags["team"])
+	}
+
+	// UntagResource on non-existent secret
+	err = p.SecretsManager.UntagResource(ctx, "no-such", []string{"a"})
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerRestoreSecret(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "restore-me",
+		Value: "important-data",
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Delete (schedule for deletion)
+	if err := p.SecretsManager.DeleteSecret(ctx, "restore-me"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	// Verify it's inaccessible
+	_, err = p.SecretsManager.GetSecret(ctx, "restore-me")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("expected FailedPrecondition, got %v", err)
+	}
+
+	// Restore it
+	info, err := p.SecretsManager.RestoreSecret(ctx, "restore-me")
+	if err != nil {
+		t.Fatalf("RestoreSecret: %v", err)
+	}
+	if info.DeletedAt != "" {
+		t.Errorf("expected empty DeletedAt after restore, got %q", info.DeletedAt)
+	}
+
+	// Should be accessible again
+	val, err := p.SecretsManager.GetSecret(ctx, "restore-me")
+	if err != nil {
+		t.Fatalf("GetSecret after restore: %v", err)
+	}
+	if val.Value != "important-data" {
+		t.Errorf("expected 'important-data', got %q", val.Value)
+	}
+
+	// Restore on non-deleted secret should fail
+	_, err = p.SecretsManager.RestoreSecret(ctx, "restore-me")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("expected FailedPrecondition for non-deleted secret, got %v", err)
+	}
+
+	// Restore on non-existent secret
+	_, err = p.SecretsManager.RestoreSecret(ctx, "no-such")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerListVersions(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "versioned",
+		Value: "v1",
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	// Add more versions
+	_, err = p.SecretsManager.UpdateSecret(ctx, "versioned", "v2")
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+	_, err = p.SecretsManager.UpdateSecret(ctx, "versioned", "v3")
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+
+	versions, err := p.SecretsManager.ListSecretVersions(ctx, "versioned")
+	if err != nil {
+		t.Fatalf("ListSecretVersions: %v", err)
+	}
+	if len(versions) != 3 {
+		t.Fatalf("expected 3 versions, got %d", len(versions))
+	}
+	for i, v := range versions {
+		if v.Version != i+1 {
+			t.Errorf("version[%d]: expected version %d, got %d", i, i+1, v.Version)
+		}
+		if v.CreatedAt == "" {
+			t.Errorf("version[%d]: expected non-empty CreatedAt", i)
+		}
+	}
+
+	// ListSecretVersions on non-existent
+	_, err = p.SecretsManager.ListSecretVersions(ctx, "no-such")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestAWSSecretsManagerScheduledDeletionBlocks(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.SecretsManager.CreateSecret(ctx, smdriver.SecretConfig{
+		Name:  "blocked",
+		Value: "val",
+		Tags:  map[string]string{"a": "1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if err := p.SecretsManager.DeleteSecret(ctx, "blocked"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	// All mutating/reading operations should fail on deleted secret
+	_, err = p.SecretsManager.GetSecret(ctx, "blocked")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("GetSecret: expected FailedPrecondition, got %v", err)
+	}
+
+	_, err = p.SecretsManager.UpdateSecret(ctx, "blocked", "new")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("UpdateSecret: expected FailedPrecondition, got %v", err)
+	}
+
+	_, err = p.SecretsManager.GetSecretVersion(ctx, "blocked", 1)
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("GetSecretVersion: expected FailedPrecondition, got %v", err)
+	}
+
+	_, err = p.SecretsManager.RotateSecret(ctx, "blocked", func(v string) (string, error) {
+		return v, nil
+	})
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("RotateSecret: expected FailedPrecondition, got %v", err)
+	}
+
+	err = p.SecretsManager.TagResource(ctx, "blocked", map[string]string{"b": "2"})
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("TagResource: expected FailedPrecondition, got %v", err)
+	}
+
+	err = p.SecretsManager.UntagResource(ctx, "blocked", []string{"a"})
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("UntagResource: expected FailedPrecondition, got %v", err)
+	}
+
+	// Double-delete should also fail
+	err = p.SecretsManager.DeleteSecret(ctx, "blocked")
+	if !cerrors.IsFailedPrecondition(err) {
+		t.Errorf("double DeleteSecret: expected FailedPrecondition, got %v", err)
 	}
 }

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/providers/aws/route53"
 	"github.com/stackshy/cloudemu/providers/aws/s3"
+	"github.com/stackshy/cloudemu/providers/aws/secretsmanager"
 	"github.com/stackshy/cloudemu/providers/aws/sqs"
 	"github.com/stackshy/cloudemu/providers/aws/vpc"
 )
@@ -25,8 +26,9 @@ type Provider struct {
 	CloudWatch *cloudwatch.Mock
 	IAM        *awsiam.Mock
 	Route53    *route53.Mock
-	ELB        *elb.Mock
-	SQS        *sqs.Mock
+	ELB            *elb.Mock
+	SQS            *sqs.Mock
+	SecretsManager *secretsmanager.Mock
 }
 
 // New creates a new AWS provider with all mock services.
@@ -41,8 +43,9 @@ func New(opts ...config.Option) *Provider {
 		CloudWatch: cloudwatch.New(o),
 		IAM:        awsiam.New(o),
 		Route53:    route53.New(o),
-		ELB:        elb.New(o),
-		SQS:        sqs.New(o),
+		ELB:            elb.New(o),
+		SQS:            sqs.New(o),
+		SecretsManager: secretsmanager.New(o),
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
 

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -1,0 +1,366 @@
+// Package secretsmanager provides an in-memory mock implementation of AWS Secrets Manager.
+package secretsmanager
+
+import (
+	"context"
+	"sync"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/secretmanager/driver"
+)
+
+// Compile-time check that Mock implements driver.SecretManager.
+var _ driver.SecretManager = (*Mock)(nil)
+
+// versionEntry holds a single version of a secret value.
+type versionEntry struct {
+	Value     string
+	Version   int
+	CreatedAt string
+}
+
+// secretData holds the internal state of a single secret.
+type secretData struct {
+	name        string
+	arn         string
+	description string
+	tags        map[string]string
+	createdAt   string
+	updatedAt   string
+	deletedAt   string // non-empty means scheduled for deletion
+	current     int    // current version number
+	versions    []versionEntry
+	mu          sync.RWMutex
+}
+
+// Mock is an in-memory mock implementation of the AWS Secrets Manager service.
+type Mock struct {
+	secrets *memstore.Store[*secretData]
+	opts    *config.Options
+}
+
+// New creates a new Secrets Manager mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		secrets: memstore.New[*secretData](),
+		opts:    opts,
+	}
+}
+
+// CreateSecret creates a new secret with the given name and value.
+func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig) (*driver.SecretInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "secret name is required")
+	}
+
+	arn := idgen.AWSARN("secretsmanager", m.opts.Region, m.opts.AccountID, "secret:"+cfg.Name)
+	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	tags := copyTags(cfg.Tags)
+
+	sd := &secretData{
+		name:        cfg.Name,
+		arn:         arn,
+		description: cfg.Description,
+		tags:        tags,
+		createdAt:   now,
+		updatedAt:   now,
+		current:     1,
+		versions: []versionEntry{
+			{Value: cfg.Value, Version: 1, CreatedAt: now},
+		},
+	}
+
+	if !m.secrets.SetIfAbsent(cfg.Name, sd) {
+		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
+	}
+
+	return &driver.SecretInfo{
+		Name:        cfg.Name,
+		ARN:         arn,
+		Description: cfg.Description,
+		Version:     1,
+		Tags:        copyTags(tags),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}, nil
+}
+
+// GetSecret retrieves the current version of a secret.
+func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretValue, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	if sd.deletedAt != "" {
+		return nil, errors.Newf(errors.FailedPrecondition, "secret %q is scheduled for deletion", name)
+	}
+
+	current := sd.versions[sd.current-1]
+
+	return &driver.SecretValue{
+		Name:    sd.name,
+		ARN:     sd.arn,
+		Value:   current.Value,
+		Version: current.Version,
+	}, nil
+}
+
+// UpdateSecret updates the value of an existing secret and auto-increments the version.
+func (m *Mock) UpdateSecret(_ context.Context, name, value string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if sd.deletedAt != "" {
+		return nil, errors.Newf(errors.FailedPrecondition, "secret %q is scheduled for deletion", name)
+	}
+
+	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	sd.current++
+	sd.versions = append(sd.versions, versionEntry{Value: value, Version: sd.current, CreatedAt: now})
+	sd.updatedAt = now
+
+	return buildSecretInfo(sd), nil
+}
+
+// DeleteSecret schedules a secret for deletion. Use RestoreSecret to cancel.
+func (m *Mock) DeleteSecret(_ context.Context, name string) error {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if sd.deletedAt != "" {
+		return errors.Newf(errors.FailedPrecondition, "secret %q is already scheduled for deletion", name)
+	}
+
+	sd.deletedAt = m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	return nil
+}
+
+// RestoreSecret cancels a scheduled deletion and restores the secret.
+func (m *Mock) RestoreSecret(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if sd.deletedAt == "" {
+		return nil, errors.Newf(errors.FailedPrecondition, "secret %q is not scheduled for deletion", name)
+	}
+
+	sd.deletedAt = ""
+
+	return buildSecretInfo(sd), nil
+}
+
+// ListSecrets returns all non-deleted secrets (names and metadata only, no values).
+func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
+	all := m.secrets.All()
+
+	results := make([]driver.SecretInfo, 0, len(all))
+
+	for _, sd := range all {
+		sd.mu.RLock()
+
+		if sd.deletedAt == "" {
+			results = append(results, driver.SecretInfo{
+				Name:        sd.name,
+				ARN:         sd.arn,
+				Description: sd.description,
+				Version:     sd.current,
+				Tags:        copyTags(sd.tags),
+				CreatedAt:   sd.createdAt,
+				UpdatedAt:   sd.updatedAt,
+			})
+		}
+
+		sd.mu.RUnlock()
+	}
+
+	return results, nil
+}
+
+// GetSecretVersion retrieves a specific version of a secret.
+func (m *Mock) GetSecretVersion(_ context.Context, name string, version int) (*driver.SecretValue, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	if sd.deletedAt != "" {
+		return nil, errors.Newf(errors.FailedPrecondition, "secret %q is scheduled for deletion", name)
+	}
+
+	if version < 1 || version > len(sd.versions) {
+		return nil, errors.Newf(errors.NotFound, "secret %q version %d not found", name, version)
+	}
+
+	entry := sd.versions[version-1]
+
+	return &driver.SecretValue{
+		Name:    sd.name,
+		ARN:     sd.arn,
+		Value:   entry.Value,
+		Version: entry.Version,
+	}, nil
+}
+
+// RotateSecret simulates secret rotation by invoking the callback with the current value
+// and storing the returned value as a new version.
+func (m *Mock) RotateSecret(_ context.Context, name string, callback driver.RotateCallback) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+
+	if sd.deletedAt != "" {
+		sd.mu.Unlock()
+		return nil, errors.Newf(errors.FailedPrecondition, "secret %q is scheduled for deletion", name)
+	}
+
+	currentValue := sd.versions[sd.current-1].Value
+	sd.mu.Unlock()
+
+	newValue, err := callback(currentValue)
+	if err != nil {
+		return nil, errors.Newf(errors.Internal, "rotation callback failed: %v", err)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z")
+
+	sd.current++
+	sd.versions = append(sd.versions, versionEntry{Value: newValue, Version: sd.current, CreatedAt: now})
+	sd.updatedAt = now
+
+	return buildSecretInfo(sd), nil
+}
+
+// DescribeSecret returns metadata about a secret without the value.
+func (m *Mock) DescribeSecret(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	return buildSecretInfo(sd), nil
+}
+
+// TagResource adds or updates tags on an existing secret.
+func (m *Mock) TagResource(_ context.Context, name string, tags map[string]string) error {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if sd.deletedAt != "" {
+		return errors.Newf(errors.FailedPrecondition, "secret %q is scheduled for deletion", name)
+	}
+
+	for k, v := range tags {
+		sd.tags[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes tags from an existing secret by key.
+func (m *Mock) UntagResource(_ context.Context, name string, tagKeys []string) error {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if sd.deletedAt != "" {
+		return errors.Newf(errors.FailedPrecondition, "secret %q is scheduled for deletion", name)
+	}
+
+	for _, key := range tagKeys {
+		delete(sd.tags, key)
+	}
+
+	return nil
+}
+
+// ListSecretVersions returns all version metadata for a secret.
+func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.VersionInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	results := make([]driver.VersionInfo, len(sd.versions))
+
+	for i, v := range sd.versions {
+		results[i] = driver.VersionInfo{
+			Version:   v.Version,
+			CreatedAt: v.CreatedAt,
+		}
+	}
+
+	return results, nil
+}
+
+// buildSecretInfo creates a SecretInfo from internal secretData. Caller must hold at least a read lock.
+func buildSecretInfo(sd *secretData) *driver.SecretInfo {
+	return &driver.SecretInfo{
+		Name:        sd.name,
+		ARN:         sd.arn,
+		Description: sd.description,
+		Version:     sd.current,
+		Tags:        copyTags(sd.tags),
+		CreatedAt:   sd.createdAt,
+		UpdatedAt:   sd.updatedAt,
+		DeletedAt:   sd.deletedAt,
+	}
+}
+
+// copyTags creates a shallow copy of a tag map.
+func copyTags(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}

--- a/secretmanager/driver/driver.go
+++ b/secretmanager/driver/driver.go
@@ -1,0 +1,58 @@
+// Package driver defines the interface for secret manager service implementations.
+package driver
+
+import "context"
+
+// SecretConfig describes a secret to create.
+type SecretConfig struct {
+	Name        string
+	Value       string
+	Description string
+	Tags        map[string]string
+}
+
+// SecretInfo describes a stored secret.
+type SecretInfo struct {
+	Name        string
+	ARN         string
+	Description string
+	Version     int
+	Tags        map[string]string
+	CreatedAt   string
+	UpdatedAt   string
+	DeletedAt   string // non-empty if scheduled for deletion
+}
+
+// SecretValue holds the secret payload and version metadata.
+type SecretValue struct {
+	Name    string
+	ARN     string
+	Value   string
+	Version int
+}
+
+// VersionInfo describes a single version of a secret.
+type VersionInfo struct {
+	Version   int
+	CreatedAt string
+}
+
+// RotateCallback is invoked during secret rotation with the current value.
+// It returns the new rotated value.
+type RotateCallback func(currentValue string) (string, error)
+
+// SecretManager is the interface that secret manager provider implementations must satisfy.
+type SecretManager interface {
+	CreateSecret(ctx context.Context, cfg SecretConfig) (*SecretInfo, error)
+	GetSecret(ctx context.Context, name string) (*SecretValue, error)
+	UpdateSecret(ctx context.Context, name, value string) (*SecretInfo, error)
+	DeleteSecret(ctx context.Context, name string) error
+	ListSecrets(ctx context.Context) ([]SecretInfo, error)
+	GetSecretVersion(ctx context.Context, name string, version int) (*SecretValue, error)
+	RotateSecret(ctx context.Context, name string, callback RotateCallback) (*SecretInfo, error)
+	DescribeSecret(ctx context.Context, name string) (*SecretInfo, error)
+	TagResource(ctx context.Context, name string, tags map[string]string) error
+	UntagResource(ctx context.Context, name string, tagKeys []string) error
+	RestoreSecret(ctx context.Context, name string) (*SecretInfo, error)
+	ListSecretVersions(ctx context.Context, name string) ([]VersionInfo, error)
+}


### PR DESCRIPTION
## Summary
- Adds new `secretmanager/driver/driver.go` with `SecretManager` interface (12 operations)
- Adds in-memory AWS implementation in `providers/aws/secretsmanager/`
- Wires `SecretsManager` into the AWS `Provider` struct and factory
- Adds 12 integration tests in `cloudemu_test.go` — all passing, linter clean

### Operations
| Operation | Description |
|-----------|-------------|
| `CreateSecret` | Store a secret with name, value, description, tags |
| `GetSecret` | Retrieve current secret value |
| `UpdateSecret` | Update value, auto-increment version |
| `DeleteSecret` | Schedule for deletion (like real AWS) |
| `ListSecrets` | List metadata only (excludes deleted) |
| `GetSecretVersion` | Retrieve specific version |
| `RotateSecret` | Simulate rotation with callback |
| `DescribeSecret` | Get metadata without the value |
| `TagResource` | Add/update tags after creation |
| `UntagResource` | Remove tags by key |
| `RestoreSecret` | Cancel scheduled deletion |
| `ListSecretVersions` | List all version metadata |

### Key behaviors
- Thread-safe with `sync.RWMutex`
- Auto-incrementing versions on update/rotate
- Scheduled deletion (not immediate) — blocks all operations with `FailedPrecondition` until restored
- Rotation callback receives current value, failed callback preserves original
- Duplicate names return `AlreadyExists`, missing secrets return `NotFound`

Closes #29

## Test plan
- [x] 12 tests covering all 12 operations
- [x] Error cases: NotFound, AlreadyExists, InvalidArgument, FailedPrecondition
- [x] Scheduled deletion blocks Get, Update, GetVersion, Rotate, Tag, Untag, double-Delete
- [x] Restore cancels deletion and re-enables access
- [x] Rotation callback error preserves original value/version
- [x] Full test suite passes (`go test ./...`)
- [x] Linter passes (`golangci-lint run` — 0 issues)

