### PR TITLE
added new resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
   <a href="https://github.com/stackshy/cloudemu/blob/development/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <a href="https://github.com/stackshy/cloudemu/actions"><img src="https://img.shields.io/github/actions/workflow/status/stackshy/cloudemu/go.yml?branch=development&label=tests" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white" alt="Go Version">
-  <img src="https://img.shields.io/badge/services-30_mocks-green" alt="30 Mocks">
+  <img src="https://img.shields.io/badge/services-42_mocks-green" alt="42 Mocks">
   <img src="https://img.shields.io/badge/providers-AWS_|_Azure_|_GCP-orange" alt="Providers">
   <img src="https://img.shields.io/badge/cost-$0-brightgreen" alt="Zero Cost">
 </p>
 
 ---
 
-cloudemu is a lightweight Go library that provides mock implementations of 30 cloud services (10 each for AWS, Azure, and GCP). It runs entirely in memory — no real cloud accounts, no Docker containers, no network calls needed. Just import the package and start testing your cloud-dependent code instantly.
+cloudemu is a lightweight Go library that provides mock implementations of 42 cloud services (14 each for AWS, Azure, and GCP). It runs entirely in memory — no real cloud accounts, no Docker containers, no network calls needed. Just import the package and start testing your cloud-dependent code instantly.
 
 ```go
 aws := cloudemu.NewAWS()
@@ -46,7 +46,7 @@ Testing cloud-dependent code is painful. You either pay for real cloud accounts,
 
 ## Supported Services
 
-cloudemu covers 10 cloud services across all three major providers, giving you 30 mock implementations in total.
+cloudemu covers 14 cloud services across all three major providers, giving you 42 mock implementations in total.
 
 | Service | AWS | Azure | GCP |
 |---------|-----|-------|-----|
@@ -60,6 +60,10 @@ cloudemu covers 10 cloud services across all three major providers, giving you 3
 | DNS | Route53 | Azure DNS | Cloud DNS |
 | Load Balancer | ELB | Azure LB | GCP LB |
 | Message Queue | SQS | Service Bus | Pub/Sub |
+| Cache | ElastiCache | Azure Cache for Redis | Memorystore |
+| Secret Management | Secrets Manager | Key Vault | Secret Manager |
+| Logging | CloudWatch Logs | Log Analytics | Cloud Logging |
+| Notifications | SNS | Notification Hubs | FCM |
 
 ## Quick Start
 
@@ -123,6 +127,79 @@ mainQ, _ := aws.SQS.CreateQueue(ctx, mqdriver.QueueConfig{
 aws.SQS.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: mainQ.URL, Body: "hello"})
 ```
 
+### Cache
+
+Store and retrieve values with TTL-based expiry, key pattern matching, and flush support. Works the same way across ElastiCache, Azure Cache for Redis, and Memorystore. Expired keys are lazily cleaned up on access.
+
+```go
+aws.ElastiCache.CreateCache(ctx, cachedriver.CacheConfig{Name: "session-store", Engine: "redis"})
+aws.ElastiCache.Set(ctx, "session-store", "sess:abc", []byte("user-data"), 30*time.Minute)
+
+item, _ := aws.ElastiCache.Get(ctx, "session-store", "sess:abc")
+// item.Value == []byte("user-data"), item.TTL shows remaining time
+
+keys, _ := aws.ElastiCache.Keys(ctx, "session-store", "sess:*")
+aws.ElastiCache.FlushAll(ctx, "session-store")
+```
+
+### Secret Management
+
+Create secrets with versioned values, rotate them by pushing new versions, and retrieve any version by ID. The latest version is always accessible with an empty version ID. Works across Secrets Manager, Key Vault, and GCP Secret Manager.
+
+```go
+aws.SecretsManager.CreateSecret(ctx, secretsdriver.SecretConfig{
+    Name: "db-password", Description: "Production DB credentials",
+}, []byte("s3cret-v1"))
+
+aws.SecretsManager.PutSecretValue(ctx, "db-password", []byte("s3cret-v2"))
+
+ver, _ := aws.SecretsManager.GetSecretValue(ctx, "db-password", "")
+// ver.Value == []byte("s3cret-v2"), ver.Current == true
+
+versions, _ := aws.SecretsManager.ListSecretVersions(ctx, "db-password")
+// versions[0].Current == false, versions[1].Current == true
+```
+
+### Logging
+
+Create log groups and streams, write log events, and query them by time range, stream, or text pattern. Works across CloudWatch Logs, Azure Log Analytics, and GCP Cloud Logging.
+
+```go
+aws.CloudWatchLogs.CreateLogGroup(ctx, logdriver.LogGroupConfig{
+    Name: "/app/web", RetentionDays: 14,
+})
+aws.CloudWatchLogs.CreateLogStream(ctx, "/app/web", "instance-1")
+aws.CloudWatchLogs.PutLogEvents(ctx, "/app/web", "instance-1", []logdriver.LogEvent{
+    {Timestamp: time.Now(), Message: "server started on :8080"},
+    {Timestamp: time.Now(), Message: "error: connection refused"},
+})
+
+events, _ := aws.CloudWatchLogs.GetLogEvents(ctx, logdriver.LogQueryInput{
+    LogGroup: "/app/web", Pattern: "error",
+})
+// events contains only the "error: connection refused" entry
+```
+
+### Notifications
+
+Create topics, subscribe endpoints, and publish fan-out messages. Works across SNS, Azure Notification Hubs, and Firebase Cloud Messaging.
+
+```go
+topic, _ := aws.SNS.CreateTopic(ctx, notifdriver.TopicConfig{Name: "order-events"})
+
+aws.SNS.Subscribe(ctx, notifdriver.SubscriptionConfig{
+    TopicID: topic.ARN, Protocol: "email", Endpoint: "team@example.com",
+})
+aws.SNS.Subscribe(ctx, notifdriver.SubscriptionConfig{
+    TopicID: topic.ARN, Protocol: "sqs", Endpoint: "arn:aws:sqs:us-east-1:123:orders",
+})
+
+out, _ := aws.SNS.Publish(ctx, notifdriver.PublishInput{
+    TopicID: topic.ARN, Subject: "New Order", Message: "Order #123 placed",
+})
+// out.MessageID is the unique message identifier
+```
+
 ### Serverless Triggers
 
 Wire message queues to serverless functions so that every incoming message automatically triggers a function invocation. This emulates real event source mappings like AWS SQS -> Lambda, Azure Service Bus -> Functions, and GCP Pub/Sub -> Cloud Functions.
@@ -172,6 +249,9 @@ cloudemu goes beyond basic CRUD mocks. These behaviors make it behave like real 
 - **Serverless Triggers** — Register event source mappings so messages automatically invoke Lambda, Azure Functions, or Cloud Functions.
 - **Numeric-Aware DB Comparisons** — Database filters compare values numerically when both sides are valid numbers, avoiding string-sorting bugs.
 - **Cost Simulation** — Track estimated cloud costs per operation with default or custom pricing rates.
+- **TTL Expiry** — Cached items automatically expire after their TTL elapses. Expired keys are lazily cleaned up on access, matching real Redis behavior.
+- **Secret Versioning** — Secrets maintain a full version history. Pushing a new value creates a new version and marks it current; previous versions remain accessible by ID.
+- **Log Filtering** — Query logs by time range, stream, and text pattern. Stored bytes are tracked per log group for realistic quota simulation.
 
 ## Cross-Cutting Features
 
@@ -225,7 +305,7 @@ if cerrors.IsNotFound(err) { /* handle */ }
 
 ## Architecture
 
-cloudemu follows a three-layer design inspired by Go CDK. The portable API layer adds cross-cutting concerns on top of minimal driver interfaces, which are implemented by in-memory provider backends. All 30 mocks are backed by a single generic, thread-safe `memstore.Store[V]`.
+cloudemu follows a three-layer design inspired by Go CDK. The portable API layer adds cross-cutting concerns on top of minimal driver interfaces, which are implemented by in-memory provider backends. All 42 mocks are backed by a single generic, thread-safe `memstore.Store[V]`.
 
 ```
 Portable API     →  recording, metrics, rate limiting, error injection

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,182 @@
+// Package cache provides a portable cache API with cross-cutting concerns.
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+// Cache is the portable cache type wrapping a driver with cross-cutting concerns.
+type Cache struct {
+	driver   driver.Cache
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// NewCache creates a new portable Cache wrapping the given driver.
+func NewCache(d driver.Cache, opts ...Option) *Cache {
+	c := &Cache{driver: d}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Option configures a portable Cache.
+type Option func(*Cache)
+
+// WithRecorder sets the recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(c *Cache) { c.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(c *Cache) { c.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(c *Cache) { c.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(c *Cache) { c.injector = i } }
+
+// WithLatency sets simulated latency.
+func WithLatency(d time.Duration) Option { return func(c *Cache) { c.latency = d } }
+
+func (c *Cache) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if c.injector != nil {
+		if err := c.injector.Check("cache", op); err != nil {
+			c.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if c.limiter != nil {
+		if err := c.limiter.Allow(); err != nil {
+			c.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if c.latency > 0 {
+		time.Sleep(c.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if c.metrics != nil {
+		labels := map[string]string{"service": "cache", "operation": op}
+		c.metrics.Counter("calls_total", 1, labels)
+		c.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			c.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	c.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (c *Cache) rec(op string, input, output any, err error, dur time.Duration) {
+	if c.recorder != nil {
+		c.recorder.Record("cache", op, input, output, err, dur)
+	}
+}
+
+// CreateCache creates a new cache instance.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (c *Cache) CreateCache(ctx context.Context, config driver.CacheConfig) (*driver.CacheInfo, error) {
+	out, err := c.do(ctx, "CreateCache", config, func() (any, error) { return c.driver.CreateCache(ctx, config) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.CacheInfo), nil
+}
+
+// DeleteCache deletes a cache instance.
+func (c *Cache) DeleteCache(ctx context.Context, name string) error {
+	_, err := c.do(ctx, "DeleteCache", name, func() (any, error) { return nil, c.driver.DeleteCache(ctx, name) })
+	return err
+}
+
+// GetCache retrieves cache instance info.
+func (c *Cache) GetCache(ctx context.Context, name string) (*driver.CacheInfo, error) {
+	out, err := c.do(ctx, "GetCache", name, func() (any, error) { return c.driver.GetCache(ctx, name) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.CacheInfo), nil
+}
+
+// ListCaches lists all cache instances.
+func (c *Cache) ListCaches(ctx context.Context) ([]driver.CacheInfo, error) {
+	out, err := c.do(ctx, "ListCaches", nil, func() (any, error) { return c.driver.ListCaches(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.CacheInfo), nil
+}
+
+// Set stores a value in the cache.
+func (c *Cache) Set(ctx context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
+	_, err := c.do(ctx, "Set", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return nil, c.driver.Set(ctx, cacheName, key, value, ttl)
+	})
+
+	return err
+}
+
+// Get retrieves a value from the cache.
+func (c *Cache) Get(ctx context.Context, cacheName, key string) (*driver.Item, error) {
+	out, err := c.do(ctx, "Get", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return c.driver.Get(ctx, cacheName, key)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Item), nil
+}
+
+// Delete removes a value from the cache.
+func (c *Cache) Delete(ctx context.Context, cacheName, key string) error {
+	_, err := c.do(ctx, "Delete", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return nil, c.driver.Delete(ctx, cacheName, key)
+	})
+
+	return err
+}
+
+// Keys returns all keys matching the given pattern.
+func (c *Cache) Keys(ctx context.Context, cacheName, pattern string) ([]string, error) {
+	out, err := c.do(ctx, "Keys", map[string]string{"cache": cacheName, "pattern": pattern}, func() (any, error) {
+		return c.driver.Keys(ctx, cacheName, pattern)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]string), nil
+}
+
+// FlushAll removes all items from the cache.
+func (c *Cache) FlushAll(ctx context.Context, cacheName string) error {
+	_, err := c.do(ctx, "FlushAll", cacheName, func() (any, error) { return nil, c.driver.FlushAll(ctx, cacheName) })
+	return err
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -96,8 +96,6 @@ func (c *Cache) rec(op string, input, output any, err error, dur time.Duration) 
 }
 
 // CreateCache creates a new cache instance.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (c *Cache) CreateCache(ctx context.Context, config driver.CacheConfig) (*driver.CacheInfo, error) {
 	out, err := c.do(ctx, "CreateCache", config, func() (any, error) { return c.driver.CreateCache(ctx, config) })
 	if err != nil {

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,457 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/elasticache"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestDriver() (driver.Cache, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return elasticache.New(opts), fc
+}
+
+func newTestCache(opts ...Option) (*Cache, *config.FakeClock) {
+	d, fc := newTestDriver()
+	return NewCache(d, opts...), fc
+}
+
+func setupCacheWithItem(t *testing.T, c *Cache) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "test-cache"})
+	if err != nil {
+		t.Fatalf("failed to create cache: %v", err)
+	}
+
+	err = c.Set(ctx, "test-cache", "key1", []byte("value1"), 0)
+	if err != nil {
+		t.Fatalf("failed to set item: %v", err)
+	}
+}
+
+func TestNewCache(t *testing.T) {
+	c, _ := newTestCache()
+
+	if c == nil {
+		t.Fatal("expected non-nil cache")
+	}
+
+	if c.driver == nil {
+		t.Fatal("expected non-nil driver")
+	}
+}
+
+func TestCreateCachePortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := c.CreateCache(ctx, driver.CacheConfig{Name: "my-cache"})
+		requireNoError(t, err)
+		assertEqual(t, "my-cache", info.Name)
+		assertNotEmpty(t, info.Endpoint)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := c.CreateCache(ctx, driver.CacheConfig{})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteCachePortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "del-cache"})
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := c.DeleteCache(ctx, "del-cache")
+		requireNoError(t, delErr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		delErr := c.DeleteCache(ctx, "nonexistent")
+		assertError(t, delErr, true)
+	})
+}
+
+func TestGetCachePortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "get-cache"})
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, getErr := c.GetCache(ctx, "get-cache")
+		requireNoError(t, getErr)
+		assertEqual(t, "get-cache", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, getErr := c.GetCache(ctx, "nonexistent")
+		assertError(t, getErr, true)
+	})
+}
+
+func TestListCachesPortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	caches, err := c.ListCaches(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(caches))
+
+	_, err = c.CreateCache(ctx, driver.CacheConfig{Name: "a"})
+	requireNoError(t, err)
+
+	_, err = c.CreateCache(ctx, driver.CacheConfig{Name: "b"})
+	requireNoError(t, err)
+
+	caches, err = c.ListCaches(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(caches))
+}
+
+func TestSetGetDeletePortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	setupCacheWithItem(t, c)
+
+	t.Run("get existing key", func(t *testing.T) {
+		item, err := c.Get(ctx, "test-cache", "key1")
+		requireNoError(t, err)
+		assertEqual(t, "key1", item.Key)
+		assertEqual(t, string([]byte("value1")), string(item.Value))
+	})
+
+	t.Run("delete key", func(t *testing.T) {
+		err := c.Delete(ctx, "test-cache", "key1")
+		requireNoError(t, err)
+
+		_, getErr := c.Get(ctx, "test-cache", "key1")
+		assertError(t, getErr, true)
+	})
+}
+
+func TestKeysPortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "keys-cache"})
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "keys-cache", "user:1", []byte("a"), 0)
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "keys-cache", "user:2", []byte("b"), 0)
+	requireNoError(t, err)
+
+	keys, err := c.Keys(ctx, "keys-cache", "user:*")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(keys))
+}
+
+func TestFlushAllPortable(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "flush-cache"})
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "flush-cache", "k1", []byte("v1"), 0)
+	requireNoError(t, err)
+
+	err = c.FlushAll(ctx, "flush-cache")
+	requireNoError(t, err)
+
+	keys, err := c.Keys(ctx, "flush-cache", "*")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(keys))
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	c, _ := newTestCache(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "rec-cache"})
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "rec-cache", "k", []byte("v"), 0)
+	requireNoError(t, err)
+
+	_, err = c.Get(ctx, "rec-cache", "k")
+	requireNoError(t, err)
+
+	totalCalls := rec.CallCount()
+	if totalCalls < 3 {
+		t.Errorf("expected at least 3 recorded calls, got %d", totalCalls)
+	}
+
+	createCalls := rec.CallCountFor("cache", "CreateCache")
+	assertEqual(t, 1, createCalls)
+
+	setCalls := rec.CallCountFor("cache", "Set")
+	assertEqual(t, 1, setCalls)
+
+	getCalls := rec.CallCountFor("cache", "Get")
+	assertEqual(t, 1, getCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	c, _ := newTestCache(WithRecorder(rec))
+	ctx := context.Background()
+
+	// This should fail and still be recorded.
+	_, _ = c.GetCache(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assertEqual(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	if last == nil {
+		t.Fatal("expected a recorded call")
+	}
+
+	if last.Error == nil {
+		t.Error("expected recorded call to have an error")
+	}
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	c, _ := newTestCache(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "met-cache"})
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "met-cache", "k", []byte("v"), 0)
+	requireNoError(t, err)
+
+	_, err = c.Get(ctx, "met-cache", "k")
+	requireNoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	if callsCount < 3 {
+		t.Errorf("expected at least 3 calls_total metrics, got %d", callsCount)
+	}
+
+	durCount := q.ByName("call_duration").Count()
+	if durCount < 3 {
+		t.Errorf("expected at least 3 call_duration metrics, got %d", durCount)
+	}
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	c, _ := newTestCache(WithMetrics(mc))
+	ctx := context.Background()
+
+	// This should fail.
+	_, _ = c.GetCache(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assertEqual(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	c, _ := newTestCache(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("cache", "CreateCache", injectedErr, inject.Always{})
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "fail-cache"})
+	assertError(t, err, true)
+
+	if err != injectedErr {
+		t.Errorf("expected injected error, got %v", err)
+	}
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	c, _ := newTestCache(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("cache", "Set", injectedErr, inject.Always{})
+
+	// CreateCache should work since injection is only on Set.
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "inj-cache"})
+	requireNoError(t, err)
+
+	// Set should fail due to injection.
+	err = c.Set(ctx, "inj-cache", "k", []byte("v"), 0)
+	assertError(t, err, true)
+
+	// Verify the error was recorded.
+	setCalls := rec.CallsFor("cache", "Set")
+	assertEqual(t, 1, len(setCalls))
+
+	if setCalls[0].Error == nil {
+		t.Error("expected recorded Set call to have an error")
+	}
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	c, _ := newTestCache(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("cache", "CreateCache", injectedErr, inject.Always{})
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "test"})
+	assertError(t, err, true)
+
+	// Remove the injection rule.
+	inj.Remove("cache", "CreateCache")
+
+	_, err = c.CreateCache(ctx, driver.CacheConfig{Name: "test"})
+	requireNoError(t, err)
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	c, _ := newTestCache(WithLatency(latency))
+	ctx := context.Background()
+
+	// Just verify it does not break normal operation.
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "lat-cache"})
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "lat-cache", "k", []byte("v"), 0)
+	requireNoError(t, err)
+
+	item, err := c.Get(ctx, "lat-cache", "k")
+	requireNoError(t, err)
+	assertEqual(t, "k", item.Key)
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	c, _ := newTestCache(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "all-opts"})
+	requireNoError(t, err)
+
+	err = c.Set(ctx, "all-opts", "k", []byte("v"), 0)
+	requireNoError(t, err)
+
+	// Verify recorder captured calls.
+	assertEqual(t, 2, rec.CallCount())
+
+	// Verify metrics captured calls.
+	q := metrics.NewQuery(mc)
+	assertEqual(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableDeleteCacheError(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	err := c.Delete(ctx, "no-cache", "k")
+	assertError(t, err, true)
+}
+
+func TestPortableKeysError(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	_, err := c.Keys(ctx, "no-cache", "*")
+	assertError(t, err, true)
+}
+
+func TestPortableFlushAllError(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	err := c.FlushAll(ctx, "no-cache")
+	assertError(t, err, true)
+}
+
+func TestPortableSetError(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	err := c.Set(ctx, "no-cache", "k", []byte("v"), 0)
+	assertError(t, err, true)
+}
+
+func TestPortableGetError(t *testing.T) {
+	c, _ := newTestCache()
+	ctx := context.Background()
+
+	_, err := c.Get(ctx, "no-cache", "k")
+	assertError(t, err, true)
+}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -12,42 +12,9 @@ import (
 	"github.com/stackshy/cloudemu/metrics"
 	"github.com/stackshy/cloudemu/providers/aws/elasticache"
 	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestDriver() (driver.Cache, *config.FakeClock) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -80,13 +47,8 @@ func setupCacheWithItem(t *testing.T, c *Cache) {
 func TestNewCache(t *testing.T) {
 	c, _ := newTestCache()
 
-	if c == nil {
-		t.Fatal("expected non-nil cache")
-	}
-
-	if c.driver == nil {
-		t.Fatal("expected non-nil driver")
-	}
+	require.NotNil(t, c)
+	require.NotNil(t, c.driver)
 }
 
 func TestCreateCachePortable(t *testing.T) {
@@ -95,14 +57,14 @@ func TestCreateCachePortable(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		info, err := c.CreateCache(ctx, driver.CacheConfig{Name: "my-cache"})
-		requireNoError(t, err)
-		assertEqual(t, "my-cache", info.Name)
-		assertNotEmpty(t, info.Endpoint)
+		require.NoError(t, err)
+		assert.Equal(t, "my-cache", info.Name)
+		assert.NotEmpty(t, info.Endpoint)
 	})
 
 	t.Run("empty name error", func(t *testing.T) {
 		_, err := c.CreateCache(ctx, driver.CacheConfig{})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -111,16 +73,16 @@ func TestDeleteCachePortable(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "del-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		delErr := c.DeleteCache(ctx, "del-cache")
-		requireNoError(t, delErr)
+		require.NoError(t, delErr)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		delErr := c.DeleteCache(ctx, "nonexistent")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 }
 
@@ -129,17 +91,17 @@ func TestGetCachePortable(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "get-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		info, getErr := c.GetCache(ctx, "get-cache")
-		requireNoError(t, getErr)
-		assertEqual(t, "get-cache", info.Name)
+		require.NoError(t, getErr)
+		assert.Equal(t, "get-cache", info.Name)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		_, getErr := c.GetCache(ctx, "nonexistent")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 }
 
@@ -148,18 +110,18 @@ func TestListCachesPortable(t *testing.T) {
 	ctx := context.Background()
 
 	caches, err := c.ListCaches(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(caches))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(caches))
 
 	_, err = c.CreateCache(ctx, driver.CacheConfig{Name: "a"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = c.CreateCache(ctx, driver.CacheConfig{Name: "b"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	caches, err = c.ListCaches(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 2, len(caches))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(caches))
 }
 
 func TestSetGetDeletePortable(t *testing.T) {
@@ -170,17 +132,17 @@ func TestSetGetDeletePortable(t *testing.T) {
 
 	t.Run("get existing key", func(t *testing.T) {
 		item, err := c.Get(ctx, "test-cache", "key1")
-		requireNoError(t, err)
-		assertEqual(t, "key1", item.Key)
-		assertEqual(t, string([]byte("value1")), string(item.Value))
+		require.NoError(t, err)
+		assert.Equal(t, "key1", item.Key)
+		assert.Equal(t, string([]byte("value1")), string(item.Value))
 	})
 
 	t.Run("delete key", func(t *testing.T) {
 		err := c.Delete(ctx, "test-cache", "key1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, getErr := c.Get(ctx, "test-cache", "key1")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 }
 
@@ -189,17 +151,17 @@ func TestKeysPortable(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "keys-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "keys-cache", "user:1", []byte("a"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "keys-cache", "user:2", []byte("b"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	keys, err := c.Keys(ctx, "keys-cache", "user:*")
-	requireNoError(t, err)
-	assertEqual(t, 2, len(keys))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(keys))
 }
 
 func TestFlushAllPortable(t *testing.T) {
@@ -207,17 +169,17 @@ func TestFlushAllPortable(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "flush-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "flush-cache", "k1", []byte("v1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.FlushAll(ctx, "flush-cache")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	keys, err := c.Keys(ctx, "flush-cache", "*")
-	requireNoError(t, err)
-	assertEqual(t, 0, len(keys))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(keys))
 }
 
 func TestWithRecorder(t *testing.T) {
@@ -226,27 +188,25 @@ func TestWithRecorder(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "rec-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "rec-cache", "k", []byte("v"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = c.Get(ctx, "rec-cache", "k")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	totalCalls := rec.CallCount()
-	if totalCalls < 3 {
-		t.Errorf("expected at least 3 recorded calls, got %d", totalCalls)
-	}
+	assert.GreaterOrEqual(t, totalCalls, 3)
 
 	createCalls := rec.CallCountFor("cache", "CreateCache")
-	assertEqual(t, 1, createCalls)
+	assert.Equal(t, 1, createCalls)
 
 	setCalls := rec.CallCountFor("cache", "Set")
-	assertEqual(t, 1, setCalls)
+	assert.Equal(t, 1, setCalls)
 
 	getCalls := rec.CallCountFor("cache", "Get")
-	assertEqual(t, 1, getCalls)
+	assert.Equal(t, 1, getCalls)
 }
 
 func TestWithRecorderOnError(t *testing.T) {
@@ -258,16 +218,11 @@ func TestWithRecorderOnError(t *testing.T) {
 	_, _ = c.GetCache(ctx, "nonexistent")
 
 	totalCalls := rec.CallCount()
-	assertEqual(t, 1, totalCalls)
+	assert.Equal(t, 1, totalCalls)
 
 	last := rec.LastCall()
-	if last == nil {
-		t.Fatal("expected a recorded call")
-	}
-
-	if last.Error == nil {
-		t.Error("expected recorded call to have an error")
-	}
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
 }
 
 func TestWithMetrics(t *testing.T) {
@@ -276,25 +231,21 @@ func TestWithMetrics(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "met-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "met-cache", "k", []byte("v"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = c.Get(ctx, "met-cache", "k")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	q := metrics.NewQuery(mc)
 
 	callsCount := q.ByName("calls_total").Count()
-	if callsCount < 3 {
-		t.Errorf("expected at least 3 calls_total metrics, got %d", callsCount)
-	}
+	assert.GreaterOrEqual(t, callsCount, 3)
 
 	durCount := q.ByName("call_duration").Count()
-	if durCount < 3 {
-		t.Errorf("expected at least 3 call_duration metrics, got %d", durCount)
-	}
+	assert.GreaterOrEqual(t, durCount, 3)
 }
 
 func TestWithMetricsOnError(t *testing.T) {
@@ -308,7 +259,7 @@ func TestWithMetricsOnError(t *testing.T) {
 	q := metrics.NewQuery(mc)
 
 	errCount := q.ByName("errors_total").Count()
-	assertEqual(t, 1, errCount)
+	assert.Equal(t, 1, errCount)
 }
 
 func TestWithErrorInjection(t *testing.T) {
@@ -320,11 +271,8 @@ func TestWithErrorInjection(t *testing.T) {
 	inj.Set("cache", "CreateCache", injectedErr, inject.Always{})
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "fail-cache"})
-	assertError(t, err, true)
-
-	if err != injectedErr {
-		t.Errorf("expected injected error, got %v", err)
-	}
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
 }
 
 func TestWithErrorInjectionRecorded(t *testing.T) {
@@ -338,19 +286,16 @@ func TestWithErrorInjectionRecorded(t *testing.T) {
 
 	// CreateCache should work since injection is only on Set.
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "inj-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	// Set should fail due to injection.
 	err = c.Set(ctx, "inj-cache", "k", []byte("v"), 0)
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	// Verify the error was recorded.
 	setCalls := rec.CallsFor("cache", "Set")
-	assertEqual(t, 1, len(setCalls))
-
-	if setCalls[0].Error == nil {
-		t.Error("expected recorded Set call to have an error")
-	}
+	assert.Equal(t, 1, len(setCalls))
+	assert.NotNil(t, setCalls[0].Error, "expected recorded Set call to have an error")
 }
 
 func TestWithErrorInjectionRemoved(t *testing.T) {
@@ -362,13 +307,13 @@ func TestWithErrorInjectionRemoved(t *testing.T) {
 	inj.Set("cache", "CreateCache", injectedErr, inject.Always{})
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "test"})
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	// Remove the injection rule.
 	inj.Remove("cache", "CreateCache")
 
 	_, err = c.CreateCache(ctx, driver.CacheConfig{Name: "test"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestWithLatency(t *testing.T) {
@@ -378,14 +323,14 @@ func TestWithLatency(t *testing.T) {
 
 	// Just verify it does not break normal operation.
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "lat-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "lat-cache", "k", []byte("v"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	item, err := c.Get(ctx, "lat-cache", "k")
-	requireNoError(t, err)
-	assertEqual(t, "k", item.Key)
+	require.NoError(t, err)
+	assert.Equal(t, "k", item.Key)
 }
 
 func TestAllOptionsComposed(t *testing.T) {
@@ -403,17 +348,17 @@ func TestAllOptionsComposed(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.CreateCache(ctx, driver.CacheConfig{Name: "all-opts"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = c.Set(ctx, "all-opts", "k", []byte("v"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	// Verify recorder captured calls.
-	assertEqual(t, 2, rec.CallCount())
+	assert.Equal(t, 2, rec.CallCount())
 
 	// Verify metrics captured calls.
 	q := metrics.NewQuery(mc)
-	assertEqual(t, 2, q.ByName("calls_total").Count())
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
 }
 
 func TestPortableDeleteCacheError(t *testing.T) {
@@ -421,7 +366,7 @@ func TestPortableDeleteCacheError(t *testing.T) {
 	ctx := context.Background()
 
 	err := c.Delete(ctx, "no-cache", "k")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPortableKeysError(t *testing.T) {
@@ -429,7 +374,7 @@ func TestPortableKeysError(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.Keys(ctx, "no-cache", "*")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPortableFlushAllError(t *testing.T) {
@@ -437,7 +382,7 @@ func TestPortableFlushAllError(t *testing.T) {
 	ctx := context.Background()
 
 	err := c.FlushAll(ctx, "no-cache")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPortableSetError(t *testing.T) {
@@ -445,7 +390,7 @@ func TestPortableSetError(t *testing.T) {
 	ctx := context.Background()
 
 	err := c.Set(ctx, "no-cache", "k", []byte("v"), 0)
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPortableGetError(t *testing.T) {
@@ -453,5 +398,5 @@ func TestPortableGetError(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := c.Get(ctx, "no-cache", "k")
-	assertError(t, err, true)
+	require.Error(t, err)
 }

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -1,0 +1,47 @@
+// Package driver defines the interface for cache service implementations.
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// Item represents a cached item.
+type Item struct {
+	Key       string
+	Value     []byte
+	TTL       time.Duration
+	ExpiresAt time.Time
+}
+
+// CacheInfo describes a cache instance.
+type CacheInfo struct {
+	Name      string
+	NodeType  string
+	Engine    string
+	Status    string
+	Endpoint  string
+	CreatedAt string
+}
+
+// CacheConfig describes a cache instance to create.
+type CacheConfig struct {
+	Name     string
+	NodeType string
+	Engine   string // "redis", "memcached"
+	Tags     map[string]string
+}
+
+// Cache is the interface that cache provider implementations must satisfy.
+type Cache interface {
+	CreateCache(ctx context.Context, config CacheConfig) (*CacheInfo, error)
+	DeleteCache(ctx context.Context, name string) error
+	GetCache(ctx context.Context, name string) (*CacheInfo, error)
+	ListCaches(ctx context.Context) ([]CacheInfo, error)
+
+	Set(ctx context.Context, cacheName, key string, value []byte, ttl time.Duration) error
+	Get(ctx context.Context, cacheName, key string) (*Item, error)
+	Delete(ctx context.Context, cacheName, key string) error
+	Keys(ctx context.Context, cacheName, pattern string) ([]string, error)
+	FlushAll(ctx context.Context, cacheName string) error
+}

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -25,6 +25,11 @@ import (
 	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
 	"github.com/stackshy/cloudemu/storage"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	loggingdriver "github.com/stackshy/cloudemu/logging/driver"
+	notifdriver "github.com/stackshy/cloudemu/notification/driver"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
 )
 
 func TestStorageLifecycle(t *testing.T) {
@@ -1600,5 +1605,604 @@ func TestGCPCloudFunctionPubSubTrigger(t *testing.T) {
 
 	if len(received) != 3 {
 		t.Errorf("expected 3 triggered messages, got %d", len(received))
+	}
+}
+
+// ==============================================================================
+// Integration Tests: Secrets (AWS SecretsManager, Azure KeyVault, GCP SecretManager)
+// ==============================================================================
+
+func TestAWSSecretsManagerOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testSecretsWithDriver(t, ctx, p.SecretsManager)
+}
+
+func TestAzureKeyVaultOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testSecretsWithDriver(t, ctx, p.KeyVault)
+}
+
+func TestGCPSecretManagerOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testSecretsWithDriver(t, ctx, p.SecretManager)
+}
+
+func testSecretsWithDriver(t *testing.T, ctx context.Context, d secretsdriver.Secrets) {
+	t.Helper()
+
+	// Create secret
+	info, err := d.CreateSecret(ctx, secretsdriver.SecretConfig{
+		Name:        "db-password",
+		Description: "Database password",
+		Tags:        map[string]string{"env": "production"},
+	}, []byte("s3cret-v1"))
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if info.Name != "db-password" {
+		t.Errorf("expected name 'db-password', got %q", info.Name)
+	}
+	if info.ResourceID == "" {
+		t.Error("expected non-empty ResourceID")
+	}
+
+	// Get secret
+	got, err := d.GetSecret(ctx, "db-password")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if got.Name != "db-password" {
+		t.Errorf("expected 'db-password', got %q", got.Name)
+	}
+
+	// Get secret value
+	ver, err := d.GetSecretValue(ctx, "db-password", "")
+	if err != nil {
+		t.Fatalf("GetSecretValue: %v", err)
+	}
+	if string(ver.Value) != "s3cret-v1" {
+		t.Errorf("expected 's3cret-v1', got %q", string(ver.Value))
+	}
+
+	// Put new version
+	ver2, err := d.PutSecretValue(ctx, "db-password", []byte("s3cret-v2"))
+	if err != nil {
+		t.Fatalf("PutSecretValue: %v", err)
+	}
+	if !ver2.Current {
+		t.Error("expected new version to be current")
+	}
+
+	// Verify new version is returned as current
+	latest, err := d.GetSecretValue(ctx, "db-password", "")
+	if err != nil {
+		t.Fatalf("GetSecretValue (latest): %v", err)
+	}
+	if string(latest.Value) != "s3cret-v2" {
+		t.Errorf("expected 's3cret-v2', got %q", string(latest.Value))
+	}
+
+	// List versions
+	versions, err := d.ListSecretVersions(ctx, "db-password")
+	if err != nil {
+		t.Fatalf("ListSecretVersions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Errorf("expected 2 versions, got %d", len(versions))
+	}
+
+	// List secrets
+	secrets, err := d.ListSecrets(ctx)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(secrets) != 1 {
+		t.Errorf("expected 1 secret, got %d", len(secrets))
+	}
+
+	// Delete secret (soft-delete)
+	if err := d.DeleteSecret(ctx, "db-password"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	// Verify deleted secret is not accessible
+	_, err = d.GetSecret(ctx, "db-password")
+	if err == nil {
+		t.Error("expected error getting deleted secret")
+	}
+
+	// Verify not found for non-existent
+	_, err = d.GetSecret(ctx, "does-not-exist")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+// ==============================================================================
+// Integration Tests: Cache (AWS ElastiCache, Azure Cache, GCP Memorystore)
+// ==============================================================================
+
+func TestAWSElastiCacheOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testCacheWithDriver(t, ctx, p.ElastiCache)
+}
+
+func TestAzureCacheOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testCacheWithDriver(t, ctx, p.Cache)
+}
+
+func TestGCPMemorystoreOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testCacheWithDriver(t, ctx, p.Memorystore)
+}
+
+func testCacheWithDriver(t *testing.T, ctx context.Context, d cachedriver.Cache) {
+	t.Helper()
+
+	// Create cache
+	info, err := d.CreateCache(ctx, cachedriver.CacheConfig{
+		Name:   "session-cache",
+		Engine: "redis",
+	})
+	if err != nil {
+		t.Fatalf("CreateCache: %v", err)
+	}
+	if info.Name == "" {
+		t.Error("expected non-empty cache name")
+	}
+	if info.Endpoint == "" {
+		t.Error("expected non-empty endpoint")
+	}
+
+	// Set values
+	if err := d.Set(ctx, "session-cache", "user:1:session", []byte("token-abc"), 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := d.Set(ctx, "session-cache", "user:2:session", []byte("token-def"), 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := d.Set(ctx, "session-cache", "config:app", []byte("settings"), 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Get value
+	item, err := d.Get(ctx, "session-cache", "user:1:session")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(item.Value) != "token-abc" {
+		t.Errorf("expected 'token-abc', got %q", string(item.Value))
+	}
+
+	// Keys with glob pattern (middle wildcard)
+	keys, err := d.Keys(ctx, "session-cache", "user:*:session")
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys matching 'user:*:session', got %d: %v", len(keys), keys)
+	}
+
+	// Keys with prefix pattern
+	allKeys, err := d.Keys(ctx, "session-cache", "*")
+	if err != nil {
+		t.Fatalf("Keys(*): %v", err)
+	}
+	if len(allKeys) != 3 {
+		t.Errorf("expected 3 total keys, got %d", len(allKeys))
+	}
+
+	// Delete key
+	if err := d.Delete(ctx, "session-cache", "user:1:session"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_, err = d.Get(ctx, "session-cache", "user:1:session")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound after delete, got %v", err)
+	}
+
+	// FlushAll
+	if err := d.FlushAll(ctx, "session-cache"); err != nil {
+		t.Fatalf("FlushAll: %v", err)
+	}
+	remainingKeys, _ := d.Keys(ctx, "session-cache", "*")
+	if len(remainingKeys) != 0 {
+		t.Errorf("expected 0 keys after flush, got %d", len(remainingKeys))
+	}
+
+	// List caches
+	caches, err := d.ListCaches(ctx)
+	if err != nil {
+		t.Fatalf("ListCaches: %v", err)
+	}
+	if len(caches) != 1 {
+		t.Errorf("expected 1 cache, got %d", len(caches))
+	}
+
+	// Delete cache
+	if err := d.DeleteCache(ctx, "session-cache"); err != nil {
+		t.Fatalf("DeleteCache: %v", err)
+	}
+	_, err = d.GetCache(ctx, "session-cache")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+// ==============================================================================
+// Integration Tests: Logging (AWS CloudWatch Logs, Azure Log Analytics, GCP Cloud Logging)
+// ==============================================================================
+
+func TestAWSCloudWatchLogsOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testLoggingWithDriver(t, ctx, p.CloudWatchLogs)
+}
+
+func TestAzureLogAnalyticsOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testLoggingWithDriver(t, ctx, p.LogAnalytics)
+}
+
+func TestGCPCloudLoggingOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testLoggingWithDriver(t, ctx, p.CloudLogging)
+}
+
+func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Logging) {
+	t.Helper()
+
+	// Create log group
+	groupInfo, err := d.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{
+		Name:          "app-logs",
+		RetentionDays: 7,
+	})
+	if err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+	if groupInfo.Name != "app-logs" {
+		t.Errorf("expected name 'app-logs', got %q", groupInfo.Name)
+	}
+	if groupInfo.ResourceID == "" {
+		t.Error("expected non-empty ResourceID")
+	}
+	if groupInfo.RetentionDays != 7 {
+		t.Errorf("expected retention 7, got %d", groupInfo.RetentionDays)
+	}
+
+	// Create log stream
+	streamInfo, err := d.CreateLogStream(ctx, "app-logs", "web-server")
+	if err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+	if streamInfo.Name != "web-server" {
+		t.Errorf("expected 'web-server', got %q", streamInfo.Name)
+	}
+
+	// Put log events
+	now := time.Now()
+	events := []loggingdriver.LogEvent{
+		{Timestamp: now.Add(-2 * time.Hour), Message: "Starting server"},
+		{Timestamp: now.Add(-time.Hour), Message: "Request received: GET /api/health"},
+		{Timestamp: now, Message: "Error: connection timeout"},
+	}
+	if err := d.PutLogEvents(ctx, "app-logs", "web-server", events); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	// Get all events
+	allEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+		LogGroup: "app-logs",
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents (all): %v", err)
+	}
+	if len(allEvents) != 3 {
+		t.Errorf("expected 3 events, got %d", len(allEvents))
+	}
+
+	// Get events from specific stream
+	streamEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+		LogGroup:  "app-logs",
+		LogStream: "web-server",
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents (stream): %v", err)
+	}
+	if len(streamEvents) != 3 {
+		t.Errorf("expected 3 events from stream, got %d", len(streamEvents))
+	}
+
+	// Filter by pattern
+	errorEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+		LogGroup: "app-logs",
+		Pattern:  "Error",
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents (pattern): %v", err)
+	}
+	if len(errorEvents) != 1 {
+		t.Errorf("expected 1 error event, got %d", len(errorEvents))
+	}
+
+	// Filter by time range
+	recentEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+		LogGroup:  "app-logs",
+		StartTime: now.Add(-90 * time.Minute),
+		EndTime:   now.Add(time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents (time range): %v", err)
+	}
+	if len(recentEvents) != 2 {
+		t.Errorf("expected 2 recent events, got %d", len(recentEvents))
+	}
+
+	// List log streams
+	streams, err := d.ListLogStreams(ctx, "app-logs")
+	if err != nil {
+		t.Fatalf("ListLogStreams: %v", err)
+	}
+	if len(streams) != 1 {
+		t.Errorf("expected 1 stream, got %d", len(streams))
+	}
+
+	// List log groups
+	groups, err := d.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatalf("ListLogGroups: %v", err)
+	}
+	if len(groups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(groups))
+	}
+
+	// Delete stream
+	if err := d.DeleteLogStream(ctx, "app-logs", "web-server"); err != nil {
+		t.Fatalf("DeleteLogStream: %v", err)
+	}
+
+	// Delete group
+	if err := d.DeleteLogGroup(ctx, "app-logs"); err != nil {
+		t.Fatalf("DeleteLogGroup: %v", err)
+	}
+	_, err = d.GetLogGroup(ctx, "app-logs")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+// ==============================================================================
+// Integration Tests: Notification (AWS SNS, Azure Notification Hubs, GCP FCM)
+// ==============================================================================
+
+func TestAWSSNSOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testNotificationWithDriver(t, ctx, p.SNS)
+}
+
+func TestAzureNotificationHubsOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testNotificationWithDriver(t, ctx, p.NotificationHubs)
+}
+
+func TestGCPFCMOperations(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testNotificationWithDriver(t, ctx, p.FCM)
+}
+
+func testNotificationWithDriver(t *testing.T, ctx context.Context, d notifdriver.Notification) {
+	t.Helper()
+
+	// Create topic
+	topic, err := d.CreateTopic(ctx, notifdriver.TopicConfig{
+		Name:        "order-events",
+		DisplayName: "Order Events",
+		Tags:        map[string]string{"team": "commerce"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+	if topic.Name != "order-events" {
+		t.Errorf("expected 'order-events', got %q", topic.Name)
+	}
+	if topic.ResourceID == "" {
+		t.Error("expected non-empty ResourceID")
+	}
+
+	// Get topic
+	got, err := d.GetTopic(ctx, "order-events")
+	if err != nil {
+		t.Fatalf("GetTopic: %v", err)
+	}
+	if got.Name != "order-events" {
+		t.Errorf("expected 'order-events', got %q", got.Name)
+	}
+
+	// Subscribe
+	sub, err := d.Subscribe(ctx, notifdriver.SubscriptionConfig{
+		TopicID:  "order-events",
+		Protocol: "email",
+		Endpoint: "admin@example.com",
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	if sub.ID == "" {
+		t.Error("expected non-empty subscription ID")
+	}
+	if sub.Status != "confirmed" {
+		t.Errorf("expected 'confirmed', got %q", sub.Status)
+	}
+
+	// Subscribe another
+	sub2, err := d.Subscribe(ctx, notifdriver.SubscriptionConfig{
+		TopicID:  "order-events",
+		Protocol: "https",
+		Endpoint: "https://webhook.example.com/orders",
+	})
+	if err != nil {
+		t.Fatalf("Subscribe (2): %v", err)
+	}
+
+	// List subscriptions
+	subs, err := d.ListSubscriptions(ctx, "order-events")
+	if err != nil {
+		t.Fatalf("ListSubscriptions: %v", err)
+	}
+	if len(subs) != 2 {
+		t.Errorf("expected 2 subscriptions, got %d", len(subs))
+	}
+
+	// Verify topic subscription count
+	topicInfo, _ := d.GetTopic(ctx, "order-events")
+	if topicInfo.SubscriptionCount != 2 {
+		t.Errorf("expected subscription count 2, got %d", topicInfo.SubscriptionCount)
+	}
+
+	// Publish message
+	pubOut, err := d.Publish(ctx, notifdriver.PublishInput{
+		TopicID: "order-events",
+		Subject: "New Order",
+		Message: `{"orderId": "12345", "total": 99.99}`,
+	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	if pubOut.MessageID == "" {
+		t.Error("expected non-empty message ID")
+	}
+
+	// Unsubscribe
+	if err := d.Unsubscribe(ctx, sub2.ID); err != nil {
+		t.Fatalf("Unsubscribe: %v", err)
+	}
+	subs, _ = d.ListSubscriptions(ctx, "order-events")
+	if len(subs) != 1 {
+		t.Errorf("expected 1 subscription after unsubscribe, got %d", len(subs))
+	}
+
+	// List topics
+	topics, err := d.ListTopics(ctx)
+	if err != nil {
+		t.Fatalf("ListTopics: %v", err)
+	}
+	if len(topics) != 1 {
+		t.Errorf("expected 1 topic, got %d", len(topics))
+	}
+
+	// Delete topic
+	if err := d.DeleteTopic(ctx, "order-events"); err != nil {
+		t.Fatalf("DeleteTopic: %v", err)
+	}
+	_, err = d.GetTopic(ctx, "order-events")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+// ==============================================================================
+// Cross-Provider Integration: All 4 new services work consistently
+// ==============================================================================
+
+func TestCrossProviderNewServices(t *testing.T) {
+	ctx := context.Background()
+
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	// Test secrets across providers
+	secretsProviders := []struct {
+		name string
+		d    secretsdriver.Secrets
+	}{
+		{"aws", awsP.SecretsManager},
+		{"azure", azureP.KeyVault},
+		{"gcp", gcpP.SecretManager},
+	}
+
+	for _, sp := range secretsProviders {
+		t.Run("secrets/"+sp.name, func(t *testing.T) {
+			info, err := sp.d.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "api-key"}, []byte("key-123"))
+			if err != nil {
+				t.Fatalf("CreateSecret: %v", err)
+			}
+			if info.ResourceID == "" {
+				t.Error("expected non-empty ResourceID")
+			}
+
+			ver, _ := sp.d.GetSecretValue(ctx, "api-key", "")
+			if string(ver.Value) != "key-123" {
+				t.Errorf("expected 'key-123', got %q", string(ver.Value))
+			}
+		})
+	}
+
+	// Test caches across providers
+	cacheProviders := []struct {
+		name string
+		d    cachedriver.Cache
+	}{
+		{"aws", awsP.ElastiCache},
+		{"azure", azureP.Cache},
+		{"gcp", gcpP.Memorystore},
+	}
+
+	for _, cp := range cacheProviders {
+		t.Run("cache/"+cp.name, func(t *testing.T) {
+			_, err := cp.d.CreateCache(ctx, cachedriver.CacheConfig{Name: "test-cache"})
+			if err != nil {
+				t.Fatalf("CreateCache: %v", err)
+			}
+
+			cp.d.Set(ctx, "test-cache", "key", []byte("value"), 0)
+			item, _ := cp.d.Get(ctx, "test-cache", "key")
+			if string(item.Value) != "value" {
+				t.Errorf("expected 'value', got %q", string(item.Value))
+			}
+		})
+	}
+
+	// Test notification across providers — all use name-based topic lookup
+	notifProviders := []struct {
+		name string
+		d    notifdriver.Notification
+	}{
+		{"aws", awsP.SNS},
+		{"azure", azureP.NotificationHubs},
+		{"gcp", gcpP.FCM},
+	}
+
+	for _, np := range notifProviders {
+		t.Run("notification/"+np.name, func(t *testing.T) {
+			topic, err := np.d.CreateTopic(ctx, notifdriver.TopicConfig{Name: "alerts"})
+			if err != nil {
+				t.Fatalf("CreateTopic: %v", err)
+			}
+			if topic.ResourceID == "" {
+				t.Error("expected non-empty ResourceID")
+			}
+
+			// All providers use name as key — portable API contract
+			got, err := np.d.GetTopic(ctx, "alerts")
+			if err != nil {
+				t.Fatalf("GetTopic by name: %v", err)
+			}
+			if got.Name != "alerts" {
+				t.Errorf("expected 'alerts', got %q", got.Name)
+			}
+		})
 	}
 }

--- a/logging/driver/driver.go
+++ b/logging/driver/driver.go
@@ -1,0 +1,62 @@
+// Package driver defines the interface for logging service implementations.
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// LogGroupConfig describes a log group to create.
+type LogGroupConfig struct {
+	Name          string
+	RetentionDays int
+	Tags          map[string]string
+}
+
+// LogGroupInfo describes a log group.
+type LogGroupInfo struct {
+	Name          string
+	ARN           string
+	RetentionDays int
+	CreatedAt     string
+	StoredBytes   int64
+	Tags          map[string]string
+}
+
+// LogStreamInfo describes a log stream within a log group.
+type LogStreamInfo struct {
+	Name      string
+	CreatedAt string
+	LastEvent string
+}
+
+// LogEvent represents a single log entry.
+type LogEvent struct {
+	Timestamp time.Time
+	Message   string
+}
+
+// LogQueryInput configures a log query operation.
+type LogQueryInput struct {
+	LogGroup  string
+	LogStream string // empty means all streams
+	StartTime time.Time
+	EndTime   time.Time
+	Pattern   string // filter pattern, empty means all
+	Limit     int
+}
+
+// Logging is the interface that logging provider implementations must satisfy.
+type Logging interface {
+	CreateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
+	DeleteLogGroup(ctx context.Context, name string) error
+	GetLogGroup(ctx context.Context, name string) (*LogGroupInfo, error)
+	ListLogGroups(ctx context.Context) ([]LogGroupInfo, error)
+
+	CreateLogStream(ctx context.Context, logGroup, streamName string) (*LogStreamInfo, error)
+	DeleteLogStream(ctx context.Context, logGroup, streamName string) error
+	ListLogStreams(ctx context.Context, logGroup string) ([]LogStreamInfo, error)
+
+	PutLogEvents(ctx context.Context, logGroup, streamName string, events []LogEvent) error
+	GetLogEvents(ctx context.Context, input LogQueryInput) ([]LogEvent, error)
+}

--- a/logging/driver/driver.go
+++ b/logging/driver/driver.go
@@ -16,7 +16,7 @@ type LogGroupConfig struct {
 // LogGroupInfo describes a log group.
 type LogGroupInfo struct {
 	Name          string
-	ARN           string
+	ResourceID    string
 	RetentionDays int
 	CreatedAt     string
 	StoredBytes   int64

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,186 @@
+// Package logging provides a portable logging API with cross-cutting concerns.
+package logging
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+// Logging is the portable logging type wrapping a driver with cross-cutting concerns.
+type Logging struct {
+	driver   driver.Logging
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// NewLogging creates a new portable Logging wrapping the given driver.
+func NewLogging(d driver.Logging, opts ...Option) *Logging {
+	l := &Logging{driver: d}
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
+}
+
+// Option configures a portable Logging.
+type Option func(*Logging)
+
+// WithRecorder sets the recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(l *Logging) { l.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(l *Logging) { l.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(rl *ratelimit.Limiter) Option { return func(l *Logging) { l.limiter = rl } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(l *Logging) { l.injector = i } }
+
+// WithLatency sets simulated latency.
+func WithLatency(d time.Duration) Option { return func(l *Logging) { l.latency = d } }
+
+func (l *Logging) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if l.injector != nil {
+		if err := l.injector.Check("logging", op); err != nil {
+			l.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if l.limiter != nil {
+		if err := l.limiter.Allow(); err != nil {
+			l.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if l.latency > 0 {
+		time.Sleep(l.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if l.metrics != nil {
+		labels := map[string]string{"service": "logging", "operation": op}
+		l.metrics.Counter("calls_total", 1, labels)
+		l.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			l.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	l.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (l *Logging) rec(op string, input, output any, err error, dur time.Duration) {
+	if l.recorder != nil {
+		l.recorder.Record("logging", op, input, output, err, dur)
+	}
+}
+
+// CreateLogGroup creates a new log group.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (l *Logging) CreateLogGroup(ctx context.Context, config driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	out, err := l.do(ctx, "CreateLogGroup", config, func() (any, error) { return l.driver.CreateLogGroup(ctx, config) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LogGroupInfo), nil
+}
+
+// DeleteLogGroup deletes a log group.
+func (l *Logging) DeleteLogGroup(ctx context.Context, name string) error {
+	_, err := l.do(ctx, "DeleteLogGroup", name, func() (any, error) { return nil, l.driver.DeleteLogGroup(ctx, name) })
+	return err
+}
+
+// GetLogGroup retrieves log group info.
+func (l *Logging) GetLogGroup(ctx context.Context, name string) (*driver.LogGroupInfo, error) {
+	out, err := l.do(ctx, "GetLogGroup", name, func() (any, error) { return l.driver.GetLogGroup(ctx, name) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LogGroupInfo), nil
+}
+
+// ListLogGroups lists all log groups.
+func (l *Logging) ListLogGroups(ctx context.Context) ([]driver.LogGroupInfo, error) {
+	out, err := l.do(ctx, "ListLogGroups", nil, func() (any, error) { return l.driver.ListLogGroups(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LogGroupInfo), nil
+}
+
+// CreateLogStream creates a new log stream in a log group.
+func (l *Logging) CreateLogStream(ctx context.Context, logGroup, streamName string) (*driver.LogStreamInfo, error) {
+	out, err := l.do(ctx, "CreateLogStream", map[string]string{"logGroup": logGroup, "stream": streamName}, func() (any, error) {
+		return l.driver.CreateLogStream(ctx, logGroup, streamName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LogStreamInfo), nil
+}
+
+// DeleteLogStream deletes a log stream from a log group.
+func (l *Logging) DeleteLogStream(ctx context.Context, logGroup, streamName string) error {
+	_, err := l.do(ctx, "DeleteLogStream", map[string]string{"logGroup": logGroup, "stream": streamName}, func() (any, error) {
+		return nil, l.driver.DeleteLogStream(ctx, logGroup, streamName)
+	})
+
+	return err
+}
+
+// ListLogStreams lists all log streams in a log group.
+func (l *Logging) ListLogStreams(ctx context.Context, logGroup string) ([]driver.LogStreamInfo, error) {
+	out, err := l.do(ctx, "ListLogStreams", logGroup, func() (any, error) { return l.driver.ListLogStreams(ctx, logGroup) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LogStreamInfo), nil
+}
+
+// PutLogEvents writes log events to a stream.
+func (l *Logging) PutLogEvents(ctx context.Context, logGroup, streamName string, events []driver.LogEvent) error {
+	_, err := l.do(ctx, "PutLogEvents", map[string]string{"logGroup": logGroup, "stream": streamName}, func() (any, error) {
+		return nil, l.driver.PutLogEvents(ctx, logGroup, streamName, events)
+	})
+
+	return err
+}
+
+// GetLogEvents retrieves log events matching the query.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (l *Logging) GetLogEvents(ctx context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+	out, err := l.do(ctx, "GetLogEvents", input, func() (any, error) { return l.driver.GetLogEvents(ctx, input) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LogEvent), nil
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -96,8 +96,6 @@ func (l *Logging) rec(op string, input, output any, err error, dur time.Duration
 }
 
 // CreateLogGroup creates a new log group.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (l *Logging) CreateLogGroup(ctx context.Context, config driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
 	out, err := l.do(ctx, "CreateLogGroup", config, func() (any, error) { return l.driver.CreateLogGroup(ctx, config) })
 	if err != nil {

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -13,42 +13,9 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/cloudwatchlogs"
 	"github.com/stackshy/cloudemu/ratelimit"
 	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestLogging(opts ...Option) *Logging {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -63,10 +30,10 @@ func setupTestGroupAndStream(t *testing.T, l *Logging) {
 	ctx := context.Background()
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = l.CreateLogStream(ctx, "test-group", "test-stream")
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateLogGroup(t *testing.T) {
@@ -76,17 +43,17 @@ func TestCreateLogGroup(t *testing.T) {
 		l := newTestLogging()
 
 		info, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "grp", info.Name)
-		assertNotEmpty(t, info.ResourceID)
+		assert.Equal(t, "grp", info.Name)
+		assert.NotEmpty(t, info.ResourceID)
 	})
 
 	t.Run("empty name error", func(t *testing.T) {
 		l := newTestLogging()
 
 		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -97,17 +64,17 @@ func TestDeleteLogGroup(t *testing.T) {
 		l := newTestLogging()
 
 		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = l.DeleteLogGroup(ctx, "del")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		l := newTestLogging()
 
 		err := l.DeleteLogGroup(ctx, "nope")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -118,19 +85,19 @@ func TestGetLogGroup(t *testing.T) {
 		l := newTestLogging()
 
 		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := l.GetLogGroup(ctx, "g1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "g1", info.Name)
+		assert.Equal(t, "g1", info.Name)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		l := newTestLogging()
 
 		_, err := l.GetLogGroup(ctx, "missing")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -139,15 +106,15 @@ func TestListLogGroups(t *testing.T) {
 	l := newTestLogging()
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "a"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "b"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	groups, err := l.ListLogGroups(ctx)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, 2, len(groups))
+	assert.Equal(t, 2, len(groups))
 }
 
 func TestCreateLogStream(t *testing.T) {
@@ -157,19 +124,19 @@ func TestCreateLogStream(t *testing.T) {
 		l := newTestLogging()
 
 		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := l.CreateLogStream(ctx, "grp", "s1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "s1", info.Name)
+		assert.Equal(t, "s1", info.Name)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		l := newTestLogging()
 
 		_, err := l.CreateLogStream(ctx, "nope", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -181,14 +148,14 @@ func TestDeleteLogStream(t *testing.T) {
 		setupTestGroupAndStream(t, l)
 
 		err := l.DeleteLogStream(ctx, "test-group", "test-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		l := newTestLogging()
 
 		err := l.DeleteLogStream(ctx, "nope", "nope")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -198,9 +165,9 @@ func TestListLogStreams(t *testing.T) {
 	setupTestGroupAndStream(t, l)
 
 	streams, err := l.ListLogStreams(ctx, "test-group")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, 1, len(streams))
+	assert.Equal(t, 1, len(streams))
 }
 
 func TestPutLogEvents(t *testing.T) {
@@ -214,14 +181,14 @@ func TestPutLogEvents(t *testing.T) {
 		err := l.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "hello"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent stream error", func(t *testing.T) {
 		l := newTestLogging()
 
 		err := l.PutLogEvents(ctx, "nope", "nope", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -237,14 +204,14 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime, Message: "msg1"},
 			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := l.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
@@ -253,7 +220,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := l.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "nope",
 		})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -263,19 +230,16 @@ func TestWithRecorder(t *testing.T) {
 	l := newTestLogging(WithRecorder(rec))
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "rec-grp"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, 1, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCount())
 
 	calls := rec.CallsFor("logging", "CreateLogGroup")
-	assertEqual(t, 1, len(calls))
+	assert.Equal(t, 1, len(calls))
 
-	assertEqual(t, "logging", calls[0].Service)
-	assertEqual(t, "CreateLogGroup", calls[0].Operation)
-
-	if calls[0].Error != nil {
-		t.Errorf("expected nil error in recorded call, got %v", calls[0].Error)
-	}
+	assert.Equal(t, "logging", calls[0].Service)
+	assert.Equal(t, "CreateLogGroup", calls[0].Operation)
+	assert.Nil(t, calls[0].Error)
 }
 
 func TestWithRecorderRecordsErrors(t *testing.T) {
@@ -284,14 +248,11 @@ func TestWithRecorderRecordsErrors(t *testing.T) {
 	l := newTestLogging(WithRecorder(rec))
 
 	_, err := l.GetLogGroup(ctx, "nonexistent")
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	calls := rec.CallsFor("logging", "GetLogGroup")
-	assertEqual(t, 1, len(calls))
-
-	if calls[0].Error == nil {
-		t.Error("expected error in recorded call, got nil")
-	}
+	assert.Equal(t, 1, len(calls))
+	assert.NotNil(t, calls[0].Error)
 }
 
 func TestWithRecorderMultipleOps(t *testing.T) {
@@ -300,17 +261,17 @@ func TestWithRecorderMultipleOps(t *testing.T) {
 	l := newTestLogging(WithRecorder(rec))
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = l.CreateLogStream(ctx, "grp", "s1")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_ = l.DeleteLogGroup(ctx, "grp")
 
-	assertEqual(t, 3, rec.CallCount())
-	assertEqual(t, 1, rec.CallCountFor("logging", "CreateLogGroup"))
-	assertEqual(t, 1, rec.CallCountFor("logging", "CreateLogStream"))
-	assertEqual(t, 1, rec.CallCountFor("logging", "DeleteLogGroup"))
+	assert.Equal(t, 3, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCountFor("logging", "CreateLogGroup"))
+	assert.Equal(t, 1, rec.CallCountFor("logging", "CreateLogStream"))
+	assert.Equal(t, 1, rec.CallCountFor("logging", "DeleteLogGroup"))
 }
 
 func TestWithMetrics(t *testing.T) {
@@ -319,7 +280,7 @@ func TestWithMetrics(t *testing.T) {
 	l := newTestLogging(WithMetrics(mc))
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "m-grp"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	q := metrics.NewQuery(mc)
 
@@ -327,13 +288,13 @@ func TestWithMetrics(t *testing.T) {
 		ByLabel("service", "logging").
 		ByLabel("operation", "CreateLogGroup").
 		Count()
-	assertEqual(t, 1, callsCount)
+	assert.Equal(t, 1, callsCount)
 
 	durCount := q.ByName("call_duration").
 		ByLabel("service", "logging").
 		ByLabel("operation", "CreateLogGroup").
 		Count()
-	assertEqual(t, 1, durCount)
+	assert.Equal(t, 1, durCount)
 }
 
 func TestWithMetricsRecordsErrors(t *testing.T) {
@@ -349,7 +310,7 @@ func TestWithMetricsRecordsErrors(t *testing.T) {
 		ByLabel("service", "logging").
 		ByLabel("operation", "DeleteLogGroup").
 		Count()
-	assertEqual(t, 1, errCount)
+	assert.Equal(t, 1, errCount)
 }
 
 func TestWithErrorInjection(t *testing.T) {
@@ -361,9 +322,9 @@ func TestWithErrorInjection(t *testing.T) {
 	inj.Set("logging", "CreateLogGroup", injectedErr, inject.Always{})
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "fail"})
-	assertError(t, err, true)
+	require.Error(t, err)
 
-	assertEqual(t, injectedErr.Error(), err.Error())
+	assert.Equal(t, injectedErr.Error(), err.Error())
 }
 
 func TestWithErrorInjectionSelectiveOp(t *testing.T) {
@@ -375,10 +336,10 @@ func TestWithErrorInjectionSelectiveOp(t *testing.T) {
 	inj.Set("logging", "DeleteLogGroup", injectedErr, inject.Always{})
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "ok-grp"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = l.DeleteLogGroup(ctx, "ok-grp")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithErrorInjectionCountdown(t *testing.T) {
@@ -390,12 +351,12 @@ func TestWithErrorInjectionCountdown(t *testing.T) {
 	inj.Set("logging", "ListLogGroups", injectedErr, inject.NewCountdown(1))
 
 	_, err := l.ListLogGroups(ctx)
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	groups, err := l.ListLogGroups(ctx)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, 0, len(groups))
+	assert.Equal(t, 0, len(groups))
 }
 
 func TestWithErrorInjectionRecorded(t *testing.T) {
@@ -410,11 +371,8 @@ func TestWithErrorInjectionRecorded(t *testing.T) {
 	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "fail"})
 
 	calls := rec.CallsFor("logging", "CreateLogGroup")
-	assertEqual(t, 1, len(calls))
-
-	if calls[0].Error == nil {
-		t.Error("expected error in recorded call, got nil")
-	}
+	assert.Equal(t, 1, len(calls))
+	assert.NotNil(t, calls[0].Error)
 }
 
 func TestWithMetricsAndRecorderCombined(t *testing.T) {
@@ -424,14 +382,14 @@ func TestWithMetricsAndRecorderCombined(t *testing.T) {
 	l := newTestLogging(WithRecorder(rec), WithMetrics(mc))
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "combo"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, 1, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCount())
 
 	q := metrics.NewQuery(mc)
 
 	callsCount := q.ByName("calls_total").Count()
-	assertEqual(t, 1, callsCount)
+	assert.Equal(t, 1, callsCount)
 }
 
 func TestAllOperationsRecorded(t *testing.T) {
@@ -454,7 +412,7 @@ func TestAllOperationsRecorded(t *testing.T) {
 	_ = l.DeleteLogStream(ctx, "grp", "s1")
 	_ = l.DeleteLogGroup(ctx, "grp")
 
-	assertEqual(t, 9, rec.CallCount())
+	assert.Equal(t, 9, rec.CallCount())
 
 	ops := []string{
 		"CreateLogGroup", "GetLogGroup", "ListLogGroups",
@@ -465,9 +423,7 @@ func TestAllOperationsRecorded(t *testing.T) {
 
 	for _, op := range ops {
 		count := rec.CallCountFor("logging", op)
-		if count != 1 {
-			t.Errorf("expected 1 call for %s, got %d", op, count)
-		}
+		assert.Equal(t, 1, count, "expected 1 call for %s", op)
 	}
 }
 
@@ -478,10 +434,10 @@ func TestWithRateLimiter(t *testing.T) {
 	l := newTestLogging(WithRateLimiter(limiter))
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp1"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp2"})
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithRateLimiterRecorded(t *testing.T) {
@@ -495,11 +451,8 @@ func TestWithRateLimiterRecorded(t *testing.T) {
 	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp2"})
 
 	calls := rec.CallsFor("logging", "CreateLogGroup")
-	assertEqual(t, 2, len(calls))
-
-	if calls[1].Error == nil {
-		t.Error("expected rate limit error in second call")
-	}
+	assert.Equal(t, 2, len(calls))
+	assert.NotNil(t, calls[1].Error)
 }
 
 func TestWithLatency(t *testing.T) {
@@ -509,13 +462,10 @@ func TestWithLatency(t *testing.T) {
 	start := time.Now()
 
 	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "lat-grp"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	elapsed := time.Since(start)
-
-	if elapsed < time.Millisecond {
-		t.Errorf("expected at least 1ms latency, got %v", elapsed)
-	}
+	assert.GreaterOrEqual(t, elapsed, time.Millisecond)
 }
 
 func TestListLogStreamsError(t *testing.T) {
@@ -523,7 +473,7 @@ func TestListLogStreamsError(t *testing.T) {
 	l := newTestLogging()
 
 	_, err := l.ListLogStreams(ctx, "nonexistent")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestAllOperationsMetrics(t *testing.T) {
@@ -549,8 +499,8 @@ func TestAllOperationsMetrics(t *testing.T) {
 	q := metrics.NewQuery(mc)
 
 	totalCalls := q.ByName("calls_total").ByLabel("service", "logging").Count()
-	assertEqual(t, 9, totalCalls)
+	assert.Equal(t, 9, totalCalls)
 
 	totalDur := q.ByName("call_duration").ByLabel("service", "logging").Count()
-	assertEqual(t, 9, totalDur)
+	assert.Equal(t, 9, totalDur)
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -79,7 +79,7 @@ func TestCreateLogGroup(t *testing.T) {
 		requireNoError(t, err)
 
 		assertEqual(t, "grp", info.Name)
-		assertNotEmpty(t, info.ARN)
+		assertNotEmpty(t, info.ResourceID)
 	})
 
 	t.Run("empty name error", func(t *testing.T) {

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -1,0 +1,556 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatchlogs"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestLogging(opts ...Option) *Logging {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	o := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return NewLogging(cloudwatchlogs.New(o), opts...)
+}
+
+func setupTestGroupAndStream(t *testing.T, l *Logging) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
+	requireNoError(t, err)
+
+	_, err = l.CreateLogStream(ctx, "test-group", "test-stream")
+	requireNoError(t, err)
+}
+
+func TestCreateLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+
+		info, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		assertEqual(t, "grp", info.Name)
+		assertNotEmpty(t, info.ARN)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del"})
+		requireNoError(t, err)
+
+		err = l.DeleteLogGroup(ctx, "del")
+		requireNoError(t, err)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		l := newTestLogging()
+
+		err := l.DeleteLogGroup(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
+		requireNoError(t, err)
+
+		info, err := l.GetLogGroup(ctx, "g1")
+		requireNoError(t, err)
+
+		assertEqual(t, "g1", info.Name)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.GetLogGroup(ctx, "missing")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogGroups(t *testing.T) {
+	ctx := context.Background()
+	l := newTestLogging()
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "a"})
+	requireNoError(t, err)
+
+	_, err = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "b"})
+	requireNoError(t, err)
+
+	groups, err := l.ListLogGroups(ctx)
+	requireNoError(t, err)
+
+	assertEqual(t, 2, len(groups))
+}
+
+func TestCreateLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		info, err := l.CreateLogStream(ctx, "grp", "s1")
+		requireNoError(t, err)
+
+		assertEqual(t, "s1", info.Name)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.CreateLogStream(ctx, "nope", "s1")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+		setupTestGroupAndStream(t, l)
+
+		err := l.DeleteLogStream(ctx, "test-group", "test-stream")
+		requireNoError(t, err)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		l := newTestLogging()
+
+		err := l.DeleteLogStream(ctx, "nope", "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogStreams(t *testing.T) {
+	ctx := context.Background()
+	l := newTestLogging()
+	setupTestGroupAndStream(t, l)
+
+	streams, err := l.ListLogStreams(ctx, "test-group")
+	requireNoError(t, err)
+
+	assertEqual(t, 1, len(streams))
+}
+
+func TestPutLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+		setupTestGroupAndStream(t, l)
+
+		err := l.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "hello"},
+		})
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent stream error", func(t *testing.T) {
+		l := newTestLogging()
+
+		err := l.PutLogEvents(ctx, "nope", "nope", nil)
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("success", func(t *testing.T) {
+		l := newTestLogging()
+		setupTestGroupAndStream(t, l)
+
+		err := l.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "msg1"},
+			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
+		})
+		requireNoError(t, err)
+
+		events, err := l.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		l := newTestLogging()
+
+		_, err := l.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "nope",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestWithRecorder(t *testing.T) {
+	ctx := context.Background()
+	rec := recorder.New()
+	l := newTestLogging(WithRecorder(rec))
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "rec-grp"})
+	requireNoError(t, err)
+
+	assertEqual(t, 1, rec.CallCount())
+
+	calls := rec.CallsFor("logging", "CreateLogGroup")
+	assertEqual(t, 1, len(calls))
+
+	assertEqual(t, "logging", calls[0].Service)
+	assertEqual(t, "CreateLogGroup", calls[0].Operation)
+
+	if calls[0].Error != nil {
+		t.Errorf("expected nil error in recorded call, got %v", calls[0].Error)
+	}
+}
+
+func TestWithRecorderRecordsErrors(t *testing.T) {
+	ctx := context.Background()
+	rec := recorder.New()
+	l := newTestLogging(WithRecorder(rec))
+
+	_, err := l.GetLogGroup(ctx, "nonexistent")
+	assertError(t, err, true)
+
+	calls := rec.CallsFor("logging", "GetLogGroup")
+	assertEqual(t, 1, len(calls))
+
+	if calls[0].Error == nil {
+		t.Error("expected error in recorded call, got nil")
+	}
+}
+
+func TestWithRecorderMultipleOps(t *testing.T) {
+	ctx := context.Background()
+	rec := recorder.New()
+	l := newTestLogging(WithRecorder(rec))
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+	requireNoError(t, err)
+
+	_, err = l.CreateLogStream(ctx, "grp", "s1")
+	requireNoError(t, err)
+
+	_ = l.DeleteLogGroup(ctx, "grp")
+
+	assertEqual(t, 3, rec.CallCount())
+	assertEqual(t, 1, rec.CallCountFor("logging", "CreateLogGroup"))
+	assertEqual(t, 1, rec.CallCountFor("logging", "CreateLogStream"))
+	assertEqual(t, 1, rec.CallCountFor("logging", "DeleteLogGroup"))
+}
+
+func TestWithMetrics(t *testing.T) {
+	ctx := context.Background()
+	mc := metrics.NewCollector()
+	l := newTestLogging(WithMetrics(mc))
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "m-grp"})
+	requireNoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").
+		ByLabel("service", "logging").
+		ByLabel("operation", "CreateLogGroup").
+		Count()
+	assertEqual(t, 1, callsCount)
+
+	durCount := q.ByName("call_duration").
+		ByLabel("service", "logging").
+		ByLabel("operation", "CreateLogGroup").
+		Count()
+	assertEqual(t, 1, durCount)
+}
+
+func TestWithMetricsRecordsErrors(t *testing.T) {
+	ctx := context.Background()
+	mc := metrics.NewCollector()
+	l := newTestLogging(WithMetrics(mc))
+
+	_ = l.DeleteLogGroup(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").
+		ByLabel("service", "logging").
+		ByLabel("operation", "DeleteLogGroup").
+		Count()
+	assertEqual(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	ctx := context.Background()
+	inj := inject.NewInjector()
+	l := newTestLogging(WithErrorInjection(inj))
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("logging", "CreateLogGroup", injectedErr, inject.Always{})
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "fail"})
+	assertError(t, err, true)
+
+	assertEqual(t, injectedErr.Error(), err.Error())
+}
+
+func TestWithErrorInjectionSelectiveOp(t *testing.T) {
+	ctx := context.Background()
+	inj := inject.NewInjector()
+	l := newTestLogging(WithErrorInjection(inj))
+
+	injectedErr := fmt.Errorf("injected")
+	inj.Set("logging", "DeleteLogGroup", injectedErr, inject.Always{})
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "ok-grp"})
+	requireNoError(t, err)
+
+	err = l.DeleteLogGroup(ctx, "ok-grp")
+	assertError(t, err, true)
+}
+
+func TestWithErrorInjectionCountdown(t *testing.T) {
+	ctx := context.Background()
+	inj := inject.NewInjector()
+	l := newTestLogging(WithErrorInjection(inj))
+
+	injectedErr := fmt.Errorf("countdown error")
+	inj.Set("logging", "ListLogGroups", injectedErr, inject.NewCountdown(1))
+
+	_, err := l.ListLogGroups(ctx)
+	assertError(t, err, true)
+
+	groups, err := l.ListLogGroups(ctx)
+	requireNoError(t, err)
+
+	assertEqual(t, 0, len(groups))
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	ctx := context.Background()
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	l := newTestLogging(WithRecorder(rec), WithErrorInjection(inj))
+
+	injectedErr := fmt.Errorf("injected")
+	inj.Set("logging", "CreateLogGroup", injectedErr, inject.Always{})
+
+	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "fail"})
+
+	calls := rec.CallsFor("logging", "CreateLogGroup")
+	assertEqual(t, 1, len(calls))
+
+	if calls[0].Error == nil {
+		t.Error("expected error in recorded call, got nil")
+	}
+}
+
+func TestWithMetricsAndRecorderCombined(t *testing.T) {
+	ctx := context.Background()
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	l := newTestLogging(WithRecorder(rec), WithMetrics(mc))
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "combo"})
+	requireNoError(t, err)
+
+	assertEqual(t, 1, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assertEqual(t, 1, callsCount)
+}
+
+func TestAllOperationsRecorded(t *testing.T) {
+	ctx := context.Background()
+	rec := recorder.New()
+	l := newTestLogging(WithRecorder(rec))
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+	_, _ = l.GetLogGroup(ctx, "grp")
+	_, _ = l.ListLogGroups(ctx)
+	_, _ = l.CreateLogStream(ctx, "grp", "s1")
+	_, _ = l.ListLogStreams(ctx, "grp")
+
+	_ = l.PutLogEvents(ctx, "grp", "s1", []driver.LogEvent{
+		{Timestamp: baseTime, Message: "test"},
+	})
+
+	_, _ = l.GetLogEvents(ctx, driver.LogQueryInput{LogGroup: "grp"})
+	_ = l.DeleteLogStream(ctx, "grp", "s1")
+	_ = l.DeleteLogGroup(ctx, "grp")
+
+	assertEqual(t, 9, rec.CallCount())
+
+	ops := []string{
+		"CreateLogGroup", "GetLogGroup", "ListLogGroups",
+		"CreateLogStream", "ListLogStreams",
+		"PutLogEvents", "GetLogEvents",
+		"DeleteLogStream", "DeleteLogGroup",
+	}
+
+	for _, op := range ops {
+		count := rec.CallCountFor("logging", op)
+		if count != 1 {
+			t.Errorf("expected 1 call for %s, got %d", op, count)
+		}
+	}
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	ctx := context.Background()
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	limiter := ratelimit.New(1, 1, fc)
+	l := newTestLogging(WithRateLimiter(limiter))
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp1"})
+	requireNoError(t, err)
+
+	_, err = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp2"})
+	assertError(t, err, true)
+}
+
+func TestWithRateLimiterRecorded(t *testing.T) {
+	ctx := context.Background()
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	limiter := ratelimit.New(1, 1, fc)
+	rec := recorder.New()
+	l := newTestLogging(WithRateLimiter(limiter), WithRecorder(rec))
+
+	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp1"})
+	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp2"})
+
+	calls := rec.CallsFor("logging", "CreateLogGroup")
+	assertEqual(t, 2, len(calls))
+
+	if calls[1].Error == nil {
+		t.Error("expected rate limit error in second call")
+	}
+}
+
+func TestWithLatency(t *testing.T) {
+	l := newTestLogging(WithLatency(time.Millisecond))
+	ctx := context.Background()
+
+	start := time.Now()
+
+	_, err := l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "lat-grp"})
+	requireNoError(t, err)
+
+	elapsed := time.Since(start)
+
+	if elapsed < time.Millisecond {
+		t.Errorf("expected at least 1ms latency, got %v", elapsed)
+	}
+}
+
+func TestListLogStreamsError(t *testing.T) {
+	ctx := context.Background()
+	l := newTestLogging()
+
+	_, err := l.ListLogStreams(ctx, "nonexistent")
+	assertError(t, err, true)
+}
+
+func TestAllOperationsMetrics(t *testing.T) {
+	ctx := context.Background()
+	mc := metrics.NewCollector()
+	l := newTestLogging(WithMetrics(mc))
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	_, _ = l.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+	_, _ = l.GetLogGroup(ctx, "grp")
+	_, _ = l.ListLogGroups(ctx)
+	_, _ = l.CreateLogStream(ctx, "grp", "s1")
+	_, _ = l.ListLogStreams(ctx, "grp")
+
+	_ = l.PutLogEvents(ctx, "grp", "s1", []driver.LogEvent{
+		{Timestamp: baseTime, Message: "test"},
+	})
+
+	_, _ = l.GetLogEvents(ctx, driver.LogQueryInput{LogGroup: "grp"})
+	_ = l.DeleteLogStream(ctx, "grp", "s1")
+	_ = l.DeleteLogGroup(ctx, "grp")
+
+	q := metrics.NewQuery(mc)
+
+	totalCalls := q.ByName("calls_total").ByLabel("service", "logging").Count()
+	assertEqual(t, 9, totalCalls)
+
+	totalDur := q.ByName("call_duration").ByLabel("service", "logging").Count()
+	assertEqual(t, 9, totalDur)
+}

--- a/notification/driver/driver.go
+++ b/notification/driver/driver.go
@@ -14,7 +14,7 @@ type TopicConfig struct {
 type TopicInfo struct {
 	ID                string
 	Name              string
-	ARN               string
+	ResourceID        string
 	DisplayName       string
 	SubscriptionCount int
 	Tags              map[string]string

--- a/notification/driver/driver.go
+++ b/notification/driver/driver.go
@@ -1,0 +1,64 @@
+// Package driver defines the interface for notification service implementations.
+package driver
+
+import "context"
+
+// TopicConfig describes a notification topic to create.
+type TopicConfig struct {
+	Name        string
+	DisplayName string
+	Tags        map[string]string
+}
+
+// TopicInfo describes a notification topic.
+type TopicInfo struct {
+	ID                string
+	Name              string
+	ARN               string
+	DisplayName       string
+	SubscriptionCount int
+	Tags              map[string]string
+}
+
+// SubscriptionConfig describes a subscription to create.
+type SubscriptionConfig struct {
+	TopicID  string
+	Protocol string // "email", "sms", "http", "https", "sqs", "lambda"
+	Endpoint string
+}
+
+// SubscriptionInfo describes a subscription.
+type SubscriptionInfo struct {
+	ID       string
+	TopicID  string
+	Protocol string
+	Endpoint string
+	Status   string // "confirmed", "pending"
+}
+
+// PublishInput configures a message publish operation.
+type PublishInput struct {
+	TopicID    string
+	Subject    string
+	Message    string
+	Attributes map[string]string
+}
+
+// PublishOutput is the result of publishing a message.
+type PublishOutput struct {
+	MessageID string
+}
+
+// Notification is the interface that notification provider implementations must satisfy.
+type Notification interface {
+	CreateTopic(ctx context.Context, config TopicConfig) (*TopicInfo, error)
+	DeleteTopic(ctx context.Context, id string) error
+	GetTopic(ctx context.Context, id string) (*TopicInfo, error)
+	ListTopics(ctx context.Context) ([]TopicInfo, error)
+
+	Subscribe(ctx context.Context, config SubscriptionConfig) (*SubscriptionInfo, error)
+	Unsubscribe(ctx context.Context, subscriptionID string) error
+	ListSubscriptions(ctx context.Context, topicID string) ([]SubscriptionInfo, error)
+
+	Publish(ctx context.Context, input PublishInput) (*PublishOutput, error)
+}

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -1,0 +1,174 @@
+// Package notification provides a portable notification API with cross-cutting concerns.
+package notification
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/notification/driver"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+// Notification is the portable notification type wrapping a driver with cross-cutting concerns.
+type Notification struct {
+	driver   driver.Notification
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// NewNotification creates a new portable Notification wrapping the given driver.
+func NewNotification(d driver.Notification, opts ...Option) *Notification {
+	n := &Notification{driver: d}
+	for _, opt := range opts {
+		opt(n)
+	}
+
+	return n
+}
+
+// Option configures a portable Notification.
+type Option func(*Notification)
+
+// WithRecorder sets the recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(n *Notification) { n.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(n *Notification) { n.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(n *Notification) { n.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(n *Notification) { n.injector = i } }
+
+// WithLatency sets simulated latency.
+func WithLatency(d time.Duration) Option { return func(n *Notification) { n.latency = d } }
+
+func (n *Notification) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if n.injector != nil {
+		if err := n.injector.Check("notification", op); err != nil {
+			n.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if n.limiter != nil {
+		if err := n.limiter.Allow(); err != nil {
+			n.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if n.latency > 0 {
+		time.Sleep(n.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if n.metrics != nil {
+		labels := map[string]string{"service": "notification", "operation": op}
+		n.metrics.Counter("calls_total", 1, labels)
+		n.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			n.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	n.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (n *Notification) rec(op string, input, output any, err error, dur time.Duration) {
+	if n.recorder != nil {
+		n.recorder.Record("notification", op, input, output, err, dur)
+	}
+}
+
+// CreateTopic creates a new notification topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (n *Notification) CreateTopic(ctx context.Context, config driver.TopicConfig) (*driver.TopicInfo, error) {
+	out, err := n.do(ctx, "CreateTopic", config, func() (any, error) { return n.driver.CreateTopic(ctx, config) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.TopicInfo), nil
+}
+
+// DeleteTopic deletes a notification topic.
+func (n *Notification) DeleteTopic(ctx context.Context, id string) error {
+	_, err := n.do(ctx, "DeleteTopic", id, func() (any, error) { return nil, n.driver.DeleteTopic(ctx, id) })
+	return err
+}
+
+// GetTopic retrieves topic info.
+func (n *Notification) GetTopic(ctx context.Context, id string) (*driver.TopicInfo, error) {
+	out, err := n.do(ctx, "GetTopic", id, func() (any, error) { return n.driver.GetTopic(ctx, id) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.TopicInfo), nil
+}
+
+// ListTopics lists all topics.
+func (n *Notification) ListTopics(ctx context.Context) ([]driver.TopicInfo, error) {
+	out, err := n.do(ctx, "ListTopics", nil, func() (any, error) { return n.driver.ListTopics(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.TopicInfo), nil
+}
+
+// Subscribe creates a subscription to a topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (n *Notification) Subscribe(ctx context.Context, config driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
+	out, err := n.do(ctx, "Subscribe", config, func() (any, error) { return n.driver.Subscribe(ctx, config) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.SubscriptionInfo), nil
+}
+
+// Unsubscribe removes a subscription.
+func (n *Notification) Unsubscribe(ctx context.Context, subscriptionID string) error {
+	_, err := n.do(ctx, "Unsubscribe", subscriptionID, func() (any, error) { return nil, n.driver.Unsubscribe(ctx, subscriptionID) })
+	return err
+}
+
+// ListSubscriptions lists all subscriptions for a topic.
+func (n *Notification) ListSubscriptions(ctx context.Context, topicID string) ([]driver.SubscriptionInfo, error) {
+	out, err := n.do(ctx, "ListSubscriptions", topicID, func() (any, error) { return n.driver.ListSubscriptions(ctx, topicID) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SubscriptionInfo), nil
+}
+
+// Publish publishes a message to a topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (n *Notification) Publish(ctx context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
+	out, err := n.do(ctx, "Publish", input, func() (any, error) { return n.driver.Publish(ctx, input) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PublishOutput), nil
+}

--- a/notification/notification.go
+++ b/notification/notification.go
@@ -96,8 +96,6 @@ func (n *Notification) rec(op string, input, output any, err error, dur time.Dur
 }
 
 // CreateTopic creates a new notification topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (n *Notification) CreateTopic(ctx context.Context, config driver.TopicConfig) (*driver.TopicInfo, error) {
 	out, err := n.do(ctx, "CreateTopic", config, func() (any, error) { return n.driver.CreateTopic(ctx, config) })
 	if err != nil {
@@ -134,8 +132,6 @@ func (n *Notification) ListTopics(ctx context.Context) ([]driver.TopicInfo, erro
 }
 
 // Subscribe creates a subscription to a topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (n *Notification) Subscribe(ctx context.Context, config driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
 	out, err := n.do(ctx, "Subscribe", config, func() (any, error) { return n.driver.Subscribe(ctx, config) })
 	if err != nil {
@@ -162,8 +158,6 @@ func (n *Notification) ListSubscriptions(ctx context.Context, topicID string) ([
 }
 
 // Publish publishes a message to a topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (n *Notification) Publish(ctx context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
 	out, err := n.do(ctx, "Publish", input, func() (any, error) { return n.driver.Publish(ctx, input) })
 	if err != nil {

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -1,0 +1,478 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/notification/driver"
+	"github.com/stackshy/cloudemu/providers/aws/sns"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestNotification(opts ...Option) *Notification {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	o := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return NewNotification(sns.New(o), opts...)
+}
+
+func createTopicVia(t *testing.T, n *Notification, name string) *driver.TopicInfo {
+	t.Helper()
+
+	info, err := n.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateTopicPortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	info, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "test-topic", DisplayName: "Test"})
+	requireNoError(t, err)
+
+	assertNotEmpty(t, info.ID)
+	assertNotEmpty(t, info.ARN)
+	assertEqual(t, "test-topic", info.Name)
+	assertEqual(t, "Test", info.DisplayName)
+}
+
+func TestCreateTopicPortableError(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	_, err := n.CreateTopic(ctx, driver.TopicConfig{})
+	assertError(t, err, true)
+}
+
+func TestDeleteTopicPortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	info := createTopicVia(t, n, "del-topic")
+
+	err := n.DeleteTopic(ctx, info.ARN)
+	requireNoError(t, err)
+}
+
+func TestDeleteTopicPortableNotFound(t *testing.T) {
+	n := newTestNotification()
+
+	err := n.DeleteTopic(context.Background(), "arn:aws:sns:us-east-1:123456789012:nope")
+	assertError(t, err, true)
+}
+
+func TestGetTopicPortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	created := createTopicVia(t, n, "get-topic")
+
+	info, err := n.GetTopic(ctx, created.ARN)
+	requireNoError(t, err)
+	assertEqual(t, "get-topic", info.Name)
+}
+
+func TestGetTopicPortableNotFound(t *testing.T) {
+	n := newTestNotification()
+
+	_, err := n.GetTopic(context.Background(), "arn:aws:sns:us-east-1:123456789012:nope")
+	assertError(t, err, true)
+}
+
+func TestListTopicsPortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	topics, err := n.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+
+	createTopicVia(t, n, "t1")
+	createTopicVia(t, n, "t2")
+
+	topics, err = n.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(topics))
+}
+
+func TestSubscribePortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	topic := createTopicVia(t, n, "sub-topic")
+
+	sub, err := n.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	assertNotEmpty(t, sub.ID)
+	assertEqual(t, "email", sub.Protocol)
+	assertEqual(t, "confirmed", sub.Status)
+}
+
+func TestSubscribePortableError(t *testing.T) {
+	n := newTestNotification()
+
+	_, err := n.Subscribe(context.Background(), driver.SubscriptionConfig{
+		TopicID: "arn:aws:sns:us-east-1:123456789012:nope", Protocol: "email", Endpoint: "a@b.com",
+	})
+	assertError(t, err, true)
+}
+
+func TestUnsubscribePortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	topic := createTopicVia(t, n, "unsub-topic")
+
+	sub, err := n.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	err = n.Unsubscribe(ctx, sub.ID)
+	requireNoError(t, err)
+}
+
+func TestUnsubscribePortableNotFound(t *testing.T) {
+	n := newTestNotification()
+
+	err := n.Unsubscribe(context.Background(), "nonexistent-sub")
+	assertError(t, err, true)
+}
+
+func TestListSubscriptionsPortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	topic := createTopicVia(t, n, "list-subs")
+
+	_, err := n.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "x@y.com",
+	})
+	requireNoError(t, err)
+
+	subs, err := n.ListSubscriptions(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(subs))
+}
+
+func TestListSubscriptionsPortableNotFound(t *testing.T) {
+	n := newTestNotification()
+
+	_, err := n.ListSubscriptions(context.Background(), "arn:aws:sns:us-east-1:123456789012:nope")
+	assertError(t, err, true)
+}
+
+func TestPublishPortable(t *testing.T) {
+	n := newTestNotification()
+	ctx := context.Background()
+
+	topic := createTopicVia(t, n, "pub-topic")
+
+	out, err := n.Publish(ctx, driver.PublishInput{
+		TopicID: topic.ARN,
+		Message: "hello",
+	})
+	requireNoError(t, err)
+	assertNotEmpty(t, out.MessageID)
+}
+
+func TestPublishPortableError(t *testing.T) {
+	n := newTestNotification()
+
+	_, err := n.Publish(context.Background(), driver.PublishInput{
+		TopicID: "arn:aws:sns:us-east-1:123456789012:nope",
+		Message: "hello",
+	})
+	assertError(t, err, true)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	n := newTestNotification(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = n.CreateTopic(ctx, driver.TopicConfig{Name: "rec-topic"})
+
+	assertEqual(t, 1, rec.CallCount())
+
+	calls := rec.CallsFor("notification", "CreateTopic")
+	assertEqual(t, 1, len(calls))
+	assertEqual(t, "notification", calls[0].Service)
+	assertEqual(t, "CreateTopic", calls[0].Operation)
+}
+
+func TestWithRecorderMultipleOps(t *testing.T) {
+	rec := recorder.New()
+	n := newTestNotification(WithRecorder(rec))
+	ctx := context.Background()
+
+	topic, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "rec-multi"})
+	requireNoError(t, err)
+
+	_, _ = n.GetTopic(ctx, topic.ARN)
+	_, _ = n.ListTopics(ctx)
+	_ = n.DeleteTopic(ctx, topic.ARN)
+
+	assertEqual(t, 4, rec.CallCount())
+	assertEqual(t, 1, rec.CallCountFor("notification", "CreateTopic"))
+	assertEqual(t, 1, rec.CallCountFor("notification", "GetTopic"))
+	assertEqual(t, 1, rec.CallCountFor("notification", "ListTopics"))
+	assertEqual(t, 1, rec.CallCountFor("notification", "DeleteTopic"))
+}
+
+func TestWithRecorderRecordsErrors(t *testing.T) {
+	rec := recorder.New()
+	n := newTestNotification(WithRecorder(rec))
+
+	_, _ = n.CreateTopic(context.Background(), driver.TopicConfig{})
+
+	calls := rec.CallsFor("notification", "CreateTopic")
+	assertEqual(t, 1, len(calls))
+
+	if calls[0].Error == nil {
+		t.Error("expected recorded error to be non-nil")
+	}
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	n := newTestNotification(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = n.CreateTopic(ctx, driver.TopicConfig{Name: "met-topic"})
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").
+		ByLabel("service", "notification").
+		ByLabel("operation", "CreateTopic").
+		Count()
+	assertEqual(t, 1, callsCount)
+
+	durCount := q.ByName("call_duration").
+		ByLabel("service", "notification").
+		ByLabel("operation", "CreateTopic").
+		Count()
+	assertEqual(t, 1, durCount)
+}
+
+func TestWithMetricsRecordsErrors(t *testing.T) {
+	mc := metrics.NewCollector()
+	n := newTestNotification(WithMetrics(mc))
+
+	_, _ = n.CreateTopic(context.Background(), driver.TopicConfig{})
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").
+		ByLabel("service", "notification").
+		ByLabel("operation", "CreateTopic").
+		Count()
+	assertEqual(t, 1, errCount)
+}
+
+func TestWithMetricsNoErrorMetricOnSuccess(t *testing.T) {
+	mc := metrics.NewCollector()
+	n := newTestNotification(WithMetrics(mc))
+
+	_, _ = n.CreateTopic(context.Background(), driver.TopicConfig{Name: "ok"})
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").
+		ByLabel("service", "notification").
+		ByLabel("operation", "CreateTopic").
+		Count()
+	assertEqual(t, 0, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("notification", "CreateTopic", injectedErr, inject.Always{})
+
+	n := newTestNotification(WithErrorInjection(inj))
+
+	_, err := n.CreateTopic(context.Background(), driver.TopicConfig{Name: "inj-topic"})
+	assertError(t, err, true)
+	assertEqual(t, injectedErr.Error(), err.Error())
+}
+
+func TestWithErrorInjectionSelectiveOps(t *testing.T) {
+	inj := inject.NewInjector()
+	injectedErr := fmt.Errorf("publish broken")
+	inj.Set("notification", "Publish", injectedErr, inject.Always{})
+
+	n := newTestNotification(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	// CreateTopic should succeed (not injected).
+	topic, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "sel-topic"})
+	requireNoError(t, err)
+
+	// Publish should fail (injected).
+	_, err = n.Publish(ctx, driver.PublishInput{
+		TopicID: topic.ARN,
+		Message: "hello",
+	})
+	assertError(t, err, true)
+	assertEqual(t, injectedErr.Error(), err.Error())
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	inj := inject.NewInjector()
+	rec := recorder.New()
+	injectedErr := fmt.Errorf("injected")
+	inj.Set("notification", "GetTopic", injectedErr, inject.Always{})
+
+	n := newTestNotification(WithErrorInjection(inj), WithRecorder(rec))
+
+	_, _ = n.GetTopic(context.Background(), "any-id")
+
+	calls := rec.CallsFor("notification", "GetTopic")
+	assertEqual(t, 1, len(calls))
+
+	if calls[0].Error == nil {
+		t.Error("expected recorded error to be non-nil")
+	}
+}
+
+func TestWithErrorInjectionAndMetrics(t *testing.T) {
+	inj := inject.NewInjector()
+	mc := metrics.NewCollector()
+	injectedErr := fmt.Errorf("injected")
+	inj.Set("notification", "DeleteTopic", injectedErr, inject.Always{})
+
+	n := newTestNotification(WithErrorInjection(inj), WithMetrics(mc))
+
+	_ = n.DeleteTopic(context.Background(), "any-id")
+
+	// The injected error should NOT record metrics since it returns before the driver call.
+	q := metrics.NewQuery(mc)
+
+	// calls_total should not be recorded for injected errors.
+	callsCount := q.ByName("calls_total").
+		ByLabel("service", "notification").
+		ByLabel("operation", "DeleteTopic").
+		Count()
+	assertEqual(t, 0, callsCount)
+}
+
+func TestWithLatency(t *testing.T) {
+	n := newTestNotification(WithLatency(1 * time.Millisecond))
+	ctx := context.Background()
+
+	start := time.Now()
+
+	_, _ = n.CreateTopic(ctx, driver.TopicConfig{Name: "lat-topic"})
+
+	elapsed := time.Since(start)
+
+	if elapsed < 1*time.Millisecond {
+		t.Errorf("expected at least 1ms latency, got %v", elapsed)
+	}
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+
+	n := newTestNotification(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+	)
+	ctx := context.Background()
+
+	topic, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "composed"})
+	requireNoError(t, err)
+	assertNotEmpty(t, topic.ID)
+
+	assertEqual(t, 1, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").
+		ByLabel("service", "notification").
+		Count()
+	assertEqual(t, 1, callsCount)
+}
+
+func TestSubscribeViaPortableAllPaths(t *testing.T) {
+	rec := recorder.New()
+	n := newTestNotification(WithRecorder(rec))
+	ctx := context.Background()
+
+	topic := createTopicVia(t, n, "full-flow")
+
+	sub, err := n.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "u@e.com",
+	})
+	requireNoError(t, err)
+
+	subs, err := n.ListSubscriptions(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(subs))
+
+	err = n.Unsubscribe(ctx, sub.ID)
+	requireNoError(t, err)
+
+	out, err := n.Publish(ctx, driver.PublishInput{
+		TopicID: topic.ARN, Message: "test msg",
+	})
+	requireNoError(t, err)
+	assertNotEmpty(t, out.MessageID)
+
+	// Verify all operations were recorded.
+	assertEqual(t, 5, rec.CallCount())
+	assertEqual(t, 1, rec.CallCountFor("notification", "Subscribe"))
+	assertEqual(t, 1, rec.CallCountFor("notification", "ListSubscriptions"))
+	assertEqual(t, 1, rec.CallCountFor("notification", "Unsubscribe"))
+	assertEqual(t, 1, rec.CallCountFor("notification", "Publish"))
+}

--- a/notification/notification_test.go
+++ b/notification/notification_test.go
@@ -12,42 +12,9 @@ import (
 	"github.com/stackshy/cloudemu/notification/driver"
 	"github.com/stackshy/cloudemu/providers/aws/sns"
 	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestNotification(opts ...Option) *Notification {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -60,7 +27,7 @@ func createTopicVia(t *testing.T, n *Notification, name string) *driver.TopicInf
 	t.Helper()
 
 	info, err := n.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -70,12 +37,12 @@ func TestCreateTopicPortable(t *testing.T) {
 	ctx := context.Background()
 
 	info, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "test-topic", DisplayName: "Test"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertNotEmpty(t, info.ID)
-	assertNotEmpty(t, info.ARN)
-	assertEqual(t, "test-topic", info.Name)
-	assertEqual(t, "Test", info.DisplayName)
+	assert.NotEmpty(t, info.ID)
+	assert.NotEmpty(t, info.ResourceID)
+	assert.Equal(t, "test-topic", info.Name)
+	assert.Equal(t, "Test", info.DisplayName)
 }
 
 func TestCreateTopicPortableError(t *testing.T) {
@@ -83,7 +50,7 @@ func TestCreateTopicPortableError(t *testing.T) {
 	ctx := context.Background()
 
 	_, err := n.CreateTopic(ctx, driver.TopicConfig{})
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestDeleteTopicPortable(t *testing.T) {
@@ -92,15 +59,15 @@ func TestDeleteTopicPortable(t *testing.T) {
 
 	info := createTopicVia(t, n, "del-topic")
 
-	err := n.DeleteTopic(ctx, info.ARN)
-	requireNoError(t, err)
+	err := n.DeleteTopic(ctx, info.Name)
+	require.NoError(t, err)
 }
 
 func TestDeleteTopicPortableNotFound(t *testing.T) {
 	n := newTestNotification()
 
 	err := n.DeleteTopic(context.Background(), "arn:aws:sns:us-east-1:123456789012:nope")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestGetTopicPortable(t *testing.T) {
@@ -109,16 +76,16 @@ func TestGetTopicPortable(t *testing.T) {
 
 	created := createTopicVia(t, n, "get-topic")
 
-	info, err := n.GetTopic(ctx, created.ARN)
-	requireNoError(t, err)
-	assertEqual(t, "get-topic", info.Name)
+	info, err := n.GetTopic(ctx, created.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "get-topic", info.Name)
 }
 
 func TestGetTopicPortableNotFound(t *testing.T) {
 	n := newTestNotification()
 
 	_, err := n.GetTopic(context.Background(), "arn:aws:sns:us-east-1:123456789012:nope")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListTopicsPortable(t *testing.T) {
@@ -126,15 +93,15 @@ func TestListTopicsPortable(t *testing.T) {
 	ctx := context.Background()
 
 	topics, err := n.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 
 	createTopicVia(t, n, "t1")
 	createTopicVia(t, n, "t2")
 
 	topics, err = n.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 2, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(topics))
 }
 
 func TestSubscribePortable(t *testing.T) {
@@ -144,13 +111,13 @@ func TestSubscribePortable(t *testing.T) {
 	topic := createTopicVia(t, n, "sub-topic")
 
 	sub, err := n.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertNotEmpty(t, sub.ID)
-	assertEqual(t, "email", sub.Protocol)
-	assertEqual(t, "confirmed", sub.Status)
+	assert.NotEmpty(t, sub.ID)
+	assert.Equal(t, "email", sub.Protocol)
+	assert.Equal(t, "confirmed", sub.Status)
 }
 
 func TestSubscribePortableError(t *testing.T) {
@@ -159,7 +126,7 @@ func TestSubscribePortableError(t *testing.T) {
 	_, err := n.Subscribe(context.Background(), driver.SubscriptionConfig{
 		TopicID: "arn:aws:sns:us-east-1:123456789012:nope", Protocol: "email", Endpoint: "a@b.com",
 	})
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestUnsubscribePortable(t *testing.T) {
@@ -169,19 +136,19 @@ func TestUnsubscribePortable(t *testing.T) {
 	topic := createTopicVia(t, n, "unsub-topic")
 
 	sub, err := n.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = n.Unsubscribe(ctx, sub.ID)
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestUnsubscribePortableNotFound(t *testing.T) {
 	n := newTestNotification()
 
 	err := n.Unsubscribe(context.Background(), "nonexistent-sub")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSubscriptionsPortable(t *testing.T) {
@@ -191,20 +158,20 @@ func TestListSubscriptionsPortable(t *testing.T) {
 	topic := createTopicVia(t, n, "list-subs")
 
 	_, err := n.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "x@y.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "x@y.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	subs, err := n.ListSubscriptions(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 1, len(subs))
+	subs, err := n.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(subs))
 }
 
 func TestListSubscriptionsPortableNotFound(t *testing.T) {
 	n := newTestNotification()
 
 	_, err := n.ListSubscriptions(context.Background(), "arn:aws:sns:us-east-1:123456789012:nope")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPublishPortable(t *testing.T) {
@@ -214,11 +181,11 @@ func TestPublishPortable(t *testing.T) {
 	topic := createTopicVia(t, n, "pub-topic")
 
 	out, err := n.Publish(ctx, driver.PublishInput{
-		TopicID: topic.ARN,
+		TopicID: topic.Name,
 		Message: "hello",
 	})
-	requireNoError(t, err)
-	assertNotEmpty(t, out.MessageID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.MessageID)
 }
 
 func TestPublishPortableError(t *testing.T) {
@@ -228,7 +195,7 @@ func TestPublishPortableError(t *testing.T) {
 		TopicID: "arn:aws:sns:us-east-1:123456789012:nope",
 		Message: "hello",
 	})
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithRecorder(t *testing.T) {
@@ -238,12 +205,12 @@ func TestWithRecorder(t *testing.T) {
 
 	_, _ = n.CreateTopic(ctx, driver.TopicConfig{Name: "rec-topic"})
 
-	assertEqual(t, 1, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCount())
 
 	calls := rec.CallsFor("notification", "CreateTopic")
-	assertEqual(t, 1, len(calls))
-	assertEqual(t, "notification", calls[0].Service)
-	assertEqual(t, "CreateTopic", calls[0].Operation)
+	assert.Equal(t, 1, len(calls))
+	assert.Equal(t, "notification", calls[0].Service)
+	assert.Equal(t, "CreateTopic", calls[0].Operation)
 }
 
 func TestWithRecorderMultipleOps(t *testing.T) {
@@ -252,17 +219,17 @@ func TestWithRecorderMultipleOps(t *testing.T) {
 	ctx := context.Background()
 
 	topic, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "rec-multi"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	_, _ = n.GetTopic(ctx, topic.ARN)
+	_, _ = n.GetTopic(ctx, topic.Name)
 	_, _ = n.ListTopics(ctx)
-	_ = n.DeleteTopic(ctx, topic.ARN)
+	_ = n.DeleteTopic(ctx, topic.Name)
 
-	assertEqual(t, 4, rec.CallCount())
-	assertEqual(t, 1, rec.CallCountFor("notification", "CreateTopic"))
-	assertEqual(t, 1, rec.CallCountFor("notification", "GetTopic"))
-	assertEqual(t, 1, rec.CallCountFor("notification", "ListTopics"))
-	assertEqual(t, 1, rec.CallCountFor("notification", "DeleteTopic"))
+	assert.Equal(t, 4, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCountFor("notification", "CreateTopic"))
+	assert.Equal(t, 1, rec.CallCountFor("notification", "GetTopic"))
+	assert.Equal(t, 1, rec.CallCountFor("notification", "ListTopics"))
+	assert.Equal(t, 1, rec.CallCountFor("notification", "DeleteTopic"))
 }
 
 func TestWithRecorderRecordsErrors(t *testing.T) {
@@ -272,11 +239,8 @@ func TestWithRecorderRecordsErrors(t *testing.T) {
 	_, _ = n.CreateTopic(context.Background(), driver.TopicConfig{})
 
 	calls := rec.CallsFor("notification", "CreateTopic")
-	assertEqual(t, 1, len(calls))
-
-	if calls[0].Error == nil {
-		t.Error("expected recorded error to be non-nil")
-	}
+	assert.Equal(t, 1, len(calls))
+	assert.NotNil(t, calls[0].Error)
 }
 
 func TestWithMetrics(t *testing.T) {
@@ -292,13 +256,13 @@ func TestWithMetrics(t *testing.T) {
 		ByLabel("service", "notification").
 		ByLabel("operation", "CreateTopic").
 		Count()
-	assertEqual(t, 1, callsCount)
+	assert.Equal(t, 1, callsCount)
 
 	durCount := q.ByName("call_duration").
 		ByLabel("service", "notification").
 		ByLabel("operation", "CreateTopic").
 		Count()
-	assertEqual(t, 1, durCount)
+	assert.Equal(t, 1, durCount)
 }
 
 func TestWithMetricsRecordsErrors(t *testing.T) {
@@ -313,7 +277,7 @@ func TestWithMetricsRecordsErrors(t *testing.T) {
 		ByLabel("service", "notification").
 		ByLabel("operation", "CreateTopic").
 		Count()
-	assertEqual(t, 1, errCount)
+	assert.Equal(t, 1, errCount)
 }
 
 func TestWithMetricsNoErrorMetricOnSuccess(t *testing.T) {
@@ -328,7 +292,7 @@ func TestWithMetricsNoErrorMetricOnSuccess(t *testing.T) {
 		ByLabel("service", "notification").
 		ByLabel("operation", "CreateTopic").
 		Count()
-	assertEqual(t, 0, errCount)
+	assert.Equal(t, 0, errCount)
 }
 
 func TestWithErrorInjection(t *testing.T) {
@@ -339,8 +303,8 @@ func TestWithErrorInjection(t *testing.T) {
 	n := newTestNotification(WithErrorInjection(inj))
 
 	_, err := n.CreateTopic(context.Background(), driver.TopicConfig{Name: "inj-topic"})
-	assertError(t, err, true)
-	assertEqual(t, injectedErr.Error(), err.Error())
+	require.Error(t, err)
+	assert.Equal(t, injectedErr.Error(), err.Error())
 }
 
 func TestWithErrorInjectionSelectiveOps(t *testing.T) {
@@ -353,15 +317,15 @@ func TestWithErrorInjectionSelectiveOps(t *testing.T) {
 
 	// CreateTopic should succeed (not injected).
 	topic, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "sel-topic"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	// Publish should fail (injected).
 	_, err = n.Publish(ctx, driver.PublishInput{
-		TopicID: topic.ARN,
+		TopicID: topic.Name,
 		Message: "hello",
 	})
-	assertError(t, err, true)
-	assertEqual(t, injectedErr.Error(), err.Error())
+	require.Error(t, err)
+	assert.Equal(t, injectedErr.Error(), err.Error())
 }
 
 func TestWithErrorInjectionRecorded(t *testing.T) {
@@ -375,11 +339,8 @@ func TestWithErrorInjectionRecorded(t *testing.T) {
 	_, _ = n.GetTopic(context.Background(), "any-id")
 
 	calls := rec.CallsFor("notification", "GetTopic")
-	assertEqual(t, 1, len(calls))
-
-	if calls[0].Error == nil {
-		t.Error("expected recorded error to be non-nil")
-	}
+	assert.Equal(t, 1, len(calls))
+	assert.NotNil(t, calls[0].Error)
 }
 
 func TestWithErrorInjectionAndMetrics(t *testing.T) {
@@ -400,7 +361,7 @@ func TestWithErrorInjectionAndMetrics(t *testing.T) {
 		ByLabel("service", "notification").
 		ByLabel("operation", "DeleteTopic").
 		Count()
-	assertEqual(t, 0, callsCount)
+	assert.Equal(t, 0, callsCount)
 }
 
 func TestWithLatency(t *testing.T) {
@@ -413,9 +374,7 @@ func TestWithLatency(t *testing.T) {
 
 	elapsed := time.Since(start)
 
-	if elapsed < 1*time.Millisecond {
-		t.Errorf("expected at least 1ms latency, got %v", elapsed)
-	}
+	assert.GreaterOrEqual(t, elapsed, 1*time.Millisecond)
 }
 
 func TestAllOptionsComposed(t *testing.T) {
@@ -431,17 +390,17 @@ func TestAllOptionsComposed(t *testing.T) {
 	ctx := context.Background()
 
 	topic, err := n.CreateTopic(ctx, driver.TopicConfig{Name: "composed"})
-	requireNoError(t, err)
-	assertNotEmpty(t, topic.ID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, topic.ID)
 
-	assertEqual(t, 1, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCount())
 
 	q := metrics.NewQuery(mc)
 
 	callsCount := q.ByName("calls_total").
 		ByLabel("service", "notification").
 		Count()
-	assertEqual(t, 1, callsCount)
+	assert.Equal(t, 1, callsCount)
 }
 
 func TestSubscribeViaPortableAllPaths(t *testing.T) {
@@ -452,27 +411,27 @@ func TestSubscribeViaPortableAllPaths(t *testing.T) {
 	topic := createTopicVia(t, n, "full-flow")
 
 	sub, err := n.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "u@e.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "u@e.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	subs, err := n.ListSubscriptions(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 1, len(subs))
+	subs, err := n.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(subs))
 
 	err = n.Unsubscribe(ctx, sub.ID)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	out, err := n.Publish(ctx, driver.PublishInput{
-		TopicID: topic.ARN, Message: "test msg",
+		TopicID: topic.Name, Message: "test msg",
 	})
-	requireNoError(t, err)
-	assertNotEmpty(t, out.MessageID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.MessageID)
 
 	// Verify all operations were recorded.
-	assertEqual(t, 5, rec.CallCount())
-	assertEqual(t, 1, rec.CallCountFor("notification", "Subscribe"))
-	assertEqual(t, 1, rec.CallCountFor("notification", "ListSubscriptions"))
-	assertEqual(t, 1, rec.CallCountFor("notification", "Unsubscribe"))
-	assertEqual(t, 1, rec.CallCountFor("notification", "Publish"))
+	assert.Equal(t, 5, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCountFor("notification", "Subscribe"))
+	assert.Equal(t, 1, rec.CallCountFor("notification", "ListSubscriptions"))
+	assert.Equal(t, 1, rec.CallCountFor("notification", "Unsubscribe"))
+	assert.Equal(t, 1, rec.CallCountFor("notification", "Publish"))
 }

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -5,44 +5,56 @@ import (
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/providers/aws/awsiam"
 	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatchlogs"
 	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
 	"github.com/stackshy/cloudemu/providers/aws/ec2"
+	"github.com/stackshy/cloudemu/providers/aws/elasticache"
 	"github.com/stackshy/cloudemu/providers/aws/elb"
 	"github.com/stackshy/cloudemu/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/providers/aws/route53"
 	"github.com/stackshy/cloudemu/providers/aws/s3"
+	"github.com/stackshy/cloudemu/providers/aws/secretsmanager"
+	"github.com/stackshy/cloudemu/providers/aws/sns"
 	"github.com/stackshy/cloudemu/providers/aws/sqs"
 	"github.com/stackshy/cloudemu/providers/aws/vpc"
 )
 
 // Provider holds all AWS mock services.
 type Provider struct {
-	S3         *s3.Mock
-	EC2        *ec2.Mock
-	DynamoDB   *dynamodb.Mock
-	Lambda     *lambda.Mock
-	VPC        *vpc.Mock
-	CloudWatch *cloudwatch.Mock
-	IAM        *awsiam.Mock
-	Route53    *route53.Mock
-	ELB        *elb.Mock
-	SQS        *sqs.Mock
+	S3             *s3.Mock
+	EC2            *ec2.Mock
+	DynamoDB       *dynamodb.Mock
+	Lambda         *lambda.Mock
+	VPC            *vpc.Mock
+	CloudWatch     *cloudwatch.Mock
+	IAM            *awsiam.Mock
+	Route53        *route53.Mock
+	ELB            *elb.Mock
+	SQS            *sqs.Mock
+	ElastiCache    *elasticache.Mock
+	SecretsManager *secretsmanager.Mock
+	CloudWatchLogs *cloudwatchlogs.Mock
+	SNS            *sns.Mock
 }
 
 // New creates a new AWS provider with all mock services.
 func New(opts ...config.Option) *Provider {
 	o := config.NewOptions(opts...)
 	p := &Provider{
-		S3:         s3.New(o),
-		EC2:        ec2.New(o),
-		DynamoDB:   dynamodb.New(o),
-		Lambda:     lambda.New(o),
-		VPC:        vpc.New(o),
-		CloudWatch: cloudwatch.New(o),
-		IAM:        awsiam.New(o),
-		Route53:    route53.New(o),
-		ELB:        elb.New(o),
-		SQS:        sqs.New(o),
+		S3:             s3.New(o),
+		EC2:            ec2.New(o),
+		DynamoDB:       dynamodb.New(o),
+		Lambda:         lambda.New(o),
+		VPC:            vpc.New(o),
+		CloudWatch:     cloudwatch.New(o),
+		IAM:            awsiam.New(o),
+		Route53:        route53.New(o),
+		ELB:            elb.New(o),
+		SQS:            sqs.New(o),
+		ElastiCache:    elasticache.New(o),
+		SecretsManager: secretsmanager.New(o),
+		CloudWatchLogs: cloudwatchlogs.New(o),
+		SNS:            sns.New(o),
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
 

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -1,0 +1,296 @@
+// Package cloudwatchlogs provides an in-memory mock implementation of AWS CloudWatch Logs.
+package cloudwatchlogs
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/logging/driver"
+)
+
+// Compile-time check that Mock implements driver.Logging.
+var _ driver.Logging = (*Mock)(nil)
+
+type logStream struct {
+	info   driver.LogStreamInfo
+	events []driver.LogEvent
+	mu     sync.RWMutex
+}
+
+type logGroup struct {
+	info    driver.LogGroupInfo
+	streams *memstore.Store[*logStream]
+}
+
+// Mock is an in-memory mock implementation of the AWS CloudWatch Logs service.
+type Mock struct {
+	groups *memstore.Store[*logGroup]
+	opts   *config.Options
+}
+
+// New creates a new CloudWatch Logs mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		groups: memstore.New[*logGroup](),
+		opts:   opts,
+	}
+}
+
+// CreateLogGroup creates a new CloudWatch log group.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "log group name is required")
+	}
+
+	if m.groups.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "log group %q already exists", cfg.Name)
+	}
+
+	retentionDays := cfg.RetentionDays
+	if retentionDays == 0 {
+		retentionDays = 30
+	}
+
+	arn := idgen.AWSARN("logs", m.opts.Region, m.opts.AccountID, "log-group:"+cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.LogGroupInfo{
+		Name:          cfg.Name,
+		ARN:           arn,
+		RetentionDays: retentionDays,
+		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		StoredBytes:   0,
+		Tags:          tags,
+	}
+
+	g := &logGroup{
+		info:    info,
+		streams: memstore.New[*logStream](),
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteLogGroup deletes a CloudWatch log group by name.
+func (m *Mock) DeleteLogGroup(_ context.Context, name string) error {
+	if !m.groups.Delete(name) {
+		return errors.Newf(errors.NotFound, "log group %q not found", name)
+	}
+
+	return nil
+}
+
+// GetLogGroup retrieves information about a CloudWatch log group.
+func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", name)
+	}
+
+	result := g.info
+
+	return &result, nil
+}
+
+// ListLogGroups lists all CloudWatch log groups.
+func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+	all := m.groups.All()
+
+	groups := make([]driver.LogGroupInfo, 0, len(all))
+	for _, g := range all {
+		groups = append(groups, g.info)
+	}
+
+	return groups, nil
+}
+
+// CreateLogStream creates a new log stream in a log group.
+func (m *Mock) CreateLogStream(_ context.Context, logGroup, streamName string) (*driver.LogStreamInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if streamName == "" {
+		return nil, errors.New(errors.InvalidArgument, "stream name is required")
+	}
+
+	if g.streams.Has(streamName) {
+		return nil, errors.Newf(errors.AlreadyExists, "log stream %q already exists in group %q", streamName, logGroup)
+	}
+
+	info := driver.LogStreamInfo{
+		Name:      streamName,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	s := &logStream{
+		info:   info,
+		events: make([]driver.LogEvent, 0),
+	}
+
+	g.streams.Set(streamName, s)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteLogStream deletes a log stream from a log group.
+func (m *Mock) DeleteLogStream(_ context.Context, logGroup, streamName string) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if !g.streams.Delete(streamName) {
+		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, logGroup)
+	}
+
+	return nil
+}
+
+// ListLogStreams lists all log streams in a log group.
+func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogStreamInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	all := g.streams.All()
+
+	streams := make([]driver.LogStreamInfo, 0, len(all))
+	for _, s := range all {
+		s.mu.RLock()
+		streams = append(streams, s.info)
+		s.mu.RUnlock()
+	}
+
+	return streams, nil
+}
+
+// PutLogEvents writes log events to a stream.
+func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, events []driver.LogEvent) error {
+	g, ok := m.groups.Get(groupName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", groupName)
+	}
+
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, groupName)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	copied := make([]driver.LogEvent, len(events))
+	copy(copied, events)
+
+	s.events = append(s.events, copied...)
+
+	if len(events) > 0 {
+		s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
+	}
+
+	// Update stored bytes estimate.
+	var totalBytes int64
+	for _, e := range events {
+		totalBytes += int64(len(e.Message))
+	}
+
+	m.groups.Update(groupName, func(lg *logGroup) *logGroup {
+		lg.info.StoredBytes += totalBytes
+		return lg
+	})
+
+	return nil
+}
+
+// GetLogEvents retrieves log events matching the query.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+	g, ok := m.groups.Get(input.LogGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", input.LogGroup)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var results []driver.LogEvent
+
+	if input.LogStream != "" {
+		events := m.getStreamEvents(g, input.LogStream, input)
+		results = append(results, events...)
+	} else {
+		all := g.streams.All()
+		for _, s := range all {
+			events := m.filterEvents(s, input)
+			results = append(results, events...)
+		}
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	if results == nil {
+		results = []driver.LogEvent{}
+	}
+
+	return results, nil
+}
+
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQueryInput) []driver.LogEvent {
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return nil
+	}
+
+	return m.filterEvents(s, input)
+}
+
+func (m *Mock) filterEvents(s *logStream, input driver.LogQueryInput) []driver.LogEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []driver.LogEvent
+
+	for _, e := range s.events {
+		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
+			continue
+		}
+
+		if !input.EndTime.IsZero() && e.Timestamp.After(input.EndTime) {
+			continue
+		}
+
+		if input.Pattern != "" && !strings.Contains(e.Message, input.Pattern) {
+			continue
+		}
+
+		results = append(results, e)
+	}
+
+	return results
+}

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stackshy/cloudemu/logging/driver"
 )
 
+const (
+	defaultRetentionDays = 30
+	defaultLogLimit      = 100
+)
+
 // Compile-time check that Mock implements driver.Logging.
 var _ driver.Logging = (*Mock)(nil)
 
@@ -54,7 +59,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	retentionDays := cfg.RetentionDays
 	if retentionDays == 0 {
-		retentionDays = 30
+		retentionDays = defaultRetentionDays
 	}
 
 	arn := idgen.AWSARN("logs", m.opts.Region, m.opts.AccountID, "log-group:"+cfg.Name)
@@ -66,7 +71,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
-		ARN:           arn,
+		ResourceID:    arn,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		StoredBytes:   0,
@@ -233,18 +238,20 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 
 	limit := input.Limit
 	if limit <= 0 {
-		limit = 100
+		limit = defaultLogLimit
 	}
+
+	retentionCutoff := m.opts.Clock.Now().AddDate(0, 0, -g.info.RetentionDays)
 
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, &input)
+		events := m.getStreamEvents(g, input.LogStream, &input, retentionCutoff)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, &input)
+			events := m.filterEvents(s, &input, retentionCutoff)
 			results = append(results, events...)
 		}
 	}
@@ -260,22 +267,26 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput) []driver.LogEvent {
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
 	s, ok := g.streams.Get(streamName)
 	if !ok {
 		return nil
 	}
 
-	return m.filterEvents(s, input)
+	return m.filterEvents(s, input, retentionCutoff)
 }
 
-func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput) []driver.LogEvent {
+func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var results []driver.LogEvent
 
 	for _, e := range s.events {
+		if !retentionCutoff.IsZero() && e.Timestamp.Before(retentionCutoff) {
+			continue
+		}
+
 		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
 			continue
 		}

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -43,8 +43,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateLogGroup creates a new CloudWatch log group.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "log group name is required")
@@ -176,6 +174,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 	all := g.streams.All()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
+
 	for _, s := range all {
 		s.mu.RLock()
 		streams = append(streams, s.info)
@@ -240,12 +239,12 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, input)
+		events := m.getStreamEvents(g, input.LogStream, &input)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, input)
+			events := m.filterEvents(s, &input)
 			results = append(results, events...)
 		}
 	}
@@ -261,7 +260,7 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQueryInput) []driver.LogEvent {
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput) []driver.LogEvent {
 	s, ok := g.streams.Get(streamName)
 	if !ok {
 		return nil
@@ -270,7 +269,7 @@ func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQ
 	return m.filterEvents(s, input)
 }
 
-func (m *Mock) filterEvents(s *logStream, input driver.LogQueryInput) []driver.LogEvent {
+func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -57,10 +24,10 @@ func setupGroupAndStream(t *testing.T, m *Mock) {
 	ctx := context.Background()
 
 	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.CreateLogStream(ctx, "test-group", "test-stream")
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateLogGroup(t *testing.T) {
@@ -72,12 +39,12 @@ func TestCreateLogGroup(t *testing.T) {
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
 			Name: "my-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "my-group", info.Name)
-		assertNotEmpty(t, info.ARN)
-		assertNotEmpty(t, info.CreatedAt)
-		assertEqual(t, int64(0), info.StoredBytes)
+		assert.Equal(t, "my-group", info.Name)
+		assert.NotEmpty(t, info.ResourceID)
+		assert.NotEmpty(t, info.CreatedAt)
+		assert.Equal(t, int64(0), info.StoredBytes)
 	})
 
 	t.Run("default retention 30 days", func(t *testing.T) {
@@ -86,9 +53,9 @@ func TestCreateLogGroup(t *testing.T) {
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
 			Name: "retention-test",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 30, info.RetentionDays)
+		assert.Equal(t, 30, info.RetentionDays)
 	})
 
 	t.Run("custom retention", func(t *testing.T) {
@@ -98,9 +65,9 @@ func TestCreateLogGroup(t *testing.T) {
 			Name:          "custom-ret",
 			RetentionDays: 90,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 90, info.RetentionDays)
+		assert.Equal(t, 90, info.RetentionDays)
 	})
 
 	t.Run("with tags", func(t *testing.T) {
@@ -111,27 +78,27 @@ func TestCreateLogGroup(t *testing.T) {
 			Name: "tagged-group",
 			Tags: tags,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "prod", info.Tags["env"])
-		assertEqual(t, "backend", info.Tags["team"])
+		assert.Equal(t, "prod", info.Tags["env"])
+		assert.Equal(t, "backend", info.Tags["team"])
 	})
 
 	t.Run("empty name error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("duplicate error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -142,20 +109,20 @@ func TestDeleteLogGroup(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del-me"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.DeleteLogGroup(ctx, "del-me")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.GetLogGroup(ctx, "del-me")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.DeleteLogGroup(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -166,19 +133,19 @@ func TestGetLogGroup(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "get-me"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.GetLogGroup(ctx, "get-me")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "get-me", info.Name)
+		assert.Equal(t, "get-me", info.Name)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.GetLogGroup(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -189,24 +156,24 @@ func TestListLogGroups(t *testing.T) {
 		m := newTestMock()
 
 		groups, err := m.ListLogGroups(ctx)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(groups))
+		assert.Equal(t, 0, len(groups))
 	})
 
 	t.Run("multiple groups", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		groups, err := m.ListLogGroups(ctx)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(groups))
+		assert.Equal(t, 2, len(groups))
 	})
 }
 
@@ -217,43 +184,43 @@ func TestCreateLogStream(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.CreateLogStream(ctx, "grp", "stream-1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "stream-1", info.Name)
-		assertNotEmpty(t, info.CreatedAt)
+		assert.Equal(t, "stream-1", info.Name)
+		assert.NotEmpty(t, info.CreatedAt)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogStream(ctx, "no-group", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("empty stream name error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("duplicate stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -265,24 +232,24 @@ func TestDeleteLogStream(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		err := m.DeleteLogStream(ctx, "test-group", "test-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.DeleteLogStream(ctx, "no-group", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("not found stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.DeleteLogStream(ctx, "grp", "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -293,25 +260,25 @@ func TestListLogStreams(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "s1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "s2")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		streams, err := m.ListLogStreams(ctx, "grp")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(streams))
+		assert.Equal(t, 2, len(streams))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.ListLogStreams(ctx, "no-group")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -329,7 +296,7 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("updates LastEvent", func(t *testing.T) {
@@ -342,13 +309,13 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		streams, err := m.ListLogStreams(ctx, "test-group")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		expected := baseTime.Add(5 * time.Second).UTC().Format(time.RFC3339)
-		assertEqual(t, expected, streams[0].LastEvent)
+		assert.Equal(t, expected, streams[0].LastEvent)
 	})
 
 	t.Run("updates StoredBytes", func(t *testing.T) {
@@ -360,29 +327,29 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.GetLogGroup(ctx, "test-group")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, int64(5), info.StoredBytes)
+		assert.Equal(t, int64(5), info.StoredBytes)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.PutLogEvents(ctx, "no-group", "s1", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("nonexistent stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -395,24 +362,24 @@ func TestGetLogEvents(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		_, err := m.CreateLogStream(ctx, "test-group", "stream-2")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "msg1"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "stream-2", []driver.LogEvent{
 			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("specific stream filter", func(t *testing.T) {
@@ -420,26 +387,26 @@ func TestGetLogEvents(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		_, err := m.CreateLogStream(ctx, "test-group", "other")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "target"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "other", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "ignore"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "test-group",
 			LogStream: "test-stream",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 1, len(events))
-		assertEqual(t, "target", events[0].Message)
+		assert.Equal(t, 1, len(events))
+		assert.Equal(t, "target", events[0].Message)
 	})
 
 	t.Run("pattern filter", func(t *testing.T) {
@@ -451,15 +418,15 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime.Add(time.Second), Message: "INFO: all good"},
 			{Timestamp: baseTime.Add(2 * time.Second), Message: "ERROR: another failure"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 			Pattern:  "ERROR",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("time range filter", func(t *testing.T) {
@@ -471,17 +438,17 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime.Add(time.Hour), Message: "middle"},
 			{Timestamp: baseTime.Add(2 * time.Hour), Message: "late"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "test-group",
 			StartTime: baseTime.Add(30 * time.Minute),
 			EndTime:   baseTime.Add(90 * time.Minute),
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 1, len(events))
-		assertEqual(t, "middle", events[0].Message)
+		assert.Equal(t, 1, len(events))
+		assert.Equal(t, "middle", events[0].Message)
 	})
 
 	t.Run("with limit", func(t *testing.T) {
@@ -497,15 +464,15 @@ func TestGetLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 			Limit:    3,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 3, len(result))
+		assert.Equal(t, 3, len(result))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
@@ -514,22 +481,22 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "no-group",
 		})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("nonexistent stream returns empty", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(events))
+		assert.Equal(t, 0, len(events))
 	})
 
 	t.Run("default limit 100", func(t *testing.T) {
@@ -545,27 +512,27 @@ func TestGetLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 100, len(result))
+		assert.Equal(t, 100, len(result))
 	})
 
 	t.Run("empty group returns empty slice", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "empty-grp",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(events))
+		assert.Equal(t, 0, len(events))
 	})
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -1,0 +1,571 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/logging/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func setupGroupAndStream(t *testing.T, m *Mock) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
+	requireNoError(t, err)
+
+	_, err = m.CreateLogStream(ctx, "test-group", "test-stream")
+	requireNoError(t, err)
+}
+
+func TestCreateLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "my-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, "my-group", info.Name)
+		assertNotEmpty(t, info.ARN)
+		assertNotEmpty(t, info.CreatedAt)
+		assertEqual(t, int64(0), info.StoredBytes)
+	})
+
+	t.Run("default retention 30 days", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "retention-test",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 30, info.RetentionDays)
+	})
+
+	t.Run("custom retention", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name:          "custom-ret",
+			RetentionDays: 90,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 90, info.RetentionDays)
+	})
+
+	t.Run("with tags", func(t *testing.T) {
+		m := newTestMock()
+		tags := map[string]string{"env": "prod", "team": "backend"}
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "tagged-group",
+			Tags: tags,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, "prod", info.Tags["env"])
+		assertEqual(t, "backend", info.Tags["team"])
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del-me"})
+		requireNoError(t, err)
+
+		err = m.DeleteLogGroup(ctx, "del-me")
+		requireNoError(t, err)
+
+		_, err = m.GetLogGroup(ctx, "del-me")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.DeleteLogGroup(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "get-me"})
+		requireNoError(t, err)
+
+		info, err := m.GetLogGroup(ctx, "get-me")
+		requireNoError(t, err)
+
+		assertEqual(t, "get-me", info.Name)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.GetLogGroup(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogGroups(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		m := newTestMock()
+
+		groups, err := m.ListLogGroups(ctx)
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(groups))
+	})
+
+	t.Run("multiple groups", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
+		requireNoError(t, err)
+
+		groups, err := m.ListLogGroups(ctx)
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(groups))
+	})
+}
+
+func TestCreateLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		info, err := m.CreateLogStream(ctx, "grp", "stream-1")
+		requireNoError(t, err)
+
+		assertEqual(t, "stream-1", info.Name)
+		assertNotEmpty(t, info.CreatedAt)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogStream(ctx, "no-group", "s1")
+		assertError(t, err, true)
+	})
+
+	t.Run("empty stream name error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.DeleteLogStream(ctx, "test-group", "test-stream")
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.DeleteLogStream(ctx, "no-group", "s1")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		err = m.DeleteLogStream(ctx, "grp", "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogStreams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "s1")
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "s2")
+		requireNoError(t, err)
+
+		streams, err := m.ListLogStreams(ctx, "grp")
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(streams))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.ListLogStreams(ctx, "no-group")
+		assertError(t, err, true)
+	})
+}
+
+func TestPutLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "hello"},
+			{Timestamp: baseTime.Add(time.Second), Message: "world"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+	})
+
+	t.Run("updates LastEvent", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "first"},
+			{Timestamp: baseTime.Add(5 * time.Second), Message: "last"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		streams, err := m.ListLogStreams(ctx, "test-group")
+		requireNoError(t, err)
+
+		expected := baseTime.Add(5 * time.Second).UTC().Format(time.RFC3339)
+		assertEqual(t, expected, streams[0].LastEvent)
+	})
+
+	t.Run("updates StoredBytes", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "12345"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		info, err := m.GetLogGroup(ctx, "test-group")
+		requireNoError(t, err)
+
+		assertEqual(t, int64(5), info.StoredBytes)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.PutLogEvents(ctx, "no-group", "s1", nil)
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("all events from all streams", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		_, err := m.CreateLogStream(ctx, "test-group", "stream-2")
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "msg1"},
+		})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "stream-2", []driver.LogEvent{
+			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("specific stream filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		_, err := m.CreateLogStream(ctx, "test-group", "other")
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "target"},
+		})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "other", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "ignore"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "test-group",
+			LogStream: "test-stream",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 1, len(events))
+		assertEqual(t, "target", events[0].Message)
+	})
+
+	t.Run("pattern filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "ERROR: something failed"},
+			{Timestamp: baseTime.Add(time.Second), Message: "INFO: all good"},
+			{Timestamp: baseTime.Add(2 * time.Second), Message: "ERROR: another failure"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+			Pattern:  "ERROR",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("time range filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "early"},
+			{Timestamp: baseTime.Add(time.Hour), Message: "middle"},
+			{Timestamp: baseTime.Add(2 * time.Hour), Message: "late"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "test-group",
+			StartTime: baseTime.Add(30 * time.Minute),
+			EndTime:   baseTime.Add(90 * time.Minute),
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 1, len(events))
+		assertEqual(t, "middle", events[0].Message)
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := make([]driver.LogEvent, 10)
+		for i := range events {
+			events[i] = driver.LogEvent{
+				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+				Message:   "msg",
+			}
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+			Limit:    3,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 3, len(result))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "no-group",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent stream returns empty", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "grp",
+			LogStream: "no-stream",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(events))
+	})
+
+	t.Run("default limit 100", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := make([]driver.LogEvent, 150)
+		for i := range events {
+			events[i] = driver.LogEvent{
+				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+				Message:   "msg",
+			}
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 100, len(result))
+	})
+
+	t.Run("empty group returns empty slice", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "empty-grp",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(events))
+	})
+}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -4,7 +4,7 @@ package elasticache
 import (
 	"context"
 	"fmt"
-	"strings"
+	"path"
 	"time"
 
 	"github.com/stackshy/cloudemu/cache/driver"
@@ -12,6 +12,8 @@ import (
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
 )
+
+const defaultRedisPort = 6379
 
 // Compile-time check that Mock implements driver.Cache.
 var _ driver.Cache = (*Mock)(nil)
@@ -61,7 +63,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		nodeType = "cache.t3.micro"
 	}
 
-	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:6379", cfg.Name, m.opts.Region)
+	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:%d", cfg.Name, m.opts.Region, defaultRedisPort)
 
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
@@ -242,22 +244,16 @@ func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
 }
 
 // matchPattern matches a key against a glob-like pattern.
-// Supports "*" as a wildcard matching any sequence of characters.
+// Supports full glob syntax including middle wildcards like "user:*:session".
 func matchPattern(pattern, key string) bool {
 	if pattern == "" || pattern == "*" {
 		return true
 	}
 
-	// Simple prefix match for "prefix*" patterns.
-	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
-		return strings.HasPrefix(key, pattern[:len(pattern)-1])
+	matched, err := path.Match(pattern, key)
+	if err != nil {
+		return false
 	}
 
-	// Simple suffix match for "*suffix" patterns.
-	if strings.HasPrefix(pattern, "*") && !strings.Contains(pattern[1:], "*") {
-		return strings.HasSuffix(key, pattern[1:])
-	}
-
-	// Exact match as fallback.
-	return key == pattern
+	return matched
 }

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -42,8 +42,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateCache creates a new ElastiCache cluster.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "cache name is required")

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -1,0 +1,265 @@
+// Package elasticache provides an in-memory mock implementation of AWS ElastiCache.
+package elasticache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+)
+
+// Compile-time check that Mock implements driver.Cache.
+var _ driver.Cache = (*Mock)(nil)
+
+type cacheItem struct {
+	Value     []byte
+	ExpiresAt time.Time
+	HasTTL    bool
+}
+
+type cacheData struct {
+	info  driver.CacheInfo
+	items *memstore.Store[cacheItem]
+}
+
+// Mock is an in-memory mock implementation of the AWS ElastiCache service.
+type Mock struct {
+	caches *memstore.Store[*cacheData]
+	opts   *config.Options
+}
+
+// New creates a new ElastiCache mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		caches: memstore.New[*cacheData](),
+		opts:   opts,
+	}
+}
+
+// CreateCache creates a new ElastiCache cluster.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "cache name is required")
+	}
+
+	if m.caches.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "cache %q already exists", cfg.Name)
+	}
+
+	engine := cfg.Engine
+	if engine == "" {
+		engine = "redis"
+	}
+
+	nodeType := cfg.NodeType
+	if nodeType == "" {
+		nodeType = "cache.t3.micro"
+	}
+
+	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:6379", cfg.Name, m.opts.Region)
+
+	info := driver.CacheInfo{
+		Name:      cfg.Name,
+		NodeType:  nodeType,
+		Engine:    engine,
+		Status:    "available",
+		Endpoint:  endpoint,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	cd := &cacheData{
+		info:  info,
+		items: memstore.New[cacheItem](),
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteCache deletes an ElastiCache cluster by name.
+func (m *Mock) DeleteCache(_ context.Context, name string) error {
+	if !m.caches.Delete(name) {
+		return errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	return nil
+}
+
+// GetCache retrieves information about an ElastiCache cluster.
+func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	result := cd.info
+
+	return &result, nil
+}
+
+// ListCaches lists all ElastiCache clusters.
+func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+	all := m.caches.All()
+
+	caches := make([]driver.CacheInfo, 0, len(all))
+	for _, cd := range all {
+		caches = append(caches, cd.info)
+	}
+
+	return caches, nil
+}
+
+// Set stores a value in the cache with an optional TTL.
+func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	item := cacheItem{
+		Value: data,
+	}
+
+	if ttl > 0 {
+		item.ExpiresAt = m.opts.Clock.Now().Add(ttl)
+		item.HasTTL = true
+	}
+
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// Get retrieves a value from the cache.
+func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	// Check TTL expiry.
+	now := m.opts.Clock.Now()
+	if item.HasTTL && now.After(item.ExpiresAt) {
+		cd.items.Delete(key)
+
+		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	data := make([]byte, len(item.Value))
+	copy(data, item.Value)
+
+	result := &driver.Item{
+		Key:   key,
+		Value: data,
+	}
+
+	if item.HasTTL {
+		result.TTL = item.ExpiresAt.Sub(now)
+		result.ExpiresAt = item.ExpiresAt
+	}
+
+	return result, nil
+}
+
+// Delete removes a value from the cache.
+func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	if !cd.items.Delete(key) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	return nil
+}
+
+// Keys returns all keys matching the given pattern in the cache.
+// Supports "*" as a wildcard. Empty pattern returns all keys.
+func (m *Mock) Keys(_ context.Context, cacheName, pattern string) ([]string, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	now := m.opts.Clock.Now()
+	allKeys := cd.items.Keys()
+
+	var matched []string
+
+	for _, key := range allKeys {
+		item, ok := cd.items.Get(key)
+		if !ok {
+			continue
+		}
+
+		// Skip expired keys.
+		if item.HasTTL && now.After(item.ExpiresAt) {
+			cd.items.Delete(key)
+
+			continue
+		}
+
+		if matchPattern(pattern, key) {
+			matched = append(matched, key)
+		}
+	}
+
+	if matched == nil {
+		matched = []string{}
+	}
+
+	return matched, nil
+}
+
+// FlushAll removes all items from the cache.
+func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	cd.items.Clear()
+
+	return nil
+}
+
+// matchPattern matches a key against a glob-like pattern.
+// Supports "*" as a wildcard matching any sequence of characters.
+func matchPattern(pattern, key string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+
+	// Simple prefix match for "prefix*" patterns.
+	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
+		return strings.HasPrefix(key, pattern[:len(pattern)-1])
+	}
+
+	// Simple suffix match for "*suffix" patterns.
+	if strings.HasPrefix(pattern, "*") && !strings.Contains(pattern[1:], "*") {
+		return strings.HasSuffix(key, pattern[1:])
+	}
+
+	// Exact match as fallback.
+	return key == pattern
+}

--- a/providers/aws/elasticache/elasticache_test.go
+++ b/providers/aws/elasticache/elasticache_test.go
@@ -1,0 +1,412 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts), fc
+}
+
+func createTestCache(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateCache(context.Background(), driver.CacheConfig{Name: name})
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+}
+
+func TestCreateCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.CacheConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{name: "success with defaults", cfg: driver.CacheConfig{Name: "my-cache"}},
+		{
+			name: "success with custom engine and node type",
+			cfg:  driver.CacheConfig{Name: "custom", Engine: "memcached", NodeType: "cache.m5.large"},
+		},
+		{name: "empty name", cfg: driver.CacheConfig{}, expectErr: true},
+		{
+			name: "duplicate cache",
+			cfg:  driver.CacheConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestCache(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateCache(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, tc.cfg.Name, info.Name)
+			assertEqual(t, "available", info.Status)
+			assertNotEmpty(t, info.Endpoint)
+			assertNotEmpty(t, info.CreatedAt)
+		})
+	}
+}
+
+func TestCreateCacheDefaults(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "default-cache"})
+	requireNoError(t, err)
+
+	assertEqual(t, "redis", info.Engine)
+	assertEqual(t, "cache.t3.micro", info.NodeType)
+}
+
+func TestCreateCacheCustomValues(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name:     "custom-cache",
+		Engine:   "memcached",
+		NodeType: "cache.r6g.large",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "memcached", info.Engine)
+	assertEqual(t, "cache.r6g.large", info.NodeType)
+}
+
+func TestDeleteCache(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "to-delete")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteCache(ctx, "to-delete")
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteCache(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetCache(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := m.GetCache(ctx, "my-cache")
+		requireNoError(t, err)
+		assertEqual(t, "my-cache", info.Name)
+		assertEqual(t, "available", info.Status)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetCache(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListCaches(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		caches, err := m.ListCaches(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(caches))
+	})
+
+	createTestCache(t, m, "cache-a")
+	createTestCache(t, m, "cache-b")
+
+	t.Run("two caches", func(t *testing.T) {
+		caches, err := m.ListCaches(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(caches))
+	})
+}
+
+func TestSet(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
+		requireNoError(t, err)
+	})
+
+	t.Run("with TTL", func(t *testing.T) {
+		ttl := 5 * time.Minute
+		err := m.Set(ctx, "my-cache", "key-ttl", []byte("val"), ttl)
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		err := m.Set(ctx, "no-cache", "key1", []byte("val"), 0)
+		assertError(t, err, true)
+	})
+}
+
+func TestGet(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		item, getErr := m.Get(ctx, "my-cache", "key1")
+		requireNoError(t, getErr)
+		assertEqual(t, "key1", item.Key)
+		assertEqual(t, string([]byte("value1")), string(item.Value))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		_, getErr := m.Get(ctx, "no-cache", "key1")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		_, getErr := m.Get(ctx, "my-cache", "missing")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("expired key", func(t *testing.T) {
+		ttl := 10 * time.Second
+		setErr := m.Set(ctx, "my-cache", "expiring", []byte("temp"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(20 * time.Second)
+
+		_, getErr := m.Get(ctx, "my-cache", "expiring")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("not yet expired key", func(t *testing.T) {
+		ttl := 30 * time.Minute
+		setErr := m.Set(ctx, "my-cache", "long-lived", []byte("still-here"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(10 * time.Minute)
+
+		item, getErr := m.Get(ctx, "my-cache", "long-lived")
+		requireNoError(t, getErr)
+		assertEqual(t, "long-lived", item.Key)
+
+		if item.TTL <= 0 {
+			t.Error("expected positive TTL for non-expired key")
+		}
+	})
+}
+
+func TestDelete(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "key1", []byte("val"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := m.Delete(ctx, "my-cache", "key1")
+		requireNoError(t, delErr)
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		delErr := m.Delete(ctx, "my-cache", "missing")
+		assertError(t, delErr, true)
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		delErr := m.Delete(ctx, "no-cache", "key1")
+		assertError(t, delErr, true)
+	})
+}
+
+func TestKeys(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "user:1", []byte("a"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "user:2", []byte("b"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "session:abc", []byte("c"), 0)
+	requireNoError(t, err)
+
+	t.Run("wildcard all", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 3, len(keys))
+	})
+
+	t.Run("prefix match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "user:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 2, len(keys))
+	})
+
+	t.Run("suffix match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "*abc")
+		requireNoError(t, keysErr)
+		assertEqual(t, 1, len(keys))
+	})
+
+	t.Run("exact match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "user:1")
+		requireNoError(t, keysErr)
+		assertEqual(t, 1, len(keys))
+	})
+
+	t.Run("empty pattern returns all", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "")
+		requireNoError(t, keysErr)
+		assertEqual(t, 3, len(keys))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "orders:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		_, keysErr := m.Keys(ctx, "no-cache", "*")
+		assertError(t, keysErr, true)
+	})
+
+	t.Run("expired keys filtered out", func(t *testing.T) {
+		ttl := 5 * time.Second
+		setErr := m.Set(ctx, "my-cache", "temp:1", []byte("x"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(10 * time.Second)
+
+		keys, keysErr := m.Keys(ctx, "my-cache", "temp:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+}
+
+func TestFlushAll(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "k1", []byte("v1"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "k2", []byte("v2"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		flushErr := m.FlushAll(ctx, "my-cache")
+		requireNoError(t, flushErr)
+
+		keys, keysErr := m.Keys(ctx, "my-cache", "*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		flushErr := m.FlushAll(ctx, "no-cache")
+		assertError(t, flushErr, true)
+	})
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		key     string
+		want    bool
+	}{
+		{name: "empty pattern matches all", pattern: "", key: "anything", want: true},
+		{name: "star matches all", pattern: "*", key: "anything", want: true},
+		{name: "prefix star match", pattern: "user:*", key: "user:123", want: true},
+		{name: "prefix star no match", pattern: "user:*", key: "session:1", want: false},
+		{name: "suffix star match", pattern: "*:end", key: "key:end", want: true},
+		{name: "suffix star no match", pattern: "*:end", key: "key:start", want: false},
+		{name: "exact match", pattern: "exact", key: "exact", want: true},
+		{name: "exact no match", pattern: "exact", key: "other", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchPattern(tc.pattern, tc.key)
+			assertEqual(t, tc.want, got)
+		})
+	}
+}

--- a/providers/aws/elasticache/elasticache_test.go
+++ b/providers/aws/elasticache/elasticache_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/cache/driver"
 	"github.com/stackshy/cloudemu/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() (*Mock, *config.FakeClock) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -92,16 +59,17 @@ func TestCreateCache(t *testing.T) {
 			}
 
 			info, err := m.CreateCache(context.Background(), tc.cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertEqual(t, tc.cfg.Name, info.Name)
-			assertEqual(t, "available", info.Status)
-			assertNotEmpty(t, info.Endpoint)
-			assertNotEmpty(t, info.CreatedAt)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, "available", info.Status)
+			assert.NotEmpty(t, info.Endpoint)
+			assert.NotEmpty(t, info.CreatedAt)
 		})
 	}
 }
@@ -111,10 +79,10 @@ func TestCreateCacheDefaults(t *testing.T) {
 	ctx := context.Background()
 
 	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "default-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "redis", info.Engine)
-	assertEqual(t, "cache.t3.micro", info.NodeType)
+	assert.Equal(t, "redis", info.Engine)
+	assert.Equal(t, "cache.t3.micro", info.NodeType)
 }
 
 func TestCreateCacheCustomValues(t *testing.T) {
@@ -126,10 +94,10 @@ func TestCreateCacheCustomValues(t *testing.T) {
 		Engine:   "memcached",
 		NodeType: "cache.r6g.large",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "memcached", info.Engine)
-	assertEqual(t, "cache.r6g.large", info.NodeType)
+	assert.Equal(t, "memcached", info.Engine)
+	assert.Equal(t, "cache.r6g.large", info.NodeType)
 }
 
 func TestDeleteCache(t *testing.T) {
@@ -140,12 +108,12 @@ func TestDeleteCache(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		err := m.DeleteCache(ctx, "to-delete")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		err := m.DeleteCache(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -157,14 +125,14 @@ func TestGetCache(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		info, err := m.GetCache(ctx, "my-cache")
-		requireNoError(t, err)
-		assertEqual(t, "my-cache", info.Name)
-		assertEqual(t, "available", info.Status)
+		require.NoError(t, err)
+		assert.Equal(t, "my-cache", info.Name)
+		assert.Equal(t, "available", info.Status)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		_, err := m.GetCache(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -174,8 +142,8 @@ func TestListCaches(t *testing.T) {
 
 	t.Run("empty list", func(t *testing.T) {
 		caches, err := m.ListCaches(ctx)
-		requireNoError(t, err)
-		assertEqual(t, 0, len(caches))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(caches))
 	})
 
 	createTestCache(t, m, "cache-a")
@@ -183,8 +151,8 @@ func TestListCaches(t *testing.T) {
 
 	t.Run("two caches", func(t *testing.T) {
 		caches, err := m.ListCaches(ctx)
-		requireNoError(t, err)
-		assertEqual(t, 2, len(caches))
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(caches))
 	})
 }
 
@@ -196,18 +164,18 @@ func TestSet(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with TTL", func(t *testing.T) {
 		ttl := 5 * time.Minute
 		err := m.Set(ctx, "my-cache", "key-ttl", []byte("val"), ttl)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		err := m.Set(ctx, "no-cache", "key1", []byte("val"), 0)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -218,50 +186,47 @@ func TestGet(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		item, getErr := m.Get(ctx, "my-cache", "key1")
-		requireNoError(t, getErr)
-		assertEqual(t, "key1", item.Key)
-		assertEqual(t, string([]byte("value1")), string(item.Value))
+		require.NoError(t, getErr)
+		assert.Equal(t, "key1", item.Key)
+		assert.Equal(t, string([]byte("value1")), string(item.Value))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		_, getErr := m.Get(ctx, "no-cache", "key1")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("nonexistent key", func(t *testing.T) {
 		_, getErr := m.Get(ctx, "my-cache", "missing")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("expired key", func(t *testing.T) {
 		ttl := 10 * time.Second
 		setErr := m.Set(ctx, "my-cache", "expiring", []byte("temp"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(20 * time.Second)
 
 		_, getErr := m.Get(ctx, "my-cache", "expiring")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("not yet expired key", func(t *testing.T) {
 		ttl := 30 * time.Minute
 		setErr := m.Set(ctx, "my-cache", "long-lived", []byte("still-here"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(10 * time.Minute)
 
 		item, getErr := m.Get(ctx, "my-cache", "long-lived")
-		requireNoError(t, getErr)
-		assertEqual(t, "long-lived", item.Key)
-
-		if item.TTL <= 0 {
-			t.Error("expected positive TTL for non-expired key")
-		}
+		require.NoError(t, getErr)
+		assert.Equal(t, "long-lived", item.Key)
+		assert.Greater(t, item.TTL, time.Duration(0))
 	})
 }
 
@@ -272,21 +237,21 @@ func TestDelete(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "key1", []byte("val"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		delErr := m.Delete(ctx, "my-cache", "key1")
-		requireNoError(t, delErr)
+		require.NoError(t, delErr)
 	})
 
 	t.Run("nonexistent key", func(t *testing.T) {
 		delErr := m.Delete(ctx, "my-cache", "missing")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		delErr := m.Delete(ctx, "no-cache", "key1")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 }
 
@@ -297,65 +262,65 @@ func TestKeys(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "user:1", []byte("a"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "user:2", []byte("b"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "session:abc", []byte("c"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("wildcard all", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 3, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 3, len(keys))
 	})
 
 	t.Run("prefix match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "user:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 2, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 2, len(keys))
 	})
 
 	t.Run("suffix match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "*abc")
-		requireNoError(t, keysErr)
-		assertEqual(t, 1, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 1, len(keys))
 	})
 
 	t.Run("exact match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "user:1")
-		requireNoError(t, keysErr)
-		assertEqual(t, 1, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 1, len(keys))
 	})
 
 	t.Run("empty pattern returns all", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "")
-		requireNoError(t, keysErr)
-		assertEqual(t, 3, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 3, len(keys))
 	})
 
 	t.Run("no match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "orders:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		_, keysErr := m.Keys(ctx, "no-cache", "*")
-		assertError(t, keysErr, true)
+		require.Error(t, keysErr)
 	})
 
 	t.Run("expired keys filtered out", func(t *testing.T) {
 		ttl := 5 * time.Second
 		setErr := m.Set(ctx, "my-cache", "temp:1", []byte("x"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(10 * time.Second)
 
 		keys, keysErr := m.Keys(ctx, "my-cache", "temp:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 }
 
@@ -366,23 +331,23 @@ func TestFlushAll(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "k1", []byte("v1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "k2", []byte("v2"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		flushErr := m.FlushAll(ctx, "my-cache")
-		requireNoError(t, flushErr)
+		require.NoError(t, flushErr)
 
 		keys, keysErr := m.Keys(ctx, "my-cache", "*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		flushErr := m.FlushAll(ctx, "no-cache")
-		assertError(t, flushErr, true)
+		require.Error(t, flushErr)
 	})
 }
 
@@ -406,7 +371,7 @@ func TestMatchPattern(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := matchPattern(tc.pattern, tc.key)
-			assertEqual(t, tc.want, got)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -1,0 +1,221 @@
+// Package secretsmanager provides an in-memory mock implementation of AWS Secrets Manager.
+package secretsmanager
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// Compile-time check that Mock implements driver.Secrets.
+var _ driver.Secrets = (*Mock)(nil)
+
+type secretData struct {
+	info     driver.SecretInfo
+	versions []driver.SecretVersion
+	mu       sync.RWMutex
+}
+
+// Mock is an in-memory mock implementation of the AWS Secrets Manager service.
+type Mock struct {
+	secrets *memstore.Store[*secretData]
+	opts    *config.Options
+}
+
+// New creates a new Secrets Manager mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		secrets: memstore.New[*secretData](),
+		opts:    opts,
+	}
+}
+
+// CreateSecret creates a new secret with an initial value.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "secret name is required")
+	}
+
+	if m.secrets.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	arn := idgen.AWSARN("secretsmanager", m.opts.Region, m.opts.AccountID, "secret:"+cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.SecretInfo{
+		ID:          idgen.GenerateID("secret-"),
+		Name:        cfg.Name,
+		ARN:         arn,
+		Description: cfg.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Tags:        tags,
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	versionID := idgen.GenerateID("ver-")
+	version := driver.SecretVersion{
+		VersionID: versionID,
+		Value:     data,
+		CreatedAt: now,
+		Current:   true,
+	}
+
+	sd := &secretData{
+		info:     info,
+		versions: []driver.SecretVersion{version},
+	}
+
+	m.secrets.Set(cfg.Name, sd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteSecret deletes a secret by name.
+func (m *Mock) DeleteSecret(_ context.Context, name string) error {
+	if !m.secrets.Delete(name) {
+		return errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	return nil
+}
+
+// GetSecret retrieves secret metadata by name.
+func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	result := sd.info
+
+	return &result, nil
+}
+
+// ListSecrets lists all secrets.
+func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
+	all := m.secrets.All()
+
+	secrets := make([]driver.SecretInfo, 0, len(all))
+	for _, sd := range all {
+		sd.mu.RLock()
+		secrets = append(secrets, sd.info)
+		sd.mu.RUnlock()
+	}
+
+	return secrets, nil
+}
+
+// PutSecretValue stores a new version of a secret value.
+func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+
+	// Mark all existing versions as not current.
+	for i := range sd.versions {
+		sd.versions[i].Current = false
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	versionID := idgen.GenerateID("ver-")
+	version := driver.SecretVersion{
+		VersionID: versionID,
+		Value:     data,
+		CreatedAt: now,
+		Current:   true,
+	}
+
+	sd.versions = append(sd.versions, version)
+	sd.info.UpdatedAt = now
+
+	result := version
+
+	return &result, nil
+}
+
+// GetSecretValue retrieves a secret value. Empty versionID returns the current version.
+func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	for _, v := range sd.versions {
+		if versionID == "" && v.Current {
+			result := v
+
+			data := make([]byte, len(v.Value))
+			copy(data, v.Value)
+			result.Value = data
+
+			return &result, nil
+		}
+
+		if v.VersionID == versionID {
+			result := v
+
+			data := make([]byte, len(v.Value))
+			copy(data, v.Value)
+			result.Value = data
+
+			return &result, nil
+		}
+	}
+
+	return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
+}
+
+// ListSecretVersions lists all versions of a secret.
+func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	versions := make([]driver.SecretVersion, len(sd.versions))
+	for i, v := range sd.versions {
+		versions[i] = driver.SecretVersion{
+			VersionID: v.VersionID,
+			CreatedAt: v.CreatedAt,
+			Current:   v.Current,
+		}
+	}
+
+	return versions, nil
+}

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -16,10 +16,13 @@ import (
 // Compile-time check that Mock implements driver.Secrets.
 var _ driver.Secrets = (*Mock)(nil)
 
+const defaultRecoveryDays = 30
+
 type secretData struct {
-	info     driver.SecretInfo
-	versions []driver.SecretVersion
-	mu       sync.RWMutex
+	info      driver.SecretInfo
+	versions  []driver.SecretVersion
+	deletedAt time.Time
+	mu        sync.RWMutex
 }
 
 // Mock is an in-memory mock implementation of the AWS Secrets Manager service.
@@ -57,7 +60,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	info := driver.SecretInfo{
 		ID:          idgen.GenerateID("secret-"),
 		Name:        cfg.Name,
-		ARN:         arn,
+		ResourceID:  arn,
 		Description: cfg.Description,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -87,11 +90,21 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	return &result, nil
 }
 
-// DeleteSecret deletes a secret by name.
+// DeleteSecret soft-deletes a secret by name, scheduling it for deletion after a recovery window.
 func (m *Mock) DeleteSecret(_ context.Context, name string) error {
-	if !m.secrets.Delete(name) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
 		return errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	sd.deletedAt = m.opts.Clock.Now().UTC()
 
 	return nil
 }
@@ -106,12 +119,16 @@ func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, er
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
 	result := sd.info
 
 	return &result, nil
 }
 
-// ListSecrets lists all secrets.
+// ListSecrets lists all secrets, excluding soft-deleted ones.
 func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
@@ -119,7 +136,9 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 
 	for _, sd := range all {
 		sd.mu.RLock()
-		secrets = append(secrets, sd.info)
+		if sd.deletedAt.IsZero() {
+			secrets = append(secrets, sd.info)
+		}
 		sd.mu.RUnlock()
 	}
 
@@ -135,6 +154,10 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
@@ -172,6 +195,10 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
 	for _, v := range sd.versions {
 		if versionID == "" && v.Current {
 			result := v
@@ -206,6 +233,10 @@ func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.Secr
 
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
 
 	versions := make([]driver.SecretVersion, len(sd.versions))
 	for i, v := range sd.versions {

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -37,8 +37,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateSecret creates a new secret with an initial value.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "secret name is required")
@@ -118,6 +116,7 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
 	secrets := make([]driver.SecretInfo, 0, len(all))
+
 	for _, sd := range all {
 		sd.mu.RLock()
 		secrets = append(secrets, sd.info)

--- a/providers/aws/secretsmanager/secretsmanager.go
+++ b/providers/aws/secretsmanager/secretsmanager.go
@@ -16,8 +16,6 @@ import (
 // Compile-time check that Mock implements driver.Secrets.
 var _ driver.Secrets = (*Mock)(nil)
 
-const defaultRecoveryDays = 30
-
 type secretData struct {
 	info      driver.SecretInfo
 	versions  []driver.SecretVersion

--- a/providers/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/aws/secretsmanager/secretsmanager_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -57,7 +24,7 @@ func createTestSecret(t *testing.T, m *Mock, name, value string) *driver.SecretI
 	cfg := driver.SecretConfig{Name: name, Description: "test secret"}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte(value))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -88,16 +55,19 @@ func TestCreateSecret(t *testing.T) {
 			m := newTestMock()
 
 			info, err := m.CreateSecret(context.Background(), tc.cfg, tc.value)
-			assertError(t, err, tc.expectErr)
-
-			if !tc.expectErr {
-				assertNotEmpty(t, info.ID)
-				assertEqual(t, tc.cfg.Name, info.Name)
-				assertEqual(t, tc.cfg.Description, info.Description)
-				assertNotEmpty(t, info.ARN)
-				assertNotEmpty(t, info.CreatedAt)
-				assertNotEmpty(t, info.UpdatedAt)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
 			}
+
+			assert.NotEmpty(t, info.ID)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, tc.cfg.Description, info.Description)
+			assert.NotEmpty(t, info.ResourceID)
+			assert.NotEmpty(t, info.CreatedAt)
+			assert.NotEmpty(t, info.UpdatedAt)
 		})
 	}
 }
@@ -110,7 +80,7 @@ func TestCreateSecretDuplicate(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "dup-secret"}
 	_, err := m.CreateSecret(context.Background(), cfg, []byte("val2"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestCreateSecretWithTags(t *testing.T) {
@@ -123,10 +93,10 @@ func TestCreateSecretWithTags(t *testing.T) {
 	}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "prod", info.Tags["env"])
-	assertEqual(t, "platform", info.Tags["team"])
+	assert.Equal(t, "prod", info.Tags["env"])
+	assert.Equal(t, "platform", info.Tags["team"])
 }
 
 func TestDeleteSecret(t *testing.T) {
@@ -159,7 +129,12 @@ func TestDeleteSecret(t *testing.T) {
 			}
 
 			err := m.DeleteSecret(context.Background(), tc.secretNm)
-			assertError(t, err, tc.expectErr)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }
@@ -194,12 +169,15 @@ func TestGetSecret(t *testing.T) {
 			}
 
 			info, err := m.GetSecret(context.Background(), tc.secretNm)
-			assertError(t, err, tc.expectErr)
-
-			if !tc.expectErr {
-				assertEqual(t, tc.secretNm, info.Name)
-				assertNotEmpty(t, info.ID)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
 			}
+
+			assert.Equal(t, tc.secretNm, info.Name)
+			assert.NotEmpty(t, info.ID)
 		})
 	}
 }
@@ -208,16 +186,16 @@ func TestListSecrets(t *testing.T) {
 	m := newTestMock()
 
 	list, err := m.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 0, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(list))
 
 	createTestSecret(t, m, "s1", "v1")
 	createTestSecret(t, m, "s2", "v2")
 	createTestSecret(t, m, "s3", "v3")
 
 	list, err = m.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 3, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(list))
 }
 
 func TestPutSecretValue(t *testing.T) {
@@ -226,11 +204,11 @@ func TestPutSecretValue(t *testing.T) {
 	createTestSecret(t, m, "put-secret", "initial")
 
 	ver, err := m.PutSecretValue(context.Background(), "put-secret", []byte("updated"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertNotEmpty(t, ver.VersionID)
-	assertEqual(t, true, ver.Current)
-	assertEqual(t, "updated", string(ver.Value))
+	assert.NotEmpty(t, ver.VersionID)
+	assert.Equal(t, true, ver.Current)
+	assert.Equal(t, "updated", string(ver.Value))
 }
 
 func TestPutSecretValueNotFound(t *testing.T) {
@@ -238,7 +216,7 @@ func TestPutSecretValueNotFound(t *testing.T) {
 
 	_, err := m.PutSecretValue(context.Background(), "no-such-secret", []byte("val"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
@@ -247,11 +225,11 @@ func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
 	createTestSecret(t, m, "ver-secret", "v1")
 
 	_, err := m.PutSecretValue(context.Background(), "ver-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := m.ListSecretVersions(context.Background(), "ver-secret")
-	requireNoError(t, err)
-	assertEqual(t, 2, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(versions))
 
 	currentCount := 0
 
@@ -261,7 +239,7 @@ func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
 		}
 	}
 
-	assertEqual(t, 1, currentCount)
+	assert.Equal(t, 1, currentCount)
 }
 
 func TestGetSecretValueEmptyVersionID(t *testing.T) {
@@ -270,10 +248,10 @@ func TestGetSecretValueEmptyVersionID(t *testing.T) {
 	createTestSecret(t, m, "gv-secret", "my-value")
 
 	ver, err := m.GetSecretValue(context.Background(), "gv-secret", "")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, true, ver.Current)
-	assertEqual(t, "my-value", string(ver.Value))
+	assert.Equal(t, true, ver.Current)
+	assert.Equal(t, "my-value", string(ver.Value))
 }
 
 func TestGetSecretValueSpecificVersion(t *testing.T) {
@@ -282,13 +260,13 @@ func TestGetSecretValueSpecificVersion(t *testing.T) {
 	createTestSecret(t, m, "sv-secret", "v1")
 
 	v2, err := m.PutSecretValue(context.Background(), "sv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	got, err := m.GetSecretValue(context.Background(), "sv-secret", v2.VersionID)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, v2.VersionID, got.VersionID)
-	assertEqual(t, "v2", string(got.Value))
+	assert.Equal(t, v2.VersionID, got.VersionID)
+	assert.Equal(t, "v2", string(got.Value))
 }
 
 func TestGetSecretValueNonexistentVersion(t *testing.T) {
@@ -298,7 +276,7 @@ func TestGetSecretValueNonexistentVersion(t *testing.T) {
 
 	_, err := m.GetSecretValue(context.Background(), "nv-secret", "bad-version-id")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestGetSecretValueNonexistentSecret(t *testing.T) {
@@ -306,7 +284,7 @@ func TestGetSecretValueNonexistentSecret(t *testing.T) {
 
 	_, err := m.GetSecretValue(context.Background(), "no-secret", "")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersions(t *testing.T) {
@@ -315,14 +293,14 @@ func TestListSecretVersions(t *testing.T) {
 	createTestSecret(t, m, "lv-secret", "v1")
 
 	_, err := m.PutSecretValue(context.Background(), "lv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.PutSecretValue(context.Background(), "lv-secret", []byte("v3"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := m.ListSecretVersions(context.Background(), "lv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 3, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(versions))
 }
 
 func TestListSecretVersionsNotFound(t *testing.T) {
@@ -330,7 +308,7 @@ func TestListSecretVersionsNotFound(t *testing.T) {
 
 	_, err := m.ListSecretVersions(context.Background(), "missing")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersionsPrivacy(t *testing.T) {
@@ -339,13 +317,11 @@ func TestListSecretVersionsPrivacy(t *testing.T) {
 	createTestSecret(t, m, "priv-secret", "sensitive")
 
 	versions, err := m.ListSecretVersions(context.Background(), "priv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 1, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(versions))
 
 	for _, v := range versions {
-		if len(v.Value) != 0 {
-			t.Error("expected empty Value in listed versions for privacy")
-		}
+		assert.Empty(t, v.Value, "expected empty Value in listed versions for privacy")
 	}
 }
 
@@ -356,12 +332,12 @@ func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		_, err := m.PutSecretValue(context.Background(), "multi-secret", []byte("update"))
-		requireNoError(t, err)
+		require.NoError(t, err)
 	}
 
 	versions, err := m.ListSecretVersions(context.Background(), "multi-secret")
-	requireNoError(t, err)
-	assertEqual(t, 6, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 6, len(versions))
 
 	currentCount := 0
 
@@ -371,7 +347,7 @@ func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
 		}
 	}
 
-	assertEqual(t, 1, currentCount)
+	assert.Equal(t, 1, currentCount)
 }
 
 func TestDeleteThenGetReturnsError(t *testing.T) {
@@ -380,10 +356,10 @@ func TestDeleteThenGetReturnsError(t *testing.T) {
 	createTestSecret(t, m, "dtg-secret", "val")
 
 	err := m.DeleteSecret(context.Background(), "dtg-secret")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.GetSecret(context.Background(), "dtg-secret")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestCreateSecretTagsCopied(t *testing.T) {
@@ -393,9 +369,9 @@ func TestCreateSecretTagsCopied(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "tag-copy", Tags: tags}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	tags["key"] = "mutated"
 
-	assertEqual(t, "original", info.Tags["key"])
+	assert.Equal(t, "original", info.Tags["key"])
 }

--- a/providers/aws/secretsmanager/secretsmanager_test.go
+++ b/providers/aws/secretsmanager/secretsmanager_test.go
@@ -1,0 +1,401 @@
+package secretsmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func createTestSecret(t *testing.T, m *Mock, name, value string) *driver.SecretInfo {
+	t.Helper()
+
+	cfg := driver.SecretConfig{Name: name, Description: "test secret"}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte(value))
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.SecretConfig
+		value     []byte
+		expectErr bool
+	}{
+		{
+			name:      "valid secret",
+			cfg:       driver.SecretConfig{Name: "my-secret", Description: "desc"},
+			value:     []byte("secret-value"),
+			expectErr: false,
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.SecretConfig{Name: ""},
+			value:     []byte("val"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			info, err := m.CreateSecret(context.Background(), tc.cfg, tc.value)
+			assertError(t, err, tc.expectErr)
+
+			if !tc.expectErr {
+				assertNotEmpty(t, info.ID)
+				assertEqual(t, tc.cfg.Name, info.Name)
+				assertEqual(t, tc.cfg.Description, info.Description)
+				assertNotEmpty(t, info.ARN)
+				assertNotEmpty(t, info.CreatedAt)
+				assertNotEmpty(t, info.UpdatedAt)
+			}
+		})
+	}
+}
+
+func TestCreateSecretDuplicate(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "dup-secret", "val1")
+
+	cfg := driver.SecretConfig{Name: "dup-secret"}
+	_, err := m.CreateSecret(context.Background(), cfg, []byte("val2"))
+
+	assertError(t, err, true)
+}
+
+func TestCreateSecretWithTags(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"env": "prod", "team": "platform"}
+
+	cfg := driver.SecretConfig{
+		Name: "tagged-secret",
+		Tags: tags,
+	}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
+	requireNoError(t, err)
+
+	assertEqual(t, "prod", info.Tags["env"])
+	assertEqual(t, "platform", info.Tags["team"])
+}
+
+func TestDeleteSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     bool
+		secretNm  string
+		expectErr bool
+	}{
+		{
+			name:      "existing secret",
+			setup:     true,
+			secretNm:  "del-secret",
+			expectErr: false,
+		},
+		{
+			name:      "not found",
+			setup:     false,
+			secretNm:  "nonexistent",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			if tc.setup {
+				createTestSecret(t, m, tc.secretNm, "val")
+			}
+
+			err := m.DeleteSecret(context.Background(), tc.secretNm)
+			assertError(t, err, tc.expectErr)
+		})
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     bool
+		secretNm  string
+		expectErr bool
+	}{
+		{
+			name:      "existing secret",
+			setup:     true,
+			secretNm:  "get-secret",
+			expectErr: false,
+		},
+		{
+			name:      "not found",
+			setup:     false,
+			secretNm:  "missing",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			if tc.setup {
+				createTestSecret(t, m, tc.secretNm, "val")
+			}
+
+			info, err := m.GetSecret(context.Background(), tc.secretNm)
+			assertError(t, err, tc.expectErr)
+
+			if !tc.expectErr {
+				assertEqual(t, tc.secretNm, info.Name)
+				assertNotEmpty(t, info.ID)
+			}
+		})
+	}
+}
+
+func TestListSecrets(t *testing.T) {
+	m := newTestMock()
+
+	list, err := m.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 0, len(list))
+
+	createTestSecret(t, m, "s1", "v1")
+	createTestSecret(t, m, "s2", "v2")
+	createTestSecret(t, m, "s3", "v3")
+
+	list, err = m.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 3, len(list))
+}
+
+func TestPutSecretValue(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "put-secret", "initial")
+
+	ver, err := m.PutSecretValue(context.Background(), "put-secret", []byte("updated"))
+	requireNoError(t, err)
+
+	assertNotEmpty(t, ver.VersionID)
+	assertEqual(t, true, ver.Current)
+	assertEqual(t, "updated", string(ver.Value))
+}
+
+func TestPutSecretValueNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.PutSecretValue(context.Background(), "no-such-secret", []byte("val"))
+
+	assertError(t, err, true)
+}
+
+func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "ver-secret", "v1")
+
+	_, err := m.PutSecretValue(context.Background(), "ver-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	versions, err := m.ListSecretVersions(context.Background(), "ver-secret")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(versions))
+
+	currentCount := 0
+
+	for _, v := range versions {
+		if v.Current {
+			currentCount++
+		}
+	}
+
+	assertEqual(t, 1, currentCount)
+}
+
+func TestGetSecretValueEmptyVersionID(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "gv-secret", "my-value")
+
+	ver, err := m.GetSecretValue(context.Background(), "gv-secret", "")
+	requireNoError(t, err)
+
+	assertEqual(t, true, ver.Current)
+	assertEqual(t, "my-value", string(ver.Value))
+}
+
+func TestGetSecretValueSpecificVersion(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "sv-secret", "v1")
+
+	v2, err := m.PutSecretValue(context.Background(), "sv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	got, err := m.GetSecretValue(context.Background(), "sv-secret", v2.VersionID)
+	requireNoError(t, err)
+
+	assertEqual(t, v2.VersionID, got.VersionID)
+	assertEqual(t, "v2", string(got.Value))
+}
+
+func TestGetSecretValueNonexistentVersion(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "nv-secret", "val")
+
+	_, err := m.GetSecretValue(context.Background(), "nv-secret", "bad-version-id")
+
+	assertError(t, err, true)
+}
+
+func TestGetSecretValueNonexistentSecret(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.GetSecretValue(context.Background(), "no-secret", "")
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersions(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "lv-secret", "v1")
+
+	_, err := m.PutSecretValue(context.Background(), "lv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	_, err = m.PutSecretValue(context.Background(), "lv-secret", []byte("v3"))
+	requireNoError(t, err)
+
+	versions, err := m.ListSecretVersions(context.Background(), "lv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 3, len(versions))
+}
+
+func TestListSecretVersionsNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListSecretVersions(context.Background(), "missing")
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersionsPrivacy(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "priv-secret", "sensitive")
+
+	versions, err := m.ListSecretVersions(context.Background(), "priv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(versions))
+
+	for _, v := range versions {
+		if len(v.Value) != 0 {
+			t.Error("expected empty Value in listed versions for privacy")
+		}
+	}
+}
+
+func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "multi-secret", "v1")
+
+	for i := 0; i < 5; i++ {
+		_, err := m.PutSecretValue(context.Background(), "multi-secret", []byte("update"))
+		requireNoError(t, err)
+	}
+
+	versions, err := m.ListSecretVersions(context.Background(), "multi-secret")
+	requireNoError(t, err)
+	assertEqual(t, 6, len(versions))
+
+	currentCount := 0
+
+	for _, v := range versions {
+		if v.Current {
+			currentCount++
+		}
+	}
+
+	assertEqual(t, 1, currentCount)
+}
+
+func TestDeleteThenGetReturnsError(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "dtg-secret", "val")
+
+	err := m.DeleteSecret(context.Background(), "dtg-secret")
+	requireNoError(t, err)
+
+	_, err = m.GetSecret(context.Background(), "dtg-secret")
+	assertError(t, err, true)
+}
+
+func TestCreateSecretTagsCopied(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"key": "original"}
+
+	cfg := driver.SecretConfig{Name: "tag-copy", Tags: tags}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
+	requireNoError(t, err)
+
+	tags["key"] = "mutated"
+
+	assertEqual(t, "original", info.Tags["key"])
+}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -34,8 +34,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateTopic creates a new SNS topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
@@ -100,6 +98,7 @@ func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
 	all := m.topics.All()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
+
 	for _, td := range all {
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
@@ -110,8 +109,6 @@ func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
 }
 
 // Subscribe creates a subscription to an SNS topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
 	td, ok := m.topics.Get(cfg.TopicID)
 	if !ok {
@@ -175,8 +172,6 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 }
 
 // Publish publishes a message to an SNS topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
 	if _, ok := m.topics.Get(input.TopicID); !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -1,0 +1,192 @@
+// Package sns provides an in-memory mock implementation of AWS Simple Notification Service.
+package sns
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/notification/driver"
+)
+
+// Compile-time check that Mock implements driver.Notification.
+var _ driver.Notification = (*Mock)(nil)
+
+type topicData struct {
+	info          driver.TopicInfo
+	subscriptions *memstore.Store[driver.SubscriptionInfo]
+}
+
+// Mock is an in-memory mock implementation of the AWS SNS service.
+type Mock struct {
+	topics *memstore.Store[*topicData]
+	opts   *config.Options
+}
+
+// New creates a new SNS mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		topics: memstore.New[*topicData](),
+		opts:   opts,
+	}
+}
+
+// CreateTopic creates a new SNS topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, cfg.Name)
+
+	if m.topics.Has(arn) {
+		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
+	}
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.TopicInfo{
+		ID:                idgen.GenerateID("topic-"),
+		Name:              cfg.Name,
+		ARN:               arn,
+		DisplayName:       cfg.DisplayName,
+		SubscriptionCount: 0,
+		Tags:              tags,
+	}
+
+	td := &topicData{
+		info:          info,
+		subscriptions: memstore.New[driver.SubscriptionInfo](),
+	}
+
+	m.topics.Set(arn, td)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteTopic deletes an SNS topic by ARN.
+func (m *Mock) DeleteTopic(_ context.Context, id string) error {
+	if !m.topics.Delete(id) {
+		return errors.Newf(errors.NotFound, "topic %q not found", id)
+	}
+
+	return nil
+}
+
+// GetTopic retrieves information about an SNS topic.
+func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", id)
+	}
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
+}
+
+// ListTopics lists all SNS topics.
+func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+	all := m.topics.All()
+
+	topics := make([]driver.TopicInfo, 0, len(all))
+	for _, td := range all {
+		info := td.info
+		info.SubscriptionCount = td.subscriptions.Len()
+		topics = append(topics, info)
+	}
+
+	return topics, nil
+}
+
+// Subscribe creates a subscription to an SNS topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
+	td, ok := m.topics.Get(cfg.TopicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.TopicID)
+	}
+
+	if cfg.Protocol == "" {
+		return nil, errors.New(errors.InvalidArgument, "protocol is required")
+	}
+
+	if cfg.Endpoint == "" {
+		return nil, errors.New(errors.InvalidArgument, "endpoint is required")
+	}
+
+	subID := idgen.GenerateID("sub-")
+	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, "subscription/"+subID)
+
+	sub := driver.SubscriptionInfo{
+		ID:       arn,
+		TopicID:  cfg.TopicID,
+		Protocol: cfg.Protocol,
+		Endpoint: cfg.Endpoint,
+		Status:   "confirmed",
+	}
+
+	td.subscriptions.Set(arn, sub)
+
+	result := sub
+
+	return &result, nil
+}
+
+// Unsubscribe removes a subscription from an SNS topic.
+func (m *Mock) Unsubscribe(_ context.Context, subscriptionID string) error {
+	all := m.topics.All()
+
+	for _, td := range all {
+		if td.subscriptions.Delete(subscriptionID) {
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.NotFound, "subscription %q not found", subscriptionID)
+}
+
+// ListSubscriptions lists all subscriptions for an SNS topic.
+func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.SubscriptionInfo, error) {
+	td, ok := m.topics.Get(topicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
+	}
+
+	all := td.subscriptions.All()
+
+	subs := make([]driver.SubscriptionInfo, 0, len(all))
+	for _, s := range all {
+		subs = append(subs, s)
+	}
+
+	return subs, nil
+}
+
+// Publish publishes a message to an SNS topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
+	if _, ok := m.topics.Get(input.TopicID); !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
+	}
+
+	if input.Message == "" {
+		return nil, errors.New(errors.InvalidArgument, "message is required")
+	}
+
+	msgID := idgen.GenerateID("msg-")
+
+	return &driver.PublishOutput{MessageID: msgID}, nil
+}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -3,6 +3,7 @@ package sns
 
 import (
 	"context"
+	"sync"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/errors"
@@ -14,9 +15,19 @@ import (
 // Compile-time check that Mock implements driver.Notification.
 var _ driver.Notification = (*Mock)(nil)
 
+type publishedMessage struct {
+	ID         string
+	TopicID    string
+	Subject    string
+	Message    string
+	Attributes map[string]string
+}
+
 type topicData struct {
 	info          driver.TopicInfo
 	subscriptions *memstore.Store[driver.SubscriptionInfo]
+	messages      []publishedMessage
+	mu            sync.RWMutex
 }
 
 // Mock is an in-memory mock implementation of the AWS SNS service.
@@ -39,11 +50,11 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
 	}
 
-	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, cfg.Name)
-
-	if m.topics.Has(arn) {
+	if m.topics.Has(cfg.Name) {
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
 	}
+
+	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -53,7 +64,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
-		ARN:               arn,
+		ResourceID:        arn,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
 		Tags:              tags,
@@ -64,14 +75,14 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 		subscriptions: memstore.New[driver.SubscriptionInfo](),
 	}
 
-	m.topics.Set(arn, td)
+	m.topics.Set(cfg.Name, td)
 
 	result := info
 
 	return &result, nil
 }
 
-// DeleteTopic deletes an SNS topic by ARN.
+// DeleteTopic deletes an SNS topic by name.
 func (m *Mock) DeleteTopic(_ context.Context, id string) error {
 	if !m.topics.Delete(id) {
 		return errors.Newf(errors.NotFound, "topic %q not found", id)
@@ -173,7 +184,8 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 
 // Publish publishes a message to an SNS topic.
 func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
-	if _, ok := m.topics.Get(input.TopicID); !ok {
+	td, ok := m.topics.Get(input.TopicID)
+	if !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
 	}
 
@@ -182,6 +194,21 @@ func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.Pu
 	}
 
 	msgID := idgen.GenerateID("msg-")
+
+	attrs := make(map[string]string, len(input.Attributes))
+	for k, v := range input.Attributes {
+		attrs[k] = v
+	}
+
+	td.mu.Lock()
+	td.messages = append(td.messages, publishedMessage{
+		ID:         msgID,
+		TopicID:    input.TopicID,
+		Subject:    input.Subject,
+		Message:    input.Message,
+		Attributes: attrs,
+	})
+	td.mu.Unlock()
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
 }

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -1,0 +1,531 @@
+package sns
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/notification/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func createTestTopic(t *testing.T, m *Mock, name string) *driver.TopicInfo {
+	t.Helper()
+
+	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.TopicConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name: "basic topic",
+			cfg:  driver.TopicConfig{Name: "my-topic"},
+		},
+		{
+			name: "with display name",
+			cfg:  driver.TopicConfig{Name: "alerts", DisplayName: "Alert Notifications"},
+		},
+		{
+			name: "with tags",
+			cfg: driver.TopicConfig{
+				Name: "tagged-topic",
+				Tags: map[string]string{"env": "prod", "team": "platform"},
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.TopicConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate topic",
+			cfg:  driver.TopicConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				_, _ = m.CreateTopic(context.Background(), driver.TopicConfig{Name: "dup"})
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateTopic(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, info.ID)
+			assertNotEmpty(t, info.ARN)
+			assertEqual(t, tc.cfg.Name, info.Name)
+			assertEqual(t, tc.cfg.DisplayName, info.DisplayName)
+			assertEqual(t, 0, info.SubscriptionCount)
+		})
+	}
+}
+
+func TestCreateTopicWithTags(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"env": "staging", "service": "notifications"}
+
+	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+		Name: "tagged",
+		Tags: tags,
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "staging", info.Tags["env"])
+	assertEqual(t, "notifications", info.Tags["service"])
+
+	// Verify tags are copied and not shared.
+	tags["env"] = "production"
+	assertEqual(t, "staging", info.Tags["env"])
+}
+
+func TestDeleteTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicID   string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) string {
+				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: "del"})
+				return info.ARN
+			},
+		},
+		{
+			name:      "not found",
+			topicID:   "arn:aws:sns:us-east-1:123456789012:nonexistent",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			id := tc.topicID
+
+			if tc.setup != nil {
+				id = tc.setup(m)
+			}
+
+			err := m.DeleteTopic(context.Background(), id)
+			assertError(t, err, tc.expectErr)
+		})
+	}
+}
+
+func TestDeleteTopicRemovesFromList(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	info := createTestTopic(t, m, "to-delete")
+
+	err := m.DeleteTopic(ctx, info.ARN)
+	requireNoError(t, err)
+
+	topics, err := m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+}
+
+func TestGetTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicID   string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) string {
+				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name:        "get-me",
+					DisplayName: "Get Me",
+				})
+				return info.ARN
+			},
+		},
+		{
+			name:      "not found",
+			topicID:   "arn:aws:sns:us-east-1:123456789012:nope",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			id := tc.topicID
+
+			if tc.setup != nil {
+				id = tc.setup(m)
+			}
+
+			info, err := m.GetTopic(context.Background(), id)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, "get-me", info.Name)
+			assertEqual(t, "Get Me", info.DisplayName)
+		})
+	}
+}
+
+func TestGetTopicSubscriptionCount(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "sub-count")
+
+	info, err := m.GetTopic(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 0, info.SubscriptionCount)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID:  topic.ARN,
+		Protocol: "email",
+		Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID:  topic.ARN,
+		Protocol: "sms",
+		Endpoint: "+1234567890",
+	})
+	requireNoError(t, err)
+
+	info, err = m.GetTopic(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 2, info.SubscriptionCount)
+}
+
+func TestListTopics(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topics, err := m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+
+	createTestTopic(t, m, "topic-1")
+	createTestTopic(t, m, "topic-2")
+	createTestTopic(t, m, "topic-3")
+
+	topics, err = m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(topics))
+}
+
+func TestSubscribe(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.SubscriptionConfig
+		setup     func(*Mock) driver.SubscriptionConfig
+		expectErr bool
+	}{
+		{
+			name: "email subscription",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "sub-topic")
+				return driver.SubscriptionConfig{
+					TopicID: info.ARN, Protocol: "email", Endpoint: "user@example.com",
+				}
+			},
+		},
+		{
+			name: "sms subscription",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "sms-topic")
+				return driver.SubscriptionConfig{
+					TopicID: info.ARN, Protocol: "sms", Endpoint: "+1234567890",
+				}
+			},
+		},
+		{
+			name: "nonexistent topic",
+			cfg: driver.SubscriptionConfig{
+				TopicID: "arn:aws:sns:us-east-1:123456789012:nope", Protocol: "email", Endpoint: "a@b.com",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty protocol",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "no-proto")
+				return driver.SubscriptionConfig{
+					TopicID: info.ARN, Protocol: "", Endpoint: "a@b.com",
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty endpoint",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "no-endpoint")
+				return driver.SubscriptionConfig{
+					TopicID: info.ARN, Protocol: "email", Endpoint: "",
+				}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			cfg := tc.cfg
+
+			if tc.setup != nil {
+				cfg = tc.setup(m)
+			}
+
+			sub, err := m.Subscribe(context.Background(), cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, sub.ID)
+			assertEqual(t, cfg.Protocol, sub.Protocol)
+			assertEqual(t, cfg.Endpoint, sub.Endpoint)
+			assertEqual(t, "confirmed", sub.Status)
+		})
+	}
+}
+
+func createTopicHelper(m *Mock, name string) *driver.TopicInfo {
+	info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	return info
+}
+
+func TestMultipleSubscriptionsSameTopic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "multi-sub")
+
+	_, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "sms", Endpoint: "+111",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "https", Endpoint: "https://hook.example.com",
+	})
+	requireNoError(t, err)
+
+	subs, err := m.ListSubscriptions(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(subs))
+}
+
+func TestUnsubscribe(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "unsub-topic")
+
+	sub, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := m.Unsubscribe(ctx, sub.ID)
+		requireNoError(t, err)
+
+		subs, err := m.ListSubscriptions(ctx, topic.ARN)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(subs))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.Unsubscribe(ctx, "arn:aws:sns:us-east-1:123456789012:subscription/nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListSubscriptions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "list-subs")
+
+	subs, err := m.ListSubscriptions(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(subs))
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.ARN, Protocol: "email", Endpoint: "x@y.com",
+	})
+	requireNoError(t, err)
+
+	subs, err = m.ListSubscriptions(ctx, topic.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(subs))
+}
+
+func TestListSubscriptionsNonexistentTopic(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListSubscriptions(
+		context.Background(),
+		"arn:aws:sns:us-east-1:123456789012:nonexistent",
+	)
+	assertError(t, err, true)
+}
+
+func TestPublish(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     driver.PublishInput
+		setup     func(*Mock) driver.PublishInput
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "pub-topic")
+				return driver.PublishInput{
+					TopicID: info.ARN,
+					Message: "hello world",
+					Subject: "greetings",
+				}
+			},
+		},
+		{
+			name: "with attributes",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "attr-topic")
+				return driver.PublishInput{
+					TopicID:    info.ARN,
+					Message:    "test",
+					Attributes: map[string]string{"key": "value"},
+				}
+			},
+		},
+		{
+			name: "nonexistent topic",
+			input: driver.PublishInput{
+				TopicID: "arn:aws:sns:us-east-1:123456789012:nope",
+				Message: "hello",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty message",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "empty-msg")
+				return driver.PublishInput{TopicID: info.ARN, Message: ""}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			input := tc.input
+
+			if tc.setup != nil {
+				input = tc.setup(m)
+			}
+
+			out, err := m.Publish(context.Background(), input)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, out.MessageID)
+		})
+	}
+}
+
+func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "unique-ids")
+
+	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.ARN, Message: "msg1"})
+	requireNoError(t, err)
+
+	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.ARN, Message: "msg2"})
+	requireNoError(t, err)
+
+	if out1.MessageID == out2.MessageID {
+		t.Error("expected unique message IDs")
+	}
+}

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/notification/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -55,7 +22,7 @@ func createTestTopic(t *testing.T, m *Mock, name string) *driver.TopicInfo {
 	t.Helper()
 
 	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -105,17 +72,18 @@ func TestCreateTopic(t *testing.T) {
 			}
 
 			info, err := m.CreateTopic(context.Background(), tc.cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, info.ID)
-			assertNotEmpty(t, info.ARN)
-			assertEqual(t, tc.cfg.Name, info.Name)
-			assertEqual(t, tc.cfg.DisplayName, info.DisplayName)
-			assertEqual(t, 0, info.SubscriptionCount)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, info.ID)
+			assert.NotEmpty(t, info.ResourceID)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, tc.cfg.DisplayName, info.DisplayName)
+			assert.Equal(t, 0, info.SubscriptionCount)
 		})
 	}
 }
@@ -128,14 +96,14 @@ func TestCreateTopicWithTags(t *testing.T) {
 		Name: "tagged",
 		Tags: tags,
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "staging", info.Tags["env"])
-	assertEqual(t, "notifications", info.Tags["service"])
+	assert.Equal(t, "staging", info.Tags["env"])
+	assert.Equal(t, "notifications", info.Tags["service"])
 
 	// Verify tags are copied and not shared.
 	tags["env"] = "production"
-	assertEqual(t, "staging", info.Tags["env"])
+	assert.Equal(t, "staging", info.Tags["env"])
 }
 
 func TestDeleteTopic(t *testing.T) {
@@ -149,7 +117,7 @@ func TestDeleteTopic(t *testing.T) {
 			name: "success",
 			setup: func(m *Mock) string {
 				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: "del"})
-				return info.ARN
+				return info.Name
 			},
 		},
 		{
@@ -169,7 +137,12 @@ func TestDeleteTopic(t *testing.T) {
 			}
 
 			err := m.DeleteTopic(context.Background(), id)
-			assertError(t, err, tc.expectErr)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -180,12 +153,12 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 
 	info := createTestTopic(t, m, "to-delete")
 
-	err := m.DeleteTopic(ctx, info.ARN)
-	requireNoError(t, err)
+	err := m.DeleteTopic(ctx, info.Name)
+	require.NoError(t, err)
 
 	topics, err := m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 }
 
 func TestGetTopic(t *testing.T) {
@@ -202,7 +175,7 @@ func TestGetTopic(t *testing.T) {
 					Name:        "get-me",
 					DisplayName: "Get Me",
 				})
-				return info.ARN
+				return info.Name
 			},
 		},
 		{
@@ -222,14 +195,15 @@ func TestGetTopic(t *testing.T) {
 			}
 
 			info, err := m.GetTopic(context.Background(), id)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertEqual(t, "get-me", info.Name)
-			assertEqual(t, "Get Me", info.DisplayName)
+			require.NoError(t, err)
+
+			assert.Equal(t, "get-me", info.Name)
+			assert.Equal(t, "Get Me", info.DisplayName)
 		})
 	}
 }
@@ -240,27 +214,27 @@ func TestGetTopicSubscriptionCount(t *testing.T) {
 
 	topic := createTestTopic(t, m, "sub-count")
 
-	info, err := m.GetTopic(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 0, info.SubscriptionCount)
+	info, err := m.GetTopic(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.SubscriptionCount)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID:  topic.ARN,
+		TopicID:  topic.Name,
 		Protocol: "email",
 		Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID:  topic.ARN,
+		TopicID:  topic.Name,
 		Protocol: "sms",
 		Endpoint: "+1234567890",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	info, err = m.GetTopic(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 2, info.SubscriptionCount)
+	info, err = m.GetTopic(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 2, info.SubscriptionCount)
 }
 
 func TestListTopics(t *testing.T) {
@@ -268,16 +242,16 @@ func TestListTopics(t *testing.T) {
 	ctx := context.Background()
 
 	topics, err := m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 
 	createTestTopic(t, m, "topic-1")
 	createTestTopic(t, m, "topic-2")
 	createTestTopic(t, m, "topic-3")
 
 	topics, err = m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 3, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(topics))
 }
 
 func TestSubscribe(t *testing.T) {
@@ -292,7 +266,7 @@ func TestSubscribe(t *testing.T) {
 			setup: func(m *Mock) driver.SubscriptionConfig {
 				info := createTopicHelper(m, "sub-topic")
 				return driver.SubscriptionConfig{
-					TopicID: info.ARN, Protocol: "email", Endpoint: "user@example.com",
+					TopicID: info.Name, Protocol: "email", Endpoint: "user@example.com",
 				}
 			},
 		},
@@ -301,7 +275,7 @@ func TestSubscribe(t *testing.T) {
 			setup: func(m *Mock) driver.SubscriptionConfig {
 				info := createTopicHelper(m, "sms-topic")
 				return driver.SubscriptionConfig{
-					TopicID: info.ARN, Protocol: "sms", Endpoint: "+1234567890",
+					TopicID: info.Name, Protocol: "sms", Endpoint: "+1234567890",
 				}
 			},
 		},
@@ -317,7 +291,7 @@ func TestSubscribe(t *testing.T) {
 			setup: func(m *Mock) driver.SubscriptionConfig {
 				info := createTopicHelper(m, "no-proto")
 				return driver.SubscriptionConfig{
-					TopicID: info.ARN, Protocol: "", Endpoint: "a@b.com",
+					TopicID: info.Name, Protocol: "", Endpoint: "a@b.com",
 				}
 			},
 			expectErr: true,
@@ -327,7 +301,7 @@ func TestSubscribe(t *testing.T) {
 			setup: func(m *Mock) driver.SubscriptionConfig {
 				info := createTopicHelper(m, "no-endpoint")
 				return driver.SubscriptionConfig{
-					TopicID: info.ARN, Protocol: "email", Endpoint: "",
+					TopicID: info.Name, Protocol: "email", Endpoint: "",
 				}
 			},
 			expectErr: true,
@@ -344,16 +318,17 @@ func TestSubscribe(t *testing.T) {
 			}
 
 			sub, err := m.Subscribe(context.Background(), cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, sub.ID)
-			assertEqual(t, cfg.Protocol, sub.Protocol)
-			assertEqual(t, cfg.Endpoint, sub.Endpoint)
-			assertEqual(t, "confirmed", sub.Status)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, sub.ID)
+			assert.Equal(t, cfg.Protocol, sub.Protocol)
+			assert.Equal(t, cfg.Endpoint, sub.Endpoint)
+			assert.Equal(t, "confirmed", sub.Status)
 		})
 	}
 }
@@ -370,23 +345,23 @@ func TestMultipleSubscriptionsSameTopic(t *testing.T) {
 	topic := createTestTopic(t, m, "multi-sub")
 
 	_, err := m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "sms", Endpoint: "+111",
+		TopicID: topic.Name, Protocol: "sms", Endpoint: "+111",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "https", Endpoint: "https://hook.example.com",
+		TopicID: topic.Name, Protocol: "https", Endpoint: "https://hook.example.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	subs, err := m.ListSubscriptions(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 3, len(subs))
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(subs))
 }
 
 func TestUnsubscribe(t *testing.T) {
@@ -396,22 +371,22 @@ func TestUnsubscribe(t *testing.T) {
 	topic := createTestTopic(t, m, "unsub-topic")
 
 	sub, err := m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "a@b.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		err := m.Unsubscribe(ctx, sub.ID)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		subs, err := m.ListSubscriptions(ctx, topic.ARN)
-		requireNoError(t, err)
-		assertEqual(t, 0, len(subs))
+		subs, err := m.ListSubscriptions(ctx, topic.Name)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(subs))
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		err := m.Unsubscribe(ctx, "arn:aws:sns:us-east-1:123456789012:subscription/nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -421,18 +396,18 @@ func TestListSubscriptions(t *testing.T) {
 
 	topic := createTestTopic(t, m, "list-subs")
 
-	subs, err := m.ListSubscriptions(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(subs))
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(subs))
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
-		TopicID: topic.ARN, Protocol: "email", Endpoint: "x@y.com",
+		TopicID: topic.Name, Protocol: "email", Endpoint: "x@y.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	subs, err = m.ListSubscriptions(ctx, topic.ARN)
-	requireNoError(t, err)
-	assertEqual(t, 1, len(subs))
+	subs, err = m.ListSubscriptions(ctx, topic.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(subs))
 }
 
 func TestListSubscriptionsNonexistentTopic(t *testing.T) {
@@ -442,7 +417,7 @@ func TestListSubscriptionsNonexistentTopic(t *testing.T) {
 		context.Background(),
 		"arn:aws:sns:us-east-1:123456789012:nonexistent",
 	)
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPublish(t *testing.T) {
@@ -457,7 +432,7 @@ func TestPublish(t *testing.T) {
 			setup: func(m *Mock) driver.PublishInput {
 				info := createTopicHelper(m, "pub-topic")
 				return driver.PublishInput{
-					TopicID: info.ARN,
+					TopicID: info.Name,
 					Message: "hello world",
 					Subject: "greetings",
 				}
@@ -468,7 +443,7 @@ func TestPublish(t *testing.T) {
 			setup: func(m *Mock) driver.PublishInput {
 				info := createTopicHelper(m, "attr-topic")
 				return driver.PublishInput{
-					TopicID:    info.ARN,
+					TopicID:    info.Name,
 					Message:    "test",
 					Attributes: map[string]string{"key": "value"},
 				}
@@ -486,7 +461,7 @@ func TestPublish(t *testing.T) {
 			name: "empty message",
 			setup: func(m *Mock) driver.PublishInput {
 				info := createTopicHelper(m, "empty-msg")
-				return driver.PublishInput{TopicID: info.ARN, Message: ""}
+				return driver.PublishInput{TopicID: info.Name, Message: ""}
 			},
 			expectErr: true,
 		},
@@ -502,13 +477,14 @@ func TestPublish(t *testing.T) {
 			}
 
 			out, err := m.Publish(context.Background(), input)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, out.MessageID)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, out.MessageID)
 		})
 	}
 }
@@ -519,13 +495,11 @@ func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
 
 	topic := createTestTopic(t, m, "unique-ids")
 
-	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.ARN, Message: "msg1"})
-	requireNoError(t, err)
+	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg1"})
+	require.NoError(t, err)
 
-	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.ARN, Message: "msg2"})
-	requireNoError(t, err)
+	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg2"})
+	require.NoError(t, err)
 
-	if out1.MessageID == out2.MessageID {
-		t.Error("expected unique message IDs")
-	}
+	assert.NotEqual(t, out1.MessageID, out2.MessageID)
 }

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -3,6 +3,7 @@ package azure
 
 import (
 	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/providers/azure/azurecache"
 	"github.com/stackshy/cloudemu/providers/azure/azuredns"
 	"github.com/stackshy/cloudemu/providers/azure/azureiam"
 	"github.com/stackshy/cloudemu/providers/azure/azurelb"
@@ -10,6 +11,9 @@ import (
 	"github.com/stackshy/cloudemu/providers/azure/blobstorage"
 	"github.com/stackshy/cloudemu/providers/azure/cosmosdb"
 	"github.com/stackshy/cloudemu/providers/azure/functions"
+	"github.com/stackshy/cloudemu/providers/azure/keyvault"
+	"github.com/stackshy/cloudemu/providers/azure/loganalytics"
+	"github.com/stackshy/cloudemu/providers/azure/notificationhubs"
 	"github.com/stackshy/cloudemu/providers/azure/servicebus"
 	"github.com/stackshy/cloudemu/providers/azure/virtualmachines"
 	"github.com/stackshy/cloudemu/providers/azure/vnet"
@@ -17,32 +21,40 @@ import (
 
 // Provider holds all Azure mock services.
 type Provider struct {
-	BlobStorage     *blobstorage.Mock
-	VirtualMachines *virtualmachines.Mock
-	CosmosDB        *cosmosdb.Mock
-	Functions       *functions.Mock
-	VNet            *vnet.Mock
-	Monitor         *azuremonitor.Mock
-	IAM             *azureiam.Mock
-	DNS             *azuredns.Mock
-	LB              *azurelb.Mock
-	ServiceBus      *servicebus.Mock
+	BlobStorage      *blobstorage.Mock
+	VirtualMachines  *virtualmachines.Mock
+	CosmosDB         *cosmosdb.Mock
+	Functions        *functions.Mock
+	VNet             *vnet.Mock
+	Monitor          *azuremonitor.Mock
+	IAM              *azureiam.Mock
+	DNS              *azuredns.Mock
+	LB               *azurelb.Mock
+	ServiceBus       *servicebus.Mock
+	Cache            *azurecache.Mock
+	KeyVault         *keyvault.Mock
+	LogAnalytics     *loganalytics.Mock
+	NotificationHubs *notificationhubs.Mock
 }
 
 // New creates a new Azure provider with all mock services.
 func New(opts ...config.Option) *Provider {
 	o := config.NewOptions(opts...)
 	p := &Provider{
-		BlobStorage:     blobstorage.New(o),
-		VirtualMachines: virtualmachines.New(o),
-		CosmosDB:        cosmosdb.New(o),
-		Functions:       functions.New(o),
-		VNet:            vnet.New(o),
-		Monitor:         azuremonitor.New(o),
-		IAM:             azureiam.New(o),
-		DNS:             azuredns.New(o),
-		LB:              azurelb.New(o),
-		ServiceBus:      servicebus.New(o),
+		BlobStorage:      blobstorage.New(o),
+		VirtualMachines:  virtualmachines.New(o),
+		CosmosDB:         cosmosdb.New(o),
+		Functions:        functions.New(o),
+		VNet:             vnet.New(o),
+		Monitor:          azuremonitor.New(o),
+		IAM:              azureiam.New(o),
+		DNS:              azuredns.New(o),
+		LB:               azurelb.New(o),
+		ServiceBus:       servicebus.New(o),
+		Cache:            azurecache.New(o),
+		KeyVault:         keyvault.New(o),
+		LogAnalytics:     loganalytics.New(o),
+		NotificationHubs: notificationhubs.New(o),
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
 

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -42,8 +42,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateCache creates a new Azure Cache for Redis instance.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "cache name is required")

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -1,0 +1,255 @@
+// Package azurecache provides an in-memory mock implementation of Azure Cache for Redis.
+package azurecache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+)
+
+// Compile-time check that Mock implements driver.Cache.
+var _ driver.Cache = (*Mock)(nil)
+
+type cacheItem struct {
+	Value     []byte
+	ExpiresAt time.Time
+	HasTTL    bool
+}
+
+type cacheData struct {
+	info  driver.CacheInfo
+	items *memstore.Store[cacheItem]
+}
+
+// Mock is an in-memory mock implementation of Azure Cache for Redis.
+type Mock struct {
+	caches *memstore.Store[*cacheData]
+	opts   *config.Options
+}
+
+// New creates a new Azure Cache mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		caches: memstore.New[*cacheData](),
+		opts:   opts,
+	}
+}
+
+// CreateCache creates a new Azure Cache for Redis instance.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "cache name is required")
+	}
+
+	if m.caches.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "cache %q already exists", cfg.Name)
+	}
+
+	engine := cfg.Engine
+	if engine == "" {
+		engine = "redis"
+	}
+
+	nodeType := cfg.NodeType
+	if nodeType == "" {
+		nodeType = "Standard_C1"
+	}
+
+	endpoint := fmt.Sprintf("%s.redis.cache.windows.net:6380", cfg.Name)
+
+	info := driver.CacheInfo{
+		Name:      cfg.Name,
+		NodeType:  nodeType,
+		Engine:    engine,
+		Status:    "Running",
+		Endpoint:  endpoint,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	cd := &cacheData{
+		info:  info,
+		items: memstore.New[cacheItem](),
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteCache deletes an Azure Cache for Redis instance by name.
+func (m *Mock) DeleteCache(_ context.Context, name string) error {
+	if !m.caches.Delete(name) {
+		return errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	return nil
+}
+
+// GetCache retrieves information about an Azure Cache for Redis instance.
+func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	result := cd.info
+
+	return &result, nil
+}
+
+// ListCaches lists all Azure Cache for Redis instances.
+func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+	all := m.caches.All()
+
+	caches := make([]driver.CacheInfo, 0, len(all))
+	for _, cd := range all {
+		caches = append(caches, cd.info)
+	}
+
+	return caches, nil
+}
+
+// Set stores a value in the cache with an optional TTL.
+func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	item := cacheItem{Value: data}
+
+	if ttl > 0 {
+		item.ExpiresAt = m.opts.Clock.Now().Add(ttl)
+		item.HasTTL = true
+	}
+
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// Get retrieves a value from the cache.
+func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	now := m.opts.Clock.Now()
+	if item.HasTTL && now.After(item.ExpiresAt) {
+		cd.items.Delete(key)
+
+		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	data := make([]byte, len(item.Value))
+	copy(data, item.Value)
+
+	result := &driver.Item{
+		Key:   key,
+		Value: data,
+	}
+
+	if item.HasTTL {
+		result.TTL = item.ExpiresAt.Sub(now)
+		result.ExpiresAt = item.ExpiresAt
+	}
+
+	return result, nil
+}
+
+// Delete removes a value from the cache.
+func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	if !cd.items.Delete(key) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	return nil
+}
+
+// Keys returns all keys matching the given pattern in the cache.
+func (m *Mock) Keys(_ context.Context, cacheName, pattern string) ([]string, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	now := m.opts.Clock.Now()
+	allKeys := cd.items.Keys()
+
+	var matched []string
+
+	for _, key := range allKeys {
+		item, ok := cd.items.Get(key)
+		if !ok {
+			continue
+		}
+
+		if item.HasTTL && now.After(item.ExpiresAt) {
+			cd.items.Delete(key)
+
+			continue
+		}
+
+		if matchPattern(pattern, key) {
+			matched = append(matched, key)
+		}
+	}
+
+	if matched == nil {
+		matched = []string{}
+	}
+
+	return matched, nil
+}
+
+// FlushAll removes all items from the cache.
+func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	cd.items.Clear()
+
+	return nil
+}
+
+func matchPattern(pattern, key string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+
+	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
+		return strings.HasPrefix(key, pattern[:len(pattern)-1])
+	}
+
+	if strings.HasPrefix(pattern, "*") && !strings.Contains(pattern[1:], "*") {
+		return strings.HasSuffix(key, pattern[1:])
+	}
+
+	return key == pattern
+}

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -4,7 +4,7 @@ package azurecache
 import (
 	"context"
 	"fmt"
-	"strings"
+	"path"
 	"time"
 
 	"github.com/stackshy/cloudemu/cache/driver"
@@ -12,6 +12,8 @@ import (
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
 )
+
+const defaultRedisSSLPort = 6380
 
 // Compile-time check that Mock implements driver.Cache.
 var _ driver.Cache = (*Mock)(nil)
@@ -61,7 +63,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		nodeType = "Standard_C1"
 	}
 
-	endpoint := fmt.Sprintf("%s.redis.cache.windows.net:6380", cfg.Name)
+	endpoint := fmt.Sprintf("%s.redis.cache.windows.net:%d", cfg.Name, defaultRedisSSLPort)
 
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
@@ -236,18 +238,17 @@ func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
 	return nil
 }
 
+// matchPattern matches a key against a glob-like pattern.
+// Supports full glob syntax including middle wildcards like "user:*:session".
 func matchPattern(pattern, key string) bool {
 	if pattern == "" || pattern == "*" {
 		return true
 	}
 
-	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
-		return strings.HasPrefix(key, pattern[:len(pattern)-1])
+	matched, err := path.Match(pattern, key)
+	if err != nil {
+		return false
 	}
 
-	if strings.HasPrefix(pattern, "*") && !strings.Contains(pattern[1:], "*") {
-		return strings.HasSuffix(key, pattern[1:])
-	}
-
-	return key == pattern
+	return matched
 }

--- a/providers/azure/azurecache/azurecache_test.go
+++ b/providers/azure/azurecache/azurecache_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/cache/driver"
 	"github.com/stackshy/cloudemu/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() (*Mock, *config.FakeClock) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -92,16 +59,17 @@ func TestCreateCache(t *testing.T) {
 			}
 
 			info, err := m.CreateCache(context.Background(), tc.cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertEqual(t, tc.cfg.Name, info.Name)
-			assertEqual(t, "Running", info.Status)
-			assertNotEmpty(t, info.Endpoint)
-			assertNotEmpty(t, info.CreatedAt)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, "Running", info.Status)
+			assert.NotEmpty(t, info.Endpoint)
+			assert.NotEmpty(t, info.CreatedAt)
 		})
 	}
 }
@@ -111,10 +79,10 @@ func TestCreateCacheDefaults(t *testing.T) {
 	ctx := context.Background()
 
 	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "default-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "redis", info.Engine)
-	assertEqual(t, "Standard_C1", info.NodeType)
+	assert.Equal(t, "redis", info.Engine)
+	assert.Equal(t, "Standard_C1", info.NodeType)
 }
 
 func TestCreateCacheCustomValues(t *testing.T) {
@@ -126,10 +94,10 @@ func TestCreateCacheCustomValues(t *testing.T) {
 		Engine:   "memcached",
 		NodeType: "Premium_P1",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "memcached", info.Engine)
-	assertEqual(t, "Premium_P1", info.NodeType)
+	assert.Equal(t, "memcached", info.Engine)
+	assert.Equal(t, "Premium_P1", info.NodeType)
 }
 
 func TestDeleteCache(t *testing.T) {
@@ -140,12 +108,12 @@ func TestDeleteCache(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		err := m.DeleteCache(ctx, "to-delete")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		err := m.DeleteCache(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -157,14 +125,14 @@ func TestGetCache(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		info, err := m.GetCache(ctx, "my-cache")
-		requireNoError(t, err)
-		assertEqual(t, "my-cache", info.Name)
-		assertEqual(t, "Running", info.Status)
+		require.NoError(t, err)
+		assert.Equal(t, "my-cache", info.Name)
+		assert.Equal(t, "Running", info.Status)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		_, err := m.GetCache(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -174,8 +142,8 @@ func TestListCaches(t *testing.T) {
 
 	t.Run("empty list", func(t *testing.T) {
 		caches, err := m.ListCaches(ctx)
-		requireNoError(t, err)
-		assertEqual(t, 0, len(caches))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(caches))
 	})
 
 	createTestCache(t, m, "cache-a")
@@ -183,8 +151,8 @@ func TestListCaches(t *testing.T) {
 
 	t.Run("two caches", func(t *testing.T) {
 		caches, err := m.ListCaches(ctx)
-		requireNoError(t, err)
-		assertEqual(t, 2, len(caches))
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(caches))
 	})
 }
 
@@ -196,18 +164,18 @@ func TestSet(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with TTL", func(t *testing.T) {
 		ttl := 5 * time.Minute
 		err := m.Set(ctx, "my-cache", "key-ttl", []byte("val"), ttl)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		err := m.Set(ctx, "no-cache", "key1", []byte("val"), 0)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -218,50 +186,47 @@ func TestGet(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		item, getErr := m.Get(ctx, "my-cache", "key1")
-		requireNoError(t, getErr)
-		assertEqual(t, "key1", item.Key)
-		assertEqual(t, string([]byte("value1")), string(item.Value))
+		require.NoError(t, getErr)
+		assert.Equal(t, "key1", item.Key)
+		assert.Equal(t, string([]byte("value1")), string(item.Value))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		_, getErr := m.Get(ctx, "no-cache", "key1")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("nonexistent key", func(t *testing.T) {
 		_, getErr := m.Get(ctx, "my-cache", "missing")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("expired key", func(t *testing.T) {
 		ttl := 10 * time.Second
 		setErr := m.Set(ctx, "my-cache", "expiring", []byte("temp"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(20 * time.Second)
 
 		_, getErr := m.Get(ctx, "my-cache", "expiring")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("not yet expired key", func(t *testing.T) {
 		ttl := 30 * time.Minute
 		setErr := m.Set(ctx, "my-cache", "long-lived", []byte("still-here"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(10 * time.Minute)
 
 		item, getErr := m.Get(ctx, "my-cache", "long-lived")
-		requireNoError(t, getErr)
-		assertEqual(t, "long-lived", item.Key)
-
-		if item.TTL <= 0 {
-			t.Error("expected positive TTL for non-expired key")
-		}
+		require.NoError(t, getErr)
+		assert.Equal(t, "long-lived", item.Key)
+		assert.Greater(t, item.TTL, time.Duration(0))
 	})
 }
 
@@ -272,21 +237,21 @@ func TestDelete(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "key1", []byte("val"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		delErr := m.Delete(ctx, "my-cache", "key1")
-		requireNoError(t, delErr)
+		require.NoError(t, delErr)
 	})
 
 	t.Run("nonexistent key", func(t *testing.T) {
 		delErr := m.Delete(ctx, "my-cache", "missing")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		delErr := m.Delete(ctx, "no-cache", "key1")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 }
 
@@ -297,65 +262,65 @@ func TestKeys(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "user:1", []byte("a"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "user:2", []byte("b"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "session:abc", []byte("c"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("wildcard all", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 3, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 3, len(keys))
 	})
 
 	t.Run("prefix match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "user:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 2, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 2, len(keys))
 	})
 
 	t.Run("suffix match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "*abc")
-		requireNoError(t, keysErr)
-		assertEqual(t, 1, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 1, len(keys))
 	})
 
 	t.Run("exact match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "user:1")
-		requireNoError(t, keysErr)
-		assertEqual(t, 1, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 1, len(keys))
 	})
 
 	t.Run("empty pattern returns all", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "")
-		requireNoError(t, keysErr)
-		assertEqual(t, 3, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 3, len(keys))
 	})
 
 	t.Run("no match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "orders:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		_, keysErr := m.Keys(ctx, "no-cache", "*")
-		assertError(t, keysErr, true)
+		require.Error(t, keysErr)
 	})
 
 	t.Run("expired keys filtered out", func(t *testing.T) {
 		ttl := 5 * time.Second
 		setErr := m.Set(ctx, "my-cache", "temp:1", []byte("x"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(10 * time.Second)
 
 		keys, keysErr := m.Keys(ctx, "my-cache", "temp:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 }
 
@@ -366,23 +331,23 @@ func TestFlushAll(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "k1", []byte("v1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "k2", []byte("v2"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		flushErr := m.FlushAll(ctx, "my-cache")
-		requireNoError(t, flushErr)
+		require.NoError(t, flushErr)
 
 		keys, keysErr := m.Keys(ctx, "my-cache", "*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		flushErr := m.FlushAll(ctx, "no-cache")
-		assertError(t, flushErr, true)
+		require.Error(t, flushErr)
 	})
 }
 
@@ -406,7 +371,7 @@ func TestMatchPattern(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := matchPattern(tc.pattern, tc.key)
-			assertEqual(t, tc.want, got)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/providers/azure/azurecache/azurecache_test.go
+++ b/providers/azure/azurecache/azurecache_test.go
@@ -1,0 +1,412 @@
+package azurecache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("eastus"))
+
+	return New(opts), fc
+}
+
+func createTestCache(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateCache(context.Background(), driver.CacheConfig{Name: name})
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+}
+
+func TestCreateCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.CacheConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{name: "success with defaults", cfg: driver.CacheConfig{Name: "my-cache"}},
+		{
+			name: "success with custom engine and node type",
+			cfg:  driver.CacheConfig{Name: "custom", Engine: "memcached", NodeType: "Premium_P1"},
+		},
+		{name: "empty name", cfg: driver.CacheConfig{}, expectErr: true},
+		{
+			name: "duplicate cache",
+			cfg:  driver.CacheConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestCache(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateCache(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, tc.cfg.Name, info.Name)
+			assertEqual(t, "Running", info.Status)
+			assertNotEmpty(t, info.Endpoint)
+			assertNotEmpty(t, info.CreatedAt)
+		})
+	}
+}
+
+func TestCreateCacheDefaults(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "default-cache"})
+	requireNoError(t, err)
+
+	assertEqual(t, "redis", info.Engine)
+	assertEqual(t, "Standard_C1", info.NodeType)
+}
+
+func TestCreateCacheCustomValues(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name:     "custom-cache",
+		Engine:   "memcached",
+		NodeType: "Premium_P1",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "memcached", info.Engine)
+	assertEqual(t, "Premium_P1", info.NodeType)
+}
+
+func TestDeleteCache(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "to-delete")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteCache(ctx, "to-delete")
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteCache(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetCache(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := m.GetCache(ctx, "my-cache")
+		requireNoError(t, err)
+		assertEqual(t, "my-cache", info.Name)
+		assertEqual(t, "Running", info.Status)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetCache(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListCaches(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		caches, err := m.ListCaches(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(caches))
+	})
+
+	createTestCache(t, m, "cache-a")
+	createTestCache(t, m, "cache-b")
+
+	t.Run("two caches", func(t *testing.T) {
+		caches, err := m.ListCaches(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(caches))
+	})
+}
+
+func TestSet(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
+		requireNoError(t, err)
+	})
+
+	t.Run("with TTL", func(t *testing.T) {
+		ttl := 5 * time.Minute
+		err := m.Set(ctx, "my-cache", "key-ttl", []byte("val"), ttl)
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		err := m.Set(ctx, "no-cache", "key1", []byte("val"), 0)
+		assertError(t, err, true)
+	})
+}
+
+func TestGet(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		item, getErr := m.Get(ctx, "my-cache", "key1")
+		requireNoError(t, getErr)
+		assertEqual(t, "key1", item.Key)
+		assertEqual(t, string([]byte("value1")), string(item.Value))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		_, getErr := m.Get(ctx, "no-cache", "key1")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		_, getErr := m.Get(ctx, "my-cache", "missing")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("expired key", func(t *testing.T) {
+		ttl := 10 * time.Second
+		setErr := m.Set(ctx, "my-cache", "expiring", []byte("temp"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(20 * time.Second)
+
+		_, getErr := m.Get(ctx, "my-cache", "expiring")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("not yet expired key", func(t *testing.T) {
+		ttl := 30 * time.Minute
+		setErr := m.Set(ctx, "my-cache", "long-lived", []byte("still-here"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(10 * time.Minute)
+
+		item, getErr := m.Get(ctx, "my-cache", "long-lived")
+		requireNoError(t, getErr)
+		assertEqual(t, "long-lived", item.Key)
+
+		if item.TTL <= 0 {
+			t.Error("expected positive TTL for non-expired key")
+		}
+	})
+}
+
+func TestDelete(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "key1", []byte("val"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := m.Delete(ctx, "my-cache", "key1")
+		requireNoError(t, delErr)
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		delErr := m.Delete(ctx, "my-cache", "missing")
+		assertError(t, delErr, true)
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		delErr := m.Delete(ctx, "no-cache", "key1")
+		assertError(t, delErr, true)
+	})
+}
+
+func TestKeys(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "user:1", []byte("a"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "user:2", []byte("b"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "session:abc", []byte("c"), 0)
+	requireNoError(t, err)
+
+	t.Run("wildcard all", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 3, len(keys))
+	})
+
+	t.Run("prefix match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "user:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 2, len(keys))
+	})
+
+	t.Run("suffix match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "*abc")
+		requireNoError(t, keysErr)
+		assertEqual(t, 1, len(keys))
+	})
+
+	t.Run("exact match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "user:1")
+		requireNoError(t, keysErr)
+		assertEqual(t, 1, len(keys))
+	})
+
+	t.Run("empty pattern returns all", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "")
+		requireNoError(t, keysErr)
+		assertEqual(t, 3, len(keys))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "orders:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		_, keysErr := m.Keys(ctx, "no-cache", "*")
+		assertError(t, keysErr, true)
+	})
+
+	t.Run("expired keys filtered out", func(t *testing.T) {
+		ttl := 5 * time.Second
+		setErr := m.Set(ctx, "my-cache", "temp:1", []byte("x"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(10 * time.Second)
+
+		keys, keysErr := m.Keys(ctx, "my-cache", "temp:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+}
+
+func TestFlushAll(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "k1", []byte("v1"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "k2", []byte("v2"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		flushErr := m.FlushAll(ctx, "my-cache")
+		requireNoError(t, flushErr)
+
+		keys, keysErr := m.Keys(ctx, "my-cache", "*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		flushErr := m.FlushAll(ctx, "no-cache")
+		assertError(t, flushErr, true)
+	})
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		key     string
+		want    bool
+	}{
+		{name: "empty pattern matches all", pattern: "", key: "anything", want: true},
+		{name: "star matches all", pattern: "*", key: "anything", want: true},
+		{name: "prefix star match", pattern: "user:*", key: "user:123", want: true},
+		{name: "prefix star no match", pattern: "user:*", key: "session:1", want: false},
+		{name: "suffix star match", pattern: "*:end", key: "key:end", want: true},
+		{name: "suffix star no match", pattern: "*:end", key: "key:start", want: false},
+		{name: "exact match", pattern: "exact", key: "exact", want: true},
+		{name: "exact no match", pattern: "exact", key: "other", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchPattern(tc.pattern, tc.key)
+			assertEqual(t, tc.want, got)
+		})
+	}
+}

--- a/providers/azure/keyvault/keyvault.go
+++ b/providers/azure/keyvault/keyvault.go
@@ -3,7 +3,6 @@ package keyvault
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -17,10 +16,13 @@ import (
 // Compile-time check that Mock implements driver.Secrets.
 var _ driver.Secrets = (*Mock)(nil)
 
+const defaultRecoveryDays = 30
+
 type secretData struct {
-	info     driver.SecretInfo
-	versions []driver.SecretVersion
-	mu       sync.RWMutex
+	info      driver.SecretInfo
+	versions  []driver.SecretVersion
+	deletedAt time.Time
+	mu        sync.RWMutex
 }
 
 // Mock is an in-memory mock implementation of Azure Key Vault.
@@ -48,7 +50,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
-	vaultURL := fmt.Sprintf("https://%s.vault.azure.net/secrets/%s", m.opts.AccountID, cfg.Name)
+	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.KeyVault", "vaults/default/secrets", cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -58,7 +60,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	info := driver.SecretInfo{
 		ID:          idgen.GenerateID("secret-"),
 		Name:        cfg.Name,
-		ARN:         vaultURL,
+		ResourceID:  resourceID,
 		Description: cfg.Description,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -88,11 +90,21 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	return &result, nil
 }
 
-// DeleteSecret deletes a secret by name.
+// DeleteSecret soft-deletes a secret by name, scheduling it for deletion after a recovery window.
 func (m *Mock) DeleteSecret(_ context.Context, name string) error {
-	if !m.secrets.Delete(name) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
 		return errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	sd.deletedAt = m.opts.Clock.Now().UTC()
 
 	return nil
 }
@@ -107,12 +119,16 @@ func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, er
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
 	result := sd.info
 
 	return &result, nil
 }
 
-// ListSecrets lists all secrets.
+// ListSecrets lists all secrets, excluding soft-deleted ones.
 func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
@@ -120,7 +136,9 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 
 	for _, sd := range all {
 		sd.mu.RLock()
-		secrets = append(secrets, sd.info)
+		if sd.deletedAt.IsZero() {
+			secrets = append(secrets, sd.info)
+		}
 		sd.mu.RUnlock()
 	}
 
@@ -136,6 +154,10 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
@@ -172,6 +194,10 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
 	for _, v := range sd.versions {
 		if versionID == "" && v.Current {
 			result := v
@@ -206,6 +232,10 @@ func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.Secr
 
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
 
 	versions := make([]driver.SecretVersion, len(sd.versions))
 	for i, v := range sd.versions {

--- a/providers/azure/keyvault/keyvault.go
+++ b/providers/azure/keyvault/keyvault.go
@@ -1,0 +1,221 @@
+// Package keyvault provides an in-memory mock implementation of Azure Key Vault.
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// Compile-time check that Mock implements driver.Secrets.
+var _ driver.Secrets = (*Mock)(nil)
+
+type secretData struct {
+	info     driver.SecretInfo
+	versions []driver.SecretVersion
+	mu       sync.RWMutex
+}
+
+// Mock is an in-memory mock implementation of Azure Key Vault.
+type Mock struct {
+	secrets *memstore.Store[*secretData]
+	opts    *config.Options
+}
+
+// New creates a new Key Vault mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		secrets: memstore.New[*secretData](),
+		opts:    opts,
+	}
+}
+
+// CreateSecret creates a new secret with an initial value.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "secret name is required")
+	}
+
+	if m.secrets.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	vaultURL := fmt.Sprintf("https://%s.vault.azure.net/secrets/%s", m.opts.AccountID, cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.SecretInfo{
+		ID:          idgen.GenerateID("secret-"),
+		Name:        cfg.Name,
+		ARN:         vaultURL,
+		Description: cfg.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Tags:        tags,
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	versionID := idgen.GenerateID("ver-")
+	version := driver.SecretVersion{
+		VersionID: versionID,
+		Value:     data,
+		CreatedAt: now,
+		Current:   true,
+	}
+
+	sd := &secretData{
+		info:     info,
+		versions: []driver.SecretVersion{version},
+	}
+
+	m.secrets.Set(cfg.Name, sd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteSecret deletes a secret by name.
+func (m *Mock) DeleteSecret(_ context.Context, name string) error {
+	if !m.secrets.Delete(name) {
+		return errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	return nil
+}
+
+// GetSecret retrieves secret metadata by name.
+func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	result := sd.info
+
+	return &result, nil
+}
+
+// ListSecrets lists all secrets.
+func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
+	all := m.secrets.All()
+
+	secrets := make([]driver.SecretInfo, 0, len(all))
+	for _, sd := range all {
+		sd.mu.RLock()
+		secrets = append(secrets, sd.info)
+		sd.mu.RUnlock()
+	}
+
+	return secrets, nil
+}
+
+// PutSecretValue stores a new version of a secret value.
+func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+
+	for i := range sd.versions {
+		sd.versions[i].Current = false
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	versionID := idgen.GenerateID("ver-")
+	version := driver.SecretVersion{
+		VersionID: versionID,
+		Value:     data,
+		CreatedAt: now,
+		Current:   true,
+	}
+
+	sd.versions = append(sd.versions, version)
+	sd.info.UpdatedAt = now
+
+	result := version
+
+	return &result, nil
+}
+
+// GetSecretValue retrieves a secret value. Empty versionID returns the current version.
+func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	for _, v := range sd.versions {
+		if versionID == "" && v.Current {
+			result := v
+
+			data := make([]byte, len(v.Value))
+			copy(data, v.Value)
+			result.Value = data
+
+			return &result, nil
+		}
+
+		if v.VersionID == versionID {
+			result := v
+
+			data := make([]byte, len(v.Value))
+			copy(data, v.Value)
+			result.Value = data
+
+			return &result, nil
+		}
+	}
+
+	return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
+}
+
+// ListSecretVersions lists all versions of a secret.
+func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	versions := make([]driver.SecretVersion, len(sd.versions))
+	for i, v := range sd.versions {
+		versions[i] = driver.SecretVersion{
+			VersionID: v.VersionID,
+			CreatedAt: v.CreatedAt,
+			Current:   v.Current,
+		}
+	}
+
+	return versions, nil
+}

--- a/providers/azure/keyvault/keyvault.go
+++ b/providers/azure/keyvault/keyvault.go
@@ -38,8 +38,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateSecret creates a new secret with an initial value.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "secret name is required")
@@ -119,6 +117,7 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
 	secrets := make([]driver.SecretInfo, 0, len(all))
+
 	for _, sd := range all {
 		sd.mu.RLock()
 		secrets = append(secrets, sd.info)

--- a/providers/azure/keyvault/keyvault.go
+++ b/providers/azure/keyvault/keyvault.go
@@ -16,8 +16,6 @@ import (
 // Compile-time check that Mock implements driver.Secrets.
 var _ driver.Secrets = (*Mock)(nil)
 
-const defaultRecoveryDays = 30
-
 type secretData struct {
 	info      driver.SecretInfo
 	versions  []driver.SecretVersion

--- a/providers/azure/keyvault/keyvault_test.go
+++ b/providers/azure/keyvault/keyvault_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -57,7 +24,7 @@ func createTestSecret(t *testing.T, m *Mock, name, value string) *driver.SecretI
 	cfg := driver.SecretConfig{Name: name, Description: "test secret"}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte(value))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -88,16 +55,19 @@ func TestCreateSecret(t *testing.T) {
 			m := newTestMock()
 
 			info, err := m.CreateSecret(context.Background(), tc.cfg, tc.value)
-			assertError(t, err, tc.expectErr)
-
-			if !tc.expectErr {
-				assertNotEmpty(t, info.ID)
-				assertEqual(t, tc.cfg.Name, info.Name)
-				assertEqual(t, tc.cfg.Description, info.Description)
-				assertNotEmpty(t, info.ARN)
-				assertNotEmpty(t, info.CreatedAt)
-				assertNotEmpty(t, info.UpdatedAt)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
 			}
+
+			assert.NotEmpty(t, info.ID)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, tc.cfg.Description, info.Description)
+			assert.NotEmpty(t, info.ResourceID)
+			assert.NotEmpty(t, info.CreatedAt)
+			assert.NotEmpty(t, info.UpdatedAt)
 		})
 	}
 }
@@ -110,7 +80,7 @@ func TestCreateSecretDuplicate(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "dup-secret"}
 	_, err := m.CreateSecret(context.Background(), cfg, []byte("val2"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestCreateSecretWithTags(t *testing.T) {
@@ -123,10 +93,10 @@ func TestCreateSecretWithTags(t *testing.T) {
 	}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "prod", info.Tags["env"])
-	assertEqual(t, "platform", info.Tags["team"])
+	assert.Equal(t, "prod", info.Tags["env"])
+	assert.Equal(t, "platform", info.Tags["team"])
 }
 
 func TestCreateSecretARNFormat(t *testing.T) {
@@ -134,9 +104,7 @@ func TestCreateSecretARNFormat(t *testing.T) {
 
 	info := createTestSecret(t, m, "arn-secret", "val")
 
-	if len(info.ARN) == 0 {
-		t.Fatal("expected non-empty ARN (vault URL)")
-	}
+	require.NotEmpty(t, info.ResourceID, "expected non-empty ARN (vault URL)")
 }
 
 func TestDeleteSecret(t *testing.T) {
@@ -169,7 +137,12 @@ func TestDeleteSecret(t *testing.T) {
 			}
 
 			err := m.DeleteSecret(context.Background(), tc.secretNm)
-			assertError(t, err, tc.expectErr)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }
@@ -204,12 +177,15 @@ func TestGetSecret(t *testing.T) {
 			}
 
 			info, err := m.GetSecret(context.Background(), tc.secretNm)
-			assertError(t, err, tc.expectErr)
-
-			if !tc.expectErr {
-				assertEqual(t, tc.secretNm, info.Name)
-				assertNotEmpty(t, info.ID)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
 			}
+
+			assert.Equal(t, tc.secretNm, info.Name)
+			assert.NotEmpty(t, info.ID)
 		})
 	}
 }
@@ -218,16 +194,16 @@ func TestListSecrets(t *testing.T) {
 	m := newTestMock()
 
 	list, err := m.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 0, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(list))
 
 	createTestSecret(t, m, "s1", "v1")
 	createTestSecret(t, m, "s2", "v2")
 	createTestSecret(t, m, "s3", "v3")
 
 	list, err = m.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 3, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(list))
 }
 
 func TestPutSecretValue(t *testing.T) {
@@ -236,11 +212,11 @@ func TestPutSecretValue(t *testing.T) {
 	createTestSecret(t, m, "put-secret", "initial")
 
 	ver, err := m.PutSecretValue(context.Background(), "put-secret", []byte("updated"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertNotEmpty(t, ver.VersionID)
-	assertEqual(t, true, ver.Current)
-	assertEqual(t, "updated", string(ver.Value))
+	assert.NotEmpty(t, ver.VersionID)
+	assert.Equal(t, true, ver.Current)
+	assert.Equal(t, "updated", string(ver.Value))
 }
 
 func TestPutSecretValueNotFound(t *testing.T) {
@@ -248,7 +224,7 @@ func TestPutSecretValueNotFound(t *testing.T) {
 
 	_, err := m.PutSecretValue(context.Background(), "no-such-secret", []byte("val"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
@@ -257,11 +233,11 @@ func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
 	createTestSecret(t, m, "ver-secret", "v1")
 
 	_, err := m.PutSecretValue(context.Background(), "ver-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := m.ListSecretVersions(context.Background(), "ver-secret")
-	requireNoError(t, err)
-	assertEqual(t, 2, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(versions))
 
 	currentCount := 0
 
@@ -271,7 +247,7 @@ func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
 		}
 	}
 
-	assertEqual(t, 1, currentCount)
+	assert.Equal(t, 1, currentCount)
 }
 
 func TestGetSecretValueEmptyVersionID(t *testing.T) {
@@ -280,10 +256,10 @@ func TestGetSecretValueEmptyVersionID(t *testing.T) {
 	createTestSecret(t, m, "gv-secret", "my-value")
 
 	ver, err := m.GetSecretValue(context.Background(), "gv-secret", "")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, true, ver.Current)
-	assertEqual(t, "my-value", string(ver.Value))
+	assert.Equal(t, true, ver.Current)
+	assert.Equal(t, "my-value", string(ver.Value))
 }
 
 func TestGetSecretValueSpecificVersion(t *testing.T) {
@@ -292,13 +268,13 @@ func TestGetSecretValueSpecificVersion(t *testing.T) {
 	createTestSecret(t, m, "sv-secret", "v1")
 
 	v2, err := m.PutSecretValue(context.Background(), "sv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	got, err := m.GetSecretValue(context.Background(), "sv-secret", v2.VersionID)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, v2.VersionID, got.VersionID)
-	assertEqual(t, "v2", string(got.Value))
+	assert.Equal(t, v2.VersionID, got.VersionID)
+	assert.Equal(t, "v2", string(got.Value))
 }
 
 func TestGetSecretValueNonexistentVersion(t *testing.T) {
@@ -308,7 +284,7 @@ func TestGetSecretValueNonexistentVersion(t *testing.T) {
 
 	_, err := m.GetSecretValue(context.Background(), "nv-secret", "bad-version-id")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestGetSecretValueNonexistentSecret(t *testing.T) {
@@ -316,7 +292,7 @@ func TestGetSecretValueNonexistentSecret(t *testing.T) {
 
 	_, err := m.GetSecretValue(context.Background(), "no-secret", "")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersions(t *testing.T) {
@@ -325,14 +301,14 @@ func TestListSecretVersions(t *testing.T) {
 	createTestSecret(t, m, "lv-secret", "v1")
 
 	_, err := m.PutSecretValue(context.Background(), "lv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.PutSecretValue(context.Background(), "lv-secret", []byte("v3"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := m.ListSecretVersions(context.Background(), "lv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 3, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(versions))
 }
 
 func TestListSecretVersionsNotFound(t *testing.T) {
@@ -340,7 +316,7 @@ func TestListSecretVersionsNotFound(t *testing.T) {
 
 	_, err := m.ListSecretVersions(context.Background(), "missing")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersionsPrivacy(t *testing.T) {
@@ -349,13 +325,11 @@ func TestListSecretVersionsPrivacy(t *testing.T) {
 	createTestSecret(t, m, "priv-secret", "sensitive")
 
 	versions, err := m.ListSecretVersions(context.Background(), "priv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 1, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(versions))
 
 	for _, v := range versions {
-		if len(v.Value) != 0 {
-			t.Error("expected empty Value in listed versions for privacy")
-		}
+		assert.Empty(t, v.Value, "expected empty Value in listed versions for privacy")
 	}
 }
 
@@ -366,12 +340,12 @@ func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		_, err := m.PutSecretValue(context.Background(), "multi-secret", []byte("update"))
-		requireNoError(t, err)
+		require.NoError(t, err)
 	}
 
 	versions, err := m.ListSecretVersions(context.Background(), "multi-secret")
-	requireNoError(t, err)
-	assertEqual(t, 6, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 6, len(versions))
 
 	currentCount := 0
 
@@ -381,7 +355,7 @@ func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
 		}
 	}
 
-	assertEqual(t, 1, currentCount)
+	assert.Equal(t, 1, currentCount)
 }
 
 func TestDeleteThenGetReturnsError(t *testing.T) {
@@ -390,10 +364,10 @@ func TestDeleteThenGetReturnsError(t *testing.T) {
 	createTestSecret(t, m, "dtg-secret", "val")
 
 	err := m.DeleteSecret(context.Background(), "dtg-secret")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.GetSecret(context.Background(), "dtg-secret")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestCreateSecretTagsCopied(t *testing.T) {
@@ -403,9 +377,9 @@ func TestCreateSecretTagsCopied(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "tag-copy", Tags: tags}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	tags["key"] = "mutated"
 
-	assertEqual(t, "original", info.Tags["key"])
+	assert.Equal(t, "original", info.Tags["key"])
 }

--- a/providers/azure/keyvault/keyvault_test.go
+++ b/providers/azure/keyvault/keyvault_test.go
@@ -1,0 +1,411 @@
+package keyvault
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func createTestSecret(t *testing.T, m *Mock, name, value string) *driver.SecretInfo {
+	t.Helper()
+
+	cfg := driver.SecretConfig{Name: name, Description: "test secret"}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte(value))
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.SecretConfig
+		value     []byte
+		expectErr bool
+	}{
+		{
+			name:      "valid secret",
+			cfg:       driver.SecretConfig{Name: "my-secret", Description: "desc"},
+			value:     []byte("secret-value"),
+			expectErr: false,
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.SecretConfig{Name: ""},
+			value:     []byte("val"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			info, err := m.CreateSecret(context.Background(), tc.cfg, tc.value)
+			assertError(t, err, tc.expectErr)
+
+			if !tc.expectErr {
+				assertNotEmpty(t, info.ID)
+				assertEqual(t, tc.cfg.Name, info.Name)
+				assertEqual(t, tc.cfg.Description, info.Description)
+				assertNotEmpty(t, info.ARN)
+				assertNotEmpty(t, info.CreatedAt)
+				assertNotEmpty(t, info.UpdatedAt)
+			}
+		})
+	}
+}
+
+func TestCreateSecretDuplicate(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "dup-secret", "val1")
+
+	cfg := driver.SecretConfig{Name: "dup-secret"}
+	_, err := m.CreateSecret(context.Background(), cfg, []byte("val2"))
+
+	assertError(t, err, true)
+}
+
+func TestCreateSecretWithTags(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"env": "prod", "team": "platform"}
+
+	cfg := driver.SecretConfig{
+		Name: "tagged-secret",
+		Tags: tags,
+	}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
+	requireNoError(t, err)
+
+	assertEqual(t, "prod", info.Tags["env"])
+	assertEqual(t, "platform", info.Tags["team"])
+}
+
+func TestCreateSecretARNFormat(t *testing.T) {
+	m := newTestMock()
+
+	info := createTestSecret(t, m, "arn-secret", "val")
+
+	if len(info.ARN) == 0 {
+		t.Fatal("expected non-empty ARN (vault URL)")
+	}
+}
+
+func TestDeleteSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     bool
+		secretNm  string
+		expectErr bool
+	}{
+		{
+			name:      "existing secret",
+			setup:     true,
+			secretNm:  "del-secret",
+			expectErr: false,
+		},
+		{
+			name:      "not found",
+			setup:     false,
+			secretNm:  "nonexistent",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			if tc.setup {
+				createTestSecret(t, m, tc.secretNm, "val")
+			}
+
+			err := m.DeleteSecret(context.Background(), tc.secretNm)
+			assertError(t, err, tc.expectErr)
+		})
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     bool
+		secretNm  string
+		expectErr bool
+	}{
+		{
+			name:      "existing secret",
+			setup:     true,
+			secretNm:  "get-secret",
+			expectErr: false,
+		},
+		{
+			name:      "not found",
+			setup:     false,
+			secretNm:  "missing",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			if tc.setup {
+				createTestSecret(t, m, tc.secretNm, "val")
+			}
+
+			info, err := m.GetSecret(context.Background(), tc.secretNm)
+			assertError(t, err, tc.expectErr)
+
+			if !tc.expectErr {
+				assertEqual(t, tc.secretNm, info.Name)
+				assertNotEmpty(t, info.ID)
+			}
+		})
+	}
+}
+
+func TestListSecrets(t *testing.T) {
+	m := newTestMock()
+
+	list, err := m.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 0, len(list))
+
+	createTestSecret(t, m, "s1", "v1")
+	createTestSecret(t, m, "s2", "v2")
+	createTestSecret(t, m, "s3", "v3")
+
+	list, err = m.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 3, len(list))
+}
+
+func TestPutSecretValue(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "put-secret", "initial")
+
+	ver, err := m.PutSecretValue(context.Background(), "put-secret", []byte("updated"))
+	requireNoError(t, err)
+
+	assertNotEmpty(t, ver.VersionID)
+	assertEqual(t, true, ver.Current)
+	assertEqual(t, "updated", string(ver.Value))
+}
+
+func TestPutSecretValueNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.PutSecretValue(context.Background(), "no-such-secret", []byte("val"))
+
+	assertError(t, err, true)
+}
+
+func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "ver-secret", "v1")
+
+	_, err := m.PutSecretValue(context.Background(), "ver-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	versions, err := m.ListSecretVersions(context.Background(), "ver-secret")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(versions))
+
+	currentCount := 0
+
+	for _, v := range versions {
+		if v.Current {
+			currentCount++
+		}
+	}
+
+	assertEqual(t, 1, currentCount)
+}
+
+func TestGetSecretValueEmptyVersionID(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "gv-secret", "my-value")
+
+	ver, err := m.GetSecretValue(context.Background(), "gv-secret", "")
+	requireNoError(t, err)
+
+	assertEqual(t, true, ver.Current)
+	assertEqual(t, "my-value", string(ver.Value))
+}
+
+func TestGetSecretValueSpecificVersion(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "sv-secret", "v1")
+
+	v2, err := m.PutSecretValue(context.Background(), "sv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	got, err := m.GetSecretValue(context.Background(), "sv-secret", v2.VersionID)
+	requireNoError(t, err)
+
+	assertEqual(t, v2.VersionID, got.VersionID)
+	assertEqual(t, "v2", string(got.Value))
+}
+
+func TestGetSecretValueNonexistentVersion(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "nv-secret", "val")
+
+	_, err := m.GetSecretValue(context.Background(), "nv-secret", "bad-version-id")
+
+	assertError(t, err, true)
+}
+
+func TestGetSecretValueNonexistentSecret(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.GetSecretValue(context.Background(), "no-secret", "")
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersions(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "lv-secret", "v1")
+
+	_, err := m.PutSecretValue(context.Background(), "lv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	_, err = m.PutSecretValue(context.Background(), "lv-secret", []byte("v3"))
+	requireNoError(t, err)
+
+	versions, err := m.ListSecretVersions(context.Background(), "lv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 3, len(versions))
+}
+
+func TestListSecretVersionsNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListSecretVersions(context.Background(), "missing")
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersionsPrivacy(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "priv-secret", "sensitive")
+
+	versions, err := m.ListSecretVersions(context.Background(), "priv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(versions))
+
+	for _, v := range versions {
+		if len(v.Value) != 0 {
+			t.Error("expected empty Value in listed versions for privacy")
+		}
+	}
+}
+
+func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "multi-secret", "v1")
+
+	for i := 0; i < 5; i++ {
+		_, err := m.PutSecretValue(context.Background(), "multi-secret", []byte("update"))
+		requireNoError(t, err)
+	}
+
+	versions, err := m.ListSecretVersions(context.Background(), "multi-secret")
+	requireNoError(t, err)
+	assertEqual(t, 6, len(versions))
+
+	currentCount := 0
+
+	for _, v := range versions {
+		if v.Current {
+			currentCount++
+		}
+	}
+
+	assertEqual(t, 1, currentCount)
+}
+
+func TestDeleteThenGetReturnsError(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "dtg-secret", "val")
+
+	err := m.DeleteSecret(context.Background(), "dtg-secret")
+	requireNoError(t, err)
+
+	_, err = m.GetSecret(context.Background(), "dtg-secret")
+	assertError(t, err, true)
+}
+
+func TestCreateSecretTagsCopied(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"key": "original"}
+
+	cfg := driver.SecretConfig{Name: "tag-copy", Tags: tags}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
+	requireNoError(t, err)
+
+	tags["key"] = "mutated"
+
+	assertEqual(t, "original", info.Tags["key"])
+}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -1,0 +1,295 @@
+// Package loganalytics provides an in-memory mock implementation of Azure Log Analytics.
+package loganalytics
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/logging/driver"
+)
+
+// Compile-time check that Mock implements driver.Logging.
+var _ driver.Logging = (*Mock)(nil)
+
+type logStream struct {
+	info   driver.LogStreamInfo
+	events []driver.LogEvent
+	mu     sync.RWMutex
+}
+
+type logGroup struct {
+	info    driver.LogGroupInfo
+	streams *memstore.Store[*logStream]
+}
+
+// Mock is an in-memory mock implementation of Azure Log Analytics.
+type Mock struct {
+	groups *memstore.Store[*logGroup]
+	opts   *config.Options
+}
+
+// New creates a new Log Analytics mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		groups: memstore.New[*logGroup](),
+		opts:   opts,
+	}
+}
+
+// CreateLogGroup creates a new Log Analytics workspace.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "log group name is required")
+	}
+
+	if m.groups.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "log group %q already exists", cfg.Name)
+	}
+
+	retentionDays := cfg.RetentionDays
+	if retentionDays == 0 {
+		retentionDays = 30
+	}
+
+	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.OperationalInsights", "workspaces", cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.LogGroupInfo{
+		Name:          cfg.Name,
+		ARN:           resourceID,
+		RetentionDays: retentionDays,
+		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		StoredBytes:   0,
+		Tags:          tags,
+	}
+
+	g := &logGroup{
+		info:    info,
+		streams: memstore.New[*logStream](),
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteLogGroup deletes a Log Analytics workspace by name.
+func (m *Mock) DeleteLogGroup(_ context.Context, name string) error {
+	if !m.groups.Delete(name) {
+		return errors.Newf(errors.NotFound, "log group %q not found", name)
+	}
+
+	return nil
+}
+
+// GetLogGroup retrieves information about a Log Analytics workspace.
+func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", name)
+	}
+
+	result := g.info
+
+	return &result, nil
+}
+
+// ListLogGroups lists all Log Analytics workspaces.
+func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+	all := m.groups.All()
+
+	groups := make([]driver.LogGroupInfo, 0, len(all))
+	for _, g := range all {
+		groups = append(groups, g.info)
+	}
+
+	return groups, nil
+}
+
+// CreateLogStream creates a new log stream in a workspace.
+func (m *Mock) CreateLogStream(_ context.Context, logGroup, streamName string) (*driver.LogStreamInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if streamName == "" {
+		return nil, errors.New(errors.InvalidArgument, "stream name is required")
+	}
+
+	if g.streams.Has(streamName) {
+		return nil, errors.Newf(errors.AlreadyExists, "log stream %q already exists in group %q", streamName, logGroup)
+	}
+
+	info := driver.LogStreamInfo{
+		Name:      streamName,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	s := &logStream{
+		info:   info,
+		events: make([]driver.LogEvent, 0),
+	}
+
+	g.streams.Set(streamName, s)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteLogStream deletes a log stream from a workspace.
+func (m *Mock) DeleteLogStream(_ context.Context, logGroup, streamName string) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if !g.streams.Delete(streamName) {
+		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, logGroup)
+	}
+
+	return nil
+}
+
+// ListLogStreams lists all log streams in a workspace.
+func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogStreamInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	all := g.streams.All()
+
+	streams := make([]driver.LogStreamInfo, 0, len(all))
+	for _, s := range all {
+		s.mu.RLock()
+		streams = append(streams, s.info)
+		s.mu.RUnlock()
+	}
+
+	return streams, nil
+}
+
+// PutLogEvents writes log events to a stream.
+func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, events []driver.LogEvent) error {
+	g, ok := m.groups.Get(groupName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", groupName)
+	}
+
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, groupName)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	copied := make([]driver.LogEvent, len(events))
+	copy(copied, events)
+
+	s.events = append(s.events, copied...)
+
+	if len(events) > 0 {
+		s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
+	}
+
+	var totalBytes int64
+	for _, e := range events {
+		totalBytes += int64(len(e.Message))
+	}
+
+	m.groups.Update(groupName, func(lg *logGroup) *logGroup {
+		lg.info.StoredBytes += totalBytes
+		return lg
+	})
+
+	return nil
+}
+
+// GetLogEvents retrieves log events matching the query.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+	g, ok := m.groups.Get(input.LogGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", input.LogGroup)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var results []driver.LogEvent
+
+	if input.LogStream != "" {
+		events := m.getStreamEvents(g, input.LogStream, input)
+		results = append(results, events...)
+	} else {
+		all := g.streams.All()
+		for _, s := range all {
+			events := m.filterEvents(s, input)
+			results = append(results, events...)
+		}
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	if results == nil {
+		results = []driver.LogEvent{}
+	}
+
+	return results, nil
+}
+
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQueryInput) []driver.LogEvent {
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return nil
+	}
+
+	return m.filterEvents(s, input)
+}
+
+func (m *Mock) filterEvents(s *logStream, input driver.LogQueryInput) []driver.LogEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []driver.LogEvent
+
+	for _, e := range s.events {
+		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
+			continue
+		}
+
+		if !input.EndTime.IsZero() && e.Timestamp.After(input.EndTime) {
+			continue
+		}
+
+		if input.Pattern != "" && !strings.Contains(e.Message, input.Pattern) {
+			continue
+		}
+
+		results = append(results, e)
+	}
+
+	return results
+}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stackshy/cloudemu/logging/driver"
 )
 
+const (
+	defaultRetentionDays = 30
+	defaultLogLimit      = 100
+)
+
 // Compile-time check that Mock implements driver.Logging.
 var _ driver.Logging = (*Mock)(nil)
 
@@ -54,7 +59,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	retentionDays := cfg.RetentionDays
 	if retentionDays == 0 {
-		retentionDays = 30
+		retentionDays = defaultRetentionDays
 	}
 
 	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.OperationalInsights", "workspaces", cfg.Name)
@@ -66,7 +71,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
-		ARN:           resourceID,
+		ResourceID:    resourceID,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		StoredBytes:   0,
@@ -232,18 +237,20 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 
 	limit := input.Limit
 	if limit <= 0 {
-		limit = 100
+		limit = defaultLogLimit
 	}
+
+	retentionCutoff := m.opts.Clock.Now().AddDate(0, 0, -g.info.RetentionDays)
 
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, &input)
+		events := m.getStreamEvents(g, input.LogStream, &input, retentionCutoff)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, &input)
+			events := m.filterEvents(s, &input, retentionCutoff)
 			results = append(results, events...)
 		}
 	}
@@ -259,22 +266,26 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput) []driver.LogEvent {
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
 	s, ok := g.streams.Get(streamName)
 	if !ok {
 		return nil
 	}
 
-	return m.filterEvents(s, input)
+	return m.filterEvents(s, input, retentionCutoff)
 }
 
-func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput) []driver.LogEvent {
+func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var results []driver.LogEvent
 
 	for _, e := range s.events {
+		if !retentionCutoff.IsZero() && e.Timestamp.Before(retentionCutoff) {
+			continue
+		}
+
 		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
 			continue
 		}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -43,8 +43,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateLogGroup creates a new Log Analytics workspace.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "log group name is required")
@@ -176,6 +174,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 	all := g.streams.All()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
+
 	for _, s := range all {
 		s.mu.RLock()
 		streams = append(streams, s.info)
@@ -239,12 +238,12 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, input)
+		events := m.getStreamEvents(g, input.LogStream, &input)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, input)
+			events := m.filterEvents(s, &input)
 			results = append(results, events...)
 		}
 	}
@@ -260,7 +259,7 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQueryInput) []driver.LogEvent {
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput) []driver.LogEvent {
 	s, ok := g.streams.Get(streamName)
 	if !ok {
 		return nil
@@ -269,7 +268,7 @@ func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQ
 	return m.filterEvents(s, input)
 }
 
-func (m *Mock) filterEvents(s *logStream, input driver.LogQueryInput) []driver.LogEvent {
+func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/providers/azure/loganalytics/loganalytics_test.go
+++ b/providers/azure/loganalytics/loganalytics_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -57,10 +24,10 @@ func setupGroupAndStream(t *testing.T, m *Mock) {
 	ctx := context.Background()
 
 	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.CreateLogStream(ctx, "test-group", "test-stream")
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateLogGroup(t *testing.T) {
@@ -72,12 +39,12 @@ func TestCreateLogGroup(t *testing.T) {
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
 			Name: "my-workspace",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "my-workspace", info.Name)
-		assertNotEmpty(t, info.ResourceID)
-		assertNotEmpty(t, info.CreatedAt)
-		assertEqual(t, int64(0), info.StoredBytes)
+		assert.Equal(t, "my-workspace", info.Name)
+		assert.NotEmpty(t, info.ResourceID)
+		assert.NotEmpty(t, info.CreatedAt)
+		assert.Equal(t, int64(0), info.StoredBytes)
 	})
 
 	t.Run("default retention 30 days", func(t *testing.T) {
@@ -86,9 +53,9 @@ func TestCreateLogGroup(t *testing.T) {
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
 			Name: "retention-test",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 30, info.RetentionDays)
+		assert.Equal(t, 30, info.RetentionDays)
 	})
 
 	t.Run("custom retention", func(t *testing.T) {
@@ -98,9 +65,9 @@ func TestCreateLogGroup(t *testing.T) {
 			Name:          "custom-ret",
 			RetentionDays: 90,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 90, info.RetentionDays)
+		assert.Equal(t, 90, info.RetentionDays)
 	})
 
 	t.Run("with tags", func(t *testing.T) {
@@ -111,27 +78,27 @@ func TestCreateLogGroup(t *testing.T) {
 			Name: "tagged-workspace",
 			Tags: tags,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "prod", info.Tags["env"])
-		assertEqual(t, "backend", info.Tags["team"])
+		assert.Equal(t, "prod", info.Tags["env"])
+		assert.Equal(t, "backend", info.Tags["team"])
 	})
 
 	t.Run("empty name error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("duplicate error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -142,20 +109,20 @@ func TestDeleteLogGroup(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del-me"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.DeleteLogGroup(ctx, "del-me")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.GetLogGroup(ctx, "del-me")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.DeleteLogGroup(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -166,19 +133,19 @@ func TestGetLogGroup(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "get-me"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.GetLogGroup(ctx, "get-me")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "get-me", info.Name)
+		assert.Equal(t, "get-me", info.Name)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.GetLogGroup(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -189,24 +156,24 @@ func TestListLogGroups(t *testing.T) {
 		m := newTestMock()
 
 		groups, err := m.ListLogGroups(ctx)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(groups))
+		assert.Equal(t, 0, len(groups))
 	})
 
 	t.Run("multiple groups", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		groups, err := m.ListLogGroups(ctx)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(groups))
+		assert.Equal(t, 2, len(groups))
 	})
 }
 
@@ -217,43 +184,43 @@ func TestCreateLogStream(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.CreateLogStream(ctx, "grp", "stream-1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "stream-1", info.Name)
-		assertNotEmpty(t, info.CreatedAt)
+		assert.Equal(t, "stream-1", info.Name)
+		assert.NotEmpty(t, info.CreatedAt)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogStream(ctx, "no-group", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("empty stream name error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("duplicate stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -265,24 +232,24 @@ func TestDeleteLogStream(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		err := m.DeleteLogStream(ctx, "test-group", "test-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.DeleteLogStream(ctx, "no-group", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("not found stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.DeleteLogStream(ctx, "grp", "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -293,25 +260,25 @@ func TestListLogStreams(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "s1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "s2")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		streams, err := m.ListLogStreams(ctx, "grp")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(streams))
+		assert.Equal(t, 2, len(streams))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.ListLogStreams(ctx, "no-group")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -329,7 +296,7 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("updates LastEvent", func(t *testing.T) {
@@ -342,13 +309,13 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		streams, err := m.ListLogStreams(ctx, "test-group")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		expected := baseTime.Add(5 * time.Second).UTC().Format(time.RFC3339)
-		assertEqual(t, expected, streams[0].LastEvent)
+		assert.Equal(t, expected, streams[0].LastEvent)
 	})
 
 	t.Run("updates StoredBytes", func(t *testing.T) {
@@ -360,29 +327,29 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.GetLogGroup(ctx, "test-group")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, int64(5), info.StoredBytes)
+		assert.Equal(t, int64(5), info.StoredBytes)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.PutLogEvents(ctx, "no-group", "s1", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("nonexistent stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -395,24 +362,24 @@ func TestGetLogEvents(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		_, err := m.CreateLogStream(ctx, "test-group", "stream-2")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "msg1"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "stream-2", []driver.LogEvent{
 			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("specific stream filter", func(t *testing.T) {
@@ -420,26 +387,26 @@ func TestGetLogEvents(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		_, err := m.CreateLogStream(ctx, "test-group", "other")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "target"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "other", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "ignore"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "test-group",
 			LogStream: "test-stream",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 1, len(events))
-		assertEqual(t, "target", events[0].Message)
+		assert.Equal(t, 1, len(events))
+		assert.Equal(t, "target", events[0].Message)
 	})
 
 	t.Run("pattern filter", func(t *testing.T) {
@@ -451,15 +418,15 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime.Add(time.Second), Message: "INFO: all good"},
 			{Timestamp: baseTime.Add(2 * time.Second), Message: "ERROR: another failure"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 			Pattern:  "ERROR",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("time range filter", func(t *testing.T) {
@@ -471,17 +438,17 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime.Add(time.Hour), Message: "middle"},
 			{Timestamp: baseTime.Add(2 * time.Hour), Message: "late"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "test-group",
 			StartTime: baseTime.Add(30 * time.Minute),
 			EndTime:   baseTime.Add(90 * time.Minute),
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 1, len(events))
-		assertEqual(t, "middle", events[0].Message)
+		assert.Equal(t, 1, len(events))
+		assert.Equal(t, "middle", events[0].Message)
 	})
 
 	t.Run("with limit", func(t *testing.T) {
@@ -497,15 +464,15 @@ func TestGetLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 			Limit:    3,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 3, len(result))
+		assert.Equal(t, 3, len(result))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
@@ -514,22 +481,22 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "no-group",
 		})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("nonexistent stream returns empty", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(events))
+		assert.Equal(t, 0, len(events))
 	})
 
 	t.Run("default limit 100", func(t *testing.T) {
@@ -545,27 +512,27 @@ func TestGetLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 100, len(result))
+		assert.Equal(t, 100, len(result))
 	})
 
 	t.Run("empty group returns empty slice", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "empty-grp",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(events))
+		assert.Equal(t, 0, len(events))
 	})
 }

--- a/providers/azure/loganalytics/loganalytics_test.go
+++ b/providers/azure/loganalytics/loganalytics_test.go
@@ -1,0 +1,571 @@
+package loganalytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/logging/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func setupGroupAndStream(t *testing.T, m *Mock) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
+	requireNoError(t, err)
+
+	_, err = m.CreateLogStream(ctx, "test-group", "test-stream")
+	requireNoError(t, err)
+}
+
+func TestCreateLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "my-workspace",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, "my-workspace", info.Name)
+		assertNotEmpty(t, info.ARN)
+		assertNotEmpty(t, info.CreatedAt)
+		assertEqual(t, int64(0), info.StoredBytes)
+	})
+
+	t.Run("default retention 30 days", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "retention-test",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 30, info.RetentionDays)
+	})
+
+	t.Run("custom retention", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name:          "custom-ret",
+			RetentionDays: 90,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 90, info.RetentionDays)
+	})
+
+	t.Run("with tags", func(t *testing.T) {
+		m := newTestMock()
+		tags := map[string]string{"env": "prod", "team": "backend"}
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "tagged-workspace",
+			Tags: tags,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, "prod", info.Tags["env"])
+		assertEqual(t, "backend", info.Tags["team"])
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del-me"})
+		requireNoError(t, err)
+
+		err = m.DeleteLogGroup(ctx, "del-me")
+		requireNoError(t, err)
+
+		_, err = m.GetLogGroup(ctx, "del-me")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.DeleteLogGroup(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "get-me"})
+		requireNoError(t, err)
+
+		info, err := m.GetLogGroup(ctx, "get-me")
+		requireNoError(t, err)
+
+		assertEqual(t, "get-me", info.Name)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.GetLogGroup(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogGroups(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		m := newTestMock()
+
+		groups, err := m.ListLogGroups(ctx)
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(groups))
+	})
+
+	t.Run("multiple groups", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
+		requireNoError(t, err)
+
+		groups, err := m.ListLogGroups(ctx)
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(groups))
+	})
+}
+
+func TestCreateLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		info, err := m.CreateLogStream(ctx, "grp", "stream-1")
+		requireNoError(t, err)
+
+		assertEqual(t, "stream-1", info.Name)
+		assertNotEmpty(t, info.CreatedAt)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogStream(ctx, "no-group", "s1")
+		assertError(t, err, true)
+	})
+
+	t.Run("empty stream name error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.DeleteLogStream(ctx, "test-group", "test-stream")
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.DeleteLogStream(ctx, "no-group", "s1")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		err = m.DeleteLogStream(ctx, "grp", "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogStreams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "s1")
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "s2")
+		requireNoError(t, err)
+
+		streams, err := m.ListLogStreams(ctx, "grp")
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(streams))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.ListLogStreams(ctx, "no-group")
+		assertError(t, err, true)
+	})
+}
+
+func TestPutLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "hello"},
+			{Timestamp: baseTime.Add(time.Second), Message: "world"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+	})
+
+	t.Run("updates LastEvent", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "first"},
+			{Timestamp: baseTime.Add(5 * time.Second), Message: "last"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		streams, err := m.ListLogStreams(ctx, "test-group")
+		requireNoError(t, err)
+
+		expected := baseTime.Add(5 * time.Second).UTC().Format(time.RFC3339)
+		assertEqual(t, expected, streams[0].LastEvent)
+	})
+
+	t.Run("updates StoredBytes", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "12345"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		info, err := m.GetLogGroup(ctx, "test-group")
+		requireNoError(t, err)
+
+		assertEqual(t, int64(5), info.StoredBytes)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.PutLogEvents(ctx, "no-group", "s1", nil)
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("all events from all streams", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		_, err := m.CreateLogStream(ctx, "test-group", "stream-2")
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "msg1"},
+		})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "stream-2", []driver.LogEvent{
+			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("specific stream filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		_, err := m.CreateLogStream(ctx, "test-group", "other")
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "target"},
+		})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "other", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "ignore"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "test-group",
+			LogStream: "test-stream",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 1, len(events))
+		assertEqual(t, "target", events[0].Message)
+	})
+
+	t.Run("pattern filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "ERROR: something failed"},
+			{Timestamp: baseTime.Add(time.Second), Message: "INFO: all good"},
+			{Timestamp: baseTime.Add(2 * time.Second), Message: "ERROR: another failure"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+			Pattern:  "ERROR",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("time range filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "early"},
+			{Timestamp: baseTime.Add(time.Hour), Message: "middle"},
+			{Timestamp: baseTime.Add(2 * time.Hour), Message: "late"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "test-group",
+			StartTime: baseTime.Add(30 * time.Minute),
+			EndTime:   baseTime.Add(90 * time.Minute),
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 1, len(events))
+		assertEqual(t, "middle", events[0].Message)
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := make([]driver.LogEvent, 10)
+		for i := range events {
+			events[i] = driver.LogEvent{
+				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+				Message:   "msg",
+			}
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+			Limit:    3,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 3, len(result))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "no-group",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent stream returns empty", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "grp",
+			LogStream: "no-stream",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(events))
+	})
+
+	t.Run("default limit 100", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := make([]driver.LogEvent, 150)
+		for i := range events {
+			events[i] = driver.LogEvent{
+				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+				Message:   "msg",
+			}
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 100, len(result))
+	})
+
+	t.Run("empty group returns empty slice", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "empty-grp",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(events))
+	})
+}

--- a/providers/azure/loganalytics/loganalytics_test.go
+++ b/providers/azure/loganalytics/loganalytics_test.go
@@ -75,7 +75,7 @@ func TestCreateLogGroup(t *testing.T) {
 		requireNoError(t, err)
 
 		assertEqual(t, "my-workspace", info.Name)
-		assertNotEmpty(t, info.ARN)
+		assertNotEmpty(t, info.ResourceID)
 		assertNotEmpty(t, info.CreatedAt)
 		assertEqual(t, int64(0), info.StoredBytes)
 	})

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -35,8 +35,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateTopic creates a new notification hub.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
@@ -101,6 +99,7 @@ func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
 	all := m.topics.All()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
+
 	for _, td := range all {
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
@@ -111,8 +110,6 @@ func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
 }
 
 // Subscribe creates a subscription to a notification hub.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
 	td, ok := m.topics.Get(cfg.TopicID)
 	if !ok {
@@ -176,8 +173,6 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 }
 
 // Publish publishes a message to a notification hub.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
 	if _, ok := m.topics.Get(input.TopicID); !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -4,6 +4,7 @@ package notificationhubs
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/errors"
@@ -15,9 +16,19 @@ import (
 // Compile-time check that Mock implements driver.Notification.
 var _ driver.Notification = (*Mock)(nil)
 
+type publishedMessage struct {
+	ID         string
+	TopicID    string
+	Subject    string
+	Message    string
+	Attributes map[string]string
+}
+
 type topicData struct {
 	info          driver.TopicInfo
 	subscriptions *memstore.Store[driver.SubscriptionInfo]
+	messages      []publishedMessage
+	mu            sync.RWMutex
 }
 
 // Mock is an in-memory mock implementation of Azure Notification Hubs.
@@ -54,7 +65,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
-		ARN:               resourceID,
+		ResourceID:        resourceID,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
 		Tags:              tags,
@@ -125,7 +136,7 @@ func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*dri
 	}
 
 	subID := idgen.GenerateID("sub-")
-	resourceID := fmt.Sprintf("%s/subscriptions/%s", td.info.ARN, subID)
+	resourceID := fmt.Sprintf("%s/subscriptions/%s", td.info.ResourceID, subID)
 
 	sub := driver.SubscriptionInfo{
 		ID:       resourceID,
@@ -174,7 +185,8 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 
 // Publish publishes a message to a notification hub.
 func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
-	if _, ok := m.topics.Get(input.TopicID); !ok {
+	td, ok := m.topics.Get(input.TopicID)
+	if !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
 	}
 
@@ -183,6 +195,21 @@ func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.Pu
 	}
 
 	msgID := idgen.GenerateID("msg-")
+
+	attrs := make(map[string]string, len(input.Attributes))
+	for k, v := range input.Attributes {
+		attrs[k] = v
+	}
+
+	td.mu.Lock()
+	td.messages = append(td.messages, publishedMessage{
+		ID:         msgID,
+		TopicID:    input.TopicID,
+		Subject:    input.Subject,
+		Message:    input.Message,
+		Attributes: attrs,
+	})
+	td.mu.Unlock()
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
 }

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -1,0 +1,193 @@
+// Package notificationhubs provides an in-memory mock implementation of Azure Notification Hubs.
+package notificationhubs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/notification/driver"
+)
+
+// Compile-time check that Mock implements driver.Notification.
+var _ driver.Notification = (*Mock)(nil)
+
+type topicData struct {
+	info          driver.TopicInfo
+	subscriptions *memstore.Store[driver.SubscriptionInfo]
+}
+
+// Mock is an in-memory mock implementation of Azure Notification Hubs.
+type Mock struct {
+	topics *memstore.Store[*topicData]
+	opts   *config.Options
+}
+
+// New creates a new Notification Hubs mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		topics: memstore.New[*topicData](),
+		opts:   opts,
+	}
+}
+
+// CreateTopic creates a new notification hub.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.NotificationHubs", "namespaces/default/notificationHubs", cfg.Name)
+
+	if m.topics.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
+	}
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.TopicInfo{
+		ID:                idgen.GenerateID("topic-"),
+		Name:              cfg.Name,
+		ARN:               resourceID,
+		DisplayName:       cfg.DisplayName,
+		SubscriptionCount: 0,
+		Tags:              tags,
+	}
+
+	td := &topicData{
+		info:          info,
+		subscriptions: memstore.New[driver.SubscriptionInfo](),
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteTopic deletes a notification hub by name.
+func (m *Mock) DeleteTopic(_ context.Context, id string) error {
+	if !m.topics.Delete(id) {
+		return errors.Newf(errors.NotFound, "topic %q not found", id)
+	}
+
+	return nil
+}
+
+// GetTopic retrieves information about a notification hub.
+func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", id)
+	}
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
+}
+
+// ListTopics lists all notification hubs.
+func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+	all := m.topics.All()
+
+	topics := make([]driver.TopicInfo, 0, len(all))
+	for _, td := range all {
+		info := td.info
+		info.SubscriptionCount = td.subscriptions.Len()
+		topics = append(topics, info)
+	}
+
+	return topics, nil
+}
+
+// Subscribe creates a subscription to a notification hub.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
+	td, ok := m.topics.Get(cfg.TopicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.TopicID)
+	}
+
+	if cfg.Protocol == "" {
+		return nil, errors.New(errors.InvalidArgument, "protocol is required")
+	}
+
+	if cfg.Endpoint == "" {
+		return nil, errors.New(errors.InvalidArgument, "endpoint is required")
+	}
+
+	subID := idgen.GenerateID("sub-")
+	resourceID := fmt.Sprintf("%s/subscriptions/%s", td.info.ARN, subID)
+
+	sub := driver.SubscriptionInfo{
+		ID:       resourceID,
+		TopicID:  cfg.TopicID,
+		Protocol: cfg.Protocol,
+		Endpoint: cfg.Endpoint,
+		Status:   "confirmed",
+	}
+
+	td.subscriptions.Set(resourceID, sub)
+
+	result := sub
+
+	return &result, nil
+}
+
+// Unsubscribe removes a subscription.
+func (m *Mock) Unsubscribe(_ context.Context, subscriptionID string) error {
+	all := m.topics.All()
+
+	for _, td := range all {
+		if td.subscriptions.Delete(subscriptionID) {
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.NotFound, "subscription %q not found", subscriptionID)
+}
+
+// ListSubscriptions lists all subscriptions for a notification hub.
+func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.SubscriptionInfo, error) {
+	td, ok := m.topics.Get(topicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
+	}
+
+	all := td.subscriptions.All()
+
+	subs := make([]driver.SubscriptionInfo, 0, len(all))
+	for _, s := range all {
+		subs = append(subs, s)
+	}
+
+	return subs, nil
+}
+
+// Publish publishes a message to a notification hub.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
+	if _, ok := m.topics.Get(input.TopicID); !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
+	}
+
+	if input.Message == "" {
+		return nil, errors.New(errors.InvalidArgument, "message is required")
+	}
+
+	msgID := idgen.GenerateID("msg-")
+
+	return &driver.PublishOutput{MessageID: msgID}, nil
+}

--- a/providers/azure/notificationhubs/notificationhubs_test.go
+++ b/providers/azure/notificationhubs/notificationhubs_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/notification/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -55,7 +22,7 @@ func createTestTopic(t *testing.T, m *Mock, name string) *driver.TopicInfo {
 	t.Helper()
 
 	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -105,17 +72,18 @@ func TestCreateTopic(t *testing.T) {
 			}
 
 			info, err := m.CreateTopic(context.Background(), tc.cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, info.ID)
-			assertNotEmpty(t, info.ARN)
-			assertEqual(t, tc.cfg.Name, info.Name)
-			assertEqual(t, tc.cfg.DisplayName, info.DisplayName)
-			assertEqual(t, 0, info.SubscriptionCount)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, info.ID)
+			assert.NotEmpty(t, info.ResourceID)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, tc.cfg.DisplayName, info.DisplayName)
+			assert.Equal(t, 0, info.SubscriptionCount)
 		})
 	}
 }
@@ -128,14 +96,14 @@ func TestCreateTopicWithTags(t *testing.T) {
 		Name: "tagged",
 		Tags: tags,
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "staging", info.Tags["env"])
-	assertEqual(t, "notifications", info.Tags["service"])
+	assert.Equal(t, "staging", info.Tags["env"])
+	assert.Equal(t, "notifications", info.Tags["service"])
 
 	// Verify tags are copied and not shared.
 	tags["env"] = "production"
-	assertEqual(t, "staging", info.Tags["env"])
+	assert.Equal(t, "staging", info.Tags["env"])
 }
 
 func TestDeleteTopic(t *testing.T) {
@@ -169,7 +137,12 @@ func TestDeleteTopic(t *testing.T) {
 			}
 
 			err := m.DeleteTopic(context.Background(), id)
-			assertError(t, err, tc.expectErr)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -181,11 +154,11 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	info := createTestTopic(t, m, "to-delete")
 
 	err := m.DeleteTopic(ctx, info.Name)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	topics, err := m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 }
 
 func TestGetTopic(t *testing.T) {
@@ -222,14 +195,15 @@ func TestGetTopic(t *testing.T) {
 			}
 
 			info, err := m.GetTopic(context.Background(), id)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertEqual(t, "get-me", info.Name)
-			assertEqual(t, "Get Me", info.DisplayName)
+			require.NoError(t, err)
+
+			assert.Equal(t, "get-me", info.Name)
+			assert.Equal(t, "Get Me", info.DisplayName)
 		})
 	}
 }
@@ -241,26 +215,26 @@ func TestGetTopicSubscriptionCount(t *testing.T) {
 	topic := createTestTopic(t, m, "sub-count")
 
 	info, err := m.GetTopic(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 0, info.SubscriptionCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.SubscriptionCount)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID:  topic.Name,
 		Protocol: "email",
 		Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID:  topic.Name,
 		Protocol: "sms",
 		Endpoint: "+1234567890",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	info, err = m.GetTopic(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 2, info.SubscriptionCount)
+	require.NoError(t, err)
+	assert.Equal(t, 2, info.SubscriptionCount)
 }
 
 func TestListTopics(t *testing.T) {
@@ -268,16 +242,16 @@ func TestListTopics(t *testing.T) {
 	ctx := context.Background()
 
 	topics, err := m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 
 	createTestTopic(t, m, "hub-1")
 	createTestTopic(t, m, "hub-2")
 	createTestTopic(t, m, "hub-3")
 
 	topics, err = m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 3, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(topics))
 }
 
 func TestSubscribe(t *testing.T) {
@@ -344,16 +318,17 @@ func TestSubscribe(t *testing.T) {
 			}
 
 			sub, err := m.Subscribe(context.Background(), cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, sub.ID)
-			assertEqual(t, cfg.Protocol, sub.Protocol)
-			assertEqual(t, cfg.Endpoint, sub.Endpoint)
-			assertEqual(t, "confirmed", sub.Status)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, sub.ID)
+			assert.Equal(t, cfg.Protocol, sub.Protocol)
+			assert.Equal(t, cfg.Endpoint, sub.Endpoint)
+			assert.Equal(t, "confirmed", sub.Status)
 		})
 	}
 }
@@ -372,21 +347,21 @@ func TestMultipleSubscriptionsSameTopic(t *testing.T) {
 	_, err := m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "sms", Endpoint: "+111",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "https", Endpoint: "https://hook.example.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	subs, err := m.ListSubscriptions(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 3, len(subs))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(subs))
 }
 
 func TestUnsubscribe(t *testing.T) {
@@ -398,20 +373,20 @@ func TestUnsubscribe(t *testing.T) {
 	sub, err := m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		err := m.Unsubscribe(ctx, sub.ID)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		subs, err := m.ListSubscriptions(ctx, topic.Name)
-		requireNoError(t, err)
-		assertEqual(t, 0, len(subs))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(subs))
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		err := m.Unsubscribe(ctx, "nonexistent-sub-id")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -422,24 +397,24 @@ func TestListSubscriptions(t *testing.T) {
 	topic := createTestTopic(t, m, "list-subs")
 
 	subs, err := m.ListSubscriptions(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(subs))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(subs))
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "email", Endpoint: "x@y.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	subs, err = m.ListSubscriptions(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 1, len(subs))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(subs))
 }
 
 func TestListSubscriptionsNonexistentTopic(t *testing.T) {
 	m := newTestMock()
 
 	_, err := m.ListSubscriptions(context.Background(), "nonexistent-hub")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPublish(t *testing.T) {
@@ -499,13 +474,14 @@ func TestPublish(t *testing.T) {
 			}
 
 			out, err := m.Publish(context.Background(), input)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, out.MessageID)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, out.MessageID)
 		})
 	}
 }
@@ -517,12 +493,10 @@ func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
 	topic := createTestTopic(t, m, "unique-ids")
 
 	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg1"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg2"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	if out1.MessageID == out2.MessageID {
-		t.Error("expected unique message IDs")
-	}
+	assert.NotEqual(t, out1.MessageID, out2.MessageID)
 }

--- a/providers/azure/notificationhubs/notificationhubs_test.go
+++ b/providers/azure/notificationhubs/notificationhubs_test.go
@@ -1,0 +1,528 @@
+package notificationhubs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/notification/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("eastus"))
+
+	return New(opts)
+}
+
+func createTestTopic(t *testing.T, m *Mock, name string) *driver.TopicInfo {
+	t.Helper()
+
+	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.TopicConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name: "basic topic",
+			cfg:  driver.TopicConfig{Name: "my-hub"},
+		},
+		{
+			name: "with display name",
+			cfg:  driver.TopicConfig{Name: "alerts", DisplayName: "Alert Hub"},
+		},
+		{
+			name: "with tags",
+			cfg: driver.TopicConfig{
+				Name: "tagged-hub",
+				Tags: map[string]string{"env": "prod", "team": "platform"},
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.TopicConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate topic",
+			cfg:  driver.TopicConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				_, _ = m.CreateTopic(context.Background(), driver.TopicConfig{Name: "dup"})
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateTopic(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, info.ID)
+			assertNotEmpty(t, info.ARN)
+			assertEqual(t, tc.cfg.Name, info.Name)
+			assertEqual(t, tc.cfg.DisplayName, info.DisplayName)
+			assertEqual(t, 0, info.SubscriptionCount)
+		})
+	}
+}
+
+func TestCreateTopicWithTags(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"env": "staging", "service": "notifications"}
+
+	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+		Name: "tagged",
+		Tags: tags,
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "staging", info.Tags["env"])
+	assertEqual(t, "notifications", info.Tags["service"])
+
+	// Verify tags are copied and not shared.
+	tags["env"] = "production"
+	assertEqual(t, "staging", info.Tags["env"])
+}
+
+func TestDeleteTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicID   string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) string {
+				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: "del"})
+				return info.Name
+			},
+		},
+		{
+			name:      "not found",
+			topicID:   "nonexistent-hub",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			id := tc.topicID
+
+			if tc.setup != nil {
+				id = tc.setup(m)
+			}
+
+			err := m.DeleteTopic(context.Background(), id)
+			assertError(t, err, tc.expectErr)
+		})
+	}
+}
+
+func TestDeleteTopicRemovesFromList(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	info := createTestTopic(t, m, "to-delete")
+
+	err := m.DeleteTopic(ctx, info.Name)
+	requireNoError(t, err)
+
+	topics, err := m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+}
+
+func TestGetTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicID   string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) string {
+				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name:        "get-me",
+					DisplayName: "Get Me",
+				})
+				return info.Name
+			},
+		},
+		{
+			name:      "not found",
+			topicID:   "nonexistent-hub",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			id := tc.topicID
+
+			if tc.setup != nil {
+				id = tc.setup(m)
+			}
+
+			info, err := m.GetTopic(context.Background(), id)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, "get-me", info.Name)
+			assertEqual(t, "Get Me", info.DisplayName)
+		})
+	}
+}
+
+func TestGetTopicSubscriptionCount(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "sub-count")
+
+	info, err := m.GetTopic(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 0, info.SubscriptionCount)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID:  topic.Name,
+		Protocol: "email",
+		Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID:  topic.Name,
+		Protocol: "sms",
+		Endpoint: "+1234567890",
+	})
+	requireNoError(t, err)
+
+	info, err = m.GetTopic(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 2, info.SubscriptionCount)
+}
+
+func TestListTopics(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topics, err := m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+
+	createTestTopic(t, m, "hub-1")
+	createTestTopic(t, m, "hub-2")
+	createTestTopic(t, m, "hub-3")
+
+	topics, err = m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(topics))
+}
+
+func TestSubscribe(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.SubscriptionConfig
+		setup     func(*Mock) driver.SubscriptionConfig
+		expectErr bool
+	}{
+		{
+			name: "email subscription",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "sub-hub")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "email", Endpoint: "user@example.com",
+				}
+			},
+		},
+		{
+			name: "sms subscription",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "sms-hub")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "sms", Endpoint: "+1234567890",
+				}
+			},
+		},
+		{
+			name: "nonexistent topic",
+			cfg: driver.SubscriptionConfig{
+				TopicID: "nonexistent-hub", Protocol: "email", Endpoint: "a@b.com",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty protocol",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "no-proto")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "", Endpoint: "a@b.com",
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty endpoint",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "no-endpoint")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "email", Endpoint: "",
+				}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			cfg := tc.cfg
+
+			if tc.setup != nil {
+				cfg = tc.setup(m)
+			}
+
+			sub, err := m.Subscribe(context.Background(), cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, sub.ID)
+			assertEqual(t, cfg.Protocol, sub.Protocol)
+			assertEqual(t, cfg.Endpoint, sub.Endpoint)
+			assertEqual(t, "confirmed", sub.Status)
+		})
+	}
+}
+
+func createTopicHelper(m *Mock, name string) *driver.TopicInfo {
+	info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	return info
+}
+
+func TestMultipleSubscriptionsSameTopic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "multi-sub")
+
+	_, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "sms", Endpoint: "+111",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "https", Endpoint: "https://hook.example.com",
+	})
+	requireNoError(t, err)
+
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(subs))
+}
+
+func TestUnsubscribe(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "unsub-hub")
+
+	sub, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := m.Unsubscribe(ctx, sub.ID)
+		requireNoError(t, err)
+
+		subs, err := m.ListSubscriptions(ctx, topic.Name)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(subs))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.Unsubscribe(ctx, "nonexistent-sub-id")
+		assertError(t, err, true)
+	})
+}
+
+func TestListSubscriptions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "list-subs")
+
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(subs))
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "x@y.com",
+	})
+	requireNoError(t, err)
+
+	subs, err = m.ListSubscriptions(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(subs))
+}
+
+func TestListSubscriptionsNonexistentTopic(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListSubscriptions(context.Background(), "nonexistent-hub")
+	assertError(t, err, true)
+}
+
+func TestPublish(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     driver.PublishInput
+		setup     func(*Mock) driver.PublishInput
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "pub-hub")
+				return driver.PublishInput{
+					TopicID: info.Name,
+					Message: "hello world",
+					Subject: "greetings",
+				}
+			},
+		},
+		{
+			name: "with attributes",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "attr-hub")
+				return driver.PublishInput{
+					TopicID:    info.Name,
+					Message:    "test",
+					Attributes: map[string]string{"key": "value"},
+				}
+			},
+		},
+		{
+			name: "nonexistent topic",
+			input: driver.PublishInput{
+				TopicID: "nonexistent-hub",
+				Message: "hello",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty message",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "empty-msg")
+				return driver.PublishInput{TopicID: info.Name, Message: ""}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			input := tc.input
+
+			if tc.setup != nil {
+				input = tc.setup(m)
+			}
+
+			out, err := m.Publish(context.Background(), input)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, out.MessageID)
+		})
+	}
+}
+
+func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "unique-ids")
+
+	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg1"})
+	requireNoError(t, err)
+
+	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg2"})
+	requireNoError(t, err)
+
+	if out1.MessageID == out2.MessageID {
+		t.Error("expected unique message IDs")
+	}
+}

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -43,8 +43,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateLogGroup creates a new Cloud Logging log bucket.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "log group name is required")
@@ -176,6 +174,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 	all := g.streams.All()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
+
 	for _, s := range all {
 		s.mu.RLock()
 		streams = append(streams, s.info)
@@ -239,12 +238,12 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, input)
+		events := m.getStreamEvents(g, input.LogStream, &input)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, input)
+			events := m.filterEvents(s, &input)
 			results = append(results, events...)
 		}
 	}
@@ -260,7 +259,7 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQueryInput) []driver.LogEvent {
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput) []driver.LogEvent {
 	s, ok := g.streams.Get(streamName)
 	if !ok {
 		return nil
@@ -269,7 +268,7 @@ func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQ
 	return m.filterEvents(s, input)
 }
 
-func (m *Mock) filterEvents(s *logStream, input driver.LogQueryInput) []driver.LogEvent {
+func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -1,0 +1,295 @@
+// Package cloudlogging provides an in-memory mock implementation of GCP Cloud Logging.
+package cloudlogging
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/logging/driver"
+)
+
+// Compile-time check that Mock implements driver.Logging.
+var _ driver.Logging = (*Mock)(nil)
+
+type logStream struct {
+	info   driver.LogStreamInfo
+	events []driver.LogEvent
+	mu     sync.RWMutex
+}
+
+type logGroup struct {
+	info    driver.LogGroupInfo
+	streams *memstore.Store[*logStream]
+}
+
+// Mock is an in-memory mock implementation of GCP Cloud Logging.
+type Mock struct {
+	groups *memstore.Store[*logGroup]
+	opts   *config.Options
+}
+
+// New creates a new Cloud Logging mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		groups: memstore.New[*logGroup](),
+		opts:   opts,
+	}
+}
+
+// CreateLogGroup creates a new Cloud Logging log bucket.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "log group name is required")
+	}
+
+	if m.groups.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "log group %q already exists", cfg.Name)
+	}
+
+	retentionDays := cfg.RetentionDays
+	if retentionDays == 0 {
+		retentionDays = 30
+	}
+
+	selfLink := idgen.GCPID(m.opts.ProjectID, "logs", cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.LogGroupInfo{
+		Name:          cfg.Name,
+		ARN:           selfLink,
+		RetentionDays: retentionDays,
+		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		StoredBytes:   0,
+		Tags:          tags,
+	}
+
+	g := &logGroup{
+		info:    info,
+		streams: memstore.New[*logStream](),
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteLogGroup deletes a Cloud Logging log bucket by name.
+func (m *Mock) DeleteLogGroup(_ context.Context, name string) error {
+	if !m.groups.Delete(name) {
+		return errors.Newf(errors.NotFound, "log group %q not found", name)
+	}
+
+	return nil
+}
+
+// GetLogGroup retrieves information about a Cloud Logging log bucket.
+func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", name)
+	}
+
+	result := g.info
+
+	return &result, nil
+}
+
+// ListLogGroups lists all Cloud Logging log buckets.
+func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+	all := m.groups.All()
+
+	groups := make([]driver.LogGroupInfo, 0, len(all))
+	for _, g := range all {
+		groups = append(groups, g.info)
+	}
+
+	return groups, nil
+}
+
+// CreateLogStream creates a new log stream in a log bucket.
+func (m *Mock) CreateLogStream(_ context.Context, logGroup, streamName string) (*driver.LogStreamInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if streamName == "" {
+		return nil, errors.New(errors.InvalidArgument, "stream name is required")
+	}
+
+	if g.streams.Has(streamName) {
+		return nil, errors.Newf(errors.AlreadyExists, "log stream %q already exists in group %q", streamName, logGroup)
+	}
+
+	info := driver.LogStreamInfo{
+		Name:      streamName,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	s := &logStream{
+		info:   info,
+		events: make([]driver.LogEvent, 0),
+	}
+
+	g.streams.Set(streamName, s)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteLogStream deletes a log stream from a log bucket.
+func (m *Mock) DeleteLogStream(_ context.Context, logGroup, streamName string) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	if !g.streams.Delete(streamName) {
+		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, logGroup)
+	}
+
+	return nil
+}
+
+// ListLogStreams lists all log streams in a log bucket.
+func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogStreamInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
+	}
+
+	all := g.streams.All()
+
+	streams := make([]driver.LogStreamInfo, 0, len(all))
+	for _, s := range all {
+		s.mu.RLock()
+		streams = append(streams, s.info)
+		s.mu.RUnlock()
+	}
+
+	return streams, nil
+}
+
+// PutLogEvents writes log events to a stream.
+func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, events []driver.LogEvent) error {
+	g, ok := m.groups.Get(groupName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log group %q not found", groupName)
+	}
+
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "log stream %q not found in group %q", streamName, groupName)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	copied := make([]driver.LogEvent, len(events))
+	copy(copied, events)
+
+	s.events = append(s.events, copied...)
+
+	if len(events) > 0 {
+		s.info.LastEvent = events[len(events)-1].Timestamp.UTC().Format(time.RFC3339)
+	}
+
+	var totalBytes int64
+	for _, e := range events {
+		totalBytes += int64(len(e.Message))
+	}
+
+	m.groups.Update(groupName, func(lg *logGroup) *logGroup {
+		lg.info.StoredBytes += totalBytes
+		return lg
+	})
+
+	return nil
+}
+
+// GetLogEvents retrieves log events matching the query.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+	g, ok := m.groups.Get(input.LogGroup)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", input.LogGroup)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+
+	var results []driver.LogEvent
+
+	if input.LogStream != "" {
+		events := m.getStreamEvents(g, input.LogStream, input)
+		results = append(results, events...)
+	} else {
+		all := g.streams.All()
+		for _, s := range all {
+			events := m.filterEvents(s, input)
+			results = append(results, events...)
+		}
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	if results == nil {
+		results = []driver.LogEvent{}
+	}
+
+	return results, nil
+}
+
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input driver.LogQueryInput) []driver.LogEvent {
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return nil
+	}
+
+	return m.filterEvents(s, input)
+}
+
+func (m *Mock) filterEvents(s *logStream, input driver.LogQueryInput) []driver.LogEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []driver.LogEvent
+
+	for _, e := range s.events {
+		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
+			continue
+		}
+
+		if !input.EndTime.IsZero() && e.Timestamp.After(input.EndTime) {
+			continue
+		}
+
+		if input.Pattern != "" && !strings.Contains(e.Message, input.Pattern) {
+			continue
+		}
+
+		results = append(results, e)
+	}
+
+	return results
+}

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stackshy/cloudemu/logging/driver"
 )
 
+const (
+	defaultRetentionDays = 30
+	defaultLogLimit      = 100
+)
+
 // Compile-time check that Mock implements driver.Logging.
 var _ driver.Logging = (*Mock)(nil)
 
@@ -54,7 +59,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	retentionDays := cfg.RetentionDays
 	if retentionDays == 0 {
-		retentionDays = 30
+		retentionDays = defaultRetentionDays
 	}
 
 	selfLink := idgen.GCPID(m.opts.ProjectID, "logs", cfg.Name)
@@ -66,7 +71,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
-		ARN:           selfLink,
+		ResourceID:    selfLink,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		StoredBytes:   0,
@@ -232,18 +237,20 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 
 	limit := input.Limit
 	if limit <= 0 {
-		limit = 100
+		limit = defaultLogLimit
 	}
+
+	retentionCutoff := m.opts.Clock.Now().AddDate(0, 0, -g.info.RetentionDays)
 
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, &input)
+		events := m.getStreamEvents(g, input.LogStream, &input, retentionCutoff)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, &input)
+			events := m.filterEvents(s, &input, retentionCutoff)
 			results = append(results, events...)
 		}
 	}
@@ -259,22 +266,26 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	return results, nil
 }
 
-func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput) []driver.LogEvent {
+func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
 	s, ok := g.streams.Get(streamName)
 	if !ok {
 		return nil
 	}
 
-	return m.filterEvents(s, input)
+	return m.filterEvents(s, input, retentionCutoff)
 }
 
-func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput) []driver.LogEvent {
+func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var results []driver.LogEvent
 
 	for _, e := range s.events {
+		if !retentionCutoff.IsZero() && e.Timestamp.Before(retentionCutoff) {
+			continue
+		}
+
 		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
 			continue
 		}

--- a/providers/gcp/cloudlogging/cloudlogging_test.go
+++ b/providers/gcp/cloudlogging/cloudlogging_test.go
@@ -1,0 +1,571 @@
+package cloudlogging
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/logging/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func setupGroupAndStream(t *testing.T, m *Mock) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
+	requireNoError(t, err)
+
+	_, err = m.CreateLogStream(ctx, "test-group", "test-stream")
+	requireNoError(t, err)
+}
+
+func TestCreateLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "my-bucket",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, "my-bucket", info.Name)
+		assertNotEmpty(t, info.ARN)
+		assertNotEmpty(t, info.CreatedAt)
+		assertEqual(t, int64(0), info.StoredBytes)
+	})
+
+	t.Run("default retention 30 days", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "retention-test",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 30, info.RetentionDays)
+	})
+
+	t.Run("custom retention", func(t *testing.T) {
+		m := newTestMock()
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name:          "custom-ret",
+			RetentionDays: 90,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 90, info.RetentionDays)
+	})
+
+	t.Run("with tags", func(t *testing.T) {
+		m := newTestMock()
+		tags := map[string]string{"env": "prod", "team": "backend"}
+
+		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
+			Name: "tagged-bucket",
+			Tags: tags,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, "prod", info.Tags["env"])
+		assertEqual(t, "backend", info.Tags["team"])
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del-me"})
+		requireNoError(t, err)
+
+		err = m.DeleteLogGroup(ctx, "del-me")
+		requireNoError(t, err)
+
+		_, err = m.GetLogGroup(ctx, "del-me")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.DeleteLogGroup(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "get-me"})
+		requireNoError(t, err)
+
+		info, err := m.GetLogGroup(ctx, "get-me")
+		requireNoError(t, err)
+
+		assertEqual(t, "get-me", info.Name)
+	})
+
+	t.Run("not found error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.GetLogGroup(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogGroups(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		m := newTestMock()
+
+		groups, err := m.ListLogGroups(ctx)
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(groups))
+	})
+
+	t.Run("multiple groups", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
+		requireNoError(t, err)
+
+		groups, err := m.ListLogGroups(ctx)
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(groups))
+	})
+}
+
+func TestCreateLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		info, err := m.CreateLogStream(ctx, "grp", "stream-1")
+		requireNoError(t, err)
+
+		assertEqual(t, "stream-1", info.Name)
+		assertNotEmpty(t, info.CreatedAt)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogStream(ctx, "no-group", "s1")
+		assertError(t, err, true)
+	})
+
+	t.Run("empty stream name error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLogStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.DeleteLogStream(ctx, "test-group", "test-stream")
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.DeleteLogStream(ctx, "no-group", "s1")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		err = m.DeleteLogStream(ctx, "grp", "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLogStreams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "s1")
+		requireNoError(t, err)
+
+		_, err = m.CreateLogStream(ctx, "grp", "s2")
+		requireNoError(t, err)
+
+		streams, err := m.ListLogStreams(ctx, "grp")
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(streams))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.ListLogStreams(ctx, "no-group")
+		assertError(t, err, true)
+	})
+}
+
+func TestPutLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "hello"},
+			{Timestamp: baseTime.Add(time.Second), Message: "world"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+	})
+
+	t.Run("updates LastEvent", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "first"},
+			{Timestamp: baseTime.Add(5 * time.Second), Message: "last"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		streams, err := m.ListLogStreams(ctx, "test-group")
+		requireNoError(t, err)
+
+		expected := baseTime.Add(5 * time.Second).UTC().Format(time.RFC3339)
+		assertEqual(t, expected, streams[0].LastEvent)
+	})
+
+	t.Run("updates StoredBytes", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := []driver.LogEvent{
+			{Timestamp: baseTime, Message: "12345"},
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		info, err := m.GetLogGroup(ctx, "test-group")
+		requireNoError(t, err)
+
+		assertEqual(t, int64(5), info.StoredBytes)
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.PutLogEvents(ctx, "no-group", "s1", nil)
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent stream error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLogEvents(t *testing.T) {
+	ctx := context.Background()
+	baseTime := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("all events from all streams", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		_, err := m.CreateLogStream(ctx, "test-group", "stream-2")
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "msg1"},
+		})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "stream-2", []driver.LogEvent{
+			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("specific stream filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		_, err := m.CreateLogStream(ctx, "test-group", "other")
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "target"},
+		})
+		requireNoError(t, err)
+
+		err = m.PutLogEvents(ctx, "test-group", "other", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "ignore"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "test-group",
+			LogStream: "test-stream",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 1, len(events))
+		assertEqual(t, "target", events[0].Message)
+	})
+
+	t.Run("pattern filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "ERROR: something failed"},
+			{Timestamp: baseTime.Add(time.Second), Message: "INFO: all good"},
+			{Timestamp: baseTime.Add(2 * time.Second), Message: "ERROR: another failure"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+			Pattern:  "ERROR",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 2, len(events))
+	})
+
+	t.Run("time range filter", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
+			{Timestamp: baseTime, Message: "early"},
+			{Timestamp: baseTime.Add(time.Hour), Message: "middle"},
+			{Timestamp: baseTime.Add(2 * time.Hour), Message: "late"},
+		})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "test-group",
+			StartTime: baseTime.Add(30 * time.Minute),
+			EndTime:   baseTime.Add(90 * time.Minute),
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 1, len(events))
+		assertEqual(t, "middle", events[0].Message)
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := make([]driver.LogEvent, 10)
+		for i := range events {
+			events[i] = driver.LogEvent{
+				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+				Message:   "msg",
+			}
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+			Limit:    3,
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 3, len(result))
+	})
+
+	t.Run("nonexistent group error", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "no-group",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent stream returns empty", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup:  "grp",
+			LogStream: "no-stream",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(events))
+	})
+
+	t.Run("default limit 100", func(t *testing.T) {
+		m := newTestMock()
+		setupGroupAndStream(t, m)
+
+		events := make([]driver.LogEvent, 150)
+		for i := range events {
+			events[i] = driver.LogEvent{
+				Timestamp: baseTime.Add(time.Duration(i) * time.Second),
+				Message:   "msg",
+			}
+		}
+
+		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
+		requireNoError(t, err)
+
+		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "test-group",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 100, len(result))
+	})
+
+	t.Run("empty group returns empty slice", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
+		requireNoError(t, err)
+
+		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+			LogGroup: "empty-grp",
+		})
+		requireNoError(t, err)
+
+		assertEqual(t, 0, len(events))
+	})
+}

--- a/providers/gcp/cloudlogging/cloudlogging_test.go
+++ b/providers/gcp/cloudlogging/cloudlogging_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -57,10 +24,10 @@ func setupGroupAndStream(t *testing.T, m *Mock) {
 	ctx := context.Background()
 
 	_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "test-group"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.CreateLogStream(ctx, "test-group", "test-stream")
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCreateLogGroup(t *testing.T) {
@@ -72,12 +39,12 @@ func TestCreateLogGroup(t *testing.T) {
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
 			Name: "my-bucket",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "my-bucket", info.Name)
-		assertNotEmpty(t, info.ARN)
-		assertNotEmpty(t, info.CreatedAt)
-		assertEqual(t, int64(0), info.StoredBytes)
+		assert.Equal(t, "my-bucket", info.Name)
+		assert.NotEmpty(t, info.ResourceID)
+		assert.NotEmpty(t, info.CreatedAt)
+		assert.Equal(t, int64(0), info.StoredBytes)
 	})
 
 	t.Run("default retention 30 days", func(t *testing.T) {
@@ -86,9 +53,9 @@ func TestCreateLogGroup(t *testing.T) {
 		info, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{
 			Name: "retention-test",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 30, info.RetentionDays)
+		assert.Equal(t, 30, info.RetentionDays)
 	})
 
 	t.Run("custom retention", func(t *testing.T) {
@@ -98,9 +65,9 @@ func TestCreateLogGroup(t *testing.T) {
 			Name:          "custom-ret",
 			RetentionDays: 90,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 90, info.RetentionDays)
+		assert.Equal(t, 90, info.RetentionDays)
 	})
 
 	t.Run("with tags", func(t *testing.T) {
@@ -111,27 +78,27 @@ func TestCreateLogGroup(t *testing.T) {
 			Name: "tagged-bucket",
 			Tags: tags,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "prod", info.Tags["env"])
-		assertEqual(t, "backend", info.Tags["team"])
+		assert.Equal(t, "prod", info.Tags["env"])
+		assert.Equal(t, "backend", info.Tags["team"])
 	})
 
 	t.Run("empty name error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: ""})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("duplicate error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "dup"})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -142,20 +109,20 @@ func TestDeleteLogGroup(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "del-me"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.DeleteLogGroup(ctx, "del-me")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.GetLogGroup(ctx, "del-me")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.DeleteLogGroup(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -166,19 +133,19 @@ func TestGetLogGroup(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "get-me"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.GetLogGroup(ctx, "get-me")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "get-me", info.Name)
+		assert.Equal(t, "get-me", info.Name)
 	})
 
 	t.Run("not found error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.GetLogGroup(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -189,24 +156,24 @@ func TestListLogGroups(t *testing.T) {
 		m := newTestMock()
 
 		groups, err := m.ListLogGroups(ctx)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(groups))
+		assert.Equal(t, 0, len(groups))
 	})
 
 	t.Run("multiple groups", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g1"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		groups, err := m.ListLogGroups(ctx)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(groups))
+		assert.Equal(t, 2, len(groups))
 	})
 }
 
@@ -217,43 +184,43 @@ func TestCreateLogStream(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.CreateLogStream(ctx, "grp", "stream-1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, "stream-1", info.Name)
-		assertNotEmpty(t, info.CreatedAt)
+		assert.Equal(t, "stream-1", info.Name)
+		assert.NotEmpty(t, info.CreatedAt)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogStream(ctx, "no-group", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("empty stream name error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("duplicate stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "dup-stream")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -265,24 +232,24 @@ func TestDeleteLogStream(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		err := m.DeleteLogStream(ctx, "test-group", "test-stream")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.DeleteLogStream(ctx, "no-group", "s1")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("not found stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.DeleteLogStream(ctx, "grp", "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -293,25 +260,25 @@ func TestListLogStreams(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "s1")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		_, err = m.CreateLogStream(ctx, "grp", "s2")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		streams, err := m.ListLogStreams(ctx, "grp")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(streams))
+		assert.Equal(t, 2, len(streams))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.ListLogStreams(ctx, "no-group")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -329,7 +296,7 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("updates LastEvent", func(t *testing.T) {
@@ -342,13 +309,13 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		streams, err := m.ListLogStreams(ctx, "test-group")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		expected := baseTime.Add(5 * time.Second).UTC().Format(time.RFC3339)
-		assertEqual(t, expected, streams[0].LastEvent)
+		assert.Equal(t, expected, streams[0].LastEvent)
 	})
 
 	t.Run("updates StoredBytes", func(t *testing.T) {
@@ -360,29 +327,29 @@ func TestPutLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		info, err := m.GetLogGroup(ctx, "test-group")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, int64(5), info.StoredBytes)
+		assert.Equal(t, int64(5), info.StoredBytes)
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
 		err := m.PutLogEvents(ctx, "no-group", "s1", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("nonexistent stream error", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "grp", "no-stream", nil)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -395,24 +362,24 @@ func TestGetLogEvents(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		_, err := m.CreateLogStream(ctx, "test-group", "stream-2")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "msg1"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "stream-2", []driver.LogEvent{
 			{Timestamp: baseTime.Add(time.Second), Message: "msg2"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("specific stream filter", func(t *testing.T) {
@@ -420,26 +387,26 @@ func TestGetLogEvents(t *testing.T) {
 		setupGroupAndStream(t, m)
 
 		_, err := m.CreateLogStream(ctx, "test-group", "other")
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "test-stream", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "target"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		err = m.PutLogEvents(ctx, "test-group", "other", []driver.LogEvent{
 			{Timestamp: baseTime, Message: "ignore"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "test-group",
 			LogStream: "test-stream",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 1, len(events))
-		assertEqual(t, "target", events[0].Message)
+		assert.Equal(t, 1, len(events))
+		assert.Equal(t, "target", events[0].Message)
 	})
 
 	t.Run("pattern filter", func(t *testing.T) {
@@ -451,15 +418,15 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime.Add(time.Second), Message: "INFO: all good"},
 			{Timestamp: baseTime.Add(2 * time.Second), Message: "ERROR: another failure"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 			Pattern:  "ERROR",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 2, len(events))
+		assert.Equal(t, 2, len(events))
 	})
 
 	t.Run("time range filter", func(t *testing.T) {
@@ -471,17 +438,17 @@ func TestGetLogEvents(t *testing.T) {
 			{Timestamp: baseTime.Add(time.Hour), Message: "middle"},
 			{Timestamp: baseTime.Add(2 * time.Hour), Message: "late"},
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "test-group",
 			StartTime: baseTime.Add(30 * time.Minute),
 			EndTime:   baseTime.Add(90 * time.Minute),
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 1, len(events))
-		assertEqual(t, "middle", events[0].Message)
+		assert.Equal(t, 1, len(events))
+		assert.Equal(t, "middle", events[0].Message)
 	})
 
 	t.Run("with limit", func(t *testing.T) {
@@ -497,15 +464,15 @@ func TestGetLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 			Limit:    3,
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 3, len(result))
+		assert.Equal(t, 3, len(result))
 	})
 
 	t.Run("nonexistent group error", func(t *testing.T) {
@@ -514,22 +481,22 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "no-group",
 		})
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 
 	t.Run("nonexistent stream returns empty", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(events))
+		assert.Equal(t, 0, len(events))
 	})
 
 	t.Run("default limit 100", func(t *testing.T) {
@@ -545,27 +512,27 @@ func TestGetLogEvents(t *testing.T) {
 		}
 
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 100, len(result))
+		assert.Equal(t, 100, len(result))
 	})
 
 	t.Run("empty group returns empty slice", func(t *testing.T) {
 		m := newTestMock()
 
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
 			LogGroup: "empty-grp",
 		})
-		requireNoError(t, err)
+		require.NoError(t, err)
 
-		assertEqual(t, 0, len(events))
+		assert.Equal(t, 0, len(events))
 	})
 }

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -1,0 +1,192 @@
+// Package fcm provides an in-memory mock implementation of GCP Firebase Cloud Messaging.
+package fcm
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/notification/driver"
+)
+
+// Compile-time check that Mock implements driver.Notification.
+var _ driver.Notification = (*Mock)(nil)
+
+type topicData struct {
+	info          driver.TopicInfo
+	subscriptions *memstore.Store[driver.SubscriptionInfo]
+}
+
+// Mock is an in-memory mock implementation of GCP Firebase Cloud Messaging.
+type Mock struct {
+	topics *memstore.Store[*topicData]
+	opts   *config.Options
+}
+
+// New creates a new FCM mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		topics: memstore.New[*topicData](),
+		opts:   opts,
+	}
+}
+
+// CreateTopic creates a new FCM topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	selfLink := idgen.GCPID(m.opts.ProjectID, "topics", cfg.Name)
+
+	if m.topics.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
+	}
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.TopicInfo{
+		ID:                idgen.GenerateID("topic-"),
+		Name:              cfg.Name,
+		ARN:               selfLink,
+		DisplayName:       cfg.DisplayName,
+		SubscriptionCount: 0,
+		Tags:              tags,
+	}
+
+	td := &topicData{
+		info:          info,
+		subscriptions: memstore.New[driver.SubscriptionInfo](),
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteTopic deletes an FCM topic by name.
+func (m *Mock) DeleteTopic(_ context.Context, id string) error {
+	if !m.topics.Delete(id) {
+		return errors.Newf(errors.NotFound, "topic %q not found", id)
+	}
+
+	return nil
+}
+
+// GetTopic retrieves information about an FCM topic.
+func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", id)
+	}
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
+}
+
+// ListTopics lists all FCM topics.
+func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+	all := m.topics.All()
+
+	topics := make([]driver.TopicInfo, 0, len(all))
+	for _, td := range all {
+		info := td.info
+		info.SubscriptionCount = td.subscriptions.Len()
+		topics = append(topics, info)
+	}
+
+	return topics, nil
+}
+
+// Subscribe creates a subscription to an FCM topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
+	td, ok := m.topics.Get(cfg.TopicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.TopicID)
+	}
+
+	if cfg.Protocol == "" {
+		return nil, errors.New(errors.InvalidArgument, "protocol is required")
+	}
+
+	if cfg.Endpoint == "" {
+		return nil, errors.New(errors.InvalidArgument, "endpoint is required")
+	}
+
+	subID := idgen.GenerateID("sub-")
+	selfLink := idgen.GCPID(m.opts.ProjectID, "subscriptions", subID)
+
+	sub := driver.SubscriptionInfo{
+		ID:       selfLink,
+		TopicID:  cfg.TopicID,
+		Protocol: cfg.Protocol,
+		Endpoint: cfg.Endpoint,
+		Status:   "confirmed",
+	}
+
+	td.subscriptions.Set(selfLink, sub)
+
+	result := sub
+
+	return &result, nil
+}
+
+// Unsubscribe removes a subscription.
+func (m *Mock) Unsubscribe(_ context.Context, subscriptionID string) error {
+	all := m.topics.All()
+
+	for _, td := range all {
+		if td.subscriptions.Delete(subscriptionID) {
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.NotFound, "subscription %q not found", subscriptionID)
+}
+
+// ListSubscriptions lists all subscriptions for an FCM topic.
+func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.SubscriptionInfo, error) {
+	td, ok := m.topics.Get(topicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
+	}
+
+	all := td.subscriptions.All()
+
+	subs := make([]driver.SubscriptionInfo, 0, len(all))
+	for _, s := range all {
+		subs = append(subs, s)
+	}
+
+	return subs, nil
+}
+
+// Publish publishes a message to an FCM topic.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
+	if _, ok := m.topics.Get(input.TopicID); !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
+	}
+
+	if input.Message == "" {
+		return nil, errors.New(errors.InvalidArgument, "message is required")
+	}
+
+	msgID := idgen.GenerateID("msg-")
+
+	return &driver.PublishOutput{MessageID: msgID}, nil
+}

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -34,8 +34,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateTopic creates a new FCM topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
@@ -100,6 +98,7 @@ func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
 	all := m.topics.All()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
+
 	for _, td := range all {
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
@@ -110,8 +109,6 @@ func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
 }
 
 // Subscribe creates a subscription to an FCM topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*driver.SubscriptionInfo, error) {
 	td, ok := m.topics.Get(cfg.TopicID)
 	if !ok {
@@ -175,8 +172,6 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 }
 
 // Publish publishes a message to an FCM topic.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
 	if _, ok := m.topics.Get(input.TopicID); !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -3,6 +3,7 @@ package fcm
 
 import (
 	"context"
+	"sync"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/errors"
@@ -14,9 +15,19 @@ import (
 // Compile-time check that Mock implements driver.Notification.
 var _ driver.Notification = (*Mock)(nil)
 
+type publishedMessage struct {
+	ID         string
+	TopicID    string
+	Subject    string
+	Message    string
+	Attributes map[string]string
+}
+
 type topicData struct {
 	info          driver.TopicInfo
 	subscriptions *memstore.Store[driver.SubscriptionInfo]
+	messages      []publishedMessage
+	mu            sync.RWMutex
 }
 
 // Mock is an in-memory mock implementation of GCP Firebase Cloud Messaging.
@@ -53,7 +64,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
-		ARN:               selfLink,
+		ResourceID:        selfLink,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
 		Tags:              tags,
@@ -173,7 +184,8 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 
 // Publish publishes a message to an FCM topic.
 func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
-	if _, ok := m.topics.Get(input.TopicID); !ok {
+	td, ok := m.topics.Get(input.TopicID)
+	if !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
 	}
 
@@ -182,6 +194,21 @@ func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.Pu
 	}
 
 	msgID := idgen.GenerateID("msg-")
+
+	attrs := make(map[string]string, len(input.Attributes))
+	for k, v := range input.Attributes {
+		attrs[k] = v
+	}
+
+	td.mu.Lock()
+	td.messages = append(td.messages, publishedMessage{
+		ID:         msgID,
+		TopicID:    input.TopicID,
+		Subject:    input.Subject,
+		Message:    input.Message,
+		Attributes: attrs,
+	})
+	td.mu.Unlock()
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
 }

--- a/providers/gcp/fcm/fcm_test.go
+++ b/providers/gcp/fcm/fcm_test.go
@@ -1,0 +1,532 @@
+package fcm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/notification/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("test-project"),
+	)
+
+	return New(opts)
+}
+
+func createTestTopic(t *testing.T, m *Mock, name string) *driver.TopicInfo {
+	t.Helper()
+
+	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.TopicConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name: "basic topic",
+			cfg:  driver.TopicConfig{Name: "my-topic"},
+		},
+		{
+			name: "with display name",
+			cfg:  driver.TopicConfig{Name: "alerts", DisplayName: "Alert Notifications"},
+		},
+		{
+			name: "with tags",
+			cfg: driver.TopicConfig{
+				Name: "tagged-topic",
+				Tags: map[string]string{"env": "prod", "team": "platform"},
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.TopicConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate topic",
+			cfg:  driver.TopicConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				_, _ = m.CreateTopic(context.Background(), driver.TopicConfig{Name: "dup"})
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateTopic(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, info.ID)
+			assertNotEmpty(t, info.ARN)
+			assertEqual(t, tc.cfg.Name, info.Name)
+			assertEqual(t, tc.cfg.DisplayName, info.DisplayName)
+			assertEqual(t, 0, info.SubscriptionCount)
+		})
+	}
+}
+
+func TestCreateTopicWithTags(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"env": "staging", "service": "notifications"}
+
+	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{
+		Name: "tagged",
+		Tags: tags,
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "staging", info.Tags["env"])
+	assertEqual(t, "notifications", info.Tags["service"])
+
+	// Verify tags are copied and not shared.
+	tags["env"] = "production"
+	assertEqual(t, "staging", info.Tags["env"])
+}
+
+func TestDeleteTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicID   string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) string {
+				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: "del"})
+				return info.Name
+			},
+		},
+		{
+			name:      "not found",
+			topicID:   "nonexistent-topic",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			id := tc.topicID
+
+			if tc.setup != nil {
+				id = tc.setup(m)
+			}
+
+			err := m.DeleteTopic(context.Background(), id)
+			assertError(t, err, tc.expectErr)
+		})
+	}
+}
+
+func TestDeleteTopicRemovesFromList(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	info := createTestTopic(t, m, "to-delete")
+
+	err := m.DeleteTopic(ctx, info.Name)
+	requireNoError(t, err)
+
+	topics, err := m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+}
+
+func TestGetTopic(t *testing.T) {
+	tests := []struct {
+		name      string
+		topicID   string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) string {
+				info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{
+					Name:        "get-me",
+					DisplayName: "Get Me",
+				})
+				return info.Name
+			},
+		},
+		{
+			name:      "not found",
+			topicID:   "nonexistent-topic",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			id := tc.topicID
+
+			if tc.setup != nil {
+				id = tc.setup(m)
+			}
+
+			info, err := m.GetTopic(context.Background(), id)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, "get-me", info.Name)
+			assertEqual(t, "Get Me", info.DisplayName)
+		})
+	}
+}
+
+func TestGetTopicSubscriptionCount(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "sub-count")
+
+	info, err := m.GetTopic(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 0, info.SubscriptionCount)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID:  topic.Name,
+		Protocol: "email",
+		Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID:  topic.Name,
+		Protocol: "sms",
+		Endpoint: "+1234567890",
+	})
+	requireNoError(t, err)
+
+	info, err = m.GetTopic(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 2, info.SubscriptionCount)
+}
+
+func TestListTopics(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topics, err := m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(topics))
+
+	createTestTopic(t, m, "topic-1")
+	createTestTopic(t, m, "topic-2")
+	createTestTopic(t, m, "topic-3")
+
+	topics, err = m.ListTopics(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(topics))
+}
+
+func TestSubscribe(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.SubscriptionConfig
+		setup     func(*Mock) driver.SubscriptionConfig
+		expectErr bool
+	}{
+		{
+			name: "email subscription",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "sub-topic")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "email", Endpoint: "user@example.com",
+				}
+			},
+		},
+		{
+			name: "sms subscription",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "sms-topic")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "sms", Endpoint: "+1234567890",
+				}
+			},
+		},
+		{
+			name: "nonexistent topic",
+			cfg: driver.SubscriptionConfig{
+				TopicID: "nonexistent-topic", Protocol: "email", Endpoint: "a@b.com",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty protocol",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "no-proto")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "", Endpoint: "a@b.com",
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty endpoint",
+			setup: func(m *Mock) driver.SubscriptionConfig {
+				info := createTopicHelper(m, "no-endpoint")
+				return driver.SubscriptionConfig{
+					TopicID: info.Name, Protocol: "email", Endpoint: "",
+				}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			cfg := tc.cfg
+
+			if tc.setup != nil {
+				cfg = tc.setup(m)
+			}
+
+			sub, err := m.Subscribe(context.Background(), cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, sub.ID)
+			assertEqual(t, cfg.Protocol, sub.Protocol)
+			assertEqual(t, cfg.Endpoint, sub.Endpoint)
+			assertEqual(t, "confirmed", sub.Status)
+		})
+	}
+}
+
+func createTopicHelper(m *Mock, name string) *driver.TopicInfo {
+	info, _ := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
+	return info
+}
+
+func TestMultipleSubscriptionsSameTopic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "multi-sub")
+
+	_, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "sms", Endpoint: "+111",
+	})
+	requireNoError(t, err)
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "https", Endpoint: "https://hook.example.com",
+	})
+	requireNoError(t, err)
+
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(subs))
+}
+
+func TestUnsubscribe(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "unsub-topic")
+
+	sub, err := m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
+	})
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := m.Unsubscribe(ctx, sub.ID)
+		requireNoError(t, err)
+
+		subs, err := m.ListSubscriptions(ctx, topic.Name)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(subs))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.Unsubscribe(ctx, "nonexistent-sub-id")
+		assertError(t, err, true)
+	})
+}
+
+func TestListSubscriptions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "list-subs")
+
+	subs, err := m.ListSubscriptions(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(subs))
+
+	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
+		TopicID: topic.Name, Protocol: "email", Endpoint: "x@y.com",
+	})
+	requireNoError(t, err)
+
+	subs, err = m.ListSubscriptions(ctx, topic.Name)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(subs))
+}
+
+func TestListSubscriptionsNonexistentTopic(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListSubscriptions(context.Background(), "nonexistent-topic")
+	assertError(t, err, true)
+}
+
+func TestPublish(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     driver.PublishInput
+		setup     func(*Mock) driver.PublishInput
+		expectErr bool
+	}{
+		{
+			name: "success",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "pub-topic")
+				return driver.PublishInput{
+					TopicID: info.Name,
+					Message: "hello world",
+					Subject: "greetings",
+				}
+			},
+		},
+		{
+			name: "with attributes",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "attr-topic")
+				return driver.PublishInput{
+					TopicID:    info.Name,
+					Message:    "test",
+					Attributes: map[string]string{"key": "value"},
+				}
+			},
+		},
+		{
+			name: "nonexistent topic",
+			input: driver.PublishInput{
+				TopicID: "nonexistent-topic",
+				Message: "hello",
+			},
+			expectErr: true,
+		},
+		{
+			name: "empty message",
+			setup: func(m *Mock) driver.PublishInput {
+				info := createTopicHelper(m, "empty-msg")
+				return driver.PublishInput{TopicID: info.Name, Message: ""}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			input := tc.input
+
+			if tc.setup != nil {
+				input = tc.setup(m)
+			}
+
+			out, err := m.Publish(context.Background(), input)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, out.MessageID)
+		})
+	}
+}
+
+func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	topic := createTestTopic(t, m, "unique-ids")
+
+	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg1"})
+	requireNoError(t, err)
+
+	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg2"})
+	requireNoError(t, err)
+
+	if out1.MessageID == out2.MessageID {
+		t.Error("expected unique message IDs")
+	}
+}

--- a/providers/gcp/fcm/fcm_test.go
+++ b/providers/gcp/fcm/fcm_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/notification/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -59,7 +26,7 @@ func createTestTopic(t *testing.T, m *Mock, name string) *driver.TopicInfo {
 	t.Helper()
 
 	info, err := m.CreateTopic(context.Background(), driver.TopicConfig{Name: name})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -109,17 +76,18 @@ func TestCreateTopic(t *testing.T) {
 			}
 
 			info, err := m.CreateTopic(context.Background(), tc.cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, info.ID)
-			assertNotEmpty(t, info.ARN)
-			assertEqual(t, tc.cfg.Name, info.Name)
-			assertEqual(t, tc.cfg.DisplayName, info.DisplayName)
-			assertEqual(t, 0, info.SubscriptionCount)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, info.ID)
+			assert.NotEmpty(t, info.ResourceID)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, tc.cfg.DisplayName, info.DisplayName)
+			assert.Equal(t, 0, info.SubscriptionCount)
 		})
 	}
 }
@@ -132,14 +100,14 @@ func TestCreateTopicWithTags(t *testing.T) {
 		Name: "tagged",
 		Tags: tags,
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "staging", info.Tags["env"])
-	assertEqual(t, "notifications", info.Tags["service"])
+	assert.Equal(t, "staging", info.Tags["env"])
+	assert.Equal(t, "notifications", info.Tags["service"])
 
 	// Verify tags are copied and not shared.
 	tags["env"] = "production"
-	assertEqual(t, "staging", info.Tags["env"])
+	assert.Equal(t, "staging", info.Tags["env"])
 }
 
 func TestDeleteTopic(t *testing.T) {
@@ -173,7 +141,12 @@ func TestDeleteTopic(t *testing.T) {
 			}
 
 			err := m.DeleteTopic(context.Background(), id)
-			assertError(t, err, tc.expectErr)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }
@@ -185,11 +158,11 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	info := createTestTopic(t, m, "to-delete")
 
 	err := m.DeleteTopic(ctx, info.Name)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	topics, err := m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 }
 
 func TestGetTopic(t *testing.T) {
@@ -226,14 +199,15 @@ func TestGetTopic(t *testing.T) {
 			}
 
 			info, err := m.GetTopic(context.Background(), id)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertEqual(t, "get-me", info.Name)
-			assertEqual(t, "Get Me", info.DisplayName)
+			require.NoError(t, err)
+
+			assert.Equal(t, "get-me", info.Name)
+			assert.Equal(t, "Get Me", info.DisplayName)
 		})
 	}
 }
@@ -245,26 +219,26 @@ func TestGetTopicSubscriptionCount(t *testing.T) {
 	topic := createTestTopic(t, m, "sub-count")
 
 	info, err := m.GetTopic(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 0, info.SubscriptionCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, info.SubscriptionCount)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID:  topic.Name,
 		Protocol: "email",
 		Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID:  topic.Name,
 		Protocol: "sms",
 		Endpoint: "+1234567890",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	info, err = m.GetTopic(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 2, info.SubscriptionCount)
+	require.NoError(t, err)
+	assert.Equal(t, 2, info.SubscriptionCount)
 }
 
 func TestListTopics(t *testing.T) {
@@ -272,16 +246,16 @@ func TestListTopics(t *testing.T) {
 	ctx := context.Background()
 
 	topics, err := m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(topics))
 
 	createTestTopic(t, m, "topic-1")
 	createTestTopic(t, m, "topic-2")
 	createTestTopic(t, m, "topic-3")
 
 	topics, err = m.ListTopics(ctx)
-	requireNoError(t, err)
-	assertEqual(t, 3, len(topics))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(topics))
 }
 
 func TestSubscribe(t *testing.T) {
@@ -348,16 +322,17 @@ func TestSubscribe(t *testing.T) {
 			}
 
 			sub, err := m.Subscribe(context.Background(), cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, sub.ID)
-			assertEqual(t, cfg.Protocol, sub.Protocol)
-			assertEqual(t, cfg.Endpoint, sub.Endpoint)
-			assertEqual(t, "confirmed", sub.Status)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, sub.ID)
+			assert.Equal(t, cfg.Protocol, sub.Protocol)
+			assert.Equal(t, cfg.Endpoint, sub.Endpoint)
+			assert.Equal(t, "confirmed", sub.Status)
 		})
 	}
 }
@@ -376,21 +351,21 @@ func TestMultipleSubscriptionsSameTopic(t *testing.T) {
 	_, err := m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "sms", Endpoint: "+111",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "https", Endpoint: "https://hook.example.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	subs, err := m.ListSubscriptions(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 3, len(subs))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(subs))
 }
 
 func TestUnsubscribe(t *testing.T) {
@@ -402,20 +377,20 @@ func TestUnsubscribe(t *testing.T) {
 	sub, err := m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "email", Endpoint: "a@b.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		err := m.Unsubscribe(ctx, sub.ID)
-		requireNoError(t, err)
+		require.NoError(t, err)
 
 		subs, err := m.ListSubscriptions(ctx, topic.Name)
-		requireNoError(t, err)
-		assertEqual(t, 0, len(subs))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(subs))
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		err := m.Unsubscribe(ctx, "nonexistent-sub-id")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -426,24 +401,24 @@ func TestListSubscriptions(t *testing.T) {
 	topic := createTestTopic(t, m, "list-subs")
 
 	subs, err := m.ListSubscriptions(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 0, len(subs))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(subs))
 
 	_, err = m.Subscribe(ctx, driver.SubscriptionConfig{
 		TopicID: topic.Name, Protocol: "email", Endpoint: "x@y.com",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	subs, err = m.ListSubscriptions(ctx, topic.Name)
-	requireNoError(t, err)
-	assertEqual(t, 1, len(subs))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(subs))
 }
 
 func TestListSubscriptionsNonexistentTopic(t *testing.T) {
 	m := newTestMock()
 
 	_, err := m.ListSubscriptions(context.Background(), "nonexistent-topic")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPublish(t *testing.T) {
@@ -503,13 +478,14 @@ func TestPublish(t *testing.T) {
 			}
 
 			out, err := m.Publish(context.Background(), input)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, out.MessageID)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, out.MessageID)
 		})
 	}
 }
@@ -521,12 +497,10 @@ func TestPublishReturnsUniqueMessageIDs(t *testing.T) {
 	topic := createTestTopic(t, m, "unique-ids")
 
 	out1, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg1"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	out2, err := m.Publish(ctx, driver.PublishInput{TopicID: topic.Name, Message: "msg2"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	if out1.MessageID == out2.MessageID {
-		t.Error("expected unique message IDs")
-	}
+	assert.NotEqual(t, out1.MessageID, out2.MessageID)
 }

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -5,14 +5,18 @@ import (
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/providers/gcp/clouddns"
 	"github.com/stackshy/cloudemu/providers/gcp/cloudfunctions"
+	"github.com/stackshy/cloudemu/providers/gcp/cloudlogging"
 	"github.com/stackshy/cloudemu/providers/gcp/cloudmonitoring"
+	"github.com/stackshy/cloudemu/providers/gcp/fcm"
 	"github.com/stackshy/cloudemu/providers/gcp/firestore"
 	"github.com/stackshy/cloudemu/providers/gcp/gce"
 	"github.com/stackshy/cloudemu/providers/gcp/gcpiam"
 	"github.com/stackshy/cloudemu/providers/gcp/gcplb"
 	"github.com/stackshy/cloudemu/providers/gcp/gcpvpc"
 	"github.com/stackshy/cloudemu/providers/gcp/gcs"
+	"github.com/stackshy/cloudemu/providers/gcp/memorystore"
 	"github.com/stackshy/cloudemu/providers/gcp/pubsub"
+	"github.com/stackshy/cloudemu/providers/gcp/secretmanager"
 )
 
 // Provider holds all GCP mock services.
@@ -27,6 +31,10 @@ type Provider struct {
 	CloudDNS        *clouddns.Mock
 	LB              *gcplb.Mock
 	PubSub          *pubsub.Mock
+	Memorystore     *memorystore.Mock
+	SecretManager   *secretmanager.Mock
+	CloudLogging    *cloudlogging.Mock
+	FCM             *fcm.Mock
 }
 
 // New creates a new GCP provider with all mock services.
@@ -43,6 +51,10 @@ func New(opts ...config.Option) *Provider {
 		CloudDNS:        clouddns.New(o),
 		LB:              gcplb.New(o),
 		PubSub:          pubsub.New(o),
+		Memorystore:     memorystore.New(o),
+		SecretManager:   secretmanager.New(o),
+		CloudLogging:    cloudlogging.New(o),
+		FCM:             fcm.New(o),
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -1,0 +1,257 @@
+// Package memorystore provides an in-memory mock implementation of GCP Memorystore.
+package memorystore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+)
+
+// Compile-time check that Mock implements driver.Cache.
+var _ driver.Cache = (*Mock)(nil)
+
+type cacheItem struct {
+	Value     []byte
+	ExpiresAt time.Time
+	HasTTL    bool
+}
+
+type cacheData struct {
+	info  driver.CacheInfo
+	items *memstore.Store[cacheItem]
+}
+
+// Mock is an in-memory mock implementation of GCP Memorystore.
+type Mock struct {
+	caches *memstore.Store[*cacheData]
+	opts   *config.Options
+}
+
+// New creates a new Memorystore mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		caches: memstore.New[*cacheData](),
+		opts:   opts,
+	}
+}
+
+// CreateCache creates a new Memorystore instance.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "cache name is required")
+	}
+
+	if m.caches.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "cache %q already exists", cfg.Name)
+	}
+
+	engine := cfg.Engine
+	if engine == "" {
+		engine = "redis"
+	}
+
+	nodeType := cfg.NodeType
+	if nodeType == "" {
+		nodeType = "M1"
+	}
+
+	selfLink := idgen.GCPID(m.opts.ProjectID, "instances", cfg.Name)
+	endpoint := fmt.Sprintf("%s.redis.%s.gcp.cloud:6379", cfg.Name, m.opts.Region)
+
+	info := driver.CacheInfo{
+		Name:      selfLink,
+		NodeType:  nodeType,
+		Engine:    engine,
+		Status:    "READY",
+		Endpoint:  endpoint,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	cd := &cacheData{
+		info:  info,
+		items: memstore.New[cacheItem](),
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteCache deletes a Memorystore instance by name.
+func (m *Mock) DeleteCache(_ context.Context, name string) error {
+	if !m.caches.Delete(name) {
+		return errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	return nil
+}
+
+// GetCache retrieves information about a Memorystore instance.
+func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", name)
+	}
+
+	result := cd.info
+
+	return &result, nil
+}
+
+// ListCaches lists all Memorystore instances.
+func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+	all := m.caches.All()
+
+	caches := make([]driver.CacheInfo, 0, len(all))
+	for _, cd := range all {
+		caches = append(caches, cd.info)
+	}
+
+	return caches, nil
+}
+
+// Set stores a value in the cache with an optional TTL.
+func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	item := cacheItem{Value: data}
+
+	if ttl > 0 {
+		item.ExpiresAt = m.opts.Clock.Now().Add(ttl)
+		item.HasTTL = true
+	}
+
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// Get retrieves a value from the cache.
+func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	now := m.opts.Clock.Now()
+	if item.HasTTL && now.After(item.ExpiresAt) {
+		cd.items.Delete(key)
+
+		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	data := make([]byte, len(item.Value))
+	copy(data, item.Value)
+
+	result := &driver.Item{
+		Key:   key,
+		Value: data,
+	}
+
+	if item.HasTTL {
+		result.TTL = item.ExpiresAt.Sub(now)
+		result.ExpiresAt = item.ExpiresAt
+	}
+
+	return result, nil
+}
+
+// Delete removes a value from the cache.
+func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	if !cd.items.Delete(key) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	return nil
+}
+
+// Keys returns all keys matching the given pattern in the cache.
+func (m *Mock) Keys(_ context.Context, cacheName, pattern string) ([]string, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	now := m.opts.Clock.Now()
+	allKeys := cd.items.Keys()
+
+	var matched []string
+
+	for _, key := range allKeys {
+		item, ok := cd.items.Get(key)
+		if !ok {
+			continue
+		}
+
+		if item.HasTTL && now.After(item.ExpiresAt) {
+			cd.items.Delete(key)
+
+			continue
+		}
+
+		if matchPattern(pattern, key) {
+			matched = append(matched, key)
+		}
+	}
+
+	if matched == nil {
+		matched = []string{}
+	}
+
+	return matched, nil
+}
+
+// FlushAll removes all items from the cache.
+func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	cd.items.Clear()
+
+	return nil
+}
+
+func matchPattern(pattern, key string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+
+	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
+		return strings.HasPrefix(key, pattern[:len(pattern)-1])
+	}
+
+	if strings.HasPrefix(pattern, "*") && !strings.Contains(pattern[1:], "*") {
+		return strings.HasSuffix(key, pattern[1:])
+	}
+
+	return key == pattern
+}

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -4,7 +4,7 @@ package memorystore
 import (
 	"context"
 	"fmt"
-	"strings"
+	"path"
 	"time"
 
 	"github.com/stackshy/cloudemu/cache/driver"
@@ -13,6 +13,8 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 )
+
+const defaultRedisPort = 6379
 
 // Compile-time check that Mock implements driver.Cache.
 var _ driver.Cache = (*Mock)(nil)
@@ -63,7 +65,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 	}
 
 	selfLink := idgen.GCPID(m.opts.ProjectID, "instances", cfg.Name)
-	endpoint := fmt.Sprintf("%s.redis.%s.gcp.cloud:6379", cfg.Name, m.opts.Region)
+	endpoint := fmt.Sprintf("%s.redis.%s.gcp.cloud:%d", cfg.Name, m.opts.Region, defaultRedisPort)
 
 	info := driver.CacheInfo{
 		Name:      selfLink,
@@ -238,18 +240,17 @@ func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
 	return nil
 }
 
+// matchPattern matches a key against a glob-like pattern.
+// Supports full glob syntax including middle wildcards like "user:*:session".
 func matchPattern(pattern, key string) bool {
 	if pattern == "" || pattern == "*" {
 		return true
 	}
 
-	if strings.HasSuffix(pattern, "*") && !strings.Contains(pattern[:len(pattern)-1], "*") {
-		return strings.HasPrefix(key, pattern[:len(pattern)-1])
+	matched, err := path.Match(pattern, key)
+	if err != nil {
+		return false
 	}
 
-	if strings.HasPrefix(pattern, "*") && !strings.Contains(pattern[1:], "*") {
-		return strings.HasSuffix(key, pattern[1:])
-	}
-
-	return key == pattern
+	return matched
 }

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -43,8 +43,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateCache creates a new Memorystore instance.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "cache name is required")

--- a/providers/gcp/memorystore/memorystore_test.go
+++ b/providers/gcp/memorystore/memorystore_test.go
@@ -1,0 +1,427 @@
+package memorystore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/config"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("test-project"),
+	)
+
+	return New(opts), fc
+}
+
+func createTestCache(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateCache(context.Background(), driver.CacheConfig{Name: name})
+	if err != nil {
+		t.Fatalf("failed to create test cache: %v", err)
+	}
+}
+
+func TestCreateCache(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.CacheConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{name: "success with defaults", cfg: driver.CacheConfig{Name: "my-cache"}},
+		{
+			name: "success with custom engine and node type",
+			cfg:  driver.CacheConfig{Name: "custom", Engine: "memcached", NodeType: "M3"},
+		},
+		{name: "empty name", cfg: driver.CacheConfig{}, expectErr: true},
+		{
+			name: "duplicate cache",
+			cfg:  driver.CacheConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestCache(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateCache(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, info.Name)
+			assertEqual(t, "READY", info.Status)
+			assertNotEmpty(t, info.Endpoint)
+			assertNotEmpty(t, info.CreatedAt)
+		})
+	}
+}
+
+func TestCreateCacheDefaults(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "default-cache"})
+	requireNoError(t, err)
+
+	assertEqual(t, "redis", info.Engine)
+	assertEqual(t, "M1", info.NodeType)
+}
+
+func TestCreateCacheCustomValues(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{
+		Name:     "custom-cache",
+		Engine:   "memcached",
+		NodeType: "M3",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "memcached", info.Engine)
+	assertEqual(t, "M3", info.NodeType)
+}
+
+func TestCreateCacheSelfLink(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "link-test"})
+	requireNoError(t, err)
+
+	expected := "projects/test-project/instances/link-test"
+	assertEqual(t, expected, info.Name)
+}
+
+func TestDeleteCache(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "to-delete")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteCache(ctx, "to-delete")
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteCache(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetCache(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := m.GetCache(ctx, "my-cache")
+		requireNoError(t, err)
+		assertNotEmpty(t, info.Name)
+		assertEqual(t, "READY", info.Status)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetCache(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestListCaches(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		caches, err := m.ListCaches(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(caches))
+	})
+
+	createTestCache(t, m, "cache-a")
+	createTestCache(t, m, "cache-b")
+
+	t.Run("two caches", func(t *testing.T) {
+		caches, err := m.ListCaches(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(caches))
+	})
+}
+
+func TestSet(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
+		requireNoError(t, err)
+	})
+
+	t.Run("with TTL", func(t *testing.T) {
+		ttl := 5 * time.Minute
+		err := m.Set(ctx, "my-cache", "key-ttl", []byte("val"), ttl)
+		requireNoError(t, err)
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		err := m.Set(ctx, "no-cache", "key1", []byte("val"), 0)
+		assertError(t, err, true)
+	})
+}
+
+func TestGet(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		item, getErr := m.Get(ctx, "my-cache", "key1")
+		requireNoError(t, getErr)
+		assertEqual(t, "key1", item.Key)
+		assertEqual(t, string([]byte("value1")), string(item.Value))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		_, getErr := m.Get(ctx, "no-cache", "key1")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		_, getErr := m.Get(ctx, "my-cache", "missing")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("expired key", func(t *testing.T) {
+		ttl := 10 * time.Second
+		setErr := m.Set(ctx, "my-cache", "expiring", []byte("temp"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(20 * time.Second)
+
+		_, getErr := m.Get(ctx, "my-cache", "expiring")
+		assertError(t, getErr, true)
+	})
+
+	t.Run("not yet expired key", func(t *testing.T) {
+		ttl := 30 * time.Minute
+		setErr := m.Set(ctx, "my-cache", "long-lived", []byte("still-here"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(10 * time.Minute)
+
+		item, getErr := m.Get(ctx, "my-cache", "long-lived")
+		requireNoError(t, getErr)
+		assertEqual(t, "long-lived", item.Key)
+
+		if item.TTL <= 0 {
+			t.Error("expected positive TTL for non-expired key")
+		}
+	})
+}
+
+func TestDelete(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "key1", []byte("val"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := m.Delete(ctx, "my-cache", "key1")
+		requireNoError(t, delErr)
+	})
+
+	t.Run("nonexistent key", func(t *testing.T) {
+		delErr := m.Delete(ctx, "my-cache", "missing")
+		assertError(t, delErr, true)
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		delErr := m.Delete(ctx, "no-cache", "key1")
+		assertError(t, delErr, true)
+	})
+}
+
+func TestKeys(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "user:1", []byte("a"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "user:2", []byte("b"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "session:abc", []byte("c"), 0)
+	requireNoError(t, err)
+
+	t.Run("wildcard all", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 3, len(keys))
+	})
+
+	t.Run("prefix match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "user:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 2, len(keys))
+	})
+
+	t.Run("suffix match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "*abc")
+		requireNoError(t, keysErr)
+		assertEqual(t, 1, len(keys))
+	})
+
+	t.Run("exact match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "user:1")
+		requireNoError(t, keysErr)
+		assertEqual(t, 1, len(keys))
+	})
+
+	t.Run("empty pattern returns all", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "")
+		requireNoError(t, keysErr)
+		assertEqual(t, 3, len(keys))
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		keys, keysErr := m.Keys(ctx, "my-cache", "orders:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		_, keysErr := m.Keys(ctx, "no-cache", "*")
+		assertError(t, keysErr, true)
+	})
+
+	t.Run("expired keys filtered out", func(t *testing.T) {
+		ttl := 5 * time.Second
+		setErr := m.Set(ctx, "my-cache", "temp:1", []byte("x"), ttl)
+		requireNoError(t, setErr)
+
+		fc.Advance(10 * time.Second)
+
+		keys, keysErr := m.Keys(ctx, "my-cache", "temp:*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+}
+
+func TestFlushAll(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestCache(t, m, "my-cache")
+
+	err := m.Set(ctx, "my-cache", "k1", []byte("v1"), 0)
+	requireNoError(t, err)
+
+	err = m.Set(ctx, "my-cache", "k2", []byte("v2"), 0)
+	requireNoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		flushErr := m.FlushAll(ctx, "my-cache")
+		requireNoError(t, flushErr)
+
+		keys, keysErr := m.Keys(ctx, "my-cache", "*")
+		requireNoError(t, keysErr)
+		assertEqual(t, 0, len(keys))
+	})
+
+	t.Run("nonexistent cache", func(t *testing.T) {
+		flushErr := m.FlushAll(ctx, "no-cache")
+		assertError(t, flushErr, true)
+	})
+}
+
+func TestMatchPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		key     string
+		want    bool
+	}{
+		{name: "empty pattern matches all", pattern: "", key: "anything", want: true},
+		{name: "star matches all", pattern: "*", key: "anything", want: true},
+		{name: "prefix star match", pattern: "user:*", key: "user:123", want: true},
+		{name: "prefix star no match", pattern: "user:*", key: "session:1", want: false},
+		{name: "suffix star match", pattern: "*:end", key: "key:end", want: true},
+		{name: "suffix star no match", pattern: "*:end", key: "key:start", want: false},
+		{name: "exact match", pattern: "exact", key: "exact", want: true},
+		{name: "exact no match", pattern: "exact", key: "other", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchPattern(tc.pattern, tc.key)
+			assertEqual(t, tc.want, got)
+		})
+	}
+}

--- a/providers/gcp/memorystore/memorystore_test.go
+++ b/providers/gcp/memorystore/memorystore_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/cache/driver"
 	"github.com/stackshy/cloudemu/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() (*Mock, *config.FakeClock) {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -96,16 +63,17 @@ func TestCreateCache(t *testing.T) {
 			}
 
 			info, err := m.CreateCache(context.Background(), tc.cfg)
-			assertError(t, err, tc.expectErr)
-
 			if tc.expectErr {
+				require.Error(t, err)
 				return
 			}
 
-			assertNotEmpty(t, info.Name)
-			assertEqual(t, "READY", info.Status)
-			assertNotEmpty(t, info.Endpoint)
-			assertNotEmpty(t, info.CreatedAt)
+			require.NoError(t, err)
+
+			assert.NotEmpty(t, info.Name)
+			assert.Equal(t, "READY", info.Status)
+			assert.NotEmpty(t, info.Endpoint)
+			assert.NotEmpty(t, info.CreatedAt)
 		})
 	}
 }
@@ -115,10 +83,10 @@ func TestCreateCacheDefaults(t *testing.T) {
 	ctx := context.Background()
 
 	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "default-cache"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "redis", info.Engine)
-	assertEqual(t, "M1", info.NodeType)
+	assert.Equal(t, "redis", info.Engine)
+	assert.Equal(t, "M1", info.NodeType)
 }
 
 func TestCreateCacheCustomValues(t *testing.T) {
@@ -130,10 +98,10 @@ func TestCreateCacheCustomValues(t *testing.T) {
 		Engine:   "memcached",
 		NodeType: "M3",
 	})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "memcached", info.Engine)
-	assertEqual(t, "M3", info.NodeType)
+	assert.Equal(t, "memcached", info.Engine)
+	assert.Equal(t, "M3", info.NodeType)
 }
 
 func TestCreateCacheSelfLink(t *testing.T) {
@@ -141,10 +109,10 @@ func TestCreateCacheSelfLink(t *testing.T) {
 	ctx := context.Background()
 
 	info, err := m.CreateCache(ctx, driver.CacheConfig{Name: "link-test"})
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	expected := "projects/test-project/instances/link-test"
-	assertEqual(t, expected, info.Name)
+	assert.Equal(t, expected, info.Name)
 }
 
 func TestDeleteCache(t *testing.T) {
@@ -155,12 +123,12 @@ func TestDeleteCache(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		err := m.DeleteCache(ctx, "to-delete")
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		err := m.DeleteCache(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -172,14 +140,14 @@ func TestGetCache(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		info, err := m.GetCache(ctx, "my-cache")
-		requireNoError(t, err)
-		assertNotEmpty(t, info.Name)
-		assertEqual(t, "READY", info.Status)
+		require.NoError(t, err)
+		assert.NotEmpty(t, info.Name)
+		assert.Equal(t, "READY", info.Status)
 	})
 
 	t.Run("not found", func(t *testing.T) {
 		_, err := m.GetCache(ctx, "nonexistent")
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -189,8 +157,8 @@ func TestListCaches(t *testing.T) {
 
 	t.Run("empty list", func(t *testing.T) {
 		caches, err := m.ListCaches(ctx)
-		requireNoError(t, err)
-		assertEqual(t, 0, len(caches))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(caches))
 	})
 
 	createTestCache(t, m, "cache-a")
@@ -198,8 +166,8 @@ func TestListCaches(t *testing.T) {
 
 	t.Run("two caches", func(t *testing.T) {
 		caches, err := m.ListCaches(ctx)
-		requireNoError(t, err)
-		assertEqual(t, 2, len(caches))
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(caches))
 	})
 }
 
@@ -211,18 +179,18 @@ func TestSet(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with TTL", func(t *testing.T) {
 		ttl := 5 * time.Minute
 		err := m.Set(ctx, "my-cache", "key-ttl", []byte("val"), ttl)
-		requireNoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		err := m.Set(ctx, "no-cache", "key1", []byte("val"), 0)
-		assertError(t, err, true)
+		require.Error(t, err)
 	})
 }
 
@@ -233,50 +201,47 @@ func TestGet(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "key1", []byte("value1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		item, getErr := m.Get(ctx, "my-cache", "key1")
-		requireNoError(t, getErr)
-		assertEqual(t, "key1", item.Key)
-		assertEqual(t, string([]byte("value1")), string(item.Value))
+		require.NoError(t, getErr)
+		assert.Equal(t, "key1", item.Key)
+		assert.Equal(t, string([]byte("value1")), string(item.Value))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		_, getErr := m.Get(ctx, "no-cache", "key1")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("nonexistent key", func(t *testing.T) {
 		_, getErr := m.Get(ctx, "my-cache", "missing")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("expired key", func(t *testing.T) {
 		ttl := 10 * time.Second
 		setErr := m.Set(ctx, "my-cache", "expiring", []byte("temp"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(20 * time.Second)
 
 		_, getErr := m.Get(ctx, "my-cache", "expiring")
-		assertError(t, getErr, true)
+		require.Error(t, getErr)
 	})
 
 	t.Run("not yet expired key", func(t *testing.T) {
 		ttl := 30 * time.Minute
 		setErr := m.Set(ctx, "my-cache", "long-lived", []byte("still-here"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(10 * time.Minute)
 
 		item, getErr := m.Get(ctx, "my-cache", "long-lived")
-		requireNoError(t, getErr)
-		assertEqual(t, "long-lived", item.Key)
-
-		if item.TTL <= 0 {
-			t.Error("expected positive TTL for non-expired key")
-		}
+		require.NoError(t, getErr)
+		assert.Equal(t, "long-lived", item.Key)
+		assert.Greater(t, item.TTL, time.Duration(0))
 	})
 }
 
@@ -287,21 +252,21 @@ func TestDelete(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "key1", []byte("val"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		delErr := m.Delete(ctx, "my-cache", "key1")
-		requireNoError(t, delErr)
+		require.NoError(t, delErr)
 	})
 
 	t.Run("nonexistent key", func(t *testing.T) {
 		delErr := m.Delete(ctx, "my-cache", "missing")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		delErr := m.Delete(ctx, "no-cache", "key1")
-		assertError(t, delErr, true)
+		require.Error(t, delErr)
 	})
 }
 
@@ -312,65 +277,65 @@ func TestKeys(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "user:1", []byte("a"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "user:2", []byte("b"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "session:abc", []byte("c"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("wildcard all", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 3, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 3, len(keys))
 	})
 
 	t.Run("prefix match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "user:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 2, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 2, len(keys))
 	})
 
 	t.Run("suffix match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "*abc")
-		requireNoError(t, keysErr)
-		assertEqual(t, 1, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 1, len(keys))
 	})
 
 	t.Run("exact match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "user:1")
-		requireNoError(t, keysErr)
-		assertEqual(t, 1, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 1, len(keys))
 	})
 
 	t.Run("empty pattern returns all", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "")
-		requireNoError(t, keysErr)
-		assertEqual(t, 3, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 3, len(keys))
 	})
 
 	t.Run("no match", func(t *testing.T) {
 		keys, keysErr := m.Keys(ctx, "my-cache", "orders:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		_, keysErr := m.Keys(ctx, "no-cache", "*")
-		assertError(t, keysErr, true)
+		require.Error(t, keysErr)
 	})
 
 	t.Run("expired keys filtered out", func(t *testing.T) {
 		ttl := 5 * time.Second
 		setErr := m.Set(ctx, "my-cache", "temp:1", []byte("x"), ttl)
-		requireNoError(t, setErr)
+		require.NoError(t, setErr)
 
 		fc.Advance(10 * time.Second)
 
 		keys, keysErr := m.Keys(ctx, "my-cache", "temp:*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 }
 
@@ -381,23 +346,23 @@ func TestFlushAll(t *testing.T) {
 	createTestCache(t, m, "my-cache")
 
 	err := m.Set(ctx, "my-cache", "k1", []byte("v1"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = m.Set(ctx, "my-cache", "k2", []byte("v2"), 0)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("success", func(t *testing.T) {
 		flushErr := m.FlushAll(ctx, "my-cache")
-		requireNoError(t, flushErr)
+		require.NoError(t, flushErr)
 
 		keys, keysErr := m.Keys(ctx, "my-cache", "*")
-		requireNoError(t, keysErr)
-		assertEqual(t, 0, len(keys))
+		require.NoError(t, keysErr)
+		assert.Equal(t, 0, len(keys))
 	})
 
 	t.Run("nonexistent cache", func(t *testing.T) {
 		flushErr := m.FlushAll(ctx, "no-cache")
-		assertError(t, flushErr, true)
+		require.Error(t, flushErr)
 	})
 }
 
@@ -421,7 +386,7 @@ func TestMatchPattern(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			got := matchPattern(tc.pattern, tc.key)
-			assertEqual(t, tc.want, got)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -37,8 +37,6 @@ func New(opts *config.Options) *Mock {
 }
 
 // CreateSecret creates a new secret with an initial value.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "secret name is required")
@@ -118,6 +116,7 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
 	secrets := make([]driver.SecretInfo, 0, len(all))
+
 	for _, sd := range all {
 		sd.mu.RLock()
 		secrets = append(secrets, sd.info)

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -1,0 +1,220 @@
+// Package secretmanager provides an in-memory mock implementation of GCP Secret Manager.
+package secretmanager
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// Compile-time check that Mock implements driver.Secrets.
+var _ driver.Secrets = (*Mock)(nil)
+
+type secretData struct {
+	info     driver.SecretInfo
+	versions []driver.SecretVersion
+	mu       sync.RWMutex
+}
+
+// Mock is an in-memory mock implementation of GCP Secret Manager.
+type Mock struct {
+	secrets *memstore.Store[*secretData]
+	opts    *config.Options
+}
+
+// New creates a new Secret Manager mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		secrets: memstore.New[*secretData](),
+		opts:    opts,
+	}
+}
+
+// CreateSecret creates a new secret with an initial value.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "secret name is required")
+	}
+
+	if m.secrets.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "secret %q already exists", cfg.Name)
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	selfLink := idgen.GCPID(m.opts.ProjectID, "secrets", cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.SecretInfo{
+		ID:          idgen.GenerateID("secret-"),
+		Name:        cfg.Name,
+		ARN:         selfLink,
+		Description: cfg.Description,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Tags:        tags,
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	versionID := idgen.GenerateID("ver-")
+	version := driver.SecretVersion{
+		VersionID: versionID,
+		Value:     data,
+		CreatedAt: now,
+		Current:   true,
+	}
+
+	sd := &secretData{
+		info:     info,
+		versions: []driver.SecretVersion{version},
+	}
+
+	m.secrets.Set(cfg.Name, sd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteSecret deletes a secret by name.
+func (m *Mock) DeleteSecret(_ context.Context, name string) error {
+	if !m.secrets.Delete(name) {
+		return errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	return nil
+}
+
+// GetSecret retrieves secret metadata by name.
+func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	result := sd.info
+
+	return &result, nil
+}
+
+// ListSecrets lists all secrets.
+func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
+	all := m.secrets.All()
+
+	secrets := make([]driver.SecretInfo, 0, len(all))
+	for _, sd := range all {
+		sd.mu.RLock()
+		secrets = append(secrets, sd.info)
+		sd.mu.RUnlock()
+	}
+
+	return secrets, nil
+}
+
+// PutSecretValue stores a new version of a secret value.
+func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+
+	for i := range sd.versions {
+		sd.versions[i].Current = false
+	}
+
+	data := make([]byte, len(value))
+	copy(data, value)
+
+	versionID := idgen.GenerateID("ver-")
+	version := driver.SecretVersion{
+		VersionID: versionID,
+		Value:     data,
+		CreatedAt: now,
+		Current:   true,
+	}
+
+	sd.versions = append(sd.versions, version)
+	sd.info.UpdatedAt = now
+
+	result := version
+
+	return &result, nil
+}
+
+// GetSecretValue retrieves a secret value. Empty versionID returns the current version.
+func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	for _, v := range sd.versions {
+		if versionID == "" && v.Current {
+			result := v
+
+			data := make([]byte, len(v.Value))
+			copy(data, v.Value)
+			result.Value = data
+
+			return &result, nil
+		}
+
+		if v.VersionID == versionID {
+			result := v
+
+			data := make([]byte, len(v.Value))
+			copy(data, v.Value)
+			result.Value = data
+
+			return &result, nil
+		}
+	}
+
+	return nil, errors.Newf(errors.NotFound, "version %q not found for secret %q", versionID, name)
+}
+
+// ListSecretVersions lists all versions of a secret.
+func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.SecretVersion, error) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "secret %q not found", name)
+	}
+
+	sd.mu.RLock()
+	defer sd.mu.RUnlock()
+
+	versions := make([]driver.SecretVersion, len(sd.versions))
+	for i, v := range sd.versions {
+		versions[i] = driver.SecretVersion{
+			VersionID: v.VersionID,
+			CreatedAt: v.CreatedAt,
+			Current:   v.Current,
+		}
+	}
+
+	return versions, nil
+}

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -16,10 +16,13 @@ import (
 // Compile-time check that Mock implements driver.Secrets.
 var _ driver.Secrets = (*Mock)(nil)
 
+const defaultRecoveryDays = 30
+
 type secretData struct {
-	info     driver.SecretInfo
-	versions []driver.SecretVersion
-	mu       sync.RWMutex
+	info      driver.SecretInfo
+	versions  []driver.SecretVersion
+	deletedAt time.Time
+	mu        sync.RWMutex
 }
 
 // Mock is an in-memory mock implementation of GCP Secret Manager.
@@ -57,7 +60,7 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	info := driver.SecretInfo{
 		ID:          idgen.GenerateID("secret-"),
 		Name:        cfg.Name,
-		ARN:         selfLink,
+		ResourceID:  selfLink,
 		Description: cfg.Description,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -87,11 +90,21 @@ func (m *Mock) CreateSecret(_ context.Context, cfg driver.SecretConfig, value []
 	return &result, nil
 }
 
-// DeleteSecret deletes a secret by name.
+// DeleteSecret soft-deletes a secret by name, scheduling it for deletion after a recovery window.
 func (m *Mock) DeleteSecret(_ context.Context, name string) error {
-	if !m.secrets.Delete(name) {
+	sd, ok := m.secrets.Get(name)
+	if !ok {
 		return errors.Newf(errors.NotFound, "secret %q not found", name)
 	}
+
+	sd.mu.Lock()
+	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
+	sd.deletedAt = m.opts.Clock.Now().UTC()
 
 	return nil
 }
@@ -106,12 +119,16 @@ func (m *Mock) GetSecret(_ context.Context, name string) (*driver.SecretInfo, er
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
 	result := sd.info
 
 	return &result, nil
 }
 
-// ListSecrets lists all secrets.
+// ListSecrets lists all secrets, excluding soft-deleted ones.
 func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 	all := m.secrets.All()
 
@@ -119,7 +136,9 @@ func (m *Mock) ListSecrets(_ context.Context) ([]driver.SecretInfo, error) {
 
 	for _, sd := range all {
 		sd.mu.RLock()
-		secrets = append(secrets, sd.info)
+		if sd.deletedAt.IsZero() {
+			secrets = append(secrets, sd.info)
+		}
 		sd.mu.RUnlock()
 	}
 
@@ -135,6 +154,10 @@ func (m *Mock) PutSecretValue(_ context.Context, name string, value []byte) (*dr
 
 	sd.mu.Lock()
 	defer sd.mu.Unlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
 
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
@@ -171,6 +194,10 @@ func (m *Mock) GetSecretValue(_ context.Context, name, versionID string) (*drive
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
 
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
+
 	for _, v := range sd.versions {
 		if versionID == "" && v.Current {
 			result := v
@@ -205,6 +232,10 @@ func (m *Mock) ListSecretVersions(_ context.Context, name string) ([]driver.Secr
 
 	sd.mu.RLock()
 	defer sd.mu.RUnlock()
+
+	if !sd.deletedAt.IsZero() {
+		return nil, errors.Newf(errors.NotFound, "secret %q is scheduled for deletion", name)
+	}
 
 	versions := make([]driver.SecretVersion, len(sd.versions))
 	for i, v := range sd.versions {

--- a/providers/gcp/secretmanager/secretmanager.go
+++ b/providers/gcp/secretmanager/secretmanager.go
@@ -16,8 +16,6 @@ import (
 // Compile-time check that Mock implements driver.Secrets.
 var _ driver.Secrets = (*Mock)(nil)
 
-const defaultRecoveryDays = 30
-
 type secretData struct {
 	info      driver.SecretInfo
 	versions  []driver.SecretVersion

--- a/providers/gcp/secretmanager/secretmanager_test.go
+++ b/providers/gcp/secretmanager/secretmanager_test.go
@@ -7,42 +7,9 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestMock() *Mock {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -57,7 +24,7 @@ func createTestSecret(t *testing.T, m *Mock, name, value string) *driver.SecretI
 	cfg := driver.SecretConfig{Name: name, Description: "test secret"}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte(value))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -88,16 +55,19 @@ func TestCreateSecret(t *testing.T) {
 			m := newTestMock()
 
 			info, err := m.CreateSecret(context.Background(), tc.cfg, tc.value)
-			assertError(t, err, tc.expectErr)
-
-			if !tc.expectErr {
-				assertNotEmpty(t, info.ID)
-				assertEqual(t, tc.cfg.Name, info.Name)
-				assertEqual(t, tc.cfg.Description, info.Description)
-				assertNotEmpty(t, info.ARN)
-				assertNotEmpty(t, info.CreatedAt)
-				assertNotEmpty(t, info.UpdatedAt)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
 			}
+
+			assert.NotEmpty(t, info.ID)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, tc.cfg.Description, info.Description)
+			assert.NotEmpty(t, info.ResourceID)
+			assert.NotEmpty(t, info.CreatedAt)
+			assert.NotEmpty(t, info.UpdatedAt)
 		})
 	}
 }
@@ -110,7 +80,7 @@ func TestCreateSecretDuplicate(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "dup-secret"}
 	_, err := m.CreateSecret(context.Background(), cfg, []byte("val2"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestCreateSecretWithTags(t *testing.T) {
@@ -123,10 +93,10 @@ func TestCreateSecretWithTags(t *testing.T) {
 	}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, "prod", info.Tags["env"])
-	assertEqual(t, "platform", info.Tags["team"])
+	assert.Equal(t, "prod", info.Tags["env"])
+	assert.Equal(t, "platform", info.Tags["team"])
 }
 
 func TestCreateSecretGCPSelfLink(t *testing.T) {
@@ -134,7 +104,7 @@ func TestCreateSecretGCPSelfLink(t *testing.T) {
 
 	info := createTestSecret(t, m, "link-secret", "val")
 
-	assertNotEmpty(t, info.ARN)
+	assert.NotEmpty(t, info.ResourceID)
 }
 
 func TestDeleteSecret(t *testing.T) {
@@ -167,7 +137,12 @@ func TestDeleteSecret(t *testing.T) {
 			}
 
 			err := m.DeleteSecret(context.Background(), tc.secretNm)
-			assertError(t, err, tc.expectErr)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }
@@ -202,12 +177,15 @@ func TestGetSecret(t *testing.T) {
 			}
 
 			info, err := m.GetSecret(context.Background(), tc.secretNm)
-			assertError(t, err, tc.expectErr)
-
-			if !tc.expectErr {
-				assertEqual(t, tc.secretNm, info.Name)
-				assertNotEmpty(t, info.ID)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			} else {
+				require.NoError(t, err)
 			}
+
+			assert.Equal(t, tc.secretNm, info.Name)
+			assert.NotEmpty(t, info.ID)
 		})
 	}
 }
@@ -216,16 +194,16 @@ func TestListSecrets(t *testing.T) {
 	m := newTestMock()
 
 	list, err := m.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 0, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(list))
 
 	createTestSecret(t, m, "s1", "v1")
 	createTestSecret(t, m, "s2", "v2")
 	createTestSecret(t, m, "s3", "v3")
 
 	list, err = m.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 3, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(list))
 }
 
 func TestPutSecretValue(t *testing.T) {
@@ -234,11 +212,11 @@ func TestPutSecretValue(t *testing.T) {
 	createTestSecret(t, m, "put-secret", "initial")
 
 	ver, err := m.PutSecretValue(context.Background(), "put-secret", []byte("updated"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertNotEmpty(t, ver.VersionID)
-	assertEqual(t, true, ver.Current)
-	assertEqual(t, "updated", string(ver.Value))
+	assert.NotEmpty(t, ver.VersionID)
+	assert.Equal(t, true, ver.Current)
+	assert.Equal(t, "updated", string(ver.Value))
 }
 
 func TestPutSecretValueNotFound(t *testing.T) {
@@ -246,7 +224,7 @@ func TestPutSecretValueNotFound(t *testing.T) {
 
 	_, err := m.PutSecretValue(context.Background(), "no-such-secret", []byte("val"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
@@ -255,11 +233,11 @@ func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
 	createTestSecret(t, m, "ver-secret", "v1")
 
 	_, err := m.PutSecretValue(context.Background(), "ver-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := m.ListSecretVersions(context.Background(), "ver-secret")
-	requireNoError(t, err)
-	assertEqual(t, 2, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(versions))
 
 	currentCount := 0
 
@@ -269,7 +247,7 @@ func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
 		}
 	}
 
-	assertEqual(t, 1, currentCount)
+	assert.Equal(t, 1, currentCount)
 }
 
 func TestGetSecretValueEmptyVersionID(t *testing.T) {
@@ -278,10 +256,10 @@ func TestGetSecretValueEmptyVersionID(t *testing.T) {
 	createTestSecret(t, m, "gv-secret", "my-value")
 
 	ver, err := m.GetSecretValue(context.Background(), "gv-secret", "")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, true, ver.Current)
-	assertEqual(t, "my-value", string(ver.Value))
+	assert.Equal(t, true, ver.Current)
+	assert.Equal(t, "my-value", string(ver.Value))
 }
 
 func TestGetSecretValueSpecificVersion(t *testing.T) {
@@ -290,13 +268,13 @@ func TestGetSecretValueSpecificVersion(t *testing.T) {
 	createTestSecret(t, m, "sv-secret", "v1")
 
 	v2, err := m.PutSecretValue(context.Background(), "sv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	got, err := m.GetSecretValue(context.Background(), "sv-secret", v2.VersionID)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, v2.VersionID, got.VersionID)
-	assertEqual(t, "v2", string(got.Value))
+	assert.Equal(t, v2.VersionID, got.VersionID)
+	assert.Equal(t, "v2", string(got.Value))
 }
 
 func TestGetSecretValueNonexistentVersion(t *testing.T) {
@@ -306,7 +284,7 @@ func TestGetSecretValueNonexistentVersion(t *testing.T) {
 
 	_, err := m.GetSecretValue(context.Background(), "nv-secret", "bad-version-id")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestGetSecretValueNonexistentSecret(t *testing.T) {
@@ -314,7 +292,7 @@ func TestGetSecretValueNonexistentSecret(t *testing.T) {
 
 	_, err := m.GetSecretValue(context.Background(), "no-secret", "")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersions(t *testing.T) {
@@ -323,14 +301,14 @@ func TestListSecretVersions(t *testing.T) {
 	createTestSecret(t, m, "lv-secret", "v1")
 
 	_, err := m.PutSecretValue(context.Background(), "lv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.PutSecretValue(context.Background(), "lv-secret", []byte("v3"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := m.ListSecretVersions(context.Background(), "lv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 3, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(versions))
 }
 
 func TestListSecretVersionsNotFound(t *testing.T) {
@@ -338,7 +316,7 @@ func TestListSecretVersionsNotFound(t *testing.T) {
 
 	_, err := m.ListSecretVersions(context.Background(), "missing")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersionsPrivacy(t *testing.T) {
@@ -347,13 +325,11 @@ func TestListSecretVersionsPrivacy(t *testing.T) {
 	createTestSecret(t, m, "priv-secret", "sensitive")
 
 	versions, err := m.ListSecretVersions(context.Background(), "priv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 1, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(versions))
 
 	for _, v := range versions {
-		if len(v.Value) != 0 {
-			t.Error("expected empty Value in listed versions for privacy")
-		}
+		assert.Empty(t, v.Value, "expected empty Value in listed versions for privacy")
 	}
 }
 
@@ -364,12 +340,12 @@ func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		_, err := m.PutSecretValue(context.Background(), "multi-secret", []byte("update"))
-		requireNoError(t, err)
+		require.NoError(t, err)
 	}
 
 	versions, err := m.ListSecretVersions(context.Background(), "multi-secret")
-	requireNoError(t, err)
-	assertEqual(t, 6, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 6, len(versions))
 
 	currentCount := 0
 
@@ -379,7 +355,7 @@ func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
 		}
 	}
 
-	assertEqual(t, 1, currentCount)
+	assert.Equal(t, 1, currentCount)
 }
 
 func TestDeleteThenGetReturnsError(t *testing.T) {
@@ -388,10 +364,10 @@ func TestDeleteThenGetReturnsError(t *testing.T) {
 	createTestSecret(t, m, "dtg-secret", "val")
 
 	err := m.DeleteSecret(context.Background(), "dtg-secret")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = m.GetSecret(context.Background(), "dtg-secret")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestCreateSecretTagsCopied(t *testing.T) {
@@ -401,9 +377,9 @@ func TestCreateSecretTagsCopied(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "tag-copy", Tags: tags}
 
 	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	tags["key"] = "mutated"
 
-	assertEqual(t, "original", info.Tags["key"])
+	assert.Equal(t, "original", info.Tags["key"])
 }

--- a/providers/gcp/secretmanager/secretmanager_test.go
+++ b/providers/gcp/secretmanager/secretmanager_test.go
@@ -1,0 +1,409 @@
+package secretmanager
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts)
+}
+
+func createTestSecret(t *testing.T, m *Mock, name, value string) *driver.SecretInfo {
+	t.Helper()
+
+	cfg := driver.SecretConfig{Name: name, Description: "test secret"}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte(value))
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestCreateSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.SecretConfig
+		value     []byte
+		expectErr bool
+	}{
+		{
+			name:      "valid secret",
+			cfg:       driver.SecretConfig{Name: "my-secret", Description: "desc"},
+			value:     []byte("secret-value"),
+			expectErr: false,
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.SecretConfig{Name: ""},
+			value:     []byte("val"),
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			info, err := m.CreateSecret(context.Background(), tc.cfg, tc.value)
+			assertError(t, err, tc.expectErr)
+
+			if !tc.expectErr {
+				assertNotEmpty(t, info.ID)
+				assertEqual(t, tc.cfg.Name, info.Name)
+				assertEqual(t, tc.cfg.Description, info.Description)
+				assertNotEmpty(t, info.ARN)
+				assertNotEmpty(t, info.CreatedAt)
+				assertNotEmpty(t, info.UpdatedAt)
+			}
+		})
+	}
+}
+
+func TestCreateSecretDuplicate(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "dup-secret", "val1")
+
+	cfg := driver.SecretConfig{Name: "dup-secret"}
+	_, err := m.CreateSecret(context.Background(), cfg, []byte("val2"))
+
+	assertError(t, err, true)
+}
+
+func TestCreateSecretWithTags(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"env": "prod", "team": "platform"}
+
+	cfg := driver.SecretConfig{
+		Name: "tagged-secret",
+		Tags: tags,
+	}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
+	requireNoError(t, err)
+
+	assertEqual(t, "prod", info.Tags["env"])
+	assertEqual(t, "platform", info.Tags["team"])
+}
+
+func TestCreateSecretGCPSelfLink(t *testing.T) {
+	m := newTestMock()
+
+	info := createTestSecret(t, m, "link-secret", "val")
+
+	assertNotEmpty(t, info.ARN)
+}
+
+func TestDeleteSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     bool
+		secretNm  string
+		expectErr bool
+	}{
+		{
+			name:      "existing secret",
+			setup:     true,
+			secretNm:  "del-secret",
+			expectErr: false,
+		},
+		{
+			name:      "not found",
+			setup:     false,
+			secretNm:  "nonexistent",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			if tc.setup {
+				createTestSecret(t, m, tc.secretNm, "val")
+			}
+
+			err := m.DeleteSecret(context.Background(), tc.secretNm)
+			assertError(t, err, tc.expectErr)
+		})
+	}
+}
+
+func TestGetSecret(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     bool
+		secretNm  string
+		expectErr bool
+	}{
+		{
+			name:      "existing secret",
+			setup:     true,
+			secretNm:  "get-secret",
+			expectErr: false,
+		},
+		{
+			name:      "not found",
+			setup:     false,
+			secretNm:  "missing",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			if tc.setup {
+				createTestSecret(t, m, tc.secretNm, "val")
+			}
+
+			info, err := m.GetSecret(context.Background(), tc.secretNm)
+			assertError(t, err, tc.expectErr)
+
+			if !tc.expectErr {
+				assertEqual(t, tc.secretNm, info.Name)
+				assertNotEmpty(t, info.ID)
+			}
+		})
+	}
+}
+
+func TestListSecrets(t *testing.T) {
+	m := newTestMock()
+
+	list, err := m.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 0, len(list))
+
+	createTestSecret(t, m, "s1", "v1")
+	createTestSecret(t, m, "s2", "v2")
+	createTestSecret(t, m, "s3", "v3")
+
+	list, err = m.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 3, len(list))
+}
+
+func TestPutSecretValue(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "put-secret", "initial")
+
+	ver, err := m.PutSecretValue(context.Background(), "put-secret", []byte("updated"))
+	requireNoError(t, err)
+
+	assertNotEmpty(t, ver.VersionID)
+	assertEqual(t, true, ver.Current)
+	assertEqual(t, "updated", string(ver.Value))
+}
+
+func TestPutSecretValueNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.PutSecretValue(context.Background(), "no-such-secret", []byte("val"))
+
+	assertError(t, err, true)
+}
+
+func TestPutSecretValueMarksOldNotCurrent(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "ver-secret", "v1")
+
+	_, err := m.PutSecretValue(context.Background(), "ver-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	versions, err := m.ListSecretVersions(context.Background(), "ver-secret")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(versions))
+
+	currentCount := 0
+
+	for _, v := range versions {
+		if v.Current {
+			currentCount++
+		}
+	}
+
+	assertEqual(t, 1, currentCount)
+}
+
+func TestGetSecretValueEmptyVersionID(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "gv-secret", "my-value")
+
+	ver, err := m.GetSecretValue(context.Background(), "gv-secret", "")
+	requireNoError(t, err)
+
+	assertEqual(t, true, ver.Current)
+	assertEqual(t, "my-value", string(ver.Value))
+}
+
+func TestGetSecretValueSpecificVersion(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "sv-secret", "v1")
+
+	v2, err := m.PutSecretValue(context.Background(), "sv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	got, err := m.GetSecretValue(context.Background(), "sv-secret", v2.VersionID)
+	requireNoError(t, err)
+
+	assertEqual(t, v2.VersionID, got.VersionID)
+	assertEqual(t, "v2", string(got.Value))
+}
+
+func TestGetSecretValueNonexistentVersion(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "nv-secret", "val")
+
+	_, err := m.GetSecretValue(context.Background(), "nv-secret", "bad-version-id")
+
+	assertError(t, err, true)
+}
+
+func TestGetSecretValueNonexistentSecret(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.GetSecretValue(context.Background(), "no-secret", "")
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersions(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "lv-secret", "v1")
+
+	_, err := m.PutSecretValue(context.Background(), "lv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	_, err = m.PutSecretValue(context.Background(), "lv-secret", []byte("v3"))
+	requireNoError(t, err)
+
+	versions, err := m.ListSecretVersions(context.Background(), "lv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 3, len(versions))
+}
+
+func TestListSecretVersionsNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.ListSecretVersions(context.Background(), "missing")
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersionsPrivacy(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "priv-secret", "sensitive")
+
+	versions, err := m.ListSecretVersions(context.Background(), "priv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(versions))
+
+	for _, v := range versions {
+		if len(v.Value) != 0 {
+			t.Error("expected empty Value in listed versions for privacy")
+		}
+	}
+}
+
+func TestMultipleVersionsOnlyLatestCurrent(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "multi-secret", "v1")
+
+	for i := 0; i < 5; i++ {
+		_, err := m.PutSecretValue(context.Background(), "multi-secret", []byte("update"))
+		requireNoError(t, err)
+	}
+
+	versions, err := m.ListSecretVersions(context.Background(), "multi-secret")
+	requireNoError(t, err)
+	assertEqual(t, 6, len(versions))
+
+	currentCount := 0
+
+	for _, v := range versions {
+		if v.Current {
+			currentCount++
+		}
+	}
+
+	assertEqual(t, 1, currentCount)
+}
+
+func TestDeleteThenGetReturnsError(t *testing.T) {
+	m := newTestMock()
+
+	createTestSecret(t, m, "dtg-secret", "val")
+
+	err := m.DeleteSecret(context.Background(), "dtg-secret")
+	requireNoError(t, err)
+
+	_, err = m.GetSecret(context.Background(), "dtg-secret")
+	assertError(t, err, true)
+}
+
+func TestCreateSecretTagsCopied(t *testing.T) {
+	m := newTestMock()
+	tags := map[string]string{"key": "original"}
+
+	cfg := driver.SecretConfig{Name: "tag-copy", Tags: tags}
+
+	info, err := m.CreateSecret(context.Background(), cfg, []byte("val"))
+	requireNoError(t, err)
+
+	tags["key"] = "mutated"
+
+	assertEqual(t, "original", info.Tags["key"])
+}

--- a/secrets/driver/driver.go
+++ b/secrets/driver/driver.go
@@ -14,7 +14,7 @@ type SecretConfig struct {
 type SecretInfo struct {
 	ID          string
 	Name        string
-	ARN         string
+	ResourceID  string
 	Description string
 	CreatedAt   string
 	UpdatedAt   string

--- a/secrets/driver/driver.go
+++ b/secrets/driver/driver.go
@@ -1,0 +1,42 @@
+// Package driver defines the interface for secret management service implementations.
+package driver
+
+import "context"
+
+// SecretConfig describes a secret to create.
+type SecretConfig struct {
+	Name        string
+	Description string
+	Tags        map[string]string
+}
+
+// SecretInfo describes a secret.
+type SecretInfo struct {
+	ID          string
+	Name        string
+	ARN         string
+	Description string
+	CreatedAt   string
+	UpdatedAt   string
+	Tags        map[string]string
+}
+
+// SecretVersion represents a specific version of a secret value.
+type SecretVersion struct {
+	VersionID string
+	Value     []byte
+	CreatedAt string
+	Current   bool
+}
+
+// Secrets is the interface that secret management provider implementations must satisfy.
+type Secrets interface {
+	CreateSecret(ctx context.Context, config SecretConfig, value []byte) (*SecretInfo, error)
+	DeleteSecret(ctx context.Context, name string) error
+	GetSecret(ctx context.Context, name string) (*SecretInfo, error)
+	ListSecrets(ctx context.Context) ([]SecretInfo, error)
+
+	PutSecretValue(ctx context.Context, name string, value []byte) (*SecretVersion, error)
+	GetSecretValue(ctx context.Context, name string, versionID string) (*SecretVersion, error)
+	ListSecretVersions(ctx context.Context, name string) ([]SecretVersion, error)
+}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -96,8 +96,6 @@ func (s *Secrets) rec(op string, input, output any, err error, dur time.Duration
 }
 
 // CreateSecret creates a new secret with an initial value.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (s *Secrets) CreateSecret(ctx context.Context, config driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
 	out, err := s.do(ctx, "CreateSecret", config, func() (any, error) { return s.driver.CreateSecret(ctx, config, value) })
 	if err != nil {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -1,0 +1,166 @@
+// Package secrets provides a portable secret management API with cross-cutting concerns.
+package secrets
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// Secrets is the portable secrets type wrapping a driver with cross-cutting concerns.
+type Secrets struct {
+	driver   driver.Secrets
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// NewSecrets creates a new portable Secrets wrapping the given driver.
+func NewSecrets(d driver.Secrets, opts ...Option) *Secrets {
+	s := &Secrets{driver: d}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// Option configures a portable Secrets.
+type Option func(*Secrets)
+
+// WithRecorder sets the recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(s *Secrets) { s.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(s *Secrets) { s.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(s *Secrets) { s.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(s *Secrets) { s.injector = i } }
+
+// WithLatency sets simulated latency.
+func WithLatency(d time.Duration) Option { return func(s *Secrets) { s.latency = d } }
+
+func (s *Secrets) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if s.injector != nil {
+		if err := s.injector.Check("secrets", op); err != nil {
+			s.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if s.limiter != nil {
+		if err := s.limiter.Allow(); err != nil {
+			s.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if s.metrics != nil {
+		labels := map[string]string{"service": "secrets", "operation": op}
+		s.metrics.Counter("calls_total", 1, labels)
+		s.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			s.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	s.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (s *Secrets) rec(op string, input, output any, err error, dur time.Duration) {
+	if s.recorder != nil {
+		s.recorder.Record("secrets", op, input, output, err, dur)
+	}
+}
+
+// CreateSecret creates a new secret with an initial value.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (s *Secrets) CreateSecret(ctx context.Context, config driver.SecretConfig, value []byte) (*driver.SecretInfo, error) {
+	out, err := s.do(ctx, "CreateSecret", config, func() (any, error) { return s.driver.CreateSecret(ctx, config, value) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.SecretInfo), nil
+}
+
+// DeleteSecret deletes a secret.
+func (s *Secrets) DeleteSecret(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteSecret", name, func() (any, error) { return nil, s.driver.DeleteSecret(ctx, name) })
+	return err
+}
+
+// GetSecret retrieves secret metadata.
+func (s *Secrets) GetSecret(ctx context.Context, name string) (*driver.SecretInfo, error) {
+	out, err := s.do(ctx, "GetSecret", name, func() (any, error) { return s.driver.GetSecret(ctx, name) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.SecretInfo), nil
+}
+
+// ListSecrets lists all secrets.
+func (s *Secrets) ListSecrets(ctx context.Context) ([]driver.SecretInfo, error) {
+	out, err := s.do(ctx, "ListSecrets", nil, func() (any, error) { return s.driver.ListSecrets(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SecretInfo), nil
+}
+
+// PutSecretValue stores a new version of a secret value.
+func (s *Secrets) PutSecretValue(ctx context.Context, name string, value []byte) (*driver.SecretVersion, error) {
+	out, err := s.do(ctx, "PutSecretValue", name, func() (any, error) { return s.driver.PutSecretValue(ctx, name, value) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.SecretVersion), nil
+}
+
+// GetSecretValue retrieves a secret value by version. Empty versionID returns the current version.
+func (s *Secrets) GetSecretValue(ctx context.Context, name, versionID string) (*driver.SecretVersion, error) {
+	out, err := s.do(ctx, "GetSecretValue", map[string]string{"name": name, "versionID": versionID}, func() (any, error) {
+		return s.driver.GetSecretValue(ctx, name, versionID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.SecretVersion), nil
+}
+
+// ListSecretVersions lists all versions of a secret.
+func (s *Secrets) ListSecretVersions(ctx context.Context, name string) ([]driver.SecretVersion, error) {
+	out, err := s.do(ctx, "ListSecretVersions", name, func() (any, error) { return s.driver.ListSecretVersions(ctx, name) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SecretVersion), nil
+}

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -13,42 +13,9 @@ import (
 	"github.com/stackshy/cloudemu/ratelimit"
 	"github.com/stackshy/cloudemu/recorder"
 	"github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func requireNoError(t *testing.T, err error) {
-	t.Helper()
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertError(t *testing.T, err error, expectErr bool) {
-	t.Helper()
-
-	switch {
-	case expectErr && err == nil:
-		t.Fatal("expected error but got nil")
-	case !expectErr && err != nil:
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func assertEqual(t *testing.T, expected, actual any) {
-	t.Helper()
-
-	if expected != actual {
-		t.Errorf("expected %v, got %v", expected, actual)
-	}
-}
-
-func assertNotEmpty(t *testing.T, s string) {
-	t.Helper()
-
-	if s == "" {
-		t.Error("expected non-empty string")
-	}
-}
 
 func newTestSecrets(opts ...Option) *Secrets {
 	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
@@ -63,7 +30,7 @@ func createViaPortable(t *testing.T, s *Secrets, name, value string) *driver.Sec
 	cfg := driver.SecretConfig{Name: name, Description: "test"}
 
 	info, err := s.CreateSecret(context.Background(), cfg, []byte(value))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	return info
 }
@@ -73,12 +40,12 @@ func TestBasicCreateAndGet(t *testing.T) {
 
 	info := createViaPortable(t, s, "basic-secret", "hello")
 
-	assertNotEmpty(t, info.ID)
-	assertEqual(t, "basic-secret", info.Name)
+	assert.NotEmpty(t, info.ID)
+	assert.Equal(t, "basic-secret", info.Name)
 
 	got, err := s.GetSecret(context.Background(), "basic-secret")
-	requireNoError(t, err)
-	assertEqual(t, info.Name, got.Name)
+	require.NoError(t, err)
+	assert.Equal(t, info.Name, got.Name)
 }
 
 func TestBasicDeleteSecret(t *testing.T) {
@@ -87,10 +54,10 @@ func TestBasicDeleteSecret(t *testing.T) {
 	createViaPortable(t, s, "del-secret", "val")
 
 	err := s.DeleteSecret(context.Background(), "del-secret")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.GetSecret(context.Background(), "del-secret")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestBasicListSecrets(t *testing.T) {
@@ -100,8 +67,8 @@ func TestBasicListSecrets(t *testing.T) {
 	createViaPortable(t, s, "ls2", "v2")
 
 	list, err := s.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 2, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(list))
 }
 
 func TestBasicPutAndGetValue(t *testing.T) {
@@ -110,12 +77,12 @@ func TestBasicPutAndGetValue(t *testing.T) {
 	createViaPortable(t, s, "pv-secret", "initial")
 
 	ver, err := s.PutSecretValue(context.Background(), "pv-secret", []byte("updated"))
-	requireNoError(t, err)
-	assertEqual(t, true, ver.Current)
+	require.NoError(t, err)
+	assert.Equal(t, true, ver.Current)
 
 	got, err := s.GetSecretValue(context.Background(), "pv-secret", "")
-	requireNoError(t, err)
-	assertEqual(t, "updated", string(got.Value))
+	require.NoError(t, err)
+	assert.Equal(t, "updated", string(got.Value))
 }
 
 func TestBasicListVersions(t *testing.T) {
@@ -124,11 +91,11 @@ func TestBasicListVersions(t *testing.T) {
 	createViaPortable(t, s, "vlv-secret", "v1")
 
 	_, err := s.PutSecretValue(context.Background(), "vlv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	versions, err := s.ListSecretVersions(context.Background(), "vlv-secret")
-	requireNoError(t, err)
-	assertEqual(t, 2, len(versions))
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(versions))
 }
 
 func TestWithRecorder(t *testing.T) {
@@ -138,17 +105,15 @@ func TestWithRecorder(t *testing.T) {
 	createViaPortable(t, s, "rec-secret", "val")
 
 	_, err := s.GetSecret(context.Background(), "rec-secret")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	calls := rec.Calls()
-	if len(calls) < 2 {
-		t.Fatalf("expected at least 2 recorded calls, got %d", len(calls))
-	}
+	require.GreaterOrEqual(t, len(calls), 2, "expected at least 2 recorded calls")
 
-	assertEqual(t, "secrets", calls[0].Service)
-	assertEqual(t, "CreateSecret", calls[0].Operation)
-	assertEqual(t, "secrets", calls[1].Service)
-	assertEqual(t, "GetSecret", calls[1].Operation)
+	assert.Equal(t, "secrets", calls[0].Service)
+	assert.Equal(t, "CreateSecret", calls[0].Operation)
+	assert.Equal(t, "secrets", calls[1].Service)
+	assert.Equal(t, "GetSecret", calls[1].Operation)
 }
 
 func TestWithRecorderRecordsAllOps(t *testing.T) {
@@ -159,24 +124,24 @@ func TestWithRecorderRecordsAllOps(t *testing.T) {
 	createViaPortable(t, s, "all-ops", "v1")
 
 	_, err := s.GetSecret(ctx, "all-ops")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.ListSecrets(ctx)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.PutSecretValue(ctx, "all-ops", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.GetSecretValue(ctx, "all-ops", "")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	_, err = s.ListSecretVersions(ctx, "all-ops")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	err = s.DeleteSecret(ctx, "all-ops")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, 7, rec.CallCount())
+	assert.Equal(t, 7, rec.CallCount())
 }
 
 func TestWithMetrics(t *testing.T) {
@@ -186,19 +151,15 @@ func TestWithMetrics(t *testing.T) {
 	createViaPortable(t, s, "met-secret", "val")
 
 	_, err := s.GetSecret(context.Background(), "met-secret")
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	all := mc.All()
-	if len(all) == 0 {
-		t.Fatal("expected metrics to be collected")
-	}
+	require.NotEmpty(t, all, "expected metrics to be collected")
 
 	q := metrics.NewQuery(mc)
 	callCount := q.ByName("calls_total").Count()
 
-	if callCount < 2 {
-		t.Errorf("expected at least 2 calls_total metrics, got %d", callCount)
-	}
+	assert.GreaterOrEqual(t, callCount, 2, "expected at least 2 calls_total metrics")
 }
 
 func TestWithMetricsRecordsErrors(t *testing.T) {
@@ -206,11 +167,11 @@ func TestWithMetricsRecordsErrors(t *testing.T) {
 	s := newTestSecrets(WithMetrics(mc))
 
 	_, err := s.GetSecret(context.Background(), "nonexistent")
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	q := metrics.NewQuery(mc)
 	errCount := q.ByName("errors_total").Count()
-	assertEqual(t, 1, errCount)
+	assert.Equal(t, 1, errCount)
 }
 
 func TestWithMetricsHistogram(t *testing.T) {
@@ -222,9 +183,7 @@ func TestWithMetricsHistogram(t *testing.T) {
 	q := metrics.NewQuery(mc)
 	histCount := q.ByName("call_duration").Count()
 
-	if histCount < 1 {
-		t.Error("expected at least 1 histogram metric")
-	}
+	assert.GreaterOrEqual(t, histCount, 1, "expected at least 1 histogram metric")
 }
 
 func TestWithErrorInjection(t *testing.T) {
@@ -237,7 +196,7 @@ func TestWithErrorInjection(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "inj-secret"}
 	_, err := s.CreateSecret(context.Background(), cfg, []byte("val"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithErrorInjectionSelectiveOps(t *testing.T) {
@@ -250,11 +209,11 @@ func TestWithErrorInjectionSelectiveOps(t *testing.T) {
 	inj.Set("secrets", "GetSecret", injErr, inject.Always{})
 
 	_, err := s.GetSecret(context.Background(), "sel-secret")
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	list, err := s.ListSecrets(context.Background())
-	requireNoError(t, err)
-	assertEqual(t, 1, len(list))
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(list))
 }
 
 func TestWithErrorInjectionCountdown(t *testing.T) {
@@ -265,10 +224,10 @@ func TestWithErrorInjectionCountdown(t *testing.T) {
 	inj.Set("secrets", "ListSecrets", injErr, inject.NewCountdown(1))
 
 	_, err := s.ListSecrets(context.Background())
-	assertError(t, err, true)
+	require.Error(t, err)
 
 	_, err = s.ListSecrets(context.Background())
-	requireNoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestWithRecorderAndMetricsCombined(t *testing.T) {
@@ -278,11 +237,9 @@ func TestWithRecorderAndMetricsCombined(t *testing.T) {
 
 	createViaPortable(t, s, "combo-secret", "val")
 
-	assertEqual(t, 1, rec.CallCount())
+	assert.Equal(t, 1, rec.CallCount())
 
-	if len(mc.All()) == 0 {
-		t.Error("expected metrics to be collected alongside recorder")
-	}
+	assert.NotEmpty(t, mc.All(), "expected metrics to be collected alongside recorder")
 }
 
 func TestWithErrorInjectionAndRecorder(t *testing.T) {
@@ -296,17 +253,13 @@ func TestWithErrorInjectionAndRecorder(t *testing.T) {
 	cfg := driver.SecretConfig{Name: "fail"}
 	_, err := s.CreateSecret(context.Background(), cfg, []byte("val"))
 
-	assertError(t, err, true)
-	assertEqual(t, 1, rec.CallCount())
+	require.Error(t, err)
+	assert.Equal(t, 1, rec.CallCount())
 
 	last := rec.LastCall()
-	if last == nil {
-		t.Fatal("expected last call to be recorded")
-	}
+	require.NotNil(t, last, "expected last call to be recorded")
 
-	if last.Error == nil {
-		t.Error("expected recorded call to have an error")
-	}
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
 }
 
 func TestGetSecretValueThroughPortable(t *testing.T) {
@@ -315,13 +268,13 @@ func TestGetSecretValueThroughPortable(t *testing.T) {
 	createViaPortable(t, s, "gsv-secret", "initial")
 
 	v2, err := s.PutSecretValue(context.Background(), "gsv-secret", []byte("v2"))
-	requireNoError(t, err)
+	require.NoError(t, err)
 
 	got, err := s.GetSecretValue(context.Background(), "gsv-secret", v2.VersionID)
-	requireNoError(t, err)
+	require.NoError(t, err)
 
-	assertEqual(t, v2.VersionID, got.VersionID)
-	assertEqual(t, "v2", string(got.Value))
+	assert.Equal(t, v2.VersionID, got.VersionID)
+	assert.Equal(t, "v2", string(got.Value))
 }
 
 func TestDeleteSecretNotFoundThroughPortable(t *testing.T) {
@@ -329,7 +282,7 @@ func TestDeleteSecretNotFoundThroughPortable(t *testing.T) {
 
 	err := s.DeleteSecret(context.Background(), "no-such")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestPutSecretValueNotFoundThroughPortable(t *testing.T) {
@@ -337,7 +290,7 @@ func TestPutSecretValueNotFoundThroughPortable(t *testing.T) {
 
 	_, err := s.PutSecretValue(context.Background(), "nope", []byte("val"))
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestListSecretVersionsNotFoundThroughPortable(t *testing.T) {
@@ -345,7 +298,7 @@ func TestListSecretVersionsNotFoundThroughPortable(t *testing.T) {
 
 	_, err := s.ListSecretVersions(context.Background(), "nope")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithMetricsLabels(t *testing.T) {
@@ -361,7 +314,7 @@ func TestWithMetricsLabels(t *testing.T) {
 		ByLabel("operation", "CreateSecret").
 		Count()
 
-	assertEqual(t, 1, ct)
+	assert.Equal(t, 1, ct)
 }
 
 func TestWithRateLimiter(t *testing.T) {
@@ -373,7 +326,7 @@ func TestWithRateLimiter(t *testing.T) {
 	createViaPortable(t, s, "rl-secret", "val")
 
 	_, err := s.GetSecret(context.Background(), "rl-secret")
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithLatency(t *testing.T) {
@@ -384,9 +337,7 @@ func TestWithLatency(t *testing.T) {
 	createViaPortable(t, s, "lat-secret", "val")
 
 	elapsed := time.Since(start)
-	if elapsed < time.Millisecond {
-		t.Error("expected latency to be applied")
-	}
+	assert.GreaterOrEqual(t, elapsed, time.Millisecond, "expected latency to be applied")
 }
 
 func TestGetSecretValueErrorPath(t *testing.T) {
@@ -394,7 +345,7 @@ func TestGetSecretValueErrorPath(t *testing.T) {
 
 	_, err := s.GetSecretValue(context.Background(), "missing", "")
 
-	assertError(t, err, true)
+	require.Error(t, err)
 }
 
 func TestWithRateLimiterAndRecorder(t *testing.T) {
@@ -407,7 +358,7 @@ func TestWithRateLimiterAndRecorder(t *testing.T) {
 	createViaPortable(t, s, "rlr-secret", "val")
 
 	_, err := s.ListSecrets(context.Background())
-	assertError(t, err, true)
+	require.Error(t, err)
 
-	assertEqual(t, 2, rec.CallCount())
+	assert.Equal(t, 2, rec.CallCount())
 }

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -1,0 +1,413 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/secretsmanager"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/secrets/driver"
+)
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error but got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}
+
+func newTestSecrets(opts ...Option) *Secrets {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	o := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return NewSecrets(secretsmanager.New(o), opts...)
+}
+
+func createViaPortable(t *testing.T, s *Secrets, name, value string) *driver.SecretInfo {
+	t.Helper()
+
+	cfg := driver.SecretConfig{Name: name, Description: "test"}
+
+	info, err := s.CreateSecret(context.Background(), cfg, []byte(value))
+	requireNoError(t, err)
+
+	return info
+}
+
+func TestBasicCreateAndGet(t *testing.T) {
+	s := newTestSecrets()
+
+	info := createViaPortable(t, s, "basic-secret", "hello")
+
+	assertNotEmpty(t, info.ID)
+	assertEqual(t, "basic-secret", info.Name)
+
+	got, err := s.GetSecret(context.Background(), "basic-secret")
+	requireNoError(t, err)
+	assertEqual(t, info.Name, got.Name)
+}
+
+func TestBasicDeleteSecret(t *testing.T) {
+	s := newTestSecrets()
+
+	createViaPortable(t, s, "del-secret", "val")
+
+	err := s.DeleteSecret(context.Background(), "del-secret")
+	requireNoError(t, err)
+
+	_, err = s.GetSecret(context.Background(), "del-secret")
+	assertError(t, err, true)
+}
+
+func TestBasicListSecrets(t *testing.T) {
+	s := newTestSecrets()
+
+	createViaPortable(t, s, "ls1", "v1")
+	createViaPortable(t, s, "ls2", "v2")
+
+	list, err := s.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 2, len(list))
+}
+
+func TestBasicPutAndGetValue(t *testing.T) {
+	s := newTestSecrets()
+
+	createViaPortable(t, s, "pv-secret", "initial")
+
+	ver, err := s.PutSecretValue(context.Background(), "pv-secret", []byte("updated"))
+	requireNoError(t, err)
+	assertEqual(t, true, ver.Current)
+
+	got, err := s.GetSecretValue(context.Background(), "pv-secret", "")
+	requireNoError(t, err)
+	assertEqual(t, "updated", string(got.Value))
+}
+
+func TestBasicListVersions(t *testing.T) {
+	s := newTestSecrets()
+
+	createViaPortable(t, s, "vlv-secret", "v1")
+
+	_, err := s.PutSecretValue(context.Background(), "vlv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	versions, err := s.ListSecretVersions(context.Background(), "vlv-secret")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(versions))
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	s := newTestSecrets(WithRecorder(rec))
+
+	createViaPortable(t, s, "rec-secret", "val")
+
+	_, err := s.GetSecret(context.Background(), "rec-secret")
+	requireNoError(t, err)
+
+	calls := rec.Calls()
+	if len(calls) < 2 {
+		t.Fatalf("expected at least 2 recorded calls, got %d", len(calls))
+	}
+
+	assertEqual(t, "secrets", calls[0].Service)
+	assertEqual(t, "CreateSecret", calls[0].Operation)
+	assertEqual(t, "secrets", calls[1].Service)
+	assertEqual(t, "GetSecret", calls[1].Operation)
+}
+
+func TestWithRecorderRecordsAllOps(t *testing.T) {
+	rec := recorder.New()
+	s := newTestSecrets(WithRecorder(rec))
+	ctx := context.Background()
+
+	createViaPortable(t, s, "all-ops", "v1")
+
+	_, err := s.GetSecret(ctx, "all-ops")
+	requireNoError(t, err)
+
+	_, err = s.ListSecrets(ctx)
+	requireNoError(t, err)
+
+	_, err = s.PutSecretValue(ctx, "all-ops", []byte("v2"))
+	requireNoError(t, err)
+
+	_, err = s.GetSecretValue(ctx, "all-ops", "")
+	requireNoError(t, err)
+
+	_, err = s.ListSecretVersions(ctx, "all-ops")
+	requireNoError(t, err)
+
+	err = s.DeleteSecret(ctx, "all-ops")
+	requireNoError(t, err)
+
+	assertEqual(t, 7, rec.CallCount())
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	s := newTestSecrets(WithMetrics(mc))
+
+	createViaPortable(t, s, "met-secret", "val")
+
+	_, err := s.GetSecret(context.Background(), "met-secret")
+	requireNoError(t, err)
+
+	all := mc.All()
+	if len(all) == 0 {
+		t.Fatal("expected metrics to be collected")
+	}
+
+	q := metrics.NewQuery(mc)
+	callCount := q.ByName("calls_total").Count()
+
+	if callCount < 2 {
+		t.Errorf("expected at least 2 calls_total metrics, got %d", callCount)
+	}
+}
+
+func TestWithMetricsRecordsErrors(t *testing.T) {
+	mc := metrics.NewCollector()
+	s := newTestSecrets(WithMetrics(mc))
+
+	_, err := s.GetSecret(context.Background(), "nonexistent")
+	assertError(t, err, true)
+
+	q := metrics.NewQuery(mc)
+	errCount := q.ByName("errors_total").Count()
+	assertEqual(t, 1, errCount)
+}
+
+func TestWithMetricsHistogram(t *testing.T) {
+	mc := metrics.NewCollector()
+	s := newTestSecrets(WithMetrics(mc))
+
+	createViaPortable(t, s, "hist-secret", "val")
+
+	q := metrics.NewQuery(mc)
+	histCount := q.ByName("call_duration").Count()
+
+	if histCount < 1 {
+		t.Error("expected at least 1 histogram metric")
+	}
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	s := newTestSecrets(WithErrorInjection(inj))
+
+	injErr := fmt.Errorf("injected failure")
+	inj.Set("secrets", "CreateSecret", injErr, inject.Always{})
+
+	cfg := driver.SecretConfig{Name: "inj-secret"}
+	_, err := s.CreateSecret(context.Background(), cfg, []byte("val"))
+
+	assertError(t, err, true)
+}
+
+func TestWithErrorInjectionSelectiveOps(t *testing.T) {
+	inj := inject.NewInjector()
+	s := newTestSecrets(WithErrorInjection(inj))
+
+	createViaPortable(t, s, "sel-secret", "val")
+
+	injErr := fmt.Errorf("get fails")
+	inj.Set("secrets", "GetSecret", injErr, inject.Always{})
+
+	_, err := s.GetSecret(context.Background(), "sel-secret")
+	assertError(t, err, true)
+
+	list, err := s.ListSecrets(context.Background())
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+}
+
+func TestWithErrorInjectionCountdown(t *testing.T) {
+	inj := inject.NewInjector()
+	s := newTestSecrets(WithErrorInjection(inj))
+
+	injErr := fmt.Errorf("countdown error")
+	inj.Set("secrets", "ListSecrets", injErr, inject.NewCountdown(1))
+
+	_, err := s.ListSecrets(context.Background())
+	assertError(t, err, true)
+
+	_, err = s.ListSecrets(context.Background())
+	requireNoError(t, err)
+}
+
+func TestWithRecorderAndMetricsCombined(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	s := newTestSecrets(WithRecorder(rec), WithMetrics(mc))
+
+	createViaPortable(t, s, "combo-secret", "val")
+
+	assertEqual(t, 1, rec.CallCount())
+
+	if len(mc.All()) == 0 {
+		t.Error("expected metrics to be collected alongside recorder")
+	}
+}
+
+func TestWithErrorInjectionAndRecorder(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	s := newTestSecrets(WithRecorder(rec), WithErrorInjection(inj))
+
+	injErr := fmt.Errorf("injected")
+	inj.Set("secrets", "CreateSecret", injErr, inject.Always{})
+
+	cfg := driver.SecretConfig{Name: "fail"}
+	_, err := s.CreateSecret(context.Background(), cfg, []byte("val"))
+
+	assertError(t, err, true)
+	assertEqual(t, 1, rec.CallCount())
+
+	last := rec.LastCall()
+	if last == nil {
+		t.Fatal("expected last call to be recorded")
+	}
+
+	if last.Error == nil {
+		t.Error("expected recorded call to have an error")
+	}
+}
+
+func TestGetSecretValueThroughPortable(t *testing.T) {
+	s := newTestSecrets()
+
+	createViaPortable(t, s, "gsv-secret", "initial")
+
+	v2, err := s.PutSecretValue(context.Background(), "gsv-secret", []byte("v2"))
+	requireNoError(t, err)
+
+	got, err := s.GetSecretValue(context.Background(), "gsv-secret", v2.VersionID)
+	requireNoError(t, err)
+
+	assertEqual(t, v2.VersionID, got.VersionID)
+	assertEqual(t, "v2", string(got.Value))
+}
+
+func TestDeleteSecretNotFoundThroughPortable(t *testing.T) {
+	s := newTestSecrets()
+
+	err := s.DeleteSecret(context.Background(), "no-such")
+
+	assertError(t, err, true)
+}
+
+func TestPutSecretValueNotFoundThroughPortable(t *testing.T) {
+	s := newTestSecrets()
+
+	_, err := s.PutSecretValue(context.Background(), "nope", []byte("val"))
+
+	assertError(t, err, true)
+}
+
+func TestListSecretVersionsNotFoundThroughPortable(t *testing.T) {
+	s := newTestSecrets()
+
+	_, err := s.ListSecretVersions(context.Background(), "nope")
+
+	assertError(t, err, true)
+}
+
+func TestWithMetricsLabels(t *testing.T) {
+	mc := metrics.NewCollector()
+	s := newTestSecrets(WithMetrics(mc))
+
+	createViaPortable(t, s, "label-secret", "val")
+
+	q := metrics.NewQuery(mc)
+
+	ct := q.ByName("calls_total").
+		ByLabel("service", "secrets").
+		ByLabel("operation", "CreateSecret").
+		Count()
+
+	assertEqual(t, 1, ct)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	o := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	lim := ratelimit.New(1, 1, fc)
+	s := NewSecrets(secretsmanager.New(o), WithRateLimiter(lim))
+
+	createViaPortable(t, s, "rl-secret", "val")
+
+	_, err := s.GetSecret(context.Background(), "rl-secret")
+	assertError(t, err, true)
+}
+
+func TestWithLatency(t *testing.T) {
+	s := newTestSecrets(WithLatency(time.Millisecond))
+
+	start := time.Now()
+
+	createViaPortable(t, s, "lat-secret", "val")
+
+	elapsed := time.Since(start)
+	if elapsed < time.Millisecond {
+		t.Error("expected latency to be applied")
+	}
+}
+
+func TestGetSecretValueErrorPath(t *testing.T) {
+	s := newTestSecrets()
+
+	_, err := s.GetSecretValue(context.Background(), "missing", "")
+
+	assertError(t, err, true)
+}
+
+func TestWithRateLimiterAndRecorder(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	o := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	lim := ratelimit.New(1, 1, fc)
+	rec := recorder.New()
+	s := NewSecrets(secretsmanager.New(o), WithRateLimiter(lim), WithRecorder(rec))
+
+	createViaPortable(t, s, "rlr-secret", "val")
+
+	_, err := s.ListSecrets(context.Background())
+	assertError(t, err, true)
+
+	assertEqual(t, 2, rec.CallCount())
+}


### PR DESCRIPTION
added new resources

| Cache | ElastiCache | Azure Cache for Redis | Memorystore |
| Secret Management | Secrets Manager | Key Vault | Secret Manager |
| Logging | CloudWatch Logs | Log Analytics | Cloud Logging |
| Notifications | SNS | Notification Hubs | FCM |


# 🚀 Four New Cloud Services (12 Provider Mocks)

Added **Cache, Secret Management, Logging, and Notifications** — each with:
- Driver interface
- Portable API with cross-cutting concerns
- 3 provider mocks (AWS, Azure, GCP)

---

## 📦 Services Overview

| Service       | Driver Interface        | Portable API             | AWS              | Azure              | GCP            |
|---------------|------------------------|--------------------------|------------------|--------------------|----------------|
| Cache         | `cache/driver/`        | `cache/cache.go`         | ElastiCache      | Azure Cache (Redis)| Memorystore    |
| Secrets       | `secrets/driver/`      | `secrets/secrets.go`     | Secrets Manager  | Key Vault          | Secret Manager |
| Logging       | `logging/driver/`      | `logging/logging.go`     | CloudWatch Logs  | Log Analytics      | Cloud Logging  |
| Notifications | `notification/driver/` | `notification/notification.go` | SNS              | Notification Hubs  | FCM            |

---

## 📊 Summary

- **Total new source files:** 20 (in `cloudemu` library)

---

## 🔌 Provider Wiring

Updated all provider factory files to include new services:

- `providers/aws/aws.go`  
  → Added: ElastiCache, SecretsManager, CloudWatchLogs, SNS  

- `providers/azure/azure.go`  
  → Added: Cache, KeyVault, LogAnalytics, NotificationHubs  

- `providers/gcp/gcp.go`  
  → Added: Memorystore, SecretManager, CloudLogging, FCM  

### 📈 Service Count

- Before: **10 services/provider**
- After: **14 services/provider**
- Total: **42 provider mocks**

---

## 🧪 Comprehensive Unit Tests

- **16 test files**
- **>90% coverage across all new packages**

### 📊 Coverage Breakdown

| Package                          | Coverage |
|----------------------------------|----------|
| providers/aws/elasticache        | 98.9%    |
| providers/aws/secretsmanager     | 100%     |
| providers/aws/cloudwatchlogs     | 100%     |
| providers/aws/sns                | 100%     |
| providers/azure/azurecache       | 98.9%    |
| providers/azure/keyvault         | 100%     |
| providers/azure/loganalytics     | 100%     |
| providers/azure/notificationhubs | 100%     |
| providers/gcp/memorystore        | 98.9%    |
| providers/gcp/secretmanager      | 100%     |
| providers/gcp/cloudlogging       | 100%     |
| providers/gcp/fcm                | 100%     |
| cache (portable API)             | 91.9%    |
| secrets (portable API)           | 100%     |
| logging (portable API)           | 100%     |
| notification (portable API)      | 91.8%    |

---