### PR TITLE
Add volumes, snapshots, and images to compute service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -6783,3 +6783,168 @@ func TestListenerRulesGCP(t *testing.T) {
 		t.Errorf("expected 0 rules after deletion, got %d", len(rules))
 	}
 }
+
+func TestVolumeLifecycleAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	vol, err := p.EC2.CreateVolume(ctx, computedriver.VolumeConfig{Size: 100, VolumeType: "gp3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vol.State != "available" {
+		t.Errorf("expected state 'available', got %q", vol.State)
+	}
+
+	instances, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t3.micro",
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.EC2.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf"); err != nil {
+		t.Fatal(err)
+	}
+
+	vols, err := p.EC2.DescribeVolumes(ctx, []string{vol.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vols[0].State != "in-use" {
+		t.Errorf("expected state 'in-use', got %q", vols[0].State)
+	}
+
+	if err := p.EC2.DetachVolume(ctx, vol.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.EC2.DeleteVolume(ctx, vol.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	vols, err = p.EC2.DescribeVolumes(ctx, []string{vol.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(vols) != 0 {
+		t.Errorf("expected 0 volumes after delete, got %d", len(vols))
+	}
+}
+
+func TestVolumeLifecycleAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	vol, err := p.VirtualMachines.CreateVolume(ctx, computedriver.VolumeConfig{Size: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vol.State != "available" {
+		t.Errorf("expected 'available', got %q", vol.State)
+	}
+
+	if err := p.VirtualMachines.DeleteVolume(ctx, vol.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVolumeLifecycleGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	vol, err := p.GCE.CreateVolume(ctx, computedriver.VolumeConfig{Size: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vol.State != "available" {
+		t.Errorf("expected 'available', got %q", vol.State)
+	}
+
+	if err := p.GCE.DeleteVolume(ctx, vol.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSnapshotAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	vol, err := p.EC2.CreateVolume(ctx, computedriver.VolumeConfig{Size: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := p.EC2.CreateSnapshot(ctx, computedriver.SnapshotConfig{
+		VolumeID: vol.ID, Description: "test snapshot",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if snap.VolumeID != vol.ID {
+		t.Errorf("expected VolumeID %q, got %q", vol.ID, snap.VolumeID)
+	}
+
+	if snap.Size != 100 {
+		t.Errorf("expected size 100, got %d", snap.Size)
+	}
+
+	snaps, err := p.EC2.DescribeSnapshots(ctx, []string{snap.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(snaps) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps))
+	}
+
+	if err := p.EC2.DeleteSnapshot(ctx, snap.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestImageAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	instances, err := p.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-test", InstanceType: "t3.micro",
+	}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img, err := p.EC2.CreateImage(ctx, computedriver.ImageConfig{
+		InstanceID: instances[0].ID, Name: "my-image", Description: "test image",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if img.Name != "my-image" {
+		t.Errorf("expected name 'my-image', got %q", img.Name)
+	}
+
+	if img.State != "available" {
+		t.Errorf("expected state 'available', got %q", img.State)
+	}
+
+	imgs, err := p.EC2.DescribeImages(ctx, []string{img.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(imgs) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(imgs))
+	}
+
+	if err := p.EC2.DeregisterImage(ctx, img.ID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/compute/compute.go
+++ b/compute/compute.go
@@ -358,3 +358,96 @@ func (c *Compute) ListLaunchTemplates(ctx context.Context) ([]driver.LaunchTempl
 
 	return out.([]driver.LaunchTemplate), nil
 }
+
+// CreateVolume creates a new block storage volume.
+func (c *Compute) CreateVolume(ctx context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	out, err := c.do(ctx, "CreateVolume", cfg, func() (any, error) { return c.driver.CreateVolume(ctx, cfg) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.VolumeInfo), nil
+}
+
+// DeleteVolume deletes a volume.
+func (c *Compute) DeleteVolume(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DeleteVolume", id, func() (any, error) { return nil, c.driver.DeleteVolume(ctx, id) })
+	return err
+}
+
+// DescribeVolumes returns volumes matching the given IDs.
+func (c *Compute) DescribeVolumes(ctx context.Context, ids []string) ([]driver.VolumeInfo, error) {
+	out, err := c.do(ctx, "DescribeVolumes", ids, func() (any, error) { return c.driver.DescribeVolumes(ctx, ids) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.VolumeInfo), nil
+}
+
+// AttachVolume attaches a volume to an instance.
+func (c *Compute) AttachVolume(ctx context.Context, volumeID, instanceID, device string) error {
+	_, err := c.do(ctx, "AttachVolume", volumeID, func() (any, error) {
+		return nil, c.driver.AttachVolume(ctx, volumeID, instanceID, device)
+	})
+
+	return err
+}
+
+// DetachVolume detaches a volume.
+func (c *Compute) DetachVolume(ctx context.Context, volumeID string) error {
+	_, err := c.do(ctx, "DetachVolume", volumeID, func() (any, error) { return nil, c.driver.DetachVolume(ctx, volumeID) })
+	return err
+}
+
+// CreateSnapshot creates a volume snapshot.
+func (c *Compute) CreateSnapshot(ctx context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
+	out, err := c.do(ctx, "CreateSnapshot", cfg, func() (any, error) { return c.driver.CreateSnapshot(ctx, cfg) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.SnapshotInfo), nil
+}
+
+// DeleteSnapshot deletes a snapshot.
+func (c *Compute) DeleteSnapshot(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DeleteSnapshot", id, func() (any, error) { return nil, c.driver.DeleteSnapshot(ctx, id) })
+	return err
+}
+
+// DescribeSnapshots returns snapshots matching the given IDs.
+func (c *Compute) DescribeSnapshots(ctx context.Context, ids []string) ([]driver.SnapshotInfo, error) {
+	out, err := c.do(ctx, "DescribeSnapshots", ids, func() (any, error) { return c.driver.DescribeSnapshots(ctx, ids) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SnapshotInfo), nil
+}
+
+// CreateImage creates a machine image from an instance.
+func (c *Compute) CreateImage(ctx context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
+	out, err := c.do(ctx, "CreateImage", cfg, func() (any, error) { return c.driver.CreateImage(ctx, cfg) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ImageInfo), nil
+}
+
+// DeregisterImage deregisters a machine image.
+func (c *Compute) DeregisterImage(ctx context.Context, id string) error {
+	_, err := c.do(ctx, "DeregisterImage", id, func() (any, error) { return nil, c.driver.DeregisterImage(ctx, id) })
+	return err
+}
+
+// DescribeImages returns images matching the given IDs.
+func (c *Compute) DescribeImages(ctx context.Context, ids []string) ([]driver.ImageInfo, error) {
+	out, err := c.do(ctx, "DescribeImages", ids, func() (any, error) { return c.driver.DescribeImages(ctx, ids) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.ImageInfo), nil
+}

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -517,3 +517,37 @@ func TestPortableTerminateInstancesError(t *testing.T) {
 	err := c.TerminateInstances(ctx, []string{"i-nonexistent"})
 	require.Error(t, err)
 }
+
+//nolint:dupl // test mock stubs are intentionally repetitive
+func (mc *mockCompute) CreateVolume(_ context.Context, _ driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	return nil, nil
+}
+
+func (mc *mockCompute) DeleteVolume(_ context.Context, _ string) error { return nil }
+
+func (mc *mockCompute) DescribeVolumes(_ context.Context, _ []string) ([]driver.VolumeInfo, error) {
+	return nil, nil
+}
+
+func (mc *mockCompute) AttachVolume(_ context.Context, _, _, _ string) error { return nil }
+func (mc *mockCompute) DetachVolume(_ context.Context, _ string) error       { return nil }
+
+func (mc *mockCompute) CreateSnapshot(_ context.Context, _ driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
+	return nil, nil
+}
+
+func (mc *mockCompute) DeleteSnapshot(_ context.Context, _ string) error { return nil }
+
+func (mc *mockCompute) DescribeSnapshots(_ context.Context, _ []string) ([]driver.SnapshotInfo, error) {
+	return nil, nil
+}
+
+func (mc *mockCompute) CreateImage(_ context.Context, _ driver.ImageConfig) (*driver.ImageInfo, error) {
+	return nil, nil
+}
+
+func (mc *mockCompute) DeregisterImage(_ context.Context, _ string) error { return nil }
+
+func (mc *mockCompute) DescribeImages(_ context.Context, _ []string) ([]driver.ImageInfo, error) {
+	return nil, nil
+}

--- a/compute/driver/driver.go
+++ b/compute/driver/driver.go
@@ -115,6 +115,63 @@ type LaunchTemplateConfig struct {
 	InstanceConfig InstanceConfig
 }
 
+// VolumeConfig describes a volume to create.
+type VolumeConfig struct {
+	Size             int
+	VolumeType       string
+	AvailabilityZone string
+	Tags             map[string]string
+}
+
+// VolumeInfo describes a block storage volume.
+type VolumeInfo struct {
+	ID               string
+	Size             int
+	VolumeType       string
+	State            string // "available", "in-use"
+	AvailabilityZone string
+	AttachedTo       string
+	Device           string
+	CreatedAt        string
+	Tags             map[string]string
+}
+
+// SnapshotConfig describes a snapshot to create.
+type SnapshotConfig struct {
+	VolumeID    string
+	Description string
+	Tags        map[string]string
+}
+
+// SnapshotInfo describes a volume snapshot.
+type SnapshotInfo struct {
+	ID          string
+	VolumeID    string
+	State       string // "completed", "pending"
+	Description string
+	Size        int
+	CreatedAt   string
+	Tags        map[string]string
+}
+
+// ImageConfig describes a machine image to create.
+type ImageConfig struct {
+	InstanceID  string
+	Name        string
+	Description string
+	Tags        map[string]string
+}
+
+// ImageInfo describes a machine image.
+type ImageInfo struct {
+	ID          string
+	Name        string
+	State       string // "available", "deregistered"
+	Description string
+	CreatedAt   string
+	Tags        map[string]string
+}
+
 // Compute is the interface that compute provider implementations must satisfy.
 type Compute interface {
 	RunInstances(ctx context.Context, config InstanceConfig, count int) ([]Instance, error)
@@ -148,4 +205,21 @@ type Compute interface {
 	DeleteLaunchTemplate(ctx context.Context, name string) error
 	GetLaunchTemplate(ctx context.Context, name string) (*LaunchTemplate, error)
 	ListLaunchTemplates(ctx context.Context) ([]LaunchTemplate, error)
+
+	// Volumes
+	CreateVolume(ctx context.Context, config VolumeConfig) (*VolumeInfo, error)
+	DeleteVolume(ctx context.Context, id string) error
+	DescribeVolumes(ctx context.Context, ids []string) ([]VolumeInfo, error)
+	AttachVolume(ctx context.Context, volumeID, instanceID, device string) error
+	DetachVolume(ctx context.Context, volumeID string) error
+
+	// Snapshots
+	CreateSnapshot(ctx context.Context, config SnapshotConfig) (*SnapshotInfo, error)
+	DeleteSnapshot(ctx context.Context, id string) error
+	DescribeSnapshots(ctx context.Context, ids []string) ([]SnapshotInfo, error)
+
+	// Images
+	CreateImage(ctx context.Context, config ImageConfig) (*ImageInfo, error)
+	DeregisterImage(ctx context.Context, id string) error
+	DescribeImages(ctx context.Context, ids []string) ([]ImageInfo, error)
 }

--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -18,7 +18,11 @@ import (
 
 var _ driver.Compute = (*Mock)(nil)
 
-const ipSegmentSize = 256
+const (
+	ipSegmentSize  = 256
+	stateAvailable = "available"
+	stateInUse     = "in-use"
+)
 
 type lifecycleTransition struct {
 	intermediateState string
@@ -82,9 +86,15 @@ type Mock struct {
 	asgs         *memstore.Store[*asgData]
 	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
 	templates    *memstore.Store[*driver.LaunchTemplate]
+	volumes      *memstore.Store[*driver.VolumeInfo]
+	snapshots    *memstore.Store[*driver.SnapshotInfo]
+	images       *memstore.Store[*driver.ImageInfo]
 	sm           *statemachine.Machine
 	opts         *config.Options
 	ipCounter    atomic.Int64
+	volCounter   atomic.Int64
+	snapCounter  atomic.Int64
+	amiCounter   atomic.Int64
 	monitoring   mondriver.Monitoring
 }
 
@@ -155,6 +165,9 @@ func New(opts *config.Options) *Mock {
 		asgs:         memstore.New[*asgData](),
 		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
 		templates:    memstore.New[*driver.LaunchTemplate](),
+		volumes:      memstore.New[*driver.VolumeInfo](),
+		snapshots:    memstore.New[*driver.SnapshotInfo](),
+		images:       memstore.New[*driver.ImageInfo](),
 		sm:           statemachine.New(compute.VMTransitions()),
 		opts:         opts,
 	}
@@ -349,4 +362,197 @@ func (m *Mock) ModifyInstance(_ context.Context, instanceID string, input driver
 	}
 
 	return nil
+}
+
+// CreateVolume creates a new EBS volume.
+func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	id := fmt.Sprintf("vol-%012d", m.volCounter.Add(1))
+
+	volType := cfg.VolumeType
+	if volType == "" {
+		volType = "gp3"
+	}
+
+	az := cfg.AvailabilityZone
+	if az == "" {
+		az = m.opts.Region + "a"
+	}
+
+	vol := &driver.VolumeInfo{
+		ID:               id,
+		Size:             cfg.Size,
+		VolumeType:       volType,
+		State:            stateAvailable,
+		AvailabilityZone: az,
+		CreatedAt:        m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:             copyTags(cfg.Tags),
+	}
+
+	m.volumes.Set(id, vol)
+
+	result := *vol
+
+	return &result, nil
+}
+
+// DeleteVolume deletes an EBS volume.
+func (m *Mock) DeleteVolume(_ context.Context, id string) error {
+	vol, ok := m.volumes.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "volume %q not found", id)
+	}
+
+	if vol.State == stateInUse {
+		return cerrors.Newf(cerrors.FailedPrecondition, "volume %q is attached", id)
+	}
+
+	m.volumes.Delete(id)
+
+	return nil
+}
+
+// DescribeVolumes returns volumes matching the given IDs.
+func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.VolumeInfo, error) {
+	return describeResources(m.volumes, ids), nil
+}
+
+// AttachVolume attaches a volume to an instance.
+func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "volume %q not found", volumeID)
+	}
+
+	if vol.State == stateInUse {
+		return cerrors.Newf(cerrors.FailedPrecondition, "volume %q already attached", volumeID)
+	}
+
+	if _, ok := m.instances.Get(instanceID); !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	vol.State = stateInUse
+	vol.AttachedTo = instanceID
+	vol.Device = device
+
+	return nil
+}
+
+// DetachVolume detaches a volume from an instance.
+func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "volume %q not found", volumeID)
+	}
+
+	if vol.State != "in-use" {
+		return cerrors.Newf(cerrors.FailedPrecondition, "volume %q is not attached", volumeID)
+	}
+
+	vol.State = stateAvailable
+	vol.AttachedTo = ""
+	vol.Device = ""
+
+	return nil
+}
+
+// CreateSnapshot creates a snapshot from a volume.
+func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
+	vol, ok := m.volumes.Get(cfg.VolumeID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "volume %q not found", cfg.VolumeID)
+	}
+
+	id := fmt.Sprintf("snap-%012d", m.snapCounter.Add(1))
+
+	snap := &driver.SnapshotInfo{
+		ID:          id,
+		VolumeID:    cfg.VolumeID,
+		State:       "completed",
+		Description: cfg.Description,
+		Size:        vol.Size,
+		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:        copyTags(cfg.Tags),
+	}
+
+	m.snapshots.Set(id, snap)
+
+	result := *snap
+
+	return &result, nil
+}
+
+// DeleteSnapshot deletes a snapshot.
+func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
+	if !m.snapshots.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeSnapshots returns snapshots matching the given IDs.
+func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.SnapshotInfo, error) {
+	return describeResources(m.snapshots, ids), nil
+}
+
+// CreateImage creates a machine image from an instance.
+func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
+	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", cfg.InstanceID)
+	}
+
+	id := fmt.Sprintf("ami-%012d", m.amiCounter.Add(1))
+
+	img := &driver.ImageInfo{
+		ID:          id,
+		Name:        cfg.Name,
+		State:       "available",
+		Description: cfg.Description,
+		CreatedAt:   m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:        copyTags(cfg.Tags),
+	}
+
+	m.images.Set(id, img)
+
+	result := *img
+
+	return &result, nil
+}
+
+// DeregisterImage deregisters a machine image.
+func (m *Mock) DeregisterImage(_ context.Context, id string) error {
+	if !m.images.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "image %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeImages returns images matching the given IDs.
+func (m *Mock) DescribeImages(_ context.Context, ids []string) ([]driver.ImageInfo, error) {
+	return describeResources(m.images, ids), nil
+}
+
+func describeResources[T any](store *memstore.Store[*T], ids []string) []T {
+	if len(ids) == 0 {
+		all := store.All()
+		result := make([]T, 0, len(all))
+
+		for _, v := range all {
+			result = append(result, *v)
+		}
+
+		return result
+	}
+
+	var result []T
+
+	for _, id := range ids {
+		if v, ok := store.Get(id); ok {
+			result = append(result, *v)
+		}
+	}
+
+	return result
 }

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -20,7 +20,11 @@ import (
 // Compile-time check that Mock implements driver.Compute.
 var _ driver.Compute = (*Mock)(nil)
 
-const ipSegmentSize = 256
+const (
+	ipSegmentSize  = 256
+	stateAvailable = "available"
+	stateInUse     = "in-use"
+)
 
 type lifecycleTransition struct {
 	intermediateState string
@@ -84,9 +88,15 @@ type Mock struct {
 	asgs         *memstore.Store[*asgData]
 	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
 	templates    *memstore.Store[*driver.LaunchTemplate]
+	volumes      *memstore.Store[*driver.VolumeInfo]
+	snapshots    *memstore.Store[*driver.SnapshotInfo]
+	images       *memstore.Store[*driver.ImageInfo]
 	sm           *statemachine.Machine
 	opts         *config.Options
 	ipCounter    atomic.Int64
+	volCounter   atomic.Int64
+	snapCounter  atomic.Int64
+	imgCounter   atomic.Int64
 	monitoring   mondriver.Monitoring
 }
 
@@ -157,6 +167,9 @@ func New(opts *config.Options) *Mock {
 		asgs:         memstore.New[*asgData](),
 		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
 		templates:    memstore.New[*driver.LaunchTemplate](),
+		volumes:      memstore.New[*driver.VolumeInfo](),
+		snapshots:    memstore.New[*driver.SnapshotInfo](),
+		images:       memstore.New[*driver.ImageInfo](),
 		sm:           statemachine.New(compute.VMTransitions()),
 		opts:         opts,
 	}
@@ -359,4 +372,171 @@ func containsValue(values []string, target string) bool {
 	}
 
 	return false
+}
+
+func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	id := fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/disks/disk-%d",
+		m.volCounter.Add(1))
+
+	volType := cfg.VolumeType
+	if volType == "" {
+		volType = "Premium_LRS"
+	}
+
+	vol := &driver.VolumeInfo{
+		ID: id, Size: cfg.Size, VolumeType: volType, State: stateAvailable,
+		AvailabilityZone: cfg.AvailabilityZone,
+		CreatedAt:        m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.volumes.Set(id, vol)
+
+	result := *vol
+
+	return &result, nil
+}
+
+func (m *Mock) DeleteVolume(_ context.Context, id string) error {
+	vol, ok := m.volumes.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", id)
+	}
+
+	if vol.State == stateInUse {
+		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q is attached", id)
+	}
+
+	m.volumes.Delete(id)
+
+	return nil
+}
+
+func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.VolumeInfo, error) {
+	return describeResources(m.volumes, ids), nil
+}
+
+func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	if vol.State == stateInUse {
+		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q already attached", volumeID)
+	}
+
+	if _, ok := m.instances.Get(instanceID); !ok {
+		return cerrors.Newf(cerrors.NotFound, "VM %q not found", instanceID)
+	}
+
+	vol.State = stateInUse
+	vol.AttachedTo = instanceID
+	vol.Device = device
+
+	return nil
+}
+
+func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	if vol.State != "in-use" {
+		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q is not attached", volumeID)
+	}
+
+	vol.State = stateAvailable
+	vol.AttachedTo = ""
+	vol.Device = ""
+
+	return nil
+}
+
+func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
+	vol, ok := m.volumes.Get(cfg.VolumeID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "disk %q not found", cfg.VolumeID)
+	}
+
+	id := fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/snapshots/snap-%d",
+		m.snapCounter.Add(1))
+
+	snap := &driver.SnapshotInfo{
+		ID: id, VolumeID: cfg.VolumeID, State: "completed", Description: cfg.Description,
+		Size: vol.Size, CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags: copyTags(cfg.Tags),
+	}
+	m.snapshots.Set(id, snap)
+
+	result := *snap
+
+	return &result, nil
+}
+
+func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
+	if !m.snapshots.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", id)
+	}
+
+	return nil
+}
+
+func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.SnapshotInfo, error) {
+	return describeResources(m.snapshots, ids), nil
+}
+
+func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
+	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "VM %q not found", cfg.InstanceID)
+	}
+
+	id := fmt.Sprintf("/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Compute/images/img-%d",
+		m.imgCounter.Add(1))
+
+	img := &driver.ImageInfo{
+		ID: id, Name: cfg.Name, State: stateAvailable, Description: cfg.Description,
+		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:      copyTags(cfg.Tags),
+	}
+	m.images.Set(id, img)
+
+	result := *img
+
+	return &result, nil
+}
+
+func (m *Mock) DeregisterImage(_ context.Context, id string) error {
+	if !m.images.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "image %q not found", id)
+	}
+
+	return nil
+}
+
+func (m *Mock) DescribeImages(_ context.Context, ids []string) ([]driver.ImageInfo, error) {
+	return describeResources(m.images, ids), nil
+}
+
+func describeResources[T any](store *memstore.Store[*T], ids []string) []T {
+	if len(ids) == 0 {
+		all := store.All()
+		result := make([]T, 0, len(all))
+
+		for _, v := range all {
+			result = append(result, *v)
+		}
+
+		return result
+	}
+
+	var result []T
+
+	for _, id := range ids {
+		if v, ok := store.Get(id); ok {
+			result = append(result, *v)
+		}
+	}
+
+	return result
 }

--- a/providers/gcp/gce/gce.go
+++ b/providers/gcp/gce/gce.go
@@ -20,7 +20,11 @@ import (
 // Compile-time check that Mock implements driver.Compute.
 var _ driver.Compute = (*Mock)(nil)
 
-const ipSegmentSize = 256
+const (
+	ipSegmentSize  = 256
+	stateAvailable = "available"
+	stateInUse     = "in-use"
+)
 
 type lifecycleTransition struct {
 	intermediateState string
@@ -84,9 +88,15 @@ type Mock struct {
 	asgs         *memstore.Store[*asgData]
 	spotRequests *memstore.Store[*driver.SpotInstanceRequest]
 	templates    *memstore.Store[*driver.LaunchTemplate]
+	volumes      *memstore.Store[*driver.VolumeInfo]
+	snapshots    *memstore.Store[*driver.SnapshotInfo]
+	images       *memstore.Store[*driver.ImageInfo]
 	sm           *statemachine.Machine
 	opts         *config.Options
 	ipCounter    atomic.Int64
+	volCounter   atomic.Int64
+	snapCounter  atomic.Int64
+	imgCounter   atomic.Int64
 	monitoring   mondriver.Monitoring
 }
 
@@ -167,6 +177,9 @@ func New(opts *config.Options) *Mock {
 		asgs:         memstore.New[*asgData](),
 		spotRequests: memstore.New[*driver.SpotInstanceRequest](),
 		templates:    memstore.New[*driver.LaunchTemplate](),
+		volumes:      memstore.New[*driver.VolumeInfo](),
+		snapshots:    memstore.New[*driver.SnapshotInfo](),
+		images:       memstore.New[*driver.ImageInfo](),
 		sm:           statemachine.New(compute.VMTransitions()),
 		opts:         opts,
 	}
@@ -362,4 +375,171 @@ func (m *Mock) ModifyInstance(_ context.Context, instanceID string, input driver
 	}
 
 	return nil
+}
+
+func (m *Mock) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	id := fmt.Sprintf("projects/%s/zones/%s/disks/disk-%d",
+		m.opts.ProjectID, m.opts.Region, m.volCounter.Add(1))
+
+	volType := cfg.VolumeType
+	if volType == "" {
+		volType = "pd-ssd"
+	}
+
+	vol := &driver.VolumeInfo{
+		ID: id, Size: cfg.Size, VolumeType: volType, State: stateAvailable,
+		AvailabilityZone: cfg.AvailabilityZone,
+		CreatedAt:        m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.volumes.Set(id, vol)
+
+	result := *vol
+
+	return &result, nil
+}
+
+func (m *Mock) DeleteVolume(_ context.Context, id string) error {
+	vol, ok := m.volumes.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", id)
+	}
+
+	if vol.State == stateInUse {
+		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q is attached", id)
+	}
+
+	m.volumes.Delete(id)
+
+	return nil
+}
+
+func (m *Mock) DescribeVolumes(_ context.Context, ids []string) ([]driver.VolumeInfo, error) {
+	return describeResources(m.volumes, ids), nil
+}
+
+func (m *Mock) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	if vol.State == stateInUse {
+		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q already attached", volumeID)
+	}
+
+	if _, ok := m.instances.Get(instanceID); !ok {
+		return cerrors.Newf(cerrors.NotFound, "instance %q not found", instanceID)
+	}
+
+	vol.State = stateInUse
+	vol.AttachedTo = instanceID
+	vol.Device = device
+
+	return nil
+}
+
+func (m *Mock) DetachVolume(_ context.Context, volumeID string) error {
+	vol, ok := m.volumes.Get(volumeID)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "disk %q not found", volumeID)
+	}
+
+	if vol.State != "in-use" {
+		return cerrors.Newf(cerrors.FailedPrecondition, "disk %q is not attached", volumeID)
+	}
+
+	vol.State = stateAvailable
+	vol.AttachedTo = ""
+	vol.Device = ""
+
+	return nil
+}
+
+func (m *Mock) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
+	vol, ok := m.volumes.Get(cfg.VolumeID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "disk %q not found", cfg.VolumeID)
+	}
+
+	id := fmt.Sprintf("projects/%s/global/snapshots/snap-%d",
+		m.opts.ProjectID, m.snapCounter.Add(1))
+
+	snap := &driver.SnapshotInfo{
+		ID: id, VolumeID: cfg.VolumeID, State: "completed", Description: cfg.Description,
+		Size: vol.Size, CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags: copyTags(cfg.Tags),
+	}
+	m.snapshots.Set(id, snap)
+
+	result := *snap
+
+	return &result, nil
+}
+
+func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
+	if !m.snapshots.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", id)
+	}
+
+	return nil
+}
+
+func (m *Mock) DescribeSnapshots(_ context.Context, ids []string) ([]driver.SnapshotInfo, error) {
+	return describeResources(m.snapshots, ids), nil
+}
+
+func (m *Mock) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
+	if _, ok := m.instances.Get(cfg.InstanceID); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "instance %q not found", cfg.InstanceID)
+	}
+
+	id := fmt.Sprintf("projects/%s/global/images/img-%d",
+		m.opts.ProjectID, m.imgCounter.Add(1))
+
+	img := &driver.ImageInfo{
+		ID: id, Name: cfg.Name, State: stateAvailable, Description: cfg.Description,
+		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		Tags:      copyTags(cfg.Tags),
+	}
+	m.images.Set(id, img)
+
+	result := *img
+
+	return &result, nil
+}
+
+func (m *Mock) DeregisterImage(_ context.Context, id string) error {
+	if !m.images.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "image %q not found", id)
+	}
+
+	return nil
+}
+
+func (m *Mock) DescribeImages(_ context.Context, ids []string) ([]driver.ImageInfo, error) {
+	return describeResources(m.images, ids), nil
+}
+
+func describeResources[T any](store *memstore.Store[*T], ids []string) []T {
+	if len(ids) == 0 {
+		all := store.All()
+		result := make([]T, 0, len(all))
+
+		for _, v := range all {
+			result = append(result, *v)
+		}
+
+		return result
+	}
+
+	var result []T
+
+	for _, id := range ids {
+		if v, ok := store.Get(id); ok {
+			result = append(result, *v)
+		}
+	}
+
+	return result
 }


### PR DESCRIPTION
## Summary

- Adds 11 new methods to compute driver interface: `CreateVolume`, `DeleteVolume`, `DescribeVolumes`, `AttachVolume`, `DetachVolume`, `CreateSnapshot`, `DeleteSnapshot`, `DescribeSnapshots`, `CreateImage`, `DeregisterImage`, `DescribeImages`
- Adds 6 new types: `VolumeConfig`, `VolumeInfo`, `SnapshotConfig`, `SnapshotInfo`, `ImageConfig`, `ImageInfo`
- Implements across all 3 providers: AWS EC2, Azure Virtual Machines, GCP GCE
- Volumes track state (available/in-use) and attached instance
- Snapshots reference source volume and inherit size
- Images are created from running instances
- Generic `describeResources[T]` helper eliminates code duplication

Closes #60

## Test plan

- [x] `TestVolumeLifecycleAWS` — create, attach, detach, delete with state verification
- [x] `TestVolumeLifecycleAzure` — create and delete
- [x] `TestVolumeLifecycleGCP` — create and delete
- [x] `TestSnapshotAWS` — create from volume, describe, delete
- [x] `TestImageAWS` — create from instance, describe, deregister
- [x] Linter: 0 issues
- [x] Full test suite: all passing