### PR TITLE
Add compute service test coverage (34%->99%)

### DIFF
--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -21,11 +21,27 @@ import (
 type mockCompute struct {
 	mu        sync.Mutex
 	instances map[string]*driver.Instance
+	volumes   map[string]*driver.VolumeInfo
+	snapshots map[string]*driver.SnapshotInfo
+	images    map[string]*driver.ImageInfo
+	asgs      map[string]*driver.AutoScalingGroup
+	policies  map[string]*driver.ScalingPolicy
+	spots     map[string]*driver.SpotInstanceRequest
+	templates map[string]*driver.LaunchTemplate
 	counter   int
 }
 
 func newMockCompute() *mockCompute {
-	return &mockCompute{instances: make(map[string]*driver.Instance)}
+	return &mockCompute{
+		instances: make(map[string]*driver.Instance),
+		volumes:   make(map[string]*driver.VolumeInfo),
+		snapshots: make(map[string]*driver.SnapshotInfo),
+		images:    make(map[string]*driver.ImageInfo),
+		asgs:      make(map[string]*driver.AutoScalingGroup),
+		policies:  make(map[string]*driver.ScalingPolicy),
+		spots:     make(map[string]*driver.SpotInstanceRequest),
+		templates: make(map[string]*driver.LaunchTemplate),
+	}
 }
 
 func (m *mockCompute) RunInstances(_ context.Context, cfg driver.InstanceConfig, count int) ([]driver.Instance, error) {
@@ -165,53 +181,269 @@ func (m *mockCompute) ModifyInstance(_ context.Context, id string, input driver.
 }
 
 func (m *mockCompute) CreateAutoScalingGroup(_ context.Context, cfg driver.AutoScalingGroupConfig) (*driver.AutoScalingGroup, error) {
-	return &driver.AutoScalingGroup{Name: cfg.Name, DesiredCapacity: cfg.DesiredCapacity, Status: "Active"}, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.asgs[cfg.Name]; ok {
+		return nil, fmt.Errorf("asg %s already exists", cfg.Name)
+	}
+
+	asg := &driver.AutoScalingGroup{
+		Name:            cfg.Name,
+		MinSize:         cfg.MinSize,
+		MaxSize:         cfg.MaxSize,
+		DesiredCapacity: cfg.DesiredCapacity,
+		Status:          "Active",
+	}
+	m.asgs[cfg.Name] = asg
+
+	result := *asg
+
+	return &result, nil
 }
 
-func (m *mockCompute) DeleteAutoScalingGroup(context.Context, string, bool) error { return nil }
+func (m *mockCompute) DeleteAutoScalingGroup(_ context.Context, name string, _ bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-func (m *mockCompute) GetAutoScalingGroup(_ context.Context, name string) (*driver.AutoScalingGroup, error) {
-	return &driver.AutoScalingGroup{Name: name, Status: "Active"}, nil
-}
+	if _, ok := m.asgs[name]; !ok {
+		return fmt.Errorf("asg %s not found", name)
+	}
 
-func (m *mockCompute) ListAutoScalingGroups(context.Context) ([]driver.AutoScalingGroup, error) {
-	return nil, nil
-}
+	delete(m.asgs, name)
 
-func (m *mockCompute) UpdateAutoScalingGroup(context.Context, string, int, int, int) error {
 	return nil
 }
 
-func (m *mockCompute) SetDesiredCapacity(context.Context, string, int) error { return nil }
+func (m *mockCompute) GetAutoScalingGroup(_ context.Context, name string) (*driver.AutoScalingGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-func (m *mockCompute) PutScalingPolicy(context.Context, driver.ScalingPolicy) error { return nil }
+	asg, ok := m.asgs[name]
+	if !ok {
+		return nil, fmt.Errorf("asg %s not found", name)
+	}
 
-func (m *mockCompute) DeleteScalingPolicy(context.Context, string, string) error { return nil }
+	result := *asg
 
-func (m *mockCompute) ExecuteScalingPolicy(context.Context, string, string) error { return nil }
-
-func (m *mockCompute) RequestSpotInstances(_ context.Context, cfg driver.SpotRequestConfig) ([]driver.SpotInstanceRequest, error) {
-	return []driver.SpotInstanceRequest{{ID: "sir-001", Status: "open"}}, nil
+	return &result, nil
 }
 
-func (m *mockCompute) CancelSpotRequests(context.Context, []string) error { return nil }
+func (m *mockCompute) ListAutoScalingGroups(_ context.Context) ([]driver.AutoScalingGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-func (m *mockCompute) DescribeSpotRequests(_ context.Context, _ []string) ([]driver.SpotInstanceRequest, error) {
-	return nil, nil
+	var result []driver.AutoScalingGroup
+	for _, asg := range m.asgs {
+		result = append(result, *asg)
+	}
+
+	return result, nil
+}
+
+func (m *mockCompute) UpdateAutoScalingGroup(_ context.Context, name string, desired, minSize, maxSize int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	asg, ok := m.asgs[name]
+	if !ok {
+		return fmt.Errorf("asg %s not found", name)
+	}
+
+	asg.DesiredCapacity = desired
+	asg.MinSize = minSize
+	asg.MaxSize = maxSize
+
+	return nil
+}
+
+func (m *mockCompute) SetDesiredCapacity(_ context.Context, name string, desired int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	asg, ok := m.asgs[name]
+	if !ok {
+		return fmt.Errorf("asg %s not found", name)
+	}
+
+	asg.DesiredCapacity = desired
+
+	return nil
+}
+
+// policyKey builds a map key for scaling policies.
+func policyKey(asgName, policyName string) string {
+	return asgName + "/" + policyName
+}
+
+func (m *mockCompute) PutScalingPolicy(_ context.Context, policy driver.ScalingPolicy) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.asgs[policy.AutoScalingGroup]; !ok {
+		return fmt.Errorf("asg %s not found", policy.AutoScalingGroup)
+	}
+
+	p := policy
+	m.policies[policyKey(policy.AutoScalingGroup, policy.Name)] = &p
+
+	return nil
+}
+
+func (m *mockCompute) DeleteScalingPolicy(_ context.Context, asgName, policyName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := policyKey(asgName, policyName)
+	if _, ok := m.policies[key]; !ok {
+		return fmt.Errorf("policy %s not found", policyName)
+	}
+
+	delete(m.policies, key)
+
+	return nil
+}
+
+func (m *mockCompute) ExecuteScalingPolicy(_ context.Context, asgName, policyName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := policyKey(asgName, policyName)
+	if _, ok := m.policies[key]; !ok {
+		return fmt.Errorf("policy %s not found", policyName)
+	}
+
+	return nil
+}
+
+func (m *mockCompute) RequestSpotInstances(_ context.Context, cfg driver.SpotRequestConfig) ([]driver.SpotInstanceRequest, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	count := cfg.Count
+	if count == 0 {
+		count = 1
+	}
+
+	var result []driver.SpotInstanceRequest
+
+	for range count {
+		m.counter++
+		id := fmt.Sprintf("sir-%06d", m.counter)
+
+		req := &driver.SpotInstanceRequest{
+			ID:       id,
+			MaxPrice: cfg.MaxPrice,
+			Status:   "open",
+			Type:     cfg.Type,
+		}
+		m.spots[id] = req
+		result = append(result, *req)
+	}
+
+	return result, nil
+}
+
+func (m *mockCompute) CancelSpotRequests(_ context.Context, ids []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range ids {
+		req, ok := m.spots[id]
+		if !ok {
+			return fmt.Errorf("spot request %s not found", id)
+		}
+
+		req.Status = "canceled"
+	}
+
+	return nil
+}
+
+func (m *mockCompute) DescribeSpotRequests(_ context.Context, ids []string) ([]driver.SpotInstanceRequest, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []driver.SpotInstanceRequest
+
+	if len(ids) == 0 {
+		for _, req := range m.spots {
+			result = append(result, *req)
+		}
+
+		return result, nil
+	}
+
+	for _, id := range ids {
+		req, ok := m.spots[id]
+		if !ok {
+			return nil, fmt.Errorf("spot request %s not found", id)
+		}
+
+		result = append(result, *req)
+	}
+
+	return result, nil
 }
 
 func (m *mockCompute) CreateLaunchTemplate(_ context.Context, cfg driver.LaunchTemplateConfig) (*driver.LaunchTemplate, error) {
-	return &driver.LaunchTemplate{Name: cfg.Name}, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.templates[cfg.Name]; ok {
+		return nil, fmt.Errorf("launch template %s already exists", cfg.Name)
+	}
+
+	m.counter++
+	tmpl := &driver.LaunchTemplate{
+		ID:      fmt.Sprintf("lt-%06d", m.counter),
+		Name:    cfg.Name,
+		Version: 1,
+	}
+	m.templates[cfg.Name] = tmpl
+
+	result := *tmpl
+
+	return &result, nil
 }
 
-func (m *mockCompute) DeleteLaunchTemplate(context.Context, string) error { return nil }
+func (m *mockCompute) DeleteLaunchTemplate(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.templates[name]; !ok {
+		return fmt.Errorf("launch template %s not found", name)
+	}
+
+	delete(m.templates, name)
+
+	return nil
+}
 
 func (m *mockCompute) GetLaunchTemplate(_ context.Context, name string) (*driver.LaunchTemplate, error) {
-	return &driver.LaunchTemplate{Name: name}, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tmpl, ok := m.templates[name]
+	if !ok {
+		return nil, fmt.Errorf("launch template %s not found", name)
+	}
+
+	result := *tmpl
+
+	return &result, nil
 }
 
-func (m *mockCompute) ListLaunchTemplates(context.Context) ([]driver.LaunchTemplate, error) {
-	return nil, nil
+func (m *mockCompute) ListLaunchTemplates(_ context.Context) ([]driver.LaunchTemplate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []driver.LaunchTemplate
+	for _, tmpl := range m.templates {
+		result = append(result, *tmpl)
+	}
+
+	return result, nil
 }
 
 func newTestCompute(opts ...Option) *Compute {
@@ -519,35 +751,1051 @@ func TestPortableTerminateInstancesError(t *testing.T) {
 }
 
 //nolint:dupl // test mock stubs are intentionally repetitive
-func (mc *mockCompute) CreateVolume(_ context.Context, _ driver.VolumeConfig) (*driver.VolumeInfo, error) {
-	return nil, nil
+func (mc *mockCompute) CreateVolume(_ context.Context, cfg driver.VolumeConfig) (*driver.VolumeInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	mc.counter++
+	id := fmt.Sprintf("vol-%06d", mc.counter)
+
+	volType := cfg.VolumeType
+	if volType == "" {
+		volType = "gp3"
+	}
+
+	vol := &driver.VolumeInfo{
+		ID: id, Size: cfg.Size, VolumeType: volType, State: "available",
+		AvailabilityZone: cfg.AvailabilityZone, Tags: cfg.Tags,
+	}
+	mc.volumes[id] = vol
+
+	result := *vol
+
+	return &result, nil
 }
 
-func (mc *mockCompute) DeleteVolume(_ context.Context, _ string) error { return nil }
+func (mc *mockCompute) DeleteVolume(_ context.Context, id string) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
 
-func (mc *mockCompute) DescribeVolumes(_ context.Context, _ []string) ([]driver.VolumeInfo, error) {
-	return nil, nil
+	vol, ok := mc.volumes[id]
+	if !ok {
+		return fmt.Errorf("volume %s not found", id)
+	}
+
+	if vol.State == "in-use" {
+		return fmt.Errorf("volume %s is attached", id)
+	}
+
+	delete(mc.volumes, id)
+
+	return nil
 }
 
-func (mc *mockCompute) AttachVolume(_ context.Context, _, _, _ string) error { return nil }
-func (mc *mockCompute) DetachVolume(_ context.Context, _ string) error       { return nil }
+func (mc *mockCompute) DescribeVolumes(_ context.Context, ids []string) ([]driver.VolumeInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
 
-func (mc *mockCompute) CreateSnapshot(_ context.Context, _ driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
-	return nil, nil
+	var result []driver.VolumeInfo
+
+	if len(ids) == 0 {
+		for _, v := range mc.volumes {
+			result = append(result, *v)
+		}
+
+		return result, nil
+	}
+
+	for _, id := range ids {
+		if v, ok := mc.volumes[id]; ok {
+			result = append(result, *v)
+		}
+	}
+
+	return result, nil
 }
 
-func (mc *mockCompute) DeleteSnapshot(_ context.Context, _ string) error { return nil }
+func (mc *mockCompute) AttachVolume(_ context.Context, volumeID, instanceID, device string) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
 
-func (mc *mockCompute) DescribeSnapshots(_ context.Context, _ []string) ([]driver.SnapshotInfo, error) {
-	return nil, nil
+	vol, ok := mc.volumes[volumeID]
+	if !ok {
+		return fmt.Errorf("volume %s not found", volumeID)
+	}
+
+	if _, ok := mc.instances[instanceID]; !ok {
+		return fmt.Errorf("instance %s not found", instanceID)
+	}
+
+	vol.State = "in-use"
+	vol.AttachedTo = instanceID
+	vol.Device = device
+
+	return nil
 }
 
-func (mc *mockCompute) CreateImage(_ context.Context, _ driver.ImageConfig) (*driver.ImageInfo, error) {
-	return nil, nil
+func (mc *mockCompute) DetachVolume(_ context.Context, volumeID string) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	vol, ok := mc.volumes[volumeID]
+	if !ok {
+		return fmt.Errorf("volume %s not found", volumeID)
+	}
+
+	if vol.State != "in-use" {
+		return fmt.Errorf("volume %s is not attached", volumeID)
+	}
+
+	vol.State = "available"
+	vol.AttachedTo = ""
+	vol.Device = ""
+
+	return nil
 }
 
-func (mc *mockCompute) DeregisterImage(_ context.Context, _ string) error { return nil }
+func (mc *mockCompute) CreateSnapshot(_ context.Context, cfg driver.SnapshotConfig) (*driver.SnapshotInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
 
-func (mc *mockCompute) DescribeImages(_ context.Context, _ []string) ([]driver.ImageInfo, error) {
-	return nil, nil
+	vol, ok := mc.volumes[cfg.VolumeID]
+	if !ok {
+		return nil, fmt.Errorf("volume %s not found", cfg.VolumeID)
+	}
+
+	mc.counter++
+	id := fmt.Sprintf("snap-%06d", mc.counter)
+
+	snap := &driver.SnapshotInfo{
+		ID: id, VolumeID: cfg.VolumeID, State: "completed",
+		Description: cfg.Description, Size: vol.Size, Tags: cfg.Tags,
+	}
+	mc.snapshots[id] = snap
+
+	result := *snap
+
+	return &result, nil
+}
+
+func (mc *mockCompute) DeleteSnapshot(_ context.Context, id string) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	if _, ok := mc.snapshots[id]; !ok {
+		return fmt.Errorf("snapshot %s not found", id)
+	}
+
+	delete(mc.snapshots, id)
+
+	return nil
+}
+
+func (mc *mockCompute) DescribeSnapshots(_ context.Context, ids []string) ([]driver.SnapshotInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	var result []driver.SnapshotInfo
+
+	if len(ids) == 0 {
+		for _, s := range mc.snapshots {
+			result = append(result, *s)
+		}
+
+		return result, nil
+	}
+
+	for _, id := range ids {
+		if s, ok := mc.snapshots[id]; ok {
+			result = append(result, *s)
+		}
+	}
+
+	return result, nil
+}
+
+func (mc *mockCompute) CreateImage(_ context.Context, cfg driver.ImageConfig) (*driver.ImageInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	if _, ok := mc.instances[cfg.InstanceID]; !ok {
+		return nil, fmt.Errorf("instance %s not found", cfg.InstanceID)
+	}
+
+	mc.counter++
+	id := fmt.Sprintf("img-%06d", mc.counter)
+
+	img := &driver.ImageInfo{
+		ID: id, Name: cfg.Name, State: "available",
+		Description: cfg.Description, Tags: cfg.Tags,
+	}
+	mc.images[id] = img
+
+	result := *img
+
+	return &result, nil
+}
+
+func (mc *mockCompute) DeregisterImage(_ context.Context, id string) error {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	if _, ok := mc.images[id]; !ok {
+		return fmt.Errorf("image %s not found", id)
+	}
+
+	delete(mc.images, id)
+
+	return nil
+}
+
+func (mc *mockCompute) DescribeImages(_ context.Context, ids []string) ([]driver.ImageInfo, error) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	var result []driver.ImageInfo
+
+	if len(ids) == 0 {
+		for _, img := range mc.images {
+			result = append(result, *img)
+		}
+
+		return result, nil
+	}
+
+	for _, id := range ids {
+		if img, ok := mc.images[id]; ok {
+			result = append(result, *img)
+		}
+	}
+
+	return result, nil
+}
+
+// =====================================================================
+// Volume Portable Tests
+// =====================================================================
+
+func TestCreateVolumePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 100})
+	require.NoError(t, err)
+	assert.NotEmpty(t, vol.ID)
+	assert.Equal(t, 100, vol.Size)
+	assert.Equal(t, "available", vol.State)
+}
+
+func TestCreateVolumePortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "CreateVolume", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.Error(t, err)
+}
+
+func TestDeleteVolumePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	err = c.DeleteVolume(ctx, vol.ID)
+	require.NoError(t, err)
+}
+
+func TestDeleteVolumePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.DeleteVolume(ctx, "vol-nonexistent")
+	require.Error(t, err)
+}
+
+func TestDescribeVolumesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	vols, err := c.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(vols))
+	assert.Equal(t, vol.ID, vols[0].ID)
+}
+
+func TestAttachVolumePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "ami-12345", InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	err = c.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+	require.NoError(t, err)
+
+	// Verify state
+	vols, err := c.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "in-use", vols[0].State)
+}
+
+func TestAttachVolumePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.AttachVolume(ctx, "vol-nonexistent", "i-nonexistent", "/dev/sdf")
+	require.Error(t, err)
+}
+
+func TestDetachVolumePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "ami-12345", InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	err = c.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+	require.NoError(t, err)
+
+	err = c.DetachVolume(ctx, vol.ID)
+	require.NoError(t, err)
+
+	// Verify state
+	vols, err := c.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "available", vols[0].State)
+}
+
+func TestDetachVolumePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	err = c.DetachVolume(ctx, vol.ID)
+	require.Error(t, err)
+}
+
+// =====================================================================
+// Snapshot Portable Tests
+// =====================================================================
+
+func TestCreateSnapshotPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 50})
+	require.NoError(t, err)
+
+	snap, err := c.CreateSnapshot(ctx, driver.SnapshotConfig{
+		VolumeID:    vol.ID,
+		Description: "test snapshot",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, snap.ID)
+	assert.Equal(t, vol.ID, snap.VolumeID)
+	assert.Equal(t, "completed", snap.State)
+	assert.Equal(t, 50, snap.Size)
+}
+
+func TestCreateSnapshotPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: "vol-nonexistent"})
+	require.Error(t, err)
+}
+
+func TestDeleteSnapshotPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	snap, err := c.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	err = c.DeleteSnapshot(ctx, snap.ID)
+	require.NoError(t, err)
+}
+
+func TestDeleteSnapshotPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.DeleteSnapshot(ctx, "snap-nonexistent")
+	require.Error(t, err)
+}
+
+func TestDescribeSnapshotsPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	vol, err := c.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	snap, err := c.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	snaps, err := c.DescribeSnapshots(ctx, []string{snap.ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(snaps))
+	assert.Equal(t, snap.ID, snaps[0].ID)
+}
+
+// =====================================================================
+// Image Portable Tests
+// =====================================================================
+
+func TestCreateImagePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "ami-12345", InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	img, err := c.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "test-image",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, img.ID)
+	assert.Equal(t, "test-image", img.Name)
+	assert.Equal(t, "available", img.State)
+}
+
+func TestCreateImagePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateImage(ctx, driver.ImageConfig{InstanceID: "i-nonexistent"})
+	require.Error(t, err)
+}
+
+func TestDeregisterImagePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "ami-12345", InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	img, err := c.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "del-image",
+	})
+	require.NoError(t, err)
+
+	err = c.DeregisterImage(ctx, img.ID)
+	require.NoError(t, err)
+}
+
+func TestDeregisterImagePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.DeregisterImage(ctx, "img-nonexistent")
+	require.Error(t, err)
+}
+
+func TestDescribeImagesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "ami-12345", InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	img, err := c.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "desc-image",
+	})
+	require.NoError(t, err)
+
+	imgs, err := c.DescribeImages(ctx, []string{img.ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(imgs))
+	assert.Equal(t, img.ID, imgs[0].ID)
+}
+
+// =====================================================================
+// ModifyInstance Portable Tests
+// =====================================================================
+
+func TestModifyInstancePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	instances, err := c.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "ami-12345", InstanceType: "t2.micro",
+	}, 1)
+	require.NoError(t, err)
+
+	err = c.ModifyInstance(ctx, instances[0].ID, driver.ModifyInstanceInput{
+		InstanceType: "t2.large",
+	})
+	require.NoError(t, err)
+
+	described, err := c.DescribeInstances(ctx, []string{instances[0].ID}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "t2.large", described[0].InstanceType)
+}
+
+func TestModifyInstancePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.ModifyInstance(ctx, "i-nonexistent", driver.ModifyInstanceInput{
+		InstanceType: "t2.large",
+	})
+	require.Error(t, err)
+}
+
+// =====================================================================
+// Auto Scaling Group Portable Tests
+// =====================================================================
+
+func TestCreateAutoScalingGroupPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	asg, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name:            "test-asg",
+		MinSize:         1,
+		MaxSize:         5,
+		DesiredCapacity: 2,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "test-asg", asg.Name)
+	assert.Equal(t, 2, asg.DesiredCapacity)
+	assert.Equal(t, "Active", asg.Status)
+}
+
+func TestCreateAutoScalingGroupPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "dup-asg",
+	})
+	require.NoError(t, err)
+
+	_, err = c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "dup-asg",
+	})
+	require.Error(t, err)
+}
+
+func TestDeleteAutoScalingGroupPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "del-asg",
+	})
+	require.NoError(t, err)
+
+	err = c.DeleteAutoScalingGroup(ctx, "del-asg", false)
+	require.NoError(t, err)
+}
+
+func TestDeleteAutoScalingGroupPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.DeleteAutoScalingGroup(ctx, "nonexistent-asg", false)
+	require.Error(t, err)
+}
+
+func TestGetAutoScalingGroupPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name:            "get-asg",
+		DesiredCapacity: 3,
+	})
+	require.NoError(t, err)
+
+	asg, err := c.GetAutoScalingGroup(ctx, "get-asg")
+	require.NoError(t, err)
+	assert.Equal(t, "get-asg", asg.Name)
+	assert.Equal(t, 3, asg.DesiredCapacity)
+}
+
+func TestGetAutoScalingGroupPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.GetAutoScalingGroup(ctx, "nonexistent-asg")
+	require.Error(t, err)
+}
+
+func TestListAutoScalingGroupsPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{Name: "asg-a"})
+	require.NoError(t, err)
+
+	_, err = c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{Name: "asg-b"})
+	require.NoError(t, err)
+
+	asgs, err := c.ListAutoScalingGroups(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(asgs))
+}
+
+func TestListAutoScalingGroupsPortableEmpty(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	asgs, err := c.ListAutoScalingGroups(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, asgs)
+}
+
+func TestUpdateAutoScalingGroupPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name:            "upd-asg",
+		MinSize:         1,
+		MaxSize:         5,
+		DesiredCapacity: 2,
+	})
+	require.NoError(t, err)
+
+	err = c.UpdateAutoScalingGroup(ctx, "upd-asg", 4, 2, 10)
+	require.NoError(t, err)
+
+	asg, err := c.GetAutoScalingGroup(ctx, "upd-asg")
+	require.NoError(t, err)
+	assert.Equal(t, 4, asg.DesiredCapacity)
+	assert.Equal(t, 2, asg.MinSize)
+	assert.Equal(t, 10, asg.MaxSize)
+}
+
+func TestUpdateAutoScalingGroupPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.UpdateAutoScalingGroup(ctx, "nonexistent-asg", 1, 1, 5)
+	require.Error(t, err)
+}
+
+func TestSetDesiredCapacityPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name:            "cap-asg",
+		DesiredCapacity: 1,
+	})
+	require.NoError(t, err)
+
+	err = c.SetDesiredCapacity(ctx, "cap-asg", 5)
+	require.NoError(t, err)
+
+	asg, err := c.GetAutoScalingGroup(ctx, "cap-asg")
+	require.NoError(t, err)
+	assert.Equal(t, 5, asg.DesiredCapacity)
+}
+
+func TestSetDesiredCapacityPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.SetDesiredCapacity(ctx, "nonexistent-asg", 3)
+	require.Error(t, err)
+}
+
+// =====================================================================
+// Scaling Policy Portable Tests
+// =====================================================================
+
+func TestPutScalingPolicyPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "policy-asg",
+	})
+	require.NoError(t, err)
+
+	err = c.PutScalingPolicy(ctx, driver.ScalingPolicy{
+		Name:             "scale-up",
+		AutoScalingGroup: "policy-asg",
+		PolicyType:       "SimpleScaling",
+	})
+	require.NoError(t, err)
+}
+
+func TestPutScalingPolicyPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.PutScalingPolicy(ctx, driver.ScalingPolicy{
+		Name:             "scale-up",
+		AutoScalingGroup: "nonexistent-asg",
+	})
+	require.Error(t, err)
+}
+
+func TestDeleteScalingPolicyPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "delpol-asg",
+	})
+	require.NoError(t, err)
+
+	err = c.PutScalingPolicy(ctx, driver.ScalingPolicy{
+		Name:             "scale-down",
+		AutoScalingGroup: "delpol-asg",
+	})
+	require.NoError(t, err)
+
+	err = c.DeleteScalingPolicy(ctx, "delpol-asg", "scale-down")
+	require.NoError(t, err)
+}
+
+func TestDeleteScalingPolicyPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.DeleteScalingPolicy(ctx, "nonexistent-asg", "nonexistent-policy")
+	require.Error(t, err)
+}
+
+func TestExecuteScalingPolicyPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateAutoScalingGroup(ctx, driver.AutoScalingGroupConfig{
+		Name: "exec-asg",
+	})
+	require.NoError(t, err)
+
+	err = c.PutScalingPolicy(ctx, driver.ScalingPolicy{
+		Name:             "scale-out",
+		AutoScalingGroup: "exec-asg",
+	})
+	require.NoError(t, err)
+
+	err = c.ExecuteScalingPolicy(ctx, "exec-asg", "scale-out")
+	require.NoError(t, err)
+}
+
+func TestExecuteScalingPolicyPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.ExecuteScalingPolicy(ctx, "nonexistent-asg", "nonexistent-policy")
+	require.Error(t, err)
+}
+
+// =====================================================================
+// Spot Instance Portable Tests
+// =====================================================================
+
+func TestRequestSpotInstancesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	spots, err := c.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		MaxPrice: 0.05,
+		Count:    2,
+		Type:     "one-time",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(spots))
+	assert.Equal(t, "open", spots[0].Status)
+	assert.Equal(t, "open", spots[1].Status)
+	assert.NotEqual(t, spots[0].ID, spots[1].ID)
+}
+
+func TestRequestSpotInstancesPortableDefaultCount(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	spots, err := c.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		MaxPrice: 0.10,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(spots))
+}
+
+func TestCancelSpotRequestsPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	spots, err := c.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		MaxPrice: 0.05,
+		Count:    1,
+	})
+	require.NoError(t, err)
+
+	err = c.CancelSpotRequests(ctx, []string{spots[0].ID})
+	require.NoError(t, err)
+
+	described, err := c.DescribeSpotRequests(ctx, []string{spots[0].ID})
+	require.NoError(t, err)
+	assert.Equal(t, "canceled", described[0].Status)
+}
+
+func TestCancelSpotRequestsPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.CancelSpotRequests(ctx, []string{"sir-nonexistent"})
+	require.Error(t, err)
+}
+
+func TestDescribeSpotRequestsPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	spots, err := c.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		MaxPrice: 0.05,
+		Count:    1,
+	})
+	require.NoError(t, err)
+
+	described, err := c.DescribeSpotRequests(ctx, []string{spots[0].ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(described))
+	assert.Equal(t, spots[0].ID, described[0].ID)
+}
+
+func TestDescribeSpotRequestsPortableAll(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.RequestSpotInstances(ctx, driver.SpotRequestConfig{
+		MaxPrice: 0.05,
+		Count:    3,
+	})
+	require.NoError(t, err)
+
+	described, err := c.DescribeSpotRequests(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(described))
+}
+
+func TestDescribeSpotRequestsPortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.DescribeSpotRequests(ctx, []string{"sir-nonexistent"})
+	require.Error(t, err)
+}
+
+// =====================================================================
+// Launch Template Portable Tests
+// =====================================================================
+
+func TestCreateLaunchTemplatePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	tmpl, err := c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name: "test-template",
+		InstanceConfig: driver.InstanceConfig{
+			ImageID:      "ami-12345",
+			InstanceType: "t2.micro",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "test-template", tmpl.Name)
+	assert.NotEmpty(t, tmpl.ID)
+	assert.Equal(t, 1, tmpl.Version)
+}
+
+func TestCreateLaunchTemplatePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name: "dup-template",
+	})
+	require.NoError(t, err)
+
+	_, err = c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name: "dup-template",
+	})
+	require.Error(t, err)
+}
+
+func TestDeleteLaunchTemplatePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name: "del-template",
+	})
+	require.NoError(t, err)
+
+	err = c.DeleteLaunchTemplate(ctx, "del-template")
+	require.NoError(t, err)
+}
+
+func TestDeleteLaunchTemplatePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	err := c.DeleteLaunchTemplate(ctx, "nonexistent-template")
+	require.Error(t, err)
+}
+
+func TestGetLaunchTemplatePortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{
+		Name: "get-template",
+	})
+	require.NoError(t, err)
+
+	tmpl, err := c.GetLaunchTemplate(ctx, "get-template")
+	require.NoError(t, err)
+	assert.Equal(t, "get-template", tmpl.Name)
+}
+
+func TestGetLaunchTemplatePortableError(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.GetLaunchTemplate(ctx, "nonexistent-template")
+	require.Error(t, err)
+}
+
+func TestListLaunchTemplatesPortable(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	_, err := c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{Name: "tmpl-a"})
+	require.NoError(t, err)
+
+	_, err = c.CreateLaunchTemplate(ctx, driver.LaunchTemplateConfig{Name: "tmpl-b"})
+	require.NoError(t, err)
+
+	templates, err := c.ListLaunchTemplates(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(templates))
+}
+
+func TestListLaunchTemplatesPortableEmpty(t *testing.T) {
+	c := newTestCompute()
+	ctx := context.Background()
+
+	templates, err := c.ListLaunchTemplates(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, templates)
+}
+
+// =====================================================================
+// Error Injection Tests for List/Describe methods (cover error return paths)
+// =====================================================================
+
+func TestListAutoScalingGroupsPortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "ListAutoScalingGroups", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.ListAutoScalingGroups(ctx)
+	require.Error(t, err)
+}
+
+func TestRequestSpotInstancesPortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "RequestSpotInstances", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.RequestSpotInstances(ctx, driver.SpotRequestConfig{MaxPrice: 0.05})
+	require.Error(t, err)
+}
+
+func TestDescribeSpotRequestsPortableInjectedError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "DescribeSpotRequests", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.DescribeSpotRequests(ctx, nil)
+	require.Error(t, err)
+}
+
+func TestListLaunchTemplatesPortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "ListLaunchTemplates", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.ListLaunchTemplates(ctx)
+	require.Error(t, err)
+}
+
+func TestDescribeVolumesPortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "DescribeVolumes", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.DescribeVolumes(ctx, nil)
+	require.Error(t, err)
+}
+
+func TestDescribeSnapshotsPortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "DescribeSnapshots", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.DescribeSnapshots(ctx, nil)
+	require.Error(t, err)
+}
+
+func TestDescribeImagesPortableError(t *testing.T) {
+	inj := inject.NewInjector()
+	c := newTestCompute(WithErrorInjection(inj))
+	ctx := context.Background()
+
+	inj.Set("compute", "DescribeImages", fmt.Errorf("injected"), inject.Always{})
+
+	_, err := c.DescribeImages(ctx, nil)
+	require.Error(t, err)
 }

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -286,6 +286,393 @@ func TestLifecycleStateMachine(t *testing.T) {
 	assertEqual(t, compute.StateTerminated, desc[0].State)
 }
 
+// =====================================================================
+// Volume Tests
+// =====================================================================
+
+func TestCreateVolume(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       driver.VolumeConfig
+		expectErr bool
+	}{
+		{
+			name:      "success",
+			cfg:       driver.VolumeConfig{Size: 100, VolumeType: "gp3", Tags: map[string]string{"env": "test"}},
+			expectErr: false,
+		},
+		{
+			name:      "default volume type",
+			cfg:       driver.VolumeConfig{Size: 50},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+			ctx := context.Background()
+
+			vol, err := m.CreateVolume(ctx, tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertNotEmpty(t, vol.ID)
+			assertEqual(t, tc.cfg.Size, vol.Size)
+			assertEqual(t, "available", vol.State)
+			assertNotEmpty(t, vol.CreatedAt)
+		})
+	}
+}
+
+func TestDeleteVolume(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		requireNoError(t, err)
+
+		err = m.DeleteVolume(ctx, vol.ID)
+		requireNoError(t, err)
+
+		// Should be gone
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(vols))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.DeleteVolume(ctx, "vol-nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribeVolumes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol1, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	requireNoError(t, err)
+
+	vol2, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 20})
+	requireNoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		vols, err := m.DescribeVolumes(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(vols))
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		vols, err := m.DescribeVolumes(ctx, []string{vol1.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(vols))
+		assertEqual(t, vol1.ID, vols[0].ID)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		fresh := newTestMock()
+		vols, err := fresh.DescribeVolumes(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 0, len(vols))
+	})
+
+	// Keep vol2 referenced to avoid unused variable
+	assertNotEmpty(t, vol2.ID)
+}
+
+func TestAttachVolume(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		instances, err := m.RunInstances(ctx, defaultConfig(), 1)
+		requireNoError(t, err)
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		requireNoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+		requireNoError(t, err)
+
+		// Verify state changed to in-use
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(vols))
+		assertEqual(t, "in-use", vols[0].State)
+		assertEqual(t, instances[0].ID, vols[0].AttachedTo)
+	})
+
+	t.Run("nonexistent instance", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		requireNoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, "i-nonexistent", "/dev/sdf")
+		assertError(t, err, true)
+	})
+
+	t.Run("nonexistent volume", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		instances, err := m.RunInstances(ctx, defaultConfig(), 1)
+		requireNoError(t, err)
+
+		err = m.AttachVolume(ctx, "vol-nonexistent", instances[0].ID, "/dev/sdf")
+		assertError(t, err, true)
+	})
+}
+
+func TestDetachVolume(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		instances, err := m.RunInstances(ctx, defaultConfig(), 1)
+		requireNoError(t, err)
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		requireNoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+		requireNoError(t, err)
+
+		err = m.DetachVolume(ctx, vol.ID)
+		requireNoError(t, err)
+
+		// Verify state changed back to available
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(vols))
+		assertEqual(t, "available", vols[0].State)
+	})
+
+	t.Run("detach unattached volume", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		requireNoError(t, err)
+
+		err = m.DetachVolume(ctx, vol.ID)
+		assertError(t, err, true)
+	})
+}
+
+// =====================================================================
+// Snapshot Tests
+// =====================================================================
+
+func TestCreateSnapshot(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 50})
+		requireNoError(t, err)
+
+		snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+			VolumeID:    vol.ID,
+			Description: "test snapshot",
+			Tags:        map[string]string{"env": "test"},
+		})
+		requireNoError(t, err)
+
+		assertNotEmpty(t, snap.ID)
+		assertEqual(t, vol.ID, snap.VolumeID)
+		assertEqual(t, "completed", snap.State)
+		assertEqual(t, "test snapshot", snap.Description)
+		assertEqual(t, 50, snap.Size)
+		assertNotEmpty(t, snap.CreatedAt)
+	})
+
+	t.Run("nonexistent volume", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+			VolumeID: "vol-nonexistent",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		requireNoError(t, err)
+
+		snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+		requireNoError(t, err)
+
+		err = m.DeleteSnapshot(ctx, snap.ID)
+		requireNoError(t, err)
+
+		// Should be gone
+		snaps, err := m.DescribeSnapshots(ctx, []string{snap.ID})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(snaps))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.DeleteSnapshot(ctx, "snap-nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribeSnapshots(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	requireNoError(t, err)
+
+	snap1, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	requireNoError(t, err)
+
+	snap2, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	requireNoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		snaps, err := m.DescribeSnapshots(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(snaps))
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		snaps, err := m.DescribeSnapshots(ctx, []string{snap1.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(snaps))
+		assertEqual(t, snap1.ID, snaps[0].ID)
+	})
+
+	// Keep snap2 referenced
+	assertNotEmpty(t, snap2.ID)
+}
+
+// =====================================================================
+// Image Tests
+// =====================================================================
+
+func TestCreateImage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		instances, err := m.RunInstances(ctx, defaultConfig(), 1)
+		requireNoError(t, err)
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID:  instances[0].ID,
+			Name:        "my-image",
+			Description: "test image",
+			Tags:        map[string]string{"env": "test"},
+		})
+		requireNoError(t, err)
+
+		assertNotEmpty(t, img.ID)
+		assertEqual(t, "my-image", img.Name)
+		assertEqual(t, "available", img.State)
+		assertEqual(t, "test image", img.Description)
+		assertNotEmpty(t, img.CreatedAt)
+	})
+
+	t.Run("nonexistent instance", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		_, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID: "i-nonexistent",
+			Name:       "bad-image",
+		})
+		assertError(t, err, true)
+	})
+}
+
+func TestDeregisterImage(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		instances, err := m.RunInstances(ctx, defaultConfig(), 1)
+		requireNoError(t, err)
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID: instances[0].ID,
+			Name:       "del-image",
+		})
+		requireNoError(t, err)
+
+		err = m.DeregisterImage(ctx, img.ID)
+		requireNoError(t, err)
+
+		// Should be gone
+		imgs, err := m.DescribeImages(ctx, []string{img.ID})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(imgs))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		ctx := context.Background()
+
+		err := m.DeregisterImage(ctx, "ami-nonexistent")
+		assertError(t, err, true)
+	})
+}
+
+func TestDescribeImages(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	instances, err := m.RunInstances(ctx, defaultConfig(), 1)
+	requireNoError(t, err)
+
+	img1, err := m.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "image-1",
+	})
+	requireNoError(t, err)
+
+	img2, err := m.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "image-2",
+	})
+	requireNoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		imgs, err := m.DescribeImages(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 2, len(imgs))
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		imgs, err := m.DescribeImages(ctx, []string{img1.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(imgs))
+		assertEqual(t, img1.ID, imgs[0].ID)
+	})
+
+	// Keep img2 referenced
+	assertNotEmpty(t, img2.ID)
+}
+
 // --- test helpers ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/virtualmachines/vm_test.go
+++ b/providers/azure/virtualmachines/vm_test.go
@@ -1304,6 +1304,397 @@ func TestDeleteAutoScalingGroupForceDeleteNoInstances(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// =====================================================================
+// Volume Tests
+// =====================================================================
+
+func TestCreateVolume(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		cfg     driver.VolumeConfig
+		wantErr bool
+	}{
+		{
+			name: "success",
+			cfg:  driver.VolumeConfig{Size: 100, VolumeType: "Premium_LRS", Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name: "default volume type",
+			cfg:  driver.VolumeConfig{Size: 50},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			vol, err := m.CreateVolume(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, vol.ID)
+				assert.Equal(t, tt.cfg.Size, vol.Size)
+				assert.Equal(t, "available", vol.State)
+				assert.NotEmpty(t, vol.CreatedAt)
+			}
+		})
+	}
+}
+
+func TestDeleteVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.DeleteVolume(ctx, vol.ID)
+		require.NoError(t, err)
+
+		// Should be gone
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		require.NoError(t, err)
+		assert.Empty(t, vols)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeleteVolume(ctx, "vol-nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeVolumes(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vol1, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	vol2, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 20})
+	require.NoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		vols, err := m.DescribeVolumes(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, vols, 2)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		vols, err := m.DescribeVolumes(ctx, []string{vol1.ID})
+		require.NoError(t, err)
+		assert.Len(t, vols, 1)
+		assert.Equal(t, vol1.ID, vols[0].ID)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		fresh := newTestMock()
+		vols, err := fresh.DescribeVolumes(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, vols)
+	})
+
+	// Keep vol2 referenced
+	assert.NotEmpty(t, vol2.ID)
+}
+
+func TestAttachVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "Standard_B1s",
+		}, 1)
+		require.NoError(t, err)
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+		require.NoError(t, err)
+
+		// Verify state changed to in-use
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		require.NoError(t, err)
+		require.Len(t, vols, 1)
+		assert.Equal(t, "in-use", vols[0].State)
+		assert.Equal(t, instances[0].ID, vols[0].AttachedTo)
+	})
+
+	t.Run("nonexistent instance", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, "vm-nonexistent", "/dev/sdf")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("nonexistent volume", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "Standard_B1s",
+		}, 1)
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, "vol-nonexistent", instances[0].ID, "/dev/sdf")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDetachVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "Standard_B1s",
+		}, 1)
+		require.NoError(t, err)
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+		require.NoError(t, err)
+
+		err = m.DetachVolume(ctx, vol.ID)
+		require.NoError(t, err)
+
+		// Verify state changed back to available
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		require.NoError(t, err)
+		require.Len(t, vols, 1)
+		assert.Equal(t, "available", vols[0].State)
+	})
+
+	t.Run("detach unattached volume", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.DetachVolume(ctx, vol.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not attached")
+	})
+}
+
+// =====================================================================
+// Snapshot Tests
+// =====================================================================
+
+func TestCreateSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 50})
+		require.NoError(t, err)
+
+		snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+			VolumeID:    vol.ID,
+			Description: "test snapshot",
+			Tags:        map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, snap.ID)
+		assert.Equal(t, vol.ID, snap.VolumeID)
+		assert.Equal(t, "completed", snap.State)
+		assert.Equal(t, "test snapshot", snap.Description)
+		assert.Equal(t, 50, snap.Size)
+		assert.NotEmpty(t, snap.CreatedAt)
+	})
+
+	t.Run("nonexistent volume", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+			VolumeID: "vol-nonexistent",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+		require.NoError(t, err)
+
+		err = m.DeleteSnapshot(ctx, snap.ID)
+		require.NoError(t, err)
+
+		// Should be gone
+		snaps, err := m.DescribeSnapshots(ctx, []string{snap.ID})
+		require.NoError(t, err)
+		assert.Empty(t, snaps)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeleteSnapshot(ctx, "snap-nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeSnapshots(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	snap1, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	snap2, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		snaps, err := m.DescribeSnapshots(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, snaps, 2)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		snaps, err := m.DescribeSnapshots(ctx, []string{snap1.ID})
+		require.NoError(t, err)
+		assert.Len(t, snaps, 1)
+		assert.Equal(t, snap1.ID, snaps[0].ID)
+	})
+
+	// Keep snap2 referenced
+	assert.NotEmpty(t, snap2.ID)
+}
+
+// =====================================================================
+// Image Tests
+// =====================================================================
+
+func TestCreateImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "Standard_B1s",
+		}, 1)
+		require.NoError(t, err)
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID:  instances[0].ID,
+			Name:        "my-image",
+			Description: "test image",
+			Tags:        map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, img.ID)
+		assert.Equal(t, "my-image", img.Name)
+		assert.Equal(t, "available", img.State)
+		assert.Equal(t, "test image", img.Description)
+		assert.NotEmpty(t, img.CreatedAt)
+	})
+
+	t.Run("nonexistent instance", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID: "vm-nonexistent",
+			Name:       "bad-image",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeregisterImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "Standard_B1s",
+		}, 1)
+		require.NoError(t, err)
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID: instances[0].ID,
+			Name:       "del-image",
+		})
+		require.NoError(t, err)
+
+		err = m.DeregisterImage(ctx, img.ID)
+		require.NoError(t, err)
+
+		// Should be gone
+		imgs, err := m.DescribeImages(ctx, []string{img.ID})
+		require.NoError(t, err)
+		assert.Empty(t, imgs)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeregisterImage(ctx, "img-nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeImages(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "Standard_B1s",
+	}, 1)
+	require.NoError(t, err)
+
+	img1, err := m.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "image-1",
+	})
+	require.NoError(t, err)
+
+	img2, err := m.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "image-2",
+	})
+	require.NoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		imgs, err := m.DescribeImages(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, imgs, 2)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		imgs, err := m.DescribeImages(ctx, []string{img1.ID})
+		require.NoError(t, err)
+		assert.Len(t, imgs, 1)
+		assert.Equal(t, img1.ID, imgs[0].ID)
+	})
+
+	// Keep img2 referenced
+	assert.NotEmpty(t, img2.ID)
+}
+
 type vmMetricsCollector struct {
 	data []mondriver.MetricDatum
 }

--- a/providers/gcp/gce/gce_test.go
+++ b/providers/gcp/gce/gce_test.go
@@ -1348,3 +1348,396 @@ func TestCancelSpotRequestsPersistentType(t *testing.T) {
 	require.Len(t, desc, 1)
 	assert.Equal(t, compute.StateRunning, desc[0].State)
 }
+
+// =====================================================================
+// Volume Tests
+// =====================================================================
+
+func TestCreateVolume(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		cfg       driver.VolumeConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "success",
+			cfg:  driver.VolumeConfig{Size: 100, VolumeType: "pd-ssd", Tags: map[string]string{"env": "test"}},
+		},
+		{
+			name: "default volume type",
+			cfg:  driver.VolumeConfig{Size: 50},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestMock()
+			vol, err := m.CreateVolume(ctx, tt.cfg)
+
+			switch {
+			case tt.wantErr:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			default:
+				require.NoError(t, err)
+				assert.NotEmpty(t, vol.ID)
+				assert.Equal(t, tt.cfg.Size, vol.Size)
+				assert.Equal(t, "available", vol.State)
+				assert.NotEmpty(t, vol.CreatedAt)
+			}
+		})
+	}
+}
+
+func TestDeleteVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.DeleteVolume(ctx, vol.ID)
+		require.NoError(t, err)
+
+		// Should be gone
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		require.NoError(t, err)
+		assert.Empty(t, vols)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeleteVolume(ctx, "disk-nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeVolumes(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vol1, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	vol2, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 20})
+	require.NoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		vols, err := m.DescribeVolumes(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, vols, 2)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		vols, err := m.DescribeVolumes(ctx, []string{vol1.ID})
+		require.NoError(t, err)
+		assert.Len(t, vols, 1)
+		assert.Equal(t, vol1.ID, vols[0].ID)
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		fresh := newTestMock()
+		vols, err := fresh.DescribeVolumes(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, vols)
+	})
+
+	// Keep vol2 referenced
+	assert.NotEmpty(t, vol2.ID)
+}
+
+func TestAttachVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "n1-standard-1",
+		}, 1)
+		require.NoError(t, err)
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+		require.NoError(t, err)
+
+		// Verify state changed to in-use
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		require.NoError(t, err)
+		require.Len(t, vols, 1)
+		assert.Equal(t, "in-use", vols[0].State)
+		assert.Equal(t, instances[0].ID, vols[0].AttachedTo)
+	})
+
+	t.Run("nonexistent instance", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, "inst-nonexistent", "/dev/sdf")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("nonexistent volume", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "n1-standard-1",
+		}, 1)
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, "disk-nonexistent", instances[0].ID, "/dev/sdf")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDetachVolume(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "n1-standard-1",
+		}, 1)
+		require.NoError(t, err)
+
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.AttachVolume(ctx, vol.ID, instances[0].ID, "/dev/sdf")
+		require.NoError(t, err)
+
+		err = m.DetachVolume(ctx, vol.ID)
+		require.NoError(t, err)
+
+		// Verify state changed back to available
+		vols, err := m.DescribeVolumes(ctx, []string{vol.ID})
+		require.NoError(t, err)
+		require.Len(t, vols, 1)
+		assert.Equal(t, "available", vols[0].State)
+	})
+
+	t.Run("detach unattached volume", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		err = m.DetachVolume(ctx, vol.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not attached")
+	})
+}
+
+// =====================================================================
+// Snapshot Tests
+// =====================================================================
+
+func TestCreateSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 50})
+		require.NoError(t, err)
+
+		snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+			VolumeID:    vol.ID,
+			Description: "test snapshot",
+			Tags:        map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, snap.ID)
+		assert.Equal(t, vol.ID, snap.VolumeID)
+		assert.Equal(t, "completed", snap.State)
+		assert.Equal(t, "test snapshot", snap.Description)
+		assert.Equal(t, 50, snap.Size)
+		assert.NotEmpty(t, snap.CreatedAt)
+	})
+
+	t.Run("nonexistent volume", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{
+			VolumeID: "disk-nonexistent",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+		require.NoError(t, err)
+
+		snap, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+		require.NoError(t, err)
+
+		err = m.DeleteSnapshot(ctx, snap.ID)
+		require.NoError(t, err)
+
+		// Should be gone
+		snaps, err := m.DescribeSnapshots(ctx, []string{snap.ID})
+		require.NoError(t, err)
+		assert.Empty(t, snaps)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeleteSnapshot(ctx, "snap-nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeSnapshots(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vol, err := m.CreateVolume(ctx, driver.VolumeConfig{Size: 10})
+	require.NoError(t, err)
+
+	snap1, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	snap2, err := m.CreateSnapshot(ctx, driver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		snaps, err := m.DescribeSnapshots(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, snaps, 2)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		snaps, err := m.DescribeSnapshots(ctx, []string{snap1.ID})
+		require.NoError(t, err)
+		assert.Len(t, snaps, 1)
+		assert.Equal(t, snap1.ID, snaps[0].ID)
+	})
+
+	// Keep snap2 referenced
+	assert.NotEmpty(t, snap2.ID)
+}
+
+// =====================================================================
+// Image Tests
+// =====================================================================
+
+func TestCreateImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "n1-standard-1",
+		}, 1)
+		require.NoError(t, err)
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID:  instances[0].ID,
+			Name:        "my-image",
+			Description: "test image",
+			Tags:        map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, img.ID)
+		assert.Equal(t, "my-image", img.Name)
+		assert.Equal(t, "available", img.State)
+		assert.Equal(t, "test image", img.Description)
+		assert.NotEmpty(t, img.CreatedAt)
+	})
+
+	t.Run("nonexistent instance", func(t *testing.T) {
+		m := newTestMock()
+		_, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID: "inst-nonexistent",
+			Name:       "bad-image",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDeregisterImage(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		m := newTestMock()
+		instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+			ImageID: "img-1", InstanceType: "n1-standard-1",
+		}, 1)
+		require.NoError(t, err)
+
+		img, err := m.CreateImage(ctx, driver.ImageConfig{
+			InstanceID: instances[0].ID,
+			Name:       "del-image",
+		})
+		require.NoError(t, err)
+
+		err = m.DeregisterImage(ctx, img.ID)
+		require.NoError(t, err)
+
+		// Should be gone
+		imgs, err := m.DescribeImages(ctx, []string{img.ID})
+		require.NoError(t, err)
+		assert.Empty(t, imgs)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		m := newTestMock()
+		err := m.DeregisterImage(ctx, "img-nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestDescribeImages(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	instances, err := m.RunInstances(ctx, driver.InstanceConfig{
+		ImageID: "img-1", InstanceType: "n1-standard-1",
+	}, 1)
+	require.NoError(t, err)
+
+	img1, err := m.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "image-1",
+	})
+	require.NoError(t, err)
+
+	img2, err := m.CreateImage(ctx, driver.ImageConfig{
+		InstanceID: instances[0].ID,
+		Name:       "image-2",
+	})
+	require.NoError(t, err)
+
+	t.Run("describe all", func(t *testing.T) {
+		imgs, err := m.DescribeImages(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, imgs, 2)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		imgs, err := m.DescribeImages(ctx, []string{img1.ID})
+		require.NoError(t, err)
+		assert.Len(t, imgs, 1)
+		assert.Equal(t, img1.ID, imgs[0].ID)
+	})
+
+	// Keep img2 referenced
+	assert.NotEmpty(t, img2.ID)
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for previously untested compute methods across all 3 providers and the portable API layer.

## Methods Now Tested

| Method Group | AWS EC2 | Azure VMs | GCP GCE | Portable |
|---|---|---|---|---|
| Volume (Create/Delete/Describe/Attach/Detach) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| Snapshot (Create/Delete/Describe) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| Image (Create/Deregister/Describe) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| ModifyInstance | already tested | already tested | already tested | :white_check_mark: |
| ASG (Create/Delete/Get/List/Update/SetCapacity) | already tested | already tested | already tested | :white_check_mark: |
| ScalingPolicy (Put/Delete/Execute) | already tested | already tested | already tested | :white_check_mark: |
| Spot (Request/Cancel/Describe) | already tested | already tested | already tested | :white_check_mark: |
| LaunchTemplate (Create/Delete/Get/List) | already tested | already tested | already tested | :white_check_mark: |

## Coverage Improvements

| Package | Before | After |
|---------|--------|-------|
| `aws/ec2` | 73.4% | **92.6%** |
| `azure/virtualmachines` | 78.5% | **97.0%** |
| `gcp/gce` | 78.8% | **97.2%** |
| `compute` (portable) | 34.3% | **99.4%** |

## Test plan

- [x] All new tests pass
- [x] Full test suite passes (no regressions)
- [x] Linter passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)