### PR TITLE
Add storage service test coverage (66%->96%)

### DIFF
--- a/providers/aws/s3/s3_test.go
+++ b/providers/aws/s3/s3_test.go
@@ -752,6 +752,336 @@ func TestCopyObjectMetrics(t *testing.T) {
 	assertEqual(t, true, len(result.Values) > 0)
 }
 
+func TestBucketPolicy(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("put and get policy", func(t *testing.T) {
+		policy := driver.BucketPolicy{
+			Version: "2012-10-17",
+			Statements: []driver.PolicyStatement{
+				{
+					Effect:    "Allow",
+					Principal: "*",
+					Actions:   []string{"s3:GetObject"},
+					Resources: []string{"arn:aws:s3:::bkt/*"},
+				},
+			},
+		}
+
+		err := m.PutBucketPolicy(ctx, "bkt", policy)
+		requireNoError(t, err)
+
+		got, err := m.GetBucketPolicy(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, "2012-10-17", got.Version)
+		assertEqual(t, 1, len(got.Statements))
+		assertEqual(t, "Allow", got.Statements[0].Effect)
+		assertEqual(t, "*", got.Statements[0].Principal)
+		assertEqual(t, 1, len(got.Statements[0].Actions))
+		assertEqual(t, "s3:GetObject", got.Statements[0].Actions[0])
+		assertEqual(t, 1, len(got.Statements[0].Resources))
+		assertEqual(t, "arn:aws:s3:::bkt/*", got.Statements[0].Resources[0])
+	})
+
+	t.Run("get without policy", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "no-policy-bkt")
+		_, err := m.GetBucketPolicy(ctx, "no-policy-bkt")
+		assertError(t, err, true)
+	})
+
+	t.Run("delete policy", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "del-policy-bkt")
+		policy := driver.BucketPolicy{
+			Version: "2012-10-17",
+			Statements: []driver.PolicyStatement{
+				{
+					Effect:    "Allow",
+					Principal: "*",
+					Actions:   []string{"s3:PutObject"},
+					Resources: []string{"arn:aws:s3:::del-policy-bkt/*"},
+				},
+			},
+		}
+		err := m.PutBucketPolicy(ctx, "del-policy-bkt", policy)
+		requireNoError(t, err)
+
+		err = m.DeleteBucketPolicy(ctx, "del-policy-bkt")
+		requireNoError(t, err)
+
+		_, err = m.GetBucketPolicy(ctx, "del-policy-bkt")
+		assertError(t, err, true)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutBucketPolicy(ctx, "nonexistent", driver.BucketPolicy{})
+		assertError(t, err, true)
+
+		_, err = m.GetBucketPolicy(ctx, "nonexistent")
+		assertError(t, err, true)
+
+		err = m.DeleteBucketPolicy(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestObjectTagging(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+	_ = m.PutObject(ctx, "bkt", "obj.txt", []byte("data"), "text/plain", nil)
+
+	t.Run("put and get tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod", "team": "platform"}
+		err := m.PutObjectTagging(ctx, "bkt", "obj.txt", tags)
+		requireNoError(t, err)
+
+		got, err := m.GetObjectTagging(ctx, "bkt", "obj.txt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got))
+		assertEqual(t, "prod", got["env"])
+		assertEqual(t, "platform", got["team"])
+	})
+
+	t.Run("replace tags", func(t *testing.T) {
+		oldTags := map[string]string{"env": "prod", "team": "platform"}
+		err := m.PutObjectTagging(ctx, "bkt", "obj.txt", oldTags)
+		requireNoError(t, err)
+
+		newTags := map[string]string{"env": "staging", "version": "v2"}
+		err = m.PutObjectTagging(ctx, "bkt", "obj.txt", newTags)
+		requireNoError(t, err)
+
+		got, err := m.GetObjectTagging(ctx, "bkt", "obj.txt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got))
+		assertEqual(t, "staging", got["env"])
+		assertEqual(t, "v2", got["version"])
+	})
+
+	t.Run("delete tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod"}
+		err := m.PutObjectTagging(ctx, "bkt", "obj.txt", tags)
+		requireNoError(t, err)
+
+		err = m.DeleteObjectTagging(ctx, "bkt", "obj.txt")
+		requireNoError(t, err)
+
+		got, err := m.GetObjectTagging(ctx, "bkt", "obj.txt")
+		requireNoError(t, err)
+		assertEqual(t, 0, len(got))
+	})
+
+	t.Run("object not found", func(t *testing.T) {
+		err := m.PutObjectTagging(ctx, "bkt", "missing.txt", map[string]string{"k": "v"})
+		assertError(t, err, true)
+
+		_, err = m.GetObjectTagging(ctx, "bkt", "missing.txt")
+		assertError(t, err, true)
+
+		err = m.DeleteObjectTagging(ctx, "bkt", "missing.txt")
+		assertError(t, err, true)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutObjectTagging(ctx, "nonexistent", "obj.txt", map[string]string{"k": "v"})
+		assertError(t, err, true)
+
+		_, err = m.GetObjectTagging(ctx, "nonexistent", "obj.txt")
+		assertError(t, err, true)
+
+		err = m.DeleteObjectTagging(ctx, "nonexistent", "obj.txt")
+		assertError(t, err, true)
+	})
+}
+
+func TestBucketTagging(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("put and get tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod", "team": "platform"}
+		err := m.PutBucketTagging(ctx, "bkt", tags)
+		requireNoError(t, err)
+
+		got, err := m.GetBucketTagging(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got))
+		assertEqual(t, "prod", got["env"])
+		assertEqual(t, "platform", got["team"])
+	})
+
+	t.Run("replace tags", func(t *testing.T) {
+		oldTags := map[string]string{"env": "prod", "team": "platform"}
+		err := m.PutBucketTagging(ctx, "bkt", oldTags)
+		requireNoError(t, err)
+
+		newTags := map[string]string{"env": "staging", "cost-center": "eng"}
+		err = m.PutBucketTagging(ctx, "bkt", newTags)
+		requireNoError(t, err)
+
+		got, err := m.GetBucketTagging(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got))
+		assertEqual(t, "staging", got["env"])
+		assertEqual(t, "eng", got["cost-center"])
+	})
+
+	t.Run("delete tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod"}
+		err := m.PutBucketTagging(ctx, "bkt", tags)
+		requireNoError(t, err)
+
+		err = m.DeleteBucketTagging(ctx, "bkt")
+		requireNoError(t, err)
+
+		got, err := m.GetBucketTagging(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 0, len(got))
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutBucketTagging(ctx, "nonexistent", map[string]string{"k": "v"})
+		assertError(t, err, true)
+
+		_, err = m.GetBucketTagging(ctx, "nonexistent")
+		assertError(t, err, true)
+
+		err = m.DeleteBucketTagging(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestCORSConfig(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("put and get", func(t *testing.T) {
+		cfg := driver.CORSConfig{
+			Rules: []driver.CORSRule{
+				{
+					AllowedOrigins: []string{"https://example.com"},
+					AllowedMethods: []string{"GET", "PUT"},
+					AllowedHeaders: []string{"Content-Type"},
+					ExposeHeaders:  []string{"ETag"},
+					MaxAgeSeconds:  3600,
+				},
+			},
+		}
+
+		err := m.PutCORSConfig(ctx, "bkt", cfg)
+		requireNoError(t, err)
+
+		got, err := m.GetCORSConfig(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, 1, len(got.Rules))
+		assertEqual(t, 1, len(got.Rules[0].AllowedOrigins))
+		assertEqual(t, "https://example.com", got.Rules[0].AllowedOrigins[0])
+		assertEqual(t, 2, len(got.Rules[0].AllowedMethods))
+		assertEqual(t, "GET", got.Rules[0].AllowedMethods[0])
+		assertEqual(t, "PUT", got.Rules[0].AllowedMethods[1])
+		assertEqual(t, 1, len(got.Rules[0].AllowedHeaders))
+		assertEqual(t, "Content-Type", got.Rules[0].AllowedHeaders[0])
+		assertEqual(t, 1, len(got.Rules[0].ExposeHeaders))
+		assertEqual(t, "ETag", got.Rules[0].ExposeHeaders[0])
+		assertEqual(t, 3600, got.Rules[0].MaxAgeSeconds)
+	})
+
+	t.Run("get without config", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "no-cors-bkt")
+		_, err := m.GetCORSConfig(ctx, "no-cors-bkt")
+		assertError(t, err, true)
+	})
+
+	t.Run("delete config", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "del-cors-bkt")
+		cfg := driver.CORSConfig{
+			Rules: []driver.CORSRule{
+				{
+					AllowedOrigins: []string{"*"},
+					AllowedMethods: []string{"GET"},
+				},
+			},
+		}
+		err := m.PutCORSConfig(ctx, "del-cors-bkt", cfg)
+		requireNoError(t, err)
+
+		err = m.DeleteCORSConfig(ctx, "del-cors-bkt")
+		requireNoError(t, err)
+
+		_, err = m.GetCORSConfig(ctx, "del-cors-bkt")
+		assertError(t, err, true)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutCORSConfig(ctx, "nonexistent", driver.CORSConfig{})
+		assertError(t, err, true)
+
+		_, err = m.GetCORSConfig(ctx, "nonexistent")
+		assertError(t, err, true)
+
+		err = m.DeleteCORSConfig(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestEncryptionConfig(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	_ = m.CreateBucket(ctx, "bkt")
+
+	t.Run("put and get AES256", func(t *testing.T) {
+		cfg := driver.EncryptionConfig{
+			Enabled:   true,
+			Algorithm: "AES256",
+		}
+
+		err := m.PutEncryptionConfig(ctx, "bkt", cfg)
+		requireNoError(t, err)
+
+		got, err := m.GetEncryptionConfig(ctx, "bkt")
+		requireNoError(t, err)
+		assertEqual(t, true, got.Enabled)
+		assertEqual(t, "AES256", got.Algorithm)
+		assertEqual(t, "", got.KeyID)
+	})
+
+	t.Run("put with KMS key", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "kms-bkt")
+		cfg := driver.EncryptionConfig{
+			Enabled:   true,
+			Algorithm: "aws:kms",
+			KeyID:     "key-123",
+		}
+
+		err := m.PutEncryptionConfig(ctx, "kms-bkt", cfg)
+		requireNoError(t, err)
+
+		got, err := m.GetEncryptionConfig(ctx, "kms-bkt")
+		requireNoError(t, err)
+		assertEqual(t, true, got.Enabled)
+		assertEqual(t, "aws:kms", got.Algorithm)
+		assertEqual(t, "key-123", got.KeyID)
+	})
+
+	t.Run("get without config", func(t *testing.T) {
+		_ = m.CreateBucket(ctx, "no-enc-bkt")
+		_, err := m.GetEncryptionConfig(ctx, "no-enc-bkt")
+		assertError(t, err, true)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutEncryptionConfig(ctx, "nonexistent", driver.EncryptionConfig{})
+		assertError(t, err, true)
+
+		_, err = m.GetEncryptionConfig(ctx, "nonexistent")
+		assertError(t, err, true)
+	})
+}
+
 // --- test helpers (no if/else, use t.Fatal/t.Errorf) ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/blobstorage/blobstorage_test.go
+++ b/providers/azure/blobstorage/blobstorage_test.go
@@ -643,6 +643,292 @@ func TestCopyObjectMetrics(t *testing.T) {
 	assert.True(t, mon.hasMetric("Microsoft.Storage/storageAccounts", "Transactions"))
 }
 
+func TestBucketPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "policy-bucket"))
+
+	t.Run("put and get policy", func(t *testing.T) {
+		policy := driver.BucketPolicy{
+			Version: "2012-10-17",
+			Statements: []driver.PolicyStatement{
+				{
+					Effect:    "Allow",
+					Principal: "*",
+					Actions:   []string{"s3:GetObject"},
+					Resources: []string{"arn:aws:s3:::policy-bucket/*"},
+				},
+			},
+		}
+		require.NoError(t, m.PutBucketPolicy(ctx, "policy-bucket", policy))
+
+		got, err := m.GetBucketPolicy(ctx, "policy-bucket")
+		require.NoError(t, err)
+		assert.Equal(t, "2012-10-17", got.Version)
+		require.Len(t, got.Statements, 1)
+		assert.Equal(t, "Allow", got.Statements[0].Effect)
+		assert.Equal(t, "*", got.Statements[0].Principal)
+		assert.Equal(t, []string{"s3:GetObject"}, got.Statements[0].Actions)
+		assert.Equal(t, []string{"arn:aws:s3:::policy-bucket/*"}, got.Statements[0].Resources)
+	})
+
+	t.Run("get without policy", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "no-policy-bucket"))
+
+		_, err := m.GetBucketPolicy(ctx, "no-policy-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no policy")
+	})
+
+	t.Run("delete policy", func(t *testing.T) {
+		require.NoError(t, m.DeleteBucketPolicy(ctx, "policy-bucket"))
+
+		_, err := m.GetBucketPolicy(ctx, "policy-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no policy")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutBucketPolicy(ctx, "missing", driver.BucketPolicy{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetBucketPolicy(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteBucketPolicy(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestObjectTagging(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "tag-bucket"))
+	require.NoError(t, m.PutObject(ctx, "tag-bucket", "file.txt", []byte("hello"), "text/plain", nil))
+
+	t.Run("put and get tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod", "team": "backend"}
+		require.NoError(t, m.PutObjectTagging(ctx, "tag-bucket", "file.txt", tags))
+
+		got, err := m.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "backend", got["team"])
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("replace tags", func(t *testing.T) {
+		newTags := map[string]string{"version": "v2"}
+		require.NoError(t, m.PutObjectTagging(ctx, "tag-bucket", "file.txt", newTags))
+
+		got, err := m.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "v2", got["version"])
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("delete tags", func(t *testing.T) {
+		require.NoError(t, m.DeleteObjectTagging(ctx, "tag-bucket", "file.txt"))
+
+		got, err := m.GetObjectTagging(ctx, "tag-bucket", "file.txt")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("object not found", func(t *testing.T) {
+		err := m.PutObjectTagging(ctx, "tag-bucket", "missing", map[string]string{"k": "v"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetObjectTagging(ctx, "tag-bucket", "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteObjectTagging(ctx, "tag-bucket", "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutObjectTagging(ctx, "missing", "file.txt", map[string]string{"k": "v"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetObjectTagging(ctx, "missing", "file.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteObjectTagging(ctx, "missing", "file.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestBucketTagging(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "btag-bucket"))
+
+	t.Run("put and get tags", func(t *testing.T) {
+		tags := map[string]string{"env": "staging", "cost-center": "eng"}
+		require.NoError(t, m.PutBucketTagging(ctx, "btag-bucket", tags))
+
+		got, err := m.GetBucketTagging(ctx, "btag-bucket")
+		require.NoError(t, err)
+		assert.Equal(t, "staging", got["env"])
+		assert.Equal(t, "eng", got["cost-center"])
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("replace tags", func(t *testing.T) {
+		newTags := map[string]string{"owner": "platform"}
+		require.NoError(t, m.PutBucketTagging(ctx, "btag-bucket", newTags))
+
+		got, err := m.GetBucketTagging(ctx, "btag-bucket")
+		require.NoError(t, err)
+		assert.Equal(t, "platform", got["owner"])
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("delete tags", func(t *testing.T) {
+		require.NoError(t, m.DeleteBucketTagging(ctx, "btag-bucket"))
+
+		got, err := m.GetBucketTagging(ctx, "btag-bucket")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutBucketTagging(ctx, "missing", map[string]string{"k": "v"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetBucketTagging(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteBucketTagging(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCORSConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "cors-bucket"))
+
+	t.Run("put and get", func(t *testing.T) {
+		cfg := driver.CORSConfig{
+			Rules: []driver.CORSRule{
+				{
+					AllowedOrigins: []string{"https://example.com"},
+					AllowedMethods: []string{"GET", "PUT"},
+					AllowedHeaders: []string{"Content-Type"},
+					ExposeHeaders:  []string{"ETag"},
+					MaxAgeSeconds:  3600,
+				},
+			},
+		}
+		require.NoError(t, m.PutCORSConfig(ctx, "cors-bucket", cfg))
+
+		got, err := m.GetCORSConfig(ctx, "cors-bucket")
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+		assert.Equal(t, []string{"https://example.com"}, got.Rules[0].AllowedOrigins)
+		assert.Equal(t, []string{"GET", "PUT"}, got.Rules[0].AllowedMethods)
+		assert.Equal(t, []string{"Content-Type"}, got.Rules[0].AllowedHeaders)
+		assert.Equal(t, []string{"ETag"}, got.Rules[0].ExposeHeaders)
+		assert.Equal(t, 3600, got.Rules[0].MaxAgeSeconds)
+	})
+
+	t.Run("get without config", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "no-cors-bucket"))
+
+		_, err := m.GetCORSConfig(ctx, "no-cors-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no CORS config")
+	})
+
+	t.Run("delete config", func(t *testing.T) {
+		require.NoError(t, m.DeleteCORSConfig(ctx, "cors-bucket"))
+
+		_, err := m.GetCORSConfig(ctx, "cors-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no CORS config")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutCORSConfig(ctx, "missing", driver.CORSConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetCORSConfig(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteCORSConfig(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestEncryptionConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	require.NoError(t, m.CreateBucket(ctx, "enc-bucket"))
+
+	t.Run("put and get AES256", func(t *testing.T) {
+		cfg := driver.EncryptionConfig{
+			Enabled:   true,
+			Algorithm: "AES256",
+		}
+		require.NoError(t, m.PutEncryptionConfig(ctx, "enc-bucket", cfg))
+
+		got, err := m.GetEncryptionConfig(ctx, "enc-bucket")
+		require.NoError(t, err)
+		assert.True(t, got.Enabled)
+		assert.Equal(t, "AES256", got.Algorithm)
+		assert.Empty(t, got.KeyID)
+	})
+
+	t.Run("put with KMS key", func(t *testing.T) {
+		cfg := driver.EncryptionConfig{
+			Enabled:   true,
+			Algorithm: "aws:kms",
+			KeyID:     "arn:aws:kms:us-east-1:123456789012:key/my-key-id",
+		}
+		require.NoError(t, m.PutEncryptionConfig(ctx, "enc-bucket", cfg))
+
+		got, err := m.GetEncryptionConfig(ctx, "enc-bucket")
+		require.NoError(t, err)
+		assert.True(t, got.Enabled)
+		assert.Equal(t, "aws:kms", got.Algorithm)
+		assert.Equal(t, "arn:aws:kms:us-east-1:123456789012:key/my-key-id", got.KeyID)
+	})
+
+	t.Run("get without config", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "no-enc-bucket"))
+
+		_, err := m.GetEncryptionConfig(ctx, "no-enc-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no encryption config")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutEncryptionConfig(ctx, "missing", driver.EncryptionConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetEncryptionConfig(ctx, "missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
 // metricsCollector is a simple monitoring stub that records emitted metrics.
 type metricsCollector struct {
 	data []mondriver.MetricDatum

--- a/providers/gcp/gcs/gcs_test.go
+++ b/providers/gcp/gcs/gcs_test.go
@@ -638,6 +638,321 @@ func TestCopyObjectMetrics(t *testing.T) {
 	assert.NotEmpty(t, result.Values)
 }
 
+func TestHeadObject(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+	require.NoError(t, m.PutObject(ctx, "b1", "doc.txt", []byte("hello world"), "text/plain", nil))
+
+	t.Run("success", func(t *testing.T) {
+		info, err := m.HeadObject(ctx, "b1", "doc.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "doc.txt", info.Key)
+		assert.Equal(t, int64(11), info.Size)
+		assert.Equal(t, "text/plain", info.ContentType)
+	})
+
+	t.Run("object not found", func(t *testing.T) {
+		_, err := m.HeadObject(ctx, "b1", "missing.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		_, err := m.HeadObject(ctx, "no-bucket", "doc.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestBucketPolicy(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("put and get policy", func(t *testing.T) {
+		policy := driver.BucketPolicy{
+			Version: "2012-10-17",
+			Statements: []driver.PolicyStatement{
+				{
+					Effect:    "Allow",
+					Principal: "*",
+					Actions:   []string{"storage.objects.get"},
+					Resources: []string{"projects/_/buckets/b1/objects/*"},
+				},
+			},
+		}
+		require.NoError(t, m.PutBucketPolicy(ctx, "b1", policy))
+
+		got, err := m.GetBucketPolicy(ctx, "b1")
+		require.NoError(t, err)
+		assert.Equal(t, "2012-10-17", got.Version)
+		require.Len(t, got.Statements, 1)
+		assert.Equal(t, "Allow", got.Statements[0].Effect)
+		assert.Equal(t, "*", got.Statements[0].Principal)
+		assert.Equal(t, []string{"storage.objects.get"}, got.Statements[0].Actions)
+	})
+
+	t.Run("get without policy", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "empty-policy"))
+		_, err := m.GetBucketPolicy(ctx, "empty-policy")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no policy")
+	})
+
+	t.Run("delete policy", func(t *testing.T) {
+		require.NoError(t, m.DeleteBucketPolicy(ctx, "b1"))
+
+		_, err := m.GetBucketPolicy(ctx, "b1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no policy")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutBucketPolicy(ctx, "no-bucket", driver.BucketPolicy{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetBucketPolicy(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteBucketPolicy(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestObjectTagging(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+	require.NoError(t, m.PutObject(ctx, "b1", "file.txt", []byte("data"), "text/plain", nil))
+
+	t.Run("put and get tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod", "team": "backend"}
+		require.NoError(t, m.PutObjectTagging(ctx, "b1", "file.txt", tags))
+
+		got, err := m.GetObjectTagging(ctx, "b1", "file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "backend", got["team"])
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("replace tags", func(t *testing.T) {
+		newTags := map[string]string{"env": "staging"}
+		require.NoError(t, m.PutObjectTagging(ctx, "b1", "file.txt", newTags))
+
+		got, err := m.GetObjectTagging(ctx, "b1", "file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, "staging", got["env"])
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("delete tags", func(t *testing.T) {
+		require.NoError(t, m.DeleteObjectTagging(ctx, "b1", "file.txt"))
+
+		got, err := m.GetObjectTagging(ctx, "b1", "file.txt")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("object not found", func(t *testing.T) {
+		err := m.PutObjectTagging(ctx, "b1", "missing.txt", map[string]string{"a": "b"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetObjectTagging(ctx, "b1", "missing.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteObjectTagging(ctx, "b1", "missing.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutObjectTagging(ctx, "no-bucket", "file.txt", map[string]string{"a": "b"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetObjectTagging(ctx, "no-bucket", "file.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteObjectTagging(ctx, "no-bucket", "file.txt")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestBucketTagging(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("put and get tags", func(t *testing.T) {
+		tags := map[string]string{"env": "prod", "team": "infra"}
+		require.NoError(t, m.PutBucketTagging(ctx, "b1", tags))
+
+		got, err := m.GetBucketTagging(ctx, "b1")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "infra", got["team"])
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("replace tags", func(t *testing.T) {
+		newTags := map[string]string{"env": "dev"}
+		require.NoError(t, m.PutBucketTagging(ctx, "b1", newTags))
+
+		got, err := m.GetBucketTagging(ctx, "b1")
+		require.NoError(t, err)
+		assert.Equal(t, "dev", got["env"])
+		assert.Len(t, got, 1)
+	})
+
+	t.Run("delete tags", func(t *testing.T) {
+		require.NoError(t, m.DeleteBucketTagging(ctx, "b1"))
+
+		got, err := m.GetBucketTagging(ctx, "b1")
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutBucketTagging(ctx, "no-bucket", map[string]string{"a": "b"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetBucketTagging(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteBucketTagging(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestCORSConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("put and get", func(t *testing.T) {
+		cfg := driver.CORSConfig{
+			Rules: []driver.CORSRule{
+				{
+					AllowedOrigins: []string{"https://example.com"},
+					AllowedMethods: []string{"GET", "PUT"},
+					AllowedHeaders: []string{"Content-Type"},
+					ExposeHeaders:  []string{"ETag"},
+					MaxAgeSeconds:  3600,
+				},
+			},
+		}
+		require.NoError(t, m.PutCORSConfig(ctx, "b1", cfg))
+
+		got, err := m.GetCORSConfig(ctx, "b1")
+		require.NoError(t, err)
+		require.Len(t, got.Rules, 1)
+		assert.Equal(t, []string{"https://example.com"}, got.Rules[0].AllowedOrigins)
+		assert.Equal(t, []string{"GET", "PUT"}, got.Rules[0].AllowedMethods)
+		assert.Equal(t, []string{"Content-Type"}, got.Rules[0].AllowedHeaders)
+		assert.Equal(t, []string{"ETag"}, got.Rules[0].ExposeHeaders)
+		assert.Equal(t, 3600, got.Rules[0].MaxAgeSeconds)
+	})
+
+	t.Run("get without config", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "no-cors"))
+		_, err := m.GetCORSConfig(ctx, "no-cors")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no CORS")
+	})
+
+	t.Run("delete config", func(t *testing.T) {
+		require.NoError(t, m.DeleteCORSConfig(ctx, "b1"))
+
+		_, err := m.GetCORSConfig(ctx, "b1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no CORS")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutCORSConfig(ctx, "no-bucket", driver.CORSConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetCORSConfig(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		err = m.DeleteCORSConfig(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestEncryptionConfig(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	require.NoError(t, m.CreateBucket(ctx, "b1"))
+
+	t.Run("put and get AES256", func(t *testing.T) {
+		cfg := driver.EncryptionConfig{
+			Enabled:   true,
+			Algorithm: "AES256",
+		}
+		require.NoError(t, m.PutEncryptionConfig(ctx, "b1", cfg))
+
+		got, err := m.GetEncryptionConfig(ctx, "b1")
+		require.NoError(t, err)
+		assert.True(t, got.Enabled)
+		assert.Equal(t, "AES256", got.Algorithm)
+		assert.Empty(t, got.KeyID)
+	})
+
+	t.Run("put with KMS key", func(t *testing.T) {
+		cfg := driver.EncryptionConfig{
+			Enabled:   true,
+			Algorithm: "aws:kms",
+			KeyID:     "projects/test-project/locations/global/keyRings/my-ring/cryptoKeys/my-key",
+		}
+		require.NoError(t, m.PutEncryptionConfig(ctx, "b1", cfg))
+
+		got, err := m.GetEncryptionConfig(ctx, "b1")
+		require.NoError(t, err)
+		assert.True(t, got.Enabled)
+		assert.Equal(t, "aws:kms", got.Algorithm)
+		assert.Equal(t, "projects/test-project/locations/global/keyRings/my-ring/cryptoKeys/my-key", got.KeyID)
+	})
+
+	t.Run("get without config", func(t *testing.T) {
+		require.NoError(t, m.CreateBucket(ctx, "no-enc"))
+		_, err := m.GetEncryptionConfig(ctx, "no-enc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no encryption")
+	})
+
+	t.Run("bucket not found", func(t *testing.T) {
+		err := m.PutEncryptionConfig(ctx, "no-bucket", driver.EncryptionConfig{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		_, err = m.GetEncryptionConfig(ctx, "no-bucket")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
 // newMonitoringMock creates a Cloud Monitoring mock for testing metric emission.
 func newMonitoringMock(opts *config.Options) *monitoringMock {
 	return &monitoringMock{

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -349,3 +349,388 @@ func TestPortableHeadObjectError(t *testing.T) {
 	_, err := b.HeadObject(ctx, "no-bucket", "k")
 	require.Error(t, err)
 }
+
+func TestBucketPolicyPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "pol-bkt")
+	require.NoError(t, err)
+
+	policy := driver.BucketPolicy{
+		Version: "2012-10-17",
+		Statements: []driver.PolicyStatement{
+			{Effect: "Allow", Principal: "*", Actions: []string{"s3:GetObject"}, Resources: []string{"arn:aws:s3:::pol-bkt/*"}},
+		},
+	}
+
+	err = b.PutBucketPolicy(ctx, "pol-bkt", policy)
+	require.NoError(t, err)
+
+	got, err := b.GetBucketPolicy(ctx, "pol-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, "2012-10-17", got.Version)
+	assert.Equal(t, 1, len(got.Statements))
+
+	err = b.DeleteBucketPolicy(ctx, "pol-bkt")
+	require.NoError(t, err)
+
+	_, err = b.GetBucketPolicy(ctx, "pol-bkt")
+	require.Error(t, err)
+}
+
+func TestBucketPolicyPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.PutBucketPolicy(ctx, "no-bkt", driver.BucketPolicy{})
+	require.Error(t, err)
+
+	_, err = b.GetBucketPolicy(ctx, "no-bkt")
+	require.Error(t, err)
+
+	err = b.DeleteBucketPolicy(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestObjectTaggingPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+	setupBucketWithObject(t, b)
+
+	tags, err := b.GetObjectTagging(ctx, "test-bucket", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tags))
+
+	err = b.PutObjectTagging(ctx, "test-bucket", "key1", map[string]string{"env": "prod", "team": "eng"})
+	require.NoError(t, err)
+
+	tags, err = b.GetObjectTagging(ctx, "test-bucket", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(tags))
+	assert.Equal(t, "prod", tags["env"])
+
+	err = b.DeleteObjectTagging(ctx, "test-bucket", "key1")
+	require.NoError(t, err)
+
+	tags, err = b.GetObjectTagging(ctx, "test-bucket", "key1")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tags))
+}
+
+func TestObjectTaggingPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.PutObjectTagging(ctx, "no-bkt", "k", map[string]string{"a": "b"})
+	require.Error(t, err)
+
+	_, err = b.GetObjectTagging(ctx, "no-bkt", "k")
+	require.Error(t, err)
+
+	err = b.DeleteObjectTagging(ctx, "no-bkt", "k")
+	require.Error(t, err)
+}
+
+func TestBucketTaggingPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "tag-bkt")
+	require.NoError(t, err)
+
+	tags, err := b.GetBucketTagging(ctx, "tag-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tags))
+
+	err = b.PutBucketTagging(ctx, "tag-bkt", map[string]string{"project": "cloudemu"})
+	require.NoError(t, err)
+
+	tags, err = b.GetBucketTagging(ctx, "tag-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(tags))
+	assert.Equal(t, "cloudemu", tags["project"])
+
+	err = b.DeleteBucketTagging(ctx, "tag-bkt")
+	require.NoError(t, err)
+
+	tags, err = b.GetBucketTagging(ctx, "tag-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(tags))
+}
+
+func TestBucketTaggingPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.PutBucketTagging(ctx, "no-bkt", map[string]string{"a": "b"})
+	require.Error(t, err)
+
+	_, err = b.GetBucketTagging(ctx, "no-bkt")
+	require.Error(t, err)
+
+	err = b.DeleteBucketTagging(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestCORSConfigPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "cors-bkt")
+	require.NoError(t, err)
+
+	cfg := driver.CORSConfig{
+		Rules: []driver.CORSRule{
+			{AllowedOrigins: []string{"https://example.com"}, AllowedMethods: []string{"GET", "PUT"}, MaxAgeSeconds: 300},
+		},
+	}
+
+	err = b.PutCORSConfig(ctx, "cors-bkt", cfg)
+	require.NoError(t, err)
+
+	got, err := b.GetCORSConfig(ctx, "cors-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got.Rules))
+	assert.Equal(t, 300, got.Rules[0].MaxAgeSeconds)
+
+	err = b.DeleteCORSConfig(ctx, "cors-bkt")
+	require.NoError(t, err)
+
+	_, err = b.GetCORSConfig(ctx, "cors-bkt")
+	require.Error(t, err)
+}
+
+func TestCORSConfigPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.PutCORSConfig(ctx, "no-bkt", driver.CORSConfig{})
+	require.Error(t, err)
+
+	_, err = b.GetCORSConfig(ctx, "no-bkt")
+	require.Error(t, err)
+
+	err = b.DeleteCORSConfig(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestEncryptionConfigPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "enc-bkt")
+	require.NoError(t, err)
+
+	cfg := driver.EncryptionConfig{Enabled: true, Algorithm: "AES256"}
+
+	err = b.PutEncryptionConfig(ctx, "enc-bkt", cfg)
+	require.NoError(t, err)
+
+	got, err := b.GetEncryptionConfig(ctx, "enc-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, true, got.Enabled)
+	assert.Equal(t, "AES256", got.Algorithm)
+
+	_, err = b.GetEncryptionConfig(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestEncryptionConfigPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.PutEncryptionConfig(ctx, "no-bkt", driver.EncryptionConfig{})
+	require.Error(t, err)
+
+	_, err = b.GetEncryptionConfig(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestCopyObjectPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+	setupBucketWithObject(t, b)
+
+	err := b.CreateBucket(ctx, "dst-bucket")
+	require.NoError(t, err)
+
+	err = b.CopyObject(ctx, "dst-bucket", "copied-key", driver.CopySource{Bucket: "test-bucket", Key: "key1"})
+	require.NoError(t, err)
+
+	obj, err := b.GetObject(ctx, "dst-bucket", "copied-key")
+	require.NoError(t, err)
+	assert.Equal(t, "value1", string(obj.Data))
+}
+
+func TestCopyObjectPortableError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CopyObject(ctx, "no-bkt", "k", driver.CopySource{Bucket: "no-src", Key: "k"})
+	require.Error(t, err)
+}
+
+func TestPresignedURLPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+	setupBucketWithObject(t, b)
+
+	url, err := b.GeneratePresignedURL(ctx, driver.PresignedURLRequest{
+		Bucket: "test-bucket", Key: "key1", Method: "GET", ExpiresIn: time.Minute,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, url.URL)
+	assert.Equal(t, "GET", url.Method)
+}
+
+func TestPresignedURLPortableError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	_, err := b.GeneratePresignedURL(ctx, driver.PresignedURLRequest{
+		Bucket: "no-bkt", Key: "k", Method: "GET", ExpiresIn: time.Minute,
+	})
+	require.Error(t, err)
+}
+
+func TestLifecycleConfigPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "lc-bkt")
+	require.NoError(t, err)
+
+	cfg := driver.LifecycleConfig{
+		Rules: []driver.LifecycleRule{{ID: "expire-30", Enabled: true, ExpirationDays: 30}},
+	}
+
+	err = b.PutLifecycleConfig(ctx, "lc-bkt", cfg)
+	require.NoError(t, err)
+
+	got, err := b.GetLifecycleConfig(ctx, "lc-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(got.Rules))
+	assert.Equal(t, "expire-30", got.Rules[0].ID)
+}
+
+func TestLifecycleConfigPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.PutLifecycleConfig(ctx, "no-bkt", driver.LifecycleConfig{})
+	require.Error(t, err)
+
+	_, err = b.GetLifecycleConfig(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestEvaluateLifecyclePortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "eval-bkt")
+	require.NoError(t, err)
+
+	keys, err := b.EvaluateLifecycle(ctx, "eval-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(keys))
+}
+
+func TestEvaluateLifecyclePortableError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	_, err := b.EvaluateLifecycle(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestMultipartUploadPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "mp-bkt")
+	require.NoError(t, err)
+
+	mp, err := b.CreateMultipartUpload(ctx, "mp-bkt", "bigfile.bin", "application/octet-stream")
+	require.NoError(t, err)
+	assert.NotEmpty(t, mp.UploadID)
+
+	part1, err := b.UploadPart(ctx, "mp-bkt", "bigfile.bin", mp.UploadID, 1, []byte("AAAA"))
+	require.NoError(t, err)
+	assert.Equal(t, 1, part1.PartNumber)
+
+	part2, err := b.UploadPart(ctx, "mp-bkt", "bigfile.bin", mp.UploadID, 2, []byte("BBBB"))
+	require.NoError(t, err)
+
+	err = b.CompleteMultipartUpload(ctx, "mp-bkt", "bigfile.bin", mp.UploadID, []driver.UploadPart{*part1, *part2})
+	require.NoError(t, err)
+
+	obj, err := b.GetObject(ctx, "mp-bkt", "bigfile.bin")
+	require.NoError(t, err)
+	assert.Equal(t, "AAAABBBB", string(obj.Data))
+}
+
+func TestAbortMultipartUploadPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "abort-bkt")
+	require.NoError(t, err)
+
+	mp, err := b.CreateMultipartUpload(ctx, "abort-bkt", "file.bin", "application/octet-stream")
+	require.NoError(t, err)
+
+	err = b.AbortMultipartUpload(ctx, "abort-bkt", "file.bin", mp.UploadID)
+	require.NoError(t, err)
+}
+
+func TestListMultipartUploadsPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "list-mp-bkt")
+	require.NoError(t, err)
+
+	uploads, err := b.ListMultipartUploads(ctx, "list-mp-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(uploads))
+}
+
+func TestListMultipartUploadsPortableError(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	_, err := b.ListMultipartUploads(ctx, "no-bkt")
+	require.Error(t, err)
+}
+
+func TestVersioningPortable(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.CreateBucket(ctx, "ver-bkt")
+	require.NoError(t, err)
+
+	enabled, err := b.GetBucketVersioning(ctx, "ver-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, false, enabled)
+
+	err = b.SetBucketVersioning(ctx, "ver-bkt", true)
+	require.NoError(t, err)
+
+	enabled, err = b.GetBucketVersioning(ctx, "ver-bkt")
+	require.NoError(t, err)
+	assert.Equal(t, true, enabled)
+}
+
+func TestVersioningPortableErrors(t *testing.T) {
+	b, _ := newTestBucket()
+	ctx := context.Background()
+
+	err := b.SetBucketVersioning(ctx, "no-bkt", true)
+	require.Error(t, err)
+
+	_, err = b.GetBucketVersioning(ctx, "no-bkt")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for previously untested storage methods across all 3 providers and the portable API layer.

## Methods Now Tested

| Method Group | AWS S3 | Azure Blob | GCP GCS | Portable |
|---|---|---|---|---|
| BucketPolicy (Put/Get/Delete) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| ObjectTagging (Put/Get/Delete) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| BucketTagging (Put/Get/Delete) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| CORSConfig (Put/Get/Delete) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| EncryptionConfig (Put/Get) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| HeadObject | already tested | already tested | :white_check_mark: | already tested |
| CopyObject | - | - | - | :white_check_mark: |
| PresignedURL | - | - | - | :white_check_mark: |
| Lifecycle (Put/Get/Evaluate) | - | - | - | :white_check_mark: |
| Multipart (Create/Upload/Complete/Abort/List) | - | - | - | :white_check_mark: |
| Versioning (Set/Get) | - | - | - | :white_check_mark: |

## Coverage Improvements

| Package | Before | After |
|---------|--------|-------|
| `aws/s3` | 66.7% | **96.2%** |
| `azure/blobstorage` | 65.0% | **95.5%** |
| `gcp/gcs` | 63.2% | **95.3%** |
| `storage` (portable) | 38.3% | **97.7%** |

## Test plan

- [x] All new tests pass
- [x] Full test suite passes (no regressions)
- [x] Linter passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)