### PR TITLE
Add listener rules, modify listener, and LB attributes to load balancer service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stackshy/cloudemu/storage"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+
 	cachedriver "github.com/stackshy/cloudemu/cache/driver"
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
@@ -6477,5 +6479,307 @@ func TestEncryptionConfigGCP(t *testing.T) {
 
 	if !got.Enabled {
 		t.Error("expected encryption enabled")
+	}
+}
+
+func TestListenerRulesAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	lb, err := p.ELB.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+		Name: "test-lb", Type: "application", Scheme: "internet-facing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tg, err := p.ELB.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{
+		Name: "test-tg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	li, err := p.ELB.CreateListener(ctx, lbdriver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rules with path conditions
+	rule1, err := p.ELB.CreateRule(ctx, lbdriver.RuleConfig{
+		ListenerARN: li.ARN,
+		Priority:    10,
+		Conditions:  []lbdriver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Actions:     []lbdriver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rule1.ARN == "" {
+		t.Error("expected non-empty rule ARN")
+	}
+
+	if rule1.Priority != 10 {
+		t.Errorf("expected priority 10, got %d", rule1.Priority)
+	}
+
+	_, err = p.ELB.CreateRule(ctx, lbdriver.RuleConfig{
+		ListenerARN: li.ARN,
+		Priority:    20,
+		Conditions:  []lbdriver.RuleCondition{{Field: "host-header", Values: []string{"example.com"}}},
+		Actions:     []lbdriver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Describe rules
+	rules, err := p.ELB.DescribeRules(ctx, li.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) != 2 {
+		t.Errorf("expected 2 rules, got %d", len(rules))
+	}
+
+	// Delete a rule
+	if err := p.ELB.DeleteRule(ctx, rule1.ARN); err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err = p.ELB.DescribeRules(ctx, li.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) != 1 {
+		t.Errorf("expected 1 rule after deletion, got %d", len(rules))
+	}
+}
+
+func TestModifyListenerAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	lb, err := p.ELB.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+		Name: "test-lb", Type: "application", Scheme: "internet-facing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tg, err := p.ELB.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{
+		Name: "test-tg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	li, err := p.ELB.CreateListener(ctx, lbdriver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify port
+	if err := p.ELB.ModifyListener(ctx, lbdriver.ModifyListenerInput{
+		ListenerARN: li.ARN, Port: 8080,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	listeners, err := p.ELB.DescribeListeners(ctx, lb.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(listeners) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(listeners))
+	}
+
+	if listeners[0].Port != 8080 {
+		t.Errorf("expected port 8080, got %d", listeners[0].Port)
+	}
+}
+
+func TestLBAttributesAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	lb, err := p.ELB.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+		Name: "test-lb", Type: "application", Scheme: "internet-facing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Get default attributes
+	attrs, err := p.ELB.GetLBAttributes(ctx, lb.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if attrs.IdleTimeout != 60 {
+		t.Errorf("expected default idle timeout 60, got %d", attrs.IdleTimeout)
+	}
+
+	// Put custom attributes
+	if err := p.ELB.PutLBAttributes(ctx, lb.ARN, lbdriver.LBAttributes{
+		IdleTimeout:        120,
+		DeletionProtection: true,
+		AccessLogsEnabled:  true,
+		AccessLogsBucket:   "my-access-logs",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	attrs, err = p.ELB.GetLBAttributes(ctx, lb.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if attrs.IdleTimeout != 120 {
+		t.Errorf("expected idle timeout 120, got %d", attrs.IdleTimeout)
+	}
+
+	if !attrs.DeletionProtection {
+		t.Error("expected deletion protection enabled")
+	}
+
+	if !attrs.AccessLogsEnabled {
+		t.Error("expected access logs enabled")
+	}
+
+	if attrs.AccessLogsBucket != "my-access-logs" {
+		t.Errorf("expected bucket 'my-access-logs', got %q", attrs.AccessLogsBucket)
+	}
+}
+
+func TestListenerRulesAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	lb, err := p.LB.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+		Name: "test-lb", Type: "application", Scheme: "internet-facing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tg, err := p.LB.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{
+		Name: "test-tg", Protocol: "HTTP", Port: 80, VPCID: "vnet-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	li, err := p.LB.CreateListener(ctx, lbdriver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rule, err := p.LB.CreateRule(ctx, lbdriver.RuleConfig{
+		ListenerARN: li.ARN,
+		Priority:    10,
+		Conditions:  []lbdriver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Actions:     []lbdriver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rule.ARN == "" {
+		t.Error("expected non-empty rule ARN")
+	}
+
+	rules, err := p.LB.DescribeRules(ctx, li.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) != 1 {
+		t.Errorf("expected 1 rule, got %d", len(rules))
+	}
+
+	if err := p.LB.DeleteRule(ctx, rule.ARN); err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err = p.LB.DescribeRules(ctx, li.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) != 0 {
+		t.Errorf("expected 0 rules after deletion, got %d", len(rules))
+	}
+}
+
+func TestListenerRulesGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	lb, err := p.LB.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+		Name: "test-lb", Type: "application", Scheme: "internet-facing",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tg, err := p.LB.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{
+		Name: "test-tg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	li, err := p.LB.CreateListener(ctx, lbdriver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rule, err := p.LB.CreateRule(ctx, lbdriver.RuleConfig{
+		ListenerARN: li.ARN,
+		Priority:    10,
+		Conditions:  []lbdriver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Actions:     []lbdriver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rule.ARN == "" {
+		t.Error("expected non-empty rule ARN")
+	}
+
+	rules, err := p.LB.DescribeRules(ctx, li.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) != 1 {
+		t.Errorf("expected 1 rule, got %d", len(rules))
+	}
+
+	if err := p.LB.DeleteRule(ctx, rule.ARN); err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err = p.LB.DescribeRules(ctx, li.ARN)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) != 0 {
+		t.Errorf("expected 0 rules after deletion, got %d", len(rules))
 	}
 }

--- a/loadbalancer/driver/driver.go
+++ b/loadbalancer/driver/driver.go
@@ -64,6 +64,52 @@ type ListenerInfo struct {
 	TargetGroupARN string
 }
 
+// RuleCondition describes a condition for a listener rule (e.g., path-pattern or host-header).
+type RuleCondition struct {
+	Field  string // "path-pattern" or "host-header"
+	Values []string
+}
+
+// RuleAction describes an action for a listener rule (e.g., forward to a target group).
+type RuleAction struct {
+	Type           string // "forward"
+	TargetGroupARN string
+}
+
+// RuleConfig describes a listener rule to create.
+type RuleConfig struct {
+	ListenerARN string
+	Priority    int
+	Conditions  []RuleCondition
+	Actions     []RuleAction
+}
+
+// RuleInfo describes a listener rule.
+type RuleInfo struct {
+	ARN         string
+	ListenerARN string
+	Priority    int
+	Conditions  []RuleCondition
+	Actions     []RuleAction
+	IsDefault   bool
+}
+
+// ModifyListenerInput describes modifications to apply to a listener.
+type ModifyListenerInput struct {
+	ListenerARN    string
+	Port           int
+	Protocol       string
+	DefaultActions []RuleAction
+}
+
+// LBAttributes describes configurable attributes of a load balancer.
+type LBAttributes struct {
+	IdleTimeout        int
+	DeletionProtection bool
+	AccessLogsEnabled  bool
+	AccessLogsBucket   string
+}
+
 // Target identifies a target (e.g., instance) in a target group.
 type Target struct {
 	ID   string
@@ -90,6 +136,15 @@ type LoadBalancer interface {
 	CreateListener(ctx context.Context, config ListenerConfig) (*ListenerInfo, error)
 	DeleteListener(ctx context.Context, arn string) error
 	DescribeListeners(ctx context.Context, lbARN string) ([]ListenerInfo, error)
+
+	CreateRule(ctx context.Context, config RuleConfig) (*RuleInfo, error)
+	DeleteRule(ctx context.Context, ruleARN string) error
+	DescribeRules(ctx context.Context, listenerARN string) ([]RuleInfo, error)
+
+	ModifyListener(ctx context.Context, input ModifyListenerInput) error
+
+	GetLBAttributes(ctx context.Context, lbARN string) (*LBAttributes, error)
+	PutLBAttributes(ctx context.Context, lbARN string, attrs LBAttributes) error
 
 	RegisterTargets(ctx context.Context, targetGroupARN string, targets []Target) error
 	DeregisterTargets(ctx context.Context, targetGroupARN string, targets []Target) error

--- a/loadbalancer/loadbalancer.go
+++ b/loadbalancer/loadbalancer.go
@@ -154,6 +154,48 @@ func (lb *LB) DescribeListeners(ctx context.Context, lbARN string) ([]driver.Lis
 	return out.([]driver.ListenerInfo), nil
 }
 
+func (lb *LB) CreateRule(ctx context.Context, config driver.RuleConfig) (*driver.RuleInfo, error) {
+	out, err := lb.do(ctx, "CreateRule", config, func() (any, error) { return lb.driver.CreateRule(ctx, config) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.RuleInfo), nil
+}
+
+func (lb *LB) DeleteRule(ctx context.Context, ruleARN string) error {
+	_, err := lb.do(ctx, "DeleteRule", ruleARN, func() (any, error) { return nil, lb.driver.DeleteRule(ctx, ruleARN) })
+	return err
+}
+
+func (lb *LB) DescribeRules(ctx context.Context, listenerARN string) ([]driver.RuleInfo, error) {
+	out, err := lb.do(ctx, "DescribeRules", listenerARN, func() (any, error) { return lb.driver.DescribeRules(ctx, listenerARN) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.RuleInfo), nil
+}
+
+func (lb *LB) ModifyListener(ctx context.Context, input driver.ModifyListenerInput) error {
+	_, err := lb.do(ctx, "ModifyListener", input, func() (any, error) { return nil, lb.driver.ModifyListener(ctx, input) })
+	return err
+}
+
+func (lb *LB) GetLBAttributes(ctx context.Context, lbARN string) (*driver.LBAttributes, error) {
+	out, err := lb.do(ctx, "GetLBAttributes", lbARN, func() (any, error) { return lb.driver.GetLBAttributes(ctx, lbARN) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.LBAttributes), nil
+}
+
+func (lb *LB) PutLBAttributes(ctx context.Context, lbARN string, attrs driver.LBAttributes) error {
+	_, err := lb.do(ctx, "PutLBAttributes", lbARN, func() (any, error) { return nil, lb.driver.PutLBAttributes(ctx, lbARN, attrs) })
+	return err
+}
+
 func (lb *LB) RegisterTargets(ctx context.Context, tgARN string, targets []driver.Target) error {
 	_, err := lb.do(ctx, "RegisterTargets", tgARN, func() (any, error) { return nil, lb.driver.RegisterTargets(ctx, tgARN, targets) })
 	return err

--- a/loadbalancer/loadbalancer_test.go
+++ b/loadbalancer/loadbalancer_test.go
@@ -19,7 +19,9 @@ type mockDriver struct {
 	lbs          map[string]*driver.LBInfo
 	targetGroups map[string]*driver.TargetGroupInfo
 	listeners    map[string]*driver.ListenerInfo
+	rules        map[string]*driver.RuleInfo
 	targets      map[string][]driver.TargetHealth
+	attrs        map[string]driver.LBAttributes
 	seq          int
 }
 
@@ -28,7 +30,9 @@ func newMockDriver() *mockDriver {
 		lbs:          make(map[string]*driver.LBInfo),
 		targetGroups: make(map[string]*driver.TargetGroupInfo),
 		listeners:    make(map[string]*driver.ListenerInfo),
+		rules:        make(map[string]*driver.RuleInfo),
 		targets:      make(map[string][]driver.TargetHealth),
+		attrs:        make(map[string]driver.LBAttributes),
 	}
 }
 
@@ -199,6 +203,83 @@ func (m *mockDriver) SetTargetHealth(_ context.Context, tgARN, targetID, state s
 	}
 
 	return fmt.Errorf("target not found")
+}
+
+func (m *mockDriver) CreateRule(_ context.Context, config driver.RuleConfig) (*driver.RuleInfo, error) {
+	if _, ok := m.listeners[config.ListenerARN]; !ok {
+		return nil, fmt.Errorf("listener not found")
+	}
+
+	arn := "arn:rule/" + m.nextID("rule")
+	info := &driver.RuleInfo{
+		ARN: arn, ListenerARN: config.ListenerARN, Priority: config.Priority,
+		Conditions: config.Conditions, Actions: config.Actions,
+	}
+	m.rules[arn] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteRule(_ context.Context, ruleARN string) error {
+	if _, ok := m.rules[ruleARN]; !ok {
+		return fmt.Errorf("rule not found")
+	}
+
+	delete(m.rules, ruleARN)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeRules(_ context.Context, listenerARN string) ([]driver.RuleInfo, error) {
+	var result []driver.RuleInfo
+
+	for _, r := range m.rules {
+		if r.ListenerARN == listenerARN {
+			result = append(result, *r)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) ModifyListener(_ context.Context, input driver.ModifyListenerInput) error {
+	li, ok := m.listeners[input.ListenerARN]
+	if !ok {
+		return fmt.Errorf("listener not found")
+	}
+
+	if input.Port != 0 {
+		li.Port = input.Port
+	}
+
+	if input.Protocol != "" {
+		li.Protocol = input.Protocol
+	}
+
+	return nil
+}
+
+func (m *mockDriver) GetLBAttributes(_ context.Context, lbARN string) (*driver.LBAttributes, error) {
+	if _, ok := m.lbs[lbARN]; !ok {
+		return nil, fmt.Errorf("lb not found")
+	}
+
+	attrs, ok := m.attrs[lbARN]
+	if !ok {
+		attrs = driver.LBAttributes{IdleTimeout: 60}
+	}
+
+	return &attrs, nil
+}
+
+func (m *mockDriver) PutLBAttributes(_ context.Context, lbARN string, attrs driver.LBAttributes) error {
+	if _, ok := m.lbs[lbARN]; !ok {
+		return fmt.Errorf("lb not found")
+	}
+
+	m.attrs[lbARN] = attrs
+
+	return nil
 }
 
 func newTestLB(opts ...Option) *LB {

--- a/providers/aws/elb/elb.go
+++ b/providers/aws/elb/elb.go
@@ -16,15 +16,22 @@ import (
 // Compile-time check that Mock implements driver.LoadBalancer.
 var _ driver.LoadBalancer = (*Mock)(nil)
 
+// defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
+const defaultIdleTimeoutSec = 60
+
 // Mock is an in-memory mock implementation of the AWS ELB service.
 type Mock struct {
 	lbs       *memstore.Store[driver.LBInfo]
 	tgs       *memstore.Store[driver.TargetGroupInfo]
 	listeners *memstore.Store[driver.ListenerInfo]
+	rules     *memstore.Store[driver.RuleInfo]
 	opts      *config.Options
 
 	healthMu sync.RWMutex
 	health   map[string]map[string]*driver.TargetHealth // tgARN -> targetID -> health
+
+	attrsMu sync.RWMutex
+	attrs   map[string]driver.LBAttributes // lbARN -> attributes
 }
 
 // New creates a new ELB mock with the given configuration options.
@@ -33,8 +40,10 @@ func New(opts *config.Options) *Mock {
 		lbs:       memstore.New[driver.LBInfo](),
 		tgs:       memstore.New[driver.TargetGroupInfo](),
 		listeners: memstore.New[driver.ListenerInfo](),
+		rules:     memstore.New[driver.RuleInfo](),
 		opts:      opts,
 		health:    make(map[string]map[string]*driver.TargetHealth),
+		attrs:     make(map[string]driver.LBAttributes),
 	}
 }
 
@@ -186,6 +195,18 @@ func describeResources[T any](store *memstore.Store[T], keys []string) []T {
 	return results
 }
 
+// filterToSlice returns a slice of values from the store that match the predicate.
+func filterToSlice[T any](store *memstore.Store[T], pred func(string, T) bool) []T {
+	filtered := store.Filter(pred)
+
+	results := make([]T, 0, len(filtered))
+	for _, item := range filtered {
+		results = append(results, item)
+	}
+
+	return results
+}
+
 // CreateListener creates a new listener on a load balancer.
 func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*driver.ListenerInfo, error) {
 	if _, ok := m.lbs.Get(cfg.LBARN); !ok {
@@ -225,16 +246,114 @@ func (m *Mock) DescribeListeners(_ context.Context, lbARN string) ([]driver.List
 		return nil, errors.Newf(errors.NotFound, "load balancer %q not found", lbARN)
 	}
 
-	filtered := m.listeners.Filter(func(_ string, li driver.ListenerInfo) bool {
+	return filterToSlice(m.listeners, func(_ string, li driver.ListenerInfo) bool {
 		return li.LBARN == lbARN
-	})
+	}), nil
+}
 
-	results := make([]driver.ListenerInfo, 0, len(filtered))
-	for _, li := range filtered {
-		results = append(results, li)
+// CreateRule creates a new listener rule.
+func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.RuleInfo, error) {
+	if _, ok := m.listeners.Get(cfg.ListenerARN); !ok {
+		return nil, errors.Newf(errors.NotFound, "listener %q not found", cfg.ListenerARN)
 	}
 
-	return results, nil
+	arn := idgen.AWSARN("elasticloadbalancing", m.opts.Region, m.opts.AccountID,
+		fmt.Sprintf("rule/%s/%s", cfg.ListenerARN, idgen.GenerateID("rule-")))
+
+	conditions := make([]driver.RuleCondition, len(cfg.Conditions))
+	copy(conditions, cfg.Conditions)
+
+	actions := make([]driver.RuleAction, len(cfg.Actions))
+	copy(actions, cfg.Actions)
+
+	rule := driver.RuleInfo{
+		ARN:         arn,
+		ListenerARN: cfg.ListenerARN,
+		Priority:    cfg.Priority,
+		Conditions:  conditions,
+		Actions:     actions,
+		IsDefault:   false,
+	}
+
+	m.rules.Set(arn, rule)
+
+	result := rule
+
+	return &result, nil
+}
+
+// DeleteRule deletes a listener rule by ARN.
+func (m *Mock) DeleteRule(_ context.Context, ruleARN string) error {
+	if !m.rules.Delete(ruleARN) {
+		return errors.Newf(errors.NotFound, "rule %q not found", ruleARN)
+	}
+
+	return nil
+}
+
+// DescribeRules returns all rules for the specified listener.
+func (m *Mock) DescribeRules(_ context.Context, listenerARN string) ([]driver.RuleInfo, error) {
+	if _, ok := m.listeners.Get(listenerARN); !ok {
+		return nil, errors.Newf(errors.NotFound, "listener %q not found", listenerARN)
+	}
+
+	return filterToSlice(m.rules, func(_ string, r driver.RuleInfo) bool {
+		return r.ListenerARN == listenerARN
+	}), nil
+}
+
+// ModifyListener modifies an existing listener's port, protocol, or default actions.
+func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInput) error {
+	li, ok := m.listeners.Get(input.ListenerARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "listener %q not found", input.ListenerARN)
+	}
+
+	if input.Port != 0 {
+		li.Port = input.Port
+	}
+
+	if input.Protocol != "" {
+		li.Protocol = input.Protocol
+	}
+
+	if len(input.DefaultActions) > 0 {
+		li.TargetGroupARN = input.DefaultActions[0].TargetGroupARN
+	}
+
+	m.listeners.Set(input.ListenerARN, li)
+
+	return nil
+}
+
+// GetLBAttributes returns the attributes for a load balancer.
+func (m *Mock) GetLBAttributes(_ context.Context, lbARN string) (*driver.LBAttributes, error) {
+	if _, ok := m.lbs.Get(lbARN); !ok {
+		return nil, errors.Newf(errors.NotFound, "load balancer %q not found", lbARN)
+	}
+
+	m.attrsMu.RLock()
+	defer m.attrsMu.RUnlock()
+
+	attrs, ok := m.attrs[lbARN]
+	if !ok {
+		attrs = driver.LBAttributes{IdleTimeout: defaultIdleTimeoutSec}
+	}
+
+	return &attrs, nil
+}
+
+// PutLBAttributes sets the attributes for a load balancer.
+func (m *Mock) PutLBAttributes(_ context.Context, lbARN string, attrs driver.LBAttributes) error {
+	if _, ok := m.lbs.Get(lbARN); !ok {
+		return errors.Newf(errors.NotFound, "load balancer %q not found", lbARN)
+	}
+
+	m.attrsMu.Lock()
+	m.attrs[lbARN] = attrs
+	m.attrsMu.Unlock()
+
+	return nil
 }
 
 // RegisterTargets registers targets with a target group.

--- a/providers/aws/elb/elb_test.go
+++ b/providers/aws/elb/elb_test.go
@@ -323,6 +323,157 @@ func TestSetTargetHealth(t *testing.T) {
 	})
 }
 
+func TestCreateRule(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+	tg := createTestTG(m)
+	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+
+	t.Run("success", func(t *testing.T) {
+		rule, err := m.CreateRule(ctx, driver.RuleConfig{
+			ListenerARN: li.ARN,
+			Priority:    10,
+			Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+			Actions:     []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+		})
+		requireNoError(t, err)
+		assertNotEmpty(t, rule.ARN)
+		assertEqual(t, li.ARN, rule.ListenerARN)
+		assertEqual(t, 10, rule.Priority)
+		assertEqual(t, false, rule.IsDefault)
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		_, err := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: "arn:nope"})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteRule(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80,
+	})
+	rule, _ := m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 10,
+	})
+
+	requireNoError(t, m.DeleteRule(ctx, rule.ARN))
+	assertError(t, m.DeleteRule(ctx, "arn:nope"), true)
+}
+
+func TestDescribeRules(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+	tg := createTestTG(m)
+	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 10,
+		Conditions: []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Actions:    []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 20,
+		Conditions: []driver.RuleCondition{{Field: "host-header", Values: []string{"example.com"}}},
+		Actions:    []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+
+	t.Run("success", func(t *testing.T) {
+		rules, err := m.DescribeRules(ctx, li.ARN)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(rules))
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		_, err := m.DescribeRules(ctx, "arn:nope")
+		assertError(t, err, true)
+	})
+}
+
+func TestModifyListener(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+	tg := createTestTG(m)
+	li, _ := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+
+	t.Run("modify port", func(t *testing.T) {
+		err := m.ModifyListener(ctx, driver.ModifyListenerInput{
+			ListenerARN: li.ARN, Port: 8080,
+		})
+		requireNoError(t, err)
+
+		listeners, _ := m.DescribeListeners(ctx, lb.ARN)
+		assertEqual(t, 8080, listeners[0].Port)
+	})
+
+	t.Run("modify protocol", func(t *testing.T) {
+		err := m.ModifyListener(ctx, driver.ModifyListenerInput{
+			ListenerARN: li.ARN, Protocol: "HTTPS",
+		})
+		requireNoError(t, err)
+
+		listeners, _ := m.DescribeListeners(ctx, lb.ARN)
+		assertEqual(t, "HTTPS", listeners[0].Protocol)
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		err := m.ModifyListener(ctx, driver.ModifyListenerInput{ListenerARN: "arn:nope", Port: 80})
+		assertError(t, err, true)
+	})
+}
+
+func TestLBAttributes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	lb := createTestLB(m)
+
+	t.Run("default attributes", func(t *testing.T) {
+		attrs, err := m.GetLBAttributes(ctx, lb.ARN)
+		requireNoError(t, err)
+		assertEqual(t, 60, attrs.IdleTimeout)
+		assertEqual(t, false, attrs.DeletionProtection)
+	})
+
+	t.Run("put and get", func(t *testing.T) {
+		err := m.PutLBAttributes(ctx, lb.ARN, driver.LBAttributes{
+			IdleTimeout:        120,
+			DeletionProtection: true,
+			AccessLogsEnabled:  true,
+			AccessLogsBucket:   "my-logs",
+		})
+		requireNoError(t, err)
+
+		attrs, err := m.GetLBAttributes(ctx, lb.ARN)
+		requireNoError(t, err)
+		assertEqual(t, 120, attrs.IdleTimeout)
+		assertEqual(t, true, attrs.DeletionProtection)
+		assertEqual(t, true, attrs.AccessLogsEnabled)
+		assertEqual(t, "my-logs", attrs.AccessLogsBucket)
+	})
+
+	t.Run("LB not found get", func(t *testing.T) {
+		_, err := m.GetLBAttributes(ctx, "arn:nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("LB not found put", func(t *testing.T) {
+		err := m.PutLBAttributes(ctx, "arn:nope", driver.LBAttributes{})
+		assertError(t, err, true)
+	})
+}
+
 // --- test helpers ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/azurelb/lb.go
+++ b/providers/azure/azurelb/lb.go
@@ -16,15 +16,22 @@ import (
 // Compile-time check that Mock implements driver.LoadBalancer.
 var _ driver.LoadBalancer = (*Mock)(nil)
 
+// defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
+const defaultIdleTimeoutSec = 60
+
 // Mock is an in-memory mock implementation of the Azure Load Balancer service.
 type Mock struct {
 	lbs       *memstore.Store[driver.LBInfo]
 	tgs       *memstore.Store[driver.TargetGroupInfo]
 	listeners *memstore.Store[driver.ListenerInfo]
+	rules     *memstore.Store[driver.RuleInfo]
 	opts      *config.Options
 
 	healthMu sync.RWMutex
 	health   map[string]map[string]*driver.TargetHealth // tgARN -> targetID -> health
+
+	attrsMu sync.RWMutex
+	attrs   map[string]driver.LBAttributes // lbARN -> attributes
 }
 
 // New creates a new Azure Load Balancer mock with the given configuration options.
@@ -33,8 +40,10 @@ func New(opts *config.Options) *Mock {
 		lbs:       memstore.New[driver.LBInfo](),
 		tgs:       memstore.New[driver.TargetGroupInfo](),
 		listeners: memstore.New[driver.ListenerInfo](),
+		rules:     memstore.New[driver.RuleInfo](),
 		opts:      opts,
 		health:    make(map[string]map[string]*driver.TargetHealth),
+		attrs:     make(map[string]driver.LBAttributes),
 	}
 }
 
@@ -115,6 +124,18 @@ func describeResources[T any](store *memstore.Store[T], keys []string) []T {
 			continue
 		}
 
+		results = append(results, item)
+	}
+
+	return results
+}
+
+// filterToSlice returns a slice of values from the store that match the predicate.
+func filterToSlice[T any](store *memstore.Store[T], pred func(string, T) bool) []T {
+	filtered := store.Filter(pred)
+
+	results := make([]T, 0, len(filtered))
+	for _, item := range filtered {
 		results = append(results, item)
 	}
 
@@ -225,16 +246,114 @@ func (m *Mock) DescribeListeners(_ context.Context, lbARN string) ([]driver.List
 		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", lbARN)
 	}
 
-	filtered := m.listeners.Filter(func(_ string, li driver.ListenerInfo) bool {
+	return filterToSlice(m.listeners, func(_ string, li driver.ListenerInfo) bool {
 		return li.LBARN == lbARN
-	})
+	}), nil
+}
 
-	results := make([]driver.ListenerInfo, 0, len(filtered))
-	for _, li := range filtered {
-		results = append(results, li)
+// CreateRule creates a new routing rule for a load balancing rule (listener).
+func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.RuleInfo, error) {
+	if _, ok := m.listeners.Get(cfg.ListenerARN); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "listener %q not found", cfg.ListenerARN)
 	}
 
-	return results, nil
+	arn := idgen.AzureID(m.opts.AccountID, "cloud-mock", "Microsoft.Network",
+		"routingRules", idgen.GenerateID("rule-"))
+
+	conditions := make([]driver.RuleCondition, len(cfg.Conditions))
+	copy(conditions, cfg.Conditions)
+
+	actions := make([]driver.RuleAction, len(cfg.Actions))
+	copy(actions, cfg.Actions)
+
+	rule := driver.RuleInfo{
+		ARN:         arn,
+		ListenerARN: cfg.ListenerARN,
+		Priority:    cfg.Priority,
+		Conditions:  conditions,
+		Actions:     actions,
+		IsDefault:   false,
+	}
+
+	m.rules.Set(arn, rule)
+
+	result := rule
+
+	return &result, nil
+}
+
+// DeleteRule deletes a routing rule by ARN.
+func (m *Mock) DeleteRule(_ context.Context, ruleARN string) error {
+	if !m.rules.Delete(ruleARN) {
+		return cerrors.Newf(cerrors.NotFound, "rule %q not found", ruleARN)
+	}
+
+	return nil
+}
+
+// DescribeRules returns all routing rules for the specified listener.
+func (m *Mock) DescribeRules(_ context.Context, listenerARN string) ([]driver.RuleInfo, error) {
+	if _, ok := m.listeners.Get(listenerARN); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "listener %q not found", listenerARN)
+	}
+
+	return filterToSlice(m.rules, func(_ string, r driver.RuleInfo) bool {
+		return r.ListenerARN == listenerARN
+	}), nil
+}
+
+// ModifyListener modifies an existing load balancing rule's port, protocol, or default actions.
+func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInput) error {
+	li, ok := m.listeners.Get(input.ListenerARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "listener %q not found", input.ListenerARN)
+	}
+
+	if input.Port != 0 {
+		li.Port = input.Port
+	}
+
+	if input.Protocol != "" {
+		li.Protocol = input.Protocol
+	}
+
+	if len(input.DefaultActions) > 0 {
+		li.TargetGroupARN = input.DefaultActions[0].TargetGroupARN
+	}
+
+	m.listeners.Set(input.ListenerARN, li)
+
+	return nil
+}
+
+// GetLBAttributes returns the attributes for a load balancer.
+func (m *Mock) GetLBAttributes(_ context.Context, lbARN string) (*driver.LBAttributes, error) {
+	if _, ok := m.lbs.Get(lbARN); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", lbARN)
+	}
+
+	m.attrsMu.RLock()
+	defer m.attrsMu.RUnlock()
+
+	attrs, ok := m.attrs[lbARN]
+	if !ok {
+		attrs = driver.LBAttributes{IdleTimeout: defaultIdleTimeoutSec}
+	}
+
+	return &attrs, nil
+}
+
+// PutLBAttributes sets the attributes for a load balancer.
+func (m *Mock) PutLBAttributes(_ context.Context, lbARN string, attrs driver.LBAttributes) error {
+	if _, ok := m.lbs.Get(lbARN); !ok {
+		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", lbARN)
+	}
+
+	m.attrsMu.Lock()
+	m.attrs[lbARN] = attrs
+	m.attrsMu.Unlock()
+
+	return nil
 }
 
 // RegisterTargets registers targets (backend instances) with a backend pool.

--- a/providers/azure/azurelb/lb_test.go
+++ b/providers/azure/azurelb/lb_test.go
@@ -409,6 +409,163 @@ func TestDescribeTargetHealthNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestCreateRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	lbARN := createTestLB(t, m)
+	tgARN := createTestTargetGroup(t, m)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lbARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tgARN,
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		rule, ruleErr := m.CreateRule(ctx, driver.RuleConfig{
+			ListenerARN: li.ARN,
+			Priority:    10,
+			Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+			Actions:     []driver.RuleAction{{Type: "forward", TargetGroupARN: tgARN}},
+		})
+		require.NoError(t, ruleErr)
+		assert.NotEmpty(t, rule.ARN)
+		assert.Equal(t, li.ARN, rule.ListenerARN)
+		assert.Equal(t, 10, rule.Priority)
+		assert.False(t, rule.IsDefault)
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		_, ruleErr := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: "missing"})
+		require.Error(t, ruleErr)
+		assert.Contains(t, ruleErr.Error(), "not found")
+	})
+}
+
+func TestDeleteRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	lbARN := createTestLB(t, m)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lbARN, Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	rule, err := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: li.ARN, Priority: 10})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		require.NoError(t, m.DeleteRule(ctx, rule.ARN))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeRules(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	lbARN := createTestLB(t, m)
+	tgARN := createTestTargetGroup(t, m)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lbARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tgARN,
+	})
+	require.NoError(t, err)
+
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 10,
+		Conditions: []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Actions:    []driver.RuleAction{{Type: "forward", TargetGroupARN: tgARN}},
+	})
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 20,
+		Conditions: []driver.RuleCondition{{Field: "host-header", Values: []string{"example.com"}}},
+		Actions:    []driver.RuleAction{{Type: "forward", TargetGroupARN: tgARN}},
+	})
+
+	t.Run("success", func(t *testing.T) {
+		rules, descErr := m.DescribeRules(ctx, li.ARN)
+		require.NoError(t, descErr)
+		assert.Len(t, rules, 2)
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		_, descErr := m.DescribeRules(ctx, "missing")
+		require.Error(t, descErr)
+		assert.Contains(t, descErr.Error(), "not found")
+	})
+}
+
+func TestModifyListener(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	lbARN := createTestLB(t, m)
+	tgARN := createTestTargetGroup(t, m)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lbARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tgARN,
+	})
+	require.NoError(t, err)
+
+	t.Run("modify port", func(t *testing.T) {
+		require.NoError(t, m.ModifyListener(ctx, driver.ModifyListenerInput{
+			ListenerARN: li.ARN, Port: 8080,
+		}))
+
+		listeners, _ := m.DescribeListeners(ctx, lbARN)
+		assert.Equal(t, 8080, listeners[0].Port)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.ModifyListener(ctx, driver.ModifyListenerInput{ListenerARN: "missing", Port: 80})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestLBAttributes(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	lbARN := createTestLB(t, m)
+
+	t.Run("default attributes", func(t *testing.T) {
+		attrs, err := m.GetLBAttributes(ctx, lbARN)
+		require.NoError(t, err)
+		assert.Equal(t, 60, attrs.IdleTimeout)
+		assert.False(t, attrs.DeletionProtection)
+	})
+
+	t.Run("put and get", func(t *testing.T) {
+		require.NoError(t, m.PutLBAttributes(ctx, lbARN, driver.LBAttributes{
+			IdleTimeout:        120,
+			DeletionProtection: true,
+			AccessLogsEnabled:  true,
+			AccessLogsBucket:   "my-logs",
+		}))
+
+		attrs, err := m.GetLBAttributes(ctx, lbARN)
+		require.NoError(t, err)
+		assert.Equal(t, 120, attrs.IdleTimeout)
+		assert.True(t, attrs.DeletionProtection)
+		assert.True(t, attrs.AccessLogsEnabled)
+		assert.Equal(t, "my-logs", attrs.AccessLogsBucket)
+	})
+
+	t.Run("LB not found get", func(t *testing.T) {
+		_, err := m.GetLBAttributes(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("LB not found put", func(t *testing.T) {
+		err := m.PutLBAttributes(ctx, "missing", driver.LBAttributes{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
 func TestDeleteLBCascadesListeners(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()

--- a/providers/gcp/gcplb/lb.go
+++ b/providers/gcp/gcplb/lb.go
@@ -16,15 +16,22 @@ import (
 // Compile-time check that Mock implements driver.LoadBalancer.
 var _ driver.LoadBalancer = (*Mock)(nil)
 
+// defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
+const defaultIdleTimeoutSec = 60
+
 // Mock is an in-memory mock implementation of the GCP Cloud Load Balancing service.
 type Mock struct {
 	lbs       *memstore.Store[driver.LBInfo]
 	tgs       *memstore.Store[driver.TargetGroupInfo]
 	listeners *memstore.Store[driver.ListenerInfo]
+	rules     *memstore.Store[driver.RuleInfo]
 	opts      *config.Options
 
 	healthMu sync.RWMutex
 	health   map[string]map[string]*driver.TargetHealth // tgARN -> targetID -> health
+
+	attrsMu sync.RWMutex
+	attrs   map[string]driver.LBAttributes // lbARN -> attributes
 }
 
 // New creates a new Cloud Load Balancing mock with the given configuration options.
@@ -33,8 +40,10 @@ func New(opts *config.Options) *Mock {
 		lbs:       memstore.New[driver.LBInfo](),
 		tgs:       memstore.New[driver.TargetGroupInfo](),
 		listeners: memstore.New[driver.ListenerInfo](),
+		rules:     memstore.New[driver.RuleInfo](),
 		opts:      opts,
 		health:    make(map[string]map[string]*driver.TargetHealth),
+		attrs:     make(map[string]driver.LBAttributes),
 	}
 }
 
@@ -186,6 +195,18 @@ func describeResources[T any](store *memstore.Store[T], keys []string) []T {
 	return results
 }
 
+// filterToSlice returns a slice of values from the store that match the predicate.
+func filterToSlice[T any](store *memstore.Store[T], pred func(string, T) bool) []T {
+	filtered := store.Filter(pred)
+
+	results := make([]T, 0, len(filtered))
+	for _, item := range filtered {
+		results = append(results, item)
+	}
+
+	return results
+}
+
 // CreateListener creates a new URL map / listener on a load balancer.
 func (m *Mock) CreateListener(_ context.Context, cfg driver.ListenerConfig) (*driver.ListenerInfo, error) {
 	if _, ok := m.lbs.Get(cfg.LBARN); !ok {
@@ -225,16 +246,113 @@ func (m *Mock) DescribeListeners(_ context.Context, lbARN string) ([]driver.List
 		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", lbARN)
 	}
 
-	filtered := m.listeners.Filter(func(_ string, li driver.ListenerInfo) bool {
+	return filterToSlice(m.listeners, func(_ string, li driver.ListenerInfo) bool {
 		return li.LBARN == lbARN
-	})
+	}), nil
+}
 
-	results := make([]driver.ListenerInfo, 0, len(filtered))
-	for _, li := range filtered {
-		results = append(results, li)
+// CreateRule creates a new URL map path rule for a listener.
+func (m *Mock) CreateRule(_ context.Context, cfg driver.RuleConfig) (*driver.RuleInfo, error) {
+	if _, ok := m.listeners.Get(cfg.ListenerARN); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "listener %q not found", cfg.ListenerARN)
 	}
 
-	return results, nil
+	arn := idgen.GCPID(m.opts.ProjectID, "pathRules", idgen.GenerateID("rule-"))
+
+	conditions := make([]driver.RuleCondition, len(cfg.Conditions))
+	copy(conditions, cfg.Conditions)
+
+	actions := make([]driver.RuleAction, len(cfg.Actions))
+	copy(actions, cfg.Actions)
+
+	rule := driver.RuleInfo{
+		ARN:         arn,
+		ListenerARN: cfg.ListenerARN,
+		Priority:    cfg.Priority,
+		Conditions:  conditions,
+		Actions:     actions,
+		IsDefault:   false,
+	}
+
+	m.rules.Set(arn, rule)
+
+	result := rule
+
+	return &result, nil
+}
+
+// DeleteRule deletes a URL map path rule by resource name (ARN).
+func (m *Mock) DeleteRule(_ context.Context, ruleARN string) error {
+	if !m.rules.Delete(ruleARN) {
+		return cerrors.Newf(cerrors.NotFound, "rule %q not found", ruleARN)
+	}
+
+	return nil
+}
+
+// DescribeRules returns all path rules for the specified listener.
+func (m *Mock) DescribeRules(_ context.Context, listenerARN string) ([]driver.RuleInfo, error) {
+	if _, ok := m.listeners.Get(listenerARN); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "listener %q not found", listenerARN)
+	}
+
+	return filterToSlice(m.rules, func(_ string, r driver.RuleInfo) bool {
+		return r.ListenerARN == listenerARN
+	}), nil
+}
+
+// ModifyListener modifies an existing URL map listener's port, protocol, or default actions.
+func (m *Mock) ModifyListener(_ context.Context, input driver.ModifyListenerInput) error {
+	li, ok := m.listeners.Get(input.ListenerARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "listener %q not found", input.ListenerARN)
+	}
+
+	if input.Port != 0 {
+		li.Port = input.Port
+	}
+
+	if input.Protocol != "" {
+		li.Protocol = input.Protocol
+	}
+
+	if len(input.DefaultActions) > 0 {
+		li.TargetGroupARN = input.DefaultActions[0].TargetGroupARN
+	}
+
+	m.listeners.Set(input.ListenerARN, li)
+
+	return nil
+}
+
+// GetLBAttributes returns the attributes for a load balancer.
+func (m *Mock) GetLBAttributes(_ context.Context, lbARN string) (*driver.LBAttributes, error) {
+	if _, ok := m.lbs.Get(lbARN); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", lbARN)
+	}
+
+	m.attrsMu.RLock()
+	defer m.attrsMu.RUnlock()
+
+	attrs, ok := m.attrs[lbARN]
+	if !ok {
+		attrs = driver.LBAttributes{IdleTimeout: defaultIdleTimeoutSec}
+	}
+
+	return &attrs, nil
+}
+
+// PutLBAttributes sets the attributes for a load balancer.
+func (m *Mock) PutLBAttributes(_ context.Context, lbARN string, attrs driver.LBAttributes) error {
+	if _, ok := m.lbs.Get(lbARN); !ok {
+		return cerrors.Newf(cerrors.NotFound, "load balancer %q not found", lbARN)
+	}
+
+	m.attrsMu.Lock()
+	m.attrs[lbARN] = attrs
+	m.attrsMu.Unlock()
+
+	return nil
 }
 
 // RegisterTargets adds instances to a backend service (target group).

--- a/providers/gcp/gcplb/lb_test.go
+++ b/providers/gcp/gcplb/lb_test.go
@@ -355,6 +355,179 @@ func TestDescribeListeners(t *testing.T) {
 	})
 }
 
+func TestCreateRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb1"})
+	require.NoError(t, err)
+
+	tg, err := m.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "tg1", Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		rule, ruleErr := m.CreateRule(ctx, driver.RuleConfig{
+			ListenerARN: li.ARN,
+			Priority:    10,
+			Conditions:  []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+			Actions:     []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+		})
+		require.NoError(t, ruleErr)
+		assert.NotEmpty(t, rule.ARN)
+		assert.Equal(t, li.ARN, rule.ListenerARN)
+		assert.Equal(t, 10, rule.Priority)
+		assert.False(t, rule.IsDefault)
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		_, ruleErr := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: "missing"})
+		require.Error(t, ruleErr)
+		assert.Contains(t, ruleErr.Error(), "not found")
+	})
+}
+
+func TestDeleteRule(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb1"})
+	require.NoError(t, err)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{LBARN: lb.ARN, Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	rule, err := m.CreateRule(ctx, driver.RuleConfig{ListenerARN: li.ARN, Priority: 10})
+	require.NoError(t, err)
+
+	t.Run("success", func(t *testing.T) {
+		require.NoError(t, m.DeleteRule(ctx, rule.ARN))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.DeleteRule(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeRules(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb1"})
+	require.NoError(t, err)
+
+	tg, err := m.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "tg1", Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	require.NoError(t, err)
+
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 10,
+		Conditions: []driver.RuleCondition{{Field: "path-pattern", Values: []string{"/api/*"}}},
+		Actions:    []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+	_, _ = m.CreateRule(ctx, driver.RuleConfig{
+		ListenerARN: li.ARN, Priority: 20,
+		Conditions: []driver.RuleCondition{{Field: "host-header", Values: []string{"example.com"}}},
+		Actions:    []driver.RuleAction{{Type: "forward", TargetGroupARN: tg.ARN}},
+	})
+
+	t.Run("success", func(t *testing.T) {
+		rules, descErr := m.DescribeRules(ctx, li.ARN)
+		require.NoError(t, descErr)
+		assert.Len(t, rules, 2)
+	})
+
+	t.Run("listener not found", func(t *testing.T) {
+		_, descErr := m.DescribeRules(ctx, "missing")
+		require.Error(t, descErr)
+		assert.Contains(t, descErr.Error(), "not found")
+	})
+}
+
+func TestModifyListener(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb1"})
+	require.NoError(t, err)
+
+	tg, err := m.CreateTargetGroup(ctx, driver.TargetGroupConfig{Name: "tg1", Protocol: "HTTP", Port: 80})
+	require.NoError(t, err)
+
+	li, err := m.CreateListener(ctx, driver.ListenerConfig{
+		LBARN: lb.ARN, Protocol: "HTTP", Port: 80, TargetGroupARN: tg.ARN,
+	})
+	require.NoError(t, err)
+
+	t.Run("modify port", func(t *testing.T) {
+		require.NoError(t, m.ModifyListener(ctx, driver.ModifyListenerInput{
+			ListenerARN: li.ARN, Port: 8080,
+		}))
+
+		listeners, _ := m.DescribeListeners(ctx, lb.ARN)
+		assert.Equal(t, 8080, listeners[0].Port)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := m.ModifyListener(ctx, driver.ModifyListenerInput{ListenerARN: "missing", Port: 80})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestLBAttributes(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	lb, err := m.CreateLoadBalancer(ctx, driver.LBConfig{Name: "lb1"})
+	require.NoError(t, err)
+
+	t.Run("default attributes", func(t *testing.T) {
+		attrs, attrErr := m.GetLBAttributes(ctx, lb.ARN)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 60, attrs.IdleTimeout)
+		assert.False(t, attrs.DeletionProtection)
+	})
+
+	t.Run("put and get", func(t *testing.T) {
+		require.NoError(t, m.PutLBAttributes(ctx, lb.ARN, driver.LBAttributes{
+			IdleTimeout:        120,
+			DeletionProtection: true,
+			AccessLogsEnabled:  true,
+			AccessLogsBucket:   "my-logs",
+		}))
+
+		attrs, attrErr := m.GetLBAttributes(ctx, lb.ARN)
+		require.NoError(t, attrErr)
+		assert.Equal(t, 120, attrs.IdleTimeout)
+		assert.True(t, attrs.DeletionProtection)
+		assert.True(t, attrs.AccessLogsEnabled)
+		assert.Equal(t, "my-logs", attrs.AccessLogsBucket)
+	})
+
+	t.Run("LB not found get", func(t *testing.T) {
+		_, attrErr := m.GetLBAttributes(ctx, "missing")
+		require.Error(t, attrErr)
+		assert.Contains(t, attrErr.Error(), "not found")
+	})
+
+	t.Run("LB not found put", func(t *testing.T) {
+		attrErr := m.PutLBAttributes(ctx, "missing", driver.LBAttributes{})
+		require.Error(t, attrErr)
+		assert.Contains(t, attrErr.Error(), "not found")
+	})
+}
+
 func TestDeleteListenerCleansUpOnLBDelete(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()


### PR DESCRIPTION
## Summary

- Adds 6 new types: `RuleCondition`, `RuleAction`, `RuleConfig`, `RuleInfo`, `ModifyListenerInput`, `LBAttributes`
- Adds 6 new methods to LoadBalancer interface: `CreateRule`, `DeleteRule`, `DescribeRules`, `ModifyListener`, `GetLBAttributes`, `PutLBAttributes`
- Implements across all 3 providers: AWS ELB, Azure LB, GCP LB
- Wires through portable API layer with metrics, recording, rate limiting, and error injection
- Rules support path-pattern and host-header conditions with priority ordering
- LB attributes include idle timeout, deletion protection, and access logs

Closes #63

## Test plan

### Unit tests (per provider)
- [x] `TestCreateRule`, `TestDeleteRule`, `TestDescribeRules`
- [x] `TestModifyListener`
- [x] `TestLBAttributes`

### Integration tests (cloudemu_test.go)
- [x] `TestListenerRulesAWS` — create LB, listener, rules with path conditions
- [x] `TestModifyListenerAWS` — modify listener port
- [x] `TestLBAttributesAWS` — put and get attributes
- [x] `TestListenerRulesAzure`, `TestListenerRulesGCP`

### Verification
- [x] Linter: 0 issues
- [x] Full test suite: all passing