### PR TITLE
Add 2 new services, enhance 8 existing services, wire metrics for all 16 services

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -27,6 +27,8 @@ import (
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 
 	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
 	loggingdriver "github.com/stackshy/cloudemu/logging/driver"
 	notifdriver "github.com/stackshy/cloudemu/notification/driver"
 	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
@@ -2399,4 +2401,3172 @@ func TestLogQueryInputPointer(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Container Registry Tests
+// ---------------------------------------------------------------------------
+
+func TestContainerRegistryOperations(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    crdriver.ContainerRegistry
+	}{
+		{"AWS", awsP.ECR},
+		{"Azure", azureP.ACR},
+		{"GCP", gcpP.ArtifactRegistry},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			// CreateRepository
+			repo, err := p.d.CreateRepository(ctx, crdriver.RepositoryConfig{
+				Name:               "my-app",
+				Tags:               map[string]string{"env": "test"},
+				ImageTagMutability: "MUTABLE",
+			})
+			if err != nil {
+				t.Fatalf("CreateRepository: %v", err)
+			}
+			if repo == nil {
+				t.Fatalf("expected non-nil repo")
+			}
+
+			// GetRepository
+			got, err := p.d.GetRepository(ctx, "my-app")
+			if err != nil {
+				t.Fatalf("GetRepository: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil repo from Get")
+			}
+
+			// ListRepositories
+			repos, err := p.d.ListRepositories(ctx)
+			if err != nil {
+				t.Fatalf("ListRepositories: %v", err)
+			}
+			if len(repos) != 1 {
+				t.Errorf("expected 1 repo, got %d", len(repos))
+			}
+
+			// PutImage
+			img, err := p.d.PutImage(ctx, &crdriver.ImageManifest{
+				Repository: "my-app",
+				Tag:        "v1.0",
+				Digest:     "sha256:abc123",
+				MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+				SizeBytes:  1024,
+			})
+			if err != nil {
+				t.Fatalf("PutImage: %v", err)
+			}
+			if len(img.Tags) == 0 {
+				t.Errorf("expected at least one tag on image")
+			}
+
+			// GetImage
+			imgDetail, err := p.d.GetImage(ctx, "my-app", "v1.0")
+			if err != nil {
+				t.Fatalf("GetImage: %v", err)
+			}
+			if imgDetail.Digest != "sha256:abc123" {
+				t.Errorf("expected digest sha256:abc123, got %s", imgDetail.Digest)
+			}
+
+			// ListImages
+			images, err := p.d.ListImages(ctx, "my-app")
+			if err != nil {
+				t.Fatalf("ListImages: %v", err)
+			}
+			if len(images) != 1 {
+				t.Errorf("expected 1 image, got %d", len(images))
+			}
+
+			// TagImage
+			err = p.d.TagImage(ctx, "my-app", "v1.0", "latest")
+			if err != nil {
+				t.Fatalf("TagImage: %v", err)
+			}
+			imgDetail2, err := p.d.GetImage(ctx, "my-app", "latest")
+			if err != nil {
+				t.Fatalf("GetImage after TagImage: %v", err)
+			}
+			if imgDetail2.Digest != "sha256:abc123" {
+				t.Errorf("expected same digest after tagging, got %s", imgDetail2.Digest)
+			}
+
+			// DeleteImage
+			err = p.d.DeleteImage(ctx, "my-app", "v1.0")
+			if err != nil {
+				t.Fatalf("DeleteImage: %v", err)
+			}
+
+			// DeleteRepository
+			err = p.d.DeleteRepository(ctx, "my-app", true)
+			if err != nil {
+				t.Fatalf("DeleteRepository: %v", err)
+			}
+			_, err = p.d.GetRepository(ctx, "my-app")
+			if err == nil {
+				t.Errorf("expected error after deleting repo, got nil")
+			}
+		})
+	}
+}
+
+func TestContainerRegistryImmutableTags(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    crdriver.ContainerRegistry
+	}{
+		{"AWS", awsP.ECR},
+		{"Azure", azureP.ACR},
+		{"GCP", gcpP.ArtifactRegistry},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateRepository(ctx, crdriver.RepositoryConfig{
+				Name:               "immutable-repo",
+				ImageTagMutability: "IMMUTABLE",
+			})
+			if err != nil {
+				t.Fatalf("CreateRepository: %v", err)
+			}
+
+			_, err = p.d.PutImage(ctx, &crdriver.ImageManifest{
+				Repository: "immutable-repo",
+				Tag:        "v1.0",
+				Digest:     "sha256:first",
+				SizeBytes:  512,
+			})
+			if err != nil {
+				t.Fatalf("PutImage first: %v", err)
+			}
+
+			// Push duplicate tag should fail on IMMUTABLE
+			_, err = p.d.PutImage(ctx, &crdriver.ImageManifest{
+				Repository: "immutable-repo",
+				Tag:        "v1.0",
+				Digest:     "sha256:second",
+				SizeBytes:  512,
+			})
+			if err == nil {
+				t.Errorf("expected error pushing duplicate tag to immutable repo, got nil")
+			}
+		})
+	}
+}
+
+func TestContainerRegistryLifecyclePolicy(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    crdriver.ContainerRegistry
+	}{
+		{"AWS", awsP.ECR},
+		{"Azure", azureP.ACR},
+		{"GCP", gcpP.ArtifactRegistry},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateRepository(ctx, crdriver.RepositoryConfig{
+				Name:               "lifecycle-repo",
+				ImageTagMutability: "MUTABLE",
+			})
+			if err != nil {
+				t.Fatalf("CreateRepository: %v", err)
+			}
+
+			policy := crdriver.LifecyclePolicy{
+				Rules: []crdriver.LifecycleRule{
+					{
+						Priority:    1,
+						Description: "expire untagged",
+						TagStatus:   "untagged",
+						CountType:   "imageCountMoreThan",
+						CountValue:  5,
+						Action:      "expire",
+					},
+				},
+			}
+			err = p.d.PutLifecyclePolicy(ctx, "lifecycle-repo", policy)
+			if err != nil {
+				t.Fatalf("PutLifecyclePolicy: %v", err)
+			}
+
+			got, err := p.d.GetLifecyclePolicy(ctx, "lifecycle-repo")
+			if err != nil {
+				t.Fatalf("GetLifecyclePolicy: %v", err)
+			}
+			if len(got.Rules) != 1 {
+				t.Errorf("expected 1 lifecycle rule, got %d", len(got.Rules))
+			}
+
+			_, err = p.d.EvaluateLifecyclePolicy(ctx, "lifecycle-repo")
+			if err != nil {
+				t.Fatalf("EvaluateLifecyclePolicy: %v", err)
+			}
+		})
+	}
+}
+
+func TestContainerRegistryImageScan(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    crdriver.ContainerRegistry
+	}{
+		{"AWS", awsP.ECR},
+		{"Azure", azureP.ACR},
+		{"GCP", gcpP.ArtifactRegistry},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateRepository(ctx, crdriver.RepositoryConfig{
+				Name:               "scan-repo",
+				ImageTagMutability: "MUTABLE",
+				ImageScanOnPush:    true,
+			})
+			if err != nil {
+				t.Fatalf("CreateRepository: %v", err)
+			}
+
+			_, err = p.d.PutImage(ctx, &crdriver.ImageManifest{
+				Repository: "scan-repo",
+				Tag:        "latest",
+				Digest:     "sha256:scanme",
+				SizeBytes:  2048,
+			})
+			if err != nil {
+				t.Fatalf("PutImage: %v", err)
+			}
+
+			scanResult, err := p.d.StartImageScan(ctx, "scan-repo", "latest")
+			if err != nil {
+				t.Fatalf("StartImageScan: %v", err)
+			}
+			if scanResult.Status == "" {
+				t.Errorf("expected scan status, got empty")
+			}
+
+			results, err := p.d.GetImageScanResults(ctx, "scan-repo", "latest")
+			if err != nil {
+				t.Fatalf("GetImageScanResults: %v", err)
+			}
+			if results.Repository != "scan-repo" {
+				t.Errorf("expected repository scan-repo, got %s", results.Repository)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event Bus Tests
+// ---------------------------------------------------------------------------
+
+func TestEventBusOperations(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    ebdriver.EventBus
+	}{
+		{"AWS", awsP.EventBridge},
+		{"Azure", azureP.EventGrid},
+		{"GCP", gcpP.Eventarc},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			// CreateEventBus
+			bus, err := p.d.CreateEventBus(ctx, ebdriver.EventBusConfig{
+				Name: "test-bus",
+				Tags: map[string]string{"env": "test"},
+			})
+			if err != nil {
+				t.Fatalf("CreateEventBus: %v", err)
+			}
+			if bus.Name != "test-bus" {
+				t.Errorf("expected bus name test-bus, got %s", bus.Name)
+			}
+
+			// GetEventBus
+			gotBus, err := p.d.GetEventBus(ctx, "test-bus")
+			if err != nil {
+				t.Fatalf("GetEventBus: %v", err)
+			}
+			if gotBus.Name != "test-bus" {
+				t.Errorf("expected test-bus, got %s", gotBus.Name)
+			}
+
+			// ListEventBuses
+			buses, err := p.d.ListEventBuses(ctx)
+			if err != nil {
+				t.Fatalf("ListEventBuses: %v", err)
+			}
+			if len(buses) < 1 {
+				t.Errorf("expected at least 1 bus, got %d", len(buses))
+			}
+
+			// PutRule
+			rule, err := p.d.PutRule(ctx, &ebdriver.RuleConfig{
+				Name:         "test-rule",
+				EventBus:     "test-bus",
+				Description:  "test rule",
+				EventPattern: `{"source":["my.app"]}`,
+				State:        "ENABLED",
+			})
+			if err != nil {
+				t.Fatalf("PutRule: %v", err)
+			}
+			if rule.Name != "test-rule" {
+				t.Errorf("expected rule name test-rule, got %s", rule.Name)
+			}
+
+			// GetRule
+			gotRule, err := p.d.GetRule(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("GetRule: %v", err)
+			}
+			if gotRule.State != "ENABLED" {
+				t.Errorf("expected ENABLED, got %s", gotRule.State)
+			}
+
+			// ListRules
+			rules, err := p.d.ListRules(ctx, "test-bus")
+			if err != nil {
+				t.Fatalf("ListRules: %v", err)
+			}
+			if len(rules) != 1 {
+				t.Errorf("expected 1 rule, got %d", len(rules))
+			}
+
+			// DisableRule
+			err = p.d.DisableRule(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("DisableRule: %v", err)
+			}
+			gotRule, err = p.d.GetRule(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("GetRule after disable: %v", err)
+			}
+			if gotRule.State != "DISABLED" {
+				t.Errorf("expected DISABLED, got %s", gotRule.State)
+			}
+
+			// EnableRule
+			err = p.d.EnableRule(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("EnableRule: %v", err)
+			}
+
+			// PutTargets
+			err = p.d.PutTargets(ctx, "test-bus", "test-rule", []ebdriver.Target{
+				{ID: "target-1", ARN: "arn:aws:lambda:us-east-1:123456:function:my-func"},
+			})
+			if err != nil {
+				t.Fatalf("PutTargets: %v", err)
+			}
+
+			// ListTargets
+			targets, err := p.d.ListTargets(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("ListTargets: %v", err)
+			}
+			if len(targets) != 1 {
+				t.Errorf("expected 1 target, got %d", len(targets))
+			}
+
+			// RemoveTargets
+			err = p.d.RemoveTargets(ctx, "test-bus", "test-rule", []string{"target-1"})
+			if err != nil {
+				t.Fatalf("RemoveTargets: %v", err)
+			}
+			targets, err = p.d.ListTargets(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("ListTargets after remove: %v", err)
+			}
+			if len(targets) != 0 {
+				t.Errorf("expected 0 targets after remove, got %d", len(targets))
+			}
+
+			// DeleteRule
+			err = p.d.DeleteRule(ctx, "test-bus", "test-rule")
+			if err != nil {
+				t.Fatalf("DeleteRule: %v", err)
+			}
+
+			// DeleteEventBus
+			err = p.d.DeleteEventBus(ctx, "test-bus")
+			if err != nil {
+				t.Fatalf("DeleteEventBus: %v", err)
+			}
+			_, err = p.d.GetEventBus(ctx, "test-bus")
+			if err == nil {
+				t.Errorf("expected error after deleting bus, got nil")
+			}
+		})
+	}
+}
+
+func TestEventPatternMatching(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    ebdriver.EventBus
+	}{
+		{"AWS", awsP.EventBridge},
+		{"Azure", azureP.EventGrid},
+		{"GCP", gcpP.Eventarc},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "pattern-bus"})
+			if err != nil {
+				t.Fatalf("CreateEventBus: %v", err)
+			}
+
+			_, err = p.d.PutRule(ctx, &ebdriver.RuleConfig{
+				Name:         "pattern-rule",
+				EventBus:     "pattern-bus",
+				EventPattern: `{"source":["my.app"]}`,
+				State:        "ENABLED",
+			})
+			if err != nil {
+				t.Fatalf("PutRule: %v", err)
+			}
+
+			result, err := p.d.PutEvents(ctx, []ebdriver.Event{
+				{
+					Source:     "my.app",
+					DetailType: "OrderCreated",
+					Detail:     `{"orderId":"123"}`,
+					EventBus:   "pattern-bus",
+				},
+			})
+			if err != nil {
+				t.Fatalf("PutEvents: %v", err)
+			}
+			if result.SuccessCount != 1 {
+				t.Errorf("expected 1 success, got %d", result.SuccessCount)
+			}
+
+			history, err := p.d.GetEventHistory(ctx, "pattern-bus", 10)
+			if err != nil {
+				t.Fatalf("GetEventHistory: %v", err)
+			}
+			if len(history) < 1 {
+				t.Errorf("expected at least 1 event in history, got %d", len(history))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Storage Enhancement Tests
+// ---------------------------------------------------------------------------
+
+func TestPresignedURLs(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    storagedriver.Bucket
+	}{
+		{"AWS", awsP.S3},
+		{"Azure", azureP.BlobStorage},
+		{"GCP", gcpP.GCS},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateBucket(ctx, "presign-bucket")
+			if err != nil {
+				t.Fatalf("CreateBucket: %v", err)
+			}
+			err = p.d.PutObject(ctx, "presign-bucket", "test.txt", []byte("hello"), "text/plain", nil)
+			if err != nil {
+				t.Fatalf("PutObject: %v", err)
+			}
+
+			// GET presigned URL
+			getURL, err := p.d.GeneratePresignedURL(ctx, storagedriver.PresignedURLRequest{
+				Bucket:    "presign-bucket",
+				Key:       "test.txt",
+				Method:    "GET",
+				ExpiresIn: 15 * time.Minute,
+			})
+			if err != nil {
+				t.Fatalf("GeneratePresignedURL GET: %v", err)
+			}
+			if getURL.URL == "" {
+				t.Errorf("expected non-empty presigned URL")
+			}
+			if getURL.Method != "GET" {
+				t.Errorf("expected method GET, got %s", getURL.Method)
+			}
+
+			// PUT presigned URL
+			putURL, err := p.d.GeneratePresignedURL(ctx, storagedriver.PresignedURLRequest{
+				Bucket:    "presign-bucket",
+				Key:       "upload.txt",
+				Method:    "PUT",
+				ExpiresIn: 30 * time.Minute,
+			})
+			if err != nil {
+				t.Fatalf("GeneratePresignedURL PUT: %v", err)
+			}
+			if putURL.URL == "" {
+				t.Errorf("expected non-empty presigned URL")
+			}
+			if putURL.Method != "PUT" {
+				t.Errorf("expected method PUT, got %s", putURL.Method)
+			}
+		})
+	}
+}
+
+func TestBucketLifecycle(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	awsP := NewAWS(config.WithClock(clk))
+	azureP := NewAzure(config.WithClock(clk))
+	gcpP := NewGCP(config.WithClock(clk))
+
+	providers := []struct {
+		name string
+		d    storagedriver.Bucket
+	}{
+		{"AWS", awsP.S3},
+		{"Azure", azureP.BlobStorage},
+		{"GCP", gcpP.GCS},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateBucket(ctx, "lc-bucket")
+			if err != nil {
+				t.Fatalf("CreateBucket: %v", err)
+			}
+
+			// Put objects
+			err = p.d.PutObject(ctx, "lc-bucket", "old-file.txt", []byte("old"), "text/plain", nil)
+			if err != nil {
+				t.Fatalf("PutObject: %v", err)
+			}
+
+			// Set lifecycle with 1-day expiration
+			err = p.d.PutLifecycleConfig(ctx, "lc-bucket", storagedriver.LifecycleConfig{
+				Rules: []storagedriver.LifecycleRule{
+					{
+						ID:             "expire-old",
+						Enabled:        true,
+						Prefix:         "",
+						ExpirationDays: 1,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("PutLifecycleConfig: %v", err)
+			}
+
+			gotLC, err := p.d.GetLifecycleConfig(ctx, "lc-bucket")
+			if err != nil {
+				t.Fatalf("GetLifecycleConfig: %v", err)
+			}
+			if len(gotLC.Rules) != 1 {
+				t.Errorf("expected 1 lifecycle rule, got %d", len(gotLC.Rules))
+			}
+
+			// Advance time past expiration
+			clk.Advance(48 * time.Hour)
+
+			expired, err := p.d.EvaluateLifecycle(ctx, "lc-bucket")
+			if err != nil {
+				t.Fatalf("EvaluateLifecycle: %v", err)
+			}
+			if len(expired) < 1 {
+				t.Errorf("expected at least 1 expired object, got %d", len(expired))
+			}
+		})
+	}
+}
+
+func TestMultipartUpload(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    storagedriver.Bucket
+	}{
+		{"AWS", awsP.S3},
+		{"Azure", azureP.BlobStorage},
+		{"GCP", gcpP.GCS},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateBucket(ctx, "mp-bucket")
+			if err != nil {
+				t.Fatalf("CreateBucket: %v", err)
+			}
+
+			// Create multipart upload
+			upload, err := p.d.CreateMultipartUpload(ctx, "mp-bucket", "big-file.bin", "application/octet-stream")
+			if err != nil {
+				t.Fatalf("CreateMultipartUpload: %v", err)
+			}
+			if upload.UploadID == "" {
+				t.Fatalf("expected non-empty upload ID")
+			}
+
+			// Upload parts
+			part1, err := p.d.UploadPart(ctx, "mp-bucket", "big-file.bin", upload.UploadID, 1, []byte("part-one-"))
+			if err != nil {
+				t.Fatalf("UploadPart 1: %v", err)
+			}
+			part2, err := p.d.UploadPart(ctx, "mp-bucket", "big-file.bin", upload.UploadID, 2, []byte("part-two"))
+			if err != nil {
+				t.Fatalf("UploadPart 2: %v", err)
+			}
+
+			// List multipart uploads
+			uploads, err := p.d.ListMultipartUploads(ctx, "mp-bucket")
+			if err != nil {
+				t.Fatalf("ListMultipartUploads: %v", err)
+			}
+			if len(uploads) < 1 {
+				t.Errorf("expected at least 1 upload, got %d", len(uploads))
+			}
+
+			// Complete
+			err = p.d.CompleteMultipartUpload(ctx, "mp-bucket", "big-file.bin", upload.UploadID, []storagedriver.UploadPart{*part1, *part2})
+			if err != nil {
+				t.Fatalf("CompleteMultipartUpload: %v", err)
+			}
+
+			// Verify final object
+			obj, err := p.d.GetObject(ctx, "mp-bucket", "big-file.bin")
+			if err != nil {
+				t.Fatalf("GetObject after multipart: %v", err)
+			}
+			if string(obj.Data) != "part-one-part-two" {
+				t.Errorf("expected 'part-one-part-two', got '%s'", string(obj.Data))
+			}
+		})
+	}
+}
+
+func TestMultipartUploadAbort(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    storagedriver.Bucket
+	}{
+		{"AWS", awsP.S3},
+		{"Azure", azureP.BlobStorage},
+		{"GCP", gcpP.GCS},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateBucket(ctx, "abort-bucket")
+			if err != nil {
+				t.Fatalf("CreateBucket: %v", err)
+			}
+
+			upload, err := p.d.CreateMultipartUpload(ctx, "abort-bucket", "aborted.bin", "application/octet-stream")
+			if err != nil {
+				t.Fatalf("CreateMultipartUpload: %v", err)
+			}
+
+			_, err = p.d.UploadPart(ctx, "abort-bucket", "aborted.bin", upload.UploadID, 1, []byte("data"))
+			if err != nil {
+				t.Fatalf("UploadPart: %v", err)
+			}
+
+			err = p.d.AbortMultipartUpload(ctx, "abort-bucket", "aborted.bin", upload.UploadID)
+			if err != nil {
+				t.Fatalf("AbortMultipartUpload: %v", err)
+			}
+
+			// Object should not exist
+			_, err = p.d.GetObject(ctx, "abort-bucket", "aborted.bin")
+			if err == nil {
+				t.Errorf("expected error getting object after abort, got nil")
+			}
+		})
+	}
+}
+
+func TestBucketVersioning(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    storagedriver.Bucket
+	}{
+		{"AWS", awsP.S3},
+		{"Azure", azureP.BlobStorage},
+		{"GCP", gcpP.GCS},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateBucket(ctx, "ver-bucket")
+			if err != nil {
+				t.Fatalf("CreateBucket: %v", err)
+			}
+
+			// Default should be disabled
+			enabled, err := p.d.GetBucketVersioning(ctx, "ver-bucket")
+			if err != nil {
+				t.Fatalf("GetBucketVersioning: %v", err)
+			}
+			if enabled {
+				t.Errorf("expected versioning disabled by default")
+			}
+
+			// Enable
+			err = p.d.SetBucketVersioning(ctx, "ver-bucket", true)
+			if err != nil {
+				t.Fatalf("SetBucketVersioning enable: %v", err)
+			}
+
+			enabled, err = p.d.GetBucketVersioning(ctx, "ver-bucket")
+			if err != nil {
+				t.Fatalf("GetBucketVersioning after enable: %v", err)
+			}
+			if !enabled {
+				t.Errorf("expected versioning enabled")
+			}
+
+			// Disable
+			err = p.d.SetBucketVersioning(ctx, "ver-bucket", false)
+			if err != nil {
+				t.Fatalf("SetBucketVersioning disable: %v", err)
+			}
+			enabled, err = p.d.GetBucketVersioning(ctx, "ver-bucket")
+			if err != nil {
+				t.Fatalf("GetBucketVersioning after disable: %v", err)
+			}
+			if enabled {
+				t.Errorf("expected versioning disabled")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Database Enhancement Tests
+// ---------------------------------------------------------------------------
+
+func TestDatabaseTTL(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	awsP := NewAWS(config.WithClock(clk))
+	azureP := NewAzure(config.WithClock(clk))
+	gcpP := NewGCP(config.WithClock(clk))
+
+	providers := []struct {
+		name string
+		d    driver.Database
+		pk   string
+	}{
+		{"AWS", awsP.DynamoDB, "pk"},
+		{"Azure", azureP.CosmosDB, "pk"},
+		{"GCP", gcpP.Firestore, "pk"},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateTable(ctx, driver.TableConfig{
+				Name:         "ttl-table",
+				PartitionKey: p.pk,
+			})
+			if err != nil {
+				t.Fatalf("CreateTable: %v", err)
+			}
+
+			// Enable TTL
+			err = p.d.UpdateTTL(ctx, "ttl-table", driver.TTLConfig{
+				Enabled:       true,
+				AttributeName: "expiresAt",
+			})
+			if err != nil {
+				t.Fatalf("UpdateTTL: %v", err)
+			}
+
+			ttlConfig, err := p.d.DescribeTTL(ctx, "ttl-table")
+			if err != nil {
+				t.Fatalf("DescribeTTL: %v", err)
+			}
+			if !ttlConfig.Enabled {
+				t.Errorf("expected TTL enabled")
+			}
+			if ttlConfig.AttributeName != "expiresAt" {
+				t.Errorf("expected TTL attribute expiresAt, got %s", ttlConfig.AttributeName)
+			}
+
+			// Put items with TTL (epoch seconds)
+			ttlTime := clk.Now().Add(1 * time.Hour).Unix()
+			err = p.d.PutItem(ctx, "ttl-table", map[string]any{
+				p.pk:        "item-1",
+				"expiresAt": ttlTime,
+				"data":      "should expire",
+			})
+			if err != nil {
+				t.Fatalf("PutItem: %v", err)
+			}
+
+			// Item should be visible before TTL
+			item, err := p.d.GetItem(ctx, "ttl-table", map[string]any{p.pk: "item-1"})
+			if err != nil {
+				t.Fatalf("GetItem before TTL: %v", err)
+			}
+			if item == nil {
+				t.Fatalf("expected item before TTL expiry")
+			}
+
+			// Advance past TTL
+			clk.Advance(2 * time.Hour)
+
+			_, err = p.d.GetItem(ctx, "ttl-table", map[string]any{p.pk: "item-1"})
+			if err == nil {
+				t.Errorf("expected error or nil for expired item")
+			}
+		})
+	}
+}
+
+func TestDatabaseStreams(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    driver.Database
+		pk   string
+	}{
+		{"AWS", awsP.DynamoDB, "pk"},
+		{"Azure", azureP.CosmosDB, "pk"},
+		{"GCP", gcpP.Firestore, "pk"},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateTable(ctx, driver.TableConfig{
+				Name:         "stream-table",
+				PartitionKey: p.pk,
+			})
+			if err != nil {
+				t.Fatalf("CreateTable: %v", err)
+			}
+
+			// Enable streams
+			err = p.d.UpdateStreamConfig(ctx, "stream-table", driver.StreamConfig{
+				Enabled:  true,
+				ViewType: "NEW_AND_OLD_IMAGES",
+			})
+			if err != nil {
+				t.Fatalf("UpdateStreamConfig: %v", err)
+			}
+
+			// Put item -> INSERT
+			err = p.d.PutItem(ctx, "stream-table", map[string]any{
+				p.pk:   "stream-1",
+				"data": "initial",
+			})
+			if err != nil {
+				t.Fatalf("PutItem: %v", err)
+			}
+
+			// Modify item -> MODIFY
+			err = p.d.PutItem(ctx, "stream-table", map[string]any{
+				p.pk:   "stream-1",
+				"data": "modified",
+			})
+			if err != nil {
+				t.Fatalf("PutItem modify: %v", err)
+			}
+
+			// Delete item -> REMOVE
+			err = p.d.DeleteItem(ctx, "stream-table", map[string]any{p.pk: "stream-1"})
+			if err != nil {
+				t.Fatalf("DeleteItem: %v", err)
+			}
+
+			// Get stream records
+			iter, err := p.d.GetStreamRecords(ctx, "stream-table", 10, "")
+			if err != nil {
+				t.Fatalf("GetStreamRecords: %v", err)
+			}
+			if len(iter.Records) < 3 {
+				t.Errorf("expected at least 3 stream records (INSERT/MODIFY/REMOVE), got %d", len(iter.Records))
+			}
+
+			// Verify event types
+			eventTypes := make(map[string]bool)
+			for _, r := range iter.Records {
+				eventTypes[r.EventType] = true
+			}
+			for _, expected := range []string{"INSERT", "MODIFY", "REMOVE"} {
+				if !eventTypes[expected] {
+					t.Errorf("expected event type %s in stream records", expected)
+				}
+			}
+
+			// Verify sequence numbers are ordered
+			for i := 1; i < len(iter.Records); i++ {
+				if iter.Records[i].SequenceNumber <= iter.Records[i-1].SequenceNumber {
+					t.Errorf("expected increasing sequence numbers, got %s <= %s",
+						iter.Records[i].SequenceNumber, iter.Records[i-1].SequenceNumber)
+				}
+			}
+		})
+	}
+}
+
+func TestTransactWriteItems(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    driver.Database
+		pk   string
+	}{
+		{"AWS", awsP.DynamoDB, "pk"},
+		{"Azure", azureP.CosmosDB, "pk"},
+		{"GCP", gcpP.Firestore, "pk"},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			err := p.d.CreateTable(ctx, driver.TableConfig{
+				Name:         "txn-table",
+				PartitionKey: p.pk,
+			})
+			if err != nil {
+				t.Fatalf("CreateTable: %v", err)
+			}
+
+			// Seed an item to delete
+			err = p.d.PutItem(ctx, "txn-table", map[string]any{
+				p.pk:   "to-delete",
+				"data": "will be removed",
+			})
+			if err != nil {
+				t.Fatalf("PutItem seed: %v", err)
+			}
+
+			// Transact: put 2 items and delete 1
+			err = p.d.TransactWriteItems(ctx, "txn-table",
+				[]map[string]any{
+					{p.pk: "txn-1", "data": "first"},
+					{p.pk: "txn-2", "data": "second"},
+				},
+				[]map[string]any{
+					{p.pk: "to-delete"},
+				},
+			)
+			if err != nil {
+				t.Fatalf("TransactWriteItems: %v", err)
+			}
+
+			// Verify puts
+			item1, err := p.d.GetItem(ctx, "txn-table", map[string]any{p.pk: "txn-1"})
+			if err != nil {
+				t.Fatalf("GetItem txn-1: %v", err)
+			}
+			if item1["data"] != "first" {
+				t.Errorf("expected data=first, got %v", item1["data"])
+			}
+
+			item2, err := p.d.GetItem(ctx, "txn-table", map[string]any{p.pk: "txn-2"})
+			if err != nil {
+				t.Fatalf("GetItem txn-2: %v", err)
+			}
+			if item2["data"] != "second" {
+				t.Errorf("expected data=second, got %v", item2["data"])
+			}
+
+			// Verify delete
+			_, err = p.d.GetItem(ctx, "txn-table", map[string]any{p.pk: "to-delete"})
+			if err == nil {
+				t.Errorf("expected error for deleted item, got nil")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compute Enhancement Tests
+// ---------------------------------------------------------------------------
+
+func TestAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    computedriver.Compute
+	}{
+		{"AWS", awsP.EC2},
+		{"Azure", azureP.VirtualMachines},
+		{"GCP", gcpP.GCE},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			asg, err := p.d.CreateAutoScalingGroup(ctx, computedriver.AutoScalingGroupConfig{
+				Name:            "test-asg",
+				MinSize:         1,
+				MaxSize:         5,
+				DesiredCapacity: 2,
+				InstanceConfig: computedriver.InstanceConfig{
+					ImageID:      "ami-test",
+					InstanceType: "t2.micro",
+				},
+				Tags: map[string]string{"env": "test"},
+			})
+			if err != nil {
+				t.Fatalf("CreateAutoScalingGroup: %v", err)
+			}
+			if asg.Name != "test-asg" {
+				t.Errorf("expected ASG name test-asg, got %s", asg.Name)
+			}
+			if asg.DesiredCapacity != 2 {
+				t.Errorf("expected desired capacity 2, got %d", asg.DesiredCapacity)
+			}
+
+			// Verify instances launched
+			got, err := p.d.GetAutoScalingGroup(ctx, "test-asg")
+			if err != nil {
+				t.Fatalf("GetAutoScalingGroup: %v", err)
+			}
+			if len(got.InstanceIDs) != 2 {
+				t.Errorf("expected 2 instances, got %d", len(got.InstanceIDs))
+			}
+
+			// Scale up
+			err = p.d.SetDesiredCapacity(ctx, "test-asg", 4)
+			if err != nil {
+				t.Fatalf("SetDesiredCapacity up: %v", err)
+			}
+			got, err = p.d.GetAutoScalingGroup(ctx, "test-asg")
+			if err != nil {
+				t.Fatalf("GetAutoScalingGroup after scale up: %v", err)
+			}
+			if len(got.InstanceIDs) != 4 {
+				t.Errorf("expected 4 instances after scale up, got %d", len(got.InstanceIDs))
+			}
+
+			// Scale down
+			err = p.d.SetDesiredCapacity(ctx, "test-asg", 1)
+			if err != nil {
+				t.Fatalf("SetDesiredCapacity down: %v", err)
+			}
+			got, err = p.d.GetAutoScalingGroup(ctx, "test-asg")
+			if err != nil {
+				t.Fatalf("GetAutoScalingGroup after scale down: %v", err)
+			}
+			if len(got.InstanceIDs) != 1 {
+				t.Errorf("expected 1 instance after scale down, got %d", len(got.InstanceIDs))
+			}
+
+			// List
+			asgs, err := p.d.ListAutoScalingGroups(ctx)
+			if err != nil {
+				t.Fatalf("ListAutoScalingGroups: %v", err)
+			}
+			if len(asgs) != 1 {
+				t.Errorf("expected 1 ASG, got %d", len(asgs))
+			}
+
+			// Delete
+			err = p.d.DeleteAutoScalingGroup(ctx, "test-asg", true)
+			if err != nil {
+				t.Fatalf("DeleteAutoScalingGroup: %v", err)
+			}
+			_, err = p.d.GetAutoScalingGroup(ctx, "test-asg")
+			if err == nil {
+				t.Errorf("expected error after deleting ASG, got nil")
+			}
+		})
+	}
+}
+
+func TestScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    computedriver.Compute
+	}{
+		{"AWS", awsP.EC2},
+		{"Azure", azureP.VirtualMachines},
+		{"GCP", gcpP.GCE},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateAutoScalingGroup(ctx, computedriver.AutoScalingGroupConfig{
+				Name:            "policy-asg",
+				MinSize:         1,
+				MaxSize:         10,
+				DesiredCapacity: 2,
+				InstanceConfig: computedriver.InstanceConfig{
+					ImageID:      "ami-test",
+					InstanceType: "t2.micro",
+				},
+			})
+			if err != nil {
+				t.Fatalf("CreateAutoScalingGroup: %v", err)
+			}
+
+			err = p.d.PutScalingPolicy(ctx, computedriver.ScalingPolicy{
+				Name:              "scale-out",
+				AutoScalingGroup:  "policy-asg",
+				PolicyType:        "SimpleScaling",
+				AdjustmentType:    "ChangeInCapacity",
+				ScalingAdjustment: 2,
+				Cooldown:          60,
+			})
+			if err != nil {
+				t.Fatalf("PutScalingPolicy: %v", err)
+			}
+
+			// Execute policy
+			err = p.d.ExecuteScalingPolicy(ctx, "policy-asg", "scale-out")
+			if err != nil {
+				t.Fatalf("ExecuteScalingPolicy: %v", err)
+			}
+
+			asg, err := p.d.GetAutoScalingGroup(ctx, "policy-asg")
+			if err != nil {
+				t.Fatalf("GetAutoScalingGroup after execute: %v", err)
+			}
+			if asg.DesiredCapacity != 4 {
+				t.Errorf("expected desired capacity 4, got %d", asg.DesiredCapacity)
+			}
+
+			// Delete policy
+			err = p.d.DeleteScalingPolicy(ctx, "policy-asg", "scale-out")
+			if err != nil {
+				t.Fatalf("DeleteScalingPolicy: %v", err)
+			}
+		})
+	}
+}
+
+func TestSpotInstances(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    computedriver.Compute
+	}{
+		{"AWS", awsP.EC2},
+		{"Azure", azureP.VirtualMachines},
+		{"GCP", gcpP.GCE},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			reqs, err := p.d.RequestSpotInstances(ctx, computedriver.SpotRequestConfig{
+				InstanceConfig: computedriver.InstanceConfig{
+					ImageID:      "ami-spot",
+					InstanceType: "m4.large",
+				},
+				MaxPrice: 0.5,
+				Count:    2,
+				Type:     "one-time",
+			})
+			if err != nil {
+				t.Fatalf("RequestSpotInstances: %v", err)
+			}
+			if len(reqs) != 2 {
+				t.Fatalf("expected 2 spot requests, got %d", len(reqs))
+			}
+
+			// Describe spot requests
+			ids := make([]string, len(reqs))
+			for i, r := range reqs {
+				ids[i] = r.ID
+			}
+			described, err := p.d.DescribeSpotRequests(ctx, ids)
+			if err != nil {
+				t.Fatalf("DescribeSpotRequests: %v", err)
+			}
+			if len(described) != 2 {
+				t.Errorf("expected 2 described requests, got %d", len(described))
+			}
+
+			// Cancel
+			err = p.d.CancelSpotRequests(ctx, ids)
+			if err != nil {
+				t.Fatalf("CancelSpotRequests: %v", err)
+			}
+
+			described, err = p.d.DescribeSpotRequests(ctx, ids)
+			if err != nil {
+				t.Fatalf("DescribeSpotRequests after cancel: %v", err)
+			}
+			for _, d := range described {
+				if d.Status != "canceled" && d.Status != "cancelled" {
+					t.Errorf("expected canceled status, got %s", d.Status)
+				}
+			}
+		})
+	}
+}
+
+func TestLaunchTemplates(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    computedriver.Compute
+	}{
+		{"AWS", awsP.EC2},
+		{"Azure", azureP.VirtualMachines},
+		{"GCP", gcpP.GCE},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			lt, err := p.d.CreateLaunchTemplate(ctx, computedriver.LaunchTemplateConfig{
+				Name: "test-template",
+				InstanceConfig: computedriver.InstanceConfig{
+					ImageID:      "ami-template",
+					InstanceType: "t2.micro",
+				},
+			})
+			if err != nil {
+				t.Fatalf("CreateLaunchTemplate: %v", err)
+			}
+			if lt.Name != "test-template" {
+				t.Errorf("expected name test-template, got %s", lt.Name)
+			}
+			if lt.Version != 1 {
+				t.Errorf("expected version 1, got %d", lt.Version)
+			}
+
+			// Get
+			got, err := p.d.GetLaunchTemplate(ctx, "test-template")
+			if err != nil {
+				t.Fatalf("GetLaunchTemplate: %v", err)
+			}
+			if got.Name != "test-template" {
+				t.Errorf("expected test-template, got %s", got.Name)
+			}
+
+			// List
+			templates, err := p.d.ListLaunchTemplates(ctx)
+			if err != nil {
+				t.Fatalf("ListLaunchTemplates: %v", err)
+			}
+			if len(templates) != 1 {
+				t.Errorf("expected 1 template, got %d", len(templates))
+			}
+
+			// Delete
+			err = p.d.DeleteLaunchTemplate(ctx, "test-template")
+			if err != nil {
+				t.Fatalf("DeleteLaunchTemplate: %v", err)
+			}
+			_, err = p.d.GetLaunchTemplate(ctx, "test-template")
+			if err == nil {
+				t.Errorf("expected error after deleting template, got nil")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Serverless Enhancement Tests
+// ---------------------------------------------------------------------------
+
+func TestFunctionVersions(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    serverlessdriver.Serverless
+	}{
+		{"AWS", awsP.Lambda},
+		{"Azure", azureP.Functions},
+		{"GCP", gcpP.CloudFunctions},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+				Name:    "version-func",
+				Runtime: "go1.x",
+				Handler: "main",
+				Memory:  128,
+				Timeout: 30,
+			})
+			if err != nil {
+				t.Fatalf("CreateFunction: %v", err)
+			}
+
+			// Publish version
+			v1, err := p.d.PublishVersion(ctx, "version-func", "first version")
+			if err != nil {
+				t.Fatalf("PublishVersion: %v", err)
+			}
+			if v1.Version != "1" {
+				t.Errorf("expected version 1, got %s", v1.Version)
+			}
+
+			// Publish another
+			v2, err := p.d.PublishVersion(ctx, "version-func", "second version")
+			if err != nil {
+				t.Fatalf("PublishVersion 2: %v", err)
+			}
+			if v2.Version != "2" {
+				t.Errorf("expected version 2, got %s", v2.Version)
+			}
+
+			// List versions
+			versions, err := p.d.ListVersions(ctx, "version-func")
+			if err != nil {
+				t.Fatalf("ListVersions: %v", err)
+			}
+			if len(versions) < 2 {
+				t.Errorf("expected at least 2 versions, got %d", len(versions))
+			}
+		})
+	}
+}
+
+func TestFunctionAliases(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    serverlessdriver.Serverless
+	}{
+		{"AWS", awsP.Lambda},
+		{"Azure", azureP.Functions},
+		{"GCP", gcpP.CloudFunctions},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+				Name:    "alias-func",
+				Runtime: "go1.x",
+				Handler: "main",
+				Memory:  128,
+				Timeout: 30,
+			})
+			if err != nil {
+				t.Fatalf("CreateFunction: %v", err)
+			}
+
+			v1, err := p.d.PublishVersion(ctx, "alias-func", "v1")
+			if err != nil {
+				t.Fatalf("PublishVersion: %v", err)
+			}
+
+			// Create alias
+			alias, err := p.d.CreateAlias(ctx, serverlessdriver.AliasConfig{
+				FunctionName:    "alias-func",
+				Name:            "prod",
+				FunctionVersion: v1.Version,
+				Description:     "production alias",
+			})
+			if err != nil {
+				t.Fatalf("CreateAlias: %v", err)
+			}
+			if alias.Name != "prod" {
+				t.Errorf("expected alias name prod, got %s", alias.Name)
+			}
+
+			// Get alias
+			gotAlias, err := p.d.GetAlias(ctx, "alias-func", "prod")
+			if err != nil {
+				t.Fatalf("GetAlias: %v", err)
+			}
+			if gotAlias.FunctionVersion != v1.Version {
+				t.Errorf("expected version %s, got %s", v1.Version, gotAlias.FunctionVersion)
+			}
+
+			// Update alias
+			v2, err := p.d.PublishVersion(ctx, "alias-func", "v2")
+			if err != nil {
+				t.Fatalf("PublishVersion v2: %v", err)
+			}
+			_, err = p.d.UpdateAlias(ctx, serverlessdriver.AliasConfig{
+				FunctionName:    "alias-func",
+				Name:            "prod",
+				FunctionVersion: v2.Version,
+			})
+			if err != nil {
+				t.Fatalf("UpdateAlias: %v", err)
+			}
+
+			gotAlias, err = p.d.GetAlias(ctx, "alias-func", "prod")
+			if err != nil {
+				t.Fatalf("GetAlias after update: %v", err)
+			}
+			if gotAlias.FunctionVersion != v2.Version {
+				t.Errorf("expected updated version %s, got %s", v2.Version, gotAlias.FunctionVersion)
+			}
+
+			// List aliases
+			aliases, err := p.d.ListAliases(ctx, "alias-func")
+			if err != nil {
+				t.Fatalf("ListAliases: %v", err)
+			}
+			if len(aliases) != 1 {
+				t.Errorf("expected 1 alias, got %d", len(aliases))
+			}
+
+			// Delete alias
+			err = p.d.DeleteAlias(ctx, "alias-func", "prod")
+			if err != nil {
+				t.Fatalf("DeleteAlias: %v", err)
+			}
+			_, err = p.d.GetAlias(ctx, "alias-func", "prod")
+			if err == nil {
+				t.Errorf("expected error after deleting alias, got nil")
+			}
+		})
+	}
+}
+
+func TestLayers(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    serverlessdriver.Serverless
+	}{
+		{"AWS", awsP.Lambda},
+		{"Azure", azureP.Functions},
+		{"GCP", gcpP.CloudFunctions},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			// Publish layer version 1
+			lv1, err := p.d.PublishLayerVersion(ctx, serverlessdriver.LayerConfig{
+				Name:               "my-layer",
+				Description:        "first version",
+				Content:            []byte("layer-content-v1"),
+				CompatibleRuntimes: []string{"go1.x", "python3.9"},
+			})
+			if err != nil {
+				t.Fatalf("PublishLayerVersion: %v", err)
+			}
+			if lv1.Version != 1 {
+				t.Errorf("expected layer version 1, got %d", lv1.Version)
+			}
+
+			// Publish version 2
+			lv2, err := p.d.PublishLayerVersion(ctx, serverlessdriver.LayerConfig{
+				Name:               "my-layer",
+				Description:        "second version",
+				Content:            []byte("layer-content-v2"),
+				CompatibleRuntimes: []string{"go1.x"},
+			})
+			if err != nil {
+				t.Fatalf("PublishLayerVersion 2: %v", err)
+			}
+			if lv2.Version != 2 {
+				t.Errorf("expected layer version 2, got %d", lv2.Version)
+			}
+
+			// Get layer version
+			got, err := p.d.GetLayerVersion(ctx, "my-layer", 1)
+			if err != nil {
+				t.Fatalf("GetLayerVersion: %v", err)
+			}
+			if got.Description != "first version" {
+				t.Errorf("expected description 'first version', got '%s'", got.Description)
+			}
+
+			// List layer versions
+			versions, err := p.d.ListLayerVersions(ctx, "my-layer")
+			if err != nil {
+				t.Fatalf("ListLayerVersions: %v", err)
+			}
+			if len(versions) != 2 {
+				t.Errorf("expected 2 layer versions, got %d", len(versions))
+			}
+
+			// List layers
+			layers, err := p.d.ListLayers(ctx)
+			if err != nil {
+				t.Fatalf("ListLayers: %v", err)
+			}
+			if len(layers) < 1 {
+				t.Errorf("expected at least 1 layer, got %d", len(layers))
+			}
+
+			// Delete layer version
+			err = p.d.DeleteLayerVersion(ctx, "my-layer", 1)
+			if err != nil {
+				t.Fatalf("DeleteLayerVersion: %v", err)
+			}
+			_, err = p.d.GetLayerVersion(ctx, "my-layer", 1)
+			if err == nil {
+				t.Errorf("expected error after deleting layer version, got nil")
+			}
+		})
+	}
+}
+
+func TestFunctionConcurrency(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    serverlessdriver.Serverless
+	}{
+		{"AWS", awsP.Lambda},
+		{"Azure", azureP.Functions},
+		{"GCP", gcpP.CloudFunctions},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			_, err := p.d.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+				Name:    "conc-func",
+				Runtime: "go1.x",
+				Handler: "main",
+				Memory:  128,
+				Timeout: 30,
+			})
+			if err != nil {
+				t.Fatalf("CreateFunction: %v", err)
+			}
+
+			// Put concurrency
+			err = p.d.PutFunctionConcurrency(ctx, serverlessdriver.ConcurrencyConfig{
+				FunctionName:                 "conc-func",
+				ReservedConcurrentExecutions: 10,
+			})
+			if err != nil {
+				t.Fatalf("PutFunctionConcurrency: %v", err)
+			}
+
+			// Get concurrency
+			conc, err := p.d.GetFunctionConcurrency(ctx, "conc-func")
+			if err != nil {
+				t.Fatalf("GetFunctionConcurrency: %v", err)
+			}
+			if conc.ReservedConcurrentExecutions != 10 {
+				t.Errorf("expected 10 reserved concurrency, got %d", conc.ReservedConcurrentExecutions)
+			}
+
+			// Delete concurrency
+			err = p.d.DeleteFunctionConcurrency(ctx, "conc-func")
+			if err != nil {
+				t.Fatalf("DeleteFunctionConcurrency: %v", err)
+			}
+
+			conc, err = p.d.GetFunctionConcurrency(ctx, "conc-func")
+			if err != nil {
+				// NotFound after delete is acceptable
+				return
+			}
+			if conc.ReservedConcurrentExecutions != 0 {
+				t.Errorf("expected 0 after delete, got %d", conc.ReservedConcurrentExecutions)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Message Queue Enhancement Tests
+// ---------------------------------------------------------------------------
+
+func TestBatchSendMessages(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    mqdriver.MessageQueue
+	}{
+		{"AWS", awsP.SQS},
+		{"Azure", azureP.ServiceBus},
+		{"GCP", gcpP.PubSub},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			q, err := p.d.CreateQueue(ctx, mqdriver.QueueConfig{Name: "batch-send-q"})
+			if err != nil {
+				t.Fatalf("CreateQueue: %v", err)
+			}
+
+			result, err := p.d.SendMessageBatch(ctx, q.URL, []mqdriver.BatchSendEntry{
+				{ID: "1", Body: "message one"},
+				{ID: "2", Body: "message two"},
+				{ID: "3", Body: "message three"},
+			})
+			if err != nil {
+				t.Fatalf("SendMessageBatch: %v", err)
+			}
+			if len(result.Successful) != 3 {
+				t.Errorf("expected 3 successful, got %d", len(result.Successful))
+			}
+
+			// Receive all messages
+			var received []mqdriver.Message
+			msgs, err := p.d.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{
+				QueueURL:    q.URL,
+				MaxMessages: 10,
+			})
+			if err != nil {
+				t.Fatalf("ReceiveMessages: %v", err)
+			}
+			received = append(received, msgs...)
+			if len(received) < 3 {
+				t.Errorf("expected at least 3 messages, got %d", len(received))
+			}
+		})
+	}
+}
+
+func TestBatchDeleteMessages(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    mqdriver.MessageQueue
+	}{
+		{"AWS", awsP.SQS},
+		{"Azure", azureP.ServiceBus},
+		{"GCP", gcpP.PubSub},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			q, err := p.d.CreateQueue(ctx, mqdriver.QueueConfig{Name: "batch-del-q"})
+			if err != nil {
+				t.Fatalf("CreateQueue: %v", err)
+			}
+
+			// Send messages
+			for i := 0; i < 3; i++ {
+				_, err = p.d.SendMessage(ctx, mqdriver.SendMessageInput{
+					QueueURL: q.URL,
+					Body:     "msg",
+				})
+				if err != nil {
+					t.Fatalf("SendMessage %d: %v", i, err)
+				}
+			}
+
+			// Receive
+			msgs, err := p.d.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{
+				QueueURL:    q.URL,
+				MaxMessages: 10,
+			})
+			if err != nil {
+				t.Fatalf("ReceiveMessages: %v", err)
+			}
+
+			entries := make([]mqdriver.BatchDeleteEntry, len(msgs))
+			for i, m := range msgs {
+				entries[i] = mqdriver.BatchDeleteEntry{
+					ID:            m.MessageID,
+					ReceiptHandle: m.ReceiptHandle,
+				}
+			}
+
+			delResult, err := p.d.DeleteMessageBatch(ctx, q.URL, entries)
+			if err != nil {
+				t.Fatalf("DeleteMessageBatch: %v", err)
+			}
+			if len(delResult.Successful) != len(msgs) {
+				t.Errorf("expected %d successful deletes, got %d", len(msgs), len(delResult.Successful))
+			}
+
+			// Verify empty
+			remaining, err := p.d.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{
+				QueueURL:    q.URL,
+				MaxMessages: 10,
+			})
+			if err != nil {
+				t.Fatalf("ReceiveMessages after delete: %v", err)
+			}
+			if len(remaining) != 0 {
+				t.Errorf("expected 0 messages after batch delete, got %d", len(remaining))
+			}
+		})
+	}
+}
+
+func TestQueueAttributes(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    mqdriver.MessageQueue
+	}{
+		{"AWS", awsP.SQS},
+		{"Azure", azureP.ServiceBus},
+		{"GCP", gcpP.PubSub},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			q, err := p.d.CreateQueue(ctx, mqdriver.QueueConfig{
+				Name:              "attr-q",
+				VisibilityTimeout: 30,
+			})
+			if err != nil {
+				t.Fatalf("CreateQueue: %v", err)
+			}
+
+			attrs, err := p.d.GetQueueAttributes(ctx, q.URL)
+			if err != nil {
+				t.Fatalf("GetQueueAttributes: %v", err)
+			}
+			if attrs.VisibilityTimeout != 30 {
+				t.Errorf("expected visibility timeout 30, got %d", attrs.VisibilityTimeout)
+			}
+
+			// Set attributes
+			err = p.d.SetQueueAttributes(ctx, q.URL, map[string]int{
+				"VisibilityTimeout": 60,
+			})
+			if err != nil {
+				t.Fatalf("SetQueueAttributes: %v", err)
+			}
+
+			attrs, err = p.d.GetQueueAttributes(ctx, q.URL)
+			if err != nil {
+				t.Fatalf("GetQueueAttributes after set: %v", err)
+			}
+			if attrs.VisibilityTimeout != 60 {
+				t.Errorf("expected visibility timeout 60, got %d", attrs.VisibilityTimeout)
+			}
+		})
+	}
+}
+
+func TestPurgeQueue(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    mqdriver.MessageQueue
+	}{
+		{"AWS", awsP.SQS},
+		{"Azure", azureP.ServiceBus},
+		{"GCP", gcpP.PubSub},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			q, err := p.d.CreateQueue(ctx, mqdriver.QueueConfig{Name: "purge-q"})
+			if err != nil {
+				t.Fatalf("CreateQueue: %v", err)
+			}
+
+			// Send messages
+			for i := 0; i < 5; i++ {
+				_, err = p.d.SendMessage(ctx, mqdriver.SendMessageInput{
+					QueueURL: q.URL,
+					Body:     "to-purge",
+				})
+				if err != nil {
+					t.Fatalf("SendMessage: %v", err)
+				}
+			}
+
+			// Purge
+			err = p.d.PurgeQueue(ctx, q.URL)
+			if err != nil {
+				t.Fatalf("PurgeQueue: %v", err)
+			}
+
+			// Verify empty
+			msgs, err := p.d.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{
+				QueueURL:    q.URL,
+				MaxMessages: 10,
+			})
+			if err != nil {
+				t.Fatalf("ReceiveMessages after purge: %v", err)
+			}
+			if len(msgs) != 0 {
+				t.Errorf("expected 0 messages after purge, got %d", len(msgs))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Networking Enhancement Tests
+// ---------------------------------------------------------------------------
+
+func TestVPCPeering(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    netdriver.Networking
+	}{
+		{"AWS", awsP.VPC},
+		{"Azure", azureP.VNet},
+		{"GCP", gcpP.VPC},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			vpc1, err := p.d.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+			if err != nil {
+				t.Fatalf("CreateVPC 1: %v", err)
+			}
+			vpc2, err := p.d.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.1.0.0/16"})
+			if err != nil {
+				t.Fatalf("CreateVPC 2: %v", err)
+			}
+
+			// Create peering
+			peering, err := p.d.CreatePeeringConnection(ctx, netdriver.PeeringConfig{
+				RequesterVPC: vpc1.ID,
+				AccepterVPC:  vpc2.ID,
+				Tags:         map[string]string{"env": "test"},
+			})
+			if err != nil {
+				t.Fatalf("CreatePeeringConnection: %v", err)
+			}
+			if peering.Status != "pending-acceptance" {
+				t.Errorf("expected pending-acceptance, got %s", peering.Status)
+			}
+
+			// Accept
+			err = p.d.AcceptPeeringConnection(ctx, peering.ID)
+			if err != nil {
+				t.Fatalf("AcceptPeeringConnection: %v", err)
+			}
+
+			// Describe
+			peers, err := p.d.DescribePeeringConnections(ctx, []string{peering.ID})
+			if err != nil {
+				t.Fatalf("DescribePeeringConnections: %v", err)
+			}
+			if len(peers) != 1 {
+				t.Fatalf("expected 1 peering, got %d", len(peers))
+			}
+			if peers[0].Status != "active" {
+				t.Errorf("expected active, got %s", peers[0].Status)
+			}
+
+			// Delete
+			err = p.d.DeletePeeringConnection(ctx, peering.ID)
+			if err != nil {
+				t.Fatalf("DeletePeeringConnection: %v", err)
+			}
+		})
+	}
+}
+
+func TestNATGateway(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    netdriver.Networking
+	}{
+		{"AWS", awsP.VPC},
+		{"Azure", azureP.VNet},
+		{"GCP", gcpP.VPC},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			vpcInfo, err := p.d.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+			if err != nil {
+				t.Fatalf("CreateVPC: %v", err)
+			}
+
+			subnet, err := p.d.CreateSubnet(ctx, netdriver.SubnetConfig{
+				VPCID:     vpcInfo.ID,
+				CIDRBlock: "10.0.1.0/24",
+			})
+			if err != nil {
+				t.Fatalf("CreateSubnet: %v", err)
+			}
+
+			nat, err := p.d.CreateNATGateway(ctx, netdriver.NATGatewayConfig{
+				SubnetID: subnet.ID,
+				Tags:     map[string]string{"env": "test"},
+			})
+			if err != nil {
+				t.Fatalf("CreateNATGateway: %v", err)
+			}
+			if nat.SubnetID != subnet.ID {
+				t.Errorf("expected subnet %s, got %s", subnet.ID, nat.SubnetID)
+			}
+
+			// Describe
+			nats, err := p.d.DescribeNATGateways(ctx, []string{nat.ID})
+			if err != nil {
+				t.Fatalf("DescribeNATGateways: %v", err)
+			}
+			if len(nats) != 1 {
+				t.Fatalf("expected 1 NAT gateway, got %d", len(nats))
+			}
+
+			// Delete
+			err = p.d.DeleteNATGateway(ctx, nat.ID)
+			if err != nil {
+				t.Fatalf("DeleteNATGateway: %v", err)
+			}
+		})
+	}
+}
+
+func TestFlowLogs(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    netdriver.Networking
+	}{
+		{"AWS", awsP.VPC},
+		{"Azure", azureP.VNet},
+		{"GCP", gcpP.VPC},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			vpcInfo, err := p.d.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+			if err != nil {
+				t.Fatalf("CreateVPC: %v", err)
+			}
+
+			fl, err := p.d.CreateFlowLog(ctx, netdriver.FlowLogConfig{
+				ResourceID:   vpcInfo.ID,
+				ResourceType: "VPC",
+				TrafficType:  "ALL",
+				Tags:         map[string]string{"env": "test"},
+			})
+			if err != nil {
+				t.Fatalf("CreateFlowLog: %v", err)
+			}
+			if fl.Status != "ACTIVE" {
+				t.Errorf("expected ACTIVE, got %s", fl.Status)
+			}
+
+			// Describe
+			fls, err := p.d.DescribeFlowLogs(ctx, []string{fl.ID})
+			if err != nil {
+				t.Fatalf("DescribeFlowLogs: %v", err)
+			}
+			if len(fls) != 1 {
+				t.Fatalf("expected 1 flow log, got %d", len(fls))
+			}
+
+			// GetFlowLogRecords
+			records, err := p.d.GetFlowLogRecords(ctx, fl.ID, 10)
+			if err != nil {
+				t.Fatalf("GetFlowLogRecords: %v", err)
+			}
+			// May be empty initially, that's ok
+			_ = records
+
+			// Delete
+			err = p.d.DeleteFlowLog(ctx, fl.ID)
+			if err != nil {
+				t.Fatalf("DeleteFlowLog: %v", err)
+			}
+		})
+	}
+}
+
+func TestRouteTables(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    netdriver.Networking
+	}{
+		{"AWS", awsP.VPC},
+		{"Azure", azureP.VNet},
+		{"GCP", gcpP.VPC},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			vpcInfo, err := p.d.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+			if err != nil {
+				t.Fatalf("CreateVPC: %v", err)
+			}
+
+			rt, err := p.d.CreateRouteTable(ctx, netdriver.RouteTableConfig{
+				VPCID: vpcInfo.ID,
+				Tags:  map[string]string{"env": "test"},
+			})
+			if err != nil {
+				t.Fatalf("CreateRouteTable: %v", err)
+			}
+			if rt.VPCID != vpcInfo.ID {
+				t.Errorf("expected VPC %s, got %s", vpcInfo.ID, rt.VPCID)
+			}
+
+			// Create route
+			err = p.d.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-12345", "gateway")
+			if err != nil {
+				t.Fatalf("CreateRoute: %v", err)
+			}
+
+			// Describe
+			rts, err := p.d.DescribeRouteTables(ctx, []string{rt.ID})
+			if err != nil {
+				t.Fatalf("DescribeRouteTables: %v", err)
+			}
+			if len(rts) != 1 {
+				t.Fatalf("expected 1 route table, got %d", len(rts))
+			}
+			if len(rts[0].Routes) < 1 {
+				t.Errorf("expected at least 1 route, got %d", len(rts[0].Routes))
+			}
+
+			// Delete route
+			err = p.d.DeleteRoute(ctx, rt.ID, "0.0.0.0/0")
+			if err != nil {
+				t.Fatalf("DeleteRoute: %v", err)
+			}
+
+			// Delete route table
+			err = p.d.DeleteRouteTable(ctx, rt.ID)
+			if err != nil {
+				t.Fatalf("DeleteRouteTable: %v", err)
+			}
+		})
+	}
+}
+
+func TestNetworkACLs(t *testing.T) {
+	ctx := context.Background()
+	awsP := NewAWS()
+	azureP := NewAzure()
+	gcpP := NewGCP()
+
+	providers := []struct {
+		name string
+		d    netdriver.Networking
+	}{
+		{"AWS", awsP.VPC},
+		{"Azure", azureP.VNet},
+		{"GCP", gcpP.VPC},
+	}
+
+	for _, p := range providers {
+		t.Run(p.name, func(t *testing.T) {
+			vpcInfo, err := p.d.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+			if err != nil {
+				t.Fatalf("CreateVPC: %v", err)
+			}
+
+			acl, err := p.d.CreateNetworkACL(ctx, vpcInfo.ID, map[string]string{"env": "test"})
+			if err != nil {
+				t.Fatalf("CreateNetworkACL: %v", err)
+			}
+			if acl.VPCID != vpcInfo.ID {
+				t.Errorf("expected VPC %s, got %s", vpcInfo.ID, acl.VPCID)
+			}
+
+			// Add rule
+			err = p.d.AddNetworkACLRule(ctx, acl.ID, &netdriver.NetworkACLRule{
+				RuleNumber: 100,
+				Protocol:   "tcp",
+				Action:     "allow",
+				CIDR:       "0.0.0.0/0",
+				FromPort:   80,
+				ToPort:     80,
+				Egress:     false,
+			})
+			if err != nil {
+				t.Fatalf("AddNetworkACLRule: %v", err)
+			}
+
+			// Describe
+			acls, err := p.d.DescribeNetworkACLs(ctx, []string{acl.ID})
+			if err != nil {
+				t.Fatalf("DescribeNetworkACLs: %v", err)
+			}
+			if len(acls) != 1 {
+				t.Fatalf("expected 1 ACL, got %d", len(acls))
+			}
+			if len(acls[0].Rules) < 1 {
+				t.Errorf("expected at least 1 rule, got %d", len(acls[0].Rules))
+			}
+
+			// Remove rule
+			err = p.d.RemoveNetworkACLRule(ctx, acl.ID, 100, false)
+			if err != nil {
+				t.Fatalf("RemoveNetworkACLRule: %v", err)
+			}
+
+			// Delete ACL
+			err = p.d.DeleteNetworkACL(ctx, acl.ID)
+			if err != nil {
+				t.Fatalf("DeleteNetworkACL: %v", err)
+			}
+		})
+	}
+}
+
+// helperGetMetric is a test helper that queries a monitoring service for a single metric.
+func helperGetMetric(
+	t *testing.T,
+	ctx context.Context,
+	mon mondriver.Monitoring,
+	clk *config.FakeClock,
+	namespace, metricName string,
+	dims map[string]string,
+) float64 {
+	t.Helper()
+
+	result, err := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  namespace,
+		MetricName: metricName,
+		Dimensions: dims,
+		StartTime:  clk.Now().Add(-time.Minute),
+		EndTime:    clk.Now().Add(time.Minute),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	if err != nil {
+		t.Fatalf("GetMetricData(%s/%s): %v", namespace, metricName, err)
+	}
+
+	if len(result.Values) == 0 {
+		t.Fatalf("expected metric %s/%s to have values, got none", namespace, metricName)
+	}
+
+	return result.Values[0]
+}
+
+func TestAWSMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Now())
+	p := NewAWS(config.WithClock(clk))
+	mon := p.CloudWatch
+
+	t.Run("S3", func(t *testing.T) {
+		if err := p.S3.CreateBucket(ctx, "m-bucket"); err != nil {
+			t.Fatalf("CreateBucket: %v", err)
+		}
+
+		if err := p.S3.PutObject(ctx, "m-bucket", "f.txt", []byte("hello"), "text/plain", nil); err != nil {
+			t.Fatalf("PutObject: %v", err)
+		}
+
+		dims := map[string]string{"BucketName": "m-bucket"}
+		ns := "AWS/S3"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "PutRequests", dims)
+		if v != 1.0 {
+			t.Errorf("PutRequests: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "BytesUploaded", dims)
+		if v != 5.0 {
+			t.Errorf("BytesUploaded: expected 5, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "AllRequests", dims)
+		if v != 1.0 {
+			t.Errorf("AllRequests: expected 1, got %v", v)
+		}
+
+		_, err := p.S3.GetObject(ctx, "m-bucket", "f.txt")
+		if err != nil {
+			t.Fatalf("GetObject: %v", err)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "GetRequests", dims)
+		if v != 1.0 {
+			t.Errorf("GetRequests: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "BytesDownloaded", dims)
+		if v != 5.0 {
+			t.Errorf("BytesDownloaded: expected 5, got %v", v)
+		}
+	})
+
+	t.Run("DynamoDB", func(t *testing.T) {
+		if err := p.DynamoDB.CreateTable(ctx, driver.TableConfig{
+			Name: "m-tbl", PartitionKey: "pk",
+		}); err != nil {
+			t.Fatalf("CreateTable: %v", err)
+		}
+
+		if err := p.DynamoDB.PutItem(ctx, "m-tbl", map[string]any{"pk": "k1", "val": "v1"}); err != nil {
+			t.Fatalf("PutItem: %v", err)
+		}
+
+		dims := map[string]string{"TableName": "m-tbl"}
+		ns := "AWS/DynamoDB"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "ConsumedWriteCapacityUnits", dims)
+		if v != 1.0 {
+			t.Errorf("ConsumedWriteCapacityUnits: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "SuccessfulRequestCount", dims)
+		if v < 1.0 {
+			t.Errorf("SuccessfulRequestCount: expected >=1, got %v", v)
+		}
+
+		_, err := p.DynamoDB.GetItem(ctx, "m-tbl", map[string]any{"pk": "k1"})
+		if err != nil {
+			t.Fatalf("GetItem: %v", err)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "ConsumedReadCapacityUnits", dims)
+		if v != 1.0 {
+			t.Errorf("ConsumedReadCapacityUnits: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("Lambda", func(t *testing.T) {
+		_, err := p.Lambda.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+			Name: "m-fn", Runtime: "go1.x", Handler: "main",
+		})
+		if err != nil {
+			t.Fatalf("CreateFunction: %v", err)
+		}
+
+		p.Lambda.RegisterHandler("m-fn", func(_ context.Context, payload []byte) ([]byte, error) {
+			return []byte("ok"), nil
+		})
+
+		_, err = p.Lambda.Invoke(ctx, serverlessdriver.InvokeInput{
+			FunctionName: "m-fn", Payload: []byte("{}"),
+		})
+		if err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+
+		dims := map[string]string{"FunctionName": "m-fn"}
+		ns := "AWS/Lambda"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "Invocations", dims)
+		if v != 1.0 {
+			t.Errorf("Invocations: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "Duration", dims)
+		if v != 1.0 {
+			t.Errorf("Duration: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "ConcurrentExecutions", dims)
+		if v != 1.0 {
+			t.Errorf("ConcurrentExecutions: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("SQS", func(t *testing.T) {
+		qi, err := p.SQS.CreateQueue(ctx, mqdriver.QueueConfig{Name: "m-q"})
+		if err != nil {
+			t.Fatalf("CreateQueue: %v", err)
+		}
+
+		_, err = p.SQS.SendMessage(ctx, mqdriver.SendMessageInput{
+			QueueURL: qi.URL, Body: "hello-sqs",
+		})
+		if err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		dims := map[string]string{"QueueName": "m-q"}
+		ns := "AWS/SQS"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "NumberOfMessagesSent", dims)
+		if v != 1.0 {
+			t.Errorf("NumberOfMessagesSent: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "SentMessageSize", dims)
+		if v != 9.0 {
+			t.Errorf("SentMessageSize: expected 9, got %v", v)
+		}
+	})
+
+	t.Run("ElastiCache", func(t *testing.T) {
+		_, err := p.ElastiCache.CreateCache(ctx, cachedriver.CacheConfig{
+			Name: "m-cache", Engine: "redis", NodeType: "cache.t2.micro",
+		})
+		if err != nil {
+			t.Fatalf("CreateCache: %v", err)
+		}
+
+		if err := p.ElastiCache.Set(ctx, "m-cache", "key1", []byte("val1"), 0); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+
+		_, err = p.ElastiCache.Get(ctx, "m-cache", "key1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		dims := map[string]string{"CacheClusterId": "m-cache"}
+		ns := "AWS/ElastiCache"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "SetCommands", dims)
+		if v != 1.0 {
+			t.Errorf("SetCommands: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "CacheHits", dims)
+		if v != 1.0 {
+			t.Errorf("CacheHits: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "GetCommands", dims)
+		if v != 1.0 {
+			t.Errorf("GetCommands: expected 1, got %v", v)
+		}
+
+		// Get a missing key to trigger CacheMisses
+		_, _ = p.ElastiCache.Get(ctx, "m-cache", "no-key")
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "CacheMisses", dims)
+		if v < 1.0 {
+			t.Errorf("CacheMisses: expected >=1, got %v", v)
+		}
+	})
+
+	t.Run("CloudWatchLogs", func(t *testing.T) {
+		_, err := p.CloudWatchLogs.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{Name: "m-lg"})
+		if err != nil {
+			t.Fatalf("CreateLogGroup: %v", err)
+		}
+
+		_, err = p.CloudWatchLogs.CreateLogStream(ctx, "m-lg", "m-stream")
+		if err != nil {
+			t.Fatalf("CreateLogStream: %v", err)
+		}
+
+		err = p.CloudWatchLogs.PutLogEvents(ctx, "m-lg", "m-stream", []loggingdriver.LogEvent{
+			{Timestamp: clk.Now(), Message: "test log message"},
+		})
+		if err != nil {
+			t.Fatalf("PutLogEvents: %v", err)
+		}
+
+		dims := map[string]string{"LogGroupName": "m-lg"}
+		ns := "AWS/Logs"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "IncomingLogEvents", dims)
+		if v != 1.0 {
+			t.Errorf("IncomingLogEvents: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "IncomingBytes", dims)
+		if v != 16.0 {
+			t.Errorf("IncomingBytes: expected 16, got %v", v)
+		}
+	})
+
+	t.Run("SNS", func(t *testing.T) {
+		_, err := p.SNS.CreateTopic(ctx, notifdriver.TopicConfig{Name: "m-topic"})
+		if err != nil {
+			t.Fatalf("CreateTopic: %v", err)
+		}
+
+		_, err = p.SNS.Publish(ctx, notifdriver.PublishInput{
+			TopicID: "m-topic", Message: "hello-sns",
+		})
+		if err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+
+		dims := map[string]string{"TopicName": "m-topic"}
+		ns := "AWS/SNS"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "NumberOfMessagesPublished", dims)
+		if v != 1.0 {
+			t.Errorf("NumberOfMessagesPublished: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "PublishSize", dims)
+		if v != 9.0 {
+			t.Errorf("PublishSize: expected 9, got %v", v)
+		}
+	})
+
+	t.Run("ECR", func(t *testing.T) {
+		_, err := p.ECR.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "m-repo"})
+		if err != nil {
+			t.Fatalf("CreateRepository: %v", err)
+		}
+
+		_, err = p.ECR.PutImage(ctx, &crdriver.ImageManifest{
+			Repository: "m-repo", Tag: "latest", Digest: "sha256:abc123",
+			MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+			SizeBytes: 1024,
+		})
+		if err != nil {
+			t.Fatalf("PutImage: %v", err)
+		}
+
+		_, err = p.ECR.GetImage(ctx, "m-repo", "latest")
+		if err != nil {
+			t.Fatalf("GetImage: %v", err)
+		}
+
+		dims := map[string]string{"RepositoryName": "m-repo"}
+		ns := "AWS/ECR"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "ImagePushCount", dims)
+		if v != 1.0 {
+			t.Errorf("ImagePushCount: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "ImagePullCount", dims)
+		if v != 1.0 {
+			t.Errorf("ImagePullCount: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("EventBridge", func(t *testing.T) {
+		_, err := p.EventBridge.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "m-bus"})
+		if err != nil {
+			t.Fatalf("CreateEventBus: %v", err)
+		}
+
+		_, err = p.EventBridge.PutRule(ctx, &ebdriver.RuleConfig{
+			Name:         "m-rule",
+			EventBus:     "m-bus",
+			EventPattern: `{"source":["my.app"]}`,
+			State:        "ENABLED",
+		})
+		if err != nil {
+			t.Fatalf("PutRule: %v", err)
+		}
+
+		_, err = p.EventBridge.PutEvents(ctx, []ebdriver.Event{
+			{Source: "my.app", DetailType: "test", Detail: `{"key":"val"}`, EventBus: "m-bus"},
+		})
+		if err != nil {
+			t.Fatalf("PutEvents: %v", err)
+		}
+
+		dims := map[string]string{"EventBusName": "m-bus"}
+		ns := "AWS/Events"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "PutEventsRequestCount", dims)
+		if v != 1.0 {
+			t.Errorf("PutEventsRequestCount: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "MatchedEvents", dims)
+		if v != 1.0 {
+			t.Errorf("MatchedEvents: expected 1, got %v", v)
+		}
+	})
+}
+
+func TestAzureMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Now())
+	p := NewAzure(config.WithClock(clk))
+	mon := p.Monitor
+
+	t.Run("BlobStorage", func(t *testing.T) {
+		if err := p.BlobStorage.CreateBucket(ctx, "m-container"); err != nil {
+			t.Fatalf("CreateBucket: %v", err)
+		}
+
+		if err := p.BlobStorage.PutObject(ctx, "m-container", "f.txt", []byte("hello"), "text/plain", nil); err != nil {
+			t.Fatalf("PutObject: %v", err)
+		}
+
+		dims := map[string]string{"containerName": "m-container"}
+		ns := "Microsoft.Storage/storageAccounts"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "Transactions", dims)
+		if v != 1.0 {
+			t.Errorf("Transactions: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "Ingress", dims)
+		if v != 5.0 {
+			t.Errorf("Ingress: expected 5, got %v", v)
+		}
+
+		_, err := p.BlobStorage.GetObject(ctx, "m-container", "f.txt")
+		if err != nil {
+			t.Fatalf("GetObject: %v", err)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "Egress", dims)
+		if v != 5.0 {
+			t.Errorf("Egress: expected 5, got %v", v)
+		}
+	})
+
+	t.Run("CosmosDB", func(t *testing.T) {
+		if err := p.CosmosDB.CreateTable(ctx, driver.TableConfig{
+			Name: "m-coll", PartitionKey: "pk",
+		}); err != nil {
+			t.Fatalf("CreateTable: %v", err)
+		}
+
+		if err := p.CosmosDB.PutItem(ctx, "m-coll", map[string]any{"pk": "k1", "val": "v1"}); err != nil {
+			t.Fatalf("PutItem: %v", err)
+		}
+
+		dims := map[string]string{"containerName": "m-coll"}
+		ns := "Microsoft.DocumentDB/databaseAccounts"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "TotalRequests", dims)
+		if v < 1.0 {
+			t.Errorf("TotalRequests: expected >=1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "TotalRequestUnits", dims)
+		if v < 1.0 {
+			t.Errorf("TotalRequestUnits: expected >=1, got %v", v)
+		}
+	})
+
+	t.Run("Functions", func(t *testing.T) {
+		_, err := p.Functions.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+			Name: "m-fn", Runtime: "dotnet6", Handler: "main",
+		})
+		if err != nil {
+			t.Fatalf("CreateFunction: %v", err)
+		}
+
+		p.Functions.RegisterHandler("m-fn", func(_ context.Context, payload []byte) ([]byte, error) {
+			return []byte("ok"), nil
+		})
+
+		_, err = p.Functions.Invoke(ctx, serverlessdriver.InvokeInput{
+			FunctionName: "m-fn", Payload: []byte("{}"),
+		})
+		if err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+
+		dims := map[string]string{"functionName": "m-fn"}
+		ns := "Microsoft.Web/sites"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "FunctionExecutionCount", dims)
+		if v != 1.0 {
+			t.Errorf("FunctionExecutionCount: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "FunctionExecutionUnits", dims)
+		if v != 1.0 {
+			t.Errorf("FunctionExecutionUnits: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("ServiceBus", func(t *testing.T) {
+		qi, err := p.ServiceBus.CreateQueue(ctx, mqdriver.QueueConfig{Name: "m-q"})
+		if err != nil {
+			t.Fatalf("CreateQueue: %v", err)
+		}
+
+		_, err = p.ServiceBus.SendMessage(ctx, mqdriver.SendMessageInput{
+			QueueURL: qi.URL, Body: "hello-bus",
+		})
+		if err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		dims := map[string]string{"queueName": "m-q"}
+		ns := "Microsoft.ServiceBus/namespaces"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "IncomingMessages", dims)
+		if v != 1.0 {
+			t.Errorf("IncomingMessages: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "Size", dims)
+		if v != 9.0 {
+			t.Errorf("Size: expected 9, got %v", v)
+		}
+	})
+
+	t.Run("AzureCache", func(t *testing.T) {
+		_, err := p.Cache.CreateCache(ctx, cachedriver.CacheConfig{
+			Name: "m-cache", Engine: "redis", NodeType: "Standard_C1",
+		})
+		if err != nil {
+			t.Fatalf("CreateCache: %v", err)
+		}
+
+		if err := p.Cache.Set(ctx, "m-cache", "key1", []byte("val1"), 0); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+
+		_, err = p.Cache.Get(ctx, "m-cache", "key1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		dims := map[string]string{"cacheName": "m-cache"}
+		ns := "Microsoft.Cache/redis"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "SetCommands", dims)
+		if v != 1.0 {
+			t.Errorf("SetCommands: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "CacheHits", dims)
+		if v != 1.0 {
+			t.Errorf("CacheHits: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "TotalCommandsProcessed", dims)
+		if v >= 2.0 {
+			// Set + Get should yield at least 2
+		} else {
+			t.Errorf("TotalCommandsProcessed: expected >=2, got %v", v)
+		}
+
+		_, _ = p.Cache.Get(ctx, "m-cache", "no-key")
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "CacheMisses", dims)
+		if v < 1.0 {
+			t.Errorf("CacheMisses: expected >=1, got %v", v)
+		}
+	})
+
+	t.Run("LogAnalytics", func(t *testing.T) {
+		_, err := p.LogAnalytics.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{Name: "m-lg"})
+		if err != nil {
+			t.Fatalf("CreateLogGroup: %v", err)
+		}
+
+		_, err = p.LogAnalytics.CreateLogStream(ctx, "m-lg", "m-stream")
+		if err != nil {
+			t.Fatalf("CreateLogStream: %v", err)
+		}
+
+		err = p.LogAnalytics.PutLogEvents(ctx, "m-lg", "m-stream", []loggingdriver.LogEvent{
+			{Timestamp: clk.Now(), Message: "azure log msg"},
+		})
+		if err != nil {
+			t.Fatalf("PutLogEvents: %v", err)
+		}
+
+		dims := map[string]string{"logGroupName": "m-lg"}
+		ns := "Microsoft.OperationalInsights/workspaces"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "IngestedEvents", dims)
+		if v != 1.0 {
+			t.Errorf("IngestedEvents: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "IngestedBytes", dims)
+		if v != 13.0 {
+			t.Errorf("IngestedBytes: expected 13, got %v", v)
+		}
+	})
+
+	t.Run("NotificationHubs", func(t *testing.T) {
+		_, err := p.NotificationHubs.CreateTopic(ctx, notifdriver.TopicConfig{Name: "m-topic"})
+		if err != nil {
+			t.Fatalf("CreateTopic: %v", err)
+		}
+
+		_, err = p.NotificationHubs.Publish(ctx, notifdriver.PublishInput{
+			TopicID: "m-topic", Message: "hello-nh",
+		})
+		if err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+
+		dims := map[string]string{"topicName": "m-topic"}
+		ns := "Microsoft.NotificationHubs/namespaces"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "OutgoingNotifications", dims)
+		if v != 1.0 {
+			t.Errorf("OutgoingNotifications: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("ACR", func(t *testing.T) {
+		_, err := p.ACR.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "m-repo"})
+		if err != nil {
+			t.Fatalf("CreateRepository: %v", err)
+		}
+
+		_, err = p.ACR.PutImage(ctx, &crdriver.ImageManifest{
+			Repository: "m-repo", Tag: "latest", Digest: "sha256:def456",
+			MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+			SizeBytes: 2048,
+		})
+		if err != nil {
+			t.Fatalf("PutImage: %v", err)
+		}
+
+		_, err = p.ACR.GetImage(ctx, "m-repo", "latest")
+		if err != nil {
+			t.Fatalf("GetImage: %v", err)
+		}
+
+		dims := map[string]string{"repositoryName": "m-repo"}
+		ns := "Microsoft.ContainerRegistry/registries"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "ImagePushCount", dims)
+		if v != 1.0 {
+			t.Errorf("ImagePushCount: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "ImagePullCount", dims)
+		if v != 1.0 {
+			t.Errorf("ImagePullCount: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("EventGrid", func(t *testing.T) {
+		_, err := p.EventGrid.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "m-topic"})
+		if err != nil {
+			t.Fatalf("CreateEventBus: %v", err)
+		}
+
+		_, err = p.EventGrid.PutRule(ctx, &ebdriver.RuleConfig{
+			Name:         "m-rule",
+			EventBus:     "m-topic",
+			EventPattern: `{"source":["my.app"]}`,
+			State:        "ENABLED",
+		})
+		if err != nil {
+			t.Fatalf("PutRule: %v", err)
+		}
+
+		_, err = p.EventGrid.PutEvents(ctx, []ebdriver.Event{
+			{Source: "my.app", DetailType: "test", Detail: `{"k":"v"}`, EventBus: "m-topic"},
+		})
+		if err != nil {
+			t.Fatalf("PutEvents: %v", err)
+		}
+
+		dims := map[string]string{"topicName": "m-topic"}
+		ns := "Microsoft.EventGrid/topics"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "PublishedEvents", dims)
+		if v != 1.0 {
+			t.Errorf("PublishedEvents: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "MatchedEvents", dims)
+		if v != 1.0 {
+			t.Errorf("MatchedEvents: expected 1, got %v", v)
+		}
+	})
+}
+
+func TestGCPMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Now())
+	p := NewGCP(config.WithClock(clk))
+	mon := p.CloudMonitoring
+
+	t.Run("GCS", func(t *testing.T) {
+		if err := p.GCS.CreateBucket(ctx, "m-bucket"); err != nil {
+			t.Fatalf("CreateBucket: %v", err)
+		}
+
+		if err := p.GCS.PutObject(ctx, "m-bucket", "f.txt", []byte("hello"), "text/plain", nil); err != nil {
+			t.Fatalf("PutObject: %v", err)
+		}
+
+		dims := map[string]string{"bucket_name": "m-bucket"}
+		ns := "storage.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "api/request_count", dims)
+		if v != 1.0 {
+			t.Errorf("api/request_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "network/received_bytes_count", dims)
+		if v != 5.0 {
+			t.Errorf("network/received_bytes_count: expected 5, got %v", v)
+		}
+
+		_, err := p.GCS.GetObject(ctx, "m-bucket", "f.txt")
+		if err != nil {
+			t.Fatalf("GetObject: %v", err)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "network/sent_bytes_count", dims)
+		if v != 5.0 {
+			t.Errorf("network/sent_bytes_count: expected 5, got %v", v)
+		}
+	})
+
+	t.Run("Firestore", func(t *testing.T) {
+		if err := p.Firestore.CreateTable(ctx, driver.TableConfig{
+			Name: "m-coll", PartitionKey: "pk",
+		}); err != nil {
+			t.Fatalf("CreateTable: %v", err)
+		}
+
+		if err := p.Firestore.PutItem(ctx, "m-coll", map[string]any{"pk": "k1", "val": "v1"}); err != nil {
+			t.Fatalf("PutItem: %v", err)
+		}
+
+		dims := map[string]string{"collection_id": "m-coll"}
+		ns := "firestore.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "document/write_count", dims)
+		if v != 1.0 {
+			t.Errorf("document/write_count: expected 1, got %v", v)
+		}
+
+		_, err := p.Firestore.GetItem(ctx, "m-coll", map[string]any{"pk": "k1"})
+		if err != nil {
+			t.Fatalf("GetItem: %v", err)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "document/read_count", dims)
+		if v != 1.0 {
+			t.Errorf("document/read_count: expected 1, got %v", v)
+		}
+
+		if err := p.Firestore.DeleteItem(ctx, "m-coll", map[string]any{"pk": "k1"}); err != nil {
+			t.Fatalf("DeleteItem: %v", err)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "document/delete_count", dims)
+		if v != 1.0 {
+			t.Errorf("document/delete_count: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("CloudFunctions", func(t *testing.T) {
+		_, err := p.CloudFunctions.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+			Name: "m-fn", Runtime: "go121", Handler: "main",
+		})
+		if err != nil {
+			t.Fatalf("CreateFunction: %v", err)
+		}
+
+		p.CloudFunctions.RegisterHandler("m-fn", func(_ context.Context, payload []byte) ([]byte, error) {
+			return []byte("ok"), nil
+		})
+
+		_, err = p.CloudFunctions.Invoke(ctx, serverlessdriver.InvokeInput{
+			FunctionName: "m-fn", Payload: []byte("{}"),
+		})
+		if err != nil {
+			t.Fatalf("Invoke: %v", err)
+		}
+
+		dims := map[string]string{"function_name": "m-fn"}
+		ns := "cloudfunctions.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "function/execution_count", dims)
+		if v != 1.0 {
+			t.Errorf("function/execution_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "function/execution_times", dims)
+		if v != 1.0 {
+			t.Errorf("function/execution_times: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("PubSub", func(t *testing.T) {
+		qi, err := p.PubSub.CreateQueue(ctx, mqdriver.QueueConfig{Name: "m-q"})
+		if err != nil {
+			t.Fatalf("CreateQueue: %v", err)
+		}
+
+		_, err = p.PubSub.SendMessage(ctx, mqdriver.SendMessageInput{
+			QueueURL: qi.URL, Body: "hello-pub",
+		})
+		if err != nil {
+			t.Fatalf("SendMessage: %v", err)
+		}
+
+		dims := map[string]string{"topic_id": "m-q"}
+		ns := "pubsub.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "topic/send_message_operation_count", dims)
+		if v != 1.0 {
+			t.Errorf("topic/send_message_operation_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "topic/byte_cost", dims)
+		if v != 9.0 {
+			t.Errorf("topic/byte_cost: expected 9, got %v", v)
+		}
+	})
+
+	t.Run("Memorystore", func(t *testing.T) {
+		_, err := p.Memorystore.CreateCache(ctx, cachedriver.CacheConfig{
+			Name: "m-cache", Engine: "redis", NodeType: "BASIC",
+		})
+		if err != nil {
+			t.Fatalf("CreateCache: %v", err)
+		}
+
+		if err := p.Memorystore.Set(ctx, "m-cache", "key1", []byte("val1"), 0); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+
+		_, err = p.Memorystore.Get(ctx, "m-cache", "key1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+
+		dims := map[string]string{"instance_id": "m-cache"}
+		ns := "redis.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "commands/set", dims)
+		if v != 1.0 {
+			t.Errorf("commands/set: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "stats/cache_hit_count", dims)
+		if v != 1.0 {
+			t.Errorf("stats/cache_hit_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "commands/get", dims)
+		if v != 1.0 {
+			t.Errorf("commands/get: expected 1, got %v", v)
+		}
+
+		_, _ = p.Memorystore.Get(ctx, "m-cache", "no-key")
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "stats/cache_miss_count", dims)
+		if v < 1.0 {
+			t.Errorf("stats/cache_miss_count: expected >=1, got %v", v)
+		}
+	})
+
+	t.Run("CloudLogging", func(t *testing.T) {
+		_, err := p.CloudLogging.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{Name: "m-lg"})
+		if err != nil {
+			t.Fatalf("CreateLogGroup: %v", err)
+		}
+
+		_, err = p.CloudLogging.CreateLogStream(ctx, "m-lg", "m-stream")
+		if err != nil {
+			t.Fatalf("CreateLogStream: %v", err)
+		}
+
+		err = p.CloudLogging.PutLogEvents(ctx, "m-lg", "m-stream", []loggingdriver.LogEvent{
+			{Timestamp: clk.Now(), Message: "gcp log msg"},
+		})
+		if err != nil {
+			t.Fatalf("PutLogEvents: %v", err)
+		}
+
+		dims := map[string]string{"log_group": "m-lg"}
+		ns := "logging.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "api/request_count", dims)
+		if v != 1.0 {
+			t.Errorf("api/request_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "byte_count", dims)
+		if v != 11.0 {
+			t.Errorf("byte_count: expected 11, got %v", v)
+		}
+	})
+
+	t.Run("FCM", func(t *testing.T) {
+		_, err := p.FCM.CreateTopic(ctx, notifdriver.TopicConfig{Name: "m-topic"})
+		if err != nil {
+			t.Fatalf("CreateTopic: %v", err)
+		}
+
+		_, err = p.FCM.Publish(ctx, notifdriver.PublishInput{
+			TopicID: "m-topic", Message: "hello-fcm",
+		})
+		if err != nil {
+			t.Fatalf("Publish: %v", err)
+		}
+
+		dims := map[string]string{"topic_name": "m-topic"}
+		ns := "fcm.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "message_count", dims)
+		if v != 1.0 {
+			t.Errorf("message_count: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("ArtifactRegistry", func(t *testing.T) {
+		_, err := p.ArtifactRegistry.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "m-repo"})
+		if err != nil {
+			t.Fatalf("CreateRepository: %v", err)
+		}
+
+		_, err = p.ArtifactRegistry.PutImage(ctx, &crdriver.ImageManifest{
+			Repository: "m-repo", Tag: "latest", Digest: "sha256:ghi789",
+			MediaType: "application/vnd.docker.distribution.manifest.v2+json",
+			SizeBytes: 4096,
+		})
+		if err != nil {
+			t.Fatalf("PutImage: %v", err)
+		}
+
+		_, err = p.ArtifactRegistry.GetImage(ctx, "m-repo", "latest")
+		if err != nil {
+			t.Fatalf("GetImage: %v", err)
+		}
+
+		dims := map[string]string{"repository_name": "m-repo"}
+		ns := "artifactregistry.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "push_request_count", dims)
+		if v != 1.0 {
+			t.Errorf("push_request_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "pull_request_count", dims)
+		if v != 1.0 {
+			t.Errorf("pull_request_count: expected 1, got %v", v)
+		}
+	})
+
+	t.Run("Eventarc", func(t *testing.T) {
+		_, err := p.Eventarc.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "m-channel"})
+		if err != nil {
+			t.Fatalf("CreateEventBus: %v", err)
+		}
+
+		_, err = p.Eventarc.PutRule(ctx, &ebdriver.RuleConfig{
+			Name:         "m-rule",
+			EventBus:     "m-channel",
+			EventPattern: `{"source":["my.app"]}`,
+			State:        "ENABLED",
+		})
+		if err != nil {
+			t.Fatalf("PutRule: %v", err)
+		}
+
+		_, err = p.Eventarc.PutEvents(ctx, []ebdriver.Event{
+			{Source: "my.app", DetailType: "test", Detail: `{"k":"v"}`, EventBus: "m-channel"},
+		})
+		if err != nil {
+			t.Fatalf("PutEvents: %v", err)
+		}
+
+		dims := map[string]string{"channel_name": "m-channel"}
+		ns := "eventarc.googleapis.com"
+
+		v := helperGetMetric(t, ctx, mon, clk, ns, "event_count", dims)
+		if v != 1.0 {
+			t.Errorf("event_count: expected 1, got %v", v)
+		}
+
+		v = helperGetMetric(t, ctx, mon, clk, ns, "matched_event_count", dims)
+		if v != 1.0 {
+			t.Errorf("matched_event_count: expected 1, got %v", v)
+		}
+	})
 }

--- a/compute/compute.go
+++ b/compute/compute.go
@@ -166,3 +166,195 @@ func (c *Compute) ModifyInstance(ctx context.Context, instanceID string, input d
 
 	return err
 }
+
+// CreateAutoScalingGroup creates an auto-scaling group.
+//
+//nolint:gocritic // hugeParam: config passed by value to match driver.Compute interface pattern
+func (c *Compute) CreateAutoScalingGroup(
+	ctx context.Context, config driver.AutoScalingGroupConfig,
+) (*driver.AutoScalingGroup, error) {
+	out, err := c.do(ctx, "CreateAutoScalingGroup", config, func() (any, error) {
+		return c.driver.CreateAutoScalingGroup(ctx, config)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.AutoScalingGroup), nil
+}
+
+// DeleteAutoScalingGroup deletes an auto-scaling group.
+func (c *Compute) DeleteAutoScalingGroup(ctx context.Context, name string, forceDelete bool) error {
+	_, err := c.do(ctx, "DeleteAutoScalingGroup", name, func() (any, error) {
+		return nil, c.driver.DeleteAutoScalingGroup(ctx, name, forceDelete)
+	})
+
+	return err
+}
+
+// GetAutoScalingGroup returns an auto-scaling group.
+func (c *Compute) GetAutoScalingGroup(ctx context.Context, name string) (*driver.AutoScalingGroup, error) {
+	out, err := c.do(ctx, "GetAutoScalingGroup", name, func() (any, error) {
+		return c.driver.GetAutoScalingGroup(ctx, name)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.AutoScalingGroup), nil
+}
+
+// ListAutoScalingGroups lists all auto-scaling groups.
+func (c *Compute) ListAutoScalingGroups(ctx context.Context) ([]driver.AutoScalingGroup, error) {
+	out, err := c.do(ctx, "ListAutoScalingGroups", nil, func() (any, error) {
+		return c.driver.ListAutoScalingGroups(ctx)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.AutoScalingGroup), nil
+}
+
+// UpdateAutoScalingGroup updates an auto-scaling group.
+func (c *Compute) UpdateAutoScalingGroup(ctx context.Context, name string, desired, minSize, maxSize int) error {
+	_, err := c.do(ctx, "UpdateAutoScalingGroup", name, func() (any, error) {
+		return nil, c.driver.UpdateAutoScalingGroup(ctx, name, desired, minSize, maxSize)
+	})
+
+	return err
+}
+
+// SetDesiredCapacity sets the desired capacity of an auto-scaling group.
+func (c *Compute) SetDesiredCapacity(ctx context.Context, name string, desired int) error {
+	_, err := c.do(ctx, "SetDesiredCapacity", name, func() (any, error) {
+		return nil, c.driver.SetDesiredCapacity(ctx, name, desired)
+	})
+
+	return err
+}
+
+// PutScalingPolicy attaches a scaling policy to an auto-scaling group.
+//
+//nolint:gocritic // hugeParam: policy passed by value to match driver.Compute interface pattern
+func (c *Compute) PutScalingPolicy(ctx context.Context, policy driver.ScalingPolicy) error {
+	_, err := c.do(ctx, "PutScalingPolicy", policy, func() (any, error) {
+		return nil, c.driver.PutScalingPolicy(ctx, policy)
+	})
+
+	return err
+}
+
+// DeleteScalingPolicy removes a scaling policy.
+func (c *Compute) DeleteScalingPolicy(ctx context.Context, asgName, policyName string) error {
+	_, err := c.do(ctx, "DeleteScalingPolicy", asgName, func() (any, error) {
+		return nil, c.driver.DeleteScalingPolicy(ctx, asgName, policyName)
+	})
+
+	return err
+}
+
+// ExecuteScalingPolicy executes a scaling policy.
+func (c *Compute) ExecuteScalingPolicy(ctx context.Context, asgName, policyName string) error {
+	_, err := c.do(ctx, "ExecuteScalingPolicy", asgName, func() (any, error) {
+		return nil, c.driver.ExecuteScalingPolicy(ctx, asgName, policyName)
+	})
+
+	return err
+}
+
+// RequestSpotInstances creates spot/preemptible instance requests.
+//
+//nolint:gocritic // hugeParam: config passed by value to match driver.Compute interface pattern
+func (c *Compute) RequestSpotInstances(
+	ctx context.Context, config driver.SpotRequestConfig,
+) ([]driver.SpotInstanceRequest, error) {
+	out, err := c.do(ctx, "RequestSpotInstances", config, func() (any, error) {
+		return c.driver.RequestSpotInstances(ctx, config)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SpotInstanceRequest), nil
+}
+
+// CancelSpotRequests cancels spot/preemptible instance requests.
+func (c *Compute) CancelSpotRequests(ctx context.Context, requestIDs []string) error {
+	_, err := c.do(ctx, "CancelSpotRequests", requestIDs, func() (any, error) {
+		return nil, c.driver.CancelSpotRequests(ctx, requestIDs)
+	})
+
+	return err
+}
+
+// DescribeSpotRequests describes spot/preemptible instance requests.
+func (c *Compute) DescribeSpotRequests(
+	ctx context.Context, requestIDs []string,
+) ([]driver.SpotInstanceRequest, error) {
+	out, err := c.do(ctx, "DescribeSpotRequests", requestIDs, func() (any, error) {
+		return c.driver.DescribeSpotRequests(ctx, requestIDs)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SpotInstanceRequest), nil
+}
+
+// CreateLaunchTemplate creates a launch template.
+//
+//nolint:gocritic // hugeParam: config passed by value to match driver.Compute interface pattern
+func (c *Compute) CreateLaunchTemplate(
+	ctx context.Context, config driver.LaunchTemplateConfig,
+) (*driver.LaunchTemplate, error) {
+	out, err := c.do(ctx, "CreateLaunchTemplate", config, func() (any, error) {
+		return c.driver.CreateLaunchTemplate(ctx, config)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LaunchTemplate), nil
+}
+
+// DeleteLaunchTemplate deletes a launch template.
+func (c *Compute) DeleteLaunchTemplate(ctx context.Context, name string) error {
+	_, err := c.do(ctx, "DeleteLaunchTemplate", name, func() (any, error) {
+		return nil, c.driver.DeleteLaunchTemplate(ctx, name)
+	})
+
+	return err
+}
+
+// GetLaunchTemplate returns a launch template.
+func (c *Compute) GetLaunchTemplate(ctx context.Context, name string) (*driver.LaunchTemplate, error) {
+	out, err := c.do(ctx, "GetLaunchTemplate", name, func() (any, error) {
+		return c.driver.GetLaunchTemplate(ctx, name)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LaunchTemplate), nil
+}
+
+// ListLaunchTemplates lists all launch templates.
+func (c *Compute) ListLaunchTemplates(ctx context.Context) ([]driver.LaunchTemplate, error) {
+	out, err := c.do(ctx, "ListLaunchTemplates", nil, func() (any, error) {
+		return c.driver.ListLaunchTemplates(ctx)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LaunchTemplate), nil
+}

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -1,0 +1,519 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCompute is a minimal in-memory mock that satisfies driver.Compute.
+type mockCompute struct {
+	mu        sync.Mutex
+	instances map[string]*driver.Instance
+	counter   int
+}
+
+func newMockCompute() *mockCompute {
+	return &mockCompute{instances: make(map[string]*driver.Instance)}
+}
+
+func (m *mockCompute) RunInstances(_ context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []driver.Instance
+
+	for range count {
+		m.counter++
+		id := fmt.Sprintf("i-%06d", m.counter)
+
+		inst := &driver.Instance{
+			ID:           id,
+			ImageID:      cfg.ImageID,
+			InstanceType: cfg.InstanceType,
+			State:        "running",
+			Tags:         cfg.Tags,
+		}
+		m.instances[id] = inst
+		result = append(result, *inst)
+	}
+
+	return result, nil
+}
+
+func (m *mockCompute) findInstance(id string) (*driver.Instance, error) {
+	inst, ok := m.instances[id]
+	if !ok {
+		return nil, fmt.Errorf("instance %s not found", id)
+	}
+
+	return inst, nil
+}
+
+func (m *mockCompute) StartInstances(_ context.Context, ids []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range ids {
+		inst, err := m.findInstance(id)
+		if err != nil {
+			return err
+		}
+
+		inst.State = "running"
+	}
+
+	return nil
+}
+
+func (m *mockCompute) StopInstances(_ context.Context, ids []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range ids {
+		inst, err := m.findInstance(id)
+		if err != nil {
+			return err
+		}
+
+		inst.State = "stopped"
+	}
+
+	return nil
+}
+
+func (m *mockCompute) RebootInstances(_ context.Context, ids []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range ids {
+		if _, err := m.findInstance(id); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockCompute) TerminateInstances(_ context.Context, ids []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range ids {
+		inst, err := m.findInstance(id)
+		if err != nil {
+			return err
+		}
+
+		inst.State = "terminated"
+	}
+
+	return nil
+}
+
+func (m *mockCompute) DescribeInstances(_ context.Context, ids []string, _ []driver.DescribeFilter) ([]driver.Instance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []driver.Instance
+
+	if len(ids) == 0 {
+		for _, inst := range m.instances {
+			result = append(result, *inst)
+		}
+
+		return result, nil
+	}
+
+	for _, id := range ids {
+		inst, err := m.findInstance(id)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, *inst)
+	}
+
+	return result, nil
+}
+
+func (m *mockCompute) ModifyInstance(_ context.Context, id string, input driver.ModifyInstanceInput) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, err := m.findInstance(id)
+	if err != nil {
+		return err
+	}
+
+	if input.InstanceType != "" {
+		inst.InstanceType = input.InstanceType
+	}
+
+	return nil
+}
+
+func (m *mockCompute) CreateAutoScalingGroup(_ context.Context, cfg driver.AutoScalingGroupConfig) (*driver.AutoScalingGroup, error) {
+	return &driver.AutoScalingGroup{Name: cfg.Name, DesiredCapacity: cfg.DesiredCapacity, Status: "Active"}, nil
+}
+
+func (m *mockCompute) DeleteAutoScalingGroup(context.Context, string, bool) error { return nil }
+
+func (m *mockCompute) GetAutoScalingGroup(_ context.Context, name string) (*driver.AutoScalingGroup, error) {
+	return &driver.AutoScalingGroup{Name: name, Status: "Active"}, nil
+}
+
+func (m *mockCompute) ListAutoScalingGroups(context.Context) ([]driver.AutoScalingGroup, error) {
+	return nil, nil
+}
+
+func (m *mockCompute) UpdateAutoScalingGroup(context.Context, string, int, int, int) error {
+	return nil
+}
+
+func (m *mockCompute) SetDesiredCapacity(context.Context, string, int) error { return nil }
+
+func (m *mockCompute) PutScalingPolicy(context.Context, driver.ScalingPolicy) error { return nil }
+
+func (m *mockCompute) DeleteScalingPolicy(context.Context, string, string) error { return nil }
+
+func (m *mockCompute) ExecuteScalingPolicy(context.Context, string, string) error { return nil }
+
+func (m *mockCompute) RequestSpotInstances(_ context.Context, cfg driver.SpotRequestConfig) ([]driver.SpotInstanceRequest, error) {
+	return []driver.SpotInstanceRequest{{ID: "sir-001", Status: "open"}}, nil
+}
+
+func (m *mockCompute) CancelSpotRequests(context.Context, []string) error { return nil }
+
+func (m *mockCompute) DescribeSpotRequests(_ context.Context, _ []string) ([]driver.SpotInstanceRequest, error) {
+	return nil, nil
+}
+
+func (m *mockCompute) CreateLaunchTemplate(_ context.Context, cfg driver.LaunchTemplateConfig) (*driver.LaunchTemplate, error) {
+	return &driver.LaunchTemplate{Name: cfg.Name}, nil
+}
+
+func (m *mockCompute) DeleteLaunchTemplate(context.Context, string) error { return nil }
+
+func (m *mockCompute) GetLaunchTemplate(_ context.Context, name string) (*driver.LaunchTemplate, error) {
+	return &driver.LaunchTemplate{Name: name}, nil
+}
+
+func (m *mockCompute) ListLaunchTemplates(context.Context) ([]driver.LaunchTemplate, error) {
+	return nil, nil
+}
+
+func newTestCompute(opts ...Option) *Compute {
+	return NewCompute(newMockCompute(), opts...)
+}
+
+func TestNewCompute(t *testing.T) {
+	c := newTestCompute()
+
+	require.NotNil(t, c)
+	require.NotNil(t, c.driver)
+}
+
+func TestRunInstancesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(instances))
+	assert.Equal(t, "running", instances[0].State)
+}
+
+func TestDescribeInstancesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	described, err := c.DescribeInstances(ctx, []string{instances[0].ID}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(described))
+	assert.Equal(t, instances[0].ID, described[0].ID)
+}
+
+func TestStopStartInstancesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	err = c.StopInstances(ctx, []string{instances[0].ID})
+	require.NoError(t, err)
+
+	err = c.StartInstances(ctx, []string{instances[0].ID})
+	require.NoError(t, err)
+}
+
+func TestTerminateInstancesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	err = c.TerminateInstances(ctx, []string{instances[0].ID})
+	require.NoError(t, err)
+}
+
+func TestRebootInstancesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	err = c.RebootInstances(ctx, []string{instances[0].ID})
+	require.NoError(t, err)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	c := newTestCompute(WithRecorder(rec))
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	_, err = c.DescribeInstances(ctx, []string{instances[0].ID}, nil)
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 2)
+
+	runCalls := rec.CallCountFor("compute", "RunInstances")
+	assert.Equal(t, 1, runCalls)
+
+	describeCalls := rec.CallCountFor("compute", "DescribeInstances")
+	assert.Equal(t, 1, describeCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	c := newTestCompute(WithRecorder(rec))
+	ctx := context.Background()
+
+	_ = c.StopInstances(ctx, []string{"i-nonexistent"})
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	c := newTestCompute(WithMetrics(mc))
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	_, err = c.DescribeInstances(ctx, []string{instances[0].ID}, nil)
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 2)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 2)
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	c := newTestCompute(WithMetrics(mc))
+	ctx := context.Background()
+
+	_ = c.StopInstances(ctx, []string{"i-nonexistent"})
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("compute", "RunInstances", injectedErr, inject.Always{})
+
+	_, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("compute", "StopInstances", injectedErr, inject.Always{})
+
+	_, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	err = c.StopInstances(ctx, []string{"i-12345"})
+	require.Error(t, err)
+
+	stopCalls := rec.CallsFor("compute", "StopInstances")
+	assert.Equal(t, 1, len(stopCalls))
+	assert.NotNil(t, stopCalls[0].Error, "expected recorded StopInstances call to have an error")
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("compute", "RunInstances", injectedErr, inject.Always{})
+
+	_, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.Error(t, err)
+
+	inj.Remove("compute", "RunInstances")
+
+	_, err = c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	limiter := ratelimit.New(1, 1, fc)
+	c := NewCompute(newMockCompute(), WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	_, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	_, err = c.DescribeInstances(ctx, nil, nil)
+	require.Error(t, err, "expected rate limit error on second call without time advance")
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	c := newTestCompute(WithLatency(latency))
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(instances))
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	c := NewCompute(newMockCompute(),
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID:      "ami-12345",
+		InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	_, err = c.DescribeInstances(ctx, nil, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableStopInstancesError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.StopInstances(ctx, []string{"i-nonexistent"})
+	require.Error(t, err)
+}
+
+func TestPortableStartInstancesError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.StartInstances(ctx, []string{"i-nonexistent"})
+	require.Error(t, err)
+}
+
+func TestPortableTerminateInstancesError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.TerminateInstances(ctx, []string{"i-nonexistent"})
+	require.Error(t, err)
+}

--- a/compute/driver/driver.go
+++ b/compute/driver/driver.go
@@ -41,6 +41,80 @@ type DescribeFilter struct {
 	Values []string
 }
 
+// AutoScalingGroupConfig configures an auto-scaling group.
+type AutoScalingGroupConfig struct {
+	Name              string
+	MinSize           int
+	MaxSize           int
+	DesiredCapacity   int
+	InstanceConfig    InstanceConfig
+	HealthCheckType   string // "EC2", "ELB"
+	HealthCheckGrace  int    // seconds
+	Tags              map[string]string
+	AvailabilityZones []string
+}
+
+// AutoScalingGroup describes an auto-scaling group.
+type AutoScalingGroup struct {
+	Name              string
+	MinSize           int
+	MaxSize           int
+	DesiredCapacity   int
+	CurrentSize       int
+	InstanceIDs       []string
+	Status            string
+	HealthCheckType   string
+	CreatedAt         string
+	Tags              map[string]string
+	AvailabilityZones []string
+}
+
+// ScalingPolicy defines when to scale.
+type ScalingPolicy struct {
+	Name              string
+	AutoScalingGroup  string
+	PolicyType        string // "SimpleScaling", "TargetTracking", "StepScaling"
+	AdjustmentType    string // "ChangeInCapacity", "ExactCapacity", "PercentChangeInCapacity"
+	ScalingAdjustment int
+	Cooldown          int     // seconds
+	TargetValue       float64 // for TargetTracking
+	MetricName        string  // for TargetTracking
+}
+
+// SpotInstanceRequest describes a spot/preemptible instance request.
+type SpotInstanceRequest struct {
+	ID             string
+	InstanceConfig InstanceConfig
+	MaxPrice       float64
+	Status         string // "open", "active", "closed", "canceled"
+	InstanceID     string
+	CreatedAt      string
+	Type           string // "one-time", "persistent"
+}
+
+// SpotRequestConfig configures a spot instance request.
+type SpotRequestConfig struct {
+	InstanceConfig InstanceConfig
+	MaxPrice       float64
+	Count          int
+	Type           string // "one-time", "persistent"
+}
+
+// LaunchTemplate describes a launch template.
+type LaunchTemplate struct {
+	ID             string
+	Name           string
+	Version        int
+	InstanceConfig InstanceConfig
+	CreatedAt      string
+}
+
+// LaunchTemplateConfig configures a launch template.
+type LaunchTemplateConfig struct {
+	Name           string
+	InstanceConfig InstanceConfig
+}
+
 // Compute is the interface that compute provider implementations must satisfy.
 type Compute interface {
 	RunInstances(ctx context.Context, config InstanceConfig, count int) ([]Instance, error)
@@ -50,4 +124,28 @@ type Compute interface {
 	TerminateInstances(ctx context.Context, instanceIDs []string) error
 	DescribeInstances(ctx context.Context, instanceIDs []string, filters []DescribeFilter) ([]Instance, error)
 	ModifyInstance(ctx context.Context, instanceID string, input ModifyInstanceInput) error
+
+	// Auto-Scaling Groups
+	CreateAutoScalingGroup(ctx context.Context, config AutoScalingGroupConfig) (*AutoScalingGroup, error)
+	DeleteAutoScalingGroup(ctx context.Context, name string, forceDelete bool) error
+	GetAutoScalingGroup(ctx context.Context, name string) (*AutoScalingGroup, error)
+	ListAutoScalingGroups(ctx context.Context) ([]AutoScalingGroup, error)
+	UpdateAutoScalingGroup(ctx context.Context, name string, desired, minSize, maxSize int) error
+	SetDesiredCapacity(ctx context.Context, name string, desired int) error
+
+	// Scaling Policies
+	PutScalingPolicy(ctx context.Context, policy ScalingPolicy) error
+	DeleteScalingPolicy(ctx context.Context, asgName, policyName string) error
+	ExecuteScalingPolicy(ctx context.Context, asgName, policyName string) error
+
+	// Spot/Preemptible Instances
+	RequestSpotInstances(ctx context.Context, config SpotRequestConfig) ([]SpotInstanceRequest, error)
+	CancelSpotRequests(ctx context.Context, requestIDs []string) error
+	DescribeSpotRequests(ctx context.Context, requestIDs []string) ([]SpotInstanceRequest, error)
+
+	// Launch Templates
+	CreateLaunchTemplate(ctx context.Context, config LaunchTemplateConfig) (*LaunchTemplate, error)
+	DeleteLaunchTemplate(ctx context.Context, name string) error
+	GetLaunchTemplate(ctx context.Context, name string) (*LaunchTemplate, error)
+	ListLaunchTemplates(ctx context.Context) ([]LaunchTemplate, error)
 }

--- a/containerregistry/containerregistry.go
+++ b/containerregistry/containerregistry.go
@@ -1,0 +1,290 @@
+// Package containerregistry provides a portable container registry API with cross-cutting concerns.
+package containerregistry
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+const serviceName = "containerregistry"
+
+// ContainerRegistry is the portable container registry type wrapping a driver with cross-cutting concerns.
+type ContainerRegistry struct {
+	driver   driver.ContainerRegistry
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// NewContainerRegistry creates a new portable ContainerRegistry wrapping the given driver.
+func NewContainerRegistry(d driver.ContainerRegistry, opts ...Option) *ContainerRegistry {
+	c := &ContainerRegistry{driver: d}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Option configures a portable ContainerRegistry.
+type Option func(*ContainerRegistry)
+
+// WithRecorder sets the recorder.
+func WithRecorder(r *recorder.Recorder) Option {
+	return func(c *ContainerRegistry) { c.recorder = r }
+}
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option {
+	return func(c *ContainerRegistry) { c.metrics = m }
+}
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option {
+	return func(c *ContainerRegistry) { c.limiter = l }
+}
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option {
+	return func(c *ContainerRegistry) { c.injector = i }
+}
+
+// WithLatency sets simulated latency.
+func WithLatency(d time.Duration) Option { return func(c *ContainerRegistry) { c.latency = d } }
+
+func (c *ContainerRegistry) do(
+	_ context.Context, op string, input any, fn func() (any, error),
+) (any, error) {
+	start := time.Now()
+
+	if c.injector != nil {
+		if err := c.injector.Check(serviceName, op); err != nil {
+			c.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if c.limiter != nil {
+		if err := c.limiter.Allow(); err != nil {
+			c.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if c.latency > 0 {
+		time.Sleep(c.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if c.metrics != nil {
+		labels := map[string]string{"service": serviceName, "operation": op}
+		c.metrics.Counter("calls_total", 1, labels)
+		c.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			c.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	c.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (c *ContainerRegistry) rec(op string, input, output any, err error, dur time.Duration) {
+	if c.recorder != nil {
+		c.recorder.Record(serviceName, op, input, output, err, dur)
+	}
+}
+
+// CreateRepository creates a new container repository.
+func (c *ContainerRegistry) CreateRepository(
+	ctx context.Context, config driver.RepositoryConfig,
+) (*driver.Repository, error) {
+	out, err := c.do(ctx, "CreateRepository", config, func() (any, error) {
+		return c.driver.CreateRepository(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Repository), nil
+}
+
+// DeleteRepository deletes a container repository.
+func (c *ContainerRegistry) DeleteRepository(ctx context.Context, name string, force bool) error {
+	_, err := c.do(ctx, "DeleteRepository", map[string]any{"name": name, "force": force}, func() (any, error) {
+		return nil, c.driver.DeleteRepository(ctx, name, force)
+	})
+
+	return err
+}
+
+// GetRepository retrieves repository info.
+func (c *ContainerRegistry) GetRepository(ctx context.Context, name string) (*driver.Repository, error) {
+	out, err := c.do(ctx, "GetRepository", name, func() (any, error) {
+		return c.driver.GetRepository(ctx, name)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Repository), nil
+}
+
+// ListRepositories lists all repositories.
+func (c *ContainerRegistry) ListRepositories(ctx context.Context) ([]driver.Repository, error) {
+	out, err := c.do(ctx, "ListRepositories", nil, func() (any, error) {
+		return c.driver.ListRepositories(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Repository), nil
+}
+
+// PutImage pushes an image manifest to a repository.
+func (c *ContainerRegistry) PutImage(
+	ctx context.Context, manifest *driver.ImageManifest,
+) (*driver.ImageDetail, error) {
+	out, err := c.do(ctx, "PutImage", manifest, func() (any, error) {
+		return c.driver.PutImage(ctx, manifest)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ImageDetail), nil
+}
+
+// GetImage retrieves image details by repository and reference (tag or digest).
+func (c *ContainerRegistry) GetImage(
+	ctx context.Context, repository, reference string,
+) (*driver.ImageDetail, error) {
+	out, err := c.do(ctx, "GetImage", map[string]string{"repository": repository, "reference": reference},
+		func() (any, error) {
+			return c.driver.GetImage(ctx, repository, reference)
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ImageDetail), nil
+}
+
+// ListImages lists all images in a repository.
+func (c *ContainerRegistry) ListImages(ctx context.Context, repository string) ([]driver.ImageDetail, error) {
+	out, err := c.do(ctx, "ListImages", repository, func() (any, error) {
+		return c.driver.ListImages(ctx, repository)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.ImageDetail), nil
+}
+
+// DeleteImage deletes an image from a repository by reference (tag or digest).
+func (c *ContainerRegistry) DeleteImage(ctx context.Context, repository, reference string) error {
+	_, err := c.do(ctx, "DeleteImage", map[string]string{"repository": repository, "reference": reference},
+		func() (any, error) {
+			return nil, c.driver.DeleteImage(ctx, repository, reference)
+		})
+
+	return err
+}
+
+// TagImage adds a new tag to an existing image.
+func (c *ContainerRegistry) TagImage(ctx context.Context, repository, sourceRef, targetTag string) error {
+	_, err := c.do(ctx, "TagImage", map[string]string{
+		"repository": repository, "sourceRef": sourceRef, "targetTag": targetTag,
+	}, func() (any, error) {
+		return nil, c.driver.TagImage(ctx, repository, sourceRef, targetTag)
+	})
+
+	return err
+}
+
+// PutLifecyclePolicy sets a lifecycle policy on a repository.
+func (c *ContainerRegistry) PutLifecyclePolicy(
+	ctx context.Context, repository string, policy driver.LifecyclePolicy,
+) error {
+	_, err := c.do(ctx, "PutLifecyclePolicy", map[string]any{
+		"repository": repository, "policy": policy,
+	}, func() (any, error) {
+		return nil, c.driver.PutLifecyclePolicy(ctx, repository, policy)
+	})
+
+	return err
+}
+
+// GetLifecyclePolicy retrieves the lifecycle policy for a repository.
+func (c *ContainerRegistry) GetLifecyclePolicy(
+	ctx context.Context, repository string,
+) (*driver.LifecyclePolicy, error) {
+	out, err := c.do(ctx, "GetLifecyclePolicy", repository, func() (any, error) {
+		return c.driver.GetLifecyclePolicy(ctx, repository)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LifecyclePolicy), nil
+}
+
+// EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
+func (c *ContainerRegistry) EvaluateLifecyclePolicy(
+	ctx context.Context, repository string,
+) ([]string, error) {
+	out, err := c.do(ctx, "EvaluateLifecyclePolicy", repository, func() (any, error) {
+		return c.driver.EvaluateLifecyclePolicy(ctx, repository)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]string), nil
+}
+
+// StartImageScan starts a vulnerability scan on an image.
+func (c *ContainerRegistry) StartImageScan(
+	ctx context.Context, repository, reference string,
+) (*driver.ScanResult, error) {
+	out, err := c.do(ctx, "StartImageScan", map[string]string{
+		"repository": repository, "reference": reference,
+	}, func() (any, error) {
+		return c.driver.StartImageScan(ctx, repository, reference)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ScanResult), nil
+}
+
+// GetImageScanResults retrieves scan results for an image.
+func (c *ContainerRegistry) GetImageScanResults(
+	ctx context.Context, repository, reference string,
+) (*driver.ScanResult, error) {
+	out, err := c.do(ctx, "GetImageScanResults", map[string]string{
+		"repository": repository, "reference": reference,
+	}, func() (any, error) {
+		return c.driver.GetImageScanResults(ctx, repository, reference)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ScanResult), nil
+}

--- a/containerregistry/containerregistry_test.go
+++ b/containerregistry/containerregistry_test.go
@@ -1,0 +1,370 @@
+package containerregistry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/ecr"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDriver() (driver.ContainerRegistry, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return ecr.New(opts), fc
+}
+
+func newTestContainerRegistry(opts ...Option) (*ContainerRegistry, *config.FakeClock) {
+	d, fc := newTestDriver()
+	return NewContainerRegistry(d, opts...), fc
+}
+
+func setupRepoWithImage(t *testing.T, cr *ContainerRegistry) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "test-repo"})
+	require.NoError(t, err)
+
+	_, err = cr.PutImage(ctx, &driver.ImageManifest{
+		Repository: "test-repo",
+		Tag:        "latest",
+		Digest:     "sha256:abc123",
+		SizeBytes:  1024,
+	})
+	require.NoError(t, err)
+}
+
+func TestNewContainerRegistry(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+
+	require.NotNil(t, cr)
+	require.NotNil(t, cr.driver)
+}
+
+func TestCreateRepositoryPortable(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		repo, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "my-repo"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-repo", repo.Name)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteRepositoryPortable(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "del-repo"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := cr.DeleteRepository(ctx, "del-repo", false)
+		require.NoError(t, delErr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		delErr := cr.DeleteRepository(ctx, "nonexistent", false)
+		require.Error(t, delErr)
+	})
+}
+
+func TestGetRepositoryPortable(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "get-repo"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		repo, getErr := cr.GetRepository(ctx, "get-repo")
+		require.NoError(t, getErr)
+		assert.Equal(t, "get-repo", repo.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, getErr := cr.GetRepository(ctx, "nonexistent")
+		require.Error(t, getErr)
+	})
+}
+
+func TestListRepositoriesPortable(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	repos, err := cr.ListRepositories(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(repos))
+
+	_, err = cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "a"})
+	require.NoError(t, err)
+
+	_, err = cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "b"})
+	require.NoError(t, err)
+
+	repos, err = cr.ListRepositories(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(repos))
+}
+
+func TestPutGetDeleteImagePortable(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	setupRepoWithImage(t, cr)
+
+	t.Run("get existing image", func(t *testing.T) {
+		img, err := cr.GetImage(ctx, "test-repo", "latest")
+		require.NoError(t, err)
+		assert.Equal(t, "test-repo", img.Repository)
+	})
+
+	t.Run("list images", func(t *testing.T) {
+		imgs, err := cr.ListImages(ctx, "test-repo")
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(imgs), 1)
+	})
+
+	t.Run("delete image", func(t *testing.T) {
+		err := cr.DeleteImage(ctx, "test-repo", "latest")
+		require.NoError(t, err)
+	})
+}
+
+func TestTagImagePortable(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	setupRepoWithImage(t, cr)
+
+	err := cr.TagImage(ctx, "test-repo", "latest", "v1.0")
+	require.NoError(t, err)
+
+	img, err := cr.GetImage(ctx, "test-repo", "v1.0")
+	require.NoError(t, err)
+	assert.Equal(t, "test-repo", img.Repository)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	cr, _ := newTestContainerRegistry(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "rec-repo"})
+	require.NoError(t, err)
+
+	_, err = cr.GetRepository(ctx, "rec-repo")
+	require.NoError(t, err)
+
+	_, err = cr.ListRepositories(ctx)
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 3)
+
+	createCalls := rec.CallCountFor("containerregistry", "CreateRepository")
+	assert.Equal(t, 1, createCalls)
+
+	getCalls := rec.CallCountFor("containerregistry", "GetRepository")
+	assert.Equal(t, 1, getCalls)
+
+	listCalls := rec.CallCountFor("containerregistry", "ListRepositories")
+	assert.Equal(t, 1, listCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	cr, _ := newTestContainerRegistry(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = cr.GetRepository(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	cr, _ := newTestContainerRegistry(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "met-repo"})
+	require.NoError(t, err)
+
+	_, err = cr.GetRepository(ctx, "met-repo")
+	require.NoError(t, err)
+
+	_, err = cr.ListRepositories(ctx)
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 3)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 3)
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	cr, _ := newTestContainerRegistry(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = cr.GetRepository(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	cr, _ := newTestContainerRegistry(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("containerregistry", "CreateRepository", injectedErr, inject.Always{})
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "fail-repo"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	cr, _ := newTestContainerRegistry(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("containerregistry", "GetRepository", injectedErr, inject.Always{})
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "inj-repo"})
+	require.NoError(t, err)
+
+	_, err = cr.GetRepository(ctx, "inj-repo")
+	require.Error(t, err)
+
+	getCalls := rec.CallsFor("containerregistry", "GetRepository")
+	assert.Equal(t, 1, len(getCalls))
+	assert.NotNil(t, getCalls[0].Error, "expected recorded GetRepository call to have an error")
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	cr, _ := newTestContainerRegistry(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("containerregistry", "CreateRepository", injectedErr, inject.Always{})
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "test"})
+	require.Error(t, err)
+
+	inj.Remove("containerregistry", "CreateRepository")
+
+	_, err = cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "test"})
+	require.NoError(t, err)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	d := ecr.New(opts)
+	limiter := ratelimit.New(1, 1, fc)
+	cr := NewContainerRegistry(d, WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "rl-repo"})
+	require.NoError(t, err)
+
+	_, err = cr.GetRepository(ctx, "rl-repo")
+	require.Error(t, err, "expected rate limit error on second call without time advance")
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	cr, _ := newTestContainerRegistry(WithLatency(latency))
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "lat-repo"})
+	require.NoError(t, err)
+
+	repo, err := cr.GetRepository(ctx, "lat-repo")
+	require.NoError(t, err)
+	assert.Equal(t, "lat-repo", repo.Name)
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	cr, _ := newTestContainerRegistry(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := cr.CreateRepository(ctx, driver.RepositoryConfig{Name: "all-opts"})
+	require.NoError(t, err)
+
+	_, err = cr.GetRepository(ctx, "all-opts")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableGetImageError(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	_, err := cr.GetImage(ctx, "no-repo", "latest")
+	require.Error(t, err)
+}
+
+func TestPortableListImagesError(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	_, err := cr.ListImages(ctx, "no-repo")
+	require.Error(t, err)
+}
+
+func TestPortableDeleteImageError(t *testing.T) {
+	cr, _ := newTestContainerRegistry()
+	ctx := context.Background()
+
+	err := cr.DeleteImage(ctx, "no-repo", "latest")
+	require.Error(t, err)
+}

--- a/containerregistry/driver/driver.go
+++ b/containerregistry/driver/driver.go
@@ -1,0 +1,102 @@
+// Package driver defines the interface for container registry service implementations.
+package driver
+
+import (
+	"context"
+)
+
+// Repository represents a container repository.
+type Repository struct {
+	Name       string
+	URI        string
+	CreatedAt  string
+	Tags       map[string]string
+	ImageCount int
+}
+
+// RepositoryConfig describes a repository to create.
+type RepositoryConfig struct {
+	Name               string
+	Tags               map[string]string
+	ImageScanOnPush    bool
+	ImageTagMutability string // "MUTABLE" or "IMMUTABLE"
+}
+
+// ImageDetail describes a container image.
+type ImageDetail struct {
+	RegistryID   string
+	Repository   string
+	Digest       string
+	Tags         []string
+	SizeBytes    int64
+	PushedAt     string
+	LastPulledAt string
+	MediaType    string
+}
+
+// ImageManifest represents an image manifest for pushing.
+type ImageManifest struct {
+	Repository string
+	Tag        string
+	Digest     string
+	MediaType  string
+	SizeBytes  int64
+	Layers     []LayerInfo
+}
+
+// LayerInfo describes a layer in an image.
+type LayerInfo struct {
+	Digest    string
+	SizeBytes int64
+	MediaType string
+}
+
+// LifecycleRule defines image lifecycle policies.
+type LifecycleRule struct {
+	Priority    int
+	Description string
+	TagStatus   string // "tagged", "untagged", "any"
+	TagPattern  string // glob pattern for tag matching
+	CountType   string // "imageCountMoreThan" or "sinceImagePushed"
+	CountValue  int    // number of images or days
+	Action      string // "expire"
+}
+
+// LifecyclePolicy is a set of lifecycle rules.
+type LifecyclePolicy struct {
+	Rules []LifecycleRule
+}
+
+// ScanResult represents an image vulnerability scan result.
+type ScanResult struct {
+	Repository    string
+	Digest        string
+	Status        string         // "COMPLETE", "IN_PROGRESS", "FAILED"
+	FindingCounts map[string]int // severity -> count (CRITICAL, HIGH, MEDIUM, LOW, INFORMATIONAL)
+	CompletedAt   string
+}
+
+// ContainerRegistry is the interface that container registry providers must implement.
+type ContainerRegistry interface {
+	// Repository management
+	CreateRepository(ctx context.Context, config RepositoryConfig) (*Repository, error)
+	DeleteRepository(ctx context.Context, name string, force bool) error
+	GetRepository(ctx context.Context, name string) (*Repository, error)
+	ListRepositories(ctx context.Context) ([]Repository, error)
+
+	// Image management
+	PutImage(ctx context.Context, manifest *ImageManifest) (*ImageDetail, error)
+	GetImage(ctx context.Context, repository, reference string) (*ImageDetail, error)
+	ListImages(ctx context.Context, repository string) ([]ImageDetail, error)
+	DeleteImage(ctx context.Context, repository, reference string) error
+	TagImage(ctx context.Context, repository, sourceRef, targetTag string) error
+
+	// Lifecycle policies
+	PutLifecyclePolicy(ctx context.Context, repository string, policy LifecyclePolicy) error
+	GetLifecyclePolicy(ctx context.Context, repository string) (*LifecyclePolicy, error)
+	EvaluateLifecyclePolicy(ctx context.Context, repository string) ([]string, error)
+
+	// Image scanning
+	StartImageScan(ctx context.Context, repository, reference string) (*ScanResult, error)
+	GetImageScanResults(ctx context.Context, repository, reference string) (*ScanResult, error)
+}

--- a/database/database.go
+++ b/database/database.go
@@ -181,3 +181,55 @@ func (db *Database) BatchGetItems(ctx context.Context, table string, keys []map[
 
 	return out.([]map[string]any), nil
 }
+
+func (db *Database) UpdateTTL(ctx context.Context, table string, cfg driver.TTLConfig) error {
+	_, err := db.do(ctx, "UpdateTTL", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.UpdateTTL(ctx, table, cfg)
+	})
+
+	return err
+}
+
+func (db *Database) DescribeTTL(ctx context.Context, table string) (*driver.TTLConfig, error) {
+	out, err := db.do(ctx, "DescribeTTL", table, func() (any, error) {
+		return db.driver.DescribeTTL(ctx, table)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.TTLConfig), nil
+}
+
+func (db *Database) UpdateStreamConfig(ctx context.Context, table string, cfg driver.StreamConfig) error {
+	_, err := db.do(ctx, "UpdateStreamConfig", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.UpdateStreamConfig(ctx, table, cfg)
+	})
+
+	return err
+}
+
+func (db *Database) GetStreamRecords(
+	ctx context.Context, table string, limit int, token string,
+) (*driver.StreamIterator, error) {
+	out, err := db.do(ctx, "GetStreamRecords", map[string]any{"table": table}, func() (any, error) {
+		return db.driver.GetStreamRecords(ctx, table, limit, token)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.StreamIterator), nil
+}
+
+func (db *Database) TransactWriteItems(
+	ctx context.Context, table string, puts []map[string]any, deletes []map[string]any,
+) error {
+	_, err := db.do(ctx, "TransactWriteItems", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.TransactWriteItems(ctx, table, puts, deletes)
+	})
+
+	return err
+}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,380 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/database/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDriver() (driver.Database, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return dynamodb.New(opts), fc
+}
+
+func newTestDatabase(opts ...Option) (*Database, *config.FakeClock) {
+	d, fc := newTestDriver()
+	return NewDatabase(d, opts...), fc
+}
+
+func setupTableWithItem(t *testing.T, db *Database) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{
+		Name:         "test-table",
+		PartitionKey: "pk",
+		SortKey:      "sk",
+	})
+	require.NoError(t, err)
+
+	err = db.PutItem(ctx, "test-table", map[string]any{"pk": "user1", "sk": "item1", "data": "hello"})
+	require.NoError(t, err)
+}
+
+func TestNewDatabase(t *testing.T) {
+	db, _ := newTestDatabase()
+
+	require.NotNil(t, db)
+	require.NotNil(t, db.driver)
+}
+
+func TestCreateTablePortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		err := db.CreateTable(ctx, driver.TableConfig{Name: "my-table", PartitionKey: "pk"})
+		require.NoError(t, err)
+	})
+
+	t.Run("duplicate error", func(t *testing.T) {
+		err := db.CreateTable(ctx, driver.TableConfig{Name: "my-table", PartitionKey: "pk"})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteTablePortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "del-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := db.DeleteTable(ctx, "del-table")
+		require.NoError(t, delErr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		delErr := db.DeleteTable(ctx, "nonexistent")
+		require.Error(t, delErr)
+	})
+}
+
+func TestDescribeTablePortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "desc-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		cfg, descErr := db.DescribeTable(ctx, "desc-table")
+		require.NoError(t, descErr)
+		assert.Equal(t, "desc-table", cfg.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, descErr := db.DescribeTable(ctx, "nonexistent")
+		require.Error(t, descErr)
+	})
+}
+
+func TestListTablesPortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	tables, err := db.ListTables(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tables))
+
+	err = db.CreateTable(ctx, driver.TableConfig{Name: "a", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	err = db.CreateTable(ctx, driver.TableConfig{Name: "b", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	tables, err = db.ListTables(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(tables))
+}
+
+func TestPutGetDeleteItemPortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	setupTableWithItem(t, db)
+
+	t.Run("get existing item", func(t *testing.T) {
+		item, err := db.GetItem(ctx, "test-table", map[string]any{"pk": "user1", "sk": "item1"})
+		require.NoError(t, err)
+		assert.Equal(t, "hello", item["data"])
+	})
+
+	t.Run("delete item", func(t *testing.T) {
+		err := db.DeleteItem(ctx, "test-table", map[string]any{"pk": "user1", "sk": "item1"})
+		require.NoError(t, err)
+
+		item, _ := db.GetItem(ctx, "test-table", map[string]any{"pk": "user1", "sk": "item1"})
+		assert.Nil(t, item)
+	})
+}
+
+func TestQueryPortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	setupTableWithItem(t, db)
+
+	result, err := db.Query(ctx, driver.QueryInput{
+		Table: "test-table",
+		KeyCondition: driver.KeyCondition{
+			PartitionKey: "pk",
+			PartitionVal: "user1",
+		},
+		ScanForward: true,
+	})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.Count, 1)
+}
+
+func TestScanPortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	setupTableWithItem(t, db)
+
+	result, err := db.Scan(ctx, driver.ScanInput{Table: "test-table"})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.Count, 1)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	db, _ := newTestDatabase(WithRecorder(rec))
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "rec-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	err = db.PutItem(ctx, "rec-table", map[string]any{"pk": "k1", "data": "v"})
+	require.NoError(t, err)
+
+	_, err = db.GetItem(ctx, "rec-table", map[string]any{"pk": "k1"})
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 3)
+
+	createCalls := rec.CallCountFor("database", "CreateTable")
+	assert.Equal(t, 1, createCalls)
+
+	putCalls := rec.CallCountFor("database", "PutItem")
+	assert.Equal(t, 1, putCalls)
+
+	getCalls := rec.CallCountFor("database", "GetItem")
+	assert.Equal(t, 1, getCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	db, _ := newTestDatabase(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = db.DescribeTable(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	db, _ := newTestDatabase(WithMetrics(mc))
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "met-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	err = db.PutItem(ctx, "met-table", map[string]any{"pk": "k1", "data": "v"})
+	require.NoError(t, err)
+
+	_, err = db.GetItem(ctx, "met-table", map[string]any{"pk": "k1"})
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 3)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 3)
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	db, _ := newTestDatabase(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = db.DescribeTable(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	db, _ := newTestDatabase(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("database", "CreateTable", injectedErr, inject.Always{})
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "fail-table", PartitionKey: "pk"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	db, _ := newTestDatabase(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("database", "PutItem", injectedErr, inject.Always{})
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "inj-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	err = db.PutItem(ctx, "inj-table", map[string]any{"pk": "k1"})
+	require.Error(t, err)
+
+	putCalls := rec.CallsFor("database", "PutItem")
+	assert.Equal(t, 1, len(putCalls))
+	assert.NotNil(t, putCalls[0].Error, "expected recorded PutItem call to have an error")
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	db, _ := newTestDatabase(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("database", "CreateTable", injectedErr, inject.Always{})
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "test", PartitionKey: "pk"})
+	require.Error(t, err)
+
+	inj.Remove("database", "CreateTable")
+
+	err = db.CreateTable(ctx, driver.TableConfig{Name: "test", PartitionKey: "pk"})
+	require.NoError(t, err)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	d := dynamodb.New(opts)
+	limiter := ratelimit.New(1, 1, fc)
+	db := NewDatabase(d, WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "rl-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	_, err = db.ListTables(ctx)
+	require.Error(t, err, "expected rate limit error on second call without time advance")
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	db, _ := newTestDatabase(WithLatency(latency))
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "lat-table", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	tables, err := db.ListTables(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(tables))
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	db, _ := newTestDatabase(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	err := db.CreateTable(ctx, driver.TableConfig{Name: "all-opts", PartitionKey: "pk"})
+	require.NoError(t, err)
+
+	err = db.PutItem(ctx, "all-opts", map[string]any{"pk": "k1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableDeleteTableError(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	err := db.DeleteTable(ctx, "no-table")
+	require.Error(t, err)
+}
+
+func TestPortableGetItemError(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	_, err := db.GetItem(ctx, "no-table", map[string]any{"pk": "k1"})
+	require.Error(t, err)
+}
+
+func TestPortablePutItemError(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	err := db.PutItem(ctx, "no-table", map[string]any{"pk": "k1"})
+	require.Error(t, err)
+}

--- a/database/driver/driver.go
+++ b/database/driver/driver.go
@@ -1,7 +1,41 @@
 // Package driver defines the interface for database service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// TTLConfig configures TTL for a table.
+type TTLConfig struct {
+	Enabled       bool
+	AttributeName string // the field containing the TTL timestamp
+}
+
+// StreamRecord represents a change event in a stream.
+type StreamRecord struct {
+	EventID        string
+	EventType      string // "INSERT", "MODIFY", "REMOVE"
+	Table          string
+	Keys           map[string]any
+	NewImage       map[string]any
+	OldImage       map[string]any
+	Timestamp      time.Time
+	SequenceNumber string
+}
+
+// StreamConfig configures streams for a table.
+type StreamConfig struct {
+	Enabled  bool
+	ViewType string // "NEW_IMAGE", "OLD_IMAGE", "NEW_AND_OLD_IMAGES", "KEYS_ONLY"
+}
+
+// StreamIterator allows reading stream records.
+type StreamIterator struct {
+	ShardID   string
+	Records   []StreamRecord
+	NextToken string
+}
 
 // TableConfig describes a table to create.
 type TableConfig struct {
@@ -74,4 +108,15 @@ type Database interface {
 
 	BatchPutItems(ctx context.Context, table string, items []map[string]any) error
 	BatchGetItems(ctx context.Context, table string, keys []map[string]any) ([]map[string]any, error)
+
+	// TTL
+	UpdateTTL(ctx context.Context, table string, config TTLConfig) error
+	DescribeTTL(ctx context.Context, table string) (*TTLConfig, error)
+
+	// Streams / Change Feed
+	UpdateStreamConfig(ctx context.Context, table string, config StreamConfig) error
+	GetStreamRecords(ctx context.Context, table string, limit int, token string) (*StreamIterator, error)
+
+	// Transactional writes
+	TransactWriteItems(ctx context.Context, table string, puts []map[string]any, deletes []map[string]any) error
 }

--- a/dns/dns_test.go
+++ b/dns/dns_test.go
@@ -1,0 +1,496 @@
+package dns
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/dns/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDriver implements driver.DNS for testing the portable wrapper.
+type mockDriver struct {
+	zones   map[string]*driver.ZoneInfo
+	records map[string]map[string]*driver.RecordInfo // zoneID -> "name|type" -> record
+	seq     int
+}
+
+func newMockDriver() *mockDriver {
+	return &mockDriver{
+		zones:   make(map[string]*driver.ZoneInfo),
+		records: make(map[string]map[string]*driver.RecordInfo),
+	}
+}
+
+func (m *mockDriver) nextID(prefix string) string {
+	m.seq++
+
+	return fmt.Sprintf("%s-%d", prefix, m.seq)
+}
+
+func recordKey(name, recordType string) string {
+	return name + "|" + recordType
+}
+
+func (m *mockDriver) CreateZone(_ context.Context, config driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	id := m.nextID("zone")
+	info := &driver.ZoneInfo{ID: id, Name: config.Name, Private: config.Private, Tags: config.Tags}
+	m.zones[id] = info
+	m.records[id] = make(map[string]*driver.RecordInfo)
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteZone(_ context.Context, id string) error {
+	if _, ok := m.zones[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.zones, id)
+	delete(m.records, id)
+
+	return nil
+}
+
+func (m *mockDriver) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
+	info, ok := m.zones[id]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+	result := make([]driver.ZoneInfo, 0, len(m.zones))
+	for _, info := range m.zones {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateRecord(_ context.Context, config driver.RecordConfig) (*driver.RecordInfo, error) {
+	zoneRecords, ok := m.records[config.ZoneID]
+	if !ok {
+		return nil, fmt.Errorf("zone not found")
+	}
+
+	key := recordKey(config.Name, config.Type)
+
+	if _, ok := zoneRecords[key]; ok {
+		return nil, fmt.Errorf("record already exists")
+	}
+
+	info := &driver.RecordInfo{ZoneID: config.ZoneID, Name: config.Name, Type: config.Type, TTL: config.TTL, Values: config.Values}
+	zoneRecords[key] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteRecord(_ context.Context, zoneID, name, recordType string) error {
+	zoneRecords, ok := m.records[zoneID]
+	if !ok {
+		return fmt.Errorf("zone not found")
+	}
+
+	key := recordKey(name, recordType)
+
+	if _, ok := zoneRecords[key]; !ok {
+		return fmt.Errorf("record not found")
+	}
+
+	delete(zoneRecords, key)
+
+	return nil
+}
+
+func (m *mockDriver) GetRecord(_ context.Context, zoneID, name, recordType string) (*driver.RecordInfo, error) {
+	zoneRecords, ok := m.records[zoneID]
+	if !ok {
+		return nil, fmt.Errorf("zone not found")
+	}
+
+	key := recordKey(name, recordType)
+
+	info, ok := zoneRecords[key]
+	if !ok {
+		return nil, fmt.Errorf("record not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInfo, error) {
+	zoneRecords, ok := m.records[zoneID]
+	if !ok {
+		return nil, fmt.Errorf("zone not found")
+	}
+
+	result := make([]driver.RecordInfo, 0, len(zoneRecords))
+	for _, info := range zoneRecords {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) UpdateRecord(_ context.Context, config driver.RecordConfig) (*driver.RecordInfo, error) {
+	zoneRecords, ok := m.records[config.ZoneID]
+	if !ok {
+		return nil, fmt.Errorf("zone not found")
+	}
+
+	key := recordKey(config.Name, config.Type)
+
+	info, ok := zoneRecords[key]
+	if !ok {
+		return nil, fmt.Errorf("record not found")
+	}
+
+	info.TTL = config.TTL
+	info.Values = config.Values
+
+	return info, nil
+}
+
+func newTestDNS(opts ...Option) *DNS {
+	return NewDNS(newMockDriver(), opts...)
+}
+
+func setupZone(t *testing.T, d *DNS, name string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	info, err := d.CreateZone(ctx, driver.ZoneConfig{Name: name})
+	require.NoError(t, err)
+
+	return info.ID
+}
+
+func TestNewDNS(t *testing.T) {
+	d := newTestDNS()
+	require.NotNil(t, d)
+	require.NotNil(t, d.driver)
+}
+
+func TestCreateZone(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+		require.NoError(t, err)
+		assert.Equal(t, "example.com", info.Name)
+		assert.NotEmpty(t, info.ID)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := d.CreateZone(ctx, driver.ZoneConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteZone(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "del.example.com")
+
+	t.Run("success", func(t *testing.T) {
+		err := d.DeleteZone(ctx, zoneID)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := d.DeleteZone(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetZone(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "get.example.com")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := d.GetZone(ctx, zoneID)
+		require.NoError(t, err)
+		assert.Equal(t, "get.example.com", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := d.GetZone(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListZones(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+
+	zones, err := d.ListZones(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(zones))
+
+	setupZone(t, d, "a.example.com")
+	setupZone(t, d, "b.example.com")
+
+	zones, err = d.ListZones(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(zones))
+}
+
+func TestCreateRecord(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "rec.example.com")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := d.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zoneID, Name: "www", Type: "A", TTL: 300, Values: []string{"1.2.3.4"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "www", info.Name)
+		assert.Equal(t, "A", info.Type)
+	})
+
+	t.Run("zone not found", func(t *testing.T) {
+		_, err := d.CreateRecord(ctx, driver.RecordConfig{ZoneID: "nonexistent", Name: "www", Type: "A"})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteRecord(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "delrec.example.com")
+
+	_, err := d.CreateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "www", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := d.DeleteRecord(ctx, zoneID, "www", "A")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := d.DeleteRecord(ctx, zoneID, "nonexistent", "A")
+		require.Error(t, err)
+	})
+}
+
+func TestGetRecord(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "getrec.example.com")
+
+	_, err := d.CreateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "www", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := d.GetRecord(ctx, zoneID, "www", "A")
+		require.NoError(t, err)
+		assert.Equal(t, "www", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := d.GetRecord(ctx, zoneID, "nonexistent", "A")
+		require.Error(t, err)
+	})
+}
+
+func TestListRecords(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "listrec.example.com")
+
+	_, err := d.CreateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "www", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+	require.NoError(t, err)
+
+	_, err = d.CreateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "mail", Type: "MX", TTL: 300, Values: []string{"10 mail.example.com"}})
+	require.NoError(t, err)
+
+	records, err := d.ListRecords(ctx, zoneID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(records))
+}
+
+func TestUpdateRecord(t *testing.T) {
+	d := newTestDNS()
+	ctx := context.Background()
+	zoneID := setupZone(t, d, "updrec.example.com")
+
+	_, err := d.CreateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "www", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := d.UpdateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "www", Type: "A", TTL: 600, Values: []string{"5.6.7.8"}})
+		require.NoError(t, err)
+		assert.Equal(t, 600, info.TTL)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := d.UpdateRecord(ctx, driver.RecordConfig{ZoneID: zoneID, Name: "nonexistent", Type: "A"})
+		require.Error(t, err)
+	})
+}
+
+func TestDNSWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	d := newTestDNS(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "rec.example.com"})
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 1)
+
+	createCalls := rec.CallCountFor("dns", "CreateZone")
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestDNSWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	d := newTestDNS(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = d.GetZone(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last)
+	assert.NotNil(t, last.Error)
+}
+
+func TestDNSWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	d := newTestDNS(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "met.example.com"})
+	require.NoError(t, err)
+
+	_, err = d.GetZone(ctx, "zone-1")
+	// May or may not error; we care about metrics being collected.
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 2)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 2)
+}
+
+func TestDNSWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	d := newTestDNS(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = d.GetZone(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestDNSWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	d := newTestDNS(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("dns", "CreateZone", injectedErr, inject.Always{})
+
+	_, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "fail.example.com"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestDNSWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	d := newTestDNS(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("dns", "GetZone", injectedErr, inject.Always{})
+
+	_, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "inj.example.com"})
+	require.NoError(t, err)
+
+	_, err = d.GetZone(ctx, "zone-1")
+	require.Error(t, err)
+
+	getCalls := rec.CallsFor("dns", "GetZone")
+	assert.Equal(t, 1, len(getCalls))
+	assert.NotNil(t, getCalls[0].Error)
+}
+
+func TestDNSWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	d := newTestDNS(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("dns", "CreateZone", injectedErr, inject.Always{})
+
+	_, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "test.example.com"})
+	require.Error(t, err)
+
+	inj.Remove("dns", "CreateZone")
+
+	_, err = d.CreateZone(ctx, driver.ZoneConfig{Name: "test.example.com"})
+	require.NoError(t, err)
+}
+
+func TestDNSWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	d := newTestDNS(WithLatency(latency))
+	ctx := context.Background()
+
+	info, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "lat.example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "lat.example.com", info.Name)
+}
+
+func TestDNSAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	d := NewDNS(newMockDriver(),
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := d.CreateZone(ctx, driver.ZoneConfig{Name: "all.example.com"})
+	require.NoError(t, err)
+
+	_, err = d.ListZones(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}

--- a/eventbus/driver/driver.go
+++ b/eventbus/driver/driver.go
@@ -1,0 +1,95 @@
+// Package driver defines the interface for event bus service implementations.
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// EventBusInfo describes an event bus.
+type EventBusInfo struct {
+	Name      string
+	ARN       string // provider-specific identifier
+	State     string // "ACTIVE", "INACTIVE"
+	CreatedAt string
+	Tags      map[string]string
+}
+
+// EventBusConfig configures a new event bus.
+type EventBusConfig struct {
+	Name string
+	Tags map[string]string
+}
+
+// Rule defines an event routing rule with filtering.
+type Rule struct {
+	Name         string
+	EventBus     string
+	Description  string
+	EventPattern string // JSON pattern for event matching
+	State        string // "ENABLED", "DISABLED"
+	Targets      []Target
+	CreatedAt    string
+}
+
+// RuleConfig configures a new rule.
+type RuleConfig struct {
+	Name         string
+	EventBus     string
+	Description  string
+	EventPattern string
+	State        string
+}
+
+// Target is a destination for matched events.
+type Target struct {
+	ID    string
+	ARN   string // target resource identifier
+	Input string // optional input transformation
+}
+
+// Event represents an event to publish.
+type Event struct {
+	ID         string
+	Source     string
+	DetailType string
+	Detail     string // JSON string
+	Time       time.Time
+	EventBus   string
+	Resources  []string
+}
+
+// PublishResult is the result of publishing events.
+type PublishResult struct {
+	SuccessCount int
+	FailCount    int
+	EventIDs     []string
+}
+
+// EventBus is the interface that event bus provider implementations must satisfy.
+type EventBus interface {
+	// Bus management
+	CreateEventBus(ctx context.Context, config EventBusConfig) (*EventBusInfo, error)
+	DeleteEventBus(ctx context.Context, name string) error
+	GetEventBus(ctx context.Context, name string) (*EventBusInfo, error)
+	ListEventBuses(ctx context.Context) ([]EventBusInfo, error)
+
+	// Rule management
+	PutRule(ctx context.Context, config *RuleConfig) (*Rule, error)
+	DeleteRule(ctx context.Context, eventBus, ruleName string) error
+	GetRule(ctx context.Context, eventBus, ruleName string) (*Rule, error)
+	ListRules(ctx context.Context, eventBus string) ([]Rule, error)
+	EnableRule(ctx context.Context, eventBus, ruleName string) error
+	DisableRule(ctx context.Context, eventBus, ruleName string) error
+
+	// Target management
+	PutTargets(ctx context.Context, eventBus, ruleName string, targets []Target) error
+	RemoveTargets(ctx context.Context, eventBus, ruleName string, targetIDs []string) error
+	ListTargets(ctx context.Context, eventBus, ruleName string) ([]Target, error)
+
+	// Event publishing
+	PutEvents(ctx context.Context, events []Event) (*PublishResult, error)
+
+	// Event history (replay)
+	GetEventHistory(ctx context.Context, eventBus string, limit int) ([]Event, error)
+}

--- a/eventbus/eventbus.go
+++ b/eventbus/eventbus.go
@@ -1,0 +1,260 @@
+// Package eventbus provides a portable event bus API with cross-cutting concerns.
+package eventbus
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+)
+
+// EventBus is the portable event bus type wrapping a driver with cross-cutting concerns.
+type EventBus struct {
+	driver   driver.EventBus
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// NewEventBus creates a new portable EventBus wrapping the given driver.
+func NewEventBus(d driver.EventBus, opts ...Option) *EventBus {
+	eb := &EventBus{driver: d}
+	for _, opt := range opts {
+		opt(eb)
+	}
+
+	return eb
+}
+
+// Option configures a portable EventBus.
+type Option func(*EventBus)
+
+// WithRecorder sets the recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(eb *EventBus) { eb.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(eb *EventBus) { eb.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(eb *EventBus) { eb.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(eb *EventBus) { eb.injector = i } }
+
+// WithLatency sets simulated latency.
+func WithLatency(d time.Duration) Option { return func(eb *EventBus) { eb.latency = d } }
+
+func (eb *EventBus) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if eb.injector != nil {
+		if err := eb.injector.Check("eventbus", op); err != nil {
+			eb.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if eb.limiter != nil {
+		if err := eb.limiter.Allow(); err != nil {
+			eb.rec(op, input, nil, err, time.Since(start))
+			return nil, err
+		}
+	}
+
+	if eb.latency > 0 {
+		time.Sleep(eb.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if eb.metrics != nil {
+		labels := map[string]string{"service": "eventbus", "operation": op}
+		eb.metrics.Counter("calls_total", 1, labels)
+		eb.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			eb.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	eb.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (eb *EventBus) rec(op string, input, output any, err error, dur time.Duration) {
+	if eb.recorder != nil {
+		eb.recorder.Record("eventbus", op, input, output, err, dur)
+	}
+}
+
+// CreateEventBus creates a new event bus.
+func (eb *EventBus) CreateEventBus(ctx context.Context, config driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	out, err := eb.do(ctx, "CreateEventBus", config, func() (any, error) {
+		return eb.driver.CreateEventBus(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.EventBusInfo), nil
+}
+
+// DeleteEventBus deletes an event bus.
+func (eb *EventBus) DeleteEventBus(ctx context.Context, name string) error {
+	_, err := eb.do(ctx, "DeleteEventBus", name, func() (any, error) {
+		return nil, eb.driver.DeleteEventBus(ctx, name)
+	})
+
+	return err
+}
+
+// GetEventBus retrieves event bus info.
+func (eb *EventBus) GetEventBus(ctx context.Context, name string) (*driver.EventBusInfo, error) {
+	out, err := eb.do(ctx, "GetEventBus", name, func() (any, error) {
+		return eb.driver.GetEventBus(ctx, name)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.EventBusInfo), nil
+}
+
+// ListEventBuses lists all event buses.
+func (eb *EventBus) ListEventBuses(ctx context.Context) ([]driver.EventBusInfo, error) {
+	out, err := eb.do(ctx, "ListEventBuses", nil, func() (any, error) {
+		return eb.driver.ListEventBuses(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.EventBusInfo), nil
+}
+
+// PutRule creates or updates a rule.
+func (eb *EventBus) PutRule(ctx context.Context, config *driver.RuleConfig) (*driver.Rule, error) {
+	out, err := eb.do(ctx, "PutRule", config, func() (any, error) {
+		return eb.driver.PutRule(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Rule), nil
+}
+
+// DeleteRule deletes a rule.
+func (eb *EventBus) DeleteRule(ctx context.Context, eventBus, ruleName string) error {
+	_, err := eb.do(ctx, "DeleteRule", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return nil, eb.driver.DeleteRule(ctx, eventBus, ruleName)
+	})
+
+	return err
+}
+
+// GetRule retrieves a rule.
+func (eb *EventBus) GetRule(ctx context.Context, eventBus, ruleName string) (*driver.Rule, error) {
+	out, err := eb.do(ctx, "GetRule", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return eb.driver.GetRule(ctx, eventBus, ruleName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Rule), nil
+}
+
+// ListRules lists all rules for an event bus.
+func (eb *EventBus) ListRules(ctx context.Context, eventBus string) ([]driver.Rule, error) {
+	out, err := eb.do(ctx, "ListRules", eventBus, func() (any, error) {
+		return eb.driver.ListRules(ctx, eventBus)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Rule), nil
+}
+
+// EnableRule enables a rule.
+func (eb *EventBus) EnableRule(ctx context.Context, eventBus, ruleName string) error {
+	_, err := eb.do(ctx, "EnableRule", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return nil, eb.driver.EnableRule(ctx, eventBus, ruleName)
+	})
+
+	return err
+}
+
+// DisableRule disables a rule.
+func (eb *EventBus) DisableRule(ctx context.Context, eventBus, ruleName string) error {
+	_, err := eb.do(ctx, "DisableRule", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return nil, eb.driver.DisableRule(ctx, eventBus, ruleName)
+	})
+
+	return err
+}
+
+// PutTargets adds targets to a rule.
+func (eb *EventBus) PutTargets(
+	ctx context.Context, eventBus, ruleName string, targets []driver.Target,
+) error {
+	_, err := eb.do(ctx, "PutTargets", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return nil, eb.driver.PutTargets(ctx, eventBus, ruleName, targets)
+	})
+
+	return err
+}
+
+// RemoveTargets removes targets from a rule.
+func (eb *EventBus) RemoveTargets(ctx context.Context, eventBus, ruleName string, targetIDs []string) error {
+	_, err := eb.do(ctx, "RemoveTargets", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return nil, eb.driver.RemoveTargets(ctx, eventBus, ruleName, targetIDs)
+	})
+
+	return err
+}
+
+// ListTargets lists targets for a rule.
+func (eb *EventBus) ListTargets(ctx context.Context, eventBus, ruleName string) ([]driver.Target, error) {
+	out, err := eb.do(ctx, "ListTargets", map[string]string{"eventBus": eventBus, "rule": ruleName}, func() (any, error) {
+		return eb.driver.ListTargets(ctx, eventBus, ruleName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Target), nil
+}
+
+// PutEvents publishes events to the event bus.
+func (eb *EventBus) PutEvents(ctx context.Context, events []driver.Event) (*driver.PublishResult, error) {
+	out, err := eb.do(ctx, "PutEvents", events, func() (any, error) {
+		return eb.driver.PutEvents(ctx, events)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PublishResult), nil
+}
+
+// GetEventHistory retrieves event history for replay.
+func (eb *EventBus) GetEventHistory(ctx context.Context, eventBus string, limit int) ([]driver.Event, error) {
+	out, err := eb.do(ctx, "GetEventHistory", map[string]any{"eventBus": eventBus, "limit": limit}, func() (any, error) {
+		return eb.driver.GetEventHistory(ctx, eventBus, limit)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Event), nil
+}

--- a/eventbus/eventbus_test.go
+++ b/eventbus/eventbus_test.go
@@ -1,0 +1,351 @@
+package eventbus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/eventbridge"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDriver() (driver.EventBus, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return eventbridge.New(opts), fc
+}
+
+func newTestEventBus(opts ...Option) (*EventBus, *config.FakeClock) {
+	d, fc := newTestDriver()
+	return NewEventBus(d, opts...), fc
+}
+
+func TestNewEventBus(t *testing.T) {
+	eb, _ := newTestEventBus()
+
+	require.NotNil(t, eb)
+	require.NotNil(t, eb.driver)
+}
+
+func TestCreateEventBusPortable(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "my-bus"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-bus", info.Name)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteEventBusPortable(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "del-bus"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := eb.DeleteEventBus(ctx, "del-bus")
+		require.NoError(t, delErr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		delErr := eb.DeleteEventBus(ctx, "nonexistent")
+		require.Error(t, delErr)
+	})
+}
+
+func TestGetEventBusPortable(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "get-bus"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, getErr := eb.GetEventBus(ctx, "get-bus")
+		require.NoError(t, getErr)
+		assert.Equal(t, "get-bus", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, getErr := eb.GetEventBus(ctx, "nonexistent")
+		require.Error(t, getErr)
+	})
+}
+
+func TestListEventBusesPortable(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	buses, err := eb.ListEventBuses(ctx)
+	require.NoError(t, err)
+	initialCount := len(buses)
+
+	_, err = eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "a"})
+	require.NoError(t, err)
+
+	_, err = eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "b"})
+	require.NoError(t, err)
+
+	buses, err = eb.ListEventBuses(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, initialCount+2, len(buses))
+}
+
+func TestPutRulePortable(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "rule-bus"})
+	require.NoError(t, err)
+
+	rule, err := eb.PutRule(ctx, &driver.RuleConfig{
+		Name:         "my-rule",
+		EventBus:     "rule-bus",
+		EventPattern: `{"source": ["my.app"]}`,
+		State:        "ENABLED",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-rule", rule.Name)
+}
+
+func TestPutEventsPortable(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "evt-bus"})
+	require.NoError(t, err)
+
+	result, err := eb.PutEvents(ctx, []driver.Event{
+		{
+			Source:     "my.app",
+			DetailType: "MyEvent",
+			Detail:     `{"key": "value"}`,
+			EventBus:   "evt-bus",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.SuccessCount)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	eb, _ := newTestEventBus(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "rec-bus"})
+	require.NoError(t, err)
+
+	_, err = eb.GetEventBus(ctx, "rec-bus")
+	require.NoError(t, err)
+
+	_, err = eb.ListEventBuses(ctx)
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 3)
+
+	createCalls := rec.CallCountFor("eventbus", "CreateEventBus")
+	assert.Equal(t, 1, createCalls)
+
+	getCalls := rec.CallCountFor("eventbus", "GetEventBus")
+	assert.Equal(t, 1, getCalls)
+
+	listCalls := rec.CallCountFor("eventbus", "ListEventBuses")
+	assert.Equal(t, 1, listCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	eb, _ := newTestEventBus(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = eb.GetEventBus(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	eb, _ := newTestEventBus(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "met-bus"})
+	require.NoError(t, err)
+
+	_, err = eb.GetEventBus(ctx, "met-bus")
+	require.NoError(t, err)
+
+	_, err = eb.ListEventBuses(ctx)
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 3)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 3)
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	eb, _ := newTestEventBus(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = eb.GetEventBus(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	eb, _ := newTestEventBus(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("eventbus", "CreateEventBus", injectedErr, inject.Always{})
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "fail-bus"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	eb, _ := newTestEventBus(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("eventbus", "GetEventBus", injectedErr, inject.Always{})
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "inj-bus"})
+	require.NoError(t, err)
+
+	_, err = eb.GetEventBus(ctx, "inj-bus")
+	require.Error(t, err)
+
+	getCalls := rec.CallsFor("eventbus", "GetEventBus")
+	assert.Equal(t, 1, len(getCalls))
+	assert.NotNil(t, getCalls[0].Error, "expected recorded GetEventBus call to have an error")
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	eb, _ := newTestEventBus(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("eventbus", "CreateEventBus", injectedErr, inject.Always{})
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "test"})
+	require.Error(t, err)
+
+	inj.Remove("eventbus", "CreateEventBus")
+
+	_, err = eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "test"})
+	require.NoError(t, err)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	d := eventbridge.New(opts)
+	limiter := ratelimit.New(1, 1, fc)
+	eb := NewEventBus(d, WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "rl-bus"})
+	require.NoError(t, err)
+
+	_, err = eb.GetEventBus(ctx, "rl-bus")
+	require.Error(t, err, "expected rate limit error on second call without time advance")
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	eb, _ := newTestEventBus(WithLatency(latency))
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "lat-bus"})
+	require.NoError(t, err)
+
+	info, err := eb.GetEventBus(ctx, "lat-bus")
+	require.NoError(t, err)
+	assert.Equal(t, "lat-bus", info.Name)
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	eb, _ := newTestEventBus(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := eb.CreateEventBus(ctx, driver.EventBusConfig{Name: "all-opts"})
+	require.NoError(t, err)
+
+	_, err = eb.GetEventBus(ctx, "all-opts")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableDeleteEventBusError(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	err := eb.DeleteEventBus(ctx, "no-bus")
+	require.Error(t, err)
+}
+
+func TestPortableDeleteRuleError(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	err := eb.DeleteRule(ctx, "no-bus", "no-rule")
+	require.Error(t, err)
+}
+
+func TestPortableGetRuleError(t *testing.T) {
+	eb, _ := newTestEventBus()
+	ctx := context.Background()
+
+	_, err := eb.GetRule(ctx, "no-bus", "no-rule")
+	require.Error(t, err)
+}

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -1,0 +1,715 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/iam/driver"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDriver implements driver.IAM for testing the portable wrapper.
+type mockDriver struct {
+	users          map[string]*driver.UserInfo
+	roles          map[string]*driver.RoleInfo
+	policies       map[string]*driver.PolicyInfo
+	userPolicies   map[string][]string // userName -> []policyARN
+	rolePolicies   map[string][]string // roleName -> []policyARN
+	seq            int
+}
+
+func newMockDriver() *mockDriver {
+	return &mockDriver{
+		users:        make(map[string]*driver.UserInfo),
+		roles:        make(map[string]*driver.RoleInfo),
+		policies:     make(map[string]*driver.PolicyInfo),
+		userPolicies: make(map[string][]string),
+		rolePolicies: make(map[string][]string),
+	}
+}
+
+func (m *mockDriver) nextID(prefix string) string {
+	m.seq++
+
+	return fmt.Sprintf("%s-%d", prefix, m.seq)
+}
+
+func (m *mockDriver) CreateUser(_ context.Context, config driver.UserConfig) (*driver.UserInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	if _, ok := m.users[config.Name]; ok {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	info := &driver.UserInfo{
+		Name: config.Name,
+		ID:   m.nextID("user"),
+		ARN:  "arn:aws:iam::123456789012:user/" + config.Name,
+		Path: config.Path,
+		Tags: config.Tags,
+	}
+	m.users[config.Name] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteUser(_ context.Context, name string) error {
+	if _, ok := m.users[name]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.users, name)
+	delete(m.userPolicies, name)
+
+	return nil
+}
+
+func (m *mockDriver) GetUser(_ context.Context, name string) (*driver.UserInfo, error) {
+	info, ok := m.users[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListUsers(_ context.Context) ([]driver.UserInfo, error) {
+	result := make([]driver.UserInfo, 0, len(m.users))
+	for _, info := range m.users {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateRole(_ context.Context, config driver.RoleConfig) (*driver.RoleInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	if _, ok := m.roles[config.Name]; ok {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	info := &driver.RoleInfo{
+		Name: config.Name,
+		ID:   m.nextID("role"),
+		ARN:  "arn:aws:iam::123456789012:role/" + config.Name,
+		Path: config.Path,
+	}
+	m.roles[config.Name] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteRole(_ context.Context, name string) error {
+	if _, ok := m.roles[name]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.roles, name)
+	delete(m.rolePolicies, name)
+
+	return nil
+}
+
+func (m *mockDriver) GetRole(_ context.Context, name string) (*driver.RoleInfo, error) {
+	info, ok := m.roles[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListRoles(_ context.Context) ([]driver.RoleInfo, error) {
+	result := make([]driver.RoleInfo, 0, len(m.roles))
+	for _, info := range m.roles {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreatePolicy(_ context.Context, config driver.PolicyConfig) (*driver.PolicyInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	arn := "arn:aws:iam::123456789012:policy/" + config.Name
+
+	if _, ok := m.policies[arn]; ok {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	info := &driver.PolicyInfo{
+		Name:           config.Name,
+		ID:             m.nextID("policy"),
+		ARN:            arn,
+		Path:           config.Path,
+		PolicyDocument: config.PolicyDocument,
+		Description:    config.Description,
+	}
+	m.policies[arn] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeletePolicy(_ context.Context, arn string) error {
+	if _, ok := m.policies[arn]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.policies, arn)
+
+	return nil
+}
+
+func (m *mockDriver) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, error) {
+	info, ok := m.policies[arn]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
+	result := make([]driver.PolicyInfo, 0, len(m.policies))
+	for _, info := range m.policies {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) AttachUserPolicy(_ context.Context, userName, policyARN string) error {
+	if _, ok := m.users[userName]; !ok {
+		return fmt.Errorf("user not found")
+	}
+
+	m.userPolicies[userName] = append(m.userPolicies[userName], policyARN)
+
+	return nil
+}
+
+func (m *mockDriver) DetachUserPolicy(_ context.Context, userName, _ string) error {
+	if _, ok := m.users[userName]; !ok {
+		return fmt.Errorf("user not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) AttachRolePolicy(_ context.Context, roleName, policyARN string) error {
+	if _, ok := m.roles[roleName]; !ok {
+		return fmt.Errorf("role not found")
+	}
+
+	m.rolePolicies[roleName] = append(m.rolePolicies[roleName], policyARN)
+
+	return nil
+}
+
+func (m *mockDriver) DetachRolePolicy(_ context.Context, roleName, _ string) error {
+	if _, ok := m.roles[roleName]; !ok {
+		return fmt.Errorf("role not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) ListAttachedUserPolicies(_ context.Context, userName string) ([]string, error) {
+	if _, ok := m.users[userName]; !ok {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	return m.userPolicies[userName], nil
+}
+
+func (m *mockDriver) ListAttachedRolePolicies(_ context.Context, roleName string) ([]string, error) {
+	if _, ok := m.roles[roleName]; !ok {
+		return nil, fmt.Errorf("role not found")
+	}
+
+	return m.rolePolicies[roleName], nil
+}
+
+func (m *mockDriver) CheckPermission(_ context.Context, principal, _, _ string) (bool, error) {
+	if _, ok := m.users[principal]; !ok {
+		if _, ok2 := m.roles[principal]; !ok2 {
+			return false, fmt.Errorf("principal not found")
+		}
+	}
+
+	return true, nil
+}
+
+func newTestIAM(opts ...Option) *IAM {
+	return NewIAM(newMockDriver(), opts...)
+}
+
+func TestNewIAM(t *testing.T) {
+	i := newTestIAM()
+	require.NotNil(t, i)
+	require.NotNil(t, i.driver)
+}
+
+func TestCreateUser(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := i.CreateUser(ctx, driver.UserConfig{Name: "alice"})
+		require.NoError(t, err)
+		assert.Equal(t, "alice", info.Name)
+		assert.NotEmpty(t, info.ARN)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := i.CreateUser(ctx, driver.UserConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteUser(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "bob"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := i.DeleteUser(ctx, "bob")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := i.DeleteUser(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetUser(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "carol"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := i.GetUser(ctx, "carol")
+		require.NoError(t, err)
+		assert.Equal(t, "carol", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := i.GetUser(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListUsers(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	users, err := i.ListUsers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(users))
+
+	_, err = i.CreateUser(ctx, driver.UserConfig{Name: "u1"})
+	require.NoError(t, err)
+
+	_, err = i.CreateUser(ctx, driver.UserConfig{Name: "u2"})
+	require.NoError(t, err)
+
+	users, err = i.ListUsers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(users))
+}
+
+func TestCreateRole(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := i.CreateRole(ctx, driver.RoleConfig{Name: "admin"})
+		require.NoError(t, err)
+		assert.Equal(t, "admin", info.Name)
+		assert.NotEmpty(t, info.ARN)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := i.CreateRole(ctx, driver.RoleConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteRole(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateRole(ctx, driver.RoleConfig{Name: "del-role"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := i.DeleteRole(ctx, "del-role")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := i.DeleteRole(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetRole(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateRole(ctx, driver.RoleConfig{Name: "get-role"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := i.GetRole(ctx, "get-role")
+		require.NoError(t, err)
+		assert.Equal(t, "get-role", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := i.GetRole(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListRoles(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	roles, err := i.ListRoles(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(roles))
+
+	_, err = i.CreateRole(ctx, driver.RoleConfig{Name: "r1"})
+	require.NoError(t, err)
+
+	_, err = i.CreateRole(ctx, driver.RoleConfig{Name: "r2"})
+	require.NoError(t, err)
+
+	roles, err = i.ListRoles(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(roles))
+}
+
+func TestCreatePolicy(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := i.CreatePolicy(ctx, driver.PolicyConfig{Name: "my-policy", PolicyDocument: "{}"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-policy", info.Name)
+		assert.NotEmpty(t, info.ARN)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := i.CreatePolicy(ctx, driver.PolicyConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeletePolicy(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	pol, err := i.CreatePolicy(ctx, driver.PolicyConfig{Name: "del-policy"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := i.DeletePolicy(ctx, pol.ARN)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := i.DeletePolicy(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetPolicy(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	pol, err := i.CreatePolicy(ctx, driver.PolicyConfig{Name: "get-policy"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := i.GetPolicy(ctx, pol.ARN)
+		require.NoError(t, err)
+		assert.Equal(t, "get-policy", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := i.GetPolicy(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListPolicies(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	policies, err := i.ListPolicies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(policies))
+
+	_, err = i.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1"})
+	require.NoError(t, err)
+
+	_, err = i.CreatePolicy(ctx, driver.PolicyConfig{Name: "p2"})
+	require.NoError(t, err)
+
+	policies, err = i.ListPolicies(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(policies))
+}
+
+func TestAttachDetachUserPolicy(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "pol-user"})
+	require.NoError(t, err)
+
+	t.Run("attach success", func(t *testing.T) {
+		err := i.AttachUserPolicy(ctx, "pol-user", "arn:aws:iam::123456789012:policy/test")
+		require.NoError(t, err)
+	})
+
+	t.Run("list attached", func(t *testing.T) {
+		pols, err := i.ListAttachedUserPolicies(ctx, "pol-user")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(pols))
+	})
+
+	t.Run("detach success", func(t *testing.T) {
+		err := i.DetachUserPolicy(ctx, "pol-user", "arn:aws:iam::123456789012:policy/test")
+		require.NoError(t, err)
+	})
+
+	t.Run("attach user not found", func(t *testing.T) {
+		err := i.AttachUserPolicy(ctx, "nonexistent", "some-arn")
+		require.Error(t, err)
+	})
+}
+
+func TestAttachDetachRolePolicy(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateRole(ctx, driver.RoleConfig{Name: "pol-role"})
+	require.NoError(t, err)
+
+	t.Run("attach success", func(t *testing.T) {
+		err := i.AttachRolePolicy(ctx, "pol-role", "arn:aws:iam::123456789012:policy/test")
+		require.NoError(t, err)
+	})
+
+	t.Run("list attached", func(t *testing.T) {
+		pols, err := i.ListAttachedRolePolicies(ctx, "pol-role")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(pols))
+	})
+
+	t.Run("detach success", func(t *testing.T) {
+		err := i.DetachRolePolicy(ctx, "pol-role", "arn:aws:iam::123456789012:policy/test")
+		require.NoError(t, err)
+	})
+
+	t.Run("attach role not found", func(t *testing.T) {
+		err := i.AttachRolePolicy(ctx, "nonexistent", "some-arn")
+		require.Error(t, err)
+	})
+}
+
+func TestCheckPermission(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "perm-user"})
+	require.NoError(t, err)
+
+	t.Run("allowed", func(t *testing.T) {
+		allowed, err := i.CheckPermission(ctx, "perm-user", "s3:GetObject", "arn:aws:s3:::my-bucket/*")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("principal not found", func(t *testing.T) {
+		_, err := i.CheckPermission(ctx, "nonexistent", "s3:GetObject", "arn:aws:s3:::my-bucket/*")
+		require.Error(t, err)
+	})
+}
+
+func TestIAMWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	i := newTestIAM(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "rec-user"})
+	require.NoError(t, err)
+
+	_, err = i.GetUser(ctx, "rec-user")
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 2)
+
+	createCalls := rec.CallCountFor("iam", "CreateUser")
+	assert.Equal(t, 1, createCalls)
+
+	getCalls := rec.CallCountFor("iam", "GetUser")
+	assert.Equal(t, 1, getCalls)
+}
+
+func TestIAMWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	i := newTestIAM(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = i.GetUser(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last)
+	assert.NotNil(t, last.Error)
+}
+
+func TestIAMWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	i := newTestIAM(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "met-user"})
+	require.NoError(t, err)
+
+	_, err = i.GetUser(ctx, "met-user")
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 2)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 2)
+}
+
+func TestIAMWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	i := newTestIAM(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = i.GetUser(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestIAMWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	i := newTestIAM(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("iam", "CreateUser", injectedErr, inject.Always{})
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "fail-user"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestIAMWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	i := newTestIAM(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("iam", "GetUser", injectedErr, inject.Always{})
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "inj-user"})
+	require.NoError(t, err)
+
+	_, err = i.GetUser(ctx, "inj-user")
+	require.Error(t, err)
+
+	getCalls := rec.CallsFor("iam", "GetUser")
+	assert.Equal(t, 1, len(getCalls))
+	assert.NotNil(t, getCalls[0].Error)
+}
+
+func TestIAMWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	i := newTestIAM(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("iam", "CreateUser", injectedErr, inject.Always{})
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "test"})
+	require.Error(t, err)
+
+	inj.Remove("iam", "CreateUser")
+
+	_, err = i.CreateUser(ctx, driver.UserConfig{Name: "test"})
+	require.NoError(t, err)
+}
+
+func TestIAMWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	i := newTestIAM(WithLatency(latency))
+	ctx := context.Background()
+
+	info, err := i.CreateUser(ctx, driver.UserConfig{Name: "lat-user"})
+	require.NoError(t, err)
+	assert.Equal(t, "lat-user", info.Name)
+}
+
+func TestIAMAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	i := NewIAM(newMockDriver(),
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := i.CreateUser(ctx, driver.UserConfig{Name: "all-opts"})
+	require.NoError(t, err)
+
+	_, err = i.GetUser(ctx, "all-opts")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}

--- a/loadbalancer/loadbalancer_test.go
+++ b/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,570 @@
+package loadbalancer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDriver implements driver.LoadBalancer for testing the portable wrapper.
+type mockDriver struct {
+	lbs          map[string]*driver.LBInfo
+	targetGroups map[string]*driver.TargetGroupInfo
+	listeners    map[string]*driver.ListenerInfo
+	targets      map[string][]driver.TargetHealth
+	seq          int
+}
+
+func newMockDriver() *mockDriver {
+	return &mockDriver{
+		lbs:          make(map[string]*driver.LBInfo),
+		targetGroups: make(map[string]*driver.TargetGroupInfo),
+		listeners:    make(map[string]*driver.ListenerInfo),
+		targets:      make(map[string][]driver.TargetHealth),
+	}
+}
+
+func (m *mockDriver) nextID(prefix string) string {
+	m.seq++
+
+	return fmt.Sprintf("%s-%d", prefix, m.seq)
+}
+
+func (m *mockDriver) CreateLoadBalancer(_ context.Context, config driver.LBConfig) (*driver.LBInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	arn := "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/" + m.nextID("lb")
+	info := &driver.LBInfo{ARN: arn, Name: config.Name, Type: config.Type, Scheme: config.Scheme, State: "active", DNSName: config.Name + ".elb.amazonaws.com"}
+	m.lbs[arn] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteLoadBalancer(_ context.Context, arn string) error {
+	if _, ok := m.lbs[arn]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.lbs, arn)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeLoadBalancers(_ context.Context, arns []string) ([]driver.LBInfo, error) {
+	if len(arns) == 0 {
+		result := make([]driver.LBInfo, 0, len(m.lbs))
+		for _, lb := range m.lbs {
+			result = append(result, *lb)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.LBInfo
+
+	for _, arn := range arns {
+		if lb, ok := m.lbs[arn]; ok {
+			result = append(result, *lb)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateTargetGroup(_ context.Context, config driver.TargetGroupConfig) (*driver.TargetGroupInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	arn := "arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/" + m.nextID("tg")
+	info := &driver.TargetGroupInfo{ARN: arn, Name: config.Name, Protocol: config.Protocol, Port: config.Port, VPCID: config.VPCID}
+	m.targetGroups[arn] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteTargetGroup(_ context.Context, arn string) error {
+	if _, ok := m.targetGroups[arn]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.targetGroups, arn)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeTargetGroups(_ context.Context, arns []string) ([]driver.TargetGroupInfo, error) {
+	if len(arns) == 0 {
+		result := make([]driver.TargetGroupInfo, 0, len(m.targetGroups))
+		for _, tg := range m.targetGroups {
+			result = append(result, *tg)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.TargetGroupInfo
+
+	for _, arn := range arns {
+		if tg, ok := m.targetGroups[arn]; ok {
+			result = append(result, *tg)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateListener(_ context.Context, config driver.ListenerConfig) (*driver.ListenerInfo, error) {
+	if _, ok := m.lbs[config.LBARN]; !ok {
+		return nil, fmt.Errorf("lb not found")
+	}
+
+	arn := "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/" + m.nextID("lis")
+	info := &driver.ListenerInfo{ARN: arn, LBARN: config.LBARN, Protocol: config.Protocol, Port: config.Port, TargetGroupARN: config.TargetGroupARN}
+	m.listeners[arn] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteListener(_ context.Context, arn string) error {
+	if _, ok := m.listeners[arn]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.listeners, arn)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeListeners(_ context.Context, lbARN string) ([]driver.ListenerInfo, error) {
+	var result []driver.ListenerInfo
+
+	for _, lis := range m.listeners {
+		if lis.LBARN == lbARN {
+			result = append(result, *lis)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) RegisterTargets(_ context.Context, tgARN string, targets []driver.Target) error {
+	if _, ok := m.targetGroups[tgARN]; !ok {
+		return fmt.Errorf("target group not found")
+	}
+
+	for _, t := range targets {
+		m.targets[tgARN] = append(m.targets[tgARN], driver.TargetHealth{Target: t, State: "healthy"})
+	}
+
+	return nil
+}
+
+func (m *mockDriver) DeregisterTargets(_ context.Context, tgARN string, _ []driver.Target) error {
+	if _, ok := m.targetGroups[tgARN]; !ok {
+		return fmt.Errorf("target group not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) DescribeTargetHealth(_ context.Context, tgARN string) ([]driver.TargetHealth, error) {
+	if _, ok := m.targetGroups[tgARN]; !ok {
+		return nil, fmt.Errorf("target group not found")
+	}
+
+	return m.targets[tgARN], nil
+}
+
+func (m *mockDriver) SetTargetHealth(_ context.Context, tgARN, targetID, state string) error {
+	if _, ok := m.targetGroups[tgARN]; !ok {
+		return fmt.Errorf("target group not found")
+	}
+
+	for idx := range m.targets[tgARN] {
+		if m.targets[tgARN][idx].Target.ID == targetID {
+			m.targets[tgARN][idx].State = state
+			return nil
+		}
+	}
+
+	return fmt.Errorf("target not found")
+}
+
+func newTestLB(opts ...Option) *LB {
+	return NewLB(newMockDriver(), opts...)
+}
+
+func TestNewLB(t *testing.T) {
+	lb := newTestLB()
+	require.NotNil(t, lb)
+	require.NotNil(t, lb.driver)
+}
+
+func TestCreateLoadBalancer(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "my-lb", Type: "application"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-lb", info.Name)
+		assert.NotEmpty(t, info.ARN)
+		assert.Equal(t, "active", info.State)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteLoadBalancer(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	info, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "del-lb"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := lb.DeleteLoadBalancer(ctx, info.ARN)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := lb.DeleteLoadBalancer(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDescribeLoadBalancers(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb-a"})
+	require.NoError(t, err)
+
+	_, err = lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb-b"})
+	require.NoError(t, err)
+
+	lbs, err := lb.DescribeLoadBalancers(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(lbs))
+}
+
+func TestCreateTargetGroup(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "my-tg", Protocol: "HTTP", Port: 80})
+		require.NoError(t, err)
+		assert.Equal(t, "my-tg", info.Name)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteTargetGroup(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	tg, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "del-tg"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := lb.DeleteTargetGroup(ctx, tg.ARN)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := lb.DeleteTargetGroup(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDescribeTargetGroups(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	_, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "tg-a"})
+	require.NoError(t, err)
+
+	_, err = lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "tg-b"})
+	require.NoError(t, err)
+
+	tgs, err := lb.DescribeTargetGroups(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(tgs))
+}
+
+func TestCreateListener(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	lbInfo, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lis-lb"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := lb.CreateListener(ctx, driver.ListenerConfig{LBARN: lbInfo.ARN, Protocol: "HTTP", Port: 80})
+		require.NoError(t, err)
+		assert.Equal(t, lbInfo.ARN, info.LBARN)
+	})
+
+	t.Run("lb not found", func(t *testing.T) {
+		_, err := lb.CreateListener(ctx, driver.ListenerConfig{LBARN: "nonexistent"})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteListener(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	lbInfo, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "dellis-lb"})
+	require.NoError(t, err)
+
+	lis, err := lb.CreateListener(ctx, driver.ListenerConfig{LBARN: lbInfo.ARN, Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := lb.DeleteListener(ctx, lis.ARN)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := lb.DeleteListener(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDescribeListeners(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	lbInfo, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "desclis-lb"})
+	require.NoError(t, err)
+
+	_, err = lb.CreateListener(ctx, driver.ListenerConfig{LBARN: lbInfo.ARN, Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	listeners, err := lb.DescribeListeners(ctx, lbInfo.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(listeners))
+}
+
+func TestRegisterAndDescribeTargets(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	tg, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "reg-tg"})
+	require.NoError(t, err)
+
+	targets := []driver.Target{{ID: "i-1234", Port: 80}}
+
+	err = lb.RegisterTargets(ctx, tg.ARN, targets)
+	require.NoError(t, err)
+
+	health, err := lb.DescribeTargetHealth(ctx, tg.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(health))
+	assert.Equal(t, "healthy", health[0].State)
+}
+
+func TestDeregisterTargets(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	tg, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "dereg-tg"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := lb.DeregisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1234", Port: 80}})
+		require.NoError(t, err)
+	})
+
+	t.Run("tg not found", func(t *testing.T) {
+		err := lb.DeregisterTargets(ctx, "nonexistent", []driver.Target{{ID: "i-1234"}})
+		require.Error(t, err)
+	})
+}
+
+func TestSetTargetHealth(t *testing.T) {
+	lb := newTestLB()
+	ctx := context.Background()
+
+	tg, err := lb.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "health-tg"})
+	require.NoError(t, err)
+
+	err = lb.RegisterTargets(ctx, tg.ARN, []driver.Target{{ID: "i-1234", Port: 80}})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := lb.SetTargetHealth(ctx, tg.ARN, "i-1234", "unhealthy")
+		require.NoError(t, err)
+	})
+
+	t.Run("target not found", func(t *testing.T) {
+		err := lb.SetTargetHealth(ctx, tg.ARN, "nonexistent", "unhealthy")
+		require.Error(t, err)
+	})
+}
+
+func TestLBWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	lb := newTestLB(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "rec-lb"})
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 1)
+
+	createCalls := rec.CallCountFor("loadbalancer", "CreateLoadBalancer")
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestLBWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	lb := newTestLB(WithRecorder(rec))
+	ctx := context.Background()
+
+	_ = lb.DeleteLoadBalancer(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last)
+	assert.NotNil(t, last.Error)
+}
+
+func TestLBWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	lb := newTestLB(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "met-lb"})
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 1)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 1)
+}
+
+func TestLBWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	lb := newTestLB(WithMetrics(mc))
+	ctx := context.Background()
+
+	_ = lb.DeleteLoadBalancer(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestLBWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	lb := newTestLB(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("loadbalancer", "CreateLoadBalancer", injectedErr, inject.Always{})
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "fail-lb"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestLBWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	lb := newTestLB(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("loadbalancer", "DeleteLoadBalancer", injectedErr, inject.Always{})
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "inj-lb"})
+	require.NoError(t, err)
+
+	err = lb.DeleteLoadBalancer(ctx, "some-arn")
+	require.Error(t, err)
+
+	delCalls := rec.CallsFor("loadbalancer", "DeleteLoadBalancer")
+	assert.Equal(t, 1, len(delCalls))
+	assert.NotNil(t, delCalls[0].Error)
+}
+
+func TestLBWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	lb := newTestLB(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("loadbalancer", "CreateLoadBalancer", injectedErr, inject.Always{})
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "test"})
+	require.Error(t, err)
+
+	inj.Remove("loadbalancer", "CreateLoadBalancer")
+
+	_, err = lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "test"})
+	require.NoError(t, err)
+}
+
+func TestLBWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	lb := newTestLB(WithLatency(latency))
+	ctx := context.Background()
+
+	info, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lat-lb"})
+	require.NoError(t, err)
+	assert.Equal(t, "lat-lb", info.Name)
+}
+
+func TestLBAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	lb := NewLB(newMockDriver(),
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := lb.CreateLoadBalancer(ctx, driver.LBConfig{Name: "all-opts"})
+	require.NoError(t, err)
+
+	_, err = lb.DescribeLoadBalancers(ctx, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}

--- a/messagequeue/driver/driver.go
+++ b/messagequeue/driver/driver.go
@@ -1,7 +1,13 @@
 // Package driver defines the interface for message queue service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// MaxBatchSize is the maximum number of entries allowed in a batch operation.
+const MaxBatchSize = 10
 
 // QueueConfig describes a message queue to create.
 type QueueConfig struct {
@@ -63,6 +69,69 @@ type Message struct {
 	GroupID       string
 }
 
+// BatchSendEntry represents a single message in a batch send.
+type BatchSendEntry struct {
+	ID              string
+	Body            string
+	DelaySeconds    int
+	GroupID         string
+	DeduplicationID string
+	Attributes      map[string]string
+}
+
+// BatchSendResult is the result of a batch send.
+type BatchSendResult struct {
+	Successful []BatchSendResultEntry
+	Failed     []BatchSendFailEntry
+}
+
+// BatchSendResultEntry is a successful batch entry.
+type BatchSendResultEntry struct {
+	ID        string
+	MessageID string
+}
+
+// BatchSendFailEntry is a failed batch entry.
+type BatchSendFailEntry struct {
+	ID      string
+	Code    string
+	Message string
+}
+
+// BatchDeleteEntry represents a message to delete in batch.
+type BatchDeleteEntry struct {
+	ID            string
+	ReceiptHandle string
+}
+
+// BatchDeleteResult is the result of a batch delete.
+type BatchDeleteResult struct {
+	Successful []string // entry IDs
+	Failed     []BatchSendFailEntry
+}
+
+// ReceiveOptions configures a receive operation.
+type ReceiveOptions struct {
+	MaxMessages       int
+	WaitTimeSeconds   int // long polling: 0 = short poll, >0 = check once
+	VisibilityTimeout int // override queue default
+}
+
+// QueueAttributes describes queue attributes.
+type QueueAttributes struct {
+	DelaySeconds               int
+	MaximumMessageSize         int
+	MessageRetentionPeriod     int // seconds
+	VisibilityTimeout          int // seconds
+	ApproximateMessageCount    int
+	ApproximateNotVisibleCount int
+	CreatedAt                  time.Time
+	LastModifiedAt             time.Time
+	FifoQueue                  bool
+	ContentBasedDeduplication  bool
+	RedrivePolicy              string // JSON string pointing to DLQ
+}
+
 // MessageQueue is the interface that message queue provider implementations must satisfy.
 type MessageQueue interface {
 	CreateQueue(ctx context.Context, config QueueConfig) (*QueueInfo, error)
@@ -74,4 +143,18 @@ type MessageQueue interface {
 	ReceiveMessages(ctx context.Context, input ReceiveMessageInput) ([]Message, error)
 	DeleteMessage(ctx context.Context, queueURL, receiptHandle string) error
 	ChangeVisibility(ctx context.Context, queueURL, receiptHandle string, timeout int) error
+
+	// Batch operations
+	SendMessageBatch(ctx context.Context, queue string, entries []BatchSendEntry) (*BatchSendResult, error)
+	DeleteMessageBatch(ctx context.Context, queue string, entries []BatchDeleteEntry) (*BatchDeleteResult, error)
+
+	// Enhanced receive with options
+	ReceiveMessagesWithOptions(ctx context.Context, queue string, opts ReceiveOptions) ([]Message, error)
+
+	// Queue attributes
+	GetQueueAttributes(ctx context.Context, queue string) (*QueueAttributes, error)
+	SetQueueAttributes(ctx context.Context, queue string, attrs map[string]int) error
+
+	// Purge
+	PurgeQueue(ctx context.Context, queue string) error
 }

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -146,3 +146,73 @@ func (mq *MQ) ChangeVisibility(ctx context.Context, queueURL, receiptHandle stri
 
 	return err
 }
+
+func (mq *MQ) SendMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchSendEntry,
+) (*driver.BatchSendResult, error) {
+	out, err := mq.do(ctx, "SendMessageBatch", queue, func() (any, error) {
+		return mq.driver.SendMessageBatch(ctx, queue, entries)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.BatchSendResult), nil
+}
+
+func (mq *MQ) DeleteMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchDeleteEntry,
+) (*driver.BatchDeleteResult, error) {
+	out, err := mq.do(ctx, "DeleteMessageBatch", queue, func() (any, error) {
+		return mq.driver.DeleteMessageBatch(ctx, queue, entries)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.BatchDeleteResult), nil
+}
+
+func (mq *MQ) ReceiveMessagesWithOptions(
+	ctx context.Context, queue string, opts driver.ReceiveOptions,
+) ([]driver.Message, error) {
+	out, err := mq.do(ctx, "ReceiveMessagesWithOptions", queue, func() (any, error) {
+		return mq.driver.ReceiveMessagesWithOptions(ctx, queue, opts)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Message), nil
+}
+
+func (mq *MQ) GetQueueAttributes(
+	ctx context.Context, queue string,
+) (*driver.QueueAttributes, error) {
+	out, err := mq.do(ctx, "GetQueueAttributes", queue, func() (any, error) {
+		return mq.driver.GetQueueAttributes(ctx, queue)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.QueueAttributes), nil
+}
+
+func (mq *MQ) SetQueueAttributes(
+	ctx context.Context, queue string, attrs map[string]int,
+) error {
+	_, err := mq.do(ctx, "SetQueueAttributes", queue, func() (any, error) {
+		return nil, mq.driver.SetQueueAttributes(ctx, queue, attrs)
+	})
+
+	return err
+}
+
+func (mq *MQ) PurgeQueue(ctx context.Context, queue string) error {
+	_, err := mq.do(ctx, "PurgeQueue", queue, func() (any, error) {
+		return nil, mq.driver.PurgeQueue(ctx, queue)
+	})
+
+	return err
+}

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -1,0 +1,557 @@
+package messagequeue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/messagequeue/driver"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDriver implements driver.MessageQueue for testing the portable wrapper.
+type mockDriver struct {
+	queues   map[string]*driver.QueueInfo
+	messages map[string][]driver.Message
+	msgSeq   int
+}
+
+func newMockDriver() *mockDriver {
+	return &mockDriver{
+		queues:   make(map[string]*driver.QueueInfo),
+		messages: make(map[string][]driver.Message),
+	}
+}
+
+func (m *mockDriver) CreateQueue(_ context.Context, config driver.QueueConfig) (*driver.QueueInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	url := "https://sqs.us-east-1.amazonaws.com/123456789012/" + config.Name
+
+	if _, ok := m.queues[url]; ok {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	info := &driver.QueueInfo{URL: url, Name: config.Name, FIFO: config.FIFO}
+	m.queues[url] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteQueue(_ context.Context, url string) error {
+	if _, ok := m.queues[url]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.queues, url)
+	delete(m.messages, url)
+
+	return nil
+}
+
+func (m *mockDriver) GetQueueInfo(_ context.Context, url string) (*driver.QueueInfo, error) {
+	info, ok := m.queues[url]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListQueues(_ context.Context, _ string) ([]driver.QueueInfo, error) {
+	result := make([]driver.QueueInfo, 0, len(m.queues))
+	for _, info := range m.queues {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) SendMessage(_ context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
+	if _, ok := m.queues[input.QueueURL]; !ok {
+		return nil, fmt.Errorf("queue not found")
+	}
+
+	m.msgSeq++
+	msgID := fmt.Sprintf("msg-%d", m.msgSeq)
+	msg := driver.Message{MessageID: msgID, Body: input.Body, ReceiptHandle: "rh-" + msgID}
+	m.messages[input.QueueURL] = append(m.messages[input.QueueURL], msg)
+
+	return &driver.SendMessageOutput{MessageID: msgID}, nil
+}
+
+func (m *mockDriver) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInput) ([]driver.Message, error) {
+	if _, ok := m.queues[input.QueueURL]; !ok {
+		return nil, fmt.Errorf("queue not found")
+	}
+
+	msgs := m.messages[input.QueueURL]
+	max := input.MaxMessages
+
+	if max <= 0 || max > len(msgs) {
+		max = len(msgs)
+	}
+
+	return msgs[:max], nil
+}
+
+func (m *mockDriver) DeleteMessage(_ context.Context, queueURL, _ string) error {
+	if _, ok := m.queues[queueURL]; !ok {
+		return fmt.Errorf("queue not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) ChangeVisibility(_ context.Context, queueURL, _ string, _ int) error {
+	if _, ok := m.queues[queueURL]; !ok {
+		return fmt.Errorf("queue not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) SendMessageBatch(
+	_ context.Context, queue string, entries []driver.BatchSendEntry,
+) (*driver.BatchSendResult, error) {
+	if _, ok := m.queues[queue]; !ok {
+		return nil, fmt.Errorf("queue not found")
+	}
+
+	result := &driver.BatchSendResult{}
+	for _, e := range entries {
+		m.msgSeq++
+		msgID := fmt.Sprintf("msg-%d", m.msgSeq)
+		result.Successful = append(result.Successful, driver.BatchSendResultEntry{ID: e.ID, MessageID: msgID})
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) DeleteMessageBatch(
+	_ context.Context, queue string, entries []driver.BatchDeleteEntry,
+) (*driver.BatchDeleteResult, error) {
+	if _, ok := m.queues[queue]; !ok {
+		return nil, fmt.Errorf("queue not found")
+	}
+
+	result := &driver.BatchDeleteResult{}
+	for _, e := range entries {
+		result.Successful = append(result.Successful, e.ID)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) ReceiveMessagesWithOptions(
+	_ context.Context, queue string, _ driver.ReceiveOptions,
+) ([]driver.Message, error) {
+	if _, ok := m.queues[queue]; !ok {
+		return nil, fmt.Errorf("queue not found")
+	}
+
+	return m.messages[queue], nil
+}
+
+func (m *mockDriver) GetQueueAttributes(_ context.Context, queue string) (*driver.QueueAttributes, error) {
+	if _, ok := m.queues[queue]; !ok {
+		return nil, fmt.Errorf("queue not found")
+	}
+
+	return &driver.QueueAttributes{VisibilityTimeout: 30}, nil
+}
+
+func (m *mockDriver) SetQueueAttributes(_ context.Context, queue string, _ map[string]int) error {
+	if _, ok := m.queues[queue]; !ok {
+		return fmt.Errorf("queue not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) PurgeQueue(_ context.Context, queue string) error {
+	if _, ok := m.queues[queue]; !ok {
+		return fmt.Errorf("queue not found")
+	}
+
+	m.messages[queue] = nil
+
+	return nil
+}
+
+func newTestMQ(opts ...Option) *MQ {
+	return NewMQ(newMockDriver(), opts...)
+}
+
+func setupQueue(t *testing.T, mq *MQ, name string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	info, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: name})
+	require.NoError(t, err)
+
+	return info.URL
+}
+
+func TestNewMQ(t *testing.T) {
+	mq := newTestMQ()
+	require.NotNil(t, mq)
+	require.NotNil(t, mq.driver)
+}
+
+func TestCreateQueue(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "my-queue"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-queue", info.Name)
+		assert.NotEmpty(t, info.URL)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := mq.CreateQueue(ctx, driver.QueueConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteQueue(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "del-queue")
+
+	t.Run("success", func(t *testing.T) {
+		err := mq.DeleteQueue(ctx, url)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := mq.DeleteQueue(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetQueueInfo(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "info-queue")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := mq.GetQueueInfo(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, "info-queue", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := mq.GetQueueInfo(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListQueues(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+
+	queues, err := mq.ListQueues(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(queues))
+
+	setupQueue(t, mq, "q-a")
+	setupQueue(t, mq, "q-b")
+
+	queues, err = mq.ListQueues(ctx, "")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(queues))
+}
+
+func TestSendAndReceiveMessage(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "msg-queue")
+
+	out, err := mq.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "hello"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.MessageID)
+
+	msgs, err := mq.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(msgs))
+	assert.Equal(t, "hello", msgs[0].Body)
+}
+
+func TestDeleteMessage(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "delmsg-queue")
+
+	t.Run("success", func(t *testing.T) {
+		err := mq.DeleteMessage(ctx, url, "rh-1")
+		require.NoError(t, err)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		err := mq.DeleteMessage(ctx, "nonexistent", "rh-1")
+		require.Error(t, err)
+	})
+}
+
+func TestChangeVisibility(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "vis-queue")
+
+	t.Run("success", func(t *testing.T) {
+		err := mq.ChangeVisibility(ctx, url, "rh-1", 60)
+		require.NoError(t, err)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		err := mq.ChangeVisibility(ctx, "nonexistent", "rh-1", 60)
+		require.Error(t, err)
+	})
+}
+
+func TestSendMessageBatch(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "batch-queue")
+
+	entries := []driver.BatchSendEntry{
+		{ID: "e1", Body: "msg1"},
+		{ID: "e2", Body: "msg2"},
+	}
+
+	result, err := mq.SendMessageBatch(ctx, url, entries)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(result.Successful))
+}
+
+func TestDeleteMessageBatch(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "delbatch-queue")
+
+	entries := []driver.BatchDeleteEntry{
+		{ID: "e1", ReceiptHandle: "rh-1"},
+		{ID: "e2", ReceiptHandle: "rh-2"},
+	}
+
+	result, err := mq.DeleteMessageBatch(ctx, url, entries)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(result.Successful))
+}
+
+func TestReceiveMessagesWithOptions(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "opts-queue")
+
+	_, err := mq.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "hello"})
+	require.NoError(t, err)
+
+	msgs, err := mq.ReceiveMessagesWithOptions(ctx, url, driver.ReceiveOptions{MaxMessages: 10})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(msgs))
+}
+
+func TestGetQueueAttributes(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "attr-queue")
+
+	t.Run("success", func(t *testing.T) {
+		attrs, err := mq.GetQueueAttributes(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, 30, attrs.VisibilityTimeout)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := mq.GetQueueAttributes(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestSetQueueAttributes(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "setattr-queue")
+
+	t.Run("success", func(t *testing.T) {
+		err := mq.SetQueueAttributes(ctx, url, map[string]int{"VisibilityTimeout": 60})
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := mq.SetQueueAttributes(ctx, "nonexistent", map[string]int{"VisibilityTimeout": 60})
+		require.Error(t, err)
+	})
+}
+
+func TestPurgeQueue(t *testing.T) {
+	mq := newTestMQ()
+	ctx := context.Background()
+	url := setupQueue(t, mq, "purge-queue")
+
+	_, err := mq.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "hello"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := mq.PurgeQueue(ctx, url)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := mq.PurgeQueue(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestMQWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	mq := newTestMQ(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "rec-queue"})
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 1)
+
+	createCalls := rec.CallCountFor("messagequeue", "CreateQueue")
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestMQWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	mq := newTestMQ(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = mq.GetQueueInfo(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last)
+	assert.NotNil(t, last.Error)
+}
+
+func TestMQWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	mq := newTestMQ(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "met-queue"})
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 1)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 1)
+}
+
+func TestMQWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	mq := newTestMQ(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = mq.GetQueueInfo(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestMQWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	mq := newTestMQ(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("messagequeue", "CreateQueue", injectedErr, inject.Always{})
+
+	_, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "fail-queue"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestMQWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	mq := newTestMQ(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("messagequeue", "SendMessage", injectedErr, inject.Always{})
+
+	url := setupQueue(t, mq, "inj-queue")
+
+	_, err := mq.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "hello"})
+	require.Error(t, err)
+
+	sendCalls := rec.CallsFor("messagequeue", "SendMessage")
+	assert.Equal(t, 1, len(sendCalls))
+	assert.NotNil(t, sendCalls[0].Error)
+}
+
+func TestMQWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	mq := newTestMQ(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("messagequeue", "CreateQueue", injectedErr, inject.Always{})
+
+	_, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "test"})
+	require.Error(t, err)
+
+	inj.Remove("messagequeue", "CreateQueue")
+
+	_, err = mq.CreateQueue(ctx, driver.QueueConfig{Name: "test"})
+	require.NoError(t, err)
+}
+
+func TestMQWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	mq := newTestMQ(WithLatency(latency))
+	ctx := context.Background()
+
+	_, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "lat-queue"})
+	require.NoError(t, err)
+}
+
+func TestMQAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	mq := NewMQ(newMockDriver(),
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := mq.CreateQueue(ctx, driver.QueueConfig{Name: "all-opts"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 1, q.ByName("calls_total").Count())
+}

--- a/monitoring/monitoring_test.go
+++ b/monitoring/monitoring_test.go
@@ -1,0 +1,383 @@
+package monitoring
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDriver() (driver.Monitoring, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return cloudwatch.New(opts), fc
+}
+
+func newTestMonitoring(opts ...Option) (*Monitoring, *config.FakeClock) {
+	d, fc := newTestDriver()
+	return NewMonitoring(d, opts...), fc
+}
+
+func TestNewMonitoring(t *testing.T) {
+	m, _ := newTestMonitoring()
+
+	require.NotNil(t, m)
+	require.NotNil(t, m.driver)
+}
+
+func TestPutMetricDataPortable(t *testing.T) {
+	m, fc := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{
+			Namespace:  "TestNS",
+			MetricName: "CPUUtilization",
+			Value:      42.0,
+			Unit:       "Percent",
+			Timestamp:  fc.Now(),
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestGetMetricDataPortable(t *testing.T) {
+	m, fc := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{
+			Namespace:  "TestNS",
+			MetricName: "CPUUtilization",
+			Value:      42.0,
+			Unit:       "Percent",
+			Timestamp:  fc.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := m.GetMetricData(ctx, driver.GetMetricInput{
+		Namespace:  "TestNS",
+		MetricName: "CPUUtilization",
+		StartTime:  fc.Now().Add(-1 * time.Hour),
+		EndTime:    fc.Now().Add(1 * time.Hour),
+		Period:     60,
+		Stat:       "Average",
+	})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(result.Values), 1)
+}
+
+func TestListMetricsPortable(t *testing.T) {
+	m, fc := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{
+			Namespace:  "TestNS",
+			MetricName: "CPUUtilization",
+			Value:      42.0,
+			Timestamp:  fc.Now(),
+		},
+	})
+	require.NoError(t, err)
+
+	metricNames, err := m.ListMetrics(ctx, "TestNS")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(metricNames), 1)
+}
+
+func TestCreateDeleteAlarmPortable(t *testing.T) {
+	m, _ := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name:               "test-alarm",
+		Namespace:          "TestNS",
+		MetricName:         "CPUUtilization",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          80.0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	})
+	require.NoError(t, err)
+
+	alarms, err := m.DescribeAlarms(ctx, []string{"test-alarm"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(alarms))
+	assert.Equal(t, "test-alarm", alarms[0].Name)
+
+	err = m.DeleteAlarm(ctx, "test-alarm")
+	require.NoError(t, err)
+}
+
+func TestSetAlarmStatePortable(t *testing.T) {
+	m, _ := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name:               "state-alarm",
+		Namespace:          "TestNS",
+		MetricName:         "CPUUtilization",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          80.0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	})
+	require.NoError(t, err)
+
+	err = m.SetAlarmState(ctx, "state-alarm", "ALARM", "testing")
+	require.NoError(t, err)
+
+	alarms, err := m.DescribeAlarms(ctx, []string{"state-alarm"})
+	require.NoError(t, err)
+	assert.Equal(t, "ALARM", alarms[0].State)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	m, fc := newTestMonitoring(WithRecorder(rec))
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+
+	_, err = m.ListMetrics(ctx, "TestNS")
+	require.NoError(t, err)
+
+	err = m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name:               "rec-alarm",
+		Namespace:          "TestNS",
+		MetricName:         "CPU",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          50.0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	})
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 3)
+
+	putCalls := rec.CallCountFor("monitoring", "PutMetricData")
+	assert.Equal(t, 1, putCalls)
+
+	listCalls := rec.CallCountFor("monitoring", "ListMetrics")
+	assert.Equal(t, 1, listCalls)
+
+	createCalls := rec.CallCountFor("monitoring", "CreateAlarm")
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	m, _ := newTestMonitoring(WithRecorder(rec))
+	ctx := context.Background()
+
+	// Delete nonexistent alarm should fail.
+	_ = m.DeleteAlarm(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	m, fc := newTestMonitoring(WithMetrics(mc))
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+
+	_, err = m.ListMetrics(ctx, "TestNS")
+	require.NoError(t, err)
+
+	err = m.CreateAlarm(ctx, driver.AlarmConfig{
+		Name:               "met-alarm",
+		Namespace:          "TestNS",
+		MetricName:         "CPU",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          50.0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	})
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 3)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 3)
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	m, _ := newTestMonitoring(WithMetrics(mc))
+	ctx := context.Background()
+
+	_ = m.DeleteAlarm(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	m, _ := newTestMonitoring(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("monitoring", "PutMetricData", injectedErr, inject.Always{})
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0},
+	})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	m, fc := newTestMonitoring(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("monitoring", "ListMetrics", injectedErr, inject.Always{})
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+
+	_, err = m.ListMetrics(ctx, "TestNS")
+	require.Error(t, err)
+
+	listCalls := rec.CallsFor("monitoring", "ListMetrics")
+	assert.Equal(t, 1, len(listCalls))
+	assert.NotNil(t, listCalls[0].Error, "expected recorded ListMetrics call to have an error")
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	m, fc := newTestMonitoring(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("monitoring", "PutMetricData", injectedErr, inject.Always{})
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.Error(t, err)
+
+	inj.Remove("monitoring", "PutMetricData")
+
+	err = m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	d := cloudwatch.New(opts)
+	limiter := ratelimit.New(1, 1, fc)
+	m := NewMonitoring(d, WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+
+	_, err = m.ListMetrics(ctx, "TestNS")
+	require.Error(t, err, "expected rate limit error on second call without time advance")
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	m, fc := newTestMonitoring(WithLatency(latency))
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+
+	metricNames, err := m.ListMetrics(ctx, "TestNS")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(metricNames), 1)
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	m, fc := newTestMonitoring(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	err := m.PutMetricData(ctx, []driver.MetricDatum{
+		{Namespace: "TestNS", MetricName: "CPU", Value: 10.0, Timestamp: fc.Now()},
+	})
+	require.NoError(t, err)
+
+	_, err = m.ListMetrics(ctx, "TestNS")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableDeleteAlarmError(t *testing.T) {
+	m, _ := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.DeleteAlarm(ctx, "no-alarm")
+	require.Error(t, err)
+}
+
+func TestPortableSetAlarmStateError(t *testing.T) {
+	m, _ := newTestMonitoring()
+	ctx := context.Background()
+
+	err := m.SetAlarmState(ctx, "no-alarm", "OK", "test")
+	require.Error(t, err)
+}

--- a/networking/driver/driver.go
+++ b/networking/driver/driver.go
@@ -62,6 +62,115 @@ type SecurityRule struct {
 	CIDR     string
 }
 
+// PeeringConnection represents a VPC peering connection.
+type PeeringConnection struct {
+	ID           string
+	RequesterVPC string
+	AccepterVPC  string
+	Status       string // "pending-acceptance", "active", "rejected", "deleted"
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// PeeringConfig configures a peering connection.
+type PeeringConfig struct {
+	RequesterVPC string
+	AccepterVPC  string
+	Tags         map[string]string
+}
+
+// NATGateway represents a NAT gateway.
+type NATGateway struct {
+	ID        string
+	SubnetID  string
+	VPCID     string
+	PublicIP  string
+	State     string // "pending", "available", "deleting", "deleted", "failed"
+	CreatedAt string
+	Tags      map[string]string
+}
+
+// NATGatewayConfig configures a NAT gateway.
+type NATGatewayConfig struct {
+	SubnetID string
+	Tags     map[string]string
+}
+
+// FlowLog represents a VPC flow log configuration.
+type FlowLog struct {
+	ID           string
+	ResourceID   string
+	ResourceType string // "VPC", "Subnet", "NetworkInterface"
+	TrafficType  string // "ACCEPT", "REJECT", "ALL"
+	Status       string // "ACTIVE", "INACTIVE"
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// FlowLogConfig configures a flow log.
+type FlowLogConfig struct {
+	ResourceID   string
+	ResourceType string
+	TrafficType  string
+	Tags         map[string]string
+}
+
+// FlowLogRecord represents a single flow log entry.
+type FlowLogRecord struct {
+	Timestamp  string
+	SourceIP   string
+	DestIP     string
+	SourcePort int
+	DestPort   int
+	Protocol   string
+	Packets    int
+	Bytes      int
+	Action     string // "ACCEPT" or "REJECT"
+	FlowLogID  string
+}
+
+// RouteTable represents a route table.
+type RouteTable struct {
+	ID     string
+	VPCID  string
+	Routes []Route
+	Tags   map[string]string
+}
+
+// Route represents a route in a route table.
+type Route struct {
+	DestinationCIDR string
+	TargetID        string // gateway ID, NAT gateway ID, peering connection ID, etc.
+	TargetType      string // "gateway", "nat-gateway", "peering", "local"
+	State           string // "active", "blackhole"
+}
+
+// RouteTableConfig configures a route table.
+type RouteTableConfig struct {
+	VPCID string
+	Tags  map[string]string
+}
+
+// NetworkACL represents a network ACL.
+type NetworkACL struct {
+	ID        string
+	VPCID     string
+	Rules     []NetworkACLRule
+	Tags      map[string]string
+	IsDefault bool
+}
+
+// NetworkACLRule represents a rule in a network ACL.
+type NetworkACLRule struct {
+	RuleNumber int
+	Protocol   string
+	Action     string // "allow" or "deny"
+	CIDR       string
+	FromPort   int
+	ToPort     int
+	Egress     bool
+}
+
 // Networking is the interface that networking provider implementations must satisfy.
 type Networking interface {
 	CreateVPC(ctx context.Context, config VPCConfig) (*VPCInfo, error)
@@ -80,4 +189,36 @@ type Networking interface {
 	AddEgressRule(ctx context.Context, groupID string, rule SecurityRule) error
 	RemoveIngressRule(ctx context.Context, groupID string, rule SecurityRule) error
 	RemoveEgressRule(ctx context.Context, groupID string, rule SecurityRule) error
+
+	// VPC Peering
+	CreatePeeringConnection(ctx context.Context, config PeeringConfig) (*PeeringConnection, error)
+	AcceptPeeringConnection(ctx context.Context, peeringID string) error
+	RejectPeeringConnection(ctx context.Context, peeringID string) error
+	DeletePeeringConnection(ctx context.Context, peeringID string) error
+	DescribePeeringConnections(ctx context.Context, ids []string) ([]PeeringConnection, error)
+
+	// NAT Gateways
+	CreateNATGateway(ctx context.Context, config NATGatewayConfig) (*NATGateway, error)
+	DeleteNATGateway(ctx context.Context, id string) error
+	DescribeNATGateways(ctx context.Context, ids []string) ([]NATGateway, error)
+
+	// Flow Logs
+	CreateFlowLog(ctx context.Context, config FlowLogConfig) (*FlowLog, error)
+	DeleteFlowLog(ctx context.Context, id string) error
+	DescribeFlowLogs(ctx context.Context, ids []string) ([]FlowLog, error)
+	GetFlowLogRecords(ctx context.Context, flowLogID string, limit int) ([]FlowLogRecord, error)
+
+	// Route Tables
+	CreateRouteTable(ctx context.Context, config RouteTableConfig) (*RouteTable, error)
+	DeleteRouteTable(ctx context.Context, id string) error
+	DescribeRouteTables(ctx context.Context, ids []string) ([]RouteTable, error)
+	CreateRoute(ctx context.Context, routeTableID, destinationCIDR, targetID, targetType string) error
+	DeleteRoute(ctx context.Context, routeTableID, destinationCIDR string) error
+
+	// Network ACLs
+	CreateNetworkACL(ctx context.Context, vpcID string, tags map[string]string) (*NetworkACL, error)
+	DeleteNetworkACL(ctx context.Context, id string) error
+	DescribeNetworkACLs(ctx context.Context, ids []string) ([]NetworkACL, error)
+	AddNetworkACLRule(ctx context.Context, aclID string, rule *NetworkACLRule) error
+	RemoveNetworkACLRule(ctx context.Context, aclID string, ruleNumber int, egress bool) error
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -191,3 +191,262 @@ func (n *Networking) RemoveEgressRule(ctx context.Context, groupID string, rule 
 
 	return err
 }
+
+// CreatePeeringConnection creates a VPC peering connection.
+func (n *Networking) CreatePeeringConnection(
+	ctx context.Context, config driver.PeeringConfig,
+) (*driver.PeeringConnection, error) {
+	out, err := n.do(ctx, "CreatePeeringConnection", config, func() (any, error) {
+		return n.driver.CreatePeeringConnection(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PeeringConnection), nil
+}
+
+// AcceptPeeringConnection accepts a pending peering connection.
+func (n *Networking) AcceptPeeringConnection(ctx context.Context, peeringID string) error {
+	_, err := n.do(ctx, "AcceptPeeringConnection", peeringID, func() (any, error) {
+		return nil, n.driver.AcceptPeeringConnection(ctx, peeringID)
+	})
+
+	return err
+}
+
+// RejectPeeringConnection rejects a pending peering connection.
+func (n *Networking) RejectPeeringConnection(ctx context.Context, peeringID string) error {
+	_, err := n.do(ctx, "RejectPeeringConnection", peeringID, func() (any, error) {
+		return nil, n.driver.RejectPeeringConnection(ctx, peeringID)
+	})
+
+	return err
+}
+
+// DeletePeeringConnection deletes a peering connection.
+func (n *Networking) DeletePeeringConnection(ctx context.Context, peeringID string) error {
+	_, err := n.do(ctx, "DeletePeeringConnection", peeringID, func() (any, error) {
+		return nil, n.driver.DeletePeeringConnection(ctx, peeringID)
+	})
+
+	return err
+}
+
+// DescribePeeringConnections returns peering connections matching the given IDs.
+func (n *Networking) DescribePeeringConnections(
+	ctx context.Context, ids []string,
+) ([]driver.PeeringConnection, error) {
+	out, err := n.do(ctx, "DescribePeeringConnections", ids, func() (any, error) {
+		return n.driver.DescribePeeringConnections(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.PeeringConnection), nil
+}
+
+// CreateNATGateway creates a NAT gateway.
+func (n *Networking) CreateNATGateway(
+	ctx context.Context, config driver.NATGatewayConfig,
+) (*driver.NATGateway, error) {
+	out, err := n.do(ctx, "CreateNATGateway", config, func() (any, error) {
+		return n.driver.CreateNATGateway(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.NATGateway), nil
+}
+
+// DeleteNATGateway deletes a NAT gateway.
+func (n *Networking) DeleteNATGateway(ctx context.Context, id string) error {
+	_, err := n.do(ctx, "DeleteNATGateway", id, func() (any, error) {
+		return nil, n.driver.DeleteNATGateway(ctx, id)
+	})
+
+	return err
+}
+
+// DescribeNATGateways returns NAT gateways matching the given IDs.
+func (n *Networking) DescribeNATGateways(
+	ctx context.Context, ids []string,
+) ([]driver.NATGateway, error) {
+	out, err := n.do(ctx, "DescribeNATGateways", ids, func() (any, error) {
+		return n.driver.DescribeNATGateways(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.NATGateway), nil
+}
+
+// CreateFlowLog creates a flow log.
+func (n *Networking) CreateFlowLog(
+	ctx context.Context, config driver.FlowLogConfig,
+) (*driver.FlowLog, error) {
+	out, err := n.do(ctx, "CreateFlowLog", config, func() (any, error) {
+		return n.driver.CreateFlowLog(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.FlowLog), nil
+}
+
+// DeleteFlowLog deletes a flow log.
+func (n *Networking) DeleteFlowLog(ctx context.Context, id string) error {
+	_, err := n.do(ctx, "DeleteFlowLog", id, func() (any, error) {
+		return nil, n.driver.DeleteFlowLog(ctx, id)
+	})
+
+	return err
+}
+
+// DescribeFlowLogs returns flow logs matching the given IDs.
+func (n *Networking) DescribeFlowLogs(
+	ctx context.Context, ids []string,
+) ([]driver.FlowLog, error) {
+	out, err := n.do(ctx, "DescribeFlowLogs", ids, func() (any, error) {
+		return n.driver.DescribeFlowLogs(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.FlowLog), nil
+}
+
+// GetFlowLogRecords returns flow log records for the specified flow log.
+func (n *Networking) GetFlowLogRecords(
+	ctx context.Context, flowLogID string, limit int,
+) ([]driver.FlowLogRecord, error) {
+	out, err := n.do(ctx, "GetFlowLogRecords", flowLogID, func() (any, error) {
+		return n.driver.GetFlowLogRecords(ctx, flowLogID, limit)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.FlowLogRecord), nil
+}
+
+// CreateRouteTable creates a route table.
+func (n *Networking) CreateRouteTable(
+	ctx context.Context, config driver.RouteTableConfig,
+) (*driver.RouteTable, error) {
+	out, err := n.do(ctx, "CreateRouteTable", config, func() (any, error) {
+		return n.driver.CreateRouteTable(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.RouteTable), nil
+}
+
+// DeleteRouteTable deletes a route table.
+func (n *Networking) DeleteRouteTable(ctx context.Context, id string) error {
+	_, err := n.do(ctx, "DeleteRouteTable", id, func() (any, error) {
+		return nil, n.driver.DeleteRouteTable(ctx, id)
+	})
+
+	return err
+}
+
+// DescribeRouteTables returns route tables matching the given IDs.
+func (n *Networking) DescribeRouteTables(
+	ctx context.Context, ids []string,
+) ([]driver.RouteTable, error) {
+	out, err := n.do(ctx, "DescribeRouteTables", ids, func() (any, error) {
+		return n.driver.DescribeRouteTables(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.RouteTable), nil
+}
+
+// CreateRoute adds a route to a route table.
+func (n *Networking) CreateRoute(
+	ctx context.Context, routeTableID, destinationCIDR, targetID, targetType string,
+) error {
+	_, err := n.do(ctx, "CreateRoute", routeTableID, func() (any, error) {
+		return nil, n.driver.CreateRoute(ctx, routeTableID, destinationCIDR, targetID, targetType)
+	})
+
+	return err
+}
+
+// DeleteRoute removes a route from a route table.
+func (n *Networking) DeleteRoute(ctx context.Context, routeTableID, destinationCIDR string) error {
+	_, err := n.do(ctx, "DeleteRoute", routeTableID, func() (any, error) {
+		return nil, n.driver.DeleteRoute(ctx, routeTableID, destinationCIDR)
+	})
+
+	return err
+}
+
+// CreateNetworkACL creates a network ACL.
+func (n *Networking) CreateNetworkACL(
+	ctx context.Context, vpcID string, tags map[string]string,
+) (*driver.NetworkACL, error) {
+	out, err := n.do(ctx, "CreateNetworkACL", vpcID, func() (any, error) {
+		return n.driver.CreateNetworkACL(ctx, vpcID, tags)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.NetworkACL), nil
+}
+
+// DeleteNetworkACL deletes a network ACL.
+func (n *Networking) DeleteNetworkACL(ctx context.Context, id string) error {
+	_, err := n.do(ctx, "DeleteNetworkACL", id, func() (any, error) {
+		return nil, n.driver.DeleteNetworkACL(ctx, id)
+	})
+
+	return err
+}
+
+// DescribeNetworkACLs returns network ACLs matching the given IDs.
+func (n *Networking) DescribeNetworkACLs(
+	ctx context.Context, ids []string,
+) ([]driver.NetworkACL, error) {
+	out, err := n.do(ctx, "DescribeNetworkACLs", ids, func() (any, error) {
+		return n.driver.DescribeNetworkACLs(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.NetworkACL), nil
+}
+
+// AddNetworkACLRule adds a rule to a network ACL.
+func (n *Networking) AddNetworkACLRule(
+	ctx context.Context, aclID string, rule *driver.NetworkACLRule,
+) error {
+	_, err := n.do(ctx, "AddNetworkACLRule", aclID, func() (any, error) {
+		return nil, n.driver.AddNetworkACLRule(ctx, aclID, rule)
+	})
+
+	return err
+}
+
+// RemoveNetworkACLRule removes a rule from a network ACL.
+func (n *Networking) RemoveNetworkACLRule(
+	ctx context.Context, aclID string, ruleNumber int, egress bool,
+) error {
+	_, err := n.do(ctx, "RemoveNetworkACLRule", aclID, func() (any, error) {
+		return nil, n.driver.RemoveNetworkACLRule(ctx, aclID, ruleNumber, egress)
+	})
+
+	return err
+}

--- a/networking/networking_test.go
+++ b/networking/networking_test.go
@@ -1,0 +1,944 @@
+package networking
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDriver implements driver.Networking for testing the portable wrapper.
+type mockDriver struct {
+	vpcs           map[string]*driver.VPCInfo
+	subnets        map[string]*driver.SubnetInfo
+	securityGroups map[string]*driver.SecurityGroupInfo
+	peerings       map[string]*driver.PeeringConnection
+	natGateways    map[string]*driver.NATGateway
+	flowLogs       map[string]*driver.FlowLog
+	routeTables    map[string]*driver.RouteTable
+	networkACLs    map[string]*driver.NetworkACL
+	seq            int
+}
+
+func newMockDriver() *mockDriver {
+	return &mockDriver{
+		vpcs:           make(map[string]*driver.VPCInfo),
+		subnets:        make(map[string]*driver.SubnetInfo),
+		securityGroups: make(map[string]*driver.SecurityGroupInfo),
+		peerings:       make(map[string]*driver.PeeringConnection),
+		natGateways:    make(map[string]*driver.NATGateway),
+		flowLogs:       make(map[string]*driver.FlowLog),
+		routeTables:    make(map[string]*driver.RouteTable),
+		networkACLs:    make(map[string]*driver.NetworkACL),
+	}
+}
+
+func (m *mockDriver) nextID(prefix string) string {
+	m.seq++
+
+	return fmt.Sprintf("%s-%d", prefix, m.seq)
+}
+
+func (m *mockDriver) CreateVPC(_ context.Context, config driver.VPCConfig) (*driver.VPCInfo, error) {
+	if config.CIDRBlock == "" {
+		return nil, fmt.Errorf("cidr required")
+	}
+
+	id := m.nextID("vpc")
+	info := &driver.VPCInfo{ID: id, CIDRBlock: config.CIDRBlock, State: "available", Tags: config.Tags}
+	m.vpcs[id] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteVPC(_ context.Context, id string) error {
+	if _, ok := m.vpcs[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.vpcs, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeVPCs(_ context.Context, ids []string) ([]driver.VPCInfo, error) {
+	if len(ids) == 0 {
+		result := make([]driver.VPCInfo, 0, len(m.vpcs))
+		for _, v := range m.vpcs {
+			result = append(result, *v)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.VPCInfo
+
+	for _, id := range ids {
+		if v, ok := m.vpcs[id]; ok {
+			result = append(result, *v)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateSubnet(_ context.Context, config driver.SubnetConfig) (*driver.SubnetInfo, error) {
+	if config.VPCID == "" {
+		return nil, fmt.Errorf("vpc id required")
+	}
+
+	id := m.nextID("subnet")
+	info := &driver.SubnetInfo{ID: id, VPCID: config.VPCID, CIDRBlock: config.CIDRBlock, State: "available"}
+	m.subnets[id] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteSubnet(_ context.Context, id string) error {
+	if _, ok := m.subnets[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.subnets, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeSubnets(_ context.Context, ids []string) ([]driver.SubnetInfo, error) {
+	if len(ids) == 0 {
+		result := make([]driver.SubnetInfo, 0, len(m.subnets))
+		for _, s := range m.subnets {
+			result = append(result, *s)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.SubnetInfo
+
+	for _, id := range ids {
+		if s, ok := m.subnets[id]; ok {
+			result = append(result, *s)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateSecurityGroup(_ context.Context, config driver.SecurityGroupConfig) (*driver.SecurityGroupInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	id := m.nextID("sg")
+	info := &driver.SecurityGroupInfo{ID: id, Name: config.Name, VPCID: config.VPCID}
+	m.securityGroups[id] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteSecurityGroup(_ context.Context, id string) error {
+	if _, ok := m.securityGroups[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.securityGroups, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeSecurityGroups(_ context.Context, ids []string) ([]driver.SecurityGroupInfo, error) {
+	if len(ids) == 0 {
+		result := make([]driver.SecurityGroupInfo, 0, len(m.securityGroups))
+		for _, sg := range m.securityGroups {
+			result = append(result, *sg)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.SecurityGroupInfo
+
+	for _, id := range ids {
+		if sg, ok := m.securityGroups[id]; ok {
+			result = append(result, *sg)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) AddIngressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
+	sg, ok := m.securityGroups[groupID]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	sg.IngressRules = append(sg.IngressRules, rule)
+
+	return nil
+}
+
+func (m *mockDriver) AddEgressRule(_ context.Context, groupID string, rule driver.SecurityRule) error {
+	sg, ok := m.securityGroups[groupID]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	sg.EgressRules = append(sg.EgressRules, rule)
+
+	return nil
+}
+
+func (m *mockDriver) RemoveIngressRule(_ context.Context, groupID string, _ driver.SecurityRule) error {
+	if _, ok := m.securityGroups[groupID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) RemoveEgressRule(_ context.Context, groupID string, _ driver.SecurityRule) error {
+	if _, ok := m.securityGroups[groupID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) CreatePeeringConnection(_ context.Context, config driver.PeeringConfig) (*driver.PeeringConnection, error) {
+	id := m.nextID("pcx")
+	pc := &driver.PeeringConnection{ID: id, RequesterVPC: config.RequesterVPC, AccepterVPC: config.AccepterVPC, Status: "pending-acceptance"}
+	m.peerings[id] = pc
+
+	return pc, nil
+}
+
+func (m *mockDriver) AcceptPeeringConnection(_ context.Context, peeringID string) error {
+	pc, ok := m.peerings[peeringID]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	pc.Status = "active"
+
+	return nil
+}
+
+func (m *mockDriver) RejectPeeringConnection(_ context.Context, peeringID string) error {
+	pc, ok := m.peerings[peeringID]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	pc.Status = "rejected"
+
+	return nil
+}
+
+func (m *mockDriver) DeletePeeringConnection(_ context.Context, peeringID string) error {
+	if _, ok := m.peerings[peeringID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.peerings, peeringID)
+
+	return nil
+}
+
+func (m *mockDriver) DescribePeeringConnections(_ context.Context, ids []string) ([]driver.PeeringConnection, error) {
+	if len(ids) == 0 {
+		result := make([]driver.PeeringConnection, 0, len(m.peerings))
+		for _, pc := range m.peerings {
+			result = append(result, *pc)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.PeeringConnection
+
+	for _, id := range ids {
+		if pc, ok := m.peerings[id]; ok {
+			result = append(result, *pc)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateNATGateway(_ context.Context, config driver.NATGatewayConfig) (*driver.NATGateway, error) {
+	id := m.nextID("nat")
+	nat := &driver.NATGateway{ID: id, SubnetID: config.SubnetID, State: "available"}
+	m.natGateways[id] = nat
+
+	return nat, nil
+}
+
+func (m *mockDriver) DeleteNATGateway(_ context.Context, id string) error {
+	if _, ok := m.natGateways[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.natGateways, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NATGateway, error) {
+	if len(ids) == 0 {
+		result := make([]driver.NATGateway, 0, len(m.natGateways))
+		for _, nat := range m.natGateways {
+			result = append(result, *nat)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.NATGateway
+
+	for _, id := range ids {
+		if nat, ok := m.natGateways[id]; ok {
+			result = append(result, *nat)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateFlowLog(_ context.Context, config driver.FlowLogConfig) (*driver.FlowLog, error) {
+	id := m.nextID("fl")
+	fl := &driver.FlowLog{ID: id, ResourceID: config.ResourceID, ResourceType: config.ResourceType, TrafficType: config.TrafficType, Status: "ACTIVE"}
+	m.flowLogs[id] = fl
+
+	return fl, nil
+}
+
+func (m *mockDriver) DeleteFlowLog(_ context.Context, id string) error {
+	if _, ok := m.flowLogs[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.flowLogs, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeFlowLogs(_ context.Context, ids []string) ([]driver.FlowLog, error) {
+	if len(ids) == 0 {
+		result := make([]driver.FlowLog, 0, len(m.flowLogs))
+		for _, fl := range m.flowLogs {
+			result = append(result, *fl)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.FlowLog
+
+	for _, id := range ids {
+		if fl, ok := m.flowLogs[id]; ok {
+			result = append(result, *fl)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) GetFlowLogRecords(_ context.Context, flowLogID string, _ int) ([]driver.FlowLogRecord, error) {
+	if _, ok := m.flowLogs[flowLogID]; !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return []driver.FlowLogRecord{}, nil
+}
+
+func (m *mockDriver) CreateRouteTable(_ context.Context, config driver.RouteTableConfig) (*driver.RouteTable, error) {
+	id := m.nextID("rtb")
+	rt := &driver.RouteTable{ID: id, VPCID: config.VPCID, Tags: config.Tags}
+	m.routeTables[id] = rt
+
+	return rt, nil
+}
+
+func (m *mockDriver) DeleteRouteTable(_ context.Context, id string) error {
+	if _, ok := m.routeTables[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.routeTables, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeRouteTables(_ context.Context, ids []string) ([]driver.RouteTable, error) {
+	if len(ids) == 0 {
+		result := make([]driver.RouteTable, 0, len(m.routeTables))
+		for _, rt := range m.routeTables {
+			result = append(result, *rt)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.RouteTable
+
+	for _, id := range ids {
+		if rt, ok := m.routeTables[id]; ok {
+			result = append(result, *rt)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateRoute(_ context.Context, routeTableID, _, _, _ string) error {
+	if _, ok := m.routeTables[routeTableID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) DeleteRoute(_ context.Context, routeTableID, _ string) error {
+	if _, ok := m.routeTables[routeTableID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) CreateNetworkACL(_ context.Context, vpcID string, tags map[string]string) (*driver.NetworkACL, error) {
+	if _, ok := m.vpcs[vpcID]; !ok {
+		return nil, fmt.Errorf("vpc not found")
+	}
+
+	id := m.nextID("acl")
+	acl := &driver.NetworkACL{ID: id, VPCID: vpcID, Tags: tags}
+	m.networkACLs[id] = acl
+
+	return acl, nil
+}
+
+func (m *mockDriver) DeleteNetworkACL(_ context.Context, id string) error {
+	if _, ok := m.networkACLs[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.networkACLs, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeNetworkACLs(_ context.Context, ids []string) ([]driver.NetworkACL, error) {
+	if len(ids) == 0 {
+		result := make([]driver.NetworkACL, 0, len(m.networkACLs))
+		for _, acl := range m.networkACLs {
+			result = append(result, *acl)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.NetworkACL
+
+	for _, id := range ids {
+		if acl, ok := m.networkACLs[id]; ok {
+			result = append(result, *acl)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) AddNetworkACLRule(_ context.Context, aclID string, _ *driver.NetworkACLRule) error {
+	if _, ok := m.networkACLs[aclID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	return nil
+}
+
+func (m *mockDriver) RemoveNetworkACLRule(_ context.Context, aclID string, _ int, _ bool) error {
+	if _, ok := m.networkACLs[aclID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	return nil
+}
+
+func newTestNetworking(opts ...Option) *Networking {
+	return NewNetworking(newMockDriver(), opts...)
+}
+
+func TestNewNetworking(t *testing.T) {
+	n := newTestNetworking()
+	require.NotNil(t, n)
+	require.NotNil(t, n.driver)
+}
+
+func TestCreateVPC(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		assert.Equal(t, "10.0.0.0/16", info.CIDRBlock)
+		assert.Equal(t, "available", info.State)
+	})
+
+	t.Run("empty cidr error", func(t *testing.T) {
+		_, err := n.CreateVPC(ctx, driver.VPCConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteVPC(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := n.DeleteVPC(ctx, vpc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := n.DeleteVPC(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDescribeVPCs(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	_, err = n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.1.0.0/16"})
+	require.NoError(t, err)
+
+	vpcs, err := n.DescribeVPCs(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(vpcs))
+}
+
+func TestCreateSubnet(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		info, err := n.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+		require.NoError(t, err)
+		assert.Equal(t, vpc.ID, info.VPCID)
+	})
+
+	t.Run("empty vpc error", func(t *testing.T) {
+		_, err := n.CreateSubnet(ctx, driver.SubnetConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteSubnet(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	subnet, err := n.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := n.DeleteSubnet(ctx, subnet.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := n.DeleteSubnet(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestCreateSecurityGroup(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := n.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "my-sg", VPCID: "vpc-1"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-sg", info.Name)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := n.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestSecurityGroupRules(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	sg, err := n.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "rule-sg", VPCID: "vpc-1"})
+	require.NoError(t, err)
+
+	rule := driver.SecurityRule{Protocol: "tcp", FromPort: 80, ToPort: 80, CIDR: "0.0.0.0/0"}
+
+	t.Run("add ingress", func(t *testing.T) {
+		err := n.AddIngressRule(ctx, sg.ID, rule)
+		require.NoError(t, err)
+	})
+
+	t.Run("add egress", func(t *testing.T) {
+		err := n.AddEgressRule(ctx, sg.ID, rule)
+		require.NoError(t, err)
+	})
+
+	t.Run("remove ingress", func(t *testing.T) {
+		err := n.RemoveIngressRule(ctx, sg.ID, rule)
+		require.NoError(t, err)
+	})
+
+	t.Run("remove egress", func(t *testing.T) {
+		err := n.RemoveEgressRule(ctx, sg.ID, rule)
+		require.NoError(t, err)
+	})
+
+	t.Run("ingress not found", func(t *testing.T) {
+		err := n.AddIngressRule(ctx, "nonexistent", rule)
+		require.Error(t, err)
+	})
+}
+
+func TestPeeringConnection(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	pc, err := n.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: "vpc-1", AccepterVPC: "vpc-2"})
+	require.NoError(t, err)
+	assert.Equal(t, "pending-acceptance", pc.Status)
+
+	t.Run("accept", func(t *testing.T) {
+		err := n.AcceptPeeringConnection(ctx, pc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("describe", func(t *testing.T) {
+		pcs, err := n.DescribePeeringConnections(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(pcs))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := n.DeletePeeringConnection(ctx, pc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := n.DeletePeeringConnection(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestRejectPeeringConnection(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	pc, err := n.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: "vpc-1", AccepterVPC: "vpc-2"})
+	require.NoError(t, err)
+
+	err = n.RejectPeeringConnection(ctx, pc.ID)
+	require.NoError(t, err)
+}
+
+func TestNATGateway(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	nat, err := n.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: "subnet-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "available", nat.State)
+
+	t.Run("describe", func(t *testing.T) {
+		nats, err := n.DescribeNATGateways(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(nats))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := n.DeleteNATGateway(ctx, nat.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := n.DeleteNATGateway(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestFlowLog(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	fl, err := n.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: "vpc-1", ResourceType: "VPC", TrafficType: "ALL"})
+	require.NoError(t, err)
+	assert.Equal(t, "ACTIVE", fl.Status)
+
+	t.Run("describe", func(t *testing.T) {
+		fls, err := n.DescribeFlowLogs(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(fls))
+	})
+
+	t.Run("get records", func(t *testing.T) {
+		records, err := n.GetFlowLogRecords(ctx, fl.ID, 10)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(records))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := n.DeleteFlowLog(ctx, fl.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := n.DeleteFlowLog(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestRouteTable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	rt, err := n.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: "vpc-1"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, rt.ID)
+
+	t.Run("create route", func(t *testing.T) {
+		err := n.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-1", "gateway")
+		require.NoError(t, err)
+	})
+
+	t.Run("delete route", func(t *testing.T) {
+		err := n.DeleteRoute(ctx, rt.ID, "0.0.0.0/0")
+		require.NoError(t, err)
+	})
+
+	t.Run("describe", func(t *testing.T) {
+		rts, err := n.DescribeRouteTables(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(rts))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := n.DeleteRouteTable(ctx, rt.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		err := n.DeleteRouteTable(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestNetworkACL(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	// Create a VPC first so the ACL creation succeeds.
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	acl, err := n.CreateNetworkACL(ctx, vpc.ID, nil)
+	require.NoError(t, err)
+	assert.NotEmpty(t, acl.ID)
+
+	t.Run("add rule", func(t *testing.T) {
+		rule := &driver.NetworkACLRule{RuleNumber: 100, Protocol: "tcp", Action: "allow", CIDR: "0.0.0.0/0"}
+		err := n.AddNetworkACLRule(ctx, acl.ID, rule)
+		require.NoError(t, err)
+	})
+
+	t.Run("remove rule", func(t *testing.T) {
+		err := n.RemoveNetworkACLRule(ctx, acl.ID, 100, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("describe", func(t *testing.T) {
+		acls, err := n.DescribeNetworkACLs(ctx, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(acls))
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		err := n.DeleteNetworkACL(ctx, acl.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("vpc not found", func(t *testing.T) {
+		_, err := n.CreateNetworkACL(ctx, "nonexistent", nil)
+		require.Error(t, err)
+	})
+}
+
+func TestNetworkingWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	n := newTestNetworking(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 1)
+
+	createCalls := rec.CallCountFor("networking", "CreateVPC")
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestNetworkingWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	n := newTestNetworking(WithRecorder(rec))
+	ctx := context.Background()
+
+	_ = n.DeleteVPC(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last)
+	assert.NotNil(t, last.Error)
+}
+
+func TestNetworkingWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	n := newTestNetworking(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 1)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 1)
+}
+
+func TestNetworkingWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	n := newTestNetworking(WithMetrics(mc))
+	ctx := context.Background()
+
+	_ = n.DeleteVPC(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestNetworkingWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	n := newTestNetworking(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("networking", "CreateVPC", injectedErr, inject.Always{})
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestNetworkingWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	n := newTestNetworking(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("networking", "DeleteVPC", injectedErr, inject.Always{})
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	err = n.DeleteVPC(ctx, "vpc-1")
+	require.Error(t, err)
+
+	delCalls := rec.CallsFor("networking", "DeleteVPC")
+	assert.Equal(t, 1, len(delCalls))
+	assert.NotNil(t, delCalls[0].Error)
+}
+
+func TestNetworkingWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	n := newTestNetworking(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("networking", "CreateVPC", injectedErr, inject.Always{})
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.Error(t, err)
+
+	inj.Remove("networking", "CreateVPC")
+
+	_, err = n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+}
+
+func TestNetworkingWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	n := newTestNetworking(WithLatency(latency))
+	ctx := context.Background()
+
+	info, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.0/16", info.CIDRBlock)
+}
+
+func TestNetworkingAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	n := NewNetworking(newMockDriver(),
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	_, err = n.DescribeVPCs(ctx, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/cloudwatchlogs"
 	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
 	"github.com/stackshy/cloudemu/providers/aws/ec2"
+	"github.com/stackshy/cloudemu/providers/aws/ecr"
 	"github.com/stackshy/cloudemu/providers/aws/elasticache"
 	"github.com/stackshy/cloudemu/providers/aws/elb"
+	"github.com/stackshy/cloudemu/providers/aws/eventbridge"
 	"github.com/stackshy/cloudemu/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/providers/aws/route53"
 	"github.com/stackshy/cloudemu/providers/aws/s3"
@@ -35,6 +37,8 @@ type Provider struct {
 	SecretsManager *secretsmanager.Mock
 	CloudWatchLogs *cloudwatchlogs.Mock
 	SNS            *sns.Mock
+	ECR            *ecr.Mock
+	EventBridge    *eventbridge.Mock
 }
 
 // New creates a new AWS provider with all mock services.
@@ -55,8 +59,19 @@ func New(opts ...config.Option) *Provider {
 		SecretsManager: secretsmanager.New(o),
 		CloudWatchLogs: cloudwatchlogs.New(o),
 		SNS:            sns.New(o),
+		ECR:            ecr.New(o),
+		EventBridge:    eventbridge.New(o),
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
+	p.S3.SetMonitoring(p.CloudWatch)
+	p.DynamoDB.SetMonitoring(p.CloudWatch)
+	p.Lambda.SetMonitoring(p.CloudWatch)
+	p.SQS.SetMonitoring(p.CloudWatch)
+	p.ElastiCache.SetMonitoring(p.CloudWatch)
+	p.CloudWatchLogs.SetMonitoring(p.CloudWatch)
+	p.SNS.SetMonitoring(p.CloudWatch)
+	p.ECR.SetMonitoring(p.CloudWatch)
+	p.EventBridge.SetMonitoring(p.CloudWatch)
 
 	return p
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/logging/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 const (
@@ -35,8 +36,25 @@ type logGroup struct {
 
 // Mock is an in-memory mock implementation of the AWS CloudWatch Logs service.
 type Mock struct {
-	groups *memstore.Store[*logGroup]
-	opts   *config.Options
+	groups     *memstore.Store[*logGroup]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/Logs", MetricName: metricName, Value: value, Unit: unit,
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new CloudWatch Logs mock with the given configuration options.
@@ -223,6 +241,10 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 		lg.info.StoredBytes += totalBytes
 		return lg
 	})
+
+	dims := map[string]string{"LogGroupName": groupName}
+	m.emitMetric("IncomingLogEvents", float64(len(events)), "Count", dims)
+	m.emitMetric("IncomingBytes", float64(totalBytes), "Bytes", dims)
 
 	return nil
 }

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/database/driver"
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/pagination"
 )
 
@@ -27,18 +29,49 @@ const (
 	OpBetween      = "BETWEEN"
 )
 
+// Stream view type constants.
+const (
+	ViewNewImage       = "NEW_IMAGE"
+	ViewOldImage       = "OLD_IMAGE"
+	ViewNewAndOld      = "NEW_AND_OLD_IMAGES"
+	ViewKeysOnly       = "KEYS_ONLY"
+	maxStreamRecords   = 1000
+	defaultStreamLimit = 100
+)
+
 var _ driver.Database = (*Mock)(nil)
 
 type tableData struct {
-	config driver.TableConfig
-	items  *memstore.Store[map[string]any]
+	config        driver.TableConfig
+	items         *memstore.Store[map[string]any]
+	ttlConfig     driver.TTLConfig
+	streamConfig  driver.StreamConfig
+	streamRecords []driver.StreamRecord
+	seqCounter    atomic.Int64
 }
 
 // Mock is an in-memory mock implementation of DynamoDB.
 type Mock struct {
-	mu     sync.RWMutex
-	tables map[string]*tableData
-	opts   *config.Options
+	mu         sync.RWMutex
+	tables     map[string]*tableData
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/DynamoDB", MetricName: metricName, Value: value, Unit: "Count",
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new DynamoDB mock.
@@ -108,15 +141,23 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 }
 
 func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) error {
-	m.mu.RLock()
-	td, exists := m.tables[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	td, exists := m.tables[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
-	td.items.Set(itemKey(td.config, item), item)
+	key := itemKey(td.config, item)
+	oldItem, hadOld := td.items.Get(key)
+	td.items.Set(key, item)
+	m.recordStreamEvent(td, oldItem, item, hadOld)
+	m.mu.Unlock()
+
+	dims := map[string]string{"TableName": table}
+	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
+	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
 	return nil
 }
@@ -130,24 +171,47 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
-	item, ok := td.items.Get(itemKey(td.config, key))
+	k := itemKey(td.config, key)
+	item, ok := td.items.Get(k)
+
 	if !ok {
 		return nil, cerrors.New(cerrors.NotFound, "item not found")
 	}
+
+	if m.isItemExpired(td, item) {
+		td.items.Delete(k)
+		return nil, cerrors.New(cerrors.NotFound, "item not found")
+	}
+
+	dims := map[string]string{"TableName": table}
+	m.emitMetric("ConsumedReadCapacityUnits", 1, dims)
+	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
 	return item, nil
 }
 
 func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) error {
-	m.mu.RLock()
-	td, exists := m.tables[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	td, exists := m.tables[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
-	td.items.Delete(itemKey(td.config, key))
+	k := itemKey(td.config, key)
+	oldItem, hadOld := td.items.Get(k)
+	td.items.Delete(k)
+
+	if hadOld {
+		m.recordStreamRemove(td, oldItem)
+	}
+
+	m.mu.Unlock()
+
+	dims := map[string]string{"TableName": table}
+	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
+	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
 	return nil
 }
@@ -167,7 +231,7 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
-	matched := matchQueryItems(td, pkField, skField, &input)
+	matched := m.matchQueryItems(td, pkField, skField, &input)
 
 	limit := input.Limit
 	if limit <= 0 {
@@ -175,6 +239,10 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 	}
 
 	page, _ := pagination.Paginate(matched, input.PageToken, limit)
+
+	dims := map[string]string{"TableName": input.Table}
+	m.emitMetric("ConsumedReadCapacityUnits", float64(len(page.Items)), dims)
+	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
 	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
 }
@@ -196,12 +264,18 @@ func resolveKeyFields(td *tableData, indexName string) (pkField, skField string,
 	return "", "", cerrors.Newf(cerrors.NotFound, "index %s not found", indexName)
 }
 
-func matchQueryItems(td *tableData, pkField, skField string, input *driver.QueryInput) []map[string]any {
+func (m *Mock) matchQueryItems(
+	td *tableData, pkField, skField string, input *driver.QueryInput,
+) []map[string]any {
 	allItems := td.items.All()
 
 	var matched []map[string]any
 
 	for _, item := range allItems {
+		if m.isItemExpired(td, item) {
+			continue
+		}
+
 		pkVal := fmt.Sprintf("%v", item[pkField])
 		if pkVal != fmt.Sprintf("%v", input.KeyCondition.PartitionVal) {
 			continue
@@ -236,6 +310,10 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 	var matched []map[string]any
 
 	for _, item := range allItems {
+		if m.isItemExpired(td, item) {
+			continue
+		}
+
 		if matchesFilters(item, input.Filters) {
 			matched = append(matched, item)
 		}
@@ -248,21 +326,31 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 
 	page, _ := pagination.Paginate(matched, input.PageToken, limit)
 
+	dims := map[string]string{"TableName": input.Table}
+	m.emitMetric("ConsumedReadCapacityUnits", float64(len(page.Items)), dims)
+	m.emitMetric("SuccessfulRequestCount", 1, dims)
+
 	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
 }
 
 func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {
-	m.mu.RLock()
-	td, exists := m.tables[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	td, exists := m.tables[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
 	}
 
 	for _, item := range items {
-		td.items.Set(itemKey(td.config, item), item)
+		key := itemKey(td.config, item)
+		oldItem, hadOld := td.items.Get(key)
+		td.items.Set(key, item)
+
+		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}
+
+	m.mu.Unlock()
 
 	return nil
 }
@@ -370,4 +458,273 @@ func matchesSingleScanFilter(item map[string]any, f driver.ScanFilter) bool {
 	default:
 		return false
 	}
+}
+
+// UpdateTTL configures TTL for a table.
+func (m *Mock) UpdateTTL(_ context.Context, table string, cfg driver.TTLConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	td.ttlConfig = cfg
+
+	return nil
+}
+
+// DescribeTTL returns the TTL configuration for a table.
+func (m *Mock) DescribeTTL(_ context.Context, table string) (*driver.TTLConfig, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	cfg := td.ttlConfig
+
+	return &cfg, nil
+}
+
+// UpdateStreamConfig configures streams for a table.
+func (m *Mock) UpdateStreamConfig(_ context.Context, table string, cfg driver.StreamConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	td.streamConfig = cfg
+
+	return nil
+}
+
+// GetStreamRecords returns stream records after the given token.
+func (m *Mock) GetStreamRecords(
+	_ context.Context, table string, limit int, token string,
+) (*driver.StreamIterator, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if !td.streamConfig.Enabled {
+		return nil, cerrors.New(cerrors.FailedPrecondition, "streams not enabled")
+	}
+
+	return filterStreamRecords(td.streamRecords, limit, token), nil
+}
+
+func filterStreamRecords(records []driver.StreamRecord, limit int, token string) *driver.StreamIterator {
+	if limit <= 0 {
+		limit = defaultStreamLimit
+	}
+
+	startIdx := 0
+
+	if token != "" {
+		for i, r := range records {
+			if r.SequenceNumber == token {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+
+	end := startIdx + limit
+	if end > len(records) {
+		end = len(records)
+	}
+
+	result := records[startIdx:end]
+	nextToken := ""
+
+	if end < len(records) {
+		nextToken = result[len(result)-1].SequenceNumber
+	}
+
+	return &driver.StreamIterator{
+		ShardID:   "shard-000",
+		Records:   result,
+		NextToken: nextToken,
+	}
+}
+
+// TransactWriteItems executes puts and deletes atomically.
+func (m *Mock) TransactWriteItems(
+	_ context.Context, table string, puts []map[string]any, deletes []map[string]any,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	m.applyTransactPuts(td, puts)
+	m.applyTransactDeletes(td, deletes)
+
+	return nil
+}
+
+func (m *Mock) applyTransactPuts(td *tableData, puts []map[string]any) {
+	for _, item := range puts {
+		key := itemKey(td.config, item)
+		oldItem, hadOld := td.items.Get(key)
+		td.items.Set(key, item)
+		m.recordStreamEvent(td, oldItem, item, hadOld)
+	}
+}
+
+func (m *Mock) applyTransactDeletes(td *tableData, deletes []map[string]any) {
+	for _, key := range deletes {
+		k := itemKey(td.config, key)
+		oldItem, hadOld := td.items.Get(k)
+		td.items.Delete(k)
+
+		if hadOld {
+			m.recordStreamRemove(td, oldItem)
+		}
+	}
+}
+
+// isItemExpired checks if an item has expired based on TTL config.
+func (m *Mock) isItemExpired(td *tableData, item map[string]any) bool {
+	if !td.ttlConfig.Enabled {
+		return false
+	}
+
+	ttlVal, ok := item[td.ttlConfig.AttributeName]
+	if !ok {
+		return false
+	}
+
+	ttlUnix := toUnixTimestamp(ttlVal)
+	if ttlUnix <= 0 {
+		return false
+	}
+
+	return m.opts.Clock.Now().Unix() > ttlUnix
+}
+
+func toUnixTimestamp(val any) int64 {
+	switch v := val.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	default:
+		parsed, err := strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
+		if err != nil {
+			return 0
+		}
+
+		return int64(parsed)
+	}
+}
+
+// recordStreamEvent records an INSERT or MODIFY stream event. Caller must hold m.mu.
+func (m *Mock) recordStreamEvent(td *tableData, oldItem, newItem map[string]any, hadOld bool) {
+	if !td.streamConfig.Enabled {
+		return
+	}
+
+	eventType := "INSERT"
+	if hadOld {
+		eventType = "MODIFY"
+	}
+
+	rec := m.buildStreamRecord(td, eventType, oldItem, newItem)
+	td.streamRecords = appendStreamRecord(td.streamRecords, &rec)
+}
+
+// recordStreamRemove records a REMOVE stream event. Caller must hold m.mu.
+func (m *Mock) recordStreamRemove(td *tableData, oldItem map[string]any) {
+	if !td.streamConfig.Enabled {
+		return
+	}
+
+	rec := m.buildStreamRecord(td, "REMOVE", oldItem, nil)
+	td.streamRecords = appendStreamRecord(td.streamRecords, &rec)
+}
+
+func (m *Mock) buildStreamRecord(
+	td *tableData, eventType string, oldItem, newItem map[string]any,
+) driver.StreamRecord {
+	seq := td.seqCounter.Add(1)
+	keys := extractKeys(td.config, oldItem, newItem)
+
+	rec := driver.StreamRecord{
+		EventID:        fmt.Sprintf("event-%d", seq),
+		EventType:      eventType,
+		Table:          td.config.Name,
+		Keys:           keys,
+		Timestamp:      m.opts.Clock.Now(),
+		SequenceNumber: fmt.Sprintf("%d", seq),
+	}
+
+	applyViewType(&rec, td.streamConfig.ViewType, oldItem, newItem)
+
+	return rec
+}
+
+func extractKeys(cfg driver.TableConfig, oldItem, newItem map[string]any) map[string]any {
+	src := newItem
+	if src == nil {
+		src = oldItem
+	}
+
+	keys := map[string]any{cfg.PartitionKey: src[cfg.PartitionKey]}
+	if cfg.SortKey != "" {
+		keys[cfg.SortKey] = src[cfg.SortKey]
+	}
+
+	return keys
+}
+
+func applyViewType(rec *driver.StreamRecord, viewType string, oldItem, newItem map[string]any) {
+	switch viewType {
+	case ViewNewImage:
+		rec.NewImage = copyItem(newItem)
+	case ViewOldImage:
+		rec.OldImage = copyItem(oldItem)
+	case ViewNewAndOld:
+		rec.NewImage = copyItem(newItem)
+		rec.OldImage = copyItem(oldItem)
+	case ViewKeysOnly:
+	}
+}
+
+func copyItem(item map[string]any) map[string]any {
+	if item == nil {
+		return nil
+	}
+
+	cp := make(map[string]any, len(item))
+	for k, v := range item {
+		cp[k] = v
+	}
+
+	return cp
+}
+
+func appendStreamRecord(records []driver.StreamRecord, rec *driver.StreamRecord) []driver.StreamRecord {
+	records = append(records, *rec)
+	if len(records) > maxStreamRecords {
+		records = records[len(records)-maxStreamRecords:]
+	}
+
+	return records
 }

--- a/providers/aws/dynamodb/dynamodb_test.go
+++ b/providers/aws/dynamodb/dynamodb_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/database/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
 )
 
 func newTestMock() *Mock {
@@ -366,6 +368,320 @@ func TestQueryWithGSI(t *testing.T) {
 	})
 }
 
+func TestUpdateTTL(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	t.Run("enable TTL", func(t *testing.T) {
+		err := m.UpdateTTL(ctx, "tbl", driver.TTLConfig{Enabled: true, AttributeName: "expiresAt"})
+		requireNoError(t, err)
+
+		cfg, err := m.DescribeTTL(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, true, cfg.Enabled)
+		assertEqual(t, "expiresAt", cfg.AttributeName)
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		err := m.UpdateTTL(ctx, "nope", driver.TTLConfig{Enabled: true, AttributeName: "ttl"})
+		assertError(t, err, true)
+	})
+
+	t.Run("describe TTL table not found", func(t *testing.T) {
+		_, err := m.DescribeTTL(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestTTLExpiry(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc))
+	m := New(opts)
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	// Enable TTL
+	err := m.UpdateTTL(ctx, "tbl", driver.TTLConfig{Enabled: true, AttributeName: "expiresAt"})
+	requireNoError(t, err)
+
+	// Put item with TTL 1 hour from now
+	ttlTime := fc.Now().Add(1 * time.Hour).Unix()
+	err = m.PutItem(ctx, "tbl", map[string]any{
+		"pk": "user1", "sk": "info", "name": "Alice", "expiresAt": ttlTime,
+	})
+	requireNoError(t, err)
+
+	// Item should be accessible before TTL
+	item, err := m.GetItem(ctx, "tbl", map[string]any{"pk": "user1", "sk": "info"})
+	requireNoError(t, err)
+	assertEqual(t, "Alice", item["name"])
+
+	// Advance clock past TTL
+	fc.Advance(2 * time.Hour)
+
+	// Item should now be expired
+	_, err = m.GetItem(ctx, "tbl", map[string]any{"pk": "user1", "sk": "info"})
+	assertError(t, err, true)
+}
+
+func TestTTLFilterInScan(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc))
+	m := New(opts)
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	err := m.UpdateTTL(ctx, "tbl", driver.TTLConfig{Enabled: true, AttributeName: "ttl"})
+	requireNoError(t, err)
+
+	// One item expires in 1 hour, one in 3 hours
+	_ = m.PutItem(ctx, "tbl", map[string]any{
+		"pk": "1", "sk": "a", "ttl": fc.Now().Add(1 * time.Hour).Unix(),
+	})
+	_ = m.PutItem(ctx, "tbl", map[string]any{
+		"pk": "2", "sk": "b", "ttl": fc.Now().Add(3 * time.Hour).Unix(),
+	})
+	_ = m.PutItem(ctx, "tbl", map[string]any{
+		"pk": "3", "sk": "c", // no TTL attribute - never expires
+	})
+
+	// Before any expiry - all 3 visible
+	result, err := m.Scan(ctx, driver.ScanInput{Table: "tbl"})
+	requireNoError(t, err)
+	assertEqual(t, 3, result.Count)
+
+	// Advance 2 hours - item 1 expired
+	fc.Advance(2 * time.Hour)
+
+	result, err = m.Scan(ctx, driver.ScanInput{Table: "tbl"})
+	requireNoError(t, err)
+	assertEqual(t, 2, result.Count)
+
+	// Advance 2 more hours - item 2 also expired
+	fc.Advance(2 * time.Hour)
+
+	result, err = m.Scan(ctx, driver.ScanInput{Table: "tbl"})
+	requireNoError(t, err)
+	assertEqual(t, 1, result.Count)
+}
+
+func TestTTLFilterInQuery(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc))
+	m := New(opts)
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	err := m.UpdateTTL(ctx, "tbl", driver.TTLConfig{Enabled: true, AttributeName: "ttl"})
+	requireNoError(t, err)
+
+	_ = m.PutItem(ctx, "tbl", map[string]any{
+		"pk": "user1", "sk": "a", "ttl": fc.Now().Add(1 * time.Hour).Unix(),
+	})
+	_ = m.PutItem(ctx, "tbl", map[string]any{
+		"pk": "user1", "sk": "b", "ttl": fc.Now().Add(3 * time.Hour).Unix(),
+	})
+
+	// Both items visible
+	result, err := m.Query(ctx, driver.QueryInput{
+		Table:        "tbl",
+		KeyCondition: driver.KeyCondition{PartitionKey: "pk", PartitionVal: "user1"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 2, result.Count)
+
+	// Expire one
+	fc.Advance(2 * time.Hour)
+
+	result, err = m.Query(ctx, driver.QueryInput{
+		Table:        "tbl",
+		KeyCondition: driver.KeyCondition{PartitionKey: "pk", PartitionVal: "user1"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 1, result.Count)
+}
+
+func TestStreamConfig(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	t.Run("enable streams", func(t *testing.T) {
+		err := m.UpdateStreamConfig(ctx, "tbl", driver.StreamConfig{
+			Enabled:  true,
+			ViewType: "NEW_AND_OLD_IMAGES",
+		})
+		requireNoError(t, err)
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		err := m.UpdateStreamConfig(ctx, "nope", driver.StreamConfig{Enabled: true})
+		assertError(t, err, true)
+	})
+
+	t.Run("streams not enabled returns error", func(t *testing.T) {
+		createTestTable(m, "no-stream")
+		_, err := m.GetStreamRecords(ctx, "no-stream", 10, "")
+		assertError(t, err, true)
+	})
+}
+
+func TestStreamRecords(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	err := m.UpdateStreamConfig(ctx, "tbl", driver.StreamConfig{
+		Enabled:  true,
+		ViewType: "NEW_AND_OLD_IMAGES",
+	})
+	requireNoError(t, err)
+
+	// INSERT event
+	_ = m.PutItem(ctx, "tbl", map[string]any{"pk": "user1", "sk": "info", "name": "Alice"})
+
+	// MODIFY event
+	_ = m.PutItem(ctx, "tbl", map[string]any{"pk": "user1", "sk": "info", "name": "Alice Updated"})
+
+	// DELETE (REMOVE event)
+	_ = m.DeleteItem(ctx, "tbl", map[string]any{"pk": "user1", "sk": "info"})
+
+	iter, err := m.GetStreamRecords(ctx, "tbl", 100, "")
+	requireNoError(t, err)
+	assertEqual(t, 3, len(iter.Records))
+	assertEqual(t, "INSERT", iter.Records[0].EventType)
+	assertEqual(t, "MODIFY", iter.Records[1].EventType)
+	assertEqual(t, "REMOVE", iter.Records[2].EventType)
+
+	// Verify NEW_AND_OLD_IMAGES view type
+	assertEqual(t, "Alice", iter.Records[1].OldImage["name"])
+	assertEqual(t, "Alice Updated", iter.Records[1].NewImage["name"])
+}
+
+func TestStreamPagination(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	err := m.UpdateStreamConfig(ctx, "tbl", driver.StreamConfig{
+		Enabled:  true,
+		ViewType: "KEYS_ONLY",
+	})
+	requireNoError(t, err)
+
+	// Insert 5 items to generate 5 stream records
+	for i := 0; i < 5; i++ {
+		_ = m.PutItem(ctx, "tbl", map[string]any{
+			"pk": "user", "sk": string(rune('a' + i)),
+		})
+	}
+
+	// Get first page of 2
+	iter, err := m.GetStreamRecords(ctx, "tbl", 2, "")
+	requireNoError(t, err)
+	assertEqual(t, 2, len(iter.Records))
+	assertNotEmpty(t, iter.NextToken)
+
+	// Get next page using token
+	iter2, err := m.GetStreamRecords(ctx, "tbl", 2, iter.NextToken)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(iter2.Records))
+	assertNotEmpty(t, iter2.NextToken)
+
+	// Last page
+	iter3, err := m.GetStreamRecords(ctx, "tbl", 2, iter2.NextToken)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(iter3.Records))
+	assertEqual(t, "", iter3.NextToken)
+}
+
+func TestTransactWriteItems(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	createTestTable(m, "tbl")
+
+	t.Run("atomic puts and deletes", func(t *testing.T) {
+		// Pre-insert an item to delete
+		_ = m.PutItem(ctx, "tbl", map[string]any{"pk": "old", "sk": "item", "val": "delete-me"})
+
+		puts := []map[string]any{
+			{"pk": "new1", "sk": "a", "val": "x"},
+			{"pk": "new2", "sk": "b", "val": "y"},
+		}
+		deletes := []map[string]any{
+			{"pk": "old", "sk": "item"},
+		}
+
+		err := m.TransactWriteItems(ctx, "tbl", puts, deletes)
+		requireNoError(t, err)
+
+		// Verify puts succeeded
+		item, err := m.GetItem(ctx, "tbl", map[string]any{"pk": "new1", "sk": "a"})
+		requireNoError(t, err)
+		assertEqual(t, "x", item["val"])
+
+		item, err = m.GetItem(ctx, "tbl", map[string]any{"pk": "new2", "sk": "b"})
+		requireNoError(t, err)
+		assertEqual(t, "y", item["val"])
+
+		// Verify delete succeeded
+		_, err = m.GetItem(ctx, "tbl", map[string]any{"pk": "old", "sk": "item"})
+		assertError(t, err, true)
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		err := m.TransactWriteItems(ctx, "nope", nil, nil)
+		assertError(t, err, true)
+	})
+}
+
+func TestDynamoDBMetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc))
+	m := New(opts)
+	ctx := context.Background()
+
+	cw := cloudwatch.New(opts)
+	m.SetMonitoring(cw)
+
+	createTestTable(m, "tbl")
+
+	t.Run("PutItem emits metrics", func(t *testing.T) {
+		err := m.PutItem(ctx, "tbl", map[string]any{"pk": "u1", "sk": "a"})
+		requireNoError(t, err)
+
+		result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "AWS/DynamoDB",
+			MetricName: "ConsumedWriteCapacityUnits",
+			Dimensions: map[string]string{"TableName": "tbl"},
+			StartTime:  fc.Now().Add(-1 * time.Hour),
+			EndTime:    fc.Now().Add(1 * time.Hour),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		requireNoError(t, err)
+		assertEqual(t, true, len(result.Values) > 0)
+	})
+
+	t.Run("GetItem emits metrics", func(t *testing.T) {
+		_, err := m.GetItem(ctx, "tbl", map[string]any{"pk": "u1", "sk": "a"})
+		requireNoError(t, err)
+
+		result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "AWS/DynamoDB",
+			MetricName: "ConsumedReadCapacityUnits",
+			Dimensions: map[string]string{"TableName": "tbl"},
+			StartTime:  fc.Now().Add(-1 * time.Hour),
+			EndTime:    fc.Now().Add(1 * time.Hour),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		requireNoError(t, err)
+		assertEqual(t, true, len(result.Values) > 0)
+	})
+}
+
 // --- test helpers ---
 
 func requireNoError(t *testing.T, err error) {
@@ -389,5 +705,12 @@ func assertEqual(t *testing.T, expected, actual any) {
 	t.Helper()
 	if expected != actual {
 		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+	if s == "" {
+		t.Error("expected non-empty string")
 	}
 }

--- a/providers/aws/ec2/asg.go
+++ b/providers/aws/ec2/asg.go
@@ -1,0 +1,326 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+)
+
+const (
+	asgStatusActive = "active"
+	percentDivisor  = 100
+)
+
+// CreateAutoScalingGroup creates an auto-scaling group and launches desired instances.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateAutoScalingGroup(
+	ctx context.Context, cfg driver.AutoScalingGroupConfig,
+) (*driver.AutoScalingGroup, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "ASG name is required")
+	}
+
+	if m.asgs.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "ASG %q already exists", cfg.Name)
+	}
+
+	if err := validateASGBounds(cfg.DesiredCapacity, cfg.MinSize, cfg.MaxSize); err != nil {
+		return nil, err
+	}
+
+	instances, err := m.RunInstances(ctx, cfg.InstanceConfig, cfg.DesiredCapacity)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "failed to launch instances: %v", err)
+	}
+
+	ids := extractInstanceIDs(instances)
+
+	asg := &asgData{
+		config: driver.AutoScalingGroup{
+			Name:              cfg.Name,
+			MinSize:           cfg.MinSize,
+			MaxSize:           cfg.MaxSize,
+			DesiredCapacity:   cfg.DesiredCapacity,
+			CurrentSize:       len(ids),
+			InstanceIDs:       ids,
+			Status:            asgStatusActive,
+			HealthCheckType:   cfg.HealthCheckType,
+			CreatedAt:         m.opts.Clock.Now().UTC().Format(timeFormat),
+			Tags:              copyTags(cfg.Tags),
+			AvailabilityZones: copyStrings(cfg.AvailabilityZones),
+		},
+		policies: memstore.New[driver.ScalingPolicy](),
+	}
+
+	m.asgs.Set(cfg.Name, asg)
+
+	result := asg.config
+
+	return &result, nil
+}
+
+// DeleteAutoScalingGroup deletes an ASG, optionally force-terminating its instances.
+func (m *Mock) DeleteAutoScalingGroup(ctx context.Context, name string, forceDelete bool) error {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "ASG %q not found", name)
+	}
+
+	if !forceDelete && len(asg.config.InstanceIDs) > 0 {
+		return cerrors.Newf(cerrors.FailedPrecondition, "ASG %q has instances; use forceDelete", name)
+	}
+
+	if forceDelete && len(asg.config.InstanceIDs) > 0 {
+		if err := m.TerminateInstances(ctx, asg.config.InstanceIDs); err != nil {
+			return err
+		}
+	}
+
+	m.asgs.Delete(name)
+
+	return nil
+}
+
+// GetAutoScalingGroup returns details of an ASG.
+func (m *Mock) GetAutoScalingGroup(_ context.Context, name string) (*driver.AutoScalingGroup, error) {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "ASG %q not found", name)
+	}
+
+	result := asg.config
+
+	return &result, nil
+}
+
+// ListAutoScalingGroups returns all ASGs.
+func (m *Mock) ListAutoScalingGroups(_ context.Context) ([]driver.AutoScalingGroup, error) {
+	all := m.asgs.All()
+	results := make([]driver.AutoScalingGroup, 0, len(all))
+
+	for _, asg := range all {
+		results = append(results, asg.config)
+	}
+
+	return results, nil
+}
+
+// UpdateAutoScalingGroup updates the capacity settings of an ASG.
+func (m *Mock) UpdateAutoScalingGroup(
+	ctx context.Context, name string, desired, minSize, maxSize int,
+) error {
+	if err := validateASGBounds(desired, minSize, maxSize); err != nil {
+		return err
+	}
+
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "ASG %q not found", name)
+	}
+
+	asg.config.MinSize = minSize
+	asg.config.MaxSize = maxSize
+
+	return m.reconcileASG(ctx, asg, desired)
+}
+
+// SetDesiredCapacity sets the desired capacity of an ASG.
+func (m *Mock) SetDesiredCapacity(ctx context.Context, name string, desired int) error {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "ASG %q not found", name)
+	}
+
+	if desired < asg.config.MinSize || desired > asg.config.MaxSize {
+		return cerrors.Newf(
+			cerrors.InvalidArgument,
+			"desired %d outside bounds [%d, %d]", desired, asg.config.MinSize, asg.config.MaxSize,
+		)
+	}
+
+	return m.reconcileASG(ctx, asg, desired)
+}
+
+// reconcileASG scales instances up or down to match the desired capacity.
+func (m *Mock) reconcileASG(ctx context.Context, asg *asgData, desired int) error {
+	current := len(asg.config.InstanceIDs)
+
+	if desired > current {
+		return m.scaleUp(ctx, asg, desired-current)
+	}
+
+	if desired < current {
+		return m.scaleDown(ctx, asg, current-desired)
+	}
+
+	return nil
+}
+
+func (m *Mock) scaleUp(ctx context.Context, asg *asgData, count int) error {
+	cfg := instanceConfigFromASG(asg)
+
+	instances, err := m.RunInstances(ctx, cfg, count)
+	if err != nil {
+		return err
+	}
+
+	asg.config.InstanceIDs = append(asg.config.InstanceIDs, extractInstanceIDs(instances)...)
+	asg.config.CurrentSize = len(asg.config.InstanceIDs)
+	asg.config.DesiredCapacity = asg.config.CurrentSize
+
+	return nil
+}
+
+func (m *Mock) scaleDown(ctx context.Context, asg *asgData, count int) error {
+	ids := asg.config.InstanceIDs
+
+	// Terminate newest first (last added).
+	toTerminate := ids[len(ids)-count:]
+	remaining := make([]string, len(ids)-count)
+	copy(remaining, ids[:len(ids)-count])
+
+	if err := m.TerminateInstances(ctx, toTerminate); err != nil {
+		return err
+	}
+
+	asg.config.InstanceIDs = remaining
+	asg.config.CurrentSize = len(remaining)
+	asg.config.DesiredCapacity = asg.config.CurrentSize
+
+	return nil
+}
+
+func instanceConfigFromASG(asg *asgData) driver.InstanceConfig {
+	return driver.InstanceConfig{
+		Tags: copyTags(asg.config.Tags),
+	}
+}
+
+func validateASGBounds(desired, minSize, maxSize int) error {
+	if minSize < 0 {
+		return cerrors.New(cerrors.InvalidArgument, "min size must be >= 0")
+	}
+
+	if maxSize < minSize {
+		return cerrors.New(cerrors.InvalidArgument, "max size must be >= min size")
+	}
+
+	if desired < minSize || desired > maxSize {
+		return cerrors.Newf(
+			cerrors.InvalidArgument,
+			"desired capacity %d outside bounds [%d, %d]", desired, minSize, maxSize,
+		)
+	}
+
+	return nil
+}
+
+func extractInstanceIDs(instances []driver.Instance) []string {
+	ids := make([]string, len(instances))
+
+	for i := range instances {
+		ids[i] = instances[i].ID
+	}
+
+	return ids
+}
+
+// PutScalingPolicy attaches a scaling policy to an ASG.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutScalingPolicy(_ context.Context, policy driver.ScalingPolicy) error {
+	asg, ok := m.asgs.Get(policy.AutoScalingGroup)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "ASG %q not found", policy.AutoScalingGroup)
+	}
+
+	asg.policies.Set(policy.Name, policy)
+
+	return nil
+}
+
+// DeleteScalingPolicy removes a scaling policy from an ASG.
+func (m *Mock) DeleteScalingPolicy(_ context.Context, asgName, policyName string) error {
+	asg, ok := m.asgs.Get(asgName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "ASG %q not found", asgName)
+	}
+
+	if !asg.policies.Delete(policyName) {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found in ASG %q", policyName, asgName)
+	}
+
+	return nil
+}
+
+// ExecuteScalingPolicy executes a scaling policy on an ASG.
+func (m *Mock) ExecuteScalingPolicy(ctx context.Context, asgName, policyName string) error {
+	asg, ok := m.asgs.Get(asgName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "ASG %q not found", asgName)
+	}
+
+	policy, ok := asg.policies.Get(policyName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found in ASG %q", policyName, asgName)
+	}
+
+	newDesired := computeNewDesired(&asg.config, &policy)
+
+	return m.reconcileASG(ctx, asg, newDesired)
+}
+
+func computeNewDesired(cfg *driver.AutoScalingGroup, policy *driver.ScalingPolicy) int {
+	desired := cfg.DesiredCapacity
+
+	switch policy.AdjustmentType {
+	case "ExactCapacity":
+		desired = policy.ScalingAdjustment
+	case "ChangeInCapacity":
+		desired += policy.ScalingAdjustment
+	case "PercentChangeInCapacity":
+		delta := (desired * policy.ScalingAdjustment) / percentDivisor
+		desired += delta
+	}
+
+	return clampDesired(desired, cfg.MinSize, cfg.MaxSize)
+}
+
+func clampDesired(desired, minSize, maxSize int) int {
+	if desired < minSize {
+		return minSize
+	}
+
+	if desired > maxSize {
+		return maxSize
+	}
+
+	return desired
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}
+
+func copyStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make([]string, len(src))
+	copy(dst, src)
+
+	return dst
+}

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -71,13 +71,21 @@ type instanceData struct {
 	LaunchTime     string
 }
 
+type asgData struct {
+	config   driver.AutoScalingGroup
+	policies *memstore.Store[driver.ScalingPolicy]
+}
+
 // Mock is an in-memory mock implementation of the AWS EC2 service.
 type Mock struct {
-	instances  *memstore.Store[*instanceData]
-	sm         *statemachine.Machine
-	opts       *config.Options
-	ipCounter  atomic.Int64
-	monitoring mondriver.Monitoring
+	instances    *memstore.Store[*instanceData]
+	asgs         *memstore.Store[*asgData]
+	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
+	templates    *memstore.Store[*driver.LaunchTemplate]
+	sm           *statemachine.Machine
+	opts         *config.Options
+	ipCounter    atomic.Int64
+	monitoring   mondriver.Monitoring
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -143,9 +151,12 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, valu
 // New creates a new EC2 mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		instances: memstore.New[*instanceData](),
-		sm:        statemachine.New(compute.VMTransitions()),
-		opts:      opts,
+		instances:    memstore.New[*instanceData](),
+		asgs:         memstore.New[*asgData](),
+		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
+		templates:    memstore.New[*driver.LaunchTemplate](),
+		sm:           statemachine.New(compute.VMTransitions()),
+		opts:         opts,
 	}
 }
 

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -318,3 +318,1170 @@ func assertNotEmpty(t *testing.T, s string) {
 		t.Error("expected non-empty string")
 	}
 }
+
+func assertTrue(t *testing.T, val bool, msg string) {
+	t.Helper()
+	if !val {
+		t.Errorf("expected true: %s", msg)
+	}
+}
+
+// =====================================================================
+// Auto-Scaling Group Tests
+// =====================================================================
+
+func TestCreateAutoScalingGroup(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.AutoScalingGroupConfig
+		expectErr bool
+	}{
+		{
+			name: "success",
+			cfg: driver.AutoScalingGroupConfig{
+				Name:              "my-asg",
+				MinSize:           1,
+				MaxSize:           5,
+				DesiredCapacity:   2,
+				InstanceConfig:    defaultConfig(),
+				HealthCheckType:   "EC2",
+				Tags:              map[string]string{"env": "test"},
+				AvailabilityZones: []string{"us-east-1a", "us-east-1b"},
+			},
+		},
+		{
+			name: "empty name",
+			cfg: driver.AutoScalingGroupConfig{
+				MinSize:         1,
+				MaxSize:         5,
+				DesiredCapacity: 2,
+				InstanceConfig:  defaultConfig(),
+			},
+			expectErr: true,
+		},
+		{
+			name: "desired below min",
+			cfg: driver.AutoScalingGroupConfig{
+				Name:            "bad-desired",
+				MinSize:         3,
+				MaxSize:         5,
+				DesiredCapacity: 1,
+				InstanceConfig:  defaultConfig(),
+			},
+			expectErr: true,
+		},
+		{
+			name: "desired above max",
+			cfg: driver.AutoScalingGroupConfig{
+				Name:            "bad-desired-high",
+				MinSize:         1,
+				MaxSize:         3,
+				DesiredCapacity: 5,
+				InstanceConfig:  defaultConfig(),
+			},
+			expectErr: true,
+		},
+		{
+			name: "max less than min",
+			cfg: driver.AutoScalingGroupConfig{
+				Name:            "bad-bounds",
+				MinSize:         5,
+				MaxSize:         3,
+				DesiredCapacity: 4,
+				InstanceConfig:  defaultConfig(),
+			},
+			expectErr: true,
+		},
+		{
+			name: "negative min",
+			cfg: driver.AutoScalingGroupConfig{
+				Name:            "neg-min",
+				MinSize:         -1,
+				MaxSize:         3,
+				DesiredCapacity: 1,
+				InstanceConfig:  defaultConfig(),
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			ctx := context.Background()
+			asg, err := m.CreateAutoScalingGroup(ctx, tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, tc.cfg.Name, asg.Name)
+			assertEqual(t, tc.cfg.MinSize, asg.MinSize)
+			assertEqual(t, tc.cfg.MaxSize, asg.MaxSize)
+			assertEqual(t, tc.cfg.DesiredCapacity, asg.DesiredCapacity)
+			assertEqual(t, tc.cfg.DesiredCapacity, asg.CurrentSize)
+			assertEqual(t, tc.cfg.DesiredCapacity, len(asg.InstanceIDs))
+			assertEqual(t, "active", asg.Status)
+			assertEqual(t, tc.cfg.HealthCheckType, asg.HealthCheckType)
+			assertNotEmpty(t, asg.CreatedAt)
+			assertEqual(t, "test", asg.Tags["env"])
+			assertEqual(t, 2, len(asg.AvailabilityZones))
+		})
+	}
+}
+
+func TestCreateAutoScalingGroupDuplicate(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cfg := driver.AutoScalingGroupConfig{
+		Name:            "dup-asg",
+		MinSize:         0,
+		MaxSize:         2,
+		DesiredCapacity: 1,
+		InstanceConfig:  defaultConfig(),
+	}
+
+	_, err := m.CreateAutoScalingGroup(ctx, cfg)
+	requireNoError(t, err)
+
+	_, err = m.CreateAutoScalingGroup(ctx, cfg)
+	assertError(t, err, true)
+}
+
+func TestDeleteAutoScalingGroup(t *testing.T) {
+	t.Run("force delete with instances", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		cfg := driver.AutoScalingGroupConfig{
+			Name:            "del-force",
+			MinSize:         1,
+			MaxSize:         3,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		}
+		asg, err := m.CreateAutoScalingGroup(ctx, cfg)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(asg.InstanceIDs))
+
+		err = m.DeleteAutoScalingGroup(ctx, "del-force", true)
+		requireNoError(t, err)
+
+		// ASG should be gone
+		_, err = m.GetAutoScalingGroup(ctx, "del-force")
+		assertError(t, err, true)
+	})
+
+	t.Run("no force with instances fails", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		cfg := driver.AutoScalingGroupConfig{
+			Name:            "del-noforce",
+			MinSize:         1,
+			MaxSize:         3,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		}
+		_, err := m.CreateAutoScalingGroup(ctx, cfg)
+		requireNoError(t, err)
+
+		err = m.DeleteAutoScalingGroup(ctx, "del-noforce", false)
+		assertError(t, err, true)
+	})
+
+	t.Run("no force with zero instances succeeds", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		// Create with 1 instance, then scale down to 0 via update
+		cfg := driver.AutoScalingGroupConfig{
+			Name:            "del-empty",
+			MinSize:         0,
+			MaxSize:         3,
+			DesiredCapacity: 1,
+			InstanceConfig:  defaultConfig(),
+		}
+		_, err := m.CreateAutoScalingGroup(ctx, cfg)
+		requireNoError(t, err)
+
+		// Scale down to 0
+		err = m.UpdateAutoScalingGroup(ctx, "del-empty", 0, 0, 3)
+		requireNoError(t, err)
+
+		err = m.DeleteAutoScalingGroup(ctx, "del-empty", false)
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.DeleteAutoScalingGroup(ctx, "nonexistent", true)
+		assertError(t, err, true)
+	})
+}
+
+func TestGetAutoScalingGroup(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		cfg := driver.AutoScalingGroupConfig{
+			Name:            "get-asg",
+			MinSize:         1,
+			MaxSize:         5,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		}
+		_, err := m.CreateAutoScalingGroup(ctx, cfg)
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "get-asg")
+		requireNoError(t, err)
+		assertEqual(t, "get-asg", asg.Name)
+		assertEqual(t, 2, asg.DesiredCapacity)
+		assertEqual(t, 2, asg.CurrentSize)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.GetAutoScalingGroup(ctx, "missing")
+		assertError(t, err, true)
+	})
+}
+
+func TestListAutoScalingGroups(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		asgs, err := m.ListAutoScalingGroups(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(asgs))
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		for _, name := range []string{"asg-a", "asg-b", "asg-c"} {
+			_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+				Name:            name,
+				MinSize:         1,
+				MaxSize:         2,
+				DesiredCapacity: 1,
+				InstanceConfig:  defaultConfig(),
+			})
+			requireNoError(t, err)
+		}
+
+		asgs, err := m.ListAutoScalingGroups(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 3, len(asgs))
+	})
+}
+
+func TestUpdateAutoScalingGroup(t *testing.T) {
+	t.Run("scale up", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "update-up",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.UpdateAutoScalingGroup(ctx, "update-up", 5, 1, 10)
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "update-up")
+		requireNoError(t, err)
+		assertEqual(t, 5, asg.CurrentSize)
+		assertEqual(t, 5, asg.DesiredCapacity)
+		assertEqual(t, 5, len(asg.InstanceIDs))
+	})
+
+	t.Run("scale down", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "update-down",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 5,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.UpdateAutoScalingGroup(ctx, "update-down", 2, 1, 10)
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "update-down")
+		requireNoError(t, err)
+		assertEqual(t, 2, asg.CurrentSize)
+		assertEqual(t, 2, asg.DesiredCapacity)
+		assertEqual(t, 2, len(asg.InstanceIDs))
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "update-same",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 3,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.UpdateAutoScalingGroup(ctx, "update-same", 3, 1, 10)
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "update-same")
+		requireNoError(t, err)
+		assertEqual(t, 3, asg.CurrentSize)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.UpdateAutoScalingGroup(ctx, "missing", 2, 1, 5)
+		assertError(t, err, true)
+	})
+
+	t.Run("invalid bounds", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "update-bad",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		// desired outside new bounds
+		err = m.UpdateAutoScalingGroup(ctx, "update-bad", 20, 1, 10)
+		assertError(t, err, true)
+	})
+}
+
+func TestSetDesiredCapacity(t *testing.T) {
+	t.Run("scale up", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "setcap-up",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.SetDesiredCapacity(ctx, "setcap-up", 5)
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "setcap-up")
+		requireNoError(t, err)
+		assertEqual(t, 5, asg.CurrentSize)
+		assertEqual(t, 5, asg.DesiredCapacity)
+	})
+
+	t.Run("scale down terminates newest", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		created, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "setcap-down",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 4,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+		assertEqual(t, 4, len(created.InstanceIDs))
+
+		// Keep the first two instance IDs - they should survive
+		firstTwo := created.InstanceIDs[:2]
+
+		err = m.SetDesiredCapacity(ctx, "setcap-down", 2)
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "setcap-down")
+		requireNoError(t, err)
+		assertEqual(t, 2, asg.CurrentSize)
+		assertEqual(t, 2, len(asg.InstanceIDs))
+		// The oldest instances should remain
+		assertEqual(t, firstTwo[0], asg.InstanceIDs[0])
+		assertEqual(t, firstTwo[1], asg.InstanceIDs[1])
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.SetDesiredCapacity(ctx, "missing", 3)
+		assertError(t, err, true)
+	})
+
+	t.Run("desired below min", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "setcap-low",
+			MinSize:         2,
+			MaxSize:         10,
+			DesiredCapacity: 3,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.SetDesiredCapacity(ctx, "setcap-low", 1)
+		assertError(t, err, true)
+	})
+
+	t.Run("desired above max", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "setcap-high",
+			MinSize:         1,
+			MaxSize:         5,
+			DesiredCapacity: 3,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.SetDesiredCapacity(ctx, "setcap-high", 10)
+		assertError(t, err, true)
+	})
+}
+
+// =====================================================================
+// Scaling Policy Tests
+// =====================================================================
+
+func TestPutScalingPolicy(t *testing.T) {
+	t.Run("create new policy", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "policy-asg",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "scale-up",
+			AutoScalingGroup:  "policy-asg",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 2,
+		})
+		requireNoError(t, err)
+	})
+
+	t.Run("update existing policy", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "policy-upd",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "my-policy",
+			AutoScalingGroup:  "policy-upd",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 1,
+		})
+		requireNoError(t, err)
+
+		// Overwrite with new adjustment
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "my-policy",
+			AutoScalingGroup:  "policy-upd",
+			AdjustmentType:    "ExactCapacity",
+			ScalingAdjustment: 5,
+		})
+		requireNoError(t, err)
+
+		// Execute to verify it was updated
+		err = m.ExecuteScalingPolicy(ctx, "policy-upd", "my-policy")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "policy-upd")
+		requireNoError(t, err)
+		assertEqual(t, 5, asg.DesiredCapacity)
+	})
+
+	t.Run("ASG not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:             "orphan",
+			AutoScalingGroup: "nonexistent",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteScalingPolicy(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "delpol-asg",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 2,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "to-delete",
+			AutoScalingGroup:  "delpol-asg",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 1,
+		})
+		requireNoError(t, err)
+
+		err = m.DeleteScalingPolicy(ctx, "delpol-asg", "to-delete")
+		requireNoError(t, err)
+
+		// Executing deleted policy should fail
+		err = m.ExecuteScalingPolicy(ctx, "delpol-asg", "to-delete")
+		assertError(t, err, true)
+	})
+
+	t.Run("policy not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "delpol-asg2",
+			MinSize:         1,
+			MaxSize:         5,
+			DesiredCapacity: 1,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.DeleteScalingPolicy(ctx, "delpol-asg2", "nonexistent")
+		assertError(t, err, true)
+	})
+
+	t.Run("ASG not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.DeleteScalingPolicy(ctx, "no-asg", "no-policy")
+		assertError(t, err, true)
+	})
+}
+
+func TestExecuteScalingPolicy(t *testing.T) {
+	t.Run("ChangeInCapacity positive", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-change",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 3,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "add-two",
+			AutoScalingGroup:  "exec-change",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 2,
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-change", "add-two")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "exec-change")
+		requireNoError(t, err)
+		assertEqual(t, 5, asg.DesiredCapacity)
+	})
+
+	t.Run("ChangeInCapacity negative (scale down)", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-neg",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 5,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "remove-two",
+			AutoScalingGroup:  "exec-neg",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: -2,
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-neg", "remove-two")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "exec-neg")
+		requireNoError(t, err)
+		assertEqual(t, 3, asg.DesiredCapacity)
+	})
+
+	t.Run("ExactCapacity", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-exact",
+			MinSize:         1,
+			MaxSize:         10,
+			DesiredCapacity: 3,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "set-seven",
+			AutoScalingGroup:  "exec-exact",
+			AdjustmentType:    "ExactCapacity",
+			ScalingAdjustment: 7,
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-exact", "set-seven")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "exec-exact")
+		requireNoError(t, err)
+		assertEqual(t, 7, asg.DesiredCapacity)
+	})
+
+	t.Run("PercentChangeInCapacity", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-pct",
+			MinSize:         1,
+			MaxSize:         20,
+			DesiredCapacity: 10,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "grow-50pct",
+			AutoScalingGroup:  "exec-pct",
+			AdjustmentType:    "PercentChangeInCapacity",
+			ScalingAdjustment: 50,
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-pct", "grow-50pct")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "exec-pct")
+		requireNoError(t, err)
+		// 10 + (10*50/100) = 15
+		assertEqual(t, 15, asg.DesiredCapacity)
+	})
+
+	t.Run("clamped to max", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-clamp-max",
+			MinSize:         1,
+			MaxSize:         5,
+			DesiredCapacity: 4,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "add-ten",
+			AutoScalingGroup:  "exec-clamp-max",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 10,
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-clamp-max", "add-ten")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "exec-clamp-max")
+		requireNoError(t, err)
+		assertEqual(t, 5, asg.DesiredCapacity)
+	})
+
+	t.Run("clamped to min", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-clamp-min",
+			MinSize:         2,
+			MaxSize:         10,
+			DesiredCapacity: 3,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name:              "remove-ten",
+			AutoScalingGroup:  "exec-clamp-min",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: -10,
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-clamp-min", "remove-ten")
+		requireNoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "exec-clamp-min")
+		requireNoError(t, err)
+		assertEqual(t, 2, asg.DesiredCapacity)
+	})
+
+	t.Run("ASG not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.ExecuteScalingPolicy(ctx, "missing", "policy")
+		assertError(t, err, true)
+	})
+
+	t.Run("policy not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name:            "exec-nopol",
+			MinSize:         1,
+			MaxSize:         5,
+			DesiredCapacity: 1,
+			InstanceConfig:  defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "exec-nopol", "missing")
+		assertError(t, err, true)
+	})
+}
+
+// =====================================================================
+// Spot Instance Tests
+// =====================================================================
+
+func TestRequestSpotInstances(t *testing.T) {
+	t.Run("single one-time", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          1,
+			Type:           "one-time",
+		})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(reqs))
+		assertEqual(t, "active", reqs[0].Status)
+		assertEqual(t, "one-time", reqs[0].Type)
+		assertNotEmpty(t, reqs[0].ID)
+		assertNotEmpty(t, reqs[0].InstanceID)
+		assertNotEmpty(t, reqs[0].CreatedAt)
+		assertTrue(t, reqs[0].MaxPrice == 0.05, "max price should be 0.05")
+	})
+
+	t.Run("multiple persistent", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.10,
+			Count:          3,
+			Type:           "persistent",
+		})
+		requireNoError(t, err)
+		assertEqual(t, 3, len(reqs))
+
+		for _, req := range reqs {
+			assertEqual(t, "active", req.Status)
+			assertEqual(t, "persistent", req.Type)
+			assertNotEmpty(t, req.InstanceID)
+		}
+	})
+
+	t.Run("zero count", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          0,
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("negative count", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          -1,
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("zero max price", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0,
+			Count:          1,
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("negative max price", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       -1.0,
+			Count:          1,
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestCancelSpotRequests(t *testing.T) {
+	t.Run("one-time terminates instance", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          1,
+			Type:           "one-time",
+		})
+		requireNoError(t, err)
+
+		instanceID := reqs[0].InstanceID
+
+		err = m.CancelSpotRequests(ctx, []string{reqs[0].ID})
+		requireNoError(t, err)
+
+		// Verify spot request is canceled
+		desc, err := m.DescribeSpotRequests(ctx, []string{reqs[0].ID})
+		requireNoError(t, err)
+		assertEqual(t, "canceled", desc[0].Status)
+
+		// Verify instance is terminated
+		instances, err := m.DescribeInstances(ctx, []string{instanceID}, nil)
+		requireNoError(t, err)
+		assertEqual(t, 1, len(instances))
+		assertEqual(t, "terminated", instances[0].State)
+	})
+
+	t.Run("persistent does not terminate instance", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          1,
+			Type:           "persistent",
+		})
+		requireNoError(t, err)
+
+		instanceID := reqs[0].InstanceID
+
+		err = m.CancelSpotRequests(ctx, []string{reqs[0].ID})
+		requireNoError(t, err)
+
+		// Verify spot request is canceled
+		desc, err := m.DescribeSpotRequests(ctx, []string{reqs[0].ID})
+		requireNoError(t, err)
+		assertEqual(t, "canceled", desc[0].Status)
+
+		// Verify instance is still running
+		instances, err := m.DescribeInstances(ctx, []string{instanceID}, nil)
+		requireNoError(t, err)
+		assertEqual(t, 1, len(instances))
+		assertEqual(t, "running", instances[0].State)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.CancelSpotRequests(ctx, []string{"sir-nonexistent"})
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribeSpotRequests(t *testing.T) {
+	t.Run("all requests (empty filter)", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          2,
+			Type:           "one-time",
+		})
+		requireNoError(t, err)
+
+		_, err = m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.10,
+			Count:          1,
+			Type:           "persistent",
+		})
+		requireNoError(t, err)
+
+		all, err := m.DescribeSpotRequests(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 3, len(all))
+	})
+
+	t.Run("empty IDs returns all", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		all, err := m.DescribeSpotRequests(ctx, []string{})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(all))
+	})
+
+	t.Run("filter by specific IDs", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+			InstanceConfig: defaultConfig(),
+			MaxPrice:       0.05,
+			Count:          3,
+			Type:           "one-time",
+		})
+		requireNoError(t, err)
+
+		filtered, err := m.DescribeSpotRequests(ctx, []string{reqs[0].ID, reqs[2].ID})
+		requireNoError(t, err)
+		assertEqual(t, 2, len(filtered))
+	})
+
+	t.Run("ID not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.DescribeSpotRequests(ctx, []string{"sir-nonexistent"})
+		assertError(t, err, true)
+	})
+}
+
+// =====================================================================
+// Launch Template Tests
+// =====================================================================
+
+func TestCreateLaunchTemplate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		tmpl, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "my-template",
+			InstanceConfig: defaultConfig(),
+		})
+		requireNoError(t, err)
+		assertEqual(t, "my-template", tmpl.Name)
+		assertNotEmpty(t, tmpl.ID)
+		assertNotEmpty(t, tmpl.CreatedAt)
+		assertTrue(t, tmpl.Version > 0, "version should be positive")
+		assertEqual(t, "ami-12345", tmpl.InstanceConfig.ImageID)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			InstanceConfig: defaultConfig(),
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("duplicate name", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "dup-tmpl",
+			InstanceConfig: defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		_, err = m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "dup-tmpl",
+			InstanceConfig: defaultConfig(),
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("version numbering increments", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		tmpl1, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "tmpl-v1",
+			InstanceConfig: defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		tmpl2, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "tmpl-v2",
+			InstanceConfig: defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		assertTrue(t, tmpl2.Version > tmpl1.Version, "second template version should be greater")
+	})
+}
+
+func TestDeleteLaunchTemplate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "del-tmpl",
+			InstanceConfig: defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		err = m.DeleteLaunchTemplate(ctx, "del-tmpl")
+		requireNoError(t, err)
+
+		// Should be gone
+		_, err = m.GetLaunchTemplate(ctx, "del-tmpl")
+		assertError(t, err, true)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.DeleteLaunchTemplate(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestGetLaunchTemplate(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		created, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "get-tmpl",
+			InstanceConfig: defaultConfig(),
+		})
+		requireNoError(t, err)
+
+		fetched, err := m.GetLaunchTemplate(ctx, "get-tmpl")
+		requireNoError(t, err)
+		assertEqual(t, created.ID, fetched.ID)
+		assertEqual(t, created.Name, fetched.Name)
+		assertEqual(t, created.Version, fetched.Version)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.GetLaunchTemplate(ctx, "missing")
+		assertError(t, err, true)
+	})
+}
+
+func TestListLaunchTemplates(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		templates, err := m.ListLaunchTemplates(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(templates))
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		for _, name := range []string{"tmpl-a", "tmpl-b", "tmpl-c"} {
+			_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+				Name:           name,
+				InstanceConfig: defaultConfig(),
+			})
+			requireNoError(t, err)
+		}
+
+		templates, err := m.ListLaunchTemplates(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 3, len(templates))
+	})
+}

--- a/providers/aws/ec2/spot.go
+++ b/providers/aws/ec2/spot.go
@@ -1,0 +1,112 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+const (
+	spotStatusOpen     = "open"
+	spotStatusActive   = "active"
+	spotStatusCanceled = "canceled"
+	spotTypeOneTime    = "one-time"
+	timeFormat         = "2006-01-02T15:04:05Z"
+)
+
+// RequestSpotInstances creates spot instance requests and immediately fulfills them.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) RequestSpotInstances(
+	ctx context.Context, cfg driver.SpotRequestConfig,
+) ([]driver.SpotInstanceRequest, error) {
+	if cfg.Count <= 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
+	}
+
+	if cfg.MaxPrice <= 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "max price must be greater than 0")
+	}
+
+	instances, err := m.RunInstances(ctx, cfg.InstanceConfig, cfg.Count)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	for _, inst := range instances {
+		reqID := idgen.GenerateID("sir-")
+
+		req := &driver.SpotInstanceRequest{
+			ID:             reqID,
+			InstanceConfig: cfg.InstanceConfig,
+			MaxPrice:       cfg.MaxPrice,
+			Status:         spotStatusActive,
+			InstanceID:     inst.ID,
+			CreatedAt:      now,
+			Type:           cfg.Type,
+		}
+
+		m.spotRequests.Set(reqID, req)
+		results = append(results, *req)
+	}
+
+	return results, nil
+}
+
+// CancelSpotRequests cancels spot requests and terminates instances for one-time requests.
+func (m *Mock) CancelSpotRequests(ctx context.Context, requestIDs []string) error {
+	for _, reqID := range requestIDs {
+		req, ok := m.spotRequests.Get(reqID)
+		if !ok {
+			return cerrors.Newf(cerrors.NotFound, "spot request %q not found", reqID)
+		}
+
+		req.Status = spotStatusCanceled
+
+		if req.Type == spotTypeOneTime && req.InstanceID != "" {
+			if err := m.TerminateInstances(ctx, []string{req.InstanceID}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// DescribeSpotRequests returns spot requests matching the given IDs.
+func (m *Mock) DescribeSpotRequests(
+	_ context.Context, requestIDs []string,
+) ([]driver.SpotInstanceRequest, error) {
+	if len(requestIDs) == 0 {
+		return m.allSpotRequests(), nil
+	}
+
+	results := make([]driver.SpotInstanceRequest, 0, len(requestIDs))
+
+	for _, reqID := range requestIDs {
+		req, ok := m.spotRequests.Get(reqID)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "spot request %q not found", reqID)
+		}
+
+		results = append(results, *req)
+	}
+
+	return results, nil
+}
+
+func (m *Mock) allSpotRequests() []driver.SpotInstanceRequest {
+	all := m.spotRequests.All()
+	results := make([]driver.SpotInstanceRequest, 0, len(all))
+
+	for _, req := range all {
+		results = append(results, *req)
+	}
+
+	return results
+}

--- a/providers/aws/ec2/template.go
+++ b/providers/aws/ec2/template.go
@@ -1,0 +1,77 @@
+package ec2
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+//nolint:gochecknoglobals // atomic counter for template versioning
+var templateVersion uint64
+
+// CreateLaunchTemplate creates a new launch template.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLaunchTemplate(
+	_ context.Context, cfg driver.LaunchTemplateConfig,
+) (*driver.LaunchTemplate, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "template name is required")
+	}
+
+	if m.templates.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "template %q already exists", cfg.Name)
+	}
+
+	ver := int(atomic.AddUint64(&templateVersion, 1)) //nolint:gosec // overflow impossible in mock
+
+	tmpl := &driver.LaunchTemplate{
+		ID:             idgen.GenerateID("lt-"),
+		Name:           cfg.Name,
+		Version:        ver,
+		InstanceConfig: cfg.InstanceConfig,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	m.templates.Set(cfg.Name, tmpl)
+
+	result := *tmpl
+
+	return &result, nil
+}
+
+// DeleteLaunchTemplate deletes a launch template by name.
+func (m *Mock) DeleteLaunchTemplate(_ context.Context, name string) error {
+	if !m.templates.Delete(name) {
+		return cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+	}
+
+	return nil
+}
+
+// GetLaunchTemplate returns a launch template by name.
+func (m *Mock) GetLaunchTemplate(_ context.Context, name string) (*driver.LaunchTemplate, error) {
+	tmpl, ok := m.templates.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+	}
+
+	result := *tmpl
+
+	return &result, nil
+}
+
+// ListLaunchTemplates returns all launch templates.
+func (m *Mock) ListLaunchTemplates(_ context.Context) ([]driver.LaunchTemplate, error) {
+	all := m.templates.All()
+	results := make([]driver.LaunchTemplate, 0, len(all))
+
+	for _, tmpl := range all {
+		results = append(results, *tmpl)
+	}
+
+	return results, nil
+}

--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -1,0 +1,636 @@
+// Package ecr provides an in-memory mock implementation of AWS Elastic Container Registry.
+package ecr
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"path"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	defaultMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
+	mutableTag           = "MUTABLE"
+	immutableTag         = "IMMUTABLE"
+	scanStatusComplete   = "COMPLETE"
+	digestHashFormatByte = 8
+)
+
+// Compile-time check that Mock implements driver.ContainerRegistry.
+var _ driver.ContainerRegistry = (*Mock)(nil)
+
+type imageData struct {
+	detail driver.ImageDetail
+	layers []driver.LayerInfo
+}
+
+type repoData struct {
+	info          driver.Repository
+	images        *memstore.Store[*imageData]
+	scans         *memstore.Store[*driver.ScanResult]
+	policy        *driver.LifecyclePolicy
+	scanOnPush    bool
+	tagMutability string
+}
+
+// Mock is an in-memory mock implementation of the AWS ECR service.
+type Mock struct {
+	repos      *memstore.Store[*repoData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/ECR", MetricName: metricName, Value: value, Unit: "Count",
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
+}
+
+// New creates a new ECR mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		repos: memstore.New[*repoData](),
+		opts:  opts,
+	}
+}
+
+// CreateRepository creates a new ECR repository.
+func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) (*driver.Repository, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "repository name is required")
+	}
+
+	if m.repos.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "repository %q already exists", cfg.Name)
+	}
+
+	mutability := cfg.ImageTagMutability
+	if mutability == "" {
+		mutability = mutableTag
+	}
+
+	tags := copyTags(cfg.Tags)
+	uri := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", m.opts.AccountID, m.opts.Region, cfg.Name)
+
+	info := driver.Repository{
+		Name:       cfg.Name,
+		URI:        uri,
+		CreatedAt:  m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:       tags,
+		ImageCount: 0,
+	}
+
+	rd := &repoData{
+		info:          info,
+		images:        memstore.New[*imageData](),
+		scans:         memstore.New[*driver.ScanResult](),
+		scanOnPush:    cfg.ImageScanOnPush,
+		tagMutability: mutability,
+	}
+
+	m.repos.Set(cfg.Name, rd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteRepository deletes an ECR repository.
+func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	if !force && rd.images.Len() > 0 {
+		return errors.Newf(errors.FailedPrecondition, "repository %q is not empty; use force to delete", name)
+	}
+
+	m.repos.Delete(name)
+
+	return nil
+}
+
+// GetRepository retrieves information about an ECR repository.
+func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository, error) {
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	result := rd.info
+	result.ImageCount = rd.images.Len()
+
+	return &result, nil
+}
+
+// ListRepositories lists all ECR repositories.
+func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
+	all := m.repos.All()
+	repos := make([]driver.Repository, 0, len(all))
+
+	for _, rd := range all {
+		repo := rd.info
+		repo.ImageCount = rd.images.Len()
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
+}
+
+// PutImage pushes an image manifest to an ECR repository.
+func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(manifest.Repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
+	}
+
+	if err := checkTagMutability(rd, manifest.Tag); err != nil {
+		return nil, err
+	}
+
+	digest := resolveDigest(manifest, m.opts.Clock.Now())
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	mediaType := resolveMediaType(manifest.MediaType)
+
+	detail := driver.ImageDetail{
+		RegistryID: m.opts.AccountID,
+		Repository: manifest.Repository,
+		Digest:     digest,
+		Tags:       []string{manifest.Tag},
+		SizeBytes:  manifest.SizeBytes,
+		PushedAt:   now,
+		MediaType:  mediaType,
+	}
+
+	img := &imageData{detail: detail, layers: manifest.Layers}
+	rd.images.Set(digest, img)
+
+	if manifest.Tag != "" {
+		updateTagIndex(rd, digest, manifest.Tag)
+	}
+
+	rd.info.ImageCount = rd.images.Len()
+
+	if rd.scanOnPush {
+		autoScan(rd, digest, manifest.Repository, m.opts.Clock.Now())
+	}
+
+	m.emitMetric("ImagePushCount", 1, map[string]string{"RepositoryName": manifest.Repository})
+
+	result := detail
+
+	return &result, nil
+}
+
+// GetImage retrieves image details by repository and reference.
+func (m *Mock) GetImage(_ context.Context, repository, reference string) (*driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	m.emitMetric("ImagePullCount", 1, map[string]string{"RepositoryName": repository})
+
+	result := img.detail
+
+	return &result, nil
+}
+
+// ListImages lists all images in an ECR repository.
+func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	all := rd.images.All()
+	images := make([]driver.ImageDetail, 0, len(all))
+
+	for _, img := range all {
+		images = append(images, img.detail)
+	}
+
+	return images, nil
+}
+
+// DeleteImage deletes an image from an ECR repository by reference.
+func (m *Mock) DeleteImage(_ context.Context, repository, reference string) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	rd.images.Delete(img.detail.Digest)
+	rd.scans.Delete(img.detail.Digest)
+	rd.info.ImageCount = rd.images.Len()
+
+	return nil
+}
+
+// TagImage adds a new tag to an existing image in an ECR repository.
+func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag string) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, sourceRef)
+	if img == nil {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", sourceRef, repository)
+	}
+
+	if err := checkTagMutability(rd, targetTag); err != nil {
+		return err
+	}
+
+	updateTagIndex(rd, img.detail.Digest, targetTag)
+
+	return nil
+}
+
+// PutLifecyclePolicy sets a lifecycle policy on an ECR repository.
+func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy driver.LifecyclePolicy) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	policyCopy := copyLifecyclePolicy(policy)
+	rd.policy = &policyCopy
+
+	return nil
+}
+
+// GetLifecyclePolicy retrieves the lifecycle policy for an ECR repository.
+func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return nil, errors.Newf(errors.NotFound, "no lifecycle policy for repository %q", repository)
+	}
+
+	result := copyLifecyclePolicy(*rd.policy)
+
+	return &result, nil
+}
+
+// EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
+func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return []string{}, nil
+	}
+
+	return evaluateRules(rd, m.opts.Clock.Now()), nil
+}
+
+// StartImageScan starts a vulnerability scan on an image in an ECR repository.
+func (m *Mock) StartImageScan(_ context.Context, repository, reference string) (*driver.ScanResult, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	scan := generateScanResult(repository, img.detail.Digest, m.opts.Clock.Now())
+	rd.scans.Set(img.detail.Digest, scan)
+
+	result := *scan
+
+	return &result, nil
+}
+
+// GetImageScanResults retrieves scan results for an image in an ECR repository.
+func (m *Mock) GetImageScanResults(
+	_ context.Context, repository, reference string,
+) (*driver.ScanResult, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	scan, ok := rd.scans.Get(img.detail.Digest)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "no scan results for image %q in repository %q", reference, repository)
+	}
+
+	result := *scan
+
+	return &result, nil
+}
+
+// findImage locates an image by tag or digest.
+func findImage(rd *repoData, reference string) *imageData {
+	// Try direct digest lookup first.
+	if img, ok := rd.images.Get(reference); ok {
+		return img
+	}
+
+	// Search by tag.
+	all := rd.images.All()
+	for _, img := range all {
+		for _, tag := range img.detail.Tags {
+			if tag == reference {
+				return img
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkTagMutability validates that a tag can be overwritten.
+func checkTagMutability(rd *repoData, tag string) error {
+	if tag == "" || rd.tagMutability != immutableTag {
+		return nil
+	}
+
+	all := rd.images.All()
+	for _, img := range all {
+		for _, t := range img.detail.Tags {
+			if t == tag {
+				return errors.Newf(
+					errors.FailedPrecondition,
+					"tag %q already exists and repository has IMMUTABLE tag mutability",
+					tag,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// resolveDigest generates a digest from the manifest if not provided.
+func resolveDigest(manifest *driver.ImageManifest, now time.Time) string {
+	if manifest.Digest != "" {
+		return manifest.Digest
+	}
+
+	input := fmt.Sprintf("%s:%s:%s", manifest.Repository, manifest.Tag, now.String())
+	hash := sha256.Sum256([]byte(input))
+
+	return fmt.Sprintf("sha256:%x", hash[:digestHashFormatByte])
+}
+
+// updateTagIndex removes a tag from any existing image and adds it to the target digest.
+func updateTagIndex(rd *repoData, digest, tag string) {
+	// Remove tag from any other image.
+	all := rd.images.All()
+	for d, img := range all {
+		if d == digest {
+			continue
+		}
+
+		filtered := removeTag(img.detail.Tags, tag)
+		if len(filtered) != len(img.detail.Tags) {
+			img.detail.Tags = filtered
+			rd.images.Set(d, img)
+		}
+	}
+
+	// Add tag to target image.
+	if img, ok := rd.images.Get(digest); ok {
+		if !hasTag(img.detail.Tags, tag) {
+			img.detail.Tags = append(img.detail.Tags, tag)
+			rd.images.Set(digest, img)
+		}
+	}
+}
+
+// autoScan creates a scan result automatically when scanOnPush is enabled.
+func autoScan(rd *repoData, digest, repository string, now time.Time) {
+	scan := generateScanResult(repository, digest, now)
+	rd.scans.Set(digest, scan)
+}
+
+// generateScanResult produces deterministic scan findings based on the digest hash.
+func generateScanResult(repository, digest string, now time.Time) *driver.ScanResult {
+	hash := sha256.Sum256([]byte(digest))
+
+	findings := map[string]int{
+		"CRITICAL":      int(hash[0]) % 3,
+		"HIGH":          int(hash[1]) % 5,
+		"MEDIUM":        int(hash[2]) % 10,
+		"LOW":           int(hash[3]) % 15,
+		"INFORMATIONAL": int(hash[4]) % 8,
+	}
+
+	return &driver.ScanResult{
+		Repository:    repository,
+		Digest:        digest,
+		Status:        scanStatusComplete,
+		FindingCounts: findings,
+		CompletedAt:   now.UTC().Format(time.RFC3339),
+	}
+}
+
+// evaluateRules applies lifecycle rules sorted by priority and returns digests to expire.
+func evaluateRules(rd *repoData, now time.Time) []string {
+	rules := rd.policy.Rules
+	sorted := make([]driver.LifecycleRule, len(rules))
+	copy(sorted, rules)
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Priority < sorted[j].Priority })
+
+	expired := make(map[string]bool)
+
+	for idx := range sorted {
+		digests := evaluateSingleRule(rd, &sorted[idx], now)
+		for _, d := range digests {
+			expired[d] = true
+		}
+	}
+
+	result := make([]string, 0, len(expired))
+	for d := range expired {
+		result = append(result, d)
+	}
+
+	return result
+}
+
+// evaluateSingleRule evaluates one lifecycle rule and returns matching digests.
+func evaluateSingleRule(rd *repoData, rule *driver.LifecycleRule, now time.Time) []string {
+	images := collectMatchingImages(rd, rule)
+
+	sort.Slice(images, func(i, j int) bool { return images[i].detail.PushedAt < images[j].detail.PushedAt })
+
+	switch rule.CountType {
+	case "imageCountMoreThan":
+		return expireByCount(images, rule.CountValue)
+	case "sinceImagePushed":
+		return expireBySince(images, rule.CountValue, now)
+	default:
+		return nil
+	}
+}
+
+// collectMatchingImages returns images matching the rule's tag status and pattern.
+func collectMatchingImages(rd *repoData, rule *driver.LifecycleRule) []*imageData {
+	all := rd.images.All()
+
+	var matched []*imageData
+
+	for _, img := range all {
+		if matchesTagRule(img, rule) {
+			matched = append(matched, img)
+		}
+	}
+
+	return matched
+}
+
+// matchesTagRule checks if an image matches the rule's tag filter.
+func matchesTagRule(img *imageData, rule *driver.LifecycleRule) bool {
+	switch rule.TagStatus {
+	case "untagged":
+		return len(img.detail.Tags) == 0
+	case "tagged":
+		return len(img.detail.Tags) > 0 && matchTagPattern(img.detail.Tags, rule.TagPattern)
+	default: // "any"
+		return true
+	}
+}
+
+// matchTagPattern checks if any tag matches the given glob pattern.
+func matchTagPattern(tags []string, pattern string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+
+	for _, tag := range tags {
+		if matched, err := path.Match(pattern, tag); err == nil && matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// expireByCount returns digests of excess images beyond the count threshold.
+func expireByCount(images []*imageData, maxCount int) []string {
+	if len(images) <= maxCount {
+		return nil
+	}
+
+	excess := len(images) - maxCount
+	result := make([]string, 0, excess)
+
+	for i := range excess {
+		result = append(result, images[i].detail.Digest)
+	}
+
+	return result
+}
+
+// expireBySince returns digests of images pushed more than N days ago.
+func expireBySince(images []*imageData, days int, now time.Time) []string {
+	cutoff := now.AddDate(0, 0, -days)
+
+	var result []string
+
+	for _, img := range images {
+		pushedAt, err := time.Parse(time.RFC3339, img.detail.PushedAt)
+		if err != nil {
+			continue
+		}
+
+		if pushedAt.Before(cutoff) {
+			result = append(result, img.detail.Digest)
+		}
+	}
+
+	return result
+}
+
+func resolveMediaType(mediaType string) string {
+	if mediaType != "" {
+		return mediaType
+	}
+
+	return defaultMediaType
+}
+
+func copyTags(src map[string]string) map[string]string {
+	tags := make(map[string]string, len(src))
+	for k, v := range src {
+		tags[k] = v
+	}
+
+	return tags
+}
+
+func copyLifecyclePolicy(p driver.LifecyclePolicy) driver.LifecyclePolicy {
+	rules := make([]driver.LifecycleRule, len(p.Rules))
+	copy(rules, p.Rules)
+
+	return driver.LifecyclePolicy{Rules: rules}
+}
+
+func removeTag(tags []string, tag string) []string {
+	result := make([]string, 0, len(tags))
+
+	for _, t := range tags {
+		if t != tag {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/ecr/ecr.go
+++ b/providers/aws/ecr/ecr.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
@@ -43,6 +44,7 @@ type repoData struct {
 
 // Mock is an in-memory mock implementation of the AWS ECR service.
 type Mock struct {
+	mu         sync.Mutex
 	repos      *memstore.Store[*repoData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
@@ -158,6 +160,11 @@ func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) 
 
 // PutImage pushes an image manifest to an ECR repository.
 func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*driver.ImageDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Allow empty tag for untagged images (digest-only)
+
 	rd, ok := m.repos.Get(manifest.Repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
@@ -239,6 +246,9 @@ func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageD
 
 // DeleteImage deletes an image from an ECR repository by reference.
 func (m *Mock) DeleteImage(_ context.Context, repository, reference string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -258,6 +268,13 @@ func (m *Mock) DeleteImage(_ context.Context, repository, reference string) erro
 
 // TagImage adds a new tag to an existing image in an ECR repository.
 func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag string) error {
+	if targetTag == "" {
+		return errors.New(errors.InvalidArgument, "target tag cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -273,6 +290,7 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 	}
 
 	updateTagIndex(rd, img.detail.Digest, targetTag)
+	rd.info.ImageCount = rd.images.Len()
 
 	return nil
 }

--- a/providers/aws/ecr/ecr_test.go
+++ b/providers/aws/ecr/ecr_test.go
@@ -1,0 +1,770 @@
+package ecr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts), fc
+}
+
+func createTestRepo(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateRepository(context.Background(), driver.RepositoryConfig{Name: name})
+	require.NoError(t, err)
+}
+
+func pushTestImage(t *testing.T, m *Mock, repo, tag string) *driver.ImageDetail {
+	t.Helper()
+
+	detail, err := m.PutImage(context.Background(), &driver.ImageManifest{
+		Repository: repo,
+		Tag:        tag,
+		SizeBytes:  1024,
+	})
+	require.NoError(t, err)
+
+	return detail
+}
+
+func TestCreateRepository(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.RepositoryConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name: "success",
+			cfg:  driver.RepositoryConfig{Name: "my-repo"},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.RepositoryConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate",
+			cfg:  driver.RepositoryConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+		{
+			name: "with tags",
+			cfg:  driver.RepositoryConfig{Name: "tagged-repo", Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name: "with immutable tag mutability",
+			cfg:  driver.RepositoryConfig{Name: "immutable-repo", ImageTagMutability: "IMMUTABLE"},
+		},
+		{
+			name: "with scan on push",
+			cfg:  driver.RepositoryConfig{Name: "scan-repo", ImageScanOnPush: true},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			repo, err := m.CreateRepository(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.cfg.Name, repo.Name)
+			assert.NotEmpty(t, repo.URI)
+			assert.NotEmpty(t, repo.CreatedAt)
+			assert.Equal(t, 0, repo.ImageCount)
+		})
+	}
+}
+
+func TestDeleteRepository(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoName  string
+		force     bool
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:     "success empty repo",
+			repoName: "empty-repo",
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "empty-repo")
+			},
+		},
+		{
+			name:      "not found",
+			repoName:  "nonexistent",
+			expectErr: true,
+		},
+		{
+			name:     "non-empty repo without force fails",
+			repoName: "full-repo",
+			force:    false,
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "full-repo")
+				pushTestImage(&testing.T{}, m, "full-repo", "v1")
+			},
+			expectErr: true,
+		},
+		{
+			name:     "force delete with images",
+			repoName: "full-repo",
+			force:    true,
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "full-repo")
+				pushTestImage(&testing.T{}, m, "full-repo", "v1")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			err := m.DeleteRepository(context.Background(), tc.repoName, tc.force)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			_, getErr := m.GetRepository(context.Background(), tc.repoName)
+			require.Error(t, getErr)
+		})
+	}
+}
+
+func TestGetRepository(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("success", func(t *testing.T) {
+		repo, err := m.GetRepository(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, "my-repo", repo.Name)
+		assert.Equal(t, 0, repo.ImageCount)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetRepository(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("image count reflects pushed images", func(t *testing.T) {
+		pushTestImage(t, m, "my-repo", "v1")
+		pushTestImage(t, m, "my-repo", "v2")
+
+		repo, err := m.GetRepository(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 2, repo.ImageCount)
+	})
+}
+
+func TestListRepositories(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		repos, err := m.ListRepositories(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(repos))
+	})
+
+	createTestRepo(t, m, "repo-a")
+	createTestRepo(t, m, "repo-b")
+
+	t.Run("two repositories", func(t *testing.T) {
+		repos, err := m.ListRepositories(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(repos))
+	})
+}
+
+func TestPutImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  driver.ImageManifest
+		setup     func(*Mock)
+		expectErr bool
+		checkFn   func(*testing.T, *driver.ImageDetail)
+	}{
+		{
+			name:     "success",
+			manifest: driver.ImageManifest{Repository: "my-repo", Tag: "latest", SizeBytes: 2048},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, d *driver.ImageDetail) {
+				t.Helper()
+				assert.Equal(t, "my-repo", d.Repository)
+				assert.NotEmpty(t, d.Digest)
+				assert.Contains(t, d.Tags, "latest")
+				assert.Equal(t, int64(2048), d.SizeBytes)
+				assert.NotEmpty(t, d.PushedAt)
+				assert.Equal(t, defaultMediaType, d.MediaType)
+			},
+		},
+		{
+			name: "with custom tag",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo", Tag: "v1.0.0", SizeBytes: 512,
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, d *driver.ImageDetail) {
+				t.Helper()
+				assert.Contains(t, d.Tags, "v1.0.0")
+			},
+		},
+		{
+			name: "with layers",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo", Tag: "layered", SizeBytes: 4096,
+				Layers: []driver.LayerInfo{
+					{Digest: "sha256:aaa", SizeBytes: 1024, MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip"},
+					{Digest: "sha256:bbb", SizeBytes: 3072, MediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip"},
+				},
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, d *driver.ImageDetail) {
+				t.Helper()
+				assert.NotEmpty(t, d.Digest)
+			},
+		},
+		{
+			name:      "repo not found",
+			manifest:  driver.ImageManifest{Repository: "nonexistent", Tag: "latest"},
+			expectErr: true,
+		},
+		{
+			name: "with explicit digest",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo", Tag: "pinned",
+				Digest: "sha256:abcdef1234567890", SizeBytes: 100,
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, d *driver.ImageDetail) {
+				t.Helper()
+				assert.Equal(t, "sha256:abcdef1234567890", d.Digest)
+			},
+		},
+		{
+			name: "with custom media type",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo", Tag: "oci",
+				MediaType: "application/vnd.oci.image.manifest.v1+json", SizeBytes: 256,
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, d *driver.ImageDetail) {
+				t.Helper()
+				assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", d.MediaType)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			detail, err := m.PutImage(context.Background(), &tc.manifest)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.checkFn != nil {
+				tc.checkFn(t, detail)
+			}
+		})
+	}
+}
+
+func TestGetImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	img := pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("by tag", func(t *testing.T) {
+		detail, err := m.GetImage(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, img.Digest, detail.Digest)
+		assert.Contains(t, detail.Tags, "v1")
+	})
+
+	t.Run("by digest", func(t *testing.T) {
+		detail, err := m.GetImage(ctx, "my-repo", img.Digest)
+		require.NoError(t, err)
+		assert.Equal(t, img.Digest, detail.Digest)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "my-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "nonexistent", "v1")
+		require.Error(t, err)
+	})
+}
+
+func TestListImages(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("empty repo", func(t *testing.T) {
+		images, err := m.ListImages(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(images))
+	})
+
+	pushTestImage(t, m, "my-repo", "v1")
+	pushTestImage(t, m, "my-repo", "v2")
+
+	t.Run("two images", func(t *testing.T) {
+		images, err := m.ListImages(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(images))
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		_, err := m.ListImages(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      string
+		ref       string
+		setup     func(*Mock) string
+		expectErr bool
+	}{
+		{
+			name: "success by tag",
+			repo: "my-repo",
+			ref:  "v1",
+			setup: func(m *Mock) string {
+				createTestRepo(&testing.T{}, m, "my-repo")
+				pushTestImage(&testing.T{}, m, "my-repo", "v1")
+				return ""
+			},
+		},
+		{
+			name: "success by digest",
+			repo: "my-repo",
+			setup: func(m *Mock) string {
+				createTestRepo(&testing.T{}, m, "my-repo")
+				img := pushTestImage(&testing.T{}, m, "my-repo", "v1")
+				return img.Digest
+			},
+		},
+		{
+			name: "not found",
+			repo: "my-repo",
+			ref:  "nonexistent",
+			setup: func(m *Mock) string {
+				createTestRepo(&testing.T{}, m, "my-repo")
+				return ""
+			},
+			expectErr: true,
+		},
+		{
+			name:      "repo not found",
+			repo:      "nonexistent",
+			ref:       "v1",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			ref := tc.ref
+			if tc.setup != nil {
+				if r := tc.setup(m); r != "" {
+					ref = r
+				}
+			}
+
+			err := m.DeleteImage(context.Background(), tc.repo, ref)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			_, getErr := m.GetImage(context.Background(), tc.repo, ref)
+			require.Error(t, getErr)
+		})
+	}
+}
+
+func TestTagImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		repo      string
+		sourceRef string
+		targetTag string
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:      "success",
+			repo:      "my-repo",
+			sourceRef: "v1",
+			targetTag: "latest",
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+				pushTestImage(&testing.T{}, m, "my-repo", "v1")
+			},
+		},
+		{
+			name:      "source not found",
+			repo:      "my-repo",
+			sourceRef: "nonexistent",
+			targetTag: "latest",
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			expectErr: true,
+		},
+		{
+			name:      "repo not found",
+			repo:      "nonexistent",
+			sourceRef: "v1",
+			targetTag: "latest",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			err := m.TagImage(context.Background(), tc.repo, tc.sourceRef, tc.targetTag)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			detail, getErr := m.GetImage(context.Background(), tc.repo, tc.targetTag)
+			require.NoError(t, getErr)
+			assert.Contains(t, detail.Tags, tc.targetTag)
+		})
+	}
+}
+
+func TestImageTagMutability(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutability string
+		expectErr bool
+	}{
+		{
+			name:       "MUTABLE allows duplicate tags",
+			mutability: "MUTABLE",
+			expectErr:  false,
+		},
+		{
+			name:       "IMMUTABLE rejects duplicate tags",
+			mutability: "IMMUTABLE",
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+			ctx := context.Background()
+
+			_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+				Name:               "my-repo",
+				ImageTagMutability: tc.mutability,
+			})
+			require.NoError(t, err)
+
+			_, err = m.PutImage(ctx, &driver.ImageManifest{
+				Repository: "my-repo", Tag: "v1", SizeBytes: 100,
+			})
+			require.NoError(t, err)
+
+			_, err = m.PutImage(ctx, &driver.ImageManifest{
+				Repository: "my-repo", Tag: "v1", SizeBytes: 200,
+			})
+
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLifecyclePolicy(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("get policy before set returns error", func(t *testing.T) {
+		_, err := m.GetLifecyclePolicy(ctx, "my-repo")
+		require.Error(t, err)
+	})
+
+	policy := driver.LifecyclePolicy{
+		Rules: []driver.LifecycleRule{
+			{
+				Priority:    1,
+				Description: "keep only 2 tagged images",
+				TagStatus:   "tagged",
+				TagPattern:  "*",
+				CountType:   "imageCountMoreThan",
+				CountValue:  2,
+				Action:      "expire",
+			},
+		},
+	}
+
+	t.Run("put lifecycle policy", func(t *testing.T) {
+		err := m.PutLifecyclePolicy(ctx, "my-repo", policy)
+		require.NoError(t, err)
+	})
+
+	t.Run("get lifecycle policy", func(t *testing.T) {
+		got, err := m.GetLifecyclePolicy(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(got.Rules))
+		assert.Equal(t, "imageCountMoreThan", got.Rules[0].CountType)
+		assert.Equal(t, 2, got.Rules[0].CountValue)
+	})
+
+	t.Run("evaluate image count rule", func(t *testing.T) {
+		pushTestImage(t, m, "my-repo", "v1")
+		fc.Advance(time.Minute)
+		pushTestImage(t, m, "my-repo", "v2")
+		fc.Advance(time.Minute)
+		pushTestImage(t, m, "my-repo", "v3")
+
+		expired, err := m.EvaluateLifecyclePolicy(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(expired))
+	})
+
+	t.Run("put policy on nonexistent repo", func(t *testing.T) {
+		err := m.PutLifecyclePolicy(ctx, "nonexistent", policy)
+		require.Error(t, err)
+	})
+
+	t.Run("get policy on nonexistent repo", func(t *testing.T) {
+		_, err := m.GetLifecyclePolicy(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("evaluate on nonexistent repo", func(t *testing.T) {
+		_, err := m.EvaluateLifecyclePolicy(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestLifecyclePolicyAgeRule(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "age-repo")
+
+	pushTestImage(t, m, "age-repo", "old-v1")
+	fc.Advance(time.Minute)
+	pushTestImage(t, m, "age-repo", "old-v2")
+
+	fc.Advance(31 * 24 * time.Hour)
+
+	pushTestImage(t, m, "age-repo", "new-v1")
+
+	policy := driver.LifecyclePolicy{
+		Rules: []driver.LifecycleRule{
+			{
+				Priority:    1,
+				Description: "expire images older than 30 days",
+				TagStatus:   "any",
+				CountType:   "sinceImagePushed",
+				CountValue:  30,
+				Action:      "expire",
+			},
+		},
+	}
+
+	err := m.PutLifecyclePolicy(ctx, "age-repo", policy)
+	require.NoError(t, err)
+
+	expired, err := m.EvaluateLifecyclePolicy(ctx, "age-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(expired))
+}
+
+func TestLifecyclePolicyNoPolicy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "no-policy-repo")
+	pushTestImage(t, m, "no-policy-repo", "v1")
+
+	expired, err := m.EvaluateLifecyclePolicy(ctx, "no-policy-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(expired))
+}
+
+func TestImageScan(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "scan-repo")
+	pushTestImage(t, m, "scan-repo", "v1")
+
+	t.Run("start scan", func(t *testing.T) {
+		result, err := m.StartImageScan(ctx, "scan-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, scanStatusComplete, result.Status)
+		assert.Equal(t, "scan-repo", result.Repository)
+		assert.NotEmpty(t, result.Digest)
+		assert.NotEmpty(t, result.CompletedAt)
+		assert.NotNil(t, result.FindingCounts)
+	})
+
+	t.Run("get scan results", func(t *testing.T) {
+		result, err := m.GetImageScanResults(ctx, "scan-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, scanStatusComplete, result.Status)
+		assert.Contains(t, result.FindingCounts, "CRITICAL")
+		assert.Contains(t, result.FindingCounts, "HIGH")
+		assert.Contains(t, result.FindingCounts, "MEDIUM")
+		assert.Contains(t, result.FindingCounts, "LOW")
+		assert.Contains(t, result.FindingCounts, "INFORMATIONAL")
+	})
+
+	t.Run("get scan results no scan", func(t *testing.T) {
+		pushTestImage(t, m, "scan-repo", "v2")
+		_, err := m.GetImageScanResults(ctx, "scan-repo", "v2")
+		require.Error(t, err)
+	})
+
+	t.Run("start scan image not found", func(t *testing.T) {
+		_, err := m.StartImageScan(ctx, "scan-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("start scan repo not found", func(t *testing.T) {
+		_, err := m.StartImageScan(ctx, "nonexistent", "v1")
+		require.Error(t, err)
+	})
+
+	t.Run("get scan results repo not found", func(t *testing.T) {
+		_, err := m.GetImageScanResults(ctx, "nonexistent", "v1")
+		require.Error(t, err)
+	})
+}
+
+func TestScanOnPush(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+		Name:            "auto-scan-repo",
+		ImageScanOnPush: true,
+	})
+	require.NoError(t, err)
+
+	pushTestImage(t, m, "auto-scan-repo", "v1")
+
+	result, err := m.GetImageScanResults(ctx, "auto-scan-repo", "v1")
+	require.NoError(t, err)
+	assert.Equal(t, scanStatusComplete, result.Status)
+}
+
+func TestMetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	cw := cloudwatch.New(opts)
+	m := New(opts)
+	m.SetMonitoring(cw)
+
+	ctx := context.Background()
+
+	createTestRepo(t, m, "metrics-repo")
+
+	t.Run("PutImage emits ImagePushCount", func(t *testing.T) {
+		pushTestImage(t, m, "metrics-repo", "v1")
+
+		metrics, err := cw.ListMetrics(ctx, "AWS/ECR")
+		require.NoError(t, err)
+		assert.Contains(t, metrics, "ImagePushCount")
+	})
+
+	t.Run("GetImage emits ImagePullCount", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "metrics-repo", "v1")
+		require.NoError(t, err)
+
+		metrics, err := cw.ListMetrics(ctx, "AWS/ECR")
+		require.NoError(t, err)
+		assert.Contains(t, metrics, "ImagePullCount")
+	})
+}

--- a/providers/aws/ecr/ecr_test.go
+++ b/providers/aws/ecr/ecr_test.go
@@ -512,6 +512,39 @@ func TestTagImage(t *testing.T) {
 	}
 }
 
+func TestTagImageUpdatesImageCount(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "count-repo")
+	pushTestImage(t, m, "count-repo", "v1")
+	pushTestImage(t, m, "count-repo", "v2")
+
+	repo, err := m.GetRepository(ctx, "count-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.ImageCount)
+
+	// Tag image v1 with a new tag - should not change image count
+	err = m.TagImage(ctx, "count-repo", "v1", "latest")
+	require.NoError(t, err)
+
+	repo, err = m.GetRepository(ctx, "count-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.ImageCount)
+}
+
+func TestTagImageEmptyTagRejected(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "empty-tag-repo")
+	pushTestImage(t, m, "empty-tag-repo", "v1")
+
+	err := m.TagImage(ctx, "empty-tag-repo", "v1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
 func TestImageTagMutability(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 const defaultRedisPort = 6379
@@ -31,8 +32,26 @@ type cacheData struct {
 
 // Mock is an in-memory mock implementation of the AWS ElastiCache service.
 type Mock struct {
-	caches *memstore.Store[*cacheData]
-	opts   *config.Options
+	caches     *memstore.Store[*cacheData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+//nolint:unparam // value is always 1 today but kept for future metrics like evictions or replication lag.
+func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/ElastiCache", MetricName: metricName, Value: value, Unit: "Count",
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new ElastiCache mock with the given configuration options.
@@ -146,6 +165,8 @@ func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl t
 
 	cd.items.Set(key, item)
 
+	m.emitMetric("SetCommands", 1, map[string]string{"CacheClusterId": cacheName})
+
 	return nil
 }
 
@@ -156,8 +177,13 @@ func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, erro
 		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
 	}
 
+	dims := map[string]string{"CacheClusterId": cacheName}
+
 	item, ok := cd.items.Get(key)
 	if !ok {
+		m.emitMetric("CacheMisses", 1, dims)
+		m.emitMetric("GetCommands", 1, dims)
+
 		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
 
@@ -165,9 +191,14 @@ func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, erro
 	now := m.opts.Clock.Now()
 	if item.HasTTL && now.After(item.ExpiresAt) {
 		cd.items.Delete(key)
+		m.emitMetric("CacheMisses", 1, dims)
+		m.emitMetric("GetCommands", 1, dims)
 
 		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
+
+	m.emitMetric("CacheHits", 1, dims)
+	m.emitMetric("GetCommands", 1, dims)
 
 	data := make([]byte, len(item.Value))
 	copy(data, item.Value)
@@ -195,6 +226,8 @@ func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
 	if !cd.items.Delete(key) {
 		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
+
+	m.emitMetric("DeleteCommands", 1, map[string]string{"CacheClusterId": cacheName})
 
 	return nil
 }

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -1,0 +1,540 @@
+// Package eventbridge provides an in-memory mock implementation of AWS EventBridge.
+package eventbridge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	defaultBusName   = "default"
+	maxEventHistory  = 1000
+	defaultRuleState = "ENABLED"
+	activeBusState   = "ACTIVE"
+)
+
+// Compile-time check that Mock implements driver.EventBus.
+var _ driver.EventBus = (*Mock)(nil)
+
+type ruleData struct {
+	rule    driver.Rule
+	targets *memstore.Store[driver.Target]
+}
+
+type busData struct {
+	info   driver.EventBusInfo
+	rules  *memstore.Store[*ruleData]
+	mu     sync.RWMutex
+	events []driver.Event
+}
+
+// Mock is an in-memory mock implementation of AWS EventBridge.
+type Mock struct {
+	buses      *memstore.Store[*busData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/Events", MetricName: metricName, Value: value, Unit: "Count",
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
+}
+
+// New creates a new EventBridge mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	m := &Mock{
+		buses: memstore.New[*busData](),
+		opts:  opts,
+	}
+
+	// Create the default event bus automatically.
+	busARN := idgen.AWSARN("events", opts.Region, opts.AccountID, "event-bus/"+defaultBusName)
+	defaultBus := &busData{
+		info: driver.EventBusInfo{
+			Name:      defaultBusName,
+			ARN:       busARN,
+			State:     activeBusState,
+			CreatedAt: opts.Clock.Now().UTC().Format(time.RFC3339),
+			Tags:      map[string]string{},
+		},
+		rules:  memstore.New[*ruleData](),
+		events: []driver.Event{},
+	}
+	m.buses.Set(defaultBusName, defaultBus)
+
+	return m
+}
+
+// CreateEventBus creates a new EventBridge event bus.
+func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "event bus name is required")
+	}
+
+	if m.buses.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "event bus %q already exists", cfg.Name)
+	}
+
+	busARN := idgen.AWSARN("events", m.opts.Region, m.opts.AccountID, "event-bus/"+cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.EventBusInfo{
+		Name:      cfg.Name,
+		ARN:       busARN,
+		State:     activeBusState,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:      tags,
+	}
+
+	bd := &busData{
+		info:   info,
+		rules:  memstore.New[*ruleData](),
+		events: []driver.Event{},
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteEventBus deletes an EventBridge event bus.
+func (m *Mock) DeleteEventBus(_ context.Context, name string) error {
+	if name == defaultBusName {
+		return errors.New(errors.InvalidArgument, "cannot delete the default event bus")
+	}
+
+	if !m.buses.Delete(name) {
+		return errors.Newf(errors.NotFound, "event bus %q not found", name)
+	}
+
+	return nil
+}
+
+// GetEventBus retrieves information about an EventBridge event bus.
+func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", name)
+	}
+
+	result := bd.info
+
+	return &result, nil
+}
+
+// ListEventBuses lists all EventBridge event buses.
+func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+	all := m.buses.All()
+
+	buses := make([]driver.EventBusInfo, 0, len(all))
+	for _, bd := range all {
+		buses = append(buses, bd.info)
+	}
+
+	return buses, nil
+}
+
+// PutRule creates or updates a rule on an event bus.
+func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "rule name is required")
+	}
+
+	busName := cfg.EventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	state := cfg.State
+	if state == "" {
+		state = defaultRuleState
+	}
+
+	rule := driver.Rule{
+		Name:         cfg.Name,
+		EventBus:     busName,
+		Description:  cfg.Description,
+		EventPattern: cfg.EventPattern,
+		State:        state,
+		Targets:      []driver.Target{},
+		CreatedAt:    m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Preserve existing targets if updating.
+	if existing, exists := bd.rules.Get(cfg.Name); exists {
+		rule.Targets = existing.rule.Targets
+		rule.CreatedAt = existing.rule.CreatedAt
+	}
+
+	rd := &ruleData{
+		rule:    rule,
+		targets: memstore.New[driver.Target](),
+	}
+
+	for _, t := range rule.Targets {
+		rd.targets.Set(t.ID, t)
+	}
+
+	bd.rules.Set(cfg.Name, rd)
+
+	result := rule
+
+	return &result, nil
+}
+
+// DeleteRule deletes a rule from an event bus.
+func (m *Mock) DeleteRule(_ context.Context, eventBus, ruleName string) error {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	if !bd.rules.Delete(ruleName) {
+		return errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
+	}
+
+	return nil
+}
+
+// GetRule retrieves a rule from an event bus.
+func (m *Mock) GetRule(_ context.Context, eventBus, ruleName string) (*driver.Rule, error) {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
+	}
+
+	result := rd.rule
+
+	return &result, nil
+}
+
+// ListRules lists all rules on an event bus.
+func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, error) {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	all := bd.rules.All()
+
+	rules := make([]driver.Rule, 0, len(all))
+	for _, rd := range all {
+		rules = append(rules, rd.rule)
+	}
+
+	return rules, nil
+}
+
+// EnableRule enables a rule on an event bus.
+func (m *Mock) EnableRule(_ context.Context, eventBus, ruleName string) error {
+	return m.setRuleState(eventBus, ruleName, defaultRuleState)
+}
+
+// DisableRule disables a rule on an event bus.
+func (m *Mock) DisableRule(_ context.Context, eventBus, ruleName string) error {
+	return m.setRuleState(eventBus, ruleName, "DISABLED")
+}
+
+func (m *Mock) setRuleState(eventBus, ruleName, state string) error {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
+	}
+
+	rd.rule.State = state
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// PutTargets adds targets to a rule.
+func (m *Mock) PutTargets(_ context.Context, eventBus, ruleName string, targets []driver.Target) error {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
+	}
+
+	for _, t := range targets {
+		rd.targets.Set(t.ID, t)
+	}
+
+	rd.rule.Targets = targetsFromStore(rd.targets)
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// RemoveTargets removes targets from a rule.
+func (m *Mock) RemoveTargets(_ context.Context, eventBus, ruleName string, targetIDs []string) error {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
+	}
+
+	for _, id := range targetIDs {
+		rd.targets.Delete(id)
+	}
+
+	rd.rule.Targets = targetsFromStore(rd.targets)
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// ListTargets lists all targets for a rule.
+func (m *Mock) ListTargets(_ context.Context, eventBus, ruleName string) ([]driver.Target, error) {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "rule %q not found on event bus %q", ruleName, busName)
+	}
+
+	return targetsFromStore(rd.targets), nil
+}
+
+// PutEvents publishes events to the event bus.
+func (m *Mock) PutEvents(_ context.Context, events []driver.Event) (*driver.PublishResult, error) {
+	result := &driver.PublishResult{
+		EventIDs: make([]string, 0, len(events)),
+	}
+
+	for i := range events {
+		eventID := generateEventID(&events[i], m.opts.Clock.Now())
+		events[i].ID = eventID
+
+		if events[i].Time.IsZero() {
+			events[i].Time = m.opts.Clock.Now()
+		}
+
+		busName := events[i].EventBus
+		if busName == "" {
+			busName = defaultBusName
+		}
+
+		bd, ok := m.buses.Get(busName)
+		if !ok {
+			result.FailCount++
+
+			continue
+		}
+
+		m.storeEvent(bd, &events[i])
+		matched := m.MatchedRules(&events[i])
+
+		dims := map[string]string{"EventBusName": busName}
+		m.emitMetric("PutEventsRequestCount", 1, dims)
+		m.emitMetric("MatchedEvents", float64(len(matched)), dims)
+
+		result.SuccessCount++
+		result.EventIDs = append(result.EventIDs, eventID)
+	}
+
+	return result, nil
+}
+
+// GetEventHistory retrieves event history for an event bus.
+func (m *Mock) GetEventHistory(_ context.Context, eventBus string, limit int) ([]driver.Event, error) {
+	busName := eventBus
+	if busName == "" {
+		busName = defaultBusName
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
+	}
+
+	bd.mu.RLock()
+	defer bd.mu.RUnlock()
+
+	history := bd.events
+	if limit > 0 && limit < len(history) {
+		history = history[len(history)-limit:]
+	}
+
+	result := make([]driver.Event, len(history))
+	copy(result, history)
+
+	return result, nil
+}
+
+func (*Mock) storeEvent(bd *busData, event *driver.Event) {
+	bd.mu.Lock()
+	defer bd.mu.Unlock()
+
+	bd.events = append(bd.events, *event)
+	if len(bd.events) > maxEventHistory {
+		bd.events = bd.events[len(bd.events)-maxEventHistory:]
+	}
+}
+
+func targetsFromStore(store *memstore.Store[driver.Target]) []driver.Target {
+	all := store.All()
+
+	targets := make([]driver.Target, 0, len(all))
+	for _, t := range all {
+		targets = append(targets, t)
+	}
+
+	return targets
+}
+
+func generateEventID(event *driver.Event, now time.Time) string {
+	data := fmt.Sprintf("%s:%s:%s:%s:%d", event.Source, event.DetailType, event.Detail, event.EventBus, now.UnixNano())
+	hash := sha256.Sum256([]byte(data))
+
+	return fmt.Sprintf("%x", hash[:16])
+}
+
+func matchesPattern(event *driver.Event, pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal([]byte(pattern), &p); err != nil {
+		return false
+	}
+
+	if sources, ok := p["source"]; ok {
+		if !matchesField(event.Source, sources) {
+			return false
+		}
+	}
+
+	if detailTypes, ok := p["detail-type"]; ok {
+		if !matchesField(event.DetailType, detailTypes) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchesField(value string, allowed any) bool {
+	arr, ok := allowed.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, v := range arr {
+		if fmt.Sprintf("%v", v) == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchedRules returns all rules that match the given event (exported for testing).
+func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
+	var matched []driver.Rule
+
+	all := m.buses.All()
+	for _, bd := range all {
+		rules := bd.rules.All()
+		for _, rd := range rules {
+			if rd.rule.State != defaultRuleState {
+				continue
+			}
+
+			if matchesPattern(event, rd.rule.EventPattern) {
+				matched = append(matched, rd.rule)
+			}
+		}
+	}
+
+	return matched
+}

--- a/providers/aws/eventbridge/eventbridge_test.go
+++ b/providers/aws/eventbridge/eventbridge_test.go
@@ -1,0 +1,772 @@
+package eventbridge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return New(opts), fc
+}
+
+func createTestBus(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateEventBus(context.Background(), driver.EventBusConfig{Name: name})
+	require.NoError(t, err)
+}
+
+func createTestRule(t *testing.T, m *Mock, busName, ruleName string) {
+	t.Helper()
+
+	_, err := m.PutRule(context.Background(), &driver.RuleConfig{
+		Name:     ruleName,
+		EventBus: busName,
+	})
+	require.NoError(t, err)
+}
+
+func TestCreateEventBus(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.EventBusConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name: "success",
+			cfg:  driver.EventBusConfig{Name: "my-bus"},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.EventBusConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate",
+			cfg:  driver.EventBusConfig{Name: "dup-bus"},
+			setup: func(m *Mock) {
+				createTestBus(&testing.T{}, m, "dup-bus")
+			},
+			expectErr: true,
+		},
+		{
+			name: "duplicate default bus",
+			cfg:  driver.EventBusConfig{Name: "default"},
+			expectErr: true,
+		},
+		{
+			name: "with tags",
+			cfg:  driver.EventBusConfig{Name: "tagged-bus", Tags: map[string]string{"env": "prod"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateEventBus(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.NotEmpty(t, info.ARN)
+			assert.Equal(t, activeBusState, info.State)
+			assert.NotEmpty(t, info.CreatedAt)
+		})
+	}
+}
+
+func TestDeleteEventBus(t *testing.T) {
+	tests := []struct {
+		name      string
+		busName   string
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:    "success",
+			busName: "my-bus",
+			setup: func(m *Mock) {
+				createTestBus(&testing.T{}, m, "my-bus")
+			},
+		},
+		{
+			name:      "not found",
+			busName:   "nonexistent",
+			expectErr: true,
+		},
+		{
+			name:      "cannot delete default",
+			busName:   "default",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			err := m.DeleteEventBus(context.Background(), tc.busName)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			_, getErr := m.GetEventBus(context.Background(), tc.busName)
+			require.Error(t, getErr)
+		})
+	}
+}
+
+func TestGetEventBus(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("success default bus", func(t *testing.T) {
+		info, err := m.GetEventBus(ctx, "default")
+		require.NoError(t, err)
+		assert.Equal(t, "default", info.Name)
+		assert.Equal(t, activeBusState, info.State)
+		assert.NotEmpty(t, info.ARN)
+	})
+
+	createTestBus(t, m, "custom-bus")
+
+	t.Run("success custom bus", func(t *testing.T) {
+		info, err := m.GetEventBus(ctx, "custom-bus")
+		require.NoError(t, err)
+		assert.Equal(t, "custom-bus", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetEventBus(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListEventBuses(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("includes default bus", func(t *testing.T) {
+		buses, err := m.ListEventBuses(ctx)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(buses), 1)
+
+		found := false
+		for _, b := range buses {
+			if b.Name == "default" {
+				found = true
+			}
+		}
+		assert.True(t, found)
+	})
+
+	createTestBus(t, m, "bus-a")
+	createTestBus(t, m, "bus-b")
+
+	t.Run("default plus two custom", func(t *testing.T) {
+		buses, err := m.ListEventBuses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(buses))
+	})
+}
+
+func TestPutRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.RuleConfig
+		expectErr bool
+	}{
+		{
+			name: "success on default bus",
+			cfg:  driver.RuleConfig{Name: "my-rule"},
+		},
+		{
+			name: "success with description and pattern",
+			cfg: driver.RuleConfig{
+				Name:         "detailed-rule",
+				Description:  "catches EC2 events",
+				EventPattern: `{"source":["aws.ec2"]}`,
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.RuleConfig{},
+			expectErr: true,
+		},
+		{
+			name: "disabled rule",
+			cfg:  driver.RuleConfig{Name: "disabled-rule", State: "DISABLED"},
+		},
+		{
+			name:      "bus not found",
+			cfg:       driver.RuleConfig{Name: "orphan-rule", EventBus: "nonexistent"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			rule, err := m.PutRule(context.Background(), &tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.cfg.Name, rule.Name)
+			assert.NotEmpty(t, rule.CreatedAt)
+
+			if tc.cfg.State == "DISABLED" {
+				assert.Equal(t, "DISABLED", rule.State)
+			} else {
+				assert.Equal(t, defaultRuleState, rule.State)
+			}
+		})
+	}
+}
+
+func TestPutRuleUpdate(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "my-rule",
+		EventPattern: `{"source":["aws.ec2"]}`,
+	})
+	require.NoError(t, err)
+
+	err = m.PutTargets(ctx, "", "my-rule", []driver.Target{
+		{ID: "t1", ARN: "arn:aws:lambda:us-east-1:123:function:my-fn"},
+	})
+	require.NoError(t, err)
+
+	updated, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "my-rule",
+		EventPattern: `{"source":["aws.s3"]}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `{"source":["aws.s3"]}`, updated.EventPattern)
+	assert.Equal(t, 1, len(updated.Targets))
+}
+
+func TestDeleteRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		bus       string
+		ruleName  string
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:     "success",
+			bus:      "",
+			ruleName: "my-rule",
+			setup: func(m *Mock) {
+				createTestRule(&testing.T{}, m, "", "my-rule")
+			},
+		},
+		{
+			name:      "not found",
+			bus:       "",
+			ruleName:  "nonexistent",
+			expectErr: true,
+		},
+		{
+			name:      "bus not found",
+			bus:       "nonexistent",
+			ruleName:  "some-rule",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			err := m.DeleteRule(context.Background(), tc.bus, tc.ruleName)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			_, getErr := m.GetRule(context.Background(), tc.bus, tc.ruleName)
+			require.Error(t, getErr)
+		})
+	}
+}
+
+func TestGetRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRule(t, m, "", "my-rule")
+
+	t.Run("success", func(t *testing.T) {
+		rule, err := m.GetRule(ctx, "", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, "my-rule", rule.Name)
+		assert.Equal(t, "default", rule.EventBus)
+		assert.Equal(t, defaultRuleState, rule.State)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("bus not found", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "nonexistent", "my-rule")
+		require.Error(t, err)
+	})
+}
+
+func TestListRules(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty", func(t *testing.T) {
+		rules, err := m.ListRules(ctx, "")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(rules))
+	})
+
+	createTestRule(t, m, "", "rule-a")
+	createTestRule(t, m, "", "rule-b")
+
+	t.Run("two rules", func(t *testing.T) {
+		rules, err := m.ListRules(ctx, "")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(rules))
+	})
+
+	t.Run("bus not found", func(t *testing.T) {
+		_, err := m.ListRules(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestEnableDisableRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{Name: "toggle-rule"})
+	require.NoError(t, err)
+
+	t.Run("disable rule", func(t *testing.T) {
+		disableErr := m.DisableRule(ctx, "", "toggle-rule")
+		require.NoError(t, disableErr)
+
+		rule, getErr := m.GetRule(ctx, "", "toggle-rule")
+		require.NoError(t, getErr)
+		assert.Equal(t, "DISABLED", rule.State)
+	})
+
+	t.Run("enable rule", func(t *testing.T) {
+		enableErr := m.EnableRule(ctx, "", "toggle-rule")
+		require.NoError(t, enableErr)
+
+		rule, getErr := m.GetRule(ctx, "", "toggle-rule")
+		require.NoError(t, getErr)
+		assert.Equal(t, defaultRuleState, rule.State)
+	})
+
+	t.Run("disable nonexistent rule", func(t *testing.T) {
+		disableErr := m.DisableRule(ctx, "", "nonexistent")
+		require.Error(t, disableErr)
+	})
+
+	t.Run("enable nonexistent rule", func(t *testing.T) {
+		enableErr := m.EnableRule(ctx, "", "nonexistent")
+		require.Error(t, enableErr)
+	})
+
+	t.Run("disable on nonexistent bus", func(t *testing.T) {
+		disableErr := m.DisableRule(ctx, "nonexistent", "toggle-rule")
+		require.Error(t, disableErr)
+	})
+}
+
+func TestPutTargets(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRule(t, m, "", "my-rule")
+
+	t.Run("add targets", func(t *testing.T) {
+		err := m.PutTargets(ctx, "", "my-rule", []driver.Target{
+			{ID: "t1", ARN: "arn:aws:lambda:us-east-1:123:function:fn1"},
+			{ID: "t2", ARN: "arn:aws:sqs:us-east-1:123:my-queue"},
+		})
+		require.NoError(t, err)
+
+		targets, listErr := m.ListTargets(ctx, "", "my-rule")
+		require.NoError(t, listErr)
+		assert.Equal(t, 2, len(targets))
+	})
+
+	t.Run("add more targets", func(t *testing.T) {
+		err := m.PutTargets(ctx, "", "my-rule", []driver.Target{
+			{ID: "t3", ARN: "arn:aws:sns:us-east-1:123:my-topic"},
+		})
+		require.NoError(t, err)
+
+		targets, listErr := m.ListTargets(ctx, "", "my-rule")
+		require.NoError(t, listErr)
+		assert.Equal(t, 3, len(targets))
+	})
+
+	t.Run("update existing target", func(t *testing.T) {
+		err := m.PutTargets(ctx, "", "my-rule", []driver.Target{
+			{ID: "t1", ARN: "arn:aws:lambda:us-east-1:123:function:fn-updated", Input: `{"key":"value"}`},
+		})
+		require.NoError(t, err)
+
+		targets, listErr := m.ListTargets(ctx, "", "my-rule")
+		require.NoError(t, listErr)
+		assert.Equal(t, 3, len(targets))
+	})
+
+	t.Run("rule not found", func(t *testing.T) {
+		err := m.PutTargets(ctx, "", "nonexistent", []driver.Target{
+			{ID: "t1", ARN: "arn"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("bus not found", func(t *testing.T) {
+		err := m.PutTargets(ctx, "nonexistent", "my-rule", []driver.Target{
+			{ID: "t1", ARN: "arn"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestRemoveTargets(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRule(t, m, "", "my-rule")
+
+	err := m.PutTargets(ctx, "", "my-rule", []driver.Target{
+		{ID: "t1", ARN: "arn:aws:lambda:us-east-1:123:function:fn1"},
+		{ID: "t2", ARN: "arn:aws:sqs:us-east-1:123:my-queue"},
+		{ID: "t3", ARN: "arn:aws:sns:us-east-1:123:my-topic"},
+	})
+	require.NoError(t, err)
+
+	t.Run("remove one target", func(t *testing.T) {
+		removeErr := m.RemoveTargets(ctx, "", "my-rule", []string{"t2"})
+		require.NoError(t, removeErr)
+
+		targets, listErr := m.ListTargets(ctx, "", "my-rule")
+		require.NoError(t, listErr)
+		assert.Equal(t, 2, len(targets))
+	})
+
+	t.Run("remove multiple targets", func(t *testing.T) {
+		removeErr := m.RemoveTargets(ctx, "", "my-rule", []string{"t1", "t3"})
+		require.NoError(t, removeErr)
+
+		targets, listErr := m.ListTargets(ctx, "", "my-rule")
+		require.NoError(t, listErr)
+		assert.Equal(t, 0, len(targets))
+	})
+
+	t.Run("rule not found", func(t *testing.T) {
+		removeErr := m.RemoveTargets(ctx, "", "nonexistent", []string{"t1"})
+		require.Error(t, removeErr)
+	})
+
+	t.Run("bus not found", func(t *testing.T) {
+		removeErr := m.RemoveTargets(ctx, "nonexistent", "my-rule", []string{"t1"})
+		require.Error(t, removeErr)
+	})
+}
+
+func TestPutEvents(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("events published to default bus", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "my.app", DetailType: "OrderCreated", Detail: `{"orderId":"123"}`},
+			{Source: "my.app", DetailType: "OrderShipped", Detail: `{"orderId":"456"}`},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.SuccessCount)
+		assert.Equal(t, 0, result.FailCount)
+		assert.Equal(t, 2, len(result.EventIDs))
+	})
+
+	t.Run("events to nonexistent bus counted as failures", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "my.app", DetailType: "Test", Detail: "{}", EventBus: "nonexistent"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+
+	t.Run("history stores events", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(history))
+	})
+
+	t.Run("mixed success and failure", func(t *testing.T) {
+		createTestBus(t, m, "custom-bus")
+
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "my.app", DetailType: "OK", Detail: "{}", EventBus: "custom-bus"},
+			{Source: "my.app", DetailType: "Fail", Detail: "{}", EventBus: "ghost-bus"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+}
+
+func TestEventPatternMatching(t *testing.T) {
+	tests := []struct {
+		name         string
+		pattern      string
+		event        driver.Event
+		shouldMatch  bool
+	}{
+		{
+			name:    "match by source",
+			pattern: `{"source":["aws.ec2"]}`,
+			event:   driver.Event{Source: "aws.ec2", DetailType: "EC2 Instance State-change"},
+			shouldMatch: true,
+		},
+		{
+			name:    "no match by source",
+			pattern: `{"source":["aws.ec2"]}`,
+			event:   driver.Event{Source: "aws.s3", DetailType: "Object Created"},
+			shouldMatch: false,
+		},
+		{
+			name:    "match by detail-type",
+			pattern: `{"detail-type":["OrderCreated"]}`,
+			event:   driver.Event{Source: "my.app", DetailType: "OrderCreated"},
+			shouldMatch: true,
+		},
+		{
+			name:    "no match by detail-type",
+			pattern: `{"detail-type":["OrderCreated"]}`,
+			event:   driver.Event{Source: "my.app", DetailType: "OrderShipped"},
+			shouldMatch: false,
+		},
+		{
+			name:    "match by source and detail-type",
+			pattern: `{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change"]}`,
+			event:   driver.Event{Source: "aws.ec2", DetailType: "EC2 Instance State-change"},
+			shouldMatch: true,
+		},
+		{
+			name:    "source matches but detail-type does not",
+			pattern: `{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change"]}`,
+			event:   driver.Event{Source: "aws.ec2", DetailType: "Other Event"},
+			shouldMatch: false,
+		},
+		{
+			name:    "empty pattern matches all",
+			pattern: "",
+			event:   driver.Event{Source: "anything", DetailType: "anything"},
+			shouldMatch: true,
+		},
+		{
+			name:    "multiple sources",
+			pattern: `{"source":["aws.ec2","aws.s3"]}`,
+			event:   driver.Event{Source: "aws.s3", DetailType: "Object Created"},
+			shouldMatch: true,
+		},
+		{
+			name:    "invalid json pattern",
+			pattern: "not json",
+			event:   driver.Event{Source: "anything"},
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesPattern(&tc.event, tc.pattern)
+			assert.Equal(t, tc.shouldMatch, got)
+		})
+	}
+}
+
+func TestGetEventHistory(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty history", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(history))
+	})
+
+	_, err := m.PutEvents(ctx, []driver.Event{
+		{Source: "app", DetailType: "Event1", Detail: "{}"},
+		{Source: "app", DetailType: "Event2", Detail: "{}"},
+		{Source: "app", DetailType: "Event3", Detail: "{}"},
+	})
+	require.NoError(t, err)
+
+	t.Run("all events", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(history))
+	})
+
+	t.Run("limited events", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "", 2)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(history))
+	})
+
+	t.Run("limit greater than total", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "", 100)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(history))
+	})
+
+	t.Run("bus not found", func(t *testing.T) {
+		_, err := m.GetEventHistory(ctx, "nonexistent", 0)
+		require.Error(t, err)
+	})
+}
+
+func TestMatchedRules(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "ec2-rule",
+		EventPattern: `{"source":["aws.ec2"]}`,
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "s3-rule",
+		EventPattern: `{"source":["aws.s3"]}`,
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "catch-all-rule",
+		EventPattern: "",
+	})
+	require.NoError(t, err)
+
+	t.Run("ec2 event matches ec2-rule and catch-all", func(t *testing.T) {
+		event := &driver.Event{Source: "aws.ec2", DetailType: "State Change"}
+		matched := m.MatchedRules(event)
+		assert.GreaterOrEqual(t, len(matched), 2)
+
+		names := make([]string, 0, len(matched))
+		for _, r := range matched {
+			names = append(names, r.Name)
+		}
+		assert.Contains(t, names, "ec2-rule")
+		assert.Contains(t, names, "catch-all-rule")
+	})
+
+	t.Run("s3 event matches s3-rule and catch-all", func(t *testing.T) {
+		event := &driver.Event{Source: "aws.s3", DetailType: "Object Created"}
+		matched := m.MatchedRules(event)
+		assert.GreaterOrEqual(t, len(matched), 2)
+
+		names := make([]string, 0, len(matched))
+		for _, r := range matched {
+			names = append(names, r.Name)
+		}
+		assert.Contains(t, names, "s3-rule")
+		assert.Contains(t, names, "catch-all-rule")
+	})
+
+	t.Run("disabled rule not matched", func(t *testing.T) {
+		disableErr := m.DisableRule(ctx, "", "ec2-rule")
+		require.NoError(t, disableErr)
+
+		event := &driver.Event{Source: "aws.ec2", DetailType: "State Change"}
+		matched := m.MatchedRules(event)
+
+		names := make([]string, 0, len(matched))
+		for _, r := range matched {
+			names = append(names, r.Name)
+		}
+		assert.NotContains(t, names, "ec2-rule")
+	})
+
+	t.Run("unmatched source", func(t *testing.T) {
+		event := &driver.Event{Source: "custom.source", DetailType: "Custom Event"}
+		matched := m.MatchedRules(event)
+
+		names := make([]string, 0, len(matched))
+		for _, r := range matched {
+			names = append(names, r.Name)
+		}
+		assert.NotContains(t, names, "ec2-rule")
+		assert.NotContains(t, names, "s3-rule")
+		assert.Contains(t, names, "catch-all-rule")
+	})
+}
+
+func TestMetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	cw := cloudwatch.New(opts)
+	m := New(opts)
+	m.SetMonitoring(cw)
+
+	ctx := context.Background()
+
+	t.Run("PutEvents emits metrics", func(t *testing.T) {
+		_, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "my.app", DetailType: "TestEvent", Detail: "{}"},
+		})
+		require.NoError(t, err)
+
+		metrics, listErr := cw.ListMetrics(ctx, "AWS/Events")
+		require.NoError(t, listErr)
+		assert.Contains(t, metrics, "PutEventsRequestCount")
+		assert.Contains(t, metrics, "MatchedEvents")
+	})
+}

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -34,7 +34,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Name:            cfg.Name,
 		FunctionVersion: cfg.FunctionVersion,
 		Description:     cfg.Description,
-		RoutingConfig:   cfg.RoutingConfig,
+		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
 		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
 	}
@@ -71,7 +71,7 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	}
 
 	if cfg.RoutingConfig != nil {
-		ad.alias.RoutingConfig = cfg.RoutingConfig
+		ad.alias.RoutingConfig = copyRoutingConfig(cfg.RoutingConfig)
 	}
 
 	fd.aliases.Set(cfg.Name, ad)
@@ -129,6 +129,16 @@ func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Ali
 	}
 
 	return aliases, nil
+}
+
+func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig {
+	if rc == nil {
+		return nil
+	}
+
+	cp := *rc
+
+	return &cp
 }
 
 // versionExists checks whether a version string exists for the given function.

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -1,0 +1,147 @@
+package lambda
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// CreateAlias creates a new alias pointing to a specific function version.
+func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if fd.aliases.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "alias %s already exists", cfg.Name)
+	}
+
+	if !m.versionExists(&fd, cfg.FunctionVersion) {
+		return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
+	}
+
+	aliasARN := idgen.AWSARN(
+		"lambda", m.opts.Region, m.opts.AccountID,
+		"function:"+cfg.FunctionName+":"+cfg.Name,
+	)
+
+	a := driver.Alias{
+		FunctionName:    cfg.FunctionName,
+		Name:            cfg.Name,
+		FunctionVersion: cfg.FunctionVersion,
+		Description:     cfg.Description,
+		RoutingConfig:   cfg.RoutingConfig,
+		AliasARN:        aliasARN,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+
+	fd.aliases.Set(cfg.Name, &aliasData{alias: a})
+
+	result := a
+
+	return &result, nil
+}
+
+// UpdateAlias updates an existing alias configuration.
+func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	ad, ok := fd.aliases.Get(cfg.Name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", cfg.Name)
+	}
+
+	if cfg.FunctionVersion != "" {
+		if !m.versionExists(&fd, cfg.FunctionVersion) {
+			return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
+		}
+
+		ad.alias.FunctionVersion = cfg.FunctionVersion
+	}
+
+	if cfg.Description != "" {
+		ad.alias.Description = cfg.Description
+	}
+
+	if cfg.RoutingConfig != nil {
+		ad.alias.RoutingConfig = cfg.RoutingConfig
+	}
+
+	fd.aliases.Set(cfg.Name, ad)
+
+	result := ad.alias
+
+	return &result, nil
+}
+
+// DeleteAlias removes an alias from a function.
+func (m *Mock) DeleteAlias(_ context.Context, functionName, aliasName string) error {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if !fd.aliases.Has(aliasName) {
+		return cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
+	}
+
+	fd.aliases.Delete(aliasName)
+
+	return nil
+}
+
+// GetAlias retrieves a specific alias for a function.
+func (m *Mock) GetAlias(_ context.Context, functionName, aliasName string) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	ad, ok := fd.aliases.Get(aliasName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
+	}
+
+	result := ad.alias
+
+	return &result, nil
+}
+
+// ListAliases returns all aliases for a function.
+func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Alias, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	all := fd.aliases.All()
+	aliases := make([]driver.Alias, 0, len(all))
+
+	for _, ad := range all {
+		aliases = append(aliases, ad.alias)
+	}
+
+	return aliases, nil
+}
+
+// versionExists checks whether a version string exists for the given function.
+func (*Mock) versionExists(fd *funcData, version string) bool {
+	if version == latestVersion {
+		return true
+	}
+
+	for _, v := range fd.versions {
+		if v.version == version {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/lambda/concurrency.go
+++ b/providers/aws/lambda/concurrency.go
@@ -1,0 +1,53 @@
+package lambda
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PutFunctionConcurrency sets reserved concurrency for a function.
+func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyConfig) error {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	fd.concurrency = &driver.ConcurrencyConfig{
+		FunctionName:                 cfg.FunctionName,
+		ReservedConcurrentExecutions: cfg.ReservedConcurrentExecutions,
+	}
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	return nil
+}
+
+// GetFunctionConcurrency retrieves the concurrency configuration for a function.
+func (m *Mock) GetFunctionConcurrency(_ context.Context, functionName string) (*driver.ConcurrencyConfig, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if fd.concurrency == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no concurrency config for function %s", functionName)
+	}
+
+	result := *fd.concurrency
+
+	return &result, nil
+}
+
+// DeleteFunctionConcurrency removes the concurrency configuration for a function.
+func (m *Mock) DeleteFunctionConcurrency(_ context.Context, functionName string) error {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	fd.concurrency = nil
+	m.funcs.Set(functionName, fd)
+
+	return nil
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -53,6 +53,7 @@ type Mock struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
+	mu         sync.Mutex // guards PublishVersion read-modify-write on funcData
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -2,6 +2,8 @@ package lambda
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"sync"
 	"time"
 
@@ -9,28 +11,72 @@ import (
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/serverless/driver"
 )
 
 var _ driver.Serverless = (*Mock)(nil)
 
+// initialVersion is the starting version number for published versions.
+const initialVersion = 1
+
+type versionData struct {
+	config    driver.FunctionConfig
+	version   string
+	codeSHA   string
+	createdAt string
+}
+
+type aliasData struct {
+	alias driver.Alias
+}
+
+type layerData struct {
+	versions *memstore.Store[*driver.LayerVersion]
+	nextVer  int
+}
+
 type funcData struct {
-	info    driver.FunctionInfo
-	handler driver.HandlerFunc
+	info        driver.FunctionInfo
+	handler     driver.HandlerFunc
+	versions    []*versionData
+	nextVersion int
+	aliases     *memstore.Store[*aliasData]
+	concurrency *driver.ConcurrencyConfig
 }
 
 // Mock is an in-memory mock implementation of AWS Lambda.
 type Mock struct {
 	funcs      *memstore.Store[funcData]
+	layers     *memstore.Store[*layerData]
 	opts       *config.Options
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+//nolint:unparam // value is always 1 today but kept for future metrics like batch invocation counts.
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{{
+		Namespace: "AWS/Lambda", MetricName: metricName, Value: value, Unit: "Count",
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new Lambda mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		funcs:    memstore.New[funcData](),
+		layers:   memstore.New[*layerData](),
 		opts:     opts,
 		handlers: make(map[string]driver.HandlerFunc),
 	}
@@ -54,7 +100,11 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	h := m.handlers[cfg.Name]
 	m.handlersMu.RUnlock()
 
-	m.funcs.Set(cfg.Name, funcData{info: info, handler: h})
+	m.funcs.Set(cfg.Name, funcData{
+		info: info, handler: h,
+		nextVersion: initialVersion,
+		aliases:     memstore.New[*aliasData](),
+	})
 
 	result := info
 
@@ -101,7 +151,68 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 	}
 
 	info := fd.info
+	applyConfigUpdates(&info, cfg)
+	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	fd.info = info
+	m.funcs.Set(name, fd)
 
+	result := info
+
+	return &result, nil
+}
+
+func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.InvokeOutput, error) {
+	fd, ok := m.funcs.Get(input.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", input.FunctionName)
+	}
+
+	dims := map[string]string{"FunctionName": input.FunctionName}
+
+	h := fd.handler
+	if h == nil {
+		m.handlersMu.RLock()
+		h = m.handlers[input.FunctionName]
+		m.handlersMu.RUnlock()
+	}
+
+	if h == nil {
+		m.emitMetric(ctx, "Invocations", 1, dims)
+		m.emitMetric(ctx, "Errors", 1, dims)
+
+		return &driver.InvokeOutput{StatusCode: 500, Error: "no handler registered"}, nil
+	}
+
+	payload, err := h(ctx, input.Payload)
+	if err != nil {
+		m.emitMetric(ctx, "Invocations", 1, dims)
+		m.emitMetric(ctx, "Errors", 1, dims)
+
+		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
+	}
+
+	m.emitMetric(ctx, "Invocations", 1, dims)
+	m.emitMetric(ctx, "Duration", 1.0, dims)
+	m.emitMetric(ctx, "ConcurrentExecutions", 1, dims)
+
+	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
+}
+
+func (m *Mock) RegisterHandler(name string, handler driver.HandlerFunc) {
+	m.handlersMu.Lock()
+	m.handlers[name] = handler
+	m.handlersMu.Unlock()
+
+	if fd, ok := m.funcs.Get(name); ok {
+		fd.handler = handler
+		m.funcs.Set(name, fd)
+	}
+}
+
+// applyConfigUpdates applies non-zero config fields to the function info.
+//
+//nolint:gocritic // hugeParam: config passed by value intentionally for snapshot semantics.
+func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	if cfg.Runtime != "" {
 		info.Runtime = cfg.Runtime
 	}
@@ -125,47 +236,11 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 	if cfg.Tags != nil {
 		info.Tags = cfg.Tags
 	}
-
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
-	m.funcs.Set(name, funcData{info: info, handler: fd.handler})
-
-	result := info
-
-	return &result, nil
 }
 
-func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.InvokeOutput, error) {
-	fd, ok := m.funcs.Get(input.FunctionName)
-	if !ok {
-		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", input.FunctionName)
-	}
+func codeSHA(info *driver.FunctionInfo) string {
+	data := fmt.Sprintf("%s:%s:%s", info.Name, info.Handler, info.Runtime)
+	hash := sha256.Sum256([]byte(data))
 
-	h := fd.handler
-	if h == nil {
-		m.handlersMu.RLock()
-		h = m.handlers[input.FunctionName]
-		m.handlersMu.RUnlock()
-	}
-
-	if h == nil {
-		return &driver.InvokeOutput{StatusCode: 500, Error: "no handler registered"}, nil
-	}
-
-	payload, err := h(ctx, input.Payload)
-	if err != nil {
-		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
-	}
-
-	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
-}
-
-func (m *Mock) RegisterHandler(name string, handler driver.HandlerFunc) {
-	m.handlersMu.Lock()
-	m.handlers[name] = handler
-	m.handlersMu.Unlock()
-
-	if fd, ok := m.funcs.Get(name); ok {
-		fd.handler = handler
-		m.funcs.Set(name, fd)
-	}
+	return fmt.Sprintf("%x", hash)
 }

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/serverless/driver"
 )
 
@@ -217,6 +219,447 @@ func TestRegisterHandlerBeforeCreate(t *testing.T) {
 	requireNoError(t, err)
 	assertEqual(t, 200, out.StatusCode)
 	assertEqual(t, "pre-registered", string(out.Payload))
+}
+
+func TestPublishVersion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+
+	t.Run("publish first version", func(t *testing.T) {
+		ver, err := m.PublishVersion(ctx, "my-func", "first release")
+		requireNoError(t, err)
+		assertEqual(t, "my-func", ver.FunctionName)
+		assertEqual(t, "1", ver.Version)
+		assertEqual(t, "first release", ver.Description)
+		assertNotEmpty(t, ver.CodeSHA256)
+		assertNotEmpty(t, ver.CreatedAt)
+	})
+
+	t.Run("publish second version", func(t *testing.T) {
+		ver, err := m.PublishVersion(ctx, "my-func", "second release")
+		requireNoError(t, err)
+		assertEqual(t, "2", ver.Version)
+	})
+
+	t.Run("list versions includes LATEST and published", func(t *testing.T) {
+		versions, err := m.ListVersions(ctx, "my-func")
+		requireNoError(t, err)
+		assertEqual(t, 3, len(versions)) // $LATEST + 2 published
+		assertEqual(t, "$LATEST", versions[0].Version)
+		assertEqual(t, "1", versions[1].Version)
+		assertEqual(t, "2", versions[2].Version)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.PublishVersion(ctx, "nope", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("list versions function not found", func(t *testing.T) {
+		_, err := m.ListVersions(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestVersionImmutability(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+
+	// Publish version with original config
+	ver1, err := m.PublishVersion(ctx, "my-func", "v1")
+	requireNoError(t, err)
+	origSHA := ver1.CodeSHA256
+
+	// Update the function config
+	_, err = m.UpdateFunction(ctx, "my-func", driver.FunctionConfig{
+		Runtime: "python3.9",
+		Handler: "new_handler",
+	})
+	requireNoError(t, err)
+
+	// Publish new version - should have different SHA
+	ver2, err := m.PublishVersion(ctx, "my-func", "v2")
+	requireNoError(t, err)
+
+	// The two versions should have different code SHAs since config changed
+	assertEqual(t, true, origSHA != ver2.CodeSHA256)
+
+	// Verify that version list still has original version
+	versions, err := m.ListVersions(ctx, "my-func")
+	requireNoError(t, err)
+	assertEqual(t, "1", versions[1].Version)
+	assertEqual(t, origSHA, versions[1].CodeSHA256)
+}
+
+func TestCreateAlias(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+
+	t.Run("create alias", func(t *testing.T) {
+		alias, err := m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName:    "my-func",
+			Name:            "prod",
+			FunctionVersion: "1",
+			Description:     "production alias",
+		})
+		requireNoError(t, err)
+		assertEqual(t, "prod", alias.Name)
+		assertEqual(t, "1", alias.FunctionVersion)
+		assertEqual(t, "production alias", alias.Description)
+		assertNotEmpty(t, alias.AliasARN)
+	})
+
+	t.Run("get alias", func(t *testing.T) {
+		alias, err := m.GetAlias(ctx, "my-func", "prod")
+		requireNoError(t, err)
+		assertEqual(t, "prod", alias.Name)
+		assertEqual(t, "1", alias.FunctionVersion)
+	})
+
+	t.Run("list aliases", func(t *testing.T) {
+		aliases, err := m.ListAliases(ctx, "my-func")
+		requireNoError(t, err)
+		assertEqual(t, 1, len(aliases))
+	})
+
+	t.Run("alias already exists", func(t *testing.T) {
+		_, err := m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName:    "my-func",
+			Name:            "prod",
+			FunctionVersion: "1",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		_, err := m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName:    "my-func",
+			Name:            "staging",
+			FunctionVersion: "99",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName: "nope",
+			Name:         "x",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestUpdateAlias(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+	_, _ = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "prod", FunctionVersion: "1",
+	})
+
+	t.Run("update to new version", func(t *testing.T) {
+		alias, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName:    "my-func",
+			Name:            "prod",
+			FunctionVersion: "2",
+			Description:     "updated",
+		})
+		requireNoError(t, err)
+		assertEqual(t, "2", alias.FunctionVersion)
+		assertEqual(t, "updated", alias.Description)
+	})
+
+	t.Run("alias not found", func(t *testing.T) {
+		_, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "my-func", Name: "nope", FunctionVersion: "1",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "nope", Name: "prod",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteAlias(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func", Name: "prod", FunctionVersion: "1",
+	})
+
+	t.Run("delete alias", func(t *testing.T) {
+		err := m.DeleteAlias(ctx, "my-func", "prod")
+		requireNoError(t, err)
+
+		_, err = m.GetAlias(ctx, "my-func", "prod")
+		assertError(t, err, true)
+	})
+
+	t.Run("alias not found", func(t *testing.T) {
+		err := m.DeleteAlias(ctx, "my-func", "nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		err := m.DeleteAlias(ctx, "nope", "prod")
+		assertError(t, err, true)
+	})
+}
+
+func TestAliasWeightedRouting(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+	_, _ = m.PublishVersion(ctx, "my-func", "v2")
+
+	alias, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "canary",
+		FunctionVersion: "1",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersion: "2",
+			Weight:            0.1,
+		},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "1", alias.FunctionVersion)
+	assertEqual(t, "2", alias.RoutingConfig.AdditionalVersion)
+	assertEqual(t, 0.1, alias.RoutingConfig.Weight)
+
+	// Update routing config
+	updated, err := m.UpdateAlias(ctx, driver.AliasConfig{
+		FunctionName: "my-func",
+		Name:         "canary",
+		RoutingConfig: &driver.AliasRoutingConfig{
+			AdditionalVersion: "2",
+			Weight:            0.5,
+		},
+	})
+	requireNoError(t, err)
+	assertEqual(t, 0.5, updated.RoutingConfig.Weight)
+}
+
+func TestPublishLayerVersion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	t.Run("publish first layer version", func(t *testing.T) {
+		lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name:               "my-layer",
+			Description:        "shared utilities",
+			Content:            []byte("layer-content-v1"),
+			CompatibleRuntimes: []string{"go1.x", "python3.9"},
+		})
+		requireNoError(t, err)
+		assertEqual(t, "my-layer", lv.Name)
+		assertEqual(t, 1, lv.Version)
+		assertEqual(t, "shared utilities", lv.Description)
+		assertEqual(t, int64(16), lv.ContentSize)
+		assertNotEmpty(t, lv.ContentSHA256)
+		assertNotEmpty(t, lv.ARN)
+	})
+
+	t.Run("publish second version", func(t *testing.T) {
+		lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name:    "my-layer",
+			Content: []byte("layer-content-v2"),
+		})
+		requireNoError(t, err)
+		assertEqual(t, 2, lv.Version)
+	})
+
+	t.Run("get layer version", func(t *testing.T) {
+		lv, err := m.GetLayerVersion(ctx, "my-layer", 1)
+		requireNoError(t, err)
+		assertEqual(t, 1, lv.Version)
+		assertEqual(t, "shared utilities", lv.Description)
+	})
+
+	t.Run("list layer versions", func(t *testing.T) {
+		versions, err := m.ListLayerVersions(ctx, "my-layer")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(versions))
+	})
+
+	t.Run("layer not found for get", func(t *testing.T) {
+		_, err := m.GetLayerVersion(ctx, "nope", 1)
+		assertError(t, err, true)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		_, err := m.GetLayerVersion(ctx, "my-layer", 99)
+		assertError(t, err, true)
+	})
+
+	t.Run("list versions layer not found", func(t *testing.T) {
+		_, err := m.ListLayerVersions(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteLayerVersion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, _ = m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer", Content: []byte("v1")})
+	_, _ = m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer", Content: []byte("v2")})
+
+	t.Run("delete specific version", func(t *testing.T) {
+		err := m.DeleteLayerVersion(ctx, "layer", 1)
+		requireNoError(t, err)
+
+		_, err = m.GetLayerVersion(ctx, "layer", 1)
+		assertError(t, err, true)
+
+		// Version 2 should still exist
+		lv, err := m.GetLayerVersion(ctx, "layer", 2)
+		requireNoError(t, err)
+		assertEqual(t, 2, lv.Version)
+	})
+
+	t.Run("layer not found", func(t *testing.T) {
+		err := m.DeleteLayerVersion(ctx, "nope", 1)
+		assertError(t, err, true)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		err := m.DeleteLayerVersion(ctx, "layer", 99)
+		assertError(t, err, true)
+	})
+}
+
+func TestListLayers(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty", func(t *testing.T) {
+		layers, err := m.ListLayers(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(layers))
+	})
+
+	t.Run("returns latest version per layer", func(t *testing.T) {
+		_, _ = m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer-a", Content: []byte("a1")})
+		_, _ = m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer-a", Content: []byte("a2")})
+		_, _ = m.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer-b", Content: []byte("b1")})
+
+		layers, err := m.ListLayers(ctx)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(layers))
+	})
+}
+
+func TestPutFunctionConcurrency(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+
+	t.Run("set concurrency", func(t *testing.T) {
+		err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName:                 "my-func",
+			ReservedConcurrentExecutions: 100,
+		})
+		requireNoError(t, err)
+	})
+
+	t.Run("get concurrency", func(t *testing.T) {
+		cfg, err := m.GetFunctionConcurrency(ctx, "my-func")
+		requireNoError(t, err)
+		assertEqual(t, 100, cfg.ReservedConcurrentExecutions)
+		assertEqual(t, "my-func", cfg.FunctionName)
+	})
+
+	t.Run("delete concurrency", func(t *testing.T) {
+		err := m.DeleteFunctionConcurrency(ctx, "my-func")
+		requireNoError(t, err)
+
+		_, err = m.GetFunctionConcurrency(ctx, "my-func")
+		assertError(t, err, true)
+	})
+
+	t.Run("function not found set", func(t *testing.T) {
+		err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{FunctionName: "nope"})
+		assertError(t, err, true)
+	})
+
+	t.Run("function not found get", func(t *testing.T) {
+		_, err := m.GetFunctionConcurrency(ctx, "nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("function not found delete", func(t *testing.T) {
+		err := m.DeleteFunctionConcurrency(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestLambdaMetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	m := New(opts)
+	ctx := context.Background()
+
+	cw := cloudwatch.New(opts)
+	m.SetMonitoring(cw)
+
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	m.RegisterHandler("my-func", func(_ context.Context, payload []byte) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	t.Run("invoke emits metrics", func(t *testing.T) {
+		_, err := m.Invoke(ctx, driver.InvokeInput{
+			FunctionName: "my-func",
+			Payload:      []byte("test"),
+		})
+		requireNoError(t, err)
+
+		result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "AWS/Lambda",
+			MetricName: "Invocations",
+			Dimensions: map[string]string{"FunctionName": "my-func"},
+			StartTime:  fc.Now().Add(-1 * time.Hour),
+			EndTime:    fc.Now().Add(1 * time.Hour),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		requireNoError(t, err)
+		assertEqual(t, true, len(result.Values) > 0)
+	})
+
+	t.Run("error invoke emits error metrics", func(t *testing.T) {
+		m.RegisterHandler("my-func", func(_ context.Context, _ []byte) ([]byte, error) {
+			return nil, fmt.Errorf("fail")
+		})
+
+		_, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "my-func"})
+		requireNoError(t, err)
+
+		result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "AWS/Lambda",
+			MetricName: "Errors",
+			Dimensions: map[string]string{"FunctionName": "my-func"},
+			StartTime:  fc.Now().Add(-1 * time.Hour),
+			EndTime:    fc.Now().Add(1 * time.Hour),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		requireNoError(t, err)
+		assertEqual(t, true, len(result.Values) > 0)
+	})
 }
 
 // --- test helpers ---

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -3,6 +3,7 @@ package lambda
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -660,6 +661,62 @@ func TestLambdaMetricsEmission(t *testing.T) {
 		requireNoError(t, err)
 		assertEqual(t, true, len(result.Values) > 0)
 	})
+}
+
+func TestPublishVersionConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			_, _ = m.PublishVersion(ctx, "my-func", "concurrent")
+		}()
+	}
+
+	wg.Wait()
+
+	versions, err := m.ListVersions(ctx, "my-func")
+	requireNoError(t, err)
+	assertEqual(t, 11, len(versions)) // $LATEST + 10 published
+
+	seen := make(map[string]bool)
+	for _, v := range versions {
+		assertEqual(t, false, seen[v.Version])
+		seen[v.Version] = true
+	}
+}
+
+func TestAliasRoutingConfigDeepCopy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_, _ = m.CreateFunction(ctx, defaultFuncConfig())
+	_, _ = m.PublishVersion(ctx, "my-func", "v1")
+
+	rc := &driver.AliasRoutingConfig{
+		AdditionalVersion: "1",
+		Weight:            0.5,
+	}
+
+	_, err := m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "my-func",
+		Name:            "deep-copy",
+		FunctionVersion: "$LATEST",
+		RoutingConfig:   rc,
+	})
+	requireNoError(t, err)
+
+	// Mutate the original config
+	rc.Weight = 0.9
+
+	alias, err := m.GetAlias(ctx, "my-func", "deep-copy")
+	requireNoError(t, err)
+	assertEqual(t, 0.5, alias.RoutingConfig.Weight)
 }
 
 // --- test helpers ---

--- a/providers/aws/lambda/layers.go
+++ b/providers/aws/lambda/layers.go
@@ -1,0 +1,137 @@
+package lambda
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PublishLayerVersion publishes a new version of a layer.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(cfg.Name)
+	if !ok {
+		ld = &layerData{
+			versions: memstore.New[*driver.LayerVersion](),
+			nextVer:  initialVersion,
+		}
+		m.layers.Set(cfg.Name, ld)
+	}
+
+	ver := ld.nextVer
+	ld.nextVer++
+
+	hash := sha256.Sum256(cfg.Content)
+	shaStr := fmt.Sprintf("%x", hash)
+
+	arn := idgen.AWSARN(
+		"lambda", m.opts.Region, m.opts.AccountID,
+		"layer:"+cfg.Name+":"+strconv.Itoa(ver),
+	)
+
+	lv := &driver.LayerVersion{
+		Name:               cfg.Name,
+		Version:            ver,
+		Description:        cfg.Description,
+		ContentSHA256:      shaStr,
+		ContentSize:        int64(len(cfg.Content)),
+		CompatibleRuntimes: cfg.CompatibleRuntimes,
+		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		ARN:                arn,
+	}
+
+	ld.versions.Set(strconv.Itoa(ver), lv)
+
+	result := *lv
+
+	return &result, nil
+}
+
+// GetLayerVersion retrieves a specific version of a layer.
+func (m *Mock) GetLayerVersion(_ context.Context, name string, version int) (*driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	lv, ok := ld.versions.Get(strconv.Itoa(version))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "layer %s version %d not found", name, version)
+	}
+
+	result := *lv
+
+	return &result, nil
+}
+
+// ListLayerVersions returns all versions of a layer.
+func (m *Mock) ListLayerVersions(_ context.Context, name string) ([]driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	all := ld.versions.All()
+	result := make([]driver.LayerVersion, 0, len(all))
+
+	for _, lv := range all {
+		result = append(result, *lv)
+	}
+
+	return result, nil
+}
+
+// DeleteLayerVersion removes a specific version of a layer.
+func (m *Mock) DeleteLayerVersion(_ context.Context, name string, version int) error {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	verStr := strconv.Itoa(version)
+	if !ld.versions.Has(verStr) {
+		return cerrors.Newf(cerrors.NotFound, "layer %s version %d not found", name, version)
+	}
+
+	ld.versions.Delete(verStr)
+
+	return nil
+}
+
+// ListLayers returns the latest version of each layer.
+func (m *Mock) ListLayers(_ context.Context) ([]driver.LayerVersion, error) {
+	all := m.layers.All()
+	result := make([]driver.LayerVersion, 0, len(all))
+
+	for _, ld := range all {
+		latest := findLatestLayerVersion(ld)
+		if latest != nil {
+			result = append(result, *latest)
+		}
+	}
+
+	return result, nil
+}
+
+// findLatestLayerVersion returns the layer version with the highest version number.
+func findLatestLayerVersion(ld *layerData) *driver.LayerVersion {
+	all := ld.versions.All()
+
+	var latest *driver.LayerVersion
+
+	for _, lv := range all {
+		if latest == nil || lv.Version > latest.Version {
+			latest = lv
+		}
+	}
+
+	return latest
+}

--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -14,6 +14,9 @@ const latestVersion = "$LATEST"
 
 // PublishVersion snapshots the current function state as an immutable version.
 func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(functionName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)

--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -1,0 +1,95 @@
+package lambda
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// latestVersion is the symbolic version for the current function code.
+const latestVersion = "$LATEST"
+
+// PublishVersion snapshots the current function state as an immutable version.
+func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	verNum := fd.nextVersion
+	fd.nextVersion++
+
+	verStr := strconv.Itoa(verNum)
+	sha := codeSHA(&fd.info)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	vd := &versionData{
+		config:    snapshotConfig(&fd.info),
+		version:   verStr,
+		codeSHA:   sha,
+		createdAt: now,
+	}
+	fd.versions = append(fd.versions, vd)
+	m.funcs.Set(functionName, fd)
+
+	return &driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      verStr,
+		Description:  description,
+		CodeSHA256:   sha,
+		CreatedAt:    now,
+	}, nil
+}
+
+// ListVersions returns all published versions for a function.
+func (m *Mock) ListVersions(_ context.Context, functionName string) ([]driver.FunctionVersion, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	result := make([]driver.FunctionVersion, 0, len(fd.versions)+1)
+	// $LATEST is always present
+	result = append(result, driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      latestVersion,
+		CodeSHA256:   codeSHA(&fd.info),
+	})
+
+	for _, v := range fd.versions {
+		result = append(result, driver.FunctionVersion{
+			FunctionName: functionName,
+			Version:      v.version,
+			CodeSHA256:   v.codeSHA,
+			CreatedAt:    v.createdAt,
+		})
+	}
+
+	return result, nil
+}
+
+// snapshotConfig creates a FunctionConfig snapshot from a FunctionInfo.
+func snapshotConfig(info *driver.FunctionInfo) driver.FunctionConfig {
+	env := make(map[string]string, len(info.Environment))
+	for k, v := range info.Environment {
+		env[k] = v
+	}
+
+	tags := make(map[string]string, len(info.Tags))
+	for k, v := range info.Tags {
+		tags[k] = v
+	}
+
+	return driver.FunctionConfig{
+		Name:        info.Name,
+		Runtime:     info.Runtime,
+		Handler:     info.Handler,
+		Memory:      info.Memory,
+		Timeout:     info.Timeout,
+		Environment: env,
+		Tags:        tags,
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -4,14 +4,26 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/pagination"
 	"github.com/stackshy/cloudemu/storage/driver"
+)
+
+const (
+	s3DefaultPresignExpiry = 15 * time.Minute
+	s3MaxPresignExpiry     = 7 * 24 * time.Hour
+	s3DefaultMaxKeys       = 1000
+	s3TimeFormat           = "2006-01-02T15:04:05Z"
+	hoursPerDay            = 24
 )
 
 var _ driver.Bucket = (*Mock)(nil)
@@ -25,17 +37,45 @@ type s3Object struct {
 	Metadata     map[string]string
 }
 
+type multipartUpload struct {
+	id          string
+	key         string
+	contentType string
+	parts       map[int][]byte
+	createdAt   string
+}
+
 type bucketMeta struct {
-	Name      string
-	Region    string
-	CreatedAt string
-	objects   *memstore.Store[*s3Object]
+	Name       string
+	Region     string
+	CreatedAt  string
+	objects    *memstore.Store[*s3Object]
+	lifecycle  *driver.LifecycleConfig
+	multiparts *memstore.Store[*multipartUpload]
+	versioning bool
 }
 
 // Mock is an in-memory mock implementation of the AWS S3 service.
 type Mock struct {
-	buckets *memstore.Store[*bucketMeta]
-	opts    *config.Options
+	buckets    *memstore.Store[*bucketMeta]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/S3", MetricName: metricName, Value: value, Unit: unit,
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new S3 mock.
@@ -56,10 +96,11 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 	}
 
 	m.buckets.Set(name, &bucketMeta{
-		Name:      name,
-		Region:    m.opts.Region,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-		objects:   memstore.New[*s3Object](),
+		Name:       name,
+		Region:     m.opts.Region,
+		CreatedAt:  m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		objects:    memstore.New[*s3Object](),
+		multiparts: memstore.New[*multipartUpload](),
 	})
 
 	return nil
@@ -115,9 +156,14 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		Data:         dataCopy,
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata:     metadata,
 	})
+
+	dims := map[string]string{"BucketName": bucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("PutRequests", 1, "Count", dims)
+	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
 
 	return nil
 }
@@ -135,6 +181,11 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 
 	dataCopy := make([]byte, len(obj.Data))
 	copy(dataCopy, obj.Data)
+
+	dims := map[string]string{"BucketName": bucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("GetRequests", 1, "Count", dims)
+	m.emitMetric("BytesDownloaded", float64(len(obj.Data)), "Bytes", dims)
 
 	return &driver.Object{
 		Info: driver.ObjectInfo{
@@ -156,6 +207,10 @@ func (m *Mock) DeleteObject(_ context.Context, bucket, key string) error {
 	}
 
 	bkt.objects.Delete(key)
+
+	dims := map[string]string{"BucketName": bucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("DeleteRequests", 1, "Count", dims)
 
 	return nil
 }
@@ -225,10 +280,14 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 	maxKeys := opts.MaxKeys
 	if maxKeys <= 0 {
-		maxKeys = 1000
+		maxKeys = s3DefaultMaxKeys
 	}
 
 	page, _ := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+
+	dims := map[string]string{"BucketName": bucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("ListRequests", 1, "Count", dims)
 
 	return &driver.ListResult{
 		Objects:        page.Items,
@@ -264,9 +323,272 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 
 	dstBkt.objects.Set(dstKey, &s3Object{
 		Key: dstKey, Data: dataCopy, ContentType: srcObj.ContentType,
-		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata: meta,
 	})
 
 	return nil
+}
+
+func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
+	if req.Method != http.MethodGet && req.Method != http.MethodPut {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "method must be GET or PUT, got %q", req.Method)
+	}
+
+	if !m.buckets.Has(req.Bucket) {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", req.Bucket)
+	}
+
+	expiry := req.ExpiresIn
+	if expiry <= 0 {
+		expiry = s3DefaultPresignExpiry
+	}
+
+	if expiry > s3MaxPresignExpiry {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expiry %v exceeds maximum of 7 days", expiry)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+	token := fmt.Sprintf("%x", sha256.Sum256([]byte(req.Bucket+req.Key+now.String())))
+	expiresAt := now.Add(expiry)
+	seconds := int(expiry.Seconds())
+
+	url := fmt.Sprintf(
+		"https://%s.s3.%s.amazonaws.com/%s?X-Amz-Signature=%s&X-Amz-Expires=%d",
+		req.Bucket, m.opts.Region, req.Key, token, seconds,
+	)
+
+	return &driver.PresignedURL{URL: url, Method: req.Method, ExpiresAt: expiresAt}, nil
+}
+
+func (m *Mock) PutLifecycleConfig(_ context.Context, bucket string, cfg driver.LifecycleConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	cfgCopy := driver.LifecycleConfig{Rules: make([]driver.LifecycleRule, len(cfg.Rules))}
+	copy(cfgCopy.Rules, cfg.Rules)
+	bkt.lifecycle = &cfgCopy
+
+	return nil
+}
+
+func (m *Mock) GetLifecycleConfig(_ context.Context, bucket string) (*driver.LifecycleConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.lifecycle == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no lifecycle configuration for bucket %q", bucket)
+	}
+
+	return bkt.lifecycle, nil
+}
+
+func (m *Mock) EvaluateLifecycle(_ context.Context, bucket string) ([]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.lifecycle == nil {
+		return nil, nil
+	}
+
+	now := m.opts.Clock.Now().UTC()
+	expired := collectExpiredKeys(bkt, now)
+	sort.Strings(expired)
+
+	return expired, nil
+}
+
+func collectExpiredKeys(bkt *bucketMeta, now time.Time) []string {
+	var result []string
+
+	for _, key := range bkt.objects.Keys() {
+		obj, objOk := bkt.objects.Get(key)
+		if !objOk {
+			continue
+		}
+
+		if objectExpired(obj, bkt.lifecycle, now) {
+			result = append(result, key)
+		}
+	}
+
+	return result
+}
+
+func objectExpired(obj *s3Object, cfg *driver.LifecycleConfig, now time.Time) bool {
+	modified, err := time.Parse(s3TimeFormat, obj.LastModified)
+	if err != nil {
+		return false
+	}
+
+	age := now.Sub(modified)
+
+	for _, rule := range cfg.Rules {
+		if !rule.Enabled {
+			continue
+		}
+
+		if rule.Prefix != "" && !strings.HasPrefix(obj.Key, rule.Prefix) {
+			continue
+		}
+
+		if rule.ExpirationDays > 0 && age >= time.Duration(rule.ExpirationDays)*hoursPerDay*time.Hour {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Mock) CreateMultipartUpload(_ context.Context, bucket, key, contentType string) (*driver.MultipartUpload, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	uploadID := idgen.GenerateID("upload-")
+	now := m.opts.Clock.Now().UTC().Format(s3TimeFormat)
+
+	bkt.multiparts.Set(uploadID, &multipartUpload{
+		id:          uploadID,
+		key:         key,
+		contentType: contentType,
+		parts:       make(map[int][]byte),
+		createdAt:   now,
+	})
+
+	return &driver.MultipartUpload{
+		UploadID: uploadID, Bucket: bucket, Key: key, CreatedAt: now,
+	}, nil
+}
+
+func (m *Mock) UploadPart(_ context.Context, bucket, _, uploadID string, partNumber int, data []byte) (*driver.UploadPart, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	mp, ok := bkt.multiparts.Get(uploadID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	mp.parts[partNumber] = dataCopy
+
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+
+	return &driver.UploadPart{
+		PartNumber: partNumber, ETag: etag, Size: int64(len(data)),
+	}, nil
+}
+
+func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID string, _ []driver.UploadPart) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	mp, ok := bkt.multiparts.Get(uploadID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	data := assembleMultipartData(mp.parts)
+
+	bkt.objects.Set(key, &s3Object{
+		Key:          key,
+		Data:         data,
+		ContentType:  mp.contentType,
+		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
+		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
+		Metadata:     make(map[string]string),
+	})
+
+	bkt.multiparts.Delete(uploadID)
+
+	return nil
+}
+
+func assembleMultipartData(parts map[int][]byte) []byte {
+	keys := make([]int, 0, len(parts))
+	for k := range parts {
+		keys = append(keys, k)
+	}
+
+	sort.Ints(keys)
+
+	var data []byte
+	for _, k := range keys {
+		data = append(data, parts[k]...)
+	}
+
+	return data
+}
+
+func (m *Mock) AbortMultipartUpload(_ context.Context, bucket, _, uploadID string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if !bkt.multiparts.Has(uploadID) {
+		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	bkt.multiparts.Delete(uploadID)
+
+	return nil
+}
+
+func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.MultipartUpload, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	keys := bkt.multiparts.Keys()
+	sort.Strings(keys)
+
+	result := make([]driver.MultipartUpload, 0, len(keys))
+
+	for _, k := range keys {
+		mp, mpOk := bkt.multiparts.Get(k)
+		if !mpOk {
+			continue
+		}
+
+		result = append(result, driver.MultipartUpload{
+			UploadID: mp.id, Bucket: bucket, Key: mp.key, CreatedAt: mp.createdAt,
+		})
+	}
+
+	return result, nil
+}
+
+func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versioning = enabled
+
+	return nil
+}
+
+func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	return bkt.versioning, nil
 }

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -327,9 +327,15 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 		Metadata: meta,
 	})
 
+	dims := map[string]string{"BucketName": dstBucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("CopyRequests", 1, "Count", dims)
+
 	return nil
 }
 
+// GeneratePresignedURL generates a mock presigned URL.
+// Note: expiry is tracked in the URL but not enforced on use — this is a mock limitation.
 func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
 	if req.Method != http.MethodGet && req.Method != http.MethodPut {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "method must be GET or PUT, got %q", req.Method)
@@ -490,7 +496,7 @@ func (m *Mock) UploadPart(_ context.Context, bucket, _, uploadID string, partNum
 	}, nil
 }
 
-func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID string, _ []driver.UploadPart) error {
+func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID string, parts []driver.UploadPart) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -501,7 +507,13 @@ func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID 
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
-	data := assembleMultipartData(mp.parts)
+	for _, p := range parts {
+		if _, exists := mp.parts[p.PartNumber]; !exists {
+			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
+		}
+	}
+
+	data := assemblePartsInOrder(mp.parts, parts)
 
 	bkt.objects.Set(key, &s3Object{
 		Key:          key,
@@ -514,20 +526,18 @@ func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID 
 
 	bkt.multiparts.Delete(uploadID)
 
+	dims := map[string]string{"BucketName": bucket}
+	m.emitMetric("AllRequests", 1, "Count", dims)
+	m.emitMetric("PutRequests", 1, "Count", dims)
+	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
+
 	return nil
 }
 
-func assembleMultipartData(parts map[int][]byte) []byte {
-	keys := make([]int, 0, len(parts))
-	for k := range parts {
-		keys = append(keys, k)
-	}
-
-	sort.Ints(keys)
-
+func assemblePartsInOrder(allParts map[int][]byte, parts []driver.UploadPart) []byte {
 	var data []byte
-	for _, k := range keys {
-		data = append(data, parts[k]...)
+	for _, p := range parts {
+		data = append(data, allParts[p.PartNumber]...)
 	}
 
 	return data
@@ -573,6 +583,8 @@ func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.
 	return result, nil
 }
 
+// SetBucketVersioning enables or disables versioning on a bucket.
+// Note: this sets the flag but does not maintain object version history — mock limitation.
 func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {

--- a/providers/aws/s3/s3_test.go
+++ b/providers/aws/s3/s3_test.go
@@ -670,6 +670,88 @@ func monitoringGetInput(metricName, bucket string, fc *config.FakeClock) mondriv
 	}
 }
 
+func TestCompleteMultipartUploadPartsValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("only part 1 yields part 1 data", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "bkt", "file1.bin", "application/octet-stream")
+		requireNoError(t, err)
+
+		part1, err := m.UploadPart(ctx, "bkt", "file1.bin", mp.UploadID, 1, []byte("AAAA"))
+		requireNoError(t, err)
+		_, err = m.UploadPart(ctx, "bkt", "file1.bin", mp.UploadID, 2, []byte("BBBB"))
+		requireNoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "bkt", "file1.bin", mp.UploadID, []driver.UploadPart{*part1})
+		requireNoError(t, err)
+
+		obj, err := m.GetObject(ctx, "bkt", "file1.bin")
+		requireNoError(t, err)
+		assertEqual(t, "AAAA", string(obj.Data))
+	})
+
+	t.Run("reversed order yields part2+part1 data", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "bkt", "file2.bin", "application/octet-stream")
+		requireNoError(t, err)
+
+		part1, err := m.UploadPart(ctx, "bkt", "file2.bin", mp.UploadID, 1, []byte("AAAA"))
+		requireNoError(t, err)
+		part2, err := m.UploadPart(ctx, "bkt", "file2.bin", mp.UploadID, 2, []byte("BBBB"))
+		requireNoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "bkt", "file2.bin", mp.UploadID, []driver.UploadPart{*part2, *part1})
+		requireNoError(t, err)
+
+		obj, err := m.GetObject(ctx, "bkt", "file2.bin")
+		requireNoError(t, err)
+		assertEqual(t, "BBBBAAAA", string(obj.Data))
+	})
+
+	t.Run("non-existent part 99 returns error", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "bkt", "file3.bin", "application/octet-stream")
+		requireNoError(t, err)
+
+		_, err = m.UploadPart(ctx, "bkt", "file3.bin", mp.UploadID, 1, []byte("AAAA"))
+		requireNoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "bkt", "file3.bin", mp.UploadID, []driver.UploadPart{
+			{PartNumber: 99, ETag: "fake"},
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestCopyObjectMetrics(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	m := New(opts)
+	ctx := context.Background()
+
+	cw := cloudwatch.New(opts)
+	m.SetMonitoring(cw)
+
+	_ = m.CreateBucket(ctx, "src-bkt")
+	_ = m.CreateBucket(ctx, "dst-bkt")
+	_ = m.PutObject(ctx, "src-bkt", "file.txt", []byte("data"), "text/plain", nil)
+
+	err := m.CopyObject(ctx, "dst-bkt", "copy.txt", driver.CopySource{Bucket: "src-bkt", Key: "file.txt"})
+	requireNoError(t, err)
+
+	result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  "AWS/S3",
+		MetricName: "AllRequests",
+		Dimensions: map[string]string{"BucketName": "dst-bkt"},
+		StartTime:  fc.Now().Add(-1 * time.Hour),
+		EndTime:    fc.Now().Add(1 * time.Hour),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	requireNoError(t, err)
+	assertEqual(t, true, len(result.Values) > 0)
+}
+
 // --- test helpers (no if/else, use t.Fatal/t.Errorf) ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/aws/s3/s3_test.go
+++ b/providers/aws/s3/s3_test.go
@@ -2,10 +2,14 @@ package s3
 
 import (
 	"context"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/storage/driver"
 )
 
@@ -351,6 +355,319 @@ func TestHeadObject(t *testing.T) {
 
 	_, err = m.HeadObject(ctx, "nope", "file.txt")
 	assertError(t, err, true)
+}
+
+func TestGeneratePresignedURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		req       driver.PresignedURLRequest
+		setup     func(m *Mock)
+		expectErr bool
+		checkURL  func(t *testing.T, url *driver.PresignedURL)
+	}{
+		{
+			name: "GET presigned URL",
+			req:  driver.PresignedURLRequest{Bucket: "bkt", Key: "file.txt", Method: http.MethodGet},
+			setup: func(m *Mock) {
+				_ = m.CreateBucket(context.Background(), "bkt")
+			},
+			checkURL: func(t *testing.T, url *driver.PresignedURL) {
+				t.Helper()
+				assertEqual(t, http.MethodGet, url.Method)
+				assertEqual(t, true, strings.Contains(url.URL, "bkt"))
+				assertEqual(t, true, strings.Contains(url.URL, "file.txt"))
+				assertEqual(t, true, strings.Contains(url.URL, "X-Amz-Signature"))
+				assertEqual(t, true, strings.Contains(url.URL, "X-Amz-Expires"))
+			},
+		},
+		{
+			name: "PUT presigned URL",
+			req:  driver.PresignedURLRequest{Bucket: "bkt", Key: "upload.bin", Method: http.MethodPut},
+			setup: func(m *Mock) {
+				_ = m.CreateBucket(context.Background(), "bkt")
+			},
+			checkURL: func(t *testing.T, url *driver.PresignedURL) {
+				t.Helper()
+				assertEqual(t, http.MethodPut, url.Method)
+				assertEqual(t, true, strings.Contains(url.URL, "upload.bin"))
+			},
+		},
+		{
+			name: "custom expiry",
+			req:  driver.PresignedURLRequest{Bucket: "bkt", Key: "k", Method: http.MethodGet, ExpiresIn: 30 * time.Minute},
+			setup: func(m *Mock) {
+				_ = m.CreateBucket(context.Background(), "bkt")
+			},
+			checkURL: func(t *testing.T, url *driver.PresignedURL) {
+				t.Helper()
+				assertEqual(t, true, strings.Contains(url.URL, "1800"))
+			},
+		},
+		{
+			name:      "bucket not found",
+			req:       driver.PresignedURLRequest{Bucket: "nope", Key: "k", Method: http.MethodGet},
+			expectErr: true,
+		},
+		{
+			name: "invalid method",
+			req:  driver.PresignedURLRequest{Bucket: "bkt", Key: "k", Method: http.MethodPost},
+			setup: func(m *Mock) {
+				_ = m.CreateBucket(context.Background(), "bkt")
+			},
+			expectErr: true,
+		},
+		{
+			name: "expiry exceeds maximum",
+			req:  driver.PresignedURLRequest{Bucket: "bkt", Key: "k", Method: http.MethodGet, ExpiresIn: 8 * 24 * time.Hour},
+			setup: func(m *Mock) {
+				_ = m.CreateBucket(context.Background(), "bkt")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+			url, err := m.GeneratePresignedURL(context.Background(), tc.req)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			tc.checkURL(t, url)
+		})
+	}
+}
+
+func TestBucketLifecycleConfig(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	m := New(opts)
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("put and get lifecycle config", func(t *testing.T) {
+		cfg := driver.LifecycleConfig{
+			Rules: []driver.LifecycleRule{
+				{ID: "expire-logs", Enabled: true, Prefix: "logs/", ExpirationDays: 30},
+				{ID: "disabled-rule", Enabled: false, Prefix: "tmp/", ExpirationDays: 7},
+			},
+		}
+
+		err := m.PutLifecycleConfig(ctx, "bkt", cfg)
+		requireNoError(t, err)
+
+		got, err := m.GetLifecycleConfig(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got.Rules))
+		assertEqual(t, "expire-logs", got.Rules[0].ID)
+		assertEqual(t, 30, got.Rules[0].ExpirationDays)
+	})
+
+	t.Run("get lifecycle no config", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "empty-bkt")
+		_, err := m.GetLifecycleConfig(ctx, "empty-bkt")
+		assertError(t, err, true)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutLifecycleConfig(ctx, "nope", driver.LifecycleConfig{})
+		assertError(t, err, true)
+	})
+
+	t.Run("evaluate lifecycle with FakeClock", func(t *testing.T) {
+		_ = m.PutObject(ctx, "bkt", "logs/old.txt", []byte("old"), "", nil)
+		_ = m.PutObject(ctx, "bkt", "logs/new.txt", []byte("new"), "", nil)
+		_ = m.PutObject(ctx, "bkt", "data/keep.txt", []byte("keep"), "", nil)
+
+		// Before expiry: no expired keys
+		expired, err := m.EvaluateLifecycle(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 0, len(expired))
+
+		// Advance clock past 30 days
+		fc.Advance(31 * 24 * time.Hour)
+
+		expired, err = m.EvaluateLifecycle(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(expired))
+		assertEqual(t, "logs/new.txt", expired[0])
+		assertEqual(t, "logs/old.txt", expired[1])
+	})
+}
+
+func TestMultipartUpload(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("create upload parts and complete", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "bkt", "big-file.bin", "application/octet-stream")
+		requireNoError(t, err)
+		assertEqual(t, "bkt", mp.Bucket)
+		assertEqual(t, "big-file.bin", mp.Key)
+
+		part1, err := m.UploadPart(ctx, "bkt", "big-file.bin", mp.UploadID, 1, []byte("part1-"))
+		requireNoError(t, err)
+		assertEqual(t, 1, part1.PartNumber)
+
+		part2, err := m.UploadPart(ctx, "bkt", "big-file.bin", mp.UploadID, 2, []byte("part2"))
+		requireNoError(t, err)
+		assertEqual(t, 2, part2.PartNumber)
+
+		err = m.CompleteMultipartUpload(ctx, "bkt", "big-file.bin", mp.UploadID, []driver.UploadPart{*part1, *part2})
+		requireNoError(t, err)
+
+		obj, err := m.GetObject(ctx, "bkt", "big-file.bin")
+		requireNoError(t, err)
+		assertEqual(t, "part1-part2", string(obj.Data))
+	})
+
+	t.Run("bucket not found for create", func(t *testing.T) {
+		_, err := m.CreateMultipartUpload(ctx, "nope", "k", "")
+		assertError(t, err, true)
+	})
+
+	t.Run("upload not found for upload part", func(t *testing.T) {
+		_, err := m.UploadPart(ctx, "bkt", "k", "bad-upload-id", 1, []byte("x"))
+		assertError(t, err, true)
+	})
+}
+
+func TestAbortMultipartUpload(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	mp, err := m.CreateMultipartUpload(ctx, "bkt", "file.bin", "")
+	requireNoError(t, err)
+
+	_, err = m.UploadPart(ctx, "bkt", "file.bin", mp.UploadID, 1, []byte("data"))
+	requireNoError(t, err)
+
+	err = m.AbortMultipartUpload(ctx, "bkt", "file.bin", mp.UploadID)
+	requireNoError(t, err)
+
+	// Verify upload is gone
+	uploads, err := m.ListMultipartUploads(ctx, "bkt")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(uploads))
+
+	// Object should not exist
+	_, err = m.GetObject(ctx, "bkt", "file.bin")
+	assertError(t, err, true)
+}
+
+func TestListMultipartUploads(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("empty list", func(t *testing.T) {
+		uploads, err := m.ListMultipartUploads(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 0, len(uploads))
+	})
+
+	t.Run("multiple uploads", func(t *testing.T) {
+		_, err := m.CreateMultipartUpload(ctx, "bkt", "file1.bin", "")
+		requireNoError(t, err)
+		_, err = m.CreateMultipartUpload(ctx, "bkt", "file2.bin", "")
+		requireNoError(t, err)
+
+		uploads, err := m.ListMultipartUploads(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(uploads))
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		_, err := m.ListMultipartUploads(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestBucketVersioning(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("default disabled", func(t *testing.T) {
+		enabled, err := m.GetBucketVersioning(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, false, enabled)
+	})
+
+	t.Run("enable versioning", func(t *testing.T) {
+		err := m.SetBucketVersioning(ctx, "bkt", true)
+		requireNoError(t, err)
+
+		enabled, err := m.GetBucketVersioning(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, true, enabled)
+	})
+
+	t.Run("disable versioning", func(t *testing.T) {
+		err := m.SetBucketVersioning(ctx, "bkt", false)
+		requireNoError(t, err)
+
+		enabled, err := m.GetBucketVersioning(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, false, enabled)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.SetBucketVersioning(ctx, "nope", true)
+		assertError(t, err, true)
+
+		_, err = m.GetBucketVersioning(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestS3MetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	m := New(opts)
+	ctx := context.Background()
+
+	cw := cloudwatch.New(opts)
+	m.SetMonitoring(cw)
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("PutObject emits metrics", func(t *testing.T) {
+		err := m.PutObject(ctx, "bkt", "key", []byte("hello"), "text/plain", nil)
+		requireNoError(t, err)
+
+		result, err := cw.GetMetricData(ctx, monitoringGetInput("PutRequests", "bkt", fc))
+		requireNoError(t, err)
+		assertEqual(t, true, len(result.Values) > 0)
+	})
+
+	t.Run("GetObject emits metrics", func(t *testing.T) {
+		_, err := m.GetObject(ctx, "bkt", "key")
+		requireNoError(t, err)
+
+		result, err := cw.GetMetricData(ctx, monitoringGetInput("GetRequests", "bkt", fc))
+		requireNoError(t, err)
+		assertEqual(t, true, len(result.Values) > 0)
+	})
+}
+
+func monitoringGetInput(metricName, bucket string, fc *config.FakeClock) mondriver.GetMetricInput {
+	return mondriver.GetMetricInput{
+		Namespace:  "AWS/S3",
+		MetricName: metricName,
+		Dimensions: map[string]string{"BucketName": bucket},
+		StartTime:  fc.Now().Add(-1 * time.Hour),
+		EndTime:    fc.Now().Add(1 * time.Hour),
+		Period:     60,
+		Stat:       "Sum",
+	}
 }
 
 // --- test helpers (no if/else, use t.Fatal/t.Errorf) ---

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/notification/driver"
 )
 
@@ -32,8 +33,25 @@ type topicData struct {
 
 // Mock is an in-memory mock implementation of the AWS SNS service.
 type Mock struct {
-	topics *memstore.Store[*topicData]
-	opts   *config.Options
+	topics     *memstore.Store[*topicData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/SNS", MetricName: metricName, Value: value, Unit: unit,
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new SNS mock with the given configuration options.
@@ -209,6 +227,10 @@ func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.Pu
 		Attributes: attrs,
 	})
 	td.mu.Unlock()
+
+	dims := map[string]string{"TopicName": input.TopicID}
+	m.emitMetric("NumberOfMessagesPublished", 1, "Count", dims)
+	m.emitMetric("PublishSize", float64(len(input.Message)), "Bytes", dims)
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
 }

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -605,6 +605,13 @@ func (m *Mock) ReceiveMessagesWithOptions(
 		results = []driver.Message{}
 	}
 
+	dims := map[string]string{"QueueName": qd.info.Name}
+	if len(results) > 0 {
+		m.emitMetric("NumberOfMessagesReceived", float64(len(results)), "Count", dims)
+	} else {
+		m.emitMetric("NumberOfEmptyReceives", 1.0, "Count", dims)
+	}
+
 	return results, nil
 }
 

--- a/providers/aws/sqs/sqs.go
+++ b/providers/aws/sqs/sqs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 // Compile-time check that Mock implements driver.MessageQueue.
@@ -47,6 +48,8 @@ type queueData struct {
 	visibilityTimeout  int
 	maxMessageSize     int
 	messageRetention   int
+	createdAt          time.Time
+	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
 	dlqConfig          *driver.DeadLetterConfig
 }
@@ -56,10 +59,27 @@ type LambdaTrigger func(queueURL string, message driver.Message)
 
 // Mock is an in-memory mock implementation of the AWS SQS service.
 type Mock struct {
-	queues   *memstore.Store[*queueData]
-	opts     *config.Options
-	mu       sync.RWMutex
-	triggers map[string]LambdaTrigger // queueURL -> trigger
+	queues     *memstore.Store[*queueData]
+	opts       *config.Options
+	mu         sync.RWMutex
+	triggers   map[string]LambdaTrigger // queueURL -> trigger
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/SQS", MetricName: metricName, Value: value, Unit: unit,
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
 }
 
 // New creates a new SQS mock with the given configuration options.
@@ -124,6 +144,8 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		Tags:               tags,
 	}
 
+	now := m.opts.Clock.Now()
+
 	qd := &queueData{
 		info:               info,
 		messages:           make([]*sqsMessage, 0),
@@ -131,6 +153,8 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		visibilityTimeout:  visibilityTimeout,
 		maxMessageSize:     cfg.MaxMessageSize,
 		messageRetention:   cfg.MessageRetention,
+		createdAt:          now,
+		lastModifiedAt:     now,
 		deduplicationIndex: make(map[string]time.Time),
 		dlqConfig:          cfg.DeadLetterQueue,
 	}
@@ -262,6 +286,10 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		trigger(input.QueueURL, triggerMsg)
 	}
 
+	dims := map[string]string{"QueueName": qd.info.Name}
+	m.emitMetric("NumberOfMessagesSent", 1, "Count", dims)
+	m.emitMetric("SentMessageSize", float64(len(input.Body)), "Bytes", dims)
+
 	return &driver.SendMessageOutput{
 		MessageID: msgID,
 	}, nil
@@ -335,6 +363,13 @@ func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInp
 
 	if results == nil {
 		results = []driver.Message{}
+	}
+
+	dims := map[string]string{"QueueName": qd.info.Name}
+	if len(results) > 0 {
+		m.emitMetric("NumberOfMessagesReceived", float64(len(results)), "Count", dims)
+	} else {
+		m.emitMetric("NumberOfEmptyReceives", 1, "Count", dims)
 	}
 
 	return results, nil
@@ -440,6 +475,8 @@ func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) 
 	for i, msg := range qd.messages {
 		if msg.ReceiptHandle == receiptHandle {
 			qd.messages = append(qd.messages[:i], qd.messages[i+1:]...)
+			m.emitMetric("NumberOfMessagesDeleted", 1, "Count", map[string]string{"QueueName": qd.info.Name})
+
 			return nil
 		}
 	}
@@ -467,4 +504,205 @@ func (m *Mock) ChangeVisibility(_ context.Context, queueURL, receiptHandle strin
 	}
 
 	return errors.Newf(errors.NotFound, "message with receipt handle %q not found", receiptHandle)
+}
+
+// SendMessageBatch sends up to 10 messages to the specified SQS queue.
+func (m *Mock) SendMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchSendEntry,
+) (*driver.BatchSendResult, error) {
+	if len(entries) > driver.MaxBatchSize {
+		return nil, errors.Newf(
+			errors.InvalidArgument, "batch size %d exceeds max %d", len(entries), driver.MaxBatchSize,
+		)
+	}
+
+	result := &driver.BatchSendResult{}
+
+	for _, entry := range entries {
+		input := batchEntryToSendInput(queue, &entry)
+
+		out, err := m.SendMessage(ctx, input)
+		if err != nil {
+			result.Failed = append(result.Failed, driver.BatchSendFailEntry{
+				ID: entry.ID, Code: "SendFailure", Message: err.Error(),
+			})
+
+			continue
+		}
+
+		result.Successful = append(result.Successful, driver.BatchSendResultEntry{
+			ID: entry.ID, MessageID: out.MessageID,
+		})
+	}
+
+	return result, nil
+}
+
+func batchEntryToSendInput(queue string, entry *driver.BatchSendEntry) driver.SendMessageInput {
+	return driver.SendMessageInput{
+		QueueURL:        queue,
+		Body:            entry.Body,
+		DelaySeconds:    entry.DelaySeconds,
+		GroupID:         entry.GroupID,
+		DeduplicationID: entry.DeduplicationID,
+		Attributes:      entry.Attributes,
+	}
+}
+
+// DeleteMessageBatch deletes up to 10 messages from the specified SQS queue.
+func (m *Mock) DeleteMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchDeleteEntry,
+) (*driver.BatchDeleteResult, error) {
+	if len(entries) > driver.MaxBatchSize {
+		return nil, errors.Newf(
+			errors.InvalidArgument, "batch size %d exceeds max %d", len(entries), driver.MaxBatchSize,
+		)
+	}
+
+	result := &driver.BatchDeleteResult{}
+
+	for _, entry := range entries {
+		err := m.DeleteMessage(ctx, queue, entry.ReceiptHandle)
+		if err != nil {
+			result.Failed = append(result.Failed, driver.BatchSendFailEntry{
+				ID: entry.ID, Code: "DeleteFailure", Message: err.Error(),
+			})
+
+			continue
+		}
+
+		result.Successful = append(result.Successful, entry.ID)
+	}
+
+	return result, nil
+}
+
+// ReceiveMessagesWithOptions receives messages with configurable options.
+func (m *Mock) ReceiveMessagesWithOptions(
+	_ context.Context, queue string, opts driver.ReceiveOptions,
+) ([]driver.Message, error) {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	maxMsgs := clampMaxMessages(opts.MaxMessages)
+
+	visTimeout := opts.VisibilityTimeout
+	if visTimeout == 0 {
+		visTimeout = qd.visibilityTimeout
+	}
+
+	now := m.opts.Clock.Now()
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now)
+
+	removeByIndices(qd, toRemove)
+
+	if results == nil {
+		results = []driver.Message{}
+	}
+
+	return results, nil
+}
+
+// GetQueueAttributes returns detailed attributes of the specified queue.
+func (m *Mock) GetQueueAttributes(
+	_ context.Context, queue string,
+) (*driver.QueueAttributes, error) {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	now := m.opts.Clock.Now()
+	visible, notVisible := countMessages(qd, now)
+
+	return &driver.QueueAttributes{
+		DelaySeconds:               qd.delaySeconds,
+		MaximumMessageSize:         qd.maxMessageSize,
+		MessageRetentionPeriod:     qd.messageRetention,
+		VisibilityTimeout:          qd.visibilityTimeout,
+		ApproximateMessageCount:    visible,
+		ApproximateNotVisibleCount: notVisible,
+		CreatedAt:                  qd.createdAt,
+		LastModifiedAt:             qd.lastModifiedAt,
+		FifoQueue:                  qd.info.FIFO,
+	}, nil
+}
+
+// SetQueueAttributes updates the attributes of the specified queue.
+func (m *Mock) SetQueueAttributes(
+	_ context.Context, queue string, attrs map[string]int,
+) error {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return errors.Newf(errors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	applyQueueAttributes(qd, attrs)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+func applyQueueAttributes(qd *queueData, attrs map[string]int) {
+	if v, ok := attrs["DelaySeconds"]; ok {
+		qd.delaySeconds = v
+	}
+
+	if v, ok := attrs["VisibilityTimeout"]; ok {
+		qd.visibilityTimeout = v
+	}
+
+	if v, ok := attrs["MaximumMessageSize"]; ok {
+		qd.maxMessageSize = v
+	}
+
+	if v, ok := attrs["MessageRetentionPeriod"]; ok {
+		qd.messageRetention = v
+	}
+}
+
+// PurgeQueue removes all messages from the specified queue.
+func (m *Mock) PurgeQueue(_ context.Context, queue string) error {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return errors.Newf(errors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	qd.messages = make([]*sqsMessage, 0)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+func countMessages(qd *queueData, now time.Time) (visible, notVisible int) {
+	for _, msg := range qd.messages {
+		if msg.VisibleAt.After(now) {
+			notVisible++
+		} else {
+			visible++
+		}
+	}
+
+	return visible, notVisible
+}
+
+func removeByIndices(qd *queueData, indices []int) {
+	for i := len(indices) - 1; i >= 0; i-- {
+		idx := indices[i]
+		qd.messages = append(qd.messages[:idx], qd.messages[idx+1:]...)
+	}
 }

--- a/providers/aws/sqs/sqs_test.go
+++ b/providers/aws/sqs/sqs_test.go
@@ -585,6 +585,35 @@ func TestLambdaTrigger(t *testing.T) {
 	assertEqual(t, false, triggered)
 }
 
+func TestReceiveMessagesWithOptionsMetrics(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	cw := cloudwatch.New(opts)
+	m := New(opts)
+	m.SetMonitoring(cw)
+
+	ctx := context.Background()
+	q := createSQSQueue(m, "rwopt-queue")
+
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "hello"})
+	requireNoError(t, err)
+
+	_, err = m.ReceiveMessagesWithOptions(ctx, q.URL, driver.ReceiveOptions{MaxMessages: 10})
+	requireNoError(t, err)
+
+	result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  "AWS/SQS",
+		MetricName: "NumberOfMessagesReceived",
+		Dimensions: map[string]string{"QueueName": "rwopt-queue"},
+		StartTime:  fc.Now().Add(-time.Minute),
+		EndTime:    fc.Now().Add(time.Minute),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	requireNoError(t, err)
+	assertGreaterThan(t, len(result.Values), 0)
+}
+
 // --- test helpers ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/aws/sqs/sqs_test.go
+++ b/providers/aws/sqs/sqs_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
 )
 
 func newTestMock() (*Mock, *config.FakeClock) {
@@ -318,6 +320,247 @@ func TestChangeVisibility(t *testing.T) {
 	})
 }
 
+func TestSendMessageBatch(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	q := createStdQueue(m, "batch-queue")
+
+	entries := []driver.BatchSendEntry{
+		{ID: "e1", Body: "msg-1"},
+		{ID: "e2", Body: "msg-2"},
+		{ID: "e3", Body: "msg-3"},
+	}
+
+	result, err := m.SendMessageBatch(ctx, q.URL, entries)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(result.Successful))
+	assertEqual(t, 0, len(result.Failed))
+
+	// Verify all messages can be received.
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	requireNoError(t, err)
+	assertEqual(t, 3, len(msgs))
+}
+
+func TestSendMessageBatchLimit(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	q := createStdQueue(m, "batch-limit-queue")
+
+	entries := make([]driver.BatchSendEntry, 11)
+	for i := range entries {
+		entries[i] = driver.BatchSendEntry{ID: "e", Body: "x"}
+	}
+
+	_, err := m.SendMessageBatch(ctx, q.URL, entries)
+	assertError(t, err, true)
+}
+
+func TestDeleteMessageBatch(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	q := createStdQueue(m, "batch-del-queue")
+
+	// Send 3 messages.
+	for i := 0; i < 3; i++ {
+		_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "msg"})
+	}
+
+	// Receive them.
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	requireNoError(t, err)
+	assertEqual(t, 3, len(msgs))
+
+	// Batch delete.
+	delEntries := make([]driver.BatchDeleteEntry, len(msgs))
+	for i, msg := range msgs {
+		delEntries[i] = driver.BatchDeleteEntry{ID: msg.MessageID, ReceiptHandle: msg.ReceiptHandle}
+	}
+
+	result, err := m.DeleteMessageBatch(ctx, q.URL, delEntries)
+	requireNoError(t, err)
+	assertEqual(t, 3, len(result.Successful))
+	assertEqual(t, 0, len(result.Failed))
+
+	// Verify queue is empty.
+	remaining, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	requireNoError(t, err)
+	assertEqual(t, 0, len(remaining))
+}
+
+func TestReceiveMessagesWithOptions(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	q := createStdQueue(m, "opts-queue")
+
+	for i := 0; i < 5; i++ {
+		_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "msg"})
+	}
+
+	t.Run("MaxMessages limits results", func(t *testing.T) {
+		msgs, err := m.ReceiveMessagesWithOptions(ctx, q.URL, driver.ReceiveOptions{MaxMessages: 2})
+		requireNoError(t, err)
+		assertEqual(t, 2, len(msgs))
+	})
+
+	t.Run("VisibilityTimeout override", func(t *testing.T) {
+		// Wait for previous visibility to expire, then receive with short timeout.
+		fc.Advance(31 * time.Second)
+		msgs, err := m.ReceiveMessagesWithOptions(ctx, q.URL, driver.ReceiveOptions{
+			MaxMessages:       10,
+			VisibilityTimeout: 5,
+		})
+		requireNoError(t, err)
+		assertEqual(t, 5, len(msgs))
+
+		// Messages should be invisible now.
+		msgs2, err := m.ReceiveMessagesWithOptions(ctx, q.URL, driver.ReceiveOptions{MaxMessages: 10})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(msgs2))
+
+		// After 6 seconds all messages become visible again.
+		fc.Advance(6 * time.Second)
+		msgs3, err := m.ReceiveMessagesWithOptions(ctx, q.URL, driver.ReceiveOptions{MaxMessages: 10})
+		requireNoError(t, err)
+		assertEqual(t, 5, len(msgs3))
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		_, err := m.ReceiveMessagesWithOptions(ctx, "https://nope", driver.ReceiveOptions{})
+		assertError(t, err, true)
+	})
+}
+
+func TestGetQueueAttributes(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	q, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name:              "attr-queue",
+		DelaySeconds:      5,
+		VisibilityTimeout: 45,
+		MaxMessageSize:    1024,
+		MessageRetention:  3600,
+	})
+	requireNoError(t, err)
+
+	attrs, err := m.GetQueueAttributes(ctx, q.URL)
+	requireNoError(t, err)
+	assertEqual(t, 5, attrs.DelaySeconds)
+	assertEqual(t, 45, attrs.VisibilityTimeout)
+	assertEqual(t, 1024, attrs.MaximumMessageSize)
+	assertEqual(t, 3600, attrs.MessageRetentionPeriod)
+	assertEqual(t, 0, attrs.ApproximateMessageCount)
+	assertEqual(t, false, attrs.FifoQueue)
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetQueueAttributes(ctx, "https://nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestSetQueueAttributes(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	q := createStdQueue(m, "set-attr-queue")
+
+	err := m.SetQueueAttributes(ctx, q.URL, map[string]int{
+		"DelaySeconds":      10,
+		"VisibilityTimeout": 60,
+	})
+	requireNoError(t, err)
+
+	attrs, err := m.GetQueueAttributes(ctx, q.URL)
+	requireNoError(t, err)
+	assertEqual(t, 10, attrs.DelaySeconds)
+	assertEqual(t, 60, attrs.VisibilityTimeout)
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.SetQueueAttributes(ctx, "https://nope", map[string]int{"DelaySeconds": 1})
+		assertError(t, err, true)
+	})
+}
+
+func TestPurgeQueue(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	q := createStdQueue(m, "purge-queue")
+
+	// Send several messages.
+	for i := 0; i < 5; i++ {
+		_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "msg"})
+	}
+
+	// Verify messages exist.
+	info, _ := m.GetQueueInfo(ctx, q.URL)
+	assertEqual(t, 5, info.ApproxMessageCount)
+
+	// Purge.
+	err := m.PurgeQueue(ctx, q.URL)
+	requireNoError(t, err)
+
+	// Verify empty.
+	info, _ = m.GetQueueInfo(ctx, q.URL)
+	assertEqual(t, 0, info.ApproxMessageCount)
+
+	msgs, _ := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 10})
+	assertEqual(t, 0, len(msgs))
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.PurgeQueue(ctx, "https://nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestMetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	cw := cloudwatch.New(opts)
+	m := New(opts)
+	m.SetMonitoring(cw)
+
+	ctx := context.Background()
+	q := createSQSQueue(m, "metrics-queue")
+
+	// Send a message - should emit NumberOfMessagesSent metric.
+	_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: q.URL, Body: "hello"})
+	requireNoError(t, err)
+
+	// Query the metric.
+	result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  "AWS/SQS",
+		MetricName: "NumberOfMessagesSent",
+		Dimensions: map[string]string{"QueueName": "metrics-queue"},
+		StartTime:  fc.Now().Add(-time.Minute),
+		EndTime:    fc.Now().Add(time.Minute),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	requireNoError(t, err)
+	assertGreaterThan(t, len(result.Values), 0)
+
+	// Receive the message - should emit NumberOfMessagesReceived.
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: q.URL, MaxMessages: 1})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(msgs))
+
+	recvResult, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  "AWS/SQS",
+		MetricName: "NumberOfMessagesReceived",
+		Dimensions: map[string]string{"QueueName": "metrics-queue"},
+		StartTime:  fc.Now().Add(-time.Minute),
+		EndTime:    fc.Now().Add(time.Minute),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	requireNoError(t, err)
+	assertGreaterThan(t, len(recvResult.Values), 0)
+}
+
+func createSQSQueue(m *Mock, name string) *driver.QueueInfo {
+	info, _ := m.CreateQueue(context.Background(), driver.QueueConfig{Name: name})
+	return info
+}
+
 func TestLambdaTrigger(t *testing.T) {
 	m, _ := newTestMock()
 	ctx := context.Background()
@@ -372,5 +615,19 @@ func assertNotEmpty(t *testing.T, s string) {
 	t.Helper()
 	if s == "" {
 		t.Error("expected non-empty string")
+	}
+}
+
+func assertNotNegative(t *testing.T, n int) {
+	t.Helper()
+	if n < 0 {
+		t.Errorf("expected non-negative, got %d", n)
+	}
+}
+
+func assertGreaterThan(t *testing.T, actual, threshold int) {
+	t.Helper()
+	if actual <= threshold {
+		t.Errorf("expected > %d, got %d", threshold, actual)
 	}
 }

--- a/providers/aws/vpc/acl.go
+++ b/providers/aws/vpc/acl.go
@@ -1,0 +1,137 @@
+package vpc
+
+import (
+	"context"
+	"sort"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Default ACL rule constants.
+const (
+	defaultACLRuleNumber = 100
+	allTrafficProtocol   = "-1"
+	allTrafficCIDR       = "0.0.0.0/0"
+	actionAllow          = "allow"
+)
+
+type networkACLData struct {
+	ID        string
+	VPCID     string
+	Rules     []driver.NetworkACLRule
+	Tags      map[string]string
+	IsDefault bool
+}
+
+// CreateNetworkACL creates a network ACL for the specified VPC.
+func (m *Mock) CreateNetworkACL(_ context.Context, vpcID string, tags map[string]string) (*driver.NetworkACL, error) {
+	if vpcID == "" {
+		return nil, errors.New(errors.InvalidArgument, "VPC ID is required")
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return nil, errors.Newf(errors.NotFound, "vpc %q not found", vpcID)
+	}
+
+	id := idgen.GenerateID("acl-")
+	acl := &networkACLData{
+		ID:        id,
+		VPCID:     vpcID,
+		Rules:     defaultACLRules(),
+		Tags:      copyTags(tags),
+		IsDefault: false,
+	}
+	m.networkACLs.Set(id, acl)
+
+	info := toNetworkACLInfo(acl)
+
+	return &info, nil
+}
+
+// defaultACLRules returns the default allow-all rules for a new ACL.
+func defaultACLRules() []driver.NetworkACLRule {
+	return []driver.NetworkACLRule{
+		{
+			RuleNumber: defaultACLRuleNumber,
+			Protocol:   allTrafficProtocol,
+			Action:     actionAllow,
+			CIDR:       allTrafficCIDR,
+			Egress:     false,
+		},
+		{
+			RuleNumber: defaultACLRuleNumber,
+			Protocol:   allTrafficProtocol,
+			Action:     actionAllow,
+			CIDR:       allTrafficCIDR,
+			Egress:     true,
+		},
+	}
+}
+
+// DeleteNetworkACL deletes the network ACL with the given ID.
+func (m *Mock) DeleteNetworkACL(_ context.Context, id string) error {
+	acl, ok := m.networkACLs.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "network ACL %q not found", id)
+	}
+
+	if acl.IsDefault {
+		return errors.Newf(errors.FailedPrecondition, "cannot delete default network ACL %q", id)
+	}
+
+	m.networkACLs.Delete(id)
+
+	return nil
+}
+
+// DescribeNetworkACLs returns network ACLs matching the given IDs, or all if empty.
+func (m *Mock) DescribeNetworkACLs(_ context.Context, ids []string) ([]driver.NetworkACL, error) {
+	return describeResources(m.networkACLs, ids, toNetworkACLInfo), nil
+}
+
+// AddNetworkACLRule adds a rule to the specified network ACL, keeping rules sorted by number.
+func (m *Mock) AddNetworkACLRule(_ context.Context, aclID string, rule *driver.NetworkACLRule) error {
+	acl, ok := m.networkACLs.Get(aclID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "network ACL %q not found", aclID)
+	}
+
+	acl.Rules = append(acl.Rules, *rule)
+	sort.Slice(acl.Rules, func(i, j int) bool {
+		return acl.Rules[i].RuleNumber < acl.Rules[j].RuleNumber
+	})
+
+	return nil
+}
+
+// RemoveNetworkACLRule removes a rule from the specified network ACL by rule number and direction.
+func (m *Mock) RemoveNetworkACLRule(_ context.Context, aclID string, ruleNumber int, egress bool) error {
+	acl, ok := m.networkACLs.Get(aclID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "network ACL %q not found", aclID)
+	}
+
+	for i, r := range acl.Rules {
+		if r.RuleNumber == ruleNumber && r.Egress == egress {
+			acl.Rules = append(acl.Rules[:i], acl.Rules[i+1:]...)
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.NotFound, "rule %d not found in network ACL %q", ruleNumber, aclID)
+}
+
+func toNetworkACLInfo(acl *networkACLData) driver.NetworkACL {
+	rules := make([]driver.NetworkACLRule, len(acl.Rules))
+	copy(rules, acl.Rules)
+
+	return driver.NetworkACL{
+		ID:        acl.ID,
+		VPCID:     acl.VPCID,
+		Rules:     rules,
+		Tags:      copyTags(acl.Tags),
+		IsDefault: acl.IsDefault,
+	}
+}

--- a/providers/aws/vpc/flowlog.go
+++ b/providers/aws/vpc/flowlog.go
@@ -1,0 +1,159 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Flow log status constants.
+const (
+	FlowLogStatusActive = "ACTIVE"
+)
+
+// Flow log traffic type constants.
+const (
+	TrafficTypeAll    = "ALL"
+	TrafficTypeAccept = "ACCEPT"
+	TrafficTypeReject = "REJECT"
+)
+
+// Mock flow log record constants.
+const (
+	mockSourcePort = 443
+	mockDestPort   = 52000
+	mockPackets    = 10
+	mockBytes      = 1500
+)
+
+type flowLogData struct {
+	ID           string
+	ResourceID   string
+	ResourceType string
+	TrafficType  string
+	Status       string
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// CreateFlowLog creates a flow log for a VPC or subnet resource.
+func (m *Mock) CreateFlowLog(_ context.Context, cfg driver.FlowLogConfig) (*driver.FlowLog, error) {
+	if cfg.ResourceID == "" {
+		return nil, errors.New(errors.InvalidArgument, "resource ID is required")
+	}
+
+	if err := m.validateFlowLogResource(cfg.ResourceID, cfg.ResourceType); err != nil {
+		return nil, err
+	}
+
+	trafficType := cfg.TrafficType
+	if trafficType == "" {
+		trafficType = TrafficTypeAll
+	}
+
+	id := idgen.GenerateID("fl-")
+	fl := &flowLogData{
+		ID:           id,
+		ResourceID:   cfg.ResourceID,
+		ResourceType: cfg.ResourceType,
+		TrafficType:  trafficType,
+		Status:       FlowLogStatusActive,
+		CreatedAt:    m.opts.Clock.Now().Format(timeFormat),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.flowLogs.Set(id, fl)
+
+	info := toFlowLogInfo(fl)
+
+	return &info, nil
+}
+
+// validateFlowLogResource checks that the target resource exists.
+func (m *Mock) validateFlowLogResource(resourceID, resourceType string) error {
+	switch resourceType {
+	case "VPC":
+		if !m.vpcs.Has(resourceID) {
+			return errors.Newf(errors.NotFound, "vpc %q not found", resourceID)
+		}
+	case "Subnet":
+		if !m.subnets.Has(resourceID) {
+			return errors.Newf(errors.NotFound, "subnet %q not found", resourceID)
+		}
+	default:
+		return errors.Newf(errors.InvalidArgument, "unsupported resource type %q", resourceType)
+	}
+
+	return nil
+}
+
+// DeleteFlowLog deletes the flow log with the given ID.
+func (m *Mock) DeleteFlowLog(_ context.Context, id string) error {
+	if !m.flowLogs.Delete(id) {
+		return errors.Newf(errors.NotFound, "flow log %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeFlowLogs returns flow logs matching the given IDs, or all if empty.
+func (m *Mock) DescribeFlowLogs(_ context.Context, ids []string) ([]driver.FlowLog, error) {
+	return describeResources(m.flowLogs, ids, toFlowLogInfo), nil
+}
+
+// GetFlowLogRecords generates mock flow log records for the given flow log.
+func (m *Mock) GetFlowLogRecords(
+	_ context.Context, flowLogID string, limit int,
+) ([]driver.FlowLogRecord, error) {
+	fl, ok := m.flowLogs.Get(flowLogID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "flow log %q not found", flowLogID)
+	}
+
+	return generateMockRecords(fl, limit), nil
+}
+
+// generateMockRecords creates simulated flow log records.
+func generateMockRecords(fl *flowLogData, limit int) []driver.FlowLogRecord {
+	if limit <= 0 {
+		limit = defaultFlowLogRecordLimit
+	}
+
+	records := make([]driver.FlowLogRecord, 0, limit)
+
+	for i := range limit {
+		action := TrafficTypeAccept
+		if fl.TrafficType == TrafficTypeReject || (fl.TrafficType == TrafficTypeAll && i%2 == 1) {
+			action = TrafficTypeReject
+		}
+
+		records = append(records, driver.FlowLogRecord{
+			Timestamp:  fl.CreatedAt,
+			SourceIP:   fmt.Sprintf("10.0.0.%d", i+1),
+			DestIP:     fmt.Sprintf("10.0.1.%d", i+1),
+			SourcePort: mockSourcePort,
+			DestPort:   mockDestPort + i,
+			Protocol:   "tcp",
+			Packets:    mockPackets,
+			Bytes:      mockBytes,
+			Action:     action,
+			FlowLogID:  fl.ID,
+		})
+	}
+
+	return records
+}
+
+func toFlowLogInfo(fl *flowLogData) driver.FlowLog {
+	return driver.FlowLog{
+		ID:           fl.ID,
+		ResourceID:   fl.ResourceID,
+		ResourceType: fl.ResourceType,
+		TrafficType:  fl.TrafficType,
+		Status:       fl.Status,
+		CreatedAt:    fl.CreatedAt,
+		Tags:         copyTags(fl.Tags),
+	}
+}

--- a/providers/aws/vpc/natgw.go
+++ b/providers/aws/vpc/natgw.go
@@ -1,0 +1,79 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// NAT gateway state constants.
+const (
+	NATStateAvailable = "available"
+	NATStateDeleted   = "deleted"
+)
+
+type natGatewayData struct {
+	ID        string
+	SubnetID  string
+	VPCID     string
+	PublicIP  string
+	State     string
+	CreatedAt string
+	Tags      map[string]string
+}
+
+// CreateNATGateway creates a NAT gateway in the specified subnet.
+func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) (*driver.NATGateway, error) {
+	if cfg.SubnetID == "" {
+		return nil, errors.New(errors.InvalidArgument, "subnet ID is required")
+	}
+
+	subnet, ok := m.subnets.Get(cfg.SubnetID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "subnet %q not found", cfg.SubnetID)
+	}
+
+	id := idgen.GenerateID("nat-")
+	nat := &natGatewayData{
+		ID:        id,
+		SubnetID:  cfg.SubnetID,
+		VPCID:     subnet.VPCID,
+		PublicIP:  mockPublicIP(id),
+		State:     NATStateAvailable,
+		CreatedAt: m.opts.Clock.Now().Format(timeFormat),
+		Tags:      copyTags(cfg.Tags),
+	}
+	m.natGateways.Set(id, nat)
+
+	info := toNATGatewayInfo(nat)
+
+	return &info, nil
+}
+
+// DeleteNATGateway deletes the NAT gateway with the given ID.
+func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
+	if !m.natGateways.Delete(id) {
+		return errors.Newf(errors.NotFound, "NAT gateway %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeNATGateways returns NAT gateways matching the given IDs, or all if empty.
+func (m *Mock) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NATGateway, error) {
+	return describeResources(m.natGateways, ids, toNATGatewayInfo), nil
+}
+
+func toNATGatewayInfo(n *natGatewayData) driver.NATGateway {
+	return driver.NATGateway{
+		ID:        n.ID,
+		SubnetID:  n.SubnetID,
+		VPCID:     n.VPCID,
+		PublicIP:  n.PublicIP,
+		State:     n.State,
+		CreatedAt: n.CreatedAt,
+		Tags:      copyTags(n.Tags),
+	}
+}

--- a/providers/aws/vpc/peering.go
+++ b/providers/aws/vpc/peering.go
@@ -1,0 +1,159 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Peering status constants.
+const (
+	PeeringStatusPending  = "pending-acceptance"
+	PeeringStatusActive   = "active"
+	PeeringStatusRejected = "rejected"
+	PeeringStatusDeleted  = "deleted"
+)
+
+type peeringData struct {
+	ID           string
+	RequesterVPC string
+	AccepterVPC  string
+	Status       string
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// CreatePeeringConnection creates a VPC peering connection between two VPCs.
+func (m *Mock) CreatePeeringConnection(
+	_ context.Context, cfg driver.PeeringConfig,
+) (*driver.PeeringConnection, error) {
+	if cfg.RequesterVPC == "" || cfg.AccepterVPC == "" {
+		return nil, errors.New(errors.InvalidArgument, "both requester and accepter VPC IDs are required")
+	}
+
+	reqVPC, ok := m.vpcs.Get(cfg.RequesterVPC)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "requester vpc %q not found", cfg.RequesterVPC)
+	}
+
+	accVPC, ok := m.vpcs.Get(cfg.AccepterVPC)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "accepter vpc %q not found", cfg.AccepterVPC)
+	}
+
+	if cidrsOverlap(reqVPC.CIDRBlock, accVPC.CIDRBlock) {
+		return nil, errors.New(errors.InvalidArgument, "VPC CIDRs must not overlap for peering")
+	}
+
+	id := idgen.GenerateID("pcx-")
+	p := &peeringData{
+		ID:           id,
+		RequesterVPC: cfg.RequesterVPC,
+		AccepterVPC:  cfg.AccepterVPC,
+		Status:       PeeringStatusPending,
+		CreatedAt:    m.opts.Clock.Now().Format(timeFormat),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.peerings.Set(id, p)
+
+	info := toPeeringInfo(p)
+
+	return &info, nil
+}
+
+// AcceptPeeringConnection accepts a pending peering connection.
+func (m *Mock) AcceptPeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "peering connection %q not found", peeringID)
+	}
+
+	if p.Status != PeeringStatusPending {
+		return errors.Newf(errors.FailedPrecondition, "peering %q is in state %q, expected %q",
+			peeringID, p.Status, PeeringStatusPending)
+	}
+
+	p.Status = PeeringStatusActive
+
+	return nil
+}
+
+// RejectPeeringConnection rejects a pending peering connection.
+func (m *Mock) RejectPeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "peering connection %q not found", peeringID)
+	}
+
+	if p.Status != PeeringStatusPending {
+		return errors.Newf(errors.FailedPrecondition, "peering %q is in state %q, expected %q",
+			peeringID, p.Status, PeeringStatusPending)
+	}
+
+	p.Status = PeeringStatusRejected
+
+	return nil
+}
+
+// DeletePeeringConnection deletes a peering connection.
+func (m *Mock) DeletePeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "peering connection %q not found", peeringID)
+	}
+
+	p.Status = PeeringStatusDeleted
+
+	m.peerings.Delete(peeringID)
+
+	return nil
+}
+
+// DescribePeeringConnections returns peering connections matching the given IDs.
+func (m *Mock) DescribePeeringConnections(
+	_ context.Context, ids []string,
+) ([]driver.PeeringConnection, error) {
+	return describeResources(m.peerings, ids, toPeeringInfo), nil
+}
+
+func toPeeringInfo(p *peeringData) driver.PeeringConnection {
+	return driver.PeeringConnection{
+		ID:           p.ID,
+		RequesterVPC: p.RequesterVPC,
+		AccepterVPC:  p.AccepterVPC,
+		Status:       p.Status,
+		CreatedAt:    p.CreatedAt,
+		Tags:         copyTags(p.Tags),
+	}
+}
+
+// cidrsOverlap checks whether two CIDR blocks overlap.
+func cidrsOverlap(cidrA, cidrB string) bool {
+	_, netA, errA := net.ParseCIDR(cidrA)
+	_, netB, errB := net.ParseCIDR(cidrB)
+
+	if errA != nil || errB != nil {
+		// If we can't parse, do a simple string comparison as fallback.
+		return cidrA == cidrB
+	}
+
+	return netA.Contains(netB.IP) || netB.Contains(netA.IP)
+}
+
+// mockPublicIP generates a mock public IP from a counter value.
+func mockPublicIP(id string) string {
+	// Use a simple hash-like approach from the ID suffix.
+	var sum int
+	for _, c := range id {
+		sum += int(c)
+	}
+
+	octet3 := sum % maxOctetValue
+	octet4 := (sum / maxOctetValue) % maxOctetValue
+
+	return fmt.Sprintf("10.0.%d.%d", octet3, octet4)
+}

--- a/providers/aws/vpc/routetable.go
+++ b/providers/aws/vpc/routetable.go
@@ -1,0 +1,123 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Route target type constants.
+const (
+	RouteTargetLocal = "local"
+)
+
+type routeTableData struct {
+	ID     string
+	VPCID  string
+	Routes []driver.Route
+	Tags   map[string]string
+}
+
+// CreateRouteTable creates a route table for the specified VPC.
+func (m *Mock) CreateRouteTable(_ context.Context, cfg driver.RouteTableConfig) (*driver.RouteTable, error) {
+	if cfg.VPCID == "" {
+		return nil, errors.New(errors.InvalidArgument, "VPC ID is required")
+	}
+
+	v, ok := m.vpcs.Get(cfg.VPCID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "vpc %q not found", cfg.VPCID)
+	}
+
+	id := idgen.GenerateID("rtb-")
+	localRoute := driver.Route{
+		DestinationCIDR: v.CIDRBlock,
+		TargetID:        RouteTargetLocal,
+		TargetType:      RouteTargetLocal,
+		State:           "active",
+	}
+
+	rt := &routeTableData{
+		ID:     id,
+		VPCID:  cfg.VPCID,
+		Routes: []driver.Route{localRoute},
+		Tags:   copyTags(cfg.Tags),
+	}
+	m.routeTables.Set(id, rt)
+
+	info := toRouteTableInfo(rt)
+
+	return &info, nil
+}
+
+// DeleteRouteTable deletes the route table with the given ID.
+func (m *Mock) DeleteRouteTable(_ context.Context, id string) error {
+	if !m.routeTables.Delete(id) {
+		return errors.Newf(errors.NotFound, "route table %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeRouteTables returns route tables matching the given IDs, or all if empty.
+func (m *Mock) DescribeRouteTables(_ context.Context, ids []string) ([]driver.RouteTable, error) {
+	return describeResources(m.routeTables, ids, toRouteTableInfo), nil
+}
+
+// CreateRoute adds a route to the specified route table.
+func (m *Mock) CreateRoute(
+	_ context.Context, routeTableID, destinationCIDR, targetID, targetType string,
+) error {
+	rt, ok := m.routeTables.Get(routeTableID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "route table %q not found", routeTableID)
+	}
+
+	for _, r := range rt.Routes {
+		if r.DestinationCIDR == destinationCIDR {
+			return errors.Newf(errors.AlreadyExists,
+				"route for %q already exists in route table %q", destinationCIDR, routeTableID)
+		}
+	}
+
+	rt.Routes = append(rt.Routes, driver.Route{
+		DestinationCIDR: destinationCIDR,
+		TargetID:        targetID,
+		TargetType:      targetType,
+		State:           "active",
+	})
+
+	return nil
+}
+
+// DeleteRoute removes a route from the specified route table.
+func (m *Mock) DeleteRoute(_ context.Context, routeTableID, destinationCIDR string) error {
+	rt, ok := m.routeTables.Get(routeTableID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "route table %q not found", routeTableID)
+	}
+
+	for i, r := range rt.Routes {
+		if r.DestinationCIDR == destinationCIDR {
+			rt.Routes = append(rt.Routes[:i], rt.Routes[i+1:]...)
+			return nil
+		}
+	}
+
+	return errors.Newf(errors.NotFound, "route %q not found in route table %q",
+		destinationCIDR, routeTableID)
+}
+
+func toRouteTableInfo(rt *routeTableData) driver.RouteTable {
+	routes := make([]driver.Route, len(rt.Routes))
+	copy(routes, rt.Routes)
+
+	return driver.RouteTable{
+		ID:     rt.ID,
+		VPCID:  rt.VPCID,
+		Routes: routes,
+		Tags:   copyTags(rt.Tags),
+	}
+}

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -3,12 +3,20 @@ package vpc
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Time format and mock constants.
+const (
+	timeFormat                = time.RFC3339
+	maxOctetValue             = 256
+	defaultFlowLogRecordLimit = 10
 )
 
 // Compile-time check that Mock implements driver.Networking.
@@ -19,6 +27,11 @@ type Mock struct {
 	vpcs           *memstore.Store[*vpcData]
 	subnets        *memstore.Store[*subnetData]
 	securityGroups *memstore.Store[*sgData]
+	peerings       *memstore.Store[*peeringData]
+	natGateways    *memstore.Store[*natGatewayData]
+	flowLogs       *memstore.Store[*flowLogData]
+	routeTables    *memstore.Store[*routeTableData]
+	networkACLs    *memstore.Store[*networkACLData]
 	opts           *config.Options
 }
 
@@ -54,6 +67,11 @@ func New(opts *config.Options) *Mock {
 		vpcs:           memstore.New[*vpcData](),
 		subnets:        memstore.New[*subnetData](),
 		securityGroups: memstore.New[*sgData](),
+		peerings:       memstore.New[*peeringData](),
+		natGateways:    memstore.New[*natGatewayData](),
+		flowLogs:       memstore.New[*flowLogData](),
+		routeTables:    memstore.New[*routeTableData](),
+		networkACLs:    memstore.New[*networkACLData](),
 		opts:           opts,
 	}
 }

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -295,6 +295,544 @@ func TestAddAndRemoveSecurityGroupRules(t *testing.T) {
 	})
 }
 
+// --- Peering Connection tests ---
+
+func TestCreatePeeringConnection(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v1 := createTestVPC(m)
+	v2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	t.Run("success", func(t *testing.T) {
+		pc, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+			RequesterVPC: v1.ID,
+			AccepterVPC:  v2.ID,
+		})
+		requireNoError(t, err)
+		assertNotEmpty(t, pc.ID)
+		assertEqual(t, "pending-acceptance", pc.Status)
+		assertEqual(t, v1.ID, pc.RequesterVPC)
+		assertEqual(t, v2.ID, pc.AccepterVPC)
+	})
+
+	t.Run("missing VPC IDs", func(t *testing.T) {
+		_, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent requester VPC", func(t *testing.T) {
+		_, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+			RequesterVPC: "vpc-nope", AccepterVPC: v2.ID,
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent accepter VPC", func(t *testing.T) {
+		_, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+			RequesterVPC: v1.ID, AccepterVPC: "vpc-nope",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestAcceptPeeringConnection(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v1 := createTestVPC(m)
+	v2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	pc, _ := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: v1.ID, AccepterVPC: v2.ID,
+	})
+
+	t.Run("accept pending", func(t *testing.T) {
+		err := m.AcceptPeeringConnection(ctx, pc.ID)
+		requireNoError(t, err)
+
+		pcs, _ := m.DescribePeeringConnections(ctx, []string{pc.ID})
+		assertEqual(t, 1, len(pcs))
+		assertEqual(t, "active", pcs[0].Status)
+	})
+
+	t.Run("accept already active fails", func(t *testing.T) {
+		err := m.AcceptPeeringConnection(ctx, pc.ID)
+		assertError(t, err, true)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.AcceptPeeringConnection(ctx, "pcx-nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestRejectPeeringConnection(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v1 := createTestVPC(m)
+	v2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	pc, _ := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: v1.ID, AccepterVPC: v2.ID,
+	})
+
+	t.Run("reject pending", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, pc.ID)
+		requireNoError(t, err)
+
+		pcs, _ := m.DescribePeeringConnections(ctx, []string{pc.ID})
+		assertEqual(t, 1, len(pcs))
+		assertEqual(t, "rejected", pcs[0].Status)
+	})
+
+	t.Run("reject already rejected fails", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, pc.ID)
+		assertError(t, err, true)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, "pcx-nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeletePeeringConnection(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v1 := createTestVPC(m)
+	v2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	pc, _ := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: v1.ID, AccepterVPC: v2.ID,
+	})
+
+	t.Run("delete existing", func(t *testing.T) {
+		err := m.DeletePeeringConnection(ctx, pc.ID)
+		requireNoError(t, err)
+
+		pcs, _ := m.DescribePeeringConnections(ctx, []string{pc.ID})
+		assertEqual(t, 0, len(pcs))
+	})
+
+	t.Run("delete nonexistent", func(t *testing.T) {
+		err := m.DeletePeeringConnection(ctx, "pcx-nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribePeeringConnections(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v1 := createTestVPC(m)
+	v2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	v3, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "192.168.0.0/16"})
+
+	pc1, _ := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: v1.ID, AccepterVPC: v2.ID,
+	})
+	_, _ = m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: v1.ID, AccepterVPC: v3.ID,
+	})
+
+	t.Run("all", func(t *testing.T) {
+		pcs, err := m.DescribePeeringConnections(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(pcs))
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		pcs, err := m.DescribePeeringConnections(ctx, []string{pc1.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(pcs))
+		assertEqual(t, pc1.ID, pcs[0].ID)
+	})
+}
+
+// --- NAT Gateway tests ---
+
+func TestCreateNATGateway(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+
+	t.Run("success", func(t *testing.T) {
+		nat, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+		requireNoError(t, err)
+		assertNotEmpty(t, nat.ID)
+		assertEqual(t, s.ID, nat.SubnetID)
+		assertEqual(t, v.ID, nat.VPCID)
+		assertEqual(t, "available", nat.State)
+		assertNotEmpty(t, nat.PublicIP)
+	})
+
+	t.Run("empty subnet ID", func(t *testing.T) {
+		_, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent subnet", func(t *testing.T) {
+		_, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: "subnet-nope"})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteNATGateway(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	nat, _ := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteNATGateway(ctx, nat.ID)
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteNATGateway(ctx, "nat-nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribeNATGateways(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	nat1, _ := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+	_, _ = m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s.ID})
+
+	t.Run("all", func(t *testing.T) {
+		nats, err := m.DescribeNATGateways(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(nats))
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		nats, err := m.DescribeNATGateways(ctx, []string{nat1.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(nats))
+		assertEqual(t, nat1.ID, nats[0].ID)
+	})
+}
+
+// --- Flow Log tests ---
+
+func TestCreateFlowLog(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	t.Run("VPC flow log", func(t *testing.T) {
+		fl, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+			ResourceID:   v.ID,
+			ResourceType: "VPC",
+			TrafficType:  "ALL",
+		})
+		requireNoError(t, err)
+		assertNotEmpty(t, fl.ID)
+		assertEqual(t, v.ID, fl.ResourceID)
+		assertEqual(t, "VPC", fl.ResourceType)
+		assertEqual(t, "ALL", fl.TrafficType)
+		assertEqual(t, "ACTIVE", fl.Status)
+	})
+
+	t.Run("empty resource ID", func(t *testing.T) {
+		_, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceType: "VPC"})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent VPC", func(t *testing.T) {
+		_, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+			ResourceID: "vpc-nope", ResourceType: "VPC",
+		})
+		assertError(t, err, true)
+	})
+
+	t.Run("unsupported resource type", func(t *testing.T) {
+		_, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+			ResourceID: v.ID, ResourceType: "Unknown",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteFlowLog(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	fl, _ := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+		ResourceID: v.ID, ResourceType: "VPC",
+	})
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteFlowLog(ctx, fl.ID)
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteFlowLog(ctx, "fl-nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribeFlowLogs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	fl1, _ := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+		ResourceID: v.ID, ResourceType: "VPC", TrafficType: "ACCEPT",
+	})
+	_, _ = m.CreateFlowLog(ctx, driver.FlowLogConfig{
+		ResourceID: v.ID, ResourceType: "VPC", TrafficType: "REJECT",
+	})
+
+	t.Run("all", func(t *testing.T) {
+		fls, err := m.DescribeFlowLogs(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(fls))
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		fls, err := m.DescribeFlowLogs(ctx, []string{fl1.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(fls))
+		assertEqual(t, fl1.ID, fls[0].ID)
+	})
+}
+
+func TestGetFlowLogRecords(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	fl, _ := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+		ResourceID: v.ID, ResourceType: "VPC", TrafficType: "ALL",
+	})
+
+	t.Run("returns records", func(t *testing.T) {
+		records, err := m.GetFlowLogRecords(ctx, fl.ID, 5)
+		requireNoError(t, err)
+		assertEqual(t, 5, len(records))
+		assertEqual(t, fl.ID, records[0].FlowLogID)
+		assertNotEmpty(t, records[0].SourceIP)
+		assertNotEmpty(t, records[0].DestIP)
+	})
+
+	t.Run("default limit", func(t *testing.T) {
+		records, err := m.GetFlowLogRecords(ctx, fl.ID, 0)
+		requireNoError(t, err)
+		assertEqual(t, 10, len(records))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetFlowLogRecords(ctx, "fl-nope", 5)
+		assertError(t, err, true)
+	})
+}
+
+// --- Route Table tests ---
+
+func TestCreateRouteTable(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	t.Run("success with default route", func(t *testing.T) {
+		rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+		requireNoError(t, err)
+		assertNotEmpty(t, rt.ID)
+		assertEqual(t, v.ID, rt.VPCID)
+		// Should have a default local route.
+		assertEqual(t, 1, len(rt.Routes))
+		assertEqual(t, "10.0.0.0/16", rt.Routes[0].DestinationCIDR)
+		assertEqual(t, "local", rt.Routes[0].TargetType)
+		assertEqual(t, "active", rt.Routes[0].State)
+	})
+
+	t.Run("empty VPC ID", func(t *testing.T) {
+		_, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{})
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent VPC", func(t *testing.T) {
+		_, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: "vpc-nope"})
+		assertError(t, err, true)
+	})
+}
+
+func TestCreateRoute(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+
+	t.Run("add route", func(t *testing.T) {
+		err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-12345", "gateway")
+		requireNoError(t, err)
+
+		rts, _ := m.DescribeRouteTables(ctx, []string{rt.ID})
+		assertEqual(t, 2, len(rts[0].Routes))
+	})
+
+	t.Run("duplicate CIDR fails", func(t *testing.T) {
+		err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-other", "gateway")
+		assertError(t, err, true)
+	})
+
+	t.Run("route table not found", func(t *testing.T) {
+		err := m.CreateRoute(ctx, "rtb-nope", "10.1.0.0/16", "igw-1", "gateway")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteRoute(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+	_ = m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-12345", "gateway")
+
+	t.Run("delete existing route", func(t *testing.T) {
+		err := m.DeleteRoute(ctx, rt.ID, "0.0.0.0/0")
+		requireNoError(t, err)
+
+		rts, _ := m.DescribeRouteTables(ctx, []string{rt.ID})
+		assertEqual(t, 1, len(rts[0].Routes)) // only local route remains
+	})
+
+	t.Run("delete nonexistent route", func(t *testing.T) {
+		err := m.DeleteRoute(ctx, rt.ID, "192.168.0.0/16")
+		assertError(t, err, true)
+	})
+
+	t.Run("route table not found", func(t *testing.T) {
+		err := m.DeleteRoute(ctx, "rtb-nope", "0.0.0.0/0")
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteRouteTable(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteRouteTable(ctx, rt.ID)
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteRouteTable(ctx, "rtb-nope")
+		assertError(t, err, true)
+	})
+}
+
+// --- Network ACL tests ---
+
+func TestCreateNetworkACL(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	t.Run("success", func(t *testing.T) {
+		acl, err := m.CreateNetworkACL(ctx, v.ID, map[string]string{"env": "test"})
+		requireNoError(t, err)
+		assertNotEmpty(t, acl.ID)
+		assertEqual(t, v.ID, acl.VPCID)
+		assertEqual(t, false, acl.IsDefault)
+		// Should have 2 default rules (ingress + egress allow-all).
+		assertEqual(t, 2, len(acl.Rules))
+	})
+
+	t.Run("empty VPC ID", func(t *testing.T) {
+		_, err := m.CreateNetworkACL(ctx, "", nil)
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent VPC", func(t *testing.T) {
+		_, err := m.CreateNetworkACL(ctx, "vpc-nope", nil)
+		assertError(t, err, true)
+	})
+}
+
+func TestAddNetworkACLRule(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	acl, _ := m.CreateNetworkACL(ctx, v.ID, nil)
+
+	t.Run("add rule and verify ordering", func(t *testing.T) {
+		// Add a rule with lower number than default (100).
+		err := m.AddNetworkACLRule(ctx, acl.ID, &driver.NetworkACLRule{
+			RuleNumber: 50,
+			Protocol:   "tcp",
+			Action:     "deny",
+			CIDR:       "10.0.0.0/8",
+			FromPort:   22,
+			ToPort:     22,
+			Egress:     false,
+		})
+		requireNoError(t, err)
+
+		acls, _ := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+		assertEqual(t, 3, len(acls[0].Rules))
+		// First rule should be number 50 (sorted).
+		assertEqual(t, 50, acls[0].Rules[0].RuleNumber)
+	})
+
+	t.Run("ACL not found", func(t *testing.T) {
+		err := m.AddNetworkACLRule(ctx, "acl-nope", &driver.NetworkACLRule{
+			RuleNumber: 10, Protocol: "tcp", Action: "allow", CIDR: "0.0.0.0/0",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestRemoveNetworkACLRule(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	acl, _ := m.CreateNetworkACL(ctx, v.ID, nil)
+
+	t.Run("remove default ingress rule", func(t *testing.T) {
+		err := m.RemoveNetworkACLRule(ctx, acl.ID, 100, false)
+		requireNoError(t, err)
+
+		acls, _ := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+		assertEqual(t, 1, len(acls[0].Rules))
+		// Only egress rule remains.
+		assertEqual(t, true, acls[0].Rules[0].Egress)
+	})
+
+	t.Run("remove nonexistent rule", func(t *testing.T) {
+		err := m.RemoveNetworkACLRule(ctx, acl.ID, 999, false)
+		assertError(t, err, true)
+	})
+
+	t.Run("ACL not found", func(t *testing.T) {
+		err := m.RemoveNetworkACLRule(ctx, "acl-nope", 100, false)
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteNetworkACL(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	acl, _ := m.CreateNetworkACL(ctx, v.ID, nil)
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteNetworkACL(ctx, acl.ID)
+		requireNoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteNetworkACL(ctx, "acl-nope")
+		assertError(t, err, true)
+	})
+}
+
 // --- test helpers ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -1,0 +1,650 @@
+// Package acr provides an in-memory mock implementation of Azure Container Registry.
+package acr
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"path"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	registryName         = "cloudemu"
+	defaultMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
+	mutableTag           = "MUTABLE"
+	immutableTag         = "IMMUTABLE"
+	scanStatusComplete   = "COMPLETE"
+	digestHashFormatByte = 8
+	resourceProvider     = "Microsoft.ContainerRegistry"
+	resourceType         = "registries"
+)
+
+// Compile-time check that Mock implements driver.ContainerRegistry.
+var _ driver.ContainerRegistry = (*Mock)(nil)
+
+type imageData struct {
+	detail driver.ImageDetail
+	layers []driver.LayerInfo
+}
+
+type repoData struct {
+	info          driver.Repository
+	images        *memstore.Store[*imageData]
+	scans         *memstore.Store[*driver.ScanResult]
+	policy        *driver.LifecyclePolicy
+	scanOnPush    bool
+	tagMutability string
+}
+
+// Mock is an in-memory mock implementation of the Azure Container Registry service.
+type Mock struct {
+	repos      *memstore.Store[*repoData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(repoName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.ContainerRegistry/registries",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"repositoryName": repoName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
+}
+
+// New creates a new ACR mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		repos: memstore.New[*repoData](),
+		opts:  opts,
+	}
+}
+
+// CreateRepository creates a new ACR repository.
+func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) (*driver.Repository, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "repository name is required")
+	}
+
+	if m.repos.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "repository %q already exists", cfg.Name)
+	}
+
+	mutability := cfg.ImageTagMutability
+	if mutability == "" {
+		mutability = mutableTag
+	}
+
+	tags := copyTags(cfg.Tags)
+	uri := fmt.Sprintf("%s.azurecr.io/%s", registryName, cfg.Name)
+	azureID := idgen.AzureID(m.opts.AccountID, "cloudemu-rg", resourceProvider, resourceType, cfg.Name)
+
+	info := driver.Repository{
+		Name:       azureID,
+		URI:        uri,
+		CreatedAt:  m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:       tags,
+		ImageCount: 0,
+	}
+
+	rd := &repoData{
+		info:          info,
+		images:        memstore.New[*imageData](),
+		scans:         memstore.New[*driver.ScanResult](),
+		scanOnPush:    cfg.ImageScanOnPush,
+		tagMutability: mutability,
+	}
+
+	m.repos.Set(cfg.Name, rd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteRepository deletes an ACR repository.
+func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	if !force && rd.images.Len() > 0 {
+		return errors.Newf(errors.FailedPrecondition, "repository %q is not empty; use force to delete", name)
+	}
+
+	m.repos.Delete(name)
+
+	return nil
+}
+
+// GetRepository retrieves information about an ACR repository.
+func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository, error) {
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	result := rd.info
+	result.ImageCount = rd.images.Len()
+
+	return &result, nil
+}
+
+// ListRepositories lists all ACR repositories.
+func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
+	all := m.repos.All()
+	repos := make([]driver.Repository, 0, len(all))
+
+	for _, rd := range all {
+		repo := rd.info
+		repo.ImageCount = rd.images.Len()
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
+}
+
+// PutImage pushes an image manifest to an ACR repository.
+func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(manifest.Repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
+	}
+
+	if err := checkTagMutability(rd, manifest.Tag); err != nil {
+		return nil, err
+	}
+
+	digest := resolveDigest(manifest, m.opts.Clock.Now())
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	mediaType := resolveMediaType(manifest.MediaType)
+
+	detail := driver.ImageDetail{
+		RegistryID: registryName,
+		Repository: manifest.Repository,
+		Digest:     digest,
+		Tags:       []string{manifest.Tag},
+		SizeBytes:  manifest.SizeBytes,
+		PushedAt:   now,
+		MediaType:  mediaType,
+	}
+
+	img := &imageData{detail: detail, layers: manifest.Layers}
+	rd.images.Set(digest, img)
+
+	if manifest.Tag != "" {
+		updateTagIndex(rd, digest, manifest.Tag)
+	}
+
+	rd.info.ImageCount = rd.images.Len()
+
+	if rd.scanOnPush {
+		autoScan(rd, digest, manifest.Repository, m.opts.Clock.Now())
+	}
+
+	m.emitMetric(manifest.Repository, map[string]float64{"ImagePushCount": 1})
+
+	result := detail
+
+	return &result, nil
+}
+
+// GetImage retrieves image details by repository and reference.
+func (m *Mock) GetImage(_ context.Context, repository, reference string) (*driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	m.emitMetric(repository, map[string]float64{"ImagePullCount": 1})
+
+	result := img.detail
+
+	return &result, nil
+}
+
+// ListImages lists all images in an ACR repository.
+func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	all := rd.images.All()
+	images := make([]driver.ImageDetail, 0, len(all))
+
+	for _, img := range all {
+		images = append(images, img.detail)
+	}
+
+	return images, nil
+}
+
+// DeleteImage deletes an image from an ACR repository by reference.
+func (m *Mock) DeleteImage(_ context.Context, repository, reference string) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	rd.images.Delete(img.detail.Digest)
+	rd.scans.Delete(img.detail.Digest)
+	rd.info.ImageCount = rd.images.Len()
+
+	return nil
+}
+
+// TagImage adds a new tag to an existing image in an ACR repository.
+func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag string) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, sourceRef)
+	if img == nil {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", sourceRef, repository)
+	}
+
+	if err := checkTagMutability(rd, targetTag); err != nil {
+		return err
+	}
+
+	updateTagIndex(rd, img.detail.Digest, targetTag)
+
+	return nil
+}
+
+// PutLifecyclePolicy sets a lifecycle policy on an ACR repository.
+func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy driver.LifecyclePolicy) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	policyCopy := copyLifecyclePolicy(policy)
+	rd.policy = &policyCopy
+
+	return nil
+}
+
+// GetLifecyclePolicy retrieves the lifecycle policy for an ACR repository.
+func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return nil, errors.Newf(errors.NotFound, "no lifecycle policy for repository %q", repository)
+	}
+
+	result := copyLifecyclePolicy(*rd.policy)
+
+	return &result, nil
+}
+
+// EvaluateLifecyclePolicy evaluates the lifecycle policy and returns digests to expire.
+func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return []string{}, nil
+	}
+
+	return evaluateRules(rd, m.opts.Clock.Now()), nil
+}
+
+// StartImageScan starts a vulnerability scan on an image in an ACR repository.
+func (m *Mock) StartImageScan(_ context.Context, repository, reference string) (*driver.ScanResult, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	scan := generateScanResult(repository, img.detail.Digest, m.opts.Clock.Now())
+	rd.scans.Set(img.detail.Digest, scan)
+
+	result := *scan
+
+	return &result, nil
+}
+
+// GetImageScanResults retrieves scan results for an image in an ACR repository.
+func (m *Mock) GetImageScanResults(
+	_ context.Context, repository, reference string,
+) (*driver.ScanResult, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	scan, ok := rd.scans.Get(img.detail.Digest)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "no scan results for image %q in repository %q", reference, repository,
+		)
+	}
+
+	result := *scan
+
+	return &result, nil
+}
+
+// findImage locates an image by tag or digest.
+func findImage(rd *repoData, reference string) *imageData {
+	if img, ok := rd.images.Get(reference); ok {
+		return img
+	}
+
+	all := rd.images.All()
+	for _, img := range all {
+		for _, tag := range img.detail.Tags {
+			if tag == reference {
+				return img
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkTagMutability validates that a tag can be overwritten.
+func checkTagMutability(rd *repoData, tag string) error {
+	if tag == "" || rd.tagMutability != immutableTag {
+		return nil
+	}
+
+	all := rd.images.All()
+	for _, img := range all {
+		for _, t := range img.detail.Tags {
+			if t == tag {
+				return errors.Newf(
+					errors.FailedPrecondition,
+					"tag %q already exists and repository has IMMUTABLE tag mutability",
+					tag,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// resolveDigest generates a digest from the manifest if not provided.
+func resolveDigest(manifest *driver.ImageManifest, now time.Time) string {
+	if manifest.Digest != "" {
+		return manifest.Digest
+	}
+
+	input := fmt.Sprintf("%s:%s:%s", manifest.Repository, manifest.Tag, now.String())
+	hash := sha256.Sum256([]byte(input))
+
+	return fmt.Sprintf("sha256:%x", hash[:digestHashFormatByte])
+}
+
+// updateTagIndex removes a tag from any existing image and adds it to the target digest.
+func updateTagIndex(rd *repoData, digest, tag string) {
+	all := rd.images.All()
+	for d, img := range all {
+		if d == digest {
+			continue
+		}
+
+		filtered := removeTag(img.detail.Tags, tag)
+		if len(filtered) != len(img.detail.Tags) {
+			img.detail.Tags = filtered
+			rd.images.Set(d, img)
+		}
+	}
+
+	if img, ok := rd.images.Get(digest); ok {
+		if !hasTag(img.detail.Tags, tag) {
+			img.detail.Tags = append(img.detail.Tags, tag)
+			rd.images.Set(digest, img)
+		}
+	}
+}
+
+// autoScan creates a scan result automatically when scanOnPush is enabled.
+func autoScan(rd *repoData, digest, repository string, now time.Time) {
+	scan := generateScanResult(repository, digest, now)
+	rd.scans.Set(digest, scan)
+}
+
+// generateScanResult produces deterministic scan findings based on the digest hash.
+func generateScanResult(repository, digest string, now time.Time) *driver.ScanResult {
+	hash := sha256.Sum256([]byte(digest))
+
+	findings := map[string]int{
+		"CRITICAL":      int(hash[0]) % 3,
+		"HIGH":          int(hash[1]) % 5,
+		"MEDIUM":        int(hash[2]) % 10,
+		"LOW":           int(hash[3]) % 15,
+		"INFORMATIONAL": int(hash[4]) % 8,
+	}
+
+	return &driver.ScanResult{
+		Repository:    repository,
+		Digest:        digest,
+		Status:        scanStatusComplete,
+		FindingCounts: findings,
+		CompletedAt:   now.UTC().Format(time.RFC3339),
+	}
+}
+
+// evaluateRules applies lifecycle rules sorted by priority and returns digests to expire.
+func evaluateRules(rd *repoData, now time.Time) []string {
+	rules := rd.policy.Rules
+	sorted := make([]driver.LifecycleRule, len(rules))
+	copy(sorted, rules)
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Priority < sorted[j].Priority })
+
+	expired := make(map[string]bool)
+
+	for idx := range sorted {
+		digests := evaluateSingleRule(rd, &sorted[idx], now)
+		for _, d := range digests {
+			expired[d] = true
+		}
+	}
+
+	result := make([]string, 0, len(expired))
+	for d := range expired {
+		result = append(result, d)
+	}
+
+	return result
+}
+
+// evaluateSingleRule evaluates one lifecycle rule and returns matching digests.
+func evaluateSingleRule(rd *repoData, rule *driver.LifecycleRule, now time.Time) []string {
+	images := collectMatchingImages(rd, rule)
+
+	sort.Slice(images, func(i, j int) bool { return images[i].detail.PushedAt < images[j].detail.PushedAt })
+
+	switch rule.CountType {
+	case "imageCountMoreThan":
+		return expireByCount(images, rule.CountValue)
+	case "sinceImagePushed":
+		return expireBySince(images, rule.CountValue, now)
+	default:
+		return nil
+	}
+}
+
+// collectMatchingImages returns images matching the rule's tag status and pattern.
+func collectMatchingImages(rd *repoData, rule *driver.LifecycleRule) []*imageData {
+	all := rd.images.All()
+
+	var matched []*imageData
+
+	for _, img := range all {
+		if matchesTagRule(img, rule) {
+			matched = append(matched, img)
+		}
+	}
+
+	return matched
+}
+
+// matchesTagRule checks if an image matches the rule's tag filter.
+func matchesTagRule(img *imageData, rule *driver.LifecycleRule) bool {
+	switch rule.TagStatus {
+	case "untagged":
+		return len(img.detail.Tags) == 0
+	case "tagged":
+		return len(img.detail.Tags) > 0 && matchTagPattern(img.detail.Tags, rule.TagPattern)
+	default: // "any"
+		return true
+	}
+}
+
+// matchTagPattern checks if any tag matches the given glob pattern.
+func matchTagPattern(tags []string, pattern string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+
+	for _, tag := range tags {
+		if matched, err := path.Match(pattern, tag); err == nil && matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// expireByCount returns digests of excess images beyond the count threshold.
+func expireByCount(images []*imageData, maxCount int) []string {
+	if len(images) <= maxCount {
+		return nil
+	}
+
+	excess := len(images) - maxCount
+	result := make([]string, 0, excess)
+
+	for i := range excess {
+		result = append(result, images[i].detail.Digest)
+	}
+
+	return result
+}
+
+// expireBySince returns digests of images pushed more than N days ago.
+func expireBySince(images []*imageData, days int, now time.Time) []string {
+	cutoff := now.AddDate(0, 0, -days)
+
+	var result []string
+
+	for _, img := range images {
+		pushedAt, err := time.Parse(time.RFC3339, img.detail.PushedAt)
+		if err != nil {
+			continue
+		}
+
+		if pushedAt.Before(cutoff) {
+			result = append(result, img.detail.Digest)
+		}
+	}
+
+	return result
+}
+
+func resolveMediaType(mediaType string) string {
+	if mediaType != "" {
+		return mediaType
+	}
+
+	return defaultMediaType
+}
+
+func copyTags(src map[string]string) map[string]string {
+	tags := make(map[string]string, len(src))
+	for k, v := range src {
+		tags[k] = v
+	}
+
+	return tags
+}
+
+func copyLifecyclePolicy(p driver.LifecyclePolicy) driver.LifecyclePolicy {
+	rules := make([]driver.LifecycleRule, len(p.Rules))
+	copy(rules, p.Rules)
+
+	return driver.LifecyclePolicy{Rules: rules}
+}
+
+func removeTag(tags []string, tag string) []string {
+	result := make([]string, 0, len(tags))
+
+	for _, t := range tags {
+		if t != tag {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/azure/acr/acr.go
+++ b/providers/azure/acr/acr.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
@@ -47,6 +48,7 @@ type repoData struct {
 
 // Mock is an in-memory mock implementation of the Azure Container Registry service.
 type Mock struct {
+	mu         sync.Mutex
 	repos      *memstore.Store[*repoData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
@@ -174,6 +176,11 @@ func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) 
 
 // PutImage pushes an image manifest to an ACR repository.
 func (m *Mock) PutImage(_ context.Context, manifest *driver.ImageManifest) (*driver.ImageDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Allow empty tag for untagged images (digest-only)
+
 	rd, ok := m.repos.Get(manifest.Repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
@@ -255,6 +262,9 @@ func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageD
 
 // DeleteImage deletes an image from an ACR repository by reference.
 func (m *Mock) DeleteImage(_ context.Context, repository, reference string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -274,6 +284,13 @@ func (m *Mock) DeleteImage(_ context.Context, repository, reference string) erro
 
 // TagImage adds a new tag to an existing image in an ACR repository.
 func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag string) error {
+	if targetTag == "" {
+		return errors.New(errors.InvalidArgument, "target tag cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -289,6 +306,7 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 	}
 
 	updateTagIndex(rd, img.detail.Digest, targetTag)
+	rd.info.ImageCount = rd.images.Len()
 
 	return nil
 }

--- a/providers/azure/acr/acr_test.go
+++ b/providers/azure/acr/acr_test.go
@@ -363,6 +363,39 @@ func TestTagImage(t *testing.T) {
 	})
 }
 
+func TestTagImageUpdatesImageCount(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "count-repo")
+	pushTestImage(t, m, "count-repo", "v1")
+	pushTestImage(t, m, "count-repo", "v2")
+
+	repo, err := m.GetRepository(ctx, "count-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.ImageCount)
+
+	// Tag image v1 with a new tag - should not change image count
+	err = m.TagImage(ctx, "count-repo", "v1", "latest")
+	require.NoError(t, err)
+
+	repo, err = m.GetRepository(ctx, "count-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.ImageCount)
+}
+
+func TestTagImageEmptyTagRejected(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "empty-tag-repo")
+	pushTestImage(t, m, "empty-tag-repo", "v1")
+
+	err := m.TagImage(ctx, "empty-tag-repo", "v1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
 func TestImageTagMutability(t *testing.T) {
 	ctx := context.Background()
 

--- a/providers/azure/acr/acr_test.go
+++ b/providers/azure/acr/acr_test.go
@@ -1,0 +1,732 @@
+package acr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("eastus"))
+
+	return New(opts), fc
+}
+
+func createTestRepo(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateRepository(context.Background(), driver.RepositoryConfig{Name: name})
+	require.NoError(t, err)
+}
+
+func pushTestImage(t *testing.T, m *Mock, repo, tag string) *driver.ImageDetail {
+	t.Helper()
+
+	detail, err := m.PutImage(context.Background(), &driver.ImageManifest{
+		Repository: repo,
+		Tag:        tag,
+		SizeBytes:  1024,
+	})
+	require.NoError(t, err)
+
+	return detail
+}
+
+func TestCreateRepository(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.RepositoryConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{name: "success with defaults", cfg: driver.RepositoryConfig{Name: "my-repo"}},
+		{
+			name: "success with tags",
+			cfg: driver.RepositoryConfig{
+				Name: "tagged-repo",
+				Tags: map[string]string{"env": "dev"},
+			},
+		},
+		{name: "empty name", cfg: driver.RepositoryConfig{}, expectErr: true},
+		{
+			name: "duplicate repository",
+			cfg:  driver.RepositoryConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			repo, err := m.CreateRepository(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Contains(t, repo.URI, "cloudemu.azurecr.io/"+tc.cfg.Name)
+			assert.NotEmpty(t, repo.Name)
+			assert.NotEmpty(t, repo.CreatedAt)
+			assert.Equal(t, 0, repo.ImageCount)
+		})
+	}
+}
+
+func TestDeleteRepository(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoName  string
+		force     bool
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:     "success empty repo",
+			repoName: "to-delete",
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "to-delete")
+			},
+		},
+		{
+			name:     "force delete non-empty repo",
+			repoName: "non-empty",
+			force:    true,
+			setup: func(m *Mock) {
+				tt := &testing.T{}
+				createTestRepo(tt, m, "non-empty")
+				pushTestImage(tt, m, "non-empty", "v1")
+			},
+		},
+		{
+			name:     "non-empty without force",
+			repoName: "non-empty2",
+			force:    false,
+			setup: func(m *Mock) {
+				tt := &testing.T{}
+				createTestRepo(tt, m, "non-empty2")
+				pushTestImage(tt, m, "non-empty2", "v1")
+			},
+			expectErr: true,
+		},
+		{
+			name:      "not found",
+			repoName:  "nonexistent",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			err := m.DeleteRepository(context.Background(), tc.repoName, tc.force)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGetRepository(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("success", func(t *testing.T) {
+		repo, err := m.GetRepository(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Contains(t, repo.URI, "cloudemu.azurecr.io/my-repo")
+		assert.Equal(t, 0, repo.ImageCount)
+	})
+
+	t.Run("with images", func(t *testing.T) {
+		pushTestImage(t, m, "my-repo", "v1")
+
+		repo, err := m.GetRepository(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.ImageCount)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetRepository(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListRepositories(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		repos, err := m.ListRepositories(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(repos))
+	})
+
+	createTestRepo(t, m, "repo-a")
+	createTestRepo(t, m, "repo-b")
+
+	t.Run("two repositories", func(t *testing.T) {
+		repos, err := m.ListRepositories(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(repos))
+	})
+}
+
+func TestPutImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  driver.ImageManifest
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:     "success",
+			manifest: driver.ImageManifest{Repository: "my-repo", Tag: "v1", SizeBytes: 2048},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+		},
+		{
+			name:     "with custom digest",
+			manifest: driver.ImageManifest{Repository: "my-repo", Tag: "v2", Digest: "sha256:abcdef", SizeBytes: 512},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+		},
+		{
+			name:      "repo not found",
+			manifest:  driver.ImageManifest{Repository: "missing", Tag: "v1"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			detail, err := m.PutImage(context.Background(), &tc.manifest)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.manifest.Repository, detail.Repository)
+			assert.Contains(t, detail.Tags, tc.manifest.Tag)
+			assert.NotEmpty(t, detail.Digest)
+			assert.NotEmpty(t, detail.PushedAt)
+			assert.Equal(t, registryName, detail.RegistryID)
+		})
+	}
+}
+
+func TestGetImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	img := pushTestImage(t, m, "my-repo", "latest")
+
+	t.Run("by tag", func(t *testing.T) {
+		detail, err := m.GetImage(ctx, "my-repo", "latest")
+		require.NoError(t, err)
+		assert.Equal(t, img.Digest, detail.Digest)
+		assert.Contains(t, detail.Tags, "latest")
+	})
+
+	t.Run("by digest", func(t *testing.T) {
+		detail, err := m.GetImage(ctx, "my-repo", img.Digest)
+		require.NoError(t, err)
+		assert.Equal(t, img.Digest, detail.Digest)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "my-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "missing", "latest")
+		require.Error(t, err)
+	})
+}
+
+func TestListImages(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("empty list", func(t *testing.T) {
+		images, err := m.ListImages(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(images))
+	})
+
+	pushTestImage(t, m, "my-repo", "v1")
+	pushTestImage(t, m, "my-repo", "v2")
+
+	t.Run("two images", func(t *testing.T) {
+		images, err := m.ListImages(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(images))
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		_, err := m.ListImages(ctx, "missing")
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	img := pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("success by tag", func(t *testing.T) {
+		err := m.DeleteImage(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+
+		_, err = m.GetImage(ctx, "my-repo", img.Digest)
+		require.Error(t, err)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		err := m.DeleteImage(ctx, "my-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		err := m.DeleteImage(ctx, "missing", "v1")
+		require.Error(t, err)
+	})
+}
+
+func TestTagImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.TagImage(ctx, "my-repo", "v1", "latest")
+		require.NoError(t, err)
+
+		detail, err := m.GetImage(ctx, "my-repo", "latest")
+		require.NoError(t, err)
+		assert.Contains(t, detail.Tags, "v1")
+		assert.Contains(t, detail.Tags, "latest")
+	})
+
+	t.Run("source not found", func(t *testing.T) {
+		err := m.TagImage(ctx, "my-repo", "nonexistent", "latest")
+		require.Error(t, err)
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		err := m.TagImage(ctx, "missing", "v1", "latest")
+		require.Error(t, err)
+	})
+}
+
+func TestImageTagMutability(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("mutable allows tag overwrite", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+			Name:               "mutable-repo",
+			ImageTagMutability: "MUTABLE",
+		})
+		require.NoError(t, err)
+
+		pushTestImage(t, m, "mutable-repo", "latest")
+
+		_, err = m.PutImage(ctx, &driver.ImageManifest{
+			Repository: "mutable-repo",
+			Tag:        "latest",
+			SizeBytes:  2048,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("immutable blocks tag overwrite", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+			Name:               "immutable-repo",
+			ImageTagMutability: "IMMUTABLE",
+		})
+		require.NoError(t, err)
+
+		pushTestImage(t, m, "immutable-repo", "v1")
+
+		_, err = m.PutImage(ctx, &driver.ImageManifest{
+			Repository: "immutable-repo",
+			Tag:        "v1",
+			SizeBytes:  2048,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("immutable allows different tags", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+			Name:               "immutable-repo2",
+			ImageTagMutability: "IMMUTABLE",
+		})
+		require.NoError(t, err)
+
+		pushTestImage(t, m, "immutable-repo2", "v1")
+		pushTestImage(t, m, "immutable-repo2", "v2")
+
+		images, err := m.ListImages(ctx, "immutable-repo2")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(images))
+	})
+
+	t.Run("default mutability is MUTABLE", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.CreateRepository(ctx, driver.RepositoryConfig{Name: "default-repo"})
+		require.NoError(t, err)
+
+		pushTestImage(t, m, "default-repo", "latest")
+
+		_, err = m.PutImage(ctx, &driver.ImageManifest{
+			Repository: "default-repo",
+			Tag:        "latest",
+			SizeBytes:  2048,
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestLifecyclePolicy(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("put and get policy", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "my-repo")
+
+		policy := driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{Priority: 1, TagStatus: "untagged", CountType: "imageCountMoreThan", CountValue: 5, Action: "expire"},
+			},
+		}
+
+		err := m.PutLifecyclePolicy(ctx, "my-repo", policy)
+		require.NoError(t, err)
+
+		got, err := m.GetLifecyclePolicy(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(got.Rules))
+		assert.Equal(t, 1, got.Rules[0].Priority)
+	})
+
+	t.Run("get policy not set", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "no-policy")
+
+		_, err := m.GetLifecyclePolicy(ctx, "no-policy")
+		require.Error(t, err)
+	})
+
+	t.Run("repo not found", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		err := m.PutLifecyclePolicy(ctx, "missing", driver.LifecyclePolicy{})
+		require.Error(t, err)
+
+		_, err = m.GetLifecyclePolicy(ctx, "missing")
+		require.Error(t, err)
+	})
+
+	t.Run("evaluate imageCountMoreThan", func(t *testing.T) {
+		m, fc := newTestMock()
+		createTestRepo(t, m, "eval-repo")
+
+		for i := range 5 {
+			fc.Advance(time.Minute)
+			pushTestImage(t, m, "eval-repo", "")
+
+			_ = i
+		}
+
+		policy := driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{Priority: 1, TagStatus: "any", CountType: "imageCountMoreThan", CountValue: 3, Action: "expire"},
+			},
+		}
+
+		err := m.PutLifecyclePolicy(ctx, "eval-repo", policy)
+		require.NoError(t, err)
+
+		expired, err := m.EvaluateLifecyclePolicy(ctx, "eval-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(expired))
+	})
+
+	t.Run("evaluate sinceImagePushed", func(t *testing.T) {
+		m, fc := newTestMock()
+		createTestRepo(t, m, "since-repo")
+
+		pushTestImage(t, m, "since-repo", "old")
+
+		fc.Advance(31 * 24 * time.Hour)
+
+		pushTestImage(t, m, "since-repo", "new")
+
+		policy := driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{Priority: 1, TagStatus: "any", CountType: "sinceImagePushed", CountValue: 30, Action: "expire"},
+			},
+		}
+
+		err := m.PutLifecyclePolicy(ctx, "since-repo", policy)
+		require.NoError(t, err)
+
+		expired, err := m.EvaluateLifecyclePolicy(ctx, "since-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(expired))
+	})
+
+	t.Run("evaluate no policy returns empty", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "no-policy-repo")
+
+		expired, err := m.EvaluateLifecyclePolicy(ctx, "no-policy-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(expired))
+	})
+
+	t.Run("evaluate repo not found", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.EvaluateLifecyclePolicy(ctx, "missing")
+		require.Error(t, err)
+	})
+}
+
+func TestImageScan(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("manual scan", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "scan-repo")
+		pushTestImage(t, m, "scan-repo", "v1")
+
+		scan, err := m.StartImageScan(ctx, "scan-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, "COMPLETE", scan.Status)
+		assert.Equal(t, "scan-repo", scan.Repository)
+		assert.NotEmpty(t, scan.FindingCounts)
+		assert.NotEmpty(t, scan.CompletedAt)
+	})
+
+	t.Run("get scan results", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "scan-repo")
+		pushTestImage(t, m, "scan-repo", "v1")
+
+		_, err := m.StartImageScan(ctx, "scan-repo", "v1")
+		require.NoError(t, err)
+
+		result, err := m.GetImageScanResults(ctx, "scan-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, "COMPLETE", result.Status)
+	})
+
+	t.Run("scan on push", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+			Name:            "auto-scan-repo",
+			ImageScanOnPush: true,
+		})
+		require.NoError(t, err)
+
+		pushTestImage(t, m, "auto-scan-repo", "v1")
+
+		result, err := m.GetImageScanResults(ctx, "auto-scan-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, "COMPLETE", result.Status)
+	})
+
+	t.Run("no scan results", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "no-scan-repo")
+		pushTestImage(t, m, "no-scan-repo", "v1")
+
+		_, err := m.GetImageScanResults(ctx, "no-scan-repo", "v1")
+		require.Error(t, err)
+	})
+
+	t.Run("scan image not found", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "scan-repo2")
+
+		_, err := m.StartImageScan(ctx, "scan-repo2", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("scan repo not found", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.StartImageScan(ctx, "missing", "v1")
+		require.Error(t, err)
+	})
+
+	t.Run("get scan results repo not found", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.GetImageScanResults(ctx, "missing", "v1")
+		require.Error(t, err)
+	})
+
+	t.Run("delete image removes scan results", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "del-scan-repo")
+		pushTestImage(t, m, "del-scan-repo", "v1")
+
+		_, err := m.StartImageScan(ctx, "del-scan-repo", "v1")
+		require.NoError(t, err)
+
+		err = m.DeleteImage(ctx, "del-scan-repo", "v1")
+		require.NoError(t, err)
+	})
+}
+
+// fakeMonitoring is a minimal monitoring mock for testing metric emission.
+type fakeMonitoring struct {
+	data []mondriver.MetricDatum
+}
+
+func (f *fakeMonitoring) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	f.data = append(f.data, data...)
+	return nil
+}
+
+func (f *fakeMonitoring) GetMetricData(
+	_ context.Context, _ mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (f *fakeMonitoring) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (f *fakeMonitoring) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (f *fakeMonitoring) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeMonitoring) DescribeAlarms(
+	_ context.Context, _ []string,
+) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeMonitoring) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("push emits ImagePushCount", func(t *testing.T) {
+		m, _ := newTestMock()
+		mon := &fakeMonitoring{}
+		m.SetMonitoring(mon)
+		createTestRepo(t, m, "metric-repo")
+
+		pushTestImage(t, m, "metric-repo", "v1")
+
+		require.NotEmpty(t, mon.data)
+
+		found := false
+		for _, d := range mon.data {
+			if d.MetricName == "ImagePushCount" {
+				found = true
+				assert.Equal(t, "Microsoft.ContainerRegistry/registries", d.Namespace)
+				assert.Equal(t, "metric-repo", d.Dimensions["repositoryName"])
+				assert.Equal(t, float64(1), d.Value)
+			}
+		}
+		assert.True(t, found, "expected ImagePushCount metric")
+	})
+
+	t.Run("pull emits ImagePullCount", func(t *testing.T) {
+		m, _ := newTestMock()
+		mon := &fakeMonitoring{}
+		m.SetMonitoring(mon)
+		createTestRepo(t, m, "metric-repo")
+		pushTestImage(t, m, "metric-repo", "v1")
+
+		mon.data = nil
+
+		_, err := m.GetImage(ctx, "metric-repo", "v1")
+		require.NoError(t, err)
+
+		found := false
+		for _, d := range mon.data {
+			if d.MetricName == "ImagePullCount" {
+				found = true
+				assert.Equal(t, "Microsoft.ContainerRegistry/registries", d.Namespace)
+				assert.Equal(t, "metric-repo", d.Dimensions["repositoryName"])
+				assert.Equal(t, float64(1), d.Value)
+			}
+		}
+		assert.True(t, found, "expected ImagePullCount metric")
+	})
+
+	t.Run("no monitoring does not panic", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestRepo(t, m, "no-mon-repo")
+
+		pushTestImage(t, m, "no-mon-repo", "v1")
+
+		_, err := m.GetImage(ctx, "no-mon-repo", "v1")
+		require.NoError(t, err)
+	})
+}

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -3,6 +3,7 @@ package azure
 
 import (
 	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/providers/azure/acr"
 	"github.com/stackshy/cloudemu/providers/azure/azurecache"
 	"github.com/stackshy/cloudemu/providers/azure/azuredns"
 	"github.com/stackshy/cloudemu/providers/azure/azureiam"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/azure/azuremonitor"
 	"github.com/stackshy/cloudemu/providers/azure/blobstorage"
 	"github.com/stackshy/cloudemu/providers/azure/cosmosdb"
+	"github.com/stackshy/cloudemu/providers/azure/eventgrid"
 	"github.com/stackshy/cloudemu/providers/azure/functions"
 	"github.com/stackshy/cloudemu/providers/azure/keyvault"
 	"github.com/stackshy/cloudemu/providers/azure/loganalytics"
@@ -35,6 +37,8 @@ type Provider struct {
 	KeyVault         *keyvault.Mock
 	LogAnalytics     *loganalytics.Mock
 	NotificationHubs *notificationhubs.Mock
+	ACR              *acr.Mock
+	EventGrid        *eventgrid.Mock
 }
 
 // New creates a new Azure provider with all mock services.
@@ -55,8 +59,19 @@ func New(opts ...config.Option) *Provider {
 		KeyVault:         keyvault.New(o),
 		LogAnalytics:     loganalytics.New(o),
 		NotificationHubs: notificationhubs.New(o),
+		ACR:              acr.New(o),
+		EventGrid:        eventgrid.New(o),
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
+	p.BlobStorage.SetMonitoring(p.Monitor)
+	p.CosmosDB.SetMonitoring(p.Monitor)
+	p.Functions.SetMonitoring(p.Monitor)
+	p.ServiceBus.SetMonitoring(p.Monitor)
+	p.Cache.SetMonitoring(p.Monitor)
+	p.LogAnalytics.SetMonitoring(p.Monitor)
+	p.NotificationHubs.SetMonitoring(p.Monitor)
+	p.ACR.SetMonitoring(p.Monitor)
+	p.EventGrid.SetMonitoring(p.Monitor)
 
 	return p
 }

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 const defaultRedisSSLPort = 6380
@@ -31,8 +32,36 @@ type cacheData struct {
 
 // Mock is an in-memory mock implementation of Azure Cache for Redis.
 type Mock struct {
-	caches *memstore.Store[*cacheData]
-	opts   *config.Options
+	caches     *memstore.Store[*cacheData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(cacheName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.Cache/redis",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"cacheName": cacheName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Azure Cache mock with the given configuration options.
@@ -144,6 +173,8 @@ func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl t
 
 	cd.items.Set(key, item)
 
+	m.emitMetric(cacheName, map[string]float64{"SetCommands": 1, "TotalCommandsProcessed": 1})
+
 	return nil
 }
 
@@ -156,12 +187,20 @@ func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, erro
 
 	item, ok := cd.items.Get(key)
 	if !ok {
+		m.emitMetric(cacheName, map[string]float64{
+			"CacheMisses": 1, "GetCommands": 1, "TotalCommandsProcessed": 1,
+		})
+
 		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
 
 	now := m.opts.Clock.Now()
 	if item.HasTTL && now.After(item.ExpiresAt) {
 		cd.items.Delete(key)
+
+		m.emitMetric(cacheName, map[string]float64{
+			"CacheMisses": 1, "GetCommands": 1, "TotalCommandsProcessed": 1,
+		})
 
 		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
@@ -179,6 +218,10 @@ func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, erro
 		result.ExpiresAt = item.ExpiresAt
 	}
 
+	m.emitMetric(cacheName, map[string]float64{
+		"CacheHits": 1, "GetCommands": 1, "TotalCommandsProcessed": 1,
+	})
+
 	return result, nil
 }
 
@@ -192,6 +235,8 @@ func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
 	if !cd.items.Delete(key) {
 		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
+
+	m.emitMetric(cacheName, map[string]float64{"TotalCommandsProcessed": 1})
 
 	return nil
 }

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -340,9 +340,13 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 		Metadata: meta,
 	})
 
+	m.emitMetric(dstBucket, map[string]float64{"Transactions": 1})
+
 	return nil
 }
 
+// GeneratePresignedURL generates a mock presigned URL.
+// Note: expiry is tracked in the URL but not enforced on use — this is a mock limitation.
 func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
 	if req.Method != http.MethodGet && req.Method != http.MethodPut {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "method must be GET or PUT, got %q", req.Method)
@@ -509,7 +513,7 @@ func (m *Mock) UploadPart(
 }
 
 func (m *Mock) CompleteMultipartUpload(
-	_ context.Context, bucket, key, uploadID string, _ []driver.UploadPart,
+	_ context.Context, bucket, key, uploadID string, parts []driver.UploadPart,
 ) error {
 	ctr, ok := m.containers.Get(bucket)
 	if !ok {
@@ -521,7 +525,13 @@ func (m *Mock) CompleteMultipartUpload(
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
-	data := assembleBlobParts(mp.parts)
+	for _, p := range parts {
+		if _, exists := mp.parts[p.PartNumber]; !exists {
+			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
+		}
+	}
+
+	data := assembleBlobPartsInOrder(mp.parts, parts)
 
 	ctr.objects.Set(key, &blobObject{
 		Key:          key,
@@ -534,20 +544,15 @@ func (m *Mock) CompleteMultipartUpload(
 
 	ctr.multiparts.Delete(uploadID)
 
+	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
+
 	return nil
 }
 
-func assembleBlobParts(parts map[int][]byte) []byte {
-	keys := make([]int, 0, len(parts))
-	for k := range parts {
-		keys = append(keys, k)
-	}
-
-	sort.Ints(keys)
-
+func assembleBlobPartsInOrder(allParts map[int][]byte, parts []driver.UploadPart) []byte {
 	var data []byte
-	for _, k := range keys {
-		data = append(data, parts[k]...)
+	for _, p := range parts {
+		data = append(data, allParts[p.PartNumber]...)
 	}
 
 	return data
@@ -593,6 +598,8 @@ func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.
 	return result, nil
 }
 
+// SetBucketVersioning enables or disables versioning on a bucket.
+// Note: this sets the flag but does not maintain object version history — mock limitation.
 func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
 	ctr, ok := m.containers.Get(bucket)
 	if !ok {

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -5,14 +5,26 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/pagination"
 	"github.com/stackshy/cloudemu/storage/driver"
+)
+
+const (
+	blobDefaultSASExpiry = time.Hour
+	blobDefaultMaxKeys   = 1000
+	blobTimeFormat       = "2006-01-02T15:04:05Z"
+	blobAccountName      = "cloudemu"
+	blobHoursPerDay      = 24
 )
 
 // Compile-time check that Mock implements driver.Bucket.
@@ -27,17 +39,56 @@ type blobObject struct {
 	Metadata     map[string]string
 }
 
+type blobMultipartUpload struct {
+	id          string
+	key         string
+	contentType string
+	parts       map[int][]byte
+	createdAt   string
+}
+
 type containerMeta struct {
-	Name      string
-	Region    string
-	CreatedAt string
-	objects   *memstore.Store[*blobObject]
+	Name       string
+	Region     string
+	CreatedAt  string
+	objects    *memstore.Store[*blobObject]
+	lifecycle  *driver.LifecycleConfig
+	multiparts *memstore.Store[*blobMultipartUpload]
+	versioning bool
 }
 
 // Mock is an in-memory mock implementation of Azure Blob Storage.
 type Mock struct {
 	containers *memstore.Store[*containerMeta]
 	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(container string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.Storage/storageAccounts",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"containerName": container},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Azure Blob Storage mock.
@@ -59,10 +110,11 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 	}
 
 	m.containers.Set(name, &containerMeta{
-		Name:      name,
-		Region:    m.opts.Region,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-		objects:   memstore.New[*blobObject](),
+		Name:       name,
+		Region:     m.opts.Region,
+		CreatedAt:  m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+		objects:    memstore.New[*blobObject](),
+		multiparts: memstore.New[*blobMultipartUpload](),
 	})
 
 	return nil
@@ -122,9 +174,11 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		Data:         dataCopy,
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
 		Metadata:     metadata,
 	})
+
+	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
 
 	return nil
 }
@@ -143,6 +197,8 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 
 	dataCopy := make([]byte, len(obj.Data))
 	copy(dataCopy, obj.Data)
+
+	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Egress": float64(len(obj.Data))})
 
 	return &driver.Object{
 		Info: driver.ObjectInfo{
@@ -165,6 +221,8 @@ func (m *Mock) DeleteObject(_ context.Context, bucket, key string) error {
 	}
 
 	ctr.objects.Delete(key)
+
+	m.emitMetric(bucket, map[string]float64{"Transactions": 1})
 
 	return nil
 }
@@ -236,10 +294,12 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 	maxKeys := opts.MaxKeys
 	if maxKeys <= 0 {
-		maxKeys = 1000
+		maxKeys = blobDefaultMaxKeys
 	}
 
 	page, _ := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+
+	m.emitMetric(bucket, map[string]float64{"Transactions": 1})
 
 	return &driver.ListResult{
 		Objects:        page.Items,
@@ -276,9 +336,279 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 
 	dstCtr.objects.Set(dstKey, &blobObject{
 		Key: dstKey, Data: dataCopy, ContentType: srcObj.ContentType,
-		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
 		Metadata: meta,
 	})
 
 	return nil
+}
+
+func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
+	if req.Method != http.MethodGet && req.Method != http.MethodPut {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "method must be GET or PUT, got %q", req.Method)
+	}
+
+	if !m.containers.Has(req.Bucket) {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", req.Bucket)
+	}
+
+	expiry := req.ExpiresIn
+	if expiry <= 0 {
+		expiry = blobDefaultSASExpiry
+	}
+
+	now := m.opts.Clock.Now().UTC()
+	sig := fmt.Sprintf("%x", sha256.Sum256([]byte(req.Bucket+req.Key+now.String())))
+	expiresAt := now.Add(expiry)
+	permissions := "r"
+
+	if req.Method == http.MethodPut {
+		permissions = "w"
+	}
+
+	url := fmt.Sprintf(
+		"https://%s.blob.core.windows.net/%s/%s?sv=2023-11-03&sig=%s&se=%s&sp=%s",
+		blobAccountName, req.Bucket, req.Key, sig,
+		expiresAt.Format(blobTimeFormat), permissions,
+	)
+
+	return &driver.PresignedURL{URL: url, Method: req.Method, ExpiresAt: expiresAt}, nil
+}
+
+func (m *Mock) PutLifecycleConfig(_ context.Context, bucket string, cfg driver.LifecycleConfig) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	cfgCopy := driver.LifecycleConfig{Rules: make([]driver.LifecycleRule, len(cfg.Rules))}
+	copy(cfgCopy.Rules, cfg.Rules)
+	ctr.lifecycle = &cfgCopy
+
+	return nil
+}
+
+func (m *Mock) GetLifecycleConfig(_ context.Context, bucket string) (*driver.LifecycleConfig, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if ctr.lifecycle == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no lifecycle configuration for container %q", bucket)
+	}
+
+	return ctr.lifecycle, nil
+}
+
+func (m *Mock) EvaluateLifecycle(_ context.Context, bucket string) ([]string, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if ctr.lifecycle == nil {
+		return nil, nil
+	}
+
+	now := m.opts.Clock.Now().UTC()
+	expired := collectExpiredBlobKeys(ctr, now)
+	sort.Strings(expired)
+
+	return expired, nil
+}
+
+func collectExpiredBlobKeys(ctr *containerMeta, now time.Time) []string {
+	var result []string
+
+	for _, key := range ctr.objects.Keys() {
+		obj, objOk := ctr.objects.Get(key)
+		if !objOk {
+			continue
+		}
+
+		if blobExpired(obj, ctr.lifecycle, now) {
+			result = append(result, key)
+		}
+	}
+
+	return result
+}
+
+func blobExpired(obj *blobObject, cfg *driver.LifecycleConfig, now time.Time) bool {
+	modified, err := time.Parse(blobTimeFormat, obj.LastModified)
+	if err != nil {
+		return false
+	}
+
+	age := now.Sub(modified)
+
+	for _, rule := range cfg.Rules {
+		if !rule.Enabled {
+			continue
+		}
+
+		if rule.Prefix != "" && !strings.HasPrefix(obj.Key, rule.Prefix) {
+			continue
+		}
+
+		if rule.ExpirationDays > 0 && age >= time.Duration(rule.ExpirationDays)*blobHoursPerDay*time.Hour {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Mock) CreateMultipartUpload(
+	_ context.Context, bucket, key, contentType string,
+) (*driver.MultipartUpload, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	uploadID := idgen.GenerateID("upload-")
+	now := m.opts.Clock.Now().UTC().Format(blobTimeFormat)
+
+	ctr.multiparts.Set(uploadID, &blobMultipartUpload{
+		id:          uploadID,
+		key:         key,
+		contentType: contentType,
+		parts:       make(map[int][]byte),
+		createdAt:   now,
+	})
+
+	return &driver.MultipartUpload{
+		UploadID: uploadID, Bucket: bucket, Key: key, CreatedAt: now,
+	}, nil
+}
+
+func (m *Mock) UploadPart(
+	_ context.Context, bucket, _, uploadID string, partNumber int, data []byte,
+) (*driver.UploadPart, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	mp, ok := ctr.multiparts.Get(uploadID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	mp.parts[partNumber] = dataCopy
+
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+
+	return &driver.UploadPart{
+		PartNumber: partNumber, ETag: etag, Size: int64(len(data)),
+	}, nil
+}
+
+func (m *Mock) CompleteMultipartUpload(
+	_ context.Context, bucket, key, uploadID string, _ []driver.UploadPart,
+) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	mp, ok := ctr.multiparts.Get(uploadID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	data := assembleBlobParts(mp.parts)
+
+	ctr.objects.Set(key, &blobObject{
+		Key:          key,
+		Data:         data,
+		ContentType:  mp.contentType,
+		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
+		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
+		Metadata:     make(map[string]string),
+	})
+
+	ctr.multiparts.Delete(uploadID)
+
+	return nil
+}
+
+func assembleBlobParts(parts map[int][]byte) []byte {
+	keys := make([]int, 0, len(parts))
+	for k := range parts {
+		keys = append(keys, k)
+	}
+
+	sort.Ints(keys)
+
+	var data []byte
+	for _, k := range keys {
+		data = append(data, parts[k]...)
+	}
+
+	return data
+}
+
+func (m *Mock) AbortMultipartUpload(_ context.Context, bucket, _, uploadID string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if !ctr.multiparts.Has(uploadID) {
+		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	ctr.multiparts.Delete(uploadID)
+
+	return nil
+}
+
+func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.MultipartUpload, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	keys := ctr.multiparts.Keys()
+	sort.Strings(keys)
+
+	result := make([]driver.MultipartUpload, 0, len(keys))
+
+	for _, k := range keys {
+		mp, mpOk := ctr.multiparts.Get(k)
+		if !mpOk {
+			continue
+		}
+
+		result = append(result, driver.MultipartUpload{
+			UploadID: mp.id, Bucket: bucket, Key: mp.key, CreatedAt: mp.createdAt,
+		})
+	}
+
+	return result, nil
+}
+
+func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	ctr.versioning = enabled
+
+	return nil
+}
+
+func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return false, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	return ctr.versioning, nil
 }

--- a/providers/azure/blobstorage/blobstorage_test.go
+++ b/providers/azure/blobstorage/blobstorage_test.go
@@ -571,6 +571,78 @@ func TestMetricsEmission(t *testing.T) {
 	})
 }
 
+func TestCompleteMultipartUploadPartsValidation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "mp-val"))
+
+	t.Run("only part 1 yields part 1 data", func(t *testing.T) {
+		upload, err := m.CreateMultipartUpload(ctx, "mp-val", "file1.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		part1, err := m.UploadPart(ctx, "mp-val", "file1.bin", upload.UploadID, 1, []byte("AAAA"))
+		require.NoError(t, err)
+		_, err = m.UploadPart(ctx, "mp-val", "file1.bin", upload.UploadID, 2, []byte("BBBB"))
+		require.NoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-val", "file1.bin", upload.UploadID, []driver.UploadPart{*part1})
+		require.NoError(t, err)
+
+		obj, err := m.GetObject(ctx, "mp-val", "file1.bin")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("AAAA"), obj.Data)
+	})
+
+	t.Run("reversed order yields part2+part1 data", func(t *testing.T) {
+		upload, err := m.CreateMultipartUpload(ctx, "mp-val", "file2.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		part1, err := m.UploadPart(ctx, "mp-val", "file2.bin", upload.UploadID, 1, []byte("AAAA"))
+		require.NoError(t, err)
+		part2, err := m.UploadPart(ctx, "mp-val", "file2.bin", upload.UploadID, 2, []byte("BBBB"))
+		require.NoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-val", "file2.bin", upload.UploadID, []driver.UploadPart{*part2, *part1})
+		require.NoError(t, err)
+
+		obj, err := m.GetObject(ctx, "mp-val", "file2.bin")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("BBBBAAAA"), obj.Data)
+	})
+
+	t.Run("non-existent part 99 returns error", func(t *testing.T) {
+		upload, err := m.CreateMultipartUpload(ctx, "mp-val", "file3.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		_, err = m.UploadPart(ctx, "mp-val", "file3.bin", upload.UploadID, 1, []byte("AAAA"))
+		require.NoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-val", "file3.bin", upload.UploadID, []driver.UploadPart{
+			{PartNumber: 99, ETag: "fake"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCopyObjectMetrics(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("eastus"))
+	m := New(opts)
+
+	mon := &metricsCollector{}
+	m.SetMonitoring(mon)
+
+	require.NoError(t, m.CreateBucket(ctx, "src-bucket"))
+	require.NoError(t, m.CreateBucket(ctx, "dst-bucket"))
+	require.NoError(t, m.PutObject(ctx, "src-bucket", "file.txt", []byte("data"), "text/plain", nil))
+
+	mon.reset()
+	err := m.CopyObject(ctx, "dst-bucket", "copy.txt", driver.CopySource{Bucket: "src-bucket", Key: "file.txt"})
+	require.NoError(t, err)
+	assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Transactions"))
+}
+
 // metricsCollector is a simple monitoring stub that records emitted metrics.
 type metricsCollector struct {
 	data []mondriver.MetricDatum

--- a/providers/azure/blobstorage/blobstorage_test.go
+++ b/providers/azure/blobstorage/blobstorage_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/storage/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -314,4 +315,305 @@ func TestHeadObject(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
+}
+
+func TestGeneratePresignedURL(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "sas-bucket"))
+
+	tests := []struct {
+		name    string
+		req     driver.PresignedURLRequest
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "GET presigned URL",
+			req:  driver.PresignedURLRequest{Bucket: "sas-bucket", Key: "file.txt", Method: "GET", ExpiresIn: time.Hour},
+		},
+		{
+			name: "PUT presigned URL",
+			req:  driver.PresignedURLRequest{Bucket: "sas-bucket", Key: "upload.txt", Method: "PUT", ExpiresIn: time.Hour},
+		},
+		{
+			name: "default expiry",
+			req:  driver.PresignedURLRequest{Bucket: "sas-bucket", Key: "file.txt", Method: "GET"},
+		},
+		{
+			name:    "container not found",
+			req:     driver.PresignedURLRequest{Bucket: "missing", Key: "file.txt", Method: "GET"},
+			wantErr: true, errMsg: "not found",
+		},
+		{
+			name:    "invalid method",
+			req:     driver.PresignedURLRequest{Bucket: "sas-bucket", Key: "file.txt", Method: "DELETE"},
+			wantErr: true, errMsg: "method must be GET or PUT",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := m.GeneratePresignedURL(ctx, tt.req)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, result.URL)
+				assert.Equal(t, tt.req.Method, result.Method)
+				assert.False(t, result.ExpiresAt.IsZero())
+				assert.Contains(t, result.URL, "blob.core.windows.net")
+			}
+		})
+	}
+}
+
+func TestBucketLifecycleConfig(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("eastus"))
+	m := New(opts)
+
+	require.NoError(t, m.CreateBucket(ctx, "lifecycle-bucket"))
+
+	t.Run("put and get lifecycle config", func(t *testing.T) {
+		cfg := driver.LifecycleConfig{
+			Rules: []driver.LifecycleRule{
+				{ID: "expire-logs", Prefix: "logs/", ExpirationDays: 30, Enabled: true},
+				{ID: "expire-tmp", Prefix: "tmp/", ExpirationDays: 7, Enabled: true},
+			},
+		}
+		require.NoError(t, m.PutLifecycleConfig(ctx, "lifecycle-bucket", cfg))
+
+		got, err := m.GetLifecycleConfig(ctx, "lifecycle-bucket")
+		require.NoError(t, err)
+		assert.Len(t, got.Rules, 2)
+		assert.Equal(t, "expire-logs", got.Rules[0].ID)
+	})
+
+	t.Run("get lifecycle not configured", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "no-lifecycle"))
+		_, err := m.GetLifecycleConfig(ctx, "no-lifecycle")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no lifecycle")
+	})
+
+	t.Run("evaluate lifecycle expires old objects", func(t *testing.T) {
+		require.NoError(t, m.PutObject(ctx, "lifecycle-bucket", "logs/old.txt", []byte("old"), "text/plain", nil))
+		require.NoError(t, m.PutObject(ctx, "lifecycle-bucket", "keep.txt", []byte("keep"), "text/plain", nil))
+
+		// Advance clock past 30-day expiration
+		clk.Advance(31 * 24 * time.Hour)
+
+		expired, err := m.EvaluateLifecycle(ctx, "lifecycle-bucket")
+		require.NoError(t, err)
+		assert.Contains(t, expired, "logs/old.txt")
+	})
+
+	t.Run("container not found", func(t *testing.T) {
+		err := m.PutLifecycleConfig(ctx, "missing", driver.LifecycleConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestMultipartUpload(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "mp-bucket"))
+
+	t.Run("full multipart upload flow", func(t *testing.T) {
+		upload, err := m.CreateMultipartUpload(ctx, "mp-bucket", "large-file.bin", "application/octet-stream")
+		require.NoError(t, err)
+		assert.NotEmpty(t, upload.UploadID)
+		assert.Equal(t, "mp-bucket", upload.Bucket)
+		assert.Equal(t, "large-file.bin", upload.Key)
+
+		part1, err := m.UploadPart(ctx, "mp-bucket", "large-file.bin", upload.UploadID, 1, []byte("part1-"))
+		require.NoError(t, err)
+		assert.Equal(t, 1, part1.PartNumber)
+		assert.NotEmpty(t, part1.ETag)
+
+		part2, err := m.UploadPart(ctx, "mp-bucket", "large-file.bin", upload.UploadID, 2, []byte("part2"))
+		require.NoError(t, err)
+		assert.Equal(t, 2, part2.PartNumber)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-bucket", "large-file.bin", upload.UploadID, []driver.UploadPart{*part1, *part2})
+		require.NoError(t, err)
+
+		obj, err := m.GetObject(ctx, "mp-bucket", "large-file.bin")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("part1-part2"), obj.Data)
+	})
+
+	t.Run("list multipart uploads", func(t *testing.T) {
+		_, err := m.CreateMultipartUpload(ctx, "mp-bucket", "pending.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		uploads, err := m.ListMultipartUploads(ctx, "mp-bucket")
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(uploads), 1)
+	})
+
+	t.Run("container not found", func(t *testing.T) {
+		_, err := m.CreateMultipartUpload(ctx, "missing", "file.bin", "text/plain")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestAbortMultipartUpload(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "abort-bucket"))
+
+	upload, err := m.CreateMultipartUpload(ctx, "abort-bucket", "file.bin", "application/octet-stream")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		bucket   string
+		uploadID string
+		wantErr  bool
+		errMsg   string
+	}{
+		{name: "success", bucket: "abort-bucket", uploadID: upload.UploadID},
+		{name: "upload not found", bucket: "abort-bucket", uploadID: "bad-id", wantErr: true, errMsg: "not found"},
+		{name: "container not found", bucket: "missing", uploadID: "x", wantErr: true, errMsg: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.AbortMultipartUpload(ctx, tt.bucket, "file.bin", tt.uploadID)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBucketVersioning(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "ver-bucket"))
+
+	t.Run("default versioning is disabled", func(t *testing.T) {
+		enabled, err := m.GetBucketVersioning(ctx, "ver-bucket")
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("enable versioning", func(t *testing.T) {
+		require.NoError(t, m.SetBucketVersioning(ctx, "ver-bucket", true))
+
+		enabled, err := m.GetBucketVersioning(ctx, "ver-bucket")
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("disable versioning", func(t *testing.T) {
+		require.NoError(t, m.SetBucketVersioning(ctx, "ver-bucket", false))
+
+		enabled, err := m.GetBucketVersioning(ctx, "ver-bucket")
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("container not found", func(t *testing.T) {
+		err := m.SetBucketVersioning(ctx, "missing", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetBucketVersioning(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestMetricsEmission(t *testing.T) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("eastus"))
+	m := New(opts)
+
+	mon := &metricsCollector{}
+	m.SetMonitoring(mon)
+
+	ctx := context.Background()
+	require.NoError(t, m.CreateBucket(ctx, "metrics-bucket"))
+
+	t.Run("PutObject emits metrics", func(t *testing.T) {
+		mon.reset()
+		require.NoError(t, m.PutObject(ctx, "metrics-bucket", "file.txt", []byte("hello"), "text/plain", nil))
+		assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Transactions"))
+		assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Ingress"))
+	})
+
+	t.Run("GetObject emits metrics", func(t *testing.T) {
+		mon.reset()
+		_, err := m.GetObject(ctx, "metrics-bucket", "file.txt")
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Transactions"))
+		assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Egress"))
+	})
+
+	t.Run("DeleteObject emits metrics", func(t *testing.T) {
+		mon.reset()
+		require.NoError(t, m.DeleteObject(ctx, "metrics-bucket", "file.txt"))
+		assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Transactions"))
+	})
+}
+
+// metricsCollector is a simple monitoring stub that records emitted metrics.
+type metricsCollector struct {
+	data []mondriver.MetricDatum
+}
+
+func (c *metricsCollector) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	c.data = append(c.data, data...)
+	return nil
+}
+
+func (c *metricsCollector) GetMetricData(_ context.Context, _ mondriver.GetMetricInput) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (c *metricsCollector) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (c *metricsCollector) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (c *metricsCollector) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (c *metricsCollector) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (c *metricsCollector) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *metricsCollector) reset() {
+	c.data = nil
+}
+
+func (c *metricsCollector) hasMetric(namespace, metricName string) bool {
+	for _, d := range c.data {
+		if d.Namespace == namespace && d.MetricName == metricName {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -7,11 +7,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/database/driver"
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/pagination"
 )
 
@@ -28,19 +30,61 @@ const (
 	OpBetween      = "BETWEEN"
 )
 
+// Change feed and TTL constants.
+const (
+	ViewNewImage     = "NEW_IMAGE"
+	ViewOldImage     = "OLD_IMAGE"
+	ViewNewAndOld    = "NEW_AND_OLD_IMAGES"
+	ViewKeysOnly     = "KEYS_ONLY"
+	maxFeedRecords   = 1000
+	defaultFeedLimit = 100
+)
+
 // Compile-time check that Mock implements driver.Database.
 var _ driver.Database = (*Mock)(nil)
 
 type tableData struct {
-	config driver.TableConfig
-	items  *memstore.Store[map[string]any]
+	config        driver.TableConfig
+	items         *memstore.Store[map[string]any]
+	ttlConfig     driver.TTLConfig
+	streamConfig  driver.StreamConfig
+	streamRecords []driver.StreamRecord
+	seqCounter    atomic.Int64
 }
 
 // Mock is an in-memory mock implementation of Azure Cosmos DB.
 type Mock struct {
-	mu     sync.RWMutex
-	tables map[string]*tableData
-	opts   *config.Options
+	mu         sync.RWMutex
+	tables     map[string]*tableData
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(container string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.DocumentDB/databaseAccounts",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"containerName": container},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Cosmos DB mock.
@@ -116,15 +160,21 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 
 // PutItem stores an item in a container.
 func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) error {
-	m.mu.RLock()
-	td, exists := m.tables[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	td, exists := m.tables[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
 	}
 
-	td.items.Set(itemKey(td.config, item), item)
+	key := itemKey(td.config, item)
+	oldItem, hadOld := td.items.Get(key)
+	td.items.Set(key, item)
+	m.recordStreamEvent(td, oldItem, item, hadOld)
+	m.mu.Unlock()
+
+	m.emitMetric(table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
 	return nil
 }
@@ -139,25 +189,44 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 		return nil, cerrors.Newf(cerrors.NotFound, "container %s not found", table)
 	}
 
-	item, ok := td.items.Get(itemKey(td.config, key))
+	k := itemKey(td.config, key)
+	item, ok := td.items.Get(k)
+
 	if !ok {
 		return nil, cerrors.New(cerrors.NotFound, "item not found")
 	}
+
+	if m.isItemExpired(td, item) {
+		td.items.Delete(k)
+		return nil, cerrors.New(cerrors.NotFound, "item not found")
+	}
+
+	m.emitMetric(table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
 	return item, nil
 }
 
 // DeleteItem deletes an item from a container by key.
 func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) error {
-	m.mu.RLock()
-	td, exists := m.tables[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	td, exists := m.tables[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
 	}
 
-	td.items.Delete(itemKey(td.config, key))
+	k := itemKey(td.config, key)
+	oldItem, hadOld := td.items.Get(k)
+	td.items.Delete(k)
+
+	if hadOld {
+		m.recordStreamRemove(td, oldItem)
+	}
+
+	m.mu.Unlock()
+
+	m.emitMetric(table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
 	return nil
 }
@@ -179,27 +248,7 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
-	allItems := td.items.All()
-
-	var matched []map[string]any
-
-	for _, item := range allItems {
-		pkVal := fmt.Sprintf("%v", item[pkField])
-		if pkVal != fmt.Sprintf("%v", input.KeyCondition.PartitionVal) {
-			continue
-		}
-
-		if input.KeyCondition.SortOp != "" && skField != "" {
-			skVal := fmt.Sprintf("%v", item[skField])
-			condSK := fmt.Sprintf("%v", input.KeyCondition.SortVal)
-
-			if !applySortCondition(skVal, input.KeyCondition.SortOp, condSK, input.KeyCondition.SortValEnd) {
-				continue
-			}
-		}
-
-		matched = append(matched, item)
-	}
+	matched := m.matchQueryItems(td, pkField, skField, &input)
 
 	limit := input.Limit
 	if limit <= 0 {
@@ -207,6 +256,8 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 	}
 
 	page, _ := pagination.Paginate(matched, input.PageToken, limit)
+
+	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": float64(len(page.Items))})
 
 	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
 }
@@ -243,6 +294,10 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 	var matched []map[string]any
 
 	for _, item := range allItems {
+		if m.isItemExpired(td, item) {
+			continue
+		}
+
 		if matchesFilters(item, input.Filters) {
 			matched = append(matched, item)
 		}
@@ -255,22 +310,29 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 
 	page, _ := pagination.Paginate(matched, input.PageToken, limit)
 
+	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": float64(len(page.Items))})
+
 	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
 }
 
 // BatchPutItems stores multiple items in a container.
 func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {
-	m.mu.RLock()
-	td, exists := m.tables[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	td, exists := m.tables[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
 	}
 
 	for _, item := range items {
-		td.items.Set(itemKey(td.config, item), item)
+		key := itemKey(td.config, item)
+		oldItem, hadOld := td.items.Get(key)
+		td.items.Set(key, item)
+		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}
+
+	m.mu.Unlock()
 
 	return nil
 }
@@ -379,4 +441,306 @@ func matchesSingleScanFilter(item map[string]any, f driver.ScanFilter) bool {
 	default:
 		return false
 	}
+}
+
+func (m *Mock) matchQueryItems(
+	td *tableData, pkField, skField string, input *driver.QueryInput,
+) []map[string]any {
+	allItems := td.items.All()
+
+	var matched []map[string]any
+
+	for _, item := range allItems {
+		if m.isItemExpired(td, item) {
+			continue
+		}
+
+		pkVal := fmt.Sprintf("%v", item[pkField])
+		if pkVal != fmt.Sprintf("%v", input.KeyCondition.PartitionVal) {
+			continue
+		}
+
+		if input.KeyCondition.SortOp != "" && skField != "" {
+			skVal := fmt.Sprintf("%v", item[skField])
+			condSK := fmt.Sprintf("%v", input.KeyCondition.SortVal)
+
+			if !applySortCondition(skVal, input.KeyCondition.SortOp, condSK, input.KeyCondition.SortValEnd) {
+				continue
+			}
+		}
+
+		matched = append(matched, item)
+	}
+
+	return matched
+}
+
+// UpdateTTL configures TTL for a container.
+func (m *Mock) UpdateTTL(_ context.Context, table string, cfg driver.TTLConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	td.ttlConfig = cfg
+
+	return nil
+}
+
+// DescribeTTL returns the TTL configuration for a container.
+func (m *Mock) DescribeTTL(_ context.Context, table string) (*driver.TTLConfig, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	cfg := td.ttlConfig
+
+	return &cfg, nil
+}
+
+// UpdateStreamConfig configures the change feed for a container.
+func (m *Mock) UpdateStreamConfig(_ context.Context, table string, cfg driver.StreamConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	td.streamConfig = cfg
+
+	return nil
+}
+
+// GetStreamRecords returns change feed records after the given token.
+func (m *Mock) GetStreamRecords(
+	_ context.Context, table string, limit int, token string,
+) (*driver.StreamIterator, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	if !td.streamConfig.Enabled {
+		return nil, cerrors.New(cerrors.FailedPrecondition, "change feed not enabled")
+	}
+
+	return filterFeedRecords(td.streamRecords, limit, token), nil
+}
+
+func filterFeedRecords(records []driver.StreamRecord, limit int, token string) *driver.StreamIterator {
+	if limit <= 0 {
+		limit = defaultFeedLimit
+	}
+
+	startIdx := 0
+
+	if token != "" {
+		for i, r := range records {
+			if r.SequenceNumber == token {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+
+	end := startIdx + limit
+	if end > len(records) {
+		end = len(records)
+	}
+
+	result := records[startIdx:end]
+	nextToken := ""
+
+	if end < len(records) {
+		nextToken = result[len(result)-1].SequenceNumber
+	}
+
+	return &driver.StreamIterator{
+		ShardID:   "lease-000",
+		Records:   result,
+		NextToken: nextToken,
+	}
+}
+
+// TransactWriteItems executes puts and deletes atomically.
+func (m *Mock) TransactWriteItems(
+	_ context.Context, table string, puts []map[string]any, deletes []map[string]any,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	m.applyTransactPuts(td, puts)
+	m.applyTransactDeletes(td, deletes)
+
+	return nil
+}
+
+func (m *Mock) applyTransactPuts(td *tableData, puts []map[string]any) {
+	for _, item := range puts {
+		key := itemKey(td.config, item)
+		oldItem, hadOld := td.items.Get(key)
+		td.items.Set(key, item)
+		m.recordStreamEvent(td, oldItem, item, hadOld)
+	}
+}
+
+func (m *Mock) applyTransactDeletes(td *tableData, deletes []map[string]any) {
+	for _, key := range deletes {
+		k := itemKey(td.config, key)
+		oldItem, hadOld := td.items.Get(k)
+		td.items.Delete(k)
+
+		if hadOld {
+			m.recordStreamRemove(td, oldItem)
+		}
+	}
+}
+
+// isItemExpired checks if an item has expired based on TTL config.
+// CosmosDB uses TTL in seconds relative to a _ts field or creation time.
+func (m *Mock) isItemExpired(td *tableData, item map[string]any) bool {
+	if !td.ttlConfig.Enabled {
+		return false
+	}
+
+	ttlVal, ok := item[td.ttlConfig.AttributeName]
+	if !ok {
+		return false
+	}
+
+	ttlUnix := toUnixTimestamp(ttlVal)
+	if ttlUnix <= 0 {
+		return false
+	}
+
+	return m.opts.Clock.Now().Unix() > ttlUnix
+}
+
+func toUnixTimestamp(val any) int64 {
+	switch v := val.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	default:
+		parsed, err := strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
+		if err != nil {
+			return 0
+		}
+
+		return int64(parsed)
+	}
+}
+
+// recordStreamEvent records an INSERT or MODIFY change feed event. Caller must hold m.mu.
+func (m *Mock) recordStreamEvent(td *tableData, oldItem, newItem map[string]any, hadOld bool) {
+	if !td.streamConfig.Enabled {
+		return
+	}
+
+	eventType := "INSERT"
+	if hadOld {
+		eventType = "MODIFY"
+	}
+
+	rec := m.buildStreamRecord(td, eventType, oldItem, newItem)
+	td.streamRecords = appendFeedRecord(td.streamRecords, &rec)
+}
+
+// recordStreamRemove records a REMOVE change feed event. Caller must hold m.mu.
+func (m *Mock) recordStreamRemove(td *tableData, oldItem map[string]any) {
+	if !td.streamConfig.Enabled {
+		return
+	}
+
+	rec := m.buildStreamRecord(td, "REMOVE", oldItem, nil)
+	td.streamRecords = appendFeedRecord(td.streamRecords, &rec)
+}
+
+func (m *Mock) buildStreamRecord(
+	td *tableData, eventType string, oldItem, newItem map[string]any,
+) driver.StreamRecord {
+	seq := td.seqCounter.Add(1)
+	keys := extractKeys(td.config, oldItem, newItem)
+
+	rec := driver.StreamRecord{
+		EventID:        fmt.Sprintf("event-%d", seq),
+		EventType:      eventType,
+		Table:          td.config.Name,
+		Keys:           keys,
+		Timestamp:      m.opts.Clock.Now(),
+		SequenceNumber: fmt.Sprintf("%d", seq),
+	}
+
+	applyViewType(&rec, td.streamConfig.ViewType, oldItem, newItem)
+
+	return rec
+}
+
+func extractKeys(cfg driver.TableConfig, oldItem, newItem map[string]any) map[string]any {
+	src := newItem
+	if src == nil {
+		src = oldItem
+	}
+
+	keys := map[string]any{cfg.PartitionKey: src[cfg.PartitionKey]}
+	if cfg.SortKey != "" {
+		keys[cfg.SortKey] = src[cfg.SortKey]
+	}
+
+	return keys
+}
+
+func applyViewType(rec *driver.StreamRecord, viewType string, oldItem, newItem map[string]any) {
+	switch viewType {
+	case ViewNewImage:
+		rec.NewImage = copyItem(newItem)
+	case ViewOldImage:
+		rec.OldImage = copyItem(oldItem)
+	case ViewNewAndOld:
+		rec.NewImage = copyItem(newItem)
+		rec.OldImage = copyItem(oldItem)
+	case ViewKeysOnly:
+	}
+}
+
+func copyItem(item map[string]any) map[string]any {
+	if item == nil {
+		return nil
+	}
+
+	cp := make(map[string]any, len(item))
+	for k, v := range item {
+		cp[k] = v
+	}
+
+	return cp
+}
+
+func appendFeedRecord(records []driver.StreamRecord, rec *driver.StreamRecord) []driver.StreamRecord {
+	records = append(records, *rec)
+	if len(records) > maxFeedRecords {
+		records = records[len(records)-maxFeedRecords:]
+	}
+
+	return records
 }

--- a/providers/azure/cosmosdb/cosmosdb_test.go
+++ b/providers/azure/cosmosdb/cosmosdb_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/database/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -381,4 +382,308 @@ func TestBatchOperations(t *testing.T) {
 		_, err := m.BatchGetItems(ctx, "missing", []map[string]any{{"pk": "x"}})
 		require.Error(t, err)
 	})
+}
+
+func TestUpdateTTL(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(t, m)
+
+	tests := []struct {
+		name    string
+		table   string
+		cfg     driver.TTLConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "enable TTL",
+			table: "users",
+			cfg:   driver.TTLConfig{Enabled: true, AttributeName: "expiry"},
+		},
+		{
+			name:  "disable TTL",
+			table: "users",
+			cfg:   driver.TTLConfig{Enabled: false, AttributeName: "expiry"},
+		},
+		{
+			name:    "table not found",
+			table:   "missing",
+			cfg:     driver.TTLConfig{Enabled: true, AttributeName: "expiry"},
+			wantErr: true, errMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.UpdateTTL(ctx, tt.table, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+
+				got, err := m.DescribeTTL(ctx, tt.table)
+				require.NoError(t, err)
+				assert.Equal(t, tt.cfg.Enabled, got.Enabled)
+				assert.Equal(t, tt.cfg.AttributeName, got.AttributeName)
+			}
+		})
+	}
+}
+
+func TestTTLExpiry(t *testing.T) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk))
+	m := New(opts)
+
+	ctx := context.Background()
+
+	err := m.CreateTable(ctx, driver.TableConfig{Name: "ttl-table", PartitionKey: "pk", SortKey: "sk"})
+	require.NoError(t, err)
+
+	require.NoError(t, m.UpdateTTL(ctx, "ttl-table", driver.TTLConfig{Enabled: true, AttributeName: "expiry"}))
+
+	pastExpiry := clk.Now().Unix() - 100
+	futureExpiry := clk.Now().Unix() + 3600
+
+	require.NoError(t, m.PutItem(ctx, "ttl-table", map[string]any{
+		"pk": "u1", "sk": "s1", "expiry": pastExpiry,
+	}))
+	require.NoError(t, m.PutItem(ctx, "ttl-table", map[string]any{
+		"pk": "u2", "sk": "s2", "expiry": futureExpiry,
+	}))
+
+	t.Run("expired item not returned by GetItem", func(t *testing.T) {
+		_, err := m.GetItem(ctx, "ttl-table", map[string]any{"pk": "u1", "sk": "s1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("non-expired item returned", func(t *testing.T) {
+		item, err := m.GetItem(ctx, "ttl-table", map[string]any{"pk": "u2", "sk": "s2"})
+		require.NoError(t, err)
+		assert.Equal(t, "u2", item["pk"])
+	})
+
+	t.Run("expired items excluded from Scan", func(t *testing.T) {
+		result, err := m.Scan(ctx, driver.ScanInput{Table: "ttl-table"})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Count)
+	})
+}
+
+func TestStreamConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(t, m)
+
+	tests := []struct {
+		name    string
+		table   string
+		cfg     driver.StreamConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:  "enable change feed",
+			table: "users",
+			cfg:   driver.StreamConfig{Enabled: true, ViewType: "NEW_AND_OLD_IMAGES"},
+		},
+		{
+			name:    "table not found",
+			table:   "missing",
+			cfg:     driver.StreamConfig{Enabled: true, ViewType: "NEW_IMAGE"},
+			wantErr: true, errMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.UpdateStreamConfig(ctx, tt.table, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStreamRecords(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(t, m)
+
+	t.Run("stream not enabled returns error", func(t *testing.T) {
+		_, err := m.GetStreamRecords(ctx, "users", 10, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not enabled")
+	})
+
+	require.NoError(t, m.UpdateStreamConfig(ctx, "users", driver.StreamConfig{
+		Enabled: true, ViewType: "NEW_AND_OLD_IMAGES",
+	}))
+
+	t.Run("INSERT event recorded", func(t *testing.T) {
+		require.NoError(t, m.PutItem(ctx, "users", map[string]any{"pk": "u1", "sk": "s1", "name": "Alice"}))
+
+		iter, err := m.GetStreamRecords(ctx, "users", 10, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, iter.Records)
+		assert.Equal(t, "INSERT", iter.Records[0].EventType)
+		assert.NotNil(t, iter.Records[0].NewImage)
+	})
+
+	t.Run("MODIFY event recorded", func(t *testing.T) {
+		require.NoError(t, m.PutItem(ctx, "users", map[string]any{"pk": "u1", "sk": "s1", "name": "Bob"}))
+
+		iter, err := m.GetStreamRecords(ctx, "users", 10, "")
+		require.NoError(t, err)
+		require.Len(t, iter.Records, 2)
+		assert.Equal(t, "MODIFY", iter.Records[1].EventType)
+	})
+
+	t.Run("REMOVE event recorded", func(t *testing.T) {
+		require.NoError(t, m.DeleteItem(ctx, "users", map[string]any{"pk": "u1", "sk": "s1"}))
+
+		iter, err := m.GetStreamRecords(ctx, "users", 10, "")
+		require.NoError(t, err)
+		require.Len(t, iter.Records, 3)
+		assert.Equal(t, "REMOVE", iter.Records[2].EventType)
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		_, err := m.GetStreamRecords(ctx, "missing", 10, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestTransactWriteItems(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	createTestTable(t, m)
+
+	t.Run("puts and deletes atomically", func(t *testing.T) {
+		// Seed an item to delete
+		require.NoError(t, m.PutItem(ctx, "users", map[string]any{"pk": "del1", "sk": "s1", "val": "old"}))
+
+		puts := []map[string]any{
+			{"pk": "new1", "sk": "s1", "val": "v1"},
+			{"pk": "new2", "sk": "s2", "val": "v2"},
+		}
+		deletes := []map[string]any{
+			{"pk": "del1", "sk": "s1"},
+		}
+
+		err := m.TransactWriteItems(ctx, "users", puts, deletes)
+		require.NoError(t, err)
+
+		// Verify puts
+		item, err := m.GetItem(ctx, "users", map[string]any{"pk": "new1", "sk": "s1"})
+		require.NoError(t, err)
+		assert.Equal(t, "v1", item["val"])
+
+		item, err = m.GetItem(ctx, "users", map[string]any{"pk": "new2", "sk": "s2"})
+		require.NoError(t, err)
+		assert.Equal(t, "v2", item["val"])
+
+		// Verify delete
+		_, err = m.GetItem(ctx, "users", map[string]any{"pk": "del1", "sk": "s1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		err := m.TransactWriteItems(ctx, "missing", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCosmosDBMetricsEmission(t *testing.T) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk))
+	m := New(opts)
+
+	mon := &cosmosMetricsCollector{}
+	m.SetMonitoring(mon)
+
+	ctx := context.Background()
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "metrics-table", PartitionKey: "pk", SortKey: "sk"}))
+
+	t.Run("PutItem emits metrics", func(t *testing.T) {
+		mon.reset()
+		require.NoError(t, m.PutItem(ctx, "metrics-table", map[string]any{"pk": "u1", "sk": "s1"}))
+		assert.True(t, mon.hasMetric("Microsoft.DocumentDB/databaseAccounts", "TotalRequests"))
+	})
+
+	t.Run("GetItem emits metrics", func(t *testing.T) {
+		mon.reset()
+		_, err := m.GetItem(ctx, "metrics-table", map[string]any{"pk": "u1", "sk": "s1"})
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.DocumentDB/databaseAccounts", "TotalRequests"))
+	})
+
+	t.Run("Query emits metrics", func(t *testing.T) {
+		mon.reset()
+		_, err := m.Query(ctx, driver.QueryInput{
+			Table:        "metrics-table",
+			KeyCondition: driver.KeyCondition{PartitionKey: "pk", PartitionVal: "u1"},
+		})
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.DocumentDB/databaseAccounts", "TotalRequests"))
+	})
+}
+
+type cosmosMetricsCollector struct {
+	data []mondriver.MetricDatum
+}
+
+func (c *cosmosMetricsCollector) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	c.data = append(c.data, data...)
+	return nil
+}
+
+func (c *cosmosMetricsCollector) GetMetricData(_ context.Context, _ mondriver.GetMetricInput) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (c *cosmosMetricsCollector) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (c *cosmosMetricsCollector) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (c *cosmosMetricsCollector) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (c *cosmosMetricsCollector) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (c *cosmosMetricsCollector) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *cosmosMetricsCollector) reset() {
+	c.data = nil
+}
+
+func (c *cosmosMetricsCollector) hasMetric(namespace, metricName string) bool {
+	for _, d := range c.data {
+		if d.Namespace == namespace && d.MetricName == metricName {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -1,0 +1,524 @@
+// Package eventgrid provides an in-memory mock implementation of Azure Event Grid.
+package eventgrid
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	maxEventHistory  = 1000
+	defaultRuleState = "ENABLED"
+	activeTopicState = "ACTIVE"
+	resourceProvider = "Microsoft.EventGrid"
+	resourceType     = "topics"
+)
+
+// Compile-time check that Mock implements driver.EventBus.
+var _ driver.EventBus = (*Mock)(nil)
+
+type ruleData struct {
+	rule    driver.Rule
+	targets *memstore.Store[driver.Target]
+}
+
+type busData struct {
+	info   driver.EventBusInfo
+	rules  *memstore.Store[*ruleData]
+	mu     sync.RWMutex
+	events []driver.Event
+}
+
+// Mock is an in-memory mock implementation of Azure Event Grid.
+type Mock struct {
+	buses      *memstore.Store[*busData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(topicName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.EventGrid/topics",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"topicName": topicName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
+}
+
+// New creates a new Event Grid mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		buses: memstore.New[*busData](),
+		opts:  opts,
+	}
+}
+
+// CreateEventBus creates a new Event Grid topic.
+func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	if m.buses.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
+	}
+
+	topicID := idgen.AzureID(m.opts.AccountID, m.opts.Region, resourceProvider, resourceType, cfg.Name)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.EventBusInfo{
+		Name:      cfg.Name,
+		ARN:       topicID,
+		State:     activeTopicState,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:      tags,
+	}
+
+	bd := &busData{
+		info:   info,
+		rules:  memstore.New[*ruleData](),
+		events: []driver.Event{},
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteEventBus deletes an Event Grid topic.
+func (m *Mock) DeleteEventBus(_ context.Context, name string) error {
+	if !m.buses.Delete(name) {
+		return errors.Newf(errors.NotFound, "topic %q not found", name)
+	}
+
+	return nil
+}
+
+// GetEventBus retrieves information about an Event Grid topic.
+func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", name)
+	}
+
+	result := bd.info
+
+	return &result, nil
+}
+
+// ListEventBuses lists all Event Grid topics.
+func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+	all := m.buses.All()
+
+	buses := make([]driver.EventBusInfo, 0, len(all))
+	for _, bd := range all {
+		buses = append(buses, bd.info)
+	}
+
+	return buses, nil
+}
+
+// PutRule creates or updates an event subscription on a topic.
+func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "subscription name is required")
+	}
+
+	busName := cfg.EventBus
+	if busName == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", busName)
+	}
+
+	state := cfg.State
+	if state == "" {
+		state = defaultRuleState
+	}
+
+	rule := driver.Rule{
+		Name:         cfg.Name,
+		EventBus:     busName,
+		Description:  cfg.Description,
+		EventPattern: cfg.EventPattern,
+		State:        state,
+		Targets:      []driver.Target{},
+		CreatedAt:    m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	if existing, exists := bd.rules.Get(cfg.Name); exists {
+		rule.Targets = existing.rule.Targets
+		rule.CreatedAt = existing.rule.CreatedAt
+	}
+
+	rd := &ruleData{
+		rule:    rule,
+		targets: memstore.New[driver.Target](),
+	}
+
+	for _, t := range rule.Targets {
+		rd.targets.Set(t.ID, t)
+	}
+
+	bd.rules.Set(cfg.Name, rd)
+
+	result := rule
+
+	return &result, nil
+}
+
+// DeleteRule deletes an event subscription from a topic.
+func (m *Mock) DeleteRule(_ context.Context, eventBus, ruleName string) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	if !bd.rules.Delete(ruleName) {
+		return errors.Newf(errors.NotFound, "subscription %q not found on topic %q", ruleName, eventBus)
+	}
+
+	return nil
+}
+
+// GetRule retrieves an event subscription from a topic.
+func (m *Mock) GetRule(_ context.Context, eventBus, ruleName string) (*driver.Rule, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "subscription %q not found on topic %q", ruleName, eventBus)
+	}
+
+	result := rd.rule
+
+	return &result, nil
+}
+
+// ListRules lists all event subscriptions on a topic.
+func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	all := bd.rules.All()
+
+	rules := make([]driver.Rule, 0, len(all))
+	for _, rd := range all {
+		rules = append(rules, rd.rule)
+	}
+
+	return rules, nil
+}
+
+// EnableRule enables an event subscription on a topic.
+func (m *Mock) EnableRule(_ context.Context, eventBus, ruleName string) error {
+	return m.setRuleState(eventBus, ruleName, defaultRuleState)
+}
+
+// DisableRule disables an event subscription on a topic.
+func (m *Mock) DisableRule(_ context.Context, eventBus, ruleName string) error {
+	return m.setRuleState(eventBus, ruleName, "DISABLED")
+}
+
+func (m *Mock) setRuleState(eventBus, ruleName, state string) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subscription %q not found on topic %q", ruleName, eventBus)
+	}
+
+	rd.rule.State = state
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// PutTargets adds targets to an event subscription.
+func (m *Mock) PutTargets(_ context.Context, eventBus, ruleName string, targets []driver.Target) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subscription %q not found on topic %q", ruleName, eventBus)
+	}
+
+	for _, t := range targets {
+		rd.targets.Set(t.ID, t)
+	}
+
+	rd.rule.Targets = targetsFromStore(rd.targets)
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// RemoveTargets removes targets from an event subscription.
+func (m *Mock) RemoveTargets(_ context.Context, eventBus, ruleName string, targetIDs []string) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subscription %q not found on topic %q", ruleName, eventBus)
+	}
+
+	for _, id := range targetIDs {
+		rd.targets.Delete(id)
+	}
+
+	rd.rule.Targets = targetsFromStore(rd.targets)
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// ListTargets lists all targets for an event subscription.
+func (m *Mock) ListTargets(_ context.Context, eventBus, ruleName string) ([]driver.Target, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "subscription %q not found on topic %q", ruleName, eventBus)
+	}
+
+	return targetsFromStore(rd.targets), nil
+}
+
+// PutEvents publishes events to Event Grid topics.
+func (m *Mock) PutEvents(_ context.Context, events []driver.Event) (*driver.PublishResult, error) {
+	result := &driver.PublishResult{
+		EventIDs: make([]string, 0, len(events)),
+	}
+
+	for i := range events {
+		eventID := generateEventID(&events[i], m.opts.Clock.Now())
+		events[i].ID = eventID
+
+		if events[i].Time.IsZero() {
+			events[i].Time = m.opts.Clock.Now()
+		}
+
+		busName := events[i].EventBus
+		if busName == "" {
+			result.FailCount++
+
+			continue
+		}
+
+		bd, ok := m.buses.Get(busName)
+		if !ok {
+			result.FailCount++
+
+			continue
+		}
+
+		m.storeEvent(bd, &events[i])
+
+		matchedCount := len(m.MatchedRules(&events[i]))
+		m.emitMetric(busName, map[string]float64{
+			"PublishedEvents": 1, "MatchedEvents": float64(matchedCount),
+		})
+
+		result.SuccessCount++
+		result.EventIDs = append(result.EventIDs, eventID)
+	}
+
+	return result, nil
+}
+
+// GetEventHistory retrieves event history for a topic.
+func (m *Mock) GetEventHistory(_ context.Context, eventBus string, limit int) ([]driver.Event, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "topic name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", eventBus)
+	}
+
+	bd.mu.RLock()
+	defer bd.mu.RUnlock()
+
+	history := bd.events
+	if limit > 0 && limit < len(history) {
+		history = history[len(history)-limit:]
+	}
+
+	result := make([]driver.Event, len(history))
+	copy(result, history)
+
+	return result, nil
+}
+
+func (*Mock) storeEvent(bd *busData, event *driver.Event) {
+	bd.mu.Lock()
+	defer bd.mu.Unlock()
+
+	bd.events = append(bd.events, *event)
+	if len(bd.events) > maxEventHistory {
+		bd.events = bd.events[len(bd.events)-maxEventHistory:]
+	}
+}
+
+func targetsFromStore(store *memstore.Store[driver.Target]) []driver.Target {
+	all := store.All()
+
+	targets := make([]driver.Target, 0, len(all))
+	for _, t := range all {
+		targets = append(targets, t)
+	}
+
+	return targets
+}
+
+func generateEventID(event *driver.Event, now time.Time) string {
+	data := fmt.Sprintf("%s:%s:%s:%s:%d", event.Source, event.DetailType, event.Detail, event.EventBus, now.UnixNano())
+	hash := sha256.Sum256([]byte(data))
+
+	return fmt.Sprintf("%x", hash[:16])
+}
+
+func matchesPattern(event *driver.Event, pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal([]byte(pattern), &p); err != nil {
+		return false
+	}
+
+	if sources, ok := p["source"]; ok {
+		if !matchesField(event.Source, sources) {
+			return false
+		}
+	}
+
+	if detailTypes, ok := p["detail-type"]; ok {
+		if !matchesField(event.DetailType, detailTypes) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchesField(value string, allowed any) bool {
+	arr, ok := allowed.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, v := range arr {
+		if fmt.Sprintf("%v", v) == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchedRules returns all subscriptions that match the given event (exported for testing).
+func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
+	var matched []driver.Rule
+
+	all := m.buses.All()
+	for _, bd := range all {
+		rules := bd.rules.All()
+		for _, rd := range rules {
+			if rd.rule.State != defaultRuleState {
+				continue
+			}
+
+			if matchesPattern(event, rd.rule.EventPattern) {
+				matched = append(matched, rd.rule)
+			}
+		}
+	}
+
+	return matched
+}

--- a/providers/azure/eventgrid/eventgrid_test.go
+++ b/providers/azure/eventgrid/eventgrid_test.go
@@ -1,0 +1,815 @@
+package eventgrid
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("eastus"))
+
+	return New(opts), fc
+}
+
+func createTestTopic(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateEventBus(context.Background(), driver.EventBusConfig{Name: name})
+	require.NoError(t, err)
+}
+
+func createTestRule(t *testing.T, m *Mock, topicName, ruleName string) {
+	t.Helper()
+
+	_, err := m.PutRule(context.Background(), &driver.RuleConfig{
+		Name:     ruleName,
+		EventBus: topicName,
+	})
+	require.NoError(t, err)
+}
+
+func TestCreateEventBus(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.EventBusConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{name: "success", cfg: driver.EventBusConfig{Name: "my-topic"}},
+		{
+			name: "success with tags",
+			cfg: driver.EventBusConfig{
+				Name: "tagged-topic",
+				Tags: map[string]string{"env": "prod"},
+			},
+		},
+		{name: "empty name", cfg: driver.EventBusConfig{}, expectErr: true},
+		{
+			name: "duplicate topic",
+			cfg:  driver.EventBusConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestTopic(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateEventBus(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.cfg.Name, info.Name)
+			assert.Equal(t, "ACTIVE", info.State)
+			assert.NotEmpty(t, info.ARN)
+			assert.NotEmpty(t, info.CreatedAt)
+		})
+	}
+}
+
+func TestDeleteEventBus(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "to-delete")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteEventBus(ctx, "to-delete")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteEventBus(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetEventBus(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := m.GetEventBus(ctx, "my-topic")
+		require.NoError(t, err)
+		assert.Equal(t, "my-topic", info.Name)
+		assert.Equal(t, "ACTIVE", info.State)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetEventBus(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListEventBuses(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		buses, err := m.ListEventBuses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(buses))
+	})
+
+	createTestTopic(t, m, "topic-a")
+	createTestTopic(t, m, "topic-b")
+
+	t.Run("two topics", func(t *testing.T) {
+		buses, err := m.ListEventBuses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(buses))
+	})
+}
+
+func TestPutRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.RuleConfig
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name: "success",
+			cfg:  driver.RuleConfig{Name: "my-rule", EventBus: "my-topic"},
+			setup: func(m *Mock) {
+				createTestTopic(&testing.T{}, m, "my-topic")
+			},
+		},
+		{
+			name: "with event pattern",
+			cfg: driver.RuleConfig{
+				Name:         "pattern-rule",
+				EventBus:     "my-topic",
+				EventPattern: `{"source":["my.app"]}`,
+			},
+			setup: func(m *Mock) {
+				createTestTopic(&testing.T{}, m, "my-topic")
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.RuleConfig{EventBus: "my-topic"},
+			expectErr: true,
+		},
+		{
+			name:      "empty topic",
+			cfg:       driver.RuleConfig{Name: "my-rule"},
+			expectErr: true,
+		},
+		{
+			name:      "topic not found",
+			cfg:       driver.RuleConfig{Name: "my-rule", EventBus: "missing"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			rule, err := m.PutRule(context.Background(), &tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.cfg.Name, rule.Name)
+			assert.Equal(t, tc.cfg.EventBus, rule.EventBus)
+			assert.Equal(t, "ENABLED", rule.State)
+			assert.NotEmpty(t, rule.CreatedAt)
+		})
+	}
+}
+
+func TestDeleteRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+	createTestRule(t, m, "my-topic", "my-rule")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+	})
+
+	t.Run("rule not found", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "my-topic", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("topic not found", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "missing", "my-rule")
+		require.Error(t, err)
+	})
+
+	t.Run("empty topic name", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "", "my-rule")
+		require.Error(t, err)
+	})
+}
+
+func TestGetRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+	createTestRule(t, m, "my-topic", "my-rule")
+
+	t.Run("success", func(t *testing.T) {
+		rule, err := m.GetRule(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, "my-rule", rule.Name)
+		assert.Equal(t, "my-topic", rule.EventBus)
+	})
+
+	t.Run("rule not found", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "my-topic", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("topic not found", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "missing", "my-rule")
+		require.Error(t, err)
+	})
+
+	t.Run("empty topic name", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "", "my-rule")
+		require.Error(t, err)
+	})
+}
+
+func TestListRules(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+
+	t.Run("empty list", func(t *testing.T) {
+		rules, err := m.ListRules(ctx, "my-topic")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(rules))
+	})
+
+	createTestRule(t, m, "my-topic", "rule-a")
+	createTestRule(t, m, "my-topic", "rule-b")
+
+	t.Run("two rules", func(t *testing.T) {
+		rules, err := m.ListRules(ctx, "my-topic")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(rules))
+	})
+
+	t.Run("topic not found", func(t *testing.T) {
+		_, err := m.ListRules(ctx, "missing")
+		require.Error(t, err)
+	})
+
+	t.Run("empty topic name", func(t *testing.T) {
+		_, err := m.ListRules(ctx, "")
+		require.Error(t, err)
+	})
+}
+
+func TestEnableDisableRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+	createTestRule(t, m, "my-topic", "my-rule")
+
+	t.Run("disable rule", func(t *testing.T) {
+		err := m.DisableRule(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+
+		rule, err := m.GetRule(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, "DISABLED", rule.State)
+	})
+
+	t.Run("enable rule", func(t *testing.T) {
+		err := m.EnableRule(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+
+		rule, err := m.GetRule(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, "ENABLED", rule.State)
+	})
+
+	t.Run("enable nonexistent rule", func(t *testing.T) {
+		err := m.EnableRule(ctx, "my-topic", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("disable nonexistent topic", func(t *testing.T) {
+		err := m.DisableRule(ctx, "missing", "my-rule")
+		require.Error(t, err)
+	})
+
+	t.Run("enable empty topic", func(t *testing.T) {
+		err := m.EnableRule(ctx, "", "my-rule")
+		require.Error(t, err)
+	})
+}
+
+func TestPutTargets(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+	createTestRule(t, m, "my-topic", "my-rule")
+
+	t.Run("add targets", func(t *testing.T) {
+		targets := []driver.Target{
+			{ID: "t1", ARN: "/subscriptions/123/functions/func1"},
+			{ID: "t2", ARN: "/subscriptions/123/functions/func2"},
+		}
+
+		err := m.PutTargets(ctx, "my-topic", "my-rule", targets)
+		require.NoError(t, err)
+
+		listed, err := m.ListTargets(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(listed))
+	})
+
+	t.Run("update existing target", func(t *testing.T) {
+		targets := []driver.Target{
+			{ID: "t1", ARN: "/subscriptions/123/functions/updated-func"},
+		}
+
+		err := m.PutTargets(ctx, "my-topic", "my-rule", targets)
+		require.NoError(t, err)
+
+		listed, err := m.ListTargets(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(listed))
+	})
+
+	t.Run("rule not found", func(t *testing.T) {
+		err := m.PutTargets(ctx, "my-topic", "missing", []driver.Target{{ID: "t1"}})
+		require.Error(t, err)
+	})
+
+	t.Run("topic not found", func(t *testing.T) {
+		err := m.PutTargets(ctx, "missing", "my-rule", []driver.Target{{ID: "t1"}})
+		require.Error(t, err)
+	})
+}
+
+func TestRemoveTargets(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+	createTestRule(t, m, "my-topic", "my-rule")
+
+	targets := []driver.Target{
+		{ID: "t1", ARN: "/subscriptions/123/functions/func1"},
+		{ID: "t2", ARN: "/subscriptions/123/functions/func2"},
+		{ID: "t3", ARN: "/subscriptions/123/functions/func3"},
+	}
+
+	err := m.PutTargets(ctx, "my-topic", "my-rule", targets)
+	require.NoError(t, err)
+
+	t.Run("remove one target", func(t *testing.T) {
+		err := m.RemoveTargets(ctx, "my-topic", "my-rule", []string{"t2"})
+		require.NoError(t, err)
+
+		listed, err := m.ListTargets(ctx, "my-topic", "my-rule")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(listed))
+	})
+
+	t.Run("remove nonexistent target is idempotent", func(t *testing.T) {
+		err := m.RemoveTargets(ctx, "my-topic", "my-rule", []string{"nonexistent"})
+		require.NoError(t, err)
+	})
+
+	t.Run("rule not found", func(t *testing.T) {
+		err := m.RemoveTargets(ctx, "my-topic", "missing", []string{"t1"})
+		require.Error(t, err)
+	})
+
+	t.Run("topic not found", func(t *testing.T) {
+		err := m.RemoveTargets(ctx, "missing", "my-rule", []string{"t1"})
+		require.Error(t, err)
+	})
+}
+
+func TestPutEvents(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{
+				Source:     "my.app",
+				DetailType: "OrderPlaced",
+				Detail:     `{"orderId":"123"}`,
+				EventBus:   "my-topic",
+			},
+		}
+
+		result, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.SuccessCount)
+		assert.Equal(t, 0, result.FailCount)
+		assert.Equal(t, 1, len(result.EventIDs))
+	})
+
+	t.Run("multiple events", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{Source: "app1", DetailType: "Event1", Detail: "{}", EventBus: "my-topic"},
+			{Source: "app2", DetailType: "Event2", Detail: "{}", EventBus: "my-topic"},
+		}
+
+		result, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.SuccessCount)
+		assert.Equal(t, 0, result.FailCount)
+	})
+
+	t.Run("topic not found increments fail count", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt", Detail: "{}", EventBus: "missing"},
+		}
+
+		result, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+
+	t.Run("empty event bus fails", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt", Detail: "{}"},
+		}
+
+		result, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+
+	t.Run("mixed success and failure", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Good", Detail: "{}", EventBus: "my-topic"},
+			{Source: "app", DetailType: "Bad", Detail: "{}", EventBus: "missing"},
+		}
+
+		result, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+}
+
+func TestEventPatternMatching(t *testing.T) {
+	tests := []struct {
+		name         string
+		pattern      string
+		event        driver.Event
+		expectMatch  bool
+	}{
+		{
+			name:    "empty pattern matches all",
+			pattern: "",
+			event: driver.Event{
+				Source:     "any.source",
+				DetailType: "AnyType",
+			},
+			expectMatch: true,
+		},
+		{
+			name:    "source match",
+			pattern: `{"source":["my.app"]}`,
+			event: driver.Event{
+				Source:     "my.app",
+				DetailType: "SomeType",
+			},
+			expectMatch: true,
+		},
+		{
+			name:    "source no match",
+			pattern: `{"source":["my.app"]}`,
+			event: driver.Event{
+				Source:     "other.app",
+				DetailType: "SomeType",
+			},
+			expectMatch: false,
+		},
+		{
+			name:    "detail-type match",
+			pattern: `{"detail-type":["OrderPlaced"]}`,
+			event: driver.Event{
+				Source:     "any",
+				DetailType: "OrderPlaced",
+			},
+			expectMatch: true,
+		},
+		{
+			name:    "detail-type no match",
+			pattern: `{"detail-type":["OrderPlaced"]}`,
+			event: driver.Event{
+				Source:     "any",
+				DetailType: "OrderCancelled",
+			},
+			expectMatch: false,
+		},
+		{
+			name:    "both source and detail-type match",
+			pattern: `{"source":["my.app"],"detail-type":["OrderPlaced"]}`,
+			event: driver.Event{
+				Source:     "my.app",
+				DetailType: "OrderPlaced",
+			},
+			expectMatch: true,
+		},
+		{
+			name:    "source matches but detail-type does not",
+			pattern: `{"source":["my.app"],"detail-type":["OrderPlaced"]}`,
+			event: driver.Event{
+				Source:     "my.app",
+				DetailType: "OrderCancelled",
+			},
+			expectMatch: false,
+		},
+		{
+			name:    "multiple allowed sources",
+			pattern: `{"source":["app1","app2"]}`,
+			event: driver.Event{
+				Source:     "app2",
+				DetailType: "Evt",
+			},
+			expectMatch: true,
+		},
+		{
+			name:    "invalid json pattern no match",
+			pattern: `{invalid`,
+			event: driver.Event{
+				Source: "any",
+			},
+			expectMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchesPattern(&tc.event, tc.pattern)
+			assert.Equal(t, tc.expectMatch, got)
+		})
+	}
+}
+
+func TestMatchedRulesIntegration(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestTopic(t, m, "my-topic")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "order-rule",
+		EventBus:     "my-topic",
+		EventPattern: `{"source":["order.service"]}`,
+	})
+	require.NoError(t, err)
+
+	_, err = m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "catch-all",
+		EventBus:     "my-topic",
+		EventPattern: "",
+	})
+	require.NoError(t, err)
+
+	t.Run("event matches specific rule and catch-all", func(t *testing.T) {
+		event := &driver.Event{
+			Source:     "order.service",
+			DetailType: "OrderCreated",
+			EventBus:   "my-topic",
+		}
+		matched := m.MatchedRules(event)
+		assert.Equal(t, 2, len(matched))
+	})
+
+	t.Run("event matches only catch-all", func(t *testing.T) {
+		event := &driver.Event{
+			Source:     "other.service",
+			DetailType: "SomeEvent",
+			EventBus:   "my-topic",
+		}
+		matched := m.MatchedRules(event)
+		assert.Equal(t, 1, len(matched))
+	})
+
+	t.Run("disabled rule not matched", func(t *testing.T) {
+		err := m.DisableRule(ctx, "my-topic", "catch-all")
+		require.NoError(t, err)
+
+		event := &driver.Event{
+			Source:     "other.service",
+			DetailType: "SomeEvent",
+			EventBus:   "my-topic",
+		}
+		matched := m.MatchedRules(event)
+		assert.Equal(t, 0, len(matched))
+	})
+}
+
+func TestGetEventHistory(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("retrieves published events", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt1", Detail: `{"k":"v1"}`, EventBus: "my-topic"},
+			{Source: "app", DetailType: "Evt2", Detail: `{"k":"v2"}`, EventBus: "my-topic"},
+			{Source: "app", DetailType: "Evt3", Detail: `{"k":"v3"}`, EventBus: "my-topic"},
+		}
+
+		_, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+
+		history, err := m.GetEventHistory(ctx, "my-topic", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(history))
+	})
+
+	t.Run("limit returns last N events", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt1", Detail: "{}", EventBus: "my-topic"},
+			{Source: "app", DetailType: "Evt2", Detail: "{}", EventBus: "my-topic"},
+			{Source: "app", DetailType: "Evt3", Detail: "{}", EventBus: "my-topic"},
+		}
+
+		_, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+
+		history, err := m.GetEventHistory(ctx, "my-topic", 2)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(history))
+	})
+
+	t.Run("empty history", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		history, err := m.GetEventHistory(ctx, "my-topic", 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(history))
+	})
+
+	t.Run("topic not found", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.GetEventHistory(ctx, "missing", 0)
+		require.Error(t, err)
+	})
+
+	t.Run("empty topic name", func(t *testing.T) {
+		m, _ := newTestMock()
+
+		_, err := m.GetEventHistory(ctx, "", 0)
+		require.Error(t, err)
+	})
+}
+
+// fakeMonitoring is a minimal monitoring mock for testing metric emission.
+type fakeMonitoring struct {
+	data []mondriver.MetricDatum
+}
+
+func (f *fakeMonitoring) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	f.data = append(f.data, data...)
+	return nil
+}
+
+func (f *fakeMonitoring) GetMetricData(
+	_ context.Context, _ mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (f *fakeMonitoring) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (f *fakeMonitoring) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (f *fakeMonitoring) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeMonitoring) DescribeAlarms(
+	_ context.Context, _ []string,
+) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (f *fakeMonitoring) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("publish emits PublishedEvents and MatchedEvents", func(t *testing.T) {
+		m, _ := newTestMock()
+		mon := &fakeMonitoring{}
+		m.SetMonitoring(mon)
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt", Detail: "{}", EventBus: "my-topic"},
+		}
+
+		_, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, mon.data)
+
+		metricNames := make(map[string]bool)
+		for _, d := range mon.data {
+			metricNames[d.MetricName] = true
+			assert.Equal(t, "Microsoft.EventGrid/topics", d.Namespace)
+			assert.Equal(t, "my-topic", d.Dimensions["topicName"])
+		}
+
+		assert.True(t, metricNames["PublishedEvents"], "expected PublishedEvents metric")
+		assert.True(t, metricNames["MatchedEvents"], "expected MatchedEvents metric")
+	})
+
+	t.Run("failed events do not emit metrics", func(t *testing.T) {
+		m, _ := newTestMock()
+		mon := &fakeMonitoring{}
+		m.SetMonitoring(mon)
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt", Detail: "{}", EventBus: "missing"},
+		}
+
+		_, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, len(mon.data))
+	})
+
+	t.Run("no monitoring does not panic", func(t *testing.T) {
+		m, _ := newTestMock()
+		createTestTopic(t, m, "my-topic")
+
+		events := []driver.Event{
+			{Source: "app", DetailType: "Evt", Detail: "{}", EventBus: "my-topic"},
+		}
+
+		_, err := m.PutEvents(ctx, events)
+		require.NoError(t, err)
+	})
+}

--- a/providers/azure/functions/aliases.go
+++ b/providers/azure/functions/aliases.go
@@ -1,0 +1,147 @@
+package functions
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// CreateAlias creates a new deployment slot alias pointing to a specific function version.
+func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if fd.aliases.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "alias %s already exists", cfg.Name)
+	}
+
+	if !m.versionExists(&fd, cfg.FunctionVersion) {
+		return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
+	}
+
+	aliasARN := idgen.AzureID(
+		m.opts.AccountID, "cloudemu-rg", "Microsoft.Web",
+		"sites", cfg.FunctionName+"/slots/"+cfg.Name,
+	)
+
+	a := driver.Alias{
+		FunctionName:    cfg.FunctionName,
+		Name:            cfg.Name,
+		FunctionVersion: cfg.FunctionVersion,
+		Description:     cfg.Description,
+		RoutingConfig:   cfg.RoutingConfig,
+		AliasARN:        aliasARN,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+
+	fd.aliases.Set(cfg.Name, &aliasData{alias: a})
+
+	result := a
+
+	return &result, nil
+}
+
+// UpdateAlias updates an existing deployment slot alias.
+func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	ad, ok := fd.aliases.Get(cfg.Name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", cfg.Name)
+	}
+
+	if cfg.FunctionVersion != "" {
+		if !m.versionExists(&fd, cfg.FunctionVersion) {
+			return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
+		}
+
+		ad.alias.FunctionVersion = cfg.FunctionVersion
+	}
+
+	if cfg.Description != "" {
+		ad.alias.Description = cfg.Description
+	}
+
+	if cfg.RoutingConfig != nil {
+		ad.alias.RoutingConfig = cfg.RoutingConfig
+	}
+
+	fd.aliases.Set(cfg.Name, ad)
+
+	result := ad.alias
+
+	return &result, nil
+}
+
+// DeleteAlias removes a deployment slot alias from a function.
+func (m *Mock) DeleteAlias(_ context.Context, functionName, aliasName string) error {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if !fd.aliases.Has(aliasName) {
+		return cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
+	}
+
+	fd.aliases.Delete(aliasName)
+
+	return nil
+}
+
+// GetAlias retrieves a specific deployment slot alias for a function.
+func (m *Mock) GetAlias(_ context.Context, functionName, aliasName string) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	ad, ok := fd.aliases.Get(aliasName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
+	}
+
+	result := ad.alias
+
+	return &result, nil
+}
+
+// ListAliases returns all deployment slot aliases for a function.
+func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Alias, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	all := fd.aliases.All()
+	aliases := make([]driver.Alias, 0, len(all))
+
+	for _, ad := range all {
+		aliases = append(aliases, ad.alias)
+	}
+
+	return aliases, nil
+}
+
+// versionExists checks whether a version string exists for the given function.
+func (*Mock) versionExists(fd *funcData, version string) bool {
+	if version == latestVersion {
+		return true
+	}
+
+	for _, v := range fd.versions {
+		if v.version == version {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/azure/functions/aliases.go
+++ b/providers/azure/functions/aliases.go
@@ -34,7 +34,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Name:            cfg.Name,
 		FunctionVersion: cfg.FunctionVersion,
 		Description:     cfg.Description,
-		RoutingConfig:   cfg.RoutingConfig,
+		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
 		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
 	}
@@ -71,7 +71,7 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	}
 
 	if cfg.RoutingConfig != nil {
-		ad.alias.RoutingConfig = cfg.RoutingConfig
+		ad.alias.RoutingConfig = copyRoutingConfig(cfg.RoutingConfig)
 	}
 
 	fd.aliases.Set(cfg.Name, ad)
@@ -129,6 +129,16 @@ func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Ali
 	}
 
 	return aliases, nil
+}
+
+func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig {
+	if rc == nil {
+		return nil
+	}
+
+	cp := *rc
+
+	return &cp
 }
 
 // versionExists checks whether a version string exists for the given function.

--- a/providers/azure/functions/concurrency.go
+++ b/providers/azure/functions/concurrency.go
@@ -1,0 +1,53 @@
+package functions
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PutFunctionConcurrency sets reserved concurrency for an Azure Function.
+func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyConfig) error {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	fd.concurrency = &driver.ConcurrencyConfig{
+		FunctionName:                 cfg.FunctionName,
+		ReservedConcurrentExecutions: cfg.ReservedConcurrentExecutions,
+	}
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	return nil
+}
+
+// GetFunctionConcurrency retrieves the concurrency configuration for an Azure Function.
+func (m *Mock) GetFunctionConcurrency(_ context.Context, functionName string) (*driver.ConcurrencyConfig, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if fd.concurrency == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no concurrency config for function %s", functionName)
+	}
+
+	result := *fd.concurrency
+
+	return &result, nil
+}
+
+// DeleteFunctionConcurrency removes the concurrency configuration for an Azure Function.
+func (m *Mock) DeleteFunctionConcurrency(_ context.Context, functionName string) error {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	fd.concurrency = nil
+	m.funcs.Set(functionName, fd)
+
+	return nil
+}

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -3,6 +3,8 @@ package functions
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"sync"
 	"time"
 
@@ -10,29 +12,83 @@ import (
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/serverless/driver"
 )
 
 // Compile-time check that Mock implements driver.Serverless.
 var _ driver.Serverless = (*Mock)(nil)
 
+// initialVersion is the starting version number for published versions.
+const initialVersion = 1
+
+type versionData struct {
+	config    driver.FunctionConfig
+	version   string
+	codeSHA   string
+	createdAt string
+}
+
+type aliasData struct {
+	alias driver.Alias
+}
+
+type layerData struct {
+	versions *memstore.Store[*driver.LayerVersion]
+	nextVer  int
+}
+
 type funcData struct {
-	info    driver.FunctionInfo
-	handler driver.HandlerFunc
+	info        driver.FunctionInfo
+	handler     driver.HandlerFunc
+	versions    []*versionData
+	nextVersion int
+	aliases     *memstore.Store[*aliasData]
+	concurrency *driver.ConcurrencyConfig
 }
 
 // Mock is an in-memory mock implementation of Azure Functions.
 type Mock struct {
 	funcs      *memstore.Store[funcData]
+	layers     *memstore.Store[*layerData]
 	opts       *config.Options
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(functionName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.Web/sites",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"functionName": functionName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Azure Functions mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		funcs:    memstore.New[funcData](),
+		layers:   memstore.New[*layerData](),
 		opts:     opts,
 		handlers: make(map[string]driver.HandlerFunc),
 	}
@@ -58,7 +114,12 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	h := m.handlers[cfg.Name]
 	m.handlersMu.RUnlock()
 
-	m.funcs.Set(cfg.Name, funcData{info: info, handler: h})
+	m.funcs.Set(cfg.Name, funcData{
+		info: info, handler: h,
+		nextVersion: initialVersion,
+		aliases:     memstore.New[*aliasData](),
+	})
+
 	result := info
 
 	return &result, nil
@@ -109,33 +170,11 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 	}
 
 	info := fd.info
-
-	if cfg.Runtime != "" {
-		info.Runtime = cfg.Runtime
-	}
-
-	if cfg.Handler != "" {
-		info.Handler = cfg.Handler
-	}
-
-	if cfg.Memory != 0 {
-		info.Memory = cfg.Memory
-	}
-
-	if cfg.Timeout != 0 {
-		info.Timeout = cfg.Timeout
-	}
-
-	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
-	}
-
-	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
-	}
-
+	applyConfigUpdates(&info, cfg)
 	info.LastModified = time.Now().UTC().Format(time.RFC3339)
-	m.funcs.Set(name, funcData{info: info, handler: fd.handler})
+	fd.info = info
+	m.funcs.Set(name, fd)
+
 	result := info
 
 	return &result, nil
@@ -161,8 +200,16 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 
 	payload, err := h(ctx, input.Payload)
 	if err != nil {
+		m.emitMetric(input.FunctionName, map[string]float64{
+			"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1, "FunctionErrors": 1,
+		})
+
 		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
 	}
+
+	m.emitMetric(input.FunctionName, map[string]float64{
+		"FunctionExecutionCount": 1, "FunctionExecutionUnits": 1,
+	})
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
 }
@@ -177,4 +224,40 @@ func (m *Mock) RegisterHandler(name string, handler driver.HandlerFunc) {
 		fd.handler = handler
 		m.funcs.Set(name, fd)
 	}
+}
+
+// applyConfigUpdates applies non-zero config fields to the function info.
+//
+//nolint:gocritic // hugeParam: config passed by value intentionally for snapshot semantics.
+func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
+	if cfg.Runtime != "" {
+		info.Runtime = cfg.Runtime
+	}
+
+	if cfg.Handler != "" {
+		info.Handler = cfg.Handler
+	}
+
+	if cfg.Memory != 0 {
+		info.Memory = cfg.Memory
+	}
+
+	if cfg.Timeout != 0 {
+		info.Timeout = cfg.Timeout
+	}
+
+	if cfg.Environment != nil {
+		info.Environment = cfg.Environment
+	}
+
+	if cfg.Tags != nil {
+		info.Tags = cfg.Tags
+	}
+}
+
+func codeSHA(info *driver.FunctionInfo) string {
+	data := fmt.Sprintf("%s:%s:%s", info.Name, info.Handler, info.Runtime)
+	hash := sha256.Sum256([]byte(data))
+
+	return fmt.Sprintf("%x", hash)
 }

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -55,6 +55,7 @@ type Mock struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
+	mu         sync.Mutex // guards PublishVersion read-modify-write on funcData
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.

--- a/providers/azure/functions/functions_test.go
+++ b/providers/azure/functions/functions_test.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -921,4 +922,66 @@ func TestDeleteFunctionConcurrency(t *testing.T) {
 		err = m.DeleteFunctionConcurrency(ctx, "fn-del-cc2")
 		require.NoError(t, err)
 	})
+}
+
+func TestPublishVersionConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn-conc", Runtime: "dotnet6"})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			_, _ = m.PublishVersion(ctx, "fn-conc", "concurrent")
+		}()
+	}
+
+	wg.Wait()
+
+	versions, err := m.ListVersions(ctx, "fn-conc")
+	require.NoError(t, err)
+	require.Len(t, versions, 11) // $LATEST + 10 published
+
+	seen := make(map[string]bool)
+	for _, v := range versions {
+		assert.False(t, seen[v.Version], "duplicate version: %s", v.Version)
+		seen[v.Version] = true
+	}
+}
+
+func TestAliasRoutingConfigDeepCopy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn-dc", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn-dc", "v1")
+	require.NoError(t, err)
+
+	rc := &driver.AliasRoutingConfig{
+		AdditionalVersion: "1",
+		Weight:            0.5,
+	}
+
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "fn-dc",
+		Name:            "deep-copy",
+		FunctionVersion: "$LATEST",
+		RoutingConfig:   rc,
+	})
+	require.NoError(t, err)
+
+	// Mutate the original config
+	rc.Weight = 0.9
+
+	alias, err := m.GetAlias(ctx, "fn-dc", "deep-copy")
+	require.NoError(t, err)
+	require.NotNil(t, alias.RoutingConfig)
+	assert.InDelta(t, 0.5, alias.RoutingConfig.Weight, 0.001)
 }

--- a/providers/azure/functions/functions_test.go
+++ b/providers/azure/functions/functions_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/serverless/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -225,4 +226,699 @@ func TestRegisterHandlerBeforeCreate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 200, out.StatusCode)
 	assert.Equal(t, "pre-registered", string(out.Payload))
+}
+
+func TestPublishVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6", Handler: "MyApp::Handler"})
+	require.NoError(t, err)
+
+	t.Run("publish first version", func(t *testing.T) {
+		ver, err := m.PublishVersion(ctx, "fn1", "first release")
+		require.NoError(t, err)
+		assert.Equal(t, "1", ver.Version)
+		assert.Equal(t, "fn1", ver.FunctionName)
+		assert.Equal(t, "first release", ver.Description)
+		assert.NotEmpty(t, ver.CodeSHA256)
+		assert.NotEmpty(t, ver.CreatedAt)
+	})
+
+	t.Run("publish second version", func(t *testing.T) {
+		ver, err := m.PublishVersion(ctx, "fn1", "second release")
+		require.NoError(t, err)
+		assert.Equal(t, "2", ver.Version)
+	})
+
+	t.Run("list versions includes $LATEST and published", func(t *testing.T) {
+		versions, err := m.ListVersions(ctx, "fn1")
+		require.NoError(t, err)
+		assert.Len(t, versions, 3) // $LATEST + 2 published
+		assert.Equal(t, "$LATEST", versions[0].Version)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.PublishVersion(ctx, "missing", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCreateAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v1")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cfg     driver.AliasConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "create alias to version 1",
+			cfg: driver.AliasConfig{
+				FunctionName: "fn1", Name: "prod", FunctionVersion: "1", Description: "production slot",
+			},
+		},
+		{
+			name: "create alias to $LATEST",
+			cfg: driver.AliasConfig{
+				FunctionName: "fn1", Name: "staging", FunctionVersion: "$LATEST",
+			},
+		},
+		{
+			name: "duplicate alias",
+			cfg: driver.AliasConfig{
+				FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+			},
+			wantErr: true, errMsg: "already exists",
+		},
+		{
+			name: "version not found",
+			cfg: driver.AliasConfig{
+				FunctionName: "fn1", Name: "bad", FunctionVersion: "999",
+			},
+			wantErr: true, errMsg: "not found",
+		},
+		{
+			name: "function not found",
+			cfg: driver.AliasConfig{
+				FunctionName: "missing", Name: "alias", FunctionVersion: "1",
+			},
+			wantErr: true, errMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := m.CreateAlias(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, tt.cfg.Name, result.Name)
+				assert.Equal(t, tt.cfg.FunctionVersion, result.FunctionVersion)
+				assert.NotEmpty(t, result.AliasARN)
+			}
+		})
+	}
+}
+
+func TestUpdateAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v1")
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v2")
+	require.NoError(t, err)
+
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	t.Run("update version", func(t *testing.T) {
+		result, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "prod", FunctionVersion: "2",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "2", result.FunctionVersion)
+	})
+
+	t.Run("alias not found", func(t *testing.T) {
+		_, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "missing", FunctionVersion: "1",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "missing", Name: "prod", FunctionVersion: "1",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeleteAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v1")
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		fnName   string
+		alias    string
+		wantErr  bool
+		errMsg   string
+	}{
+		{name: "success", fnName: "fn1", alias: "prod"},
+		{name: "alias not found", fnName: "fn1", alias: "missing", wantErr: true, errMsg: "not found"},
+		{name: "function not found", fnName: "missing", alias: "prod", wantErr: true, errMsg: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.DeleteAlias(ctx, tt.fnName, tt.alias)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPublishLayerVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("publish first version", func(t *testing.T) {
+		lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name:               "my-extension",
+			Description:        "shared utils",
+			Content:            []byte("extension-code"),
+			CompatibleRuntimes: []string{"dotnet6", "dotnet8"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-extension", lv.Name)
+		assert.Equal(t, 1, lv.Version)
+		assert.NotEmpty(t, lv.ContentSHA256)
+		assert.Equal(t, int64(14), lv.ContentSize)
+		assert.NotEmpty(t, lv.ARN)
+	})
+
+	t.Run("publish second version", func(t *testing.T) {
+		lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name:    "my-extension",
+			Content: []byte("updated-code"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, lv.Version)
+	})
+
+	t.Run("list versions", func(t *testing.T) {
+		versions, err := m.ListLayerVersions(ctx, "my-extension")
+		require.NoError(t, err)
+		assert.Len(t, versions, 2)
+	})
+
+	t.Run("get specific version", func(t *testing.T) {
+		lv, err := m.GetLayerVersion(ctx, "my-extension", 1)
+		require.NoError(t, err)
+		assert.Equal(t, 1, lv.Version)
+		assert.Equal(t, "shared utils", lv.Description)
+	})
+}
+
+func TestDeleteLayerVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "ext", Content: []byte("code"),
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		layer   string
+		version int
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "success", layer: "ext", version: 1},
+		{name: "version not found", layer: "ext", version: 99, wantErr: true, errMsg: "not found"},
+		{name: "extension not found", layer: "missing", version: 1, wantErr: true, errMsg: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.DeleteLayerVersion(ctx, tt.layer, tt.version)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPutFunctionConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+
+	t.Run("set concurrency", func(t *testing.T) {
+		err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName: "fn1", ReservedConcurrentExecutions: 10,
+		})
+		require.NoError(t, err)
+
+		cfg, err := m.GetFunctionConcurrency(ctx, "fn1")
+		require.NoError(t, err)
+		assert.Equal(t, 10, cfg.ReservedConcurrentExecutions)
+	})
+
+	t.Run("update concurrency", func(t *testing.T) {
+		err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName: "fn1", ReservedConcurrentExecutions: 50,
+		})
+		require.NoError(t, err)
+
+		cfg, err := m.GetFunctionConcurrency(ctx, "fn1")
+		require.NoError(t, err)
+		assert.Equal(t, 50, cfg.ReservedConcurrentExecutions)
+	})
+
+	t.Run("delete concurrency", func(t *testing.T) {
+		err := m.DeleteFunctionConcurrency(ctx, "fn1")
+		require.NoError(t, err)
+
+		_, err = m.GetFunctionConcurrency(ctx, "fn1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no concurrency")
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		err := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName: "missing", ReservedConcurrentExecutions: 10,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestFunctionsMetricsEmission(t *testing.T) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithAccountID("test-sub"))
+	m := New(opts)
+
+	mon := &funcMetricsCollector{}
+	m.SetMonitoring(mon)
+
+	ctx := context.Background()
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+
+	m.RegisterHandler("fn1", func(_ context.Context, payload []byte) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	t.Run("successful invoke emits metrics", func(t *testing.T) {
+		mon.reset()
+		_, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "fn1", Payload: []byte("test")})
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.Web/sites", "FunctionExecutionCount"))
+		assert.True(t, mon.hasMetric("Microsoft.Web/sites", "FunctionExecutionUnits"))
+		assert.False(t, mon.hasMetric("Microsoft.Web/sites", "FunctionErrors"))
+	})
+
+	t.Run("failed invoke emits error metrics", func(t *testing.T) {
+		m.RegisterHandler("fn1", func(_ context.Context, _ []byte) ([]byte, error) {
+			return nil, errors.New("boom")
+		})
+		mon.reset()
+		_, err := m.Invoke(ctx, driver.InvokeInput{FunctionName: "fn1"})
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.Web/sites", "FunctionErrors"))
+	})
+}
+
+type funcMetricsCollector struct {
+	data []mondriver.MetricDatum
+}
+
+func (c *funcMetricsCollector) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	c.data = append(c.data, data...)
+	return nil
+}
+
+func (c *funcMetricsCollector) GetMetricData(_ context.Context, _ mondriver.GetMetricInput) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (c *funcMetricsCollector) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (c *funcMetricsCollector) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (c *funcMetricsCollector) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (c *funcMetricsCollector) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (c *funcMetricsCollector) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *funcMetricsCollector) reset() {
+	c.data = nil
+}
+
+func (c *funcMetricsCollector) hasMetric(namespace, metricName string) bool {
+	for _, d := range c.data {
+		if d.Namespace == namespace && d.MetricName == metricName {
+			return true
+		}
+	}
+	return false
+}
+
+func TestListVersions(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.ListVersions(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("only LATEST when no published versions", func(t *testing.T) {
+		_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn-ver", Runtime: "dotnet6", Handler: "h"})
+		require.NoError(t, err)
+
+		versions, err := m.ListVersions(ctx, "fn-ver")
+		require.NoError(t, err)
+		require.Len(t, versions, 1)
+		assert.Equal(t, "$LATEST", versions[0].Version)
+	})
+
+	t.Run("multiple published versions", func(t *testing.T) {
+		_, err := m.PublishVersion(ctx, "fn-ver", "v1")
+		require.NoError(t, err)
+		_, err = m.PublishVersion(ctx, "fn-ver", "v2")
+		require.NoError(t, err)
+		_, err = m.PublishVersion(ctx, "fn-ver", "v3")
+		require.NoError(t, err)
+
+		versions, err := m.ListVersions(ctx, "fn-ver")
+		require.NoError(t, err)
+		assert.Len(t, versions, 4) // $LATEST + 3 published
+		assert.Equal(t, "$LATEST", versions[0].Version)
+		assert.Equal(t, "1", versions[1].Version)
+		assert.Equal(t, "2", versions[2].Version)
+		assert.Equal(t, "3", versions[3].Version)
+	})
+}
+
+func TestGetAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v1")
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		alias, err := m.GetAlias(ctx, "fn1", "prod")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", alias.Name)
+		assert.Equal(t, "1", alias.FunctionVersion)
+		assert.Equal(t, "fn1", alias.FunctionName)
+		assert.NotEmpty(t, alias.AliasARN)
+	})
+
+	t.Run("alias not found", func(t *testing.T) {
+		_, err := m.GetAlias(ctx, "fn1", "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.GetAlias(ctx, "missing-fn", "prod")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestListAliases(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v1")
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v2")
+	require.NoError(t, err)
+
+	t.Run("empty", func(t *testing.T) {
+		aliases, err := m.ListAliases(ctx, "fn1")
+		require.NoError(t, err)
+		assert.Empty(t, aliases)
+	})
+
+	t.Run("multiple aliases", func(t *testing.T) {
+		_, err := m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+		})
+		require.NoError(t, err)
+
+		_, err = m.CreateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "staging", FunctionVersion: "2",
+		})
+		require.NoError(t, err)
+
+		aliases, err := m.ListAliases(ctx, "fn1")
+		require.NoError(t, err)
+		assert.Len(t, aliases, 2)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.ListAliases(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestUpdateAliasWithRoutingConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn1", Runtime: "dotnet6"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v1")
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "fn1", "v2")
+	require.NoError(t, err)
+
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	t.Run("update with routing config", func(t *testing.T) {
+		rc := &driver.AliasRoutingConfig{
+			AdditionalVersion: "2",
+			Weight:            0.1,
+		}
+		result, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "prod", FunctionVersion: "1",
+			RoutingConfig: rc,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result.RoutingConfig)
+		assert.Equal(t, "2", result.RoutingConfig.AdditionalVersion)
+		assert.InDelta(t, 0.1, result.RoutingConfig.Weight, 0.001)
+	})
+
+	t.Run("update description only", func(t *testing.T) {
+		result, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "prod", Description: "updated desc",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "updated desc", result.Description)
+		// Routing config should be preserved from previous update
+		require.NotNil(t, result.RoutingConfig)
+	})
+
+	t.Run("update version not found", func(t *testing.T) {
+		_, err := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "fn1", Name: "prod", FunctionVersion: "999",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestGetLayerVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "ext1", Content: []byte("code"), Description: "test extension",
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		lv, err := m.GetLayerVersion(ctx, "ext1", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "ext1", lv.Name)
+		assert.Equal(t, 1, lv.Version)
+		assert.Equal(t, "test extension", lv.Description)
+		assert.NotEmpty(t, lv.ContentSHA256)
+		assert.NotEmpty(t, lv.ARN)
+	})
+
+	t.Run("version not found", func(t *testing.T) {
+		_, err := m.GetLayerVersion(ctx, "ext1", 99)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("extension not found", func(t *testing.T) {
+		_, err := m.GetLayerVersion(ctx, "missing", 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestListLayers(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty", func(t *testing.T) {
+		m := newTestMock()
+		layers, err := m.ListLayers(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, layers)
+	})
+
+	t.Run("multiple layers with latest versions", func(t *testing.T) {
+		m := newTestMock()
+
+		_, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name: "ext-a", Content: []byte("a-v1"),
+		})
+		require.NoError(t, err)
+		_, err = m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name: "ext-a", Content: []byte("a-v2"),
+		})
+		require.NoError(t, err)
+
+		_, err = m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name: "ext-b", Content: []byte("b-v1"),
+		})
+		require.NoError(t, err)
+
+		layers, err := m.ListLayers(ctx)
+		require.NoError(t, err)
+		assert.Len(t, layers, 2)
+
+		// Verify we get latest version for each layer
+		for _, layer := range layers {
+			switch layer.Name {
+			case "ext-a":
+				assert.Equal(t, 2, layer.Version)
+			case "ext-b":
+				assert.Equal(t, 1, layer.Version)
+			}
+		}
+	})
+}
+
+func TestGetFunctionConcurrencyNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := m.GetFunctionConcurrency(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("no concurrency set", func(t *testing.T) {
+		_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn-nocc", Runtime: "dotnet6"})
+		require.NoError(t, err)
+
+		_, err = m.GetFunctionConcurrency(ctx, "fn-nocc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no concurrency")
+	})
+}
+
+func TestDeleteFunctionConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("function not found", func(t *testing.T) {
+		err := m.DeleteFunctionConcurrency(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("success removes concurrency config", func(t *testing.T) {
+		_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn-del-cc", Runtime: "dotnet6"})
+		require.NoError(t, err)
+
+		err = m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName: "fn-del-cc", ReservedConcurrentExecutions: 25,
+		})
+		require.NoError(t, err)
+
+		// Verify it exists
+		cfg, err := m.GetFunctionConcurrency(ctx, "fn-del-cc")
+		require.NoError(t, err)
+		assert.Equal(t, 25, cfg.ReservedConcurrentExecutions)
+
+		// Delete it
+		err = m.DeleteFunctionConcurrency(ctx, "fn-del-cc")
+		require.NoError(t, err)
+
+		// Verify it's gone
+		_, err = m.GetFunctionConcurrency(ctx, "fn-del-cc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no concurrency")
+	})
+
+	t.Run("delete when no concurrency set is idempotent", func(t *testing.T) {
+		_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "fn-del-cc2", Runtime: "dotnet6"})
+		require.NoError(t, err)
+
+		// Delete without ever setting - should still succeed
+		err = m.DeleteFunctionConcurrency(ctx, "fn-del-cc2")
+		require.NoError(t, err)
+	})
 }

--- a/providers/azure/functions/layers.go
+++ b/providers/azure/functions/layers.go
@@ -1,0 +1,137 @@
+package functions
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PublishLayerVersion publishes a new version of a shared code extension.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(cfg.Name)
+	if !ok {
+		ld = &layerData{
+			versions: memstore.New[*driver.LayerVersion](),
+			nextVer:  initialVersion,
+		}
+		m.layers.Set(cfg.Name, ld)
+	}
+
+	ver := ld.nextVer
+	ld.nextVer++
+
+	hash := sha256.Sum256(cfg.Content)
+	shaStr := fmt.Sprintf("%x", hash)
+
+	arn := idgen.AzureID(
+		m.opts.AccountID, "cloudemu-rg", "Microsoft.Web",
+		"extensions", cfg.Name+"/versions/"+strconv.Itoa(ver),
+	)
+
+	lv := &driver.LayerVersion{
+		Name:               cfg.Name,
+		Version:            ver,
+		Description:        cfg.Description,
+		ContentSHA256:      shaStr,
+		ContentSize:        int64(len(cfg.Content)),
+		CompatibleRuntimes: cfg.CompatibleRuntimes,
+		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		ARN:                arn,
+	}
+
+	ld.versions.Set(strconv.Itoa(ver), lv)
+
+	result := *lv
+
+	return &result, nil
+}
+
+// GetLayerVersion retrieves a specific version of a shared code extension.
+func (m *Mock) GetLayerVersion(_ context.Context, name string, version int) (*driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "extension %s not found", name)
+	}
+
+	lv, ok := ld.versions.Get(strconv.Itoa(version))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "extension %s version %d not found", name, version)
+	}
+
+	result := *lv
+
+	return &result, nil
+}
+
+// ListLayerVersions returns all versions of a shared code extension.
+func (m *Mock) ListLayerVersions(_ context.Context, name string) ([]driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "extension %s not found", name)
+	}
+
+	all := ld.versions.All()
+	result := make([]driver.LayerVersion, 0, len(all))
+
+	for _, lv := range all {
+		result = append(result, *lv)
+	}
+
+	return result, nil
+}
+
+// DeleteLayerVersion removes a specific version of a shared code extension.
+func (m *Mock) DeleteLayerVersion(_ context.Context, name string, version int) error {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "extension %s not found", name)
+	}
+
+	verStr := strconv.Itoa(version)
+	if !ld.versions.Has(verStr) {
+		return cerrors.Newf(cerrors.NotFound, "extension %s version %d not found", name, version)
+	}
+
+	ld.versions.Delete(verStr)
+
+	return nil
+}
+
+// ListLayers returns the latest version of each shared code extension.
+func (m *Mock) ListLayers(_ context.Context) ([]driver.LayerVersion, error) {
+	all := m.layers.All()
+	result := make([]driver.LayerVersion, 0, len(all))
+
+	for _, ld := range all {
+		latest := findLatestLayerVersion(ld)
+		if latest != nil {
+			result = append(result, *latest)
+		}
+	}
+
+	return result, nil
+}
+
+// findLatestLayerVersion returns the layer version with the highest version number.
+func findLatestLayerVersion(ld *layerData) *driver.LayerVersion {
+	all := ld.versions.All()
+
+	var latest *driver.LayerVersion
+
+	for _, lv := range all {
+		if latest == nil || lv.Version > latest.Version {
+			latest = lv
+		}
+	}
+
+	return latest
+}

--- a/providers/azure/functions/versions.go
+++ b/providers/azure/functions/versions.go
@@ -14,6 +14,9 @@ const latestVersion = "$LATEST"
 
 // PublishVersion snapshots the current function state as an immutable deployment slot version.
 func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(functionName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)

--- a/providers/azure/functions/versions.go
+++ b/providers/azure/functions/versions.go
@@ -1,0 +1,94 @@
+package functions
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// latestVersion is the symbolic version for the current function code.
+const latestVersion = "$LATEST"
+
+// PublishVersion snapshots the current function state as an immutable deployment slot version.
+func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	verNum := fd.nextVersion
+	fd.nextVersion++
+
+	verStr := strconv.Itoa(verNum)
+	sha := codeSHA(&fd.info)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	vd := &versionData{
+		config:    snapshotConfig(&fd.info),
+		version:   verStr,
+		codeSHA:   sha,
+		createdAt: now,
+	}
+	fd.versions = append(fd.versions, vd)
+	m.funcs.Set(functionName, fd)
+
+	return &driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      verStr,
+		Description:  description,
+		CodeSHA256:   sha,
+		CreatedAt:    now,
+	}, nil
+}
+
+// ListVersions returns all published versions (deployment slots) for a function.
+func (m *Mock) ListVersions(_ context.Context, functionName string) ([]driver.FunctionVersion, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	result := make([]driver.FunctionVersion, 0, len(fd.versions)+1)
+	result = append(result, driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      latestVersion,
+		CodeSHA256:   codeSHA(&fd.info),
+	})
+
+	for _, v := range fd.versions {
+		result = append(result, driver.FunctionVersion{
+			FunctionName: functionName,
+			Version:      v.version,
+			CodeSHA256:   v.codeSHA,
+			CreatedAt:    v.createdAt,
+		})
+	}
+
+	return result, nil
+}
+
+// snapshotConfig creates a FunctionConfig snapshot from a FunctionInfo.
+func snapshotConfig(info *driver.FunctionInfo) driver.FunctionConfig {
+	env := make(map[string]string, len(info.Environment))
+	for k, v := range info.Environment {
+		env[k] = v
+	}
+
+	tags := make(map[string]string, len(info.Tags))
+	for k, v := range info.Tags {
+		tags[k] = v
+	}
+
+	return driver.FunctionConfig{
+		Name:        info.Name,
+		Runtime:     info.Runtime,
+		Handler:     info.Handler,
+		Memory:      info.Memory,
+		Timeout:     info.Timeout,
+		Environment: env,
+		Tags:        tags,
+	}
+}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/logging/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 const (
@@ -35,8 +36,36 @@ type logGroup struct {
 
 // Mock is an in-memory mock implementation of Azure Log Analytics.
 type Mock struct {
-	groups *memstore.Store[*logGroup]
-	opts   *config.Options
+	groups     *memstore.Store[*logGroup]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(logGroupName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.OperationalInsights/workspaces",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"logGroupName": logGroupName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Log Analytics mock with the given configuration options.
@@ -221,6 +250,10 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 	m.groups.Update(groupName, func(lg *logGroup) *logGroup {
 		lg.info.StoredBytes += totalBytes
 		return lg
+	})
+
+	m.emitMetric(groupName, map[string]float64{
+		"IngestedEvents": float64(len(events)), "IngestedBytes": float64(totalBytes),
 	})
 
 	return nil

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/notification/driver"
 )
 
@@ -33,8 +34,36 @@ type topicData struct {
 
 // Mock is an in-memory mock implementation of Azure Notification Hubs.
 type Mock struct {
-	topics *memstore.Store[*topicData]
-	opts   *config.Options
+	topics     *memstore.Store[*topicData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(topicName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.NotificationHubs/namespaces",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"topicName": topicName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Notification Hubs mock with the given configuration options.
@@ -210,6 +239,8 @@ func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.Pu
 		Attributes: attrs,
 	})
 	td.mu.Unlock()
+
+	m.emitMetric(input.TopicID, map[string]float64{"OutgoingNotifications": 1})
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
 }

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 // Compile-time check that Mock implements driver.MessageQueue.
@@ -47,6 +48,8 @@ type queueData struct {
 	visibilityTimeout  int
 	maxMessageSize     int
 	messageRetention   int
+	createdAt          time.Time
+	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
 	dlqConfig          *driver.DeadLetterConfig
 }
@@ -56,10 +59,38 @@ type FunctionTrigger func(queueURL string, message driver.Message)
 
 // Mock is an in-memory mock implementation of the Azure Service Bus service.
 type Mock struct {
-	queues   *memstore.Store[*queueData]
-	opts     *config.Options
-	mu       sync.RWMutex
-	triggers map[string]FunctionTrigger // queueURL -> trigger
+	queues     *memstore.Store[*queueData]
+	opts       *config.Options
+	mu         sync.RWMutex
+	triggers   map[string]FunctionTrigger // queueURL -> trigger
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(queueName string, metrics map[string]float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	data := make([]mondriver.MetricDatum, 0, len(metrics))
+
+	for name, value := range metrics {
+		data = append(data, mondriver.MetricDatum{
+			Namespace:  "Microsoft.ServiceBus/namespaces",
+			MetricName: name,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: map[string]string{"queueName": queueName},
+			Timestamp:  now,
+		})
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), data)
 }
 
 // New creates a new Service Bus mock with the given configuration options.
@@ -123,6 +154,8 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		Tags:               tags,
 	}
 
+	now := m.opts.Clock.Now()
+
 	qd := &queueData{
 		info:               info,
 		messages:           make([]*sbMessage, 0),
@@ -130,6 +163,8 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		visibilityTimeout:  visibilityTimeout,
 		maxMessageSize:     cfg.MaxMessageSize,
 		messageRetention:   cfg.MessageRetention,
+		createdAt:          now,
+		lastModifiedAt:     now,
 		deduplicationIndex: make(map[string]time.Time),
 		dlqConfig:          cfg.DeadLetterQueue,
 	}
@@ -261,6 +296,10 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		trigger(input.QueueURL, triggerMsg)
 	}
 
+	m.emitMetric(qd.info.Name, map[string]float64{
+		"IncomingMessages": 1, "Size": float64(len(input.Body)),
+	})
+
 	return &driver.SendMessageOutput{
 		MessageID: msgID,
 	}, nil
@@ -335,6 +374,11 @@ func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInp
 	if results == nil {
 		results = []driver.Message{}
 	}
+
+	remaining := len(qd.messages)
+	m.emitMetric(qd.info.Name, map[string]float64{
+		"OutgoingMessages": float64(len(results)), "ActiveMessages": float64(remaining),
+	})
 
 	return results, nil
 }
@@ -439,6 +483,9 @@ func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) 
 	for i, msg := range qd.messages {
 		if msg.ReceiptHandle == receiptHandle {
 			qd.messages = append(qd.messages[:i], qd.messages[i+1:]...)
+
+			m.emitMetric(qd.info.Name, map[string]float64{"CompletedMessages": 1})
+
 			return nil
 		}
 	}
@@ -466,4 +513,205 @@ func (m *Mock) ChangeVisibility(_ context.Context, queueURL, receiptHandle strin
 	}
 
 	return cerrors.Newf(cerrors.NotFound, "message with receipt handle %q not found", receiptHandle)
+}
+
+// SendMessageBatch sends up to 10 messages to the specified Service Bus queue.
+func (m *Mock) SendMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchSendEntry,
+) (*driver.BatchSendResult, error) {
+	if len(entries) > driver.MaxBatchSize {
+		return nil, cerrors.Newf(
+			cerrors.InvalidArgument, "batch size %d exceeds max %d", len(entries), driver.MaxBatchSize,
+		)
+	}
+
+	result := &driver.BatchSendResult{}
+
+	for _, entry := range entries {
+		input := batchEntryToSendInput(queue, &entry)
+
+		out, err := m.SendMessage(ctx, input)
+		if err != nil {
+			result.Failed = append(result.Failed, driver.BatchSendFailEntry{
+				ID: entry.ID, Code: "SendFailure", Message: err.Error(),
+			})
+
+			continue
+		}
+
+		result.Successful = append(result.Successful, driver.BatchSendResultEntry{
+			ID: entry.ID, MessageID: out.MessageID,
+		})
+	}
+
+	return result, nil
+}
+
+func batchEntryToSendInput(queue string, entry *driver.BatchSendEntry) driver.SendMessageInput {
+	return driver.SendMessageInput{
+		QueueURL:        queue,
+		Body:            entry.Body,
+		DelaySeconds:    entry.DelaySeconds,
+		GroupID:         entry.GroupID,
+		DeduplicationID: entry.DeduplicationID,
+		Attributes:      entry.Attributes,
+	}
+}
+
+// DeleteMessageBatch deletes up to 10 messages from the specified Service Bus queue.
+func (m *Mock) DeleteMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchDeleteEntry,
+) (*driver.BatchDeleteResult, error) {
+	if len(entries) > driver.MaxBatchSize {
+		return nil, cerrors.Newf(
+			cerrors.InvalidArgument, "batch size %d exceeds max %d", len(entries), driver.MaxBatchSize,
+		)
+	}
+
+	result := &driver.BatchDeleteResult{}
+
+	for _, entry := range entries {
+		err := m.DeleteMessage(ctx, queue, entry.ReceiptHandle)
+		if err != nil {
+			result.Failed = append(result.Failed, driver.BatchSendFailEntry{
+				ID: entry.ID, Code: "DeleteFailure", Message: err.Error(),
+			})
+
+			continue
+		}
+
+		result.Successful = append(result.Successful, entry.ID)
+	}
+
+	return result, nil
+}
+
+// ReceiveMessagesWithOptions receives messages with configurable options.
+func (m *Mock) ReceiveMessagesWithOptions(
+	_ context.Context, queue string, opts driver.ReceiveOptions,
+) ([]driver.Message, error) {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	maxMsgs := clampMaxMessages(opts.MaxMessages)
+
+	visTimeout := opts.VisibilityTimeout
+	if visTimeout == 0 {
+		visTimeout = qd.visibilityTimeout
+	}
+
+	now := m.opts.Clock.Now()
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now)
+
+	removeByIndices(qd, toRemove)
+
+	if results == nil {
+		results = []driver.Message{}
+	}
+
+	return results, nil
+}
+
+// GetQueueAttributes returns detailed attributes of the specified queue.
+func (m *Mock) GetQueueAttributes(
+	_ context.Context, queue string,
+) (*driver.QueueAttributes, error) {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	now := m.opts.Clock.Now()
+	visible, notVisible := countMessages(qd, now)
+
+	return &driver.QueueAttributes{
+		DelaySeconds:               qd.delaySeconds,
+		MaximumMessageSize:         qd.maxMessageSize,
+		MessageRetentionPeriod:     qd.messageRetention,
+		VisibilityTimeout:          qd.visibilityTimeout,
+		ApproximateMessageCount:    visible,
+		ApproximateNotVisibleCount: notVisible,
+		CreatedAt:                  qd.createdAt,
+		LastModifiedAt:             qd.lastModifiedAt,
+		FifoQueue:                  qd.info.FIFO,
+	}, nil
+}
+
+// SetQueueAttributes updates the attributes of the specified queue.
+func (m *Mock) SetQueueAttributes(
+	_ context.Context, queue string, attrs map[string]int,
+) error {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	applyQueueAttributes(qd, attrs)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+func applyQueueAttributes(qd *queueData, attrs map[string]int) {
+	if v, ok := attrs["DelaySeconds"]; ok {
+		qd.delaySeconds = v
+	}
+
+	if v, ok := attrs["VisibilityTimeout"]; ok {
+		qd.visibilityTimeout = v
+	}
+
+	if v, ok := attrs["MaximumMessageSize"]; ok {
+		qd.maxMessageSize = v
+	}
+
+	if v, ok := attrs["MessageRetentionPeriod"]; ok {
+		qd.messageRetention = v
+	}
+}
+
+// PurgeQueue removes all messages from the specified queue.
+func (m *Mock) PurgeQueue(_ context.Context, queue string) error {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "queue %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	qd.messages = make([]*sbMessage, 0)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+func countMessages(qd *queueData, now time.Time) (visible, notVisible int) {
+	for _, msg := range qd.messages {
+		if msg.VisibleAt.After(now) {
+			notVisible++
+		} else {
+			visible++
+		}
+	}
+
+	return visible, notVisible
+}
+
+func removeByIndices(qd *queueData, indices []int) {
+	for i := len(indices) - 1; i >= 0; i-- {
+		idx := indices[i]
+		qd.messages = append(qd.messages[:idx], qd.messages[idx+1:]...)
+	}
 }

--- a/providers/azure/servicebus/servicebus.go
+++ b/providers/azure/servicebus/servicebus.go
@@ -614,6 +614,11 @@ func (m *Mock) ReceiveMessagesWithOptions(
 		results = []driver.Message{}
 	}
 
+	remaining := len(qd.messages)
+	m.emitMetric(qd.info.Name, map[string]float64{
+		"OutgoingMessages": float64(len(results)), "ActiveMessages": float64(remaining),
+	})
+
 	return results, nil
 }
 

--- a/providers/azure/servicebus/servicebus_test.go
+++ b/providers/azure/servicebus/servicebus_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -380,4 +381,261 @@ func TestTrigger(t *testing.T) {
 	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "no-trigger"})
 	require.NoError(t, err)
 	assert.False(t, triggered)
+}
+
+func TestSendMessageBatch(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	t.Run("successful batch", func(t *testing.T) {
+		entries := []driver.BatchSendEntry{
+			{ID: "e1", Body: "msg1"},
+			{ID: "e2", Body: "msg2"},
+			{ID: "e3", Body: "msg3"},
+		}
+
+		result, err := m.SendMessageBatch(ctx, url, entries)
+		require.NoError(t, err)
+		assert.Len(t, result.Successful, 3)
+		assert.Empty(t, result.Failed)
+
+		for _, entry := range result.Successful {
+			assert.NotEmpty(t, entry.MessageID)
+		}
+	})
+
+	t.Run("batch exceeds max size", func(t *testing.T) {
+		entries := make([]driver.BatchSendEntry, 11)
+		for i := range entries {
+			entries[i] = driver.BatchSendEntry{ID: "e", Body: "m"}
+		}
+
+		_, err := m.SendMessageBatch(ctx, url, entries)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds max")
+	})
+
+	t.Run("batch with invalid queue", func(t *testing.T) {
+		entries := []driver.BatchSendEntry{{ID: "e1", Body: "msg1"}}
+
+		result, err := m.SendMessageBatch(ctx, "bad-url", entries)
+		require.NoError(t, err)
+		assert.Len(t, result.Failed, 1)
+		assert.Equal(t, "e1", result.Failed[0].ID)
+	})
+}
+
+func TestDeleteMessageBatch(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	// Send messages
+	_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "m1"})
+	_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "m2"})
+
+	// Receive messages
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: url, MaxMessages: 10})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	t.Run("successful batch delete", func(t *testing.T) {
+		entries := []driver.BatchDeleteEntry{
+			{ID: "d1", ReceiptHandle: msgs[0].ReceiptHandle},
+			{ID: "d2", ReceiptHandle: msgs[1].ReceiptHandle},
+		}
+
+		result, err := m.DeleteMessageBatch(ctx, url, entries)
+		require.NoError(t, err)
+		assert.Len(t, result.Successful, 2)
+		assert.Empty(t, result.Failed)
+	})
+
+	t.Run("batch with invalid handles", func(t *testing.T) {
+		entries := []driver.BatchDeleteEntry{
+			{ID: "d1", ReceiptHandle: "bad-handle"},
+		}
+
+		result, err := m.DeleteMessageBatch(ctx, url, entries)
+		require.NoError(t, err)
+		assert.Len(t, result.Failed, 1)
+	})
+
+	t.Run("batch exceeds max size", func(t *testing.T) {
+		entries := make([]driver.BatchDeleteEntry, 11)
+		for i := range entries {
+			entries[i] = driver.BatchDeleteEntry{ID: "d", ReceiptHandle: "h"}
+		}
+
+		_, err := m.DeleteMessageBatch(ctx, url, entries)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds max")
+	})
+}
+
+func TestGetQueueAttributes(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	t.Run("success", func(t *testing.T) {
+		attrs, err := m.GetQueueAttributes(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, defaultVisibilityTimeout, attrs.VisibilityTimeout)
+		assert.Equal(t, 0, attrs.ApproximateMessageCount)
+		assert.False(t, attrs.FifoQueue)
+		assert.False(t, attrs.CreatedAt.IsZero())
+	})
+
+	t.Run("with messages", func(t *testing.T) {
+		_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "m1"})
+		_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "m2"})
+
+		attrs, err := m.GetQueueAttributes(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, 2, attrs.ApproximateMessageCount)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetQueueAttributes(ctx, "bad-url")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestSetQueueAttributes(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	t.Run("update attributes", func(t *testing.T) {
+		err := m.SetQueueAttributes(ctx, url, map[string]int{
+			"DelaySeconds":      5,
+			"VisibilityTimeout": 60,
+			"MaximumMessageSize": 1024,
+		})
+		require.NoError(t, err)
+
+		attrs, err := m.GetQueueAttributes(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, 5, attrs.DelaySeconds)
+		assert.Equal(t, 60, attrs.VisibilityTimeout)
+		assert.Equal(t, 1024, attrs.MaximumMessageSize)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.SetQueueAttributes(ctx, "bad-url", map[string]int{"DelaySeconds": 1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestPurgeQueue(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+	url := createStdQueue(t, m)
+
+	_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "m1"})
+	_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: url, Body: "m2"})
+
+	t.Run("purge removes all messages", func(t *testing.T) {
+		err := m.PurgeQueue(ctx, url)
+		require.NoError(t, err)
+
+		info, err := m.GetQueueInfo(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, 0, info.ApproxMessageCount)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.PurgeQueue(ctx, "bad-url")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestServiceBusMetricsEmission(t *testing.T) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithAccountID("test-ns"))
+	m := New(opts)
+
+	mon := &sbMetricsCollector{}
+	m.SetMonitoring(mon)
+
+	ctx := context.Background()
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "metric-queue"})
+	require.NoError(t, err)
+
+	t.Run("SendMessage emits metrics", func(t *testing.T) {
+		mon.reset()
+		_, err := m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "hello"})
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.ServiceBus/namespaces", "IncomingMessages"))
+		assert.True(t, mon.hasMetric("Microsoft.ServiceBus/namespaces", "Size"))
+	})
+
+	t.Run("ReceiveMessages emits metrics", func(t *testing.T) {
+		mon.reset()
+		_, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: info.URL, MaxMessages: 10})
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.ServiceBus/namespaces", "OutgoingMessages"))
+	})
+
+	t.Run("DeleteMessage emits metrics", func(t *testing.T) {
+		_, _ = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "to-delete"})
+		msgs, _ := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: info.URL, MaxMessages: 1})
+		require.NotEmpty(t, msgs)
+
+		mon.reset()
+		err := m.DeleteMessage(ctx, info.URL, msgs[0].ReceiptHandle)
+		require.NoError(t, err)
+		assert.True(t, mon.hasMetric("Microsoft.ServiceBus/namespaces", "CompletedMessages"))
+	})
+}
+
+type sbMetricsCollector struct {
+	data []mondriver.MetricDatum
+}
+
+func (c *sbMetricsCollector) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	c.data = append(c.data, data...)
+	return nil
+}
+
+func (c *sbMetricsCollector) GetMetricData(_ context.Context, _ mondriver.GetMetricInput) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (c *sbMetricsCollector) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (c *sbMetricsCollector) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (c *sbMetricsCollector) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (c *sbMetricsCollector) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (c *sbMetricsCollector) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *sbMetricsCollector) reset() {
+	c.data = nil
+}
+
+func (c *sbMetricsCollector) hasMetric(namespace, metricName string) bool {
+	for _, d := range c.data {
+		if d.Namespace == namespace && d.MetricName == metricName {
+			return true
+		}
+	}
+	return false
 }

--- a/providers/azure/servicebus/servicebus_test.go
+++ b/providers/azure/servicebus/servicebus_test.go
@@ -594,6 +594,27 @@ func TestServiceBusMetricsEmission(t *testing.T) {
 	})
 }
 
+func TestReceiveMessagesWithOptionsMetrics(t *testing.T) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithAccountID("test-ns"))
+	m := New(opts)
+
+	mon := &sbMetricsCollector{}
+	m.SetMonitoring(mon)
+
+	ctx := context.Background()
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "rwopt-queue"})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "hello"})
+	require.NoError(t, err)
+
+	mon.reset()
+	_, err = m.ReceiveMessagesWithOptions(ctx, info.URL, driver.ReceiveOptions{MaxMessages: 10})
+	require.NoError(t, err)
+	assert.True(t, mon.hasMetric("Microsoft.ServiceBus/namespaces", "OutgoingMessages"))
+}
+
 type sbMetricsCollector struct {
 	data []mondriver.MetricDatum
 }

--- a/providers/azure/virtualmachines/asg.go
+++ b/providers/azure/virtualmachines/asg.go
@@ -1,0 +1,324 @@
+package virtualmachines
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+)
+
+const (
+	asgStatusActive = "active"
+	percentDivisor  = 100
+)
+
+// CreateAutoScalingGroup creates a VM scale set and launches desired instances.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateAutoScalingGroup(
+	ctx context.Context, cfg driver.AutoScalingGroupConfig,
+) (*driver.AutoScalingGroup, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "scale set name is required")
+	}
+
+	if m.asgs.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "scale set %q already exists", cfg.Name)
+	}
+
+	if err := validateASGBounds(cfg.DesiredCapacity, cfg.MinSize, cfg.MaxSize); err != nil {
+		return nil, err
+	}
+
+	instances, err := m.RunInstances(ctx, cfg.InstanceConfig, cfg.DesiredCapacity)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "failed to launch instances: %v", err)
+	}
+
+	ids := extractInstanceIDs(instances)
+
+	asg := &asgData{
+		config: driver.AutoScalingGroup{
+			Name:              cfg.Name,
+			MinSize:           cfg.MinSize,
+			MaxSize:           cfg.MaxSize,
+			DesiredCapacity:   cfg.DesiredCapacity,
+			CurrentSize:       len(ids),
+			InstanceIDs:       ids,
+			Status:            asgStatusActive,
+			HealthCheckType:   cfg.HealthCheckType,
+			CreatedAt:         m.opts.Clock.Now().UTC().Format(timeFormat),
+			Tags:              copyTags(cfg.Tags),
+			AvailabilityZones: copyStrings(cfg.AvailabilityZones),
+		},
+		policies: memstore.New[driver.ScalingPolicy](),
+	}
+
+	m.asgs.Set(cfg.Name, asg)
+
+	result := asg.config
+
+	return &result, nil
+}
+
+// DeleteAutoScalingGroup deletes a scale set, optionally force-terminating instances.
+func (m *Mock) DeleteAutoScalingGroup(ctx context.Context, name string, forceDelete bool) error {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "scale set %q not found", name)
+	}
+
+	if !forceDelete && len(asg.config.InstanceIDs) > 0 {
+		return cerrors.Newf(cerrors.FailedPrecondition, "scale set %q has instances; use forceDelete", name)
+	}
+
+	if forceDelete && len(asg.config.InstanceIDs) > 0 {
+		if err := m.TerminateInstances(ctx, asg.config.InstanceIDs); err != nil {
+			return err
+		}
+	}
+
+	m.asgs.Delete(name)
+
+	return nil
+}
+
+// GetAutoScalingGroup returns details of a scale set.
+func (m *Mock) GetAutoScalingGroup(_ context.Context, name string) (*driver.AutoScalingGroup, error) {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "scale set %q not found", name)
+	}
+
+	result := asg.config
+
+	return &result, nil
+}
+
+// ListAutoScalingGroups returns all scale sets.
+func (m *Mock) ListAutoScalingGroups(_ context.Context) ([]driver.AutoScalingGroup, error) {
+	all := m.asgs.All()
+	results := make([]driver.AutoScalingGroup, 0, len(all))
+
+	for _, asg := range all {
+		results = append(results, asg.config)
+	}
+
+	return results, nil
+}
+
+// UpdateAutoScalingGroup updates the capacity settings of a scale set.
+func (m *Mock) UpdateAutoScalingGroup(
+	ctx context.Context, name string, desired, minSize, maxSize int,
+) error {
+	if err := validateASGBounds(desired, minSize, maxSize); err != nil {
+		return err
+	}
+
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "scale set %q not found", name)
+	}
+
+	asg.config.MinSize = minSize
+	asg.config.MaxSize = maxSize
+
+	return m.reconcileASG(ctx, asg, desired)
+}
+
+// SetDesiredCapacity sets the desired capacity of a scale set.
+func (m *Mock) SetDesiredCapacity(ctx context.Context, name string, desired int) error {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "scale set %q not found", name)
+	}
+
+	if desired < asg.config.MinSize || desired > asg.config.MaxSize {
+		return cerrors.Newf(
+			cerrors.InvalidArgument,
+			"desired %d outside bounds [%d, %d]", desired, asg.config.MinSize, asg.config.MaxSize,
+		)
+	}
+
+	return m.reconcileASG(ctx, asg, desired)
+}
+
+func (m *Mock) reconcileASG(ctx context.Context, asg *asgData, desired int) error {
+	current := len(asg.config.InstanceIDs)
+
+	if desired > current {
+		return m.scaleUp(ctx, asg, desired-current)
+	}
+
+	if desired < current {
+		return m.scaleDown(ctx, asg, current-desired)
+	}
+
+	return nil
+}
+
+func (m *Mock) scaleUp(ctx context.Context, asg *asgData, count int) error {
+	cfg := instanceConfigFromASG(asg)
+
+	instances, err := m.RunInstances(ctx, cfg, count)
+	if err != nil {
+		return err
+	}
+
+	asg.config.InstanceIDs = append(asg.config.InstanceIDs, extractInstanceIDs(instances)...)
+	asg.config.CurrentSize = len(asg.config.InstanceIDs)
+	asg.config.DesiredCapacity = asg.config.CurrentSize
+
+	return nil
+}
+
+func (m *Mock) scaleDown(ctx context.Context, asg *asgData, count int) error {
+	ids := asg.config.InstanceIDs
+
+	toTerminate := ids[len(ids)-count:]
+	remaining := make([]string, len(ids)-count)
+	copy(remaining, ids[:len(ids)-count])
+
+	if err := m.TerminateInstances(ctx, toTerminate); err != nil {
+		return err
+	}
+
+	asg.config.InstanceIDs = remaining
+	asg.config.CurrentSize = len(remaining)
+	asg.config.DesiredCapacity = asg.config.CurrentSize
+
+	return nil
+}
+
+func instanceConfigFromASG(asg *asgData) driver.InstanceConfig {
+	return driver.InstanceConfig{
+		Tags: copyTags(asg.config.Tags),
+	}
+}
+
+func validateASGBounds(desired, minSize, maxSize int) error {
+	if minSize < 0 {
+		return cerrors.New(cerrors.InvalidArgument, "min size must be >= 0")
+	}
+
+	if maxSize < minSize {
+		return cerrors.New(cerrors.InvalidArgument, "max size must be >= min size")
+	}
+
+	if desired < minSize || desired > maxSize {
+		return cerrors.Newf(
+			cerrors.InvalidArgument,
+			"desired capacity %d outside bounds [%d, %d]", desired, minSize, maxSize,
+		)
+	}
+
+	return nil
+}
+
+func extractInstanceIDs(instances []driver.Instance) []string {
+	ids := make([]string, len(instances))
+
+	for i := range instances {
+		ids[i] = instances[i].ID
+	}
+
+	return ids
+}
+
+// PutScalingPolicy attaches a scaling policy to a scale set.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutScalingPolicy(_ context.Context, policy driver.ScalingPolicy) error {
+	asg, ok := m.asgs.Get(policy.AutoScalingGroup)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "scale set %q not found", policy.AutoScalingGroup)
+	}
+
+	asg.policies.Set(policy.Name, policy)
+
+	return nil
+}
+
+// DeleteScalingPolicy removes a scaling policy from a scale set.
+func (m *Mock) DeleteScalingPolicy(_ context.Context, asgName, policyName string) error {
+	asg, ok := m.asgs.Get(asgName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "scale set %q not found", asgName)
+	}
+
+	if !asg.policies.Delete(policyName) {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found in scale set %q", policyName, asgName)
+	}
+
+	return nil
+}
+
+// ExecuteScalingPolicy executes a scaling policy on a scale set.
+func (m *Mock) ExecuteScalingPolicy(ctx context.Context, asgName, policyName string) error {
+	asg, ok := m.asgs.Get(asgName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "scale set %q not found", asgName)
+	}
+
+	policy, ok := asg.policies.Get(policyName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found in scale set %q", policyName, asgName)
+	}
+
+	newDesired := computeNewDesired(&asg.config, &policy)
+
+	return m.reconcileASG(ctx, asg, newDesired)
+}
+
+func computeNewDesired(cfg *driver.AutoScalingGroup, policy *driver.ScalingPolicy) int {
+	desired := cfg.DesiredCapacity
+
+	switch policy.AdjustmentType {
+	case "ExactCapacity":
+		desired = policy.ScalingAdjustment
+	case "ChangeInCapacity":
+		desired += policy.ScalingAdjustment
+	case "PercentChangeInCapacity":
+		delta := (desired * policy.ScalingAdjustment) / percentDivisor
+		desired += delta
+	}
+
+	return clampDesired(desired, cfg.MinSize, cfg.MaxSize)
+}
+
+func clampDesired(desired, minSize, maxSize int) int {
+	if desired < minSize {
+		return minSize
+	}
+
+	if desired > maxSize {
+		return maxSize
+	}
+
+	return desired
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}
+
+func copyStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make([]string, len(src))
+	copy(dst, src)
+
+	return dst
+}

--- a/providers/azure/virtualmachines/spot.go
+++ b/providers/azure/virtualmachines/spot.go
@@ -1,0 +1,111 @@
+package virtualmachines
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+const (
+	spotStatusActive   = "active"
+	spotStatusCanceled = "canceled"
+	spotTypeOneTime    = "one-time"
+	timeFormat         = "2006-01-02T15:04:05Z"
+)
+
+// RequestSpotInstances creates spot VM requests and immediately fulfills them.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) RequestSpotInstances(
+	ctx context.Context, cfg driver.SpotRequestConfig,
+) ([]driver.SpotInstanceRequest, error) {
+	if cfg.Count <= 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
+	}
+
+	if cfg.MaxPrice <= 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "max price must be greater than 0")
+	}
+
+	instances, err := m.RunInstances(ctx, cfg.InstanceConfig, cfg.Count)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	for _, inst := range instances {
+		reqID := idgen.GenerateID("spot-")
+
+		req := &driver.SpotInstanceRequest{
+			ID:             reqID,
+			InstanceConfig: cfg.InstanceConfig,
+			MaxPrice:       cfg.MaxPrice,
+			Status:         spotStatusActive,
+			InstanceID:     inst.ID,
+			CreatedAt:      now,
+			Type:           cfg.Type,
+		}
+
+		m.spotRequests.Set(reqID, req)
+		results = append(results, *req)
+	}
+
+	return results, nil
+}
+
+// CancelSpotRequests cancels spot VM requests and terminates instances for one-time requests.
+func (m *Mock) CancelSpotRequests(ctx context.Context, requestIDs []string) error {
+	for _, reqID := range requestIDs {
+		req, ok := m.spotRequests.Get(reqID)
+		if !ok {
+			return cerrors.Newf(cerrors.NotFound, "spot request %q not found", reqID)
+		}
+
+		req.Status = spotStatusCanceled
+
+		if req.Type == spotTypeOneTime && req.InstanceID != "" {
+			if err := m.TerminateInstances(ctx, []string{req.InstanceID}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// DescribeSpotRequests returns spot requests matching the given IDs.
+func (m *Mock) DescribeSpotRequests(
+	_ context.Context, requestIDs []string,
+) ([]driver.SpotInstanceRequest, error) {
+	if len(requestIDs) == 0 {
+		return m.allSpotRequests(), nil
+	}
+
+	results := make([]driver.SpotInstanceRequest, 0, len(requestIDs))
+
+	for _, reqID := range requestIDs {
+		req, ok := m.spotRequests.Get(reqID)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "spot request %q not found", reqID)
+		}
+
+		results = append(results, *req)
+	}
+
+	return results, nil
+}
+
+func (m *Mock) allSpotRequests() []driver.SpotInstanceRequest {
+	all := m.spotRequests.All()
+	results := make([]driver.SpotInstanceRequest, 0, len(all))
+
+	for _, req := range all {
+		results = append(results, *req)
+	}
+
+	return results
+}

--- a/providers/azure/virtualmachines/template.go
+++ b/providers/azure/virtualmachines/template.go
@@ -1,0 +1,77 @@
+package virtualmachines
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+//nolint:gochecknoglobals // atomic counter for template versioning
+var templateVersion uint64
+
+// CreateLaunchTemplate creates a new VM image template.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLaunchTemplate(
+	_ context.Context, cfg driver.LaunchTemplateConfig,
+) (*driver.LaunchTemplate, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "template name is required")
+	}
+
+	if m.templates.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "template %q already exists", cfg.Name)
+	}
+
+	ver := int(atomic.AddUint64(&templateVersion, 1)) //nolint:gosec // overflow impossible in mock
+
+	tmpl := &driver.LaunchTemplate{
+		ID:             idgen.GenerateID("vmtpl-"),
+		Name:           cfg.Name,
+		Version:        ver,
+		InstanceConfig: cfg.InstanceConfig,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	m.templates.Set(cfg.Name, tmpl)
+
+	result := *tmpl
+
+	return &result, nil
+}
+
+// DeleteLaunchTemplate deletes a VM image template by name.
+func (m *Mock) DeleteLaunchTemplate(_ context.Context, name string) error {
+	if !m.templates.Delete(name) {
+		return cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+	}
+
+	return nil
+}
+
+// GetLaunchTemplate returns a VM image template by name.
+func (m *Mock) GetLaunchTemplate(_ context.Context, name string) (*driver.LaunchTemplate, error) {
+	tmpl, ok := m.templates.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+	}
+
+	result := *tmpl
+
+	return &result, nil
+}
+
+// ListLaunchTemplates returns all VM image templates.
+func (m *Mock) ListLaunchTemplates(_ context.Context) ([]driver.LaunchTemplate, error) {
+	all := m.templates.All()
+	results := make([]driver.LaunchTemplate, 0, len(all))
+
+	for _, tmpl := range all {
+		results = append(results, *tmpl)
+	}
+
+	return results, nil
+}

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -73,13 +73,21 @@ type instanceData struct {
 	LaunchTime     string
 }
 
+type asgData struct {
+	config   driver.AutoScalingGroup
+	policies *memstore.Store[driver.ScalingPolicy]
+}
+
 // Mock is an in-memory mock implementation of the Azure Virtual Machines service.
 type Mock struct {
-	instances  *memstore.Store[*instanceData]
-	sm         *statemachine.Machine
-	opts       *config.Options
-	ipCounter  atomic.Int64
-	monitoring mondriver.Monitoring
+	instances    *memstore.Store[*instanceData]
+	asgs         *memstore.Store[*asgData]
+	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
+	templates    *memstore.Store[*driver.LaunchTemplate]
+	sm           *statemachine.Machine
+	opts         *config.Options
+	ipCounter    atomic.Int64
+	monitoring   mondriver.Monitoring
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -145,9 +153,12 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, valu
 // New creates a new Azure Virtual Machines mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		instances: memstore.New[*instanceData](),
-		sm:        statemachine.New(compute.VMTransitions()),
-		opts:      opts,
+		instances:    memstore.New[*instanceData](),
+		asgs:         memstore.New[*asgData](),
+		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
+		templates:    memstore.New[*driver.LaunchTemplate](),
+		sm:           statemachine.New(compute.VMTransitions()),
+		opts:         opts,
 	}
 }
 

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackshy/cloudemu/compute"
 	"github.com/stackshy/cloudemu/compute/driver"
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +18,16 @@ func newTestMock() *Mock {
 	opts := config.NewOptions(config.WithClock(clk), config.WithAccountID("test-sub"))
 
 	return New(opts)
+}
+
+func newTestMockWithMonitoring() (*Mock, *vmMetricsCollector) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithAccountID("test-sub"))
+	m := New(opts)
+	mon := &vmMetricsCollector{}
+	m.SetMonitoring(mon)
+
+	return m, mon
 }
 
 func TestRunInstances(t *testing.T) {
@@ -302,4 +313,1040 @@ func TestMatchesFilters(t *testing.T) {
 			assert.Equal(t, tt.want, matchesFilters(inst, tt.filters))
 		})
 	}
+}
+
+func TestCreateAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		cfg     driver.AutoScalingGroupConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "success",
+			cfg: driver.AutoScalingGroupConfig{
+				Name: "my-vmss", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+				Tags:           map[string]string{"env": "test"},
+			},
+		},
+		{
+			name: "empty name",
+			cfg: driver.AutoScalingGroupConfig{
+				MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"},
+			},
+			wantErr: true, errMsg: "name is required",
+		},
+		{
+			name: "desired out of bounds",
+			cfg: driver.AutoScalingGroupConfig{
+				Name: "bad-vmss", MinSize: 2, MaxSize: 5, DesiredCapacity: 10,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"},
+			},
+			wantErr: true, errMsg: "outside bounds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			asg, err := m.CreateAutoScalingGroup(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, tt.cfg.Name, asg.Name)
+				assert.Equal(t, tt.cfg.DesiredCapacity, asg.DesiredCapacity)
+				assert.Len(t, asg.InstanceIDs, tt.cfg.DesiredCapacity)
+				assert.Equal(t, "active", asg.Status)
+			}
+		})
+	}
+
+	t.Run("duplicate name", func(t *testing.T) {
+		m := newTestMock()
+		cfg := driver.AutoScalingGroupConfig{
+			Name: "dup-vmss", MinSize: 0, MaxSize: 2, DesiredCapacity: 1,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"},
+		}
+		_, err := m.CreateAutoScalingGroup(ctx, cfg)
+		require.NoError(t, err)
+
+		_, err = m.CreateAutoScalingGroup(ctx, cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+}
+
+func TestSetDesiredCapacity(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss1", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+	})
+	require.NoError(t, err)
+
+	t.Run("scale up", func(t *testing.T) {
+		err := m.SetDesiredCapacity(ctx, "vmss1", 4)
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 4, asg.CurrentSize)
+		assert.Len(t, asg.InstanceIDs, 4)
+	})
+
+	t.Run("scale down", func(t *testing.T) {
+		err := m.SetDesiredCapacity(ctx, "vmss1", 1)
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 1, asg.CurrentSize)
+	})
+
+	t.Run("outside bounds", func(t *testing.T) {
+		err := m.SetDesiredCapacity(ctx, "vmss1", 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside bounds")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.SetDesiredCapacity(ctx, "missing", 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss1", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+	})
+	require.NoError(t, err)
+
+	t.Run("put and execute ChangeInCapacity policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name: "scale-out", AutoScalingGroup: "vmss1",
+			PolicyType: "SimpleScaling", AdjustmentType: "ChangeInCapacity",
+			ScalingAdjustment: 3,
+		}
+		require.NoError(t, m.PutScalingPolicy(ctx, policy))
+
+		err := m.ExecuteScalingPolicy(ctx, "vmss1", "scale-out")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 5, asg.CurrentSize)
+	})
+
+	t.Run("put and execute ExactCapacity policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name: "set-exact", AutoScalingGroup: "vmss1",
+			PolicyType: "SimpleScaling", AdjustmentType: "ExactCapacity",
+			ScalingAdjustment: 3,
+		}
+		require.NoError(t, m.PutScalingPolicy(ctx, policy))
+
+		err := m.ExecuteScalingPolicy(ctx, "vmss1", "set-exact")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 3, asg.CurrentSize)
+	})
+
+	t.Run("delete policy", func(t *testing.T) {
+		err := m.DeleteScalingPolicy(ctx, "vmss1", "scale-out")
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss1", "scale-out")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("policy on nonexistent ASG", func(t *testing.T) {
+		err := m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "p", AutoScalingGroup: "missing",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestRequestSpotInstances(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		cfg     driver.SpotRequestConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "success",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+				MaxPrice:       0.5, Count: 2, Type: "one-time",
+			},
+		},
+		{
+			name: "zero count",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"},
+				MaxPrice:       0.5, Count: 0,
+			},
+			wantErr: true, errMsg: "count must be greater than 0",
+		},
+		{
+			name: "zero price",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"},
+				MaxPrice:       0, Count: 1,
+			},
+			wantErr: true, errMsg: "max price must be greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			reqs, err := m.RequestSpotInstances(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.Len(t, reqs, tt.cfg.Count)
+
+				for _, req := range reqs {
+					assert.NotEmpty(t, req.ID)
+					assert.Equal(t, "active", req.Status)
+					assert.NotEmpty(t, req.InstanceID)
+					assert.Equal(t, tt.cfg.MaxPrice, req.MaxPrice)
+				}
+			}
+		})
+	}
+}
+
+func TestCancelSpotRequests(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		MaxPrice:       0.5, Count: 1, Type: "one-time",
+	})
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+
+	t.Run("cancel one-time request terminates instance", func(t *testing.T) {
+		err := m.CancelSpotRequests(ctx, []string{reqs[0].ID})
+		require.NoError(t, err)
+
+		described, err := m.DescribeSpotRequests(ctx, []string{reqs[0].ID})
+		require.NoError(t, err)
+		assert.Equal(t, "canceled", described[0].Status)
+
+		// Instance should be terminated
+		instances, _ := m.DescribeInstances(ctx, []string{reqs[0].InstanceID}, nil)
+		require.Len(t, instances, 1)
+		assert.Equal(t, compute.StateTerminated, instances[0].State)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.CancelSpotRequests(ctx, []string{"missing-id"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCreateLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		cfg     driver.LaunchTemplateConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "success",
+			cfg: driver.LaunchTemplateConfig{
+				Name:           "web-template",
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B2s"},
+			},
+		},
+		{
+			name:    "empty name",
+			cfg:     driver.LaunchTemplateConfig{InstanceConfig: driver.InstanceConfig{ImageID: "img-1"}},
+			wantErr: true, errMsg: "template name is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			tmpl, err := m.CreateLaunchTemplate(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, tmpl.ID)
+				assert.Equal(t, tt.cfg.Name, tmpl.Name)
+				assert.Equal(t, tt.cfg.InstanceConfig.ImageID, tmpl.InstanceConfig.ImageID)
+				assert.Greater(t, tmpl.Version, 0)
+				assert.NotEmpty(t, tmpl.CreatedAt)
+			}
+		})
+	}
+
+	t.Run("duplicate name", func(t *testing.T) {
+		m := newTestMock()
+		cfg := driver.LaunchTemplateConfig{
+			Name:           "dup-tmpl",
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+		}
+		_, err := m.CreateLaunchTemplate(ctx, cfg)
+		require.NoError(t, err)
+
+		_, err = m.CreateLaunchTemplate(ctx, cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("get and list templates", func(t *testing.T) {
+		m := newTestMock()
+		cfg := driver.LaunchTemplateConfig{
+			Name:           "my-tmpl",
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		}
+		_, err := m.CreateLaunchTemplate(ctx, cfg)
+		require.NoError(t, err)
+
+		tmpl, err := m.GetLaunchTemplate(ctx, "my-tmpl")
+		require.NoError(t, err)
+		assert.Equal(t, "my-tmpl", tmpl.Name)
+
+		list, err := m.ListLaunchTemplates(ctx)
+		require.NoError(t, err)
+		assert.Len(t, list, 1)
+	})
+
+	t.Run("delete template", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "del-tmpl",
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, m.DeleteLaunchTemplate(ctx, "del-tmpl"))
+
+		_, err = m.GetLaunchTemplate(ctx, "del-tmpl")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeleteAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("force delete terminates instances", func(t *testing.T) {
+		m := newTestMock()
+		asg, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss1", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+		require.Len(t, asg.InstanceIDs, 2)
+
+		err = m.DeleteAutoScalingGroup(ctx, "vmss1", true)
+		require.NoError(t, err)
+
+		// ASG should be gone
+		_, err = m.GetAutoScalingGroup(ctx, "vmss1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		// Instances should be terminated
+		for _, id := range asg.InstanceIDs {
+			instances, _ := m.DescribeInstances(ctx, []string{id}, nil)
+			require.Len(t, instances, 1)
+			assert.Equal(t, compute.StateTerminated, instances[0].State)
+		}
+	})
+
+	t.Run("non-force delete with instances fails", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss2", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.DeleteAutoScalingGroup(ctx, "vmss2", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "has instances")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeleteAutoScalingGroup(ctx, "missing", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestGetAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss1", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, "vmss1", asg.Name)
+		assert.Equal(t, 2, asg.DesiredCapacity)
+		assert.Equal(t, 2, asg.CurrentSize)
+		assert.Equal(t, "active", asg.Status)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetAutoScalingGroup(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestListAutoScalingGroups(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty", func(t *testing.T) {
+		m := newTestMock()
+		asgs, err := m.ListAutoScalingGroups(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, asgs)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss1", MinSize: 0, MaxSize: 3, DesiredCapacity: 1,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		_, err = m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss2", MinSize: 0, MaxSize: 5, DesiredCapacity: 2,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		asgs, err := m.ListAutoScalingGroups(ctx)
+		require.NoError(t, err)
+		assert.Len(t, asgs, 2)
+	})
+}
+
+func TestUpdateAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("scale up", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss1", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.UpdateAutoScalingGroup(ctx, "vmss1", 5, 1, 10)
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 5, asg.CurrentSize)
+		assert.Len(t, asg.InstanceIDs, 5)
+	})
+
+	t.Run("scale down", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss2", MinSize: 1, MaxSize: 10, DesiredCapacity: 5,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.UpdateAutoScalingGroup(ctx, "vmss2", 2, 1, 10)
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss2")
+		require.NoError(t, err)
+		assert.Equal(t, 2, asg.CurrentSize)
+		assert.Len(t, asg.InstanceIDs, 2)
+	})
+
+	t.Run("invalid bounds", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss3", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.UpdateAutoScalingGroup(ctx, "vmss3", 10, 1, 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside bounds")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.UpdateAutoScalingGroup(ctx, "missing", 2, 1, 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestPutScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss1", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+	})
+	require.NoError(t, err)
+
+	t.Run("create policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name: "scale-out", AutoScalingGroup: "vmss1",
+			PolicyType: "SimpleScaling", AdjustmentType: "ChangeInCapacity",
+			ScalingAdjustment: 2,
+		}
+		err := m.PutScalingPolicy(ctx, policy)
+		require.NoError(t, err)
+	})
+
+	t.Run("update existing policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name: "scale-out", AutoScalingGroup: "vmss1",
+			PolicyType: "SimpleScaling", AdjustmentType: "ExactCapacity",
+			ScalingAdjustment: 5,
+		}
+		err := m.PutScalingPolicy(ctx, policy)
+		require.NoError(t, err)
+
+		// Execute to verify it was updated
+		err = m.ExecuteScalingPolicy(ctx, "vmss1", "scale-out")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 5, asg.CurrentSize)
+	})
+
+	t.Run("ASG not found", func(t *testing.T) {
+		err := m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "p", AutoScalingGroup: "missing",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeleteScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss1", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+	})
+	require.NoError(t, err)
+
+	err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+		Name: "scale-out", AutoScalingGroup: "vmss1",
+		PolicyType: "SimpleScaling", AdjustmentType: "ChangeInCapacity",
+		ScalingAdjustment: 2,
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteScalingPolicy(ctx, "vmss1", "scale-out")
+		require.NoError(t, err)
+	})
+
+	t.Run("policy not found", func(t *testing.T) {
+		err := m.DeleteScalingPolicy(ctx, "vmss1", "missing-policy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("ASG not found", func(t *testing.T) {
+		err := m.DeleteScalingPolicy(ctx, "missing-asg", "scale-out")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestExecuteScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ChangeInCapacity", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss1", MinSize: 1, MaxSize: 10, DesiredCapacity: 3,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "add2", AutoScalingGroup: "vmss1",
+			AdjustmentType: "ChangeInCapacity", ScalingAdjustment: 2,
+		})
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss1", "add2")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss1")
+		require.NoError(t, err)
+		assert.Equal(t, 5, asg.CurrentSize)
+	})
+
+	t.Run("ExactCapacity", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss2", MinSize: 1, MaxSize: 10, DesiredCapacity: 3,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "set7", AutoScalingGroup: "vmss2",
+			AdjustmentType: "ExactCapacity", ScalingAdjustment: 7,
+		})
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss2", "set7")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss2")
+		require.NoError(t, err)
+		assert.Equal(t, 7, asg.CurrentSize)
+	})
+
+	t.Run("PercentChangeInCapacity", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss3", MinSize: 1, MaxSize: 20, DesiredCapacity: 10,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "grow50pct", AutoScalingGroup: "vmss3",
+			AdjustmentType: "PercentChangeInCapacity", ScalingAdjustment: 50,
+		})
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss3", "grow50pct")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss3")
+		require.NoError(t, err)
+		assert.Equal(t, 15, asg.CurrentSize)
+	})
+
+	t.Run("clamped to max", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss4", MinSize: 1, MaxSize: 5, DesiredCapacity: 3,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "big-jump", AutoScalingGroup: "vmss4",
+			AdjustmentType: "ChangeInCapacity", ScalingAdjustment: 100,
+		})
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss4", "big-jump")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss4")
+		require.NoError(t, err)
+		assert.Equal(t, 5, asg.CurrentSize) // clamped to max
+	})
+
+	t.Run("clamped to min", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss5", MinSize: 2, MaxSize: 10, DesiredCapacity: 5,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "big-shrink", AutoScalingGroup: "vmss5",
+			AdjustmentType: "ChangeInCapacity", ScalingAdjustment: -100,
+		})
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss5", "big-shrink")
+		require.NoError(t, err)
+
+		asg, err := m.GetAutoScalingGroup(ctx, "vmss5")
+		require.NoError(t, err)
+		assert.Equal(t, 2, asg.CurrentSize) // clamped to min
+	})
+
+	t.Run("ASG not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.ExecuteScalingPolicy(ctx, "missing", "policy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("policy not found", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+			Name: "vmss6", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		})
+		require.NoError(t, err)
+
+		err = m.ExecuteScalingPolicy(ctx, "vmss6", "missing-policy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeSpotRequests(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		MaxPrice:       0.5, Count: 3, Type: "one-time",
+	})
+	require.NoError(t, err)
+	require.Len(t, reqs, 3)
+
+	t.Run("all spot requests without filter", func(t *testing.T) {
+		results, err := m.DescribeSpotRequests(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("filter by specific IDs", func(t *testing.T) {
+		results, err := m.DescribeSpotRequests(ctx, []string{reqs[0].ID, reqs[1].ID})
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("not found ID", func(t *testing.T) {
+		_, err := m.DescribeSpotRequests(ctx, []string{"spot-missing"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestGetLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "web-tmpl",
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B2s"},
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		tmpl, err := m.GetLaunchTemplate(ctx, "web-tmpl")
+		require.NoError(t, err)
+		assert.Equal(t, "web-tmpl", tmpl.Name)
+		assert.Equal(t, "img-1", tmpl.InstanceConfig.ImageID)
+		assert.NotEmpty(t, tmpl.ID)
+		assert.NotEmpty(t, tmpl.CreatedAt)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetLaunchTemplate(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestListLaunchTemplates(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty", func(t *testing.T) {
+		m := newTestMock()
+		list, err := m.ListLaunchTemplates(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, list)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "tmpl-a",
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+		})
+		require.NoError(t, err)
+
+		_, err = m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "tmpl-b",
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-2"},
+		})
+		require.NoError(t, err)
+
+		list, err := m.ListLaunchTemplates(ctx)
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+	})
+}
+
+func TestDeleteLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+			Name:           "del-tmpl",
+			InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+		})
+		require.NoError(t, err)
+
+		err = m.DeleteLaunchTemplate(ctx, "del-tmpl")
+		require.NoError(t, err)
+
+		_, err = m.GetLaunchTemplate(ctx, "del-tmpl")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeleteLaunchTemplate(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestRunInstancesWithMonitoring(t *testing.T) {
+	ctx := context.Background()
+	m, mon := newTestMockWithMonitoring()
+
+	cfg := driver.InstanceConfig{
+		ImageID:      "img-1",
+		InstanceType: "Standard_B1s",
+	}
+
+	instances, err := m.RunInstances(ctx, cfg, 1)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	// Should have emitted 5 metrics x 5 backfill datapoints = 25 data points
+	assert.Len(t, mon.data, 25)
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Percentage CPU"))
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Network In Total"))
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Network Out Total"))
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Disk Read Operations/Sec"))
+	assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Disk Write Operations/Sec"))
+}
+
+func TestLifecycleMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	m, mon := newTestMockWithMonitoring()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{ImageID: "img-1", InstanceType: "t2"}, 1)
+	require.NoError(t, err)
+	id := instances[0].ID
+
+	t.Run("stop emits zero metrics", func(t *testing.T) {
+		mon.reset()
+		err := m.StopInstances(ctx, []string{id})
+		require.NoError(t, err)
+		// 5 metrics, 1 datapoint each
+		assert.Len(t, mon.data, 5)
+
+		for _, d := range mon.data {
+			assert.Equal(t, 0.0, d.Value)
+		}
+	})
+
+	t.Run("start emits running metrics", func(t *testing.T) {
+		mon.reset()
+		err := m.StartInstances(ctx, []string{id})
+		require.NoError(t, err)
+		assert.Len(t, mon.data, 5)
+
+		assert.True(t, mon.hasMetric("Microsoft.Compute/virtualMachines", "Percentage CPU"))
+	})
+
+	t.Run("reboot emits running metrics", func(t *testing.T) {
+		mon.reset()
+		err := m.RebootInstances(ctx, []string{id})
+		require.NoError(t, err)
+		assert.Len(t, mon.data, 5)
+	})
+
+	t.Run("terminate emits zero metrics", func(t *testing.T) {
+		mon.reset()
+		err := m.TerminateInstances(ctx, []string{id})
+		require.NoError(t, err)
+		assert.Len(t, mon.data, 5)
+
+		for _, d := range mon.data {
+			assert.Equal(t, 0.0, d.Value)
+		}
+	})
+}
+
+func TestValidateASGBoundsNegativeMin(t *testing.T) {
+	err := validateASGBounds(1, -1, 5)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "min size must be >= 0")
+}
+
+func TestValidateASGBoundsMaxLessThanMin(t *testing.T) {
+	err := validateASGBounds(3, 5, 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max size must be >= min size")
+}
+
+func TestCancelSpotRequestPersistentType(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		MaxPrice:       0.5, Count: 1, Type: "persistent",
+	})
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+
+	// Cancel persistent request should NOT terminate instances
+	err = m.CancelSpotRequests(ctx, []string{reqs[0].ID})
+	require.NoError(t, err)
+
+	described, err := m.DescribeSpotRequests(ctx, []string{reqs[0].ID})
+	require.NoError(t, err)
+	assert.Equal(t, "canceled", described[0].Status)
+
+	// Instance should still be running (not terminated)
+	instances, _ := m.DescribeInstances(ctx, []string{reqs[0].InstanceID}, nil)
+	require.Len(t, instances, 1)
+	assert.Equal(t, compute.StateRunning, instances[0].State)
+}
+
+func TestCreateAutoScalingGroupWithAvailabilityZones(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	asg, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss-az", MinSize: 0, MaxSize: 3, DesiredCapacity: 1,
+		InstanceConfig:    driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+		AvailabilityZones: []string{"us-east-1a", "us-east-1b"},
+		HealthCheckType:   "ELB",
+		Tags:              map[string]string{"env": "test"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-east-1a", "us-east-1b"}, asg.AvailabilityZones)
+	assert.Equal(t, "ELB", asg.HealthCheckType)
+	assert.Equal(t, "test", asg.Tags["env"])
+	assert.NotEmpty(t, asg.CreatedAt)
+}
+
+func TestDeleteAutoScalingGroupForceDeleteNoInstances(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	// Create ASG with 1 instance, then scale down to 0, then non-force delete
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "vmss-empty", MinSize: 0, MaxSize: 5, DesiredCapacity: 1,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "Standard_B1s"},
+	})
+	require.NoError(t, err)
+
+	// Scale down to 0 instances
+	err = m.SetDesiredCapacity(ctx, "vmss-empty", 0)
+	require.NoError(t, err)
+
+	// Non-force delete should succeed when there are no instances
+	err = m.DeleteAutoScalingGroup(ctx, "vmss-empty", false)
+	require.NoError(t, err)
+}
+
+type vmMetricsCollector struct {
+	data []mondriver.MetricDatum
+}
+
+func (c *vmMetricsCollector) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	c.data = append(c.data, data...)
+	return nil
+}
+
+func (c *vmMetricsCollector) GetMetricData(_ context.Context, _ mondriver.GetMetricInput) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (c *vmMetricsCollector) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (c *vmMetricsCollector) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (c *vmMetricsCollector) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (c *vmMetricsCollector) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (c *vmMetricsCollector) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *vmMetricsCollector) reset() {
+	c.data = nil
+}
+
+func (c *vmMetricsCollector) hasMetric(namespace, metricName string) bool {
+	for _, d := range c.data {
+		if d.Namespace == namespace && d.MetricName == metricName {
+			return true
+		}
+	}
+
+	return false
 }

--- a/providers/azure/vnet/acl.go
+++ b/providers/azure/vnet/acl.go
@@ -1,0 +1,141 @@
+package vnet
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Default ACL rule constants.
+const (
+	defaultACLRuleNumber = 100
+	allTrafficProtocol   = "-1"
+	allTrafficCIDR       = "0.0.0.0/0"
+	actionAllow          = "allow"
+)
+
+type networkACLData struct {
+	ID        string
+	VPCID     string
+	Rules     []driver.NetworkACLRule
+	Tags      map[string]string
+	IsDefault bool
+}
+
+// CreateNetworkACL creates a network ACL for the specified VNet.
+func (m *Mock) CreateNetworkACL(
+	_ context.Context, vpcID string, tags map[string]string,
+) (*driver.NetworkACL, error) {
+	if vpcID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "VNet ID is required")
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return nil, cerrors.Newf(cerrors.NotFound, "vnet %q not found", vpcID)
+	}
+
+	id := idgen.GenerateID("acl-")
+	acl := &networkACLData{
+		ID:        id,
+		VPCID:     vpcID,
+		Rules:     defaultACLRules(),
+		Tags:      copyTags(tags),
+		IsDefault: false,
+	}
+	m.networkACLs.Set(id, acl)
+
+	info := toNetworkACLInfo(acl)
+
+	return &info, nil
+}
+
+// defaultACLRules returns the default allow-all rules for a new ACL.
+func defaultACLRules() []driver.NetworkACLRule {
+	return []driver.NetworkACLRule{
+		{
+			RuleNumber: defaultACLRuleNumber,
+			Protocol:   allTrafficProtocol,
+			Action:     actionAllow,
+			CIDR:       allTrafficCIDR,
+			Egress:     false,
+		},
+		{
+			RuleNumber: defaultACLRuleNumber,
+			Protocol:   allTrafficProtocol,
+			Action:     actionAllow,
+			CIDR:       allTrafficCIDR,
+			Egress:     true,
+		},
+	}
+}
+
+// DeleteNetworkACL deletes the network ACL with the given ID.
+func (m *Mock) DeleteNetworkACL(_ context.Context, id string) error {
+	acl, ok := m.networkACLs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network ACL %q not found", id)
+	}
+
+	if acl.IsDefault {
+		return cerrors.Newf(cerrors.FailedPrecondition, "cannot delete default network ACL %q", id)
+	}
+
+	m.networkACLs.Delete(id)
+
+	return nil
+}
+
+// DescribeNetworkACLs returns network ACLs matching the given IDs, or all if empty.
+func (m *Mock) DescribeNetworkACLs(_ context.Context, ids []string) ([]driver.NetworkACL, error) {
+	return describeResources(m.networkACLs, ids, toNetworkACLInfo), nil
+}
+
+// AddNetworkACLRule adds a rule to the specified network ACL, keeping rules sorted.
+func (m *Mock) AddNetworkACLRule(_ context.Context, aclID string, rule *driver.NetworkACLRule) error {
+	acl, ok := m.networkACLs.Get(aclID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network ACL %q not found", aclID)
+	}
+
+	acl.Rules = append(acl.Rules, *rule)
+	sort.Slice(acl.Rules, func(i, j int) bool {
+		return acl.Rules[i].RuleNumber < acl.Rules[j].RuleNumber
+	})
+
+	return nil
+}
+
+// RemoveNetworkACLRule removes a rule by rule number and direction.
+func (m *Mock) RemoveNetworkACLRule(
+	_ context.Context, aclID string, ruleNumber int, egress bool,
+) error {
+	acl, ok := m.networkACLs.Get(aclID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network ACL %q not found", aclID)
+	}
+
+	for i, r := range acl.Rules {
+		if r.RuleNumber == ruleNumber && r.Egress == egress {
+			acl.Rules = append(acl.Rules[:i], acl.Rules[i+1:]...)
+			return nil
+		}
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "rule %d not found in network ACL %q", ruleNumber, aclID)
+}
+
+func toNetworkACLInfo(acl *networkACLData) driver.NetworkACL {
+	rules := make([]driver.NetworkACLRule, len(acl.Rules))
+	copy(rules, acl.Rules)
+
+	return driver.NetworkACL{
+		ID:        acl.ID,
+		VPCID:     acl.VPCID,
+		Rules:     rules,
+		Tags:      copyTags(acl.Tags),
+		IsDefault: acl.IsDefault,
+	}
+}

--- a/providers/azure/vnet/flowlog.go
+++ b/providers/azure/vnet/flowlog.go
@@ -1,0 +1,159 @@
+package vnet
+
+import (
+	"context"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Flow log status constants.
+const (
+	FlowLogStatusActive = "ACTIVE"
+)
+
+// Flow log traffic type constants.
+const (
+	TrafficTypeAll    = "ALL"
+	TrafficTypeAccept = "ACCEPT"
+	TrafficTypeReject = "REJECT"
+)
+
+// Mock flow log record constants.
+const (
+	mockSourcePort = 443
+	mockDestPort   = 52000
+	mockPackets    = 10
+	mockBytes      = 1500
+)
+
+type flowLogData struct {
+	ID           string
+	ResourceID   string
+	ResourceType string
+	TrafficType  string
+	Status       string
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// CreateFlowLog creates a flow log for a VNet or subnet resource.
+func (m *Mock) CreateFlowLog(_ context.Context, cfg driver.FlowLogConfig) (*driver.FlowLog, error) {
+	if cfg.ResourceID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "resource ID is required")
+	}
+
+	if err := m.validateFlowLogResource(cfg.ResourceID, cfg.ResourceType); err != nil {
+		return nil, err
+	}
+
+	trafficType := cfg.TrafficType
+	if trafficType == "" {
+		trafficType = TrafficTypeAll
+	}
+
+	id := idgen.GenerateID("fl-")
+	fl := &flowLogData{
+		ID:           id,
+		ResourceID:   cfg.ResourceID,
+		ResourceType: cfg.ResourceType,
+		TrafficType:  trafficType,
+		Status:       FlowLogStatusActive,
+		CreatedAt:    m.opts.Clock.Now().Format(timeFormat),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.flowLogs.Set(id, fl)
+
+	info := toFlowLogInfo(fl)
+
+	return &info, nil
+}
+
+// validateFlowLogResource checks that the target resource exists.
+func (m *Mock) validateFlowLogResource(resourceID, resourceType string) error {
+	switch resourceType {
+	case "VPC":
+		if !m.vpcs.Has(resourceID) {
+			return cerrors.Newf(cerrors.NotFound, "vnet %q not found", resourceID)
+		}
+	case "Subnet":
+		if !m.subnets.Has(resourceID) {
+			return cerrors.Newf(cerrors.NotFound, "subnet %q not found", resourceID)
+		}
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported resource type %q", resourceType)
+	}
+
+	return nil
+}
+
+// DeleteFlowLog deletes the flow log with the given ID.
+func (m *Mock) DeleteFlowLog(_ context.Context, id string) error {
+	if !m.flowLogs.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "flow log %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeFlowLogs returns flow logs matching the given IDs, or all if empty.
+func (m *Mock) DescribeFlowLogs(_ context.Context, ids []string) ([]driver.FlowLog, error) {
+	return describeResources(m.flowLogs, ids, toFlowLogInfo), nil
+}
+
+// GetFlowLogRecords generates mock flow log records for the given flow log.
+func (m *Mock) GetFlowLogRecords(
+	_ context.Context, flowLogID string, limit int,
+) ([]driver.FlowLogRecord, error) {
+	fl, ok := m.flowLogs.Get(flowLogID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "flow log %q not found", flowLogID)
+	}
+
+	return generateMockRecords(fl, limit), nil
+}
+
+// generateMockRecords creates simulated flow log records.
+func generateMockRecords(fl *flowLogData, limit int) []driver.FlowLogRecord {
+	if limit <= 0 {
+		limit = defaultFlowLogRecordLimit
+	}
+
+	records := make([]driver.FlowLogRecord, 0, limit)
+
+	for i := range limit {
+		action := TrafficTypeAccept
+		if fl.TrafficType == TrafficTypeReject || (fl.TrafficType == TrafficTypeAll && i%2 == 1) {
+			action = TrafficTypeReject
+		}
+
+		records = append(records, driver.FlowLogRecord{
+			Timestamp:  fl.CreatedAt,
+			SourceIP:   fmt.Sprintf("10.0.0.%d", i+1),
+			DestIP:     fmt.Sprintf("10.0.1.%d", i+1),
+			SourcePort: mockSourcePort,
+			DestPort:   mockDestPort + i,
+			Protocol:   "tcp",
+			Packets:    mockPackets,
+			Bytes:      mockBytes,
+			Action:     action,
+			FlowLogID:  fl.ID,
+		})
+	}
+
+	return records
+}
+
+func toFlowLogInfo(fl *flowLogData) driver.FlowLog {
+	return driver.FlowLog{
+		ID:           fl.ID,
+		ResourceID:   fl.ResourceID,
+		ResourceType: fl.ResourceType,
+		TrafficType:  fl.TrafficType,
+		Status:       fl.Status,
+		CreatedAt:    fl.CreatedAt,
+		Tags:         copyTags(fl.Tags),
+	}
+}

--- a/providers/azure/vnet/natgw.go
+++ b/providers/azure/vnet/natgw.go
@@ -1,0 +1,78 @@
+package vnet
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// NAT gateway state constants.
+const (
+	NATStateAvailable = "available"
+)
+
+type natGatewayData struct {
+	ID        string
+	SubnetID  string
+	VPCID     string
+	PublicIP  string
+	State     string
+	CreatedAt string
+	Tags      map[string]string
+}
+
+// CreateNATGateway creates a NAT gateway in the specified subnet.
+func (m *Mock) CreateNATGateway(_ context.Context, cfg driver.NATGatewayConfig) (*driver.NATGateway, error) {
+	if cfg.SubnetID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "subnet ID is required")
+	}
+
+	subnet, ok := m.subnets.Get(cfg.SubnetID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "subnet %q not found", cfg.SubnetID)
+	}
+
+	id := idgen.GenerateID("natgw-")
+	nat := &natGatewayData{
+		ID:        id,
+		SubnetID:  cfg.SubnetID,
+		VPCID:     subnet.VPCID,
+		PublicIP:  mockPublicIP(id),
+		State:     NATStateAvailable,
+		CreatedAt: m.opts.Clock.Now().Format(timeFormat),
+		Tags:      copyTags(cfg.Tags),
+	}
+	m.natGateways.Set(id, nat)
+
+	info := toNATGatewayInfo(nat)
+
+	return &info, nil
+}
+
+// DeleteNATGateway deletes the NAT gateway with the given ID.
+func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
+	if !m.natGateways.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "NAT gateway %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeNATGateways returns NAT gateways matching the given IDs, or all if empty.
+func (m *Mock) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NATGateway, error) {
+	return describeResources(m.natGateways, ids, toNATGatewayInfo), nil
+}
+
+func toNATGatewayInfo(n *natGatewayData) driver.NATGateway {
+	return driver.NATGateway{
+		ID:        n.ID,
+		SubnetID:  n.SubnetID,
+		VPCID:     n.VPCID,
+		PublicIP:  n.PublicIP,
+		State:     n.State,
+		CreatedAt: n.CreatedAt,
+		Tags:      copyTags(n.Tags),
+	}
+}

--- a/providers/azure/vnet/peering.go
+++ b/providers/azure/vnet/peering.go
@@ -1,0 +1,157 @@
+package vnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Peering status constants.
+const (
+	PeeringStatusPending  = "pending-acceptance"
+	PeeringStatusActive   = "active"
+	PeeringStatusRejected = "rejected"
+	PeeringStatusDeleted  = "deleted"
+)
+
+type peeringData struct {
+	ID           string
+	RequesterVPC string
+	AccepterVPC  string
+	Status       string
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// CreatePeeringConnection creates a VNet peering between two virtual networks.
+func (m *Mock) CreatePeeringConnection(
+	_ context.Context, cfg driver.PeeringConfig,
+) (*driver.PeeringConnection, error) {
+	if cfg.RequesterVPC == "" || cfg.AccepterVPC == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "both requester and accepter VNet IDs are required")
+	}
+
+	reqVPC, ok := m.vpcs.Get(cfg.RequesterVPC)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "requester vnet %q not found", cfg.RequesterVPC)
+	}
+
+	accVPC, ok := m.vpcs.Get(cfg.AccepterVPC)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "accepter vnet %q not found", cfg.AccepterVPC)
+	}
+
+	if cidrsOverlap(reqVPC.CIDRBlock, accVPC.CIDRBlock) {
+		return nil, cerrors.New(cerrors.InvalidArgument, "VNet CIDRs must not overlap for peering")
+	}
+
+	id := idgen.GenerateID("peering-")
+	p := &peeringData{
+		ID:           id,
+		RequesterVPC: cfg.RequesterVPC,
+		AccepterVPC:  cfg.AccepterVPC,
+		Status:       PeeringStatusPending,
+		CreatedAt:    m.opts.Clock.Now().Format(timeFormat),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.peerings.Set(id, p)
+
+	info := toPeeringInfo(p)
+
+	return &info, nil
+}
+
+// AcceptPeeringConnection accepts a pending VNet peering.
+func (m *Mock) AcceptPeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
+
+	if p.Status != PeeringStatusPending {
+		return cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
+			peeringID, p.Status, PeeringStatusPending)
+	}
+
+	p.Status = PeeringStatusActive
+
+	return nil
+}
+
+// RejectPeeringConnection rejects a pending VNet peering.
+func (m *Mock) RejectPeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
+
+	if p.Status != PeeringStatusPending {
+		return cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
+			peeringID, p.Status, PeeringStatusPending)
+	}
+
+	p.Status = PeeringStatusRejected
+
+	return nil
+}
+
+// DeletePeeringConnection deletes a VNet peering.
+func (m *Mock) DeletePeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
+
+	p.Status = PeeringStatusDeleted
+
+	m.peerings.Delete(peeringID)
+
+	return nil
+}
+
+// DescribePeeringConnections returns VNet peerings matching the given IDs.
+func (m *Mock) DescribePeeringConnections(
+	_ context.Context, ids []string,
+) ([]driver.PeeringConnection, error) {
+	return describeResources(m.peerings, ids, toPeeringInfo), nil
+}
+
+func toPeeringInfo(p *peeringData) driver.PeeringConnection {
+	return driver.PeeringConnection{
+		ID:           p.ID,
+		RequesterVPC: p.RequesterVPC,
+		AccepterVPC:  p.AccepterVPC,
+		Status:       p.Status,
+		CreatedAt:    p.CreatedAt,
+		Tags:         copyTags(p.Tags),
+	}
+}
+
+// cidrsOverlap checks whether two CIDR blocks overlap.
+func cidrsOverlap(cidrA, cidrB string) bool {
+	_, netA, errA := net.ParseCIDR(cidrA)
+	_, netB, errB := net.ParseCIDR(cidrB)
+
+	if errA != nil || errB != nil {
+		return cidrA == cidrB
+	}
+
+	return netA.Contains(netB.IP) || netB.Contains(netA.IP)
+}
+
+// mockPublicIP generates a mock public IP from a counter value.
+func mockPublicIP(id string) string {
+	var sum int
+	for _, c := range id {
+		sum += int(c)
+	}
+
+	octet3 := sum % maxOctetValue
+	octet4 := (sum / maxOctetValue) % maxOctetValue
+
+	return fmt.Sprintf("10.0.%d.%d", octet3, octet4)
+}

--- a/providers/azure/vnet/routetable.go
+++ b/providers/azure/vnet/routetable.go
@@ -1,0 +1,123 @@
+package vnet
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Route target type constants.
+const (
+	RouteTargetLocal = "local"
+)
+
+type routeTableData struct {
+	ID     string
+	VPCID  string
+	Routes []driver.Route
+	Tags   map[string]string
+}
+
+// CreateRouteTable creates a route table for the specified VNet.
+func (m *Mock) CreateRouteTable(_ context.Context, cfg driver.RouteTableConfig) (*driver.RouteTable, error) {
+	if cfg.VPCID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "VNet ID is required")
+	}
+
+	v, ok := m.vpcs.Get(cfg.VPCID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "vnet %q not found", cfg.VPCID)
+	}
+
+	id := idgen.GenerateID("rt-")
+	localRoute := driver.Route{
+		DestinationCIDR: v.CIDRBlock,
+		TargetID:        RouteTargetLocal,
+		TargetType:      RouteTargetLocal,
+		State:           "active",
+	}
+
+	rt := &routeTableData{
+		ID:     id,
+		VPCID:  cfg.VPCID,
+		Routes: []driver.Route{localRoute},
+		Tags:   copyTags(cfg.Tags),
+	}
+	m.routeTables.Set(id, rt)
+
+	info := toRouteTableInfo(rt)
+
+	return &info, nil
+}
+
+// DeleteRouteTable deletes the route table with the given ID.
+func (m *Mock) DeleteRouteTable(_ context.Context, id string) error {
+	if !m.routeTables.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "route table %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeRouteTables returns route tables matching the given IDs, or all if empty.
+func (m *Mock) DescribeRouteTables(_ context.Context, ids []string) ([]driver.RouteTable, error) {
+	return describeResources(m.routeTables, ids, toRouteTableInfo), nil
+}
+
+// CreateRoute adds a route to the specified route table.
+func (m *Mock) CreateRoute(
+	_ context.Context, routeTableID, destinationCIDR, targetID, targetType string,
+) error {
+	rt, ok := m.routeTables.Get(routeTableID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "route table %q not found", routeTableID)
+	}
+
+	for _, r := range rt.Routes {
+		if r.DestinationCIDR == destinationCIDR {
+			return cerrors.Newf(cerrors.AlreadyExists,
+				"route for %q already exists in route table %q", destinationCIDR, routeTableID)
+		}
+	}
+
+	rt.Routes = append(rt.Routes, driver.Route{
+		DestinationCIDR: destinationCIDR,
+		TargetID:        targetID,
+		TargetType:      targetType,
+		State:           "active",
+	})
+
+	return nil
+}
+
+// DeleteRoute removes a route from the specified route table.
+func (m *Mock) DeleteRoute(_ context.Context, routeTableID, destinationCIDR string) error {
+	rt, ok := m.routeTables.Get(routeTableID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "route table %q not found", routeTableID)
+	}
+
+	for i, r := range rt.Routes {
+		if r.DestinationCIDR == destinationCIDR {
+			rt.Routes = append(rt.Routes[:i], rt.Routes[i+1:]...)
+			return nil
+		}
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "route %q not found in route table %q",
+		destinationCIDR, routeTableID)
+}
+
+func toRouteTableInfo(rt *routeTableData) driver.RouteTable {
+	routes := make([]driver.Route, len(rt.Routes))
+	copy(routes, rt.Routes)
+
+	return driver.RouteTable{
+		ID:     rt.ID,
+		VPCID:  rt.VPCID,
+		Routes: routes,
+		Tags:   copyTags(rt.Tags),
+	}
+}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -3,12 +3,20 @@ package vnet
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Time format and mock constants.
+const (
+	timeFormat                = time.RFC3339
+	maxOctetValue             = 256
+	defaultFlowLogRecordLimit = 10
 )
 
 // Compile-time check that Mock implements driver.Networking.
@@ -45,6 +53,11 @@ type Mock struct {
 	vpcs           *memstore.Store[*vpcData]
 	subnets        *memstore.Store[*subnetData]
 	securityGroups *memstore.Store[*sgData]
+	peerings       *memstore.Store[*peeringData]
+	natGateways    *memstore.Store[*natGatewayData]
+	flowLogs       *memstore.Store[*flowLogData]
+	routeTables    *memstore.Store[*routeTableData]
+	networkACLs    *memstore.Store[*networkACLData]
 	opts           *config.Options
 }
 
@@ -54,6 +67,11 @@ func New(opts *config.Options) *Mock {
 		vpcs:           memstore.New[*vpcData](),
 		subnets:        memstore.New[*subnetData](),
 		securityGroups: memstore.New[*sgData](),
+		peerings:       memstore.New[*peeringData](),
+		natGateways:    memstore.New[*natGatewayData](),
+		flowLogs:       memstore.New[*flowLogData](),
+		routeTables:    memstore.New[*routeTableData](),
+		networkACLs:    memstore.New[*networkACLData](),
 		opts:           opts,
 	}
 }

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -388,3 +388,635 @@ func TestAddSecurityGroupRules(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestCreatePeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	vpc2, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cfg     driver.PeeringConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "success",
+			cfg:  driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID, Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name:    "missing requester",
+			cfg:     driver.PeeringConfig{AccepterVPC: vpc2.ID},
+			wantErr: true, errMsg: "both requester and accepter",
+		},
+		{
+			name:    "requester not found",
+			cfg:     driver.PeeringConfig{RequesterVPC: "vnet-missing", AccepterVPC: vpc2.ID},
+			wantErr: true, errMsg: "not found",
+		},
+		{
+			name:    "accepter not found",
+			cfg:     driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: "vnet-missing"},
+			wantErr: true, errMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peering, err := m.CreatePeeringConnection(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, peering.ID)
+				assert.Equal(t, "pending-acceptance", peering.Status)
+				assert.Equal(t, vpc1.ID, peering.RequesterVPC)
+				assert.Equal(t, vpc2.ID, peering.AccepterVPC)
+			}
+		})
+	}
+}
+
+func TestAcceptPeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	vpc2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	peering, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID,
+	})
+	require.NoError(t, err)
+
+	t.Run("accept pending peering", func(t *testing.T) {
+		err := m.AcceptPeeringConnection(ctx, peering.ID)
+		require.NoError(t, err)
+
+		peers, _ := m.DescribePeeringConnections(ctx, []string{peering.ID})
+		require.Len(t, peers, 1)
+		assert.Equal(t, "active", peers[0].Status)
+	})
+
+	t.Run("accept already active peering fails", func(t *testing.T) {
+		err := m.AcceptPeeringConnection(ctx, peering.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.AcceptPeeringConnection(ctx, "peering-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCreateNATGateway(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpcID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cfg     driver.NATGatewayConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "success",
+			cfg:  driver.NATGatewayConfig{SubnetID: subnet.ID, Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name:    "empty subnet",
+			cfg:     driver.NATGatewayConfig{},
+			wantErr: true, errMsg: "subnet ID is required",
+		},
+		{
+			name:    "subnet not found",
+			cfg:     driver.NATGatewayConfig{SubnetID: "subnet-missing"},
+			wantErr: true, errMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nat, err := m.CreateNATGateway(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, nat.ID)
+				assert.Equal(t, subnet.ID, nat.SubnetID)
+				assert.Equal(t, vpcID, nat.VPCID)
+				assert.Equal(t, "available", nat.State)
+				assert.NotEmpty(t, nat.PublicIP)
+			}
+		})
+	}
+}
+
+func TestCreateFlowLog(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	tests := []struct {
+		name    string
+		cfg     driver.FlowLogConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "VPC flow log",
+			cfg:  driver.FlowLogConfig{ResourceID: vpcID, ResourceType: "VPC", TrafficType: "ALL"},
+		},
+		{
+			name:    "empty resource ID",
+			cfg:     driver.FlowLogConfig{ResourceType: "VPC"},
+			wantErr: true, errMsg: "resource ID is required",
+		},
+		{
+			name:    "VPC not found",
+			cfg:     driver.FlowLogConfig{ResourceID: "vnet-missing", ResourceType: "VPC"},
+			wantErr: true, errMsg: "not found",
+		},
+		{
+			name:    "unsupported resource type",
+			cfg:     driver.FlowLogConfig{ResourceID: vpcID, ResourceType: "Unknown"},
+			wantErr: true, errMsg: "unsupported resource type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fl, err := m.CreateFlowLog(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, fl.ID)
+				assert.Equal(t, vpcID, fl.ResourceID)
+				assert.Equal(t, "ACTIVE", fl.Status)
+
+				// Get records
+				records, err := m.GetFlowLogRecords(ctx, fl.ID, 5)
+				require.NoError(t, err)
+				assert.Len(t, records, 5)
+				assert.Equal(t, fl.ID, records[0].FlowLogID)
+			}
+		})
+	}
+}
+
+func TestCreateRouteTable(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	tests := []struct {
+		name    string
+		cfg     driver.RouteTableConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "success",
+			cfg:  driver.RouteTableConfig{VPCID: vpcID, Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name:    "empty VPC ID",
+			cfg:     driver.RouteTableConfig{},
+			wantErr: true, errMsg: "VNet ID is required",
+		},
+		{
+			name:    "VPC not found",
+			cfg:     driver.RouteTableConfig{VPCID: "vnet-missing"},
+			wantErr: true, errMsg: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, err := m.CreateRouteTable(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, rt.ID)
+				assert.Equal(t, vpcID, rt.VPCID)
+				// Should have a local route by default
+				require.Len(t, rt.Routes, 1)
+				assert.Equal(t, "local", rt.Routes[0].TargetType)
+			}
+		})
+	}
+}
+
+func TestCreateRoute(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpcID})
+	require.NoError(t, err)
+
+	t.Run("add route", func(t *testing.T) {
+		err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-123", "gateway")
+		require.NoError(t, err)
+
+		tables, _ := m.DescribeRouteTables(ctx, []string{rt.ID})
+		require.Len(t, tables, 1)
+		assert.Len(t, tables[0].Routes, 2) // local + new route
+	})
+
+	t.Run("duplicate route", func(t *testing.T) {
+		err := m.CreateRoute(ctx, rt.ID, "0.0.0.0/0", "igw-456", "gateway")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("delete route", func(t *testing.T) {
+		err := m.DeleteRoute(ctx, rt.ID, "0.0.0.0/0")
+		require.NoError(t, err)
+
+		tables, _ := m.DescribeRouteTables(ctx, []string{rt.ID})
+		require.Len(t, tables, 1)
+		assert.Len(t, tables[0].Routes, 1) // only local route
+	})
+
+	t.Run("route table not found", func(t *testing.T) {
+		err := m.CreateRoute(ctx, "rt-missing", "0.0.0.0/0", "igw", "gateway")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCreateNetworkACL(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	tests := []struct {
+		name    string
+		vpcID   string
+		wantErr bool
+		errMsg  string
+	}{
+		{name: "success", vpcID: vpcID},
+		{name: "empty VPC ID", vpcID: "", wantErr: true, errMsg: "VNet ID is required"},
+		{name: "VPC not found", vpcID: "vnet-missing", wantErr: true, errMsg: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acl, err := m.CreateNetworkACL(ctx, tt.vpcID, map[string]string{"env": "test"})
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, acl.ID)
+				assert.Equal(t, vpcID, acl.VPCID)
+				// Should have default allow-all rules
+				assert.GreaterOrEqual(t, len(acl.Rules), 2)
+			}
+		})
+	}
+}
+
+func TestAddNetworkACLRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	acl, err := m.CreateNetworkACL(ctx, vpcID, nil)
+	require.NoError(t, err)
+
+	t.Run("add ingress rule", func(t *testing.T) {
+		rule := &driver.NetworkACLRule{
+			RuleNumber: 50, Protocol: "tcp", Action: "allow",
+			CIDR: "10.0.0.0/8", FromPort: 80, ToPort: 80, Egress: false,
+		}
+		err := m.AddNetworkACLRule(ctx, acl.ID, rule)
+		require.NoError(t, err)
+
+		acls, _ := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+		require.Len(t, acls, 1)
+		// Should have default rules + new rule, sorted by rule number
+		assert.GreaterOrEqual(t, len(acls[0].Rules), 3)
+		assert.Equal(t, 50, acls[0].Rules[0].RuleNumber) // sorted first
+	})
+
+	t.Run("add egress rule", func(t *testing.T) {
+		rule := &driver.NetworkACLRule{
+			RuleNumber: 200, Protocol: "tcp", Action: "deny",
+			CIDR: "0.0.0.0/0", FromPort: 443, ToPort: 443, Egress: true,
+		}
+		err := m.AddNetworkACLRule(ctx, acl.ID, rule)
+		require.NoError(t, err)
+	})
+
+	t.Run("remove rule", func(t *testing.T) {
+		err := m.RemoveNetworkACLRule(ctx, acl.ID, 50, false)
+		require.NoError(t, err)
+	})
+
+	t.Run("ACL not found", func(t *testing.T) {
+		err := m.AddNetworkACLRule(ctx, "acl-missing", &driver.NetworkACLRule{RuleNumber: 1})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("remove nonexistent rule", func(t *testing.T) {
+		err := m.RemoveNetworkACLRule(ctx, acl.ID, 999, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeletePeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	vpc2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	peering, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		peeringID string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", peeringID: peering.ID},
+		{name: "already deleted", peeringID: peering.ID, wantErr: true, errSubstr: "not found"},
+		{name: "not found", peeringID: "peering-missing", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.DeletePeeringConnection(ctx, tt.peeringID)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				// After deletion it should no longer appear
+				peers, _ := m.DescribePeeringConnections(ctx, []string{tt.peeringID})
+				assert.Empty(t, peers)
+			}
+		})
+	}
+}
+
+func TestRejectPeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	vpc2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+
+	peering, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID,
+	})
+	require.NoError(t, err)
+
+	t.Run("reject pending peering", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, peering.ID)
+		require.NoError(t, err)
+
+		peers, _ := m.DescribePeeringConnections(ctx, []string{peering.ID})
+		require.Len(t, peers, 1)
+		assert.Equal(t, "rejected", peers[0].Status)
+	})
+
+	t.Run("reject already rejected fails", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, peering.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, "peering-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribePeeringConnectionsWithIDs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	vpc2, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	vpc3, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "192.168.0.0/16"})
+
+	p1, _ := m.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID})
+	p2, _ := m.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc3.ID})
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantCount int
+	}{
+		{name: "all peerings", ids: nil, wantCount: 2},
+		{name: "by single ID", ids: []string{p1.ID}, wantCount: 1},
+		{name: "by multiple IDs", ids: []string{p1.ID, p2.ID}, wantCount: 2},
+		{name: "nonexistent ID", ids: []string{"peering-missing"}, wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peers, err := m.DescribePeeringConnections(ctx, tt.ids)
+			require.NoError(t, err)
+			assert.Len(t, peers, tt.wantCount)
+		})
+	}
+}
+
+func TestDeleteNATGatewayNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	err := m.DeleteNATGateway(ctx, "natgw-missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDescribeNATGatewaysWithIDs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	s1, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpcID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+	s2, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpcID, CIDRBlock: "10.0.2.0/24"})
+	require.NoError(t, err)
+
+	nat1, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s1.ID})
+	require.NoError(t, err)
+	nat2, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s2.ID})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantCount int
+	}{
+		{name: "all NAT gateways", ids: nil, wantCount: 2},
+		{name: "by single ID", ids: []string{nat1.ID}, wantCount: 1},
+		{name: "by multiple IDs", ids: []string{nat1.ID, nat2.ID}, wantCount: 2},
+		{name: "nonexistent ID", ids: []string{"natgw-missing"}, wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nats, err := m.DescribeNATGateways(ctx, tt.ids)
+			require.NoError(t, err)
+			assert.Len(t, nats, tt.wantCount)
+		})
+	}
+}
+
+func TestDeleteFlowLogNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	err := m.DeleteFlowLog(ctx, "fl-missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDescribeFlowLogsWithIDs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	fl1, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: vpcID, ResourceType: "VPC", TrafficType: "ALL"})
+	require.NoError(t, err)
+	fl2, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: vpcID, ResourceType: "VPC", TrafficType: "ACCEPT"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantCount int
+	}{
+		{name: "all flow logs", ids: nil, wantCount: 2},
+		{name: "by single ID", ids: []string{fl1.ID}, wantCount: 1},
+		{name: "by multiple IDs", ids: []string{fl1.ID, fl2.ID}, wantCount: 2},
+		{name: "nonexistent ID", ids: []string{"fl-missing"}, wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fls, err := m.DescribeFlowLogs(ctx, tt.ids)
+			require.NoError(t, err)
+			assert.Len(t, fls, tt.wantCount)
+		})
+	}
+}
+
+func TestDeleteRouteTableNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	err := m.DeleteRouteTable(ctx, "rt-missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDescribeRouteTablesWithIDs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	rt1, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpcID})
+	require.NoError(t, err)
+	rt2, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpcID})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantCount int
+	}{
+		{name: "all route tables", ids: nil, wantCount: 2},
+		{name: "by single ID", ids: []string{rt1.ID}, wantCount: 1},
+		{name: "by multiple IDs", ids: []string{rt1.ID, rt2.ID}, wantCount: 2},
+		{name: "nonexistent ID", ids: []string{"rt-missing"}, wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rts, err := m.DescribeRouteTables(ctx, tt.ids)
+			require.NoError(t, err)
+			assert.Len(t, rts, tt.wantCount)
+		})
+	}
+}
+
+func TestDeleteNetworkACLNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	err := m.DeleteNetworkACL(ctx, "acl-missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDescribeNetworkACLsWithIDs(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	acl1, err := m.CreateNetworkACL(ctx, vpcID, map[string]string{"name": "acl1"})
+	require.NoError(t, err)
+	acl2, err := m.CreateNetworkACL(ctx, vpcID, map[string]string{"name": "acl2"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantCount int
+	}{
+		{name: "all ACLs", ids: nil, wantCount: 2},
+		{name: "by single ID", ids: []string{acl1.ID}, wantCount: 1},
+		{name: "by multiple IDs", ids: []string{acl1.ID, acl2.ID}, wantCount: 2},
+		{name: "nonexistent ID", ids: []string{"acl-missing"}, wantCount: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acls, err := m.DescribeNetworkACLs(ctx, tt.ids)
+			require.NoError(t, err)
+			assert.Len(t, acls, tt.wantCount)
+		})
+	}
+}

--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
@@ -44,6 +45,7 @@ type repoData struct {
 
 // Mock is an in-memory mock implementation of the GCP Artifact Registry service.
 type Mock struct {
+	mu         sync.Mutex
 	repos      *memstore.Store[*repoData]
 	opts       *config.Options
 	monitoring mondriver.Monitoring
@@ -166,6 +168,11 @@ func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) 
 
 // PutImage pushes an image manifest to an Artifact Registry repository.
 func (m *Mock) PutImage(ctx context.Context, manifest *driver.ImageManifest) (*driver.ImageDetail, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Allow empty tag for untagged images (digest-only)
+
 	rd, ok := m.repos.Get(manifest.Repository)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
@@ -247,6 +254,9 @@ func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageD
 
 // DeleteImage deletes an image from an Artifact Registry repository by reference.
 func (m *Mock) DeleteImage(_ context.Context, repository, reference string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -266,6 +276,13 @@ func (m *Mock) DeleteImage(_ context.Context, repository, reference string) erro
 
 // TagImage adds a new tag to an existing image in an Artifact Registry repository.
 func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag string) error {
+	if targetTag == "" {
+		return errors.New(errors.InvalidArgument, "target tag cannot be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rd, ok := m.repos.Get(repository)
 	if !ok {
 		return errors.Newf(errors.NotFound, "repository %q not found", repository)
@@ -281,6 +298,7 @@ func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag stri
 	}
 
 	updateTagIndex(rd, img.detail.Digest, targetTag)
+	rd.info.ImageCount = rd.images.Len()
 
 	return nil
 }

--- a/providers/gcp/artifactregistry/artifactregistry.go
+++ b/providers/gcp/artifactregistry/artifactregistry.go
@@ -1,0 +1,644 @@
+// Package artifactregistry provides an in-memory mock implementation of GCP Artifact Registry.
+package artifactregistry
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"path"
+	"sort"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	defaultMediaType     = "application/vnd.docker.distribution.manifest.v2+json"
+	mutableTag           = "MUTABLE"
+	immutableTag         = "IMMUTABLE"
+	scanStatusComplete   = "COMPLETE"
+	digestHashFormatByte = 8
+)
+
+// Compile-time check that Mock implements driver.ContainerRegistry.
+var _ driver.ContainerRegistry = (*Mock)(nil)
+
+type imageData struct {
+	detail driver.ImageDetail
+	layers []driver.LayerInfo
+}
+
+type repoData struct {
+	info          driver.Repository
+	images        *memstore.Store[*imageData]
+	scans         *memstore.Store[*driver.ScanResult]
+	policy        *driver.LifecyclePolicy
+	scanOnPush    bool
+	tagMutability string
+}
+
+// Mock is an in-memory mock implementation of the GCP Artifact Registry service.
+type Mock struct {
+	repos      *memstore.Store[*repoData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "artifactregistry.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
+}
+
+// New creates a new Artifact Registry mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		repos: memstore.New[*repoData](),
+		opts:  opts,
+	}
+}
+
+// CreateRepository creates a new Artifact Registry repository.
+func (m *Mock) CreateRepository(_ context.Context, cfg driver.RepositoryConfig) (*driver.Repository, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "repository name is required")
+	}
+
+	if m.repos.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "repository %q already exists", cfg.Name)
+	}
+
+	mutability := cfg.ImageTagMutability
+	if mutability == "" {
+		mutability = mutableTag
+	}
+
+	tags := copyTags(cfg.Tags)
+	uri := fmt.Sprintf("%s-docker.pkg.dev/%s/%s", m.opts.Region, m.opts.ProjectID, cfg.Name)
+	selfLink := idgen.GCPID(m.opts.ProjectID, "repositories", cfg.Name)
+
+	info := driver.Repository{
+		Name:       selfLink,
+		URI:        uri,
+		CreatedAt:  m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:       tags,
+		ImageCount: 0,
+	}
+
+	rd := &repoData{
+		info:          info,
+		images:        memstore.New[*imageData](),
+		scans:         memstore.New[*driver.ScanResult](),
+		scanOnPush:    cfg.ImageScanOnPush,
+		tagMutability: mutability,
+	}
+
+	m.repos.Set(cfg.Name, rd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteRepository deletes an Artifact Registry repository.
+func (m *Mock) DeleteRepository(_ context.Context, name string, force bool) error {
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	if !force && rd.images.Len() > 0 {
+		return errors.Newf(errors.FailedPrecondition, "repository %q is not empty; use force to delete", name)
+	}
+
+	m.repos.Delete(name)
+
+	return nil
+}
+
+// GetRepository retrieves information about an Artifact Registry repository.
+func (m *Mock) GetRepository(_ context.Context, name string) (*driver.Repository, error) {
+	rd, ok := m.repos.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", name)
+	}
+
+	result := rd.info
+	result.ImageCount = rd.images.Len()
+
+	return &result, nil
+}
+
+// ListRepositories lists all Artifact Registry repositories.
+func (m *Mock) ListRepositories(_ context.Context) ([]driver.Repository, error) {
+	all := m.repos.All()
+	repos := make([]driver.Repository, 0, len(all))
+
+	for _, rd := range all {
+		repo := rd.info
+		repo.ImageCount = rd.images.Len()
+		repos = append(repos, repo)
+	}
+
+	return repos, nil
+}
+
+// PutImage pushes an image manifest to an Artifact Registry repository.
+func (m *Mock) PutImage(ctx context.Context, manifest *driver.ImageManifest) (*driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(manifest.Repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", manifest.Repository)
+	}
+
+	if err := checkTagMutability(rd, manifest.Tag); err != nil {
+		return nil, err
+	}
+
+	digest := resolveDigest(manifest, m.opts.Clock.Now())
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	mediaType := resolveMediaType(manifest.MediaType)
+
+	detail := driver.ImageDetail{
+		RegistryID: m.opts.ProjectID,
+		Repository: manifest.Repository,
+		Digest:     digest,
+		Tags:       []string{manifest.Tag},
+		SizeBytes:  manifest.SizeBytes,
+		PushedAt:   now,
+		MediaType:  mediaType,
+	}
+
+	img := &imageData{detail: detail, layers: manifest.Layers}
+	rd.images.Set(digest, img)
+
+	if manifest.Tag != "" {
+		updateTagIndex(rd, digest, manifest.Tag)
+	}
+
+	rd.info.ImageCount = rd.images.Len()
+
+	if rd.scanOnPush {
+		autoScan(rd, digest, manifest.Repository, m.opts.Clock.Now())
+	}
+
+	m.emitMetric(ctx, "push_request_count", 1, map[string]string{"repository_name": manifest.Repository})
+
+	result := detail
+
+	return &result, nil
+}
+
+// GetImage retrieves image details by repository and reference.
+func (m *Mock) GetImage(ctx context.Context, repository, reference string) (*driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	m.emitMetric(ctx, "pull_request_count", 1, map[string]string{"repository_name": repository})
+
+	result := img.detail
+
+	return &result, nil
+}
+
+// ListImages lists all images in an Artifact Registry repository.
+func (m *Mock) ListImages(_ context.Context, repository string) ([]driver.ImageDetail, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	all := rd.images.All()
+	images := make([]driver.ImageDetail, 0, len(all))
+
+	for _, img := range all {
+		images = append(images, img.detail)
+	}
+
+	return images, nil
+}
+
+// DeleteImage deletes an image from an Artifact Registry repository by reference.
+func (m *Mock) DeleteImage(_ context.Context, repository, reference string) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	rd.images.Delete(img.detail.Digest)
+	rd.scans.Delete(img.detail.Digest)
+	rd.info.ImageCount = rd.images.Len()
+
+	return nil
+}
+
+// TagImage adds a new tag to an existing image in an Artifact Registry repository.
+func (m *Mock) TagImage(_ context.Context, repository, sourceRef, targetTag string) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, sourceRef)
+	if img == nil {
+		return errors.Newf(errors.NotFound, "image %q not found in repository %q", sourceRef, repository)
+	}
+
+	if err := checkTagMutability(rd, targetTag); err != nil {
+		return err
+	}
+
+	updateTagIndex(rd, img.detail.Digest, targetTag)
+
+	return nil
+}
+
+// PutLifecyclePolicy sets a cleanup policy on an Artifact Registry repository.
+func (m *Mock) PutLifecyclePolicy(_ context.Context, repository string, policy driver.LifecyclePolicy) error {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	policyCopy := copyLifecyclePolicy(policy)
+	rd.policy = &policyCopy
+
+	return nil
+}
+
+// GetLifecyclePolicy retrieves the cleanup policy for an Artifact Registry repository.
+func (m *Mock) GetLifecyclePolicy(_ context.Context, repository string) (*driver.LifecyclePolicy, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return nil, errors.Newf(errors.NotFound, "no cleanup policy for repository %q", repository)
+	}
+
+	result := copyLifecyclePolicy(*rd.policy)
+
+	return &result, nil
+}
+
+// EvaluateLifecyclePolicy evaluates the cleanup policy and returns digests to expire.
+func (m *Mock) EvaluateLifecyclePolicy(_ context.Context, repository string) ([]string, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	if rd.policy == nil {
+		return []string{}, nil
+	}
+
+	return evaluateRules(rd, m.opts.Clock.Now()), nil
+}
+
+// StartImageScan starts a vulnerability scan on an image in an Artifact Registry repository.
+func (m *Mock) StartImageScan(
+	_ context.Context, repository, reference string,
+) (*driver.ScanResult, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	scan := generateScanResult(repository, img.detail.Digest, m.opts.Clock.Now())
+	rd.scans.Set(img.detail.Digest, scan)
+
+	result := *scan
+
+	return &result, nil
+}
+
+// GetImageScanResults retrieves scan results for an image in an Artifact Registry repository.
+func (m *Mock) GetImageScanResults(
+	_ context.Context, repository, reference string,
+) (*driver.ScanResult, error) {
+	rd, ok := m.repos.Get(repository)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "repository %q not found", repository)
+	}
+
+	img := findImage(rd, reference)
+	if img == nil {
+		return nil, errors.Newf(errors.NotFound, "image %q not found in repository %q", reference, repository)
+	}
+
+	scan, ok := rd.scans.Get(img.detail.Digest)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "no scan results for image %q in repository %q", reference, repository,
+		)
+	}
+
+	result := *scan
+
+	return &result, nil
+}
+
+// findImage locates an image by tag or digest.
+func findImage(rd *repoData, reference string) *imageData {
+	if img, ok := rd.images.Get(reference); ok {
+		return img
+	}
+
+	all := rd.images.All()
+	for _, img := range all {
+		for _, tag := range img.detail.Tags {
+			if tag == reference {
+				return img
+			}
+		}
+	}
+
+	return nil
+}
+
+// checkTagMutability validates that a tag can be overwritten.
+func checkTagMutability(rd *repoData, tag string) error {
+	if tag == "" || rd.tagMutability != immutableTag {
+		return nil
+	}
+
+	all := rd.images.All()
+	for _, img := range all {
+		for _, t := range img.detail.Tags {
+			if t == tag {
+				return errors.Newf(
+					errors.FailedPrecondition,
+					"tag %q already exists and repository has IMMUTABLE tag mutability",
+					tag,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// resolveDigest generates a digest from the manifest if not provided.
+func resolveDigest(manifest *driver.ImageManifest, now time.Time) string {
+	if manifest.Digest != "" {
+		return manifest.Digest
+	}
+
+	input := fmt.Sprintf("%s:%s:%s", manifest.Repository, manifest.Tag, now.String())
+	hash := sha256.Sum256([]byte(input))
+
+	return fmt.Sprintf("sha256:%x", hash[:digestHashFormatByte])
+}
+
+// updateTagIndex removes a tag from any existing image and adds it to the target digest.
+func updateTagIndex(rd *repoData, digest, tag string) {
+	all := rd.images.All()
+	for d, img := range all {
+		if d == digest {
+			continue
+		}
+
+		filtered := removeTag(img.detail.Tags, tag)
+		if len(filtered) != len(img.detail.Tags) {
+			img.detail.Tags = filtered
+			rd.images.Set(d, img)
+		}
+	}
+
+	if img, ok := rd.images.Get(digest); ok {
+		if !hasTag(img.detail.Tags, tag) {
+			img.detail.Tags = append(img.detail.Tags, tag)
+			rd.images.Set(digest, img)
+		}
+	}
+}
+
+// autoScan creates a scan result automatically when scanOnPush is enabled.
+func autoScan(rd *repoData, digest, repository string, now time.Time) {
+	scan := generateScanResult(repository, digest, now)
+	rd.scans.Set(digest, scan)
+}
+
+// generateScanResult produces deterministic scan findings based on the digest hash.
+func generateScanResult(repository, digest string, now time.Time) *driver.ScanResult {
+	hash := sha256.Sum256([]byte(digest))
+
+	findings := map[string]int{
+		"CRITICAL":      int(hash[0]) % 3,
+		"HIGH":          int(hash[1]) % 5,
+		"MEDIUM":        int(hash[2]) % 10,
+		"LOW":           int(hash[3]) % 15,
+		"INFORMATIONAL": int(hash[4]) % 8,
+	}
+
+	return &driver.ScanResult{
+		Repository:    repository,
+		Digest:        digest,
+		Status:        scanStatusComplete,
+		FindingCounts: findings,
+		CompletedAt:   now.UTC().Format(time.RFC3339),
+	}
+}
+
+// evaluateRules applies lifecycle rules sorted by priority and returns digests to expire.
+func evaluateRules(rd *repoData, now time.Time) []string {
+	rules := rd.policy.Rules
+	sorted := make([]driver.LifecycleRule, len(rules))
+	copy(sorted, rules)
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Priority < sorted[j].Priority })
+
+	expired := make(map[string]bool)
+
+	for idx := range sorted {
+		digests := evaluateSingleRule(rd, &sorted[idx], now)
+		for _, d := range digests {
+			expired[d] = true
+		}
+	}
+
+	result := make([]string, 0, len(expired))
+	for d := range expired {
+		result = append(result, d)
+	}
+
+	return result
+}
+
+// evaluateSingleRule evaluates one lifecycle rule and returns matching digests.
+func evaluateSingleRule(rd *repoData, rule *driver.LifecycleRule, now time.Time) []string {
+	images := collectMatchingImages(rd, rule)
+
+	sort.Slice(images, func(i, j int) bool { return images[i].detail.PushedAt < images[j].detail.PushedAt })
+
+	switch rule.CountType {
+	case "imageCountMoreThan":
+		return expireByCount(images, rule.CountValue)
+	case "sinceImagePushed":
+		return expireBySince(images, rule.CountValue, now)
+	default:
+		return nil
+	}
+}
+
+// collectMatchingImages returns images matching the rule's tag status and pattern.
+func collectMatchingImages(rd *repoData, rule *driver.LifecycleRule) []*imageData {
+	all := rd.images.All()
+
+	var matched []*imageData
+
+	for _, img := range all {
+		if matchesTagRule(img, rule) {
+			matched = append(matched, img)
+		}
+	}
+
+	return matched
+}
+
+// matchesTagRule checks if an image matches the rule's tag filter.
+func matchesTagRule(img *imageData, rule *driver.LifecycleRule) bool {
+	switch rule.TagStatus {
+	case "untagged":
+		return len(img.detail.Tags) == 0
+	case "tagged":
+		return len(img.detail.Tags) > 0 && matchTagPattern(img.detail.Tags, rule.TagPattern)
+	default: // "any"
+		return true
+	}
+}
+
+// matchTagPattern checks if any tag matches the given glob pattern.
+func matchTagPattern(tags []string, pattern string) bool {
+	if pattern == "" || pattern == "*" {
+		return true
+	}
+
+	for _, tag := range tags {
+		if matched, err := path.Match(pattern, tag); err == nil && matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// expireByCount returns digests of excess images beyond the count threshold.
+func expireByCount(images []*imageData, maxCount int) []string {
+	if len(images) <= maxCount {
+		return nil
+	}
+
+	excess := len(images) - maxCount
+	result := make([]string, 0, excess)
+
+	for i := range excess {
+		result = append(result, images[i].detail.Digest)
+	}
+
+	return result
+}
+
+// expireBySince returns digests of images pushed more than N days ago.
+func expireBySince(images []*imageData, days int, now time.Time) []string {
+	cutoff := now.AddDate(0, 0, -days)
+
+	var result []string
+
+	for _, img := range images {
+		pushedAt, err := time.Parse(time.RFC3339, img.detail.PushedAt)
+		if err != nil {
+			continue
+		}
+
+		if pushedAt.Before(cutoff) {
+			result = append(result, img.detail.Digest)
+		}
+	}
+
+	return result
+}
+
+func resolveMediaType(mediaType string) string {
+	if mediaType != "" {
+		return mediaType
+	}
+
+	return defaultMediaType
+}
+
+func copyTags(src map[string]string) map[string]string {
+	tags := make(map[string]string, len(src))
+	for k, v := range src {
+		tags[k] = v
+	}
+
+	return tags
+}
+
+func copyLifecyclePolicy(p driver.LifecyclePolicy) driver.LifecyclePolicy {
+	rules := make([]driver.LifecycleRule, len(p.Rules))
+	copy(rules, p.Rules)
+
+	return driver.LifecyclePolicy{Rules: rules}
+}
+
+func removeTag(tags []string, tag string) []string {
+	result := make([]string, 0, len(tags))
+
+	for _, t := range tags {
+		if t != tag {
+			result = append(result, t)
+		}
+	}
+
+	return result
+}
+
+func hasTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/gcp/artifactregistry/artifactregistry_test.go
+++ b/providers/gcp/artifactregistry/artifactregistry_test.go
@@ -1,0 +1,713 @@
+package artifactregistry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/containerregistry/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/gcp/cloudmonitoring"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	return New(opts), fc
+}
+
+func newTestMockWithMonitoring() (*Mock, *cloudmonitoring.Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	mon := cloudmonitoring.New(opts)
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	return m, mon, fc
+}
+
+func createTestRepo(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateRepository(context.Background(), driver.RepositoryConfig{Name: name})
+	require.NoError(t, err)
+}
+
+func pushTestImage(t *testing.T, m *Mock, repo, tag string) *driver.ImageDetail {
+	t.Helper()
+
+	detail, err := m.PutImage(context.Background(), &driver.ImageManifest{
+		Repository: repo,
+		Tag:        tag,
+		SizeBytes:  1024,
+	})
+	require.NoError(t, err)
+
+	return detail
+}
+
+func TestCreateRepository(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.RepositoryConfig
+		setup     func(*Mock)
+		expectErr bool
+		checkFn   func(*testing.T, *driver.Repository)
+	}{
+		{
+			name: "success with defaults",
+			cfg:  driver.RepositoryConfig{Name: "my-repo"},
+			checkFn: func(t *testing.T, repo *driver.Repository) {
+				t.Helper()
+				assert.Contains(t, repo.URI, "us-central1-docker.pkg.dev/test-project/my-repo")
+				assert.Contains(t, repo.Name, "my-repo")
+				assert.Equal(t, 0, repo.ImageCount)
+				assert.NotEmpty(t, repo.CreatedAt)
+			},
+		},
+		{
+			name: "success with tags",
+			cfg:  driver.RepositoryConfig{Name: "tagged-repo", Tags: map[string]string{"env": "prod"}},
+			checkFn: func(t *testing.T, repo *driver.Repository) {
+				t.Helper()
+				assert.Equal(t, "prod", repo.Tags["env"])
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.RepositoryConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate repository",
+			cfg:  driver.RepositoryConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			repo, err := m.CreateRepository(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.checkFn != nil {
+				tc.checkFn(t, repo)
+			}
+		})
+	}
+}
+
+func TestDeleteRepository(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoName  string
+		force     bool
+		setup     func(*Mock)
+		expectErr bool
+	}{
+		{
+			name:     "success empty repo",
+			repoName: "empty-repo",
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "empty-repo")
+			},
+		},
+		{
+			name:     "non-empty repo without force fails",
+			repoName: "full-repo",
+			force:    false,
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "full-repo")
+				pushTestImage(&testing.T{}, m, "full-repo", "v1")
+			},
+			expectErr: true,
+		},
+		{
+			name:     "non-empty repo with force succeeds",
+			repoName: "full-repo",
+			force:    true,
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "full-repo")
+				pushTestImage(&testing.T{}, m, "full-repo", "v1")
+			},
+		},
+		{
+			name:      "not found",
+			repoName:  "nonexistent",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			err := m.DeleteRepository(context.Background(), tc.repoName, tc.force)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			_, getErr := m.GetRepository(context.Background(), tc.repoName)
+			require.Error(t, getErr)
+		})
+	}
+}
+
+func TestGetRepository(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("success", func(t *testing.T) {
+		repo, err := m.GetRepository(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Contains(t, repo.Name, "my-repo")
+		assert.Equal(t, 0, repo.ImageCount)
+	})
+
+	t.Run("image count updated", func(t *testing.T) {
+		pushTestImage(t, m, "my-repo", "v1")
+
+		repo, err := m.GetRepository(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.ImageCount)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetRepository(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListRepositories(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		repos, err := m.ListRepositories(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(repos))
+	})
+
+	createTestRepo(t, m, "repo-a")
+	createTestRepo(t, m, "repo-b")
+
+	t.Run("two repositories", func(t *testing.T) {
+		repos, err := m.ListRepositories(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(repos))
+	})
+}
+
+func TestPutImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifest  driver.ImageManifest
+		setup     func(*Mock)
+		expectErr bool
+		checkFn   func(*testing.T, *driver.ImageDetail)
+	}{
+		{
+			name: "success with tag",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo",
+				Tag:        "v1.0",
+				SizeBytes:  2048,
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, detail *driver.ImageDetail) {
+				t.Helper()
+				assert.Equal(t, "my-repo", detail.Repository)
+				assert.Equal(t, []string{"v1.0"}, detail.Tags)
+				assert.Equal(t, int64(2048), detail.SizeBytes)
+				assert.NotEmpty(t, detail.Digest)
+				assert.NotEmpty(t, detail.PushedAt)
+				assert.Equal(t, defaultMediaType, detail.MediaType)
+			},
+		},
+		{
+			name: "success with custom digest",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo",
+				Tag:        "latest",
+				Digest:     "sha256:abc123",
+				SizeBytes:  512,
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, detail *driver.ImageDetail) {
+				t.Helper()
+				assert.Equal(t, "sha256:abc123", detail.Digest)
+			},
+		},
+		{
+			name: "success with custom media type",
+			manifest: driver.ImageManifest{
+				Repository: "my-repo",
+				Tag:        "v2",
+				MediaType:  "application/vnd.oci.image.manifest.v1+json",
+				SizeBytes:  256,
+			},
+			setup: func(m *Mock) {
+				createTestRepo(&testing.T{}, m, "my-repo")
+			},
+			checkFn: func(t *testing.T, detail *driver.ImageDetail) {
+				t.Helper()
+				assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", detail.MediaType)
+			},
+		},
+		{
+			name: "repository not found",
+			manifest: driver.ImageManifest{
+				Repository: "nonexistent",
+				Tag:        "v1",
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			detail, err := m.PutImage(context.Background(), &tc.manifest)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.checkFn != nil {
+				tc.checkFn(t, detail)
+			}
+		})
+	}
+}
+
+func TestGetImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	img := pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("by tag", func(t *testing.T) {
+		detail, err := m.GetImage(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, img.Digest, detail.Digest)
+		assert.Contains(t, detail.Tags, "v1")
+	})
+
+	t.Run("by digest", func(t *testing.T) {
+		detail, err := m.GetImage(ctx, "my-repo", img.Digest)
+		require.NoError(t, err)
+		assert.Equal(t, img.Digest, detail.Digest)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "my-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "nonexistent", "v1")
+		require.Error(t, err)
+	})
+}
+
+func TestListImages(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("empty list", func(t *testing.T) {
+		images, err := m.ListImages(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(images))
+	})
+
+	pushTestImage(t, m, "my-repo", "v1")
+	pushTestImage(t, m, "my-repo", "v2")
+
+	t.Run("two images", func(t *testing.T) {
+		images, err := m.ListImages(ctx, "my-repo")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(images))
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		_, err := m.ListImages(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	img := pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("success by tag", func(t *testing.T) {
+		err := m.DeleteImage(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+
+		_, getErr := m.GetImage(ctx, "my-repo", img.Digest)
+		require.Error(t, getErr)
+	})
+
+	t.Run("success by digest", func(t *testing.T) {
+		img2 := pushTestImage(t, m, "my-repo", "v2")
+
+		err := m.DeleteImage(ctx, "my-repo", img2.Digest)
+		require.NoError(t, err)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		err := m.DeleteImage(ctx, "my-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		err := m.DeleteImage(ctx, "nonexistent", "v1")
+		require.Error(t, err)
+	})
+}
+
+func TestTagImage(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	img := pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("add new tag", func(t *testing.T) {
+		err := m.TagImage(ctx, "my-repo", "v1", "latest")
+		require.NoError(t, err)
+
+		detail, getErr := m.GetImage(ctx, "my-repo", "latest")
+		require.NoError(t, getErr)
+		assert.Equal(t, img.Digest, detail.Digest)
+		assert.Contains(t, detail.Tags, "v1")
+		assert.Contains(t, detail.Tags, "latest")
+	})
+
+	t.Run("move tag to another image", func(t *testing.T) {
+		img2 := pushTestImage(t, m, "my-repo", "v2")
+
+		err := m.TagImage(ctx, "my-repo", "v2", "latest")
+		require.NoError(t, err)
+
+		detail, getErr := m.GetImage(ctx, "my-repo", "latest")
+		require.NoError(t, getErr)
+		assert.Equal(t, img2.Digest, detail.Digest)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		err := m.TagImage(ctx, "my-repo", "nonexistent", "new-tag")
+		require.Error(t, err)
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		err := m.TagImage(ctx, "nonexistent", "v1", "new-tag")
+		require.Error(t, err)
+	})
+}
+
+func TestImageTagMutability(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutSetting string
+		pushTag   string
+		retagTag  string
+		expectErr bool
+	}{
+		{
+			name:       "mutable allows overwrite",
+			mutSetting: "MUTABLE",
+			pushTag:    "v1",
+			retagTag:   "v1",
+			expectErr:  false,
+		},
+		{
+			name:       "immutable blocks overwrite on push",
+			mutSetting: "IMMUTABLE",
+			pushTag:    "v1",
+			retagTag:   "v1",
+			expectErr:  true,
+		},
+		{
+			name:       "immutable allows new tag",
+			mutSetting: "IMMUTABLE",
+			pushTag:    "v1",
+			retagTag:   "v2",
+			expectErr:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+			ctx := context.Background()
+
+			_, err := m.CreateRepository(ctx, driver.RepositoryConfig{
+				Name:               "immut-repo",
+				ImageTagMutability: tc.mutSetting,
+			})
+			require.NoError(t, err)
+
+			pushTestImage(t, m, "immut-repo", tc.pushTag)
+
+			_, pushErr := m.PutImage(ctx, &driver.ImageManifest{
+				Repository: "immut-repo",
+				Tag:        tc.retagTag,
+				SizeBytes:  512,
+			})
+
+			if tc.expectErr {
+				require.Error(t, pushErr)
+			} else {
+				require.NoError(t, pushErr)
+			}
+		})
+	}
+}
+
+func TestLifecyclePolicy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("no policy returns not found", func(t *testing.T) {
+		_, err := m.GetLifecyclePolicy(ctx, "my-repo")
+		require.Error(t, err)
+	})
+
+	t.Run("put and get policy", func(t *testing.T) {
+		policy := driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{
+					Priority:    1,
+					Description: "expire old untagged images",
+					TagStatus:   "untagged",
+					CountType:   "imageCountMoreThan",
+					CountValue:  2,
+					Action:      "expire",
+				},
+			},
+		}
+
+		err := m.PutLifecyclePolicy(ctx, "my-repo", policy)
+		require.NoError(t, err)
+
+		got, getErr := m.GetLifecyclePolicy(ctx, "my-repo")
+		require.NoError(t, getErr)
+		assert.Equal(t, 1, len(got.Rules))
+		assert.Equal(t, "expire old untagged images", got.Rules[0].Description)
+	})
+
+	t.Run("evaluate count-based policy", func(t *testing.T) {
+		m2, fc2 := newTestMock()
+		createTestRepo(t, m2, "count-repo")
+
+		// Push 4 tagged images with unique tags
+		for i := range 4 {
+			fc2.Advance(time.Minute)
+			pushTestImage(t, m2, "count-repo", fmt.Sprintf("v%d", i))
+		}
+
+		policyErr := m2.PutLifecyclePolicy(ctx, "count-repo", driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{
+					Priority:   1,
+					TagStatus:  "any",
+					CountType:  "imageCountMoreThan",
+					CountValue: 2,
+					Action:     "expire",
+				},
+			},
+		})
+		require.NoError(t, policyErr)
+
+		expired, evalErr := m2.EvaluateLifecyclePolicy(ctx, "count-repo")
+		require.NoError(t, evalErr)
+		assert.Equal(t, 2, len(expired))
+	})
+
+	t.Run("evaluate time-based policy", func(t *testing.T) {
+		m2, fc2 := newTestMock()
+		createTestRepo(t, m2, "time-repo")
+
+		pushTestImage(t, m2, "time-repo", "old-tag")
+
+		fc2.Advance(31 * 24 * time.Hour) // advance 31 days
+
+		err := m2.PutLifecyclePolicy(ctx, "time-repo", driver.LifecyclePolicy{
+			Rules: []driver.LifecycleRule{
+				{
+					Priority:   1,
+					TagStatus:  "any",
+					CountType:  "sinceImagePushed",
+					CountValue: 30,
+					Action:     "expire",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		expired, evalErr := m2.EvaluateLifecyclePolicy(ctx, "time-repo")
+		require.NoError(t, evalErr)
+		assert.Equal(t, 1, len(expired))
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		err := m.PutLifecyclePolicy(ctx, "nonexistent", driver.LifecyclePolicy{})
+		require.Error(t, err)
+
+		_, getErr := m.GetLifecyclePolicy(ctx, "nonexistent")
+		require.Error(t, getErr)
+
+		_, evalErr := m.EvaluateLifecyclePolicy(ctx, "nonexistent")
+		require.Error(t, evalErr)
+	})
+}
+
+func TestImageScan(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+	pushTestImage(t, m, "my-repo", "v1")
+
+	t.Run("start scan", func(t *testing.T) {
+		result, err := m.StartImageScan(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, scanStatusComplete, result.Status)
+		assert.NotEmpty(t, result.Digest)
+		assert.NotEmpty(t, result.CompletedAt)
+		assert.NotNil(t, result.FindingCounts)
+	})
+
+	t.Run("get scan results", func(t *testing.T) {
+		result, err := m.GetImageScanResults(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+		assert.Equal(t, scanStatusComplete, result.Status)
+		assert.Contains(t, result.FindingCounts, "CRITICAL")
+		assert.Contains(t, result.FindingCounts, "HIGH")
+		assert.Contains(t, result.FindingCounts, "MEDIUM")
+		assert.Contains(t, result.FindingCounts, "LOW")
+		assert.Contains(t, result.FindingCounts, "INFORMATIONAL")
+	})
+
+	t.Run("scan on push enabled", func(t *testing.T) {
+		_, repoErr := m.CreateRepository(ctx, driver.RepositoryConfig{
+			Name:            "scan-repo",
+			ImageScanOnPush: true,
+		})
+		require.NoError(t, repoErr)
+
+		pushTestImage(t, m, "scan-repo", "auto-scan")
+
+		result, err := m.GetImageScanResults(ctx, "scan-repo", "auto-scan")
+		require.NoError(t, err)
+		assert.Equal(t, scanStatusComplete, result.Status)
+	})
+
+	t.Run("no scan results", func(t *testing.T) {
+		_, repoErr := m.CreateRepository(ctx, driver.RepositoryConfig{Name: "no-scan-repo"})
+		require.NoError(t, repoErr)
+
+		pushTestImage(t, m, "no-scan-repo", "v1")
+
+		_, err := m.GetImageScanResults(ctx, "no-scan-repo", "v1")
+		require.Error(t, err)
+	})
+
+	t.Run("image not found", func(t *testing.T) {
+		_, err := m.StartImageScan(ctx, "my-repo", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("repository not found", func(t *testing.T) {
+		_, err := m.StartImageScan(ctx, "nonexistent", "v1")
+		require.Error(t, err)
+	})
+}
+
+func TestMetricsEmission(t *testing.T) {
+	m, mon, _ := newTestMockWithMonitoring()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "my-repo")
+
+	t.Run("push emits metric", func(t *testing.T) {
+		pushTestImage(t, m, "my-repo", "v1")
+
+		metrics, err := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "artifactregistry.googleapis.com",
+			MetricName: "push_request_count",
+			Dimensions: map[string]string{"repository_name": "my-repo"},
+			StartTime:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		require.NoError(t, err)
+		assert.Greater(t, len(metrics.Values), 0)
+	})
+
+	t.Run("pull emits metric", func(t *testing.T) {
+		_, err := m.GetImage(ctx, "my-repo", "v1")
+		require.NoError(t, err)
+
+		metrics, getErr := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "artifactregistry.googleapis.com",
+			MetricName: "pull_request_count",
+			Dimensions: map[string]string{"repository_name": "my-repo"},
+			StartTime:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		require.NoError(t, getErr)
+		assert.Greater(t, len(metrics.Values), 0)
+	})
+}

--- a/providers/gcp/artifactregistry/artifactregistry_test.go
+++ b/providers/gcp/artifactregistry/artifactregistry_test.go
@@ -451,6 +451,39 @@ func TestTagImage(t *testing.T) {
 	})
 }
 
+func TestTagImageUpdatesImageCount(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "count-repo")
+	pushTestImage(t, m, "count-repo", "v1")
+	pushTestImage(t, m, "count-repo", "v2")
+
+	repo, err := m.GetRepository(ctx, "count-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.ImageCount)
+
+	// Tag image v1 with a new tag - should not change image count
+	err = m.TagImage(ctx, "count-repo", "v1", "latest")
+	require.NoError(t, err)
+
+	repo, err = m.GetRepository(ctx, "count-repo")
+	require.NoError(t, err)
+	assert.Equal(t, 2, repo.ImageCount)
+}
+
+func TestTagImageEmptyTagRejected(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestRepo(t, m, "empty-tag-repo")
+	pushTestImage(t, m, "empty-tag-repo", "v1")
+
+	err := m.TagImage(ctx, "empty-tag-repo", "v1", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
 func TestImageTagMutability(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/providers/gcp/cloudfunctions/aliases.go
+++ b/providers/gcp/cloudfunctions/aliases.go
@@ -1,0 +1,147 @@
+package cloudfunctions
+
+import (
+	"context"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// CreateAlias creates a new traffic split alias pointing to a specific function version.
+func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if fd.aliases.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "alias %s already exists", cfg.Name)
+	}
+
+	if !m.versionExists(&fd, cfg.FunctionVersion) {
+		return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
+	}
+
+	aliasARN := idgen.GCPID(
+		m.opts.ProjectID, "functions",
+		cfg.FunctionName+"/aliases/"+cfg.Name,
+	)
+
+	a := driver.Alias{
+		FunctionName:    cfg.FunctionName,
+		Name:            cfg.Name,
+		FunctionVersion: cfg.FunctionVersion,
+		Description:     cfg.Description,
+		RoutingConfig:   cfg.RoutingConfig,
+		AliasARN:        aliasARN,
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}
+
+	fd.aliases.Set(cfg.Name, &aliasData{alias: a})
+
+	result := a
+
+	return &result, nil
+}
+
+// UpdateAlias updates an existing traffic split alias.
+func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	ad, ok := fd.aliases.Get(cfg.Name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", cfg.Name)
+	}
+
+	if cfg.FunctionVersion != "" {
+		if !m.versionExists(&fd, cfg.FunctionVersion) {
+			return nil, cerrors.Newf(cerrors.NotFound, "version %s not found", cfg.FunctionVersion)
+		}
+
+		ad.alias.FunctionVersion = cfg.FunctionVersion
+	}
+
+	if cfg.Description != "" {
+		ad.alias.Description = cfg.Description
+	}
+
+	if cfg.RoutingConfig != nil {
+		ad.alias.RoutingConfig = cfg.RoutingConfig
+	}
+
+	fd.aliases.Set(cfg.Name, ad)
+
+	result := ad.alias
+
+	return &result, nil
+}
+
+// DeleteAlias removes a traffic split alias from a function.
+func (m *Mock) DeleteAlias(_ context.Context, functionName, aliasName string) error {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if !fd.aliases.Has(aliasName) {
+		return cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
+	}
+
+	fd.aliases.Delete(aliasName)
+
+	return nil
+}
+
+// GetAlias retrieves a specific traffic split alias for a function.
+func (m *Mock) GetAlias(_ context.Context, functionName, aliasName string) (*driver.Alias, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	ad, ok := fd.aliases.Get(aliasName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "alias %s not found", aliasName)
+	}
+
+	result := ad.alias
+
+	return &result, nil
+}
+
+// ListAliases returns all traffic split aliases for a function.
+func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Alias, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	all := fd.aliases.All()
+	aliases := make([]driver.Alias, 0, len(all))
+
+	for _, ad := range all {
+		aliases = append(aliases, ad.alias)
+	}
+
+	return aliases, nil
+}
+
+// versionExists checks whether a version string exists for the given function.
+func (*Mock) versionExists(fd *funcData, version string) bool {
+	if version == latestVersion {
+		return true
+	}
+
+	for _, v := range fd.versions {
+		if v.version == version {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/gcp/cloudfunctions/aliases.go
+++ b/providers/gcp/cloudfunctions/aliases.go
@@ -34,7 +34,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Name:            cfg.Name,
 		FunctionVersion: cfg.FunctionVersion,
 		Description:     cfg.Description,
-		RoutingConfig:   cfg.RoutingConfig,
+		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
 		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
 	}
@@ -71,7 +71,7 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	}
 
 	if cfg.RoutingConfig != nil {
-		ad.alias.RoutingConfig = cfg.RoutingConfig
+		ad.alias.RoutingConfig = copyRoutingConfig(cfg.RoutingConfig)
 	}
 
 	fd.aliases.Set(cfg.Name, ad)
@@ -129,6 +129,16 @@ func (m *Mock) ListAliases(_ context.Context, functionName string) ([]driver.Ali
 	}
 
 	return aliases, nil
+}
+
+func copyRoutingConfig(rc *driver.AliasRoutingConfig) *driver.AliasRoutingConfig {
+	if rc == nil {
+		return nil
+	}
+
+	cp := *rc
+
+	return &cp
 }
 
 // versionExists checks whether a version string exists for the given function.

--- a/providers/gcp/cloudfunctions/concurrency.go
+++ b/providers/gcp/cloudfunctions/concurrency.go
@@ -1,0 +1,53 @@
+package cloudfunctions
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PutFunctionConcurrency sets max instances (concurrency) for a Cloud Function.
+func (m *Mock) PutFunctionConcurrency(_ context.Context, cfg driver.ConcurrencyConfig) error {
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	fd.concurrency = &driver.ConcurrencyConfig{
+		FunctionName:                 cfg.FunctionName,
+		ReservedConcurrentExecutions: cfg.ReservedConcurrentExecutions,
+	}
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	return nil
+}
+
+// GetFunctionConcurrency retrieves the max instances configuration for a Cloud Function.
+func (m *Mock) GetFunctionConcurrency(_ context.Context, functionName string) (*driver.ConcurrencyConfig, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if fd.concurrency == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no concurrency config for function %s", functionName)
+	}
+
+	result := *fd.concurrency
+
+	return &result, nil
+}
+
+// DeleteFunctionConcurrency removes the max instances configuration for a Cloud Function.
+func (m *Mock) DeleteFunctionConcurrency(_ context.Context, functionName string) error {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	fd.concurrency = nil
+	m.funcs.Set(functionName, fd)
+
+	return nil
+}

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -3,6 +3,8 @@ package cloudfunctions
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"sync"
 	"time"
 
@@ -10,29 +12,79 @@ import (
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/serverless/driver"
 )
 
 // Compile-time check that Mock implements driver.Serverless.
 var _ driver.Serverless = (*Mock)(nil)
 
+// initialVersion is the starting generation number for published versions.
+const initialVersion = 1
+
+type versionData struct {
+	config    driver.FunctionConfig
+	version   string
+	codeSHA   string
+	createdAt string
+}
+
+type aliasData struct {
+	alias driver.Alias
+}
+
+type layerData struct {
+	versions *memstore.Store[*driver.LayerVersion]
+	nextVer  int
+}
+
 type funcData struct {
-	info    driver.FunctionInfo
-	handler driver.HandlerFunc
+	info        driver.FunctionInfo
+	handler     driver.HandlerFunc
+	versions    []*versionData
+	nextVersion int
+	aliases     *memstore.Store[*aliasData]
+	concurrency *driver.ConcurrencyConfig
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Functions.
 type Mock struct {
 	funcs      *memstore.Store[funcData]
+	layers     *memstore.Store[*layerData]
 	opts       *config.Options
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+//nolint:unparam // value kept as parameter for API consistency with other service emitMetric helpers.
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "cloudfunctions.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new Cloud Functions mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		funcs:    memstore.New[funcData](),
+		layers:   memstore.New[*layerData](),
 		opts:     opts,
 		handlers: make(map[string]driver.HandlerFunc),
 	}
@@ -67,7 +119,11 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	h := m.handlers[cfg.Name]
 	m.handlersMu.RUnlock()
 
-	m.funcs.Set(cfg.Name, funcData{info: info, handler: h})
+	m.funcs.Set(cfg.Name, funcData{
+		info: info, handler: h,
+		nextVersion: initialVersion,
+		aliases:     memstore.New[*aliasData](),
+	})
 
 	result := info
 
@@ -114,33 +170,10 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 	}
 
 	info := fd.info
-
-	if cfg.Runtime != "" {
-		info.Runtime = cfg.Runtime
-	}
-
-	if cfg.Handler != "" {
-		info.Handler = cfg.Handler
-	}
-
-	if cfg.Memory != 0 {
-		info.Memory = cfg.Memory
-	}
-
-	if cfg.Timeout != 0 {
-		info.Timeout = cfg.Timeout
-	}
-
-	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
-	}
-
-	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
-	}
-
+	applyConfigUpdates(&info, cfg)
 	info.LastModified = time.Now().UTC().Format(time.RFC3339)
-	m.funcs.Set(name, funcData{info: info, handler: fd.handler})
+	fd.info = info
+	m.funcs.Set(name, fd)
 
 	result := info
 
@@ -164,10 +197,19 @@ func (m *Mock) Invoke(ctx context.Context, input driver.InvokeInput) (*driver.In
 		return &driver.InvokeOutput{StatusCode: 500, Error: "no handler registered"}, nil
 	}
 
+	dims := map[string]string{"function_name": input.FunctionName}
+
 	payload, err := h(ctx, input.Payload)
 	if err != nil {
+		m.emitMetric(ctx, "function/execution_count", 1, dims)
+		m.emitMetric(ctx, "function/execution_times", 1, dims)
+		m.emitMetric(ctx, "function/error_count", 1, dims)
+
 		return &driver.InvokeOutput{StatusCode: 500, Error: err.Error()}, nil
 	}
+
+	m.emitMetric(ctx, "function/execution_count", 1, dims)
+	m.emitMetric(ctx, "function/execution_times", 1, dims)
 
 	return &driver.InvokeOutput{StatusCode: 200, Payload: payload}, nil
 }
@@ -181,4 +223,40 @@ func (m *Mock) RegisterHandler(name string, handler driver.HandlerFunc) {
 		fd.handler = handler
 		m.funcs.Set(name, fd)
 	}
+}
+
+// applyConfigUpdates applies non-zero config fields to the function info.
+//
+//nolint:gocritic // hugeParam: config passed by value intentionally for snapshot semantics.
+func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
+	if cfg.Runtime != "" {
+		info.Runtime = cfg.Runtime
+	}
+
+	if cfg.Handler != "" {
+		info.Handler = cfg.Handler
+	}
+
+	if cfg.Memory != 0 {
+		info.Memory = cfg.Memory
+	}
+
+	if cfg.Timeout != 0 {
+		info.Timeout = cfg.Timeout
+	}
+
+	if cfg.Environment != nil {
+		info.Environment = cfg.Environment
+	}
+
+	if cfg.Tags != nil {
+		info.Tags = cfg.Tags
+	}
+}
+
+func codeSHA(info *driver.FunctionInfo) string {
+	data := fmt.Sprintf("%s:%s:%s", info.Name, info.Handler, info.Runtime)
+	hash := sha256.Sum256([]byte(data))
+
+	return fmt.Sprintf("%x", hash)
 }

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -55,6 +55,7 @@ type Mock struct {
 	handlersMu sync.RWMutex
 	handlers   map[string]driver.HandlerFunc
 	monitoring mondriver.Monitoring
+	mu         sync.Mutex // guards PublishVersion read-modify-write on funcData
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.

--- a/providers/gcp/cloudfunctions/functions_test.go
+++ b/providers/gcp/cloudfunctions/functions_test.go
@@ -3,6 +3,7 @@ package cloudfunctions
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -899,4 +900,66 @@ func TestDeleteFunctionConcurrency(t *testing.T) {
 		require.Error(t, delErr)
 		assert.Contains(t, delErr.Error(), "not found")
 	})
+}
+
+func TestPublishVersionConcurrent(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-conc", Runtime: "go121"})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			_, _ = m.PublishVersion(ctx, "f-conc", "concurrent")
+		}()
+	}
+
+	wg.Wait()
+
+	versions, err := m.ListVersions(ctx, "f-conc")
+	require.NoError(t, err)
+	require.Len(t, versions, 11) // $LATEST + 10 published
+
+	seen := make(map[string]bool)
+	for _, v := range versions {
+		assert.False(t, seen[v.Version], "duplicate version: %s", v.Version)
+		seen[v.Version] = true
+	}
+}
+
+func TestAliasRoutingConfigDeepCopy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-dc", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f-dc", "v1")
+	require.NoError(t, err)
+
+	rc := &driver.AliasRoutingConfig{
+		AdditionalVersion: "1",
+		Weight:            0.5,
+	}
+
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName:    "f-dc",
+		Name:            "deep-copy",
+		FunctionVersion: "$LATEST",
+		RoutingConfig:   rc,
+	})
+	require.NoError(t, err)
+
+	// Mutate the original config
+	rc.Weight = 0.9
+
+	alias, err := m.GetAlias(ctx, "f-dc", "deep-copy")
+	require.NoError(t, err)
+	require.NotNil(t, alias.RoutingConfig)
+	assert.InDelta(t, 0.5, alias.RoutingConfig.Weight, 0.001)
 }

--- a/providers/gcp/cloudfunctions/functions_test.go
+++ b/providers/gcp/cloudfunctions/functions_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/serverless/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -219,4 +220,683 @@ func TestUpdateFunction(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPublishVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{
+		Name: "f1", Runtime: "go121", Handler: "main.Handler",
+	})
+	require.NoError(t, err)
+
+	t.Run("publish first version", func(t *testing.T) {
+		ver, pubErr := m.PublishVersion(ctx, "f1", "initial release")
+		require.NoError(t, pubErr)
+		assert.Equal(t, "1", ver.Version)
+		assert.Equal(t, "f1", ver.FunctionName)
+		assert.NotEmpty(t, ver.CodeSHA256)
+		assert.NotEmpty(t, ver.CreatedAt)
+	})
+
+	t.Run("publish second version", func(t *testing.T) {
+		ver, pubErr := m.PublishVersion(ctx, "f1", "v2")
+		require.NoError(t, pubErr)
+		assert.Equal(t, "2", ver.Version)
+	})
+
+	t.Run("list versions includes $LATEST and published", func(t *testing.T) {
+		versions, listErr := m.ListVersions(ctx, "f1")
+		require.NoError(t, listErr)
+		require.Len(t, versions, 3) // $LATEST + 2 published
+		assert.Equal(t, "$LATEST", versions[0].Version)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, pubErr := m.PublishVersion(ctx, "missing", "")
+		require.Error(t, pubErr)
+		assert.Contains(t, pubErr.Error(), "not found")
+	})
+}
+
+func TestCreateAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f1", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f1", "v1")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       driver.AliasConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg: driver.AliasConfig{
+				FunctionName: "f1", Name: "prod",
+				FunctionVersion: "1", Description: "production",
+			},
+		},
+		{
+			name: "duplicate alias",
+			cfg: driver.AliasConfig{
+				FunctionName: "f1", Name: "prod", FunctionVersion: "1",
+			},
+			wantErr:   true,
+			errSubstr: "already exists",
+		},
+		{
+			name: "function not found",
+			cfg: driver.AliasConfig{
+				FunctionName: "missing", Name: "dev", FunctionVersion: "1",
+			},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+		{
+			name: "version not found",
+			cfg: driver.AliasConfig{
+				FunctionName: "f1", Name: "staging", FunctionVersion: "99",
+			},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alias, createErr := m.CreateAlias(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, createErr)
+				assert.Contains(t, createErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, createErr)
+				assert.Equal(t, "prod", alias.Name)
+				assert.Equal(t, "1", alias.FunctionVersion)
+				assert.NotEmpty(t, alias.AliasARN)
+			}
+		})
+	}
+}
+
+func TestUpdateAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f1", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f1", "v1")
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f1", "v2")
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "f1", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       driver.AliasConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "update version",
+			cfg: driver.AliasConfig{
+				FunctionName: "f1", Name: "prod",
+				FunctionVersion: "2", Description: "updated",
+			},
+		},
+		{
+			name: "alias not found",
+			cfg: driver.AliasConfig{
+				FunctionName: "f1", Name: "missing", FunctionVersion: "1",
+			},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+		{
+			name: "function not found",
+			cfg: driver.AliasConfig{
+				FunctionName: "missing", Name: "prod", FunctionVersion: "1",
+			},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alias, updateErr := m.UpdateAlias(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, updateErr)
+				assert.Contains(t, updateErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, updateErr)
+				assert.Equal(t, "2", alias.FunctionVersion)
+				assert.Equal(t, "updated", alias.Description)
+			}
+		})
+	}
+}
+
+func TestDeleteAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f1", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f1", "v1")
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "f1", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		funcName  string
+		aliasName string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", funcName: "f1", aliasName: "prod"},
+		{name: "already deleted", funcName: "f1", aliasName: "prod", wantErr: true, errSubstr: "not found"},
+		{name: "function not found", funcName: "missing", aliasName: "x", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delErr := m.DeleteAlias(ctx, tt.funcName, tt.aliasName)
+			switch {
+			case tt.wantErr:
+				require.Error(t, delErr)
+				assert.Contains(t, delErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, delErr)
+			}
+		})
+	}
+}
+
+func TestPublishLayerVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("publish first version", func(t *testing.T) {
+		lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name:               "my-layer",
+			Description:        "test layer",
+			Content:            []byte("layer-content"),
+			CompatibleRuntimes: []string{"go121"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "my-layer", lv.Name)
+		assert.Equal(t, 1, lv.Version)
+		assert.Equal(t, int64(13), lv.ContentSize)
+		assert.NotEmpty(t, lv.ContentSHA256)
+		assert.NotEmpty(t, lv.ARN)
+	})
+
+	t.Run("publish second version", func(t *testing.T) {
+		lv, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+			Name:    "my-layer",
+			Content: []byte("updated-content"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, lv.Version)
+	})
+
+	t.Run("get specific version", func(t *testing.T) {
+		lv, err := m.GetLayerVersion(ctx, "my-layer", 1)
+		require.NoError(t, err)
+		assert.Equal(t, 1, lv.Version)
+		assert.Equal(t, "test layer", lv.Description)
+	})
+
+	t.Run("list layer versions", func(t *testing.T) {
+		versions, err := m.ListLayerVersions(ctx, "my-layer")
+		require.NoError(t, err)
+		assert.Len(t, versions, 2)
+	})
+}
+
+func TestDeleteLayerVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "my-layer", Content: []byte("data"),
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		layerName string
+		version   int
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", layerName: "my-layer", version: 1},
+		{name: "version not found", layerName: "my-layer", version: 1, wantErr: true, errSubstr: "not found"},
+		{name: "layer not found", layerName: "missing", version: 1, wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delErr := m.DeleteLayerVersion(ctx, tt.layerName, tt.version)
+			switch {
+			case tt.wantErr:
+				require.Error(t, delErr)
+				assert.Contains(t, delErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, delErr)
+			}
+		})
+	}
+}
+
+func TestPutFunctionConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f1", Runtime: "go121"})
+	require.NoError(t, err)
+
+	t.Run("set concurrency", func(t *testing.T) {
+		require.NoError(t, m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName:                 "f1",
+			ReservedConcurrentExecutions: 100,
+		}))
+
+		cfg, getErr := m.GetFunctionConcurrency(ctx, "f1")
+		require.NoError(t, getErr)
+		assert.Equal(t, 100, cfg.ReservedConcurrentExecutions)
+	})
+
+	t.Run("delete concurrency", func(t *testing.T) {
+		require.NoError(t, m.DeleteFunctionConcurrency(ctx, "f1"))
+
+		_, getErr := m.GetFunctionConcurrency(ctx, "f1")
+		require.Error(t, getErr)
+		assert.Contains(t, getErr.Error(), "no concurrency config")
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		putErr := m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+			FunctionName: "missing", ReservedConcurrentExecutions: 50,
+		})
+		require.Error(t, putErr)
+		assert.Contains(t, putErr.Error(), "not found")
+	})
+}
+
+func TestCloudFunctionsMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+
+	mon := &cfMonMock{data: make(map[string][]mondriver.MetricDatum)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f1", Runtime: "go121"})
+	require.NoError(t, err)
+	m.RegisterHandler("f1", func(_ context.Context, p []byte) ([]byte, error) {
+		return p, nil
+	})
+
+	t.Run("successful invoke emits execution metrics", func(t *testing.T) {
+		_, invokeErr := m.Invoke(ctx, driver.InvokeInput{FunctionName: "f1", Payload: []byte("hi")})
+		require.NoError(t, invokeErr)
+
+		assert.NotEmpty(t, mon.data["cloudfunctions.googleapis.com/function/execution_count"])
+		assert.NotEmpty(t, mon.data["cloudfunctions.googleapis.com/function/execution_times"])
+	})
+
+	t.Run("failed invoke emits error metric", func(t *testing.T) {
+		m.RegisterHandler("f1", func(_ context.Context, _ []byte) ([]byte, error) {
+			return nil, errors.New("fail")
+		})
+
+		_, invokeErr := m.Invoke(ctx, driver.InvokeInput{FunctionName: "f1"})
+		require.NoError(t, invokeErr) // Invoke itself doesn't error, returns 500 status
+
+		assert.NotEmpty(t, mon.data["cloudfunctions.googleapis.com/function/error_count"])
+	})
+}
+
+type cfMonMock struct {
+	data map[string][]mondriver.MetricDatum
+}
+
+func (m *cfMonMock) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	for _, d := range data {
+		key := d.Namespace + "/" + d.MetricName
+		m.data[key] = append(m.data[key], d)
+	}
+
+	return nil
+}
+
+func (m *cfMonMock) GetMetricData(
+	_ context.Context, _ mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (m *cfMonMock) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *cfMonMock) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (m *cfMonMock) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *cfMonMock) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (m *cfMonMock) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestListVersionsMultiple(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{
+		Name: "f-ver", Runtime: "go121", Handler: "main.Handler",
+	})
+	require.NoError(t, err)
+
+	// Publish three versions
+	for i := 0; i < 3; i++ {
+		_, pubErr := m.PublishVersion(ctx, "f-ver", "")
+		require.NoError(t, pubErr)
+	}
+
+	t.Run("lists $LATEST plus all published versions", func(t *testing.T) {
+		versions, err := m.ListVersions(ctx, "f-ver")
+		require.NoError(t, err)
+		require.Len(t, versions, 4) // $LATEST + 3 published
+		assert.Equal(t, "$LATEST", versions[0].Version)
+		assert.Equal(t, "1", versions[1].Version)
+		assert.Equal(t, "2", versions[2].Version)
+		assert.Equal(t, "3", versions[3].Version)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, listErr := m.ListVersions(ctx, "missing")
+		require.Error(t, listErr)
+		assert.Contains(t, listErr.Error(), "not found")
+	})
+}
+
+func TestGetAlias(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-alias", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f-alias", "v1")
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "f-alias", Name: "prod", FunctionVersion: "1", Description: "production",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		funcName  string
+		aliasName string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", funcName: "f-alias", aliasName: "prod"},
+		{name: "alias not found", funcName: "f-alias", aliasName: "missing", wantErr: true, errSubstr: "not found"},
+		{name: "function not found", funcName: "missing", aliasName: "prod", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alias, err := m.GetAlias(ctx, tt.funcName, tt.aliasName)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, "prod", alias.Name)
+				assert.Equal(t, "1", alias.FunctionVersion)
+				assert.Equal(t, "production", alias.Description)
+				assert.NotEmpty(t, alias.AliasARN)
+			}
+		})
+	}
+}
+
+func TestListAliases(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-la", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f-la", "v1")
+	require.NoError(t, err)
+
+	t.Run("empty list", func(t *testing.T) {
+		aliases, listErr := m.ListAliases(ctx, "f-la")
+		require.NoError(t, listErr)
+		assert.Empty(t, aliases)
+	})
+
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "f-la", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "f-la", Name: "staging", FunctionVersion: "$LATEST",
+	})
+	require.NoError(t, err)
+
+	t.Run("two aliases", func(t *testing.T) {
+		aliases, listErr := m.ListAliases(ctx, "f-la")
+		require.NoError(t, listErr)
+		assert.Len(t, aliases, 2)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, listErr := m.ListAliases(ctx, "missing")
+		require.Error(t, listErr)
+		assert.Contains(t, listErr.Error(), "not found")
+	})
+}
+
+func TestUpdateAliasRoutingConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-rc", Runtime: "go121"})
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f-rc", "v1")
+	require.NoError(t, err)
+	_, err = m.PublishVersion(ctx, "f-rc", "v2")
+	require.NoError(t, err)
+	_, err = m.CreateAlias(ctx, driver.AliasConfig{
+		FunctionName: "f-rc", Name: "prod", FunctionVersion: "1",
+	})
+	require.NoError(t, err)
+
+	t.Run("update with routing config", func(t *testing.T) {
+		alias, updateErr := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "f-rc", Name: "prod",
+			FunctionVersion: "1",
+			RoutingConfig: &driver.AliasRoutingConfig{
+				AdditionalVersion: "2",
+				Weight:            0.1,
+			},
+		})
+		require.NoError(t, updateErr)
+		require.NotNil(t, alias.RoutingConfig)
+		assert.Equal(t, "2", alias.RoutingConfig.AdditionalVersion)
+		assert.InDelta(t, 0.1, alias.RoutingConfig.Weight, 0.001)
+	})
+
+	t.Run("update version to non-existent fails", func(t *testing.T) {
+		_, updateErr := m.UpdateAlias(ctx, driver.AliasConfig{
+			FunctionName: "f-rc", Name: "prod", FunctionVersion: "99",
+		})
+		require.Error(t, updateErr)
+		assert.Contains(t, updateErr.Error(), "not found")
+	})
+}
+
+func TestGetLayerVersion(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "layer-get", Content: []byte("data"), Description: "test",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		layerName string
+		version   int
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", layerName: "layer-get", version: 1},
+		{name: "version not found", layerName: "layer-get", version: 99, wantErr: true, errSubstr: "not found"},
+		{name: "layer not found", layerName: "missing-layer", version: 1, wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lv, err := m.GetLayerVersion(ctx, tt.layerName, tt.version)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, "layer-get", lv.Name)
+				assert.Equal(t, 1, lv.Version)
+				assert.Equal(t, "test", lv.Description)
+			}
+		})
+	}
+}
+
+func TestListLayers(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("empty list", func(t *testing.T) {
+		layers, err := m.ListLayers(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, layers)
+	})
+
+	// Publish versions for two different layers
+	_, err := m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "layer-a", Content: []byte("a1"),
+	})
+	require.NoError(t, err)
+	_, err = m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "layer-a", Content: []byte("a2"),
+	})
+	require.NoError(t, err)
+	_, err = m.PublishLayerVersion(ctx, driver.LayerConfig{
+		Name: "layer-b", Content: []byte("b1"),
+	})
+	require.NoError(t, err)
+
+	t.Run("returns latest version of each layer", func(t *testing.T) {
+		layers, listErr := m.ListLayers(ctx)
+		require.NoError(t, listErr)
+		assert.Len(t, layers, 2)
+
+		// Find layer-a in results - should be version 2 (the latest)
+		var foundA bool
+		for _, l := range layers {
+			if l.Name == "layer-a" {
+				assert.Equal(t, 2, l.Version)
+				foundA = true
+			}
+		}
+		assert.True(t, foundA, "layer-a should be in results")
+	})
+}
+
+func TestGetFunctionConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-conc", Runtime: "go121"})
+	require.NoError(t, err)
+
+	t.Run("no concurrency set", func(t *testing.T) {
+		_, getErr := m.GetFunctionConcurrency(ctx, "f-conc")
+		require.Error(t, getErr)
+		assert.Contains(t, getErr.Error(), "no concurrency config")
+	})
+
+	require.NoError(t, m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+		FunctionName:                 "f-conc",
+		ReservedConcurrentExecutions: 50,
+	}))
+
+	t.Run("success", func(t *testing.T) {
+		cfg, getErr := m.GetFunctionConcurrency(ctx, "f-conc")
+		require.NoError(t, getErr)
+		assert.Equal(t, 50, cfg.ReservedConcurrentExecutions)
+		assert.Equal(t, "f-conc", cfg.FunctionName)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, getErr := m.GetFunctionConcurrency(ctx, "missing")
+		require.Error(t, getErr)
+		assert.Contains(t, getErr.Error(), "not found")
+	})
+}
+
+func TestDeleteFunctionConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateFunction(ctx, driver.FunctionConfig{Name: "f-delconc", Runtime: "go121"})
+	require.NoError(t, err)
+
+	require.NoError(t, m.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{
+		FunctionName:                 "f-delconc",
+		ReservedConcurrentExecutions: 100,
+	}))
+
+	t.Run("delete concurrency", func(t *testing.T) {
+		require.NoError(t, m.DeleteFunctionConcurrency(ctx, "f-delconc"))
+
+		_, getErr := m.GetFunctionConcurrency(ctx, "f-delconc")
+		require.Error(t, getErr)
+		assert.Contains(t, getErr.Error(), "no concurrency config")
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		delErr := m.DeleteFunctionConcurrency(ctx, "missing")
+		require.Error(t, delErr)
+		assert.Contains(t, delErr.Error(), "not found")
+	})
 }

--- a/providers/gcp/cloudfunctions/layers.go
+++ b/providers/gcp/cloudfunctions/layers.go
@@ -1,0 +1,137 @@
+package cloudfunctions
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PublishLayerVersion publishes a new version of a shared buildpack layer.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(cfg.Name)
+	if !ok {
+		ld = &layerData{
+			versions: memstore.New[*driver.LayerVersion](),
+			nextVer:  initialVersion,
+		}
+		m.layers.Set(cfg.Name, ld)
+	}
+
+	ver := ld.nextVer
+	ld.nextVer++
+
+	hash := sha256.Sum256(cfg.Content)
+	shaStr := fmt.Sprintf("%x", hash)
+
+	arn := idgen.GCPID(
+		m.opts.ProjectID, "layers",
+		cfg.Name+"/versions/"+strconv.Itoa(ver),
+	)
+
+	lv := &driver.LayerVersion{
+		Name:               cfg.Name,
+		Version:            ver,
+		Description:        cfg.Description,
+		ContentSHA256:      shaStr,
+		ContentSize:        int64(len(cfg.Content)),
+		CompatibleRuntimes: cfg.CompatibleRuntimes,
+		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		ARN:                arn,
+	}
+
+	ld.versions.Set(strconv.Itoa(ver), lv)
+
+	result := *lv
+
+	return &result, nil
+}
+
+// GetLayerVersion retrieves a specific version of a shared buildpack layer.
+func (m *Mock) GetLayerVersion(_ context.Context, name string, version int) (*driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	lv, ok := ld.versions.Get(strconv.Itoa(version))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "layer %s version %d not found", name, version)
+	}
+
+	result := *lv
+
+	return &result, nil
+}
+
+// ListLayerVersions returns all versions of a shared buildpack layer.
+func (m *Mock) ListLayerVersions(_ context.Context, name string) ([]driver.LayerVersion, error) {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	all := ld.versions.All()
+	result := make([]driver.LayerVersion, 0, len(all))
+
+	for _, lv := range all {
+		result = append(result, *lv)
+	}
+
+	return result, nil
+}
+
+// DeleteLayerVersion removes a specific version of a shared buildpack layer.
+func (m *Mock) DeleteLayerVersion(_ context.Context, name string, version int) error {
+	ld, ok := m.layers.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "layer %s not found", name)
+	}
+
+	verStr := strconv.Itoa(version)
+	if !ld.versions.Has(verStr) {
+		return cerrors.Newf(cerrors.NotFound, "layer %s version %d not found", name, version)
+	}
+
+	ld.versions.Delete(verStr)
+
+	return nil
+}
+
+// ListLayers returns the latest version of each shared buildpack layer.
+func (m *Mock) ListLayers(_ context.Context) ([]driver.LayerVersion, error) {
+	all := m.layers.All()
+	result := make([]driver.LayerVersion, 0, len(all))
+
+	for _, ld := range all {
+		latest := findLatestLayerVersion(ld)
+		if latest != nil {
+			result = append(result, *latest)
+		}
+	}
+
+	return result, nil
+}
+
+// findLatestLayerVersion returns the layer version with the highest version number.
+func findLatestLayerVersion(ld *layerData) *driver.LayerVersion {
+	all := ld.versions.All()
+
+	var latest *driver.LayerVersion
+
+	for _, lv := range all {
+		if latest == nil || lv.Version > latest.Version {
+			latest = lv
+		}
+	}
+
+	return latest
+}

--- a/providers/gcp/cloudfunctions/versions.go
+++ b/providers/gcp/cloudfunctions/versions.go
@@ -14,6 +14,9 @@ const latestVersion = "$LATEST"
 
 // PublishVersion snapshots the current function state as an immutable generation.
 func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fd, ok := m.funcs.Get(functionName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)

--- a/providers/gcp/cloudfunctions/versions.go
+++ b/providers/gcp/cloudfunctions/versions.go
@@ -1,0 +1,94 @@
+package cloudfunctions
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// latestVersion is the symbolic version for the current function code.
+const latestVersion = "$LATEST"
+
+// PublishVersion snapshots the current function state as an immutable generation.
+func (m *Mock) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	verNum := fd.nextVersion
+	fd.nextVersion++
+
+	verStr := strconv.Itoa(verNum)
+	sha := codeSHA(&fd.info)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	vd := &versionData{
+		config:    snapshotConfig(&fd.info),
+		version:   verStr,
+		codeSHA:   sha,
+		createdAt: now,
+	}
+	fd.versions = append(fd.versions, vd)
+	m.funcs.Set(functionName, fd)
+
+	return &driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      verStr,
+		Description:  description,
+		CodeSHA256:   sha,
+		CreatedAt:    now,
+	}, nil
+}
+
+// ListVersions returns all published generations for a function.
+func (m *Mock) ListVersions(_ context.Context, functionName string) ([]driver.FunctionVersion, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	result := make([]driver.FunctionVersion, 0, len(fd.versions)+1)
+	result = append(result, driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      latestVersion,
+		CodeSHA256:   codeSHA(&fd.info),
+	})
+
+	for _, v := range fd.versions {
+		result = append(result, driver.FunctionVersion{
+			FunctionName: functionName,
+			Version:      v.version,
+			CodeSHA256:   v.codeSHA,
+			CreatedAt:    v.createdAt,
+		})
+	}
+
+	return result, nil
+}
+
+// snapshotConfig creates a FunctionConfig snapshot from a FunctionInfo.
+func snapshotConfig(info *driver.FunctionInfo) driver.FunctionConfig {
+	env := make(map[string]string, len(info.Environment))
+	for k, v := range info.Environment {
+		env[k] = v
+	}
+
+	tags := make(map[string]string, len(info.Tags))
+	for k, v := range info.Tags {
+		tags[k] = v
+	}
+
+	return driver.FunctionConfig{
+		Name:        info.Name,
+		Runtime:     info.Runtime,
+		Handler:     info.Handler,
+		Memory:      info.Memory,
+		Timeout:     info.Timeout,
+		Environment: env,
+		Tags:        tags,
+	}
+}

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/logging/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 const (
@@ -35,8 +36,31 @@ type logGroup struct {
 
 // Mock is an in-memory mock implementation of GCP Cloud Logging.
 type Mock struct {
-	groups *memstore.Store[*logGroup]
-	opts   *config.Options
+	groups     *memstore.Store[*logGroup]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "logging.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new Cloud Logging mock with the given configuration options.
@@ -190,7 +214,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 }
 
 // PutLogEvents writes log events to a stream.
-func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, events []driver.LogEvent) error {
+func (m *Mock) PutLogEvents(ctx context.Context, groupName, streamName string, events []driver.LogEvent) error {
 	g, ok := m.groups.Get(groupName)
 	if !ok {
 		return errors.Newf(errors.NotFound, "log group %q not found", groupName)
@@ -222,6 +246,10 @@ func (m *Mock) PutLogEvents(_ context.Context, groupName, streamName string, eve
 		lg.info.StoredBytes += totalBytes
 		return lg
 	})
+
+	dims := map[string]string{"log_group": groupName}
+	m.emitMetric(ctx, "api/request_count", 1, dims)
+	m.emitMetric(ctx, "byte_count", float64(totalBytes), dims)
 
 	return nil
 }

--- a/providers/gcp/eventarc/eventarc.go
+++ b/providers/gcp/eventarc/eventarc.go
@@ -1,0 +1,550 @@
+// Package eventarc provides an in-memory mock implementation of GCP Eventarc.
+package eventarc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	maxEventHistory     = 1000
+	defaultTriggerState = "ENABLED"
+	activeChannelState  = "ACTIVE"
+)
+
+// Compile-time check that Mock implements driver.EventBus.
+var _ driver.EventBus = (*Mock)(nil)
+
+type ruleData struct {
+	rule    driver.Rule
+	targets *memstore.Store[driver.Target]
+}
+
+type busData struct {
+	info   driver.EventBusInfo
+	rules  *memstore.Store[*ruleData]
+	mu     sync.RWMutex
+	events []driver.Event
+}
+
+// Mock is an in-memory mock implementation of GCP Eventarc.
+type Mock struct {
+	buses      *memstore.Store[*busData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "eventarc.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
+}
+
+// New creates a new Eventarc mock with the given configuration options.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		buses: memstore.New[*busData](),
+		opts:  opts,
+	}
+}
+
+// CreateEventBus creates a new Eventarc channel.
+func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	if m.buses.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "channel %q already exists", cfg.Name)
+	}
+
+	channelID := fmt.Sprintf(
+		"projects/%s/locations/%s/channels/%s",
+		m.opts.ProjectID, m.opts.Region, cfg.Name,
+	)
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
+	info := driver.EventBusInfo{
+		Name:      cfg.Name,
+		ARN:       channelID,
+		State:     activeChannelState,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:      tags,
+	}
+
+	bd := &busData{
+		info:   info,
+		rules:  memstore.New[*ruleData](),
+		events: []driver.Event{},
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := info
+
+	return &result, nil
+}
+
+// DeleteEventBus deletes an Eventarc channel.
+func (m *Mock) DeleteEventBus(_ context.Context, name string) error {
+	if !m.buses.Delete(name) {
+		return errors.Newf(errors.NotFound, "channel %q not found", name)
+	}
+
+	return nil
+}
+
+// GetEventBus retrieves information about an Eventarc channel.
+func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", name)
+	}
+
+	result := bd.info
+
+	return &result, nil
+}
+
+// ListEventBuses lists all Eventarc channels.
+func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+	all := m.buses.All()
+
+	buses := make([]driver.EventBusInfo, 0, len(all))
+	for _, bd := range all {
+		buses = append(buses, bd.info)
+	}
+
+	return buses, nil
+}
+
+// PutRule creates or updates a trigger on a channel.
+func (m *Mock) PutRule(_ context.Context, cfg *driver.RuleConfig) (*driver.Rule, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "trigger name is required")
+	}
+
+	busName := cfg.EventBus
+	if busName == "" {
+		return nil, errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(busName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", busName)
+	}
+
+	state := cfg.State
+	if state == "" {
+		state = defaultTriggerState
+	}
+
+	rule := driver.Rule{
+		Name:         cfg.Name,
+		EventBus:     busName,
+		Description:  cfg.Description,
+		EventPattern: cfg.EventPattern,
+		State:        state,
+		Targets:      []driver.Target{},
+		CreatedAt:    m.opts.Clock.Now().UTC().Format(time.RFC3339),
+	}
+
+	if existing, exists := bd.rules.Get(cfg.Name); exists {
+		rule.Targets = existing.rule.Targets
+		rule.CreatedAt = existing.rule.CreatedAt
+	}
+
+	rd := &ruleData{
+		rule:    rule,
+		targets: memstore.New[driver.Target](),
+	}
+
+	for _, t := range rule.Targets {
+		rd.targets.Set(t.ID, t)
+	}
+
+	bd.rules.Set(cfg.Name, rd)
+
+	result := rule
+
+	return &result, nil
+}
+
+// DeleteRule deletes a trigger from a channel.
+func (m *Mock) DeleteRule(_ context.Context, eventBus, ruleName string) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	if !bd.rules.Delete(ruleName) {
+		return errors.Newf(errors.NotFound, "trigger %q not found on channel %q", ruleName, eventBus)
+	}
+
+	return nil
+}
+
+// GetRule retrieves a trigger from a channel.
+func (m *Mock) GetRule(_ context.Context, eventBus, ruleName string) (*driver.Rule, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "trigger %q not found on channel %q", ruleName, eventBus)
+	}
+
+	result := rd.rule
+
+	return &result, nil
+}
+
+// ListRules lists all triggers on a channel.
+func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	all := bd.rules.All()
+
+	rules := make([]driver.Rule, 0, len(all))
+	for _, rd := range all {
+		rules = append(rules, rd.rule)
+	}
+
+	return rules, nil
+}
+
+// EnableRule enables a trigger on a channel.
+func (m *Mock) EnableRule(_ context.Context, eventBus, ruleName string) error {
+	return m.setRuleState(eventBus, ruleName, defaultTriggerState)
+}
+
+// DisableRule disables a trigger on a channel.
+func (m *Mock) DisableRule(_ context.Context, eventBus, ruleName string) error {
+	return m.setRuleState(eventBus, ruleName, "DISABLED")
+}
+
+func (m *Mock) setRuleState(eventBus, ruleName, state string) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "trigger %q not found on channel %q", ruleName, eventBus)
+	}
+
+	rd.rule.State = state
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// PutTargets adds targets to a trigger.
+func (m *Mock) PutTargets(_ context.Context, eventBus, ruleName string, targets []driver.Target) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "trigger %q not found on channel %q", ruleName, eventBus)
+	}
+
+	for _, t := range targets {
+		rd.targets.Set(t.ID, t)
+	}
+
+	rd.rule.Targets = targetsFromStore(rd.targets)
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// RemoveTargets removes targets from a trigger.
+func (m *Mock) RemoveTargets(_ context.Context, eventBus, ruleName string, targetIDs []string) error {
+	if eventBus == "" {
+		return errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "trigger %q not found on channel %q", ruleName, eventBus)
+	}
+
+	for _, id := range targetIDs {
+		rd.targets.Delete(id)
+	}
+
+	rd.rule.Targets = targetsFromStore(rd.targets)
+	bd.rules.Set(ruleName, rd)
+
+	return nil
+}
+
+// ListTargets lists all targets for a trigger.
+func (m *Mock) ListTargets(_ context.Context, eventBus, ruleName string) ([]driver.Target, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	rd, ok := bd.rules.Get(ruleName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "trigger %q not found on channel %q", ruleName, eventBus)
+	}
+
+	return targetsFromStore(rd.targets), nil
+}
+
+// PutEvents publishes events to Eventarc channels.
+func (m *Mock) PutEvents(ctx context.Context, events []driver.Event) (*driver.PublishResult, error) {
+	result := &driver.PublishResult{
+		EventIDs: make([]string, 0, len(events)),
+	}
+
+	for i := range events {
+		eventID := generateEventID(&events[i], m.opts.Clock.Now())
+		events[i].ID = eventID
+
+		if events[i].Time.IsZero() {
+			events[i].Time = m.opts.Clock.Now()
+		}
+
+		busName := events[i].EventBus
+		if busName == "" {
+			result.FailCount++
+
+			continue
+		}
+
+		bd, ok := m.buses.Get(busName)
+		if !ok {
+			result.FailCount++
+
+			continue
+		}
+
+		m.storeEvent(bd, &events[i])
+
+		result.SuccessCount++
+		result.EventIDs = append(result.EventIDs, eventID)
+	}
+
+	m.emitEventMetrics(ctx, events)
+
+	return result, nil
+}
+
+func (m *Mock) emitEventMetrics(ctx context.Context, events []driver.Event) {
+	channelCounts := make(map[string]int)
+
+	for i := range events {
+		if events[i].ID != "" && events[i].EventBus != "" {
+			channelCounts[events[i].EventBus]++
+		}
+	}
+
+	for channel, count := range channelCounts {
+		dims := map[string]string{"channel_name": channel}
+		m.emitMetric(ctx, "event_count", float64(count), dims)
+
+		matchedCount := m.countMatchedEvents(events, channel)
+		m.emitMetric(ctx, "matched_event_count", float64(matchedCount), dims)
+	}
+}
+
+func (m *Mock) countMatchedEvents(events []driver.Event, channel string) int {
+	matchedCount := 0
+
+	for i := range events {
+		if events[i].EventBus != channel || events[i].ID == "" {
+			continue
+		}
+
+		if len(m.MatchedRules(&events[i])) > 0 {
+			matchedCount++
+		}
+	}
+
+	return matchedCount
+}
+
+// GetEventHistory retrieves event history for a channel.
+func (m *Mock) GetEventHistory(_ context.Context, eventBus string, limit int) ([]driver.Event, error) {
+	if eventBus == "" {
+		return nil, errors.New(errors.InvalidArgument, "channel name is required")
+	}
+
+	bd, ok := m.buses.Get(eventBus)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", eventBus)
+	}
+
+	bd.mu.RLock()
+	defer bd.mu.RUnlock()
+
+	history := bd.events
+	if limit > 0 && limit < len(history) {
+		history = history[len(history)-limit:]
+	}
+
+	result := make([]driver.Event, len(history))
+	copy(result, history)
+
+	return result, nil
+}
+
+func (*Mock) storeEvent(bd *busData, event *driver.Event) {
+	bd.mu.Lock()
+	defer bd.mu.Unlock()
+
+	bd.events = append(bd.events, *event)
+	if len(bd.events) > maxEventHistory {
+		bd.events = bd.events[len(bd.events)-maxEventHistory:]
+	}
+}
+
+func targetsFromStore(store *memstore.Store[driver.Target]) []driver.Target {
+	all := store.All()
+
+	targets := make([]driver.Target, 0, len(all))
+	for _, t := range all {
+		targets = append(targets, t)
+	}
+
+	return targets
+}
+
+func generateEventID(event *driver.Event, now time.Time) string {
+	data := fmt.Sprintf("%s:%s:%s:%s:%d", event.Source, event.DetailType, event.Detail, event.EventBus, now.UnixNano())
+	hash := sha256.Sum256([]byte(data))
+
+	return fmt.Sprintf("%x", hash[:16])
+}
+
+func matchesPattern(event *driver.Event, pattern string) bool {
+	if pattern == "" {
+		return true
+	}
+
+	var p map[string]any
+	if err := json.Unmarshal([]byte(pattern), &p); err != nil {
+		return false
+	}
+
+	if sources, ok := p["source"]; ok {
+		if !matchesField(event.Source, sources) {
+			return false
+		}
+	}
+
+	if detailTypes, ok := p["detail-type"]; ok {
+		if !matchesField(event.DetailType, detailTypes) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchesField(value string, allowed any) bool {
+	arr, ok := allowed.([]any)
+	if !ok {
+		return false
+	}
+
+	for _, v := range arr {
+		if fmt.Sprintf("%v", v) == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchedRules returns all triggers that match the given event (exported for testing).
+func (m *Mock) MatchedRules(event *driver.Event) []driver.Rule {
+	var matched []driver.Rule
+
+	all := m.buses.All()
+	for _, bd := range all {
+		rules := bd.rules.All()
+		for _, rd := range rules {
+			if rd.rule.State != defaultTriggerState {
+				continue
+			}
+
+			if matchesPattern(event, rd.rule.EventPattern) {
+				matched = append(matched, rd.rule)
+			}
+		}
+	}
+
+	return matched
+}

--- a/providers/gcp/eventarc/eventarc_test.go
+++ b/providers/gcp/eventarc/eventarc_test.go
@@ -1,0 +1,775 @@
+package eventarc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/eventbus/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/gcp/cloudmonitoring"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestMock() (*Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	return New(opts), fc
+}
+
+func newTestMockWithMonitoring() (*Mock, *cloudmonitoring.Mock, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	mon := cloudmonitoring.New(opts)
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	return m, mon, fc
+}
+
+func createTestChannel(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	_, err := m.CreateEventBus(context.Background(), driver.EventBusConfig{Name: name})
+	require.NoError(t, err)
+}
+
+func createTestTrigger(t *testing.T, m *Mock, channel, name string) {
+	t.Helper()
+
+	_, err := m.PutRule(context.Background(), &driver.RuleConfig{
+		Name:     name,
+		EventBus: channel,
+	})
+	require.NoError(t, err)
+}
+
+func TestCreateEventBus(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.EventBusConfig
+		setup     func(*Mock)
+		expectErr bool
+		checkFn   func(*testing.T, *driver.EventBusInfo)
+	}{
+		{
+			name: "success",
+			cfg:  driver.EventBusConfig{Name: "my-channel"},
+			checkFn: func(t *testing.T, info *driver.EventBusInfo) {
+				t.Helper()
+				assert.Equal(t, "my-channel", info.Name)
+				assert.Equal(t, activeChannelState, info.State)
+				assert.Contains(t, info.ARN, "projects/test-project/locations/us-central1/channels/my-channel")
+				assert.NotEmpty(t, info.CreatedAt)
+			},
+		},
+		{
+			name: "success with tags",
+			cfg:  driver.EventBusConfig{Name: "tagged-channel", Tags: map[string]string{"env": "dev"}},
+			checkFn: func(t *testing.T, info *driver.EventBusInfo) {
+				t.Helper()
+				assert.Equal(t, "dev", info.Tags["env"])
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.EventBusConfig{},
+			expectErr: true,
+		},
+		{
+			name: "duplicate channel",
+			cfg:  driver.EventBusConfig{Name: "dup"},
+			setup: func(m *Mock) {
+				createTestChannel(&testing.T{}, m, "dup")
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			info, err := m.CreateEventBus(context.Background(), tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.checkFn != nil {
+				tc.checkFn(t, info)
+			}
+		})
+	}
+}
+
+func TestDeleteEventBus(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "to-delete")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteEventBus(ctx, "to-delete")
+		require.NoError(t, err)
+
+		_, getErr := m.GetEventBus(ctx, "to-delete")
+		require.Error(t, getErr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteEventBus(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetEventBus(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := m.GetEventBus(ctx, "my-channel")
+		require.NoError(t, err)
+		assert.Equal(t, "my-channel", info.Name)
+		assert.Equal(t, activeChannelState, info.State)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetEventBus(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListEventBuses(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	t.Run("empty list", func(t *testing.T) {
+		buses, err := m.ListEventBuses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(buses))
+	})
+
+	createTestChannel(t, m, "channel-a")
+	createTestChannel(t, m, "channel-b")
+
+	t.Run("two channels", func(t *testing.T) {
+		buses, err := m.ListEventBuses(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(buses))
+	})
+}
+
+func TestPutRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.RuleConfig
+		setup     func(*Mock)
+		expectErr bool
+		checkFn   func(*testing.T, *driver.Rule)
+	}{
+		{
+			name: "success with defaults",
+			cfg:  driver.RuleConfig{Name: "my-trigger", EventBus: "my-channel"},
+			setup: func(m *Mock) {
+				createTestChannel(&testing.T{}, m, "my-channel")
+			},
+			checkFn: func(t *testing.T, rule *driver.Rule) {
+				t.Helper()
+				assert.Equal(t, "my-trigger", rule.Name)
+				assert.Equal(t, "my-channel", rule.EventBus)
+				assert.Equal(t, defaultTriggerState, rule.State)
+				assert.NotEmpty(t, rule.CreatedAt)
+			},
+		},
+		{
+			name: "success with event pattern",
+			cfg: driver.RuleConfig{
+				Name:         "pattern-trigger",
+				EventBus:     "my-channel",
+				EventPattern: `{"source":["my.app"]}`,
+				Description:  "matches my app events",
+			},
+			setup: func(m *Mock) {
+				createTestChannel(&testing.T{}, m, "my-channel")
+			},
+			checkFn: func(t *testing.T, rule *driver.Rule) {
+				t.Helper()
+				assert.Equal(t, `{"source":["my.app"]}`, rule.EventPattern)
+				assert.Equal(t, "matches my app events", rule.Description)
+			},
+		},
+		{
+			name: "update existing trigger preserves targets",
+			cfg:  driver.RuleConfig{Name: "existing-trigger", EventBus: "my-channel", Description: "updated"},
+			setup: func(m *Mock) {
+				createTestChannel(&testing.T{}, m, "my-channel")
+				createTestTrigger(&testing.T{}, m, "my-channel", "existing-trigger")
+
+				_ = m.PutTargets(context.Background(), "my-channel", "existing-trigger", []driver.Target{
+					{ID: "t1", ARN: "arn:target:1"},
+				})
+			},
+			checkFn: func(t *testing.T, rule *driver.Rule) {
+				t.Helper()
+				assert.Equal(t, "updated", rule.Description)
+				assert.Equal(t, 1, len(rule.Targets))
+			},
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.RuleConfig{EventBus: "my-channel"},
+			expectErr: true,
+		},
+		{
+			name:      "empty channel name",
+			cfg:       driver.RuleConfig{Name: "my-trigger"},
+			expectErr: true,
+		},
+		{
+			name:      "channel not found",
+			cfg:       driver.RuleConfig{Name: "my-trigger", EventBus: "nonexistent"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+
+			if tc.setup != nil {
+				tc.setup(m)
+			}
+
+			rule, err := m.PutRule(context.Background(), &tc.cfg)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.checkFn != nil {
+				tc.checkFn(t, rule)
+			}
+		})
+	}
+}
+
+func TestDeleteRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+	createTestTrigger(t, m, "my-channel", "to-delete")
+
+	t.Run("success", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "my-channel", "to-delete")
+		require.NoError(t, err)
+
+		_, getErr := m.GetRule(ctx, "my-channel", "to-delete")
+		require.Error(t, getErr)
+	})
+
+	t.Run("trigger not found", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "my-channel", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "nonexistent", "some-trigger")
+		require.Error(t, err)
+	})
+
+	t.Run("empty channel name", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "", "some-trigger")
+		require.Error(t, err)
+	})
+}
+
+func TestGetRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+	createTestTrigger(t, m, "my-channel", "my-trigger")
+
+	t.Run("success", func(t *testing.T) {
+		rule, err := m.GetRule(ctx, "my-channel", "my-trigger")
+		require.NoError(t, err)
+		assert.Equal(t, "my-trigger", rule.Name)
+		assert.Equal(t, "my-channel", rule.EventBus)
+	})
+
+	t.Run("trigger not found", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "my-channel", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "nonexistent", "my-trigger")
+		require.Error(t, err)
+	})
+
+	t.Run("empty channel name", func(t *testing.T) {
+		_, err := m.GetRule(ctx, "", "my-trigger")
+		require.Error(t, err)
+	})
+}
+
+func TestListRules(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+
+	t.Run("empty list", func(t *testing.T) {
+		rules, err := m.ListRules(ctx, "my-channel")
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(rules))
+	})
+
+	createTestTrigger(t, m, "my-channel", "trigger-a")
+	createTestTrigger(t, m, "my-channel", "trigger-b")
+
+	t.Run("two triggers", func(t *testing.T) {
+		rules, err := m.ListRules(ctx, "my-channel")
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(rules))
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		_, err := m.ListRules(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("empty channel name", func(t *testing.T) {
+		_, err := m.ListRules(ctx, "")
+		require.Error(t, err)
+	})
+}
+
+func TestEnableDisableRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+	createTestTrigger(t, m, "my-channel", "my-trigger")
+
+	t.Run("disable trigger", func(t *testing.T) {
+		err := m.DisableRule(ctx, "my-channel", "my-trigger")
+		require.NoError(t, err)
+
+		rule, getErr := m.GetRule(ctx, "my-channel", "my-trigger")
+		require.NoError(t, getErr)
+		assert.Equal(t, "DISABLED", rule.State)
+	})
+
+	t.Run("enable trigger", func(t *testing.T) {
+		err := m.EnableRule(ctx, "my-channel", "my-trigger")
+		require.NoError(t, err)
+
+		rule, getErr := m.GetRule(ctx, "my-channel", "my-trigger")
+		require.NoError(t, getErr)
+		assert.Equal(t, defaultTriggerState, rule.State)
+	})
+
+	t.Run("trigger not found", func(t *testing.T) {
+		err := m.EnableRule(ctx, "my-channel", "nonexistent")
+		require.Error(t, err)
+
+		err = m.DisableRule(ctx, "my-channel", "nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		err := m.EnableRule(ctx, "nonexistent", "my-trigger")
+		require.Error(t, err)
+	})
+
+	t.Run("empty channel name", func(t *testing.T) {
+		err := m.EnableRule(ctx, "", "my-trigger")
+		require.Error(t, err)
+	})
+}
+
+func TestPutTargets(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+	createTestTrigger(t, m, "my-channel", "my-trigger")
+
+	t.Run("add targets", func(t *testing.T) {
+		err := m.PutTargets(ctx, "my-channel", "my-trigger", []driver.Target{
+			{ID: "t1", ARN: "projects/test-project/topics/topic-1"},
+			{ID: "t2", ARN: "projects/test-project/topics/topic-2"},
+		})
+		require.NoError(t, err)
+
+		targets, listErr := m.ListTargets(ctx, "my-channel", "my-trigger")
+		require.NoError(t, listErr)
+		assert.Equal(t, 2, len(targets))
+	})
+
+	t.Run("update existing target", func(t *testing.T) {
+		err := m.PutTargets(ctx, "my-channel", "my-trigger", []driver.Target{
+			{ID: "t1", ARN: "projects/test-project/topics/updated-topic"},
+		})
+		require.NoError(t, err)
+
+		targets, listErr := m.ListTargets(ctx, "my-channel", "my-trigger")
+		require.NoError(t, listErr)
+		assert.Equal(t, 2, len(targets))
+	})
+
+	t.Run("trigger not found", func(t *testing.T) {
+		err := m.PutTargets(ctx, "my-channel", "nonexistent", []driver.Target{
+			{ID: "t1", ARN: "arn"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		err := m.PutTargets(ctx, "nonexistent", "my-trigger", []driver.Target{
+			{ID: "t1", ARN: "arn"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestRemoveTargets(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+	createTestTrigger(t, m, "my-channel", "my-trigger")
+
+	err := m.PutTargets(ctx, "my-channel", "my-trigger", []driver.Target{
+		{ID: "t1", ARN: "arn:1"},
+		{ID: "t2", ARN: "arn:2"},
+		{ID: "t3", ARN: "arn:3"},
+	})
+	require.NoError(t, err)
+
+	t.Run("remove one target", func(t *testing.T) {
+		rmErr := m.RemoveTargets(ctx, "my-channel", "my-trigger", []string{"t2"})
+		require.NoError(t, rmErr)
+
+		targets, listErr := m.ListTargets(ctx, "my-channel", "my-trigger")
+		require.NoError(t, listErr)
+		assert.Equal(t, 2, len(targets))
+	})
+
+	t.Run("remove multiple targets", func(t *testing.T) {
+		rmErr := m.RemoveTargets(ctx, "my-channel", "my-trigger", []string{"t1", "t3"})
+		require.NoError(t, rmErr)
+
+		targets, listErr := m.ListTargets(ctx, "my-channel", "my-trigger")
+		require.NoError(t, listErr)
+		assert.Equal(t, 0, len(targets))
+	})
+
+	t.Run("trigger not found", func(t *testing.T) {
+		rmErr := m.RemoveTargets(ctx, "my-channel", "nonexistent", []string{"t1"})
+		require.Error(t, rmErr)
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		rmErr := m.RemoveTargets(ctx, "nonexistent", "my-trigger", []string{"t1"})
+		require.Error(t, rmErr)
+	})
+}
+
+func TestPutEvents(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+
+	t.Run("success", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{
+				Source:     "my.app",
+				DetailType: "OrderCreated",
+				Detail:     `{"orderId":"123"}`,
+				EventBus:   "my-channel",
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.SuccessCount)
+		assert.Equal(t, 0, result.FailCount)
+		assert.Equal(t, 1, len(result.EventIDs))
+		assert.NotEmpty(t, result.EventIDs[0])
+	})
+
+	t.Run("multiple events", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "app1", DetailType: "Event1", Detail: "{}", EventBus: "my-channel"},
+			{Source: "app2", DetailType: "Event2", Detail: "{}", EventBus: "my-channel"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.SuccessCount)
+		assert.Equal(t, 2, len(result.EventIDs))
+	})
+
+	t.Run("missing channel name fails", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "app", DetailType: "Event", Detail: "{}"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+
+	t.Run("nonexistent channel fails", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "app", DetailType: "Event", Detail: "{}", EventBus: "nonexistent"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+
+	t.Run("mixed success and failure", func(t *testing.T) {
+		result, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "app", DetailType: "Event", Detail: "{}", EventBus: "my-channel"},
+			{Source: "app", DetailType: "Event", Detail: "{}", EventBus: "nonexistent"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.SuccessCount)
+		assert.Equal(t, 1, result.FailCount)
+	})
+}
+
+func TestEventPatternMatching(t *testing.T) {
+	tests := []struct {
+		name        string
+		pattern     string
+		event       driver.Event
+		shouldMatch bool
+	}{
+		{
+			name:    "empty pattern matches all",
+			pattern: "",
+			event: driver.Event{
+				Source:     "any.source",
+				DetailType: "AnyType",
+				EventBus:   "ch",
+			},
+			shouldMatch: true,
+		},
+		{
+			name:    "source match",
+			pattern: `{"source":["my.app"]}`,
+			event: driver.Event{
+				Source:     "my.app",
+				DetailType: "OrderCreated",
+				EventBus:   "ch",
+			},
+			shouldMatch: true,
+		},
+		{
+			name:    "source no match",
+			pattern: `{"source":["my.app"]}`,
+			event: driver.Event{
+				Source:     "other.app",
+				DetailType: "OrderCreated",
+				EventBus:   "ch",
+			},
+			shouldMatch: false,
+		},
+		{
+			name:    "detail-type match",
+			pattern: `{"detail-type":["OrderCreated","OrderUpdated"]}`,
+			event: driver.Event{
+				Source:     "any",
+				DetailType: "OrderCreated",
+				EventBus:   "ch",
+			},
+			shouldMatch: true,
+		},
+		{
+			name:    "detail-type no match",
+			pattern: `{"detail-type":["OrderCreated"]}`,
+			event: driver.Event{
+				Source:     "any",
+				DetailType: "OrderDeleted",
+				EventBus:   "ch",
+			},
+			shouldMatch: false,
+		},
+		{
+			name:    "source and detail-type combined match",
+			pattern: `{"source":["my.app"],"detail-type":["OrderCreated"]}`,
+			event: driver.Event{
+				Source:     "my.app",
+				DetailType: "OrderCreated",
+				EventBus:   "ch",
+			},
+			shouldMatch: true,
+		},
+		{
+			name:    "source matches but detail-type does not",
+			pattern: `{"source":["my.app"],"detail-type":["OrderCreated"]}`,
+			event: driver.Event{
+				Source:     "my.app",
+				DetailType: "OrderDeleted",
+				EventBus:   "ch",
+			},
+			shouldMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := newTestMock()
+			ctx := context.Background()
+
+			createTestChannel(t, m, "ch")
+
+			_, err := m.PutRule(ctx, &driver.RuleConfig{
+				Name:         "test-trigger",
+				EventBus:     "ch",
+				EventPattern: tc.pattern,
+			})
+			require.NoError(t, err)
+
+			matched := m.MatchedRules(&tc.event)
+
+			if tc.shouldMatch {
+				assert.Greater(t, len(matched), 0)
+			} else {
+				assert.Equal(t, 0, len(matched))
+			}
+		})
+	}
+}
+
+func TestEventPatternMatchingDisabledRule(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "ch")
+
+	_, err := m.PutRule(ctx, &driver.RuleConfig{
+		Name:         "disabled-trigger",
+		EventBus:     "ch",
+		EventPattern: `{"source":["my.app"]}`,
+	})
+	require.NoError(t, err)
+
+	err = m.DisableRule(ctx, "ch", "disabled-trigger")
+	require.NoError(t, err)
+
+	event := driver.Event{Source: "my.app", DetailType: "Test", EventBus: "ch"}
+	matched := m.MatchedRules(&event)
+	assert.Equal(t, 0, len(matched))
+}
+
+func TestGetEventHistory(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+
+	t.Run("empty history", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "my-channel", 10)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(history))
+	})
+
+	t.Run("returns published events", func(t *testing.T) {
+		_, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "app", DetailType: "Event1", Detail: `{"k":"v1"}`, EventBus: "my-channel"},
+			{Source: "app", DetailType: "Event2", Detail: `{"k":"v2"}`, EventBus: "my-channel"},
+			{Source: "app", DetailType: "Event3", Detail: `{"k":"v3"}`, EventBus: "my-channel"},
+		})
+		require.NoError(t, err)
+
+		history, getErr := m.GetEventHistory(ctx, "my-channel", 0)
+		require.NoError(t, getErr)
+		assert.Equal(t, 3, len(history))
+	})
+
+	t.Run("limit returns most recent", func(t *testing.T) {
+		history, err := m.GetEventHistory(ctx, "my-channel", 2)
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(history))
+	})
+
+	t.Run("channel not found", func(t *testing.T) {
+		_, err := m.GetEventHistory(ctx, "nonexistent", 10)
+		require.Error(t, err)
+	})
+
+	t.Run("empty channel name", func(t *testing.T) {
+		_, err := m.GetEventHistory(ctx, "", 10)
+		require.Error(t, err)
+	})
+}
+
+func TestMetricsEmission(t *testing.T) {
+	m, mon, _ := newTestMockWithMonitoring()
+	ctx := context.Background()
+
+	createTestChannel(t, m, "my-channel")
+
+	t.Run("put events emits event_count metric", func(t *testing.T) {
+		_, err := m.PutEvents(ctx, []driver.Event{
+			{Source: "app", DetailType: "Test", Detail: "{}", EventBus: "my-channel"},
+			{Source: "app", DetailType: "Test2", Detail: "{}", EventBus: "my-channel"},
+		})
+		require.NoError(t, err)
+
+		metrics, getErr := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "eventarc.googleapis.com",
+			MetricName: "event_count",
+			Dimensions: map[string]string{"channel_name": "my-channel"},
+			StartTime:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		require.NoError(t, getErr)
+		assert.Greater(t, len(metrics.Values), 0)
+	})
+
+	t.Run("matched events emit matched_event_count metric", func(t *testing.T) {
+		_, err := m.PutRule(ctx, &driver.RuleConfig{
+			Name:         "match-trigger",
+			EventBus:     "my-channel",
+			EventPattern: `{"source":["matched.app"]}`,
+		})
+		require.NoError(t, err)
+
+		_, err = m.PutEvents(ctx, []driver.Event{
+			{Source: "matched.app", DetailType: "Test", Detail: "{}", EventBus: "my-channel"},
+		})
+		require.NoError(t, err)
+
+		metrics, getErr := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "eventarc.googleapis.com",
+			MetricName: "matched_event_count",
+			Dimensions: map[string]string{"channel_name": "my-channel"},
+			StartTime:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndTime:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		require.NoError(t, getErr)
+		assert.Greater(t, len(metrics.Values), 0)
+	})
+}

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/notification/driver"
 )
 
@@ -32,8 +33,31 @@ type topicData struct {
 
 // Mock is an in-memory mock implementation of GCP Firebase Cloud Messaging.
 type Mock struct {
-	topics *memstore.Store[*topicData]
-	opts   *config.Options
+	topics     *memstore.Store[*topicData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "fcm.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new FCM mock with the given configuration options.
@@ -183,7 +207,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 }
 
 // Publish publishes a message to an FCM topic.
-func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
+func (m *Mock) Publish(ctx context.Context, input driver.PublishInput) (*driver.PublishOutput, error) {
 	td, ok := m.topics.Get(input.TopicID)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", input.TopicID)
@@ -209,6 +233,8 @@ func (m *Mock) Publish(_ context.Context, input driver.PublishInput) (*driver.Pu
 		Attributes: attrs,
 	})
 	td.mu.Unlock()
+
+	m.emitMetric(ctx, "message_count", 1, map[string]string{"topic_name": input.TopicID})
 
 	return &driver.PublishOutput{MessageID: msgID}, nil
 }

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -7,11 +7,13 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/database/driver"
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/pagination"
 )
 
@@ -28,12 +30,26 @@ const (
 	OpBetween      = "BETWEEN"
 )
 
+// Snapshot and TTL constants.
+const (
+	ViewNewImage       = "NEW_IMAGE"
+	ViewOldImage       = "OLD_IMAGE"
+	ViewNewAndOld      = "NEW_AND_OLD_IMAGES"
+	ViewKeysOnly       = "KEYS_ONLY"
+	maxSnapshotRecords = 1000
+	defaultSnapLimit   = 100
+)
+
 // Compile-time check that Mock implements driver.Database.
 var _ driver.Database = (*Mock)(nil)
 
 type collectionData struct {
-	config driver.TableConfig
-	items  *memstore.Store[map[string]any]
+	config        driver.TableConfig
+	items         *memstore.Store[map[string]any]
+	ttlConfig     driver.TTLConfig
+	streamConfig  driver.StreamConfig
+	streamRecords []driver.StreamRecord
+	seqCounter    atomic.Int64
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Firestore.
@@ -41,6 +57,29 @@ type Mock struct {
 	mu          sync.RWMutex
 	collections map[string]*collectionData
 	opts        *config.Options
+	monitoring  mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "firestore.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new Firestore mock.
@@ -109,21 +148,27 @@ func (m *Mock) ListTables(_ context.Context) ([]string, error) {
 	return names, nil
 }
 
-func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) error {
-	m.mu.RLock()
-	cd, exists := m.collections[table]
-	m.mu.RUnlock()
+func (m *Mock) PutItem(ctx context.Context, table string, item map[string]any) error {
+	m.mu.Lock()
 
+	cd, exists := m.collections[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
 	}
 
-	cd.items.Set(docKey(cd.config, item), item)
+	key := docKey(cd.config, item)
+	oldItem, hadOld := cd.items.Get(key)
+	cd.items.Set(key, item)
+	m.recordStreamEvent(cd, oldItem, item, hadOld)
+	m.mu.Unlock()
+
+	m.emitMetric(ctx, "document/write_count", 1, map[string]string{"collection_id": table})
 
 	return nil
 }
 
-func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map[string]any, error) {
+func (m *Mock) GetItem(ctx context.Context, table string, key map[string]any) (map[string]any, error) {
 	m.mu.RLock()
 	cd, exists := m.collections[table]
 	m.mu.RUnlock()
@@ -132,30 +177,49 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 		return nil, cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
 	}
 
-	item, ok := cd.items.Get(docKey(cd.config, key))
+	k := docKey(cd.config, key)
+	item, ok := cd.items.Get(k)
+
 	if !ok {
 		return nil, cerrors.New(cerrors.NotFound, "document not found")
 	}
 
+	if m.isItemExpired(cd, item) {
+		cd.items.Delete(k)
+		return nil, cerrors.New(cerrors.NotFound, "document not found")
+	}
+
+	m.emitMetric(ctx, "document/read_count", 1, map[string]string{"collection_id": table})
+
 	return item, nil
 }
 
-func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) error {
-	m.mu.RLock()
-	cd, exists := m.collections[table]
-	m.mu.RUnlock()
+func (m *Mock) DeleteItem(ctx context.Context, table string, key map[string]any) error {
+	m.mu.Lock()
 
+	cd, exists := m.collections[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
 	}
 
-	cd.items.Delete(docKey(cd.config, key))
+	k := docKey(cd.config, key)
+	oldItem, hadOld := cd.items.Get(k)
+	cd.items.Delete(k)
+
+	if hadOld {
+		m.recordStreamRemove(cd, oldItem)
+	}
+
+	m.mu.Unlock()
+
+	m.emitMetric(ctx, "document/delete_count", 1, map[string]string{"collection_id": table})
 
 	return nil
 }
 
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryResult, error) {
+func (m *Mock) Query(ctx context.Context, input driver.QueryInput) (*driver.QueryResult, error) {
 	m.mu.RLock()
 	cd, exists := m.collections[input.Table]
 	m.mu.RUnlock()
@@ -169,7 +233,7 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
-	matched := matchQueryItems(cd, pkField, skField, &input)
+	matched := m.matchQueryItems(cd, pkField, skField, &input)
 
 	limit := input.Limit
 	if limit <= 0 {
@@ -177,6 +241,8 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 	}
 
 	page, _ := pagination.Paginate(matched, input.PageToken, limit)
+
+	m.emitMetric(ctx, "document/read_count", float64(len(page.Items)), map[string]string{"collection_id": input.Table})
 
 	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
 }
@@ -198,12 +264,18 @@ func resolveKeyFields(cd *collectionData, indexName string) (pkField, skField st
 	return "", "", cerrors.Newf(cerrors.NotFound, "index %s not found", indexName)
 }
 
-func matchQueryItems(cd *collectionData, pkField, skField string, input *driver.QueryInput) []map[string]any {
+func (m *Mock) matchQueryItems(
+	cd *collectionData, pkField, skField string, input *driver.QueryInput,
+) []map[string]any {
 	allItems := cd.items.All()
 
 	var matched []map[string]any
 
 	for _, item := range allItems {
+		if m.isItemExpired(cd, item) {
+			continue
+		}
+
 		pkVal := fmt.Sprintf("%v", item[pkField])
 		if pkVal != fmt.Sprintf("%v", input.KeyCondition.PartitionVal) {
 			continue
@@ -224,7 +296,7 @@ func matchQueryItems(cd *collectionData, pkField, skField string, input *driver.
 	return matched
 }
 
-func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryResult, error) {
+func (m *Mock) Scan(ctx context.Context, input driver.ScanInput) (*driver.QueryResult, error) {
 	m.mu.RLock()
 	cd, exists := m.collections[input.Table]
 	m.mu.RUnlock()
@@ -238,6 +310,10 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 	var matched []map[string]any
 
 	for _, item := range allItems {
+		if m.isItemExpired(cd, item) {
+			continue
+		}
+
 		if matchesFilters(item, input.Filters) {
 			matched = append(matched, item)
 		}
@@ -250,21 +326,28 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 
 	page, _ := pagination.Paginate(matched, input.PageToken, limit)
 
+	m.emitMetric(ctx, "document/read_count", float64(len(page.Items)), map[string]string{"collection_id": input.Table})
+
 	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
 }
 
 func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {
-	m.mu.RLock()
-	cd, exists := m.collections[table]
-	m.mu.RUnlock()
+	m.mu.Lock()
 
+	cd, exists := m.collections[table]
 	if !exists {
+		m.mu.Unlock()
 		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
 	}
 
 	for _, item := range items {
-		cd.items.Set(docKey(cd.config, item), item)
+		key := docKey(cd.config, item)
+		oldItem, hadOld := cd.items.Get(key)
+		cd.items.Set(key, item)
+		m.recordStreamEvent(cd, oldItem, item, hadOld)
 	}
+
+	m.mu.Unlock()
 
 	return nil
 }
@@ -372,4 +455,273 @@ func matchesSingleScanFilter(item map[string]any, f driver.ScanFilter) bool {
 	default:
 		return false
 	}
+}
+
+// UpdateTTL configures TTL for a collection.
+func (m *Mock) UpdateTTL(_ context.Context, table string, cfg driver.TTLConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	cd.ttlConfig = cfg
+
+	return nil
+}
+
+// DescribeTTL returns the TTL configuration for a collection.
+func (m *Mock) DescribeTTL(_ context.Context, table string) (*driver.TTLConfig, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	cfg := cd.ttlConfig
+
+	return &cfg, nil
+}
+
+// UpdateStreamConfig configures real-time listeners for a collection.
+func (m *Mock) UpdateStreamConfig(_ context.Context, table string, cfg driver.StreamConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	cd.streamConfig = cfg
+
+	return nil
+}
+
+// GetStreamRecords returns snapshot records after the given token.
+func (m *Mock) GetStreamRecords(
+	_ context.Context, table string, limit int, token string,
+) (*driver.StreamIterator, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	if !cd.streamConfig.Enabled {
+		return nil, cerrors.New(cerrors.FailedPrecondition, "listeners not enabled")
+	}
+
+	return filterSnapRecords(cd.streamRecords, limit, token), nil
+}
+
+func filterSnapRecords(records []driver.StreamRecord, limit int, token string) *driver.StreamIterator {
+	if limit <= 0 {
+		limit = defaultSnapLimit
+	}
+
+	startIdx := 0
+
+	if token != "" {
+		for i, r := range records {
+			if r.SequenceNumber == token {
+				startIdx = i + 1
+				break
+			}
+		}
+	}
+
+	end := startIdx + limit
+	if end > len(records) {
+		end = len(records)
+	}
+
+	result := records[startIdx:end]
+	nextToken := ""
+
+	if end < len(records) {
+		nextToken = result[len(result)-1].SequenceNumber
+	}
+
+	return &driver.StreamIterator{
+		ShardID:   "snapshot-000",
+		Records:   result,
+		NextToken: nextToken,
+	}
+}
+
+// TransactWriteItems executes puts and deletes atomically.
+func (m *Mock) TransactWriteItems(
+	_ context.Context, table string, puts []map[string]any, deletes []map[string]any,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	m.applyTransactPuts(cd, puts)
+	m.applyTransactDeletes(cd, deletes)
+
+	return nil
+}
+
+func (m *Mock) applyTransactPuts(cd *collectionData, puts []map[string]any) {
+	for _, item := range puts {
+		key := docKey(cd.config, item)
+		oldItem, hadOld := cd.items.Get(key)
+		cd.items.Set(key, item)
+		m.recordStreamEvent(cd, oldItem, item, hadOld)
+	}
+}
+
+func (m *Mock) applyTransactDeletes(cd *collectionData, deletes []map[string]any) {
+	for _, key := range deletes {
+		k := docKey(cd.config, key)
+		oldItem, hadOld := cd.items.Get(k)
+		cd.items.Delete(k)
+
+		if hadOld {
+			m.recordStreamRemove(cd, oldItem)
+		}
+	}
+}
+
+// isItemExpired checks if a document has expired based on TTL config.
+func (m *Mock) isItemExpired(cd *collectionData, item map[string]any) bool {
+	if !cd.ttlConfig.Enabled {
+		return false
+	}
+
+	ttlVal, ok := item[cd.ttlConfig.AttributeName]
+	if !ok {
+		return false
+	}
+
+	ttlUnix := toUnixTimestamp(ttlVal)
+	if ttlUnix <= 0 {
+		return false
+	}
+
+	return m.opts.Clock.Now().Unix() > ttlUnix
+}
+
+func toUnixTimestamp(val any) int64 {
+	switch v := val.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	case int:
+		return int64(v)
+	default:
+		parsed, err := strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
+		if err != nil {
+			return 0
+		}
+
+		return int64(parsed)
+	}
+}
+
+// recordStreamEvent records an INSERT or MODIFY snapshot event. Caller must hold m.mu.
+func (m *Mock) recordStreamEvent(cd *collectionData, oldItem, newItem map[string]any, hadOld bool) {
+	if !cd.streamConfig.Enabled {
+		return
+	}
+
+	eventType := "INSERT"
+	if hadOld {
+		eventType = "MODIFY"
+	}
+
+	rec := m.buildStreamRecord(cd, eventType, oldItem, newItem)
+	cd.streamRecords = appendSnapRecord(cd.streamRecords, &rec)
+}
+
+// recordStreamRemove records a REMOVE snapshot event. Caller must hold m.mu.
+func (m *Mock) recordStreamRemove(cd *collectionData, oldItem map[string]any) {
+	if !cd.streamConfig.Enabled {
+		return
+	}
+
+	rec := m.buildStreamRecord(cd, "REMOVE", oldItem, nil)
+	cd.streamRecords = appendSnapRecord(cd.streamRecords, &rec)
+}
+
+func (m *Mock) buildStreamRecord(
+	cd *collectionData, eventType string, oldItem, newItem map[string]any,
+) driver.StreamRecord {
+	seq := cd.seqCounter.Add(1)
+	keys := extractKeys(cd.config, oldItem, newItem)
+
+	rec := driver.StreamRecord{
+		EventID:        fmt.Sprintf("event-%d", seq),
+		EventType:      eventType,
+		Table:          cd.config.Name,
+		Keys:           keys,
+		Timestamp:      m.opts.Clock.Now(),
+		SequenceNumber: fmt.Sprintf("%d", seq),
+	}
+
+	applyViewType(&rec, cd.streamConfig.ViewType, oldItem, newItem)
+
+	return rec
+}
+
+func extractKeys(cfg driver.TableConfig, oldItem, newItem map[string]any) map[string]any {
+	src := newItem
+	if src == nil {
+		src = oldItem
+	}
+
+	keys := map[string]any{cfg.PartitionKey: src[cfg.PartitionKey]}
+	if cfg.SortKey != "" {
+		keys[cfg.SortKey] = src[cfg.SortKey]
+	}
+
+	return keys
+}
+
+func applyViewType(rec *driver.StreamRecord, viewType string, oldItem, newItem map[string]any) {
+	switch viewType {
+	case ViewNewImage:
+		rec.NewImage = copyItem(newItem)
+	case ViewOldImage:
+		rec.OldImage = copyItem(oldItem)
+	case ViewNewAndOld:
+		rec.NewImage = copyItem(newItem)
+		rec.OldImage = copyItem(oldItem)
+	case ViewKeysOnly:
+	}
+}
+
+func copyItem(item map[string]any) map[string]any {
+	if item == nil {
+		return nil
+	}
+
+	cp := make(map[string]any, len(item))
+	for k, v := range item {
+		cp[k] = v
+	}
+
+	return cp
+}
+
+func appendSnapRecord(records []driver.StreamRecord, rec *driver.StreamRecord) []driver.StreamRecord {
+	records = append(records, *rec)
+	if len(records) > maxSnapshotRecords {
+		records = records[len(records)-maxSnapshotRecords:]
+	}
+
+	return records
 }

--- a/providers/gcp/firestore/firestore_test.go
+++ b/providers/gcp/firestore/firestore_test.go
@@ -2,11 +2,13 @@ package firestore
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/database/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -272,4 +274,683 @@ func TestQueryWithGSI(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
+}
+
+func TestUpdateTTL(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+
+	tests := []struct {
+		name      string
+		table     string
+		cfg       driver.TTLConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:  "enable TTL",
+			table: "t1",
+			cfg:   driver.TTLConfig{Enabled: true, AttributeName: "expireAt"},
+		},
+		{
+			name:      "table not found",
+			table:     "missing",
+			cfg:       driver.TTLConfig{Enabled: true, AttributeName: "expireAt"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.UpdateTTL(ctx, tt.table, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				got, descErr := m.DescribeTTL(ctx, tt.table)
+				require.NoError(t, descErr)
+				assert.True(t, got.Enabled)
+				assert.Equal(t, "expireAt", got.AttributeName)
+			}
+		})
+	}
+}
+
+func TestTTLExpiry(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+	m := New(opts)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.UpdateTTL(ctx, "t1", driver.TTLConfig{Enabled: true, AttributeName: "expireAt"}))
+
+	// Set TTL to 60 seconds from now
+	ttlTimestamp := clk.Now().Unix() + 60
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice", "expireAt": ttlTimestamp}))
+
+	t.Run("item accessible before TTL", func(t *testing.T) {
+		item, err := m.GetItem(ctx, "t1", map[string]any{"id": "1"})
+		require.NoError(t, err)
+		assert.Equal(t, "Alice", item["name"])
+	})
+
+	t.Run("item expired after TTL", func(t *testing.T) {
+		clk.Advance(61 * time.Second)
+		_, err := m.GetItem(ctx, "t1", map[string]any{"id": "1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestStreamConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+
+	tests := []struct {
+		name      string
+		table     string
+		cfg       driver.StreamConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:  "enable stream",
+			table: "t1",
+			cfg:   driver.StreamConfig{Enabled: true, ViewType: "NEW_AND_OLD_IMAGES"},
+		},
+		{
+			name:      "table not found",
+			table:     "missing",
+			cfg:       driver.StreamConfig{Enabled: true, ViewType: "NEW_IMAGE"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.UpdateStreamConfig(ctx, tt.table, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStreamRecords(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.UpdateStreamConfig(ctx, "t1", driver.StreamConfig{Enabled: true, ViewType: "NEW_AND_OLD_IMAGES"}))
+
+	t.Run("insert generates stream record", func(t *testing.T) {
+		require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+
+		iter, err := m.GetStreamRecords(ctx, "t1", 10, "")
+		require.NoError(t, err)
+		require.Len(t, iter.Records, 1)
+		assert.Equal(t, "INSERT", iter.Records[0].EventType)
+		assert.Equal(t, "Alice", iter.Records[0].NewImage["name"])
+	})
+
+	t.Run("modify generates stream record", func(t *testing.T) {
+		require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Bob"}))
+
+		iter, err := m.GetStreamRecords(ctx, "t1", 10, "")
+		require.NoError(t, err)
+		require.Len(t, iter.Records, 2)
+		assert.Equal(t, "MODIFY", iter.Records[1].EventType)
+		assert.Equal(t, "Bob", iter.Records[1].NewImage["name"])
+		assert.Equal(t, "Alice", iter.Records[1].OldImage["name"])
+	})
+
+	t.Run("delete generates stream record", func(t *testing.T) {
+		require.NoError(t, m.DeleteItem(ctx, "t1", map[string]any{"id": "1"}))
+
+		iter, err := m.GetStreamRecords(ctx, "t1", 10, "")
+		require.NoError(t, err)
+		require.Len(t, iter.Records, 3)
+		assert.Equal(t, "REMOVE", iter.Records[2].EventType)
+	})
+
+	t.Run("stream not enabled returns error", func(t *testing.T) {
+		require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t2", PartitionKey: "id"}))
+		_, err := m.GetStreamRecords(ctx, "t2", 10, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not enabled")
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		_, err := m.GetStreamRecords(ctx, "missing", 10, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestTransactWriteItems(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "2", "name": "Bob"}))
+
+	t.Run("atomic put and delete", func(t *testing.T) {
+		err := m.TransactWriteItems(ctx, "t1",
+			[]map[string]any{{"id": "3", "name": "Charlie"}},
+			[]map[string]any{{"id": "1"}},
+		)
+		require.NoError(t, err)
+
+		// item 3 should exist
+		item, getErr := m.GetItem(ctx, "t1", map[string]any{"id": "3"})
+		require.NoError(t, getErr)
+		assert.Equal(t, "Charlie", item["name"])
+
+		// item 1 should be deleted
+		_, getErr = m.GetItem(ctx, "t1", map[string]any{"id": "1"})
+		require.Error(t, getErr)
+		assert.Contains(t, getErr.Error(), "not found")
+
+		// item 2 should be unchanged
+		item, getErr = m.GetItem(ctx, "t1", map[string]any{"id": "2"})
+		require.NoError(t, getErr)
+		assert.Equal(t, "Bob", item["name"])
+	})
+
+	t.Run("table not found", func(t *testing.T) {
+		err := m.TransactWriteItems(ctx, "missing",
+			[]map[string]any{{"id": "1"}}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestFirestoreMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+
+	mon := &firestoreMonMock{data: make(map[string][]mondriver.MetricDatum)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+
+	t.Run("PutItem emits write metric", func(t *testing.T) {
+		require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+		assert.NotEmpty(t, mon.data["firestore.googleapis.com/document/write_count"])
+	})
+
+	t.Run("GetItem emits read metric", func(t *testing.T) {
+		_, err := m.GetItem(ctx, "t1", map[string]any{"id": "1"})
+		require.NoError(t, err)
+		assert.NotEmpty(t, mon.data["firestore.googleapis.com/document/read_count"])
+	})
+
+	t.Run("DeleteItem emits delete metric", func(t *testing.T) {
+		require.NoError(t, m.DeleteItem(ctx, "t1", map[string]any{"id": "1"}))
+		assert.NotEmpty(t, mon.data["firestore.googleapis.com/document/delete_count"])
+	})
+}
+
+type firestoreMonMock struct {
+	data map[string][]mondriver.MetricDatum
+}
+
+func (m *firestoreMonMock) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	for _, d := range data {
+		key := d.Namespace + "/" + d.MetricName
+		m.data[key] = append(m.data[key], d)
+	}
+
+	return nil
+}
+
+func (m *firestoreMonMock) GetMetricData(
+	_ context.Context, _ mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (m *firestoreMonMock) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *firestoreMonMock) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (m *firestoreMonMock) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *firestoreMonMock) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (m *firestoreMonMock) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestDescribeTable(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "users", PartitionKey: "pk", SortKey: "sk"}))
+
+	t.Run("success", func(t *testing.T) {
+		cfg, err := m.DescribeTable(ctx, "users")
+		require.NoError(t, err)
+		assert.Equal(t, "users", cfg.Name)
+		assert.Equal(t, "pk", cfg.PartitionKey)
+		assert.Equal(t, "sk", cfg.SortKey)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.DescribeTable(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestListTables(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "pk"}))
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t2", PartitionKey: "pk"}))
+
+	names, err := m.ListTables(ctx)
+	require.NoError(t, err)
+	assert.Len(t, names, 2)
+	assert.Contains(t, names, "t1")
+	assert.Contains(t, names, "t2")
+}
+
+func TestDescribeTTLSuccess(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.UpdateTTL(ctx, "t1", driver.TTLConfig{Enabled: true, AttributeName: "expireAt"}))
+
+	cfg, err := m.DescribeTTL(ctx, "t1")
+	require.NoError(t, err)
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "expireAt", cfg.AttributeName)
+}
+
+func TestDescribeTTLTableNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.DescribeTTL(ctx, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestTTLFilteringInQuery(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+	m := New(opts)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "orders", PartitionKey: "customer", SortKey: "orderID"}))
+	require.NoError(t, m.UpdateTTL(ctx, "orders", driver.TTLConfig{Enabled: true, AttributeName: "expireAt"}))
+
+	ttlPast := clk.Now().Unix() + 30
+	ttlFuture := clk.Now().Unix() + 3600
+
+	require.NoError(t, m.PutItem(ctx, "orders", map[string]any{"customer": "alice", "orderID": "001", "expireAt": ttlPast}))
+	require.NoError(t, m.PutItem(ctx, "orders", map[string]any{"customer": "alice", "orderID": "002", "expireAt": ttlFuture}))
+
+	t.Run("both items visible before expiry", func(t *testing.T) {
+		result, err := m.Query(ctx, driver.QueryInput{
+			Table:        "orders",
+			KeyCondition: driver.KeyCondition{PartitionKey: "customer", PartitionVal: "alice"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Count)
+	})
+
+	t.Run("expired item excluded from query", func(t *testing.T) {
+		clk.Advance(60 * time.Second)
+		result, err := m.Query(ctx, driver.QueryInput{
+			Table:        "orders",
+			KeyCondition: driver.KeyCondition{PartitionKey: "customer", PartitionVal: "alice"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, result.Count)
+	})
+}
+
+func TestStreamRecordsViewTypes(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		viewType   string
+		hasNew     bool
+		hasOld     bool
+		hasKeysNew bool
+	}{
+		{name: "KEYS_ONLY", viewType: ViewKeysOnly, hasNew: false, hasOld: false},
+		{name: "NEW_IMAGE", viewType: ViewNewImage, hasNew: true, hasOld: false},
+		{name: "OLD_IMAGE", viewType: ViewOldImage, hasNew: false, hasOld: false}, // no old on INSERT
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+			require.NoError(t, m.UpdateStreamConfig(ctx, "t1", driver.StreamConfig{Enabled: true, ViewType: tt.viewType}))
+
+			require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+
+			iter, err := m.GetStreamRecords(ctx, "t1", 10, "")
+			require.NoError(t, err)
+			require.Len(t, iter.Records, 1)
+
+			rec := iter.Records[0]
+			assert.Equal(t, "INSERT", rec.EventType)
+			assert.NotNil(t, rec.Keys)
+
+			if tt.hasNew {
+				assert.NotNil(t, rec.NewImage)
+			} else {
+				assert.Nil(t, rec.NewImage)
+			}
+
+			if tt.hasOld {
+				assert.NotNil(t, rec.OldImage)
+			} else {
+				assert.Nil(t, rec.OldImage)
+			}
+		})
+	}
+
+	t.Run("OLD_IMAGE on modify", func(t *testing.T) {
+		m := newTestMock()
+		require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+		require.NoError(t, m.UpdateStreamConfig(ctx, "t1", driver.StreamConfig{Enabled: true, ViewType: ViewOldImage}))
+
+		require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+		require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Bob"}))
+
+		iter, err := m.GetStreamRecords(ctx, "t1", 10, "")
+		require.NoError(t, err)
+		require.Len(t, iter.Records, 2)
+
+		modifyRec := iter.Records[1]
+		assert.Equal(t, "MODIFY", modifyRec.EventType)
+		assert.NotNil(t, modifyRec.OldImage)
+		assert.Equal(t, "Alice", modifyRec.OldImage["name"])
+		assert.Nil(t, modifyRec.NewImage)
+	})
+}
+
+func TestGetStreamRecordsPagination(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.UpdateStreamConfig(ctx, "t1", driver.StreamConfig{Enabled: true, ViewType: ViewNewImage}))
+
+	// Insert 5 items to generate 5 stream records
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": fmt.Sprintf("%d", i), "name": "item"}))
+	}
+
+	t.Run("paginate with limit 2", func(t *testing.T) {
+		iter, err := m.GetStreamRecords(ctx, "t1", 2, "")
+		require.NoError(t, err)
+		assert.Len(t, iter.Records, 2)
+		assert.NotEmpty(t, iter.NextToken)
+
+		// Second page using the token
+		iter2, err := m.GetStreamRecords(ctx, "t1", 2, iter.NextToken)
+		require.NoError(t, err)
+		assert.Len(t, iter2.Records, 2)
+		assert.NotEmpty(t, iter2.NextToken)
+
+		// Third page should have 1 remaining
+		iter3, err := m.GetStreamRecords(ctx, "t1", 2, iter2.NextToken)
+		require.NoError(t, err)
+		assert.Len(t, iter3.Records, 1)
+		assert.Empty(t, iter3.NextToken)
+	})
+}
+
+func TestGetStreamRecordsNotEnabled(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+
+	_, err := m.GetStreamRecords(ctx, "t1", 10, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not enabled")
+}
+
+func TestTransactWriteItemsWithStreamRecords(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.UpdateStreamConfig(ctx, "t1", driver.StreamConfig{Enabled: true, ViewType: ViewNewAndOld}))
+
+	// Pre-insert items to be deleted
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "2", "name": "Bob"}))
+
+	// Clear records by checking them
+	_, err := m.GetStreamRecords(ctx, "t1", 100, "")
+	require.NoError(t, err)
+
+	// Execute transact write with mixed puts and deletes
+	txErr := m.TransactWriteItems(ctx, "t1",
+		[]map[string]any{{"id": "3", "name": "Charlie"}, {"id": "1", "name": "AliceUpdated"}},
+		[]map[string]any{{"id": "2"}},
+	)
+	require.NoError(t, txErr)
+
+	// Verify stream records generated for all operations
+	iter, streamErr := m.GetStreamRecords(ctx, "t1", 100, "")
+	require.NoError(t, streamErr)
+
+	// 2 inserts + 2 transact puts (1 INSERT + 1 MODIFY) + 1 REMOVE = 5 total from beginning
+	// But we want to check that the transact ops generated records
+	// Total records: 2 (initial puts) + 2 (transact puts) + 1 (transact delete) = 5
+	assert.Len(t, iter.Records, 5)
+
+	// Verify the items are in correct state
+	item, getErr := m.GetItem(ctx, "t1", map[string]any{"id": "3"})
+	require.NoError(t, getErr)
+	assert.Equal(t, "Charlie", item["name"])
+
+	item, getErr = m.GetItem(ctx, "t1", map[string]any{"id": "1"})
+	require.NoError(t, getErr)
+	assert.Equal(t, "AliceUpdated", item["name"])
+
+	_, getErr = m.GetItem(ctx, "t1", map[string]any{"id": "2"})
+	require.Error(t, getErr)
+}
+
+func TestBatchPutAndGetItems(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+
+	t.Run("batch put success", func(t *testing.T) {
+		items := []map[string]any{
+			{"id": "1", "name": "Alice"},
+			{"id": "2", "name": "Bob"},
+			{"id": "3", "name": "Charlie"},
+		}
+		require.NoError(t, m.BatchPutItems(ctx, "t1", items))
+	})
+
+	t.Run("batch get success", func(t *testing.T) {
+		keys := []map[string]any{
+			{"id": "1"},
+			{"id": "2"},
+			{"id": "999"}, // non-existent
+		}
+		results, err := m.BatchGetItems(ctx, "t1", keys)
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("batch put missing table", func(t *testing.T) {
+		err := m.BatchPutItems(ctx, "missing", []map[string]any{{"id": "1"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("batch get missing table", func(t *testing.T) {
+		_, err := m.BatchGetItems(ctx, "missing", []map[string]any{{"id": "1"}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestQueryWithSortLessEqual(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "pk", SortKey: "sk"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"pk": "a", "sk": "001"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"pk": "a", "sk": "002"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"pk": "a", "sk": "003"}))
+
+	t.Run("sort <=", func(t *testing.T) {
+		result, err := m.Query(ctx, driver.QueryInput{
+			Table:        "t1",
+			KeyCondition: driver.KeyCondition{PartitionKey: "pk", PartitionVal: "a", SortOp: "<=", SortVal: "002"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Count)
+	})
+
+	t.Run("sort >=", func(t *testing.T) {
+		result, err := m.Query(ctx, driver.QueryInput{
+			Table:        "t1",
+			KeyCondition: driver.KeyCondition{PartitionKey: "pk", PartitionVal: "a", SortOp: ">=", SortVal: "002"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Count)
+	})
+
+	t.Run("sort unsupported op", func(t *testing.T) {
+		result, err := m.Query(ctx, driver.QueryInput{
+			Table:        "t1",
+			KeyCondition: driver.KeyCondition{PartitionKey: "pk", PartitionVal: "a", SortOp: "INVALID", SortVal: "002"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.Count)
+	})
+}
+
+func TestScanMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+
+	mon := &firestoreMonMock{data: make(map[string][]mondriver.MetricDatum)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "name": "Alice"}))
+
+	t.Run("Scan emits read metric", func(t *testing.T) {
+		_, err := m.Scan(ctx, driver.ScanInput{Table: "t1"})
+		require.NoError(t, err)
+		assert.NotEmpty(t, mon.data["firestore.googleapis.com/document/read_count"])
+	})
+
+	t.Run("Query emits read metric", func(t *testing.T) {
+		before := len(mon.data["firestore.googleapis.com/document/read_count"])
+		_, err := m.Query(ctx, driver.QueryInput{
+			Table:        "t1",
+			KeyCondition: driver.KeyCondition{PartitionKey: "id", PartitionVal: "1"},
+		})
+		require.NoError(t, err)
+		assert.Greater(t, len(mon.data["firestore.googleapis.com/document/read_count"]), before)
+	})
+}
+
+func TestToUnixTimestampVariousTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want int64
+	}{
+		{name: "int64", val: int64(1000), want: 1000},
+		{name: "float64", val: float64(2000.5), want: 2000},
+		{name: "int", val: int(3000), want: 3000},
+		{name: "string number", val: "4000", want: 4000},
+		{name: "invalid string", val: "not-a-number", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, toUnixTimestamp(tt.val))
+		})
+	}
+}
+
+func TestCompareValuesStringGreater(t *testing.T) {
+	assert.Equal(t, 1, compareValues("banana", "apple"))
+}
+
+func TestEmitMetricNilMonitoring(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	// No monitoring set - should not panic
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1"}))
+}
+
+func TestScanWithDefaultLimit(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+
+	// Just test that scanning with no filters and default limit works
+	result, err := m.Scan(ctx, driver.ScanInput{Table: "t1"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Count)
+}
+
+func TestScanUnsupportedFilter(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: "t1", PartitionKey: "id"}))
+	require.NoError(t, m.PutItem(ctx, "t1", map[string]any{"id": "1", "score": 10}))
+
+	result, err := m.Scan(ctx, driver.ScanInput{
+		Table:   "t1",
+		Filters: []driver.ScanFilter{{Field: "score", Op: "UNSUPPORTED", Value: 10}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Count)
 }

--- a/providers/gcp/gce/asg.go
+++ b/providers/gcp/gce/asg.go
@@ -1,0 +1,330 @@
+package gce
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+)
+
+const (
+	asgStatusActive = "active"
+	percentDivisor  = 100
+)
+
+// CreateAutoScalingGroup creates a managed instance group and launches desired instances.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateAutoScalingGroup(
+	ctx context.Context, cfg driver.AutoScalingGroupConfig,
+) (*driver.AutoScalingGroup, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "instance group name is required")
+	}
+
+	if m.asgs.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "instance group %q already exists", cfg.Name)
+	}
+
+	if err := validateASGBounds(cfg.DesiredCapacity, cfg.MinSize, cfg.MaxSize); err != nil {
+		return nil, err
+	}
+
+	instances, err := m.RunInstances(ctx, cfg.InstanceConfig, cfg.DesiredCapacity)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "failed to launch instances: %v", err)
+	}
+
+	ids := extractInstanceIDs(instances)
+
+	asg := &asgData{
+		config: driver.AutoScalingGroup{
+			Name:              cfg.Name,
+			MinSize:           cfg.MinSize,
+			MaxSize:           cfg.MaxSize,
+			DesiredCapacity:   cfg.DesiredCapacity,
+			CurrentSize:       len(ids),
+			InstanceIDs:       ids,
+			Status:            asgStatusActive,
+			HealthCheckType:   cfg.HealthCheckType,
+			CreatedAt:         m.opts.Clock.Now().UTC().Format(timeFormat),
+			Tags:              copyTags(cfg.Tags),
+			AvailabilityZones: copyStrings(cfg.AvailabilityZones),
+		},
+		policies: memstore.New[driver.ScalingPolicy](),
+	}
+
+	m.asgs.Set(cfg.Name, asg)
+
+	result := asg.config
+
+	return &result, nil
+}
+
+// DeleteAutoScalingGroup deletes a managed instance group, optionally force-terminating instances.
+func (m *Mock) DeleteAutoScalingGroup(ctx context.Context, name string, forceDelete bool) error {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance group %q not found", name)
+	}
+
+	if !forceDelete && len(asg.config.InstanceIDs) > 0 {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition, "instance group %q has instances; use forceDelete", name,
+		)
+	}
+
+	if forceDelete && len(asg.config.InstanceIDs) > 0 {
+		if err := m.TerminateInstances(ctx, asg.config.InstanceIDs); err != nil {
+			return err
+		}
+	}
+
+	m.asgs.Delete(name)
+
+	return nil
+}
+
+// GetAutoScalingGroup returns details of a managed instance group.
+func (m *Mock) GetAutoScalingGroup(_ context.Context, name string) (*driver.AutoScalingGroup, error) {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "instance group %q not found", name)
+	}
+
+	result := asg.config
+
+	return &result, nil
+}
+
+// ListAutoScalingGroups returns all managed instance groups.
+func (m *Mock) ListAutoScalingGroups(_ context.Context) ([]driver.AutoScalingGroup, error) {
+	all := m.asgs.All()
+	results := make([]driver.AutoScalingGroup, 0, len(all))
+
+	for _, asg := range all {
+		results = append(results, asg.config)
+	}
+
+	return results, nil
+}
+
+// UpdateAutoScalingGroup updates the capacity settings of a managed instance group.
+func (m *Mock) UpdateAutoScalingGroup(
+	ctx context.Context, name string, desired, minSize, maxSize int,
+) error {
+	if err := validateASGBounds(desired, minSize, maxSize); err != nil {
+		return err
+	}
+
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance group %q not found", name)
+	}
+
+	asg.config.MinSize = minSize
+	asg.config.MaxSize = maxSize
+
+	return m.reconcileASG(ctx, asg, desired)
+}
+
+// SetDesiredCapacity sets the desired capacity of a managed instance group.
+func (m *Mock) SetDesiredCapacity(ctx context.Context, name string, desired int) error {
+	asg, ok := m.asgs.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance group %q not found", name)
+	}
+
+	if desired < asg.config.MinSize || desired > asg.config.MaxSize {
+		return cerrors.Newf(
+			cerrors.InvalidArgument,
+			"desired %d outside bounds [%d, %d]", desired, asg.config.MinSize, asg.config.MaxSize,
+		)
+	}
+
+	return m.reconcileASG(ctx, asg, desired)
+}
+
+func (m *Mock) reconcileASG(ctx context.Context, asg *asgData, desired int) error {
+	current := len(asg.config.InstanceIDs)
+
+	if desired > current {
+		return m.scaleUp(ctx, asg, desired-current)
+	}
+
+	if desired < current {
+		return m.scaleDown(ctx, asg, current-desired)
+	}
+
+	return nil
+}
+
+func (m *Mock) scaleUp(ctx context.Context, asg *asgData, count int) error {
+	cfg := instanceConfigFromASG(asg)
+
+	instances, err := m.RunInstances(ctx, cfg, count)
+	if err != nil {
+		return err
+	}
+
+	asg.config.InstanceIDs = append(asg.config.InstanceIDs, extractInstanceIDs(instances)...)
+	asg.config.CurrentSize = len(asg.config.InstanceIDs)
+	asg.config.DesiredCapacity = asg.config.CurrentSize
+
+	return nil
+}
+
+func (m *Mock) scaleDown(ctx context.Context, asg *asgData, count int) error {
+	ids := asg.config.InstanceIDs
+
+	toTerminate := ids[len(ids)-count:]
+	remaining := make([]string, len(ids)-count)
+	copy(remaining, ids[:len(ids)-count])
+
+	if err := m.TerminateInstances(ctx, toTerminate); err != nil {
+		return err
+	}
+
+	asg.config.InstanceIDs = remaining
+	asg.config.CurrentSize = len(remaining)
+	asg.config.DesiredCapacity = asg.config.CurrentSize
+
+	return nil
+}
+
+func instanceConfigFromASG(asg *asgData) driver.InstanceConfig {
+	return driver.InstanceConfig{
+		Tags: copyTags(asg.config.Tags),
+	}
+}
+
+func validateASGBounds(desired, minSize, maxSize int) error {
+	if minSize < 0 {
+		return cerrors.New(cerrors.InvalidArgument, "min size must be >= 0")
+	}
+
+	if maxSize < minSize {
+		return cerrors.New(cerrors.InvalidArgument, "max size must be >= min size")
+	}
+
+	if desired < minSize || desired > maxSize {
+		return cerrors.Newf(
+			cerrors.InvalidArgument,
+			"desired capacity %d outside bounds [%d, %d]", desired, minSize, maxSize,
+		)
+	}
+
+	return nil
+}
+
+func extractInstanceIDs(instances []driver.Instance) []string {
+	ids := make([]string, len(instances))
+
+	for i := range instances {
+		ids[i] = instances[i].ID
+	}
+
+	return ids
+}
+
+// PutScalingPolicy attaches a scaling policy to a managed instance group.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) PutScalingPolicy(_ context.Context, policy driver.ScalingPolicy) error {
+	asg, ok := m.asgs.Get(policy.AutoScalingGroup)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance group %q not found", policy.AutoScalingGroup)
+	}
+
+	asg.policies.Set(policy.Name, policy)
+
+	return nil
+}
+
+// DeleteScalingPolicy removes a scaling policy from a managed instance group.
+func (m *Mock) DeleteScalingPolicy(_ context.Context, asgName, policyName string) error {
+	asg, ok := m.asgs.Get(asgName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance group %q not found", asgName)
+	}
+
+	if !asg.policies.Delete(policyName) {
+		return cerrors.Newf(
+			cerrors.NotFound, "policy %q not found in instance group %q", policyName, asgName,
+		)
+	}
+
+	return nil
+}
+
+// ExecuteScalingPolicy executes a scaling policy on a managed instance group.
+func (m *Mock) ExecuteScalingPolicy(ctx context.Context, asgName, policyName string) error {
+	asg, ok := m.asgs.Get(asgName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance group %q not found", asgName)
+	}
+
+	policy, ok := asg.policies.Get(policyName)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound, "policy %q not found in instance group %q", policyName, asgName,
+		)
+	}
+
+	newDesired := computeNewDesired(&asg.config, &policy)
+
+	return m.reconcileASG(ctx, asg, newDesired)
+}
+
+func computeNewDesired(cfg *driver.AutoScalingGroup, policy *driver.ScalingPolicy) int {
+	desired := cfg.DesiredCapacity
+
+	switch policy.AdjustmentType {
+	case "ExactCapacity":
+		desired = policy.ScalingAdjustment
+	case "ChangeInCapacity":
+		desired += policy.ScalingAdjustment
+	case "PercentChangeInCapacity":
+		delta := (desired * policy.ScalingAdjustment) / percentDivisor
+		desired += delta
+	}
+
+	return clampDesired(desired, cfg.MinSize, cfg.MaxSize)
+}
+
+func clampDesired(desired, minSize, maxSize int) int {
+	if desired < minSize {
+		return minSize
+	}
+
+	if desired > maxSize {
+		return maxSize
+	}
+
+	return desired
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+
+	return dst
+}
+
+func copyStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make([]string, len(src))
+	copy(dst, src)
+
+	return dst
+}

--- a/providers/gcp/gce/gce.go
+++ b/providers/gcp/gce/gce.go
@@ -73,13 +73,21 @@ type instanceData struct {
 	LaunchTime     string
 }
 
+type asgData struct {
+	config   driver.AutoScalingGroup
+	policies *memstore.Store[driver.ScalingPolicy]
+}
+
 // Mock is an in-memory mock implementation of Google Compute Engine.
 type Mock struct {
-	instances  *memstore.Store[*instanceData]
-	sm         *statemachine.Machine
-	opts       *config.Options
-	ipCounter  atomic.Int64
-	monitoring mondriver.Monitoring
+	instances    *memstore.Store[*instanceData]
+	asgs         *memstore.Store[*asgData]
+	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
+	templates    *memstore.Store[*driver.LaunchTemplate]
+	sm           *statemachine.Machine
+	opts         *config.Options
+	ipCounter    atomic.Int64
+	monitoring   mondriver.Monitoring
 }
 
 // SetMonitoring sets the monitoring backend for auto-metric generation.
@@ -155,9 +163,12 @@ func (m *Mock) emitLifecycleMetrics(ctx context.Context, instanceID string, valu
 // New creates a new GCE mock.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		instances: memstore.New[*instanceData](),
-		sm:        statemachine.New(compute.VMTransitions()),
-		opts:      opts,
+		instances:    memstore.New[*instanceData](),
+		asgs:         memstore.New[*asgData](),
+		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
+		templates:    memstore.New[*driver.LaunchTemplate](),
+		sm:           statemachine.New(compute.VMTransitions()),
+		opts:         opts,
 	}
 }
 

--- a/providers/gcp/gce/gce_test.go
+++ b/providers/gcp/gce/gce_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackshy/cloudemu/compute"
 	"github.com/stackshy/cloudemu/compute/driver"
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +18,55 @@ func newTestMock() *Mock {
 	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
 
 	return New(opts)
+}
+
+func newTestMockWithMonitoring() (*Mock, *gceMonMock) {
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+	mon := &gceMonMock{data: make(map[string]int)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	return m, mon
+}
+
+type gceMonMock struct {
+	data map[string]int
+}
+
+func (mon *gceMonMock) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	for _, d := range data {
+		key := d.Namespace + "/" + d.MetricName
+		mon.data[key]++
+	}
+
+	return nil
+}
+
+func (mon *gceMonMock) GetMetricData(
+	_ context.Context, _ mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (mon *gceMonMock) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (mon *gceMonMock) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (mon *gceMonMock) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (mon *gceMonMock) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (mon *gceMonMock) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
 }
 
 func TestRunInstances(t *testing.T) {
@@ -319,4 +369,982 @@ func TestMatchesFilters(t *testing.T) {
 			assert.Equal(t, tt.want, matchesFilters(inst, tt.filters))
 		})
 	}
+}
+
+func TestCreateAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	tests := []struct {
+		name      string
+		cfg       driver.AutoScalingGroupConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg: driver.AutoScalingGroupConfig{
+				Name:            "mig-1",
+				MinSize:         1,
+				MaxSize:         5,
+				DesiredCapacity: 2,
+				InstanceConfig:  driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+				Tags:            map[string]string{"env": "test"},
+			},
+		},
+		{
+			name: "duplicate name",
+			cfg: driver.AutoScalingGroupConfig{
+				Name: "mig-1", MinSize: 1, MaxSize: 3, DesiredCapacity: 1,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+			},
+			wantErr:   true,
+			errSubstr: "already exists",
+		},
+		{
+			name: "empty name",
+			cfg: driver.AutoScalingGroupConfig{
+				MinSize: 1, MaxSize: 3, DesiredCapacity: 1,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+			},
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name: "desired outside bounds",
+			cfg: driver.AutoScalingGroupConfig{
+				Name: "mig-bad", MinSize: 2, MaxSize: 5, DesiredCapacity: 10,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+			},
+			wantErr:   true,
+			errSubstr: "outside bounds",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asg, err := m.CreateAutoScalingGroup(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, tt.cfg.Name, asg.Name)
+				assert.Equal(t, tt.cfg.DesiredCapacity, asg.DesiredCapacity)
+				assert.Len(t, asg.InstanceIDs, tt.cfg.DesiredCapacity)
+				assert.Equal(t, "active", asg.Status)
+			}
+		})
+	}
+}
+
+func TestSetDesiredCapacity(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-1", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		asgName   string
+		desired   int
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "scale up", asgName: "mig-1", desired: 4},
+		{name: "scale down", asgName: "mig-1", desired: 2},
+		{name: "not found", asgName: "missing", desired: 1, wantErr: true, errSubstr: "not found"},
+		{name: "below min", asgName: "mig-1", desired: 0, wantErr: true, errSubstr: "outside bounds"},
+		{name: "above max", asgName: "mig-1", desired: 10, wantErr: true, errSubstr: "outside bounds"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.SetDesiredCapacity(ctx, tt.asgName, tt.desired)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				asg, getErr := m.GetAutoScalingGroup(ctx, tt.asgName)
+				require.NoError(t, getErr)
+				assert.Equal(t, tt.desired, asg.DesiredCapacity)
+				assert.Equal(t, tt.desired, asg.CurrentSize)
+			}
+		})
+	}
+}
+
+func TestScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-1", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+	})
+	require.NoError(t, err)
+
+	t.Run("put and execute ChangeInCapacity policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name:              "scale-out",
+			AutoScalingGroup:  "mig-1",
+			PolicyType:        "SimpleScaling",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 3,
+		}
+		require.NoError(t, m.PutScalingPolicy(ctx, policy))
+		require.NoError(t, m.ExecuteScalingPolicy(ctx, "mig-1", "scale-out"))
+
+		asg, getErr := m.GetAutoScalingGroup(ctx, "mig-1")
+		require.NoError(t, getErr)
+		assert.Equal(t, 5, asg.DesiredCapacity) // 2 + 3
+	})
+
+	t.Run("execute ExactCapacity policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name:              "set-exact",
+			AutoScalingGroup:  "mig-1",
+			PolicyType:        "SimpleScaling",
+			AdjustmentType:    "ExactCapacity",
+			ScalingAdjustment: 3,
+		}
+		require.NoError(t, m.PutScalingPolicy(ctx, policy))
+		require.NoError(t, m.ExecuteScalingPolicy(ctx, "mig-1", "set-exact"))
+
+		asg, getErr := m.GetAutoScalingGroup(ctx, "mig-1")
+		require.NoError(t, getErr)
+		assert.Equal(t, 3, asg.DesiredCapacity)
+	})
+
+	t.Run("delete scaling policy", func(t *testing.T) {
+		require.NoError(t, m.DeleteScalingPolicy(ctx, "mig-1", "scale-out"))
+
+		execErr := m.ExecuteScalingPolicy(ctx, "mig-1", "scale-out")
+		require.Error(t, execErr)
+		assert.Contains(t, execErr.Error(), "not found")
+	})
+
+	t.Run("policy on missing ASG", func(t *testing.T) {
+		putErr := m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+			Name: "p1", AutoScalingGroup: "missing",
+		})
+		require.Error(t, putErr)
+		assert.Contains(t, putErr.Error(), "not found")
+	})
+}
+
+func TestRequestSpotInstances(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	tests := []struct {
+		name      string
+		cfg       driver.SpotRequestConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+				MaxPrice:       0.05,
+				Count:          2,
+				Type:           "one-time",
+			},
+		},
+		{
+			name: "zero count",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+				MaxPrice:       0.05,
+				Count:          0,
+			},
+			wantErr:   true,
+			errSubstr: "greater than 0",
+		},
+		{
+			name: "zero price",
+			cfg: driver.SpotRequestConfig{
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+				MaxPrice:       0,
+				Count:          1,
+			},
+			wantErr:   true,
+			errSubstr: "greater than 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqs, err := m.RequestSpotInstances(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				require.Len(t, reqs, tt.cfg.Count)
+				assert.Equal(t, "active", reqs[0].Status)
+				assert.NotEmpty(t, reqs[0].InstanceID)
+				assert.NotEmpty(t, reqs[0].ID)
+			}
+		})
+	}
+}
+
+func TestCancelSpotRequests(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+		MaxPrice:       0.05,
+		Count:          1,
+		Type:           "one-time",
+	})
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", ids: []string{reqs[0].ID}},
+		{name: "not found", ids: []string{"missing"}, wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cancelErr := m.CancelSpotRequests(ctx, tt.ids)
+			switch {
+			case tt.wantErr:
+				require.Error(t, cancelErr)
+				assert.Contains(t, cancelErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, cancelErr)
+				// Verify the request is now canceled
+				described, descErr := m.DescribeSpotRequests(ctx, tt.ids)
+				require.NoError(t, descErr)
+				assert.Equal(t, "canceled", described[0].Status)
+			}
+		})
+	}
+}
+
+func TestCreateLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	tests := []struct {
+		name      string
+		cfg       driver.LaunchTemplateConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg: driver.LaunchTemplateConfig{
+				Name: "tmpl-1",
+				InstanceConfig: driver.InstanceConfig{
+					ImageID: "img-1", InstanceType: "n1-standard-1",
+				},
+			},
+		},
+		{
+			name: "duplicate",
+			cfg: driver.LaunchTemplateConfig{
+				Name:           "tmpl-1",
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+			},
+			wantErr:   true,
+			errSubstr: "already exists",
+		},
+		{
+			name:      "empty name",
+			cfg:       driver.LaunchTemplateConfig{},
+			wantErr:   true,
+			errSubstr: "required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := m.CreateLaunchTemplate(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, tt.cfg.Name, tmpl.Name)
+				assert.NotEmpty(t, tmpl.ID)
+				assert.Greater(t, tmpl.Version, 0)
+				assert.NotEmpty(t, tmpl.CreatedAt)
+
+				// Verify get works
+				got, getErr := m.GetLaunchTemplate(ctx, tt.cfg.Name)
+				require.NoError(t, getErr)
+				assert.Equal(t, tmpl.Name, got.Name)
+			}
+		})
+	}
+
+	t.Run("delete template", func(t *testing.T) {
+		require.NoError(t, m.DeleteLaunchTemplate(ctx, "tmpl-1"))
+		_, getErr := m.GetLaunchTemplate(ctx, "tmpl-1")
+		require.Error(t, getErr)
+		assert.Contains(t, getErr.Error(), "not found")
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		delErr := m.DeleteLaunchTemplate(ctx, "missing")
+		require.Error(t, delErr)
+		assert.Contains(t, delErr.Error(), "not found")
+	})
+}
+
+func TestDeleteAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-del", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		asgName     string
+		forceDelete bool
+		wantErr     bool
+		errSubstr   string
+	}{
+		{
+			name:        "non-force with instances fails",
+			asgName:     "mig-del",
+			forceDelete: false,
+			wantErr:     true,
+			errSubstr:   "has instances",
+		},
+		{
+			name:        "force delete with instances succeeds",
+			asgName:     "mig-del",
+			forceDelete: true,
+		},
+		{
+			name:        "not found",
+			asgName:     "mig-missing",
+			forceDelete: false,
+			wantErr:     true,
+			errSubstr:   "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.DeleteAutoScalingGroup(ctx, tt.asgName, tt.forceDelete)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				_, getErr := m.GetAutoScalingGroup(ctx, tt.asgName)
+				require.Error(t, getErr)
+				assert.Contains(t, getErr.Error(), "not found")
+			}
+		})
+	}
+}
+
+func TestGetAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-get", MinSize: 1, MaxSize: 5, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		asgName   string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", asgName: "mig-get"},
+		{name: "not found", asgName: "mig-missing", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asg, err := m.GetAutoScalingGroup(ctx, tt.asgName)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, "mig-get", asg.Name)
+				assert.Equal(t, 2, asg.DesiredCapacity)
+				assert.Equal(t, "active", asg.Status)
+				assert.Len(t, asg.InstanceIDs, 2)
+			}
+		})
+	}
+}
+
+func TestListAutoScalingGroups(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("empty list", func(t *testing.T) {
+		asgs, err := m.ListAutoScalingGroups(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, asgs)
+	})
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-a", MinSize: 1, MaxSize: 3, DesiredCapacity: 1,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-b", MinSize: 1, MaxSize: 3, DesiredCapacity: 1,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	t.Run("list two groups", func(t *testing.T) {
+		asgs, listErr := m.ListAutoScalingGroups(ctx)
+		require.NoError(t, listErr)
+		assert.Len(t, asgs, 2)
+	})
+}
+
+func TestUpdateAutoScalingGroup(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-upd", MinSize: 1, MaxSize: 10, DesiredCapacity: 3,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		asgName   string
+		desired   int
+		minSize   int
+		maxSize   int
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "scale up", asgName: "mig-upd", desired: 5, minSize: 1, maxSize: 10},
+		{name: "scale down", asgName: "mig-upd", desired: 2, minSize: 1, maxSize: 10},
+		{name: "update bounds", asgName: "mig-upd", desired: 2, minSize: 2, maxSize: 8},
+		{name: "not found", asgName: "mig-missing", desired: 1, minSize: 1, maxSize: 5, wantErr: true, errSubstr: "not found"},
+		{name: "invalid bounds", asgName: "mig-upd", desired: 15, minSize: 1, maxSize: 10, wantErr: true, errSubstr: "outside bounds"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.UpdateAutoScalingGroup(ctx, tt.asgName, tt.desired, tt.minSize, tt.maxSize)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				asg, getErr := m.GetAutoScalingGroup(ctx, tt.asgName)
+				require.NoError(t, getErr)
+				assert.Equal(t, tt.desired, asg.DesiredCapacity)
+				assert.Equal(t, tt.minSize, asg.MinSize)
+				assert.Equal(t, tt.maxSize, asg.MaxSize)
+			}
+		})
+	}
+}
+
+func TestPutScalingPolicyCreateAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-pol", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	t.Run("create policy", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name:              "p1",
+			AutoScalingGroup:  "mig-pol",
+			PolicyType:        "SimpleScaling",
+			AdjustmentType:    "ChangeInCapacity",
+			ScalingAdjustment: 2,
+		}
+		require.NoError(t, m.PutScalingPolicy(ctx, policy))
+
+		// Execute to verify it works
+		require.NoError(t, m.ExecuteScalingPolicy(ctx, "mig-pol", "p1"))
+		asg, getErr := m.GetAutoScalingGroup(ctx, "mig-pol")
+		require.NoError(t, getErr)
+		assert.Equal(t, 4, asg.DesiredCapacity)
+	})
+
+	t.Run("update policy by re-putting", func(t *testing.T) {
+		policy := driver.ScalingPolicy{
+			Name:              "p1",
+			AutoScalingGroup:  "mig-pol",
+			PolicyType:        "SimpleScaling",
+			AdjustmentType:    "ExactCapacity",
+			ScalingAdjustment: 2,
+		}
+		require.NoError(t, m.PutScalingPolicy(ctx, policy))
+
+		require.NoError(t, m.ExecuteScalingPolicy(ctx, "mig-pol", "p1"))
+		asg, getErr := m.GetAutoScalingGroup(ctx, "mig-pol")
+		require.NoError(t, getErr)
+		assert.Equal(t, 2, asg.DesiredCapacity)
+	})
+}
+
+func TestDeleteScalingPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-delpol", MinSize: 1, MaxSize: 10, DesiredCapacity: 2,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, m.PutScalingPolicy(ctx, driver.ScalingPolicy{
+		Name: "p1", AutoScalingGroup: "mig-delpol",
+		AdjustmentType: "ChangeInCapacity", ScalingAdjustment: 1,
+	}))
+
+	tests := []struct {
+		name      string
+		asgName   string
+		polName   string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", asgName: "mig-delpol", polName: "p1"},
+		{name: "policy not found", asgName: "mig-delpol", polName: "p1", wantErr: true, errSubstr: "not found"},
+		{name: "ASG not found", asgName: "missing", polName: "p1", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.DeleteScalingPolicy(ctx, tt.asgName, tt.polName)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestExecuteScalingPolicyAllTypes(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-exec", MinSize: 1, MaxSize: 20, DesiredCapacity: 10,
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		policy      driver.ScalingPolicy
+		wantDesired int
+	}{
+		{
+			name: "ChangeInCapacity positive",
+			policy: driver.ScalingPolicy{
+				Name: "change-up", AutoScalingGroup: "mig-exec",
+				AdjustmentType: "ChangeInCapacity", ScalingAdjustment: 3,
+			},
+			wantDesired: 13,
+		},
+		{
+			name: "ExactCapacity",
+			policy: driver.ScalingPolicy{
+				Name: "exact", AutoScalingGroup: "mig-exec",
+				AdjustmentType: "ExactCapacity", ScalingAdjustment: 5,
+			},
+			wantDesired: 5,
+		},
+		{
+			name: "PercentChangeInCapacity",
+			policy: driver.ScalingPolicy{
+				Name: "percent", AutoScalingGroup: "mig-exec",
+				AdjustmentType: "PercentChangeInCapacity", ScalingAdjustment: 100,
+			},
+			wantDesired: 10, // 5 + 100% of 5 = 10
+		},
+		{
+			name: "ChangeInCapacity negative",
+			policy: driver.ScalingPolicy{
+				Name: "change-down", AutoScalingGroup: "mig-exec",
+				AdjustmentType: "ChangeInCapacity", ScalingAdjustment: -5,
+			},
+			wantDesired: 5,
+		},
+		{
+			name: "clamp to min",
+			policy: driver.ScalingPolicy{
+				Name: "clamp-min", AutoScalingGroup: "mig-exec",
+				AdjustmentType: "ChangeInCapacity", ScalingAdjustment: -20,
+			},
+			wantDesired: 1,
+		},
+		{
+			name: "clamp to max",
+			policy: driver.ScalingPolicy{
+				Name: "clamp-max", AutoScalingGroup: "mig-exec",
+				AdjustmentType: "ExactCapacity", ScalingAdjustment: 100,
+			},
+			wantDesired: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, m.PutScalingPolicy(ctx, tt.policy))
+			require.NoError(t, m.ExecuteScalingPolicy(ctx, "mig-exec", tt.policy.Name))
+
+			asg, getErr := m.GetAutoScalingGroup(ctx, "mig-exec")
+			require.NoError(t, getErr)
+			assert.Equal(t, tt.wantDesired, asg.DesiredCapacity)
+		})
+	}
+
+	t.Run("execute on missing ASG", func(t *testing.T) {
+		execErr := m.ExecuteScalingPolicy(ctx, "missing-asg", "any-policy")
+		require.Error(t, execErr)
+		assert.Contains(t, execErr.Error(), "not found")
+	})
+
+	t.Run("execute missing policy", func(t *testing.T) {
+		execErr := m.ExecuteScalingPolicy(ctx, "mig-exec", "nonexistent-policy")
+		require.Error(t, execErr)
+		assert.Contains(t, execErr.Error(), "not found")
+	})
+}
+
+func TestDescribeSpotRequests(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+		MaxPrice:       0.05,
+		Count:          2,
+		Type:           "one-time",
+	})
+	require.NoError(t, err)
+	require.Len(t, reqs, 2)
+
+	tests := []struct {
+		name      string
+		ids       []string
+		wantCount int
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "all requests (empty IDs)", ids: nil, wantCount: 2},
+		{name: "by specific ID", ids: []string{reqs[0].ID}, wantCount: 1},
+		{name: "multiple IDs", ids: []string{reqs[0].ID, reqs[1].ID}, wantCount: 2},
+		{name: "not found", ids: []string{"preempt-missing"}, wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := m.DescribeSpotRequests(ctx, tt.ids)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Len(t, result, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestGetLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "tmpl-get",
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		tmplName  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", tmplName: "tmpl-get"},
+		{name: "not found", tmplName: "tmpl-missing", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := m.GetLaunchTemplate(ctx, tt.tmplName)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, "tmpl-get", tmpl.Name)
+				assert.Equal(t, "img-1", tmpl.InstanceConfig.ImageID)
+				assert.NotEmpty(t, tmpl.ID)
+			}
+		})
+	}
+}
+
+func TestListLaunchTemplates(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("empty list", func(t *testing.T) {
+		templates, err := m.ListLaunchTemplates(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, templates)
+	})
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "tmpl-a",
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	_, err = m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "tmpl-b",
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-2"},
+	})
+	require.NoError(t, err)
+
+	t.Run("list two templates", func(t *testing.T) {
+		templates, listErr := m.ListLaunchTemplates(ctx)
+		require.NoError(t, listErr)
+		assert.Len(t, templates, 2)
+	})
+}
+
+func TestDeleteLaunchTemplate(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	_, err := m.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name:           "tmpl-del",
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		tmplName  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", tmplName: "tmpl-del"},
+		{name: "already deleted", tmplName: "tmpl-del", wantErr: true, errSubstr: "not found"},
+		{name: "never existed", tmplName: "tmpl-missing", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.DeleteLaunchTemplate(ctx, tt.tmplName)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				_, getErr := m.GetLaunchTemplate(ctx, tt.tmplName)
+				require.Error(t, getErr)
+			}
+		})
+	}
+}
+
+func TestRunInstancesWithMonitoring(t *testing.T) {
+	ctx := context.Background()
+	m, mon := newTestMockWithMonitoring()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "n1-standard-1",
+	}, 1)
+	require.NoError(t, err)
+	require.Len(t, instances, 1)
+
+	// Each metric should have 5 backfill datapoints
+	assert.Equal(t, 5, mon.data["compute.googleapis.com/instance/cpu/utilization"])
+	assert.Equal(t, 5, mon.data["compute.googleapis.com/instance/network/received_bytes_count"])
+	assert.Equal(t, 5, mon.data["compute.googleapis.com/instance/network/sent_bytes_count"])
+	assert.Equal(t, 5, mon.data["compute.googleapis.com/instance/disk/read_ops_count"])
+	assert.Equal(t, 5, mon.data["compute.googleapis.com/instance/disk/write_ops_count"])
+}
+
+func TestLifecycleMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	m, mon := newTestMockWithMonitoring()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "n1-standard-1",
+	}, 1)
+	require.NoError(t, err)
+	id := instances[0].ID
+
+	// Clear the counters from RunInstances
+	for k := range mon.data {
+		mon.data[k] = 0
+	}
+
+	t.Run("stop emits lifecycle metrics", func(t *testing.T) {
+		require.NoError(t, m.StopInstances(ctx, []string{id}))
+		assert.Equal(t, 1, mon.data["compute.googleapis.com/instance/cpu/utilization"])
+	})
+
+	t.Run("start emits lifecycle metrics", func(t *testing.T) {
+		// Clear again
+		for k := range mon.data {
+			mon.data[k] = 0
+		}
+
+		require.NoError(t, m.StartInstances(ctx, []string{id}))
+		assert.Equal(t, 1, mon.data["compute.googleapis.com/instance/cpu/utilization"])
+	})
+
+	t.Run("reboot emits lifecycle metrics", func(t *testing.T) {
+		for k := range mon.data {
+			mon.data[k] = 0
+		}
+
+		require.NoError(t, m.RebootInstances(ctx, []string{id}))
+		assert.Equal(t, 1, mon.data["compute.googleapis.com/instance/cpu/utilization"])
+	})
+
+	t.Run("terminate emits lifecycle metrics", func(t *testing.T) {
+		for k := range mon.data {
+			mon.data[k] = 0
+		}
+
+		require.NoError(t, m.TerminateInstances(ctx, []string{id}))
+		assert.Equal(t, 1, mon.data["compute.googleapis.com/instance/cpu/utilization"])
+	})
+}
+
+func TestValidateASGBoundsEdgeCases(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	tests := []struct {
+		name      string
+		cfg       driver.AutoScalingGroupConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "negative min size",
+			cfg: driver.AutoScalingGroupConfig{
+				Name: "mig-neg", MinSize: -1, MaxSize: 5, DesiredCapacity: 1,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+			},
+			wantErr:   true,
+			errSubstr: "min size must be >= 0",
+		},
+		{
+			name: "max less than min",
+			cfg: driver.AutoScalingGroupConfig{
+				Name: "mig-bad", MinSize: 5, MaxSize: 2, DesiredCapacity: 3,
+				InstanceConfig: driver.InstanceConfig{ImageID: "img-1"},
+			},
+			wantErr:   true,
+			errSubstr: "max size must be >= min size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := m.CreateAutoScalingGroup(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateASGWithAvailabilityZones(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	asg, err := m.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "mig-zones", MinSize: 0, MaxSize: 3, DesiredCapacity: 1,
+		InstanceConfig:    driver.InstanceConfig{ImageID: "img-1"},
+		AvailabilityZones: []string{"us-central1-a", "us-central1-b"},
+		Tags:              map[string]string{"env": "test"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"us-central1-a", "us-central1-b"}, asg.AvailabilityZones)
+	assert.Equal(t, "test", asg.Tags["env"])
+}
+
+func TestCancelSpotRequestsPersistentType(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	// Create a persistent-type spot request
+	reqs, err := m.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		InstanceConfig: driver.InstanceConfig{ImageID: "img-1", InstanceType: "n1-standard-1"},
+		MaxPrice:       0.05,
+		Count:          1,
+		Type:           "persistent",
+	})
+	require.NoError(t, err)
+	require.Len(t, reqs, 1)
+
+	instID := reqs[0].InstanceID
+
+	// Cancel should not terminate instance for persistent type
+	require.NoError(t, m.CancelSpotRequests(ctx, []string{reqs[0].ID}))
+
+	// The instance should still exist and be running (persistent type does not auto-terminate)
+	desc, err := m.DescribeInstances(ctx, []string{instID}, nil)
+	require.NoError(t, err)
+	require.Len(t, desc, 1)
+	assert.Equal(t, compute.StateRunning, desc[0].State)
 }

--- a/providers/gcp/gce/spot.go
+++ b/providers/gcp/gce/spot.go
@@ -1,0 +1,111 @@
+package gce
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+const (
+	spotStatusActive   = "active"
+	spotStatusCanceled = "canceled"
+	spotTypeOneTime    = "one-time"
+	timeFormat         = "2006-01-02T15:04:05Z"
+)
+
+// RequestSpotInstances creates preemptible VM requests and immediately fulfills them.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) RequestSpotInstances(
+	ctx context.Context, cfg driver.SpotRequestConfig,
+) ([]driver.SpotInstanceRequest, error) {
+	if cfg.Count <= 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "count must be greater than 0")
+	}
+
+	if cfg.MaxPrice <= 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "max price must be greater than 0")
+	}
+
+	instances, err := m.RunInstances(ctx, cfg.InstanceConfig, cfg.Count)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]driver.SpotInstanceRequest, 0, cfg.Count)
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	for _, inst := range instances {
+		reqID := idgen.GenerateID("preempt-")
+
+		req := &driver.SpotInstanceRequest{
+			ID:             reqID,
+			InstanceConfig: cfg.InstanceConfig,
+			MaxPrice:       cfg.MaxPrice,
+			Status:         spotStatusActive,
+			InstanceID:     inst.ID,
+			CreatedAt:      now,
+			Type:           cfg.Type,
+		}
+
+		m.spotRequests.Set(reqID, req)
+		results = append(results, *req)
+	}
+
+	return results, nil
+}
+
+// CancelSpotRequests cancels preemptible VM requests and terminates instances for one-time type.
+func (m *Mock) CancelSpotRequests(ctx context.Context, requestIDs []string) error {
+	for _, reqID := range requestIDs {
+		req, ok := m.spotRequests.Get(reqID)
+		if !ok {
+			return cerrors.Newf(cerrors.NotFound, "preemptible request %q not found", reqID)
+		}
+
+		req.Status = spotStatusCanceled
+
+		if req.Type == spotTypeOneTime && req.InstanceID != "" {
+			if err := m.TerminateInstances(ctx, []string{req.InstanceID}); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// DescribeSpotRequests returns preemptible VM requests matching the given IDs.
+func (m *Mock) DescribeSpotRequests(
+	_ context.Context, requestIDs []string,
+) ([]driver.SpotInstanceRequest, error) {
+	if len(requestIDs) == 0 {
+		return m.allSpotRequests(), nil
+	}
+
+	results := make([]driver.SpotInstanceRequest, 0, len(requestIDs))
+
+	for _, reqID := range requestIDs {
+		req, ok := m.spotRequests.Get(reqID)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "preemptible request %q not found", reqID)
+		}
+
+		results = append(results, *req)
+	}
+
+	return results, nil
+}
+
+func (m *Mock) allSpotRequests() []driver.SpotInstanceRequest {
+	all := m.spotRequests.All()
+	results := make([]driver.SpotInstanceRequest, 0, len(all))
+
+	for _, req := range all {
+		results = append(results, *req)
+	}
+
+	return results
+}

--- a/providers/gcp/gce/template.go
+++ b/providers/gcp/gce/template.go
@@ -1,0 +1,77 @@
+package gce
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+//nolint:gochecknoglobals // atomic counter for template versioning
+var templateVersion uint64
+
+// CreateLaunchTemplate creates a new instance template.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) CreateLaunchTemplate(
+	_ context.Context, cfg driver.LaunchTemplateConfig,
+) (*driver.LaunchTemplate, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "template name is required")
+	}
+
+	if m.templates.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "template %q already exists", cfg.Name)
+	}
+
+	ver := int(atomic.AddUint64(&templateVersion, 1)) //nolint:gosec // overflow impossible in mock
+
+	tmpl := &driver.LaunchTemplate{
+		ID:             idgen.GCPID(m.opts.ProjectID, "instanceTemplates", cfg.Name),
+		Name:           cfg.Name,
+		Version:        ver,
+		InstanceConfig: cfg.InstanceConfig,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	m.templates.Set(cfg.Name, tmpl)
+
+	result := *tmpl
+
+	return &result, nil
+}
+
+// DeleteLaunchTemplate deletes an instance template by name.
+func (m *Mock) DeleteLaunchTemplate(_ context.Context, name string) error {
+	if !m.templates.Delete(name) {
+		return cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+	}
+
+	return nil
+}
+
+// GetLaunchTemplate returns an instance template by name.
+func (m *Mock) GetLaunchTemplate(_ context.Context, name string) (*driver.LaunchTemplate, error) {
+	tmpl, ok := m.templates.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "template %q not found", name)
+	}
+
+	result := *tmpl
+
+	return &result, nil
+}
+
+// ListLaunchTemplates returns all instance templates.
+func (m *Mock) ListLaunchTemplates(_ context.Context) ([]driver.LaunchTemplate, error) {
+	all := m.templates.All()
+	results := make([]driver.LaunchTemplate, 0, len(all))
+
+	for _, tmpl := range all {
+		results = append(results, *tmpl)
+	}
+
+	return results, nil
+}

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -3,10 +3,12 @@ package gcp
 
 import (
 	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/providers/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/providers/gcp/clouddns"
 	"github.com/stackshy/cloudemu/providers/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/providers/gcp/cloudlogging"
 	"github.com/stackshy/cloudemu/providers/gcp/cloudmonitoring"
+	"github.com/stackshy/cloudemu/providers/gcp/eventarc"
 	"github.com/stackshy/cloudemu/providers/gcp/fcm"
 	"github.com/stackshy/cloudemu/providers/gcp/firestore"
 	"github.com/stackshy/cloudemu/providers/gcp/gce"
@@ -21,42 +23,55 @@ import (
 
 // Provider holds all GCP mock services.
 type Provider struct {
-	GCS             *gcs.Mock
-	GCE             *gce.Mock
-	Firestore       *firestore.Mock
-	CloudFunctions  *cloudfunctions.Mock
-	VPC             *gcpvpc.Mock
-	CloudMonitoring *cloudmonitoring.Mock
-	IAM             *gcpiam.Mock
-	CloudDNS        *clouddns.Mock
-	LB              *gcplb.Mock
-	PubSub          *pubsub.Mock
-	Memorystore     *memorystore.Mock
-	SecretManager   *secretmanager.Mock
-	CloudLogging    *cloudlogging.Mock
-	FCM             *fcm.Mock
+	GCS              *gcs.Mock
+	GCE              *gce.Mock
+	Firestore        *firestore.Mock
+	CloudFunctions   *cloudfunctions.Mock
+	VPC              *gcpvpc.Mock
+	CloudMonitoring  *cloudmonitoring.Mock
+	IAM              *gcpiam.Mock
+	CloudDNS         *clouddns.Mock
+	LB               *gcplb.Mock
+	PubSub           *pubsub.Mock
+	Memorystore      *memorystore.Mock
+	SecretManager    *secretmanager.Mock
+	CloudLogging     *cloudlogging.Mock
+	FCM              *fcm.Mock
+	ArtifactRegistry *artifactregistry.Mock
+	Eventarc         *eventarc.Mock
 }
 
 // New creates a new GCP provider with all mock services.
 func New(opts ...config.Option) *Provider {
 	o := config.NewOptions(opts...)
 	p := &Provider{
-		GCS:             gcs.New(o),
-		GCE:             gce.New(o),
-		Firestore:       firestore.New(o),
-		CloudFunctions:  cloudfunctions.New(o),
-		VPC:             gcpvpc.New(o),
-		CloudMonitoring: cloudmonitoring.New(o),
-		IAM:             gcpiam.New(o),
-		CloudDNS:        clouddns.New(o),
-		LB:              gcplb.New(o),
-		PubSub:          pubsub.New(o),
-		Memorystore:     memorystore.New(o),
-		SecretManager:   secretmanager.New(o),
-		CloudLogging:    cloudlogging.New(o),
-		FCM:             fcm.New(o),
+		GCS:              gcs.New(o),
+		GCE:              gce.New(o),
+		Firestore:        firestore.New(o),
+		CloudFunctions:   cloudfunctions.New(o),
+		VPC:              gcpvpc.New(o),
+		CloudMonitoring:  cloudmonitoring.New(o),
+		IAM:              gcpiam.New(o),
+		CloudDNS:         clouddns.New(o),
+		LB:               gcplb.New(o),
+		PubSub:           pubsub.New(o),
+		Memorystore:      memorystore.New(o),
+		SecretManager:    secretmanager.New(o),
+		CloudLogging:     cloudlogging.New(o),
+		FCM:              fcm.New(o),
+		ArtifactRegistry: artifactregistry.New(o),
+		Eventarc:         eventarc.New(o),
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
+	p.GCS.SetMonitoring(p.CloudMonitoring)
+	p.Firestore.SetMonitoring(p.CloudMonitoring)
+	p.CloudFunctions.SetMonitoring(p.CloudMonitoring)
+	p.PubSub.SetMonitoring(p.CloudMonitoring)
+	p.Memorystore.SetMonitoring(p.CloudMonitoring)
+	p.CloudLogging.SetMonitoring(p.CloudMonitoring)
+	p.FCM.SetMonitoring(p.CloudMonitoring)
+	p.ArtifactRegistry.SetMonitoring(p.CloudMonitoring)
+	p.Eventarc.SetMonitoring(p.CloudMonitoring)
 
 	return p
 }

--- a/providers/gcp/gcpvpc/acl.go
+++ b/providers/gcp/gcpvpc/acl.go
@@ -1,0 +1,142 @@
+package gcpvpc
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Default ACL rule constants.
+const (
+	defaultACLRuleNumber = 100
+	allTrafficProtocol   = "-1"
+	allTrafficCIDR       = "0.0.0.0/0"
+	actionAllow          = "allow"
+)
+
+type networkACLData struct {
+	ID        string
+	VPCID     string
+	Rules     []driver.NetworkACLRule
+	Tags      map[string]string
+	IsDefault bool
+}
+
+// CreateNetworkACL creates a firewall policy for the specified VPC network.
+func (m *Mock) CreateNetworkACL(
+	_ context.Context, vpcID string, tags map[string]string,
+) (*driver.NetworkACL, error) {
+	if vpcID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "VPC ID is required")
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return nil, cerrors.Newf(cerrors.NotFound, "VPC %q not found", vpcID)
+	}
+
+	id := idgen.GCPID(m.opts.ProjectID, "firewallPolicies", idgen.GenerateID("acl-"))
+	acl := &networkACLData{
+		ID:        id,
+		VPCID:     vpcID,
+		Rules:     defaultACLRules(),
+		Tags:      copyTags(tags),
+		IsDefault: false,
+	}
+	m.networkACLs.Set(id, acl)
+
+	info := toNetworkACLInfo(acl)
+
+	return &info, nil
+}
+
+// defaultACLRules returns the default allow-all rules for a new ACL.
+func defaultACLRules() []driver.NetworkACLRule {
+	return []driver.NetworkACLRule{
+		{
+			RuleNumber: defaultACLRuleNumber,
+			Protocol:   allTrafficProtocol,
+			Action:     actionAllow,
+			CIDR:       allTrafficCIDR,
+			Egress:     false,
+		},
+		{
+			RuleNumber: defaultACLRuleNumber,
+			Protocol:   allTrafficProtocol,
+			Action:     actionAllow,
+			CIDR:       allTrafficCIDR,
+			Egress:     true,
+		},
+	}
+}
+
+// DeleteNetworkACL deletes the firewall policy with the given ID.
+func (m *Mock) DeleteNetworkACL(_ context.Context, id string) error {
+	acl, ok := m.networkACLs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", id)
+	}
+
+	if acl.IsDefault {
+		return cerrors.Newf(cerrors.FailedPrecondition, "cannot delete default firewall policy %q", id)
+	}
+
+	m.networkACLs.Delete(id)
+
+	return nil
+}
+
+// DescribeNetworkACLs returns firewall policies matching the given IDs, or all if empty.
+func (m *Mock) DescribeNetworkACLs(_ context.Context, ids []string) ([]driver.NetworkACL, error) {
+	return describeResources(m.networkACLs, ids, toNetworkACLInfo), nil
+}
+
+// AddNetworkACLRule adds a rule to the specified firewall policy, keeping rules sorted.
+func (m *Mock) AddNetworkACLRule(_ context.Context, aclID string, rule *driver.NetworkACLRule) error {
+	acl, ok := m.networkACLs.Get(aclID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", aclID)
+	}
+
+	acl.Rules = append(acl.Rules, *rule)
+	sort.Slice(acl.Rules, func(i, j int) bool {
+		return acl.Rules[i].RuleNumber < acl.Rules[j].RuleNumber
+	})
+
+	return nil
+}
+
+// RemoveNetworkACLRule removes a rule by rule number and direction.
+func (m *Mock) RemoveNetworkACLRule(
+	_ context.Context, aclID string, ruleNumber int, egress bool,
+) error {
+	acl, ok := m.networkACLs.Get(aclID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", aclID)
+	}
+
+	for i, r := range acl.Rules {
+		if r.RuleNumber == ruleNumber && r.Egress == egress {
+			acl.Rules = append(acl.Rules[:i], acl.Rules[i+1:]...)
+			return nil
+		}
+	}
+
+	return cerrors.Newf(cerrors.NotFound,
+		"rule %d not found in firewall policy %q", ruleNumber, aclID)
+}
+
+func toNetworkACLInfo(acl *networkACLData) driver.NetworkACL {
+	rules := make([]driver.NetworkACLRule, len(acl.Rules))
+	copy(rules, acl.Rules)
+
+	return driver.NetworkACL{
+		ID:        acl.ID,
+		VPCID:     acl.VPCID,
+		Rules:     rules,
+		Tags:      copyTags(acl.Tags),
+		IsDefault: acl.IsDefault,
+	}
+}

--- a/providers/gcp/gcpvpc/flowlog.go
+++ b/providers/gcp/gcpvpc/flowlog.go
@@ -1,0 +1,159 @@
+package gcpvpc
+
+import (
+	"context"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Flow log status constants.
+const (
+	FlowLogStatusActive = "ACTIVE"
+)
+
+// Flow log traffic type constants.
+const (
+	TrafficTypeAll    = "ALL"
+	TrafficTypeAccept = "ACCEPT"
+	TrafficTypeReject = "REJECT"
+)
+
+// Mock flow log record constants.
+const (
+	mockSourcePort = 443
+	mockDestPort   = 52000
+	mockPackets    = 10
+	mockBytes      = 1500
+)
+
+type flowLogData struct {
+	ID           string
+	ResourceID   string
+	ResourceType string
+	TrafficType  string
+	Status       string
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// CreateFlowLog creates a VPC flow log for a VPC or subnet resource.
+func (m *Mock) CreateFlowLog(_ context.Context, cfg driver.FlowLogConfig) (*driver.FlowLog, error) {
+	if cfg.ResourceID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "resource ID is required")
+	}
+
+	if err := m.validateFlowLogResource(cfg.ResourceID, cfg.ResourceType); err != nil {
+		return nil, err
+	}
+
+	trafficType := cfg.TrafficType
+	if trafficType == "" {
+		trafficType = TrafficTypeAll
+	}
+
+	id := idgen.GCPID(m.opts.ProjectID, "flowLogs", idgen.GenerateID("fl-"))
+	fl := &flowLogData{
+		ID:           id,
+		ResourceID:   cfg.ResourceID,
+		ResourceType: cfg.ResourceType,
+		TrafficType:  trafficType,
+		Status:       FlowLogStatusActive,
+		CreatedAt:    m.opts.Clock.Now().Format(timeFormat),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.flowLogs.Set(id, fl)
+
+	info := toFlowLogInfo(fl)
+
+	return &info, nil
+}
+
+// validateFlowLogResource checks that the target resource exists.
+func (m *Mock) validateFlowLogResource(resourceID, resourceType string) error {
+	switch resourceType {
+	case "VPC":
+		if !m.vpcs.Has(resourceID) {
+			return cerrors.Newf(cerrors.NotFound, "VPC %q not found", resourceID)
+		}
+	case "Subnet":
+		if !m.subnets.Has(resourceID) {
+			return cerrors.Newf(cerrors.NotFound, "subnet %q not found", resourceID)
+		}
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported resource type %q", resourceType)
+	}
+
+	return nil
+}
+
+// DeleteFlowLog deletes the flow log with the given ID.
+func (m *Mock) DeleteFlowLog(_ context.Context, id string) error {
+	if !m.flowLogs.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "flow log %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeFlowLogs returns flow logs matching the given IDs, or all if empty.
+func (m *Mock) DescribeFlowLogs(_ context.Context, ids []string) ([]driver.FlowLog, error) {
+	return describeResources(m.flowLogs, ids, toFlowLogInfo), nil
+}
+
+// GetFlowLogRecords generates mock flow log records for the given flow log.
+func (m *Mock) GetFlowLogRecords(
+	_ context.Context, flowLogID string, limit int,
+) ([]driver.FlowLogRecord, error) {
+	fl, ok := m.flowLogs.Get(flowLogID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "flow log %q not found", flowLogID)
+	}
+
+	return generateMockRecords(fl, limit), nil
+}
+
+// generateMockRecords creates simulated flow log records.
+func generateMockRecords(fl *flowLogData, limit int) []driver.FlowLogRecord {
+	if limit <= 0 {
+		limit = defaultFlowLogRecordLimit
+	}
+
+	records := make([]driver.FlowLogRecord, 0, limit)
+
+	for i := range limit {
+		action := TrafficTypeAccept
+		if fl.TrafficType == TrafficTypeReject || (fl.TrafficType == TrafficTypeAll && i%2 == 1) {
+			action = TrafficTypeReject
+		}
+
+		records = append(records, driver.FlowLogRecord{
+			Timestamp:  fl.CreatedAt,
+			SourceIP:   fmt.Sprintf("10.0.0.%d", i+1),
+			DestIP:     fmt.Sprintf("10.0.1.%d", i+1),
+			SourcePort: mockSourcePort,
+			DestPort:   mockDestPort + i,
+			Protocol:   "tcp",
+			Packets:    mockPackets,
+			Bytes:      mockBytes,
+			Action:     action,
+			FlowLogID:  fl.ID,
+		})
+	}
+
+	return records
+}
+
+func toFlowLogInfo(fl *flowLogData) driver.FlowLog {
+	return driver.FlowLog{
+		ID:           fl.ID,
+		ResourceID:   fl.ResourceID,
+		ResourceType: fl.ResourceType,
+		TrafficType:  fl.TrafficType,
+		Status:       fl.Status,
+		CreatedAt:    fl.CreatedAt,
+		Tags:         copyTags(fl.Tags),
+	}
+}

--- a/providers/gcp/gcpvpc/natgw.go
+++ b/providers/gcp/gcpvpc/natgw.go
@@ -1,0 +1,80 @@
+package gcpvpc
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// NAT gateway state constants.
+const (
+	NATStateAvailable = "available"
+)
+
+type natGatewayData struct {
+	ID        string
+	SubnetID  string
+	VPCID     string
+	PublicIP  string
+	State     string
+	CreatedAt string
+	Tags      map[string]string
+}
+
+// CreateNATGateway creates a Cloud NAT gateway in the specified subnet.
+func (m *Mock) CreateNATGateway(
+	_ context.Context, cfg driver.NATGatewayConfig,
+) (*driver.NATGateway, error) {
+	if cfg.SubnetID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "subnet ID is required")
+	}
+
+	subnet, ok := m.subnets.Get(cfg.SubnetID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "subnet %q not found", cfg.SubnetID)
+	}
+
+	id := idgen.GCPID(m.opts.ProjectID, "routers", idgen.GenerateID("nat-"))
+	nat := &natGatewayData{
+		ID:        id,
+		SubnetID:  cfg.SubnetID,
+		VPCID:     subnet.VPCID,
+		PublicIP:  mockPublicIP(id),
+		State:     NATStateAvailable,
+		CreatedAt: m.opts.Clock.Now().Format(timeFormat),
+		Tags:      copyTags(cfg.Tags),
+	}
+	m.natGateways.Set(id, nat)
+
+	info := toNATGatewayInfo(nat)
+
+	return &info, nil
+}
+
+// DeleteNATGateway deletes the Cloud NAT gateway with the given ID.
+func (m *Mock) DeleteNATGateway(_ context.Context, id string) error {
+	if !m.natGateways.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "Cloud NAT %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeNATGateways returns Cloud NAT gateways matching the given IDs, or all if empty.
+func (m *Mock) DescribeNATGateways(_ context.Context, ids []string) ([]driver.NATGateway, error) {
+	return describeResources(m.natGateways, ids, toNATGatewayInfo), nil
+}
+
+func toNATGatewayInfo(n *natGatewayData) driver.NATGateway {
+	return driver.NATGateway{
+		ID:        n.ID,
+		SubnetID:  n.SubnetID,
+		VPCID:     n.VPCID,
+		PublicIP:  n.PublicIP,
+		State:     n.State,
+		CreatedAt: n.CreatedAt,
+		Tags:      copyTags(n.Tags),
+	}
+}

--- a/providers/gcp/gcpvpc/peering.go
+++ b/providers/gcp/gcpvpc/peering.go
@@ -1,0 +1,157 @@
+package gcpvpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Peering status constants.
+const (
+	PeeringStatusPending  = "pending-acceptance"
+	PeeringStatusActive   = "active"
+	PeeringStatusRejected = "rejected"
+	PeeringStatusDeleted  = "deleted"
+)
+
+type peeringData struct {
+	ID           string
+	RequesterVPC string
+	AccepterVPC  string
+	Status       string
+	CreatedAt    string
+	Tags         map[string]string
+}
+
+// CreatePeeringConnection creates a VPC network peering between two networks.
+func (m *Mock) CreatePeeringConnection(
+	_ context.Context, cfg driver.PeeringConfig,
+) (*driver.PeeringConnection, error) {
+	if cfg.RequesterVPC == "" || cfg.AccepterVPC == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "both requester and accepter VPC IDs are required")
+	}
+
+	reqVPC, ok := m.vpcs.Get(cfg.RequesterVPC)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "requester VPC %q not found", cfg.RequesterVPC)
+	}
+
+	accVPC, ok := m.vpcs.Get(cfg.AccepterVPC)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "accepter VPC %q not found", cfg.AccepterVPC)
+	}
+
+	if cidrsOverlap(reqVPC.CIDRBlock, accVPC.CIDRBlock) {
+		return nil, cerrors.New(cerrors.InvalidArgument, "VPC CIDRs must not overlap for peering")
+	}
+
+	id := idgen.GCPID(m.opts.ProjectID, "networkPeerings", idgen.GenerateID("peering-"))
+	p := &peeringData{
+		ID:           id,
+		RequesterVPC: cfg.RequesterVPC,
+		AccepterVPC:  cfg.AccepterVPC,
+		Status:       PeeringStatusPending,
+		CreatedAt:    m.opts.Clock.Now().Format(timeFormat),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.peerings.Set(id, p)
+
+	info := toPeeringInfo(p)
+
+	return &info, nil
+}
+
+// AcceptPeeringConnection accepts a pending VPC network peering.
+func (m *Mock) AcceptPeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
+
+	if p.Status != PeeringStatusPending {
+		return cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
+			peeringID, p.Status, PeeringStatusPending)
+	}
+
+	p.Status = PeeringStatusActive
+
+	return nil
+}
+
+// RejectPeeringConnection rejects a pending VPC network peering.
+func (m *Mock) RejectPeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
+
+	if p.Status != PeeringStatusPending {
+		return cerrors.Newf(cerrors.FailedPrecondition, "peering %q is in state %q, expected %q",
+			peeringID, p.Status, PeeringStatusPending)
+	}
+
+	p.Status = PeeringStatusRejected
+
+	return nil
+}
+
+// DeletePeeringConnection deletes a VPC network peering.
+func (m *Mock) DeletePeeringConnection(_ context.Context, peeringID string) error {
+	p, ok := m.peerings.Get(peeringID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "peering %q not found", peeringID)
+	}
+
+	p.Status = PeeringStatusDeleted
+
+	m.peerings.Delete(peeringID)
+
+	return nil
+}
+
+// DescribePeeringConnections returns VPC network peerings matching the given IDs.
+func (m *Mock) DescribePeeringConnections(
+	_ context.Context, ids []string,
+) ([]driver.PeeringConnection, error) {
+	return describeResources(m.peerings, ids, toPeeringInfo), nil
+}
+
+func toPeeringInfo(p *peeringData) driver.PeeringConnection {
+	return driver.PeeringConnection{
+		ID:           p.ID,
+		RequesterVPC: p.RequesterVPC,
+		AccepterVPC:  p.AccepterVPC,
+		Status:       p.Status,
+		CreatedAt:    p.CreatedAt,
+		Tags:         copyTags(p.Tags),
+	}
+}
+
+// cidrsOverlap checks whether two CIDR blocks overlap.
+func cidrsOverlap(cidrA, cidrB string) bool {
+	_, netA, errA := net.ParseCIDR(cidrA)
+	_, netB, errB := net.ParseCIDR(cidrB)
+
+	if errA != nil || errB != nil {
+		return cidrA == cidrB
+	}
+
+	return netA.Contains(netB.IP) || netB.Contains(netA.IP)
+}
+
+// mockPublicIP generates a mock public IP from a counter value.
+func mockPublicIP(id string) string {
+	var sum int
+	for _, c := range id {
+		sum += int(c)
+	}
+
+	octet3 := sum % maxOctetValue
+	octet4 := (sum / maxOctetValue) % maxOctetValue
+
+	return fmt.Sprintf("10.0.%d.%d", octet3, octet4)
+}

--- a/providers/gcp/gcpvpc/routetable.go
+++ b/providers/gcp/gcpvpc/routetable.go
@@ -1,0 +1,125 @@
+package gcpvpc
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Route target type constants.
+const (
+	RouteTargetLocal = "local"
+)
+
+type routeTableData struct {
+	ID     string
+	VPCID  string
+	Routes []driver.Route
+	Tags   map[string]string
+}
+
+// CreateRouteTable creates a route for the specified VPC network.
+func (m *Mock) CreateRouteTable(
+	_ context.Context, cfg driver.RouteTableConfig,
+) (*driver.RouteTable, error) {
+	if cfg.VPCID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "VPC ID is required")
+	}
+
+	v, ok := m.vpcs.Get(cfg.VPCID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "VPC %q not found", cfg.VPCID)
+	}
+
+	id := idgen.GCPID(m.opts.ProjectID, "routes", idgen.GenerateID("route-"))
+	localRoute := driver.Route{
+		DestinationCIDR: v.CIDRBlock,
+		TargetID:        RouteTargetLocal,
+		TargetType:      RouteTargetLocal,
+		State:           "active",
+	}
+
+	rt := &routeTableData{
+		ID:     id,
+		VPCID:  cfg.VPCID,
+		Routes: []driver.Route{localRoute},
+		Tags:   copyTags(cfg.Tags),
+	}
+	m.routeTables.Set(id, rt)
+
+	info := toRouteTableInfo(rt)
+
+	return &info, nil
+}
+
+// DeleteRouteTable deletes the route table with the given ID.
+func (m *Mock) DeleteRouteTable(_ context.Context, id string) error {
+	if !m.routeTables.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "route %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeRouteTables returns route tables matching the given IDs, or all if empty.
+func (m *Mock) DescribeRouteTables(_ context.Context, ids []string) ([]driver.RouteTable, error) {
+	return describeResources(m.routeTables, ids, toRouteTableInfo), nil
+}
+
+// CreateRoute adds a route to the specified route table.
+func (m *Mock) CreateRoute(
+	_ context.Context, routeTableID, destinationCIDR, targetID, targetType string,
+) error {
+	rt, ok := m.routeTables.Get(routeTableID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "route %q not found", routeTableID)
+	}
+
+	for _, r := range rt.Routes {
+		if r.DestinationCIDR == destinationCIDR {
+			return cerrors.Newf(cerrors.AlreadyExists,
+				"route for %q already exists in route table %q", destinationCIDR, routeTableID)
+		}
+	}
+
+	rt.Routes = append(rt.Routes, driver.Route{
+		DestinationCIDR: destinationCIDR,
+		TargetID:        targetID,
+		TargetType:      targetType,
+		State:           "active",
+	})
+
+	return nil
+}
+
+// DeleteRoute removes a route from the specified route table.
+func (m *Mock) DeleteRoute(_ context.Context, routeTableID, destinationCIDR string) error {
+	rt, ok := m.routeTables.Get(routeTableID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "route %q not found", routeTableID)
+	}
+
+	for i, r := range rt.Routes {
+		if r.DestinationCIDR == destinationCIDR {
+			rt.Routes = append(rt.Routes[:i], rt.Routes[i+1:]...)
+			return nil
+		}
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "route %q not found in route table %q",
+		destinationCIDR, routeTableID)
+}
+
+func toRouteTableInfo(rt *routeTableData) driver.RouteTable {
+	routes := make([]driver.Route, len(rt.Routes))
+	copy(routes, rt.Routes)
+
+	return driver.RouteTable{
+		ID:     rt.ID,
+		VPCID:  rt.VPCID,
+		Routes: routes,
+		Tags:   copyTags(rt.Tags),
+	}
+}

--- a/providers/gcp/gcpvpc/vpc.go
+++ b/providers/gcp/gcpvpc/vpc.go
@@ -3,12 +3,20 @@ package gcpvpc
 
 import (
 	"context"
+	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Time format and mock constants.
+const (
+	timeFormat                = time.RFC3339
+	maxOctetValue             = 256
+	defaultFlowLogRecordLimit = 10
 )
 
 // Compile-time check that Mock implements driver.Networking.
@@ -45,6 +53,11 @@ type Mock struct {
 	vpcs           *memstore.Store[*vpcData]
 	subnets        *memstore.Store[*subnetData]
 	securityGroups *memstore.Store[*sgData]
+	peerings       *memstore.Store[*peeringData]
+	natGateways    *memstore.Store[*natGatewayData]
+	flowLogs       *memstore.Store[*flowLogData]
+	routeTables    *memstore.Store[*routeTableData]
+	networkACLs    *memstore.Store[*networkACLData]
 	opts           *config.Options
 }
 
@@ -54,6 +67,11 @@ func New(opts *config.Options) *Mock {
 		vpcs:           memstore.New[*vpcData](),
 		subnets:        memstore.New[*subnetData](),
 		securityGroups: memstore.New[*sgData](),
+		peerings:       memstore.New[*peeringData](),
+		natGateways:    memstore.New[*natGatewayData](),
+		flowLogs:       memstore.New[*flowLogData](),
+		routeTables:    memstore.New[*routeTableData](),
+		networkACLs:    memstore.New[*networkACLData](),
 		opts:           opts,
 	}
 }

--- a/providers/gcp/gcpvpc/vpc_test.go
+++ b/providers/gcp/gcpvpc/vpc_test.go
@@ -378,3 +378,839 @@ func TestAddSecurityGroupRule(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestCreatePeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	vpc2, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+	vpc3, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       driver.PeeringConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg:  driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID, Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name:      "missing requester",
+			cfg:       driver.PeeringConfig{RequesterVPC: "", AccepterVPC: vpc2.ID},
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name:      "requester not found",
+			cfg:       driver.PeeringConfig{RequesterVPC: "missing", AccepterVPC: vpc2.ID},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+		{
+			name:      "accepter not found",
+			cfg:       driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: "missing"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+		{
+			name:      "overlapping CIDRs",
+			cfg:       driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc3.ID},
+			wantErr:   true,
+			errSubstr: "overlap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			peering, peerErr := m.CreatePeeringConnection(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, peerErr)
+				assert.Contains(t, peerErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, peerErr)
+				assert.NotEmpty(t, peering.ID)
+				assert.Equal(t, "pending-acceptance", peering.Status)
+				assert.Equal(t, "test", peering.Tags["env"])
+			}
+		})
+	}
+}
+
+func TestAcceptPeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	vpc2, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+
+	peering, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID,
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		id        string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", id: peering.ID},
+		{name: "already accepted", id: peering.ID, wantErr: true, errSubstr: "expected"},
+		{name: "not found", id: "missing", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acceptErr := m.AcceptPeeringConnection(ctx, tt.id)
+			switch {
+			case tt.wantErr:
+				require.Error(t, acceptErr)
+				assert.Contains(t, acceptErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, acceptErr)
+				// Verify status is now active
+				peers, descErr := m.DescribePeeringConnections(ctx, []string{tt.id})
+				require.NoError(t, descErr)
+				require.Len(t, peers, 1)
+				assert.Equal(t, "active", peers[0].Status)
+			}
+		})
+	}
+}
+
+func TestCreateNATGateway(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{
+		VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24",
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       driver.NATGatewayConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg:  driver.NATGatewayConfig{SubnetID: subnet.ID, Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name:      "empty subnet",
+			cfg:       driver.NATGatewayConfig{SubnetID: ""},
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name:      "subnet not found",
+			cfg:       driver.NATGatewayConfig{SubnetID: "missing"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nat, natErr := m.CreateNATGateway(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, natErr)
+				assert.Contains(t, natErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, natErr)
+				assert.NotEmpty(t, nat.ID)
+				assert.Equal(t, "available", nat.State)
+				assert.NotEmpty(t, nat.PublicIP)
+				assert.Equal(t, subnet.ID, nat.SubnetID)
+			}
+		})
+	}
+
+	t.Run("delete NAT gateway", func(t *testing.T) {
+		nats, descErr := m.DescribeNATGateways(ctx, nil)
+		require.NoError(t, descErr)
+		require.NotEmpty(t, nats)
+
+		require.NoError(t, m.DeleteNATGateway(ctx, nats[0].ID))
+
+		natsAfter, descErr := m.DescribeNATGateways(ctx, nil)
+		require.NoError(t, descErr)
+		assert.Empty(t, natsAfter)
+	})
+
+	t.Run("delete not found", func(t *testing.T) {
+		delErr := m.DeleteNATGateway(ctx, "missing")
+		require.Error(t, delErr)
+		assert.Contains(t, delErr.Error(), "not found")
+	})
+}
+
+func TestCreateFlowLog(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       driver.FlowLogConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "VPC flow log",
+			cfg:  driver.FlowLogConfig{ResourceID: vpc.ID, ResourceType: "VPC", TrafficType: "ALL"},
+		},
+		{
+			name:      "empty resource ID",
+			cfg:       driver.FlowLogConfig{ResourceID: "", ResourceType: "VPC"},
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name:      "resource not found",
+			cfg:       driver.FlowLogConfig{ResourceID: "missing", ResourceType: "VPC"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+		{
+			name:      "unsupported resource type",
+			cfg:       driver.FlowLogConfig{ResourceID: vpc.ID, ResourceType: "Unknown"},
+			wantErr:   true,
+			errSubstr: "unsupported",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fl, flErr := m.CreateFlowLog(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, flErr)
+				assert.Contains(t, flErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, flErr)
+				assert.NotEmpty(t, fl.ID)
+				assert.Equal(t, "ACTIVE", fl.Status)
+				assert.Equal(t, "ALL", fl.TrafficType)
+			}
+		})
+	}
+
+	t.Run("get flow log records", func(t *testing.T) {
+		fls, descErr := m.DescribeFlowLogs(ctx, nil)
+		require.NoError(t, descErr)
+		require.NotEmpty(t, fls)
+
+		records, recErr := m.GetFlowLogRecords(ctx, fls[0].ID, 5)
+		require.NoError(t, recErr)
+		assert.Len(t, records, 5)
+		assert.Equal(t, "tcp", records[0].Protocol)
+	})
+
+	t.Run("delete flow log", func(t *testing.T) {
+		fls, descErr := m.DescribeFlowLogs(ctx, nil)
+		require.NoError(t, descErr)
+		require.NotEmpty(t, fls)
+
+		require.NoError(t, m.DeleteFlowLog(ctx, fls[0].ID))
+	})
+
+	t.Run("delete flow log not found", func(t *testing.T) {
+		delErr := m.DeleteFlowLog(ctx, "missing")
+		require.Error(t, delErr)
+		assert.Contains(t, delErr.Error(), "not found")
+	})
+}
+
+func TestCreateRouteTable(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		cfg       driver.RouteTableConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg:  driver.RouteTableConfig{VPCID: vpc.ID, Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name:      "empty VPC ID",
+			cfg:       driver.RouteTableConfig{VPCID: ""},
+			wantErr:   true,
+			errSubstr: "required",
+		},
+		{
+			name:      "VPC not found",
+			cfg:       driver.RouteTableConfig{VPCID: "missing"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt, rtErr := m.CreateRouteTable(ctx, tt.cfg)
+			switch {
+			case tt.wantErr:
+				require.Error(t, rtErr)
+				assert.Contains(t, rtErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, rtErr)
+				assert.NotEmpty(t, rt.ID)
+				assert.Equal(t, vpc.ID, rt.VPCID)
+				// Default local route should be present
+				require.Len(t, rt.Routes, 1)
+				assert.Equal(t, "10.0.0.0/16", rt.Routes[0].DestinationCIDR)
+				assert.Equal(t, "local", rt.Routes[0].TargetType)
+			}
+		})
+	}
+}
+
+func TestCreateRoute(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpc.ID})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		rtID      string
+		destCIDR  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", rtID: rt.ID, destCIDR: "0.0.0.0/0"},
+		{name: "duplicate route", rtID: rt.ID, destCIDR: "0.0.0.0/0", wantErr: true, errSubstr: "already exists"},
+		{name: "route table not found", rtID: "missing", destCIDR: "1.2.3.0/24", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			routeErr := m.CreateRoute(ctx, tt.rtID, tt.destCIDR, "igw-123", "internet-gateway")
+			switch {
+			case tt.wantErr:
+				require.Error(t, routeErr)
+				assert.Contains(t, routeErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, routeErr)
+
+				rts, descErr := m.DescribeRouteTables(ctx, []string{tt.rtID})
+				require.NoError(t, descErr)
+				require.Len(t, rts, 1)
+				assert.Len(t, rts[0].Routes, 2) // local + new route
+			}
+		})
+	}
+
+	t.Run("delete route", func(t *testing.T) {
+		require.NoError(t, m.DeleteRoute(ctx, rt.ID, "0.0.0.0/0"))
+
+		rts, descErr := m.DescribeRouteTables(ctx, []string{rt.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, rts[0].Routes, 1) // only local route remains
+	})
+
+	t.Run("delete route not found", func(t *testing.T) {
+		delErr := m.DeleteRoute(ctx, rt.ID, "9.9.9.0/24")
+		require.Error(t, delErr)
+		assert.Contains(t, delErr.Error(), "not found")
+	})
+}
+
+func TestCreateNetworkACL(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		vpcID     string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", vpcID: vpc.ID},
+		{name: "empty VPC", vpcID: "", wantErr: true, errSubstr: "required"},
+		{name: "VPC not found", vpcID: "missing", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			acl, aclErr := m.CreateNetworkACL(ctx, tt.vpcID, map[string]string{"env": "test"})
+			switch {
+			case tt.wantErr:
+				require.Error(t, aclErr)
+				assert.Contains(t, aclErr.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, aclErr)
+				assert.NotEmpty(t, acl.ID)
+				assert.Equal(t, vpc.ID, acl.VPCID)
+				// Should have 2 default rules (ingress + egress)
+				assert.Len(t, acl.Rules, 2)
+			}
+		})
+	}
+}
+
+func TestAddNetworkACLRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	acl, err := m.CreateNetworkACL(ctx, vpc.ID, nil)
+	require.NoError(t, err)
+
+	t.Run("add ingress rule", func(t *testing.T) {
+		rule := &driver.NetworkACLRule{
+			RuleNumber: 50,
+			Protocol:   "tcp",
+			Action:     "allow",
+			CIDR:       "10.0.0.0/8",
+			FromPort:   80,
+			ToPort:     80,
+			Egress:     false,
+		}
+		require.NoError(t, m.AddNetworkACLRule(ctx, acl.ID, rule))
+
+		acls, descErr := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+		require.NoError(t, descErr)
+		require.Len(t, acls, 1)
+		assert.Len(t, acls[0].Rules, 3) // 2 default + 1 new
+		// Rules should be sorted by rule number (50 first)
+		assert.Equal(t, 50, acls[0].Rules[0].RuleNumber)
+	})
+
+	t.Run("add egress rule", func(t *testing.T) {
+		rule := &driver.NetworkACLRule{
+			RuleNumber: 200,
+			Protocol:   "tcp",
+			Action:     "deny",
+			CIDR:       "0.0.0.0/0",
+			FromPort:   443,
+			ToPort:     443,
+			Egress:     true,
+		}
+		require.NoError(t, m.AddNetworkACLRule(ctx, acl.ID, rule))
+
+		acls, descErr := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, acls[0].Rules, 4)
+	})
+
+	t.Run("remove rule", func(t *testing.T) {
+		require.NoError(t, m.RemoveNetworkACLRule(ctx, acl.ID, 50, false))
+
+		acls, descErr := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, acls[0].Rules, 3)
+	})
+
+	t.Run("remove rule not found", func(t *testing.T) {
+		rmErr := m.RemoveNetworkACLRule(ctx, acl.ID, 999, false)
+		require.Error(t, rmErr)
+		assert.Contains(t, rmErr.Error(), "not found")
+	})
+
+	t.Run("ACL not found", func(t *testing.T) {
+		addErr := m.AddNetworkACLRule(ctx, "missing", &driver.NetworkACLRule{RuleNumber: 10})
+		require.Error(t, addErr)
+		assert.Contains(t, addErr.Error(), "not found")
+	})
+
+	t.Run("remove rule ACL not found", func(t *testing.T) {
+		rmErr := m.RemoveNetworkACLRule(ctx, "missing", 50, false)
+		require.Error(t, rmErr)
+		assert.Contains(t, rmErr.Error(), "not found")
+	})
+}
+
+func TestRejectPeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	vpc2, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+
+	peering, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID,
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		require.NoError(t, m.RejectPeeringConnection(ctx, peering.ID))
+
+		peers, descErr := m.DescribePeeringConnections(ctx, []string{peering.ID})
+		require.NoError(t, descErr)
+		require.Len(t, peers, 1)
+		assert.Equal(t, "rejected", peers[0].Status)
+	})
+
+	t.Run("already rejected", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, peering.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.RejectPeeringConnection(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeletePeeringConnection(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	vpc2, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+
+	peering, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{
+		RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID,
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		require.NoError(t, m.DeletePeeringConnection(ctx, peering.ID))
+
+		peers, descErr := m.DescribePeeringConnections(ctx, []string{peering.ID})
+		require.NoError(t, descErr)
+		assert.Empty(t, peers)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeletePeeringConnection(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribePeeringConnectionsFiltered(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc1, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	vpc2, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "172.16.0.0/16"})
+	require.NoError(t, err)
+	vpc3, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "192.168.0.0/16"})
+	require.NoError(t, err)
+
+	p1, err := m.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc2.ID})
+	require.NoError(t, err)
+	_, err = m.CreatePeeringConnection(ctx, driver.PeeringConfig{RequesterVPC: vpc1.ID, AccepterVPC: vpc3.ID})
+	require.NoError(t, err)
+
+	t.Run("all peerings", func(t *testing.T) {
+		peers, descErr := m.DescribePeeringConnections(ctx, nil)
+		require.NoError(t, descErr)
+		assert.Len(t, peers, 2)
+	})
+
+	t.Run("by ID filter", func(t *testing.T) {
+		peers, descErr := m.DescribePeeringConnections(ctx, []string{p1.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, peers, 1)
+		assert.Equal(t, p1.ID, peers[0].ID)
+	})
+
+	t.Run("unknown ID", func(t *testing.T) {
+		peers, descErr := m.DescribePeeringConnections(ctx, []string{"nope"})
+		require.NoError(t, descErr)
+		assert.Empty(t, peers)
+	})
+}
+
+func TestDescribeNATGatewaysWithIDFilter(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	s1, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+	s2, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.2.0/24"})
+	require.NoError(t, err)
+
+	nat1, err := m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s1.ID})
+	require.NoError(t, err)
+	_, err = m.CreateNATGateway(ctx, driver.NATGatewayConfig{SubnetID: s2.ID})
+	require.NoError(t, err)
+
+	t.Run("all NAT gateways", func(t *testing.T) {
+		nats, descErr := m.DescribeNATGateways(ctx, nil)
+		require.NoError(t, descErr)
+		assert.Len(t, nats, 2)
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		nats, descErr := m.DescribeNATGateways(ctx, []string{nat1.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, nats, 1)
+		assert.Equal(t, nat1.ID, nats[0].ID)
+	})
+
+	t.Run("unknown ID", func(t *testing.T) {
+		nats, descErr := m.DescribeNATGateways(ctx, []string{"nope"})
+		require.NoError(t, descErr)
+		assert.Empty(t, nats)
+	})
+}
+
+func TestDescribeFlowLogsWithIDFilter(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	fl1, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: vpc.ID, ResourceType: "VPC", TrafficType: "ALL"})
+	require.NoError(t, err)
+	fl2, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: vpc.ID, ResourceType: "VPC", TrafficType: "ACCEPT"})
+	require.NoError(t, err)
+
+	t.Run("all flow logs", func(t *testing.T) {
+		fls, descErr := m.DescribeFlowLogs(ctx, nil)
+		require.NoError(t, descErr)
+		assert.Len(t, fls, 2)
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		fls, descErr := m.DescribeFlowLogs(ctx, []string{fl1.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, fls, 1)
+		assert.Equal(t, fl1.ID, fls[0].ID)
+	})
+
+	t.Run("unknown ID", func(t *testing.T) {
+		fls, descErr := m.DescribeFlowLogs(ctx, []string{"nope"})
+		require.NoError(t, descErr)
+		assert.Empty(t, fls)
+	})
+
+	t.Run("flow log records for ACCEPT only", func(t *testing.T) {
+		records, recErr := m.GetFlowLogRecords(ctx, fl2.ID, 4)
+		require.NoError(t, recErr)
+		assert.Len(t, records, 4)
+
+		for _, rec := range records {
+			assert.Equal(t, "ACCEPT", rec.Action)
+		}
+	})
+}
+
+func TestDescribeRouteTablesWithIDFilter(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	rt1, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpc.ID})
+	require.NoError(t, err)
+	_, err = m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpc.ID})
+	require.NoError(t, err)
+
+	t.Run("all route tables", func(t *testing.T) {
+		rts, descErr := m.DescribeRouteTables(ctx, nil)
+		require.NoError(t, descErr)
+		assert.Len(t, rts, 2)
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		rts, descErr := m.DescribeRouteTables(ctx, []string{rt1.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, rts, 1)
+		assert.Equal(t, rt1.ID, rts[0].ID)
+	})
+
+	t.Run("unknown ID", func(t *testing.T) {
+		rts, descErr := m.DescribeRouteTables(ctx, []string{"nope"})
+		require.NoError(t, descErr)
+		assert.Empty(t, rts)
+	})
+}
+
+func TestDescribeNetworkACLsWithIDFilter(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	acl1, err := m.CreateNetworkACL(ctx, vpc.ID, nil)
+	require.NoError(t, err)
+	_, err = m.CreateNetworkACL(ctx, vpc.ID, nil)
+	require.NoError(t, err)
+
+	t.Run("all ACLs", func(t *testing.T) {
+		acls, descErr := m.DescribeNetworkACLs(ctx, nil)
+		require.NoError(t, descErr)
+		assert.Len(t, acls, 2)
+	})
+
+	t.Run("by ID", func(t *testing.T) {
+		acls, descErr := m.DescribeNetworkACLs(ctx, []string{acl1.ID})
+		require.NoError(t, descErr)
+		assert.Len(t, acls, 1)
+		assert.Equal(t, acl1.ID, acls[0].ID)
+	})
+
+	t.Run("unknown ID", func(t *testing.T) {
+		acls, descErr := m.DescribeNetworkACLs(ctx, []string{"nope"})
+		require.NoError(t, descErr)
+		assert.Empty(t, acls)
+	})
+}
+
+func TestDeleteRouteTableNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	err := m.DeleteRouteTable(ctx, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDeleteRouteTableSuccess(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpc.ID})
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteRouteTable(ctx, rt.ID))
+
+	rts, descErr := m.DescribeRouteTables(ctx, []string{rt.ID})
+	require.NoError(t, descErr)
+	assert.Empty(t, rts)
+}
+
+func TestDeleteNetworkACLNotFound(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	err := m.DeleteNetworkACL(ctx, "missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestDeleteNetworkACLSuccess(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	acl, err := m.CreateNetworkACL(ctx, vpc.ID, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, m.DeleteNetworkACL(ctx, acl.ID))
+
+	acls, descErr := m.DescribeNetworkACLs(ctx, []string{acl.ID})
+	require.NoError(t, descErr)
+	assert.Empty(t, acls)
+}
+
+func TestGetFlowLogRecordsVariousLimits(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	fl, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: vpc.ID, ResourceType: "VPC", TrafficType: "ALL"})
+	require.NoError(t, err)
+
+	t.Run("default limit when zero", func(t *testing.T) {
+		records, recErr := m.GetFlowLogRecords(ctx, fl.ID, 0)
+		require.NoError(t, recErr)
+		assert.Len(t, records, 10) // defaultFlowLogRecordLimit
+	})
+
+	t.Run("custom limit", func(t *testing.T) {
+		records, recErr := m.GetFlowLogRecords(ctx, fl.ID, 3)
+		require.NoError(t, recErr)
+		assert.Len(t, records, 3)
+	})
+
+	t.Run("large limit", func(t *testing.T) {
+		records, recErr := m.GetFlowLogRecords(ctx, fl.ID, 20)
+		require.NoError(t, recErr)
+		assert.Len(t, records, 20)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, recErr := m.GetFlowLogRecords(ctx, "missing", 5)
+		require.Error(t, recErr)
+		assert.Contains(t, recErr.Error(), "not found")
+	})
+}
+
+func TestFlowLogSubnetResource(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	fl, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: subnet.ID, ResourceType: "Subnet"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, fl.ID)
+	assert.Equal(t, "ACTIVE", fl.Status)
+}
+
+func TestFlowLogRejectTrafficType(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	fl, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{ResourceID: vpc.ID, ResourceType: "VPC", TrafficType: "REJECT"})
+	require.NoError(t, err)
+
+	records, recErr := m.GetFlowLogRecords(ctx, fl.ID, 4)
+	require.NoError(t, recErr)
+	assert.Len(t, records, 4)
+
+	for _, rec := range records {
+		assert.Equal(t, "REJECT", rec.Action)
+	}
+}

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -5,14 +5,26 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/config"
 	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/pagination"
 	"github.com/stackshy/cloudemu/storage/driver"
+)
+
+const (
+	gcsDefaultPresignExpiry = 15 * time.Minute
+	gcsMaxPresignExpiry     = 7 * 24 * time.Hour
+	gcsDefaultMaxKeys       = 1000
+	gcsTimeFormat           = "2006-01-02T15:04:05Z"
+	gcsHoursPerDay          = 24
 )
 
 // Compile-time check that Mock implements driver.Bucket.
@@ -27,17 +39,51 @@ type gcsObject struct {
 	Metadata     map[string]string
 }
 
+type gcsMultipartUpload struct {
+	id          string
+	key         string
+	contentType string
+	parts       map[int][]byte
+	createdAt   string
+}
+
 type bucketMeta struct {
-	Name      string
-	Region    string
-	CreatedAt string
-	objects   *memstore.Store[*gcsObject]
+	Name       string
+	Region     string
+	CreatedAt  string
+	objects    *memstore.Store[*gcsObject]
+	lifecycle  *driver.LifecycleConfig
+	multiparts *memstore.Store[*gcsMultipartUpload]
+	versioning bool
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Storage.
 type Mock struct {
-	buckets *memstore.Store[*bucketMeta]
-	opts    *config.Options
+	buckets    *memstore.Store[*bucketMeta]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "storage.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new GCS mock.
@@ -58,10 +104,11 @@ func (m *Mock) CreateBucket(_ context.Context, name string) error {
 	}
 
 	m.buckets.Set(name, &bucketMeta{
-		Name:      name,
-		Region:    m.opts.Region,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-		objects:   memstore.New[*gcsObject](),
+		Name:       name,
+		Region:     m.opts.Region,
+		CreatedAt:  m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		objects:    memstore.New[*gcsObject](),
+		multiparts: memstore.New[*gcsMultipartUpload](),
 	})
 
 	return nil
@@ -104,7 +151,7 @@ func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
 	return result, nil
 }
 
-func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
+func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -123,14 +170,18 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		Data:         dataCopy,
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
-		LastModified: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
 		Metadata:     metaCopy,
 	})
+
+	dims := map[string]string{"bucket_name": bucket}
+	m.emitMetric(ctx, "api/request_count", 1, dims)
+	m.emitMetric(ctx, "network/received_bytes_count", float64(len(data)), dims)
 
 	return nil
 }
 
-func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object, error) {
+func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Object, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -144,6 +195,10 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 	dataCopy := make([]byte, len(obj.Data))
 	copy(dataCopy, obj.Data)
 
+	dims := map[string]string{"bucket_name": bucket}
+	m.emitMetric(ctx, "api/request_count", 1, dims)
+	m.emitMetric(ctx, "network/sent_bytes_count", float64(len(obj.Data)), dims)
+
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
@@ -153,7 +208,7 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 	}, nil
 }
 
-func (m *Mock) DeleteObject(_ context.Context, bucket, key string) error {
+func (m *Mock) DeleteObject(ctx context.Context, bucket, key string) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -164,6 +219,8 @@ func (m *Mock) DeleteObject(_ context.Context, bucket, key string) error {
 	}
 
 	bkt.objects.Delete(key)
+
+	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
 
 	return nil
 }
@@ -185,7 +242,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 	}, nil
 }
 
-func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOptions) (*driver.ListResult, error) {
+func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListOptions) (*driver.ListResult, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
@@ -233,10 +290,12 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 	maxKeys := opts.MaxKeys
 	if maxKeys <= 0 {
-		maxKeys = 1000
+		maxKeys = gcsDefaultMaxKeys
 	}
 
 	page, _ := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+
+	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
 
 	return &driver.ListResult{
 		Objects:        page.Items,
@@ -272,9 +331,278 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 
 	dstBkt.objects.Set(dstKey, &gcsObject{
 		Key: dstKey, Data: dataCopy, ContentType: srcObj.ContentType,
-		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
 		Metadata: meta,
 	})
 
 	return nil
+}
+
+func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
+	if req.Method != http.MethodGet && req.Method != http.MethodPut {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "method must be GET or PUT, got %q", req.Method)
+	}
+
+	if !m.buckets.Has(req.Bucket) {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", req.Bucket)
+	}
+
+	expiry := req.ExpiresIn
+	if expiry <= 0 {
+		expiry = gcsDefaultPresignExpiry
+	}
+
+	if expiry > gcsMaxPresignExpiry {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expiry %v exceeds maximum of 7 days", expiry)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+	sig := fmt.Sprintf("%x", sha256.Sum256([]byte(req.Bucket+req.Key+now.String())))
+	expiresAt := now.Add(expiry)
+	seconds := int(expiry.Seconds())
+
+	url := fmt.Sprintf(
+		"https://storage.googleapis.com/%s/%s?X-Goog-Signature=%s&X-Goog-Expires=%d",
+		req.Bucket, req.Key, sig, seconds,
+	)
+
+	return &driver.PresignedURL{URL: url, Method: req.Method, ExpiresAt: expiresAt}, nil
+}
+
+func (m *Mock) PutLifecycleConfig(_ context.Context, bucket string, cfg driver.LifecycleConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	cfgCopy := driver.LifecycleConfig{Rules: make([]driver.LifecycleRule, len(cfg.Rules))}
+	copy(cfgCopy.Rules, cfg.Rules)
+	bkt.lifecycle = &cfgCopy
+
+	return nil
+}
+
+func (m *Mock) GetLifecycleConfig(_ context.Context, bucket string) (*driver.LifecycleConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.lifecycle == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no lifecycle configuration for bucket %q", bucket)
+	}
+
+	return bkt.lifecycle, nil
+}
+
+func (m *Mock) EvaluateLifecycle(_ context.Context, bucket string) ([]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.lifecycle == nil {
+		return nil, nil
+	}
+
+	now := m.opts.Clock.Now().UTC()
+	expired := collectExpiredGCSKeys(bkt, now)
+	sort.Strings(expired)
+
+	return expired, nil
+}
+
+func collectExpiredGCSKeys(bkt *bucketMeta, now time.Time) []string {
+	var result []string
+
+	for _, key := range bkt.objects.Keys() {
+		obj, objOk := bkt.objects.Get(key)
+		if !objOk {
+			continue
+		}
+
+		if gcsObjectExpired(obj, bkt.lifecycle, now) {
+			result = append(result, key)
+		}
+	}
+
+	return result
+}
+
+func gcsObjectExpired(obj *gcsObject, cfg *driver.LifecycleConfig, now time.Time) bool {
+	modified, err := time.Parse(gcsTimeFormat, obj.LastModified)
+	if err != nil {
+		return false
+	}
+
+	age := now.Sub(modified)
+
+	for _, rule := range cfg.Rules {
+		if !rule.Enabled {
+			continue
+		}
+
+		if rule.Prefix != "" && !strings.HasPrefix(obj.Key, rule.Prefix) {
+			continue
+		}
+
+		if rule.ExpirationDays > 0 && age >= time.Duration(rule.ExpirationDays)*gcsHoursPerDay*time.Hour {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (m *Mock) CreateMultipartUpload(
+	_ context.Context, bucket, key, contentType string,
+) (*driver.MultipartUpload, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	uploadID := idgen.GenerateID("upload-")
+	now := m.opts.Clock.Now().UTC().Format(gcsTimeFormat)
+
+	bkt.multiparts.Set(uploadID, &gcsMultipartUpload{
+		id:          uploadID,
+		key:         key,
+		contentType: contentType,
+		parts:       make(map[int][]byte),
+		createdAt:   now,
+	})
+
+	return &driver.MultipartUpload{
+		UploadID: uploadID, Bucket: bucket, Key: key, CreatedAt: now,
+	}, nil
+}
+
+func (m *Mock) UploadPart(
+	_ context.Context, bucket, _, uploadID string, partNumber int, data []byte,
+) (*driver.UploadPart, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	mp, ok := bkt.multiparts.Get(uploadID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+	mp.parts[partNumber] = dataCopy
+
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+
+	return &driver.UploadPart{
+		PartNumber: partNumber, ETag: etag, Size: int64(len(data)),
+	}, nil
+}
+
+func (m *Mock) CompleteMultipartUpload(
+	_ context.Context, bucket, key, uploadID string, _ []driver.UploadPart,
+) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	mp, ok := bkt.multiparts.Get(uploadID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	data := assembleGCSParts(mp.parts)
+
+	bkt.objects.Set(key, &gcsObject{
+		Key:          key,
+		Data:         data,
+		ContentType:  mp.contentType,
+		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
+		LastModified: m.opts.Clock.Now().UTC().Format(gcsTimeFormat),
+		Metadata:     make(map[string]string),
+	})
+
+	bkt.multiparts.Delete(uploadID)
+
+	return nil
+}
+
+func assembleGCSParts(parts map[int][]byte) []byte {
+	keys := make([]int, 0, len(parts))
+	for k := range parts {
+		keys = append(keys, k)
+	}
+
+	sort.Ints(keys)
+
+	var data []byte
+	for _, k := range keys {
+		data = append(data, parts[k]...)
+	}
+
+	return data
+}
+
+func (m *Mock) AbortMultipartUpload(_ context.Context, bucket, _, uploadID string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if !bkt.multiparts.Has(uploadID) {
+		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	bkt.multiparts.Delete(uploadID)
+
+	return nil
+}
+
+func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.MultipartUpload, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	keys := bkt.multiparts.Keys()
+	sort.Strings(keys)
+
+	result := make([]driver.MultipartUpload, 0, len(keys))
+
+	for _, k := range keys {
+		mp, mpOk := bkt.multiparts.Get(k)
+		if !mpOk {
+			continue
+		}
+
+		result = append(result, driver.MultipartUpload{
+			UploadID: mp.id, Bucket: bucket, Key: mp.key, CreatedAt: mp.createdAt,
+		})
+	}
+
+	return result, nil
+}
+
+func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versioning = enabled
+
+	return nil
+}
+
+func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	return bkt.versioning, nil
 }

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -305,7 +305,7 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 	}, nil
 }
 
-func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src driver.CopySource) error {
+func (m *Mock) CopyObject(ctx context.Context, dstBucket, dstKey string, src driver.CopySource) error {
 	srcBkt, ok := m.buckets.Get(src.Bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "source bucket %q not found", src.Bucket)
@@ -335,9 +335,14 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 		Metadata: meta,
 	})
 
+	dims := map[string]string{"bucket_name": dstBucket}
+	m.emitMetric(ctx, "api/request_count", 1, dims)
+
 	return nil
 }
 
+// GeneratePresignedURL generates a mock presigned URL.
+// Note: expiry is tracked in the URL but not enforced on use — this is a mock limitation.
 func (m *Mock) GeneratePresignedURL(_ context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
 	if req.Method != http.MethodGet && req.Method != http.MethodPut {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "method must be GET or PUT, got %q", req.Method)
@@ -503,7 +508,7 @@ func (m *Mock) UploadPart(
 }
 
 func (m *Mock) CompleteMultipartUpload(
-	_ context.Context, bucket, key, uploadID string, _ []driver.UploadPart,
+	ctx context.Context, bucket, key, uploadID string, parts []driver.UploadPart,
 ) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
@@ -515,7 +520,13 @@ func (m *Mock) CompleteMultipartUpload(
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
-	data := assembleGCSParts(mp.parts)
+	for _, p := range parts {
+		if _, exists := mp.parts[p.PartNumber]; !exists {
+			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
+		}
+	}
+
+	data := assembleGCSPartsInOrder(mp.parts, parts)
 
 	bkt.objects.Set(key, &gcsObject{
 		Key:          key,
@@ -528,20 +539,17 @@ func (m *Mock) CompleteMultipartUpload(
 
 	bkt.multiparts.Delete(uploadID)
 
+	dims := map[string]string{"bucket_name": bucket}
+	m.emitMetric(ctx, "api/request_count", 1, dims)
+	m.emitMetric(ctx, "network/received_bytes_count", float64(len(data)), dims)
+
 	return nil
 }
 
-func assembleGCSParts(parts map[int][]byte) []byte {
-	keys := make([]int, 0, len(parts))
-	for k := range parts {
-		keys = append(keys, k)
-	}
-
-	sort.Ints(keys)
-
+func assembleGCSPartsInOrder(allParts map[int][]byte, parts []driver.UploadPart) []byte {
 	var data []byte
-	for _, k := range keys {
-		data = append(data, parts[k]...)
+	for _, p := range parts {
+		data = append(data, allParts[p.PartNumber]...)
 	}
 
 	return data
@@ -587,6 +595,8 @@ func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.
 	return result, nil
 }
 
+// SetBucketVersioning enables or disables versioning on a bucket.
+// Note: this sets the flag but does not maintain object version history — mock limitation.
 func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {

--- a/providers/gcp/gcs/gcs_test.go
+++ b/providers/gcp/gcs/gcs_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stackshy/cloudemu/storage/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -280,4 +281,337 @@ func TestCopyObject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGeneratePresignedURL(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	tests := []struct {
+		name      string
+		req       driver.PresignedURLRequest
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "GET success",
+			req:  driver.PresignedURLRequest{Bucket: "b1", Key: "obj.txt", Method: "GET"},
+		},
+		{
+			name: "PUT success",
+			req:  driver.PresignedURLRequest{Bucket: "b1", Key: "obj.txt", Method: "PUT", ExpiresIn: 10 * time.Minute},
+		},
+		{
+			name:      "invalid method",
+			req:       driver.PresignedURLRequest{Bucket: "b1", Key: "obj.txt", Method: "DELETE"},
+			wantErr:   true,
+			errSubstr: "GET or PUT",
+		},
+		{
+			name:      "bucket not found",
+			req:       driver.PresignedURLRequest{Bucket: "nope", Key: "obj.txt", Method: "GET"},
+			wantErr:   true,
+			errSubstr: "not found",
+		},
+		{
+			name:      "expiry too long",
+			req:       driver.PresignedURLRequest{Bucket: "b1", Key: "obj.txt", Method: "GET", ExpiresIn: 8 * 24 * time.Hour},
+			wantErr:   true,
+			errSubstr: "exceeds maximum",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := m.GeneratePresignedURL(ctx, tt.req)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, result.URL)
+				assert.Contains(t, result.URL, "storage.googleapis.com")
+				assert.Equal(t, tt.req.Method, result.Method)
+				assert.False(t, result.ExpiresAt.IsZero())
+			}
+		})
+	}
+}
+
+func TestBucketLifecycleConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("no lifecycle config returns not found", func(t *testing.T) {
+		_, err := m.GetLifecycleConfig(ctx, "b1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no lifecycle")
+	})
+
+	t.Run("put and get lifecycle config", func(t *testing.T) {
+		cfg := driver.LifecycleConfig{
+			Rules: []driver.LifecycleRule{
+				{ID: "expire-logs", Enabled: true, Prefix: "logs/", ExpirationDays: 30},
+			},
+		}
+		require.NoError(t, m.PutLifecycleConfig(ctx, "b1", cfg))
+
+		got, err := m.GetLifecycleConfig(ctx, "b1")
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+		assert.Equal(t, "expire-logs", got.Rules[0].ID)
+		assert.Equal(t, 30, got.Rules[0].ExpirationDays)
+	})
+
+	t.Run("evaluate lifecycle deletes expired objects", func(t *testing.T) {
+		require.NoError(t, m.PutObject(ctx, "b1", "logs/old.txt", []byte("old"), "", nil))
+
+		// Advance clock past expiration
+		clk := m.opts.Clock.(*config.FakeClock)
+		clk.Advance(31 * 24 * time.Hour)
+
+		expired, err := m.EvaluateLifecycle(ctx, "b1")
+		require.NoError(t, err)
+		assert.Contains(t, expired, "logs/old.txt")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutLifecycleConfig(ctx, "missing", driver.LifecycleConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestMultipartUpload(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("full multipart upload flow", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "b1", "big-file.bin", "application/octet-stream")
+		require.NoError(t, err)
+		assert.NotEmpty(t, mp.UploadID)
+		assert.Equal(t, "b1", mp.Bucket)
+		assert.Equal(t, "big-file.bin", mp.Key)
+
+		part1, err := m.UploadPart(ctx, "b1", "big-file.bin", mp.UploadID, 1, []byte("part1-"))
+		require.NoError(t, err)
+		assert.Equal(t, 1, part1.PartNumber)
+		assert.NotEmpty(t, part1.ETag)
+
+		part2, err := m.UploadPart(ctx, "b1", "big-file.bin", mp.UploadID, 2, []byte("part2"))
+		require.NoError(t, err)
+		assert.Equal(t, 2, part2.PartNumber)
+
+		err = m.CompleteMultipartUpload(ctx, "b1", "big-file.bin", mp.UploadID,
+			[]driver.UploadPart{*part1, *part2})
+		require.NoError(t, err)
+
+		obj, err := m.GetObject(ctx, "b1", "big-file.bin")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("part1-part2"), obj.Data)
+	})
+
+	t.Run("list multipart uploads", func(t *testing.T) {
+		_, err := m.CreateMultipartUpload(ctx, "b1", "pending.bin", "")
+		require.NoError(t, err)
+
+		uploads, err := m.ListMultipartUploads(ctx, "b1")
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(uploads), 1)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		_, err := m.CreateMultipartUpload(ctx, "missing", "x", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestAbortMultipartUpload(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	mp, err := m.CreateMultipartUpload(ctx, "b1", "abort-me.bin", "")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		bucket    string
+		uploadID  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "success", bucket: "b1", uploadID: mp.UploadID},
+		{name: "upload not found after abort", bucket: "b1", uploadID: mp.UploadID, wantErr: true, errSubstr: "not found"},
+		{name: "bucket not found", bucket: "missing", uploadID: "x", wantErr: true, errSubstr: "not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := m.AbortMultipartUpload(ctx, tt.bucket, "", tt.uploadID)
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBucketVersioning(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("default versioning is disabled", func(t *testing.T) {
+		enabled, err := m.GetBucketVersioning(ctx, "b1")
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("enable versioning", func(t *testing.T) {
+		require.NoError(t, m.SetBucketVersioning(ctx, "b1", true))
+		enabled, err := m.GetBucketVersioning(ctx, "b1")
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("disable versioning", func(t *testing.T) {
+		require.NoError(t, m.SetBucketVersioning(ctx, "b1", false))
+		enabled, err := m.GetBucketVersioning(ctx, "b1")
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.SetBucketVersioning(ctx, "missing", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetBucketVersioning(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	monOpts := config.NewOptions(config.WithClock(clk))
+	mon := newMonitoringMock(monOpts)
+
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("PutObject emits request and received bytes metrics", func(t *testing.T) {
+		require.NoError(t, m.PutObject(ctx, "b1", "k1", []byte("hello"), "text/plain", nil))
+
+		result, err := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "storage.googleapis.com",
+			MetricName: "api/request_count",
+			Dimensions: map[string]string{"bucket_name": "b1"},
+			StartTime:  clk.Now().Add(-time.Minute),
+			EndTime:    clk.Now().Add(time.Minute),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Values)
+	})
+
+	t.Run("GetObject emits request and sent bytes metrics", func(t *testing.T) {
+		_, err := m.GetObject(ctx, "b1", "k1")
+		require.NoError(t, err)
+
+		result, err := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+			Namespace:  "storage.googleapis.com",
+			MetricName: "network/sent_bytes_count",
+			Dimensions: map[string]string{"bucket_name": "b1"},
+			StartTime:  clk.Now().Add(-time.Minute),
+			EndTime:    clk.Now().Add(time.Minute),
+			Period:     60,
+			Stat:       "Sum",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, result.Values)
+	})
+}
+
+// newMonitoringMock creates a Cloud Monitoring mock for testing metric emission.
+func newMonitoringMock(opts *config.Options) *monitoringMock {
+	return &monitoringMock{
+		data: make(map[string][]mondriver.MetricDatum),
+		opts: opts,
+	}
+}
+
+// monitoringMock is a minimal in-memory monitoring implementation for testing.
+type monitoringMock struct {
+	data map[string][]mondriver.MetricDatum
+	opts *config.Options
+}
+
+func (m *monitoringMock) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	for _, d := range data {
+		key := d.Namespace + "/" + d.MetricName
+		m.data[key] = append(m.data[key], d)
+	}
+
+	return nil
+}
+
+func (m *monitoringMock) GetMetricData(
+	_ context.Context, input mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	key := input.Namespace + "/" + input.MetricName
+	datums := m.data[key]
+
+	var timestamps []time.Time
+
+	var values []float64
+
+	for _, d := range datums {
+		if !d.Timestamp.Before(input.StartTime) && !d.Timestamp.After(input.EndTime) {
+			timestamps = append(timestamps, d.Timestamp)
+			values = append(values, d.Value)
+		}
+	}
+
+	return &mondriver.MetricDataResult{Timestamps: timestamps, Values: values}, nil
+}
+
+func (m *monitoringMock) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *monitoringMock) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (m *monitoringMock) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *monitoringMock) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (m *monitoringMock) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
 }

--- a/providers/gcp/gcs/gcs_test.go
+++ b/providers/gcp/gcs/gcs_test.go
@@ -553,6 +553,91 @@ func TestMetricsEmission(t *testing.T) {
 	})
 }
 
+func TestCompleteMultipartUploadPartsValidation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "mp-val"))
+
+	t.Run("only part 1 yields part 1 data", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "mp-val", "file1.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		part1, err := m.UploadPart(ctx, "mp-val", "file1.bin", mp.UploadID, 1, []byte("AAAA"))
+		require.NoError(t, err)
+		_, err = m.UploadPart(ctx, "mp-val", "file1.bin", mp.UploadID, 2, []byte("BBBB"))
+		require.NoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-val", "file1.bin", mp.UploadID, []driver.UploadPart{*part1})
+		require.NoError(t, err)
+
+		obj, err := m.GetObject(ctx, "mp-val", "file1.bin")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("AAAA"), obj.Data)
+	})
+
+	t.Run("reversed order yields part2+part1 data", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "mp-val", "file2.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		part1, err := m.UploadPart(ctx, "mp-val", "file2.bin", mp.UploadID, 1, []byte("AAAA"))
+		require.NoError(t, err)
+		part2, err := m.UploadPart(ctx, "mp-val", "file2.bin", mp.UploadID, 2, []byte("BBBB"))
+		require.NoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-val", "file2.bin", mp.UploadID, []driver.UploadPart{*part2, *part1})
+		require.NoError(t, err)
+
+		obj, err := m.GetObject(ctx, "mp-val", "file2.bin")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("BBBBAAAA"), obj.Data)
+	})
+
+	t.Run("non-existent part 99 returns error", func(t *testing.T) {
+		mp, err := m.CreateMultipartUpload(ctx, "mp-val", "file3.bin", "application/octet-stream")
+		require.NoError(t, err)
+
+		_, err = m.UploadPart(ctx, "mp-val", "file3.bin", mp.UploadID, 1, []byte("AAAA"))
+		require.NoError(t, err)
+
+		err = m.CompleteMultipartUpload(ctx, "mp-val", "file3.bin", mp.UploadID, []driver.UploadPart{
+			{PartNumber: 99, ETag: "fake"},
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestCopyObjectMetrics(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithRegion("us-central1"), config.WithProjectID("test-project"))
+
+	monOpts := config.NewOptions(config.WithClock(clk))
+	mon := newMonitoringMock(monOpts)
+
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	require.NoError(t, m.CreateBucket(ctx, "src"))
+	require.NoError(t, m.CreateBucket(ctx, "dst"))
+	require.NoError(t, m.PutObject(ctx, "src", "file.txt", []byte("data"), "text/plain", nil))
+
+	err := m.CopyObject(ctx, "dst", "copy.txt", driver.CopySource{Bucket: "src", Key: "file.txt"})
+	require.NoError(t, err)
+
+	result, getErr := mon.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  "storage.googleapis.com",
+		MetricName: "api/request_count",
+		Dimensions: map[string]string{"bucket_name": "dst"},
+		StartTime:  clk.Now().Add(-time.Minute),
+		EndTime:    clk.Now().Add(time.Minute),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	require.NoError(t, getErr)
+	assert.NotEmpty(t, result.Values)
+}
+
 // newMonitoringMock creates a Cloud Monitoring mock for testing metric emission.
 func newMonitoringMock(opts *config.Options) *monitoringMock {
 	return &monitoringMock{

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 const defaultRedisPort = 6379
@@ -32,8 +33,32 @@ type cacheData struct {
 
 // Mock is an in-memory mock implementation of GCP Memorystore.
 type Mock struct {
-	caches *memstore.Store[*cacheData]
-	opts   *config.Options
+	caches     *memstore.Store[*cacheData]
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+//nolint:unparam // value kept as parameter for API consistency with other service emitMetric helpers.
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "redis.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new Memorystore mock with the given configuration options.
@@ -128,7 +153,7 @@ func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
 }
 
 // Set stores a value in the cache with an optional TTL.
-func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
+func (m *Mock) Set(ctx context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
 	cd, ok := m.caches.Get(cacheName)
 	if !ok {
 		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
@@ -146,11 +171,15 @@ func (m *Mock) Set(_ context.Context, cacheName, key string, value []byte, ttl t
 
 	cd.items.Set(key, item)
 
+	dims := map[string]string{"instance_id": cacheName}
+	m.emitMetric(ctx, "commands/set", 1, dims)
+	m.emitMetric(ctx, "commands/total", 1, dims)
+
 	return nil
 }
 
 // Get retrieves a value from the cache.
-func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, error) {
+func (m *Mock) Get(ctx context.Context, cacheName, key string) (*driver.Item, error) {
 	cd, ok := m.caches.Get(cacheName)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
@@ -158,12 +187,22 @@ func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, erro
 
 	item, ok := cd.items.Get(key)
 	if !ok {
+		dims := map[string]string{"instance_id": cacheName}
+		m.emitMetric(ctx, "stats/cache_miss_count", 1, dims)
+		m.emitMetric(ctx, "commands/get", 1, dims)
+		m.emitMetric(ctx, "commands/total", 1, dims)
+
 		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
 
 	now := m.opts.Clock.Now()
 	if item.HasTTL && now.After(item.ExpiresAt) {
 		cd.items.Delete(key)
+
+		dims := map[string]string{"instance_id": cacheName}
+		m.emitMetric(ctx, "stats/cache_miss_count", 1, dims)
+		m.emitMetric(ctx, "commands/get", 1, dims)
+		m.emitMetric(ctx, "commands/total", 1, dims)
 
 		return nil, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
@@ -181,11 +220,16 @@ func (m *Mock) Get(_ context.Context, cacheName, key string) (*driver.Item, erro
 		result.ExpiresAt = item.ExpiresAt
 	}
 
+	dims := map[string]string{"instance_id": cacheName}
+	m.emitMetric(ctx, "stats/cache_hit_count", 1, dims)
+	m.emitMetric(ctx, "commands/get", 1, dims)
+	m.emitMetric(ctx, "commands/total", 1, dims)
+
 	return result, nil
 }
 
 // Delete removes a value from the cache.
-func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
+func (m *Mock) Delete(ctx context.Context, cacheName, key string) error {
 	cd, ok := m.caches.Get(cacheName)
 	if !ok {
 		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
@@ -194,6 +238,8 @@ func (m *Mock) Delete(_ context.Context, cacheName, key string) error {
 	if !cd.items.Delete(key) {
 		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
 	}
+
+	m.emitMetric(ctx, "commands/total", 1, map[string]string{"instance_id": cacheName})
 
 	return nil
 }

--- a/providers/gcp/pubsub/pubsub.go
+++ b/providers/gcp/pubsub/pubsub.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
 	"github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
 // Compile-time check that Mock implements driver.MessageQueue.
@@ -47,6 +48,8 @@ type queueData struct {
 	visibilityTimeout  int
 	maxMessageSize     int
 	messageRetention   int
+	createdAt          time.Time
+	lastModifiedAt     time.Time
 	deduplicationIndex map[string]time.Time
 	dlqConfig          *driver.DeadLetterConfig
 }
@@ -56,10 +59,33 @@ type FunctionTrigger func(queueURL string, message driver.Message)
 
 // Mock is an in-memory mock implementation of the GCP Pub/Sub service.
 type Mock struct {
-	queues   *memstore.Store[*queueData]
-	opts     *config.Options
-	mu       sync.RWMutex
-	triggers map[string]FunctionTrigger // subscriptionURL -> trigger
+	queues     *memstore.Store[*queueData]
+	opts       *config.Options
+	mu         sync.RWMutex
+	triggers   map[string]FunctionTrigger // subscriptionURL -> trigger
+	monitoring mondriver.Monitoring
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) emitMetric(ctx context.Context, metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(ctx, []mondriver.MetricDatum{
+		{
+			Namespace:  "pubsub.googleapis.com",
+			MetricName: metricName,
+			Value:      value,
+			Unit:       "None",
+			Dimensions: dims,
+			Timestamp:  m.opts.Clock.Now(),
+		},
+	})
 }
 
 // New creates a new Pub/Sub mock with the given configuration options.
@@ -123,6 +149,8 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		Tags:               tags,
 	}
 
+	now := m.opts.Clock.Now()
+
 	qd := &queueData{
 		info:               info,
 		messages:           make([]*pubsubMessage, 0),
@@ -130,6 +158,8 @@ func (m *Mock) CreateQueue(_ context.Context, cfg driver.QueueConfig) (*driver.Q
 		visibilityTimeout:  visibilityTimeout,
 		maxMessageSize:     cfg.MaxMessageSize,
 		messageRetention:   cfg.MessageRetention,
+		createdAt:          now,
+		lastModifiedAt:     now,
 		deduplicationIndex: make(map[string]time.Time),
 		dlqConfig:          cfg.DeadLetterQueue,
 	}
@@ -195,7 +225,7 @@ func (m *Mock) ListQueues(_ context.Context, prefix string) ([]driver.QueueInfo,
 // SendMessage publishes a message to the specified Pub/Sub topic.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
-func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
+func (m *Mock) SendMessage(ctx context.Context, input driver.SendMessageInput) (*driver.SendMessageOutput, error) {
 	qd, ok := m.queues.Get(input.QueueURL)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "topic %q not found", input.QueueURL)
@@ -261,6 +291,10 @@ func (m *Mock) SendMessage(_ context.Context, input driver.SendMessageInput) (*d
 		trigger(input.QueueURL, triggerMsg)
 	}
 
+	dims := map[string]string{"topic_id": qd.info.Name}
+	m.emitMetric(ctx, "topic/send_message_operation_count", 1, dims)
+	m.emitMetric(ctx, "topic/byte_cost", float64(len(input.Body)), dims)
+
 	return &driver.SendMessageOutput{
 		MessageID: msgID,
 	}, nil
@@ -307,7 +341,7 @@ func findDuplicate(qd *queueData, input *driver.SendMessageInput, now time.Time)
 
 // ReceiveMessages pulls messages from the specified Pub/Sub subscription.
 // Returns messages where VisibleAt <= now, and sets a new VisibleAt based on the ack deadline (visibility timeout).
-func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInput) ([]driver.Message, error) {
+func (m *Mock) ReceiveMessages(ctx context.Context, input driver.ReceiveMessageInput) ([]driver.Message, error) {
 	qd, ok := m.queues.Get(input.QueueURL)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "topic %q not found", input.QueueURL)
@@ -335,6 +369,10 @@ func (m *Mock) ReceiveMessages(_ context.Context, input driver.ReceiveMessageInp
 	if results == nil {
 		results = []driver.Message{}
 	}
+
+	dims := map[string]string{"subscription_id": qd.info.Name}
+	m.emitMetric(ctx, "subscription/pull_message_operation_count", 1, dims)
+	m.emitMetric(ctx, "subscription/delivered_message_count", float64(len(results)), dims)
 
 	return results, nil
 }
@@ -427,7 +465,7 @@ func (m *Mock) moveToDLQ(dlqURL string, msg *pubsubMessage) {
 }
 
 // DeleteMessage acknowledges and removes a message from the subscription using its ack ID (receipt handle).
-func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) error {
+func (m *Mock) DeleteMessage(ctx context.Context, queueURL, receiptHandle string) error {
 	qd, ok := m.queues.Get(queueURL)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "topic %q not found", queueURL)
@@ -439,6 +477,9 @@ func (m *Mock) DeleteMessage(_ context.Context, queueURL, receiptHandle string) 
 	for i, msg := range qd.messages {
 		if msg.ReceiptHandle == receiptHandle {
 			qd.messages = append(qd.messages[:i], qd.messages[i+1:]...)
+
+			m.emitMetric(ctx, "subscription/ack_message_operation_count", 1, map[string]string{"subscription_id": qd.info.Name})
+
 			return nil
 		}
 	}
@@ -466,4 +507,205 @@ func (m *Mock) ChangeVisibility(_ context.Context, queueURL, receiptHandle strin
 	}
 
 	return cerrors.Newf(cerrors.NotFound, "message with ack ID %q not found", receiptHandle)
+}
+
+// SendMessageBatch publishes up to 10 messages to the specified Pub/Sub topic.
+func (m *Mock) SendMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchSendEntry,
+) (*driver.BatchSendResult, error) {
+	if len(entries) > driver.MaxBatchSize {
+		return nil, cerrors.Newf(
+			cerrors.InvalidArgument, "batch size %d exceeds max %d", len(entries), driver.MaxBatchSize,
+		)
+	}
+
+	result := &driver.BatchSendResult{}
+
+	for _, entry := range entries {
+		input := batchEntryToSendInput(queue, &entry)
+
+		out, err := m.SendMessage(ctx, input)
+		if err != nil {
+			result.Failed = append(result.Failed, driver.BatchSendFailEntry{
+				ID: entry.ID, Code: "SendFailure", Message: err.Error(),
+			})
+
+			continue
+		}
+
+		result.Successful = append(result.Successful, driver.BatchSendResultEntry{
+			ID: entry.ID, MessageID: out.MessageID,
+		})
+	}
+
+	return result, nil
+}
+
+func batchEntryToSendInput(queue string, entry *driver.BatchSendEntry) driver.SendMessageInput {
+	return driver.SendMessageInput{
+		QueueURL:        queue,
+		Body:            entry.Body,
+		DelaySeconds:    entry.DelaySeconds,
+		GroupID:         entry.GroupID,
+		DeduplicationID: entry.DeduplicationID,
+		Attributes:      entry.Attributes,
+	}
+}
+
+// DeleteMessageBatch deletes up to 10 messages from the specified Pub/Sub subscription.
+func (m *Mock) DeleteMessageBatch(
+	ctx context.Context, queue string, entries []driver.BatchDeleteEntry,
+) (*driver.BatchDeleteResult, error) {
+	if len(entries) > driver.MaxBatchSize {
+		return nil, cerrors.Newf(
+			cerrors.InvalidArgument, "batch size %d exceeds max %d", len(entries), driver.MaxBatchSize,
+		)
+	}
+
+	result := &driver.BatchDeleteResult{}
+
+	for _, entry := range entries {
+		err := m.DeleteMessage(ctx, queue, entry.ReceiptHandle)
+		if err != nil {
+			result.Failed = append(result.Failed, driver.BatchSendFailEntry{
+				ID: entry.ID, Code: "DeleteFailure", Message: err.Error(),
+			})
+
+			continue
+		}
+
+		result.Successful = append(result.Successful, entry.ID)
+	}
+
+	return result, nil
+}
+
+// ReceiveMessagesWithOptions pulls messages with configurable options.
+func (m *Mock) ReceiveMessagesWithOptions(
+	_ context.Context, queue string, opts driver.ReceiveOptions,
+) ([]driver.Message, error) {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "topic %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	maxMsgs := clampMaxMessages(opts.MaxMessages)
+
+	visTimeout := opts.VisibilityTimeout
+	if visTimeout == 0 {
+		visTimeout = qd.visibilityTimeout
+	}
+
+	now := m.opts.Clock.Now()
+	results, toRemove := m.collectVisibleMessages(qd, maxMsgs, visTimeout, now)
+
+	removeByIndices(qd, toRemove)
+
+	if results == nil {
+		results = []driver.Message{}
+	}
+
+	return results, nil
+}
+
+// GetQueueAttributes returns detailed attributes of the specified topic/subscription.
+func (m *Mock) GetQueueAttributes(
+	_ context.Context, queue string,
+) (*driver.QueueAttributes, error) {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "topic %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	now := m.opts.Clock.Now()
+	visible, notVisible := countMessages(qd, now)
+
+	return &driver.QueueAttributes{
+		DelaySeconds:               qd.delaySeconds,
+		MaximumMessageSize:         qd.maxMessageSize,
+		MessageRetentionPeriod:     qd.messageRetention,
+		VisibilityTimeout:          qd.visibilityTimeout,
+		ApproximateMessageCount:    visible,
+		ApproximateNotVisibleCount: notVisible,
+		CreatedAt:                  qd.createdAt,
+		LastModifiedAt:             qd.lastModifiedAt,
+		FifoQueue:                  qd.info.FIFO,
+	}, nil
+}
+
+// SetQueueAttributes updates the attributes of the specified topic/subscription.
+func (m *Mock) SetQueueAttributes(
+	_ context.Context, queue string, attrs map[string]int,
+) error {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "topic %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	applyQueueAttributes(qd, attrs)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+func applyQueueAttributes(qd *queueData, attrs map[string]int) {
+	if v, ok := attrs["DelaySeconds"]; ok {
+		qd.delaySeconds = v
+	}
+
+	if v, ok := attrs["VisibilityTimeout"]; ok {
+		qd.visibilityTimeout = v
+	}
+
+	if v, ok := attrs["MaximumMessageSize"]; ok {
+		qd.maxMessageSize = v
+	}
+
+	if v, ok := attrs["MessageRetentionPeriod"]; ok {
+		qd.messageRetention = v
+	}
+}
+
+// PurgeQueue removes all messages from the specified topic/subscription.
+func (m *Mock) PurgeQueue(_ context.Context, queue string) error {
+	qd, ok := m.queues.Get(queue)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "topic %q not found", queue)
+	}
+
+	qd.mu.Lock()
+	defer qd.mu.Unlock()
+
+	qd.messages = make([]*pubsubMessage, 0)
+	qd.lastModifiedAt = m.opts.Clock.Now()
+
+	return nil
+}
+
+func countMessages(qd *queueData, now time.Time) (visible, notVisible int) {
+	for _, msg := range qd.messages {
+		if msg.VisibleAt.After(now) {
+			notVisible++
+		} else {
+			visible++
+		}
+	}
+
+	return visible, notVisible
+}
+
+func removeByIndices(qd *queueData, indices []int) {
+	for i := len(indices) - 1; i >= 0; i-- {
+		idx := indices[i]
+		qd.messages = append(qd.messages[:idx], qd.messages[idx+1:]...)
+	}
 }

--- a/providers/gcp/pubsub/pubsub.go
+++ b/providers/gcp/pubsub/pubsub.go
@@ -608,6 +608,10 @@ func (m *Mock) ReceiveMessagesWithOptions(
 		results = []driver.Message{}
 	}
 
+	dims := map[string]string{"subscription_id": qd.info.Name}
+	m.emitMetric(context.Background(), "subscription/pull_message_operation_count", 1, dims)
+	m.emitMetric(context.Background(), "subscription/delivered_message_count", float64(len(results)), dims)
+
 	return results, nil
 }
 

--- a/providers/gcp/pubsub/pubsub_test.go
+++ b/providers/gcp/pubsub/pubsub_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -327,4 +328,561 @@ func TestGetQueueInfo(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSendMessageBatch(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	t.Run("batch send success", func(t *testing.T) {
+		result, batchErr := m.SendMessageBatch(ctx, info.URL, []driver.BatchSendEntry{
+			{ID: "e1", Body: "msg1"},
+			{ID: "e2", Body: "msg2"},
+			{ID: "e3", Body: "msg3"},
+		})
+		require.NoError(t, batchErr)
+		assert.Len(t, result.Successful, 3)
+		assert.Empty(t, result.Failed)
+	})
+
+	t.Run("batch exceeds max size", func(t *testing.T) {
+		entries := make([]driver.BatchSendEntry, 11)
+		for i := range entries {
+			entries[i] = driver.BatchSendEntry{ID: "e", Body: "x"}
+		}
+		_, batchErr := m.SendMessageBatch(ctx, info.URL, entries)
+		require.Error(t, batchErr)
+		assert.Contains(t, batchErr.Error(), "exceeds max")
+	})
+
+	t.Run("verify messages received", func(t *testing.T) {
+		msgs, recvErr := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+			QueueURL: info.URL, MaxMessages: 10,
+		})
+		require.NoError(t, recvErr)
+		assert.Len(t, msgs, 3)
+	})
+}
+
+func TestDeleteMessageBatch(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	// Send and receive messages to get receipt handles
+	_, err = m.SendMessageBatch(ctx, info.URL, []driver.BatchSendEntry{
+		{ID: "e1", Body: "msg1"},
+		{ID: "e2", Body: "msg2"},
+	})
+	require.NoError(t, err)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+		QueueURL: info.URL, MaxMessages: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	t.Run("batch delete success", func(t *testing.T) {
+		entries := []driver.BatchDeleteEntry{
+			{ID: "d1", ReceiptHandle: msgs[0].ReceiptHandle},
+			{ID: "d2", ReceiptHandle: msgs[1].ReceiptHandle},
+		}
+		result, batchErr := m.DeleteMessageBatch(ctx, info.URL, entries)
+		require.NoError(t, batchErr)
+		assert.Len(t, result.Successful, 2)
+		assert.Empty(t, result.Failed)
+	})
+
+	t.Run("batch delete with invalid handle", func(t *testing.T) {
+		entries := []driver.BatchDeleteEntry{
+			{ID: "d1", ReceiptHandle: "invalid-handle"},
+		}
+		result, batchErr := m.DeleteMessageBatch(ctx, info.URL, entries)
+		require.NoError(t, batchErr)
+		assert.Empty(t, result.Successful)
+		assert.Len(t, result.Failed, 1)
+	})
+}
+
+func TestGetQueueAttributes(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{
+		Name:              "q1",
+		VisibilityTimeout: 45,
+		DelaySeconds:      5,
+		MaxMessageSize:    1024,
+		MessageRetention:  86400,
+	})
+	require.NoError(t, err)
+
+	t.Run("returns correct attributes", func(t *testing.T) {
+		attrs, attrErr := m.GetQueueAttributes(ctx, info.URL)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 45, attrs.VisibilityTimeout)
+		assert.Equal(t, 5, attrs.DelaySeconds)
+		assert.Equal(t, 1024, attrs.MaximumMessageSize)
+		assert.Equal(t, 86400, attrs.MessageRetentionPeriod)
+		assert.False(t, attrs.FifoQueue)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		_, attrErr := m.GetQueueAttributes(ctx, "missing")
+		require.Error(t, attrErr)
+		assert.Contains(t, attrErr.Error(), "not found")
+	})
+}
+
+func TestSetQueueAttributes(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	t.Run("update attributes", func(t *testing.T) {
+		require.NoError(t, m.SetQueueAttributes(ctx, info.URL, map[string]int{
+			"VisibilityTimeout":  60,
+			"DelaySeconds":       10,
+			"MaximumMessageSize": 2048,
+		}))
+
+		attrs, attrErr := m.GetQueueAttributes(ctx, info.URL)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 60, attrs.VisibilityTimeout)
+		assert.Equal(t, 10, attrs.DelaySeconds)
+		assert.Equal(t, 2048, attrs.MaximumMessageSize)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		setErr := m.SetQueueAttributes(ctx, "missing", map[string]int{"VisibilityTimeout": 60})
+		require.Error(t, setErr)
+		assert.Contains(t, setErr.Error(), "not found")
+	})
+}
+
+func TestPurgeQueue(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	// Send some messages
+	for i := 0; i < 3; i++ {
+		_, sendErr := m.SendMessage(ctx, driver.SendMessageInput{
+			QueueURL: info.URL, Body: "msg",
+		})
+		require.NoError(t, sendErr)
+	}
+
+	t.Run("purge removes all messages", func(t *testing.T) {
+		require.NoError(t, m.PurgeQueue(ctx, info.URL))
+
+		msgs, recvErr := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+			QueueURL: info.URL, MaxMessages: 10,
+		})
+		require.NoError(t, recvErr)
+		assert.Empty(t, msgs)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		purgeErr := m.PurgeQueue(ctx, "missing")
+		require.Error(t, purgeErr)
+		assert.Contains(t, purgeErr.Error(), "not found")
+	})
+}
+
+func TestPubSubMetricsEmission(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+
+	mon := &pubsubMonMock{data: make(map[string][]mondriver.MetricDatum)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	t.Run("SendMessage emits send metrics", func(t *testing.T) {
+		_, sendErr := m.SendMessage(ctx, driver.SendMessageInput{
+			QueueURL: info.URL, Body: "hello",
+		})
+		require.NoError(t, sendErr)
+
+		assert.NotEmpty(t, mon.data["pubsub.googleapis.com/topic/send_message_operation_count"])
+		assert.NotEmpty(t, mon.data["pubsub.googleapis.com/topic/byte_cost"])
+	})
+
+	t.Run("ReceiveMessages emits pull metrics", func(t *testing.T) {
+		_, recvErr := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+			QueueURL: info.URL, MaxMessages: 10,
+		})
+		require.NoError(t, recvErr)
+
+		assert.NotEmpty(t, mon.data["pubsub.googleapis.com/subscription/pull_message_operation_count"])
+	})
+}
+
+type pubsubMonMock struct {
+	data map[string][]mondriver.MetricDatum
+}
+
+func (m *pubsubMonMock) PutMetricData(_ context.Context, data []mondriver.MetricDatum) error {
+	for _, d := range data {
+		key := d.Namespace + "/" + d.MetricName
+		m.data[key] = append(m.data[key], d)
+	}
+
+	return nil
+}
+
+func (m *pubsubMonMock) GetMetricData(
+	_ context.Context, _ mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	return &mondriver.MetricDataResult{}, nil
+}
+
+func (m *pubsubMonMock) ListMetrics(_ context.Context, _ string) ([]string, error) {
+	return nil, nil
+}
+
+func (m *pubsubMonMock) CreateAlarm(_ context.Context, _ mondriver.AlarmConfig) error {
+	return nil
+}
+
+func (m *pubsubMonMock) DeleteAlarm(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *pubsubMonMock) DescribeAlarms(_ context.Context, _ []string) ([]mondriver.AlarmInfo, error) {
+	return nil, nil
+}
+
+func (m *pubsubMonMock) SetAlarmState(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestSendMessageBatchFIFOWithDedup(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "fifo.fifo", FIFO: true})
+	require.NoError(t, err)
+
+	t.Run("batch send with dedup", func(t *testing.T) {
+		result, batchErr := m.SendMessageBatch(ctx, info.URL, []driver.BatchSendEntry{
+			{ID: "e1", Body: "msg1", GroupID: "g1", DeduplicationID: "dedup-1"},
+			{ID: "e2", Body: "msg2", GroupID: "g1", DeduplicationID: "dedup-2"},
+			{ID: "e3", Body: "msg1-dup", GroupID: "g1", DeduplicationID: "dedup-1"}, // duplicate
+		})
+		require.NoError(t, batchErr)
+		assert.Len(t, result.Successful, 3) // all succeed, dedup returns existing ID
+		assert.Empty(t, result.Failed)
+	})
+
+	t.Run("batch send to FIFO without GroupID fails", func(t *testing.T) {
+		result, batchErr := m.SendMessageBatch(ctx, info.URL, []driver.BatchSendEntry{
+			{ID: "e1", Body: "msg1", DeduplicationID: "d1"}, // missing GroupID
+		})
+		require.NoError(t, batchErr)
+		assert.Empty(t, result.Successful)
+		assert.Len(t, result.Failed, 1)
+	})
+}
+
+func TestDeleteMessageBatchInvalidHandles(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	t.Run("all invalid handles", func(t *testing.T) {
+		entries := []driver.BatchDeleteEntry{
+			{ID: "d1", ReceiptHandle: "bad-handle-1"},
+			{ID: "d2", ReceiptHandle: "bad-handle-2"},
+		}
+		result, batchErr := m.DeleteMessageBatch(ctx, info.URL, entries)
+		require.NoError(t, batchErr)
+		assert.Empty(t, result.Successful)
+		assert.Len(t, result.Failed, 2)
+	})
+
+	t.Run("batch delete exceeds max size", func(t *testing.T) {
+		entries := make([]driver.BatchDeleteEntry, 11)
+		for i := range entries {
+			entries[i] = driver.BatchDeleteEntry{ID: "d", ReceiptHandle: "h"}
+		}
+		_, batchErr := m.DeleteMessageBatch(ctx, info.URL, entries)
+		require.Error(t, batchErr)
+		assert.Contains(t, batchErr.Error(), "exceeds max")
+	})
+}
+
+func TestReceiveMessagesWithOptions(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	// Send 5 messages
+	for i := 0; i < 5; i++ {
+		_, sendErr := m.SendMessage(ctx, driver.SendMessageInput{
+			QueueURL: info.URL, Body: "msg",
+		})
+		require.NoError(t, sendErr)
+	}
+
+	t.Run("MaxMessages limits results", func(t *testing.T) {
+		msgs, recvErr := m.ReceiveMessagesWithOptions(ctx, info.URL, driver.ReceiveOptions{
+			MaxMessages: 2,
+		})
+		require.NoError(t, recvErr)
+		assert.Len(t, msgs, 2)
+	})
+
+	t.Run("VisibilityTimeout override", func(t *testing.T) {
+		// Receive with short visibility timeout of 5 seconds
+		clk.Advance(31 * time.Second) // make previously received messages visible again
+		msgs, recvErr := m.ReceiveMessagesWithOptions(ctx, info.URL, driver.ReceiveOptions{
+			MaxMessages:       1,
+			VisibilityTimeout: 5,
+		})
+		require.NoError(t, recvErr)
+		assert.Len(t, msgs, 1)
+
+		// After 6 seconds, message should be visible again
+		clk.Advance(6 * time.Second)
+		msgs2, recvErr := m.ReceiveMessagesWithOptions(ctx, info.URL, driver.ReceiveOptions{
+			MaxMessages: 10,
+		})
+		require.NoError(t, recvErr)
+		assert.GreaterOrEqual(t, len(msgs2), 1)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		_, recvErr := m.ReceiveMessagesWithOptions(ctx, "missing", driver.ReceiveOptions{MaxMessages: 1})
+		require.Error(t, recvErr)
+		assert.Contains(t, recvErr.Error(), "not found")
+	})
+
+	t.Run("default max messages is 1", func(t *testing.T) {
+		clk.Advance(31 * time.Second)
+		msgs, recvErr := m.ReceiveMessagesWithOptions(ctx, info.URL, driver.ReceiveOptions{})
+		require.NoError(t, recvErr)
+		assert.Len(t, msgs, 1)
+	})
+}
+
+func TestSetQueueAttributesVarious(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	t.Run("set MessageRetentionPeriod", func(t *testing.T) {
+		require.NoError(t, m.SetQueueAttributes(ctx, info.URL, map[string]int{
+			"MessageRetentionPeriod": 172800,
+		}))
+
+		attrs, attrErr := m.GetQueueAttributes(ctx, info.URL)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 172800, attrs.MessageRetentionPeriod)
+	})
+
+	t.Run("set multiple attributes at once", func(t *testing.T) {
+		require.NoError(t, m.SetQueueAttributes(ctx, info.URL, map[string]int{
+			"DelaySeconds":       15,
+			"VisibilityTimeout":  90,
+			"MaximumMessageSize": 4096,
+		}))
+
+		attrs, attrErr := m.GetQueueAttributes(ctx, info.URL)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 15, attrs.DelaySeconds)
+		assert.Equal(t, 90, attrs.VisibilityTimeout)
+		assert.Equal(t, 4096, attrs.MaximumMessageSize)
+	})
+}
+
+func TestGetQueueAttributesMessageCounts(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	// Send 3 messages
+	for i := 0; i < 3; i++ {
+		_, sendErr := m.SendMessage(ctx, driver.SendMessageInput{
+			QueueURL: info.URL, Body: "msg",
+		})
+		require.NoError(t, sendErr)
+	}
+
+	t.Run("all visible initially", func(t *testing.T) {
+		attrs, attrErr := m.GetQueueAttributes(ctx, info.URL)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 3, attrs.ApproximateMessageCount)
+		assert.Equal(t, 0, attrs.ApproximateNotVisibleCount)
+	})
+
+	t.Run("after receiving some become not visible", func(t *testing.T) {
+		_, recvErr := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+			QueueURL: info.URL, MaxMessages: 2,
+		})
+		require.NoError(t, recvErr)
+
+		attrs, attrErr := m.GetQueueAttributes(ctx, info.URL)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 1, attrs.ApproximateMessageCount)
+		assert.Equal(t, 2, attrs.ApproximateNotVisibleCount)
+	})
+
+	t.Run("FIFO queue flag", func(t *testing.T) {
+		fifoInfo, fifoErr := m.CreateQueue(ctx, driver.QueueConfig{Name: "fifo.fifo", FIFO: true})
+		require.NoError(t, fifoErr)
+
+		attrs, attrErr := m.GetQueueAttributes(ctx, fifoInfo.URL)
+		require.NoError(t, attrErr)
+		assert.True(t, attrs.FifoQueue)
+	})
+}
+
+func TestPurgeQueueEmpty(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	// Purge an already-empty queue should succeed without error
+	require.NoError(t, m.PurgeQueue(ctx, info.URL))
+
+	msgs, recvErr := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+		QueueURL: info.URL, MaxMessages: 10,
+	})
+	require.NoError(t, recvErr)
+	assert.Empty(t, msgs)
+}
+
+func TestChangeVisibility(t *testing.T) {
+	ctx := context.Background()
+	m, clk := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "msg1"})
+	require.NoError(t, err)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: info.URL, MaxMessages: 1})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	t.Run("extend visibility", func(t *testing.T) {
+		require.NoError(t, m.ChangeVisibility(ctx, info.URL, msgs[0].ReceiptHandle, 60))
+
+		// After 31 seconds message should still be invisible (extended to 60)
+		clk.Advance(31 * time.Second)
+		visible, recvErr := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{
+			QueueURL: info.URL, MaxMessages: 1,
+		})
+		require.NoError(t, recvErr)
+		assert.Empty(t, visible)
+	})
+
+	t.Run("queue not found", func(t *testing.T) {
+		err := m.ChangeVisibility(ctx, "missing", "handle", 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("handle not found", func(t *testing.T) {
+		err := m.ChangeVisibility(ctx, info.URL, "bad-handle", 10)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestPubSubMetricsDeleteMessage(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+
+	mon := &pubsubMonMock{data: make(map[string][]mondriver.MetricDatum)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "hello"})
+	require.NoError(t, err)
+
+	msgs, err := m.ReceiveMessages(ctx, driver.ReceiveMessageInput{QueueURL: info.URL, MaxMessages: 1})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	require.NoError(t, m.DeleteMessage(ctx, info.URL, msgs[0].ReceiptHandle))
+	assert.NotEmpty(t, mon.data["pubsub.googleapis.com/subscription/ack_message_operation_count"])
+}
+
+func TestClampMaxMessages(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int
+		want  int
+	}{
+		{name: "zero defaults to 1", input: 0, want: 1},
+		{name: "negative defaults to 1", input: -5, want: 1},
+		{name: "normal value", input: 5, want: 5},
+		{name: "exceeds max clamped to 10", input: 15, want: 10},
+		{name: "exactly max", input: 10, want: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, clampMaxMessages(tt.input))
+		})
+	}
+}
+
+func TestTriggerOnSendMessage(t *testing.T) {
+	ctx := context.Background()
+	m, _ := newTestMock()
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "q1"})
+	require.NoError(t, err)
+
+	var triggered bool
+	var triggeredBody string
+
+	m.SetTrigger(info.URL, func(queueURL string, message driver.Message) {
+		triggered = true
+		triggeredBody = message.Body
+	})
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "trigger-me"})
+	require.NoError(t, err)
+	assert.True(t, triggered)
+	assert.Equal(t, "trigger-me", triggeredBody)
+
+	// Remove trigger
+	m.RemoveTrigger(info.URL)
+	triggered = false
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "no-trigger"})
+	require.NoError(t, err)
+	assert.False(t, triggered)
 }

--- a/providers/gcp/pubsub/pubsub_test.go
+++ b/providers/gcp/pubsub/pubsub_test.go
@@ -531,6 +531,27 @@ func TestPubSubMetricsEmission(t *testing.T) {
 	})
 }
 
+func TestReceiveMessagesWithOptionsMetrics(t *testing.T) {
+	ctx := context.Background()
+	clk := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(clk), config.WithProjectID("test-project"))
+
+	mon := &pubsubMonMock{data: make(map[string][]mondriver.MetricDatum)}
+	m := New(opts)
+	m.SetMonitoring(mon)
+
+	info, err := m.CreateQueue(ctx, driver.QueueConfig{Name: "rwopt-queue"})
+	require.NoError(t, err)
+
+	_, err = m.SendMessage(ctx, driver.SendMessageInput{QueueURL: info.URL, Body: "hello"})
+	require.NoError(t, err)
+
+	_, err = m.ReceiveMessagesWithOptions(ctx, info.URL, driver.ReceiveOptions{MaxMessages: 10})
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, mon.data["pubsub.googleapis.com/subscription/pull_message_operation_count"])
+}
+
 type pubsubMonMock struct {
 	data map[string][]mondriver.MetricDatum
 }

--- a/serverless/aliases.go
+++ b/serverless/aliases.go
@@ -1,0 +1,64 @@
+package serverless
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// CreateAlias creates a new alias pointing to a specific function version.
+func (s *Serverless) CreateAlias(ctx context.Context, config driver.AliasConfig) (*driver.Alias, error) {
+	out, err := s.do(ctx, "CreateAlias", config, func() (any, error) {
+		return s.driver.CreateAlias(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Alias), nil
+}
+
+// UpdateAlias updates an existing alias configuration.
+func (s *Serverless) UpdateAlias(ctx context.Context, config driver.AliasConfig) (*driver.Alias, error) {
+	out, err := s.do(ctx, "UpdateAlias", config, func() (any, error) {
+		return s.driver.UpdateAlias(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Alias), nil
+}
+
+// DeleteAlias removes an alias from a function.
+func (s *Serverless) DeleteAlias(ctx context.Context, functionName, aliasName string) error {
+	_, err := s.do(ctx, "DeleteAlias", functionName, func() (any, error) {
+		return nil, s.driver.DeleteAlias(ctx, functionName, aliasName)
+	})
+
+	return err
+}
+
+// GetAlias retrieves a specific alias for a function.
+func (s *Serverless) GetAlias(ctx context.Context, functionName, aliasName string) (*driver.Alias, error) {
+	out, err := s.do(ctx, "GetAlias", functionName, func() (any, error) {
+		return s.driver.GetAlias(ctx, functionName, aliasName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Alias), nil
+}
+
+// ListAliases returns all aliases for a function.
+func (s *Serverless) ListAliases(ctx context.Context, functionName string) ([]driver.Alias, error) {
+	out, err := s.do(ctx, "ListAliases", functionName, func() (any, error) {
+		return s.driver.ListAliases(ctx, functionName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Alias), nil
+}

--- a/serverless/concurrency.go
+++ b/serverless/concurrency.go
@@ -1,0 +1,39 @@
+package serverless
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PutFunctionConcurrency sets reserved concurrency for a function.
+func (s *Serverless) PutFunctionConcurrency(ctx context.Context, config driver.ConcurrencyConfig) error {
+	_, err := s.do(ctx, "PutFunctionConcurrency", config, func() (any, error) {
+		return nil, s.driver.PutFunctionConcurrency(ctx, config)
+	})
+
+	return err
+}
+
+// GetFunctionConcurrency retrieves the concurrency configuration for a function.
+func (s *Serverless) GetFunctionConcurrency(
+	ctx context.Context, functionName string,
+) (*driver.ConcurrencyConfig, error) {
+	out, err := s.do(ctx, "GetFunctionConcurrency", functionName, func() (any, error) {
+		return s.driver.GetFunctionConcurrency(ctx, functionName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ConcurrencyConfig), nil
+}
+
+// DeleteFunctionConcurrency removes the concurrency configuration for a function.
+func (s *Serverless) DeleteFunctionConcurrency(ctx context.Context, functionName string) error {
+	_, err := s.do(ctx, "DeleteFunctionConcurrency", functionName, func() (any, error) {
+		return nil, s.driver.DeleteFunctionConcurrency(ctx, functionName)
+	})
+
+	return err
+}

--- a/serverless/driver/driver.go
+++ b/serverless/driver/driver.go
@@ -3,6 +3,74 @@ package driver
 
 import "context"
 
+// FunctionVersion represents a published version of a function.
+type FunctionVersion struct {
+	FunctionName string
+	Version      string // "1", "2", etc. or "$LATEST"
+	Description  string
+	CodeSHA256   string
+	CreatedAt    string
+}
+
+// AliasConfig configures a function alias.
+type AliasConfig struct {
+	FunctionName    string
+	Name            string
+	FunctionVersion string
+	Description     string
+	RoutingConfig   *AliasRoutingConfig // for weighted aliases
+}
+
+// AliasRoutingConfig defines weighted routing between versions.
+type AliasRoutingConfig struct {
+	AdditionalVersion string
+	Weight            float64 // 0.0-1.0, traffic percentage to additional version
+}
+
+// Alias represents a function alias.
+type Alias struct {
+	FunctionName    string
+	Name            string
+	FunctionVersion string
+	Description     string
+	RoutingConfig   *AliasRoutingConfig
+	AliasARN        string
+	CreatedAt       string
+}
+
+// LayerConfig configures a new layer version.
+type LayerConfig struct {
+	Name               string
+	Description        string
+	Content            []byte
+	CompatibleRuntimes []string
+}
+
+// LayerVersion represents a published layer version.
+type LayerVersion struct {
+	Name               string
+	Version            int
+	Description        string
+	ContentSHA256      string
+	ContentSize        int64
+	CompatibleRuntimes []string
+	CreatedAt          string
+	ARN                string
+}
+
+// ConcurrencyConfig configures function concurrency.
+type ConcurrencyConfig struct {
+	FunctionName                 string
+	ReservedConcurrentExecutions int
+}
+
+// ProvisionedConcurrencyConfig configures provisioned concurrency.
+type ProvisionedConcurrencyConfig struct {
+	FunctionName string
+	Qualifier    string // version or alias
+	Provisioned  int
+}
+
 // FunctionConfig describes a serverless function to create.
 type FunctionConfig struct {
 	Name        string
@@ -54,4 +122,27 @@ type Serverless interface {
 	UpdateFunction(ctx context.Context, name string, config FunctionConfig) (*FunctionInfo, error)
 	Invoke(ctx context.Context, input InvokeInput) (*InvokeOutput, error)
 	RegisterHandler(name string, handler HandlerFunc)
+
+	// Versions
+	PublishVersion(ctx context.Context, functionName, description string) (*FunctionVersion, error)
+	ListVersions(ctx context.Context, functionName string) ([]FunctionVersion, error)
+
+	// Aliases
+	CreateAlias(ctx context.Context, config AliasConfig) (*Alias, error)
+	UpdateAlias(ctx context.Context, config AliasConfig) (*Alias, error)
+	DeleteAlias(ctx context.Context, functionName, aliasName string) error
+	GetAlias(ctx context.Context, functionName, aliasName string) (*Alias, error)
+	ListAliases(ctx context.Context, functionName string) ([]Alias, error)
+
+	// Layers
+	PublishLayerVersion(ctx context.Context, config LayerConfig) (*LayerVersion, error)
+	GetLayerVersion(ctx context.Context, name string, version int) (*LayerVersion, error)
+	ListLayerVersions(ctx context.Context, name string) ([]LayerVersion, error)
+	DeleteLayerVersion(ctx context.Context, name string, version int) error
+	ListLayers(ctx context.Context) ([]LayerVersion, error)
+
+	// Concurrency
+	PutFunctionConcurrency(ctx context.Context, config ConcurrencyConfig) error
+	GetFunctionConcurrency(ctx context.Context, functionName string) (*ConcurrencyConfig, error)
+	DeleteFunctionConcurrency(ctx context.Context, functionName string) error
 }

--- a/serverless/layers.go
+++ b/serverless/layers.go
@@ -1,0 +1,66 @@
+package serverless
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PublishLayerVersion publishes a new version of a layer.
+//
+//nolint:gocritic // config passed by value to match driver.Serverless interface pattern
+func (s *Serverless) PublishLayerVersion(ctx context.Context, config driver.LayerConfig) (*driver.LayerVersion, error) {
+	out, err := s.do(ctx, "PublishLayerVersion", config, func() (any, error) {
+		return s.driver.PublishLayerVersion(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LayerVersion), nil
+}
+
+// GetLayerVersion retrieves a specific version of a layer.
+func (s *Serverless) GetLayerVersion(ctx context.Context, name string, version int) (*driver.LayerVersion, error) {
+	out, err := s.do(ctx, "GetLayerVersion", name, func() (any, error) {
+		return s.driver.GetLayerVersion(ctx, name, version)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LayerVersion), nil
+}
+
+// ListLayerVersions returns all versions of a layer.
+func (s *Serverless) ListLayerVersions(ctx context.Context, name string) ([]driver.LayerVersion, error) {
+	out, err := s.do(ctx, "ListLayerVersions", name, func() (any, error) {
+		return s.driver.ListLayerVersions(ctx, name)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LayerVersion), nil
+}
+
+// DeleteLayerVersion removes a specific version of a layer.
+func (s *Serverless) DeleteLayerVersion(ctx context.Context, name string, version int) error {
+	_, err := s.do(ctx, "DeleteLayerVersion", name, func() (any, error) {
+		return nil, s.driver.DeleteLayerVersion(ctx, name, version)
+	})
+
+	return err
+}
+
+// ListLayers returns the latest version of each layer.
+func (s *Serverless) ListLayers(ctx context.Context) ([]driver.LayerVersion, error) {
+	out, err := s.do(ctx, "ListLayers", nil, func() (any, error) {
+		return s.driver.ListLayers(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LayerVersion), nil
+}

--- a/serverless/serverless_test.go
+++ b/serverless/serverless_test.go
@@ -1,0 +1,872 @@
+package serverless
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDriver implements driver.Serverless for testing the portable wrapper.
+type mockDriver struct {
+	functions   map[string]*driver.FunctionInfo
+	versions    map[string][]driver.FunctionVersion
+	aliases     map[string]map[string]*driver.Alias
+	layers      map[string][]driver.LayerVersion
+	concurrency map[string]*driver.ConcurrencyConfig
+	handlers    map[string]driver.HandlerFunc
+	versionSeq  int
+	layerSeq    int
+}
+
+func newMockDriver() *mockDriver {
+	return &mockDriver{
+		functions:   make(map[string]*driver.FunctionInfo),
+		versions:    make(map[string][]driver.FunctionVersion),
+		aliases:     make(map[string]map[string]*driver.Alias),
+		layers:      make(map[string][]driver.LayerVersion),
+		concurrency: make(map[string]*driver.ConcurrencyConfig),
+		handlers:    make(map[string]driver.HandlerFunc),
+	}
+}
+
+func (m *mockDriver) CreateFunction(_ context.Context, config driver.FunctionConfig) (*driver.FunctionInfo, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	if _, ok := m.functions[config.Name]; ok {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	info := &driver.FunctionInfo{
+		Name:    config.Name,
+		ARN:     "arn:aws:lambda:us-east-1:123456789012:function:" + config.Name,
+		Runtime: config.Runtime,
+		Handler: config.Handler,
+		Memory:  config.Memory,
+		Timeout: config.Timeout,
+		State:   "Active",
+	}
+	m.functions[config.Name] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteFunction(_ context.Context, name string) error {
+	if _, ok := m.functions[name]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.functions, name)
+
+	return nil
+}
+
+func (m *mockDriver) GetFunction(_ context.Context, name string) (*driver.FunctionInfo, error) {
+	info, ok := m.functions[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListFunctions(_ context.Context) ([]driver.FunctionInfo, error) {
+	result := make([]driver.FunctionInfo, 0, len(m.functions))
+	for _, info := range m.functions {
+		result = append(result, *info)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) UpdateFunction(_ context.Context, name string, config driver.FunctionConfig) (*driver.FunctionInfo, error) {
+	info, ok := m.functions[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	if config.Runtime != "" {
+		info.Runtime = config.Runtime
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) Invoke(_ context.Context, input driver.InvokeInput) (*driver.InvokeOutput, error) {
+	if _, ok := m.functions[input.FunctionName]; !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return &driver.InvokeOutput{StatusCode: 200, Payload: []byte("ok")}, nil
+}
+
+func (m *mockDriver) RegisterHandler(name string, handler driver.HandlerFunc) {
+	m.handlers[name] = handler
+}
+
+func (m *mockDriver) PublishVersion(_ context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	if _, ok := m.functions[functionName]; !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	m.versionSeq++
+	v := driver.FunctionVersion{
+		FunctionName: functionName,
+		Version:      fmt.Sprintf("%d", m.versionSeq),
+		Description:  description,
+	}
+	m.versions[functionName] = append(m.versions[functionName], v)
+
+	return &v, nil
+}
+
+func (m *mockDriver) ListVersions(_ context.Context, functionName string) ([]driver.FunctionVersion, error) {
+	if _, ok := m.functions[functionName]; !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return m.versions[functionName], nil
+}
+
+func (m *mockDriver) CreateAlias(_ context.Context, config driver.AliasConfig) (*driver.Alias, error) {
+	if _, ok := m.functions[config.FunctionName]; !ok {
+		return nil, fmt.Errorf("function not found")
+	}
+
+	if m.aliases[config.FunctionName] == nil {
+		m.aliases[config.FunctionName] = make(map[string]*driver.Alias)
+	}
+
+	if _, ok := m.aliases[config.FunctionName][config.Name]; ok {
+		return nil, fmt.Errorf("alias already exists")
+	}
+
+	a := &driver.Alias{
+		FunctionName:    config.FunctionName,
+		Name:            config.Name,
+		FunctionVersion: config.FunctionVersion,
+		Description:     config.Description,
+	}
+	m.aliases[config.FunctionName][config.Name] = a
+
+	return a, nil
+}
+
+func (m *mockDriver) UpdateAlias(_ context.Context, config driver.AliasConfig) (*driver.Alias, error) {
+	aliases, ok := m.aliases[config.FunctionName]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	a, ok := aliases[config.Name]
+	if !ok {
+		return nil, fmt.Errorf("alias not found")
+	}
+
+	a.FunctionVersion = config.FunctionVersion
+	a.Description = config.Description
+
+	return a, nil
+}
+
+func (m *mockDriver) DeleteAlias(_ context.Context, functionName, aliasName string) error {
+	aliases, ok := m.aliases[functionName]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	if _, ok := aliases[aliasName]; !ok {
+		return fmt.Errorf("alias not found")
+	}
+
+	delete(aliases, aliasName)
+
+	return nil
+}
+
+func (m *mockDriver) GetAlias(_ context.Context, functionName, aliasName string) (*driver.Alias, error) {
+	aliases, ok := m.aliases[functionName]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	a, ok := aliases[aliasName]
+	if !ok {
+		return nil, fmt.Errorf("alias not found")
+	}
+
+	return a, nil
+}
+
+func (m *mockDriver) ListAliases(_ context.Context, functionName string) ([]driver.Alias, error) {
+	if _, ok := m.functions[functionName]; !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	aliases := m.aliases[functionName]
+	result := make([]driver.Alias, 0, len(aliases))
+
+	for _, a := range aliases {
+		result = append(result, *a)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) PublishLayerVersion(_ context.Context, config driver.LayerConfig) (*driver.LayerVersion, error) {
+	if config.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	m.layerSeq++
+	lv := driver.LayerVersion{
+		Name:        config.Name,
+		Version:     m.layerSeq,
+		Description: config.Description,
+	}
+	m.layers[config.Name] = append(m.layers[config.Name], lv)
+
+	return &lv, nil
+}
+
+func (m *mockDriver) GetLayerVersion(_ context.Context, name string, version int) (*driver.LayerVersion, error) {
+	versions, ok := m.layers[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	for idx := range versions {
+		if versions[idx].Version == version {
+			return &versions[idx], nil
+		}
+	}
+
+	return nil, fmt.Errorf("version not found")
+}
+
+func (m *mockDriver) ListLayerVersions(_ context.Context, name string) ([]driver.LayerVersion, error) {
+	versions, ok := m.layers[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return versions, nil
+}
+
+func (m *mockDriver) DeleteLayerVersion(_ context.Context, name string, version int) error {
+	versions, ok := m.layers[name]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	for idx := range versions {
+		if versions[idx].Version == version {
+			m.layers[name] = append(versions[:idx], versions[idx+1:]...)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("version not found")
+}
+
+func (m *mockDriver) ListLayers(_ context.Context) ([]driver.LayerVersion, error) {
+	var result []driver.LayerVersion
+
+	for _, versions := range m.layers {
+		if len(versions) > 0 {
+			result = append(result, versions[len(versions)-1])
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) PutFunctionConcurrency(_ context.Context, config driver.ConcurrencyConfig) error {
+	if _, ok := m.functions[config.FunctionName]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	m.concurrency[config.FunctionName] = &config
+
+	return nil
+}
+
+func (m *mockDriver) GetFunctionConcurrency(_ context.Context, functionName string) (*driver.ConcurrencyConfig, error) {
+	c, ok := m.concurrency[functionName]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return c, nil
+}
+
+func (m *mockDriver) DeleteFunctionConcurrency(_ context.Context, functionName string) error {
+	if _, ok := m.concurrency[functionName]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.concurrency, functionName)
+
+	return nil
+}
+
+func newTestServerless(opts ...Option) *Serverless {
+	return NewServerless(newMockDriver(), opts...)
+}
+
+func setupFunction(t *testing.T, s *Serverless, name string) {
+	t.Helper()
+
+	ctx := context.Background()
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: name, Runtime: "go1.x", Handler: "main"})
+	require.NoError(t, err)
+}
+
+func TestNewServerless(t *testing.T) {
+	s := newTestServerless()
+	require.NotNil(t, s)
+	require.NotNil(t, s.driver)
+}
+
+func TestCreateFunction(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		info, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "my-func", Runtime: "go1.x"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-func", info.Name)
+		assert.Equal(t, "Active", info.State)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := s.CreateFunction(ctx, driver.FunctionConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteFunction(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "del-func")
+
+	t.Run("success", func(t *testing.T) {
+		err := s.DeleteFunction(ctx, "del-func")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := s.DeleteFunction(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetFunction(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "get-func")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := s.GetFunction(ctx, "get-func")
+		require.NoError(t, err)
+		assert.Equal(t, "get-func", info.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.GetFunction(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListFunctions(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	funcs, err := s.ListFunctions(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(funcs))
+
+	setupFunction(t, s, "func-a")
+	setupFunction(t, s, "func-b")
+
+	funcs, err = s.ListFunctions(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(funcs))
+}
+
+func TestUpdateFunction(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "upd-func")
+
+	t.Run("success", func(t *testing.T) {
+		info, err := s.UpdateFunction(ctx, "upd-func", driver.FunctionConfig{Runtime: "python3.9"})
+		require.NoError(t, err)
+		assert.Equal(t, "python3.9", info.Runtime)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.UpdateFunction(ctx, "nonexistent", driver.FunctionConfig{Runtime: "python3.9"})
+		require.Error(t, err)
+	})
+}
+
+func TestInvoke(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "inv-func")
+
+	t.Run("success", func(t *testing.T) {
+		out, err := s.Invoke(ctx, driver.InvokeInput{FunctionName: "inv-func", Payload: []byte("hello")})
+		require.NoError(t, err)
+		assert.Equal(t, 200, out.StatusCode)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.Invoke(ctx, driver.InvokeInput{FunctionName: "nonexistent"})
+		require.Error(t, err)
+	})
+}
+
+func TestRegisterHandler(t *testing.T) {
+	md := newMockDriver()
+	s := NewServerless(md)
+
+	s.RegisterHandler("my-func", func(_ context.Context, payload []byte) ([]byte, error) {
+		return payload, nil
+	})
+	assert.NotNil(t, md.handlers["my-func"])
+}
+
+func TestPublishVersion(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "ver-func")
+
+	t.Run("success", func(t *testing.T) {
+		v, err := s.PublishVersion(ctx, "ver-func", "first release")
+		require.NoError(t, err)
+		assert.Equal(t, "ver-func", v.FunctionName)
+		assert.Equal(t, "1", v.Version)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.PublishVersion(ctx, "nonexistent", "desc")
+		require.Error(t, err)
+	})
+}
+
+func TestListVersions(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "lv-func")
+
+	_, err := s.PublishVersion(ctx, "lv-func", "v1")
+	require.NoError(t, err)
+
+	_, err = s.PublishVersion(ctx, "lv-func", "v2")
+	require.NoError(t, err)
+
+	versions, err := s.ListVersions(ctx, "lv-func")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(versions))
+}
+
+func TestCreateAlias(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "alias-func")
+
+	t.Run("success", func(t *testing.T) {
+		a, err := s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "alias-func", Name: "prod", FunctionVersion: "1"})
+		require.NoError(t, err)
+		assert.Equal(t, "prod", a.Name)
+		assert.Equal(t, "1", a.FunctionVersion)
+	})
+
+	t.Run("function not found", func(t *testing.T) {
+		_, err := s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "nonexistent", Name: "prod"})
+		require.Error(t, err)
+	})
+}
+
+func TestUpdateAlias(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "ua-func")
+
+	_, err := s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "ua-func", Name: "prod", FunctionVersion: "1"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		a, err := s.UpdateAlias(ctx, driver.AliasConfig{FunctionName: "ua-func", Name: "prod", FunctionVersion: "2"})
+		require.NoError(t, err)
+		assert.Equal(t, "2", a.FunctionVersion)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.UpdateAlias(ctx, driver.AliasConfig{FunctionName: "ua-func", Name: "nonexistent"})
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteAlias(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "da-func")
+
+	_, err := s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "da-func", Name: "prod", FunctionVersion: "1"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := s.DeleteAlias(ctx, "da-func", "prod")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := s.DeleteAlias(ctx, "da-func", "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestGetAlias(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "ga-func")
+
+	_, err := s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "ga-func", Name: "prod", FunctionVersion: "1"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		a, err := s.GetAlias(ctx, "ga-func", "prod")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", a.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.GetAlias(ctx, "ga-func", "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestListAliases(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "la-func")
+
+	_, err := s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "la-func", Name: "prod", FunctionVersion: "1"})
+	require.NoError(t, err)
+
+	_, err = s.CreateAlias(ctx, driver.AliasConfig{FunctionName: "la-func", Name: "staging", FunctionVersion: "2"})
+	require.NoError(t, err)
+
+	aliases, err := s.ListAliases(ctx, "la-func")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(aliases))
+}
+
+func TestPublishLayerVersion(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		lv, err := s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "my-layer", Description: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-layer", lv.Name)
+		assert.Equal(t, 1, lv.Version)
+	})
+
+	t.Run("empty name error", func(t *testing.T) {
+		_, err := s.PublishLayerVersion(ctx, driver.LayerConfig{})
+		require.Error(t, err)
+	})
+}
+
+func TestGetLayerVersion(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	lv, err := s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "gl-layer"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		got, err := s.GetLayerVersion(ctx, "gl-layer", lv.Version)
+		require.NoError(t, err)
+		assert.Equal(t, "gl-layer", got.Name)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.GetLayerVersion(ctx, "gl-layer", 999)
+		require.Error(t, err)
+	})
+}
+
+func TestListLayerVersions(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	_, err := s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "llv-layer"})
+	require.NoError(t, err)
+
+	_, err = s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "llv-layer"})
+	require.NoError(t, err)
+
+	versions, err := s.ListLayerVersions(ctx, "llv-layer")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(versions))
+}
+
+func TestDeleteLayerVersion(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	lv, err := s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "dlv-layer"})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := s.DeleteLayerVersion(ctx, "dlv-layer", lv.Version)
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := s.DeleteLayerVersion(ctx, "dlv-layer", 999)
+		require.Error(t, err)
+	})
+}
+
+func TestListLayers(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+
+	_, err := s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer-a"})
+	require.NoError(t, err)
+
+	_, err = s.PublishLayerVersion(ctx, driver.LayerConfig{Name: "layer-b"})
+	require.NoError(t, err)
+
+	layers, err := s.ListLayers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(layers))
+}
+
+func TestPutFunctionConcurrency(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "conc-func")
+
+	t.Run("success", func(t *testing.T) {
+		err := s.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{FunctionName: "conc-func", ReservedConcurrentExecutions: 10})
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := s.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{FunctionName: "nonexistent", ReservedConcurrentExecutions: 10})
+		require.Error(t, err)
+	})
+}
+
+func TestGetFunctionConcurrency(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "gc-func")
+
+	err := s.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{FunctionName: "gc-func", ReservedConcurrentExecutions: 5})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		c, err := s.GetFunctionConcurrency(ctx, "gc-func")
+		require.NoError(t, err)
+		assert.Equal(t, 5, c.ReservedConcurrentExecutions)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := s.GetFunctionConcurrency(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteFunctionConcurrency(t *testing.T) {
+	s := newTestServerless()
+	ctx := context.Background()
+	setupFunction(t, s, "dc-func")
+
+	err := s.PutFunctionConcurrency(ctx, driver.ConcurrencyConfig{FunctionName: "dc-func", ReservedConcurrentExecutions: 5})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		err := s.DeleteFunctionConcurrency(ctx, "dc-func")
+		require.NoError(t, err)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := s.DeleteFunctionConcurrency(ctx, "nonexistent")
+		require.Error(t, err)
+	})
+}
+
+func TestServerlessWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	s := newTestServerless(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "rec-func", Runtime: "go1.x"})
+	require.NoError(t, err)
+
+	_, err = s.GetFunction(ctx, "rec-func")
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 2)
+
+	createCalls := rec.CallCountFor("serverless", "CreateFunction")
+	assert.Equal(t, 1, createCalls)
+
+	getCalls := rec.CallCountFor("serverless", "GetFunction")
+	assert.Equal(t, 1, getCalls)
+}
+
+func TestServerlessWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	s := newTestServerless(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = s.GetFunction(ctx, "nonexistent")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last)
+	assert.NotNil(t, last.Error)
+}
+
+func TestServerlessWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	s := newTestServerless(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "met-func", Runtime: "go1.x"})
+	require.NoError(t, err)
+
+	_, err = s.GetFunction(ctx, "met-func")
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 2)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 2)
+}
+
+func TestServerlessWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	s := newTestServerless(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = s.GetFunction(ctx, "nonexistent")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestServerlessWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	s := newTestServerless(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("serverless", "CreateFunction", injectedErr, inject.Always{})
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "fail-func"})
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestServerlessWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	s := newTestServerless(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("serverless", "GetFunction", injectedErr, inject.Always{})
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "inj-func", Runtime: "go1.x"})
+	require.NoError(t, err)
+
+	_, err = s.GetFunction(ctx, "inj-func")
+	require.Error(t, err)
+
+	getCalls := rec.CallsFor("serverless", "GetFunction")
+	assert.Equal(t, 1, len(getCalls))
+	assert.NotNil(t, getCalls[0].Error)
+}
+
+func TestServerlessWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	s := newTestServerless(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("serverless", "CreateFunction", injectedErr, inject.Always{})
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "test"})
+	require.Error(t, err)
+
+	inj.Remove("serverless", "CreateFunction")
+
+	_, err = s.CreateFunction(ctx, driver.FunctionConfig{Name: "test"})
+	require.NoError(t, err)
+}
+
+func TestServerlessWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	s := newTestServerless(WithLatency(latency))
+	ctx := context.Background()
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "lat-func", Runtime: "go1.x"})
+	require.NoError(t, err)
+
+	info, err := s.GetFunction(ctx, "lat-func")
+	require.NoError(t, err)
+	assert.Equal(t, "lat-func", info.Name)
+}
+
+func TestServerlessAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	s := newTestServerless(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	_, err := s.CreateFunction(ctx, driver.FunctionConfig{Name: "all-opts", Runtime: "go1.x"})
+	require.NoError(t, err)
+
+	_, err = s.GetFunction(ctx, "all-opts")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}

--- a/serverless/versions.go
+++ b/serverless/versions.go
@@ -1,0 +1,31 @@
+package serverless
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// PublishVersion publishes a new immutable version of a function.
+func (s *Serverless) PublishVersion(ctx context.Context, functionName, description string) (*driver.FunctionVersion, error) {
+	out, err := s.do(ctx, "PublishVersion", functionName, func() (any, error) {
+		return s.driver.PublishVersion(ctx, functionName, description)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.FunctionVersion), nil
+}
+
+// ListVersions returns all published versions for a function.
+func (s *Serverless) ListVersions(ctx context.Context, functionName string) ([]driver.FunctionVersion, error) {
+	out, err := s.do(ctx, "ListVersions", functionName, func() (any, error) {
+		return s.driver.ListVersions(ctx, functionName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.FunctionVersion), nil
+}

--- a/storage/driver/driver.go
+++ b/storage/driver/driver.go
@@ -1,7 +1,10 @@
 // Package driver defines the interface for storage service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // BucketInfo describes a storage bucket.
 type BucketInfo struct {
@@ -48,6 +51,53 @@ type CopySource struct {
 	Key    string
 }
 
+// PresignedURLRequest describes a presigned URL to generate.
+type PresignedURLRequest struct {
+	Bucket    string
+	Key       string
+	Method    string // "GET" or "PUT"
+	ExpiresIn time.Duration
+}
+
+// PresignedURL is a generated presigned URL.
+type PresignedURL struct {
+	URL       string
+	Method    string
+	ExpiresAt time.Time
+}
+
+// LifecycleRule defines an object lifecycle policy rule.
+type LifecycleRule struct {
+	ID                       string
+	Enabled                  bool
+	Prefix                   string
+	ExpirationDays           int
+	TransitionDays           int
+	TransitionStorageClass   string
+	AbortMultipartDays       int
+	NoncurrentExpirationDays int
+}
+
+// LifecycleConfig is a set of lifecycle rules for a bucket.
+type LifecycleConfig struct {
+	Rules []LifecycleRule
+}
+
+// MultipartUpload represents an in-progress multipart upload.
+type MultipartUpload struct {
+	UploadID  string
+	Bucket    string
+	Key       string
+	CreatedAt string
+}
+
+// UploadPart represents a part of a multipart upload.
+type UploadPart struct {
+	PartNumber int
+	ETag       string
+	Size       int64
+}
+
 // Bucket is the interface that storage provider implementations must satisfy.
 type Bucket interface {
 	CreateBucket(ctx context.Context, name string) error
@@ -60,4 +110,23 @@ type Bucket interface {
 	HeadObject(ctx context.Context, bucket, key string) (*ObjectInfo, error)
 	ListObjects(ctx context.Context, bucket string, opts ListOptions) (*ListResult, error)
 	CopyObject(ctx context.Context, dstBucket, dstKey string, src CopySource) error
+
+	// Presigned URLs
+	GeneratePresignedURL(ctx context.Context, req PresignedURLRequest) (*PresignedURL, error)
+
+	// Lifecycle policies
+	PutLifecycleConfig(ctx context.Context, bucket string, config LifecycleConfig) error
+	GetLifecycleConfig(ctx context.Context, bucket string) (*LifecycleConfig, error)
+	EvaluateLifecycle(ctx context.Context, bucket string) ([]string, error)
+
+	// Multipart uploads
+	CreateMultipartUpload(ctx context.Context, bucket, key, contentType string) (*MultipartUpload, error)
+	UploadPart(ctx context.Context, bucket, key, uploadID string, partNumber int, data []byte) (*UploadPart, error)
+	CompleteMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []UploadPart) error
+	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
+	ListMultipartUploads(ctx context.Context, bucket string) ([]MultipartUpload, error)
+
+	// Versioning
+	SetBucketVersioning(ctx context.Context, bucket string, enabled bool) error
+	GetBucketVersioning(ctx context.Context, bucket string) (bool, error)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -187,3 +187,134 @@ func (b *Bucket) CopyObject(ctx context.Context, dstBucket, dstKey string, src d
 
 	return err
 }
+
+// GeneratePresignedURL generates a presigned URL for an object.
+func (b *Bucket) GeneratePresignedURL(ctx context.Context, req driver.PresignedURLRequest) (*driver.PresignedURL, error) {
+	out, err := b.do(ctx, "GeneratePresignedURL", req, func() (any, error) {
+		return b.driver.GeneratePresignedURL(ctx, req)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PresignedURL), nil
+}
+
+// PutLifecycleConfig sets a lifecycle configuration on a bucket.
+func (b *Bucket) PutLifecycleConfig(ctx context.Context, bucket string, config driver.LifecycleConfig) error {
+	_, err := b.do(ctx, "PutLifecycleConfig", map[string]any{"bucket": bucket}, func() (any, error) {
+		return nil, b.driver.PutLifecycleConfig(ctx, bucket, config)
+	})
+
+	return err
+}
+
+// GetLifecycleConfig retrieves the lifecycle configuration for a bucket.
+func (b *Bucket) GetLifecycleConfig(ctx context.Context, bucket string) (*driver.LifecycleConfig, error) {
+	out, err := b.do(ctx, "GetLifecycleConfig", bucket, func() (any, error) {
+		return b.driver.GetLifecycleConfig(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LifecycleConfig), nil
+}
+
+// EvaluateLifecycle evaluates lifecycle rules and returns keys eligible for expiration.
+func (b *Bucket) EvaluateLifecycle(ctx context.Context, bucket string) ([]string, error) {
+	out, err := b.do(ctx, "EvaluateLifecycle", bucket, func() (any, error) {
+		return b.driver.EvaluateLifecycle(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]string), nil
+}
+
+// CreateMultipartUpload initiates a multipart upload.
+func (b *Bucket) CreateMultipartUpload(
+	ctx context.Context, bucket, key, contentType string,
+) (*driver.MultipartUpload, error) {
+	out, err := b.do(ctx, "CreateMultipartUpload", map[string]string{"bucket": bucket, "key": key}, func() (any, error) {
+		return b.driver.CreateMultipartUpload(ctx, bucket, key, contentType)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.MultipartUpload), nil
+}
+
+// UploadPart uploads a part of a multipart upload.
+func (b *Bucket) UploadPart(
+	ctx context.Context, bucket, key, uploadID string, partNumber int, data []byte,
+) (*driver.UploadPart, error) {
+	input := map[string]any{"bucket": bucket, "key": key, "uploadID": uploadID, "partNumber": partNumber}
+
+	out, err := b.do(ctx, "UploadPart", input, func() (any, error) {
+		return b.driver.UploadPart(ctx, bucket, key, uploadID, partNumber, data)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.UploadPart), nil
+}
+
+// CompleteMultipartUpload completes a multipart upload by assembling all parts.
+func (b *Bucket) CompleteMultipartUpload(
+	ctx context.Context, bucket, key, uploadID string, parts []driver.UploadPart,
+) error {
+	input := map[string]any{"bucket": bucket, "key": key, "uploadID": uploadID}
+	_, err := b.do(ctx, "CompleteMultipartUpload", input, func() (any, error) {
+		return nil, b.driver.CompleteMultipartUpload(ctx, bucket, key, uploadID, parts)
+	})
+
+	return err
+}
+
+// AbortMultipartUpload aborts a multipart upload and removes all uploaded parts.
+func (b *Bucket) AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error {
+	input := map[string]any{"bucket": bucket, "key": key, "uploadID": uploadID}
+	_, err := b.do(ctx, "AbortMultipartUpload", input, func() (any, error) {
+		return nil, b.driver.AbortMultipartUpload(ctx, bucket, key, uploadID)
+	})
+
+	return err
+}
+
+// ListMultipartUploads lists active multipart uploads for a bucket.
+func (b *Bucket) ListMultipartUploads(ctx context.Context, bucket string) ([]driver.MultipartUpload, error) {
+	out, err := b.do(ctx, "ListMultipartUploads", bucket, func() (any, error) {
+		return b.driver.ListMultipartUploads(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.MultipartUpload), nil
+}
+
+// SetBucketVersioning enables or disables versioning on a bucket.
+func (b *Bucket) SetBucketVersioning(ctx context.Context, bucket string, enabled bool) error {
+	input := map[string]any{"bucket": bucket, "enabled": enabled}
+	_, err := b.do(ctx, "SetBucketVersioning", input, func() (any, error) {
+		return nil, b.driver.SetBucketVersioning(ctx, bucket, enabled)
+	})
+
+	return err
+}
+
+// GetBucketVersioning returns whether versioning is enabled on a bucket.
+func (b *Bucket) GetBucketVersioning(ctx context.Context, bucket string) (bool, error) {
+	out, err := b.do(ctx, "GetBucketVersioning", bucket, func() (any, error) {
+		return b.driver.GetBucketVersioning(ctx, bucket)
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return out.(bool), nil
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,351 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/providers/aws/s3"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/storage/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestDriver() (driver.Bucket, *config.FakeClock) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	return s3.New(opts), fc
+}
+
+func newTestBucket(opts ...Option) (*Bucket, *config.FakeClock) {
+	d, fc := newTestDriver()
+	return NewBucket(d, opts...), fc
+}
+
+func setupBucketWithObject(t *testing.T, b *Bucket) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "test-bucket")
+	require.NoError(t, err)
+
+	err = b.PutObject(ctx, "test-bucket", "key1", []byte("value1"), "text/plain", nil)
+	require.NoError(t, err)
+}
+
+func TestNewBucket(t *testing.T) {
+	b, _ := newTestBucket()
+
+	require.NotNil(t, b)
+	require.NotNil(t, b.driver)
+}
+
+func TestCreateBucketPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		err := b.CreateBucket(ctx, "my-bucket")
+		require.NoError(t, err)
+	})
+
+	t.Run("duplicate error", func(t *testing.T) {
+		err := b.CreateBucket(ctx, "my-bucket")
+		require.Error(t, err)
+	})
+}
+
+func TestDeleteBucketPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "del-bucket")
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		delErr := b.DeleteBucket(ctx, "del-bucket")
+		require.NoError(t, delErr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		delErr := b.DeleteBucket(ctx, "nonexistent")
+		require.Error(t, delErr)
+	})
+}
+
+func TestListBucketsPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	buckets, err := b.ListBuckets(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(buckets))
+
+	err = b.CreateBucket(ctx, "a")
+	require.NoError(t, err)
+
+	err = b.CreateBucket(ctx, "b")
+	require.NoError(t, err)
+
+	buckets, err = b.ListBuckets(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(buckets))
+}
+
+func TestPutGetDeleteObjectPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	setupBucketWithObject(t, b)
+
+	t.Run("get existing object", func(t *testing.T) {
+		obj, err := b.GetObject(ctx, "test-bucket", "key1")
+		require.NoError(t, err)
+		assert.Equal(t, "key1", obj.Info.Key)
+		assert.Equal(t, string([]byte("value1")), string(obj.Data))
+	})
+
+	t.Run("delete object", func(t *testing.T) {
+		err := b.DeleteObject(ctx, "test-bucket", "key1")
+		require.NoError(t, err)
+
+		_, getErr := b.GetObject(ctx, "test-bucket", "key1")
+		require.Error(t, getErr)
+	})
+}
+
+func TestHeadObjectPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	setupBucketWithObject(t, b)
+
+	info, err := b.HeadObject(ctx, "test-bucket", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, "key1", info.Key)
+}
+
+func TestListObjectsPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	setupBucketWithObject(t, b)
+
+	result, err := b.ListObjects(ctx, "test-bucket", driver.ListOptions{})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(result.Objects), 1)
+}
+
+func TestWithRecorder(t *testing.T) {
+	rec := recorder.New()
+	b, _ := newTestBucket(WithRecorder(rec))
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "rec-bucket")
+	require.NoError(t, err)
+
+	err = b.PutObject(ctx, "rec-bucket", "k", []byte("v"), "text/plain", nil)
+	require.NoError(t, err)
+
+	_, err = b.GetObject(ctx, "rec-bucket", "k")
+	require.NoError(t, err)
+
+	totalCalls := rec.CallCount()
+	assert.GreaterOrEqual(t, totalCalls, 3)
+
+	createCalls := rec.CallCountFor("storage", "CreateBucket")
+	assert.Equal(t, 1, createCalls)
+
+	putCalls := rec.CallCountFor("storage", "PutObject")
+	assert.Equal(t, 1, putCalls)
+
+	getCalls := rec.CallCountFor("storage", "GetObject")
+	assert.Equal(t, 1, getCalls)
+}
+
+func TestWithRecorderOnError(t *testing.T) {
+	rec := recorder.New()
+	b, _ := newTestBucket(WithRecorder(rec))
+	ctx := context.Background()
+
+	_, _ = b.GetObject(ctx, "nonexistent", "k")
+
+	totalCalls := rec.CallCount()
+	assert.Equal(t, 1, totalCalls)
+
+	last := rec.LastCall()
+	require.NotNil(t, last, "expected a recorded call")
+	assert.NotNil(t, last.Error, "expected recorded call to have an error")
+}
+
+func TestWithMetrics(t *testing.T) {
+	mc := metrics.NewCollector()
+	b, _ := newTestBucket(WithMetrics(mc))
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "met-bucket")
+	require.NoError(t, err)
+
+	err = b.PutObject(ctx, "met-bucket", "k", []byte("v"), "text/plain", nil)
+	require.NoError(t, err)
+
+	_, err = b.GetObject(ctx, "met-bucket", "k")
+	require.NoError(t, err)
+
+	q := metrics.NewQuery(mc)
+
+	callsCount := q.ByName("calls_total").Count()
+	assert.GreaterOrEqual(t, callsCount, 3)
+
+	durCount := q.ByName("call_duration").Count()
+	assert.GreaterOrEqual(t, durCount, 3)
+}
+
+func TestWithMetricsOnError(t *testing.T) {
+	mc := metrics.NewCollector()
+	b, _ := newTestBucket(WithMetrics(mc))
+	ctx := context.Background()
+
+	_, _ = b.GetObject(ctx, "nonexistent", "k")
+
+	q := metrics.NewQuery(mc)
+
+	errCount := q.ByName("errors_total").Count()
+	assert.Equal(t, 1, errCount)
+}
+
+func TestWithErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	b, _ := newTestBucket(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("injected failure")
+	inj.Set("storage", "CreateBucket", injectedErr, inject.Always{})
+
+	err := b.CreateBucket(ctx, "fail-bucket")
+	require.Error(t, err)
+	assert.Equal(t, injectedErr, err)
+}
+
+func TestWithErrorInjectionRecorded(t *testing.T) {
+	rec := recorder.New()
+	inj := inject.NewInjector()
+	b, _ := newTestBucket(WithErrorInjection(inj), WithRecorder(rec))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("boom")
+	inj.Set("storage", "PutObject", injectedErr, inject.Always{})
+
+	err := b.CreateBucket(ctx, "inj-bucket")
+	require.NoError(t, err)
+
+	err = b.PutObject(ctx, "inj-bucket", "k", []byte("v"), "text/plain", nil)
+	require.Error(t, err)
+
+	putCalls := rec.CallsFor("storage", "PutObject")
+	assert.Equal(t, 1, len(putCalls))
+	assert.NotNil(t, putCalls[0].Error, "expected recorded PutObject call to have an error")
+}
+
+func TestWithErrorInjectionRemoved(t *testing.T) {
+	inj := inject.NewInjector()
+	b, _ := newTestBucket(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	injectedErr := fmt.Errorf("fail")
+	inj.Set("storage", "CreateBucket", injectedErr, inject.Always{})
+
+	err := b.CreateBucket(ctx, "test")
+	require.Error(t, err)
+
+	inj.Remove("storage", "CreateBucket")
+
+	err = b.CreateBucket(ctx, "test")
+	require.NoError(t, err)
+}
+
+func TestWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	d := s3.New(opts)
+	limiter := ratelimit.New(1, 1, fc)
+	b := NewBucket(d, WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "rl-bucket")
+	require.NoError(t, err)
+
+	err = b.DeleteBucket(ctx, "rl-bucket")
+	require.Error(t, err, "expected rate limit error on second call without time advance")
+}
+
+func TestWithLatency(t *testing.T) {
+	latency := 1 * time.Millisecond
+	b, _ := newTestBucket(WithLatency(latency))
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "lat-bucket")
+	require.NoError(t, err)
+
+	buckets, err := b.ListBuckets(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(buckets))
+}
+
+func TestAllOptionsComposed(t *testing.T) {
+	rec := recorder.New()
+	mc := metrics.NewCollector()
+	inj := inject.NewInjector()
+	latency := 1 * time.Millisecond
+
+	b, _ := newTestBucket(
+		WithRecorder(rec),
+		WithMetrics(mc),
+		WithErrorInjection(inj),
+		WithLatency(latency),
+	)
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "all-opts")
+	require.NoError(t, err)
+
+	err = b.PutObject(ctx, "all-opts", "k", []byte("v"), "text/plain", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, rec.CallCount())
+
+	q := metrics.NewQuery(mc)
+	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+func TestPortableGetObjectError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	_, err := b.GetObject(ctx, "no-bucket", "k")
+	require.Error(t, err)
+}
+
+func TestPortableDeleteObjectError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.DeleteObject(ctx, "no-bucket", "k")
+	require.Error(t, err)
+}
+
+func TestPortableHeadObjectError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	_, err := b.HeadObject(ctx, "no-bucket", "k")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

This PR completes **all 17 remaining open issues** (#33-#49) by adding 2 new cloud services, enhancing 8 existing services with real-world features, and wiring cloud-native metrics emission across all 16 services for all 3 providers (AWS, Azure, GCP).

**Before:** 14 services/provider, 42 mocks
**After:** 16 services/provider, 48 mocks, 1375 tests, all packages 90%+ coverage

---

## New Services

### Container Registry (#35, #36, #37)
| AWS | Azure | GCP |
|-----|-------|-----|
| ECR | ACR | Artifact Registry |

- Repository CRUD with image tag mutability (MUTABLE/IMMUTABLE)
- Image push/pull/delete/tag with digest tracking
- Lifecycle policies with count-based and age-based expiration evaluation
- Image vulnerability scanning (scan-on-push + manual)
- Provider-specific URIs: `dkr.ecr`, `azurecr.io`, `pkg.dev`

### Event Bus (#33, #34)
| AWS | Azure | GCP |
|-----|-------|-----|
| EventBridge | Event Grid | Eventarc |

- Event bus/topic/channel management
- Rules with JSON event pattern matching on source and detail-type
- Target routing for matched events
- Event history with max 1000 entries per bus
- AWS EventBridge includes default bus; Azure/GCP require explicit creation

---

## Enhanced Existing Services

### Storage — Presigned URLs, Lifecycle, Multipart (#38, #39, #40)
| Feature | S3 | Blob Storage | GCS |
|---------|-----|-------------|-----|
| Presigned/Signed/SAS URLs | `X-Amz-Signature` | `sv=2023-11-03&sig=` | `X-Goog-Signature` |
| Lifecycle policies | Expiration evaluation | Expiration evaluation | Expiration evaluation |
| Multipart uploads | Create/upload/complete/abort | Create/upload/complete/abort | Create/upload/complete/abort |
| Bucket versioning | Enable/disable | Enable/disable | Enable/disable |

### Database — TTL, Streams, Transactions (#41, #42, #43)
| Feature | DynamoDB | CosmosDB | Firestore |
|---------|----------|----------|-----------|
| TTL | Unix timestamp, lazy expiry on read | Container-level TTL | Document-level TTL |
| Streams/Change Feed | INSERT/MODIFY/REMOVE events | Change feed with leases | Snapshot listeners |
| View types | NEW_IMAGE, OLD_IMAGE, KEYS_ONLY, NEW_AND_OLD_IMAGES | Same | Same |
| Transactional writes | Atomic puts + deletes | Same | Same |
| Token-based pagination | Sequence number tokens | Same | Same |

### Compute — Auto-Scaling, Spot, Templates (#44, #47, #48)
| Feature | EC2 | Virtual Machines | GCE |
|---------|-----|-----------------|-----|
| Auto-scaling groups | ASG | VM Scale Sets | Managed Instance Groups |
| Scaling policies | ChangeInCapacity, ExactCapacity, PercentChange | Same | Same |
| Spot/preemptible | Spot instances (`sir-` prefix) | Spot VMs | Preemptible VMs |
| Launch templates | `lt-` prefix, auto-versioning | VM templates | Instance templates |
| Capacity reconciliation | Launch/terminate to match desired | Same | Same |

### Serverless — Versions, Aliases, Layers, Concurrency (#46)
| Feature | Lambda | Azure Functions | Cloud Functions |
|---------|--------|----------------|-----------------|
| Versions | Immutable snapshots with `$LATEST` | Deployment slots | Generation numbers |
| Aliases | Weighted routing between versions | Slot references | Traffic splits |
| Layers | Shared code packages, auto-versioning | Extensions | Buildpack layers |
| Concurrency | Reserved concurrent executions | Same | Same |

### Message Queue — Batch, Attributes, Purge (#45)
| Feature | SQS | Service Bus | Pub/Sub |
|---------|-----|------------|---------|
| Batch send (max 10) | Per-entry success/failure | Same | Same |
| Batch delete (max 10) | Per-entry success/failure | Same | Same |
| Queue attributes | Delay, retention, visibility, counts | Same | Same |
| Purge queue | Remove all messages | Same | Same |
| Enhanced receive | MaxMessages + VisibilityTimeout override | Same | Same |

### Networking — Peering, NAT, Flow Logs, Routes, ACLs (#49)
| Feature | VPC | VNet | GCP VPC |
|---------|-----|------|---------|
| VPC peering | `pcx-` IDs, CIDR overlap validation | `peering-` IDs | GCP self-links |
| NAT gateways | `nat-` IDs, auto public IP | `natgw-` IDs | Cloud NAT |
| Flow logs | `fl-` IDs, mock record generation | Azure flow logs | VPC flow logs |
| Route tables | `rtb-` IDs, default local route | `rt-` IDs | GCP routes |
| Network ACLs | `acl-` IDs, sorted rule evaluation | Azure ACLs | Firewall policies |

---

## Metrics Emission

All 16 services across all 3 providers now emit cloud-native metrics to the monitoring service. Users fetch metrics via `GetMetricData` with the same namespaces and metric names as real cloud SDKs.

| Service | AWS Namespace | Azure Namespace | GCP Namespace |
|---------|--------------|-----------------|---------------|
| Compute | `AWS/EC2` | `Microsoft.Compute/virtualMachines` | `compute.googleapis.com` |
| Storage | `AWS/S3` | `Microsoft.Storage/storageAccounts` | `storage.googleapis.com` |
| Database | `AWS/DynamoDB` | `Microsoft.DocumentDB/databaseAccounts` | `firestore.googleapis.com` |
| Serverless | `AWS/Lambda` | `Microsoft.Web/sites` | `cloudfunctions.googleapis.com` |
| Message Queue | `AWS/SQS` | `Microsoft.ServiceBus/namespaces` | `pubsub.googleapis.com` |
| Cache | `AWS/ElastiCache` | `Microsoft.Cache/redis` | `redis.googleapis.com` |
| Logging | `AWS/Logs` | `Microsoft.OperationalInsights/workspaces` | `logging.googleapis.com` |
| Notifications | `AWS/SNS` | `Microsoft.NotificationHubs/namespaces` | `fcm.googleapis.com` |
| Container Registry | `AWS/ECR` | `Microsoft.ContainerRegistry/registries` | `artifactregistry.googleapis.com` |
| Event Bus | `AWS/Events` | `Microsoft.EventGrid/topics` | `eventarc.googleapis.com` |

---

## Test Coverage

- **1,375 tests**, 0 failures
- **All 48 provider packages** at 90%+ coverage
- **All 12 portable API packages** have unit tests
- **30 integration tests** in `cloudemu_test.go` covering all features across all 3 providers
- **3 metrics emission integration tests** proving end-to-end flow

---

## Issues Resolved

### New Services
- Closes #35 — Add AWS ECR (Elastic Container Registry) service
- Closes #36 — Add Azure Container Registry (ACR) service
- Closes #37 — Add GCP Artifact Registry service
- Closes #33 — Add Azure Event Grid service
- Closes #34 — Add GCP Eventarc / Cloud Tasks service

### Storage Enhancements
- Closes #38 — Add S3 presigned URL support and bucket lifecycle policies
- Closes #39 — Add Blob Storage SAS tokens and lifecycle management
- Closes #40 — Add GCS signed URLs and object lifecycle rules

### Database Enhancements
- Closes #41 — Add DynamoDB TTL, streams, and GSI auto-projection
- Closes #42 — Add CosmosDB change feed and TTL support
- Closes #43 — Add Firestore real-time listeners and TTL support

### Compute Enhancements
- Closes #44 — Add EC2 auto-scaling and spot instance simulation
- Closes #47 — Add Virtual Machines auto-scaling and availability sets
- Closes #48 — Add GCE managed instance groups and preemptible VMs

### Serverless Enhancements
- Closes #46 — Add Lambda layers, versions, aliases, and concurrency limits

### Message Queue Enhancements
- Closes #45 — Add SQS message delay, batch operations, and long polling

### Networking Enhancements
- Closes #49 — Add VPC peering, NAT gateway, and flow logs

---

## Commits (12)

1. **add container registry service** — ECR, ACR, Artifact Registry
2. **add event bus service** — EventBridge, Event Grid, Eventarc
3. **enhance storage** — presigned URLs, lifecycle, multipart, versioning
4. **enhance databases** — TTL, streams, transactional writes
5. **enhance compute** — auto-scaling, spot/preemptible, launch templates
6. **enhance serverless** — versions, aliases, layers, concurrency
7. **enhance message queues** — batch ops, attributes, purge
8. **enhance networking** — peering, NAT, flow logs, routes, ACLs
9. **wire metrics** — all services emit to monitoring
10. **wire factories** — add new services to provider factories
11. **portable API tests** — monitoring, dns, loadbalancer, iam
12. **integration tests** — all features + metrics emission

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test -count=1 ./...` — 1,375 tests pass, 0 failures
- [x] `golangci-lint run --timeout=9m ./...` — 0 issues
- [x] All 48 provider packages at 90%+ coverage
- [x] All integration tests verify cross-provider feature parity
- [x] All metrics emission tests verify end-to-end flow