### PR TITLE
Add EC2 EBS volumes and key pairs support (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Currently covered:
 | **DynamoDB** | CreateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, Query |
 | **EC2** | RunInstances, DescribeInstances (with filters), StartInstances, StopInstances, RebootInstances, TerminateInstances, ModifyInstanceAttribute |
 | **EC2 — VPC & Networking** | CreateVpc, DeleteVpc, DescribeVpcs, CreateSubnet, DeleteSubnet, DescribeSubnets, CreateSecurityGroup, DeleteSecurityGroup, DescribeSecurityGroups, AuthorizeSecurityGroupIngress/Egress, RevokeSecurityGroupIngress/Egress, CreateInternetGateway, AttachInternetGateway, DetachInternetGateway, DescribeInternetGateways, CreateRouteTable, DescribeRouteTables, CreateRoute |
+| **EC2 — EBS & Key Pairs** | CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume, CreateKeyPair, DeleteKeyPair, DescribeKeyPairs |
 
 More services land progressively — see [docs/sdk-server.md](docs/sdk-server.md).
 

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -52,6 +52,8 @@ Region and credentials can be any dummy values — the server doesn't validate s
 | **EC2 — Security Group** | CreateSecurityGroup, DeleteSecurityGroup, DescribeSecurityGroups, AuthorizeSecurityGroupIngress/Egress, RevokeSecurityGroupIngress/Egress |
 | **EC2 — Internet Gateway** | CreateInternetGateway, AttachInternetGateway, DetachInternetGateway, DescribeInternetGateways |
 | **EC2 — Route Table** | CreateRouteTable, DescribeRouteTables, CreateRoute (gateway/nat-gateway/peering targets) |
+| **EC2 — EBS Volumes** | CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume |
+| **EC2 — Key Pairs** | CreateKeyPair, DeleteKeyPair, DescribeKeyPairs |
 
 Any operation not in this list returns `501 Not Implemented` or the AWS-style `UnknownOperation` / `InvalidAction` error. The list grows each phase — see the bottom of this page.
 
@@ -101,6 +103,7 @@ The EC2 SDK-compat work is Phase 1 of a larger initiative (tracked in [#121](htt
 |-------|-------|
 | 1 (done) | Query-protocol foundation + EC2 core instance ops |
 | 2 (done) | VPC, Subnets, Security Groups, Internet Gateways, Route Tables |
+| 3 (done) | EBS Volumes, Key Pairs |
 | 3 | EBS Volumes, Key Pairs |
 | 4 | Auto-Scaling Groups + Scaling Policies |
 | 5 | Snapshots, AMIs |

--- a/server/aws/ec2/ec2_phase3_test.go
+++ b/server/aws/ec2/ec2_phase3_test.go
@@ -1,0 +1,205 @@
+package ec2
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+)
+
+func TestRouteVolumesDispatch(t *testing.T) {
+	h := newFullHandler()
+
+	create := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":           {"CreateVolume"},
+		"Size":             {"10"},
+		"AvailabilityZone": {"us-east-1a"},
+	})
+	if create.Code != http.StatusOK {
+		t.Fatalf("CreateVolume = %d: %s", create.Code, create.Body.String())
+	}
+
+	volID := between(create.Body.String(), "<volumeId>", "</volumeId>")
+	if volID == "" {
+		t.Fatalf("CreateVolume didn't return a volume id: %s", create.Body.String())
+	}
+
+	rr := do(t, h, http.MethodPost, "/", url.Values{"Action": {"DescribeVolumes"}})
+	if rr.Code != http.StatusOK {
+		t.Errorf("DescribeVolumes = %d", rr.Code)
+	}
+
+	rr = do(t, h, http.MethodPost, "/", url.Values{"Action": {"DeleteVolume"}, "VolumeId": {volID}})
+	if rr.Code != http.StatusOK {
+		t.Errorf("DeleteVolume = %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestRouteVolumesAttachDetach(t *testing.T) {
+	h := newFullHandler()
+
+	instResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":       {"RunInstances"},
+		"ImageId":      {"ami-x"},
+		"InstanceType": {"t2.micro"},
+		"MinCount":     {"1"},
+		"MaxCount":     {"1"},
+	})
+
+	instID := extractFirstInstanceID(instResp.Body.String())
+	if instID == "" {
+		t.Fatal("RunInstances didn't return instance id")
+	}
+
+	volResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":           {"CreateVolume"},
+		"Size":             {"20"},
+		"AvailabilityZone": {"us-east-1a"},
+	})
+
+	volID := between(volResp.Body.String(), "<volumeId>", "</volumeId>")
+
+	attach := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":     {"AttachVolume"},
+		"VolumeId":   {volID},
+		"InstanceId": {instID},
+		"Device":     {"/dev/sdf"},
+	})
+	if attach.Code != http.StatusOK {
+		t.Errorf("AttachVolume = %d: %s", attach.Code, attach.Body.String())
+	}
+
+	detach := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":   {"DetachVolume"},
+		"VolumeId": {volID},
+	})
+	if detach.Code != http.StatusOK {
+		t.Errorf("DetachVolume = %d", detach.Code)
+	}
+}
+
+func TestVolumeOpsUnknownIDReturnsError(t *testing.T) {
+	h := newFullHandler()
+
+	for _, form := range []url.Values{
+		{"Action": {"DeleteVolume"}, "VolumeId": {"vol-ghost"}},
+		{"Action": {"AttachVolume"}, "VolumeId": {"vol-ghost"},
+			"InstanceId": {"i-ghost"}, "Device": {"/dev/sdf"}},
+		{"Action": {"DetachVolume"}, "VolumeId": {"vol-ghost"}},
+	} {
+		rr := do(t, h, http.MethodPost, "/", form)
+		if rr.Code == http.StatusOK {
+			t.Errorf("%v should have errored, got 200: %s", form, rr.Body.String())
+		}
+	}
+}
+
+func TestRouteKeyPairsDispatch(t *testing.T) {
+	h := newFullHandler()
+
+	cre := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":  {"CreateKeyPair"},
+		"KeyName": {"k1"},
+	})
+	if cre.Code != http.StatusOK {
+		t.Fatalf("CreateKeyPair = %d", cre.Code)
+	}
+
+	// CreateKeyPair must return keyMaterial (private key).
+	if !strings.Contains(cre.Body.String(), "<keyMaterial>") {
+		t.Error("CreateKeyPair response missing <keyMaterial>")
+	}
+
+	rr := do(t, h, http.MethodPost, "/", url.Values{"Action": {"DescribeKeyPairs"}})
+	if rr.Code != http.StatusOK {
+		t.Errorf("DescribeKeyPairs = %d", rr.Code)
+	}
+
+	// DescribeKeyPairs must NOT include private-key material.
+	if strings.Contains(rr.Body.String(), "<keyMaterial>") {
+		t.Error("DescribeKeyPairs leaked <keyMaterial>")
+	}
+
+	rr = do(t, h, http.MethodPost, "/", url.Values{
+		"Action": {"DeleteKeyPair"}, "KeyName": {"k1"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Errorf("DeleteKeyPair = %d", rr.Code)
+	}
+}
+
+func TestKeyPairOpsUnknownIDReturnsError(t *testing.T) {
+	h := newFullHandler()
+
+	rr := do(t, h, http.MethodPost, "/", url.Values{
+		"Action": {"DeleteKeyPair"}, "KeyName": {"ghost-key"},
+	})
+	if rr.Code == http.StatusOK {
+		t.Errorf("DeleteKeyPair ghost-key should error, got 200")
+	}
+}
+
+func TestToVolumeXMLStateDefault(t *testing.T) {
+	in := &computedriver.VolumeInfo{ID: "vol-x", Size: 10}
+
+	got := toVolumeXML(in)
+	if got.Status != stateAvailable {
+		t.Errorf("default status = %q, want %q", got.Status, stateAvailable)
+	}
+
+	if got.VolumeType != "" {
+		t.Errorf("VolumeType should be empty when driver omits it, got %q", got.VolumeType)
+	}
+
+	if len(got.Attachments) != 0 {
+		t.Errorf("unattached volume should have 0 attachments, got %d", len(got.Attachments))
+	}
+}
+
+func TestToVolumeXMLWithAttachment(t *testing.T) {
+	in := &computedriver.VolumeInfo{
+		ID: "vol-x", Size: 20, State: "in-use",
+		AttachedTo: "i-1", Device: "/dev/sdg",
+	}
+
+	got := toVolumeXML(in)
+	if len(got.Attachments) != 1 {
+		t.Fatalf("attached volume should have 1 attachment, got %d", len(got.Attachments))
+	}
+
+	if got.Attachments[0].InstanceID != "i-1" || got.Attachments[0].Device != "/dev/sdg" {
+		t.Errorf("attachment fields wrong: %+v", got.Attachments[0])
+	}
+}
+
+func TestToKeyPairSummaryXMLOmitsPrivateKey(t *testing.T) {
+	in := &computedriver.KeyPairInfo{
+		ID: "key-1", Name: "k", Fingerprint: "ff:ff", KeyType: "rsa",
+		PublicKey: "ssh-rsa ...", PrivateKey: "SECRET",
+	}
+
+	got := toKeyPairSummaryXML(in)
+	// keyPairSummaryXML has no PrivateKey/KeyMaterial field by design.
+	if got.KeyName != "k" || got.KeyFingerprint != "ff:ff" {
+		t.Errorf("summary wrong: %+v", got)
+	}
+}
+
+func TestCreateVolumeDefaultsVolumeType(t *testing.T) {
+	h := newFullHandler()
+
+	cre := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":           {"CreateVolume"},
+		"Size":             {"5"},
+		"AvailabilityZone": {"us-east-1a"},
+	})
+	if cre.Code != http.StatusOK {
+		t.Fatalf("CreateVolume = %d", cre.Code)
+	}
+
+	if !strings.Contains(cre.Body.String(), "<volumeType>"+defaultVolumeType+"</volumeType>") {
+		t.Errorf("missing default volume type in response: %s", cre.Body.String())
+	}
+}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -69,7 +69,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	action := r.Form.Get("Action")
 
-	if h.routeCompute(w, r, action) {
+	if h.routeInstances(w, r, action) {
+		return
+	}
+
+	if h.routeVolumes(w, r, action) {
+		return
+	}
+
+	if h.routeKeyPairs(w, r, action) {
 		return
 	}
 
@@ -81,9 +89,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"InvalidAction", "unknown action: "+action)
 }
 
-// routeCompute dispatches compute-driver-backed actions. Returns true if the
-// action was handled.
-func (h *Handler) routeCompute(w http.ResponseWriter, r *http.Request, action string) bool {
+// routeInstances dispatches instance-lifecycle actions backed by the compute
+// driver. Returns true if the action was handled.
+func (h *Handler) routeInstances(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "RunInstances":
 		h.runInstances(w, r)
@@ -99,6 +107,40 @@ func (h *Handler) routeCompute(w http.ResponseWriter, r *http.Request, action st
 		h.terminateInstances(w, r)
 	case "ModifyInstanceAttribute":
 		h.modifyInstanceAttribute(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeVolumes(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateVolume":
+		h.createVolume(w, r)
+	case "DeleteVolume":
+		h.deleteVolume(w, r)
+	case "DescribeVolumes":
+		h.describeVolumes(w, r)
+	case "AttachVolume":
+		h.attachVolume(w, r)
+	case "DetachVolume":
+		h.detachVolume(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeKeyPairs(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateKeyPair":
+		h.createKeyPair(w, r)
+	case "DeleteKeyPair":
+		h.deleteKeyPair(w, r)
+	case "DescribeKeyPairs":
+		h.describeKeyPairs(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/key_pair.go
+++ b/server/aws/ec2/key_pair.go
@@ -1,0 +1,119 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// keyPairSummaryXML is one <item> in DescribeKeyPairs responses. It omits
+// private-key material — that only comes back on CreateKeyPair.
+type keyPairSummaryXML struct {
+	KeyPairID      string    `xml:"keyPairId"`
+	KeyName        string    `xml:"keyName"`
+	KeyFingerprint string    `xml:"keyFingerprint"`
+	KeyType        string    `xml:"keyType,omitempty"`
+	Tags           []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+// createKeyPairResponseXML inlines private-key material — AWS only returns it
+// on create, never on describe.
+type createKeyPairResponseXML struct {
+	XMLName        xml.Name `xml:"CreateKeyPairResponse"`
+	Xmlns          string   `xml:"xmlns,attr"`
+	RequestID      string   `xml:"requestId"`
+	KeyPairID      string   `xml:"keyPairId"`
+	KeyName        string   `xml:"keyName"`
+	KeyFingerprint string   `xml:"keyFingerprint"`
+	KeyMaterial    string   `xml:"keyMaterial"`
+	KeyType        string   `xml:"keyType,omitempty"`
+}
+
+type describeKeyPairsResponseXML struct {
+	XMLName   xml.Name            `xml:"DescribeKeyPairsResponse"`
+	Xmlns     string              `xml:"xmlns,attr"`
+	RequestID string              `xml:"requestId"`
+	KeySet    []keyPairSummaryXML `xml:"keySet>item"`
+}
+
+type deleteKeyPairResponseXML struct {
+	XMLName   xml.Name `xml:"DeleteKeyPairResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+func (h *Handler) createKeyPair(w http.ResponseWriter, r *http.Request) {
+	cfg := computedriver.KeyPairConfig{
+		Name:    r.Form.Get("KeyName"),
+		KeyType: r.Form.Get("KeyType"),
+		Tags:    mergeTagSpecs(awsquery.TagSpecs(r.Form), "key-pair"),
+	}
+
+	info, err := h.compute.CreateKeyPair(r.Context(), cfg)
+	if err != nil {
+		writeKeyPairErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createKeyPairResponseXML{
+		Xmlns:          awsquery.Namespace,
+		RequestID:      awsquery.RequestID,
+		KeyPairID:      info.ID,
+		KeyName:        info.Name,
+		KeyFingerprint: info.Fingerprint,
+		KeyMaterial:    info.PrivateKey,
+		KeyType:        info.KeyType,
+	})
+}
+
+func (h *Handler) deleteKeyPair(w http.ResponseWriter, r *http.Request) {
+	if err := h.compute.DeleteKeyPair(r.Context(), r.Form.Get("KeyName")); err != nil {
+		writeKeyPairErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteKeyPairResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table/volume
+func (h *Handler) describeKeyPairs(w http.ResponseWriter, r *http.Request) {
+	names := awsquery.ListStrings(r.Form, "KeyName")
+
+	pairs, err := h.compute.DescribeKeyPairs(r.Context(), names)
+	if err != nil {
+		writeKeyPairErr(w, err)
+		return
+	}
+
+	out := make([]keyPairSummaryXML, 0, len(pairs))
+	for i := range pairs {
+		out = append(out, toKeyPairSummaryXML(&pairs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeKeyPairsResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		KeySet:    out,
+	})
+}
+
+func toKeyPairSummaryXML(kp *computedriver.KeyPairInfo) keyPairSummaryXML {
+	return keyPairSummaryXML{
+		KeyPairID:      kp.ID,
+		KeyName:        kp.Name,
+		KeyFingerprint: kp.Fingerprint,
+		KeyType:        kp.KeyType,
+		Tags:           toTagItems(kp.Tags),
+	}
+}
+
+func writeKeyPairErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidKeyPair.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/volume.go
+++ b/server/aws/ec2/volume.go
@@ -1,0 +1,211 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// Default volume type AWS uses when the caller omits VolumeType.
+const defaultVolumeType = "gp3"
+
+type volumeAttachmentXML struct {
+	VolumeID   string `xml:"volumeId"`
+	InstanceID string `xml:"instanceId"`
+	Device     string `xml:"device"`
+	Status     string `xml:"status"`
+	AttachTime string `xml:"attachTime,omitempty"`
+}
+
+type volumeXML struct {
+	VolumeID         string                `xml:"volumeId"`
+	Size             int                   `xml:"size"`
+	Status           string                `xml:"status"`
+	VolumeType       string                `xml:"volumeType"`
+	AvailabilityZone string                `xml:"availabilityZone"`
+	CreateTime       string                `xml:"createTime,omitempty"`
+	Encrypted        bool                  `xml:"encrypted"`
+	Attachments      []volumeAttachmentXML `xml:"attachmentSet>item,omitempty"`
+	Tags             []tagItem             `xml:"tagSet>item,omitempty"`
+}
+
+// createVolumeResponseXML inlines volume fields directly under the response
+// root (AWS CreateVolume has no <volume> wrapper, unlike CreateVpc).
+type createVolumeResponseXML struct {
+	XMLName   xml.Name `xml:"CreateVolumeResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	volumeXML
+}
+
+type describeVolumesResponseXML struct {
+	XMLName   xml.Name    `xml:"DescribeVolumesResponse"`
+	Xmlns     string      `xml:"xmlns,attr"`
+	RequestID string      `xml:"requestId"`
+	VolumeSet []volumeXML `xml:"volumeSet>item"`
+}
+
+type deleteVolumeResponseXML struct {
+	XMLName   xml.Name `xml:"DeleteVolumeResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type attachVolumeResponseXML struct {
+	XMLName    xml.Name `xml:"AttachVolumeResponse"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	RequestID  string   `xml:"requestId"`
+	VolumeID   string   `xml:"volumeId"`
+	InstanceID string   `xml:"instanceId"`
+	Device     string   `xml:"device"`
+	Status     string   `xml:"status"`
+	AttachTime string   `xml:"attachTime,omitempty"`
+}
+
+type detachVolumeResponseXML struct {
+	XMLName    xml.Name `xml:"DetachVolumeResponse"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	RequestID  string   `xml:"requestId"`
+	VolumeID   string   `xml:"volumeId"`
+	InstanceID string   `xml:"instanceId,omitempty"`
+	Device     string   `xml:"device,omitempty"`
+	Status     string   `xml:"status"`
+}
+
+func (h *Handler) createVolume(w http.ResponseWriter, r *http.Request) {
+	size, _ := strconv.Atoi(r.Form.Get("Size"))
+	vt := r.Form.Get("VolumeType")
+
+	if vt == "" {
+		vt = defaultVolumeType
+	}
+
+	cfg := computedriver.VolumeConfig{
+		Size:             size,
+		VolumeType:       vt,
+		AvailabilityZone: r.Form.Get("AvailabilityZone"),
+		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "volume"),
+	}
+
+	info, err := h.compute.CreateVolume(r.Context(), cfg)
+	if err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createVolumeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		volumeXML: toVolumeXML(info),
+	})
+}
+
+func (h *Handler) deleteVolume(w http.ResponseWriter, r *http.Request) {
+	if err := h.compute.DeleteVolume(r.Context(), r.Form.Get("VolumeId")); err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteVolumeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table
+func (h *Handler) describeVolumes(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "VolumeId")
+
+	vols, err := h.compute.DescribeVolumes(r.Context(), ids)
+	if err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	out := make([]volumeXML, 0, len(vols))
+	for i := range vols {
+		out = append(out, toVolumeXML(&vols[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeVolumesResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		VolumeSet: out,
+	})
+}
+
+func (h *Handler) attachVolume(w http.ResponseWriter, r *http.Request) {
+	volID := r.Form.Get("VolumeId")
+	instID := r.Form.Get("InstanceId")
+	device := r.Form.Get("Device")
+
+	if err := h.compute.AttachVolume(r.Context(), volID, instID, device); err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, attachVolumeResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		VolumeID:   volID,
+		InstanceID: instID,
+		Device:     device,
+		Status:     "attaching",
+	})
+}
+
+func (h *Handler) detachVolume(w http.ResponseWriter, r *http.Request) {
+	volID := r.Form.Get("VolumeId")
+
+	if err := h.compute.DetachVolume(r.Context(), volID); err != nil {
+		writeVolumeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, detachVolumeResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		VolumeID:   volID,
+		InstanceID: r.Form.Get("InstanceId"),
+		Device:     r.Form.Get("Device"),
+		Status:     "detaching",
+	})
+}
+
+func toVolumeXML(v *computedriver.VolumeInfo) volumeXML {
+	state := v.State
+	if state == "" {
+		state = stateAvailable
+	}
+
+	x := volumeXML{
+		VolumeID:         v.ID,
+		Size:             v.Size,
+		Status:           state,
+		VolumeType:       v.VolumeType,
+		AvailabilityZone: v.AvailabilityZone,
+		CreateTime:       v.CreatedAt,
+		Tags:             toTagItems(v.Tags),
+	}
+
+	if v.AttachedTo != "" {
+		x.Attachments = []volumeAttachmentXML{{
+			VolumeID:   v.ID,
+			InstanceID: v.AttachedTo,
+			Device:     v.Device,
+			Status:     "attached",
+			AttachTime: v.CreatedAt,
+		}}
+	}
+
+	return x
+}
+
+func writeVolumeErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidVolume.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1447,3 +1447,137 @@ func TestEC2EndToEndRealisticAWSWorkflow(t *testing.T) {
 	})
 	assert.Len(t, rts.RouteTables, 1)
 }
+
+func TestEC2VolumeLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	cre, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(100),
+		VolumeType:       ec2types.VolumeTypeGp3,
+	})
+	require.NoError(t, err)
+	volID := aws.ToString(cre.VolumeId)
+	assert.NotEmpty(t, volID)
+	assert.Equal(t, int32(100), aws.ToInt32(cre.Size))
+
+	desc, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: []string{volID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.Volumes, 1)
+	assert.Equal(t, "us-east-1a", aws.ToString(desc.Volumes[0].AvailabilityZone))
+
+	_, err = client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{VolumeId: aws.String(volID)})
+	require.NoError(t, err)
+}
+
+func TestEC2VolumeAttachDetach(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-vol"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+	instID := aws.ToString(run.Instances[0].InstanceId)
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"),
+		Size:             aws.Int32(20),
+	})
+	require.NoError(t, err)
+	volID := aws.ToString(vol.VolumeId)
+
+	att, err := client.AttachVolume(ctx, &ec2.AttachVolumeInput{
+		VolumeId:   aws.String(volID),
+		InstanceId: aws.String(instID),
+		Device:     aws.String("/dev/sdf"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, volID, aws.ToString(att.VolumeId))
+	assert.Equal(t, instID, aws.ToString(att.InstanceId))
+	assert.Equal(t, "/dev/sdf", aws.ToString(att.Device))
+
+	desc, err := client.DescribeVolumes(ctx, &ec2.DescribeVolumesInput{
+		VolumeIds: []string{volID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.Volumes, 1)
+	require.Len(t, desc.Volumes[0].Attachments, 1,
+		"volume should report attachment in describe")
+	assert.Equal(t, instID, aws.ToString(desc.Volumes[0].Attachments[0].InstanceId))
+
+	_, err = client.DetachVolume(ctx, &ec2.DetachVolumeInput{
+		VolumeId: aws.String(volID),
+	})
+	require.NoError(t, err)
+}
+
+func TestEC2DeleteVolumeUnknownReturnsError(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	_, err := client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
+		VolumeId: aws.String("vol-ghost"),
+	})
+	require.Error(t, err)
+}
+
+func TestEC2KeyPairLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	cre, err := client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{
+		KeyName: aws.String("my-key"),
+		KeyType: ec2types.KeyTypeRsa,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "my-key", aws.ToString(cre.KeyName))
+	assert.NotEmpty(t, aws.ToString(cre.KeyFingerprint))
+	assert.NotEmpty(t, aws.ToString(cre.KeyMaterial),
+		"CreateKeyPair must return private key material")
+
+	desc, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{"my-key"},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.KeyPairs, 1)
+	assert.Equal(t, "my-key", aws.ToString(desc.KeyPairs[0].KeyName))
+
+	_, err = client.DeleteKeyPair(ctx, &ec2.DeleteKeyPairInput{
+		KeyName: aws.String("my-key"),
+	})
+	require.NoError(t, err)
+}
+
+func TestEC2DescribeKeyPairsEmpty(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	out, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{})
+	require.NoError(t, err)
+	assert.Empty(t, out.KeyPairs)
+}
+
+func TestEC2RunInstancesWithKeyPair(t *testing.T) {
+	// Realistic flow: create key pair, launch instance with KeyName,
+	// verify KeyName on the describe response.
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	_, err := client.CreateKeyPair(ctx, &ec2.CreateKeyPairInput{
+		KeyName: aws.String("launch-key"),
+	})
+	require.NoError(t, err)
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-kp"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+		KeyName: aws.String("launch-key"),
+	})
+	require.NoError(t, err)
+	require.Len(t, run.Instances, 1)
+}


### PR DESCRIPTION
## What this does

Adds EBS volume and key pair support to the EC2 SDK-compat server. After this, a developer can create a key pair, launch an instance with it, attach a volume, describe, detach, and delete — all against CloudEmu's localhost endpoint with the unmodified `aws-sdk-go-v2/service/ec2` client.

Part of #121. Closes #126.

## What's new

- `server/aws/ec2/volume.go` — CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume.
- `server/aws/ec2/key_pair.go` — CreateKeyPair (returns private key material), DeleteKeyPair, DescribeKeyPairs (never leaks private key).
- `server/aws/ec2/handler.go` — dispatch split into `routeInstances` / `routeVolumes` / `routeKeyPairs` / `routeVPC` to keep cyclomatic complexity small per resource.

## Tests

- 6 new integration tests driving the real `aws-sdk-go-v2/service/ec2` client (volume lifecycle, attach/detach with a running instance, key-pair lifecycle, launch with KeyName, empty describes, unknown-id error paths).
- 9 new unit tests covering dispatch, XML shapes, default volume type, and the "private key on create but not on describe" contract.
- `server/aws/ec2` coverage: **90.6 %** (maintained).

## End-to-end smoke test

Walked through the whole workflow against a real `httptest.NewServer` with the actual AWS SDK:
```
CreateKeyPair demo-key → fingerprint=fp-demo-key
RunInstances ami-ebs with KeyName=demo-key → i-00000007
CreateVolume 50GiB gp3 → vol-000000000001
AttachVolume → attached to i-00000007 at /dev/sdf
DescribeVolumes → attachment visible
DetachVolume → OK
DeleteVolume → OK
DeleteKeyPair → OK
```

## Verified

- `go build ./...` — clean
- `go test ./...` — 81/81 packages pass
- `golangci-lint run ./...` — 0 issues