### PR TITLE
Add object and bucket tagging to Storage service

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -7765,3 +7765,193 @@ func TestInternetGatewayGCP(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// ─── Object & Bucket Tagging ────────────────────────────────────────────
+
+func TestObjectTaggingAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testObjectTagging(t, ctx, p.S3)
+}
+
+func TestObjectTaggingAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testObjectTagging(t, ctx, p.BlobStorage)
+}
+
+func TestObjectTaggingGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testObjectTagging(t, ctx, p.GCS)
+}
+
+func testObjectTagging(t *testing.T, ctx context.Context, d storagedriver.Bucket) {
+	t.Helper()
+
+	// Setup: create bucket and object.
+	if err := d.CreateBucket(ctx, "tag-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	if err := d.PutObject(ctx, "tag-bucket", "file.txt", []byte("data"), "text/plain", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	// Initially no tags.
+	tags, err := d.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+	if err != nil {
+		t.Fatalf("GetObjectTagging (empty): %v", err)
+	}
+
+	if len(tags) != 0 {
+		t.Errorf("expected 0 tags initially, got %d", len(tags))
+	}
+
+	// Put tags.
+	err = d.PutObjectTagging(ctx, "tag-bucket", "file.txt", map[string]string{
+		"env": "prod", "team": "platform",
+	})
+	if err != nil {
+		t.Fatalf("PutObjectTagging: %v", err)
+	}
+
+	// Get tags.
+	tags, err = d.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+	if err != nil {
+		t.Fatalf("GetObjectTagging: %v", err)
+	}
+
+	if len(tags) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(tags))
+	}
+
+	if tags["env"] != "prod" {
+		t.Errorf("expected tag env=prod, got %q", tags["env"])
+	}
+
+	if tags["team"] != "platform" {
+		t.Errorf("expected tag team=platform, got %q", tags["team"])
+	}
+
+	// Replace tags (PutObjectTagging replaces all).
+	err = d.PutObjectTagging(ctx, "tag-bucket", "file.txt", map[string]string{"version": "v2"})
+	if err != nil {
+		t.Fatalf("PutObjectTagging (replace): %v", err)
+	}
+
+	tags, err = d.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+	if err != nil {
+		t.Fatalf("GetObjectTagging (after replace): %v", err)
+	}
+
+	if len(tags) != 1 || tags["version"] != "v2" {
+		t.Errorf("expected {version: v2}, got %v", tags)
+	}
+
+	// Delete tags.
+	err = d.DeleteObjectTagging(ctx, "tag-bucket", "file.txt")
+	if err != nil {
+		t.Fatalf("DeleteObjectTagging: %v", err)
+	}
+
+	tags, err = d.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+	if err != nil {
+		t.Fatalf("GetObjectTagging (after delete): %v", err)
+	}
+
+	if len(tags) != 0 {
+		t.Errorf("expected 0 tags after delete, got %d", len(tags))
+	}
+
+	// Error: tag nonexistent object.
+	err = d.PutObjectTagging(ctx, "tag-bucket", "missing.txt", map[string]string{"a": "b"})
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for missing object, got %v", err)
+	}
+
+	// Error: tag in nonexistent bucket.
+	err = d.PutObjectTagging(ctx, "no-bucket", "file.txt", map[string]string{"a": "b"})
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for missing bucket, got %v", err)
+	}
+}
+
+func TestBucketTaggingAWS(t *testing.T) {
+	ctx := context.Background()
+	p := NewAWS()
+	testBucketTagging(t, ctx, p.S3)
+}
+
+func TestBucketTaggingAzure(t *testing.T) {
+	ctx := context.Background()
+	p := NewAzure()
+	testBucketTagging(t, ctx, p.BlobStorage)
+}
+
+func TestBucketTaggingGCP(t *testing.T) {
+	ctx := context.Background()
+	p := NewGCP()
+	testBucketTagging(t, ctx, p.GCS)
+}
+
+func testBucketTagging(t *testing.T, ctx context.Context, d storagedriver.Bucket) {
+	t.Helper()
+
+	if err := d.CreateBucket(ctx, "tagged-bucket"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	// Initially no tags.
+	tags, err := d.GetBucketTagging(ctx, "tagged-bucket")
+	if err != nil {
+		t.Fatalf("GetBucketTagging (empty): %v", err)
+	}
+
+	if len(tags) != 0 {
+		t.Errorf("expected 0 tags initially, got %d", len(tags))
+	}
+
+	// Put bucket tags.
+	err = d.PutBucketTagging(ctx, "tagged-bucket", map[string]string{
+		"project": "cloudemu", "cost-center": "engineering",
+	})
+	if err != nil {
+		t.Fatalf("PutBucketTagging: %v", err)
+	}
+
+	// Get bucket tags.
+	tags, err = d.GetBucketTagging(ctx, "tagged-bucket")
+	if err != nil {
+		t.Fatalf("GetBucketTagging: %v", err)
+	}
+
+	if len(tags) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(tags))
+	}
+
+	if tags["project"] != "cloudemu" {
+		t.Errorf("expected tag project=cloudemu, got %q", tags["project"])
+	}
+
+	// Delete bucket tags.
+	err = d.DeleteBucketTagging(ctx, "tagged-bucket")
+	if err != nil {
+		t.Fatalf("DeleteBucketTagging: %v", err)
+	}
+
+	tags, err = d.GetBucketTagging(ctx, "tagged-bucket")
+	if err != nil {
+		t.Fatalf("GetBucketTagging (after delete): %v", err)
+	}
+
+	if len(tags) != 0 {
+		t.Errorf("expected 0 tags after delete, got %d", len(tags))
+	}
+
+	// Error: nonexistent bucket.
+	err = d.PutBucketTagging(ctx, "no-bucket", map[string]string{"a": "b"})
+	if !cerrors.IsNotFound(err) {
+		t.Errorf("expected NotFound for missing bucket, got %v", err)
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -35,6 +35,7 @@ type s3Object struct {
 	ETag         string
 	LastModified string
 	Metadata     map[string]string
+	Tags         map[string]string
 }
 
 type multipartUpload struct {
@@ -56,6 +57,7 @@ type bucketMeta struct {
 	policy     *driver.BucketPolicy
 	corsConfig *driver.CORSConfig
 	encryption *driver.EncryptionConfig
+	tags       map[string]string
 }
 
 // Mock is an in-memory mock implementation of the AWS S3 service.
@@ -717,4 +719,115 @@ func (m *Mock) GetEncryptionConfig(_ context.Context, bucket string) (*driver.En
 	e := *bkt.encryption
 
 	return &e, nil
+}
+
+// PutObjectTagging sets tags on an object.
+func (m *Mock) PutObjectTagging(_ context.Context, bucket, key string, tags map[string]string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := bkt.objects.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	copied := make(map[string]string, len(tags))
+	for k, v := range tags {
+		copied[k] = v
+	}
+
+	obj.Tags = copied
+
+	return nil
+}
+
+// GetObjectTagging returns tags for an object.
+func (m *Mock) GetObjectTagging(_ context.Context, bucket, key string) (map[string]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := bkt.objects.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	if obj.Tags == nil {
+		return map[string]string{}, nil
+	}
+
+	copied := make(map[string]string, len(obj.Tags))
+	for k, v := range obj.Tags {
+		copied[k] = v
+	}
+
+	return copied, nil
+}
+
+// DeleteObjectTagging removes all tags from an object.
+func (m *Mock) DeleteObjectTagging(_ context.Context, bucket, key string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := bkt.objects.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	obj.Tags = nil
+
+	return nil
+}
+
+// PutBucketTagging sets tags on a bucket.
+func (m *Mock) PutBucketTagging(_ context.Context, bucket string, tags map[string]string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	copied := make(map[string]string, len(tags))
+	for k, v := range tags {
+		copied[k] = v
+	}
+
+	bkt.tags = copied
+
+	return nil
+}
+
+// GetBucketTagging returns tags for a bucket.
+func (m *Mock) GetBucketTagging(_ context.Context, bucket string) (map[string]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.tags == nil {
+		return map[string]string{}, nil
+	}
+
+	copied := make(map[string]string, len(bkt.tags))
+	for k, v := range bkt.tags {
+		copied[k] = v
+	}
+
+	return copied, nil
+}
+
+// DeleteBucketTagging removes all tags from a bucket.
+func (m *Mock) DeleteBucketTagging(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.tags = nil
+
+	return nil
 }

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -37,6 +37,7 @@ type blobObject struct {
 	ETag         string
 	LastModified string
 	Metadata     map[string]string
+	Tags         map[string]string
 }
 
 type blobMultipartUpload struct {
@@ -58,6 +59,7 @@ type containerMeta struct {
 	policy     *driver.BucketPolicy
 	corsConfig *driver.CORSConfig
 	encryption *driver.EncryptionConfig
+	tags       map[string]string
 }
 
 // Mock is an in-memory mock implementation of Azure Blob Storage.
@@ -724,4 +726,115 @@ func (m *Mock) GetEncryptionConfig(_ context.Context, bucket string) (*driver.En
 	e := *ctr.encryption
 
 	return &e, nil
+}
+
+// PutObjectTagging sets tags on a blob.
+func (m *Mock) PutObjectTagging(_ context.Context, bucket, key string, tags map[string]string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	obj, ok := ctr.objects.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
+	}
+
+	copied := make(map[string]string, len(tags))
+	for k, v := range tags {
+		copied[k] = v
+	}
+
+	obj.Tags = copied
+
+	return nil
+}
+
+// GetObjectTagging returns tags for a blob.
+func (m *Mock) GetObjectTagging(_ context.Context, bucket, key string) (map[string]string, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	obj, ok := ctr.objects.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
+	}
+
+	if obj.Tags == nil {
+		return map[string]string{}, nil
+	}
+
+	copied := make(map[string]string, len(obj.Tags))
+	for k, v := range obj.Tags {
+		copied[k] = v
+	}
+
+	return copied, nil
+}
+
+// DeleteObjectTagging removes all tags from a blob.
+func (m *Mock) DeleteObjectTagging(_ context.Context, bucket, key string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	obj, ok := ctr.objects.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "blob %q not found in container %q", key, bucket)
+	}
+
+	obj.Tags = nil
+
+	return nil
+}
+
+// PutBucketTagging sets tags on a container.
+func (m *Mock) PutBucketTagging(_ context.Context, bucket string, tags map[string]string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	copied := make(map[string]string, len(tags))
+	for k, v := range tags {
+		copied[k] = v
+	}
+
+	ctr.tags = copied
+
+	return nil
+}
+
+// GetBucketTagging returns tags for a container.
+func (m *Mock) GetBucketTagging(_ context.Context, bucket string) (map[string]string, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	if ctr.tags == nil {
+		return map[string]string{}, nil
+	}
+
+	copied := make(map[string]string, len(ctr.tags))
+	for k, v := range ctr.tags {
+		copied[k] = v
+	}
+
+	return copied, nil
+}
+
+// DeleteBucketTagging removes all tags from a container.
+func (m *Mock) DeleteBucketTagging(_ context.Context, bucket string) error {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	ctr.tags = nil
+
+	return nil
 }

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -37,6 +37,7 @@ type gcsObject struct {
 	ETag         string
 	LastModified string
 	Metadata     map[string]string
+	Tags         map[string]string
 }
 
 type gcsMultipartUpload struct {
@@ -58,6 +59,7 @@ type bucketMeta struct {
 	policy     *driver.BucketPolicy
 	corsConfig *driver.CORSConfig
 	encryption *driver.EncryptionConfig
+	tags       map[string]string
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Storage.
@@ -721,4 +723,115 @@ func (m *Mock) GetEncryptionConfig(_ context.Context, bucket string) (*driver.En
 	e := *bkt.encryption
 
 	return &e, nil
+}
+
+// PutObjectTagging sets labels on an object.
+func (m *Mock) PutObjectTagging(_ context.Context, bucket, key string, tags map[string]string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := bkt.objects.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	copied := make(map[string]string, len(tags))
+	for k, v := range tags {
+		copied[k] = v
+	}
+
+	obj.Tags = copied
+
+	return nil
+}
+
+// GetObjectTagging returns labels for an object.
+func (m *Mock) GetObjectTagging(_ context.Context, bucket, key string) (map[string]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := bkt.objects.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	if obj.Tags == nil {
+		return map[string]string{}, nil
+	}
+
+	copied := make(map[string]string, len(obj.Tags))
+	for k, v := range obj.Tags {
+		copied[k] = v
+	}
+
+	return copied, nil
+}
+
+// DeleteObjectTagging removes all labels from an object.
+func (m *Mock) DeleteObjectTagging(_ context.Context, bucket, key string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	obj, ok := bkt.objects.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
+	}
+
+	obj.Tags = nil
+
+	return nil
+}
+
+// PutBucketTagging sets labels on a bucket.
+func (m *Mock) PutBucketTagging(_ context.Context, bucket string, tags map[string]string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	copied := make(map[string]string, len(tags))
+	for k, v := range tags {
+		copied[k] = v
+	}
+
+	bkt.tags = copied
+
+	return nil
+}
+
+// GetBucketTagging returns labels for a bucket.
+func (m *Mock) GetBucketTagging(_ context.Context, bucket string) (map[string]string, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	if bkt.tags == nil {
+		return map[string]string{}, nil
+	}
+
+	copied := make(map[string]string, len(bkt.tags))
+	for k, v := range bkt.tags {
+		copied[k] = v
+	}
+
+	return copied, nil
+}
+
+// DeleteBucketTagging removes all labels from a bucket.
+func (m *Mock) DeleteBucketTagging(_ context.Context, bucket string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.tags = nil
+
+	return nil
 }

--- a/storage/driver/driver.go
+++ b/storage/driver/driver.go
@@ -178,4 +178,14 @@ type Bucket interface {
 	// Encryption
 	PutEncryptionConfig(ctx context.Context, bucket string, config EncryptionConfig) error
 	GetEncryptionConfig(ctx context.Context, bucket string) (*EncryptionConfig, error)
+
+	// Object Tagging
+	PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error
+	GetObjectTagging(ctx context.Context, bucket, key string) (map[string]string, error)
+	DeleteObjectTagging(ctx context.Context, bucket, key string) error
+
+	// Bucket Tagging
+	PutBucketTagging(ctx context.Context, bucket string, tags map[string]string) error
+	GetBucketTagging(ctx context.Context, bucket string) (map[string]string, error)
+	DeleteBucketTagging(ctx context.Context, bucket string) error
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -399,3 +399,63 @@ func (b *Bucket) GetEncryptionConfig(ctx context.Context, bucket string) (*drive
 
 	return out.(*driver.EncryptionConfig), nil
 }
+
+// PutObjectTagging sets tags on an object.
+func (b *Bucket) PutObjectTagging(ctx context.Context, bucket, key string, tags map[string]string) error {
+	_, err := b.do(ctx, "PutObjectTagging", map[string]string{"bucket": bucket, "key": key}, func() (any, error) {
+		return nil, b.driver.PutObjectTagging(ctx, bucket, key, tags)
+	})
+
+	return err
+}
+
+// GetObjectTagging returns tags for an object.
+func (b *Bucket) GetObjectTagging(ctx context.Context, bucket, key string) (map[string]string, error) {
+	out, err := b.do(ctx, "GetObjectTagging", map[string]string{"bucket": bucket, "key": key}, func() (any, error) {
+		return b.driver.GetObjectTagging(ctx, bucket, key)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(map[string]string), nil
+}
+
+// DeleteObjectTagging removes all tags from an object.
+func (b *Bucket) DeleteObjectTagging(ctx context.Context, bucket, key string) error {
+	_, err := b.do(ctx, "DeleteObjectTagging", map[string]string{"bucket": bucket, "key": key}, func() (any, error) {
+		return nil, b.driver.DeleteObjectTagging(ctx, bucket, key)
+	})
+
+	return err
+}
+
+// PutBucketTagging sets tags on a bucket.
+func (b *Bucket) PutBucketTagging(ctx context.Context, bucket string, tags map[string]string) error {
+	_, err := b.do(ctx, "PutBucketTagging", bucket, func() (any, error) {
+		return nil, b.driver.PutBucketTagging(ctx, bucket, tags)
+	})
+
+	return err
+}
+
+// GetBucketTagging returns tags for a bucket.
+func (b *Bucket) GetBucketTagging(ctx context.Context, bucket string) (map[string]string, error) {
+	out, err := b.do(ctx, "GetBucketTagging", bucket, func() (any, error) {
+		return b.driver.GetBucketTagging(ctx, bucket)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(map[string]string), nil
+}
+
+// DeleteBucketTagging removes all tags from a bucket.
+func (b *Bucket) DeleteBucketTagging(ctx context.Context, bucket string) error {
+	_, err := b.do(ctx, "DeleteBucketTagging", bucket, func() (any, error) {
+		return nil, b.driver.DeleteBucketTagging(ctx, bucket)
+	})
+
+	return err
+}


### PR DESCRIPTION
## Summary

- Adds **Object Tagging** (PutObjectTagging, GetObjectTagging, DeleteObjectTagging) and **Bucket Tagging** (PutBucketTagging, GetBucketTagging, DeleteBucketTagging) to the storage service
- Implements across all 3 providers: AWS S3, Azure Blob Storage, GCP GCS
- Updates the driver interface, all provider implementations, and the portable API layer with cross-cutting concerns
- Adds 6 integration tests covering all 3 providers (object tagging + bucket tagging per provider)

Closes #80

## Changes

| File | Change |
|------|--------|
| `storage/driver/driver.go` | Added 6 new methods to `Bucket` interface |
| `providers/aws/s3/s3.go` | Added `Tags` field to `s3Object` and `bucketMeta`, implemented 6 tagging methods |
| `providers/azure/blobstorage/blobstorage.go` | Added `Tags` field to `blobObject` and `containerMeta`, implemented 6 tagging methods |
| `providers/gcp/gcs/gcs.go` | Added `Tags` field to `gcsObject` and `bucketMeta`, implemented 6 tagging methods |
| `storage/storage.go` | Added 6 portable API wrapper methods with cross-cutting concerns |
| `cloudemu_test.go` | Added `TestObjectTagging{AWS,Azure,GCP}` and `TestBucketTagging{AWS,Azure,GCP}` |

## Test plan

- [x] All 6 new tagging tests pass across AWS, Azure, GCP
- [x] Full test suite passes with no regressions
- [x] Linter passes with 0 issues (`golangci-lint run --timeout=9m ./...`)

