### PR TITLE
Add project documentation (architecture, services, topology, features)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# CloudEmu Documentation
+
+CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides mock implementations of 16 cloud services across AWS, Azure, and GCP -- designed for testing and development without real cloud accounts, Docker, or network calls.
+
+## Table of Contents
+
+- [Architecture](architecture.md) -- Three-layer design, package structure, cross-service wiring
+- [Services](services.md) -- Complete provider resource reference with all operations for 16 services
+- [Features](features.md) -- Cross-cutting features: auto-metrics, alarm evaluation, IAM policy checking, FIFO dedup, cost tracking, and more
+- [Topology](topology.md) -- Network topology simulation engine
+- [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration
+
+## Quick Links
+
+| Topic | Link |
+|-------|------|
+| Creating an AWS provider | [Getting Started](getting-started.md#creating-providers) |
+| All 16 service operations | [Services Reference](services.md#master-table) |
+| Auto-metric generation | [Features](features.md#1-auto-metric-generation) |
+| Error injection and rate limiting | [Features](features.md#8-portable-api-cross-cutting-concerns) |
+| Cost tracking | [Features](features.md#7-cost-tracking) |
+| Configuration options | [Getting Started](getting-started.md#configuration-options) |
+| Package structure | [Architecture](architecture.md#package-structure-overview) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,218 @@
+# Architecture
+
+## Overview
+
+CloudEmu follows a three-layer architecture that separates portable API concerns, driver interfaces, and provider-specific implementations. This design allows each cloud provider (AWS, Azure, GCP) to implement the same driver interface while the portable API layer adds cross-cutting concerns such as recording, metrics collection, rate limiting, error injection, and latency simulation.
+
+## Three-Layer Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│         Portable API Layer                          │
+│   (storage/, compute/, database/, etc.)             │
+│   Recording, Metrics, Rate Limiting, Error Inject   │
+├─────────────────────────────────────────────────────┤
+│                      ↓                              │
+├─────────────────────────────────────────────────────┤
+│         Driver Interfaces                           │
+│   (*/driver/driver.go)                              │
+│   Minimal Go interfaces per service                 │
+├─────────────────────────────────────────────────────┤
+│                      ↓                              │
+├─────────────────────────────────────────────────────┤
+│         Provider Implementations                    │
+│   (providers/aws/, providers/azure/, providers/gcp/)│
+│   In-memory backends using memstore.Store[V]        │
+├─────────────────────────────────────────────────────┤
+│                      ↓                              │
+├─────────────────────────────────────────────────────┤
+│         In-Memory State                             │
+│   (internal/memstore) Generic Store[V]              │
+└─────────────────────────────────────────────────────┘
+```
+
+### Layer 1: Portable API
+
+The top layer lives in service-specific packages (`storage/`, `compute/`, `database/`, etc.). Each portable API type wraps a driver with cross-cutting concerns. For example, `storage.Bucket` wraps `driver.Bucket` and adds call recording, metrics collection, rate limiting, error injection, and simulated latency to every operation. This layer is provider-agnostic -- the same `storage.Bucket` works with S3, Blob Storage, or GCS.
+
+### Layer 2: Driver Interfaces
+
+Each service defines a minimal Go interface in `<service>/driver/driver.go`. These interfaces specify the operations that every provider must implement. For example, `storage/driver/driver.go` defines the `Bucket` interface with methods like `CreateBucket`, `PutObject`, `GetObject`, etc. Driver interfaces use plain Go types (no cloud SDK dependencies).
+
+### Layer 3: Provider Implementations
+
+The bottom layer contains the actual mock implementations for each cloud provider. These live in `providers/aws/`, `providers/azure/`, and `providers/gcp/`. Each implementation uses `internal/memstore.Store[V]` as its backing data structure -- a generic, thread-safe in-memory store. All state lives in process memory with no external dependencies.
+
+## Cross-Service Wiring
+
+Provider factories automatically wire cross-service dependencies using `SetMonitoring()`. When a compute instance is launched, the compute mock pushes metrics directly into the monitoring service. This wiring is established at provider creation time.
+
+```go
+// In providers/aws/aws.go
+p.EC2.SetMonitoring(p.CloudWatch)        // EC2 pushes metrics to CloudWatch
+p.S3.SetMonitoring(p.CloudWatch)         // S3 pushes metrics to CloudWatch
+p.DynamoDB.SetMonitoring(p.CloudWatch)   // DynamoDB pushes metrics to CloudWatch
+
+// In providers/azure/azure.go
+p.VirtualMachines.SetMonitoring(p.Monitor) // VMs push metrics to Azure Monitor
+p.BlobStorage.SetMonitoring(p.Monitor)     // Blob Storage pushes metrics
+
+// In providers/gcp/gcp.go
+p.GCE.SetMonitoring(p.CloudMonitoring)    // GCE pushes metrics to Cloud Monitoring
+p.GCS.SetMonitoring(p.CloudMonitoring)    // GCS pushes metrics
+```
+
+Currently, 10 services per provider are wired to push auto-metrics to their respective monitoring service: Compute, Storage, Database, Serverless, Message Queue, Cache, Logging, Notification, Container Registry, and Event Bus.
+
+## Provider Factory Pattern
+
+Each provider has a factory function (`New()`) in its top-level package (`providers/aws/aws.go`, `providers/azure/azure.go`, `providers/gcp/gcp.go`). The factory:
+
+1. Accepts functional `config.Option` values for configuration (clock, region, account ID, etc.)
+2. Creates `config.Options` from the functional options
+3. Instantiates all 16 service mocks, passing the shared options to each
+4. Wires cross-service dependencies (e.g., compute to monitoring)
+5. Returns the `Provider` struct with all services accessible as public fields
+
+```go
+aws := cloudemu.NewAWS(
+    config.WithRegion("us-west-2"),
+    config.WithAccountID("123456789012"),
+)
+
+// All 16 services are ready to use
+aws.S3.CreateBucket(ctx, "my-bucket")
+aws.EC2.RunInstances(ctx, instanceConfig, 1)
+aws.DynamoDB.CreateTable(ctx, tableConfig)
+```
+
+## Package Structure Overview
+
+| Package | Purpose |
+|---------|---------|
+| `config` | Functional options (`WithClock`, `WithRegion`, `WithAccountID`, `WithProjectID`, `WithLatency`), `Clock` interface, `RealClock`, `FakeClock` for deterministic time |
+| `errors` | Canonical error codes: `NotFound`, `AlreadyExists`, `InvalidArgument`, `FailedPrecondition`, `PermissionDenied`, `Throttled`, `Internal`, `Unimplemented`, `ResourceExhausted`, `Unavailable` |
+| `internal/memstore` | Generic thread-safe `Store[V]` -- the backing data structure for all mock implementations |
+| `internal/idgen` | ID generators: AWS ARNs, Azure resource IDs, GCP self-links |
+| `statemachine` | Generic finite state machine for VM lifecycle transitions (pending, running, stopping, stopped, terminated) with callback support |
+| `pagination` | Generic `Paginate[T]` with base64 page tokens for list operations |
+| `recorder` | Call recording for test assertions -- captures service, operation, input, output, error, and duration |
+| `metrics` | In-memory metrics collector with Counter, Gauge, and Histogram types |
+| `ratelimit` | Token bucket rate limiter that returns `Throttled` errors |
+| `inject` | Error injection with policies: `Always`, `NthCall`, `Probabilistic`, `Countdown` |
+| `cost` | Simulated cost tracking with per-operation pricing rates |
+
+## File Structure
+
+```
+cloudemu.go                           # Entry point: NewAWS(), NewAzure(), NewGCP()
+cloudemu_test.go                      # All tests
+doc.go                                # Package documentation
+go.mod                                # Module: github.com/stackshy/cloudemu
+config/
+    options.go                        # Options, WithClock, WithRegion, etc.
+    clock.go                          # Clock, RealClock, FakeClock
+errors/
+    errors.go                         # Canonical error codes and helpers
+internal/
+    memstore/                         # Generic Store[V]
+    idgen/                            # ID generators (ARNs, Azure IDs, GCP IDs)
+statemachine/
+    machine.go                        # Generic FSM
+    transitions.go                    # Transition map
+pagination/                           # Generic Paginate[T]
+recorder/                             # Call recording for assertions
+metrics/                              # In-memory metrics collection
+ratelimit/                            # Token bucket rate limiter
+inject/                               # Error injection (policies + injector)
+cost/
+    cost.go                           # Cost tracker with default rates
+storage/
+    storage.go                        # Portable storage API
+    driver/driver.go                  # Bucket interface
+compute/
+    driver/driver.go                  # Compute interface
+database/
+    driver/driver.go                  # Database interface
+serverless/
+    driver/driver.go                  # Serverless interface
+networking/
+    driver/driver.go                  # Networking interface
+monitoring/
+    driver/driver.go                  # Monitoring interface
+iam/
+    driver/driver.go                  # IAM interface
+dns/
+    driver/driver.go                  # DNS interface
+loadbalancer/
+    driver/driver.go                  # LoadBalancer interface
+messagequeue/
+    driver/driver.go                  # MessageQueue interface
+cache/
+    driver/driver.go                  # Cache interface
+secrets/
+    driver/driver.go                  # Secrets interface
+logging/
+    driver/driver.go                  # Logging interface
+notification/
+    driver/driver.go                  # Notification interface
+containerregistry/
+    driver/driver.go                  # ContainerRegistry interface
+eventbus/
+    driver/driver.go                  # EventBus interface
+providers/
+    aws/
+        aws.go                        # AWS factory (wires all 16 services)
+        s3/                           # S3 mock
+        ec2/                          # EC2 mock
+        dynamodb/                     # DynamoDB mock
+        lambda/                       # Lambda mock
+        vpc/                          # VPC mock
+        cloudwatch/                   # CloudWatch mock
+        awsiam/                       # IAM mock
+        route53/                      # Route 53 mock
+        elb/                          # ELB mock
+        sqs/                          # SQS mock
+        elasticache/                  # ElastiCache mock
+        secretsmanager/               # Secrets Manager mock
+        cloudwatchlogs/               # CloudWatch Logs mock
+        sns/                          # SNS mock
+        ecr/                          # ECR mock
+        eventbridge/                  # EventBridge mock
+    azure/
+        azure.go                      # Azure factory (wires all 16 services)
+        blobstorage/                  # Blob Storage mock
+        virtualmachines/              # Virtual Machines mock
+        cosmosdb/                     # Cosmos DB mock
+        functions/                    # Azure Functions mock
+        vnet/                         # VNet mock
+        azuremonitor/                 # Azure Monitor mock
+        azureiam/                     # Azure IAM mock
+        azuredns/                     # Azure DNS mock
+        azurelb/                      # Azure LB mock
+        servicebus/                   # Service Bus mock
+        azurecache/                   # Azure Cache mock
+        keyvault/                     # Key Vault mock
+        loganalytics/                 # Log Analytics mock
+        notificationhubs/             # Notification Hubs mock
+        acr/                          # ACR mock
+        eventgrid/                    # Event Grid mock
+    gcp/
+        gcp.go                        # GCP factory (wires all 16 services)
+        gcs/                          # GCS mock
+        gce/                          # GCE mock
+        firestore/                    # Firestore mock
+        cloudfunctions/               # Cloud Functions mock
+        gcpvpc/                       # GCP VPC mock
+        cloudmonitoring/              # Cloud Monitoring mock
+        gcpiam/                       # GCP IAM mock
+        clouddns/                     # Cloud DNS mock
+        gcplb/                        # GCP LB mock
+        pubsub/                       # Pub/Sub mock
+        memorystore/                  # Memorystore mock
+        secretmanager/                # Secret Manager mock
+        cloudlogging/                 # Cloud Logging mock
+        fcm/                          # FCM mock
+        artifactregistry/             # Artifact Registry mock
+        eventarc/                     # Eventarc mock
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,371 @@
+# Cross-Cutting Features
+
+CloudEmu goes beyond simple CRUD mocking. These features emulate real cloud behaviors so that integration tests can validate end-to-end logic without deploying to a real cloud.
+
+---
+
+## 1. Auto-Metric Generation
+
+When a compute instance is launched with `RunInstances`, the compute mock automatically pushes 5 metrics to the provider's monitoring service. This happens because the provider factory wires compute to monitoring via `SetMonitoring()`.
+
+### Metrics Pushed on RunInstances
+
+Each instance gets 5 metrics with 5 backfill datapoints at 1-minute intervals from launch time:
+
+| Provider | Namespace | Metrics | Dimension Key |
+|----------|-----------|---------|---------------|
+| AWS | `AWS/EC2` | CPUUtilization, NetworkIn, NetworkOut, DiskReadOps, DiskWriteOps | `InstanceId` |
+| Azure | `Microsoft.Compute/virtualMachines` | Percentage CPU, Network In Total, Network Out Total, Disk Read Operations/Sec, Disk Write Operations/Sec | `resourceId` |
+| GCP | `compute.googleapis.com` | instance/cpu/utilization, instance/network/received_bytes_count, instance/network/sent_bytes_count, instance/disk/read_ops_count, instance/disk/write_ops_count | `instance_id` |
+
+### Lifecycle Metric Emission
+
+All VM lifecycle operations also emit metrics via `emitLifecycleMetrics()`:
+
+| Operation | Values |
+|-----------|--------|
+| `StartInstances` | Running values (CPU=25, Network=1024/512, Disk=100/50; GCP CPU=0.25) |
+| `StopInstances` | Zero values (all 0.0) |
+| `RebootInstances` | Running values |
+| `TerminateInstances` | Zero values |
+
+Each lifecycle call emits 1 datapoint per metric at `Clock.Now()`. This allows alarms to detect state changes -- for example, a "low CPU" alarm fires when a VM is stopped.
+
+### Auto-Metrics for Other Services
+
+In addition to compute, 9 other services per provider are wired to push metrics to monitoring: Storage, Database, Serverless, Message Queue, Cache, Logging, Notification, Container Registry, and Event Bus.
+
+---
+
+## 2. Alarm Auto-Evaluation
+
+When `PutMetricData` is called, the monitoring mock automatically evaluates all alarms that match the affected namespace and metric name. This is implemented in `evaluateAlarms()` within each monitoring mock.
+
+### Evaluation Process
+
+1. For each metric datum pushed, find alarms matching the namespace + metric name + dimensions.
+2. Collect datapoints within the evaluation window: `Period * EvaluationPeriods` seconds.
+3. Compute the statistic over those datapoints:
+   - `Average` -- mean of all values
+   - `Sum` -- sum of all values
+   - `Minimum` -- smallest value
+   - `Maximum` -- largest value
+   - `SampleCount` -- number of datapoints
+4. Compare against the alarm's threshold using the configured operator.
+5. Update alarm state to `"ALARM"` or `"OK"`.
+
+### Supported Comparison Operators
+
+- `GreaterThanThreshold`
+- `LessThanThreshold`
+- `GreaterThanOrEqualToThreshold`
+- `LessThanOrEqualToThreshold`
+
+### Alarm Actions and History
+
+Alarms support three types of action channels:
+
+- `AlarmActions` -- notification channel IDs to notify when state transitions to `ALARM`
+- `OKActions` -- channel IDs to notify when state transitions to `OK`
+- `InsufficientDataActions` -- channel IDs to notify on `INSUFFICIENT_DATA`
+
+Every state transition is recorded in alarm history, queryable via `GetAlarmHistory()`. Each entry includes the alarm name, timestamp, old state, new state, and a reason string.
+
+---
+
+## 3. IAM Policy Evaluation
+
+`CheckPermission(principal, action, resource)` evaluates real JSON policy documents against a request.
+
+### Evaluation Process
+
+1. Look up the principal (user or role) and collect all attached policy ARNs.
+2. For users, also collect policies attached to the user's groups.
+3. Parse each policy's JSON document into structured statements.
+4. For each statement, check if the action and resource match using `wildcardMatch()`.
+5. Apply standard IAM evaluation logic:
+   - Explicit `Deny` always overrides `Allow`.
+   - If no statement explicitly allows the action, the default is deny.
+   - `wildcardMatch()` supports `*` (match any sequence) and `?` (match single character).
+
+### Example Policy Document
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject"],
+      "Resource": ["arn:aws:s3:::my-bucket/*"]
+    },
+    {
+      "Effect": "Deny",
+      "Action": ["s3:DeleteObject"],
+      "Resource": ["*"]
+    }
+  ]
+}
+```
+
+With this policy attached, `CheckPermission("user1", "s3:GetObject", "arn:aws:s3:::my-bucket/file.txt")` returns `true`, while `CheckPermission("user1", "s3:DeleteObject", "arn:aws:s3:::my-bucket/file.txt")` returns `false`.
+
+---
+
+## 4. FIFO Message Deduplication
+
+FIFO queues enforce a 5-minute deduplication window to prevent duplicate message processing.
+
+### How It Works
+
+1. Each FIFO queue maintains a `deduplicationIndex map[string]time.Time` tracking when each `DeduplicationID` was last seen.
+2. When `SendMessage` is called with a `DeduplicationID`:
+   - If the same ID was seen within the last 5 minutes, the call returns the existing `MessageID` without creating a new message.
+   - If the ID has not been seen, or was last seen more than 5 minutes ago, a new message is created and the dedup index is updated.
+3. `SentAt time.Time` on message structs tracks when each message was sent.
+
+This behavior matches the real AWS SQS, Azure Service Bus, and GCP Pub/Sub FIFO semantics.
+
+### Deterministic Testing
+
+Use `config.FakeClock` to control time in dedup tests:
+
+```go
+clock := config.NewFakeClock(time.Now())
+aws := cloudemu.NewAWS(config.WithClock(clock))
+
+// First send -- creates message
+aws.SQS.SendMessage(ctx, input)
+
+// Second send within 5 minutes -- returns same MessageID
+aws.SQS.SendMessage(ctx, input)
+
+// Advance past dedup window
+clock.Advance(6 * time.Minute)
+
+// Third send -- creates new message
+aws.SQS.SendMessage(ctx, input)
+```
+
+---
+
+## 5. Database Features
+
+### Global Secondary Indexes (GSI)
+
+Tables support creating GSIs with a different partition key and optional sort key. Query operations can target a specific index by name via `QueryInput.IndexName`.
+
+| Operation | Description |
+|-----------|-------------|
+| `CreateIndex` | Add a GSI to an existing table |
+| `DeleteIndex` | Remove a GSI |
+| `DescribeIndex` | Get GSI status and key schema |
+| `ListIndexes` | List all GSIs on a table |
+
+### Numeric-Aware Comparisons
+
+The `compareValues(a, b string)` helper in each database mock tries `strconv.ParseFloat` on both values. If both parse as numbers, it performs numeric comparison. Otherwise it falls back to string comparison. This is used by all comparison operators in scan filters and query sort conditions.
+
+### Full Scan Operators
+
+Scan filters support: `=`, `!=`, `<`, `>`, `<=`, `>=`, `CONTAINS`, `BEGINS_WITH`
+
+Query sort key conditions support: `=`, `<`, `>`, `<=`, `>=`, `BEGINS_WITH`, `BETWEEN`
+
+### TTL (Time To Live)
+
+Tables can be configured with TTL on a specific attribute. The TTL configuration specifies an `AttributeName` that holds a Unix timestamp. Items past their TTL can be identified and cleaned up.
+
+### Streams / Change Feed
+
+Tables can enable streams that capture change events (`INSERT`, `MODIFY`, `REMOVE`). Each `StreamRecord` includes the event type, keys, old image, new image, and a sequence number. The stream view type controls what data is captured: `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`, or `KEYS_ONLY`.
+
+### Transactional Writes
+
+`TransactWriteItems` provides atomic batch writes -- a set of puts and deletes that either all succeed or all fail. This matches DynamoDB's `TransactWriteItems`, Cosmos DB's transactional batch, and Firestore's transactions.
+
+---
+
+## 6. Dead-Letter Queues
+
+Message queues support dead-letter queue (DLQ) configuration. When creating a queue, you can specify a `DeadLetterConfig` with:
+
+- `TargetQueueURL` -- the URL of the DLQ
+- `MaxReceiveCount` -- after this many receives without deletion, the message is moved to the DLQ
+
+This enables testing of poison message handling and retry exhaustion scenarios.
+
+```go
+// Create the DLQ first
+dlq, _ := aws.SQS.CreateQueue(ctx, driver.QueueConfig{Name: "my-dlq"})
+
+// Create the main queue with DLQ config
+aws.SQS.CreateQueue(ctx, driver.QueueConfig{
+    Name: "my-queue",
+    DeadLetterQueue: &driver.DeadLetterConfig{
+        TargetQueueURL:  dlq.URL,
+        MaxReceiveCount: 3,
+    },
+})
+```
+
+---
+
+## 7. Cost Tracking
+
+The `cost.Tracker` provides simulated cost estimation for cloud operations. It ships with default per-operation rates based on approximate real cloud pricing.
+
+### Default Rates (Subset)
+
+| Operation | Rate |
+|-----------|------|
+| `compute:RunInstances` | $0.0116/instance-hour |
+| `storage:PutObject` | $0.000005 |
+| `storage:GetObject` | $0.0000004 |
+| `database:PutItem` | $0.00000125 |
+| `database:GetItem` | $0.00000025 |
+| `serverless:Invoke` | $0.0000002 |
+| `messagequeue:SendMessage` | $0.0000004 |
+| `monitoring:PutMetricData` | $0.00001 |
+| `loadbalancer:CreateLoadBalancer` | $0.0225/hour |
+
+### API
+
+```go
+tracker := cost.New()
+
+// Record operations
+tracker.Record("storage", "PutObject", 100)
+tracker.Record("compute", "RunInstances", 2)
+
+// Query costs
+total := tracker.TotalCost()                    // total across all operations
+byService := tracker.CostByService()            // map[string]float64
+byOp := tracker.CostByOperation()               // map[string]float64
+all := tracker.AllCosts()                        // []ServiceCost with full detail
+
+// Override a rate
+tracker.SetRate("compute", "RunInstances", 0.0464)  // m5.xlarge pricing
+
+// Reset
+tracker.Reset()
+```
+
+---
+
+## 8. Portable API Cross-Cutting Concerns
+
+The portable API layer wraps every driver operation with five optional cross-cutting concerns. These are configured per service instance using functional options.
+
+### 1. Recording
+
+Captures every API call with service name, operation, input, output, error, and duration. Useful for test assertions like "verify that PutObject was called exactly twice."
+
+### 2. Metrics Collection
+
+Automatically records `calls_total` (counter), `call_duration` (histogram), and `errors_total` (counter) for every operation, labeled by service and operation name.
+
+### 3. Rate Limiting
+
+Token bucket rate limiter. When the bucket is exhausted, operations return a `Throttled` error without calling the underlying driver.
+
+### 4. Error Injection
+
+Inject errors into specific service/operation pairs with configurable policies:
+
+- `Always` -- fail every call
+- `NthCall(n)` -- fail every Nth call
+- `Probabilistic(p)` -- fail with probability p (0.0-1.0)
+- `Countdown(n)` -- fail the first n calls, then succeed
+
+### 5. Latency Simulation
+
+Add a fixed delay to every operation to simulate network latency.
+
+### Example
+
+```go
+import (
+    "time"
+    "errors"
+
+    "github.com/stackshy/cloudemu/storage"
+    "github.com/stackshy/cloudemu/recorder"
+    "github.com/stackshy/cloudemu/metrics"
+    "github.com/stackshy/cloudemu/ratelimit"
+    "github.com/stackshy/cloudemu/inject"
+    cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+rec := recorder.New()
+col := metrics.NewCollector()
+lim := ratelimit.New(100, 10, nil) // 100 req/s, burst 10
+inj := inject.NewInjector()
+
+// Fail every 5th GetObject call with a Throttled error
+inj.Set("storage", "GetObject",
+    cerrors.New(cerrors.Throttled, "simulated throttle"),
+    inject.NewNthCall(5),
+)
+
+bucket := storage.NewBucket(awsProvider.S3,
+    storage.WithRecorder(rec),
+    storage.WithMetrics(col),
+    storage.WithRateLimiter(lim),
+    storage.WithErrorInjection(inj),
+    storage.WithLatency(5 * time.Millisecond),
+)
+
+// Use bucket normally -- all cross-cutting concerns are applied
+bucket.PutObject(ctx, "my-bucket", "key", data, "text/plain", nil)
+
+// Assert calls were recorded
+calls := rec.CallsFor("storage", "PutObject")
+count := rec.CallCountFor("storage", "PutObject")
+
+// Check metrics
+allMetrics := col.All()
+```
+
+---
+
+## 9. Deterministic Time
+
+All time-dependent features in CloudEmu use the `config.Clock` interface rather than calling `time.Now()` directly. This allows tests to use `config.FakeClock` for fully deterministic behavior.
+
+### Clock Interface
+
+```go
+type Clock interface {
+    Now() time.Time
+    Since(t time.Time) time.Duration
+    After(d time.Duration) <-chan time.Time
+}
+```
+
+### FakeClock
+
+```go
+// Create a fake clock set to a specific time
+clock := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+
+// Create providers with the fake clock
+aws := cloudemu.NewAWS(config.WithClock(clock))
+
+// Operations use clock.Now() for timestamps
+aws.EC2.RunInstances(ctx, config, 1)
+
+// Advance time to test time-dependent behavior
+clock.Advance(5 * time.Minute)
+
+// Set to a specific time
+clock.Set(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+```
+
+### Where FakeClock Matters
+
+- **FIFO deduplication** -- The 5-minute dedup window is evaluated against `clock.Now()`. Advance the clock past 5 minutes to test dedup expiry.
+- **Alarm evaluation** -- Metric timestamps and evaluation windows use the clock. Control when alarms transition between states.
+- **Auto-metrics** -- Backfill datapoints are generated at 1-minute intervals from `clock.Now()`. FakeClock ensures predictable timestamps.
+- **TTL evaluation** -- Database TTL checks compare item timestamps against the clock.
+- **Resource timestamps** -- All `CreatedAt`, `LastModified`, and similar fields use the clock.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,410 @@
+# Getting Started
+
+## Installation
+
+```bash
+go get github.com/stackshy/cloudemu
+```
+
+Requires Go 1.25.0 or later.
+
+## Creating Providers
+
+CloudEmu provides three top-level factory functions, one per cloud provider. Each returns a provider struct with all 16 services ready to use.
+
+### AWS
+
+```go
+package main
+
+import (
+    "context"
+
+    "github.com/stackshy/cloudemu"
+)
+
+func main() {
+    ctx := context.Background()
+    aws := cloudemu.NewAWS()
+
+    // All 16 services are available:
+    // aws.S3, aws.EC2, aws.DynamoDB, aws.Lambda, aws.VPC,
+    // aws.CloudWatch, aws.IAM, aws.Route53, aws.ELB, aws.SQS,
+    // aws.ElastiCache, aws.SecretsManager, aws.CloudWatchLogs,
+    // aws.SNS, aws.ECR, aws.EventBridge
+    _ = ctx
+}
+```
+
+### Azure
+
+```go
+azure := cloudemu.NewAzure()
+
+// azure.BlobStorage, azure.VirtualMachines, azure.CosmosDB,
+// azure.Functions, azure.VNet, azure.Monitor, azure.IAM,
+// azure.DNS, azure.LB, azure.ServiceBus, azure.Cache,
+// azure.KeyVault, azure.LogAnalytics, azure.NotificationHubs,
+// azure.ACR, azure.EventGrid
+```
+
+### GCP
+
+```go
+gcp := cloudemu.NewGCP()
+
+// gcp.GCS, gcp.GCE, gcp.Firestore, gcp.CloudFunctions,
+// gcp.VPC, gcp.CloudMonitoring, gcp.IAM, gcp.CloudDNS,
+// gcp.LB, gcp.PubSub, gcp.Memorystore, gcp.SecretManager,
+// gcp.CloudLogging, gcp.FCM, gcp.ArtifactRegistry, gcp.Eventarc
+```
+
+## Basic Storage Example
+
+Create a bucket, store an object, and retrieve it.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/stackshy/cloudemu"
+)
+
+func main() {
+    ctx := context.Background()
+    aws := cloudemu.NewAWS()
+
+    // Create a bucket
+    err := aws.S3.CreateBucket(ctx, "my-bucket")
+    if err != nil {
+        panic(err)
+    }
+
+    // Store an object
+    data := []byte("Hello, CloudEmu!")
+    err = aws.S3.PutObject(ctx, "my-bucket", "greeting.txt", data, "text/plain", nil)
+    if err != nil {
+        panic(err)
+    }
+
+    // Retrieve it
+    obj, err := aws.S3.GetObject(ctx, "my-bucket", "greeting.txt")
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Content: %s\n", obj.Data)
+    fmt.Printf("Size: %d bytes\n", obj.Info.Size)
+    fmt.Printf("Content-Type: %s\n", obj.Info.ContentType)
+}
+```
+
+## Basic Compute Example
+
+Launch an instance, describe it, and terminate it.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/stackshy/cloudemu"
+    cdriver "github.com/stackshy/cloudemu/compute/driver"
+)
+
+func main() {
+    ctx := context.Background()
+    aws := cloudemu.NewAWS()
+
+    // Launch an instance
+    instances, err := aws.EC2.RunInstances(ctx, cdriver.InstanceConfig{
+        ImageID:      "ami-12345678",
+        InstanceType: "t2.micro",
+        Tags: map[string]string{
+            "Name": "my-server",
+            "Env":  "test",
+        },
+    }, 1)
+    if err != nil {
+        panic(err)
+    }
+
+    instanceID := instances[0].ID
+    fmt.Printf("Launched: %s (state: %s)\n", instanceID, instances[0].State)
+
+    // Describe instances
+    described, err := aws.EC2.DescribeInstances(ctx, []string{instanceID}, nil)
+    if err != nil {
+        panic(err)
+    }
+    fmt.Printf("State: %s, IP: %s\n", described[0].State, described[0].PrivateIP)
+
+    // Stop, then terminate
+    _ = aws.EC2.StopInstances(ctx, []string{instanceID})
+    _ = aws.EC2.TerminateInstances(ctx, []string{instanceID})
+}
+```
+
+## Basic Database Example
+
+Create a table, put an item, and get it back.
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/stackshy/cloudemu"
+    ddriver "github.com/stackshy/cloudemu/database/driver"
+)
+
+func main() {
+    ctx := context.Background()
+    aws := cloudemu.NewAWS()
+
+    // Create a table with partition key and sort key
+    err := aws.DynamoDB.CreateTable(ctx, ddriver.TableConfig{
+        Name:         "users",
+        PartitionKey: "userID",
+        SortKey:      "email",
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    // Put an item
+    err = aws.DynamoDB.PutItem(ctx, "users", map[string]any{
+        "userID": "u-001",
+        "email":  "alice@example.com",
+        "name":   "Alice",
+        "age":    30,
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    // Get the item
+    item, err := aws.DynamoDB.GetItem(ctx, "users", map[string]any{
+        "userID": "u-001",
+        "email":  "alice@example.com",
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Name: %s, Age: %v\n", item["name"], item["age"])
+
+    // Query by partition key with sort key condition
+    result, err := aws.DynamoDB.Query(ctx, ddriver.QueryInput{
+        Table: "users",
+        KeyCondition: ddriver.KeyCondition{
+            PartitionKey: "userID",
+            PartitionVal: "u-001",
+            SortOp:       "BEGINS_WITH",
+            SortVal:      "alice",
+        },
+    })
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("Found %d items\n", result.Count)
+}
+```
+
+## Configuration Options
+
+All three factory functions accept `config.Option` values for customization.
+
+```go
+import (
+    "time"
+
+    "github.com/stackshy/cloudemu"
+    "github.com/stackshy/cloudemu/config"
+)
+
+// Custom region
+aws := cloudemu.NewAWS(config.WithRegion("eu-west-1"))
+
+// Custom account ID
+aws = cloudemu.NewAWS(config.WithAccountID("987654321098"))
+
+// Custom project ID (primarily for GCP)
+gcp := cloudemu.NewGCP(config.WithProjectID("my-gcp-project"))
+
+// Simulated latency on all operations
+aws = cloudemu.NewAWS(config.WithLatency(10 * time.Millisecond))
+
+// Deterministic time for testing
+clock := config.NewFakeClock(time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC))
+aws = cloudemu.NewAWS(config.WithClock(clock))
+
+// Combine multiple options
+aws = cloudemu.NewAWS(
+    config.WithRegion("us-west-2"),
+    config.WithAccountID("111222333444"),
+    config.WithClock(clock),
+)
+```
+
+### Available Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `WithClock(clock)` | `RealClock{}` | Clock implementation for timestamps |
+| `WithRegion(region)` | `"us-east-1"` | Cloud region string |
+| `WithAccountID(id)` | `"123456789012"` | AWS account ID / Azure subscription ID |
+| `WithProjectID(id)` | `"mock-project"` | GCP project ID |
+| `WithLatency(d)` | `0` | Simulated latency added to all operations |
+
+## Error Handling
+
+CloudEmu uses canonical error codes from the `errors` package. Use the helper functions to check error types.
+
+```go
+import (
+    cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// Try to get a non-existent bucket
+_, err := aws.S3.GetObject(ctx, "nonexistent", "key")
+if cerrors.IsNotFound(err) {
+    fmt.Println("Object not found")
+}
+
+// Try to create a duplicate
+err = aws.S3.CreateBucket(ctx, "my-bucket")
+err = aws.S3.CreateBucket(ctx, "my-bucket")
+if cerrors.IsAlreadyExists(err) {
+    fmt.Println("Bucket already exists")
+}
+
+// Extract the error code
+code := cerrors.GetCode(err)
+switch code {
+case cerrors.NotFound:
+    // handle not found
+case cerrors.AlreadyExists:
+    // handle duplicate
+case cerrors.InvalidArgument:
+    // handle bad input
+case cerrors.FailedPrecondition:
+    // handle illegal state transition
+case cerrors.PermissionDenied:
+    // handle access denied
+case cerrors.Throttled:
+    // handle rate limit
+default:
+    // handle other errors
+}
+```
+
+## Using the Topology Engine
+
+The topology engine evaluates network reachability using the live state of compute, networking, and DNS services.
+
+```go
+aws := cloudemu.NewAWS()
+ctx := context.Background()
+
+// Set up network infrastructure
+vpc, _ := aws.VPC.CreateVPC(ctx, ndriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+subnet, _ := aws.VPC.CreateSubnet(ctx, ndriver.SubnetConfig{
+    VPCID:     vpc.ID,
+    CIDRBlock: "10.0.1.0/24",
+})
+sg, _ := aws.VPC.CreateSecurityGroup(ctx, ndriver.SecurityGroupConfig{
+    Name:  "web-sg",
+    VPCID: vpc.ID,
+})
+
+// Allow inbound HTTP
+aws.VPC.AddIngressRule(ctx, sg.ID, ndriver.SecurityRule{
+    Protocol: "tcp",
+    FromPort: 80,
+    ToPort:   80,
+    CIDR:     "10.0.0.0/16",
+})
+
+// Launch instances
+instances, _ := aws.EC2.RunInstances(ctx, cdriver.InstanceConfig{
+    ImageID:        "ami-12345678",
+    InstanceType:   "t2.micro",
+    SubnetID:       subnet.ID,
+    SecurityGroups: []string{sg.ID},
+}, 2)
+
+// Now use the topology engine to check connectivity
+// between instances, evaluate security groups, etc.
+```
+
+## Running Tests
+
+```bash
+# Compile all packages
+go build ./...
+
+# Run static analysis
+go vet ./...
+
+# Run all tests
+go test -v ./...
+
+# Run a specific test
+go test -v -run TestAWSS3Operations ./...
+
+# Run tests with coverage
+go test -covermode=atomic -coverprofile=coverage.out ./...
+go tool cover -func=coverage.out
+```
+
+### Writing Tests with CloudEmu
+
+```go
+package myapp_test
+
+import (
+    "context"
+    "testing"
+    "time"
+
+    "github.com/stackshy/cloudemu"
+    "github.com/stackshy/cloudemu/config"
+    sdriver "github.com/stackshy/cloudemu/storage/driver"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestStorageWorkflow(t *testing.T) {
+    clock := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+    aws := cloudemu.NewAWS(config.WithClock(clock))
+    ctx := context.Background()
+
+    // Create bucket
+    err := aws.S3.CreateBucket(ctx, "test-bucket")
+    require.NoError(t, err)
+
+    // Put object
+    err = aws.S3.PutObject(ctx, "test-bucket", "file.txt", []byte("data"), "text/plain", nil)
+    require.NoError(t, err)
+
+    // Verify object
+    obj, err := aws.S3.GetObject(ctx, "test-bucket", "file.txt")
+    require.NoError(t, err)
+    assert.Equal(t, []byte("data"), obj.Data)
+    assert.Equal(t, "text/plain", obj.Info.ContentType)
+
+    // List objects
+    result, err := aws.S3.ListObjects(ctx, "test-bucket", sdriver.ListOptions{})
+    require.NoError(t, err)
+    assert.Len(t, result.Objects, 1)
+}
+```

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,1000 @@
+# Provider Resource Reference
+
+This document lists every service and operation available in CloudEmu across all three cloud providers.
+
+## Master Table
+
+| # | Service Category | AWS | Azure | GCP |
+|---|-----------------|-----|-------|-----|
+| 1 | Storage | `s3` | `blobstorage` | `gcs` |
+| 2 | Compute | `ec2` | `virtualmachines` | `gce` |
+| 3 | Database | `dynamodb` | `cosmosdb` | `firestore` |
+| 4 | Serverless | `lambda` | `functions` | `cloudfunctions` |
+| 5 | Networking | `vpc` | `vnet` | `gcpvpc` |
+| 6 | Monitoring | `cloudwatch` | `azuremonitor` | `cloudmonitoring` |
+| 7 | IAM | `awsiam` | `azureiam` | `gcpiam` |
+| 8 | DNS | `route53` | `azuredns` | `clouddns` |
+| 9 | Load Balancer | `elb` | `azurelb` | `gcplb` |
+| 10 | Message Queue | `sqs` | `servicebus` | `pubsub` |
+| 11 | Cache | `elasticache` | `azurecache` | `memorystore` |
+| 12 | Secrets | `secretsmanager` | `keyvault` | `secretmanager` |
+| 13 | Logging | `cloudwatchlogs` | `loganalytics` | `cloudlogging` |
+| 14 | Notification | `sns` | `notificationhubs` | `fcm` |
+| 15 | Container Registry | `ecr` | `acr` | `artifactregistry` |
+| 16 | Event Bus | `eventbridge` | `eventgrid` | `eventarc` |
+
+---
+
+## 1. Storage
+
+**Driver interface:** `storage/driver/driver.go`
+**AWS:** S3 | **Azure:** Blob Storage | **GCP:** GCS
+
+### Bucket Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateBucket` | `(ctx, name) error` |
+| `DeleteBucket` | `(ctx, name) error` |
+| `ListBuckets` | `(ctx) ([]BucketInfo, error)` |
+
+### Object Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutObject` | `(ctx, bucket, key, data, contentType, metadata) error` |
+| `GetObject` | `(ctx, bucket, key) (*Object, error)` |
+| `DeleteObject` | `(ctx, bucket, key) error` |
+| `HeadObject` | `(ctx, bucket, key) (*ObjectInfo, error)` |
+| `ListObjects` | `(ctx, bucket, opts) (*ListResult, error)` |
+| `CopyObject` | `(ctx, dstBucket, dstKey, src) error` |
+
+### Presigned URLs
+
+| Operation | Signature |
+|-----------|-----------|
+| `GeneratePresignedURL` | `(ctx, req) (*PresignedURL, error)` |
+
+### Lifecycle Policies
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutLifecycleConfig` | `(ctx, bucket, config) error` |
+| `GetLifecycleConfig` | `(ctx, bucket) (*LifecycleConfig, error)` |
+| `EvaluateLifecycle` | `(ctx, bucket) ([]string, error)` |
+
+### Multipart Uploads
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateMultipartUpload` | `(ctx, bucket, key, contentType) (*MultipartUpload, error)` |
+| `UploadPart` | `(ctx, bucket, key, uploadID, partNumber, data) (*UploadPart, error)` |
+| `CompleteMultipartUpload` | `(ctx, bucket, key, uploadID, parts) error` |
+| `AbortMultipartUpload` | `(ctx, bucket, key, uploadID) error` |
+| `ListMultipartUploads` | `(ctx, bucket) ([]MultipartUpload, error)` |
+
+### Versioning
+
+| Operation | Signature |
+|-----------|-----------|
+| `SetBucketVersioning` | `(ctx, bucket, enabled) error` |
+| `GetBucketVersioning` | `(ctx, bucket) (bool, error)` |
+
+### Bucket Policy
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutBucketPolicy` | `(ctx, bucket, policy) error` |
+| `GetBucketPolicy` | `(ctx, bucket) (*BucketPolicy, error)` |
+| `DeleteBucketPolicy` | `(ctx, bucket) error` |
+
+### CORS
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutCORSConfig` | `(ctx, bucket, config) error` |
+| `GetCORSConfig` | `(ctx, bucket) (*CORSConfig, error)` |
+| `DeleteCORSConfig` | `(ctx, bucket) error` |
+
+### Encryption
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutEncryptionConfig` | `(ctx, bucket, config) error` |
+| `GetEncryptionConfig` | `(ctx, bucket) (*EncryptionConfig, error)` |
+
+### Object Tagging
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutObjectTagging` | `(ctx, bucket, key, tags) error` |
+| `GetObjectTagging` | `(ctx, bucket, key) (map[string]string, error)` |
+| `DeleteObjectTagging` | `(ctx, bucket, key) error` |
+
+### Bucket Tagging
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutBucketTagging` | `(ctx, bucket, tags) error` |
+| `GetBucketTagging` | `(ctx, bucket) (map[string]string, error)` |
+| `DeleteBucketTagging` | `(ctx, bucket) error` |
+
+**Total: 33 operations**
+
+---
+
+## 2. Compute
+
+**Driver interface:** `compute/driver/driver.go`
+**AWS:** EC2 | **Azure:** Virtual Machines | **GCP:** GCE
+
+### Instance Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `RunInstances` | `(ctx, config, count) ([]Instance, error)` |
+| `StartInstances` | `(ctx, instanceIDs) error` |
+| `StopInstances` | `(ctx, instanceIDs) error` |
+| `RebootInstances` | `(ctx, instanceIDs) error` |
+| `TerminateInstances` | `(ctx, instanceIDs) error` |
+| `DescribeInstances` | `(ctx, instanceIDs, filters) ([]Instance, error)` |
+| `ModifyInstance` | `(ctx, instanceID, input) error` |
+
+### Auto-Scaling Groups (ASG)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateAutoScalingGroup` | `(ctx, config) (*AutoScalingGroup, error)` |
+| `DeleteAutoScalingGroup` | `(ctx, name, forceDelete) error` |
+| `GetAutoScalingGroup` | `(ctx, name) (*AutoScalingGroup, error)` |
+| `ListAutoScalingGroups` | `(ctx) ([]AutoScalingGroup, error)` |
+| `UpdateAutoScalingGroup` | `(ctx, name, desired, minSize, maxSize) error` |
+| `SetDesiredCapacity` | `(ctx, name, desired) error` |
+
+### Scaling Policies
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutScalingPolicy` | `(ctx, policy) error` |
+| `DeleteScalingPolicy` | `(ctx, asgName, policyName) error` |
+| `ExecuteScalingPolicy` | `(ctx, asgName, policyName) error` |
+
+### Spot/Preemptible Instances
+
+| Operation | Signature |
+|-----------|-----------|
+| `RequestSpotInstances` | `(ctx, config) ([]SpotInstanceRequest, error)` |
+| `CancelSpotRequests` | `(ctx, requestIDs) error` |
+| `DescribeSpotRequests` | `(ctx, requestIDs) ([]SpotInstanceRequest, error)` |
+
+### Launch Templates
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateLaunchTemplate` | `(ctx, config) (*LaunchTemplate, error)` |
+| `DeleteLaunchTemplate` | `(ctx, name) error` |
+| `GetLaunchTemplate` | `(ctx, name) (*LaunchTemplate, error)` |
+| `ListLaunchTemplates` | `(ctx) ([]LaunchTemplate, error)` |
+
+### Volumes
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateVolume` | `(ctx, config) (*VolumeInfo, error)` |
+| `DeleteVolume` | `(ctx, id) error` |
+| `DescribeVolumes` | `(ctx, ids) ([]VolumeInfo, error)` |
+| `AttachVolume` | `(ctx, volumeID, instanceID, device) error` |
+| `DetachVolume` | `(ctx, volumeID) error` |
+
+### Snapshots
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSnapshot` | `(ctx, config) (*SnapshotInfo, error)` |
+| `DeleteSnapshot` | `(ctx, id) error` |
+| `DescribeSnapshots` | `(ctx, ids) ([]SnapshotInfo, error)` |
+
+### Images
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateImage` | `(ctx, config) (*ImageInfo, error)` |
+| `DeregisterImage` | `(ctx, id) error` |
+| `DescribeImages` | `(ctx, ids) ([]ImageInfo, error)` |
+
+### Key Pairs
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateKeyPair` | `(ctx, config) (*KeyPairInfo, error)` |
+| `DeleteKeyPair` | `(ctx, name) error` |
+| `DescribeKeyPairs` | `(ctx, names) ([]KeyPairInfo, error)` |
+
+**Total: 35 operations**
+
+---
+
+## 3. Database
+
+**Driver interface:** `database/driver/driver.go`
+**AWS:** DynamoDB | **Azure:** Cosmos DB | **GCP:** Firestore
+
+### Table Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateTable` | `(ctx, config) error` |
+| `DeleteTable` | `(ctx, name) error` |
+| `DescribeTable` | `(ctx, name) (*TableConfig, error)` |
+| `ListTables` | `(ctx) ([]string, error)` |
+
+### Item Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutItem` | `(ctx, table, item) error` |
+| `GetItem` | `(ctx, table, key) (map[string]any, error)` |
+| `UpdateItem` | `(ctx, input) (map[string]any, error)` |
+| `DeleteItem` | `(ctx, table, key) error` |
+| `Query` | `(ctx, input) (*QueryResult, error)` |
+| `Scan` | `(ctx, input) (*QueryResult, error)` |
+
+### Batch Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `BatchPutItems` | `(ctx, table, items) error` |
+| `BatchGetItems` | `(ctx, table, keys) ([]map[string]any, error)` |
+
+### TTL
+
+| Operation | Signature |
+|-----------|-----------|
+| `UpdateTTL` | `(ctx, table, config) error` |
+| `DescribeTTL` | `(ctx, table) (*TTLConfig, error)` |
+
+### Streams / Change Feed
+
+| Operation | Signature |
+|-----------|-----------|
+| `UpdateStreamConfig` | `(ctx, table, config) error` |
+| `GetStreamRecords` | `(ctx, table, limit, token) (*StreamIterator, error)` |
+
+### Transactions
+
+| Operation | Signature |
+|-----------|-----------|
+| `TransactWriteItems` | `(ctx, table, puts, deletes) error` |
+
+### Global Secondary Indexes (GSI)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateIndex` | `(ctx, table, config) (*IndexInfo, error)` |
+| `DeleteIndex` | `(ctx, table, indexName) error` |
+| `DescribeIndex` | `(ctx, table, indexName) (*IndexInfo, error)` |
+| `ListIndexes` | `(ctx, table) ([]IndexInfo, error)` |
+
+**Total: 21 operations**
+
+---
+
+## 4. Serverless
+
+**Driver interface:** `serverless/driver/driver.go`
+**AWS:** Lambda | **Azure:** Functions | **GCP:** Cloud Functions
+
+### Function Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateFunction` | `(ctx, config) (*FunctionInfo, error)` |
+| `DeleteFunction` | `(ctx, name) error` |
+| `GetFunction` | `(ctx, name) (*FunctionInfo, error)` |
+| `ListFunctions` | `(ctx) ([]FunctionInfo, error)` |
+| `UpdateFunction` | `(ctx, name, config) (*FunctionInfo, error)` |
+| `Invoke` | `(ctx, input) (*InvokeOutput, error)` |
+| `RegisterHandler` | `(name, handler)` |
+
+### Versions
+
+| Operation | Signature |
+|-----------|-----------|
+| `PublishVersion` | `(ctx, functionName, description) (*FunctionVersion, error)` |
+| `ListVersions` | `(ctx, functionName) ([]FunctionVersion, error)` |
+
+### Aliases
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateAlias` | `(ctx, config) (*Alias, error)` |
+| `UpdateAlias` | `(ctx, config) (*Alias, error)` |
+| `DeleteAlias` | `(ctx, functionName, aliasName) error` |
+| `GetAlias` | `(ctx, functionName, aliasName) (*Alias, error)` |
+| `ListAliases` | `(ctx, functionName) ([]Alias, error)` |
+
+### Layers
+
+| Operation | Signature |
+|-----------|-----------|
+| `PublishLayerVersion` | `(ctx, config) (*LayerVersion, error)` |
+| `GetLayerVersion` | `(ctx, name, version) (*LayerVersion, error)` |
+| `ListLayerVersions` | `(ctx, name) ([]LayerVersion, error)` |
+| `DeleteLayerVersion` | `(ctx, name, version) error` |
+| `ListLayers` | `(ctx) ([]LayerVersion, error)` |
+
+### Concurrency
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutFunctionConcurrency` | `(ctx, config) error` |
+| `GetFunctionConcurrency` | `(ctx, functionName) (*ConcurrencyConfig, error)` |
+| `DeleteFunctionConcurrency` | `(ctx, functionName) error` |
+
+### Event Source Mappings
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateEventSourceMapping` | `(ctx, config) (*EventSourceMappingInfo, error)` |
+| `DeleteEventSourceMapping` | `(ctx, uuid) error` |
+| `GetEventSourceMapping` | `(ctx, uuid) (*EventSourceMappingInfo, error)` |
+| `ListEventSourceMappings` | `(ctx, functionName) ([]EventSourceMappingInfo, error)` |
+| `UpdateEventSourceMapping` | `(ctx, uuid, config) (*EventSourceMappingInfo, error)` |
+
+**Total: 26 operations**
+
+---
+
+## 5. Networking
+
+**Driver interface:** `networking/driver/driver.go`
+**AWS:** VPC | **Azure:** VNet | **GCP:** GCP VPC
+
+### VPC Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateVPC` | `(ctx, config) (*VPCInfo, error)` |
+| `DeleteVPC` | `(ctx, id) error` |
+| `DescribeVPCs` | `(ctx, ids) ([]VPCInfo, error)` |
+
+### Subnets
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSubnet` | `(ctx, config) (*SubnetInfo, error)` |
+| `DeleteSubnet` | `(ctx, id) error` |
+| `DescribeSubnets` | `(ctx, ids) ([]SubnetInfo, error)` |
+
+### Security Groups
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSecurityGroup` | `(ctx, config) (*SecurityGroupInfo, error)` |
+| `DeleteSecurityGroup` | `(ctx, id) error` |
+| `DescribeSecurityGroups` | `(ctx, ids) ([]SecurityGroupInfo, error)` |
+| `AddIngressRule` | `(ctx, groupID, rule) error` |
+| `AddEgressRule` | `(ctx, groupID, rule) error` |
+| `RemoveIngressRule` | `(ctx, groupID, rule) error` |
+| `RemoveEgressRule` | `(ctx, groupID, rule) error` |
+
+### VPC Peering
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreatePeeringConnection` | `(ctx, config) (*PeeringConnection, error)` |
+| `AcceptPeeringConnection` | `(ctx, peeringID) error` |
+| `RejectPeeringConnection` | `(ctx, peeringID) error` |
+| `DeletePeeringConnection` | `(ctx, peeringID) error` |
+| `DescribePeeringConnections` | `(ctx, ids) ([]PeeringConnection, error)` |
+
+### NAT Gateways
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateNATGateway` | `(ctx, config) (*NATGateway, error)` |
+| `DeleteNATGateway` | `(ctx, id) error` |
+| `DescribeNATGateways` | `(ctx, ids) ([]NATGateway, error)` |
+
+### Flow Logs
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateFlowLog` | `(ctx, config) (*FlowLog, error)` |
+| `DeleteFlowLog` | `(ctx, id) error` |
+| `DescribeFlowLogs` | `(ctx, ids) ([]FlowLog, error)` |
+| `GetFlowLogRecords` | `(ctx, flowLogID, limit) ([]FlowLogRecord, error)` |
+
+### Route Tables
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateRouteTable` | `(ctx, config) (*RouteTable, error)` |
+| `DeleteRouteTable` | `(ctx, id) error` |
+| `DescribeRouteTables` | `(ctx, ids) ([]RouteTable, error)` |
+| `CreateRoute` | `(ctx, routeTableID, destinationCIDR, targetID, targetType) error` |
+| `DeleteRoute` | `(ctx, routeTableID, destinationCIDR) error` |
+
+### Network ACLs
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateNetworkACL` | `(ctx, vpcID, tags) (*NetworkACL, error)` |
+| `DeleteNetworkACL` | `(ctx, id) error` |
+| `DescribeNetworkACLs` | `(ctx, ids) ([]NetworkACL, error)` |
+| `AddNetworkACLRule` | `(ctx, aclID, rule) error` |
+| `RemoveNetworkACLRule` | `(ctx, aclID, ruleNumber, egress) error` |
+
+### Internet Gateways (IGW)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateInternetGateway` | `(ctx, config) (*InternetGateway, error)` |
+| `DeleteInternetGateway` | `(ctx, id) error` |
+| `DescribeInternetGateways` | `(ctx, ids) ([]InternetGateway, error)` |
+| `AttachInternetGateway` | `(ctx, igwID, vpcID) error` |
+| `DetachInternetGateway` | `(ctx, igwID, vpcID) error` |
+
+### Elastic IPs (EIP)
+
+| Operation | Signature |
+|-----------|-----------|
+| `AllocateAddress` | `(ctx, config) (*ElasticIP, error)` |
+| `ReleaseAddress` | `(ctx, allocationID) error` |
+| `DescribeAddresses` | `(ctx, ids) ([]ElasticIP, error)` |
+| `AssociateAddress` | `(ctx, allocationID, instanceID) (string, error)` |
+| `DisassociateAddress` | `(ctx, associationID) error` |
+
+### Route Table Associations
+
+| Operation | Signature |
+|-----------|-----------|
+| `AssociateRouteTable` | `(ctx, routeTableID, subnetID) (*RouteTableAssociation, error)` |
+| `DisassociateRouteTable` | `(ctx, associationID) error` |
+
+### VPC Endpoints
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateVPCEndpoint` | `(ctx, config) (*VPCEndpoint, error)` |
+| `DeleteVPCEndpoint` | `(ctx, id) error` |
+| `DescribeVPCEndpoints` | `(ctx, ids) ([]VPCEndpoint, error)` |
+| `ModifyVPCEndpoint` | `(ctx, id, config) (*VPCEndpoint, error)` |
+
+**Total: 47 operations**
+
+---
+
+## 6. Monitoring
+
+**Driver interface:** `monitoring/driver/driver.go`
+**AWS:** CloudWatch | **Azure:** Azure Monitor | **GCP:** Cloud Monitoring
+
+### Metric Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutMetricData` | `(ctx, data) error` |
+| `GetMetricData` | `(ctx, input) (*MetricDataResult, error)` |
+| `ListMetrics` | `(ctx, namespace) ([]string, error)` |
+
+### Alarm Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateAlarm` | `(ctx, config) error` |
+| `DeleteAlarm` | `(ctx, name) error` |
+| `DescribeAlarms` | `(ctx, names) ([]AlarmInfo, error)` |
+| `SetAlarmState` | `(ctx, name, state, reason) error` |
+
+### Notification Channels
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateNotificationChannel` | `(ctx, config) (*NotificationChannelInfo, error)` |
+| `DeleteNotificationChannel` | `(ctx, id) error` |
+| `GetNotificationChannel` | `(ctx, id) (*NotificationChannelInfo, error)` |
+| `ListNotificationChannels` | `(ctx) ([]NotificationChannelInfo, error)` |
+
+### Alarm History
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetAlarmHistory` | `(ctx, alarmName, limit) ([]AlarmHistoryEntry, error)` |
+
+**Total: 12 operations**
+
+---
+
+## 7. IAM
+
+**Driver interface:** `iam/driver/driver.go`
+**AWS:** IAM | **Azure:** Azure IAM | **GCP:** GCP IAM
+
+### Users
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateUser` | `(ctx, config) (*UserInfo, error)` |
+| `DeleteUser` | `(ctx, name) error` |
+| `GetUser` | `(ctx, name) (*UserInfo, error)` |
+| `ListUsers` | `(ctx) ([]UserInfo, error)` |
+
+### Roles
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateRole` | `(ctx, config) (*RoleInfo, error)` |
+| `DeleteRole` | `(ctx, name) error` |
+| `GetRole` | `(ctx, name) (*RoleInfo, error)` |
+| `ListRoles` | `(ctx) ([]RoleInfo, error)` |
+
+### Policies
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreatePolicy` | `(ctx, config) (*PolicyInfo, error)` |
+| `DeletePolicy` | `(ctx, arn) error` |
+| `GetPolicy` | `(ctx, arn) (*PolicyInfo, error)` |
+| `ListPolicies` | `(ctx) ([]PolicyInfo, error)` |
+
+### Policy Attachments
+
+| Operation | Signature |
+|-----------|-----------|
+| `AttachUserPolicy` | `(ctx, userName, policyARN) error` |
+| `DetachUserPolicy` | `(ctx, userName, policyARN) error` |
+| `AttachRolePolicy` | `(ctx, roleName, policyARN) error` |
+| `DetachRolePolicy` | `(ctx, roleName, policyARN) error` |
+| `ListAttachedUserPolicies` | `(ctx, userName) ([]string, error)` |
+| `ListAttachedRolePolicies` | `(ctx, roleName) ([]string, error)` |
+
+### Permission Evaluation
+
+| Operation | Signature |
+|-----------|-----------|
+| `CheckPermission` | `(ctx, principal, action, resource) (bool, error)` |
+
+### Groups
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateGroup` | `(ctx, config) (*GroupInfo, error)` |
+| `DeleteGroup` | `(ctx, name) error` |
+| `GetGroup` | `(ctx, name) (*GroupInfo, error)` |
+| `ListGroups` | `(ctx) ([]GroupInfo, error)` |
+| `AddUserToGroup` | `(ctx, userName, groupName) error` |
+| `RemoveUserFromGroup` | `(ctx, userName, groupName) error` |
+| `ListGroupsForUser` | `(ctx, userName) ([]GroupInfo, error)` |
+
+### Access Keys
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateAccessKey` | `(ctx, config) (*AccessKeyInfo, error)` |
+| `DeleteAccessKey` | `(ctx, userName, accessKeyID) error` |
+| `ListAccessKeys` | `(ctx, userName) ([]AccessKeyInfo, error)` |
+
+### Instance Profiles
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateInstanceProfile` | `(ctx, config) (*InstanceProfileInfo, error)` |
+| `DeleteInstanceProfile` | `(ctx, name) error` |
+| `GetInstanceProfile` | `(ctx, name) (*InstanceProfileInfo, error)` |
+| `ListInstanceProfiles` | `(ctx) ([]InstanceProfileInfo, error)` |
+| `AddRoleToInstanceProfile` | `(ctx, profileName, roleName) error` |
+| `RemoveRoleFromInstanceProfile` | `(ctx, profileName, roleName) error` |
+
+**Total: 35 operations**
+
+---
+
+## 8. DNS
+
+**Driver interface:** `dns/driver/driver.go`
+**AWS:** Route 53 | **Azure:** Azure DNS | **GCP:** Cloud DNS
+
+### Zone Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateZone` | `(ctx, config) (*ZoneInfo, error)` |
+| `DeleteZone` | `(ctx, id) error` |
+| `GetZone` | `(ctx, id) (*ZoneInfo, error)` |
+| `ListZones` | `(ctx) ([]ZoneInfo, error)` |
+
+### Record Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateRecord` | `(ctx, config) (*RecordInfo, error)` |
+| `DeleteRecord` | `(ctx, zoneID, name, recordType) error` |
+| `GetRecord` | `(ctx, zoneID, name, recordType) (*RecordInfo, error)` |
+| `ListRecords` | `(ctx, zoneID) ([]RecordInfo, error)` |
+| `UpdateRecord` | `(ctx, config) (*RecordInfo, error)` |
+
+### Health Checks
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateHealthCheck` | `(ctx, config) (*HealthCheckInfo, error)` |
+| `DeleteHealthCheck` | `(ctx, id) error` |
+| `GetHealthCheck` | `(ctx, id) (*HealthCheckInfo, error)` |
+| `ListHealthChecks` | `(ctx) ([]HealthCheckInfo, error)` |
+| `UpdateHealthCheck` | `(ctx, id, config) (*HealthCheckInfo, error)` |
+| `SetHealthCheckStatus` | `(ctx, id, status) error` |
+
+**Total: 15 operations**
+
+---
+
+## 9. Load Balancer
+
+**Driver interface:** `loadbalancer/driver/driver.go`
+**AWS:** ELB | **Azure:** Azure LB | **GCP:** GCP LB
+
+### Load Balancer Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateLoadBalancer` | `(ctx, config) (*LBInfo, error)` |
+| `DeleteLoadBalancer` | `(ctx, arn) error` |
+| `DescribeLoadBalancers` | `(ctx, arns) ([]LBInfo, error)` |
+
+### Target Groups
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateTargetGroup` | `(ctx, config) (*TargetGroupInfo, error)` |
+| `DeleteTargetGroup` | `(ctx, arn) error` |
+| `DescribeTargetGroups` | `(ctx, arns) ([]TargetGroupInfo, error)` |
+
+### Listeners
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateListener` | `(ctx, config) (*ListenerInfo, error)` |
+| `DeleteListener` | `(ctx, arn) error` |
+| `DescribeListeners` | `(ctx, lbARN) ([]ListenerInfo, error)` |
+| `ModifyListener` | `(ctx, input) error` |
+
+### Rules
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateRule` | `(ctx, config) (*RuleInfo, error)` |
+| `DeleteRule` | `(ctx, ruleARN) error` |
+| `DescribeRules` | `(ctx, listenerARN) ([]RuleInfo, error)` |
+
+### Attributes
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetLBAttributes` | `(ctx, lbARN) (*LBAttributes, error)` |
+| `PutLBAttributes` | `(ctx, lbARN, attrs) error` |
+
+### Targets
+
+| Operation | Signature |
+|-----------|-----------|
+| `RegisterTargets` | `(ctx, targetGroupARN, targets) error` |
+| `DeregisterTargets` | `(ctx, targetGroupARN, targets) error` |
+| `DescribeTargetHealth` | `(ctx, targetGroupARN) ([]TargetHealth, error)` |
+| `SetTargetHealth` | `(ctx, targetGroupARN, targetID, state) error` |
+
+**Total: 19 operations**
+
+---
+
+## 10. Message Queue
+
+**Driver interface:** `messagequeue/driver/driver.go`
+**AWS:** SQS | **Azure:** Service Bus | **GCP:** Pub/Sub
+
+### Queue Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateQueue` | `(ctx, config) (*QueueInfo, error)` |
+| `DeleteQueue` | `(ctx, url) error` |
+| `GetQueueInfo` | `(ctx, url) (*QueueInfo, error)` |
+| `ListQueues` | `(ctx, prefix) ([]QueueInfo, error)` |
+
+### Message Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `SendMessage` | `(ctx, input) (*SendMessageOutput, error)` |
+| `ReceiveMessages` | `(ctx, input) ([]Message, error)` |
+| `DeleteMessage` | `(ctx, queueURL, receiptHandle) error` |
+| `ChangeVisibility` | `(ctx, queueURL, receiptHandle, timeout) error` |
+
+### Batch Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `SendMessageBatch` | `(ctx, queue, entries) (*BatchSendResult, error)` |
+| `DeleteMessageBatch` | `(ctx, queue, entries) (*BatchDeleteResult, error)` |
+
+### Enhanced Receive
+
+| Operation | Signature |
+|-----------|-----------|
+| `ReceiveMessagesWithOptions` | `(ctx, queue, opts) ([]Message, error)` |
+
+### Queue Attributes
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetQueueAttributes` | `(ctx, queue) (*QueueAttributes, error)` |
+| `SetQueueAttributes` | `(ctx, queue, attrs) error` |
+
+### Purge
+
+| Operation | Signature |
+|-----------|-----------|
+| `PurgeQueue` | `(ctx, queue) error` |
+
+**Total: 14 operations**
+
+---
+
+## 11. Cache
+
+**Driver interface:** `cache/driver/driver.go`
+**AWS:** ElastiCache | **Azure:** Azure Cache | **GCP:** Memorystore
+
+### Cache Instance Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateCache` | `(ctx, config) (*CacheInfo, error)` |
+| `DeleteCache` | `(ctx, name) error` |
+| `GetCache` | `(ctx, name) (*CacheInfo, error)` |
+| `ListCaches` | `(ctx) ([]CacheInfo, error)` |
+
+### Data Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `Set` | `(ctx, cacheName, key, value, ttl) error` |
+| `Get` | `(ctx, cacheName, key) (*Item, error)` |
+| `Delete` | `(ctx, cacheName, key) error` |
+| `Keys` | `(ctx, cacheName, pattern) ([]string, error)` |
+| `FlushAll` | `(ctx, cacheName) error` |
+
+### TTL Management
+
+| Operation | Signature |
+|-----------|-----------|
+| `Expire` | `(ctx, cacheName, key, ttl) error` |
+| `GetTTL` | `(ctx, cacheName, key) (time.Duration, error)` |
+| `Persist` | `(ctx, cacheName, key) error` |
+
+### Atomic Counters
+
+| Operation | Signature |
+|-----------|-----------|
+| `Incr` | `(ctx, cacheName, key) (int64, error)` |
+| `IncrBy` | `(ctx, cacheName, key, delta) (int64, error)` |
+| `Decr` | `(ctx, cacheName, key) (int64, error)` |
+| `DecrBy` | `(ctx, cacheName, key, delta) (int64, error)` |
+
+**Total: 16 operations**
+
+---
+
+## 12. Secrets
+
+**Driver interface:** `secrets/driver/driver.go`
+**AWS:** Secrets Manager | **Azure:** Key Vault | **GCP:** Secret Manager
+
+### Secret Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSecret` | `(ctx, config, value) (*SecretInfo, error)` |
+| `DeleteSecret` | `(ctx, name) error` |
+| `GetSecret` | `(ctx, name) (*SecretInfo, error)` |
+| `ListSecrets` | `(ctx) ([]SecretInfo, error)` |
+
+### Secret Versions
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutSecretValue` | `(ctx, name, value) (*SecretVersion, error)` |
+| `GetSecretValue` | `(ctx, name, versionID) (*SecretVersion, error)` |
+| `ListSecretVersions` | `(ctx, name) ([]SecretVersion, error)` |
+
+**Total: 7 operations**
+
+---
+
+## 13. Logging
+
+**Driver interface:** `logging/driver/driver.go`
+**AWS:** CloudWatch Logs | **Azure:** Log Analytics | **GCP:** Cloud Logging
+
+### Log Group Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateLogGroup` | `(ctx, config) (*LogGroupInfo, error)` |
+| `DeleteLogGroup` | `(ctx, name) error` |
+| `GetLogGroup` | `(ctx, name) (*LogGroupInfo, error)` |
+| `ListLogGroups` | `(ctx) ([]LogGroupInfo, error)` |
+
+### Log Stream Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateLogStream` | `(ctx, logGroup, streamName) (*LogStreamInfo, error)` |
+| `DeleteLogStream` | `(ctx, logGroup, streamName) error` |
+| `ListLogStreams` | `(ctx, logGroup) ([]LogStreamInfo, error)` |
+
+### Log Event Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutLogEvents` | `(ctx, logGroup, streamName, events) error` |
+| `GetLogEvents` | `(ctx, input) ([]LogEvent, error)` |
+
+### Filtering and Metric Filters
+
+| Operation | Signature |
+|-----------|-----------|
+| `FilterLogEvents` | `(ctx, input) ([]FilteredLogEvent, error)` |
+| `PutMetricFilter` | `(ctx, config) error` |
+| `DeleteMetricFilter` | `(ctx, logGroup, filterName) error` |
+| `DescribeMetricFilters` | `(ctx, logGroup) ([]MetricFilterInfo, error)` |
+
+**Total: 13 operations**
+
+---
+
+## 14. Notification
+
+**Driver interface:** `notification/driver/driver.go`
+**AWS:** SNS | **Azure:** Notification Hubs | **GCP:** FCM
+
+### Topic Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateTopic` | `(ctx, config) (*TopicInfo, error)` |
+| `DeleteTopic` | `(ctx, id) error` |
+| `GetTopic` | `(ctx, id) (*TopicInfo, error)` |
+| `ListTopics` | `(ctx) ([]TopicInfo, error)` |
+
+### Subscription Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `Subscribe` | `(ctx, config) (*SubscriptionInfo, error)` |
+| `Unsubscribe` | `(ctx, subscriptionID) error` |
+| `ListSubscriptions` | `(ctx, topicID) ([]SubscriptionInfo, error)` |
+
+### Publishing
+
+| Operation | Signature |
+|-----------|-----------|
+| `Publish` | `(ctx, input) (*PublishOutput, error)` |
+
+**Total: 8 operations**
+
+---
+
+## 15. Container Registry
+
+**Driver interface:** `containerregistry/driver/driver.go`
+**AWS:** ECR | **Azure:** ACR | **GCP:** Artifact Registry
+
+### Repository Management
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateRepository` | `(ctx, config) (*Repository, error)` |
+| `DeleteRepository` | `(ctx, name, force) error` |
+| `GetRepository` | `(ctx, name) (*Repository, error)` |
+| `ListRepositories` | `(ctx) ([]Repository, error)` |
+
+### Image Management
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutImage` | `(ctx, manifest) (*ImageDetail, error)` |
+| `GetImage` | `(ctx, repository, reference) (*ImageDetail, error)` |
+| `ListImages` | `(ctx, repository) ([]ImageDetail, error)` |
+| `DeleteImage` | `(ctx, repository, reference) error` |
+| `TagImage` | `(ctx, repository, sourceRef, targetTag) error` |
+
+### Lifecycle Policies
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutLifecyclePolicy` | `(ctx, repository, policy) error` |
+| `GetLifecyclePolicy` | `(ctx, repository) (*LifecyclePolicy, error)` |
+| `EvaluateLifecyclePolicy` | `(ctx, repository) ([]string, error)` |
+
+### Image Scanning
+
+| Operation | Signature |
+|-----------|-----------|
+| `StartImageScan` | `(ctx, repository, reference) (*ScanResult, error)` |
+| `GetImageScanResults` | `(ctx, repository, reference) (*ScanResult, error)` |
+
+**Total: 14 operations**
+
+---
+
+## 16. Event Bus
+
+**Driver interface:** `eventbus/driver/driver.go`
+**AWS:** EventBridge | **Azure:** Event Grid | **GCP:** Eventarc
+
+### Bus Management
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateEventBus` | `(ctx, config) (*EventBusInfo, error)` |
+| `DeleteEventBus` | `(ctx, name) error` |
+| `GetEventBus` | `(ctx, name) (*EventBusInfo, error)` |
+| `ListEventBuses` | `(ctx) ([]EventBusInfo, error)` |
+
+### Rule Management
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutRule` | `(ctx, config) (*Rule, error)` |
+| `DeleteRule` | `(ctx, eventBus, ruleName) error` |
+| `GetRule` | `(ctx, eventBus, ruleName) (*Rule, error)` |
+| `ListRules` | `(ctx, eventBus) ([]Rule, error)` |
+| `EnableRule` | `(ctx, eventBus, ruleName) error` |
+| `DisableRule` | `(ctx, eventBus, ruleName) error` |
+
+### Target Management
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutTargets` | `(ctx, eventBus, ruleName, targets) error` |
+| `RemoveTargets` | `(ctx, eventBus, ruleName, targetIDs) error` |
+| `ListTargets` | `(ctx, eventBus, ruleName) ([]Target, error)` |
+
+### Event Publishing
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutEvents` | `(ctx, events) (*PublishResult, error)` |
+
+### Event History
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetEventHistory` | `(ctx, eventBus, limit) ([]Event, error)` |
+
+**Total: 15 operations**
+
+---
+
+## Summary
+
+| Service | Operations |
+|---------|-----------|
+| Storage | 33 |
+| Compute | 35 |
+| Database | 21 |
+| Serverless | 26 |
+| Networking | 47 |
+| Monitoring | 12 |
+| IAM | 35 |
+| DNS | 15 |
+| Load Balancer | 19 |
+| Message Queue | 14 |
+| Cache | 16 |
+| Secrets | 7 |
+| Logging | 13 |
+| Notification | 8 |
+| Container Registry | 14 |
+| Event Bus | 15 |
+| **Grand Total** | **330** |

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -1,0 +1,159 @@
+# Network Topology Simulation
+
+## What It Is
+
+CloudEmu's topology engine is a network simulation layer that sits above the compute, networking, and DNS mock services. It reads the live state from those services -- VPCs, subnets, security groups, route tables, network ACLs, peering connections, NAT gateways, internet gateways, and DNS records -- and answers reachability questions: "Can instance A talk to instance B on port 443?" or "What path does a packet take from this subnet to the internet?" This enables integration tests that verify network architecture without deploying real infrastructure.
+
+## Why It Is Unique
+
+Most cloud mock libraries stop at CRUD operations: you can create a VPC and list it back, but the mock does not understand that two instances in different VPCs cannot reach each other unless a peering connection exists. CloudEmu's topology engine actually evaluates security group rules, network ACLs, route tables, and peering state to produce realistic connectivity answers. This means your tests can catch misconfigured security groups, missing routes, or broken peering connections before code reaches a real cloud environment.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────┐
+│               Topology Engine                    │
+│                                                  │
+│   CanConnect()   TraceRoute()   Resolve()        │
+│   EvaluateSecurityGroups()  EvaluateNetworkACL() │
+└──────┬──────────────┬──────────────┬─────────────┘
+       │              │              │
+       ▼              ▼              ▼
+  ┌─────────┐   ┌──────────┐   ┌─────────┐
+  │ Compute │   │Networking│   │   DNS   │
+  │ Driver  │   │  Driver  │   │ Driver  │
+  └─────────┘   └──────────┘   └─────────┘
+       │              │              │
+       ▼              ▼              ▼
+  ┌─────────┐   ┌──────────┐   ┌─────────┐
+  │  EC2 /  │   │ VPC/VNet │   │Route53/ │
+  │  GCE /  │   │  /GCPVPC │   │AzureDNS/│
+  │  VMs    │   │          │   │CloudDNS │
+  └─────────┘   └──────────┘   └─────────┘
+```
+
+The topology engine does not store its own state. It reads from the existing mock services on every call, so connectivity results always reflect the current configuration.
+
+## CanConnect Flow
+
+`CanConnect` determines whether traffic can flow between a source and destination.
+
+**Step-by-step evaluation:**
+
+1. **Resolve endpoints** -- Look up the source and destination instances by ID. Determine their VPC, subnet, and associated security groups.
+2. **Same VPC check** -- If both instances are in the same VPC, proceed to security group evaluation. If in different VPCs, check for a peering connection.
+3. **Peering check** -- If instances are in different VPCs, look for an active peering connection between those VPCs. If none exists (or it is not in "active" state), return unreachable.
+4. **Route table evaluation** -- Check the route table associated with the source subnet for a route to the destination CIDR. Verify the route target is valid (not a blackhole).
+5. **Network ACL evaluation** -- Evaluate inbound and outbound ACL rules in rule-number order. The first matching rule determines allow/deny.
+6. **Security group evaluation** -- Check that the destination's inbound security group rules allow traffic from the source on the requested protocol and port. Check that the source's outbound rules allow the traffic.
+7. **Return result** -- If all checks pass, the connection is allowed. The result includes which rule or component allowed or denied the traffic.
+
+## TraceRoute Flow
+
+`TraceRoute` produces a hop-by-hop path from source to destination, similar to the `traceroute` command but evaluated against the virtual network topology.
+
+**Step-by-step evaluation:**
+
+1. **Start at source** -- Record the source instance, its subnet, and VPC.
+2. **Route table lookup** -- Find the route table for the source subnet. Determine the next hop based on the destination IP (longest prefix match).
+3. **Hop through gateways** -- If the route points to a NAT gateway, internet gateway, or peering connection, record that as a hop and continue from the next network segment.
+4. **Cross VPC** -- If the route goes through a peering connection, switch to the peer VPC and evaluate its route table for the destination.
+5. **Arrive at destination** -- When the destination subnet is reached, record the final hop.
+6. **Return trace** -- Return the ordered list of hops with their types (subnet, NAT gateway, internet gateway, peering connection, destination).
+
+## API Reference
+
+### CanConnect
+
+Checks whether traffic can flow from source to destination on a given protocol and port.
+
+```go
+result, err := engine.CanConnect(ctx, CanConnectInput{
+    SourceInstanceID: "i-abc123",
+    DestInstanceID:   "i-def456",
+    Protocol:         "tcp",
+    Port:             443,
+})
+// result.Allowed  -- bool
+// result.Reason   -- string explaining why allowed/denied
+// result.DeniedBy -- which component denied (e.g., "security-group", "network-acl", "no-route")
+```
+
+### TraceRoute
+
+Produces a hop-by-hop path between two endpoints.
+
+```go
+trace, err := engine.TraceRoute(ctx, TraceRouteInput{
+    SourceInstanceID: "i-abc123",
+    DestInstanceID:   "i-def456",
+    Protocol:         "tcp",
+    Port:             80,
+})
+// trace.Hops -- []Hop with Type, ID, and description
+// trace.Reachable -- bool
+```
+
+### Resolve
+
+Resolves a DNS name to IP addresses using the mock DNS service.
+
+```go
+ips, err := engine.Resolve(ctx, "api.example.com")
+// ips -- []string{"10.0.1.50", "10.0.1.51"}
+```
+
+### EvaluateSecurityGroups
+
+Evaluates whether a set of security groups allows traffic on a given protocol, port, and source CIDR.
+
+```go
+allowed, err := engine.EvaluateSecurityGroups(ctx, EvaluateSGInput{
+    SecurityGroupIDs: []string{"sg-abc123"},
+    Direction:        "inbound",  // or "outbound"
+    Protocol:         "tcp",
+    Port:             443,
+    CIDR:             "10.0.0.0/16",
+})
+// allowed -- bool
+```
+
+### EvaluateNetworkACL
+
+Evaluates a network ACL against a specific traffic pattern.
+
+```go
+allowed, err := engine.EvaluateNetworkACL(ctx, EvaluateACLInput{
+    NetworkACLID: "acl-abc123",
+    Egress:       false,
+    Protocol:     "tcp",
+    Port:         443,
+    CIDR:         "10.0.1.0/24",
+})
+// allowed -- bool
+```
+
+## Result Types
+
+### CanConnectResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Allowed` | `bool` | Whether the connection is permitted |
+| `Reason` | `string` | Human-readable explanation |
+| `DeniedBy` | `string` | Component that denied traffic (empty if allowed): `"security-group"`, `"network-acl"`, `"no-route"`, `"no-peering"` |
+
+### TraceRouteResult
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Hops` | `[]Hop` | Ordered list of network hops |
+| `Reachable` | `bool` | Whether the destination was reached |
+
+### Hop
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Type` | `string` | Hop type: `"subnet"`, `"nat-gateway"`, `"internet-gateway"`, `"peering"`, `"destination"` |
+| `ID` | `string` | Resource ID of the hop |
+| `Description` | `string` | Human-readable label |


### PR DESCRIPTION
## Summary

Adds a `docs/` folder with comprehensive project documentation — architecture, full service reference, topology engine guide, features, and getting started guide.

## Files

| File | Lines | What |
|------|-------|------|
| `docs/README.md` | 23 | Index page with table of contents |
| `docs/architecture.md` | 218 | 3-layer design, cross-service wiring, package structure, file tree |
| `docs/services.md` | 1000 | Full resource reference — 330 operations across 16 services x 3 providers |
| `docs/topology.md` | 159 | Network topology simulation — CanConnect/TraceRoute/Resolve with flow diagrams |
| `docs/features.md` | 371 | Auto-metrics, alarms, IAM policy, FIFO dedup, cost tracking, portable API |
| `docs/getting-started.md` | 410 | Installation, code examples for each provider, configuration, error handling |
| **Total** | **2,181** | |

## Highlights

- **services.md** lists every operation for every service, organized by sub-resource (Instances, ASG, Volumes, Snapshots, Images, Key Pairs, etc.)
- **architecture.md** has ASCII diagrams showing the 3-layer design and topology engine
- **topology.md** has step-by-step CanConnect and TraceRoute flow diagrams
- **getting-started.md** has runnable Go code examples for AWS, Azure, and GCP