### PR TITLE
Add internet gateway, elastic IPs, and route table association to networking

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7490,3 +7490,278 @@ func TestAccessKeysAWS(t *testing.T) {
 		t.Error("expected error creating key for nonexistent user")
 	}
 }
+
+func TestInternetGatewayAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Create VPC first.
+	vpc, err := p.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create internet gateway.
+	igw, err := p.VPC.CreateInternetGateway(ctx, netdriver.InternetGatewayConfig{
+		Tags: map[string]string{"env": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if igw.State != "detached" {
+		t.Errorf("expected detached, got %s", igw.State)
+	}
+
+	// Attach to VPC.
+	if err := p.VPC.AttachInternetGateway(ctx, igw.ID, vpc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Describe and verify attached state.
+	igws, err := p.VPC.DescribeInternetGateways(ctx, []string{igw.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(igws) != 1 {
+		t.Fatalf("expected 1 igw, got %d", len(igws))
+	}
+
+	if igws[0].State != "attached" {
+		t.Errorf("expected attached, got %s", igws[0].State)
+	}
+
+	if igws[0].VpcID != vpc.ID {
+		t.Errorf("expected vpc %s, got %s", vpc.ID, igws[0].VpcID)
+	}
+
+	// Cannot delete while attached.
+	err = p.VPC.DeleteInternetGateway(ctx, igw.ID)
+	if err == nil {
+		t.Error("expected error deleting attached igw")
+	}
+
+	// Detach then delete.
+	if err := p.VPC.DetachInternetGateway(ctx, igw.ID, vpc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.VPC.DeleteInternetGateway(ctx, igw.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify gone.
+	igws, err = p.VPC.DescribeInternetGateways(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(igws) != 0 {
+		t.Errorf("expected 0 igws, got %d", len(igws))
+	}
+}
+
+func TestElasticIPAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Allocate EIP.
+	eip, err := p.VPC.AllocateAddress(ctx, netdriver.ElasticIPConfig{
+		Tags: map[string]string{"env": "test"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if eip.PublicIP == "" {
+		t.Error("expected public IP")
+	}
+
+	if eip.AllocationID == "" {
+		t.Error("expected allocation ID")
+	}
+
+	// Associate with instance.
+	assocID, err := p.VPC.AssociateAddress(
+		ctx, eip.AllocationID, "i-12345",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if assocID == "" {
+		t.Error("expected association ID")
+	}
+
+	// Describe and verify association.
+	eips, err := p.VPC.DescribeAddresses(
+		ctx, []string{eip.AllocationID},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(eips) != 1 {
+		t.Fatalf("expected 1 eip, got %d", len(eips))
+	}
+
+	if eips[0].InstanceID != "i-12345" {
+		t.Errorf("expected i-12345, got %s", eips[0].InstanceID)
+	}
+
+	// Cannot release while associated.
+	err = p.VPC.ReleaseAddress(ctx, eip.AllocationID)
+	if err == nil {
+		t.Error("expected error releasing associated eip")
+	}
+
+	// Disassociate then release.
+	if err := p.VPC.DisassociateAddress(ctx, assocID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.VPC.ReleaseAddress(ctx, eip.AllocationID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify gone.
+	eips, err = p.VPC.DescribeAddresses(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(eips) != 0 {
+		t.Errorf("expected 0 eips, got %d", len(eips))
+	}
+}
+
+func TestRouteTableAssociationAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+
+	// Create VPC, subnet, route table.
+	vpc, err := p.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subnet, err := p.VPC.CreateSubnet(ctx, netdriver.SubnetConfig{
+		VPCID:     vpc.ID,
+		CIDRBlock: "10.0.1.0/24",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rt, err := p.VPC.CreateRouteTable(ctx, netdriver.RouteTableConfig{
+		VPCID: vpc.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Associate route table with subnet.
+	assoc, err := p.VPC.AssociateRouteTable(
+		ctx, rt.ID, subnet.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if assoc.RouteTableID != rt.ID {
+		t.Errorf("expected rt %s, got %s", rt.ID, assoc.RouteTableID)
+	}
+
+	if assoc.SubnetID != subnet.ID {
+		t.Errorf(
+			"expected subnet %s, got %s",
+			subnet.ID, assoc.SubnetID,
+		)
+	}
+
+	// Disassociate.
+	if err := p.VPC.DisassociateRouteTable(ctx, assoc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disassociate again should fail.
+	err = p.VPC.DisassociateRouteTable(ctx, assoc.ID)
+	if err == nil {
+		t.Error("expected error on double disassociate")
+	}
+}
+
+func TestInternetGatewayAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+
+	vpc, err := p.VNet.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	igw, err := p.VNet.CreateInternetGateway(
+		ctx, netdriver.InternetGatewayConfig{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if igw.State != "detached" {
+		t.Errorf("expected detached, got %s", igw.State)
+	}
+
+	if err := p.VNet.AttachInternetGateway(ctx, igw.ID, vpc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.VNet.DetachInternetGateway(ctx, igw.ID, vpc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.VNet.DeleteInternetGateway(ctx, igw.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInternetGatewayGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+
+	vpc, err := p.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	igw, err := p.VPC.CreateInternetGateway(
+		ctx, netdriver.InternetGatewayConfig{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if igw.State != "detached" {
+		t.Errorf("expected detached, got %s", igw.State)
+	}
+
+	if err := p.VPC.AttachInternetGateway(ctx, igw.ID, vpc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.VPC.DetachInternetGateway(ctx, igw.ID, vpc.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.VPC.DeleteInternetGateway(ctx, igw.ID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/networking/driver/driver.go
+++ b/networking/driver/driver.go
@@ -171,7 +171,43 @@ type NetworkACLRule struct {
 	Egress     bool
 }
 
-// Networking is the interface that networking provider implementations must satisfy.
+// InternetGatewayConfig configures an internet gateway.
+type InternetGatewayConfig struct {
+	Tags map[string]string
+}
+
+// InternetGateway represents an internet gateway.
+type InternetGateway struct {
+	ID    string
+	VpcID string
+	State string // "detached", "attached"
+	Tags  map[string]string
+}
+
+// ElasticIPConfig configures an elastic IP allocation.
+type ElasticIPConfig struct {
+	Tags map[string]string
+}
+
+// ElasticIP represents an elastic IP address.
+type ElasticIP struct {
+	AllocationID  string
+	PublicIP      string
+	AssociationID string
+	InstanceID    string
+	Tags          map[string]string
+}
+
+// RouteTableAssociation represents an association between
+// a route table and a subnet.
+type RouteTableAssociation struct {
+	ID           string
+	RouteTableID string
+	SubnetID     string
+}
+
+// Networking is the interface that networking provider
+// implementations must satisfy.
 type Networking interface {
 	CreateVPC(ctx context.Context, config VPCConfig) (*VPCInfo, error)
 	DeleteVPC(ctx context.Context, id string) error
@@ -221,4 +257,22 @@ type Networking interface {
 	DescribeNetworkACLs(ctx context.Context, ids []string) ([]NetworkACL, error)
 	AddNetworkACLRule(ctx context.Context, aclID string, rule *NetworkACLRule) error
 	RemoveNetworkACLRule(ctx context.Context, aclID string, ruleNumber int, egress bool) error
+
+	// Internet Gateways
+	CreateInternetGateway(ctx context.Context, cfg InternetGatewayConfig) (*InternetGateway, error)
+	DeleteInternetGateway(ctx context.Context, id string) error
+	DescribeInternetGateways(ctx context.Context, ids []string) ([]InternetGateway, error)
+	AttachInternetGateway(ctx context.Context, igwID, vpcID string) error
+	DetachInternetGateway(ctx context.Context, igwID, vpcID string) error
+
+	// Elastic IPs
+	AllocateAddress(ctx context.Context, cfg ElasticIPConfig) (*ElasticIP, error)
+	ReleaseAddress(ctx context.Context, allocationID string) error
+	DescribeAddresses(ctx context.Context, ids []string) ([]ElasticIP, error)
+	AssociateAddress(ctx context.Context, allocationID, instanceID string) (string, error)
+	DisassociateAddress(ctx context.Context, associationID string) error
+
+	// Route Table Associations
+	AssociateRouteTable(ctx context.Context, routeTableID, subnetID string) (*RouteTableAssociation, error)
+	DisassociateRouteTable(ctx context.Context, associationID string) error
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -450,3 +450,154 @@ func (n *Networking) RemoveNetworkACLRule(
 
 	return err
 }
+
+// CreateInternetGateway creates an internet gateway.
+func (n *Networking) CreateInternetGateway(
+	ctx context.Context, cfg driver.InternetGatewayConfig,
+) (*driver.InternetGateway, error) {
+	out, err := n.do(ctx, "CreateInternetGateway", cfg, func() (any, error) {
+		return n.driver.CreateInternetGateway(ctx, cfg)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.InternetGateway), nil
+}
+
+// DeleteInternetGateway deletes an internet gateway.
+func (n *Networking) DeleteInternetGateway(
+	ctx context.Context, id string,
+) error {
+	_, err := n.do(ctx, "DeleteInternetGateway", id, func() (any, error) {
+		return nil, n.driver.DeleteInternetGateway(ctx, id)
+	})
+
+	return err
+}
+
+// DescribeInternetGateways returns internet gateways
+// matching the given IDs.
+func (n *Networking) DescribeInternetGateways(
+	ctx context.Context, ids []string,
+) ([]driver.InternetGateway, error) {
+	out, err := n.do(ctx, "DescribeInternetGateways", ids, func() (any, error) {
+		return n.driver.DescribeInternetGateways(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.InternetGateway), nil
+}
+
+// AttachInternetGateway attaches an internet gateway to a VPC.
+func (n *Networking) AttachInternetGateway(
+	ctx context.Context, igwID, vpcID string,
+) error {
+	_, err := n.do(ctx, "AttachInternetGateway", igwID, func() (any, error) {
+		return nil, n.driver.AttachInternetGateway(ctx, igwID, vpcID)
+	})
+
+	return err
+}
+
+// DetachInternetGateway detaches an internet gateway from a VPC.
+func (n *Networking) DetachInternetGateway(
+	ctx context.Context, igwID, vpcID string,
+) error {
+	_, err := n.do(ctx, "DetachInternetGateway", igwID, func() (any, error) {
+		return nil, n.driver.DetachInternetGateway(ctx, igwID, vpcID)
+	})
+
+	return err
+}
+
+// AllocateAddress allocates a new elastic IP address.
+func (n *Networking) AllocateAddress(
+	ctx context.Context, cfg driver.ElasticIPConfig,
+) (*driver.ElasticIP, error) {
+	out, err := n.do(ctx, "AllocateAddress", cfg, func() (any, error) {
+		return n.driver.AllocateAddress(ctx, cfg)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ElasticIP), nil
+}
+
+// ReleaseAddress releases an elastic IP address.
+func (n *Networking) ReleaseAddress(
+	ctx context.Context, allocationID string,
+) error {
+	_, err := n.do(ctx, "ReleaseAddress", allocationID, func() (any, error) {
+		return nil, n.driver.ReleaseAddress(ctx, allocationID)
+	})
+
+	return err
+}
+
+// DescribeAddresses returns elastic IPs matching the given IDs.
+func (n *Networking) DescribeAddresses(
+	ctx context.Context, ids []string,
+) ([]driver.ElasticIP, error) {
+	out, err := n.do(ctx, "DescribeAddresses", ids, func() (any, error) {
+		return n.driver.DescribeAddresses(ctx, ids)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.ElasticIP), nil
+}
+
+// AssociateAddress associates an elastic IP with an instance.
+func (n *Networking) AssociateAddress(
+	ctx context.Context, allocationID, instanceID string,
+) (string, error) {
+	out, err := n.do(ctx, "AssociateAddress", allocationID, func() (any, error) {
+		return n.driver.AssociateAddress(ctx, allocationID, instanceID)
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return out.(string), nil
+}
+
+// DisassociateAddress removes an elastic IP association.
+func (n *Networking) DisassociateAddress(
+	ctx context.Context, associationID string,
+) error {
+	_, err := n.do(ctx, "DisassociateAddress", associationID, func() (any, error) {
+		return nil, n.driver.DisassociateAddress(ctx, associationID)
+	})
+
+	return err
+}
+
+// AssociateRouteTable associates a route table with a subnet.
+func (n *Networking) AssociateRouteTable(
+	ctx context.Context, routeTableID, subnetID string,
+) (*driver.RouteTableAssociation, error) {
+	out, err := n.do(ctx, "AssociateRouteTable", routeTableID, func() (any, error) {
+		return n.driver.AssociateRouteTable(ctx, routeTableID, subnetID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.RouteTableAssociation), nil
+}
+
+// DisassociateRouteTable removes a route table association.
+func (n *Networking) DisassociateRouteTable(
+	ctx context.Context, associationID string,
+) error {
+	_, err := n.do(ctx, "DisassociateRouteTable", associationID, func() (any, error) {
+		return nil, n.driver.DisassociateRouteTable(ctx, associationID)
+	})
+
+	return err
+}

--- a/networking/networking_test.go
+++ b/networking/networking_test.go
@@ -14,7 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockDriver implements driver.Networking for testing the portable wrapper.
+// mockDriver implements driver.Networking for testing
+// the portable wrapper.
 type mockDriver struct {
 	vpcs           map[string]*driver.VPCInfo
 	subnets        map[string]*driver.SubnetInfo
@@ -24,6 +25,9 @@ type mockDriver struct {
 	flowLogs       map[string]*driver.FlowLog
 	routeTables    map[string]*driver.RouteTable
 	networkACLs    map[string]*driver.NetworkACL
+	igws           map[string]*driver.InternetGateway
+	eips           map[string]*driver.ElasticIP
+	rtAssocs       map[string]*driver.RouteTableAssociation
 	seq            int
 }
 
@@ -37,6 +41,9 @@ func newMockDriver() *mockDriver {
 		flowLogs:       make(map[string]*driver.FlowLog),
 		routeTables:    make(map[string]*driver.RouteTable),
 		networkACLs:    make(map[string]*driver.NetworkACL),
+		igws:           make(map[string]*driver.InternetGateway),
+		eips:           make(map[string]*driver.ElasticIP),
+		rtAssocs:       make(map[string]*driver.RouteTableAssociation),
 	}
 }
 
@@ -470,6 +477,190 @@ func (m *mockDriver) RemoveNetworkACLRule(_ context.Context, aclID string, _ int
 	if _, ok := m.networkACLs[aclID]; !ok {
 		return fmt.Errorf("not found")
 	}
+
+	return nil
+}
+
+func (m *mockDriver) CreateInternetGateway(
+	_ context.Context, cfg driver.InternetGatewayConfig,
+) (*driver.InternetGateway, error) {
+	id := m.nextID("igw")
+	igw := &driver.InternetGateway{
+		ID: id, State: "detached", Tags: cfg.Tags,
+	}
+	m.igws[id] = igw
+
+	return igw, nil
+}
+
+func (m *mockDriver) DeleteInternetGateway(
+	_ context.Context, id string,
+) error {
+	if _, ok := m.igws[id]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.igws, id)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeInternetGateways(
+	_ context.Context, ids []string,
+) ([]driver.InternetGateway, error) {
+	if len(ids) == 0 {
+		result := make([]driver.InternetGateway, 0, len(m.igws))
+		for _, igw := range m.igws {
+			result = append(result, *igw)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.InternetGateway
+
+	for _, id := range ids {
+		if igw, ok := m.igws[id]; ok {
+			result = append(result, *igw)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) AttachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws[igwID]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	igw.VpcID = vpcID
+	igw.State = "attached"
+
+	return nil
+}
+
+func (m *mockDriver) DetachInternetGateway(
+	_ context.Context, igwID, _ string,
+) error {
+	igw, ok := m.igws[igwID]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+
+	igw.VpcID = ""
+	igw.State = "detached"
+
+	return nil
+}
+
+func (m *mockDriver) AllocateAddress(
+	_ context.Context, cfg driver.ElasticIPConfig,
+) (*driver.ElasticIP, error) {
+	id := m.nextID("eipalloc")
+	eip := &driver.ElasticIP{
+		AllocationID: id,
+		PublicIP:     "10.0.0.1",
+		Tags:         cfg.Tags,
+	}
+	m.eips[id] = eip
+
+	return eip, nil
+}
+
+func (m *mockDriver) ReleaseAddress(
+	_ context.Context, allocationID string,
+) error {
+	if _, ok := m.eips[allocationID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.eips, allocationID)
+
+	return nil
+}
+
+func (m *mockDriver) DescribeAddresses(
+	_ context.Context, ids []string,
+) ([]driver.ElasticIP, error) {
+	if len(ids) == 0 {
+		result := make([]driver.ElasticIP, 0, len(m.eips))
+		for _, eip := range m.eips {
+			result = append(result, *eip)
+		}
+
+		return result, nil
+	}
+
+	var result []driver.ElasticIP
+
+	for _, id := range ids {
+		if eip, ok := m.eips[id]; ok {
+			result = append(result, *eip)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) AssociateAddress(
+	_ context.Context, allocationID, instanceID string,
+) (string, error) {
+	eip, ok := m.eips[allocationID]
+	if !ok {
+		return "", fmt.Errorf("not found")
+	}
+
+	assocID := m.nextID("eipassoc")
+	eip.AssociationID = assocID
+	eip.InstanceID = instanceID
+
+	return assocID, nil
+}
+
+func (m *mockDriver) DisassociateAddress(
+	_ context.Context, associationID string,
+) error {
+	for _, eip := range m.eips {
+		if eip.AssociationID == associationID {
+			eip.AssociationID = ""
+			eip.InstanceID = ""
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("not found")
+}
+
+func (m *mockDriver) AssociateRouteTable(
+	_ context.Context, routeTableID, subnetID string,
+) (*driver.RouteTableAssociation, error) {
+	if _, ok := m.routeTables[routeTableID]; !ok {
+		return nil, fmt.Errorf("not found")
+	}
+
+	id := m.nextID("rtbassoc")
+	assoc := &driver.RouteTableAssociation{
+		ID:           id,
+		RouteTableID: routeTableID,
+		SubnetID:     subnetID,
+	}
+	m.rtAssocs[id] = assoc
+
+	return assoc, nil
+}
+
+func (m *mockDriver) DisassociateRouteTable(
+	_ context.Context, associationID string,
+) error {
+	if _, ok := m.rtAssocs[associationID]; !ok {
+		return fmt.Errorf("not found")
+	}
+
+	delete(m.rtAssocs, associationID)
 
 	return nil
 }

--- a/providers/aws/vpc/eip.go
+++ b/providers/aws/vpc/eip.go
@@ -1,0 +1,122 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+type eipData struct {
+	AllocationID  string
+	PublicIP      string
+	AssociationID string
+	InstanceID    string
+	Tags          map[string]string
+}
+
+// AllocateAddress allocates a new elastic IP address.
+func (m *Mock) AllocateAddress(
+	_ context.Context, cfg driver.ElasticIPConfig,
+) (*driver.ElasticIP, error) {
+	allocID := idgen.GenerateID("eipalloc-")
+
+	eip := &eipData{
+		AllocationID: allocID,
+		PublicIP:     mockPublicIP(allocID),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.eips.Set(allocID, eip)
+
+	info := toEIPInfo(eip)
+
+	return &info, nil
+}
+
+// ReleaseAddress releases an elastic IP address.
+func (m *Mock) ReleaseAddress(
+	_ context.Context, allocationID string,
+) error {
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound,
+			"elastic IP %q not found", allocationID,
+		)
+	}
+
+	if eip.AssociationID != "" {
+		return errors.Newf(
+			errors.FailedPrecondition,
+			"elastic IP %q is still associated", allocationID,
+		)
+	}
+
+	m.eips.Delete(allocationID)
+
+	return nil
+}
+
+// DescribeAddresses returns elastic IPs matching the given
+// allocation IDs, or all if ids is empty.
+func (m *Mock) DescribeAddresses(
+	_ context.Context, ids []string,
+) ([]driver.ElasticIP, error) {
+	return describeResources(m.eips, ids, toEIPInfo), nil
+}
+
+// AssociateAddress associates an elastic IP with an instance.
+func (m *Mock) AssociateAddress(
+	_ context.Context, allocationID, instanceID string,
+) (string, error) {
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return "", errors.Newf(
+			errors.NotFound,
+			"elastic IP %q not found", allocationID,
+		)
+	}
+
+	if eip.AssociationID != "" {
+		return "", errors.Newf(
+			errors.FailedPrecondition,
+			"elastic IP %q is already associated", allocationID,
+		)
+	}
+
+	assocID := idgen.GenerateID("eipassoc-")
+	eip.AssociationID = assocID
+	eip.InstanceID = instanceID
+
+	return assocID, nil
+}
+
+// DisassociateAddress removes an elastic IP association.
+func (m *Mock) DisassociateAddress(
+	_ context.Context, associationID string,
+) error {
+	for _, eip := range m.eips.All() {
+		if eip.AssociationID == associationID {
+			eip.AssociationID = ""
+			eip.InstanceID = ""
+
+			return nil
+		}
+	}
+
+	return errors.Newf(
+		errors.NotFound,
+		"association %q not found", associationID,
+	)
+}
+
+func toEIPInfo(eip *eipData) driver.ElasticIP {
+	return driver.ElasticIP{
+		AllocationID:  eip.AllocationID,
+		PublicIP:      eip.PublicIP,
+		AssociationID: eip.AssociationID,
+		InstanceID:    eip.InstanceID,
+		Tags:          copyTags(eip.Tags),
+	}
+}

--- a/providers/aws/vpc/igw.go
+++ b/providers/aws/vpc/igw.go
@@ -1,0 +1,138 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Internet gateway state constants.
+const (
+	IGWStateDetached = "detached"
+	IGWStateAttached = "attached"
+)
+
+type igwData struct {
+	ID    string
+	VpcID string
+	State string
+	Tags  map[string]string
+}
+
+// CreateInternetGateway creates a new internet gateway.
+func (m *Mock) CreateInternetGateway(
+	_ context.Context, cfg driver.InternetGatewayConfig,
+) (*driver.InternetGateway, error) {
+	id := idgen.GenerateID("igw-")
+
+	igw := &igwData{
+		ID:    id,
+		State: IGWStateDetached,
+		Tags:  copyTags(cfg.Tags),
+	}
+	m.igws.Set(id, igw)
+
+	info := toIGWInfo(igw)
+
+	return &info, nil
+}
+
+// DeleteInternetGateway deletes the internet gateway.
+func (m *Mock) DeleteInternetGateway(
+	_ context.Context, id string,
+) error {
+	igw, ok := m.igws.Get(id)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound,
+			"internet gateway %q not found", id,
+		)
+	}
+
+	if igw.State == IGWStateAttached {
+		return errors.Newf(
+			errors.FailedPrecondition,
+			"internet gateway %q is still attached", id,
+		)
+	}
+
+	m.igws.Delete(id)
+
+	return nil
+}
+
+// DescribeInternetGateways returns internet gateways
+// matching the given IDs, or all if ids is empty.
+func (m *Mock) DescribeInternetGateways(
+	_ context.Context, ids []string,
+) ([]driver.InternetGateway, error) {
+	return describeResources(m.igws, ids, toIGWInfo), nil
+}
+
+// AttachInternetGateway attaches an internet gateway to a VPC.
+func (m *Mock) AttachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws.Get(igwID)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound,
+			"internet gateway %q not found", igwID,
+		)
+	}
+
+	if igw.State == IGWStateAttached {
+		return errors.Newf(
+			errors.FailedPrecondition,
+			"internet gateway %q is already attached", igwID,
+		)
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return errors.Newf(
+			errors.NotFound, "vpc %q not found", vpcID,
+		)
+	}
+
+	igw.VpcID = vpcID
+	igw.State = IGWStateAttached
+
+	return nil
+}
+
+// DetachInternetGateway detaches an internet gateway from a VPC.
+func (m *Mock) DetachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws.Get(igwID)
+	if !ok {
+		return errors.Newf(
+			errors.NotFound,
+			"internet gateway %q not found", igwID,
+		)
+	}
+
+	if igw.State != IGWStateAttached || igw.VpcID != vpcID {
+		return errors.Newf(
+			errors.FailedPrecondition,
+			"internet gateway %q is not attached to vpc %q",
+			igwID, vpcID,
+		)
+	}
+
+	igw.VpcID = ""
+	igw.State = IGWStateDetached
+
+	return nil
+}
+
+func toIGWInfo(igw *igwData) driver.InternetGateway {
+	return driver.InternetGateway{
+		ID:    igw.ID,
+		VpcID: igw.VpcID,
+		State: igw.State,
+		Tags:  copyTags(igw.Tags),
+	}
+}

--- a/providers/aws/vpc/rtassoc.go
+++ b/providers/aws/vpc/rtassoc.go
@@ -1,0 +1,70 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+type rtAssocData struct {
+	ID           string
+	RouteTableID string
+	SubnetID     string
+}
+
+// AssociateRouteTable associates a route table with a subnet.
+func (m *Mock) AssociateRouteTable(
+	_ context.Context, routeTableID, subnetID string,
+) (*driver.RouteTableAssociation, error) {
+	if !m.routeTables.Has(routeTableID) {
+		return nil, errors.Newf(
+			errors.NotFound,
+			"route table %q not found", routeTableID,
+		)
+	}
+
+	if !m.subnets.Has(subnetID) {
+		return nil, errors.Newf(
+			errors.NotFound,
+			"subnet %q not found", subnetID,
+		)
+	}
+
+	id := idgen.GenerateID("rtbassoc-")
+
+	assoc := &rtAssocData{
+		ID:           id,
+		RouteTableID: routeTableID,
+		SubnetID:     subnetID,
+	}
+	m.rtAssocs.Set(id, assoc)
+
+	info := toRTAssocInfo(assoc)
+
+	return &info, nil
+}
+
+// DisassociateRouteTable removes a route table association.
+func (m *Mock) DisassociateRouteTable(
+	_ context.Context, associationID string,
+) error {
+	if !m.rtAssocs.Delete(associationID) {
+		return errors.Newf(
+			errors.NotFound,
+			"route table association %q not found",
+			associationID,
+		)
+	}
+
+	return nil
+}
+
+func toRTAssocInfo(a *rtAssocData) driver.RouteTableAssociation {
+	return driver.RouteTableAssociation{
+		ID:           a.ID,
+		RouteTableID: a.RouteTableID,
+		SubnetID:     a.SubnetID,
+	}
+}

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -32,6 +32,9 @@ type Mock struct {
 	flowLogs       *memstore.Store[*flowLogData]
 	routeTables    *memstore.Store[*routeTableData]
 	networkACLs    *memstore.Store[*networkACLData]
+	igws           *memstore.Store[*igwData]
+	eips           *memstore.Store[*eipData]
+	rtAssocs       *memstore.Store[*rtAssocData]
 	opts           *config.Options
 }
 
@@ -72,6 +75,9 @@ func New(opts *config.Options) *Mock {
 		flowLogs:       memstore.New[*flowLogData](),
 		routeTables:    memstore.New[*routeTableData](),
 		networkACLs:    memstore.New[*networkACLData](),
+		igws:           memstore.New[*igwData](),
+		eips:           memstore.New[*eipData](),
+		rtAssocs:       memstore.New[*rtAssocData](),
 		opts:           opts,
 	}
 }

--- a/providers/azure/vnet/eip.go
+++ b/providers/azure/vnet/eip.go
@@ -1,0 +1,122 @@
+package vnet
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+type eipData struct {
+	AllocationID  string
+	PublicIP      string
+	AssociationID string
+	InstanceID    string
+	Tags          map[string]string
+}
+
+// AllocateAddress allocates a new public IP address.
+func (m *Mock) AllocateAddress(
+	_ context.Context, cfg driver.ElasticIPConfig,
+) (*driver.ElasticIP, error) {
+	allocID := idgen.GenerateID("ipalloc-")
+
+	eip := &eipData{
+		AllocationID: allocID,
+		PublicIP:     mockPublicIP(allocID),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.eips.Set(allocID, eip)
+
+	info := toEIPInfo(eip)
+
+	return &info, nil
+}
+
+// ReleaseAddress releases a public IP address.
+func (m *Mock) ReleaseAddress(
+	_ context.Context, allocationID string,
+) error {
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"public IP %q not found", allocationID,
+		)
+	}
+
+	if eip.AssociationID != "" {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"public IP %q is still associated", allocationID,
+		)
+	}
+
+	m.eips.Delete(allocationID)
+
+	return nil
+}
+
+// DescribeAddresses returns public IPs matching the given
+// allocation IDs, or all if ids is empty.
+func (m *Mock) DescribeAddresses(
+	_ context.Context, ids []string,
+) ([]driver.ElasticIP, error) {
+	return describeResources(m.eips, ids, toEIPInfo), nil
+}
+
+// AssociateAddress associates a public IP with an instance.
+func (m *Mock) AssociateAddress(
+	_ context.Context, allocationID, instanceID string,
+) (string, error) {
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return "", cerrors.Newf(
+			cerrors.NotFound,
+			"public IP %q not found", allocationID,
+		)
+	}
+
+	if eip.AssociationID != "" {
+		return "", cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"public IP %q is already associated", allocationID,
+		)
+	}
+
+	assocID := idgen.GenerateID("ipassoc-")
+	eip.AssociationID = assocID
+	eip.InstanceID = instanceID
+
+	return assocID, nil
+}
+
+// DisassociateAddress removes a public IP association.
+func (m *Mock) DisassociateAddress(
+	_ context.Context, associationID string,
+) error {
+	for _, eip := range m.eips.All() {
+		if eip.AssociationID == associationID {
+			eip.AssociationID = ""
+			eip.InstanceID = ""
+
+			return nil
+		}
+	}
+
+	return cerrors.Newf(
+		cerrors.NotFound,
+		"association %q not found", associationID,
+	)
+}
+
+func toEIPInfo(eip *eipData) driver.ElasticIP {
+	return driver.ElasticIP{
+		AllocationID:  eip.AllocationID,
+		PublicIP:      eip.PublicIP,
+		AssociationID: eip.AssociationID,
+		InstanceID:    eip.InstanceID,
+		Tags:          copyTags(eip.Tags),
+	}
+}

--- a/providers/azure/vnet/igw.go
+++ b/providers/azure/vnet/igw.go
@@ -1,0 +1,140 @@
+package vnet
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Internet gateway state constants.
+const (
+	IGWStateDetached = "detached"
+	IGWStateAttached = "attached"
+)
+
+type igwData struct {
+	ID    string
+	VpcID string
+	State string
+	Tags  map[string]string
+}
+
+// CreateInternetGateway creates a new internet gateway.
+func (m *Mock) CreateInternetGateway(
+	_ context.Context, cfg driver.InternetGatewayConfig,
+) (*driver.InternetGateway, error) {
+	id := idgen.GenerateID("igw-")
+
+	igw := &igwData{
+		ID:    id,
+		State: IGWStateDetached,
+		Tags:  copyTags(cfg.Tags),
+	}
+	m.igws.Set(id, igw)
+
+	info := toIGWInfo(igw)
+
+	return &info, nil
+}
+
+// DeleteInternetGateway deletes the internet gateway.
+func (m *Mock) DeleteInternetGateway(
+	_ context.Context, id string,
+) error {
+	igw, ok := m.igws.Get(id)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"internet gateway %q not found", id,
+		)
+	}
+
+	if igw.State == IGWStateAttached {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"internet gateway %q is still attached", id,
+		)
+	}
+
+	m.igws.Delete(id)
+
+	return nil
+}
+
+// DescribeInternetGateways returns internet gateways
+// matching the given IDs, or all if ids is empty.
+func (m *Mock) DescribeInternetGateways(
+	_ context.Context, ids []string,
+) ([]driver.InternetGateway, error) {
+	return describeResources(m.igws, ids, toIGWInfo), nil
+}
+
+// AttachInternetGateway attaches an internet gateway
+// to a virtual network.
+func (m *Mock) AttachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws.Get(igwID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"internet gateway %q not found", igwID,
+		)
+	}
+
+	if igw.State == IGWStateAttached {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"internet gateway %q is already attached", igwID,
+		)
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return cerrors.Newf(
+			cerrors.NotFound, "vnet %q not found", vpcID,
+		)
+	}
+
+	igw.VpcID = vpcID
+	igw.State = IGWStateAttached
+
+	return nil
+}
+
+// DetachInternetGateway detaches an internet gateway
+// from a virtual network.
+func (m *Mock) DetachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws.Get(igwID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"internet gateway %q not found", igwID,
+		)
+	}
+
+	if igw.State != IGWStateAttached || igw.VpcID != vpcID {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"internet gateway %q is not attached to vnet %q",
+			igwID, vpcID,
+		)
+	}
+
+	igw.VpcID = ""
+	igw.State = IGWStateDetached
+
+	return nil
+}
+
+func toIGWInfo(igw *igwData) driver.InternetGateway {
+	return driver.InternetGateway{
+		ID:    igw.ID,
+		VpcID: igw.VpcID,
+		State: igw.State,
+		Tags:  copyTags(igw.Tags),
+	}
+}

--- a/providers/azure/vnet/rtassoc.go
+++ b/providers/azure/vnet/rtassoc.go
@@ -1,0 +1,70 @@
+package vnet
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+type rtAssocData struct {
+	ID           string
+	RouteTableID string
+	SubnetID     string
+}
+
+// AssociateRouteTable associates a route table with a subnet.
+func (m *Mock) AssociateRouteTable(
+	_ context.Context, routeTableID, subnetID string,
+) (*driver.RouteTableAssociation, error) {
+	if !m.routeTables.Has(routeTableID) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"route table %q not found", routeTableID,
+		)
+	}
+
+	if !m.subnets.Has(subnetID) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"subnet %q not found", subnetID,
+		)
+	}
+
+	id := idgen.GenerateID("rtassoc-")
+
+	assoc := &rtAssocData{
+		ID:           id,
+		RouteTableID: routeTableID,
+		SubnetID:     subnetID,
+	}
+	m.rtAssocs.Set(id, assoc)
+
+	info := toRTAssocInfo(assoc)
+
+	return &info, nil
+}
+
+// DisassociateRouteTable removes a route table association.
+func (m *Mock) DisassociateRouteTable(
+	_ context.Context, associationID string,
+) error {
+	if !m.rtAssocs.Delete(associationID) {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"route table association %q not found",
+			associationID,
+		)
+	}
+
+	return nil
+}
+
+func toRTAssocInfo(a *rtAssocData) driver.RouteTableAssociation {
+	return driver.RouteTableAssociation{
+		ID:           a.ID,
+		RouteTableID: a.RouteTableID,
+		SubnetID:     a.SubnetID,
+	}
+}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -58,6 +58,9 @@ type Mock struct {
 	flowLogs       *memstore.Store[*flowLogData]
 	routeTables    *memstore.Store[*routeTableData]
 	networkACLs    *memstore.Store[*networkACLData]
+	igws           *memstore.Store[*igwData]
+	eips           *memstore.Store[*eipData]
+	rtAssocs       *memstore.Store[*rtAssocData]
 	opts           *config.Options
 }
 
@@ -72,6 +75,9 @@ func New(opts *config.Options) *Mock {
 		flowLogs:       memstore.New[*flowLogData](),
 		routeTables:    memstore.New[*routeTableData](),
 		networkACLs:    memstore.New[*networkACLData](),
+		igws:           memstore.New[*igwData](),
+		eips:           memstore.New[*eipData](),
+		rtAssocs:       memstore.New[*rtAssocData](),
 		opts:           opts,
 	}
 }

--- a/providers/gcp/gcpvpc/eip.go
+++ b/providers/gcp/gcpvpc/eip.go
@@ -1,0 +1,130 @@
+package gcpvpc
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+type eipData struct {
+	AllocationID  string
+	PublicIP      string
+	AssociationID string
+	InstanceID    string
+	Tags          map[string]string
+}
+
+// AllocateAddress reserves a new external IP address.
+func (m *Mock) AllocateAddress(
+	_ context.Context, cfg driver.ElasticIPConfig,
+) (*driver.ElasticIP, error) {
+	allocID := idgen.GCPID(
+		m.opts.ProjectID,
+		"addresses",
+		idgen.GenerateID("addr-"),
+	)
+
+	eip := &eipData{
+		AllocationID: allocID,
+		PublicIP:     mockPublicIP(allocID),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.eips.Set(allocID, eip)
+
+	info := toEIPInfo(eip)
+
+	return &info, nil
+}
+
+// ReleaseAddress releases a reserved external IP address.
+func (m *Mock) ReleaseAddress(
+	_ context.Context, allocationID string,
+) error {
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"address %q not found", allocationID,
+		)
+	}
+
+	if eip.AssociationID != "" {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"address %q is still associated", allocationID,
+		)
+	}
+
+	m.eips.Delete(allocationID)
+
+	return nil
+}
+
+// DescribeAddresses returns external IPs matching the given
+// allocation IDs, or all if ids is empty.
+func (m *Mock) DescribeAddresses(
+	_ context.Context, ids []string,
+) ([]driver.ElasticIP, error) {
+	return describeResources(m.eips, ids, toEIPInfo), nil
+}
+
+// AssociateAddress associates an external IP with an instance.
+func (m *Mock) AssociateAddress(
+	_ context.Context, allocationID, instanceID string,
+) (string, error) {
+	eip, ok := m.eips.Get(allocationID)
+	if !ok {
+		return "", cerrors.Newf(
+			cerrors.NotFound,
+			"address %q not found", allocationID,
+		)
+	}
+
+	if eip.AssociationID != "" {
+		return "", cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"address %q is already associated", allocationID,
+		)
+	}
+
+	assocID := idgen.GCPID(
+		m.opts.ProjectID,
+		"addressAssociations",
+		idgen.GenerateID("assoc-"),
+	)
+	eip.AssociationID = assocID
+	eip.InstanceID = instanceID
+
+	return assocID, nil
+}
+
+// DisassociateAddress removes an external IP association.
+func (m *Mock) DisassociateAddress(
+	_ context.Context, associationID string,
+) error {
+	for _, eip := range m.eips.All() {
+		if eip.AssociationID == associationID {
+			eip.AssociationID = ""
+			eip.InstanceID = ""
+
+			return nil
+		}
+	}
+
+	return cerrors.Newf(
+		cerrors.NotFound,
+		"association %q not found", associationID,
+	)
+}
+
+func toEIPInfo(eip *eipData) driver.ElasticIP {
+	return driver.ElasticIP{
+		AllocationID:  eip.AllocationID,
+		PublicIP:      eip.PublicIP,
+		AssociationID: eip.AssociationID,
+		InstanceID:    eip.InstanceID,
+		Tags:          copyTags(eip.Tags),
+	}
+}

--- a/providers/gcp/gcpvpc/igw.go
+++ b/providers/gcp/gcpvpc/igw.go
@@ -1,0 +1,144 @@
+package gcpvpc
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+// Internet gateway state constants.
+const (
+	IGWStateDetached = "detached"
+	IGWStateAttached = "attached"
+)
+
+type igwData struct {
+	ID    string
+	VpcID string
+	State string
+	Tags  map[string]string
+}
+
+// CreateInternetGateway creates a new internet gateway.
+func (m *Mock) CreateInternetGateway(
+	_ context.Context, cfg driver.InternetGatewayConfig,
+) (*driver.InternetGateway, error) {
+	id := idgen.GCPID(
+		m.opts.ProjectID,
+		"gateways",
+		idgen.GenerateID("igw-"),
+	)
+
+	igw := &igwData{
+		ID:    id,
+		State: IGWStateDetached,
+		Tags:  copyTags(cfg.Tags),
+	}
+	m.igws.Set(id, igw)
+
+	info := toIGWInfo(igw)
+
+	return &info, nil
+}
+
+// DeleteInternetGateway deletes the internet gateway.
+func (m *Mock) DeleteInternetGateway(
+	_ context.Context, id string,
+) error {
+	igw, ok := m.igws.Get(id)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"internet gateway %q not found", id,
+		)
+	}
+
+	if igw.State == IGWStateAttached {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"internet gateway %q is still attached", id,
+		)
+	}
+
+	m.igws.Delete(id)
+
+	return nil
+}
+
+// DescribeInternetGateways returns internet gateways
+// matching the given IDs, or all if ids is empty.
+func (m *Mock) DescribeInternetGateways(
+	_ context.Context, ids []string,
+) ([]driver.InternetGateway, error) {
+	return describeResources(m.igws, ids, toIGWInfo), nil
+}
+
+// AttachInternetGateway attaches an internet gateway
+// to a VPC network.
+func (m *Mock) AttachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws.Get(igwID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"internet gateway %q not found", igwID,
+		)
+	}
+
+	if igw.State == IGWStateAttached {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"internet gateway %q is already attached", igwID,
+		)
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return cerrors.Newf(
+			cerrors.NotFound, "VPC %q not found", vpcID,
+		)
+	}
+
+	igw.VpcID = vpcID
+	igw.State = IGWStateAttached
+
+	return nil
+}
+
+// DetachInternetGateway detaches an internet gateway
+// from a VPC network.
+func (m *Mock) DetachInternetGateway(
+	_ context.Context, igwID, vpcID string,
+) error {
+	igw, ok := m.igws.Get(igwID)
+	if !ok {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"internet gateway %q not found", igwID,
+		)
+	}
+
+	if igw.State != IGWStateAttached || igw.VpcID != vpcID {
+		return cerrors.Newf(
+			cerrors.FailedPrecondition,
+			"internet gateway %q is not attached to VPC %q",
+			igwID, vpcID,
+		)
+	}
+
+	igw.VpcID = ""
+	igw.State = IGWStateDetached
+
+	return nil
+}
+
+func toIGWInfo(igw *igwData) driver.InternetGateway {
+	return driver.InternetGateway{
+		ID:    igw.ID,
+		VpcID: igw.VpcID,
+		State: igw.State,
+		Tags:  copyTags(igw.Tags),
+	}
+}

--- a/providers/gcp/gcpvpc/rtassoc.go
+++ b/providers/gcp/gcpvpc/rtassoc.go
@@ -1,0 +1,74 @@
+package gcpvpc
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/networking/driver"
+)
+
+type rtAssocData struct {
+	ID           string
+	RouteTableID string
+	SubnetID     string
+}
+
+// AssociateRouteTable associates a route table with a subnet.
+func (m *Mock) AssociateRouteTable(
+	_ context.Context, routeTableID, subnetID string,
+) (*driver.RouteTableAssociation, error) {
+	if !m.routeTables.Has(routeTableID) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"route %q not found", routeTableID,
+		)
+	}
+
+	if !m.subnets.Has(subnetID) {
+		return nil, cerrors.Newf(
+			cerrors.NotFound,
+			"subnet %q not found", subnetID,
+		)
+	}
+
+	id := idgen.GCPID(
+		m.opts.ProjectID,
+		"routeAssociations",
+		idgen.GenerateID("rtassoc-"),
+	)
+
+	assoc := &rtAssocData{
+		ID:           id,
+		RouteTableID: routeTableID,
+		SubnetID:     subnetID,
+	}
+	m.rtAssocs.Set(id, assoc)
+
+	info := toRTAssocInfo(assoc)
+
+	return &info, nil
+}
+
+// DisassociateRouteTable removes a route table association.
+func (m *Mock) DisassociateRouteTable(
+	_ context.Context, associationID string,
+) error {
+	if !m.rtAssocs.Delete(associationID) {
+		return cerrors.Newf(
+			cerrors.NotFound,
+			"route table association %q not found",
+			associationID,
+		)
+	}
+
+	return nil
+}
+
+func toRTAssocInfo(a *rtAssocData) driver.RouteTableAssociation {
+	return driver.RouteTableAssociation{
+		ID:           a.ID,
+		RouteTableID: a.RouteTableID,
+		SubnetID:     a.SubnetID,
+	}
+}

--- a/providers/gcp/gcpvpc/vpc.go
+++ b/providers/gcp/gcpvpc/vpc.go
@@ -58,6 +58,9 @@ type Mock struct {
 	flowLogs       *memstore.Store[*flowLogData]
 	routeTables    *memstore.Store[*routeTableData]
 	networkACLs    *memstore.Store[*networkACLData]
+	igws           *memstore.Store[*igwData]
+	eips           *memstore.Store[*eipData]
+	rtAssocs       *memstore.Store[*rtAssocData]
 	opts           *config.Options
 }
 
@@ -72,6 +75,9 @@ func New(opts *config.Options) *Mock {
 		flowLogs:       memstore.New[*flowLogData](),
 		routeTables:    memstore.New[*routeTableData](),
 		networkACLs:    memstore.New[*networkACLData](),
+		igws:           memstore.New[*igwData](),
+		eips:           memstore.New[*eipData](),
+		rtAssocs:       memstore.New[*rtAssocData](),
 		opts:           opts,
 	}
 }


### PR DESCRIPTION
## Summary

- Adds 12 new methods to networking driver interface for IGW, Elastic IP, and Route Table Association management
- Adds 5 new types: `InternetGatewayConfig`, `InternetGateway`, `ElasticIPConfig`, `ElasticIP`, `RouteTableAssociation`
- Implements across all 3 providers: AWS VPC, Azure VNet, GCP VPC
- IGW tracks attachment state to VPC, prevents delete while attached
- Elastic IPs track association to instances, prevent release while associated
- Route table associations link route tables to subnets

Closes #62

## Test plan

- [x] `TestInternetGatewayAWS` — create, attach, describe, fail-delete-while-attached, detach, delete
- [x] `TestElasticIPAWS` — allocate, associate, describe, fail-release-while-associated, disassociate, release
- [x] `TestRouteTableAssociationAWS` — associate RT to subnet, disassociate
- [x] `TestInternetGatewayAzure` — create, attach, detach, delete
- [x] `TestInternetGatewayGCP` — create, attach, detach, delete
- [x] Linter: 0 issues
- [x] Full test suite: all passing