### PR TITLE
Add filter log events and metric filters to logging service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -1985,6 +1985,281 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 }
 
 // ==============================================================================
+// Integration Tests: FilterLogEvents and MetricFilters
+// ==============================================================================
+
+func TestFilterLogEventsAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testFilterLogEvents(t, ctx, p.CloudWatchLogs)
+}
+
+func TestFilterLogEventsAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testFilterLogEvents(t, ctx, p.LogAnalytics)
+}
+
+func TestFilterLogEventsGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testFilterLogEvents(t, ctx, p.CloudLogging)
+}
+
+func testFilterLogEvents(
+	t *testing.T,
+	ctx context.Context,
+	d loggingdriver.Logging,
+) {
+	t.Helper()
+
+	_, err := d.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{
+		Name: "filter-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	_, err = d.CreateLogStream(ctx, "filter-test", "stream-a")
+	if err != nil {
+		t.Fatalf("CreateLogStream (a): %v", err)
+	}
+
+	_, err = d.CreateLogStream(ctx, "filter-test", "stream-b")
+	if err != nil {
+		t.Fatalf("CreateLogStream (b): %v", err)
+	}
+
+	now := time.Now().UTC()
+
+	eventsA := []loggingdriver.LogEvent{
+		{Timestamp: now.Add(-3 * time.Minute), Message: "INFO starting"},
+		{Timestamp: now.Add(-2 * time.Minute), Message: "ERROR disk full"},
+		{Timestamp: now.Add(-time.Minute), Message: "INFO recovered"},
+	}
+
+	eventsB := []loggingdriver.LogEvent{
+		{Timestamp: now.Add(-2 * time.Minute), Message: "ERROR timeout"},
+		{Timestamp: now, Message: "INFO healthy"},
+	}
+
+	err = d.PutLogEvents(ctx, "filter-test", "stream-a", eventsA)
+	if err != nil {
+		t.Fatalf("PutLogEvents (a): %v", err)
+	}
+
+	err = d.PutLogEvents(ctx, "filter-test", "stream-b", eventsB)
+	if err != nil {
+		t.Fatalf("PutLogEvents (b): %v", err)
+	}
+
+	// Filter by pattern across all streams.
+	results, err := d.FilterLogEvents(ctx, &loggingdriver.FilterLogEventsInput{
+		LogGroup:      "filter-test",
+		FilterPattern: "ERROR",
+	})
+	if err != nil {
+		t.Fatalf("FilterLogEvents (ERROR): %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 ERROR events, got %d", len(results))
+	}
+
+	for _, r := range results {
+		if r.LogStream == "" {
+			t.Error("expected non-empty LogStream on filtered event")
+		}
+	}
+
+	// Filter by specific stream.
+	streamResults, err := d.FilterLogEvents(
+		ctx, &loggingdriver.FilterLogEventsInput{
+			LogGroup:      "filter-test",
+			LogStream:     "stream-a",
+			FilterPattern: "ERROR",
+		},
+	)
+	if err != nil {
+		t.Fatalf("FilterLogEvents (stream-a ERROR): %v", err)
+	}
+
+	if len(streamResults) != 1 {
+		t.Errorf("expected 1 event from stream-a, got %d", len(streamResults))
+	}
+
+	// Filter by time range (-2.5min to -0.5min captures 3 events).
+	timeResults, err := d.FilterLogEvents(
+		ctx, &loggingdriver.FilterLogEventsInput{
+			LogGroup:  "filter-test",
+			StartTime: now.Add(-150 * time.Second),
+			EndTime:   now.Add(-30 * time.Second),
+		},
+	)
+	if err != nil {
+		t.Fatalf("FilterLogEvents (time range): %v", err)
+	}
+
+	if len(timeResults) != 3 {
+		t.Errorf("expected 3 events in time range, got %d", len(timeResults))
+	}
+
+	// Filter with limit.
+	limitResults, err := d.FilterLogEvents(
+		ctx, &loggingdriver.FilterLogEventsInput{
+			LogGroup: "filter-test",
+			Limit:    2,
+		},
+	)
+	if err != nil {
+		t.Fatalf("FilterLogEvents (limit): %v", err)
+	}
+
+	if len(limitResults) > 2 {
+		t.Errorf("expected at most 2 events, got %d", len(limitResults))
+	}
+
+	// Empty result for non-matching pattern.
+	emptyResults, err := d.FilterLogEvents(
+		ctx, &loggingdriver.FilterLogEventsInput{
+			LogGroup:      "filter-test",
+			FilterPattern: "CRITICAL",
+		},
+	)
+	if err != nil {
+		t.Fatalf("FilterLogEvents (no match): %v", err)
+	}
+
+	if len(emptyResults) != 0 {
+		t.Errorf("expected 0 events, got %d", len(emptyResults))
+	}
+
+	// Not found log group.
+	_, err = d.FilterLogEvents(ctx, &loggingdriver.FilterLogEventsInput{
+		LogGroup: "nonexistent",
+	})
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestMetricFiltersAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	d := p.CloudWatchLogs
+
+	_, err := d.CreateLogGroup(ctx, loggingdriver.LogGroupConfig{
+		Name: "mf-test",
+	})
+	if err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	// Put a metric filter.
+	err = d.PutMetricFilter(ctx, &loggingdriver.MetricFilterConfig{
+		Name:            "error-count",
+		LogGroup:        "mf-test",
+		FilterPattern:   "ERROR",
+		MetricName:      "ErrorCount",
+		MetricNamespace: "App/Errors",
+		MetricValue:     "1",
+	})
+	if err != nil {
+		t.Fatalf("PutMetricFilter: %v", err)
+	}
+
+	// Describe metric filters.
+	filters, err := d.DescribeMetricFilters(ctx, "mf-test")
+	if err != nil {
+		t.Fatalf("DescribeMetricFilters: %v", err)
+	}
+
+	if len(filters) != 1 {
+		t.Fatalf("expected 1 filter, got %d", len(filters))
+	}
+
+	f := filters[0]
+	if f.Name != "error-count" {
+		t.Errorf("expected name 'error-count', got %q", f.Name)
+	}
+
+	if f.FilterPattern != "ERROR" {
+		t.Errorf("expected pattern 'ERROR', got %q", f.FilterPattern)
+	}
+
+	if f.MetricName != "ErrorCount" {
+		t.Errorf("expected metric 'ErrorCount', got %q", f.MetricName)
+	}
+
+	if f.MetricNamespace != "App/Errors" {
+		t.Errorf(
+			"expected namespace 'App/Errors', got %q",
+			f.MetricNamespace,
+		)
+	}
+
+	if f.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+
+	// Update existing filter by name.
+	err = d.PutMetricFilter(ctx, &loggingdriver.MetricFilterConfig{
+		Name:            "error-count",
+		LogGroup:        "mf-test",
+		FilterPattern:   "FATAL",
+		MetricName:      "FatalCount",
+		MetricNamespace: "App/Errors",
+		MetricValue:     "1",
+	})
+	if err != nil {
+		t.Fatalf("PutMetricFilter (update): %v", err)
+	}
+
+	filters, err = d.DescribeMetricFilters(ctx, "mf-test")
+	if err != nil {
+		t.Fatalf("DescribeMetricFilters after update: %v", err)
+	}
+
+	if len(filters) != 1 {
+		t.Fatalf("expected 1 filter after update, got %d", len(filters))
+	}
+
+	if filters[0].FilterPattern != "FATAL" {
+		t.Errorf(
+			"expected updated pattern 'FATAL', got %q",
+			filters[0].FilterPattern,
+		)
+	}
+
+	// Delete metric filter.
+	err = d.DeleteMetricFilter(ctx, "mf-test", "error-count")
+	if err != nil {
+		t.Fatalf("DeleteMetricFilter: %v", err)
+	}
+
+	filters, err = d.DescribeMetricFilters(ctx, "mf-test")
+	if err != nil {
+		t.Fatalf("DescribeMetricFilters after delete: %v", err)
+	}
+
+	if len(filters) != 0 {
+		t.Errorf("expected 0 filters after delete, got %d", len(filters))
+	}
+
+	// Delete non-existent filter.
+	err = d.DeleteMetricFilter(ctx, "mf-test", "nonexistent")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+
+	// Describe on non-existent group.
+	_, err = d.DescribeMetricFilters(ctx, "no-such-group")
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+// ==============================================================================
 // Integration Tests: Notification (AWS SNS, Azure Notification Hubs, GCP FCM)
 // ==============================================================================
 

--- a/logging/driver/driver.go
+++ b/logging/driver/driver.go
@@ -46,6 +46,44 @@ type LogQueryInput struct {
 	Limit     int
 }
 
+// FilterLogEventsInput configures a filter log events operation.
+type FilterLogEventsInput struct {
+	LogGroup      string
+	LogStream     string
+	FilterPattern string
+	StartTime     time.Time
+	EndTime       time.Time
+	Limit         int
+}
+
+// FilteredLogEvent represents a log event returned by FilterLogEvents.
+type FilteredLogEvent struct {
+	LogStream string
+	Timestamp time.Time
+	Message   string
+}
+
+// MetricFilterConfig describes a metric filter to create.
+type MetricFilterConfig struct {
+	Name            string
+	LogGroup        string
+	FilterPattern   string
+	MetricName      string
+	MetricNamespace string
+	MetricValue     string
+}
+
+// MetricFilterInfo describes a metric filter.
+type MetricFilterInfo struct {
+	Name            string
+	LogGroup        string
+	FilterPattern   string
+	MetricName      string
+	MetricNamespace string
+	MetricValue     string
+	CreatedAt       time.Time
+}
+
 // Logging is the interface that logging provider implementations must satisfy.
 type Logging interface {
 	CreateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
@@ -59,4 +97,9 @@ type Logging interface {
 
 	PutLogEvents(ctx context.Context, logGroup, streamName string, events []LogEvent) error
 	GetLogEvents(ctx context.Context, input *LogQueryInput) ([]LogEvent, error)
+
+	FilterLogEvents(ctx context.Context, input *FilterLogEventsInput) ([]FilteredLogEvent, error)
+	PutMetricFilter(ctx context.Context, config *MetricFilterConfig) error
+	DeleteMetricFilter(ctx context.Context, logGroup, filterName string) error
+	DescribeMetricFilters(ctx context.Context, logGroup string) ([]MetricFilterInfo, error)
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -172,11 +172,81 @@ func (l *Logging) PutLogEvents(ctx context.Context, logGroup, streamName string,
 }
 
 // GetLogEvents retrieves log events matching the query.
-func (l *Logging) GetLogEvents(ctx context.Context, input *driver.LogQueryInput) ([]driver.LogEvent, error) {
-	out, err := l.do(ctx, "GetLogEvents", input, func() (any, error) { return l.driver.GetLogEvents(ctx, input) })
+func (l *Logging) GetLogEvents(
+	ctx context.Context,
+	input *driver.LogQueryInput,
+) ([]driver.LogEvent, error) {
+	out, err := l.do(ctx, "GetLogEvents", input, func() (any, error) {
+		return l.driver.GetLogEvents(ctx, input)
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	return out.([]driver.LogEvent), nil
+}
+
+// FilterLogEvents filters log events across streams using a pattern.
+func (l *Logging) FilterLogEvents(
+	ctx context.Context,
+	input *driver.FilterLogEventsInput,
+) ([]driver.FilteredLogEvent, error) {
+	out, err := l.do(ctx, "FilterLogEvents", input, func() (any, error) {
+		return l.driver.FilterLogEvents(ctx, input)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.FilteredLogEvent), nil
+}
+
+// PutMetricFilter creates or updates a metric filter for a log group.
+func (l *Logging) PutMetricFilter(
+	ctx context.Context,
+	cfg *driver.MetricFilterConfig,
+) error {
+	_, err := l.do(ctx, "PutMetricFilter", cfg, func() (any, error) {
+		return nil, l.driver.PutMetricFilter(ctx, cfg)
+	})
+
+	return err
+}
+
+// DeleteMetricFilter deletes a metric filter from a log group.
+func (l *Logging) DeleteMetricFilter(
+	ctx context.Context,
+	logGroup, filterName string,
+) error {
+	_, err := l.do(
+		ctx, "DeleteMetricFilter",
+		map[string]string{
+			"logGroup": logGroup, "filterName": filterName,
+		},
+		func() (any, error) {
+			return nil, l.driver.DeleteMetricFilter(
+				ctx, logGroup, filterName,
+			)
+		},
+	)
+
+	return err
+}
+
+// DescribeMetricFilters lists all metric filters for a log group.
+func (l *Logging) DescribeMetricFilters(
+	ctx context.Context,
+	logGroup string,
+) ([]driver.MetricFilterInfo, error) {
+	out, err := l.do(
+		ctx, "DescribeMetricFilters", logGroup,
+		func() (any, error) {
+			return l.driver.DescribeMetricFilters(ctx, logGroup)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.MetricFilterInfo), nil
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -30,8 +30,9 @@ type logStream struct {
 }
 
 type logGroup struct {
-	info    driver.LogGroupInfo
-	streams *memstore.Store[*logStream]
+	info          driver.LogGroupInfo
+	streams       *memstore.Store[*logStream]
+	metricFilters *memstore.Store[*driver.MetricFilterInfo]
 }
 
 // Mock is an in-memory mock implementation of the AWS CloudWatch Logs service.
@@ -97,8 +98,9 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 	}
 
 	g := &logGroup{
-		info:    info,
-		streams: memstore.New[*logStream](),
+		info:          info,
+		streams:       memstore.New[*logStream](),
+		metricFilters: memstore.New[*driver.MetricFilterInfo](),
 	}
 
 	m.groups.Set(cfg.Name, g)
@@ -296,7 +298,11 @@ func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.Log
 	return m.filterEvents(s, input, retentionCutoff)
 }
 
-func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
+func (*Mock) filterEvents(
+	s *logStream,
+	input *driver.LogQueryInput,
+	retentionCutoff time.Time,
+) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -323,4 +329,168 @@ func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCu
 	}
 
 	return results
+}
+
+// FilterLogEvents filters log events across streams using a pattern.
+func (m *Mock) FilterLogEvents(
+	_ context.Context,
+	input *driver.FilterLogEventsInput,
+) ([]driver.FilteredLogEvent, error) {
+	g, ok := m.groups.Get(input.LogGroup)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "log group %q not found", input.LogGroup,
+		)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultLogLimit
+	}
+
+	var results []driver.FilteredLogEvent
+
+	if input.LogStream != "" {
+		results = m.filterStreamEvents(g, input.LogStream, input)
+	} else {
+		for name, s := range g.streams.All() {
+			events := m.matchEvents(s, name, input)
+			results = append(results, events...)
+		}
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	if results == nil {
+		results = []driver.FilteredLogEvent{}
+	}
+
+	return results, nil
+}
+
+func (m *Mock) filterStreamEvents(
+	g *logGroup,
+	streamName string,
+	input *driver.FilterLogEventsInput,
+) []driver.FilteredLogEvent {
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return nil
+	}
+
+	return m.matchEvents(s, streamName, input)
+}
+
+func (*Mock) matchEvents(
+	s *logStream,
+	streamName string,
+	input *driver.FilterLogEventsInput,
+) []driver.FilteredLogEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []driver.FilteredLogEvent
+
+	for _, e := range s.events {
+		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
+			continue
+		}
+
+		if !input.EndTime.IsZero() && e.Timestamp.After(input.EndTime) {
+			continue
+		}
+
+		if input.FilterPattern != "" &&
+			!strings.Contains(e.Message, input.FilterPattern) {
+			continue
+		}
+
+		results = append(results, driver.FilteredLogEvent{
+			LogStream: streamName,
+			Timestamp: e.Timestamp,
+			Message:   e.Message,
+		})
+	}
+
+	return results
+}
+
+// PutMetricFilter creates or updates a metric filter for a log group.
+func (m *Mock) PutMetricFilter(
+	_ context.Context,
+	cfg *driver.MetricFilterConfig,
+) error {
+	g, ok := m.groups.Get(cfg.LogGroup)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound, "log group %q not found", cfg.LogGroup,
+		)
+	}
+
+	if cfg.Name == "" {
+		return errors.New(
+			errors.InvalidArgument, "metric filter name is required",
+		)
+	}
+
+	info := &driver.MetricFilterInfo{
+		Name:            cfg.Name,
+		LogGroup:        cfg.LogGroup,
+		FilterPattern:   cfg.FilterPattern,
+		MetricName:      cfg.MetricName,
+		MetricNamespace: cfg.MetricNamespace,
+		MetricValue:     cfg.MetricValue,
+		CreatedAt:       m.opts.Clock.Now().UTC(),
+	}
+
+	g.metricFilters.Set(cfg.Name, info)
+
+	return nil
+}
+
+// DeleteMetricFilter deletes a metric filter from a log group.
+func (m *Mock) DeleteMetricFilter(
+	_ context.Context,
+	logGroup, filterName string,
+) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound, "log group %q not found", logGroup,
+		)
+	}
+
+	if !g.metricFilters.Delete(filterName) {
+		return errors.Newf(
+			errors.NotFound,
+			"metric filter %q not found in group %q",
+			filterName, logGroup,
+		)
+	}
+
+	return nil
+}
+
+// DescribeMetricFilters lists all metric filters for a log group.
+func (m *Mock) DescribeMetricFilters(
+	_ context.Context,
+	logGroup string,
+) ([]driver.MetricFilterInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "log group %q not found", logGroup,
+		)
+	}
+
+	all := g.metricFilters.All()
+	results := make([]driver.MetricFilterInfo, 0, len(all))
+
+	for _, mf := range all {
+		results = append(results, *mf)
+	}
+
+	return results, nil
 }

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -30,8 +30,9 @@ type logStream struct {
 }
 
 type logGroup struct {
-	info    driver.LogGroupInfo
-	streams *memstore.Store[*logStream]
+	info          driver.LogGroupInfo
+	streams       *memstore.Store[*logStream]
+	metricFilters *memstore.Store[*driver.MetricFilterInfo]
 }
 
 // Mock is an in-memory mock implementation of Azure Log Analytics.
@@ -108,8 +109,9 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 	}
 
 	g := &logGroup{
-		info:    info,
-		streams: memstore.New[*logStream](),
+		info:          info,
+		streams:       memstore.New[*logStream](),
+		metricFilters: memstore.New[*driver.MetricFilterInfo](),
 	}
 
 	m.groups.Set(cfg.Name, g)
@@ -306,7 +308,11 @@ func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.Log
 	return m.filterEvents(s, input, retentionCutoff)
 }
 
-func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
+func (*Mock) filterEvents(
+	s *logStream,
+	input *driver.LogQueryInput,
+	retentionCutoff time.Time,
+) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -333,4 +339,168 @@ func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCu
 	}
 
 	return results
+}
+
+// FilterLogEvents filters log events across streams using a pattern.
+func (m *Mock) FilterLogEvents(
+	_ context.Context,
+	input *driver.FilterLogEventsInput,
+) ([]driver.FilteredLogEvent, error) {
+	g, ok := m.groups.Get(input.LogGroup)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "log group %q not found", input.LogGroup,
+		)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultLogLimit
+	}
+
+	var results []driver.FilteredLogEvent
+
+	if input.LogStream != "" {
+		results = m.filterStreamEvents(g, input.LogStream, input)
+	} else {
+		for name, s := range g.streams.All() {
+			events := m.matchEvents(s, name, input)
+			results = append(results, events...)
+		}
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	if results == nil {
+		results = []driver.FilteredLogEvent{}
+	}
+
+	return results, nil
+}
+
+func (m *Mock) filterStreamEvents(
+	g *logGroup,
+	streamName string,
+	input *driver.FilterLogEventsInput,
+) []driver.FilteredLogEvent {
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return nil
+	}
+
+	return m.matchEvents(s, streamName, input)
+}
+
+func (*Mock) matchEvents(
+	s *logStream,
+	streamName string,
+	input *driver.FilterLogEventsInput,
+) []driver.FilteredLogEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []driver.FilteredLogEvent
+
+	for _, e := range s.events {
+		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
+			continue
+		}
+
+		if !input.EndTime.IsZero() && e.Timestamp.After(input.EndTime) {
+			continue
+		}
+
+		if input.FilterPattern != "" &&
+			!strings.Contains(e.Message, input.FilterPattern) {
+			continue
+		}
+
+		results = append(results, driver.FilteredLogEvent{
+			LogStream: streamName,
+			Timestamp: e.Timestamp,
+			Message:   e.Message,
+		})
+	}
+
+	return results
+}
+
+// PutMetricFilter creates or updates a metric filter for a log group.
+func (m *Mock) PutMetricFilter(
+	_ context.Context,
+	cfg *driver.MetricFilterConfig,
+) error {
+	g, ok := m.groups.Get(cfg.LogGroup)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound, "log group %q not found", cfg.LogGroup,
+		)
+	}
+
+	if cfg.Name == "" {
+		return errors.New(
+			errors.InvalidArgument, "metric filter name is required",
+		)
+	}
+
+	info := &driver.MetricFilterInfo{
+		Name:            cfg.Name,
+		LogGroup:        cfg.LogGroup,
+		FilterPattern:   cfg.FilterPattern,
+		MetricName:      cfg.MetricName,
+		MetricNamespace: cfg.MetricNamespace,
+		MetricValue:     cfg.MetricValue,
+		CreatedAt:       m.opts.Clock.Now().UTC(),
+	}
+
+	g.metricFilters.Set(cfg.Name, info)
+
+	return nil
+}
+
+// DeleteMetricFilter deletes a metric filter from a log group.
+func (m *Mock) DeleteMetricFilter(
+	_ context.Context,
+	logGroup, filterName string,
+) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound, "log group %q not found", logGroup,
+		)
+	}
+
+	if !g.metricFilters.Delete(filterName) {
+		return errors.Newf(
+			errors.NotFound,
+			"metric filter %q not found in group %q",
+			filterName, logGroup,
+		)
+	}
+
+	return nil
+}
+
+// DescribeMetricFilters lists all metric filters for a log group.
+func (m *Mock) DescribeMetricFilters(
+	_ context.Context,
+	logGroup string,
+) ([]driver.MetricFilterInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "log group %q not found", logGroup,
+		)
+	}
+
+	all := g.metricFilters.All()
+	results := make([]driver.MetricFilterInfo, 0, len(all))
+
+	for _, mf := range all {
+		results = append(results, *mf)
+	}
+
+	return results, nil
 }

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -30,8 +30,9 @@ type logStream struct {
 }
 
 type logGroup struct {
-	info    driver.LogGroupInfo
-	streams *memstore.Store[*logStream]
+	info          driver.LogGroupInfo
+	streams       *memstore.Store[*logStream]
+	metricFilters *memstore.Store[*driver.MetricFilterInfo]
 }
 
 // Mock is an in-memory mock implementation of GCP Cloud Logging.
@@ -103,8 +104,9 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 	}
 
 	g := &logGroup{
-		info:    info,
-		streams: memstore.New[*logStream](),
+		info:          info,
+		streams:       memstore.New[*logStream](),
+		metricFilters: memstore.New[*driver.MetricFilterInfo](),
 	}
 
 	m.groups.Set(cfg.Name, g)
@@ -301,7 +303,11 @@ func (m *Mock) getStreamEvents(g *logGroup, streamName string, input *driver.Log
 	return m.filterEvents(s, input, retentionCutoff)
 }
 
-func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCutoff time.Time) []driver.LogEvent {
+func (*Mock) filterEvents(
+	s *logStream,
+	input *driver.LogQueryInput,
+	retentionCutoff time.Time,
+) []driver.LogEvent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -328,4 +334,168 @@ func (*Mock) filterEvents(s *logStream, input *driver.LogQueryInput, retentionCu
 	}
 
 	return results
+}
+
+// FilterLogEvents filters log events across streams using a pattern.
+func (m *Mock) FilterLogEvents(
+	_ context.Context,
+	input *driver.FilterLogEventsInput,
+) ([]driver.FilteredLogEvent, error) {
+	g, ok := m.groups.Get(input.LogGroup)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "log group %q not found", input.LogGroup,
+		)
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultLogLimit
+	}
+
+	var results []driver.FilteredLogEvent
+
+	if input.LogStream != "" {
+		results = m.filterStreamEvents(g, input.LogStream, input)
+	} else {
+		for name, s := range g.streams.All() {
+			events := m.matchEvents(s, name, input)
+			results = append(results, events...)
+		}
+	}
+
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	if results == nil {
+		results = []driver.FilteredLogEvent{}
+	}
+
+	return results, nil
+}
+
+func (m *Mock) filterStreamEvents(
+	g *logGroup,
+	streamName string,
+	input *driver.FilterLogEventsInput,
+) []driver.FilteredLogEvent {
+	s, ok := g.streams.Get(streamName)
+	if !ok {
+		return nil
+	}
+
+	return m.matchEvents(s, streamName, input)
+}
+
+func (*Mock) matchEvents(
+	s *logStream,
+	streamName string,
+	input *driver.FilterLogEventsInput,
+) []driver.FilteredLogEvent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var results []driver.FilteredLogEvent
+
+	for _, e := range s.events {
+		if !input.StartTime.IsZero() && e.Timestamp.Before(input.StartTime) {
+			continue
+		}
+
+		if !input.EndTime.IsZero() && e.Timestamp.After(input.EndTime) {
+			continue
+		}
+
+		if input.FilterPattern != "" &&
+			!strings.Contains(e.Message, input.FilterPattern) {
+			continue
+		}
+
+		results = append(results, driver.FilteredLogEvent{
+			LogStream: streamName,
+			Timestamp: e.Timestamp,
+			Message:   e.Message,
+		})
+	}
+
+	return results
+}
+
+// PutMetricFilter creates or updates a metric filter for a log group.
+func (m *Mock) PutMetricFilter(
+	_ context.Context,
+	cfg *driver.MetricFilterConfig,
+) error {
+	g, ok := m.groups.Get(cfg.LogGroup)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound, "log group %q not found", cfg.LogGroup,
+		)
+	}
+
+	if cfg.Name == "" {
+		return errors.New(
+			errors.InvalidArgument, "metric filter name is required",
+		)
+	}
+
+	info := &driver.MetricFilterInfo{
+		Name:            cfg.Name,
+		LogGroup:        cfg.LogGroup,
+		FilterPattern:   cfg.FilterPattern,
+		MetricName:      cfg.MetricName,
+		MetricNamespace: cfg.MetricNamespace,
+		MetricValue:     cfg.MetricValue,
+		CreatedAt:       m.opts.Clock.Now().UTC(),
+	}
+
+	g.metricFilters.Set(cfg.Name, info)
+
+	return nil
+}
+
+// DeleteMetricFilter deletes a metric filter from a log group.
+func (m *Mock) DeleteMetricFilter(
+	_ context.Context,
+	logGroup, filterName string,
+) error {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound, "log group %q not found", logGroup,
+		)
+	}
+
+	if !g.metricFilters.Delete(filterName) {
+		return errors.Newf(
+			errors.NotFound,
+			"metric filter %q not found in group %q",
+			filterName, logGroup,
+		)
+	}
+
+	return nil
+}
+
+// DescribeMetricFilters lists all metric filters for a log group.
+func (m *Mock) DescribeMetricFilters(
+	_ context.Context,
+	logGroup string,
+) ([]driver.MetricFilterInfo, error) {
+	g, ok := m.groups.Get(logGroup)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "log group %q not found", logGroup,
+		)
+	}
+
+	all := g.metricFilters.All()
+	results := make([]driver.MetricFilterInfo, 0, len(all))
+
+	for _, mf := range all {
+		results = append(results, *mf)
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
## Summary

- Adds 4 new methods to logging driver interface: `FilterLogEvents`, `PutMetricFilter`, `DeleteMetricFilter`, `DescribeMetricFilters`
- Adds 4 new types: `FilterLogEventsInput`, `FilteredLogEvent`, `MetricFilterConfig`, `MetricFilterInfo`
- Implements across all 3 providers: AWS CloudWatch Logs, Azure Log Analytics, GCP Cloud Logging
- FilterLogEvents supports substring pattern matching, time range filtering, and limit
- Metric filters stored in memstore with full CRUD operations
- Wires through portable API layer

Closes #65

## Test plan

- [x] `TestFilterLogEventsAWS` — put events, filter by pattern, verify matches
- [x] `TestFilterLogEventsAzure` — same
- [x] `TestFilterLogEventsGCP` — same
- [x] `TestMetricFiltersAWS` — put, describe, update, delete metric filters
- [x] Linter: 0 issues
- [x] Full test suite: all passing