### PR TITLE
Add EC2 phases 4-8: Auto Scaling, Snapshots/AMIs, Spot, NAT, NACLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Currently covered:
 | **EC2** | RunInstances, DescribeInstances (with filters), StartInstances, StopInstances, RebootInstances, TerminateInstances, ModifyInstanceAttribute |
 | **EC2 — VPC & Networking** | CreateVpc, DeleteVpc, DescribeVpcs, CreateSubnet, DeleteSubnet, DescribeSubnets, CreateSecurityGroup, DeleteSecurityGroup, DescribeSecurityGroups, AuthorizeSecurityGroupIngress/Egress, RevokeSecurityGroupIngress/Egress, CreateInternetGateway, AttachInternetGateway, DetachInternetGateway, DescribeInternetGateways, CreateRouteTable, DescribeRouteTables, CreateRoute |
 | **EC2 — EBS & Key Pairs** | CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume, CreateKeyPair, DeleteKeyPair, DescribeKeyPairs |
+| **Auto Scaling** | CreateAutoScalingGroup, Update/Delete/DescribeAutoScalingGroups, SetDesiredCapacity, Put/Delete/ExecutePolicy |
+| **EC2 — Snapshots/AMIs** | Create/Delete/DescribeSnapshots, Create/Deregister/DescribeImages |
+| **EC2 — Spot/Launch Templates** | Request/Cancel/DescribeSpotInstanceRequests, Create/Delete/DescribeLaunchTemplates |
+| **EC2 — NAT/Peering/Flow Logs** | NAT gateways, VPC peering connections, VPC flow logs |
+| **EC2 — Network ACLs** | Create/Delete/DescribeNetworkAcls, Create/DeleteNetworkAclEntry |
 
 More services land progressively — see [docs/sdk-server.md](docs/sdk-server.md).
 

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -54,6 +54,15 @@ Region and credentials can be any dummy values — the server doesn't validate s
 | **EC2 — Route Table** | CreateRouteTable, DescribeRouteTables, CreateRoute (gateway/nat-gateway/peering targets) |
 | **EC2 — EBS Volumes** | CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume |
 | **EC2 — Key Pairs** | CreateKeyPair, DeleteKeyPair, DescribeKeyPairs |
+| **Auto Scaling** | CreateAutoScalingGroup, UpdateAutoScalingGroup, DeleteAutoScalingGroup, DescribeAutoScalingGroups, SetDesiredCapacity, PutScalingPolicy, DeletePolicy, ExecutePolicy |
+| **EC2 — Snapshots** | CreateSnapshot, DeleteSnapshot, DescribeSnapshots |
+| **EC2 — AMIs** | CreateImage, DeregisterImage, DescribeImages |
+| **EC2 — Spot Instances** | RequestSpotInstances, CancelSpotInstanceRequests, DescribeSpotInstanceRequests |
+| **EC2 — Launch Templates** | CreateLaunchTemplate, DeleteLaunchTemplate, DescribeLaunchTemplates |
+| **EC2 — NAT Gateways** | CreateNatGateway, DeleteNatGateway, DescribeNatGateways |
+| **EC2 — VPC Peering** | CreateVpcPeeringConnection, AcceptVpcPeeringConnection, DeleteVpcPeeringConnection, DescribeVpcPeeringConnections |
+| **EC2 — Flow Logs** | CreateFlowLogs, DeleteFlowLogs, DescribeFlowLogs |
+| **EC2 — Network ACLs** | CreateNetworkAcl, DeleteNetworkAcl, DescribeNetworkAcls, CreateNetworkAclEntry, DeleteNetworkAclEntry |
 
 Any operation not in this list returns `501 Not Implemented` or the AWS-style `UnknownOperation` / `InvalidAction` error. The list grows each phase — see the bottom of this page.
 
@@ -104,6 +113,11 @@ The EC2 SDK-compat work is Phase 1 of a larger initiative (tracked in [#121](htt
 | 1 (done) | Query-protocol foundation + EC2 core instance ops |
 | 2 (done) | VPC, Subnets, Security Groups, Internet Gateways, Route Tables |
 | 3 (done) | EBS Volumes, Key Pairs |
+| 4 (done) | Auto Scaling Groups + scaling policies |
+| 5 (done) | Snapshots + AMIs |
+| 6 (done) | Spot Instances + Launch Templates |
+| 7 (done) | NAT Gateways + VPC Peering + Flow Logs |
+| 8 (done) | Network ACLs |
 | 3 | EBS Volumes, Key Pairs |
 | 4 | Auto-Scaling Groups + Scaling Policies |
 | 5 | Snapshots, AMIs |

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22/go.mod h1:zd/JsJ4P7oGfUhXn1VyLqaRZwPmZwg44Jf2dS84Dm3Y=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1 h1:kGlbhb5GMfkP/bcqcbt3oDi50kwDTpRmNzYUY9LqbLk=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1/go.mod h1:z45kurrOonQepd3SN5LIgropAn1NGHwBn1yOMF+QVFU=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8eX6NDtFSBGfzuauMEWYQ=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1/go.mod h1:wHrWCwhXZrl2PuCP5t36UTacy9fCHDJ+vw1r3qxTL5M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 h1:9nfacm+uWgbdPaOplvJjxN50qgthexb7GOR/97ygc5o=

--- a/server/aws/ec2/auto_scaling.go
+++ b/server/aws/ec2/auto_scaling.go
@@ -14,6 +14,9 @@ import (
 // "right" one so the wire capture matches real AWS.
 const asgNamespace = "http://autoscaling.amazonaws.com/doc/2011-01-01/"
 
+// formTrue is the literal AWS SDKs emit for boolean true in form-encoded bodies.
+const formTrue = "true"
+
 type asgResponseMetadata struct {
 	RequestID string `xml:"RequestId"`
 }
@@ -115,7 +118,7 @@ func (h *Handler) createAutoScalingGroup(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *Handler) deleteAutoScalingGroup(w http.ResponseWriter, r *http.Request) {
-	force := r.Form.Get("ForceDelete") == "true"
+	force := r.Form.Get("ForceDelete") == formTrue
 
 	if err := h.compute.DeleteAutoScalingGroup(r.Context(),
 		r.Form.Get("AutoScalingGroupName"), force); err != nil {

--- a/server/aws/ec2/auto_scaling.go
+++ b/server/aws/ec2/auto_scaling.go
@@ -1,0 +1,299 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// asgNamespace is the XML namespace AutoScaling responses carry. Distinct
+// from EC2's namespace — the SDK's parser tolerates either, but we emit the
+// "right" one so the wire capture matches real AWS.
+const asgNamespace = "http://autoscaling.amazonaws.com/doc/2011-01-01/"
+
+type asgResponseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+type asgXML struct {
+	Name              string    `xml:"AutoScalingGroupName"`
+	MinSize           int       `xml:"MinSize"`
+	MaxSize           int       `xml:"MaxSize"`
+	DesiredCapacity   int       `xml:"DesiredCapacity"`
+	Status            string    `xml:"Status,omitempty"`
+	HealthCheckType   string    `xml:"HealthCheckType,omitempty"`
+	CreatedTime       string    `xml:"CreatedTime,omitempty"`
+	InstanceIDs       []string  `xml:"Instances>member>InstanceId,omitempty"`
+	AvailabilityZones []string  `xml:"AvailabilityZones>member,omitempty"`
+	Tags              []tagItem `xml:"Tags>member,omitempty"`
+}
+
+type createAutoScalingGroupResponseXML struct {
+	XMLName          xml.Name            `xml:"CreateAutoScalingGroupResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteAutoScalingGroupResponseXML struct {
+	XMLName          xml.Name            `xml:"DeleteAutoScalingGroupResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type updateAutoScalingGroupResponseXML struct {
+	XMLName          xml.Name            `xml:"UpdateAutoScalingGroupResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type setDesiredCapacityResponseXML struct {
+	XMLName          xml.Name            `xml:"SetDesiredCapacityResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type describeAutoScalingGroupsResponseXML struct {
+	XMLName xml.Name `xml:"DescribeAutoScalingGroupsResponse"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Result  struct {
+		Groups []asgXML `xml:"AutoScalingGroups>member"`
+	} `xml:"DescribeAutoScalingGroupsResult"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type putScalingPolicyResponseXML struct {
+	XMLName xml.Name `xml:"PutScalingPolicyResponse"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Result  struct {
+		PolicyARN string `xml:"PolicyARN"`
+	} `xml:"PutScalingPolicyResult"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteScalingPolicyResponseXML struct {
+	XMLName          xml.Name            `xml:"DeleteScalingPolicyResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+type executePolicyResponseXML struct {
+	XMLName          xml.Name            `xml:"ExecutePolicyResponse"`
+	Xmlns            string              `xml:"xmlns,attr"`
+	ResponseMetadata asgResponseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) createAutoScalingGroup(w http.ResponseWriter, r *http.Request) {
+	minSize, _ := strconv.Atoi(r.Form.Get("MinSize"))
+	maxSize, _ := strconv.Atoi(r.Form.Get("MaxSize"))
+	desired, _ := strconv.Atoi(r.Form.Get("DesiredCapacity"))
+
+	cfg := computedriver.AutoScalingGroupConfig{
+		Name:              r.Form.Get("AutoScalingGroupName"),
+		MinSize:           minSize,
+		MaxSize:           maxSize,
+		DesiredCapacity:   desired,
+		HealthCheckType:   r.Form.Get("HealthCheckType"),
+		AvailabilityZones: asgMembers(r.Form, "AvailabilityZones"),
+		InstanceConfig: computedriver.InstanceConfig{
+			ImageID:      r.Form.Get("LaunchConfigurationName"),
+			InstanceType: "t2.micro",
+		},
+	}
+
+	if _, err := h.compute.CreateAutoScalingGroup(r.Context(), cfg); err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createAutoScalingGroupResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteAutoScalingGroup(w http.ResponseWriter, r *http.Request) {
+	force := r.Form.Get("ForceDelete") == "true"
+
+	if err := h.compute.DeleteAutoScalingGroup(r.Context(),
+		r.Form.Get("AutoScalingGroupName"), force); err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteAutoScalingGroupResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) updateAutoScalingGroup(w http.ResponseWriter, r *http.Request) {
+	name := r.Form.Get("AutoScalingGroupName")
+	minSize, _ := strconv.Atoi(r.Form.Get("MinSize"))
+	maxSize, _ := strconv.Atoi(r.Form.Get("MaxSize"))
+	desired, _ := strconv.Atoi(r.Form.Get("DesiredCapacity"))
+
+	if err := h.compute.UpdateAutoScalingGroup(r.Context(), name, desired, minSize, maxSize); err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, updateAutoScalingGroupResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) setDesiredCapacity(w http.ResponseWriter, r *http.Request) {
+	desired, _ := strconv.Atoi(r.Form.Get("DesiredCapacity"))
+
+	if err := h.compute.SetDesiredCapacity(r.Context(),
+		r.Form.Get("AutoScalingGroupName"), desired); err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, setDesiredCapacityResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeAutoScalingGroups(w http.ResponseWriter, r *http.Request) {
+	groups, err := h.listASGs(r)
+	if err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	out := make([]asgXML, 0, len(groups))
+
+	for i := range groups {
+		out = append(out, toASGXML(&groups[i]))
+	}
+
+	resp := describeAutoScalingGroupsResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	}
+	resp.Result.Groups = out
+	awsquery.WriteXMLResponse(w, resp)
+}
+
+func (h *Handler) putScalingPolicy(w http.ResponseWriter, r *http.Request) {
+	adjustment, _ := strconv.Atoi(r.Form.Get("ScalingAdjustment"))
+	cooldown, _ := strconv.Atoi(r.Form.Get("Cooldown"))
+
+	policy := computedriver.ScalingPolicy{
+		Name:              r.Form.Get("PolicyName"),
+		AutoScalingGroup:  r.Form.Get("AutoScalingGroupName"),
+		PolicyType:        r.Form.Get("PolicyType"),
+		AdjustmentType:    r.Form.Get("AdjustmentType"),
+		ScalingAdjustment: adjustment,
+		Cooldown:          cooldown,
+	}
+
+	if err := h.compute.PutScalingPolicy(r.Context(), policy); err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	resp := putScalingPolicyResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	}
+	resp.Result.PolicyARN = "arn:aws:autoscaling:::" + policy.Name
+
+	awsquery.WriteXMLResponse(w, resp)
+}
+
+func (h *Handler) deleteScalingPolicy(w http.ResponseWriter, r *http.Request) {
+	err := h.compute.DeleteScalingPolicy(r.Context(),
+		r.Form.Get("AutoScalingGroupName"), r.Form.Get("PolicyName"))
+	if err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteScalingPolicyResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) executePolicy(w http.ResponseWriter, r *http.Request) {
+	err := h.compute.ExecuteScalingPolicy(r.Context(),
+		r.Form.Get("AutoScalingGroupName"), r.Form.Get("PolicyName"))
+	if err != nil {
+		writeASGErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, executePolicyResponseXML{
+		Xmlns:            asgNamespace,
+		ResponseMetadata: asgResponseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func toASGXML(g *computedriver.AutoScalingGroup) asgXML {
+	return asgXML{
+		Name:              g.Name,
+		MinSize:           g.MinSize,
+		MaxSize:           g.MaxSize,
+		DesiredCapacity:   g.DesiredCapacity,
+		Status:            g.Status,
+		HealthCheckType:   g.HealthCheckType,
+		CreatedTime:       g.CreatedAt,
+		InstanceIDs:       g.InstanceIDs,
+		AvailabilityZones: g.AvailabilityZones,
+		Tags:              toTagItems(g.Tags),
+	}
+}
+
+// asgMembers reads the AutoScaling wire form (member.N=value) vs EC2's (Foo.N=value).
+func asgMembers(form map[string][]string, prefix string) []string {
+	dot := prefix + ".member."
+
+	var out []string
+
+	for key, vals := range form {
+		if len(vals) == 0 {
+			continue
+		}
+
+		if len(key) > len(dot) && key[:len(dot)] == dot {
+			out = append(out, vals[0])
+		}
+	}
+
+	return out
+}
+
+// listASGs resolves the AutoScalingGroupNames filter and returns matching
+// groups (or all if no names given). Pulled out of the describe handler to
+// keep that function short and linear.
+func (h *Handler) listASGs(r *http.Request) ([]computedriver.AutoScalingGroup, error) {
+	names := asgMembers(r.Form, "AutoScalingGroupNames")
+	if len(names) == 0 {
+		return h.compute.ListAutoScalingGroups(r.Context())
+	}
+
+	var groups []computedriver.AutoScalingGroup
+
+	for _, n := range names {
+		g, err := h.compute.GetAutoScalingGroup(r.Context(), n)
+		if err != nil {
+			continue
+		}
+
+		groups = append(groups, *g)
+	}
+
+	return groups, nil
+}
+
+func writeASGErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "AutoScalingGroupNotFound", "ValidationError")
+}

--- a/server/aws/ec2/flow_log.go
+++ b/server/aws/ec2/flow_log.go
@@ -1,0 +1,132 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type flowLogXML struct {
+	FlowLogID     string    `xml:"flowLogId"`
+	ResourceID    string    `xml:"resourceId"`
+	ResourceType  string    `xml:"resourceType"`
+	TrafficType   string    `xml:"trafficType"`
+	FlowLogStatus string    `xml:"flowLogStatus"`
+	CreationTime  string    `xml:"creationTime,omitempty"`
+	Tags          []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type createFlowLogsResponseXML struct {
+	XMLName    xml.Name `xml:"CreateFlowLogsResponse"`
+	Xmlns      string   `xml:"xmlns,attr"`
+	RequestID  string   `xml:"requestId"`
+	FlowLogIDs []string `xml:"flowLogIdSet>item"`
+}
+
+type describeFlowLogsResponseXML struct {
+	XMLName    xml.Name     `xml:"DescribeFlowLogsResponse"`
+	Xmlns      string       `xml:"xmlns,attr"`
+	RequestID  string       `xml:"requestId"`
+	FlowLogSet []flowLogXML `xml:"flowLogSet>item"`
+}
+
+type deleteFlowLogsResponseXML struct {
+	XMLName      xml.Name `xml:"DeleteFlowLogsResponse"`
+	Xmlns        string   `xml:"xmlns,attr"`
+	RequestID    string   `xml:"requestId"`
+	Unsuccessful []string `xml:"unsuccessful>item,omitempty"`
+}
+
+func (h *Handler) createFlowLogs(w http.ResponseWriter, r *http.Request) {
+	resourceIDs := awsquery.ListStrings(r.Form, "ResourceId")
+	if len(resourceIDs) == 0 {
+		writeFlowLogErr(w, newInvalidParameterErr("ResourceId is required"))
+		return
+	}
+
+	var created []string
+
+	for _, rid := range resourceIDs {
+		cfg := netdriver.FlowLogConfig{
+			ResourceID:   rid,
+			ResourceType: r.Form.Get("ResourceType"),
+			TrafficType:  r.Form.Get("TrafficType"),
+			Tags:         mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpc-flow-log"),
+		}
+
+		info, err := h.vpc.CreateFlowLog(r.Context(), cfg)
+		if err != nil {
+			writeFlowLogErr(w, err)
+			return
+		}
+
+		created = append(created, info.ID)
+	}
+
+	awsquery.WriteXMLResponse(w, createFlowLogsResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		FlowLogIDs: created,
+	})
+}
+
+func (h *Handler) deleteFlowLogs(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "FlowLogId")
+
+	for _, id := range ids {
+		if err := h.vpc.DeleteFlowLog(r.Context(), id); err != nil {
+			writeFlowLogErr(w, err)
+			return
+		}
+	}
+
+	awsquery.WriteXMLResponse(w, deleteFlowLogsResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern
+func (h *Handler) describeFlowLogs(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "FlowLogId")
+
+	logs, err := h.vpc.DescribeFlowLogs(r.Context(), ids)
+	if err != nil {
+		writeFlowLogErr(w, err)
+		return
+	}
+
+	out := make([]flowLogXML, 0, len(logs))
+	for i := range logs {
+		out = append(out, toFlowLogXML(&logs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeFlowLogsResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		FlowLogSet: out,
+	})
+}
+
+func toFlowLogXML(f *netdriver.FlowLog) flowLogXML {
+	status := f.Status
+	if status == "" {
+		status = "ACTIVE"
+	}
+
+	return flowLogXML{
+		FlowLogID:     f.ID,
+		ResourceID:    f.ResourceID,
+		ResourceType:  f.ResourceType,
+		TrafficType:   f.TrafficType,
+		FlowLogStatus: status,
+		CreationTime:  f.CreatedAt,
+		Tags:          toTagItems(f.Tags),
+	}
+}
+
+func writeFlowLogErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidFlowLogId.NotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -81,12 +81,41 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if h.routeAutoScaling(w, r, action) {
+		return
+	}
+
 	if h.routeVPC(w, r, action) {
 		return
 	}
 
 	awsquery.WriteXMLError(w, http.StatusBadRequest,
 		"InvalidAction", "unknown action: "+action)
+}
+
+func (h *Handler) routeAutoScaling(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateAutoScalingGroup":
+		h.createAutoScalingGroup(w, r)
+	case "UpdateAutoScalingGroup":
+		h.updateAutoScalingGroup(w, r)
+	case "DeleteAutoScalingGroup":
+		h.deleteAutoScalingGroup(w, r)
+	case "DescribeAutoScalingGroups":
+		h.describeAutoScalingGroups(w, r)
+	case "SetDesiredCapacity":
+		h.setDesiredCapacity(w, r)
+	case "PutScalingPolicy":
+		h.putScalingPolicy(w, r)
+	case "DeletePolicy":
+		h.deleteScalingPolicy(w, r)
+	case "ExecutePolicy":
+		h.executePolicy(w, r)
+	default:
+		return false
+	}
+
+	return true
 }
 
 // routeInstances dispatches instance-lifecycle actions backed by the compute

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -58,6 +58,11 @@ func (*Handler) Matches(r *http.Request) bool {
 	return false
 }
 
+// routeFunc is a per-resource dispatcher that returns true when it handled
+// the action. ServeHTTP iterates a list of these so adding a new resource
+// means appending one function rather than editing the main handler.
+type routeFunc func(w http.ResponseWriter, r *http.Request, action string) bool
+
 // ServeHTTP parses the request form and dispatches on Action.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxFormBodyBytes)
@@ -69,32 +74,21 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	action := r.Form.Get("Action")
 
-	if h.routeInstances(w, r, action) {
-		return
+	routes := []routeFunc{
+		h.routeInstances,
+		h.routeVolumes,
+		h.routeKeyPairs,
+		h.routeAutoScaling,
+		h.routeSnapshots,
+		h.routeImages,
+		h.routeSpot,
+		h.routeLaunchTemplates,
+		h.routeVPC,
 	}
-
-	if h.routeVolumes(w, r, action) {
-		return
-	}
-
-	if h.routeKeyPairs(w, r, action) {
-		return
-	}
-
-	if h.routeAutoScaling(w, r, action) {
-		return
-	}
-
-	if h.routeSnapshots(w, r, action) {
-		return
-	}
-
-	if h.routeImages(w, r, action) {
-		return
-	}
-
-	if h.routeVPC(w, r, action) {
-		return
+	for _, route := range routes {
+		if route(w, r, action) {
+			return
+		}
 	}
 
 	awsquery.WriteXMLError(w, http.StatusBadRequest,
@@ -124,6 +118,36 @@ func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, action str
 		h.deregisterImage(w, r)
 	case "DescribeImages":
 		h.describeImages(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeSpot(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "RequestSpotInstances":
+		h.requestSpotInstances(w, r)
+	case "CancelSpotInstanceRequests":
+		h.cancelSpotInstanceRequests(w, r)
+	case "DescribeSpotInstanceRequests":
+		h.describeSpotInstanceRequests(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeLaunchTemplates(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateLaunchTemplate":
+		h.createLaunchTemplate(w, r)
+	case "DeleteLaunchTemplate":
+		h.deleteLaunchTemplate(w, r)
+	case "DescribeLaunchTemplates":
+		h.describeLaunchTemplates(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -85,12 +85,50 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if h.routeSnapshots(w, r, action) {
+		return
+	}
+
+	if h.routeImages(w, r, action) {
+		return
+	}
+
 	if h.routeVPC(w, r, action) {
 		return
 	}
 
 	awsquery.WriteXMLError(w, http.StatusBadRequest,
 		"InvalidAction", "unknown action: "+action)
+}
+
+func (h *Handler) routeSnapshots(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateSnapshot":
+		h.createSnapshot(w, r)
+	case "DeleteSnapshot":
+		h.deleteSnapshot(w, r)
+	case "DescribeSnapshots":
+		h.describeSnapshots(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateImage":
+		h.createImage(w, r)
+	case "DeregisterImage":
+		h.deregisterImage(w, r)
+	case "DescribeImages":
+		h.describeImages(w, r)
+	default:
+		return false
+	}
+
+	return true
 }
 
 func (h *Handler) routeAutoScaling(w http.ResponseWriter, r *http.Request, action string) bool {

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -86,6 +86,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeNatGateways,
 		h.routeVpcPeering,
 		h.routeFlowLogs,
+		h.routeNetworkACLs,
 		h.routeVPC,
 	}
 	for _, route := range routes {
@@ -168,6 +169,25 @@ func (h *Handler) routeFlowLogs(w http.ResponseWriter, r *http.Request, action s
 		h.deleteFlowLogs(w, r)
 	case "DescribeFlowLogs":
 		h.describeFlowLogs(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeNetworkACLs(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateNetworkAcl":
+		h.createNetworkACL(w, r)
+	case "DeleteNetworkAcl":
+		h.deleteNetworkACL(w, r)
+	case "DescribeNetworkAcls":
+		h.describeNetworkACLs(w, r)
+	case "CreateNetworkAclEntry":
+		h.createNetworkACLEntry(w, r)
+	case "DeleteNetworkAclEntry":
+		h.deleteNetworkACLEntry(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -83,6 +83,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeImages,
 		h.routeSpot,
 		h.routeLaunchTemplates,
+		h.routeNatGateways,
+		h.routeVpcPeering,
+		h.routeFlowLogs,
 		h.routeVPC,
 	}
 	for _, route := range routes {
@@ -118,6 +121,53 @@ func (h *Handler) routeImages(w http.ResponseWriter, r *http.Request, action str
 		h.deregisterImage(w, r)
 	case "DescribeImages":
 		h.describeImages(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeNatGateways(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateNatGateway":
+		h.createNatGateway(w, r)
+	case "DeleteNatGateway":
+		h.deleteNatGateway(w, r)
+	case "DescribeNatGateways":
+		h.describeNatGateways(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeVpcPeering(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateVpcPeeringConnection":
+		h.createVpcPeeringConnection(w, r)
+	case "AcceptVpcPeeringConnection":
+		h.acceptVpcPeeringConnection(w, r)
+	case "DeleteVpcPeeringConnection":
+		h.deleteVpcPeeringConnection(w, r)
+	case "DescribeVpcPeeringConnections":
+		h.describeVpcPeeringConnections(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeFlowLogs(w http.ResponseWriter, r *http.Request, action string) bool {
+	switch action {
+	case "CreateFlowLogs":
+		h.createFlowLogs(w, r)
+	case "DeleteFlowLogs":
+		h.deleteFlowLogs(w, r)
+	case "DescribeFlowLogs":
+		h.describeFlowLogs(w, r)
 	default:
 		return false
 	}

--- a/server/aws/ec2/image.go
+++ b/server/aws/ec2/image.go
@@ -1,0 +1,119 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type imageXML struct {
+	ImageID      string    `xml:"imageId"`
+	State        string    `xml:"imageState"`
+	Name         string    `xml:"name,omitempty"`
+	Description  string    `xml:"description,omitempty"`
+	CreationDate string    `xml:"creationDate,omitempty"`
+	Architecture string    `xml:"architecture"`
+	Public       bool      `xml:"isPublic"`
+	Tags         []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type createImageResponseXML struct {
+	XMLName   xml.Name `xml:"CreateImageResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	ImageID   string   `xml:"imageId"`
+}
+
+type describeImagesResponseXML struct {
+	XMLName   xml.Name   `xml:"DescribeImagesResponse"`
+	Xmlns     string     `xml:"xmlns,attr"`
+	RequestID string     `xml:"requestId"`
+	ImagesSet []imageXML `xml:"imagesSet>item"`
+}
+
+type deregisterImageResponseXML struct {
+	XMLName   xml.Name `xml:"DeregisterImageResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+func (h *Handler) createImage(w http.ResponseWriter, r *http.Request) {
+	cfg := computedriver.ImageConfig{
+		InstanceID:  r.Form.Get("InstanceId"),
+		Name:        r.Form.Get("Name"),
+		Description: r.Form.Get("Description"),
+		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "image"),
+	}
+
+	info, err := h.compute.CreateImage(r.Context(), cfg)
+	if err != nil {
+		writeImageErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createImageResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		ImageID:   info.ID,
+	})
+}
+
+func (h *Handler) deregisterImage(w http.ResponseWriter, r *http.Request) {
+	if err := h.compute.DeregisterImage(r.Context(), r.Form.Get("ImageId")); err != nil {
+		writeImageErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deregisterImageResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table/volume/keypair/snapshot
+func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "ImageId")
+
+	imgs, err := h.compute.DescribeImages(r.Context(), ids)
+	if err != nil {
+		writeImageErr(w, err)
+		return
+	}
+
+	out := make([]imageXML, 0, len(imgs))
+	for i := range imgs {
+		out = append(out, toImageXML(&imgs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeImagesResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		ImagesSet: out,
+	})
+}
+
+func toImageXML(img *computedriver.ImageInfo) imageXML {
+	state := img.State
+	if state == "" {
+		state = stateAvailable
+	}
+
+	return imageXML{
+		ImageID:      img.ID,
+		State:        state,
+		Name:         img.Name,
+		Description:  img.Description,
+		CreationDate: img.CreatedAt,
+		Architecture: "x86_64",
+		Public:       false,
+		Tags:         toTagItems(img.Tags),
+	}
+}
+
+func writeImageErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidAMIID.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/launch_template.go
+++ b/server/aws/ec2/launch_template.go
@@ -1,0 +1,134 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type launchTemplateXML struct {
+	LaunchTemplateID   string `xml:"launchTemplateId"`
+	LaunchTemplateName string `xml:"launchTemplateName"`
+	Version            int    `xml:"versionNumber"`
+	CreateTime         string `xml:"createTime,omitempty"`
+}
+
+type createLaunchTemplateResponseXML struct {
+	XMLName        xml.Name          `xml:"CreateLaunchTemplateResponse"`
+	Xmlns          string            `xml:"xmlns,attr"`
+	RequestID      string            `xml:"requestId"`
+	LaunchTemplate launchTemplateXML `xml:"launchTemplate"`
+}
+
+type describeLaunchTemplatesResponseXML struct {
+	XMLName         xml.Name            `xml:"DescribeLaunchTemplatesResponse"`
+	Xmlns           string              `xml:"xmlns,attr"`
+	RequestID       string              `xml:"requestId"`
+	LaunchTemplates []launchTemplateXML `xml:"launchTemplates>item"`
+}
+
+type deleteLaunchTemplateResponseXML struct {
+	XMLName        xml.Name          `xml:"DeleteLaunchTemplateResponse"`
+	Xmlns          string            `xml:"xmlns,attr"`
+	RequestID      string            `xml:"requestId"`
+	LaunchTemplate launchTemplateXML `xml:"launchTemplate"`
+}
+
+func (h *Handler) createLaunchTemplate(w http.ResponseWriter, r *http.Request) {
+	cfg := computedriver.LaunchTemplateConfig{
+		Name: r.Form.Get("LaunchTemplateName"),
+		InstanceConfig: computedriver.InstanceConfig{
+			ImageID:      r.Form.Get("LaunchTemplateData.ImageId"),
+			InstanceType: r.Form.Get("LaunchTemplateData.InstanceType"),
+		},
+	}
+
+	info, err := h.compute.CreateLaunchTemplate(r.Context(), cfg)
+	if err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createLaunchTemplateResponseXML{
+		Xmlns:          awsquery.Namespace,
+		RequestID:      awsquery.RequestID,
+		LaunchTemplate: toLaunchTemplateXML(info),
+	})
+}
+
+func (h *Handler) deleteLaunchTemplate(w http.ResponseWriter, r *http.Request) {
+	name := r.Form.Get("LaunchTemplateName")
+	if name == "" {
+		name = r.Form.Get("LaunchTemplateId")
+	}
+
+	// Fetch before deleting so the response can echo the deleted template (matches real AWS).
+	info, _ := h.compute.GetLaunchTemplate(r.Context(), name)
+
+	if err := h.compute.DeleteLaunchTemplate(r.Context(), name); err != nil {
+		writeLaunchTemplateErr(w, err)
+		return
+	}
+
+	resp := deleteLaunchTemplateResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+	}
+	if info != nil {
+		resp.LaunchTemplate = toLaunchTemplateXML(info)
+	}
+
+	awsquery.WriteXMLResponse(w, resp)
+}
+
+func (h *Handler) describeLaunchTemplates(w http.ResponseWriter, r *http.Request) {
+	names := awsquery.ListStrings(r.Form, "LaunchTemplateName")
+
+	var templates []computedriver.LaunchTemplate
+
+	if len(names) == 0 {
+		lts, err := h.compute.ListLaunchTemplates(r.Context())
+		if err != nil {
+			writeLaunchTemplateErr(w, err)
+			return
+		}
+
+		templates = lts
+	} else {
+		for _, n := range names {
+			lt, err := h.compute.GetLaunchTemplate(r.Context(), n)
+			if err != nil {
+				continue
+			}
+
+			templates = append(templates, *lt)
+		}
+	}
+
+	out := make([]launchTemplateXML, 0, len(templates))
+
+	for i := range templates {
+		out = append(out, toLaunchTemplateXML(&templates[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeLaunchTemplatesResponseXML{
+		Xmlns:           awsquery.Namespace,
+		RequestID:       awsquery.RequestID,
+		LaunchTemplates: out,
+	})
+}
+
+func toLaunchTemplateXML(lt *computedriver.LaunchTemplate) launchTemplateXML {
+	return launchTemplateXML{
+		LaunchTemplateID:   lt.ID,
+		LaunchTemplateName: lt.Name,
+		Version:            lt.Version,
+		CreateTime:         lt.CreatedAt,
+	}
+}
+
+func writeLaunchTemplateErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidLaunchTemplateId.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/nat_gateway.go
+++ b/server/aws/ec2/nat_gateway.go
@@ -1,0 +1,115 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type natGatewayXML struct {
+	NatGatewayID string    `xml:"natGatewayId"`
+	VpcID        string    `xml:"vpcId"`
+	SubnetID     string    `xml:"subnetId"`
+	State        string    `xml:"state"`
+	CreateTime   string    `xml:"createTime,omitempty"`
+	Tags         []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type createNatGatewayResponseXML struct {
+	XMLName    xml.Name      `xml:"CreateNatGatewayResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	RequestID  string        `xml:"requestId"`
+	NatGateway natGatewayXML `xml:"natGateway"`
+}
+
+type describeNatGatewaysResponseXML struct {
+	XMLName       xml.Name        `xml:"DescribeNatGatewaysResponse"`
+	Xmlns         string          `xml:"xmlns,attr"`
+	RequestID     string          `xml:"requestId"`
+	NatGatewaySet []natGatewayXML `xml:"natGatewaySet>item"`
+}
+
+type deleteNatGatewayResponseXML struct {
+	XMLName      xml.Name `xml:"DeleteNatGatewayResponse"`
+	Xmlns        string   `xml:"xmlns,attr"`
+	RequestID    string   `xml:"requestId"`
+	NatGatewayID string   `xml:"natGatewayId"`
+}
+
+func (h *Handler) createNatGateway(w http.ResponseWriter, r *http.Request) {
+	cfg := netdriver.NATGatewayConfig{
+		SubnetID: r.Form.Get("SubnetId"),
+		Tags:     mergeTagSpecs(awsquery.TagSpecs(r.Form), "natgateway"),
+	}
+
+	info, err := h.vpc.CreateNATGateway(r.Context(), cfg)
+	if err != nil {
+		writeNatErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createNatGatewayResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		NatGateway: toNatGatewayXML(info),
+	})
+}
+
+func (h *Handler) deleteNatGateway(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("NatGatewayId")
+
+	if err := h.vpc.DeleteNATGateway(r.Context(), id); err != nil {
+		writeNatErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteNatGatewayResponseXML{
+		Xmlns:        awsquery.Namespace,
+		RequestID:    awsquery.RequestID,
+		NatGatewayID: id,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern
+func (h *Handler) describeNatGateways(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "NatGatewayId")
+
+	nats, err := h.vpc.DescribeNATGateways(r.Context(), ids)
+	if err != nil {
+		writeNatErr(w, err)
+		return
+	}
+
+	out := make([]natGatewayXML, 0, len(nats))
+	for i := range nats {
+		out = append(out, toNatGatewayXML(&nats[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeNatGatewaysResponseXML{
+		Xmlns:         awsquery.Namespace,
+		RequestID:     awsquery.RequestID,
+		NatGatewaySet: out,
+	})
+}
+
+func toNatGatewayXML(n *netdriver.NATGateway) natGatewayXML {
+	state := n.State
+	if state == "" {
+		state = stateAvailable
+	}
+
+	return natGatewayXML{
+		NatGatewayID: n.ID,
+		VpcID:        n.VPCID,
+		SubnetID:     n.SubnetID,
+		State:        state,
+		CreateTime:   n.CreatedAt,
+		Tags:         toTagItems(n.Tags),
+	}
+}
+
+func writeNatErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "NatGatewayNotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/network_acl.go
+++ b/server/aws/ec2/network_acl.go
@@ -1,0 +1,196 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type networkACLEntryXML struct {
+	RuleNumber int    `xml:"ruleNumber"`
+	Protocol   string `xml:"protocol"`
+	RuleAction string `xml:"ruleAction"`
+	Egress     bool   `xml:"egress"`
+	CIDRBlock  string `xml:"cidrBlock,omitempty"`
+	PortRange  *struct {
+		From int `xml:"from"`
+		To   int `xml:"to"`
+	} `xml:"portRange,omitempty"`
+}
+
+type networkACLXML struct {
+	NetworkACLID string               `xml:"networkAclId"`
+	VpcID        string               `xml:"vpcId"`
+	IsDefault    bool                 `xml:"default"`
+	Entries      []networkACLEntryXML `xml:"entrySet>item,omitempty"`
+	Tags         []tagItem            `xml:"tagSet>item,omitempty"`
+}
+
+type createNetworkACLResponseXML struct {
+	XMLName    xml.Name      `xml:"CreateNetworkAclResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	RequestID  string        `xml:"requestId"`
+	NetworkACL networkACLXML `xml:"networkAcl"`
+}
+
+type describeNetworkACLsResponseXML struct {
+	XMLName       xml.Name        `xml:"DescribeNetworkAclsResponse"`
+	Xmlns         string          `xml:"xmlns,attr"`
+	RequestID     string          `xml:"requestId"`
+	NetworkACLSet []networkACLXML `xml:"networkAclSet>item"`
+}
+
+type deleteNetworkACLResponseXML struct {
+	XMLName   xml.Name `xml:"DeleteNetworkAclResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type createNetworkACLEntryResponseXML struct {
+	XMLName   xml.Name `xml:"CreateNetworkAclEntryResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type deleteNetworkACLEntryResponseXML struct {
+	XMLName   xml.Name `xml:"DeleteNetworkAclEntryResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+func (h *Handler) createNetworkACL(w http.ResponseWriter, r *http.Request) {
+	tags := mergeTagSpecs(awsquery.TagSpecs(r.Form), "network-acl")
+
+	acl, err := h.vpc.CreateNetworkACL(r.Context(), r.Form.Get("VpcId"), tags)
+	if err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createNetworkACLResponseXML{
+		Xmlns:      awsquery.Namespace,
+		RequestID:  awsquery.RequestID,
+		NetworkACL: toNetworkACLXML(acl),
+	})
+}
+
+func (h *Handler) deleteNetworkACL(w http.ResponseWriter, r *http.Request) {
+	if err := h.vpc.DeleteNetworkACL(r.Context(), r.Form.Get("NetworkAclId")); err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteNetworkACLResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern
+func (h *Handler) describeNetworkACLs(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "NetworkAclId")
+
+	acls, err := h.vpc.DescribeNetworkACLs(r.Context(), ids)
+	if err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	out := make([]networkACLXML, 0, len(acls))
+	for i := range acls {
+		out = append(out, toNetworkACLXML(&acls[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeNetworkACLsResponseXML{
+		Xmlns:         awsquery.Namespace,
+		RequestID:     awsquery.RequestID,
+		NetworkACLSet: out,
+	})
+}
+
+func (h *Handler) createNetworkACLEntry(w http.ResponseWriter, r *http.Request) {
+	ruleNum, _ := strconv.Atoi(r.Form.Get("RuleNumber"))
+	fromPort, _ := strconv.Atoi(r.Form.Get("PortRange.From"))
+	toPort, _ := strconv.Atoi(r.Form.Get("PortRange.To"))
+	egress := r.Form.Get("Egress") == formTrue
+
+	rule := &netdriver.NetworkACLRule{
+		RuleNumber: ruleNum,
+		Protocol:   r.Form.Get("Protocol"),
+		Action:     r.Form.Get("RuleAction"),
+		CIDR:       r.Form.Get("CidrBlock"),
+		FromPort:   fromPort,
+		ToPort:     toPort,
+		Egress:     egress,
+	}
+
+	if err := h.vpc.AddNetworkACLRule(r.Context(), r.Form.Get("NetworkAclId"), rule); err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createNetworkACLEntryResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+func (h *Handler) deleteNetworkACLEntry(w http.ResponseWriter, r *http.Request) {
+	ruleNum, _ := strconv.Atoi(r.Form.Get("RuleNumber"))
+	egress := r.Form.Get("Egress") == formTrue
+
+	err := h.vpc.RemoveNetworkACLRule(r.Context(),
+		r.Form.Get("NetworkAclId"), ruleNum, egress)
+	if err != nil {
+		writeNetworkACLErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteNetworkACLEntryResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+func toNetworkACLXML(a *netdriver.NetworkACL) networkACLXML {
+	x := networkACLXML{
+		NetworkACLID: a.ID,
+		VpcID:        a.VPCID,
+		IsDefault:    a.IsDefault,
+		Tags:         toTagItems(a.Tags),
+	}
+
+	for _, rule := range a.Rules {
+		entry := networkACLEntryXML{
+			RuleNumber: rule.RuleNumber,
+			Protocol:   rule.Protocol,
+			RuleAction: rule.Action,
+			Egress:     rule.Egress,
+			CIDRBlock:  rule.CIDR,
+		}
+
+		if rule.FromPort != 0 || rule.ToPort != 0 {
+			entry.PortRange = &struct {
+				From int `xml:"from"`
+				To   int `xml:"to"`
+			}{From: rule.FromPort, To: rule.ToPort}
+		}
+
+		x.Entries = append(x.Entries, entry)
+	}
+
+	return x
+}
+
+func writeNetworkACLErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidNetworkAclID.NotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/peering.go
+++ b/server/aws/ec2/peering.go
@@ -1,0 +1,149 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type peeringStatusXML struct {
+	Code string `xml:"code"`
+}
+
+type peeringConnectionXML struct {
+	VpcPeeringConnectionID string           `xml:"vpcPeeringConnectionId"`
+	RequesterVpcInfo       peeringVpcInfo   `xml:"requesterVpcInfo"`
+	AccepterVpcInfo        peeringVpcInfo   `xml:"accepterVpcInfo"`
+	Status                 peeringStatusXML `xml:"status"`
+	CreationTime           string           `xml:"creationTimestamp,omitempty"`
+	Tags                   []tagItem        `xml:"tagSet>item,omitempty"`
+}
+
+type peeringVpcInfo struct {
+	VpcID string `xml:"vpcId"`
+}
+
+type createPeeringResponseXML struct {
+	XMLName              xml.Name             `xml:"CreateVpcPeeringConnectionResponse"`
+	Xmlns                string               `xml:"xmlns,attr"`
+	RequestID            string               `xml:"requestId"`
+	VpcPeeringConnection peeringConnectionXML `xml:"vpcPeeringConnection"`
+}
+
+type acceptPeeringResponseXML struct {
+	XMLName              xml.Name             `xml:"AcceptVpcPeeringConnectionResponse"`
+	Xmlns                string               `xml:"xmlns,attr"`
+	RequestID            string               `xml:"requestId"`
+	VpcPeeringConnection peeringConnectionXML `xml:"vpcPeeringConnection"`
+}
+
+type deletePeeringResponseXML struct {
+	XMLName   xml.Name `xml:"DeleteVpcPeeringConnectionResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+type describePeeringResponseXML struct {
+	XMLName              xml.Name               `xml:"DescribeVpcPeeringConnectionsResponse"`
+	Xmlns                string                 `xml:"xmlns,attr"`
+	RequestID            string                 `xml:"requestId"`
+	VpcPeeringConnection []peeringConnectionXML `xml:"vpcPeeringConnectionSet>item"`
+}
+
+//nolint:dupl // per-resource create pattern; mirrors snapshot/flow-log shape
+func (h *Handler) createVpcPeeringConnection(w http.ResponseWriter, r *http.Request) {
+	cfg := netdriver.PeeringConfig{
+		RequesterVPC: r.Form.Get("VpcId"),
+		AccepterVPC:  r.Form.Get("PeerVpcId"),
+		Tags:         mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpc-peering-connection"),
+	}
+
+	info, err := h.vpc.CreatePeeringConnection(r.Context(), cfg)
+	if err != nil {
+		writePeeringErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createPeeringResponseXML{
+		Xmlns:                awsquery.Namespace,
+		RequestID:            awsquery.RequestID,
+		VpcPeeringConnection: toPeeringXML(info),
+	})
+}
+
+func (h *Handler) acceptVpcPeeringConnection(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("VpcPeeringConnectionId")
+
+	if err := h.vpc.AcceptPeeringConnection(r.Context(), id); err != nil {
+		writePeeringErr(w, err)
+		return
+	}
+
+	peerings, _ := h.vpc.DescribePeeringConnections(r.Context(), []string{id})
+
+	var p peeringConnectionXML
+
+	if len(peerings) > 0 {
+		p = toPeeringXML(&peerings[0])
+	}
+
+	awsquery.WriteXMLResponse(w, acceptPeeringResponseXML{
+		Xmlns:                awsquery.Namespace,
+		RequestID:            awsquery.RequestID,
+		VpcPeeringConnection: p,
+	})
+}
+
+func (h *Handler) deleteVpcPeeringConnection(w http.ResponseWriter, r *http.Request) {
+	if err := h.vpc.DeletePeeringConnection(r.Context(),
+		r.Form.Get("VpcPeeringConnectionId")); err != nil {
+		writePeeringErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deletePeeringResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern
+func (h *Handler) describeVpcPeeringConnections(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "VpcPeeringConnectionId")
+
+	peerings, err := h.vpc.DescribePeeringConnections(r.Context(), ids)
+	if err != nil {
+		writePeeringErr(w, err)
+		return
+	}
+
+	out := make([]peeringConnectionXML, 0, len(peerings))
+	for i := range peerings {
+		out = append(out, toPeeringXML(&peerings[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describePeeringResponseXML{
+		Xmlns:                awsquery.Namespace,
+		RequestID:            awsquery.RequestID,
+		VpcPeeringConnection: out,
+	})
+}
+
+func toPeeringXML(p *netdriver.PeeringConnection) peeringConnectionXML {
+	return peeringConnectionXML{
+		VpcPeeringConnectionID: p.ID,
+		RequesterVpcInfo:       peeringVpcInfo{VpcID: p.RequesterVPC},
+		AccepterVpcInfo:        peeringVpcInfo{VpcID: p.AccepterVPC},
+		Status:                 peeringStatusXML{Code: p.Status},
+		CreationTime:           p.CreatedAt,
+		Tags:                   toTagItems(p.Tags),
+	}
+}
+
+func writePeeringErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidVpcPeeringConnectionID.NotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -1,0 +1,116 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type snapshotXML struct {
+	SnapshotID  string    `xml:"snapshotId"`
+	VolumeID    string    `xml:"volumeId"`
+	State       string    `xml:"status"`
+	StartTime   string    `xml:"startTime,omitempty"`
+	Description string    `xml:"description,omitempty"`
+	VolumeSize  int       `xml:"volumeSize"`
+	Tags        []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type createSnapshotResponseXML struct {
+	XMLName   xml.Name `xml:"CreateSnapshotResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	snapshotXML
+}
+
+type describeSnapshotsResponseXML struct {
+	XMLName     xml.Name      `xml:"DescribeSnapshotsResponse"`
+	Xmlns       string        `xml:"xmlns,attr"`
+	RequestID   string        `xml:"requestId"`
+	SnapshotSet []snapshotXML `xml:"snapshotSet>item"`
+}
+
+type deleteSnapshotResponseXML struct {
+	XMLName   xml.Name `xml:"DeleteSnapshotResponse"`
+	Xmlns     string   `xml:"xmlns,attr"`
+	RequestID string   `xml:"requestId"`
+	Return    bool     `xml:"return"`
+}
+
+func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
+	cfg := computedriver.SnapshotConfig{
+		VolumeID:    r.Form.Get("VolumeId"),
+		Description: r.Form.Get("Description"),
+		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "snapshot"),
+	}
+
+	info, err := h.compute.CreateSnapshot(r.Context(), cfg)
+	if err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createSnapshotResponseXML{
+		Xmlns:       awsquery.Namespace,
+		RequestID:   awsquery.RequestID,
+		snapshotXML: toSnapshotXML(info),
+	})
+}
+
+func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
+	if err := h.compute.DeleteSnapshot(r.Context(), r.Form.Get("SnapshotId")); err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteSnapshotResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw/route_table/volume/keypair
+func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "SnapshotId")
+
+	snaps, err := h.compute.DescribeSnapshots(r.Context(), ids)
+	if err != nil {
+		writeSnapshotErr(w, err)
+		return
+	}
+
+	out := make([]snapshotXML, 0, len(snaps))
+	for i := range snaps {
+		out = append(out, toSnapshotXML(&snaps[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeSnapshotsResponseXML{
+		Xmlns:       awsquery.Namespace,
+		RequestID:   awsquery.RequestID,
+		SnapshotSet: out,
+	})
+}
+
+func toSnapshotXML(s *computedriver.SnapshotInfo) snapshotXML {
+	state := s.State
+	if state == "" {
+		state = "completed"
+	}
+
+	return snapshotXML{
+		SnapshotID:  s.ID,
+		VolumeID:    s.VolumeID,
+		State:       state,
+		StartTime:   s.CreatedAt,
+		Description: s.Description,
+		VolumeSize:  s.Size,
+		Tags:        toTagItems(s.Tags),
+	}
+}
+
+func writeSnapshotErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidSnapshot.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/snapshot.go
+++ b/server/aws/ec2/snapshot.go
@@ -39,6 +39,7 @@ type deleteSnapshotResponseXML struct {
 	Return    bool     `xml:"return"`
 }
 
+//nolint:dupl // per-resource create pattern; mirrors peering/flow-log shape
 func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
 	cfg := computedriver.SnapshotConfig{
 		VolumeID:    r.Form.Get("VolumeId"),

--- a/server/aws/ec2/spot.go
+++ b/server/aws/ec2/spot.go
@@ -1,0 +1,138 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+type spotRequestXML struct {
+	SpotInstanceRequestID string `xml:"spotInstanceRequestId"`
+	State                 string `xml:"state"`
+	Type                  string `xml:"type,omitempty"`
+	InstanceID            string `xml:"instanceId,omitempty"`
+	CreateTime            string `xml:"createTime,omitempty"`
+	SpotPrice             string `xml:"spotPrice,omitempty"`
+}
+
+type requestSpotInstancesResponseXML struct {
+	XMLName             xml.Name         `xml:"RequestSpotInstancesResponse"`
+	Xmlns               string           `xml:"xmlns,attr"`
+	RequestID           string           `xml:"requestId"`
+	SpotInstanceRequest []spotRequestXML `xml:"spotInstanceRequestSet>item"`
+}
+
+type describeSpotInstanceRequestsResponseXML struct {
+	XMLName             xml.Name         `xml:"DescribeSpotInstanceRequestsResponse"`
+	Xmlns               string           `xml:"xmlns,attr"`
+	RequestID           string           `xml:"requestId"`
+	SpotInstanceRequest []spotRequestXML `xml:"spotInstanceRequestSet>item"`
+}
+
+type cancelSpotItemXML struct {
+	SpotInstanceRequestID string `xml:"spotInstanceRequestId"`
+	State                 string `xml:"state"`
+}
+
+type cancelSpotInstanceRequestsResponseXML struct {
+	XMLName   xml.Name            `xml:"CancelSpotInstanceRequestsResponse"`
+	Xmlns     string              `xml:"xmlns,attr"`
+	RequestID string              `xml:"requestId"`
+	Items     []cancelSpotItemXML `xml:"spotInstanceRequestSet>item"`
+}
+
+func (h *Handler) requestSpotInstances(w http.ResponseWriter, r *http.Request) {
+	count, _ := strconv.Atoi(r.Form.Get("InstanceCount"))
+	if count < 1 {
+		count = 1
+	}
+
+	price, _ := strconv.ParseFloat(r.Form.Get("SpotPrice"), 64)
+
+	cfg := computedriver.SpotRequestConfig{
+		InstanceConfig: computedriver.InstanceConfig{
+			ImageID:      r.Form.Get("LaunchSpecification.ImageId"),
+			InstanceType: r.Form.Get("LaunchSpecification.InstanceType"),
+		},
+		MaxPrice: price,
+		Count:    count,
+		Type:     r.Form.Get("Type"),
+	}
+
+	reqs, err := h.compute.RequestSpotInstances(r.Context(), cfg)
+	if err != nil {
+		writeSpotErr(w, err)
+		return
+	}
+
+	out := make([]spotRequestXML, 0, len(reqs))
+	for i := range reqs {
+		out = append(out, toSpotRequestXML(&reqs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, requestSpotInstancesResponseXML{
+		Xmlns:               awsquery.Namespace,
+		RequestID:           awsquery.RequestID,
+		SpotInstanceRequest: out,
+	})
+}
+
+func (h *Handler) cancelSpotInstanceRequests(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "SpotInstanceRequestId")
+
+	if err := h.compute.CancelSpotRequests(r.Context(), ids); err != nil {
+		writeSpotErr(w, err)
+		return
+	}
+
+	items := make([]cancelSpotItemXML, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, cancelSpotItemXML{SpotInstanceRequestID: id, State: "canceled"})
+	}
+
+	awsquery.WriteXMLResponse(w, cancelSpotInstanceRequestsResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Items:     items,
+	})
+}
+
+//nolint:dupl // per-resource describe pattern
+func (h *Handler) describeSpotInstanceRequests(w http.ResponseWriter, r *http.Request) {
+	ids := awsquery.ListStrings(r.Form, "SpotInstanceRequestId")
+
+	reqs, err := h.compute.DescribeSpotRequests(r.Context(), ids)
+	if err != nil {
+		writeSpotErr(w, err)
+		return
+	}
+
+	out := make([]spotRequestXML, 0, len(reqs))
+	for i := range reqs {
+		out = append(out, toSpotRequestXML(&reqs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeSpotInstanceRequestsResponseXML{
+		Xmlns:               awsquery.Namespace,
+		RequestID:           awsquery.RequestID,
+		SpotInstanceRequest: out,
+	})
+}
+
+func toSpotRequestXML(s *computedriver.SpotInstanceRequest) spotRequestXML {
+	return spotRequestXML{
+		SpotInstanceRequestID: s.ID,
+		State:                 s.Status,
+		Type:                  s.Type,
+		InstanceID:            s.InstanceID,
+		CreateTime:            s.CreatedAt,
+		SpotPrice:             strconv.FormatFloat(s.MaxPrice, 'f', -1, 64),
+	}
+}
+
+func writeSpotErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidSpotInstanceRequestID.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -1580,4 +1581,122 @@ func TestEC2RunInstancesWithKeyPair(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, run.Instances, 1)
+}
+
+func TestASGLifecycle(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EC2: provider.EC2, VPC: provider.VPC})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("t", "t", "")))
+	require.NoError(t, err)
+
+	asc := autoscaling.NewFromConfig(cfg, func(o *autoscaling.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+	ctx := context.Background()
+
+	_, err = asc.CreateAutoScalingGroup(ctx, &autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("web-asg"),
+		MinSize:              aws.Int32(1),
+		MaxSize:              aws.Int32(5),
+		DesiredCapacity:      aws.Int32(2),
+		AvailabilityZones:    []string{"us-east-1a", "us-east-1b"},
+	})
+	require.NoError(t, err)
+
+	desc, err := asc.DescribeAutoScalingGroups(ctx, &autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []string{"web-asg"},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.AutoScalingGroups, 1)
+	assert.Equal(t, int32(5), aws.ToInt32(desc.AutoScalingGroups[0].MaxSize))
+
+	_, err = asc.SetDesiredCapacity(ctx, &autoscaling.SetDesiredCapacityInput{
+		AutoScalingGroupName: aws.String("web-asg"),
+		DesiredCapacity:      aws.Int32(3),
+	})
+	require.NoError(t, err)
+
+	_, err = asc.UpdateAutoScalingGroup(ctx, &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("web-asg"),
+		MinSize:              aws.Int32(2),
+		MaxSize:              aws.Int32(10),
+		DesiredCapacity:      aws.Int32(4),
+	})
+	require.NoError(t, err)
+
+	_, err = asc.DeleteAutoScalingGroup(ctx, &autoscaling.DeleteAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("web-asg"),
+		ForceDelete:          aws.Bool(true),
+	})
+	require.NoError(t, err)
+}
+
+func TestASGScalingPolicy(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EC2: provider.EC2, VPC: provider.VPC})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, _ := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("t", "t", "")))
+	asc := autoscaling.NewFromConfig(cfg, func(o *autoscaling.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+	ctx := context.Background()
+
+	_, err := asc.CreateAutoScalingGroup(ctx, &autoscaling.CreateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("scale-asg"),
+		MinSize:              aws.Int32(1), MaxSize: aws.Int32(3),
+		DesiredCapacity:   aws.Int32(1),
+		AvailabilityZones: []string{"us-east-1a"},
+	})
+	require.NoError(t, err)
+
+	_, err = asc.PutScalingPolicy(ctx, &autoscaling.PutScalingPolicyInput{
+		AutoScalingGroupName: aws.String("scale-asg"),
+		PolicyName:           aws.String("scale-up"),
+		AdjustmentType:       aws.String("ChangeInCapacity"),
+		ScalingAdjustment:    aws.Int32(1),
+	})
+	require.NoError(t, err)
+
+	_, err = asc.ExecutePolicy(ctx, &autoscaling.ExecutePolicyInput{
+		AutoScalingGroupName: aws.String("scale-asg"),
+		PolicyName:           aws.String("scale-up"),
+	})
+	require.NoError(t, err)
+
+	_, err = asc.DeletePolicy(ctx, &autoscaling.DeletePolicyInput{
+		AutoScalingGroupName: aws.String("scale-asg"),
+		PolicyName:           aws.String("scale-up"),
+	})
+	require.NoError(t, err)
+}
+
+func TestASGDeleteUnknownReturnsError(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EC2: provider.EC2, VPC: provider.VPC})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, _ := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("t", "t", "")))
+	asc := autoscaling.NewFromConfig(cfg, func(o *autoscaling.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	_, err := asc.DeleteAutoScalingGroup(context.Background(), &autoscaling.DeleteAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String("ghost-asg"),
+	})
+	require.Error(t, err)
 }

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1913,3 +1913,47 @@ func TestFlowLogsLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestNetworkACLLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	vpc, _ := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+
+	cre, err := client.CreateNetworkAcl(ctx, &ec2.CreateNetworkAclInput{
+		VpcId: vpc.Vpc.VpcId,
+	})
+	require.NoError(t, err)
+	aclID := aws.ToString(cre.NetworkAcl.NetworkAclId)
+	assert.NotEmpty(t, aclID)
+
+	_, err = client.CreateNetworkAclEntry(ctx, &ec2.CreateNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(100),
+		Protocol:     aws.String("6"),
+		RuleAction:   ec2types.RuleActionAllow,
+		CidrBlock:    aws.String("0.0.0.0/0"),
+		Egress:       aws.Bool(false),
+		PortRange:    &ec2types.PortRange{From: aws.Int32(80), To: aws.Int32(80)},
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		NetworkAclIds: []string{aclID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.NetworkAcls, 1)
+	assert.NotEmpty(t, desc.NetworkAcls[0].Entries)
+
+	_, err = client.DeleteNetworkAclEntry(ctx, &ec2.DeleteNetworkAclEntryInput{
+		NetworkAclId: aws.String(aclID),
+		RuleNumber:   aws.Int32(100),
+		Egress:       aws.Bool(false),
+	})
+	require.NoError(t, err)
+
+	_, err = client.DeleteNetworkAcl(ctx, &ec2.DeleteNetworkAclInput{
+		NetworkAclId: aws.String(aclID),
+	})
+	require.NoError(t, err)
+}

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1700,3 +1700,70 @@ func TestASGDeleteUnknownReturnsError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+func TestSnapshotLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	vol, err := client.CreateVolume(ctx, &ec2.CreateVolumeInput{
+		AvailabilityZone: aws.String("us-east-1a"), Size: aws.Int32(10),
+	})
+	require.NoError(t, err)
+
+	snap, err := client.CreateSnapshot(ctx, &ec2.CreateSnapshotInput{
+		VolumeId:    vol.VolumeId,
+		Description: aws.String("backup"),
+	})
+	require.NoError(t, err)
+	snapID := aws.ToString(snap.SnapshotId)
+	assert.NotEmpty(t, snapID)
+
+	desc, err := client.DescribeSnapshots(ctx, &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []string{snapID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.Snapshots, 1)
+	assert.Equal(t, aws.ToString(vol.VolumeId), aws.ToString(desc.Snapshots[0].VolumeId))
+
+	_, err = client.DeleteSnapshot(ctx, &ec2.DeleteSnapshotInput{SnapshotId: aws.String(snapID)})
+	require.NoError(t, err)
+}
+
+func TestImageLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-base"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+
+	img, err := client.CreateImage(ctx, &ec2.CreateImageInput{
+		InstanceId:  run.Instances[0].InstanceId,
+		Name:        aws.String("backup-ami"),
+		Description: aws.String("created from instance"),
+	})
+	require.NoError(t, err)
+	imgID := aws.ToString(img.ImageId)
+	assert.NotEmpty(t, imgID)
+
+	desc, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{imgID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.Images, 1)
+
+	_, err = client.DeregisterImage(ctx, &ec2.DeregisterImageInput{ImageId: aws.String(imgID)})
+	require.NoError(t, err)
+}
+
+func TestSnapshotUnknownReturnsError(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	_, err := client.DeleteSnapshot(ctx, &ec2.DeleteSnapshotInput{
+		SnapshotId: aws.String("snap-ghost"),
+	})
+	require.Error(t, err)
+}

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1823,3 +1823,93 @@ func TestLaunchTemplateLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+func TestNatGatewayLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	vpc, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	require.NoError(t, err)
+
+	sub, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId: vpc.Vpc.VpcId, CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	require.NoError(t, err)
+
+	nat, err := client.CreateNatGateway(ctx, &ec2.CreateNatGatewayInput{
+		SubnetId: sub.Subnet.SubnetId,
+	})
+	require.NoError(t, err)
+	natID := aws.ToString(nat.NatGateway.NatGatewayId)
+	assert.NotEmpty(t, natID)
+
+	desc, err := client.DescribeNatGateways(ctx, &ec2.DescribeNatGatewaysInput{
+		NatGatewayIds: []string{natID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.NatGateways, 1)
+
+	_, err = client.DeleteNatGateway(ctx, &ec2.DeleteNatGatewayInput{
+		NatGatewayId: aws.String(natID),
+	})
+	require.NoError(t, err)
+}
+
+func TestVpcPeeringLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	vpcA, _ := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	vpcB, _ := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.1.0.0/16")})
+
+	p, err := client.CreateVpcPeeringConnection(ctx, &ec2.CreateVpcPeeringConnectionInput{
+		VpcId:     vpcA.Vpc.VpcId,
+		PeerVpcId: vpcB.Vpc.VpcId,
+	})
+	require.NoError(t, err)
+	pid := aws.ToString(p.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	_, err = client.AcceptVpcPeeringConnection(ctx, &ec2.AcceptVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(pid),
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeVpcPeeringConnections(ctx, &ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []string{pid},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.VpcPeeringConnections, 1)
+
+	_, err = client.DeleteVpcPeeringConnection(ctx, &ec2.DeleteVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: aws.String(pid),
+	})
+	require.NoError(t, err)
+}
+
+func TestFlowLogsLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	vpc, _ := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	vpcID := aws.ToString(vpc.Vpc.VpcId)
+
+	create, err := client.CreateFlowLogs(ctx, &ec2.CreateFlowLogsInput{
+		ResourceIds:  []string{vpcID},
+		ResourceType: ec2types.FlowLogsResourceTypeVpc,
+		TrafficType:  ec2types.TrafficTypeAll,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, create.FlowLogIds)
+	flowID := create.FlowLogIds[0]
+
+	desc, err := client.DescribeFlowLogs(ctx, &ec2.DescribeFlowLogsInput{
+		FlowLogIds: []string{flowID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.FlowLogs, 1)
+
+	_, err = client.DeleteFlowLogs(ctx, &ec2.DeleteFlowLogsInput{
+		FlowLogIds: []string{flowID},
+	})
+	require.NoError(t, err)
+}

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -1767,3 +1767,59 @@ func TestSnapshotUnknownReturnsError(t *testing.T) {
 	})
 	require.Error(t, err)
 }
+
+func TestSpotInstanceLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	out, err := client.RequestSpotInstances(ctx, &ec2.RequestSpotInstancesInput{
+		InstanceCount: aws.Int32(1),
+		SpotPrice:     aws.String("0.05"),
+		LaunchSpecification: &ec2types.RequestSpotLaunchSpecification{
+			ImageId:      aws.String("ami-spot"),
+			InstanceType: ec2types.InstanceTypeT2Micro,
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.SpotInstanceRequests)
+
+	reqID := aws.ToString(out.SpotInstanceRequests[0].SpotInstanceRequestId)
+	assert.NotEmpty(t, reqID)
+
+	desc, err := client.DescribeSpotInstanceRequests(ctx, &ec2.DescribeSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []string{reqID},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.SpotInstanceRequests, 1)
+
+	_, err = client.CancelSpotInstanceRequests(ctx, &ec2.CancelSpotInstanceRequestsInput{
+		SpotInstanceRequestIds: []string{reqID},
+	})
+	require.NoError(t, err)
+}
+
+func TestLaunchTemplateLifecycle(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	cre, err := client.CreateLaunchTemplate(ctx, &ec2.CreateLaunchTemplateInput{
+		LaunchTemplateName: aws.String("web-template"),
+		LaunchTemplateData: &ec2types.RequestLaunchTemplateData{
+			ImageId:      aws.String("ami-tmpl"),
+			InstanceType: ec2types.InstanceTypeT2Micro,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "web-template", aws.ToString(cre.LaunchTemplate.LaunchTemplateName))
+
+	desc, err := client.DescribeLaunchTemplates(ctx, &ec2.DescribeLaunchTemplatesInput{
+		LaunchTemplateNames: []string{"web-template"},
+	})
+	require.NoError(t, err)
+	require.Len(t, desc.LaunchTemplates, 1)
+
+	_, err = client.DeleteLaunchTemplate(ctx, &ec2.DeleteLaunchTemplateInput{
+		LaunchTemplateName: aws.String("web-template"),
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## What this does

Finishes the EC2 SDK-compat initiative (#121). After this, the real `aws-sdk-go-v2` EC2 and Auto Scaling clients work end-to-end against CloudEmu for the full common operational surface.

Closes #121. Supersedes #117 (EC2 half of it; CloudWatch remains a follow-up).

## Phases bundled (one commit per phase)

- **Phase 4** — Auto Scaling Groups + scaling policies (8 ops; uses separate `aws-sdk-go-v2/service/autoscaling` SDK, same query protocol)
- **Phase 5** — Snapshots + AMIs (6 ops)
- **Phase 6** — Spot Instances + Launch Templates (6 ops)
- **Phase 7** — NAT Gateways + VPC Peering + Flow Logs (10 ops)
- **Phase 8** — Network ACLs (5 ops)

**Total this PR: ~35 new operations** on top of Phases 1-3 already in v1.5.1.

## Tests

Each phase has integration tests driving the real SDK clients via `httptest.NewServer`. Full run after every commit stayed green (81/81 packages, 0 lint issues).

Also ran a standalone end-to-end smoke program that exercises the whole surface as a developer would:

```
=== Phase 4: Auto Scaling ===
  CreateAutoScalingGroup / SetDesiredCapacity / PutScalingPolicy /
  ExecutePolicy / DeleteAutoScalingGroup

=== Phase 5: Snapshots & AMIs ===
  CreateSnapshot → snap-* / CreateImage → ami-* / Deregister + Delete

=== Phase 6: Spot & Launch Templates ===
  CreateLaunchTemplate → lt-* / RequestSpotInstances → sir-*
  CancelSpotInstanceRequests / DeleteLaunchTemplate

=== Phase 7: NAT / Peering / Flow Logs ===
  CreateNatGateway → nat-* / CreateVpcPeeringConnection → pcx-*
  AcceptVpcPeeringConnection / CreateFlowLogs → fl-* / Delete...

=== Phase 8: Network ACLs ===
  CreateNetworkAcl → acl-* / CreateNetworkAclEntry (tcp/80 allow) /
  DeleteNetworkAclEntry / DeleteNetworkAcl

ALL PHASES 4-8 FLOWS COMPLETED
```

## Refactor included

`ServeHTTP` now iterates a `[]routeFunc` list instead of 13 chained `if` statements — keeps cyclomatic complexity in check as the service list grew.

## Verified

- `go build ./...` — clean
- `go test ./...` — 81/81 packages pass
- `golangci-lint run ./...` — 0 issues