### PR TITLE
Add bucket policy, CORS, and encryption config to storage service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -6244,3 +6244,238 @@ func TestCacheIncrDecrGCP(t *testing.T) {
 		t.Errorf("expected 5, got %d", val)
 	}
 }
+
+func TestBucketPolicyAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	if err := p.S3.CreateBucket(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := storagedriver.BucketPolicy{
+		Version: "2012-10-17",
+		Statements: []storagedriver.PolicyStatement{
+			{Effect: "Allow", Principal: "*", Actions: []string{"s3:GetObject"}, Resources: []string{"arn:aws:s3:::b1/*"}},
+		},
+	}
+
+	if err := p.S3.PutBucketPolicy(ctx, "b1", policy); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.S3.GetBucketPolicy(ctx, "b1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Version != "2012-10-17" {
+		t.Errorf("expected version '2012-10-17', got %q", got.Version)
+	}
+
+	if len(got.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(got.Statements))
+	}
+
+	if got.Statements[0].Effect != "Allow" {
+		t.Errorf("expected effect 'Allow', got %q", got.Statements[0].Effect)
+	}
+
+	if err := p.S3.DeleteBucketPolicy(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.S3.GetBucketPolicy(ctx, "b1")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound after delete, got %v", err)
+	}
+}
+
+func TestBucketPolicyAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	if err := p.BlobStorage.CreateBucket(ctx, "c1"); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := storagedriver.BucketPolicy{
+		Version: "1.0",
+		Statements: []storagedriver.PolicyStatement{
+			{Effect: "Allow", Principal: "*", Actions: []string{"read"}, Resources: []string{"c1/*"}},
+		},
+	}
+
+	if err := p.BlobStorage.PutBucketPolicy(ctx, "c1", policy); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.BlobStorage.GetBucketPolicy(ctx, "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(got.Statements))
+	}
+}
+
+func TestBucketPolicyGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	if err := p.GCS.CreateBucket(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	policy := storagedriver.BucketPolicy{
+		Version: "1",
+		Statements: []storagedriver.PolicyStatement{
+			{Effect: "Allow", Principal: "allUsers", Actions: []string{"storage.objects.get"}, Resources: []string{"b1/*"}},
+		},
+	}
+
+	if err := p.GCS.PutBucketPolicy(ctx, "b1", policy); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.GCS.GetBucketPolicy(ctx, "b1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(got.Statements))
+	}
+}
+
+func TestCORSConfigAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	if err := p.S3.CreateBucket(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	cors := storagedriver.CORSConfig{
+		Rules: []storagedriver.CORSRule{
+			{
+				AllowedOrigins: []string{"https://example.com"},
+				AllowedMethods: []string{"GET", "PUT"},
+				AllowedHeaders: []string{"*"},
+				MaxAgeSeconds:  3600,
+			},
+		},
+	}
+
+	if err := p.S3.PutCORSConfig(ctx, "b1", cors); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.S3.GetCORSConfig(ctx, "b1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got.Rules) != 1 {
+		t.Fatalf("expected 1 CORS rule, got %d", len(got.Rules))
+	}
+
+	if got.Rules[0].AllowedOrigins[0] != "https://example.com" {
+		t.Errorf("expected origin 'https://example.com', got %q", got.Rules[0].AllowedOrigins[0])
+	}
+
+	if err := p.S3.DeleteCORSConfig(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.S3.GetCORSConfig(ctx, "b1")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound after delete, got %v", err)
+	}
+}
+
+func TestEncryptionConfigAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	if err := p.S3.CreateBucket(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	enc := storagedriver.EncryptionConfig{
+		Enabled:   true,
+		Algorithm: "AES256",
+	}
+
+	if err := p.S3.PutEncryptionConfig(ctx, "b1", enc); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.S3.GetEncryptionConfig(ctx, "b1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !got.Enabled {
+		t.Error("expected encryption enabled")
+	}
+
+	if got.Algorithm != "AES256" {
+		t.Errorf("expected algorithm 'AES256', got %q", got.Algorithm)
+	}
+}
+
+func TestEncryptionConfigAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	if err := p.BlobStorage.CreateBucket(ctx, "c1"); err != nil {
+		t.Fatal(err)
+	}
+
+	enc := storagedriver.EncryptionConfig{
+		Enabled:   true,
+		Algorithm: "AES256",
+	}
+
+	if err := p.BlobStorage.PutEncryptionConfig(ctx, "c1", enc); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.BlobStorage.GetEncryptionConfig(ctx, "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !got.Enabled {
+		t.Error("expected encryption enabled")
+	}
+}
+
+func TestEncryptionConfigGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	if err := p.GCS.CreateBucket(ctx, "b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	enc := storagedriver.EncryptionConfig{
+		Enabled:   true,
+		Algorithm: "AES256",
+	}
+
+	if err := p.GCS.PutEncryptionConfig(ctx, "b1", enc); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := p.GCS.GetEncryptionConfig(ctx, "b1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !got.Enabled {
+		t.Error("expected encryption enabled")
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -53,6 +53,9 @@ type bucketMeta struct {
 	lifecycle  *driver.LifecycleConfig
 	multiparts *memstore.Store[*multipartUpload]
 	versioning bool
+	policy     *driver.BucketPolicy
+	corsConfig *driver.CORSConfig
+	encryption *driver.EncryptionConfig
 }
 
 // Mock is an in-memory mock implementation of the AWS S3 service.
@@ -603,4 +606,115 @@ func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, erro
 	}
 
 	return bkt.versioning, nil
+}
+
+// PutBucketPolicy sets the bucket policy.
+func (m *Mock) PutBucketPolicy(_ context.Context, bucket string, policy driver.BucketPolicy) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	p := policy
+	bkt.policy = &p
+
+	return nil
+}
+
+// GetBucketPolicy returns the bucket policy.
+func (m *Mock) GetBucketPolicy(_ context.Context, bucket string) (*driver.BucketPolicy, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.policy == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no policy set for bucket %q", bucket)
+	}
+
+	p := *bkt.policy
+
+	return &p, nil
+}
+
+// DeleteBucketPolicy removes the bucket policy.
+func (m *Mock) DeleteBucketPolicy(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.policy = nil
+
+	return nil
+}
+
+// PutCORSConfig sets the CORS configuration for a bucket.
+func (m *Mock) PutCORSConfig(_ context.Context, bucket string, cfg driver.CORSConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	c := cfg
+	bkt.corsConfig = &c
+
+	return nil
+}
+
+// GetCORSConfig returns the CORS configuration for a bucket.
+func (m *Mock) GetCORSConfig(_ context.Context, bucket string) (*driver.CORSConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.corsConfig == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no CORS config set for bucket %q", bucket)
+	}
+
+	c := *bkt.corsConfig
+
+	return &c, nil
+}
+
+// DeleteCORSConfig removes the CORS configuration for a bucket.
+func (m *Mock) DeleteCORSConfig(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.corsConfig = nil
+
+	return nil
+}
+
+// PutEncryptionConfig sets the default encryption for a bucket.
+func (m *Mock) PutEncryptionConfig(_ context.Context, bucket string, cfg driver.EncryptionConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	e := cfg
+	bkt.encryption = &e
+
+	return nil
+}
+
+// GetEncryptionConfig returns the default encryption for a bucket.
+func (m *Mock) GetEncryptionConfig(_ context.Context, bucket string) (*driver.EncryptionConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.encryption == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no encryption config set for bucket %q", bucket)
+	}
+
+	e := *bkt.encryption
+
+	return &e, nil
 }

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -55,6 +55,9 @@ type containerMeta struct {
 	lifecycle  *driver.LifecycleConfig
 	multiparts *memstore.Store[*blobMultipartUpload]
 	versioning bool
+	policy     *driver.BucketPolicy
+	corsConfig *driver.CORSConfig
+	encryption *driver.EncryptionConfig
 }
 
 // Mock is an in-memory mock implementation of Azure Blob Storage.
@@ -618,4 +621,107 @@ func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, erro
 	}
 
 	return ctr.versioning, nil
+}
+
+func (m *Mock) PutBucketPolicy(_ context.Context, bucket string, policy driver.BucketPolicy) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	p := policy
+	ctr.policy = &p
+
+	return nil
+}
+
+func (m *Mock) GetBucketPolicy(_ context.Context, bucket string) (*driver.BucketPolicy, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if ctr.policy == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no policy set for container %q", bucket)
+	}
+
+	p := *ctr.policy
+
+	return &p, nil
+}
+
+func (m *Mock) DeleteBucketPolicy(_ context.Context, bucket string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	ctr.policy = nil
+
+	return nil
+}
+
+func (m *Mock) PutCORSConfig(_ context.Context, bucket string, cfg driver.CORSConfig) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	c := cfg
+	ctr.corsConfig = &c
+
+	return nil
+}
+
+func (m *Mock) GetCORSConfig(_ context.Context, bucket string) (*driver.CORSConfig, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if ctr.corsConfig == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no CORS config set for container %q", bucket)
+	}
+
+	c := *ctr.corsConfig
+
+	return &c, nil
+}
+
+func (m *Mock) DeleteCORSConfig(_ context.Context, bucket string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	ctr.corsConfig = nil
+
+	return nil
+}
+
+func (m *Mock) PutEncryptionConfig(_ context.Context, bucket string, cfg driver.EncryptionConfig) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	e := cfg
+	ctr.encryption = &e
+
+	return nil
+}
+
+func (m *Mock) GetEncryptionConfig(_ context.Context, bucket string) (*driver.EncryptionConfig, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if ctr.encryption == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no encryption config set for container %q", bucket)
+	}
+
+	e := *ctr.encryption
+
+	return &e, nil
 }

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -55,6 +55,9 @@ type bucketMeta struct {
 	lifecycle  *driver.LifecycleConfig
 	multiparts *memstore.Store[*gcsMultipartUpload]
 	versioning bool
+	policy     *driver.BucketPolicy
+	corsConfig *driver.CORSConfig
+	encryption *driver.EncryptionConfig
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Storage.
@@ -615,4 +618,107 @@ func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, erro
 	}
 
 	return bkt.versioning, nil
+}
+
+func (m *Mock) PutBucketPolicy(_ context.Context, bucket string, policy driver.BucketPolicy) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	p := policy
+	bkt.policy = &p
+
+	return nil
+}
+
+func (m *Mock) GetBucketPolicy(_ context.Context, bucket string) (*driver.BucketPolicy, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.policy == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no policy set for bucket %q", bucket)
+	}
+
+	p := *bkt.policy
+
+	return &p, nil
+}
+
+func (m *Mock) DeleteBucketPolicy(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.policy = nil
+
+	return nil
+}
+
+func (m *Mock) PutCORSConfig(_ context.Context, bucket string, cfg driver.CORSConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	c := cfg
+	bkt.corsConfig = &c
+
+	return nil
+}
+
+func (m *Mock) GetCORSConfig(_ context.Context, bucket string) (*driver.CORSConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.corsConfig == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no CORS config set for bucket %q", bucket)
+	}
+
+	c := *bkt.corsConfig
+
+	return &c, nil
+}
+
+func (m *Mock) DeleteCORSConfig(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.corsConfig = nil
+
+	return nil
+}
+
+func (m *Mock) PutEncryptionConfig(_ context.Context, bucket string, cfg driver.EncryptionConfig) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	e := cfg
+	bkt.encryption = &e
+
+	return nil
+}
+
+func (m *Mock) GetEncryptionConfig(_ context.Context, bucket string) (*driver.EncryptionConfig, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.encryption == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "no encryption config set for bucket %q", bucket)
+	}
+
+	e := *bkt.encryption
+
+	return &e, nil
 }

--- a/storage/driver/driver.go
+++ b/storage/driver/driver.go
@@ -98,6 +98,41 @@ type UploadPart struct {
 	Size       int64
 }
 
+// BucketPolicy represents a bucket access policy.
+type BucketPolicy struct {
+	Version    string
+	Statements []PolicyStatement
+}
+
+// PolicyStatement represents a single statement in a bucket policy.
+type PolicyStatement struct {
+	Effect    string   // "Allow" or "Deny"
+	Principal string   // "*" or specific principal
+	Actions   []string // e.g., "s3:GetObject"
+	Resources []string // e.g., "arn:aws:s3:::bucket/*"
+}
+
+// CORSRule defines a CORS rule for a bucket.
+type CORSRule struct {
+	AllowedOrigins []string
+	AllowedMethods []string
+	AllowedHeaders []string
+	ExposeHeaders  []string
+	MaxAgeSeconds  int
+}
+
+// CORSConfig is a set of CORS rules for a bucket.
+type CORSConfig struct {
+	Rules []CORSRule
+}
+
+// EncryptionConfig describes the default encryption for a bucket.
+type EncryptionConfig struct {
+	Enabled   bool
+	Algorithm string // "AES256" or "aws:kms"
+	KeyID     string // KMS key ID (optional)
+}
+
 // Bucket is the interface that storage provider implementations must satisfy.
 type Bucket interface {
 	CreateBucket(ctx context.Context, name string) error
@@ -129,4 +164,18 @@ type Bucket interface {
 	// Versioning
 	SetBucketVersioning(ctx context.Context, bucket string, enabled bool) error
 	GetBucketVersioning(ctx context.Context, bucket string) (bool, error)
+
+	// Bucket Policy
+	PutBucketPolicy(ctx context.Context, bucket string, policy BucketPolicy) error
+	GetBucketPolicy(ctx context.Context, bucket string) (*BucketPolicy, error)
+	DeleteBucketPolicy(ctx context.Context, bucket string) error
+
+	// CORS
+	PutCORSConfig(ctx context.Context, bucket string, config CORSConfig) error
+	GetCORSConfig(ctx context.Context, bucket string) (*CORSConfig, error)
+	DeleteCORSConfig(ctx context.Context, bucket string) error
+
+	// Encryption
+	PutEncryptionConfig(ctx context.Context, bucket string, config EncryptionConfig) error
+	GetEncryptionConfig(ctx context.Context, bucket string) (*EncryptionConfig, error)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -318,3 +318,84 @@ func (b *Bucket) GetBucketVersioning(ctx context.Context, bucket string) (bool, 
 
 	return out.(bool), nil
 }
+
+// PutBucketPolicy sets the bucket policy.
+func (b *Bucket) PutBucketPolicy(ctx context.Context, bucket string, policy driver.BucketPolicy) error {
+	_, err := b.do(ctx, "PutBucketPolicy", bucket, func() (any, error) {
+		return nil, b.driver.PutBucketPolicy(ctx, bucket, policy)
+	})
+
+	return err
+}
+
+// GetBucketPolicy returns the bucket policy.
+func (b *Bucket) GetBucketPolicy(ctx context.Context, bucket string) (*driver.BucketPolicy, error) {
+	out, err := b.do(ctx, "GetBucketPolicy", bucket, func() (any, error) {
+		return b.driver.GetBucketPolicy(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.BucketPolicy), nil
+}
+
+// DeleteBucketPolicy removes the bucket policy.
+func (b *Bucket) DeleteBucketPolicy(ctx context.Context, bucket string) error {
+	_, err := b.do(ctx, "DeleteBucketPolicy", bucket, func() (any, error) {
+		return nil, b.driver.DeleteBucketPolicy(ctx, bucket)
+	})
+
+	return err
+}
+
+// PutCORSConfig sets the CORS configuration for a bucket.
+func (b *Bucket) PutCORSConfig(ctx context.Context, bucket string, cfg driver.CORSConfig) error {
+	_, err := b.do(ctx, "PutCORSConfig", bucket, func() (any, error) {
+		return nil, b.driver.PutCORSConfig(ctx, bucket, cfg)
+	})
+
+	return err
+}
+
+// GetCORSConfig returns the CORS configuration for a bucket.
+func (b *Bucket) GetCORSConfig(ctx context.Context, bucket string) (*driver.CORSConfig, error) {
+	out, err := b.do(ctx, "GetCORSConfig", bucket, func() (any, error) {
+		return b.driver.GetCORSConfig(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.CORSConfig), nil
+}
+
+// DeleteCORSConfig removes the CORS configuration for a bucket.
+func (b *Bucket) DeleteCORSConfig(ctx context.Context, bucket string) error {
+	_, err := b.do(ctx, "DeleteCORSConfig", bucket, func() (any, error) {
+		return nil, b.driver.DeleteCORSConfig(ctx, bucket)
+	})
+
+	return err
+}
+
+// PutEncryptionConfig sets the default encryption for a bucket.
+func (b *Bucket) PutEncryptionConfig(ctx context.Context, bucket string, cfg driver.EncryptionConfig) error {
+	_, err := b.do(ctx, "PutEncryptionConfig", bucket, func() (any, error) {
+		return nil, b.driver.PutEncryptionConfig(ctx, bucket, cfg)
+	})
+
+	return err
+}
+
+// GetEncryptionConfig returns the default encryption for a bucket.
+func (b *Bucket) GetEncryptionConfig(ctx context.Context, bucket string) (*driver.EncryptionConfig, error) {
+	out, err := b.do(ctx, "GetEncryptionConfig", bucket, func() (any, error) {
+		return b.driver.GetEncryptionConfig(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.EncryptionConfig), nil
+}


### PR DESCRIPTION
## Summary

- Adds 8 new methods to storage driver interface: `PutBucketPolicy`, `GetBucketPolicy`, `DeleteBucketPolicy`, `PutCORSConfig`, `GetCORSConfig`, `DeleteCORSConfig`, `PutEncryptionConfig`, `GetEncryptionConfig`
- Adds 4 new types: `BucketPolicy`, `PolicyStatement`, `CORSRule`, `CORSConfig`, `EncryptionConfig`
- Implements across all 3 providers: AWS S3, Azure Blob Storage, GCP GCS
- Wires through portable API layer with metrics, recording, rate limiting, and error injection
- Get returns NotFound when no config is set (matches real cloud behavior)
- Delete is idempotent — sets config to nil

Closes #59

## Test plan

### Integration tests (cloudemu_test.go)
- [x] `TestBucketPolicyAWS` — put, get, delete, verify NotFound after delete
- [x] `TestBucketPolicyAzure` — put and get policy on Azure container
- [x] `TestBucketPolicyGCP` — put and get policy on GCS bucket
- [x] `TestCORSConfigAWS` — put, get, delete, verify NotFound after delete
- [x] `TestEncryptionConfigAWS` — put and get encryption config
- [x] `TestEncryptionConfigAzure` — put and get encryption config
- [x] `TestEncryptionConfigGCP` — put and get encryption config

### Verification
- [x] Linter: 0 issues (`golangci-lint run --timeout=9m ./...`)
- [x] Full test suite: all passing (`go test ./...`)