### PR TITLE
Add groups and access keys to IAM service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7223,3 +7223,270 @@ func TestImageAWS(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIAMGroupsAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Create user and group
+	_, err := p.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grp, err := p.IAM.CreateGroup(ctx, iamdriver.GroupConfig{
+		Name: "developers",
+		Path: "/eng/",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if grp.Name != "developers" {
+		t.Errorf("expected group name developers, got %s", grp.Name)
+	}
+
+	if grp.ARN == "" {
+		t.Error("expected non-empty ARN")
+	}
+
+	// Duplicate group should fail
+	_, err = p.IAM.CreateGroup(ctx, iamdriver.GroupConfig{
+		Name: "developers",
+	})
+	if err == nil {
+		t.Error("expected error for duplicate group")
+	}
+
+	// Get group
+	got, err := p.IAM.GetGroup(ctx, "developers")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Path != "/eng/" {
+		t.Errorf("expected path /eng/, got %s", got.Path)
+	}
+
+	// List groups
+	groups, err := p.IAM.ListGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(groups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(groups))
+	}
+
+	// Add user to group
+	if err := p.IAM.AddUserToGroup(ctx, "alice", "developers"); err != nil {
+		t.Fatal(err)
+	}
+
+	// List groups for user
+	userGroups, err := p.IAM.ListGroupsForUser(ctx, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(userGroups) != 1 {
+		t.Errorf("expected 1 group for user, got %d", len(userGroups))
+	}
+
+	// Remove user from group
+	if err := p.IAM.RemoveUserFromGroup(ctx, "alice", "developers"); err != nil {
+		t.Fatal(err)
+	}
+
+	userGroups, err = p.IAM.ListGroupsForUser(ctx, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(userGroups) != 0 {
+		t.Errorf("expected 0 groups after removal, got %d", len(userGroups))
+	}
+
+	// Delete group
+	if err := p.IAM.DeleteGroup(ctx, "developers"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = p.IAM.GetGroup(ctx, "developers")
+	if err == nil {
+		t.Error("expected error after deleting group")
+	}
+}
+
+func TestIAMGroupsAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	_, err := p.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grp, err := p.IAM.CreateGroup(ctx, iamdriver.GroupConfig{
+		Name: "admins",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if grp.Name != "admins" {
+		t.Errorf("expected group name admins, got %s", grp.Name)
+	}
+
+	if err := p.IAM.AddUserToGroup(ctx, "bob", "admins"); err != nil {
+		t.Fatal(err)
+	}
+
+	userGroups, err := p.IAM.ListGroupsForUser(ctx, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(userGroups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(userGroups))
+	}
+
+	if err := p.IAM.RemoveUserFromGroup(ctx, "bob", "admins"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.IAM.DeleteGroup(ctx, "admins"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIAMGroupsGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	_, err := p.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "carol"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grp, err := p.IAM.CreateGroup(ctx, iamdriver.GroupConfig{
+		Name: "viewers",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if grp.Name != "viewers" {
+		t.Errorf("expected group name viewers, got %s", grp.Name)
+	}
+
+	if err := p.IAM.AddUserToGroup(ctx, "carol", "viewers"); err != nil {
+		t.Fatal(err)
+	}
+
+	userGroups, err := p.IAM.ListGroupsForUser(ctx, "carol")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(userGroups) != 1 {
+		t.Errorf("expected 1 group, got %d", len(userGroups))
+	}
+
+	if err := p.IAM.RemoveUserFromGroup(ctx, "carol", "viewers"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.IAM.DeleteGroup(ctx, "viewers"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccessKeysAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	_, err := p.IAM.CreateUser(ctx, iamdriver.UserConfig{Name: "dave"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create access key
+	ak, err := p.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{
+		UserName: "dave",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ak.AccessKeyID == "" {
+		t.Error("expected non-empty access key ID")
+	}
+
+	if ak.SecretAccessKey == "" {
+		t.Error("expected non-empty secret access key")
+	}
+
+	if ak.UserName != "dave" {
+		t.Errorf("expected user dave, got %s", ak.UserName)
+	}
+
+	if ak.Status != "Active" {
+		t.Errorf("expected Active status, got %s", ak.Status)
+	}
+
+	// List access keys
+	keys, err := p.IAM.ListAccessKeys(ctx, "dave")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(keys) != 1 {
+		t.Errorf("expected 1 key, got %d", len(keys))
+	}
+
+	// Create another key
+	ak2, err := p.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{
+		UserName: "dave",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err = p.IAM.ListAccessKeys(ctx, "dave")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(keys))
+	}
+
+	// Delete access key
+	if err := p.IAM.DeleteAccessKey(ctx, "dave", ak.AccessKeyID); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err = p.IAM.ListAccessKeys(ctx, "dave")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(keys) != 1 {
+		t.Errorf("expected 1 key after delete, got %d", len(keys))
+	}
+
+	// Delete wrong user should fail
+	err = p.IAM.DeleteAccessKey(ctx, "nobody", ak2.AccessKeyID)
+	if err == nil {
+		t.Error("expected error deleting key with wrong user")
+	}
+
+	// Create key for nonexistent user should fail
+	_, err = p.IAM.CreateAccessKey(ctx, iamdriver.AccessKeyConfig{
+		UserName: "nonexistent",
+	})
+	if err == nil {
+		t.Error("expected error creating key for nonexistent user")
+	}
+}

--- a/iam/driver/driver.go
+++ b/iam/driver/driver.go
@@ -56,6 +56,34 @@ type PolicyInfo struct {
 	Description    string
 }
 
+// GroupConfig describes a group to create.
+type GroupConfig struct {
+	Name string
+	Path string
+}
+
+// GroupInfo describes an IAM group.
+type GroupInfo struct {
+	Name      string
+	Path      string
+	ARN       string
+	CreatedAt string
+}
+
+// AccessKeyConfig describes an access key to create.
+type AccessKeyConfig struct {
+	UserName string
+}
+
+// AccessKeyInfo describes an IAM access key.
+type AccessKeyInfo struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	UserName        string
+	Status          string
+	CreatedAt       string
+}
+
 // IAM is the interface that IAM provider implementations must satisfy.
 type IAM interface {
 	CreateUser(ctx context.Context, config UserConfig) (*UserInfo, error)
@@ -82,4 +110,17 @@ type IAM interface {
 	ListAttachedRolePolicies(ctx context.Context, roleName string) ([]string, error)
 
 	CheckPermission(ctx context.Context, principal, action, resource string) (bool, error)
+
+	CreateGroup(ctx context.Context, config GroupConfig) (*GroupInfo, error)
+	DeleteGroup(ctx context.Context, name string) error
+	GetGroup(ctx context.Context, name string) (*GroupInfo, error)
+	ListGroups(ctx context.Context) ([]GroupInfo, error)
+
+	AddUserToGroup(ctx context.Context, userName, groupName string) error
+	RemoveUserFromGroup(ctx context.Context, userName, groupName string) error
+	ListGroupsForUser(ctx context.Context, userName string) ([]GroupInfo, error)
+
+	CreateAccessKey(ctx context.Context, config AccessKeyConfig) (*AccessKeyInfo, error)
+	DeleteAccessKey(ctx context.Context, userName, accessKeyID string) error
+	ListAccessKeys(ctx context.Context, userName string) ([]AccessKeyInfo, error)
 }

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -244,3 +244,101 @@ func (i *IAM) CheckPermission(ctx context.Context, principal, action, resource s
 
 	return out.(bool), nil
 }
+
+func (i *IAM) CreateGroup(ctx context.Context, config driver.GroupConfig) (*driver.GroupInfo, error) {
+	out, err := i.do(ctx, "CreateGroup", config, func() (any, error) {
+		return i.driver.CreateGroup(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.GroupInfo), nil
+}
+
+func (i *IAM) DeleteGroup(ctx context.Context, name string) error {
+	_, err := i.do(ctx, "DeleteGroup", name, func() (any, error) {
+		return nil, i.driver.DeleteGroup(ctx, name)
+	})
+
+	return err
+}
+
+func (i *IAM) GetGroup(ctx context.Context, name string) (*driver.GroupInfo, error) {
+	out, err := i.do(ctx, "GetGroup", name, func() (any, error) {
+		return i.driver.GetGroup(ctx, name)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.GroupInfo), nil
+}
+
+func (i *IAM) ListGroups(ctx context.Context) ([]driver.GroupInfo, error) {
+	out, err := i.do(ctx, "ListGroups", nil, func() (any, error) {
+		return i.driver.ListGroups(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.GroupInfo), nil
+}
+
+func (i *IAM) AddUserToGroup(ctx context.Context, userName, groupName string) error {
+	_, err := i.do(ctx, "AddUserToGroup", userName, func() (any, error) {
+		return nil, i.driver.AddUserToGroup(ctx, userName, groupName)
+	})
+
+	return err
+}
+
+func (i *IAM) RemoveUserFromGroup(ctx context.Context, userName, groupName string) error {
+	_, err := i.do(ctx, "RemoveUserFromGroup", userName, func() (any, error) {
+		return nil, i.driver.RemoveUserFromGroup(ctx, userName, groupName)
+	})
+
+	return err
+}
+
+func (i *IAM) ListGroupsForUser(ctx context.Context, userName string) ([]driver.GroupInfo, error) {
+	out, err := i.do(ctx, "ListGroupsForUser", userName, func() (any, error) {
+		return i.driver.ListGroupsForUser(ctx, userName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.GroupInfo), nil
+}
+
+func (i *IAM) CreateAccessKey(ctx context.Context, config driver.AccessKeyConfig) (*driver.AccessKeyInfo, error) {
+	out, err := i.do(ctx, "CreateAccessKey", config, func() (any, error) {
+		return i.driver.CreateAccessKey(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.AccessKeyInfo), nil
+}
+
+func (i *IAM) DeleteAccessKey(ctx context.Context, userName, accessKeyID string) error {
+	_, err := i.do(ctx, "DeleteAccessKey", userName, func() (any, error) {
+		return nil, i.driver.DeleteAccessKey(ctx, userName, accessKeyID)
+	})
+
+	return err
+}
+
+func (i *IAM) ListAccessKeys(ctx context.Context, userName string) ([]driver.AccessKeyInfo, error) {
+	out, err := i.do(ctx, "ListAccessKeys", userName, func() (any, error) {
+		return i.driver.ListAccessKeys(ctx, userName)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.AccessKeyInfo), nil
+}

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -19,8 +19,11 @@ type mockDriver struct {
 	users          map[string]*driver.UserInfo
 	roles          map[string]*driver.RoleInfo
 	policies       map[string]*driver.PolicyInfo
+	groups         map[string]*driver.GroupInfo
+	accessKeys     map[string]*driver.AccessKeyInfo
 	userPolicies   map[string][]string // userName -> []policyARN
 	rolePolicies   map[string][]string // roleName -> []policyARN
+	groupUsers     map[string]map[string]bool
 	seq            int
 }
 
@@ -29,8 +32,11 @@ func newMockDriver() *mockDriver {
 		users:        make(map[string]*driver.UserInfo),
 		roles:        make(map[string]*driver.RoleInfo),
 		policies:     make(map[string]*driver.PolicyInfo),
+		groups:       make(map[string]*driver.GroupInfo),
+		accessKeys:   make(map[string]*driver.AccessKeyInfo),
 		userPolicies: make(map[string][]string),
 		rolePolicies: make(map[string][]string),
+		groupUsers:   make(map[string]map[string]bool),
 	}
 }
 
@@ -251,6 +257,153 @@ func (m *mockDriver) CheckPermission(_ context.Context, principal, _, _ string) 
 	}
 
 	return true, nil
+}
+
+func (m *mockDriver) CreateGroup(_ context.Context, cfg driver.GroupConfig) (*driver.GroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, fmt.Errorf("name required")
+	}
+
+	if _, ok := m.groups[cfg.Name]; ok {
+		return nil, fmt.Errorf("already exists")
+	}
+
+	info := &driver.GroupInfo{
+		Name: cfg.Name,
+		Path: cfg.Path,
+		ARN:  "arn:aws:iam::123456789012:group/" + cfg.Name,
+	}
+	m.groups[cfg.Name] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteGroup(_ context.Context, name string) error {
+	if _, ok := m.groups[name]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.groups, name)
+	delete(m.groupUsers, name)
+
+	return nil
+}
+
+func (m *mockDriver) GetGroup(_ context.Context, name string) (*driver.GroupInfo, error) {
+	info, ok := m.groups[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	return info, nil
+}
+
+func (m *mockDriver) ListGroups(_ context.Context) ([]driver.GroupInfo, error) {
+	result := make([]driver.GroupInfo, 0, len(m.groups))
+	for _, g := range m.groups {
+		result = append(result, *g)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) AddUserToGroup(_ context.Context, userName, groupName string) error {
+	if _, ok := m.users[userName]; !ok {
+		return fmt.Errorf("user not found")
+	}
+
+	if _, ok := m.groups[groupName]; !ok {
+		return fmt.Errorf("group not found")
+	}
+
+	if m.groupUsers[groupName] == nil {
+		m.groupUsers[groupName] = make(map[string]bool)
+	}
+
+	m.groupUsers[groupName][userName] = true
+
+	return nil
+}
+
+func (m *mockDriver) RemoveUserFromGroup(_ context.Context, userName, groupName string) error {
+	if _, ok := m.groups[groupName]; !ok {
+		return fmt.Errorf("group not found")
+	}
+
+	members := m.groupUsers[groupName]
+	if !members[userName] {
+		return fmt.Errorf("not a member")
+	}
+
+	delete(members, userName)
+
+	return nil
+}
+
+func (m *mockDriver) ListGroupsForUser(_ context.Context, userName string) ([]driver.GroupInfo, error) {
+	if _, ok := m.users[userName]; !ok {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	var result []driver.GroupInfo
+
+	for gn, members := range m.groupUsers {
+		if members[userName] {
+			if g, ok := m.groups[gn]; ok {
+				result = append(result, *g)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) CreateAccessKey(_ context.Context, cfg driver.AccessKeyConfig) (*driver.AccessKeyInfo, error) {
+	if cfg.UserName == "" {
+		return nil, fmt.Errorf("user name required")
+	}
+
+	if _, ok := m.users[cfg.UserName]; !ok {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	keyID := m.nextID("AKIA")
+	info := &driver.AccessKeyInfo{
+		AccessKeyID:     keyID,
+		SecretAccessKey: "secret",
+		UserName:        cfg.UserName,
+		Status:          "Active",
+	}
+	m.accessKeys[keyID] = info
+
+	return info, nil
+}
+
+func (m *mockDriver) DeleteAccessKey(_ context.Context, userName, accessKeyID string) error {
+	ak, ok := m.accessKeys[accessKeyID]
+	if !ok || ak.UserName != userName {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.accessKeys, accessKeyID)
+
+	return nil
+}
+
+func (m *mockDriver) ListAccessKeys(_ context.Context, userName string) ([]driver.AccessKeyInfo, error) {
+	if _, ok := m.users[userName]; !ok {
+		return nil, fmt.Errorf("user not found")
+	}
+
+	var result []driver.AccessKeyInfo
+
+	for _, ak := range m.accessKeys {
+		if ak.UserName == userName {
+			result = append(result, *ak)
+		}
+	}
+
+	return result, nil
 }
 
 func newTestIAM(opts ...Option) *IAM {

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -4,6 +4,7 @@ package awsiam
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -14,18 +15,23 @@ import (
 	"github.com/stackshy/cloudemu/internal/memstore"
 )
 
+const timeFormat = "2006-01-02T15:04:05Z"
+
 // Compile-time check that Mock implements driver.IAM.
 var _ driver.IAM = (*Mock)(nil)
 
 // Mock is an in-memory mock implementation of the AWS IAM service.
 type Mock struct {
-	users    *memstore.Store[*userData]
-	roles    *memstore.Store[*roleData]
-	policies *memstore.Store[*policyData]
+	users      *memstore.Store[*userData]
+	roles      *memstore.Store[*roleData]
+	policies   *memstore.Store[*policyData]
+	groups     *memstore.Store[*groupData]
+	accessKeys *memstore.Store[*accessKeyData]
 
 	mu           sync.RWMutex
 	userPolicies map[string]map[string]bool // userName -> set of policy ARNs
 	rolePolicies map[string]map[string]bool // roleName -> set of policy ARNs
+	groupUsers   map[string]map[string]bool // groupName -> set of userNames
 
 	opts *config.Options
 }
@@ -57,14 +63,32 @@ type policyData struct {
 	Description    string
 }
 
+type groupData struct {
+	Name      string
+	ARN       string
+	Path      string
+	CreatedAt string
+}
+
+type accessKeyData struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	UserName        string
+	Status          string
+	CreatedAt       string
+}
+
 // New creates a new IAM mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		users:        memstore.New[*userData](),
 		roles:        memstore.New[*roleData](),
 		policies:     memstore.New[*policyData](),
+		groups:       memstore.New[*groupData](),
+		accessKeys:   memstore.New[*accessKeyData](),
 		userPolicies: make(map[string]map[string]bool),
 		rolePolicies: make(map[string]map[string]bool),
+		groupUsers:   make(map[string]map[string]bool),
 		opts:         opts,
 	}
 }
@@ -94,7 +118,7 @@ func (m *Mock) CreateUser(_ context.Context, cfg driver.UserConfig) (*driver.Use
 		ARN:       arn,
 		Path:      path,
 		Tags:      tags,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
 	}
 	m.users.Set(cfg.Name, u)
 
@@ -540,6 +564,256 @@ func (m *Mock) CheckPermission(_ context.Context, principal, action, resource st
 	return hasAllow, nil
 }
 
+// CreateGroup creates a new IAM group.
+func (m *Mock) CreateGroup(
+	_ context.Context, cfg driver.GroupConfig,
+) (*driver.GroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, errors.Newf(
+			errors.InvalidArgument, "group name is required",
+		)
+	}
+
+	if m.groups.Has(cfg.Name) {
+		return nil, errors.Newf(
+			errors.AlreadyExists, "group %q already exists", cfg.Name,
+		)
+	}
+
+	path := cfg.Path
+	if path == "" {
+		path = "/"
+	}
+
+	arn := idgen.AWSARN(
+		"iam", "", m.opts.AccountID, "group/"+cfg.Name,
+	)
+
+	g := &groupData{
+		Name:      cfg.Name,
+		ARN:       arn,
+		Path:      path,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+	m.groups.Set(cfg.Name, g)
+
+	info := toGroupInfo(g)
+
+	return &info, nil
+}
+
+// DeleteGroup deletes the IAM group with the given name.
+func (m *Mock) DeleteGroup(_ context.Context, name string) error {
+	if !m.groups.Delete(name) {
+		return errors.Newf(
+			errors.NotFound, "group %q not found", name,
+		)
+	}
+
+	m.mu.Lock()
+	delete(m.groupUsers, name)
+	m.mu.Unlock()
+
+	return nil
+}
+
+// GetGroup returns the IAM group with the given name.
+func (m *Mock) GetGroup(
+	_ context.Context, name string,
+) (*driver.GroupInfo, error) {
+	g, ok := m.groups.Get(name)
+	if !ok {
+		return nil, errors.Newf(
+			errors.NotFound, "group %q not found", name,
+		)
+	}
+
+	info := toGroupInfo(g)
+
+	return &info, nil
+}
+
+// ListGroups returns all IAM groups.
+func (m *Mock) ListGroups(
+	_ context.Context,
+) ([]driver.GroupInfo, error) {
+	all := m.groups.All()
+	result := make([]driver.GroupInfo, 0, len(all))
+
+	for _, g := range all {
+		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// AddUserToGroup adds a user to a group.
+func (m *Mock) AddUserToGroup(
+	_ context.Context, userName, groupName string,
+) error {
+	if !m.users.Has(userName) {
+		return errors.Newf(
+			errors.NotFound, "user %q not found", userName,
+		)
+	}
+
+	if !m.groups.Has(groupName) {
+		return errors.Newf(
+			errors.NotFound, "group %q not found", groupName,
+		)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.groupUsers[groupName] == nil {
+		m.groupUsers[groupName] = make(map[string]bool)
+	}
+
+	m.groupUsers[groupName][userName] = true
+
+	return nil
+}
+
+// RemoveUserFromGroup removes a user from a group.
+func (m *Mock) RemoveUserFromGroup(
+	_ context.Context, userName, groupName string,
+) error {
+	if !m.groups.Has(groupName) {
+		return errors.Newf(
+			errors.NotFound, "group %q not found", groupName,
+		)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	members, ok := m.groupUsers[groupName]
+	if !ok || !members[userName] {
+		return errors.Newf(
+			errors.NotFound,
+			"user %q is not a member of group %q",
+			userName, groupName,
+		)
+	}
+
+	delete(members, userName)
+
+	return nil
+}
+
+// ListGroupsForUser returns all groups a user belongs to.
+func (m *Mock) ListGroupsForUser(
+	_ context.Context, userName string,
+) ([]driver.GroupInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, errors.Newf(
+			errors.NotFound, "user %q not found", userName,
+		)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []driver.GroupInfo
+
+	for groupName, members := range m.groupUsers {
+		if !members[userName] {
+			continue
+		}
+
+		g, ok := m.groups.Get(groupName)
+		if !ok {
+			continue
+		}
+
+		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// CreateAccessKey creates a new access key for the given user.
+func (m *Mock) CreateAccessKey(
+	_ context.Context, cfg driver.AccessKeyConfig,
+) (*driver.AccessKeyInfo, error) {
+	if cfg.UserName == "" {
+		return nil, errors.Newf(
+			errors.InvalidArgument, "user name is required",
+		)
+	}
+
+	if !m.users.Has(cfg.UserName) {
+		return nil, errors.Newf(
+			errors.NotFound, "user %q not found", cfg.UserName,
+		)
+	}
+
+	keyID := fmt.Sprintf("AKIA%s", idgen.GenerateID(""))
+	secret := fmt.Sprintf("secret-%s", idgen.GenerateID(""))
+
+	ak := &accessKeyData{
+		AccessKeyID:     keyID,
+		SecretAccessKey: secret,
+		UserName:        cfg.UserName,
+		Status:          "Active",
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+	m.accessKeys.Set(keyID, ak)
+
+	info := toAccessKeyInfo(ak)
+
+	return &info, nil
+}
+
+// DeleteAccessKey deletes an access key.
+func (m *Mock) DeleteAccessKey(
+	_ context.Context, userName, accessKeyID string,
+) error {
+	ak, ok := m.accessKeys.Get(accessKeyID)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound,
+			"access key %q not found", accessKeyID,
+		)
+	}
+
+	if ak.UserName != userName {
+		return errors.Newf(
+			errors.NotFound,
+			"access key %q not found for user %q",
+			accessKeyID, userName,
+		)
+	}
+
+	m.accessKeys.Delete(accessKeyID)
+
+	return nil
+}
+
+// ListAccessKeys returns all access keys for the given user.
+func (m *Mock) ListAccessKeys(
+	_ context.Context, userName string,
+) ([]driver.AccessKeyInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, errors.Newf(
+			errors.NotFound, "user %q not found", userName,
+		)
+	}
+
+	all := m.accessKeys.All()
+
+	var result []driver.AccessKeyInfo
+
+	for _, ak := range all {
+		if ak.UserName == userName {
+			result = append(result, toAccessKeyInfo(ak))
+		}
+	}
+
+	return result, nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {
@@ -584,5 +858,24 @@ func toPolicyInfo(p *policyData) driver.PolicyInfo {
 		Path:           p.Path,
 		PolicyDocument: p.PolicyDocument,
 		Description:    p.Description,
+	}
+}
+
+func toGroupInfo(g *groupData) driver.GroupInfo {
+	return driver.GroupInfo{
+		Name:      g.Name,
+		Path:      g.Path,
+		ARN:       g.ARN,
+		CreatedAt: g.CreatedAt,
+	}
+}
+
+func toAccessKeyInfo(ak *accessKeyData) driver.AccessKeyInfo {
+	return driver.AccessKeyInfo{
+		AccessKeyID:     ak.AccessKeyID,
+		SecretAccessKey: ak.SecretAccessKey,
+		UserName:        ak.UserName,
+		Status:          ak.Status,
+		CreatedAt:       ak.CreatedAt,
 	}
 }

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -4,6 +4,7 @@ package azureiam
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -14,18 +15,23 @@ import (
 	"github.com/stackshy/cloudemu/internal/memstore"
 )
 
+const timeFormat = "2006-01-02T15:04:05Z"
+
 // Compile-time check that Mock implements driver.IAM.
 var _ driver.IAM = (*Mock)(nil)
 
 // Mock is an in-memory mock implementation of the Azure IAM service.
 type Mock struct {
-	users    *memstore.Store[*userData]
-	roles    *memstore.Store[*roleData]
-	policies *memstore.Store[*policyData]
+	users      *memstore.Store[*userData]
+	roles      *memstore.Store[*roleData]
+	policies   *memstore.Store[*policyData]
+	groups     *memstore.Store[*groupData]
+	accessKeys *memstore.Store[*accessKeyData]
 
 	mu           sync.RWMutex
 	userPolicies map[string]map[string]bool // userName -> set of policy ARNs
 	rolePolicies map[string]map[string]bool // roleName -> set of policy ARNs
+	groupUsers   map[string]map[string]bool // groupName -> set of userNames
 
 	opts *config.Options
 }
@@ -57,14 +63,32 @@ type policyData struct {
 	Description    string
 }
 
+type groupData struct {
+	Name      string
+	ARN       string
+	Path      string
+	CreatedAt string
+}
+
+type accessKeyData struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	UserName        string
+	Status          string
+	CreatedAt       string
+}
+
 // New creates a new Azure IAM mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		users:        memstore.New[*userData](),
 		roles:        memstore.New[*roleData](),
 		policies:     memstore.New[*policyData](),
+		groups:       memstore.New[*groupData](),
+		accessKeys:   memstore.New[*accessKeyData](),
 		userPolicies: make(map[string]map[string]bool),
 		rolePolicies: make(map[string]map[string]bool),
+		groupUsers:   make(map[string]map[string]bool),
 		opts:         opts,
 	}
 }
@@ -94,7 +118,7 @@ func (m *Mock) CreateUser(_ context.Context, cfg driver.UserConfig) (*driver.Use
 		ARN:       arn,
 		Path:      path,
 		Tags:      tags,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
 	}
 	m.users.Set(cfg.Name, u)
 
@@ -540,6 +564,258 @@ func (m *Mock) CheckPermission(_ context.Context, principal, action, resource st
 	return hasAllow, nil
 }
 
+// CreateGroup creates a new Azure AD group.
+func (m *Mock) CreateGroup(
+	_ context.Context, cfg driver.GroupConfig,
+) (*driver.GroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(
+			cerrors.InvalidArgument, "group name is required",
+		)
+	}
+
+	if m.groups.Has(cfg.Name) {
+		return nil, cerrors.Newf(
+			cerrors.AlreadyExists,
+			"group %q already exists", cfg.Name,
+		)
+	}
+
+	path := cfg.Path
+	if path == "" {
+		path = "/"
+	}
+
+	arn := idgen.AzureID(
+		m.opts.AccountID, "cloud-mock",
+		"Microsoft.Authorization", "groups", cfg.Name,
+	)
+
+	g := &groupData{
+		Name:      cfg.Name,
+		ARN:       arn,
+		Path:      path,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+	m.groups.Set(cfg.Name, g)
+
+	info := toGroupInfo(g)
+
+	return &info, nil
+}
+
+// DeleteGroup deletes the Azure AD group with the given name.
+func (m *Mock) DeleteGroup(_ context.Context, name string) error {
+	if !m.groups.Delete(name) {
+		return cerrors.Newf(
+			cerrors.NotFound, "group %q not found", name,
+		)
+	}
+
+	m.mu.Lock()
+	delete(m.groupUsers, name)
+	m.mu.Unlock()
+
+	return nil
+}
+
+// GetGroup returns the Azure AD group with the given name.
+func (m *Mock) GetGroup(
+	_ context.Context, name string,
+) (*driver.GroupInfo, error) {
+	g, ok := m.groups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(
+			cerrors.NotFound, "group %q not found", name,
+		)
+	}
+
+	info := toGroupInfo(g)
+
+	return &info, nil
+}
+
+// ListGroups returns all Azure AD groups.
+func (m *Mock) ListGroups(
+	_ context.Context,
+) ([]driver.GroupInfo, error) {
+	all := m.groups.All()
+	result := make([]driver.GroupInfo, 0, len(all))
+
+	for _, g := range all {
+		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// AddUserToGroup adds a user to a group.
+func (m *Mock) AddUserToGroup(
+	_ context.Context, userName, groupName string,
+) error {
+	if !m.users.Has(userName) {
+		return cerrors.Newf(
+			cerrors.NotFound, "user %q not found", userName,
+		)
+	}
+
+	if !m.groups.Has(groupName) {
+		return cerrors.Newf(
+			cerrors.NotFound, "group %q not found", groupName,
+		)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.groupUsers[groupName] == nil {
+		m.groupUsers[groupName] = make(map[string]bool)
+	}
+
+	m.groupUsers[groupName][userName] = true
+
+	return nil
+}
+
+// RemoveUserFromGroup removes a user from a group.
+func (m *Mock) RemoveUserFromGroup(
+	_ context.Context, userName, groupName string,
+) error {
+	if !m.groups.Has(groupName) {
+		return cerrors.Newf(
+			cerrors.NotFound, "group %q not found", groupName,
+		)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	members, ok := m.groupUsers[groupName]
+	if !ok || !members[userName] {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"user %q is not a member of group %q",
+			userName, groupName,
+		)
+	}
+
+	delete(members, userName)
+
+	return nil
+}
+
+// ListGroupsForUser returns all groups a user belongs to.
+func (m *Mock) ListGroupsForUser(
+	_ context.Context, userName string,
+) ([]driver.GroupInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound, "user %q not found", userName,
+		)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []driver.GroupInfo
+
+	for groupName, members := range m.groupUsers {
+		if !members[userName] {
+			continue
+		}
+
+		g, ok := m.groups.Get(groupName)
+		if !ok {
+			continue
+		}
+
+		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// CreateAccessKey creates a new access key for the given user.
+func (m *Mock) CreateAccessKey(
+	_ context.Context, cfg driver.AccessKeyConfig,
+) (*driver.AccessKeyInfo, error) {
+	if cfg.UserName == "" {
+		return nil, cerrors.New(
+			cerrors.InvalidArgument, "user name is required",
+		)
+	}
+
+	if !m.users.Has(cfg.UserName) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound, "user %q not found", cfg.UserName,
+		)
+	}
+
+	keyID := fmt.Sprintf("azure-key-%s", idgen.GenerateID(""))
+	secret := fmt.Sprintf("secret-%s", idgen.GenerateID(""))
+
+	ak := &accessKeyData{
+		AccessKeyID:     keyID,
+		SecretAccessKey: secret,
+		UserName:        cfg.UserName,
+		Status:          "Active",
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+	m.accessKeys.Set(keyID, ak)
+
+	info := toAccessKeyInfo(ak)
+
+	return &info, nil
+}
+
+// DeleteAccessKey deletes an access key.
+func (m *Mock) DeleteAccessKey(
+	_ context.Context, userName, accessKeyID string,
+) error {
+	ak, ok := m.accessKeys.Get(accessKeyID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"access key %q not found", accessKeyID,
+		)
+	}
+
+	if ak.UserName != userName {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"access key %q not found for user %q",
+			accessKeyID, userName,
+		)
+	}
+
+	m.accessKeys.Delete(accessKeyID)
+
+	return nil
+}
+
+// ListAccessKeys returns all access keys for the given user.
+func (m *Mock) ListAccessKeys(
+	_ context.Context, userName string,
+) ([]driver.AccessKeyInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound, "user %q not found", userName,
+		)
+	}
+
+	all := m.accessKeys.All()
+
+	var result []driver.AccessKeyInfo
+
+	for _, ak := range all {
+		if ak.UserName == userName {
+			result = append(result, toAccessKeyInfo(ak))
+		}
+	}
+
+	return result, nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {
@@ -585,5 +861,24 @@ func toPolicyInfo(p *policyData) driver.PolicyInfo {
 		Path:           p.Path,
 		PolicyDocument: p.PolicyDocument,
 		Description:    p.Description,
+	}
+}
+
+func toGroupInfo(g *groupData) driver.GroupInfo {
+	return driver.GroupInfo{
+		Name:      g.Name,
+		Path:      g.Path,
+		ARN:       g.ARN,
+		CreatedAt: g.CreatedAt,
+	}
+}
+
+func toAccessKeyInfo(ak *accessKeyData) driver.AccessKeyInfo {
+	return driver.AccessKeyInfo{
+		AccessKeyID:     ak.AccessKeyID,
+		SecretAccessKey: ak.SecretAccessKey,
+		UserName:        ak.UserName,
+		Status:          ak.Status,
+		CreatedAt:       ak.CreatedAt,
 	}
 }

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -15,18 +15,23 @@ import (
 	"github.com/stackshy/cloudemu/internal/memstore"
 )
 
+const timeFormat = "2006-01-02T15:04:05Z"
+
 // Compile-time check that Mock implements driver.IAM.
 var _ driver.IAM = (*Mock)(nil)
 
 // Mock is an in-memory mock implementation of the GCP IAM service.
 type Mock struct {
-	users    *memstore.Store[*userData]
-	roles    *memstore.Store[*roleData]
-	policies *memstore.Store[*policyData]
+	users      *memstore.Store[*userData]
+	roles      *memstore.Store[*roleData]
+	policies   *memstore.Store[*policyData]
+	groups     *memstore.Store[*groupData]
+	accessKeys *memstore.Store[*accessKeyData]
 
 	mu           sync.RWMutex
-	userPolicies map[string]map[string]bool // userName -> set of policy ARNs (resource names)
-	rolePolicies map[string]map[string]bool // roleName -> set of policy ARNs (resource names)
+	userPolicies map[string]map[string]bool
+	rolePolicies map[string]map[string]bool
+	groupUsers   map[string]map[string]bool
 
 	opts *config.Options
 }
@@ -58,14 +63,32 @@ type policyData struct {
 	Description    string
 }
 
+type groupData struct {
+	Name      string
+	ARN       string
+	Path      string
+	CreatedAt string
+}
+
+type accessKeyData struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	UserName        string
+	Status          string
+	CreatedAt       string
+}
+
 // New creates a new GCP IAM mock with the given configuration options.
 func New(opts *config.Options) *Mock {
 	return &Mock{
 		users:        memstore.New[*userData](),
 		roles:        memstore.New[*roleData](),
 		policies:     memstore.New[*policyData](),
+		groups:       memstore.New[*groupData](),
+		accessKeys:   memstore.New[*accessKeyData](),
 		userPolicies: make(map[string]map[string]bool),
 		rolePolicies: make(map[string]map[string]bool),
+		groupUsers:   make(map[string]map[string]bool),
 		opts:         opts,
 	}
 }
@@ -97,7 +120,7 @@ func (m *Mock) CreateUser(_ context.Context, cfg driver.UserConfig) (*driver.Use
 		ARN:       arn,
 		Path:      path,
 		Tags:      tags,
-		CreatedAt: m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
 	}
 	m.users.Set(cfg.Name, u)
 
@@ -544,6 +567,260 @@ func (m *Mock) CheckPermission(_ context.Context, principal, action, resource st
 	return hasAllow, nil
 }
 
+// CreateGroup creates a new GCP IAM group.
+func (m *Mock) CreateGroup(
+	_ context.Context, cfg driver.GroupConfig,
+) (*driver.GroupInfo, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.Newf(
+			cerrors.InvalidArgument, "group name is required",
+		)
+	}
+
+	if m.groups.Has(cfg.Name) {
+		return nil, cerrors.Newf(
+			cerrors.AlreadyExists,
+			"group %q already exists", cfg.Name,
+		)
+	}
+
+	path := cfg.Path
+	if path == "" {
+		path = "/"
+	}
+
+	arn := idgen.GCPID(m.opts.ProjectID, "groups", cfg.Name)
+
+	g := &groupData{
+		Name:      cfg.Name,
+		ARN:       arn,
+		Path:      path,
+		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+	m.groups.Set(cfg.Name, g)
+
+	info := toGroupInfo(g)
+
+	return &info, nil
+}
+
+// DeleteGroup deletes the GCP IAM group with the given name.
+func (m *Mock) DeleteGroup(_ context.Context, name string) error {
+	if !m.groups.Delete(name) {
+		return cerrors.Newf(
+			cerrors.NotFound, "group %q not found", name,
+		)
+	}
+
+	m.mu.Lock()
+	delete(m.groupUsers, name)
+	m.mu.Unlock()
+
+	return nil
+}
+
+// GetGroup returns the GCP IAM group with the given name.
+func (m *Mock) GetGroup(
+	_ context.Context, name string,
+) (*driver.GroupInfo, error) {
+	g, ok := m.groups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(
+			cerrors.NotFound, "group %q not found", name,
+		)
+	}
+
+	info := toGroupInfo(g)
+
+	return &info, nil
+}
+
+// ListGroups returns all GCP IAM groups.
+func (m *Mock) ListGroups(
+	_ context.Context,
+) ([]driver.GroupInfo, error) {
+	all := m.groups.All()
+	result := make([]driver.GroupInfo, 0, len(all))
+
+	for _, g := range all {
+		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// AddUserToGroup adds a user to a group.
+func (m *Mock) AddUserToGroup(
+	_ context.Context, userName, groupName string,
+) error {
+	if !m.users.Has(userName) {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"service account %q not found", userName,
+		)
+	}
+
+	if !m.groups.Has(groupName) {
+		return cerrors.Newf(
+			cerrors.NotFound, "group %q not found", groupName,
+		)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.groupUsers[groupName] == nil {
+		m.groupUsers[groupName] = make(map[string]bool)
+	}
+
+	m.groupUsers[groupName][userName] = true
+
+	return nil
+}
+
+// RemoveUserFromGroup removes a user from a group.
+func (m *Mock) RemoveUserFromGroup(
+	_ context.Context, userName, groupName string,
+) error {
+	if !m.groups.Has(groupName) {
+		return cerrors.Newf(
+			cerrors.NotFound, "group %q not found", groupName,
+		)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	members, ok := m.groupUsers[groupName]
+	if !ok || !members[userName] {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"user %q is not a member of group %q",
+			userName, groupName,
+		)
+	}
+
+	delete(members, userName)
+
+	return nil
+}
+
+// ListGroupsForUser returns all groups a user belongs to.
+func (m *Mock) ListGroupsForUser(
+	_ context.Context, userName string,
+) ([]driver.GroupInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"service account %q not found", userName,
+		)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var result []driver.GroupInfo
+
+	for groupName, members := range m.groupUsers {
+		if !members[userName] {
+			continue
+		}
+
+		g, ok := m.groups.Get(groupName)
+		if !ok {
+			continue
+		}
+
+		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// CreateAccessKey creates a new service account key.
+func (m *Mock) CreateAccessKey(
+	_ context.Context, cfg driver.AccessKeyConfig,
+) (*driver.AccessKeyInfo, error) {
+	if cfg.UserName == "" {
+		return nil, cerrors.Newf(
+			cerrors.InvalidArgument,
+			"service account name is required",
+		)
+	}
+
+	if !m.users.Has(cfg.UserName) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"service account %q not found", cfg.UserName,
+		)
+	}
+
+	keyID := fmt.Sprintf("gcp-key-%s", idgen.GenerateID(""))
+	secret := fmt.Sprintf("secret-%s", idgen.GenerateID(""))
+
+	ak := &accessKeyData{
+		AccessKeyID:     keyID,
+		SecretAccessKey: secret,
+		UserName:        cfg.UserName,
+		Status:          "Active",
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+	m.accessKeys.Set(keyID, ak)
+
+	info := toAccessKeyInfo(ak)
+
+	return &info, nil
+}
+
+// DeleteAccessKey deletes a service account key.
+func (m *Mock) DeleteAccessKey(
+	_ context.Context, userName, accessKeyID string,
+) error {
+	ak, ok := m.accessKeys.Get(accessKeyID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"access key %q not found", accessKeyID,
+		)
+	}
+
+	if ak.UserName != userName {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"access key %q not found for user %q",
+			accessKeyID, userName,
+		)
+	}
+
+	m.accessKeys.Delete(accessKeyID)
+
+	return nil
+}
+
+// ListAccessKeys returns all keys for the given service account.
+func (m *Mock) ListAccessKeys(
+	_ context.Context, userName string,
+) ([]driver.AccessKeyInfo, error) {
+	if !m.users.Has(userName) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"service account %q not found", userName,
+		)
+	}
+
+	all := m.accessKeys.All()
+
+	var result []driver.AccessKeyInfo
+
+	for _, ak := range all {
+		if ak.UserName == userName {
+			result = append(result, toAccessKeyInfo(ak))
+		}
+	}
+
+	return result, nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {
@@ -588,5 +865,24 @@ func toPolicyInfo(p *policyData) driver.PolicyInfo {
 		Path:           p.Path,
 		PolicyDocument: p.PolicyDocument,
 		Description:    p.Description,
+	}
+}
+
+func toGroupInfo(g *groupData) driver.GroupInfo {
+	return driver.GroupInfo{
+		Name:      g.Name,
+		Path:      g.Path,
+		ARN:       g.ARN,
+		CreatedAt: g.CreatedAt,
+	}
+}
+
+func toAccessKeyInfo(ak *accessKeyData) driver.AccessKeyInfo {
+	return driver.AccessKeyInfo{
+		AccessKeyID:     ak.AccessKeyID,
+		SecretAccessKey: ak.SecretAccessKey,
+		UserName:        ak.UserName,
+		Status:          ak.Status,
+		CreatedAt:       ak.CreatedAt,
 	}
 }


### PR DESCRIPTION
## Summary

- Adds 10 new methods to IAM driver interface: `CreateGroup`, `DeleteGroup`, `GetGroup`, `ListGroups`, `AddUserToGroup`, `RemoveUserFromGroup`, `ListGroupsForUser`, `CreateAccessKey`, `DeleteAccessKey`, `ListAccessKeys`
- Adds 4 new types: `GroupConfig`, `GroupInfo`, `AccessKeyConfig`, `AccessKeyInfo`
- Implements across all 3 providers: AWS IAM, Azure IAM, GCP IAM
- Group membership tracked via groupUsers map
- Access keys generated with provider-specific prefixes (AKIA for AWS, azure-key for Azure, gcp-key for GCP)
- Wires through portable API layer

Closes #61

## Test plan

- [x] `TestIAMGroupsAWS` — create group, add user, list groups for user, remove user, delete group
- [x] `TestIAMGroupsAzure` — same
- [x] `TestIAMGroupsGCP` — same
- [x] `TestAccessKeysAWS` — create, list, delete access keys
- [x] Linter: 0 issues
- [x] Full test suite: all passing