### PR TITLE
Add chaos engineering engine (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ cloudemu goes beyond basic CRUD mocks. It reproduces real cloud behaviors so you
 - **Stream/Change Feed** — Database mutations produce stream records (INSERT/MODIFY/REMOVE).
 - **Numeric-Aware Comparisons** — Database filters compare `"10" > "9"` correctly using numeric ordering.
 
+## Chaos Engineering — Test Your App Against Cloud Failure
+
+CloudEmu can deliberately fail or slow down services in controlled, time-bounded windows, so retry logic, timeouts, and graceful-degradation paths in your code can actually be exercised.
+
+```go
+engine := chaos.New(config.RealClock{})
+chaosS3 := chaos.WrapBucket(cloud.S3, engine)
+
+// Run your app against this S3...
+engine.Apply(chaos.ServiceOutage("storage", 5*time.Second))
+// ...calls fail for 5 seconds, then recover automatically.
+```
+
+Scenarios available today: `ServiceOutage`, `LatencySpike`, `ProbabilisticFailure`, `Throttle`, `Composite`. Works for both Go API and SDK-compat HTTP clients. See [docs/chaos.md](docs/chaos.md).
+
 ## Use the Real AWS SDK (no code changes)
 
 If your app already uses `aws-sdk-go-v2`, you don't have to rewrite anything. cloudemu ships an HTTP server that speaks the real AWS wire protocols. Point the SDK's `BaseEndpoint` at localhost and your production code just works.

--- a/chaos/chaos.go
+++ b/chaos/chaos.go
@@ -1,0 +1,188 @@
+// Package chaos lets tests deliberately fail or slow down CloudEmu services
+// in controlled, time-bounded ways — so app code that handles cloud failure
+// can be exercised without waiting for real cloud to misbehave.
+//
+// Typical usage:
+//
+//	engine := chaos.New(config.RealClock{})
+//	defer engine.Stop()
+//
+//	// Wrap a driver before handing it to the portable API or HTTP server
+//	chaosS3 := chaos.WrapBucket(aws.S3, engine)
+//	srv := awsserver.New(awsserver.Drivers{S3: chaosS3})
+//
+//	// Inject a failure scenario
+//	engine.Apply(chaos.ServiceOutage("storage", 5*time.Second))
+//
+//	// SDK calls now fail for 5s, then recover automatically
+package chaos
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+)
+
+// Effect is what a chaos scenario produces for a given call. Either field may
+// be the zero value (no latency / no error). When both are zero, the call
+// proceeds normally.
+type Effect struct {
+	Latency time.Duration
+	Error   error
+}
+
+// Scenario describes a chaos pattern. It's queried by the engine on every
+// driver call to decide what (if anything) should happen to it.
+type Scenario interface {
+	// EffectOn returns the effect to apply to a given service+operation call
+	// at this moment, or a zero Effect if the scenario doesn't apply.
+	EffectOn(now time.Time, service, operation string) Effect
+
+	// Active returns true while the scenario is in its effective window.
+	// Once Active returns false, the engine drops it.
+	Active(now time.Time) bool
+}
+
+// Active is a handle returned by Apply that lets a caller cancel a scenario
+// before its natural expiry.
+type Active struct {
+	engine *Engine
+	id     uint64
+}
+
+// Stop removes the scenario from the engine. Safe to call multiple times.
+func (a *Active) Stop() {
+	if a == nil || a.engine == nil {
+		return
+	}
+
+	a.engine.remove(a.id)
+}
+
+// Engine is the registry and dispatcher of active scenarios. It's safe for
+// concurrent use.
+type Engine struct {
+	clock config.Clock
+
+	mu       sync.RWMutex
+	next     uint64
+	active   map[uint64]Scenario
+	recorded []Recorded
+}
+
+// Recorded captures one chaos event for post-test inspection.
+type Recorded struct {
+	When      time.Time
+	Service   string
+	Operation string
+	Effect    Effect
+}
+
+// New returns an engine that uses clock for time-based scenario activation.
+// Pass a config.FakeClock for deterministic tests.
+func New(clock config.Clock) *Engine {
+	if clock == nil {
+		clock = config.RealClock{}
+	}
+
+	return &Engine{
+		clock:  clock,
+		active: make(map[uint64]Scenario),
+	}
+}
+
+// Apply registers a scenario. The returned Active can be used to stop it
+// before it expires.
+func (e *Engine) Apply(s Scenario) *Active {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.next++
+	id := e.next
+	e.active[id] = s
+
+	return &Active{engine: e, id: id}
+}
+
+func (e *Engine) remove(id uint64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	delete(e.active, id)
+}
+
+// Stop removes every active scenario. Idiomatic to defer at test setup.
+func (e *Engine) Stop() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.active = make(map[uint64]Scenario)
+}
+
+// Check is what driver wrappers call on every operation. It returns the
+// merged effect from every active scenario:
+//   - latencies sum (worst case)
+//   - the first non-nil error wins
+//
+// Expired scenarios are dropped lazily here.
+func (e *Engine) Check(service, operation string) Effect {
+	if e == nil {
+		return Effect{}
+	}
+
+	now := e.clock.Now()
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var merged Effect
+
+	for id, s := range e.active {
+		if !s.Active(now) {
+			delete(e.active, id)
+
+			continue
+		}
+
+		eff := s.EffectOn(now, service, operation)
+		merged.Latency += eff.Latency
+
+		if merged.Error == nil && eff.Error != nil {
+			merged.Error = eff.Error
+		}
+	}
+
+	if merged.Latency > 0 || merged.Error != nil {
+		e.recorded = append(e.recorded, Recorded{
+			When: now, Service: service, Operation: operation, Effect: merged,
+		})
+	}
+
+	return merged
+}
+
+// Recorded returns a snapshot of every chaos event the engine has seen since
+// the last Reset. Useful for post-test assertions.
+func (e *Engine) Recorded() []Recorded {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	out := make([]Recorded, len(e.recorded))
+	copy(out, e.recorded)
+
+	return out
+}
+
+// Reset clears the recorded events buffer. Active scenarios are untouched.
+func (e *Engine) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.recorded = nil
+}
+
+// ErrChaosInjected is the sentinel-style error type the engine wraps when a
+// scenario provides no specific error. Callers can errors.Is against it.
+var ErrChaosInjected = errors.New("chaos: injected failure")

--- a/chaos/chaos_test.go
+++ b/chaos/chaos_test.go
@@ -1,0 +1,279 @@
+package chaos_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	awsec2 "github.com/stackshy/cloudemu/providers/aws/ec2"
+	awss3 "github.com/stackshy/cloudemu/providers/aws/s3"
+)
+
+func TestEngineNilSafe(t *testing.T) {
+	var e *chaos.Engine
+
+	if got := e.Check("storage", "PutObject"); got.Error != nil || got.Latency != 0 {
+		t.Fatalf("nil engine should be a no-op, got %+v", got)
+	}
+}
+
+func TestServiceOutage(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	eff := e.Check("storage", "PutObject")
+	if eff.Error == nil {
+		t.Fatal("expected error during outage, got nil")
+	}
+
+	if cerrors.GetCode(eff.Error) != cerrors.Unavailable {
+		t.Errorf("expected Unavailable, got %v", eff.Error)
+	}
+
+	// Different service should not be affected.
+	if eff := e.Check("compute", "RunInstances"); eff.Error != nil {
+		t.Errorf("compute should be unaffected, got %v", eff.Error)
+	}
+}
+
+func TestServiceOutageExpiresAndUnregisters(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", 10*time.Millisecond))
+
+	if e.Check("storage", "Op").Error == nil {
+		t.Fatal("should fail while active")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	if e.Check("storage", "Op").Error != nil {
+		t.Fatal("should recover after window")
+	}
+}
+
+func TestLatencySpike(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.LatencySpike("storage", 50*time.Millisecond, time.Hour))
+
+	if eff := e.Check("storage", "Op"); eff.Latency != 50*time.Millisecond {
+		t.Errorf("latency = %v, want 50ms", eff.Latency)
+	}
+
+	// Wrong service: no latency.
+	if eff := e.Check("compute", "Op"); eff.Latency != 0 {
+		t.Errorf("expected 0 latency for compute, got %v", eff.Latency)
+	}
+}
+
+func TestProbabilisticFailure(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("test failure")
+	e.Apply(chaos.ProbabilisticFailure("storage", "GetObject", myErr, 1.0, time.Hour))
+
+	// p=1.0 means every call should fail.
+	for range 20 {
+		if eff := e.Check("storage", "GetObject"); eff.Error == nil {
+			t.Fatal("p=1.0 should always inject")
+		}
+	}
+
+	// Non-targeted op should not be affected.
+	if eff := e.Check("storage", "PutObject"); eff.Error != nil {
+		t.Errorf("PutObject should not be affected: %v", eff.Error)
+	}
+}
+
+func TestProbabilisticFailureZeroProbability(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("never")
+	e.Apply(chaos.ProbabilisticFailure("storage", "Op", myErr, 0.0, time.Hour))
+
+	for range 20 {
+		if eff := e.Check("storage", "Op"); eff.Error != nil {
+			t.Fatalf("p=0.0 should never inject, got %v", eff.Error)
+		}
+	}
+}
+
+func TestThrottle(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Throttle("compute", "RunInstances", 3, time.Hour))
+
+	// First 3 calls in the same second pass.
+	for i := range 3 {
+		if eff := e.Check("compute", "RunInstances"); eff.Error != nil {
+			t.Fatalf("call %d should pass under threshold, got %v", i, eff.Error)
+		}
+	}
+
+	// 4th in same second should be throttled.
+	if eff := e.Check("compute", "RunInstances"); eff.Error == nil {
+		t.Fatal("4th call should be throttled")
+	}
+}
+
+func TestComposite(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("composite-err")
+	e.Apply(chaos.Composite(
+		chaos.LatencySpike("storage", 10*time.Millisecond, time.Hour),
+		chaos.ProbabilisticFailure("storage", "Op", myErr, 1.0, time.Hour),
+	))
+
+	eff := e.Check("storage", "Op")
+	if eff.Latency != 10*time.Millisecond {
+		t.Errorf("composite latency = %v, want 10ms", eff.Latency)
+	}
+
+	if eff.Error == nil {
+		t.Error("composite should propagate inner failure")
+	}
+}
+
+func TestActiveStop(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	a := e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if eff := e.Check("storage", "Op"); eff.Error == nil {
+		t.Fatal("should fail while active")
+	}
+
+	a.Stop()
+
+	if eff := e.Check("storage", "Op"); eff.Error != nil {
+		t.Errorf("should be cleared after Stop, got %v", eff.Error)
+	}
+}
+
+func TestRecorded(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	for range 3 {
+		_ = e.Check("storage", "Op")
+	}
+
+	rec := e.Recorded()
+	if len(rec) != 3 {
+		t.Fatalf("len=%d want 3", len(rec))
+	}
+
+	e.Reset()
+
+	if len(e.Recorded()) != 0 {
+		t.Error("Reset should clear recorded events")
+	}
+}
+
+func TestEngineConcurrentSafe(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.LatencySpike("storage", time.Microsecond, time.Hour))
+
+	const workers = 50
+
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 100 {
+				_ = e.Check("storage", "Op")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	rec := e.Recorded()
+	if len(rec) != workers*100 {
+		t.Errorf("recorded=%d want %d", len(rec), workers*100)
+	}
+}
+
+func TestWrapBucketAppliesChaos(t *testing.T) {
+	opts := config.NewOptions()
+	bucket := awss3.New(opts)
+	e := chaos.New(config.RealClock{})
+
+	wrapped := chaos.WrapBucket(bucket, e)
+
+	ctx := context.Background()
+	if err := wrapped.CreateBucket(ctx, "test-bucket"); err != nil {
+		t.Fatalf("baseline call should succeed: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if err := wrapped.CreateBucket(ctx, "another"); err == nil {
+		t.Fatal("expected outage error after chaos applied")
+	}
+}
+
+func TestWrapComputeAppliesChaos(t *testing.T) {
+	opts := config.NewOptions()
+	ec2 := awsec2.New(opts)
+	e := chaos.New(config.RealClock{})
+
+	wrapped := chaos.WrapCompute(ec2, e)
+	ctx := context.Background()
+
+	// Baseline: instance launches fine.
+	if _, err := wrapped.RunInstances(ctx, computeInstanceConfig(), 1); err != nil {
+		t.Fatalf("baseline RunInstances: %v", err)
+	}
+
+	// Apply outage: next call should fail with chaos error before reaching driver.
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if _, err := wrapped.RunInstances(ctx, computeInstanceConfig(), 1); err == nil {
+		t.Fatal("expected chaos error during compute outage")
+	}
+}
+
+// computeInstanceConfig builds a minimal InstanceConfig the AWS EC2 mock accepts.
+func computeInstanceConfig() computeConfig {
+	return computeConfig{
+		ImageID:      "ami-test",
+		InstanceType: "t2.micro",
+	}
+}
+
+// computeConfig type-aliases the driver type so the test file doesn't need
+// to import the deeply-nested compute/driver package.
+type computeConfig = struct {
+	ImageID        string
+	InstanceType   string
+	Tags           map[string]string
+	SubnetID       string
+	SecurityGroups []string
+	KeyName        string
+	UserData       string
+}

--- a/chaos/chaos_test.go
+++ b/chaos/chaos_test.go
@@ -1,18 +1,25 @@
 package chaos_test
 
 import (
-	"context"
-	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stackshy/cloudemu/chaos"
 	"github.com/stackshy/cloudemu/config"
-	cerrors "github.com/stackshy/cloudemu/errors"
-	awsec2 "github.com/stackshy/cloudemu/providers/aws/ec2"
-	awss3 "github.com/stackshy/cloudemu/providers/aws/s3"
 )
+
+func TestNewWithNilClockUsesRealClock(t *testing.T) {
+	e := chaos.New(nil)
+	defer e.Stop()
+
+	// Apply a scenario; if the clock plumbing is broken, Active won't fire.
+	e.Apply(chaos.LatencySpike("storage", time.Millisecond, time.Hour))
+
+	if eff := e.Check("storage", "Op"); eff.Latency != time.Millisecond {
+		t.Fatalf("expected scenario to be live, got %+v", eff)
+	}
+}
 
 func TestEngineNilSafe(t *testing.T) {
 	var e *chaos.Engine
@@ -22,151 +29,97 @@ func TestEngineNilSafe(t *testing.T) {
 	}
 }
 
-func TestServiceOutage(t *testing.T) {
+func TestEngineNoActiveScenariosReturnsZeroEffect(t *testing.T) {
 	e := chaos.New(config.RealClock{})
 	defer e.Stop()
 
-	e.Apply(chaos.ServiceOutage("storage", time.Hour))
-
-	eff := e.Check("storage", "PutObject")
-	if eff.Error == nil {
-		t.Fatal("expected error during outage, got nil")
-	}
-
-	if cerrors.GetCode(eff.Error) != cerrors.Unavailable {
-		t.Errorf("expected Unavailable, got %v", eff.Error)
-	}
-
-	// Different service should not be affected.
-	if eff := e.Check("compute", "RunInstances"); eff.Error != nil {
-		t.Errorf("compute should be unaffected, got %v", eff.Error)
+	if eff := e.Check("storage", "Op"); eff.Latency != 0 || eff.Error != nil {
+		t.Fatalf("empty engine should produce zero effect, got %+v", eff)
 	}
 }
 
-func TestServiceOutageExpiresAndUnregisters(t *testing.T) {
+func TestEngineMergesMultipleScenarios(t *testing.T) {
 	e := chaos.New(config.RealClock{})
 	defer e.Stop()
 
-	e.Apply(chaos.ServiceOutage("storage", 10*time.Millisecond))
-
-	if e.Check("storage", "Op").Error == nil {
-		t.Fatal("should fail while active")
-	}
-
-	time.Sleep(20 * time.Millisecond)
-
-	if e.Check("storage", "Op").Error != nil {
-		t.Fatal("should recover after window")
-	}
-}
-
-func TestLatencySpike(t *testing.T) {
-	e := chaos.New(config.RealClock{})
-	defer e.Stop()
-
-	e.Apply(chaos.LatencySpike("storage", 50*time.Millisecond, time.Hour))
-
-	if eff := e.Check("storage", "Op"); eff.Latency != 50*time.Millisecond {
-		t.Errorf("latency = %v, want 50ms", eff.Latency)
-	}
-
-	// Wrong service: no latency.
-	if eff := e.Check("compute", "Op"); eff.Latency != 0 {
-		t.Errorf("expected 0 latency for compute, got %v", eff.Latency)
-	}
-}
-
-func TestProbabilisticFailure(t *testing.T) {
-	e := chaos.New(config.RealClock{})
-	defer e.Stop()
-
-	myErr := errors.New("test failure")
-	e.Apply(chaos.ProbabilisticFailure("storage", "GetObject", myErr, 1.0, time.Hour))
-
-	// p=1.0 means every call should fail.
-	for range 20 {
-		if eff := e.Check("storage", "GetObject"); eff.Error == nil {
-			t.Fatal("p=1.0 should always inject")
-		}
-	}
-
-	// Non-targeted op should not be affected.
-	if eff := e.Check("storage", "PutObject"); eff.Error != nil {
-		t.Errorf("PutObject should not be affected: %v", eff.Error)
-	}
-}
-
-func TestProbabilisticFailureZeroProbability(t *testing.T) {
-	e := chaos.New(config.RealClock{})
-	defer e.Stop()
-
-	myErr := errors.New("never")
-	e.Apply(chaos.ProbabilisticFailure("storage", "Op", myErr, 0.0, time.Hour))
-
-	for range 20 {
-		if eff := e.Check("storage", "Op"); eff.Error != nil {
-			t.Fatalf("p=0.0 should never inject, got %v", eff.Error)
-		}
-	}
-}
-
-func TestThrottle(t *testing.T) {
-	e := chaos.New(config.RealClock{})
-	defer e.Stop()
-
-	e.Apply(chaos.Throttle("compute", "RunInstances", 3, time.Hour))
-
-	// First 3 calls in the same second pass.
-	for i := range 3 {
-		if eff := e.Check("compute", "RunInstances"); eff.Error != nil {
-			t.Fatalf("call %d should pass under threshold, got %v", i, eff.Error)
-		}
-	}
-
-	// 4th in same second should be throttled.
-	if eff := e.Check("compute", "RunInstances"); eff.Error == nil {
-		t.Fatal("4th call should be throttled")
-	}
-}
-
-func TestComposite(t *testing.T) {
-	e := chaos.New(config.RealClock{})
-	defer e.Stop()
-
-	myErr := errors.New("composite-err")
-	e.Apply(chaos.Composite(
-		chaos.LatencySpike("storage", 10*time.Millisecond, time.Hour),
-		chaos.ProbabilisticFailure("storage", "Op", myErr, 1.0, time.Hour),
-	))
+	e.Apply(chaos.LatencySpike("storage", 10*time.Millisecond, time.Hour))
+	e.Apply(chaos.LatencySpike("storage", 20*time.Millisecond, time.Hour))
 
 	eff := e.Check("storage", "Op")
-	if eff.Latency != 10*time.Millisecond {
-		t.Errorf("composite latency = %v, want 10ms", eff.Latency)
-	}
-
-	if eff.Error == nil {
-		t.Error("composite should propagate inner failure")
+	if eff.Latency != 30*time.Millisecond {
+		t.Errorf("latencies should sum: got %v want 30ms", eff.Latency)
 	}
 }
 
-func TestActiveStop(t *testing.T) {
+func TestEngineExpiresScenariosLazily(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.LatencySpike("storage", time.Millisecond, 5*time.Millisecond))
+
+	if eff := e.Check("storage", "Op"); eff.Latency == 0 {
+		t.Fatal("scenario should be active immediately")
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	// The next Check should drop the expired scenario.
+	if eff := e.Check("storage", "Op"); eff.Latency != 0 {
+		t.Errorf("expected scenario to expire, got %+v", eff)
+	}
+}
+
+func TestActiveStopRemovesScenario(t *testing.T) {
 	e := chaos.New(config.RealClock{})
 	defer e.Stop()
 
 	a := e.Apply(chaos.ServiceOutage("storage", time.Hour))
 
-	if eff := e.Check("storage", "Op"); eff.Error == nil {
-		t.Fatal("should fail while active")
+	if e.Check("storage", "Op").Error == nil {
+		t.Fatal("scenario should be active")
 	}
 
 	a.Stop()
 
 	if eff := e.Check("storage", "Op"); eff.Error != nil {
-		t.Errorf("should be cleared after Stop, got %v", eff.Error)
+		t.Errorf("scenario should be cleared after Stop, got %v", eff.Error)
 	}
 }
 
-func TestRecorded(t *testing.T) {
+func TestActiveStopOnNilSafe(t *testing.T) {
+	var a *chaos.Active
+
+	a.Stop() // should not panic
+}
+
+func TestActiveStopIdempotent(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	a := e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	a.Stop()
+	a.Stop() // second call should be a no-op
+}
+
+func TestEngineStopClearsAllScenarios(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+	e.Apply(chaos.LatencySpike("compute", time.Second, time.Hour))
+
+	e.Stop()
+
+	if eff := e.Check("storage", "Op"); eff.Error != nil {
+		t.Errorf("Stop should clear storage outage, got %v", eff.Error)
+	}
+
+	if eff := e.Check("compute", "Op"); eff.Latency != 0 {
+		t.Errorf("Stop should clear compute latency, got %v", eff.Latency)
+	}
+}
+
+func TestRecordedCapturesAppliedEffects(t *testing.T) {
 	e := chaos.New(config.RealClock{})
 	defer e.Stop()
 
@@ -181,10 +134,44 @@ func TestRecorded(t *testing.T) {
 		t.Fatalf("len=%d want 3", len(rec))
 	}
 
+	for _, r := range rec {
+		if r.Service != "storage" || r.Operation != "Op" {
+			t.Errorf("recorded event wrong: %+v", r)
+		}
+
+		if r.Effect.Error == nil {
+			t.Errorf("recorded event missing effect error: %+v", r)
+		}
+
+		if r.When.IsZero() {
+			t.Errorf("recorded event has zero timestamp: %+v", r)
+		}
+	}
+}
+
+func TestRecordedSkipsNoOps(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	// No scenarios applied — the call should produce no recording.
+	_ = e.Check("storage", "Op")
+
+	if rec := e.Recorded(); len(rec) != 0 {
+		t.Errorf("expected no recordings without active scenario, got %d", len(rec))
+	}
+}
+
+func TestResetClearsRecorded(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+	_ = e.Check("storage", "Op")
+
 	e.Reset()
 
-	if len(e.Recorded()) != 0 {
-		t.Error("Reset should clear recorded events")
+	if rec := e.Recorded(); len(rec) != 0 {
+		t.Errorf("Reset should clear recorded events, got %d", len(rec))
 	}
 }
 
@@ -212,68 +199,17 @@ func TestEngineConcurrentSafe(t *testing.T) {
 
 	wg.Wait()
 
-	rec := e.Recorded()
-	if len(rec) != workers*100 {
+	if rec := e.Recorded(); len(rec) != workers*100 {
 		t.Errorf("recorded=%d want %d", len(rec), workers*100)
 	}
 }
 
-func TestWrapBucketAppliesChaos(t *testing.T) {
-	opts := config.NewOptions()
-	bucket := awss3.New(opts)
-	e := chaos.New(config.RealClock{})
-
-	wrapped := chaos.WrapBucket(bucket, e)
-
-	ctx := context.Background()
-	if err := wrapped.CreateBucket(ctx, "test-bucket"); err != nil {
-		t.Fatalf("baseline call should succeed: %v", err)
+func TestErrChaosInjectedExported(t *testing.T) {
+	if chaos.ErrChaosInjected == nil {
+		t.Fatal("ErrChaosInjected should be a non-nil sentinel")
 	}
 
-	e.Apply(chaos.ServiceOutage("storage", time.Hour))
-
-	if err := wrapped.CreateBucket(ctx, "another"); err == nil {
-		t.Fatal("expected outage error after chaos applied")
+	if chaos.ErrChaosInjected.Error() == "" {
+		t.Error("ErrChaosInjected should have a message")
 	}
-}
-
-func TestWrapComputeAppliesChaos(t *testing.T) {
-	opts := config.NewOptions()
-	ec2 := awsec2.New(opts)
-	e := chaos.New(config.RealClock{})
-
-	wrapped := chaos.WrapCompute(ec2, e)
-	ctx := context.Background()
-
-	// Baseline: instance launches fine.
-	if _, err := wrapped.RunInstances(ctx, computeInstanceConfig(), 1); err != nil {
-		t.Fatalf("baseline RunInstances: %v", err)
-	}
-
-	// Apply outage: next call should fail with chaos error before reaching driver.
-	e.Apply(chaos.ServiceOutage("compute", time.Hour))
-
-	if _, err := wrapped.RunInstances(ctx, computeInstanceConfig(), 1); err == nil {
-		t.Fatal("expected chaos error during compute outage")
-	}
-}
-
-// computeInstanceConfig builds a minimal InstanceConfig the AWS EC2 mock accepts.
-func computeInstanceConfig() computeConfig {
-	return computeConfig{
-		ImageID:      "ami-test",
-		InstanceType: "t2.micro",
-	}
-}
-
-// computeConfig type-aliases the driver type so the test file doesn't need
-// to import the deeply-nested compute/driver package.
-type computeConfig = struct {
-	ImageID        string
-	InstanceType   string
-	Tags           map[string]string
-	SubnetID       string
-	SecurityGroups []string
-	KeyName        string
-	UserData       string
 }

--- a/chaos/integration_test.go
+++ b/chaos/integration_test.go
@@ -1,0 +1,132 @@
+package chaos_test
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	cloudemuConfig "github.com/stackshy/cloudemu/config"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+// TestSDKObservesChaos proves the central architectural promise: a real
+// aws-sdk-go-v2 client hitting an HTTP server backed by a chaos-wrapped
+// driver experiences the chaos exactly the same as a Go-API caller would.
+func TestSDKObservesChaos(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	engine := chaos.New(cloudemuConfig.RealClock{})
+	defer engine.Stop()
+
+	// Wrap the S3 driver with chaos before handing it to the HTTP server.
+	wrappedS3 := chaos.WrapBucket(provider.S3, engine)
+
+	srv := awsserver.New(awsserver.Drivers{S3: wrappedS3})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("t", "t", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.UsePathStyle = true
+		// Disable SDK retries so we test the raw chaos behaviour, not how
+		// the retryer hides it. Real apps would re-enable retries.
+		o.RetryMaxAttempts = 1
+	})
+	ctx := context.Background()
+
+	// Baseline: ops succeed.
+	if _, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("baseline"),
+	}); err != nil {
+		t.Fatalf("baseline CreateBucket: %v", err)
+	}
+
+	// Apply S3 outage for a short window.
+	engine.Apply(chaos.ServiceOutage("storage", 200*time.Millisecond))
+
+	// Calls during the outage fail.
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("baseline"), Key: aws.String("k"),
+		Body: bytes.NewReader([]byte("x")),
+	})
+	if err == nil {
+		t.Fatal("expected failure during chaos outage, got nil")
+	}
+
+	// Wait past the outage window — ops succeed again (the SDK observes recovery).
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("baseline"), Key: aws.String("k"),
+		Body: bytes.NewReader([]byte("after-recovery")),
+	}); err != nil {
+		t.Fatalf("expected recovery, still failing: %v", err)
+	}
+
+	// Engine recorded the chaos events.
+	rec := engine.Recorded()
+	if len(rec) == 0 {
+		t.Error("expected chaos engine to record events during outage")
+	}
+}
+
+// TestSDKObservesLatencySpike confirms latency injected at the driver layer
+// is reflected in observed call duration on the SDK side.
+func TestSDKObservesLatencySpike(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	engine := chaos.New(cloudemuConfig.RealClock{})
+	defer engine.Stop()
+
+	wrappedS3 := chaos.WrapBucket(provider.S3, engine)
+	srv := awsserver.New(awsserver.Drivers{S3: wrappedS3})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, _ := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("t", "t", "")))
+	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.UsePathStyle = true
+	})
+	ctx := context.Background()
+
+	if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String("lat"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	engine.Apply(chaos.LatencySpike("storage", 100*time.Millisecond, time.Hour))
+
+	start := time.Now()
+
+	_, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String("lat"), Key: aws.String("k"),
+		Body: bytes.NewReader([]byte("x")),
+	})
+	if err != nil {
+		t.Fatalf("PutObject under latency: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("expected ≥100ms latency, observed %v", elapsed)
+	}
+}

--- a/chaos/random.go
+++ b/chaos/random.go
@@ -1,0 +1,25 @@
+package chaos
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+)
+
+// randFloat returns a float in [0.0, 1.0). Uses crypto/rand to avoid the
+// global math/rand mutex and to keep behavior reproducible-ish in tests
+// (each call is independent).
+func randFloat() float64 {
+	var b [8]byte
+
+	_, _ = rand.Read(b[:])
+
+	const mantissaBits = 53
+
+	const shift = 64 - mantissaBits
+
+	const denom = 1 << mantissaBits
+
+	v := binary.BigEndian.Uint64(b[:]) >> shift
+
+	return float64(v) / float64(denom)
+}

--- a/chaos/random_test.go
+++ b/chaos/random_test.go
@@ -1,0 +1,74 @@
+package chaos_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+)
+
+// random.go's randFloat is unexported but is exercised by ProbabilisticFailure.
+// These tests verify the distribution behaves reasonably via that public path.
+
+// TestRandFloatDistribution checks that ProbabilisticFailure with p=0.5 hits
+// roughly half the calls over a large sample. Tolerance is wide on purpose;
+// the goal is to catch a stuck-at-0 or stuck-at-1 implementation.
+func TestRandFloatDistributionRoughlyMatchesProbability(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("flaky")
+	e.Apply(chaos.ProbabilisticFailure("storage", "Op", myErr, 0.5, time.Hour))
+
+	const samples = 10000
+
+	hits := 0
+
+	for range samples {
+		if eff := e.Check("storage", "Op"); eff.Error != nil {
+			hits++
+		}
+	}
+
+	// Expect ~5000 hits. Tolerance ±5% absolute (i.e. 4500–5500).
+	const expected = samples / 2
+
+	const tolerance = samples / 20
+
+	if hits < expected-tolerance || hits > expected+tolerance {
+		t.Errorf("hits=%d, expected %d±%d (p=0.5 over %d samples)",
+			hits, expected, tolerance, samples)
+	}
+}
+
+// TestRandFloatBoundsZeroProb confirms p=0.0 produces zero hits — guards
+// against off-by-one bugs where the random source could produce 1.0.
+func TestRandFloatBoundsZeroProb(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ProbabilisticFailure("storage", "Op", errors.New("x"), 0.0, time.Hour))
+
+	for range 1000 {
+		if eff := e.Check("storage", "Op"); eff.Error != nil {
+			t.Fatalf("p=0.0 should never inject, got %v", eff.Error)
+		}
+	}
+}
+
+// TestRandFloatBoundsOneProb confirms p=1.0 produces all hits — guards
+// against off-by-one bugs where the random source could produce 0.0 only.
+func TestRandFloatBoundsOneProb(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ProbabilisticFailure("storage", "Op", errors.New("x"), 1.0, time.Hour))
+
+	for range 1000 {
+		if eff := e.Check("storage", "Op"); eff.Error == nil {
+			t.Fatal("p=1.0 should always inject")
+		}
+	}
+}

--- a/chaos/scenarios.go
+++ b/chaos/scenarios.go
@@ -1,0 +1,214 @@
+package chaos
+
+import (
+	"sync/atomic"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// window holds the common "active from start to start+duration" timing logic.
+// All scenarios with a duration embed it.
+type window struct {
+	start time.Time
+	end   time.Time
+}
+
+func newWindow(start time.Time, duration time.Duration) window {
+	return window{start: start, end: start.Add(duration)}
+}
+
+func (w window) active(now time.Time) bool {
+	return !now.Before(w.start) && now.Before(w.end)
+}
+
+// outage makes every operation on a service fail with ServiceUnavailable.
+type outage struct {
+	window
+	service string
+}
+
+// ServiceOutage simulates service svc being completely down for duration.
+// Every call to it returns a ServiceUnavailable error during the window;
+// after the window, calls succeed normally again.
+func ServiceOutage(svc string, duration time.Duration) Scenario {
+	return &outage{
+		window:  newWindow(nowOrEpoch(), duration),
+		service: svc,
+	}
+}
+
+func (o *outage) EffectOn(_ time.Time, service, _ string) Effect {
+	if service != o.service {
+		return Effect{}
+	}
+
+	return Effect{Error: cerrors.New(cerrors.Unavailable, o.service+": service unavailable (chaos)")}
+}
+
+func (o *outage) Active(now time.Time) bool { return o.window.active(now) }
+
+// latencySpike adds extra latency to every op on a service.
+type latencySpike struct {
+	window
+	service string
+	extra   time.Duration
+}
+
+// LatencySpike makes every call to service svc take an extra extra duration
+// for the next duration window. Useful for testing client-side timeouts.
+func LatencySpike(svc string, extra, duration time.Duration) Scenario {
+	return &latencySpike{
+		window:  newWindow(nowOrEpoch(), duration),
+		service: svc,
+		extra:   extra,
+	}
+}
+
+func (l *latencySpike) EffectOn(_ time.Time, service, _ string) Effect {
+	if service != l.service {
+		return Effect{}
+	}
+
+	return Effect{Latency: l.extra}
+}
+
+func (l *latencySpike) Active(now time.Time) bool { return l.window.active(now) }
+
+// probabilisticFailure injects err with probability p for the configured op.
+type probabilisticFailure struct {
+	window
+	service string
+	op      string
+	err     error
+	p       float64
+}
+
+// ProbabilisticFailure injects err on a fraction p (0.0–1.0) of calls to
+// service.operation, for the next duration window. If op is empty, applies
+// to every operation on the service.
+func ProbabilisticFailure(svc, op string, err error, p float64, duration time.Duration) Scenario {
+	return &probabilisticFailure{
+		window:  newWindow(nowOrEpoch(), duration),
+		service: svc,
+		op:      op,
+		err:     err,
+		p:       p,
+	}
+}
+
+func (f *probabilisticFailure) EffectOn(_ time.Time, service, op string) Effect {
+	if service != f.service {
+		return Effect{}
+	}
+
+	if f.op != "" && op != f.op {
+		return Effect{}
+	}
+
+	if randFloat() >= f.p {
+		return Effect{}
+	}
+
+	return Effect{Error: f.err}
+}
+
+func (f *probabilisticFailure) Active(now time.Time) bool { return f.window.active(now) }
+
+// throttle returns Throttled after a token-bucket-like rate is exceeded.
+// Uses a 1-second sliding count which is good enough for testing harnesses.
+type throttle struct {
+	window
+	service string
+	op      string
+	qps     int
+
+	// state
+	startSec int64 // unix seconds of the current bucket
+	count    int64
+}
+
+// Throttle simulates rate-limit pressure on service.operation: once qps calls
+// are seen in any given 1-second wall-clock bucket, further calls in that
+// bucket return Throttled. Resets each second. Active for duration.
+func Throttle(svc, op string, qps int, duration time.Duration) Scenario {
+	if qps < 1 {
+		qps = 1
+	}
+
+	return &throttle{
+		window:  newWindow(nowOrEpoch(), duration),
+		service: svc,
+		op:      op,
+		qps:     qps,
+	}
+}
+
+func (t *throttle) EffectOn(now time.Time, service, op string) Effect {
+	if service != t.service {
+		return Effect{}
+	}
+
+	if t.op != "" && op != t.op {
+		return Effect{}
+	}
+
+	sec := now.Unix()
+
+	// Reset bucket if we crossed a second boundary.
+	if atomic.LoadInt64(&t.startSec) != sec {
+		atomic.StoreInt64(&t.startSec, sec)
+		atomic.StoreInt64(&t.count, 0)
+	}
+
+	c := atomic.AddInt64(&t.count, 1)
+	if c <= int64(t.qps) {
+		return Effect{}
+	}
+
+	return Effect{Error: cerrors.New(cerrors.Throttled, t.service+": throttled (chaos)")}
+}
+
+func (t *throttle) Active(now time.Time) bool { return t.window.active(now) }
+
+// composite combines multiple scenarios. Latencies sum; the first non-nil
+// error wins; the composite is active while any inner scenario is active.
+type composite struct {
+	scenarios []Scenario
+}
+
+// Composite combines several scenarios into one. The merged Effect adds
+// latencies and uses the first non-nil error.
+func Composite(scenarios ...Scenario) Scenario {
+	return &composite{scenarios: scenarios}
+}
+
+func (c *composite) EffectOn(now time.Time, service, operation string) Effect {
+	var out Effect
+
+	for _, s := range c.scenarios {
+		eff := s.EffectOn(now, service, operation)
+		out.Latency += eff.Latency
+
+		if out.Error == nil && eff.Error != nil {
+			out.Error = eff.Error
+		}
+	}
+
+	return out
+}
+
+func (c *composite) Active(now time.Time) bool {
+	for _, s := range c.scenarios {
+		if s.Active(now) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// nowOrEpoch returns the wall-clock time. Scenarios constructed by callers
+// outside the engine don't have access to the engine's clock, so they pin
+// their start time at construction; the engine still drives expiry via Active.
+func nowOrEpoch() time.Time { return time.Now() }

--- a/chaos/scenarios_test.go
+++ b/chaos/scenarios_test.go
@@ -1,0 +1,300 @@
+package chaos_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+func TestServiceOutageInsideWindow(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	eff := e.Check("storage", "PutObject")
+	if eff.Error == nil {
+		t.Fatal("expected outage error")
+	}
+
+	if cerrors.GetCode(eff.Error) != cerrors.Unavailable {
+		t.Errorf("expected Unavailable code, got %v", eff.Error)
+	}
+}
+
+func TestServiceOutageDifferentServiceUnaffected(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if eff := e.Check("compute", "RunInstances"); eff.Error != nil {
+		t.Errorf("compute should be unaffected, got %v", eff.Error)
+	}
+}
+
+func TestServiceOutageExpires(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ServiceOutage("storage", 5*time.Millisecond))
+
+	if e.Check("storage", "Op").Error == nil {
+		t.Fatal("should fail while active")
+	}
+
+	time.Sleep(15 * time.Millisecond)
+
+	if eff := e.Check("storage", "Op"); eff.Error != nil {
+		t.Errorf("should recover after window, got %v", eff.Error)
+	}
+}
+
+func TestLatencySpikeAddsLatency(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.LatencySpike("storage", 50*time.Millisecond, time.Hour))
+
+	if eff := e.Check("storage", "Op"); eff.Latency != 50*time.Millisecond {
+		t.Errorf("got %v, want 50ms", eff.Latency)
+	}
+}
+
+func TestLatencySpikeOnlyAffectsTargetService(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.LatencySpike("storage", 50*time.Millisecond, time.Hour))
+
+	if eff := e.Check("compute", "Op"); eff.Latency != 0 {
+		t.Errorf("compute should be unaffected, got %v", eff.Latency)
+	}
+}
+
+func TestLatencySpikeExpires(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.LatencySpike("storage", 5*time.Millisecond, 5*time.Millisecond))
+	time.Sleep(10 * time.Millisecond)
+
+	if eff := e.Check("storage", "Op"); eff.Latency != 0 {
+		t.Errorf("should expire, got %v", eff.Latency)
+	}
+}
+
+func TestProbabilisticFailureAlwaysHits(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("boom")
+	e.Apply(chaos.ProbabilisticFailure("storage", "GetObject", myErr, 1.0, time.Hour))
+
+	for range 20 {
+		if eff := e.Check("storage", "GetObject"); eff.Error == nil {
+			t.Fatal("p=1.0 should always inject")
+		}
+	}
+}
+
+func TestProbabilisticFailureNeverHits(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("never")
+	e.Apply(chaos.ProbabilisticFailure("storage", "Op", myErr, 0.0, time.Hour))
+
+	for range 20 {
+		if eff := e.Check("storage", "Op"); eff.Error != nil {
+			t.Fatalf("p=0.0 should never inject, got %v", eff.Error)
+		}
+	}
+}
+
+func TestProbabilisticFailureRespectsOpFilter(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("only get")
+	e.Apply(chaos.ProbabilisticFailure("storage", "GetObject", myErr, 1.0, time.Hour))
+
+	if eff := e.Check("storage", "PutObject"); eff.Error != nil {
+		t.Errorf("PutObject should be unaffected, got %v", eff.Error)
+	}
+}
+
+func TestProbabilisticFailureEmptyOpAffectsAll(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("any op")
+	// Empty op = service-wide.
+	e.Apply(chaos.ProbabilisticFailure("storage", "", myErr, 1.0, time.Hour))
+
+	for _, op := range []string{"PutObject", "GetObject", "ListObjects"} {
+		if eff := e.Check("storage", op); eff.Error == nil {
+			t.Errorf("op %s should fail under service-wide rule", op)
+		}
+	}
+}
+
+func TestProbabilisticFailureDifferentServiceUnaffected(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.ProbabilisticFailure("storage", "Op", errors.New("x"), 1.0, time.Hour))
+
+	if eff := e.Check("compute", "Op"); eff.Error != nil {
+		t.Errorf("compute should be unaffected, got %v", eff.Error)
+	}
+}
+
+func TestThrottleAllowsUpToQPS(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Throttle("compute", "RunInstances", 3, time.Hour))
+
+	for i := range 3 {
+		if eff := e.Check("compute", "RunInstances"); eff.Error != nil {
+			t.Fatalf("call %d should pass under threshold, got %v", i, eff.Error)
+		}
+	}
+}
+
+func TestThrottleBlocksAfterQPS(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Throttle("compute", "RunInstances", 2, time.Hour))
+
+	// Burn the budget.
+	_ = e.Check("compute", "RunInstances")
+	_ = e.Check("compute", "RunInstances")
+
+	eff := e.Check("compute", "RunInstances")
+	if cerrors.GetCode(eff.Error) != cerrors.Throttled {
+		t.Errorf("expected Throttled, got %v", eff.Error)
+	}
+}
+
+func TestThrottleZeroQPSClampedToOne(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Throttle("compute", "Op", 0, time.Hour))
+
+	// First call should pass (clamp to 1).
+	if eff := e.Check("compute", "Op"); eff.Error != nil {
+		t.Errorf("first call after zero-qps clamp should pass, got %v", eff.Error)
+	}
+
+	// Second should be throttled.
+	if eff := e.Check("compute", "Op"); eff.Error == nil {
+		t.Error("second call should be throttled")
+	}
+}
+
+func TestThrottleDifferentServiceUnaffected(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Throttle("compute", "Op", 1, time.Hour))
+	_ = e.Check("compute", "Op") // burn
+
+	if eff := e.Check("storage", "Op"); eff.Error != nil {
+		t.Errorf("storage should be unaffected, got %v", eff.Error)
+	}
+}
+
+func TestThrottleEmptyOpAffectsAll(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Throttle("compute", "", 1, time.Hour))
+
+	_ = e.Check("compute", "Op1") // burn
+
+	if eff := e.Check("compute", "Op2"); eff.Error == nil {
+		t.Error("service-wide throttle should affect all ops")
+	}
+}
+
+func TestCompositeMergesEffects(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	myErr := errors.New("composite")
+	e.Apply(chaos.Composite(
+		chaos.LatencySpike("storage", 10*time.Millisecond, time.Hour),
+		chaos.ProbabilisticFailure("storage", "Op", myErr, 1.0, time.Hour),
+	))
+
+	eff := e.Check("storage", "Op")
+	if eff.Latency != 10*time.Millisecond {
+		t.Errorf("composite latency = %v, want 10ms", eff.Latency)
+	}
+
+	if eff.Error == nil {
+		t.Error("composite should propagate inner failure")
+	}
+}
+
+func TestCompositeFirstNonNilErrorWins(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	first := errors.New("first")
+	second := errors.New("second")
+
+	// First scenario applies → its error wins; second is also a failure but
+	// we should still see the first error in the merged effect.
+	e.Apply(chaos.Composite(
+		chaos.ProbabilisticFailure("storage", "Op", first, 1.0, time.Hour),
+		chaos.ProbabilisticFailure("storage", "Op", second, 1.0, time.Hour),
+	))
+
+	eff := e.Check("storage", "Op")
+	if eff.Error == nil {
+		t.Fatal("expected error")
+	}
+	// We don't strictly assert which error wins (depends on iteration), but
+	// it must be one of the two.
+	if !errors.Is(eff.Error, first) && !errors.Is(eff.Error, second) {
+		t.Errorf("error not from composite scenarios: %v", eff.Error)
+	}
+}
+
+func TestCompositeActiveWhileAnyChildIsActive(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	// Short scenario + long scenario in one composite.
+	e.Apply(chaos.Composite(
+		chaos.LatencySpike("storage", time.Millisecond, 5*time.Millisecond),
+		chaos.LatencySpike("storage", 2*time.Millisecond, time.Hour),
+	))
+
+	time.Sleep(10 * time.Millisecond)
+
+	// First child has expired, second is still active. Composite should still apply.
+	if eff := e.Check("storage", "Op"); eff.Latency == 0 {
+		t.Error("composite should remain active while any child is")
+	}
+}
+
+func TestCompositeEmptyIsSafe(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	e.Apply(chaos.Composite())
+
+	if eff := e.Check("storage", "Op"); eff.Latency != 0 || eff.Error != nil {
+		t.Errorf("empty composite should produce zero effect, got %+v", eff)
+	}
+}

--- a/chaos/wrappers.go
+++ b/chaos/wrappers.go
@@ -1,0 +1,253 @@
+package chaos
+
+import (
+	"context"
+	"time"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+)
+
+// Driver-wrapper middleware. Each Wrap* takes a real driver and returns one
+// that consults the chaos engine before delegating. The same wrapped driver
+// can be handed to either:
+//   - the portable API (e.g. storage.NewBucket(wrapped, ...)), or
+//   - the SDK-compat HTTP server (awsserver.Drivers{S3: wrapped}).
+//
+// Both consumption paths see the same chaos behavior, which is the whole
+// point: a real aws-sdk-go-v2 client over HTTP experiences the same outage
+// as a Go-API caller.
+
+// applyChaos is the shared "consult engine, sleep, maybe error" routine.
+func applyChaos(ctx context.Context, e *Engine, service, op string) error {
+	eff := e.Check(service, op)
+	if eff.Latency > 0 {
+		select {
+		case <-time.After(eff.Latency):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return eff.Error
+}
+
+// chaosBucket embeds the inner driver so methods we don't override fall
+// through automatically — keeps the wrapper short.
+type chaosBucket struct {
+	storagedriver.Bucket
+	engine *Engine
+}
+
+// WrapBucket returns a storage driver that consults engine on the most-used
+// data-plane operations. Less-used ops (lifecycle, multipart, tagging,
+// versioning, CORS, encryption, policies, presigned URLs) delegate through
+// without chaos for now — Phase 2 can broaden coverage.
+func WrapBucket(inner storagedriver.Bucket, engine *Engine) storagedriver.Bucket {
+	return &chaosBucket{Bucket: inner, engine: engine}
+}
+
+func (c *chaosBucket) CreateBucket(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "storage", "CreateBucket"); err != nil {
+		return err
+	}
+
+	return c.Bucket.CreateBucket(ctx, name)
+}
+
+func (c *chaosBucket) DeleteBucket(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "storage", "DeleteBucket"); err != nil {
+		return err
+	}
+
+	return c.Bucket.DeleteBucket(ctx, name)
+}
+
+func (c *chaosBucket) ListBuckets(ctx context.Context) ([]storagedriver.BucketInfo, error) {
+	if err := applyChaos(ctx, c.engine, "storage", "ListBuckets"); err != nil {
+		return nil, err
+	}
+
+	return c.Bucket.ListBuckets(ctx)
+}
+
+func (c *chaosBucket) PutObject(
+	ctx context.Context, bucket, key string, data []byte,
+	contentType string, metadata map[string]string,
+) error {
+	if err := applyChaos(ctx, c.engine, "storage", "PutObject"); err != nil {
+		return err
+	}
+
+	return c.Bucket.PutObject(ctx, bucket, key, data, contentType, metadata)
+}
+
+func (c *chaosBucket) GetObject(ctx context.Context, bucket, key string) (*storagedriver.Object, error) {
+	if err := applyChaos(ctx, c.engine, "storage", "GetObject"); err != nil {
+		return nil, err
+	}
+
+	return c.Bucket.GetObject(ctx, bucket, key)
+}
+
+func (c *chaosBucket) HeadObject(ctx context.Context, bucket, key string) (*storagedriver.ObjectInfo, error) {
+	if err := applyChaos(ctx, c.engine, "storage", "HeadObject"); err != nil {
+		return nil, err
+	}
+
+	return c.Bucket.HeadObject(ctx, bucket, key)
+}
+
+func (c *chaosBucket) DeleteObject(ctx context.Context, bucket, key string) error {
+	if err := applyChaos(ctx, c.engine, "storage", "DeleteObject"); err != nil {
+		return err
+	}
+
+	return c.Bucket.DeleteObject(ctx, bucket, key)
+}
+
+func (c *chaosBucket) ListObjects(ctx context.Context, bucket string, opts storagedriver.ListOptions) (*storagedriver.ListResult, error) {
+	if err := applyChaos(ctx, c.engine, "storage", "ListObjects"); err != nil {
+		return nil, err
+	}
+
+	return c.Bucket.ListObjects(ctx, bucket, opts)
+}
+
+func (c *chaosBucket) CopyObject(ctx context.Context, dstBucket, dstKey string, src storagedriver.CopySource) error {
+	if err := applyChaos(ctx, c.engine, "storage", "CopyObject"); err != nil {
+		return err
+	}
+
+	return c.Bucket.CopyObject(ctx, dstBucket, dstKey, src)
+}
+
+// chaosCompute wraps a compute driver. We only intercept the lifecycle ops
+// that real applications most often exercise; the rest delegate through.
+type chaosCompute struct {
+	computedriver.Compute
+	engine *Engine
+}
+
+// WrapCompute returns a compute driver that consults engine on instance ops.
+func WrapCompute(inner computedriver.Compute, engine *Engine) computedriver.Compute {
+	return &chaosCompute{Compute: inner, engine: engine}
+}
+
+//nolint:gocritic // cfg is a value type by interface contract; mirroring keeps signatures identical
+func (c *chaosCompute) RunInstances(
+	ctx context.Context, cfg computedriver.InstanceConfig, count int,
+) ([]computedriver.Instance, error) {
+	if err := applyChaos(ctx, c.engine, "compute", "RunInstances"); err != nil {
+		return nil, err
+	}
+
+	return c.Compute.RunInstances(ctx, cfg, count)
+}
+
+func (c *chaosCompute) StartInstances(ctx context.Context, ids []string) error {
+	if err := applyChaos(ctx, c.engine, "compute", "StartInstances"); err != nil {
+		return err
+	}
+
+	return c.Compute.StartInstances(ctx, ids)
+}
+
+func (c *chaosCompute) StopInstances(ctx context.Context, ids []string) error {
+	if err := applyChaos(ctx, c.engine, "compute", "StopInstances"); err != nil {
+		return err
+	}
+
+	return c.Compute.StopInstances(ctx, ids)
+}
+
+func (c *chaosCompute) RebootInstances(ctx context.Context, ids []string) error {
+	if err := applyChaos(ctx, c.engine, "compute", "RebootInstances"); err != nil {
+		return err
+	}
+
+	return c.Compute.RebootInstances(ctx, ids)
+}
+
+func (c *chaosCompute) TerminateInstances(ctx context.Context, ids []string) error {
+	if err := applyChaos(ctx, c.engine, "compute", "TerminateInstances"); err != nil {
+		return err
+	}
+
+	return c.Compute.TerminateInstances(ctx, ids)
+}
+
+func (c *chaosCompute) DescribeInstances(
+	ctx context.Context, ids []string, filters []computedriver.DescribeFilter,
+) ([]computedriver.Instance, error) {
+	if err := applyChaos(ctx, c.engine, "compute", "DescribeInstances"); err != nil {
+		return nil, err
+	}
+
+	return c.Compute.DescribeInstances(ctx, ids, filters)
+}
+
+// chaosDatabase wraps a database driver.
+type chaosDatabase struct {
+	dbdriver.Database
+	engine *Engine
+}
+
+// WrapDatabase returns a database driver that consults engine on item ops.
+func WrapDatabase(inner dbdriver.Database, engine *Engine) dbdriver.Database {
+	return &chaosDatabase{Database: inner, engine: engine}
+}
+
+func (c *chaosDatabase) PutItem(ctx context.Context, table string, item map[string]any) error {
+	if err := applyChaos(ctx, c.engine, "database", "PutItem"); err != nil {
+		return err
+	}
+
+	return c.Database.PutItem(ctx, table, item)
+}
+
+func (c *chaosDatabase) GetItem(ctx context.Context, table string, key map[string]any) (map[string]any, error) {
+	if err := applyChaos(ctx, c.engine, "database", "GetItem"); err != nil {
+		return nil, err
+	}
+
+	return c.Database.GetItem(ctx, table, key)
+}
+
+func (c *chaosDatabase) UpdateItem(ctx context.Context, input dbdriver.UpdateItemInput) (map[string]any, error) {
+	if err := applyChaos(ctx, c.engine, "database", "UpdateItem"); err != nil {
+		return nil, err
+	}
+
+	return c.Database.UpdateItem(ctx, input)
+}
+
+func (c *chaosDatabase) DeleteItem(ctx context.Context, table string, key map[string]any) error {
+	if err := applyChaos(ctx, c.engine, "database", "DeleteItem"); err != nil {
+		return err
+	}
+
+	return c.Database.DeleteItem(ctx, table, key)
+}
+
+//nolint:gocritic // input is a value type by interface contract
+func (c *chaosDatabase) Query(
+	ctx context.Context, input dbdriver.QueryInput,
+) (*dbdriver.QueryResult, error) {
+	if err := applyChaos(ctx, c.engine, "database", "Query"); err != nil {
+		return nil, err
+	}
+
+	return c.Database.Query(ctx, input)
+}
+
+func (c *chaosDatabase) Scan(
+	ctx context.Context, input dbdriver.ScanInput,
+) (*dbdriver.QueryResult, error) {
+	if err := applyChaos(ctx, c.engine, "database", "Scan"); err != nil {
+		return nil, err
+	}
+
+	return c.Database.Scan(ctx, input)
+}

--- a/chaos/wrappers_test.go
+++ b/chaos/wrappers_test.go
@@ -1,0 +1,433 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	awsdynamo "github.com/stackshy/cloudemu/providers/aws/dynamodb"
+	awsec2 "github.com/stackshy/cloudemu/providers/aws/ec2"
+	awss3 "github.com/stackshy/cloudemu/providers/aws/s3"
+	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+)
+
+// withChaos wraps a fresh AWS S3 mock with a chaos-applied engine.
+func newChaosBucket(t *testing.T) (storagedriver.Bucket, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapBucket(awss3.New(config.NewOptions()), e), e
+}
+
+func TestWrapBucketCreateBucketChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+
+	if err := b.CreateBucket(ctx, "ok"); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if err := b.CreateBucket(ctx, "fail"); err == nil {
+		t.Error("expected chaos error on CreateBucket")
+	}
+}
+
+func TestWrapBucketDeleteBucketChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+
+	_ = b.CreateBucket(ctx, "del")
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if err := b.DeleteBucket(ctx, "del"); err == nil {
+		t.Error("expected chaos error on DeleteBucket")
+	}
+}
+
+func TestWrapBucketListBucketsChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+
+	if _, err := b.ListBuckets(ctx); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if _, err := b.ListBuckets(ctx); err == nil {
+		t.Error("expected chaos error on ListBuckets")
+	}
+}
+
+func TestWrapBucketPutObjectChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "put")
+
+	if err := b.PutObject(ctx, "put", "k", []byte("v"), "text/plain", nil); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if err := b.PutObject(ctx, "put", "k", []byte("v"), "text/plain", nil); err == nil {
+		t.Error("expected chaos error on PutObject")
+	}
+}
+
+func TestWrapBucketGetObjectChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "g")
+	_ = b.PutObject(ctx, "g", "k", []byte("v"), "text/plain", nil)
+
+	if _, err := b.GetObject(ctx, "g", "k"); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if _, err := b.GetObject(ctx, "g", "k"); err == nil {
+		t.Error("expected chaos error on GetObject")
+	}
+}
+
+func TestWrapBucketHeadObjectChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "h")
+	_ = b.PutObject(ctx, "h", "k", []byte("v"), "text/plain", nil)
+
+	if _, err := b.HeadObject(ctx, "h", "k"); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if _, err := b.HeadObject(ctx, "h", "k"); err == nil {
+		t.Error("expected chaos error on HeadObject")
+	}
+}
+
+func TestWrapBucketDeleteObjectChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "d")
+	_ = b.PutObject(ctx, "d", "k", []byte("v"), "text/plain", nil)
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if err := b.DeleteObject(ctx, "d", "k"); err == nil {
+		t.Error("expected chaos error on DeleteObject")
+	}
+}
+
+func TestWrapBucketListObjectsChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "l")
+
+	if _, err := b.ListObjects(ctx, "l", storagedriver.ListOptions{}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if _, err := b.ListObjects(ctx, "l", storagedriver.ListOptions{}); err == nil {
+		t.Error("expected chaos error on ListObjects")
+	}
+}
+
+func TestWrapBucketCopyObjectChaos(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "src")
+	_ = b.CreateBucket(ctx, "dst")
+	_ = b.PutObject(ctx, "src", "k", []byte("v"), "text/plain", nil)
+
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if err := b.CopyObject(ctx, "dst", "k", storagedriver.CopySource{Bucket: "src", Key: "k"}); err == nil {
+		t.Error("expected chaos error on CopyObject")
+	}
+}
+
+func TestWrapBucketLatencyApplied(t *testing.T) {
+	b, e := newChaosBucket(t)
+	ctx := context.Background()
+	_ = b.CreateBucket(ctx, "lat")
+
+	e.Apply(chaos.LatencySpike("storage", 50*time.Millisecond, time.Hour))
+
+	start := time.Now()
+
+	_ = b.PutObject(ctx, "lat", "k", []byte("x"), "text/plain", nil)
+
+	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
+		t.Errorf("expected ≥50ms latency, got %v", elapsed)
+	}
+}
+
+func TestWrapBucketContextCancelDuringLatency(t *testing.T) {
+	b, e := newChaosBucket(t)
+	_ = b.CreateBucket(context.Background(), "ctx")
+
+	e.Apply(chaos.LatencySpike("storage", 500*time.Millisecond, time.Hour))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := b.PutObject(ctx, "ctx", "k", []byte("x"), "text/plain", nil)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+}
+
+// Compute wrapper
+
+func newChaosCompute(t *testing.T) (interface {
+	RunInstances(context.Context, struct {
+		ImageID, InstanceType string
+		Tags                  map[string]string
+		SubnetID              string
+		SecurityGroups        []string
+		KeyName, UserData     string
+	}, int) ([]struct{}, error)
+}, *chaos.Engine) {
+	t.Helper()
+	// We don't need this helper — RunInstances signature doesn't match the
+	// anonymous struct above. Tests below construct the wrapped driver
+	// directly with the concrete provider type.
+	return nil, nil
+}
+
+func TestWrapComputeRunInstancesChaos(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	c := chaos.WrapCompute(awsec2.New(config.NewOptions()), e)
+	ctx := context.Background()
+
+	cfg := computeInstanceConfigForWrappers()
+
+	if _, err := c.RunInstances(ctx, cfg, 1); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if _, err := c.RunInstances(ctx, cfg, 1); err == nil {
+		t.Error("expected chaos error on RunInstances")
+	}
+}
+
+func TestWrapComputeStartInstancesChaos(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	c := chaos.WrapCompute(awsec2.New(config.NewOptions()), e)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if err := c.StartInstances(ctx, []string{"i-x"}); err == nil {
+		t.Error("expected chaos error on StartInstances")
+	}
+}
+
+func TestWrapComputeStopInstancesChaos(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	c := chaos.WrapCompute(awsec2.New(config.NewOptions()), e)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if err := c.StopInstances(ctx, []string{"i-x"}); err == nil {
+		t.Error("expected chaos error on StopInstances")
+	}
+}
+
+func TestWrapComputeRebootInstancesChaos(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	c := chaos.WrapCompute(awsec2.New(config.NewOptions()), e)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if err := c.RebootInstances(ctx, []string{"i-x"}); err == nil {
+		t.Error("expected chaos error on RebootInstances")
+	}
+}
+
+func TestWrapComputeTerminateInstancesChaos(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	c := chaos.WrapCompute(awsec2.New(config.NewOptions()), e)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if err := c.TerminateInstances(ctx, []string{"i-x"}); err == nil {
+		t.Error("expected chaos error on TerminateInstances")
+	}
+}
+
+func TestWrapComputeDescribeInstancesChaos(t *testing.T) {
+	e := chaos.New(config.RealClock{})
+	defer e.Stop()
+
+	c := chaos.WrapCompute(awsec2.New(config.NewOptions()), e)
+	ctx := context.Background()
+
+	if _, err := c.DescribeInstances(ctx, nil, nil); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("compute", time.Hour))
+
+	if _, err := c.DescribeInstances(ctx, nil, nil); err == nil {
+		t.Error("expected chaos error on DescribeInstances")
+	}
+}
+
+// Database wrapper
+
+func newChaosDatabaseHelper(t *testing.T) (dbdriver.Database, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapDatabase(awsdynamo.New(config.NewOptions()), e), e
+}
+
+func TestWrapDatabasePutItemChaos(t *testing.T) {
+	d, e := newChaosDatabaseHelper(t)
+	ctx := context.Background()
+
+	_ = d.CreateTable(ctx, dbdriver.TableConfig{Name: "t", PartitionKey: "id"})
+
+	if err := d.PutItem(ctx, "t", map[string]any{"id": "k1"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("database", time.Hour))
+
+	if err := d.PutItem(ctx, "t", map[string]any{"id": "k2"}); err == nil {
+		t.Error("expected chaos error on PutItem")
+	}
+}
+
+func TestWrapDatabaseGetItemChaos(t *testing.T) {
+	d, e := newChaosDatabaseHelper(t)
+	ctx := context.Background()
+
+	_ = d.CreateTable(ctx, dbdriver.TableConfig{Name: "g", PartitionKey: "id"})
+	_ = d.PutItem(ctx, "g", map[string]any{"id": "k"})
+
+	if _, err := d.GetItem(ctx, "g", map[string]any{"id": "k"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("database", time.Hour))
+
+	if _, err := d.GetItem(ctx, "g", map[string]any{"id": "k"}); err == nil {
+		t.Error("expected chaos error on GetItem")
+	}
+}
+
+func TestWrapDatabaseUpdateItemChaos(t *testing.T) {
+	d, e := newChaosDatabaseHelper(t)
+	ctx := context.Background()
+
+	_ = d.CreateTable(ctx, dbdriver.TableConfig{Name: "u", PartitionKey: "id"})
+	_ = d.PutItem(ctx, "u", map[string]any{"id": "k", "v": "old"})
+
+	e.Apply(chaos.ServiceOutage("database", time.Hour))
+
+	_, err := d.UpdateItem(ctx, dbdriver.UpdateItemInput{
+		Table: "u",
+		Key:   map[string]any{"id": "k"},
+		Actions: []dbdriver.UpdateAction{
+			{Action: "SET", Field: "v", Value: "new"},
+		},
+	})
+	if err == nil {
+		t.Error("expected chaos error on UpdateItem")
+	}
+}
+
+func TestWrapDatabaseDeleteItemChaos(t *testing.T) {
+	d, e := newChaosDatabaseHelper(t)
+	ctx := context.Background()
+
+	_ = d.CreateTable(ctx, dbdriver.TableConfig{Name: "del", PartitionKey: "id"})
+	_ = d.PutItem(ctx, "del", map[string]any{"id": "k"})
+
+	e.Apply(chaos.ServiceOutage("database", time.Hour))
+
+	if err := d.DeleteItem(ctx, "del", map[string]any{"id": "k"}); err == nil {
+		t.Error("expected chaos error on DeleteItem")
+	}
+}
+
+func TestWrapDatabaseQueryChaos(t *testing.T) {
+	d, e := newChaosDatabaseHelper(t)
+	ctx := context.Background()
+
+	_ = d.CreateTable(ctx, dbdriver.TableConfig{Name: "q", PartitionKey: "id"})
+
+	e.Apply(chaos.ServiceOutage("database", time.Hour))
+
+	if _, err := d.Query(ctx, dbdriver.QueryInput{Table: "q"}); err == nil {
+		t.Error("expected chaos error on Query")
+	}
+}
+
+func TestWrapDatabaseScanChaos(t *testing.T) {
+	d, e := newChaosDatabaseHelper(t)
+	ctx := context.Background()
+
+	_ = d.CreateTable(ctx, dbdriver.TableConfig{Name: "s", PartitionKey: "id"})
+
+	e.Apply(chaos.ServiceOutage("database", time.Hour))
+
+	if _, err := d.Scan(ctx, dbdriver.ScanInput{Table: "s"}); err == nil {
+		t.Error("expected chaos error on Scan")
+	}
+}
+
+// Helper from chaos_test.go was here previously; we keep it co-located so
+// wrapper tests are self-contained.
+type computeConfigCompat = struct {
+	ImageID        string
+	InstanceType   string
+	Tags           map[string]string
+	SubnetID       string
+	SecurityGroups []string
+	KeyName        string
+	UserData       string
+}
+
+// computeInstanceConfig reproduces the helper used elsewhere in the package
+// so this file's tests don't depend on cross-file ordering.
+//
+// Re-declared with a wrapping function so we don't get a "duplicate name"
+// build error (the compute config helper already lives in chaos_test.go).
+func computeInstanceConfigForWrappers() computeConfigCompat {
+	return computeConfigCompat{ImageID: "ami-test", InstanceType: "t2.micro"}
+}
+
+var _ = computeInstanceConfigForWrappers // referenced for documentation

--- a/docs/chaos.md
+++ b/docs/chaos.md
@@ -1,0 +1,63 @@
+# Chaos Engineering
+
+CloudEmu can deliberately fail or slow down services in controlled, time-bounded ways — so the parts of your app that handle cloud failure can actually be exercised in tests.
+
+This is something real cloud can't do (you can't ask AWS to fail S3 for 5 seconds) and existing emulators don't do well.
+
+## How it works
+
+Wrap any driver with the chaos engine before handing it to the portable API or the SDK-compat HTTP server. Then declare scenarios at runtime and the chaos applies to every call that hits the wrapped driver — Go API or SDK.
+
+```go
+import (
+    "github.com/stackshy/cloudemu"
+    "github.com/stackshy/cloudemu/chaos"
+    "github.com/stackshy/cloudemu/config"
+    awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+cloud  := cloudemu.NewAWS()
+engine := chaos.New(config.RealClock{})
+defer engine.Stop()
+
+// Wrap the S3 driver. Same wrapper works for Go API or SDK-compat path.
+chaosS3 := chaos.WrapBucket(cloud.S3, engine)
+
+srv := awsserver.New(awsserver.Drivers{S3: chaosS3})
+ts  := httptest.NewServer(srv)
+
+// Apply a scenario; SDK calls during the window will fail or slow down.
+engine.Apply(chaos.ServiceOutage("storage", 5*time.Second))
+```
+
+## Scenarios shipped today
+
+| Scenario | What it does |
+|---|---|
+| `ServiceOutage(svc, duration)` | Every call to `svc` returns `Unavailable` until the window expires |
+| `LatencySpike(svc, extra, duration)` | Adds `extra` latency on every call to `svc` |
+| `ProbabilisticFailure(svc, op, err, p, duration)` | Returns `err` on a fraction `p` of calls to `svc.op` |
+| `Throttle(svc, op, qps, duration)` | Returns `Throttled` once `qps` calls/sec is exceeded |
+| `Composite(scenarios...)` | Combines several scenarios; latencies sum, first error wins |
+
+Each call to `engine.Apply` returns an `*Active` handle with `.Stop()` to cancel before the natural expiry.
+
+## What's wrapped today
+
+`WrapBucket` (S3), `WrapCompute` (EC2), `WrapDatabase` (DynamoDB). Phase 2 will wire the remaining 13 services.
+
+## Inspecting what happened
+
+```go
+events := engine.Recorded()  // every Effect that was applied
+engine.Reset()               // clear the buffer between test phases
+```
+
+## Coming next (Phase 2 / 3)
+
+- Wire chaos into the remaining 13 portable services
+- `SlowDegradation` (latency ramps up over a window)
+- `BurstFailure` (N consecutive failures)
+- `NetworkPartition` (cross-service: A → B fails, B → A is fine)
+- Pre-built scenarios based on real cloud incidents (e.g. AWS US-East-1 2017 S3 outage)
+- Cascade failures via the dependency graph


### PR DESCRIPTION
## What this does

Adds a chaos engine so users can deliberately fail or slow down CloudEmu services in time-bounded windows, then test how their app handles it. Real cloud can't do this on demand; existing emulators don't do this well — that's the gap.

Part of #104. First slice: foundation + S3/EC2/DynamoDB driver wrappers + 5 baseline scenarios.

## What's new

- `chaos/` package with `Engine`, `Scenario`, `Effect`, `Active` handle, `Recorded` events buffer.
- 5 scenarios: `ServiceOutage`, `LatencySpike`, `ProbabilisticFailure`, `Throttle`, `Composite`.
- Driver-wrapper middleware: `WrapBucket`, `WrapCompute`, `WrapDatabase`. Same wrapped driver works for both Go API and SDK-compat HTTP server — so the real `aws-sdk-go-v2` client experiences the same chaos as a Go-API caller.
- Docs: `docs/chaos.md` + a section in the README.

## How users use it

```go
engine := chaos.New(config.RealClock{})
chaosS3 := chaos.WrapBucket(cloud.S3, engine)
srv := awsserver.New(awsserver.Drivers{S3: chaosS3})

engine.Apply(chaos.ServiceOutage("storage", 5*time.Second))
// SDK calls fail for 5s, then auto-recover
```

## Tests

- 13 unit tests in `chaos/` covering each scenario, expiry, concurrent safety, recorded events, wrapper integration.
- 2 integration tests proving the real `aws-sdk-go-v2` S3 client over HTTP observes outage and recovery, and observed latency under `LatencySpike`.

## Verified

- `go build ./...` — clean
- `go test ./...` — 82/82 packages pass
- `golangci-lint run ./...` — 0 issues

## What's coming in later phases

- Phase 2: wire chaos into the remaining 13 portable services + advanced scenarios (slow degradation with jitter, network partition between VPCs, scenario playback)
- Phase 3: pre-built scenarios from real cloud incidents (AWS US-East-1 2017 S3 outage replay), cascade failure propagation, chaos report