### PR TITLE
Add networking service test coverage (66%->93%)

### DIFF
--- a/networking/networking_test.go
+++ b/networking/networking_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stackshy/cloudemu/config"
 	"github.com/stackshy/cloudemu/inject"
 	"github.com/stackshy/cloudemu/metrics"
 	"github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/ratelimit"
 	"github.com/stackshy/cloudemu/recorder"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1132,4 +1134,268 @@ func TestNetworkingAllOptionsComposed(t *testing.T) {
 
 	q := metrics.NewQuery(mc)
 	assert.Equal(t, 2, q.ByName("calls_total").Count())
+}
+
+// --- Internet Gateway portable tests ---
+
+func TestInternetGatewayPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	t.Run("create IGW", func(t *testing.T) {
+		igw, err := n.CreateInternetGateway(ctx, driver.InternetGatewayConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, igw.ID)
+		assert.Equal(t, "detached", igw.State)
+	})
+
+	t.Run("describe all IGWs", func(t *testing.T) {
+		igws, err := n.DescribeInternetGateways(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, igws, 1)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		igws, _ := n.DescribeInternetGateways(ctx, nil)
+		require.NotEmpty(t, igws)
+
+		filtered, err := n.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		require.NoError(t, err)
+		assert.Len(t, filtered, 1)
+		assert.Equal(t, igws[0].ID, filtered[0].ID)
+	})
+
+	t.Run("attach IGW to VPC", func(t *testing.T) {
+		igws, _ := n.DescribeInternetGateways(ctx, nil)
+		vpc, _ := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+
+		err := n.AttachInternetGateway(ctx, igws[0].ID, vpc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("detach IGW", func(t *testing.T) {
+		igws, _ := n.DescribeInternetGateways(ctx, nil)
+		err := n.DetachInternetGateway(ctx, igws[0].ID, "vpc-1")
+		require.NoError(t, err)
+	})
+
+	t.Run("delete IGW", func(t *testing.T) {
+		igws, _ := n.DescribeInternetGateways(ctx, nil)
+		err := n.DeleteInternetGateway(ctx, igws[0].ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("delete nonexistent IGW", func(t *testing.T) {
+		err := n.DeleteInternetGateway(ctx, "igw-nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("attach nonexistent IGW", func(t *testing.T) {
+		err := n.AttachInternetGateway(ctx, "igw-nonexistent", "vpc-1")
+		require.Error(t, err)
+	})
+
+	t.Run("detach nonexistent IGW", func(t *testing.T) {
+		err := n.DetachInternetGateway(ctx, "igw-nonexistent", "vpc-1")
+		require.Error(t, err)
+	})
+}
+
+// --- Elastic IP portable tests ---
+
+func TestElasticIPPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	t.Run("allocate address", func(t *testing.T) {
+		eip, err := n.AllocateAddress(ctx, driver.ElasticIPConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, eip.AllocationID)
+		assert.NotEmpty(t, eip.PublicIP)
+	})
+
+	t.Run("describe all addresses", func(t *testing.T) {
+		eips, err := n.DescribeAddresses(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, eips, 1)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		eips, _ := n.DescribeAddresses(ctx, nil)
+		require.NotEmpty(t, eips)
+
+		filtered, err := n.DescribeAddresses(ctx, []string{eips[0].AllocationID})
+		require.NoError(t, err)
+		assert.Len(t, filtered, 1)
+		assert.Equal(t, eips[0].AllocationID, filtered[0].AllocationID)
+	})
+
+	t.Run("associate address", func(t *testing.T) {
+		eips, _ := n.DescribeAddresses(ctx, nil)
+		assocID, err := n.AssociateAddress(ctx, eips[0].AllocationID, "i-12345")
+		require.NoError(t, err)
+		assert.NotEmpty(t, assocID)
+	})
+
+	t.Run("disassociate address", func(t *testing.T) {
+		eips, _ := n.DescribeAddresses(ctx, nil)
+		err := n.DisassociateAddress(ctx, eips[0].AssociationID)
+		require.NoError(t, err)
+	})
+
+	t.Run("release address", func(t *testing.T) {
+		eips, _ := n.DescribeAddresses(ctx, nil)
+		err := n.ReleaseAddress(ctx, eips[0].AllocationID)
+		require.NoError(t, err)
+
+		eips, _ = n.DescribeAddresses(ctx, nil)
+		assert.Empty(t, eips)
+	})
+
+	t.Run("release nonexistent", func(t *testing.T) {
+		err := n.ReleaseAddress(ctx, "eipalloc-nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("associate nonexistent allocation", func(t *testing.T) {
+		_, err := n.AssociateAddress(ctx, "eipalloc-nonexistent", "i-12345")
+		require.Error(t, err)
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := n.DisassociateAddress(ctx, "eipassoc-nonexistent")
+		require.Error(t, err)
+	})
+}
+
+// --- Route Table Association portable tests ---
+
+func TestRouteTableAssociationPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	rt, err := n.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: "vpc-1"})
+	require.NoError(t, err)
+
+	t.Run("associate route table", func(t *testing.T) {
+		assoc, err := n.AssociateRouteTable(ctx, rt.ID, "subnet-1")
+		require.NoError(t, err)
+		assert.NotEmpty(t, assoc.ID)
+		assert.Equal(t, rt.ID, assoc.RouteTableID)
+		assert.Equal(t, "subnet-1", assoc.SubnetID)
+	})
+
+	t.Run("disassociate route table", func(t *testing.T) {
+		assoc, err := n.AssociateRouteTable(ctx, rt.ID, "subnet-2")
+		require.NoError(t, err)
+
+		err = n.DisassociateRouteTable(ctx, assoc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("associate nonexistent route table", func(t *testing.T) {
+		_, err := n.AssociateRouteTable(ctx, "rtb-nonexistent", "subnet-1")
+		require.Error(t, err)
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := n.DisassociateRouteTable(ctx, "rtbassoc-nonexistent")
+		require.Error(t, err)
+	})
+}
+
+// --- GetFlowLogRecords portable tests ---
+
+func TestGetFlowLogRecordsPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	fl, err := n.CreateFlowLog(ctx, driver.FlowLogConfig{
+		ResourceID: "vpc-1", ResourceType: "VPC", TrafficType: "ALL",
+	})
+	require.NoError(t, err)
+
+	t.Run("get records", func(t *testing.T) {
+		records, err := n.GetFlowLogRecords(ctx, fl.ID, 10)
+		require.NoError(t, err)
+		// Mock driver returns empty slice.
+		assert.Equal(t, 0, len(records))
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := n.GetFlowLogRecords(ctx, "fl-nonexistent", 10)
+		require.Error(t, err)
+	})
+}
+
+func TestDescribeSubnetsPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	sub, err := n.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	subnets, err := n.DescribeSubnets(ctx, nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(subnets), 1)
+
+	subnets, err = n.DescribeSubnets(ctx, []string{sub.ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(subnets))
+}
+
+func TestDeleteSecurityGroupPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	sg, err := n.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{VPCID: vpc.ID, Name: "test-sg", Description: "test"})
+	require.NoError(t, err)
+
+	err = n.DeleteSecurityGroup(ctx, sg.ID)
+	require.NoError(t, err)
+
+	err = n.DeleteSecurityGroup(ctx, "sg-nonexistent")
+	require.Error(t, err)
+}
+
+func TestDescribeSecurityGroupsPortable(t *testing.T) {
+	n := newTestNetworking()
+	ctx := context.Background()
+
+	vpc, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	sg, err := n.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{VPCID: vpc.ID, Name: "test-sg", Description: "test"})
+	require.NoError(t, err)
+
+	groups, err := n.DescribeSecurityGroups(ctx, nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(groups), 1)
+
+	groups, err = n.DescribeSecurityGroups(ctx, []string{sg.ID})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(groups))
+}
+
+func TestNetworkingWithRateLimiter(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	limiter := ratelimit.New(1, 1, fc)
+	n := newTestNetworking(WithRateLimiter(limiter))
+	ctx := context.Background()
+
+	_, err := n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	_, err = n.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.1.0.0/16"})
+	require.Error(t, err)
 }

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -833,6 +833,214 @@ func TestDeleteNetworkACL(t *testing.T) {
 	})
 }
 
+// --- Internet Gateway tests ---
+
+func TestInternetGateway(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+
+	t.Run("create IGW", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		requireNoError(t, err)
+		assertNotEmpty(t, igw.ID)
+		assertEqual(t, "detached", igw.State)
+	})
+
+	t.Run("describe IGWs", func(t *testing.T) {
+		igws, err := m.DescribeInternetGateways(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 1, len(igws))
+		assertEqual(t, "detached", igws[0].State)
+	})
+
+	t.Run("attach IGW to VPC", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.AttachInternetGateway(ctx, igws[0].ID, v.ID)
+		requireNoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		assertEqual(t, 1, len(igws))
+		assertEqual(t, "attached", igws[0].State)
+		assertEqual(t, v.ID, igws[0].VpcID)
+	})
+
+	t.Run("detach IGW from VPC", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.DetachInternetGateway(ctx, igws[0].ID, v.ID)
+		requireNoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		assertEqual(t, 1, len(igws))
+		assertEqual(t, "detached", igws[0].State)
+	})
+
+	t.Run("delete IGW", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.DeleteInternetGateway(ctx, igws[0].ID)
+		requireNoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, nil)
+		assertEqual(t, 0, len(igws))
+	})
+
+	t.Run("delete nonexistent IGW", func(t *testing.T) {
+		err := m.DeleteInternetGateway(ctx, "igw-nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("attach to nonexistent VPC", func(t *testing.T) {
+		igw, _ := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		err := m.AttachInternetGateway(ctx, igw.ID, "vpc-nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("attach nonexistent IGW", func(t *testing.T) {
+		err := m.AttachInternetGateway(ctx, "igw-nope", v.ID)
+		assertError(t, err, true)
+	})
+
+	t.Run("detach nonexistent IGW", func(t *testing.T) {
+		err := m.DetachInternetGateway(ctx, "igw-nope", v.ID)
+		assertError(t, err, true)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		igw, _ := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		igws, err := m.DescribeInternetGateways(ctx, []string{igw.ID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(igws))
+		assertEqual(t, igw.ID, igws[0].ID)
+	})
+
+	t.Run("describe nonexistent ID", func(t *testing.T) {
+		igws, err := m.DescribeInternetGateways(ctx, []string{"igw-nope"})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(igws))
+	})
+}
+
+// --- Elastic IP tests ---
+
+func TestElasticIP(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	t.Run("allocate address", func(t *testing.T) {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		requireNoError(t, err)
+		assertNotEmpty(t, eip.AllocationID)
+		assertNotEmpty(t, eip.PublicIP)
+	})
+
+	t.Run("describe addresses", func(t *testing.T) {
+		eips, err := m.DescribeAddresses(ctx, nil)
+		requireNoError(t, err)
+		assertEqual(t, 1, len(eips))
+	})
+
+	t.Run("associate address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		assocID, err := m.AssociateAddress(ctx, eips[0].AllocationID, "i-12345")
+		requireNoError(t, err)
+		assertNotEmpty(t, assocID)
+
+		eips, _ = m.DescribeAddresses(ctx, []string{eips[0].AllocationID})
+		assertEqual(t, 1, len(eips))
+		assertEqual(t, assocID, eips[0].AssociationID)
+		assertEqual(t, "i-12345", eips[0].InstanceID)
+	})
+
+	t.Run("disassociate address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		err := m.DisassociateAddress(ctx, eips[0].AssociationID)
+		requireNoError(t, err)
+
+		eips, _ = m.DescribeAddresses(ctx, nil)
+		assertEqual(t, "", eips[0].AssociationID)
+		assertEqual(t, "", eips[0].InstanceID)
+	})
+
+	t.Run("release address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		err := m.ReleaseAddress(ctx, eips[0].AllocationID)
+		requireNoError(t, err)
+
+		eips, _ = m.DescribeAddresses(ctx, nil)
+		assertEqual(t, 0, len(eips))
+	})
+
+	t.Run("release nonexistent", func(t *testing.T) {
+		err := m.ReleaseAddress(ctx, "eipalloc-nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("associate nonexistent allocation", func(t *testing.T) {
+		_, err := m.AssociateAddress(ctx, "eipalloc-nope", "i-12345")
+		assertError(t, err, true)
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := m.DisassociateAddress(ctx, "eipassoc-nope")
+		assertError(t, err, true)
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		eip, _ := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		eips, err := m.DescribeAddresses(ctx, []string{eip.AllocationID})
+		requireNoError(t, err)
+		assertEqual(t, 1, len(eips))
+		assertEqual(t, eip.AllocationID, eips[0].AllocationID)
+	})
+
+	t.Run("describe nonexistent ID", func(t *testing.T) {
+		eips, err := m.DescribeAddresses(ctx, []string{"eipalloc-nope"})
+		requireNoError(t, err)
+		assertEqual(t, 0, len(eips))
+	})
+}
+
+// --- Route Table Association tests ---
+
+func TestRouteTableAssociation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	v := createTestVPC(m)
+	s, _ := m.CreateSubnet(ctx, driver.SubnetConfig{
+		VPCID: v.ID, CIDRBlock: "10.0.1.0/24",
+	})
+	rt, _ := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: v.ID})
+
+	t.Run("associate route table", func(t *testing.T) {
+		assoc, err := m.AssociateRouteTable(ctx, rt.ID, s.ID)
+		requireNoError(t, err)
+		assertNotEmpty(t, assoc.ID)
+		assertEqual(t, rt.ID, assoc.RouteTableID)
+		assertEqual(t, s.ID, assoc.SubnetID)
+	})
+
+	t.Run("disassociate route table", func(t *testing.T) {
+		// Re-associate to get a fresh association ID.
+		assoc, _ := m.AssociateRouteTable(ctx, rt.ID, s.ID)
+		err := m.DisassociateRouteTable(ctx, assoc.ID)
+		requireNoError(t, err)
+	})
+
+	t.Run("associate nonexistent route table", func(t *testing.T) {
+		_, err := m.AssociateRouteTable(ctx, "rtb-nope", s.ID)
+		assertError(t, err, true)
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := m.DisassociateRouteTable(ctx, "rtbassoc-nope")
+		assertError(t, err, true)
+	})
+}
+
 // --- test helpers ---
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -1020,3 +1020,263 @@ func TestDescribeNetworkACLsWithIDs(t *testing.T) {
 		})
 	}
 }
+
+// --- Internet Gateway tests ---
+
+func TestInternetGateway(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	t.Run("create IGW", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, igw.ID)
+		assert.Equal(t, "detached", igw.State)
+	})
+
+	t.Run("describe all IGWs", func(t *testing.T) {
+		igws, err := m.DescribeInternetGateways(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, igws, 1)
+		assert.Equal(t, "detached", igws[0].State)
+	})
+
+	t.Run("attach IGW to VPC", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.AttachInternetGateway(ctx, igws[0].ID, vpcID)
+		require.NoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		require.Len(t, igws, 1)
+		assert.Equal(t, "attached", igws[0].State)
+		assert.Equal(t, vpcID, igws[0].VpcID)
+	})
+
+	t.Run("detach IGW", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.DetachInternetGateway(ctx, igws[0].ID, vpcID)
+		require.NoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		require.Len(t, igws, 1)
+		assert.Equal(t, "detached", igws[0].State)
+	})
+
+	t.Run("delete IGW", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.DeleteInternetGateway(ctx, igws[0].ID)
+		require.NoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, nil)
+		assert.Empty(t, igws)
+	})
+
+	t.Run("delete nonexistent IGW", func(t *testing.T) {
+		err := m.DeleteInternetGateway(ctx, "igw-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("attach to nonexistent VPC", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		require.NoError(t, err)
+
+		err = m.AttachInternetGateway(ctx, igw.ID, "vnet-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("attach nonexistent IGW", func(t *testing.T) {
+		err := m.AttachInternetGateway(ctx, "igw-missing", vpcID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("detach nonexistent IGW", func(t *testing.T) {
+		err := m.DetachInternetGateway(ctx, "igw-missing", vpcID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		require.NoError(t, err)
+
+		igws, err := m.DescribeInternetGateways(ctx, []string{igw.ID})
+		require.NoError(t, err)
+		require.Len(t, igws, 1)
+		assert.Equal(t, igw.ID, igws[0].ID)
+	})
+
+	t.Run("describe nonexistent ID", func(t *testing.T) {
+		igws, err := m.DescribeInternetGateways(ctx, []string{"igw-missing"})
+		require.NoError(t, err)
+		assert.Empty(t, igws)
+	})
+}
+
+// --- Elastic IP tests ---
+
+func TestElasticIP(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("allocate address", func(t *testing.T) {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, eip.AllocationID)
+		assert.NotEmpty(t, eip.PublicIP)
+	})
+
+	t.Run("describe addresses", func(t *testing.T) {
+		eips, err := m.DescribeAddresses(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, eips, 1)
+	})
+
+	t.Run("associate address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		assocID, err := m.AssociateAddress(ctx, eips[0].AllocationID, "i-12345")
+		require.NoError(t, err)
+		assert.NotEmpty(t, assocID)
+
+		eips, _ = m.DescribeAddresses(ctx, []string{eips[0].AllocationID})
+		require.Len(t, eips, 1)
+		assert.Equal(t, assocID, eips[0].AssociationID)
+		assert.Equal(t, "i-12345", eips[0].InstanceID)
+	})
+
+	t.Run("disassociate address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		err := m.DisassociateAddress(ctx, eips[0].AssociationID)
+		require.NoError(t, err)
+
+		eips, _ = m.DescribeAddresses(ctx, nil)
+		assert.Equal(t, "", eips[0].AssociationID)
+		assert.Equal(t, "", eips[0].InstanceID)
+	})
+
+	t.Run("release address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		err := m.ReleaseAddress(ctx, eips[0].AllocationID)
+		require.NoError(t, err)
+
+		eips, _ = m.DescribeAddresses(ctx, nil)
+		assert.Empty(t, eips)
+	})
+
+	t.Run("release nonexistent", func(t *testing.T) {
+		err := m.ReleaseAddress(ctx, "eipalloc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("associate nonexistent allocation", func(t *testing.T) {
+		_, err := m.AssociateAddress(ctx, "eipalloc-missing", "i-12345")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := m.DisassociateAddress(ctx, "eipassoc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		require.NoError(t, err)
+
+		eips, err := m.DescribeAddresses(ctx, []string{eip.AllocationID})
+		require.NoError(t, err)
+		require.Len(t, eips, 1)
+		assert.Equal(t, eip.AllocationID, eips[0].AllocationID)
+	})
+
+	t.Run("describe nonexistent ID", func(t *testing.T) {
+		eips, err := m.DescribeAddresses(ctx, []string{"eipalloc-missing"})
+		require.NoError(t, err)
+		assert.Empty(t, eips)
+	})
+}
+
+// --- Route Table Association tests ---
+
+func TestRouteTableAssociation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpcID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpcID})
+	require.NoError(t, err)
+
+	t.Run("associate route table", func(t *testing.T) {
+		assoc, err := m.AssociateRouteTable(ctx, rt.ID, subnet.ID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, assoc.ID)
+		assert.Equal(t, rt.ID, assoc.RouteTableID)
+		assert.Equal(t, subnet.ID, assoc.SubnetID)
+	})
+
+	t.Run("disassociate route table", func(t *testing.T) {
+		assoc, err := m.AssociateRouteTable(ctx, rt.ID, subnet.ID)
+		require.NoError(t, err)
+
+		err = m.DisassociateRouteTable(ctx, assoc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("associate nonexistent route table", func(t *testing.T) {
+		_, err := m.AssociateRouteTable(ctx, "rt-missing", subnet.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := m.DisassociateRouteTable(ctx, "rtbassoc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+// --- GetFlowLogRecords tests ---
+
+func TestGetFlowLogRecords(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+	vpcID := createTestVPC(t, m)
+
+	fl, err := m.CreateFlowLog(ctx, driver.FlowLogConfig{
+		ResourceID: vpcID, ResourceType: "VPC", TrafficType: "ALL",
+	})
+	require.NoError(t, err)
+
+	t.Run("returns records", func(t *testing.T) {
+		records, err := m.GetFlowLogRecords(ctx, fl.ID, 5)
+		require.NoError(t, err)
+		assert.Len(t, records, 5)
+		assert.Equal(t, fl.ID, records[0].FlowLogID)
+		assert.NotEmpty(t, records[0].SourceIP)
+		assert.NotEmpty(t, records[0].DestIP)
+	})
+
+	t.Run("default limit", func(t *testing.T) {
+		records, err := m.GetFlowLogRecords(ctx, fl.ID, 0)
+		require.NoError(t, err)
+		assert.Len(t, records, 10)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := m.GetFlowLogRecords(ctx, "fl-missing", 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}

--- a/providers/gcp/gcpvpc/vpc_test.go
+++ b/providers/gcp/gcpvpc/vpc_test.go
@@ -1214,3 +1214,233 @@ func TestFlowLogRejectTrafficType(t *testing.T) {
 		assert.Equal(t, "REJECT", rec.Action)
 	}
 }
+
+// --- Internet Gateway tests ---
+
+func TestInternetGateway(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	t.Run("create IGW", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, igw.ID)
+		assert.Equal(t, "detached", igw.State)
+	})
+
+	t.Run("describe all IGWs", func(t *testing.T) {
+		igws, err := m.DescribeInternetGateways(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, igws, 1)
+		assert.Equal(t, "detached", igws[0].State)
+	})
+
+	t.Run("attach IGW to VPC", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.AttachInternetGateway(ctx, igws[0].ID, vpc.ID)
+		require.NoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		require.Len(t, igws, 1)
+		assert.Equal(t, "attached", igws[0].State)
+		assert.Equal(t, vpc.ID, igws[0].VpcID)
+	})
+
+	t.Run("detach IGW", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.DetachInternetGateway(ctx, igws[0].ID, vpc.ID)
+		require.NoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, []string{igws[0].ID})
+		require.Len(t, igws, 1)
+		assert.Equal(t, "detached", igws[0].State)
+	})
+
+	t.Run("delete IGW", func(t *testing.T) {
+		igws, _ := m.DescribeInternetGateways(ctx, nil)
+		err := m.DeleteInternetGateway(ctx, igws[0].ID)
+		require.NoError(t, err)
+
+		igws, _ = m.DescribeInternetGateways(ctx, nil)
+		assert.Empty(t, igws)
+	})
+
+	t.Run("delete nonexistent IGW", func(t *testing.T) {
+		err := m.DeleteInternetGateway(ctx, "igw-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("attach to nonexistent VPC", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		require.NoError(t, err)
+
+		err = m.AttachInternetGateway(ctx, igw.ID, "vpc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("attach nonexistent IGW", func(t *testing.T) {
+		err := m.AttachInternetGateway(ctx, "igw-missing", vpc.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("detach nonexistent IGW", func(t *testing.T) {
+		err := m.DetachInternetGateway(ctx, "igw-missing", vpc.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		igw, err := m.CreateInternetGateway(ctx, driver.InternetGatewayConfig{})
+		require.NoError(t, err)
+
+		igws, err := m.DescribeInternetGateways(ctx, []string{igw.ID})
+		require.NoError(t, err)
+		require.Len(t, igws, 1)
+		assert.Equal(t, igw.ID, igws[0].ID)
+	})
+
+	t.Run("describe nonexistent ID", func(t *testing.T) {
+		igws, err := m.DescribeInternetGateways(ctx, []string{"igw-missing"})
+		require.NoError(t, err)
+		assert.Empty(t, igws)
+	})
+}
+
+// --- Elastic IP tests ---
+
+func TestElasticIP(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	t.Run("allocate address", func(t *testing.T) {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{
+			Tags: map[string]string{"env": "test"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, eip.AllocationID)
+		assert.NotEmpty(t, eip.PublicIP)
+	})
+
+	t.Run("describe addresses", func(t *testing.T) {
+		eips, err := m.DescribeAddresses(ctx, nil)
+		require.NoError(t, err)
+		assert.Len(t, eips, 1)
+	})
+
+	t.Run("associate address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		assocID, err := m.AssociateAddress(ctx, eips[0].AllocationID, "i-12345")
+		require.NoError(t, err)
+		assert.NotEmpty(t, assocID)
+
+		eips, _ = m.DescribeAddresses(ctx, []string{eips[0].AllocationID})
+		require.Len(t, eips, 1)
+		assert.Equal(t, assocID, eips[0].AssociationID)
+		assert.Equal(t, "i-12345", eips[0].InstanceID)
+	})
+
+	t.Run("disassociate address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		err := m.DisassociateAddress(ctx, eips[0].AssociationID)
+		require.NoError(t, err)
+
+		eips, _ = m.DescribeAddresses(ctx, nil)
+		assert.Equal(t, "", eips[0].AssociationID)
+		assert.Equal(t, "", eips[0].InstanceID)
+	})
+
+	t.Run("release address", func(t *testing.T) {
+		eips, _ := m.DescribeAddresses(ctx, nil)
+		err := m.ReleaseAddress(ctx, eips[0].AllocationID)
+		require.NoError(t, err)
+
+		eips, _ = m.DescribeAddresses(ctx, nil)
+		assert.Empty(t, eips)
+	})
+
+	t.Run("release nonexistent", func(t *testing.T) {
+		err := m.ReleaseAddress(ctx, "eipalloc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("associate nonexistent allocation", func(t *testing.T) {
+		_, err := m.AssociateAddress(ctx, "eipalloc-missing", "i-12345")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := m.DisassociateAddress(ctx, "eipassoc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("describe by ID", func(t *testing.T) {
+		eip, err := m.AllocateAddress(ctx, driver.ElasticIPConfig{})
+		require.NoError(t, err)
+
+		eips, err := m.DescribeAddresses(ctx, []string{eip.AllocationID})
+		require.NoError(t, err)
+		require.Len(t, eips, 1)
+		assert.Equal(t, eip.AllocationID, eips[0].AllocationID)
+	})
+
+	t.Run("describe nonexistent ID", func(t *testing.T) {
+		eips, err := m.DescribeAddresses(ctx, []string{"eipalloc-missing"})
+		require.NoError(t, err)
+		assert.Empty(t, eips)
+	})
+}
+
+// --- Route Table Association tests ---
+
+func TestRouteTableAssociation(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	vpc, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	subnet, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: vpc.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	rt, err := m.CreateRouteTable(ctx, driver.RouteTableConfig{VPCID: vpc.ID})
+	require.NoError(t, err)
+
+	t.Run("associate route table", func(t *testing.T) {
+		assoc, err := m.AssociateRouteTable(ctx, rt.ID, subnet.ID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, assoc.ID)
+		assert.Equal(t, rt.ID, assoc.RouteTableID)
+		assert.Equal(t, subnet.ID, assoc.SubnetID)
+	})
+
+	t.Run("disassociate route table", func(t *testing.T) {
+		assoc, err := m.AssociateRouteTable(ctx, rt.ID, subnet.ID)
+		require.NoError(t, err)
+
+		err = m.DisassociateRouteTable(ctx, assoc.ID)
+		require.NoError(t, err)
+	})
+
+	t.Run("associate nonexistent route table", func(t *testing.T) {
+		_, err := m.AssociateRouteTable(ctx, "rt-missing", subnet.ID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("disassociate nonexistent", func(t *testing.T) {
+		err := m.DisassociateRouteTable(ctx, "rtbassoc-missing")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for previously untested networking methods across all 3 providers and the portable API layer.

## Coverage Improvements

| Package | Before | After |
|---------|--------|-------|
| `aws/vpc` | 76.8% | **96.8%** |
| `azure/vnet` | 73.3% | **93.8%** |
| `gcp/gcpvpc` | 76.8% | **96.8%** |
| `networking` (portable) | 65.6% | **92.9%** |

## Test plan

- [x] All new tests pass
- [x] Full test suite passes (no regressions)
- [x] Linter passes (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)