### PR TITLE
Add community profile: code of conduct, contributing, security, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Report a bug in CloudEmu
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Create provider with `cloudemu.NewAWS()`
+2. Call `...`
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages if applicable.
+
+## Code Sample
+
+```go
+// Minimal code to reproduce the issue
+```
+
+## Environment
+
+- Go version: [e.g., 1.25.0]
+- CloudEmu version: [e.g., v0.1.0 or commit hash]
+- OS: [e.g., macOS, Linux, Windows]
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for CloudEmu
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+
+A clear description of the feature you'd like to see.
+
+## Provider(s)
+
+Which cloud provider(s) does this apply to?
+
+- [ ] AWS
+- [ ] Azure
+- [ ] GCP
+
+## Service
+
+Which service does this relate to? (e.g., Storage, Compute, Database, etc.)
+
+## Use Case
+
+Describe the testing scenario this feature would enable.
+
+## Proposed API
+
+```go
+// Example of what the API could look like
+```
+
+## Additional Context
+
+Any other context, links to cloud documentation, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do? Keep it brief — 1-3 bullet points. -->
+
+## Changes
+
+<!-- List the key changes made. -->
+
+## Provider Coverage
+
+- [ ] AWS
+- [ ] Azure
+- [ ] GCP
+
+## Checklist
+
+- [ ] All tests pass (`go test ./...`)
+- [ ] Linter passes (`golangci-lint run --timeout=9m ./...`)
+- [ ] All 3 providers implement the same behavior
+- [ ] Integration tests added to `cloudemu_test.go`
+- [ ] Unit tests added to provider test files
+
+## Test Plan
+
+<!-- How was this tested? List the test names or describe manual testing. -->
+
+## Related Issues
+
+<!-- Link related issues: Closes #XX -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,66 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**nitinraj7488204975@gmail.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to CloudEmu
+
+Thank you for your interest in contributing to CloudEmu! This guide will help you get started.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/cloudemu.git
+   cd cloudemu
+   ```
+3. Create a feature branch from `development`:
+   ```bash
+   git checkout development
+   git checkout -b feature/your-feature-name
+   ```
+
+## Development Setup
+
+**Requirements:**
+- Go 1.25.0+
+- golangci-lint v2
+
+```bash
+go build ./...     # compile all packages
+go test ./...      # run all tests
+go vet ./...       # static analysis
+```
+
+## Code Standards
+
+- **Max line length:** 140 characters
+- **Max cyclomatic complexity:** 10
+- **Max function length:** 100 lines / 50 statements
+- **No magic numbers** — use named constants
+- **Import ordering:** stdlib, third-party, local module (enforced by `gci`)
+- **Thread safety:** all mock implementations must use `sync.RWMutex`
+
+### Linting
+
+Run the linter before submitting:
+
+```bash
+golangci-lint run --timeout=9m ./...
+```
+
+Fix all issues. If a `//nolint` directive is needed, always include an explanation.
+
+## Making Changes
+
+### Adding a New Feature to an Existing Service
+
+1. Add types and methods to the driver interface (`<service>/driver/driver.go`)
+2. Implement in **all 3 providers** (AWS, Azure, GCP)
+3. Wire through the portable API layer (`<service>/<service>.go`)
+4. Add integration tests to `cloudemu_test.go`
+5. Add unit tests to each provider test file
+6. Run linter and full test suite
+
+### Adding a New Service
+
+1. Create driver interface in `<service>/driver/driver.go`
+2. Create provider implementations in `providers/{aws,azure,gcp}/<service>/`
+3. Add field to each Provider struct
+4. Initialize in each `New()` factory
+5. Add portable API wrapper
+6. Add tests
+
+### Important Rules
+
+- All 3 providers (AWS, Azure, GCP) must implement the same behaviors
+- Use `cerrors.New()` / `cerrors.Newf()` for error codes
+- Use `config.FakeClock` for deterministic time in tests
+- Use `memstore.Store[V]` for in-memory storage
+- Use `idgen` for cloud-native ID generation
+
+## Submitting Changes
+
+1. Ensure all tests pass: `go test ./...`
+2. Ensure linter passes: `golangci-lint run --timeout=9m ./...`
+3. Push your branch and create a PR against `development`
+4. Include a summary of what changed and why in the PR description
+
+## Reporting Issues
+
+- Use GitHub Issues to report bugs or request features
+- Include steps to reproduce for bug reports
+- Tag issues with appropriate labels (aws, azure, gcp, enhancement, bug)
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| latest  | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in CloudEmu, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please email **nitinraj7488204975@gmail.com** with:
+
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Any potential impact
+
+We will acknowledge receipt within 48 hours and aim to provide a fix within 7 days for critical issues.
+
+## Scope
+
+CloudEmu is an in-memory testing library and does not handle production traffic, secrets, or real cloud credentials. However, we still take security seriously in the following areas:
+
+- **Code injection** via user-provided inputs (policy documents, filter patterns)
+- **Denial of service** via unbounded memory allocation
+- **Dependency vulnerabilities** in Go modules
+
+## Best Practices for Users
+
+- Never use CloudEmu in production environments — it is designed for testing only
+- Do not commit real cloud credentials in test files
+- Keep your Go dependencies up to date with `go get -u ./...`


### PR DESCRIPTION
## Summary

Adds all missing community profile files for the GitHub Community Standards checklist.

## Files Added

- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- `CONTRIBUTING.md` — Development setup, code standards, PR workflow
- `SECURITY.md` — Vulnerability reporting policy
- `.github/ISSUE_TEMPLATE/bug_report.md` — Bug report template
- `.github/ISSUE_TEMPLATE/feature_request.md` — Feature request template
- `.github/pull_request_template.md` — PR template with checklist

## Manual Step Required

After merging, go to **Settings > Moderation > Code review** and enable "Repository admins accept content reports" to complete the checklist.