### PR TITLE
fix CacheInfo missing Tags and LogQueryInput to pointer

### DIFF
--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -22,6 +22,7 @@ type CacheInfo struct {
 	Status    string
 	Endpoint  string
 	CreatedAt string
+	Tags      map[string]string
 }
 
 // CacheConfig describes a cache instance to create.

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -1900,7 +1900,7 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 	}
 
 	// Get all events
-	allEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+	allEvents, err := d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
 		LogGroup: "app-logs",
 	})
 	if err != nil {
@@ -1911,7 +1911,7 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 	}
 
 	// Get events from specific stream
-	streamEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+	streamEvents, err := d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
 		LogGroup:  "app-logs",
 		LogStream: "web-server",
 	})
@@ -1923,7 +1923,7 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 	}
 
 	// Filter by pattern
-	errorEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+	errorEvents, err := d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
 		LogGroup: "app-logs",
 		Pattern:  "Error",
 	})
@@ -1935,7 +1935,7 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 	}
 
 	// Filter by time range
-	recentEvents, err := d.GetLogEvents(ctx, loggingdriver.LogQueryInput{
+	recentEvents, err := d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
 		LogGroup:  "app-logs",
 		StartTime: now.Add(-90 * time.Minute),
 		EndTime:   now.Add(time.Minute),
@@ -2150,7 +2150,7 @@ func TestCrossProviderNewServices(t *testing.T) {
 		})
 	}
 
-	// Test caches across providers
+	// Test caches across providers (including tags)
 	cacheProviders := []struct {
 		name string
 		d    cachedriver.Cache
@@ -2162,12 +2162,35 @@ func TestCrossProviderNewServices(t *testing.T) {
 
 	for _, cp := range cacheProviders {
 		t.Run("cache/"+cp.name, func(t *testing.T) {
-			_, err := cp.d.CreateCache(ctx, cachedriver.CacheConfig{Name: "test-cache"})
+			info, err := cp.d.CreateCache(ctx, cachedriver.CacheConfig{
+				Name: "test-cache",
+				Tags: map[string]string{"env": "staging", "team": "backend"},
+			})
 			if err != nil {
 				t.Fatalf("CreateCache: %v", err)
 			}
 
-			cp.d.Set(ctx, "test-cache", "key", []byte("value"), 0)
+			// Verify tags are persisted in CacheInfo
+			if info.Tags["env"] != "staging" {
+				t.Errorf("expected tag env=staging, got %q", info.Tags["env"])
+			}
+			if info.Tags["team"] != "backend" {
+				t.Errorf("expected tag team=backend, got %q", info.Tags["team"])
+			}
+
+			// Verify tags survive GetCache
+			got, err := cp.d.GetCache(ctx, "test-cache")
+			if err != nil {
+				t.Fatalf("GetCache: %v", err)
+			}
+			if got.Tags["env"] != "staging" {
+				t.Errorf("GetCache: expected tag env=staging, got %q", got.Tags["env"])
+			}
+
+			err = cp.d.Set(ctx, "test-cache", "key", []byte("value"), 0)
+			if err != nil {
+				t.Fatalf("Set: %v", err)
+			}
 			item, _ := cp.d.Get(ctx, "test-cache", "key")
 			if string(item.Value) != "value" {
 				t.Errorf("expected 'value', got %q", string(item.Value))
@@ -2202,6 +2225,177 @@ func TestCrossProviderNewServices(t *testing.T) {
 			}
 			if got.Name != "alerts" {
 				t.Errorf("expected 'alerts', got %q", got.Name)
+			}
+		})
+	}
+}
+
+// ==============================================================================
+// Integration Tests: CacheInfo Tags Persistence
+// ==============================================================================
+
+func TestCacheTagsPersistence(t *testing.T) {
+	ctx := context.Background()
+
+	providers := []struct {
+		name string
+		d    cachedriver.Cache
+	}{
+		{"aws/elasticache", NewAWS().ElastiCache},
+		{"azure/cache", NewAzure().Cache},
+		{"gcp/memorystore", NewGCP().Memorystore},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			tags := map[string]string{"env": "production", "team": "platform", "cost-center": "eng-42"}
+
+			info, err := p.d.CreateCache(ctx, cachedriver.CacheConfig{
+				Name:   "tagged-cache",
+				Engine: "redis",
+				Tags:   tags,
+			})
+			if err != nil {
+				t.Fatalf("CreateCache: %v", err)
+			}
+
+			// Verify all tags are present in the returned CacheInfo
+			for k, v := range tags {
+				if info.Tags[k] != v {
+					t.Errorf("CreateCache: expected tag %s=%s, got %q", k, v, info.Tags[k])
+				}
+			}
+
+			// Verify tags survive GetCache round-trip
+			got, err := p.d.GetCache(ctx, "tagged-cache")
+			if err != nil {
+				t.Fatalf("GetCache: %v", err)
+			}
+			for k, v := range tags {
+				if got.Tags[k] != v {
+					t.Errorf("GetCache: expected tag %s=%s, got %q", k, v, got.Tags[k])
+				}
+			}
+
+			// Verify tags appear in ListCaches
+			caches, err := p.d.ListCaches(ctx)
+			if err != nil {
+				t.Fatalf("ListCaches: %v", err)
+			}
+			if len(caches) != 1 {
+				t.Fatalf("expected 1 cache, got %d", len(caches))
+			}
+			for k, v := range tags {
+				if caches[0].Tags[k] != v {
+					t.Errorf("ListCaches: expected tag %s=%s, got %q", k, v, caches[0].Tags[k])
+				}
+			}
+
+			// Verify tag isolation (modifying original map doesn't affect stored tags)
+			tags["env"] = "modified"
+			got2, _ := p.d.GetCache(ctx, "tagged-cache")
+			if got2.Tags["env"] != "production" {
+				t.Error("tag isolation broken: modifying input map affected stored tags")
+			}
+
+			// Verify empty tags work fine
+			info2, err := p.d.CreateCache(ctx, cachedriver.CacheConfig{Name: "no-tags-cache"})
+			if err != nil {
+				t.Fatalf("CreateCache (no tags): %v", err)
+			}
+			if info2.Tags == nil {
+				t.Error("expected non-nil empty tags map")
+			}
+			if len(info2.Tags) != 0 {
+				t.Errorf("expected 0 tags, got %d", len(info2.Tags))
+			}
+		})
+	}
+}
+
+// ==============================================================================
+// Integration Tests: LogQueryInput Pointer Interface
+// ==============================================================================
+
+func TestLogQueryInputPointer(t *testing.T) {
+	ctx := context.Background()
+
+	providers := []struct {
+		name string
+		d    loggingdriver.Logging
+	}{
+		{"aws/cloudwatchlogs", NewAWS().CloudWatchLogs},
+		{"azure/loganalytics", NewAzure().LogAnalytics},
+		{"gcp/cloudlogging", NewGCP().CloudLogging},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			// Setup: create log group and stream
+			_, err := p.d.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{Name: "ptr-test-group"})
+			if err != nil {
+				t.Fatalf("CreateLogGroup: %v", err)
+			}
+			_, err = p.d.CreateLogStream(ctx, "ptr-test-group", "stream-1")
+			if err != nil {
+				t.Fatalf("CreateLogStream: %v", err)
+			}
+
+			now := time.Now().UTC()
+			events := []loggingdriver.LogEvent{
+				{Timestamp: now.Add(-2 * time.Minute), Message: "info: starting up"},
+				{Timestamp: now.Add(-1 * time.Minute), Message: "error: connection failed"},
+				{Timestamp: now, Message: "info: recovered"},
+			}
+			if err := p.d.PutLogEvents(ctx, "ptr-test-group", "stream-1", events); err != nil {
+				t.Fatalf("PutLogEvents: %v", err)
+			}
+
+			// Query with pointer — basic query
+			results, err := p.d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
+				LogGroup: "ptr-test-group",
+			})
+			if err != nil {
+				t.Fatalf("GetLogEvents (all): %v", err)
+			}
+			if len(results) != 3 {
+				t.Errorf("expected 3 events, got %d", len(results))
+			}
+
+			// Query with pointer — pattern filter
+			filtered, err := p.d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
+				LogGroup: "ptr-test-group",
+				Pattern:  "error",
+			})
+			if err != nil {
+				t.Fatalf("GetLogEvents (pattern): %v", err)
+			}
+			if len(filtered) != 1 {
+				t.Errorf("expected 1 error event, got %d", len(filtered))
+			}
+
+			// Query with pointer — specific stream
+			streamResults, err := p.d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
+				LogGroup:  "ptr-test-group",
+				LogStream: "stream-1",
+			})
+			if err != nil {
+				t.Fatalf("GetLogEvents (stream): %v", err)
+			}
+			if len(streamResults) != 3 {
+				t.Errorf("expected 3 events from stream-1, got %d", len(streamResults))
+			}
+
+			// Query with pointer — limit
+			limited, err := p.d.GetLogEvents(ctx, &loggingdriver.LogQueryInput{
+				LogGroup: "ptr-test-group",
+				Limit:    1,
+			})
+			if err != nil {
+				t.Fatalf("GetLogEvents (limit): %v", err)
+			}
+			if len(limited) != 1 {
+				t.Errorf("expected 1 event with limit=1, got %d", len(limited))
 			}
 		})
 	}

--- a/logging/driver/driver.go
+++ b/logging/driver/driver.go
@@ -58,5 +58,5 @@ type Logging interface {
 	ListLogStreams(ctx context.Context, logGroup string) ([]LogStreamInfo, error)
 
 	PutLogEvents(ctx context.Context, logGroup, streamName string, events []LogEvent) error
-	GetLogEvents(ctx context.Context, input LogQueryInput) ([]LogEvent, error)
+	GetLogEvents(ctx context.Context, input *LogQueryInput) ([]LogEvent, error)
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -172,9 +172,7 @@ func (l *Logging) PutLogEvents(ctx context.Context, logGroup, streamName string,
 }
 
 // GetLogEvents retrieves log events matching the query.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (l *Logging) GetLogEvents(ctx context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+func (l *Logging) GetLogEvents(ctx context.Context, input *driver.LogQueryInput) ([]driver.LogEvent, error) {
 	out, err := l.do(ctx, "GetLogEvents", input, func() (any, error) { return l.driver.GetLogEvents(ctx, input) })
 	if err != nil {
 		return nil, err

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -206,7 +206,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := l.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := l.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestGetLogEvents(t *testing.T) {
 	t.Run("nonexistent group error", func(t *testing.T) {
 		l := newTestLogging()
 
-		_, err := l.GetLogEvents(ctx, driver.LogQueryInput{
+		_, err := l.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "nope",
 		})
 		require.Error(t, err)
@@ -408,7 +408,7 @@ func TestAllOperationsRecorded(t *testing.T) {
 		{Timestamp: baseTime, Message: "test"},
 	})
 
-	_, _ = l.GetLogEvents(ctx, driver.LogQueryInput{LogGroup: "grp"})
+	_, _ = l.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "grp"})
 	_ = l.DeleteLogStream(ctx, "grp", "s1")
 	_ = l.DeleteLogGroup(ctx, "grp")
 
@@ -492,7 +492,7 @@ func TestAllOperationsMetrics(t *testing.T) {
 		{Timestamp: baseTime, Message: "test"},
 	})
 
-	_, _ = l.GetLogEvents(ctx, driver.LogQueryInput{LogGroup: "grp"})
+	_, _ = l.GetLogEvents(ctx, &driver.LogQueryInput{LogGroup: "grp"})
 	_ = l.DeleteLogStream(ctx, "grp", "s1")
 	_ = l.DeleteLogGroup(ctx, "grp")
 

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -228,9 +228,7 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 }
 
 // GetLogEvents retrieves log events matching the query.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]driver.LogEvent, error) {
 	g, ok := m.groups.Get(input.LogGroup)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", input.LogGroup)
@@ -246,12 +244,12 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, &input, retentionCutoff)
+		events := m.getStreamEvents(g, input.LogStream, input, retentionCutoff)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, &input, retentionCutoff)
+			events := m.filterEvents(s, input, retentionCutoff)
 			results = append(results, events...)
 		}
 	}

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -374,7 +374,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "test-group",
 			LogStream: "test-stream",
 		})
@@ -420,7 +420,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 			Pattern:  "ERROR",
 		})
@@ -440,7 +440,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "test-group",
 			StartTime: baseTime.Add(30 * time.Minute),
 			EndTime:   baseTime.Add(90 * time.Minute),
@@ -466,7 +466,7 @@ func TestGetLogEvents(t *testing.T) {
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
 		require.NoError(t, err)
 
-		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		result, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 			Limit:    3,
 		})
@@ -478,7 +478,7 @@ func TestGetLogEvents(t *testing.T) {
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
-		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		_, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "no-group",
 		})
 		require.Error(t, err)
@@ -490,7 +490,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
@@ -514,7 +514,7 @@ func TestGetLogEvents(t *testing.T) {
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
 		require.NoError(t, err)
 
-		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		result, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -528,7 +528,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "empty-grp",
 		})
 		require.NoError(t, err)

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -65,6 +65,11 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	endpoint := fmt.Sprintf("%s.%s.cache.amazonaws.com:%d", cfg.Name, m.opts.Region, defaultRedisPort)
 
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
 		NodeType:  nodeType,
@@ -72,6 +77,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		Status:    "available",
 		Endpoint:  endpoint,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:      tags,
 	}
 
 	cd := &cacheData{

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -65,6 +65,11 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	endpoint := fmt.Sprintf("%s.redis.cache.windows.net:%d", cfg.Name, defaultRedisSSLPort)
 
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
 		NodeType:  nodeType,
@@ -72,6 +77,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		Status:    "Running",
 		Endpoint:  endpoint,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:      tags,
 	}
 
 	cd := &cacheData{

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -227,9 +227,7 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 }
 
 // GetLogEvents retrieves log events matching the query.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]driver.LogEvent, error) {
 	g, ok := m.groups.Get(input.LogGroup)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", input.LogGroup)
@@ -245,12 +243,12 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, &input, retentionCutoff)
+		events := m.getStreamEvents(g, input.LogStream, input, retentionCutoff)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, &input, retentionCutoff)
+			events := m.filterEvents(s, input, retentionCutoff)
 			results = append(results, events...)
 		}
 	}

--- a/providers/azure/loganalytics/loganalytics_test.go
+++ b/providers/azure/loganalytics/loganalytics_test.go
@@ -374,7 +374,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "test-group",
 			LogStream: "test-stream",
 		})
@@ -420,7 +420,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 			Pattern:  "ERROR",
 		})
@@ -440,7 +440,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "test-group",
 			StartTime: baseTime.Add(30 * time.Minute),
 			EndTime:   baseTime.Add(90 * time.Minute),
@@ -466,7 +466,7 @@ func TestGetLogEvents(t *testing.T) {
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
 		require.NoError(t, err)
 
-		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		result, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 			Limit:    3,
 		})
@@ -478,7 +478,7 @@ func TestGetLogEvents(t *testing.T) {
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
-		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		_, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "no-group",
 		})
 		require.Error(t, err)
@@ -490,7 +490,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
@@ -514,7 +514,7 @@ func TestGetLogEvents(t *testing.T) {
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
 		require.NoError(t, err)
 
-		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		result, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -528,7 +528,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "empty-grp",
 		})
 		require.NoError(t, err)

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -227,9 +227,7 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 }
 
 // GetLogEvents retrieves log events matching the query.
-//
-//nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]driver.LogEvent, error) {
+func (m *Mock) GetLogEvents(_ context.Context, input *driver.LogQueryInput) ([]driver.LogEvent, error) {
 	g, ok := m.groups.Get(input.LogGroup)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", input.LogGroup)
@@ -245,12 +243,12 @@ func (m *Mock) GetLogEvents(_ context.Context, input driver.LogQueryInput) ([]dr
 	var results []driver.LogEvent
 
 	if input.LogStream != "" {
-		events := m.getStreamEvents(g, input.LogStream, &input, retentionCutoff)
+		events := m.getStreamEvents(g, input.LogStream, input, retentionCutoff)
 		results = append(results, events...)
 	} else {
 		all := g.streams.All()
 		for _, s := range all {
-			events := m.filterEvents(s, &input, retentionCutoff)
+			events := m.filterEvents(s, input, retentionCutoff)
 			results = append(results, events...)
 		}
 	}

--- a/providers/gcp/cloudlogging/cloudlogging_test.go
+++ b/providers/gcp/cloudlogging/cloudlogging_test.go
@@ -374,7 +374,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "test-group",
 			LogStream: "test-stream",
 		})
@@ -420,7 +420,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 			Pattern:  "ERROR",
 		})
@@ -440,7 +440,7 @@ func TestGetLogEvents(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "test-group",
 			StartTime: baseTime.Add(30 * time.Minute),
 			EndTime:   baseTime.Add(90 * time.Minute),
@@ -466,7 +466,7 @@ func TestGetLogEvents(t *testing.T) {
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
 		require.NoError(t, err)
 
-		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		result, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 			Limit:    3,
 		})
@@ -478,7 +478,7 @@ func TestGetLogEvents(t *testing.T) {
 	t.Run("nonexistent group error", func(t *testing.T) {
 		m := newTestMock()
 
-		_, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		_, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "no-group",
 		})
 		require.Error(t, err)
@@ -490,7 +490,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup:  "grp",
 			LogStream: "no-stream",
 		})
@@ -514,7 +514,7 @@ func TestGetLogEvents(t *testing.T) {
 		err := m.PutLogEvents(ctx, "test-group", "test-stream", events)
 		require.NoError(t, err)
 
-		result, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		result, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "test-group",
 		})
 		require.NoError(t, err)
@@ -528,7 +528,7 @@ func TestGetLogEvents(t *testing.T) {
 		_, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "empty-grp"})
 		require.NoError(t, err)
 
-		events, err := m.GetLogEvents(ctx, driver.LogQueryInput{
+		events, err := m.GetLogEvents(ctx, &driver.LogQueryInput{
 			LogGroup: "empty-grp",
 		})
 		require.NoError(t, err)

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -67,6 +67,11 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 	selfLink := idgen.GCPID(m.opts.ProjectID, "instances", cfg.Name)
 	endpoint := fmt.Sprintf("%s.redis.%s.gcp.cloud:%d", cfg.Name, m.opts.Region, defaultRedisPort)
 
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
 	info := driver.CacheInfo{
 		Name:      selfLink,
 		NodeType:  nodeType,
@@ -74,6 +79,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 		Status:    "READY",
 		Endpoint:  endpoint,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:      tags,
 	}
 
 	cd := &cacheData{


### PR DESCRIPTION
## Summary

Follow-up fix for two issues found during PR #53 review that were not resolved before merge.

### Fix 1: CacheInfo missing Tags field

`CacheConfig` accepted a `Tags map[string]string` but `CacheInfo` had no `Tags` field. Tags passed during `CreateCache` were silently dropped across all 3 providers.

**Changes:**
- Added `Tags map[string]string` to `CacheInfo` in `cache/driver/driver.go`
- Wired tag copy and persistence in `CreateCache` for all 3 providers:
  - `providers/aws/elasticache/elasticache.go`
  - `providers/azure/azurecache/azurecache.go`
  - `providers/gcp/memorystore/memorystore.go`

### Fix 2: LogQueryInput changed from value to pointer

`LogQueryInput` is a 6-field struct that was passed by value through the entire call chain, triggering `gocritic` hugeParam warnings that were suppressed with `//nolint` annotations instead of fixing the root cause.

**Changes:**
- Changed driver interface from `GetLogEvents(ctx, LogQueryInput)` to `GetLogEvents(ctx, *LogQueryInput)` in `logging/driver/driver.go`
- Updated portable API in `logging/logging.go` — removed `//nolint:gocritic` suppression
- Updated all 3 provider implementations — removed `//nolint:gocritic` suppressions:
  - `providers/aws/cloudwatchlogs/cloudwatchlogs.go`
  - `providers/azure/loganalytics/loganalytics.go`
  - `providers/gcp/cloudlogging/cloudlogging.go`
- Updated all test call sites to pass `&LogQueryInput{...}`

## Test plan

- [x] `TestCacheTagsPersistence` — tags persist through CreateCache, GetCache, ListCaches across all 3 providers; tag isolation and empty tags verified
- [x] `TestLogQueryInputPointer` — GetLogEvents works with pointer across all 3 providers; basic query, pattern filter, stream filter, and limit verified
- [x] All existing tests pass (`go test ./...`)
- [x] Linter clean (`golangci-lint run --timeout=9m ./...`)