### PR TITLE
Add TTL management and atomic counters to cache service

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -178,3 +178,81 @@ func (c *Cache) FlushAll(ctx context.Context, cacheName string) error {
 	_, err := c.do(ctx, "FlushAll", cacheName, func() (any, error) { return nil, c.driver.FlushAll(ctx, cacheName) })
 	return err
 }
+
+// Expire sets a TTL on an existing key.
+func (c *Cache) Expire(ctx context.Context, cacheName, key string, ttl time.Duration) error {
+	_, err := c.do(ctx, "Expire", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return nil, c.driver.Expire(ctx, cacheName, key, ttl)
+	})
+
+	return err
+}
+
+// GetTTL returns the remaining TTL for a key. Returns -1 if the key has no TTL.
+func (c *Cache) GetTTL(ctx context.Context, cacheName, key string) (time.Duration, error) {
+	out, err := c.do(ctx, "GetTTL", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return c.driver.GetTTL(ctx, cacheName, key)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(time.Duration), nil
+}
+
+// Persist removes the TTL from a key, making it persistent.
+func (c *Cache) Persist(ctx context.Context, cacheName, key string) error {
+	_, err := c.do(ctx, "Persist", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return nil, c.driver.Persist(ctx, cacheName, key)
+	})
+
+	return err
+}
+
+// Incr atomically increments the integer value of a key by 1.
+func (c *Cache) Incr(ctx context.Context, cacheName, key string) (int64, error) {
+	out, err := c.do(ctx, "Incr", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return c.driver.Incr(ctx, cacheName, key)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(int64), nil
+}
+
+// IncrBy atomically increments the integer value of a key by delta.
+func (c *Cache) IncrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error) {
+	out, err := c.do(ctx, "IncrBy", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return c.driver.IncrBy(ctx, cacheName, key, delta)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(int64), nil
+}
+
+// Decr atomically decrements the integer value of a key by 1.
+func (c *Cache) Decr(ctx context.Context, cacheName, key string) (int64, error) {
+	out, err := c.do(ctx, "Decr", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return c.driver.Decr(ctx, cacheName, key)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(int64), nil
+}
+
+// DecrBy atomically decrements the integer value of a key by delta.
+func (c *Cache) DecrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error) {
+	out, err := c.do(ctx, "DecrBy", map[string]string{"cache": cacheName, "key": key}, func() (any, error) {
+		return c.driver.DecrBy(ctx, cacheName, key, delta)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(int64), nil
+}

--- a/cache/driver/driver.go
+++ b/cache/driver/driver.go
@@ -45,4 +45,15 @@ type Cache interface {
 	Delete(ctx context.Context, cacheName, key string) error
 	Keys(ctx context.Context, cacheName, pattern string) ([]string, error)
 	FlushAll(ctx context.Context, cacheName string) error
+
+	// TTL management
+	Expire(ctx context.Context, cacheName, key string, ttl time.Duration) error
+	GetTTL(ctx context.Context, cacheName, key string) (time.Duration, error)
+	Persist(ctx context.Context, cacheName, key string) error
+
+	// Atomic counters
+	Incr(ctx context.Context, cacheName, key string) (int64, error)
+	IncrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error)
+	Decr(ctx context.Context, cacheName, key string) (int64, error)
+	DecrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error)
 }

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -5968,3 +5968,279 @@ func TestUpdateItemWithStreams(t *testing.T) {
 		t.Errorf("expected new image val='new', got %v", modifyRec.NewImage["val"])
 	}
 }
+
+func TestCacheExpireAndPersistAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.ElastiCache.CreateCache(ctx, cachedriver.CacheConfig{Name: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.ElastiCache.Set(ctx, "c1", "k1", []byte("val"), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err := p.ElastiCache.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl != -1 {
+		t.Errorf("expected TTL -1, got %v", ttl)
+	}
+
+	if err := p.ElastiCache.Expire(ctx, "c1", "k1", 1*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err = p.ElastiCache.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl <= 0 {
+		t.Errorf("expected positive TTL, got %v", ttl)
+	}
+
+	if err := p.ElastiCache.Persist(ctx, "c1", "k1"); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err = p.ElastiCache.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl != -1 {
+		t.Errorf("expected TTL -1 after Persist, got %v", ttl)
+	}
+}
+
+func TestCacheExpireAndPersistAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	_, err := p.Cache.CreateCache(ctx, cachedriver.CacheConfig{Name: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Cache.Set(ctx, "c1", "k1", []byte("val"), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Cache.Expire(ctx, "c1", "k1", 1*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err := p.Cache.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl <= 0 {
+		t.Errorf("expected positive TTL, got %v", ttl)
+	}
+
+	if err := p.Cache.Persist(ctx, "c1", "k1"); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err = p.Cache.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl != -1 {
+		t.Errorf("expected TTL -1 after Persist, got %v", ttl)
+	}
+}
+
+func TestCacheExpireAndPersistGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	_, err := p.Memorystore.CreateCache(ctx, cachedriver.CacheConfig{Name: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Memorystore.Set(ctx, "c1", "k1", []byte("val"), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Memorystore.Expire(ctx, "c1", "k1", 1*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err := p.Memorystore.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl <= 0 {
+		t.Errorf("expected positive TTL, got %v", ttl)
+	}
+
+	if err := p.Memorystore.Persist(ctx, "c1", "k1"); err != nil {
+		t.Fatal(err)
+	}
+
+	ttl, err = p.Memorystore.GetTTL(ctx, "c1", "k1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ttl != -1 {
+		t.Errorf("expected TTL -1 after Persist, got %v", ttl)
+	}
+}
+
+func TestCacheIncrDecrAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.ElastiCache.CreateCache(ctx, cachedriver.CacheConfig{Name: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := p.ElastiCache.Incr(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 1 {
+		t.Errorf("expected 1, got %d", val)
+	}
+
+	val, err = p.ElastiCache.IncrBy(ctx, "c1", "counter", 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 10 {
+		t.Errorf("expected 10, got %d", val)
+	}
+
+	val, err = p.ElastiCache.Decr(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 9 {
+		t.Errorf("expected 9, got %d", val)
+	}
+
+	val, err = p.ElastiCache.DecrBy(ctx, "c1", "counter", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 5 {
+		t.Errorf("expected 5, got %d", val)
+	}
+
+	item, err := p.ElastiCache.Get(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(item.Value) != "5" {
+		t.Errorf("expected '5', got %q", string(item.Value))
+	}
+}
+
+func TestCacheIncrDecrAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	_, err := p.Cache.CreateCache(ctx, cachedriver.CacheConfig{Name: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := p.Cache.Incr(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 1 {
+		t.Errorf("expected 1, got %d", val)
+	}
+
+	val, err = p.Cache.IncrBy(ctx, "c1", "counter", 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 10 {
+		t.Errorf("expected 10, got %d", val)
+	}
+
+	val, err = p.Cache.Decr(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 9 {
+		t.Errorf("expected 9, got %d", val)
+	}
+
+	val, err = p.Cache.DecrBy(ctx, "c1", "counter", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 5 {
+		t.Errorf("expected 5, got %d", val)
+	}
+}
+
+func TestCacheIncrDecrGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	_, err := p.Memorystore.CreateCache(ctx, cachedriver.CacheConfig{Name: "c1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, err := p.Memorystore.Incr(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 1 {
+		t.Errorf("expected 1, got %d", val)
+	}
+
+	val, err = p.Memorystore.IncrBy(ctx, "c1", "counter", 9)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 10 {
+		t.Errorf("expected 10, got %d", val)
+	}
+
+	val, err = p.Memorystore.Decr(ctx, "c1", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 9 {
+		t.Errorf("expected 9, got %d", val)
+	}
+
+	val, err = p.Memorystore.DecrBy(ctx, "c1", "counter", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if val != 5 {
+		t.Errorf("expected 5, got %d", val)
+	}
+}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/stackshy/cloudemu/cache/driver"
@@ -280,6 +281,136 @@ func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
 	cd.items.Clear()
 
 	return nil
+}
+
+// Expire sets a TTL on an existing key.
+func (m *Mock) Expire(_ context.Context, cacheName, key string, ttl time.Duration) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	item.HasTTL = true
+	item.ExpiresAt = m.opts.Clock.Now().Add(ttl)
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// GetTTL returns the remaining TTL for a key. Returns -1 if the key has no TTL.
+func (m *Mock) GetTTL(_ context.Context, cacheName, key string) (time.Duration, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return 0, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	if !item.HasTTL {
+		return -1, nil
+	}
+
+	return item.ExpiresAt.Sub(m.opts.Clock.Now()), nil
+}
+
+// Persist removes the TTL from a key, making it persistent.
+func (m *Mock) Persist(_ context.Context, cacheName, key string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	item.HasTTL = false
+	item.ExpiresAt = time.Time{}
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// Incr atomically increments the integer value of a key by 1.
+func (m *Mock) Incr(ctx context.Context, cacheName, key string) (int64, error) {
+	return m.IncrBy(ctx, cacheName, key, 1)
+}
+
+// IncrBy atomically increments the integer value of a key by delta.
+func (m *Mock) IncrBy(_ context.Context, cacheName, key string, delta int64) (int64, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	newVal, err := applyDelta(cd, key, delta, m.opts.Clock.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	m.emitMetric("IncrCommands", 1, map[string]string{"CacheClusterId": cacheName})
+
+	return newVal, nil
+}
+
+// Decr atomically decrements the integer value of a key by 1.
+func (m *Mock) Decr(ctx context.Context, cacheName, key string) (int64, error) {
+	return m.DecrBy(ctx, cacheName, key, 1)
+}
+
+// DecrBy atomically decrements the integer value of a key by delta.
+func (m *Mock) DecrBy(_ context.Context, cacheName, key string, delta int64) (int64, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	newVal, err := applyDelta(cd, key, -delta, m.opts.Clock.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	m.emitMetric("DecrCommands", 1, map[string]string{"CacheClusterId": cacheName})
+
+	return newVal, nil
+}
+
+func applyDelta(cd *cacheData, key string, delta int64, now time.Time) (int64, error) {
+	item, ok := cd.items.Get(key)
+
+	var current int64
+
+	if ok && (!item.HasTTL || !now.After(item.ExpiresAt)) {
+		val, err := strconv.ParseInt(string(item.Value), 10, 64)
+		if err != nil {
+			return 0, errors.New(errors.InvalidArgument, "value is not an integer")
+		}
+
+		current = val
+	}
+
+	newVal := current + delta
+	newItem := cacheItem{
+		Value: []byte(strconv.FormatInt(newVal, 10)),
+	}
+
+	if ok && item.HasTTL && !now.After(item.ExpiresAt) {
+		newItem.HasTTL = true
+		newItem.ExpiresAt = item.ExpiresAt
+	}
+
+	cd.items.Set(key, newItem)
+
+	return newVal, nil
 }
 
 // matchPattern matches a key against a glob-like pattern.

--- a/providers/aws/elasticache/elasticache_test.go
+++ b/providers/aws/elasticache/elasticache_test.go
@@ -375,3 +375,160 @@ func TestMatchPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestExpire(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("val"), 0))
+
+	ttl, err := m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), ttl)
+
+	require.NoError(t, m.Expire(ctx, "c1", "k1", 1*time.Hour))
+
+	ttl, err = m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.True(t, ttl > 0 && ttl <= 1*time.Hour)
+
+	fc.Advance(2 * time.Hour)
+
+	_, err = m.Get(ctx, "c1", "k1")
+	require.Error(t, err)
+}
+
+func TestExpireKeyNotFound(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	err := m.Expire(ctx, "c1", "missing", 1*time.Hour)
+	require.Error(t, err)
+}
+
+func TestGetTTLKeyNotFound(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	_, err := m.GetTTL(ctx, "c1", "missing")
+	require.Error(t, err)
+}
+
+func TestPersist(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("val"), 1*time.Hour))
+
+	require.NoError(t, m.Persist(ctx, "c1", "k1"))
+
+	ttl, err := m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), ttl)
+
+	fc.Advance(2 * time.Hour)
+
+	item, err := m.Get(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("val"), item.Value)
+}
+
+func TestPersistKeyNotFound(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	err := m.Persist(ctx, "c1", "missing")
+	require.Error(t, err)
+}
+
+func TestIncr(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	val, err := m.Incr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+
+	val, err = m.Incr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), val)
+}
+
+func TestIncrBy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("10"), 0))
+
+	val, err := m.IncrBy(ctx, "c1", "counter", 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), val)
+}
+
+func TestDecr(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("10"), 0))
+
+	val, err := m.Decr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), val)
+}
+
+func TestDecrBy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("20"), 0))
+
+	val, err := m.DecrBy(ctx, "c1", "counter", 7)
+	require.NoError(t, err)
+	assert.Equal(t, int64(13), val)
+}
+
+func TestIncrNonInteger(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("not-a-number"), 0))
+
+	_, err := m.Incr(ctx, "c1", "k1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an integer")
+}
+
+func TestIncrPreservesTTL(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("5"), 1*time.Hour))
+
+	val, err := m.IncrBy(ctx, "c1", "counter", 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), val)
+
+	ttl, err := m.GetTTL(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.True(t, ttl > 0)
+}
+
+func TestIncrCacheNotFound(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.Incr(ctx, "nonexistent", "k1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/stackshy/cloudemu/cache/driver"
@@ -287,6 +288,136 @@ func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
 	cd.items.Clear()
 
 	return nil
+}
+
+// Expire sets a TTL on an existing key.
+func (m *Mock) Expire(_ context.Context, cacheName, key string, ttl time.Duration) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	item.HasTTL = true
+	item.ExpiresAt = m.opts.Clock.Now().Add(ttl)
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// GetTTL returns the remaining TTL for a key. Returns -1 if the key has no TTL.
+func (m *Mock) GetTTL(_ context.Context, cacheName, key string) (time.Duration, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return 0, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	if !item.HasTTL {
+		return -1, nil
+	}
+
+	return item.ExpiresAt.Sub(m.opts.Clock.Now()), nil
+}
+
+// Persist removes the TTL from a key, making it persistent.
+func (m *Mock) Persist(_ context.Context, cacheName, key string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	item.HasTTL = false
+	item.ExpiresAt = time.Time{}
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// Incr atomically increments the integer value of a key by 1.
+func (m *Mock) Incr(ctx context.Context, cacheName, key string) (int64, error) {
+	return m.IncrBy(ctx, cacheName, key, 1)
+}
+
+// IncrBy atomically increments the integer value of a key by delta.
+func (m *Mock) IncrBy(_ context.Context, cacheName, key string, delta int64) (int64, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	newVal, err := applyDelta(cd, key, delta, m.opts.Clock.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	m.emitMetric(cacheName, map[string]float64{"TotalCommandsProcessed": 1})
+
+	return newVal, nil
+}
+
+// Decr atomically decrements the integer value of a key by 1.
+func (m *Mock) Decr(ctx context.Context, cacheName, key string) (int64, error) {
+	return m.DecrBy(ctx, cacheName, key, 1)
+}
+
+// DecrBy atomically decrements the integer value of a key by delta.
+func (m *Mock) DecrBy(_ context.Context, cacheName, key string, delta int64) (int64, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	newVal, err := applyDelta(cd, key, -delta, m.opts.Clock.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	m.emitMetric(cacheName, map[string]float64{"TotalCommandsProcessed": 1})
+
+	return newVal, nil
+}
+
+func applyDelta(cd *cacheData, key string, delta int64, now time.Time) (int64, error) {
+	item, ok := cd.items.Get(key)
+
+	var current int64
+
+	if ok && (!item.HasTTL || !now.After(item.ExpiresAt)) {
+		val, err := strconv.ParseInt(string(item.Value), 10, 64)
+		if err != nil {
+			return 0, errors.New(errors.InvalidArgument, "value is not an integer")
+		}
+
+		current = val
+	}
+
+	newVal := current + delta
+	newItem := cacheItem{
+		Value: []byte(strconv.FormatInt(newVal, 10)),
+	}
+
+	if ok && item.HasTTL && !now.After(item.ExpiresAt) {
+		newItem.HasTTL = true
+		newItem.ExpiresAt = item.ExpiresAt
+	}
+
+	cd.items.Set(key, newItem)
+
+	return newVal, nil
 }
 
 // matchPattern matches a key against a glob-like pattern.

--- a/providers/azure/azurecache/azurecache_test.go
+++ b/providers/azure/azurecache/azurecache_test.go
@@ -375,3 +375,123 @@ func TestMatchPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestExpire(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("val"), 0))
+
+	ttl, err := m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), ttl)
+
+	require.NoError(t, m.Expire(ctx, "c1", "k1", 1*time.Hour))
+
+	ttl, err = m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.True(t, ttl > 0 && ttl <= 1*time.Hour)
+
+	fc.Advance(2 * time.Hour)
+
+	_, err = m.Get(ctx, "c1", "k1")
+	require.Error(t, err)
+}
+
+func TestPersist(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("val"), 1*time.Hour))
+	require.NoError(t, m.Persist(ctx, "c1", "k1"))
+
+	ttl, err := m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), ttl)
+
+	fc.Advance(2 * time.Hour)
+
+	item, err := m.Get(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("val"), item.Value)
+}
+
+func TestIncr(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	val, err := m.Incr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+
+	val, err = m.Incr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), val)
+}
+
+func TestIncrBy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("10"), 0))
+
+	val, err := m.IncrBy(ctx, "c1", "counter", 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), val)
+}
+
+func TestDecr(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("10"), 0))
+
+	val, err := m.Decr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), val)
+}
+
+func TestDecrBy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("20"), 0))
+
+	val, err := m.DecrBy(ctx, "c1", "counter", 7)
+	require.NoError(t, err)
+	assert.Equal(t, int64(13), val)
+}
+
+func TestIncrNonInteger(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("not-a-number"), 0))
+
+	_, err := m.Incr(ctx, "c1", "k1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an integer")
+}
+
+func TestIncrPreservesTTL(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("5"), 1*time.Hour))
+
+	val, err := m.IncrBy(ctx, "c1", "counter", 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), val)
+
+	ttl, err := m.GetTTL(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.True(t, ttl > 0)
+}

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/stackshy/cloudemu/cache/driver"
@@ -290,6 +291,136 @@ func (m *Mock) FlushAll(_ context.Context, cacheName string) error {
 	cd.items.Clear()
 
 	return nil
+}
+
+// Expire sets a TTL on an existing key.
+func (m *Mock) Expire(_ context.Context, cacheName, key string, ttl time.Duration) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	item.HasTTL = true
+	item.ExpiresAt = m.opts.Clock.Now().Add(ttl)
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// GetTTL returns the remaining TTL for a key. Returns -1 if the key has no TTL.
+func (m *Mock) GetTTL(_ context.Context, cacheName, key string) (time.Duration, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return 0, errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	if !item.HasTTL {
+		return -1, nil
+	}
+
+	return item.ExpiresAt.Sub(m.opts.Clock.Now()), nil
+}
+
+// Persist removes the TTL from a key, making it persistent.
+func (m *Mock) Persist(_ context.Context, cacheName, key string) error {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	item, ok := cd.items.Get(key)
+	if !ok || (item.HasTTL && m.opts.Clock.Now().After(item.ExpiresAt)) {
+		return errors.Newf(errors.NotFound, "key %q not found in cache %q", key, cacheName)
+	}
+
+	item.HasTTL = false
+	item.ExpiresAt = time.Time{}
+	cd.items.Set(key, item)
+
+	return nil
+}
+
+// Incr atomically increments the integer value of a key by 1.
+func (m *Mock) Incr(ctx context.Context, cacheName, key string) (int64, error) {
+	return m.IncrBy(ctx, cacheName, key, 1)
+}
+
+// IncrBy atomically increments the integer value of a key by delta.
+func (m *Mock) IncrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	newVal, err := applyDelta(cd, key, delta, m.opts.Clock.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	m.emitMetric(ctx, "commands/total", 1, map[string]string{"instance_id": cacheName})
+
+	return newVal, nil
+}
+
+// Decr atomically decrements the integer value of a key by 1.
+func (m *Mock) Decr(ctx context.Context, cacheName, key string) (int64, error) {
+	return m.DecrBy(ctx, cacheName, key, 1)
+}
+
+// DecrBy atomically decrements the integer value of a key by delta.
+func (m *Mock) DecrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error) {
+	cd, ok := m.caches.Get(cacheName)
+	if !ok {
+		return 0, errors.Newf(errors.NotFound, "cache %q not found", cacheName)
+	}
+
+	newVal, err := applyDelta(cd, key, -delta, m.opts.Clock.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	m.emitMetric(ctx, "commands/total", 1, map[string]string{"instance_id": cacheName})
+
+	return newVal, nil
+}
+
+func applyDelta(cd *cacheData, key string, delta int64, now time.Time) (int64, error) {
+	item, ok := cd.items.Get(key)
+
+	var current int64
+
+	if ok && (!item.HasTTL || !now.After(item.ExpiresAt)) {
+		val, err := strconv.ParseInt(string(item.Value), 10, 64)
+		if err != nil {
+			return 0, errors.New(errors.InvalidArgument, "value is not an integer")
+		}
+
+		current = val
+	}
+
+	newVal := current + delta
+	newItem := cacheItem{
+		Value: []byte(strconv.FormatInt(newVal, 10)),
+	}
+
+	if ok && item.HasTTL && !now.After(item.ExpiresAt) {
+		newItem.HasTTL = true
+		newItem.ExpiresAt = item.ExpiresAt
+	}
+
+	cd.items.Set(key, newItem)
+
+	return newVal, nil
 }
 
 // matchPattern matches a key against a glob-like pattern.

--- a/providers/gcp/memorystore/memorystore_test.go
+++ b/providers/gcp/memorystore/memorystore_test.go
@@ -390,3 +390,123 @@ func TestMatchPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestExpire(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("val"), 0))
+
+	ttl, err := m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), ttl)
+
+	require.NoError(t, m.Expire(ctx, "c1", "k1", 1*time.Hour))
+
+	ttl, err = m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.True(t, ttl > 0 && ttl <= 1*time.Hour)
+
+	fc.Advance(2 * time.Hour)
+
+	_, err = m.Get(ctx, "c1", "k1")
+	require.Error(t, err)
+}
+
+func TestPersist(t *testing.T) {
+	m, fc := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("val"), 1*time.Hour))
+	require.NoError(t, m.Persist(ctx, "c1", "k1"))
+
+	ttl, err := m.GetTTL(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(-1), ttl)
+
+	fc.Advance(2 * time.Hour)
+
+	item, err := m.Get(ctx, "c1", "k1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("val"), item.Value)
+}
+
+func TestIncr(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	val, err := m.Incr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+
+	val, err = m.Incr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), val)
+}
+
+func TestIncrBy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("10"), 0))
+
+	val, err := m.IncrBy(ctx, "c1", "counter", 5)
+	require.NoError(t, err)
+	assert.Equal(t, int64(15), val)
+}
+
+func TestDecr(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("10"), 0))
+
+	val, err := m.Decr(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(9), val)
+}
+
+func TestDecrBy(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("20"), 0))
+
+	val, err := m.DecrBy(ctx, "c1", "counter", 7)
+	require.NoError(t, err)
+	assert.Equal(t, int64(13), val)
+}
+
+func TestIncrNonInteger(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "k1", []byte("not-a-number"), 0))
+
+	_, err := m.Incr(ctx, "c1", "k1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not an integer")
+}
+
+func TestIncrPreservesTTL(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+	createTestCache(t, m, "c1")
+
+	require.NoError(t, m.Set(ctx, "c1", "counter", []byte("5"), 1*time.Hour))
+
+	val, err := m.IncrBy(ctx, "c1", "counter", 3)
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), val)
+
+	ttl, err := m.GetTTL(ctx, "c1", "counter")
+	require.NoError(t, err)
+	assert.True(t, ttl > 0)
+}


### PR DESCRIPTION
## Summary

- Adds 7 new methods to cache driver interface: `Expire`, `GetTTL`, `Persist`, `Incr`, `IncrBy`, `Decr`, `DecrBy`
- Implements across all 3 providers: AWS ElastiCache, Azure Cache for Redis, GCP Memorystore
- Wires through portable API layer with metrics, recording, rate limiting, and error injection
- `Incr`/`Decr` on non-existent keys start from 0 (Redis behavior)
- `Incr`/`Decr` preserve existing TTL on the key
- `GetTTL` returns -1 for keys with no TTL (Redis behavior)
- Emits provider-native metrics for counter operations

Closes #64

## Test plan

### Unit tests (per provider - 8-12 tests each)
- [x] `TestExpire` — set TTL on existing key, verify via GetTTL, verify expiry
- [x] `TestExpireKeyNotFound` — returns error for missing key
- [x] `TestPersist` — remove TTL, verify key survives past original expiry
- [x] `TestPersistKeyNotFound` — returns error for missing key
- [x] `TestIncr` — increment from 0, increment again
- [x] `TestIncrBy` — increment by arbitrary delta
- [x] `TestDecr` — decrement existing value
- [x] `TestDecrBy` — decrement by arbitrary delta
- [x] `TestIncrNonInteger` — returns error for non-integer values
- [x] `TestIncrPreservesTTL` — TTL preserved after increment
- [x] `TestIncrCacheNotFound` — returns error for missing cache (AWS)

### Integration tests (cloudemu_test.go)
- [x] `TestCacheExpireAndPersistAWS` / `Azure` / `GCP`
- [x] `TestCacheIncrDecrAWS` / `Azure` / `GCP`

### Verification
- [x] Linter: 0 issues (`golangci-lint run --timeout=9m ./...`)
- [x] Full test suite: all passing (`go test ./...`)