### PR TITLE
Extend chaos engine to 13 more services (Phase 2)

### DIFF
--- a/chaos/wrappers_baseline_test.go
+++ b/chaos/wrappers_baseline_test.go
@@ -1,0 +1,245 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	regdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	notifdriver "github.com/stackshy/cloudemu/notification/driver"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// Baseline tests exercise every wrapped op against an engine with no scenarios
+// applied, so the success path through each wrapper is covered. Errors from
+// the inner drivers (e.g. NotFound on Get without a prior Create) are ignored
+// — the goal here is to land coverage on the post-applyChaos delegation line,
+// not to validate inner-driver behaviour, which is tested in provider tests.
+
+func TestWrapServerlessBaseline(t *testing.T) {
+	s, _ := newChaosServerless(t)
+	ctx := context.Background()
+
+	cfg := serverlessdriver.FunctionConfig{Name: "b", Runtime: "go1.x", Handler: "main"}
+	_, _ = s.CreateFunction(ctx, cfg)
+	_, _ = s.GetFunction(ctx, "b")
+	_, _ = s.ListFunctions(ctx)
+	_, _ = s.UpdateFunction(ctx, "b", cfg)
+	_, _ = s.Invoke(ctx, serverlessdriver.InvokeInput{FunctionName: "b", Payload: []byte("{}")})
+	_ = s.DeleteFunction(ctx, "b")
+}
+
+func TestWrapNetworkingBaseline(t *testing.T) {
+	n, _ := newChaosNetworking(t)
+	ctx := context.Background()
+
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	_, _ = n.DescribeVPCs(ctx, nil)
+	s, _ := n.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	_, _ = n.DescribeSubnets(ctx, nil)
+	sg, _ := n.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "sg", VPCID: v.ID})
+	_, _ = n.DescribeSecurityGroups(ctx, nil)
+	rule := netdriver.SecurityRule{Protocol: "tcp", FromPort: 80, ToPort: 80, CIDR: "0.0.0.0/0"}
+	_ = n.AddIngressRule(ctx, sg.ID, rule)
+	_ = n.AddEgressRule(ctx, sg.ID, rule)
+	_ = n.DeleteSecurityGroup(ctx, sg.ID)
+	_ = n.DeleteSubnet(ctx, s.ID)
+	_ = n.DeleteVPC(ctx, v.ID)
+}
+
+func TestWrapMonitoringBaseline(t *testing.T) {
+	m, _ := newChaosMonitoring(t)
+	ctx := context.Background()
+
+	_ = m.PutMetricData(ctx, []mondriver.MetricDatum{{Namespace: "x", MetricName: "y", Value: 1, Timestamp: time.Now()}})
+	_, _ = m.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace: "x", MetricName: "y",
+		StartTime: time.Now().Add(-time.Hour), EndTime: time.Now(), Period: 60, Stat: "Average",
+	})
+	_, _ = m.ListMetrics(ctx, "x")
+	_ = m.CreateAlarm(ctx, mondriver.AlarmConfig{
+		Name: "a", Namespace: "x", MetricName: "y",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 1, Period: 60, EvaluationPeriods: 1, Stat: "Average",
+	})
+	_, _ = m.DescribeAlarms(ctx, nil)
+	_ = m.DeleteAlarm(ctx, "a")
+}
+
+func TestWrapIAMBaseline(t *testing.T) {
+	i, _ := newChaosIAM(t)
+	ctx := context.Background()
+
+	_, _ = i.CreateUser(ctx, iamdriver.UserConfig{Name: "u"})
+	_, _ = i.GetUser(ctx, "u")
+	_, _ = i.ListUsers(ctx)
+	_, _ = i.CreateRole(ctx, iamdriver.RoleConfig{Name: "r"})
+	_, _ = i.GetRole(ctx, "r")
+	_, _ = i.ListRoles(ctx)
+	p, _ := i.CreatePolicy(ctx, iamdriver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	if p != nil {
+		_, _ = i.GetPolicy(ctx, p.ARN)
+	}
+	_, _ = i.ListPolicies(ctx)
+	_, _ = i.CheckPermission(ctx, "u", "s3:GetObject", "*")
+	if p != nil {
+		_ = i.DeletePolicy(ctx, p.ARN)
+	}
+	_ = i.DeleteRole(ctx, "r")
+	_ = i.DeleteUser(ctx, "u")
+}
+
+func TestWrapDNSBaseline(t *testing.T) {
+	d, _ := newChaosDNS(t)
+	ctx := context.Background()
+
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "b.test."})
+	_, _ = d.GetZone(ctx, z.ID)
+	_, _ = d.ListZones(ctx)
+	rec := dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.b.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}}
+	_, _ = d.CreateRecord(ctx, rec)
+	_, _ = d.GetRecord(ctx, z.ID, "x.b.test.", "A")
+	_, _ = d.ListRecords(ctx, z.ID)
+	rec.TTL = 600
+	_, _ = d.UpdateRecord(ctx, rec)
+	_ = d.DeleteRecord(ctx, z.ID, "x.b.test.", "A")
+	_ = d.DeleteZone(ctx, z.ID)
+}
+
+func TestWrapLoadBalancerBaseline(t *testing.T) {
+	l, _ := newChaosLoadBalancer(t)
+	ctx := context.Background()
+
+	lb, _ := l.CreateLoadBalancer(ctx, lbdriver.LBConfig{Name: "b", Type: "application"})
+	_, _ = l.DescribeLoadBalancers(ctx, nil)
+	tg, _ := l.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{Name: "tg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1"})
+	_, _ = l.DescribeTargetGroups(ctx, nil)
+	if tg != nil {
+		_ = l.RegisterTargets(ctx, tg.ARN, []lbdriver.Target{{ID: "i-1", Port: 80}})
+		_, _ = l.DescribeTargetHealth(ctx, tg.ARN)
+		_ = l.DeregisterTargets(ctx, tg.ARN, []lbdriver.Target{{ID: "i-1", Port: 80}})
+		_ = l.DeleteTargetGroup(ctx, tg.ARN)
+	}
+	if lb != nil {
+		_ = l.DeleteLoadBalancer(ctx, lb.ARN)
+	}
+}
+
+func TestWrapMessageQueueBaseline(t *testing.T) {
+	q, _ := newChaosMessageQueue(t)
+	ctx := context.Background()
+
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "b"})
+	_, _ = q.ListQueues(ctx, "")
+	if qi != nil {
+		_, _ = q.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: qi.URL, Body: "x"})
+		_, _ = q.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: qi.URL, MaxMessages: 1})
+		_ = q.DeleteMessage(ctx, qi.URL, "rh")
+		_, _ = q.SendMessageBatch(ctx, qi.URL, []mqdriver.BatchSendEntry{{ID: "1", Body: "a"}})
+		_, _ = q.DeleteMessageBatch(ctx, qi.URL, []mqdriver.BatchDeleteEntry{{ID: "1", ReceiptHandle: "rh"}})
+		_ = q.DeleteQueue(ctx, qi.URL)
+	}
+}
+
+func TestWrapCacheBaseline(t *testing.T) {
+	c, _ := newChaosCache(t)
+	ctx := context.Background()
+
+	_ = c.Set(ctx, chaosTestCacheName, chaosTestCacheKey, []byte("v"), time.Minute)
+	_, _ = c.Get(ctx, chaosTestCacheName, chaosTestCacheKey)
+	_, _ = c.Keys(ctx, chaosTestCacheName, "*")
+	_, _ = c.Incr(ctx, chaosTestCacheName, "ctr")
+	_, _ = c.IncrBy(ctx, chaosTestCacheName, "ctr", 5)
+	_, _ = c.Decr(ctx, chaosTestCacheName, "ctr")
+	_, _ = c.DecrBy(ctx, chaosTestCacheName, "ctr", 3)
+	_ = c.Delete(ctx, chaosTestCacheName, chaosTestCacheKey)
+}
+
+func TestWrapSecretsBaseline(t *testing.T) {
+	s, _ := newChaosSecrets(t)
+	ctx := context.Background()
+
+	_, _ = s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "b"}, []byte("v"))
+	_, _ = s.GetSecret(ctx, "b")
+	_, _ = s.ListSecrets(ctx)
+	_, _ = s.PutSecretValue(ctx, "b", []byte("v2"))
+	_, _ = s.GetSecretValue(ctx, "b", "")
+	_, _ = s.ListSecretVersions(ctx, "b")
+	_ = s.DeleteSecret(ctx, "b")
+}
+
+func TestWrapLoggingBaseline(t *testing.T) {
+	l, _ := newChaosLogging(t)
+	ctx := context.Background()
+
+	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "b"})
+	_, _ = l.GetLogGroup(ctx, "b")
+	_, _ = l.ListLogGroups(ctx)
+	_, _ = l.CreateLogStream(ctx, "b", "s")
+	_ = l.PutLogEvents(ctx, "b", "s", []logdriver.LogEvent{{Timestamp: time.Now(), Message: "x"}})
+	_, _ = l.GetLogEvents(ctx, &logdriver.LogQueryInput{
+		LogGroup: "b", StartTime: time.Now().Add(-time.Hour), EndTime: time.Now(), Limit: 10,
+	})
+	_, _ = l.FilterLogEvents(ctx, &logdriver.FilterLogEventsInput{
+		LogGroup: "b", StartTime: time.Now().Add(-time.Hour), EndTime: time.Now(), Limit: 10,
+	})
+	_ = l.DeleteLogGroup(ctx, "b")
+}
+
+func TestWrapNotificationBaseline(t *testing.T) {
+	n, _ := newChaosNotification(t)
+	ctx := context.Background()
+
+	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "b"})
+	_, _ = n.ListTopics(ctx)
+	if tp != nil {
+		_, _ = n.GetTopic(ctx, tp.ID)
+		sub, _ := n.Subscribe(ctx, notifdriver.SubscriptionConfig{TopicID: tp.ID, Protocol: "email", Endpoint: "x@y.z"})
+		_, _ = n.Publish(ctx, notifdriver.PublishInput{TopicID: tp.ID, Message: "hi"})
+		if sub != nil {
+			_ = n.Unsubscribe(ctx, sub.ID)
+		}
+		_ = n.DeleteTopic(ctx, tp.ID)
+	}
+}
+
+func TestWrapContainerRegistryBaseline(t *testing.T) {
+	r, _ := newChaosContainerRegistry(t)
+	ctx := context.Background()
+
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "b"})
+	_, _ = r.GetRepository(ctx, "b")
+	_, _ = r.ListRepositories(ctx)
+	m := &regdriver.ImageManifest{Repository: "b", Tag: "v1", Digest: "sha256:abc", SizeBytes: 100}
+	_, _ = r.PutImage(ctx, m)
+	_, _ = r.GetImage(ctx, "b", "v1")
+	_, _ = r.ListImages(ctx, "b")
+	_ = r.DeleteImage(ctx, "b", "v1")
+	_ = r.DeleteRepository(ctx, "b", false)
+}
+
+func TestWrapEventBusBaseline(t *testing.T) {
+	b, _ := newChaosEventBus(t)
+	ctx := context.Background()
+
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "b"})
+	_, _ = b.GetEventBus(ctx, "b")
+	_, _ = b.ListEventBuses(ctx)
+	cfg := &ebdriver.RuleConfig{Name: "rule", EventBus: "b", EventPattern: `{"source":["x"]}`, State: "ENABLED"}
+	_, _ = b.PutRule(ctx, cfg)
+	_, _ = b.GetRule(ctx, "b", "rule")
+	_, _ = b.ListRules(ctx, "b")
+	events := []ebdriver.Event{{Source: "x", DetailType: "y", Detail: "{}", EventBus: "b", Time: time.Now()}}
+	_, _ = b.PutEvents(ctx, events)
+	_ = b.DeleteRule(ctx, "b", "rule")
+	_ = b.DeleteEventBus(ctx, "b")
+}
+

--- a/chaos/wrappers_cache.go
+++ b/chaos/wrappers_cache.go
@@ -1,0 +1,84 @@
+package chaos
+
+import (
+	"context"
+	"time"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+)
+
+// chaosCache wraps a cache driver. Hot-path: K/V ops and atomic counters.
+// Cache instance management and TTL admin delegate through.
+type chaosCache struct {
+	cachedriver.Cache
+	engine *Engine
+}
+
+// WrapCache returns a cache driver that consults engine on data-plane calls.
+func WrapCache(inner cachedriver.Cache, engine *Engine) cachedriver.Cache {
+	return &chaosCache{Cache: inner, engine: engine}
+}
+
+func (c *chaosCache) Set(ctx context.Context, cacheName, key string, value []byte, ttl time.Duration) error {
+	if err := applyChaos(ctx, c.engine, "cache", "Set"); err != nil {
+		return err
+	}
+
+	return c.Cache.Set(ctx, cacheName, key, value, ttl)
+}
+
+func (c *chaosCache) Get(ctx context.Context, cacheName, key string) (*cachedriver.Item, error) {
+	if err := applyChaos(ctx, c.engine, "cache", "Get"); err != nil {
+		return nil, err
+	}
+
+	return c.Cache.Get(ctx, cacheName, key)
+}
+
+func (c *chaosCache) Delete(ctx context.Context, cacheName, key string) error {
+	if err := applyChaos(ctx, c.engine, "cache", "Delete"); err != nil {
+		return err
+	}
+
+	return c.Cache.Delete(ctx, cacheName, key)
+}
+
+func (c *chaosCache) Keys(ctx context.Context, cacheName, pattern string) ([]string, error) {
+	if err := applyChaos(ctx, c.engine, "cache", "Keys"); err != nil {
+		return nil, err
+	}
+
+	return c.Cache.Keys(ctx, cacheName, pattern)
+}
+
+func (c *chaosCache) Incr(ctx context.Context, cacheName, key string) (int64, error) {
+	if err := applyChaos(ctx, c.engine, "cache", "Incr"); err != nil {
+		return 0, err
+	}
+
+	return c.Cache.Incr(ctx, cacheName, key)
+}
+
+func (c *chaosCache) IncrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error) {
+	if err := applyChaos(ctx, c.engine, "cache", "IncrBy"); err != nil {
+		return 0, err
+	}
+
+	return c.Cache.IncrBy(ctx, cacheName, key, delta)
+}
+
+func (c *chaosCache) Decr(ctx context.Context, cacheName, key string) (int64, error) {
+	if err := applyChaos(ctx, c.engine, "cache", "Decr"); err != nil {
+		return 0, err
+	}
+
+	return c.Cache.Decr(ctx, cacheName, key)
+}
+
+func (c *chaosCache) DecrBy(ctx context.Context, cacheName, key string, delta int64) (int64, error) {
+	if err := applyChaos(ctx, c.engine, "cache", "DecrBy"); err != nil {
+		return 0, err
+	}
+
+	return c.Cache.DecrBy(ctx, cacheName, key, delta)
+}

--- a/chaos/wrappers_cache_test.go
+++ b/chaos/wrappers_cache_test.go
@@ -1,0 +1,122 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+)
+
+const (
+	chaosTestCacheName = "c"
+	chaosTestCacheKey  = "k"
+)
+
+func newChaosCache(t *testing.T) (cachedriver.Cache, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+	c := chaos.WrapCache(cloudemu.NewAWS().ElastiCache, e)
+	_, _ = c.CreateCache(context.Background(), cachedriver.CacheConfig{Name: chaosTestCacheName, Engine: "redis"})
+
+	return c, e
+}
+
+func TestWrapCacheSetChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+
+	if err := c.Set(ctx, chaosTestCacheName, chaosTestCacheKey, []byte("v"), time.Minute); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if err := c.Set(ctx, chaosTestCacheName, chaosTestCacheKey, []byte("v"), time.Minute); err == nil {
+		t.Error("expected chaos error on Set")
+	}
+}
+
+func TestWrapCacheGetChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+	_ = c.Set(ctx, chaosTestCacheName, chaosTestCacheKey, []byte("v"), time.Minute)
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if _, err := c.Get(ctx, chaosTestCacheName, chaosTestCacheKey); err == nil {
+		t.Error("expected chaos error on Get")
+	}
+}
+
+func TestWrapCacheDeleteChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+	_ = c.Set(ctx, chaosTestCacheName, chaosTestCacheKey, []byte("v"), time.Minute)
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if err := c.Delete(ctx, chaosTestCacheName, chaosTestCacheKey); err == nil {
+		t.Error("expected chaos error on Delete")
+	}
+}
+
+func TestWrapCacheKeysChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if _, err := c.Keys(ctx, chaosTestCacheName, "*"); err == nil {
+		t.Error("expected chaos error on Keys")
+	}
+}
+
+func TestWrapCacheIncrChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if _, err := c.Incr(ctx, chaosTestCacheName, chaosTestCacheKey); err == nil {
+		t.Error("expected chaos error on Incr")
+	}
+}
+
+func TestWrapCacheIncrByChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if _, err := c.IncrBy(ctx, chaosTestCacheName, chaosTestCacheKey, 5); err == nil {
+		t.Error("expected chaos error on IncrBy")
+	}
+}
+
+func TestWrapCacheDecrChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if _, err := c.Decr(ctx, chaosTestCacheName, chaosTestCacheKey); err == nil {
+		t.Error("expected chaos error on Decr")
+	}
+}
+
+func TestWrapCacheDecrByChaos(t *testing.T) {
+	c, e := newChaosCache(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("cache", time.Hour))
+
+	if _, err := c.DecrBy(ctx, chaosTestCacheName, chaosTestCacheKey, 3); err == nil {
+		t.Error("expected chaos error on DecrBy")
+	}
+}

--- a/chaos/wrappers_containerregistry.go
+++ b/chaos/wrappers_containerregistry.go
@@ -1,0 +1,91 @@
+package chaos
+
+import (
+	"context"
+
+	regdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+// chaosContainerRegistry wraps a container registry driver. Hot-path:
+// repository CRUD + image push/pull/list/delete. Lifecycle policies and
+// scanning delegate through.
+type chaosContainerRegistry struct {
+	regdriver.ContainerRegistry
+	engine *Engine
+}
+
+// WrapContainerRegistry returns a container registry driver that consults
+// engine on repository and image data-plane calls.
+func WrapContainerRegistry(inner regdriver.ContainerRegistry, engine *Engine) regdriver.ContainerRegistry {
+	return &chaosContainerRegistry{ContainerRegistry: inner, engine: engine}
+}
+
+func (c *chaosContainerRegistry) CreateRepository(
+	ctx context.Context, cfg regdriver.RepositoryConfig,
+) (*regdriver.Repository, error) {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "CreateRepository"); err != nil {
+		return nil, err
+	}
+
+	return c.ContainerRegistry.CreateRepository(ctx, cfg)
+}
+
+func (c *chaosContainerRegistry) DeleteRepository(ctx context.Context, name string, force bool) error {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "DeleteRepository"); err != nil {
+		return err
+	}
+
+	return c.ContainerRegistry.DeleteRepository(ctx, name, force)
+}
+
+func (c *chaosContainerRegistry) GetRepository(ctx context.Context, name string) (*regdriver.Repository, error) {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "GetRepository"); err != nil {
+		return nil, err
+	}
+
+	return c.ContainerRegistry.GetRepository(ctx, name)
+}
+
+func (c *chaosContainerRegistry) ListRepositories(ctx context.Context) ([]regdriver.Repository, error) {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "ListRepositories"); err != nil {
+		return nil, err
+	}
+
+	return c.ContainerRegistry.ListRepositories(ctx)
+}
+
+func (c *chaosContainerRegistry) PutImage(
+	ctx context.Context, manifest *regdriver.ImageManifest,
+) (*regdriver.ImageDetail, error) {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "PutImage"); err != nil {
+		return nil, err
+	}
+
+	return c.ContainerRegistry.PutImage(ctx, manifest)
+}
+
+func (c *chaosContainerRegistry) GetImage(
+	ctx context.Context, repository, reference string,
+) (*regdriver.ImageDetail, error) {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "GetImage"); err != nil {
+		return nil, err
+	}
+
+	return c.ContainerRegistry.GetImage(ctx, repository, reference)
+}
+
+func (c *chaosContainerRegistry) ListImages(ctx context.Context, repository string) ([]regdriver.ImageDetail, error) {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "ListImages"); err != nil {
+		return nil, err
+	}
+
+	return c.ContainerRegistry.ListImages(ctx, repository)
+}
+
+func (c *chaosContainerRegistry) DeleteImage(ctx context.Context, repository, reference string) error {
+	if err := applyChaos(ctx, c.engine, "containerregistry", "DeleteImage"); err != nil {
+		return err
+	}
+
+	return c.ContainerRegistry.DeleteImage(ctx, repository, reference)
+}

--- a/chaos/wrappers_containerregistry_test.go
+++ b/chaos/wrappers_containerregistry_test.go
@@ -1,0 +1,120 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	regdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+func newChaosContainerRegistry(t *testing.T) (regdriver.ContainerRegistry, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapContainerRegistry(cloudemu.NewAWS().ECR, e), e
+}
+
+func TestWrapContainerRegistryCreateRepositoryChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+
+	if _, err := r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "ok"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if _, err := r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "fail"}); err == nil {
+		t.Error("expected chaos error on CreateRepository")
+	}
+}
+
+func TestWrapContainerRegistryDeleteRepositoryChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "del"})
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if err := r.DeleteRepository(ctx, "del", false); err == nil {
+		t.Error("expected chaos error on DeleteRepository")
+	}
+}
+
+func TestWrapContainerRegistryGetRepositoryChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "g"})
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if _, err := r.GetRepository(ctx, "g"); err == nil {
+		t.Error("expected chaos error on GetRepository")
+	}
+}
+
+func TestWrapContainerRegistryListRepositoriesChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if _, err := r.ListRepositories(ctx); err == nil {
+		t.Error("expected chaos error on ListRepositories")
+	}
+}
+
+func TestWrapContainerRegistryPutImageChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "img"})
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	m := &regdriver.ImageManifest{Repository: "img", Tag: "v1", Digest: "sha256:abc", SizeBytes: 100}
+	if _, err := r.PutImage(ctx, m); err == nil {
+		t.Error("expected chaos error on PutImage")
+	}
+}
+
+func TestWrapContainerRegistryGetImageChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "gimg"})
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if _, err := r.GetImage(ctx, "gimg", "v1"); err == nil {
+		t.Error("expected chaos error on GetImage")
+	}
+}
+
+func TestWrapContainerRegistryListImagesChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "limg"})
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if _, err := r.ListImages(ctx, "limg"); err == nil {
+		t.Error("expected chaos error on ListImages")
+	}
+}
+
+func TestWrapContainerRegistryDeleteImageChaos(t *testing.T) {
+	r, e := newChaosContainerRegistry(t)
+	ctx := context.Background()
+	_, _ = r.CreateRepository(ctx, regdriver.RepositoryConfig{Name: "dimg"})
+
+	e.Apply(chaos.ServiceOutage("containerregistry", time.Hour))
+
+	if err := r.DeleteImage(ctx, "dimg", "v1"); err == nil {
+		t.Error("expected chaos error on DeleteImage")
+	}
+}

--- a/chaos/wrappers_dns.go
+++ b/chaos/wrappers_dns.go
@@ -1,0 +1,93 @@
+package chaos
+
+import (
+	"context"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+)
+
+// chaosDNS wraps a DNS driver. Hot-path: zone and record CRUD.
+// Health checks delegate through.
+type chaosDNS struct {
+	dnsdriver.DNS
+	engine *Engine
+}
+
+// WrapDNS returns a DNS driver that consults engine on zone and record calls.
+func WrapDNS(inner dnsdriver.DNS, engine *Engine) dnsdriver.DNS {
+	return &chaosDNS{DNS: inner, engine: engine}
+}
+
+func (c *chaosDNS) CreateZone(ctx context.Context, cfg dnsdriver.ZoneConfig) (*dnsdriver.ZoneInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "CreateZone"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.CreateZone(ctx, cfg)
+}
+
+func (c *chaosDNS) DeleteZone(ctx context.Context, id string) error {
+	if err := applyChaos(ctx, c.engine, "dns", "DeleteZone"); err != nil {
+		return err
+	}
+
+	return c.DNS.DeleteZone(ctx, id)
+}
+
+func (c *chaosDNS) GetZone(ctx context.Context, id string) (*dnsdriver.ZoneInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "GetZone"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.GetZone(ctx, id)
+}
+
+func (c *chaosDNS) ListZones(ctx context.Context) ([]dnsdriver.ZoneInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "ListZones"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.ListZones(ctx)
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosDNS) CreateRecord(ctx context.Context, cfg dnsdriver.RecordConfig) (*dnsdriver.RecordInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "CreateRecord"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.CreateRecord(ctx, cfg)
+}
+
+func (c *chaosDNS) DeleteRecord(ctx context.Context, zoneID, name, recordType string) error {
+	if err := applyChaos(ctx, c.engine, "dns", "DeleteRecord"); err != nil {
+		return err
+	}
+
+	return c.DNS.DeleteRecord(ctx, zoneID, name, recordType)
+}
+
+func (c *chaosDNS) GetRecord(ctx context.Context, zoneID, name, recordType string) (*dnsdriver.RecordInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "GetRecord"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.GetRecord(ctx, zoneID, name, recordType)
+}
+
+func (c *chaosDNS) ListRecords(ctx context.Context, zoneID string) ([]dnsdriver.RecordInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "ListRecords"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.ListRecords(ctx, zoneID)
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosDNS) UpdateRecord(ctx context.Context, cfg dnsdriver.RecordConfig) (*dnsdriver.RecordInfo, error) {
+	if err := applyChaos(ctx, c.engine, "dns", "UpdateRecord"); err != nil {
+		return nil, err
+	}
+
+	return c.DNS.UpdateRecord(ctx, cfg)
+}

--- a/chaos/wrappers_dns_test.go
+++ b/chaos/wrappers_dns_test.go
@@ -1,0 +1,136 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+)
+
+func newChaosDNS(t *testing.T) (dnsdriver.DNS, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapDNS(cloudemu.NewAWS().Route53, e), e
+}
+
+func TestWrapDNSCreateZoneChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+
+	if _, err := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "ok.test."}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if _, err := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "fail.test."}); err == nil {
+		t.Error("expected chaos error on CreateZone")
+	}
+}
+
+func TestWrapDNSDeleteZoneChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "del.test."})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if err := d.DeleteZone(ctx, z.ID); err == nil {
+		t.Error("expected chaos error on DeleteZone")
+	}
+}
+
+func TestWrapDNSGetZoneChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "g.test."})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if _, err := d.GetZone(ctx, z.ID); err == nil {
+		t.Error("expected chaos error on GetZone")
+	}
+}
+
+func TestWrapDNSListZonesChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if _, err := d.ListZones(ctx); err == nil {
+		t.Error("expected chaos error on ListZones")
+	}
+}
+
+func TestWrapDNSCreateRecordChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "r.test."})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	cfg := dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.r.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}}
+	if _, err := d.CreateRecord(ctx, cfg); err == nil {
+		t.Error("expected chaos error on CreateRecord")
+	}
+}
+
+func TestWrapDNSDeleteRecordChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "dr.test."})
+	_, _ = d.CreateRecord(ctx, dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.dr.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if err := d.DeleteRecord(ctx, z.ID, "x.dr.test.", "A"); err == nil {
+		t.Error("expected chaos error on DeleteRecord")
+	}
+}
+
+func TestWrapDNSGetRecordChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "gr.test."})
+	_, _ = d.CreateRecord(ctx, dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.gr.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if _, err := d.GetRecord(ctx, z.ID, "x.gr.test.", "A"); err == nil {
+		t.Error("expected chaos error on GetRecord")
+	}
+}
+
+func TestWrapDNSListRecordsChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "lr.test."})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	if _, err := d.ListRecords(ctx, z.ID); err == nil {
+		t.Error("expected chaos error on ListRecords")
+	}
+}
+
+func TestWrapDNSUpdateRecordChaos(t *testing.T) {
+	d, e := newChaosDNS(t)
+	ctx := context.Background()
+	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "ur.test."})
+	_, _ = d.CreateRecord(ctx, dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.ur.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}})
+
+	e.Apply(chaos.ServiceOutage("dns", time.Hour))
+
+	cfg := dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.ur.test.", Type: "A", TTL: 600, Values: []string{"5.6.7.8"}}
+	if _, err := d.UpdateRecord(ctx, cfg); err == nil {
+		t.Error("expected chaos error on UpdateRecord")
+	}
+}

--- a/chaos/wrappers_eventbus.go
+++ b/chaos/wrappers_eventbus.go
@@ -1,0 +1,94 @@
+package chaos
+
+import (
+	"context"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+)
+
+// chaosEventBus wraps an event bus driver. Hot-path: bus CRUD, rule CRUD,
+// PutEvents. Enable/disable, target ops, and history delegate through.
+type chaosEventBus struct {
+	ebdriver.EventBus
+	engine *Engine
+}
+
+// WrapEventBus returns an event bus driver that consults engine on bus, rule,
+// and event publishing calls.
+func WrapEventBus(inner ebdriver.EventBus, engine *Engine) ebdriver.EventBus {
+	return &chaosEventBus{EventBus: inner, engine: engine}
+}
+
+func (c *chaosEventBus) CreateEventBus(
+	ctx context.Context, cfg ebdriver.EventBusConfig,
+) (*ebdriver.EventBusInfo, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "CreateEventBus"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.CreateEventBus(ctx, cfg)
+}
+
+func (c *chaosEventBus) DeleteEventBus(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "eventbus", "DeleteEventBus"); err != nil {
+		return err
+	}
+
+	return c.EventBus.DeleteEventBus(ctx, name)
+}
+
+func (c *chaosEventBus) GetEventBus(ctx context.Context, name string) (*ebdriver.EventBusInfo, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "GetEventBus"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.GetEventBus(ctx, name)
+}
+
+func (c *chaosEventBus) ListEventBuses(ctx context.Context) ([]ebdriver.EventBusInfo, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "ListEventBuses"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.ListEventBuses(ctx)
+}
+
+func (c *chaosEventBus) PutRule(ctx context.Context, cfg *ebdriver.RuleConfig) (*ebdriver.Rule, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "PutRule"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.PutRule(ctx, cfg)
+}
+
+func (c *chaosEventBus) DeleteRule(ctx context.Context, eventBus, ruleName string) error {
+	if err := applyChaos(ctx, c.engine, "eventbus", "DeleteRule"); err != nil {
+		return err
+	}
+
+	return c.EventBus.DeleteRule(ctx, eventBus, ruleName)
+}
+
+func (c *chaosEventBus) GetRule(ctx context.Context, eventBus, ruleName string) (*ebdriver.Rule, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "GetRule"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.GetRule(ctx, eventBus, ruleName)
+}
+
+func (c *chaosEventBus) ListRules(ctx context.Context, eventBus string) ([]ebdriver.Rule, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "ListRules"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.ListRules(ctx, eventBus)
+}
+
+func (c *chaosEventBus) PutEvents(ctx context.Context, events []ebdriver.Event) (*ebdriver.PublishResult, error) {
+	if err := applyChaos(ctx, c.engine, "eventbus", "PutEvents"); err != nil {
+		return nil, err
+	}
+
+	return c.EventBus.PutEvents(ctx, events)
+}

--- a/chaos/wrappers_eventbus_test.go
+++ b/chaos/wrappers_eventbus_test.go
@@ -1,0 +1,135 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+)
+
+func newChaosEventBus(t *testing.T) (ebdriver.EventBus, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapEventBus(cloudemu.NewAWS().EventBridge, e), e
+}
+
+func TestWrapEventBusCreateEventBusChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+
+	if _, err := b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "ok"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if _, err := b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "fail"}); err == nil {
+		t.Error("expected chaos error on CreateEventBus")
+	}
+}
+
+func TestWrapEventBusDeleteEventBusChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "del"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if err := b.DeleteEventBus(ctx, "del"); err == nil {
+		t.Error("expected chaos error on DeleteEventBus")
+	}
+}
+
+func TestWrapEventBusGetEventBusChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "g"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if _, err := b.GetEventBus(ctx, "g"); err == nil {
+		t.Error("expected chaos error on GetEventBus")
+	}
+}
+
+func TestWrapEventBusListEventBusesChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if _, err := b.ListEventBuses(ctx); err == nil {
+		t.Error("expected chaos error on ListEventBuses")
+	}
+}
+
+func TestWrapEventBusPutRuleChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "r"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	cfg := &ebdriver.RuleConfig{Name: "rule", EventBus: "r", EventPattern: `{"source":["x"]}`, State: "ENABLED"}
+	if _, err := b.PutRule(ctx, cfg); err == nil {
+		t.Error("expected chaos error on PutRule")
+	}
+}
+
+func TestWrapEventBusDeleteRuleChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "dr"})
+	_, _ = b.PutRule(ctx, &ebdriver.RuleConfig{Name: "rule", EventBus: "dr", EventPattern: `{"source":["x"]}`, State: "ENABLED"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if err := b.DeleteRule(ctx, "dr", "rule"); err == nil {
+		t.Error("expected chaos error on DeleteRule")
+	}
+}
+
+func TestWrapEventBusGetRuleChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "gr"})
+	_, _ = b.PutRule(ctx, &ebdriver.RuleConfig{Name: "rule", EventBus: "gr", EventPattern: `{"source":["x"]}`, State: "ENABLED"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if _, err := b.GetRule(ctx, "gr", "rule"); err == nil {
+		t.Error("expected chaos error on GetRule")
+	}
+}
+
+func TestWrapEventBusListRulesChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "lr"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	if _, err := b.ListRules(ctx, "lr"); err == nil {
+		t.Error("expected chaos error on ListRules")
+	}
+}
+
+func TestWrapEventBusPutEventsChaos(t *testing.T) {
+	b, e := newChaosEventBus(t)
+	ctx := context.Background()
+	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "pe"})
+
+	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
+
+	events := []ebdriver.Event{{Source: "x", DetailType: "y", Detail: "{}", EventBus: "pe", Time: time.Now()}}
+	if _, err := b.PutEvents(ctx, events); err == nil {
+		t.Error("expected chaos error on PutEvents")
+	}
+}

--- a/chaos/wrappers_iam.go
+++ b/chaos/wrappers_iam.go
@@ -1,0 +1,124 @@
+package chaos
+
+import (
+	"context"
+
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+)
+
+// chaosIAM wraps an IAM driver. Hot-path: user/role/policy CRUD plus
+// CheckPermission. Groups, access keys, and instance profiles delegate through.
+type chaosIAM struct {
+	iamdriver.IAM
+	engine *Engine
+}
+
+// WrapIAM returns an IAM driver that consults engine on principal/policy
+// management and permission checks.
+func WrapIAM(inner iamdriver.IAM, engine *Engine) iamdriver.IAM {
+	return &chaosIAM{IAM: inner, engine: engine}
+}
+
+func (c *chaosIAM) CreateUser(ctx context.Context, cfg iamdriver.UserConfig) (*iamdriver.UserInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "CreateUser"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.CreateUser(ctx, cfg)
+}
+
+func (c *chaosIAM) DeleteUser(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "iam", "DeleteUser"); err != nil {
+		return err
+	}
+
+	return c.IAM.DeleteUser(ctx, name)
+}
+
+func (c *chaosIAM) GetUser(ctx context.Context, name string) (*iamdriver.UserInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "GetUser"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.GetUser(ctx, name)
+}
+
+func (c *chaosIAM) ListUsers(ctx context.Context) ([]iamdriver.UserInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "ListUsers"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.ListUsers(ctx)
+}
+
+func (c *chaosIAM) CreateRole(ctx context.Context, cfg iamdriver.RoleConfig) (*iamdriver.RoleInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "CreateRole"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.CreateRole(ctx, cfg)
+}
+
+func (c *chaosIAM) DeleteRole(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "iam", "DeleteRole"); err != nil {
+		return err
+	}
+
+	return c.IAM.DeleteRole(ctx, name)
+}
+
+func (c *chaosIAM) GetRole(ctx context.Context, name string) (*iamdriver.RoleInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "GetRole"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.GetRole(ctx, name)
+}
+
+func (c *chaosIAM) ListRoles(ctx context.Context) ([]iamdriver.RoleInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "ListRoles"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.ListRoles(ctx)
+}
+
+func (c *chaosIAM) CreatePolicy(ctx context.Context, cfg iamdriver.PolicyConfig) (*iamdriver.PolicyInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "CreatePolicy"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.CreatePolicy(ctx, cfg)
+}
+
+func (c *chaosIAM) DeletePolicy(ctx context.Context, arn string) error {
+	if err := applyChaos(ctx, c.engine, "iam", "DeletePolicy"); err != nil {
+		return err
+	}
+
+	return c.IAM.DeletePolicy(ctx, arn)
+}
+
+func (c *chaosIAM) GetPolicy(ctx context.Context, arn string) (*iamdriver.PolicyInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "GetPolicy"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.GetPolicy(ctx, arn)
+}
+
+func (c *chaosIAM) ListPolicies(ctx context.Context) ([]iamdriver.PolicyInfo, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "ListPolicies"); err != nil {
+		return nil, err
+	}
+
+	return c.IAM.ListPolicies(ctx)
+}
+
+func (c *chaosIAM) CheckPermission(ctx context.Context, principal, action, resource string) (bool, error) {
+	if err := applyChaos(ctx, c.engine, "iam", "CheckPermission"); err != nil {
+		return false, err
+	}
+
+	return c.IAM.CheckPermission(ctx, principal, action, resource)
+}

--- a/chaos/wrappers_iam_test.go
+++ b/chaos/wrappers_iam_test.go
@@ -1,0 +1,172 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+)
+
+func newChaosIAM(t *testing.T) (iamdriver.IAM, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapIAM(cloudemu.NewAWS().IAM, e), e
+}
+
+func TestWrapIAMCreateUserChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	if _, err := i.CreateUser(ctx, iamdriver.UserConfig{Name: "u"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.CreateUser(ctx, iamdriver.UserConfig{Name: "u2"}); err == nil {
+		t.Error("expected chaos error on CreateUser")
+	}
+}
+
+func TestWrapIAMDeleteUserChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+	_, _ = i.CreateUser(ctx, iamdriver.UserConfig{Name: "del"})
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if err := i.DeleteUser(ctx, "del"); err == nil {
+		t.Error("expected chaos error on DeleteUser")
+	}
+}
+
+func TestWrapIAMGetUserChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+	_, _ = i.CreateUser(ctx, iamdriver.UserConfig{Name: "g"})
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.GetUser(ctx, "g"); err == nil {
+		t.Error("expected chaos error on GetUser")
+	}
+}
+
+func TestWrapIAMListUsersChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.ListUsers(ctx); err == nil {
+		t.Error("expected chaos error on ListUsers")
+	}
+}
+
+func TestWrapIAMCreateRoleChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.CreateRole(ctx, iamdriver.RoleConfig{Name: "r"}); err == nil {
+		t.Error("expected chaos error on CreateRole")
+	}
+}
+
+func TestWrapIAMDeleteRoleChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+	_, _ = i.CreateRole(ctx, iamdriver.RoleConfig{Name: "delrole"})
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if err := i.DeleteRole(ctx, "delrole"); err == nil {
+		t.Error("expected chaos error on DeleteRole")
+	}
+}
+
+func TestWrapIAMGetRoleChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+	_, _ = i.CreateRole(ctx, iamdriver.RoleConfig{Name: "gr"})
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.GetRole(ctx, "gr"); err == nil {
+		t.Error("expected chaos error on GetRole")
+	}
+}
+
+func TestWrapIAMListRolesChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.ListRoles(ctx); err == nil {
+		t.Error("expected chaos error on ListRoles")
+	}
+}
+
+func TestWrapIAMCreatePolicyChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.CreatePolicy(ctx, iamdriver.PolicyConfig{Name: "p", PolicyDocument: "{}"}); err == nil {
+		t.Error("expected chaos error on CreatePolicy")
+	}
+}
+
+func TestWrapIAMDeletePolicyChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if err := i.DeletePolicy(ctx, "arn:aws:iam::x:policy/p"); err == nil {
+		t.Error("expected chaos error on DeletePolicy")
+	}
+}
+
+func TestWrapIAMGetPolicyChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.GetPolicy(ctx, "arn:aws:iam::x:policy/p"); err == nil {
+		t.Error("expected chaos error on GetPolicy")
+	}
+}
+
+func TestWrapIAMListPoliciesChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.ListPolicies(ctx); err == nil {
+		t.Error("expected chaos error on ListPolicies")
+	}
+}
+
+func TestWrapIAMCheckPermissionChaos(t *testing.T) {
+	i, e := newChaosIAM(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("iam", time.Hour))
+
+	if _, err := i.CheckPermission(ctx, "u", "s3:GetObject", "*"); err == nil {
+		t.Error("expected chaos error on CheckPermission")
+	}
+}

--- a/chaos/wrappers_loadbalancer.go
+++ b/chaos/wrappers_loadbalancer.go
@@ -1,0 +1,107 @@
+package chaos
+
+import (
+	"context"
+
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+)
+
+// chaosLoadBalancer wraps a load balancer driver. Hot-path: LB / target group /
+// target registration + health. Listeners, rules, and attributes delegate
+// through.
+type chaosLoadBalancer struct {
+	lbdriver.LoadBalancer
+	engine *Engine
+}
+
+// WrapLoadBalancer returns a load balancer driver that consults engine on
+// LB / target-group / target operations.
+func WrapLoadBalancer(inner lbdriver.LoadBalancer, engine *Engine) lbdriver.LoadBalancer {
+	return &chaosLoadBalancer{LoadBalancer: inner, engine: engine}
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosLoadBalancer) CreateLoadBalancer(
+	ctx context.Context, cfg lbdriver.LBConfig,
+) (*lbdriver.LBInfo, error) {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "CreateLoadBalancer"); err != nil {
+		return nil, err
+	}
+
+	return c.LoadBalancer.CreateLoadBalancer(ctx, cfg)
+}
+
+func (c *chaosLoadBalancer) DeleteLoadBalancer(ctx context.Context, arn string) error {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "DeleteLoadBalancer"); err != nil {
+		return err
+	}
+
+	return c.LoadBalancer.DeleteLoadBalancer(ctx, arn)
+}
+
+func (c *chaosLoadBalancer) DescribeLoadBalancers(ctx context.Context, arns []string) ([]lbdriver.LBInfo, error) {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "DescribeLoadBalancers"); err != nil {
+		return nil, err
+	}
+
+	return c.LoadBalancer.DescribeLoadBalancers(ctx, arns)
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosLoadBalancer) CreateTargetGroup(
+	ctx context.Context, cfg lbdriver.TargetGroupConfig,
+) (*lbdriver.TargetGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "CreateTargetGroup"); err != nil {
+		return nil, err
+	}
+
+	return c.LoadBalancer.CreateTargetGroup(ctx, cfg)
+}
+
+func (c *chaosLoadBalancer) DeleteTargetGroup(ctx context.Context, arn string) error {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "DeleteTargetGroup"); err != nil {
+		return err
+	}
+
+	return c.LoadBalancer.DeleteTargetGroup(ctx, arn)
+}
+
+func (c *chaosLoadBalancer) DescribeTargetGroups(
+	ctx context.Context, arns []string,
+) ([]lbdriver.TargetGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "DescribeTargetGroups"); err != nil {
+		return nil, err
+	}
+
+	return c.LoadBalancer.DescribeTargetGroups(ctx, arns)
+}
+
+func (c *chaosLoadBalancer) RegisterTargets(
+	ctx context.Context, targetGroupARN string, targets []lbdriver.Target,
+) error {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "RegisterTargets"); err != nil {
+		return err
+	}
+
+	return c.LoadBalancer.RegisterTargets(ctx, targetGroupARN, targets)
+}
+
+func (c *chaosLoadBalancer) DeregisterTargets(
+	ctx context.Context, targetGroupARN string, targets []lbdriver.Target,
+) error {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "DeregisterTargets"); err != nil {
+		return err
+	}
+
+	return c.LoadBalancer.DeregisterTargets(ctx, targetGroupARN, targets)
+}
+
+func (c *chaosLoadBalancer) DescribeTargetHealth(
+	ctx context.Context, targetGroupARN string,
+) ([]lbdriver.TargetHealth, error) {
+	if err := applyChaos(ctx, c.engine, "loadbalancer", "DescribeTargetHealth"); err != nil {
+		return nil, err
+	}
+
+	return c.LoadBalancer.DescribeTargetHealth(ctx, targetGroupARN)
+}

--- a/chaos/wrappers_loadbalancer_test.go
+++ b/chaos/wrappers_loadbalancer_test.go
@@ -1,0 +1,131 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+)
+
+func newChaosLoadBalancer(t *testing.T) (lbdriver.LoadBalancer, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapLoadBalancer(cloudemu.NewAWS().ELB, e), e
+}
+
+func TestWrapLoadBalancerCreateLoadBalancerChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+
+	if _, err := l.CreateLoadBalancer(ctx, lbdriver.LBConfig{Name: "ok", Type: "application"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if _, err := l.CreateLoadBalancer(ctx, lbdriver.LBConfig{Name: "fail", Type: "application"}); err == nil {
+		t.Error("expected chaos error on CreateLoadBalancer")
+	}
+}
+
+func TestWrapLoadBalancerDeleteLoadBalancerChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+	lb, _ := l.CreateLoadBalancer(ctx, lbdriver.LBConfig{Name: "del", Type: "application"})
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if err := l.DeleteLoadBalancer(ctx, lb.ARN); err == nil {
+		t.Error("expected chaos error on DeleteLoadBalancer")
+	}
+}
+
+func TestWrapLoadBalancerDescribeLoadBalancersChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if _, err := l.DescribeLoadBalancers(ctx, nil); err == nil {
+		t.Error("expected chaos error on DescribeLoadBalancers")
+	}
+}
+
+func TestWrapLoadBalancerCreateTargetGroupChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	cfg := lbdriver.TargetGroupConfig{Name: "tg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1"}
+	if _, err := l.CreateTargetGroup(ctx, cfg); err == nil {
+		t.Error("expected chaos error on CreateTargetGroup")
+	}
+}
+
+func TestWrapLoadBalancerDeleteTargetGroupChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+	tg, _ := l.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{Name: "tgdel", Protocol: "HTTP", Port: 80, VPCID: "vpc-1"})
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if err := l.DeleteTargetGroup(ctx, tg.ARN); err == nil {
+		t.Error("expected chaos error on DeleteTargetGroup")
+	}
+}
+
+func TestWrapLoadBalancerDescribeTargetGroupsChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if _, err := l.DescribeTargetGroups(ctx, nil); err == nil {
+		t.Error("expected chaos error on DescribeTargetGroups")
+	}
+}
+
+func TestWrapLoadBalancerRegisterTargetsChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+	tg, _ := l.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{Name: "tgreg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1"})
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if err := l.RegisterTargets(ctx, tg.ARN, []lbdriver.Target{{ID: "i-1", Port: 80}}); err == nil {
+		t.Error("expected chaos error on RegisterTargets")
+	}
+}
+
+func TestWrapLoadBalancerDeregisterTargetsChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+	tg, _ := l.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{Name: "tgdereg", Protocol: "HTTP", Port: 80, VPCID: "vpc-1"})
+	_ = l.RegisterTargets(ctx, tg.ARN, []lbdriver.Target{{ID: "i-1", Port: 80}})
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if err := l.DeregisterTargets(ctx, tg.ARN, []lbdriver.Target{{ID: "i-1", Port: 80}}); err == nil {
+		t.Error("expected chaos error on DeregisterTargets")
+	}
+}
+
+func TestWrapLoadBalancerDescribeTargetHealthChaos(t *testing.T) {
+	l, e := newChaosLoadBalancer(t)
+	ctx := context.Background()
+	tg, _ := l.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{Name: "tgh", Protocol: "HTTP", Port: 80, VPCID: "vpc-1"})
+
+	e.Apply(chaos.ServiceOutage("loadbalancer", time.Hour))
+
+	if _, err := l.DescribeTargetHealth(ctx, tg.ARN); err == nil {
+		t.Error("expected chaos error on DescribeTargetHealth")
+	}
+}

--- a/chaos/wrappers_logging.go
+++ b/chaos/wrappers_logging.go
@@ -1,0 +1,85 @@
+package chaos
+
+import (
+	"context"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+)
+
+// chaosLogging wraps a logging driver. Hot-path: log group CRUD plus
+// PutLogEvents / GetLogEvents / FilterLogEvents. Streams and metric filters
+// delegate through.
+type chaosLogging struct {
+	logdriver.Logging
+	engine *Engine
+}
+
+// WrapLogging returns a logging driver that consults engine on log-group and
+// event-ingest/query calls.
+func WrapLogging(inner logdriver.Logging, engine *Engine) logdriver.Logging {
+	return &chaosLogging{Logging: inner, engine: engine}
+}
+
+func (c *chaosLogging) CreateLogGroup(
+	ctx context.Context, cfg logdriver.LogGroupConfig,
+) (*logdriver.LogGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "logging", "CreateLogGroup"); err != nil {
+		return nil, err
+	}
+
+	return c.Logging.CreateLogGroup(ctx, cfg)
+}
+
+func (c *chaosLogging) DeleteLogGroup(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "logging", "DeleteLogGroup"); err != nil {
+		return err
+	}
+
+	return c.Logging.DeleteLogGroup(ctx, name)
+}
+
+func (c *chaosLogging) GetLogGroup(ctx context.Context, name string) (*logdriver.LogGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "logging", "GetLogGroup"); err != nil {
+		return nil, err
+	}
+
+	return c.Logging.GetLogGroup(ctx, name)
+}
+
+func (c *chaosLogging) ListLogGroups(ctx context.Context) ([]logdriver.LogGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "logging", "ListLogGroups"); err != nil {
+		return nil, err
+	}
+
+	return c.Logging.ListLogGroups(ctx)
+}
+
+func (c *chaosLogging) PutLogEvents(
+	ctx context.Context, logGroup, streamName string, events []logdriver.LogEvent,
+) error {
+	if err := applyChaos(ctx, c.engine, "logging", "PutLogEvents"); err != nil {
+		return err
+	}
+
+	return c.Logging.PutLogEvents(ctx, logGroup, streamName, events)
+}
+
+func (c *chaosLogging) GetLogEvents(
+	ctx context.Context, input *logdriver.LogQueryInput,
+) ([]logdriver.LogEvent, error) {
+	if err := applyChaos(ctx, c.engine, "logging", "GetLogEvents"); err != nil {
+		return nil, err
+	}
+
+	return c.Logging.GetLogEvents(ctx, input)
+}
+
+func (c *chaosLogging) FilterLogEvents(
+	ctx context.Context, input *logdriver.FilterLogEventsInput,
+) ([]logdriver.FilteredLogEvent, error) {
+	if err := applyChaos(ctx, c.engine, "logging", "FilterLogEvents"); err != nil {
+		return nil, err
+	}
+
+	return c.Logging.FilterLogEvents(ctx, input)
+}

--- a/chaos/wrappers_logging_test.go
+++ b/chaos/wrappers_logging_test.go
@@ -1,0 +1,111 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+)
+
+func newChaosLogging(t *testing.T) (logdriver.Logging, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapLogging(cloudemu.NewAWS().CloudWatchLogs, e), e
+}
+
+func TestWrapLoggingCreateLogGroupChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+
+	if _, err := l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "ok"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	if _, err := l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "fail"}); err == nil {
+		t.Error("expected chaos error on CreateLogGroup")
+	}
+}
+
+func TestWrapLoggingDeleteLogGroupChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "del"})
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	if err := l.DeleteLogGroup(ctx, "del"); err == nil {
+		t.Error("expected chaos error on DeleteLogGroup")
+	}
+}
+
+func TestWrapLoggingGetLogGroupChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "g"})
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	if _, err := l.GetLogGroup(ctx, "g"); err == nil {
+		t.Error("expected chaos error on GetLogGroup")
+	}
+}
+
+func TestWrapLoggingListLogGroupsChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	if _, err := l.ListLogGroups(ctx); err == nil {
+		t.Error("expected chaos error on ListLogGroups")
+	}
+}
+
+func TestWrapLoggingPutLogEventsChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "p"})
+	_, _ = l.CreateLogStream(ctx, "p", "s")
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	events := []logdriver.LogEvent{{Timestamp: time.Now(), Message: "x"}}
+	if err := l.PutLogEvents(ctx, "p", "s", events); err == nil {
+		t.Error("expected chaos error on PutLogEvents")
+	}
+}
+
+func TestWrapLoggingGetLogEventsChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "ge"})
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	in := &logdriver.LogQueryInput{LogGroup: "ge", StartTime: time.Now().Add(-time.Hour), EndTime: time.Now(), Limit: 10}
+	if _, err := l.GetLogEvents(ctx, in); err == nil {
+		t.Error("expected chaos error on GetLogEvents")
+	}
+}
+
+func TestWrapLoggingFilterLogEventsChaos(t *testing.T) {
+	l, e := newChaosLogging(t)
+	ctx := context.Background()
+	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "fe"})
+
+	e.Apply(chaos.ServiceOutage("logging", time.Hour))
+
+	in := &logdriver.FilterLogEventsInput{LogGroup: "fe", StartTime: time.Now().Add(-time.Hour), EndTime: time.Now(), Limit: 10}
+	if _, err := l.FilterLogEvents(ctx, in); err == nil {
+		t.Error("expected chaos error on FilterLogEvents")
+	}
+}

--- a/chaos/wrappers_messagequeue.go
+++ b/chaos/wrappers_messagequeue.go
@@ -1,0 +1,96 @@
+package chaos
+
+import (
+	"context"
+
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+)
+
+// chaosMessageQueue wraps a message queue driver. Hot-path: queue CRUD plus
+// send/receive/delete (single + batch). Visibility, attributes, and purge
+// delegate through.
+type chaosMessageQueue struct {
+	mqdriver.MessageQueue
+	engine *Engine
+}
+
+// WrapMessageQueue returns a message queue driver that consults engine on
+// queue and message data-plane calls.
+func WrapMessageQueue(inner mqdriver.MessageQueue, engine *Engine) mqdriver.MessageQueue {
+	return &chaosMessageQueue{MessageQueue: inner, engine: engine}
+}
+
+func (c *chaosMessageQueue) CreateQueue(
+	ctx context.Context, cfg mqdriver.QueueConfig,
+) (*mqdriver.QueueInfo, error) {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "CreateQueue"); err != nil {
+		return nil, err
+	}
+
+	return c.MessageQueue.CreateQueue(ctx, cfg)
+}
+
+func (c *chaosMessageQueue) DeleteQueue(ctx context.Context, url string) error {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "DeleteQueue"); err != nil {
+		return err
+	}
+
+	return c.MessageQueue.DeleteQueue(ctx, url)
+}
+
+func (c *chaosMessageQueue) ListQueues(ctx context.Context, prefix string) ([]mqdriver.QueueInfo, error) {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "ListQueues"); err != nil {
+		return nil, err
+	}
+
+	return c.MessageQueue.ListQueues(ctx, prefix)
+}
+
+//nolint:gocritic // input is a value type by interface contract
+func (c *chaosMessageQueue) SendMessage(
+	ctx context.Context, input mqdriver.SendMessageInput,
+) (*mqdriver.SendMessageOutput, error) {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "SendMessage"); err != nil {
+		return nil, err
+	}
+
+	return c.MessageQueue.SendMessage(ctx, input)
+}
+
+func (c *chaosMessageQueue) ReceiveMessages(
+	ctx context.Context, input mqdriver.ReceiveMessageInput,
+) ([]mqdriver.Message, error) {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "ReceiveMessages"); err != nil {
+		return nil, err
+	}
+
+	return c.MessageQueue.ReceiveMessages(ctx, input)
+}
+
+func (c *chaosMessageQueue) DeleteMessage(ctx context.Context, queueURL, receiptHandle string) error {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "DeleteMessage"); err != nil {
+		return err
+	}
+
+	return c.MessageQueue.DeleteMessage(ctx, queueURL, receiptHandle)
+}
+
+func (c *chaosMessageQueue) SendMessageBatch(
+	ctx context.Context, queue string, entries []mqdriver.BatchSendEntry,
+) (*mqdriver.BatchSendResult, error) {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "SendMessageBatch"); err != nil {
+		return nil, err
+	}
+
+	return c.MessageQueue.SendMessageBatch(ctx, queue, entries)
+}
+
+func (c *chaosMessageQueue) DeleteMessageBatch(
+	ctx context.Context, queue string, entries []mqdriver.BatchDeleteEntry,
+) (*mqdriver.BatchDeleteResult, error) {
+	if err := applyChaos(ctx, c.engine, "messagequeue", "DeleteMessageBatch"); err != nil {
+		return nil, err
+	}
+
+	return c.MessageQueue.DeleteMessageBatch(ctx, queue, entries)
+}

--- a/chaos/wrappers_messagequeue_test.go
+++ b/chaos/wrappers_messagequeue_test.go
@@ -1,0 +1,121 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+)
+
+func newChaosMessageQueue(t *testing.T) (mqdriver.MessageQueue, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapMessageQueue(cloudemu.NewAWS().SQS, e), e
+}
+
+func TestWrapMessageQueueCreateQueueChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+
+	if _, err := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "ok"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	if _, err := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "fail"}); err == nil {
+		t.Error("expected chaos error on CreateQueue")
+	}
+}
+
+func TestWrapMessageQueueDeleteQueueChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "del"})
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	if err := q.DeleteQueue(ctx, qi.URL); err == nil {
+		t.Error("expected chaos error on DeleteQueue")
+	}
+}
+
+func TestWrapMessageQueueListQueuesChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	if _, err := q.ListQueues(ctx, ""); err == nil {
+		t.Error("expected chaos error on ListQueues")
+	}
+}
+
+func TestWrapMessageQueueSendMessageChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "send"})
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	if _, err := q.SendMessage(ctx, mqdriver.SendMessageInput{QueueURL: qi.URL, Body: "hi"}); err == nil {
+		t.Error("expected chaos error on SendMessage")
+	}
+}
+
+func TestWrapMessageQueueReceiveMessagesChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "recv"})
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	if _, err := q.ReceiveMessages(ctx, mqdriver.ReceiveMessageInput{QueueURL: qi.URL, MaxMessages: 1}); err == nil {
+		t.Error("expected chaos error on ReceiveMessages")
+	}
+}
+
+func TestWrapMessageQueueDeleteMessageChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "delm"})
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	if err := q.DeleteMessage(ctx, qi.URL, "rh"); err == nil {
+		t.Error("expected chaos error on DeleteMessage")
+	}
+}
+
+func TestWrapMessageQueueSendMessageBatchChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "sbatch"})
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	entries := []mqdriver.BatchSendEntry{{ID: "1", Body: "a"}}
+	if _, err := q.SendMessageBatch(ctx, qi.URL, entries); err == nil {
+		t.Error("expected chaos error on SendMessageBatch")
+	}
+}
+
+func TestWrapMessageQueueDeleteMessageBatchChaos(t *testing.T) {
+	q, e := newChaosMessageQueue(t)
+	ctx := context.Background()
+	qi, _ := q.CreateQueue(ctx, mqdriver.QueueConfig{Name: "dbatch"})
+
+	e.Apply(chaos.ServiceOutage("messagequeue", time.Hour))
+
+	entries := []mqdriver.BatchDeleteEntry{{ID: "1", ReceiptHandle: "rh"}}
+	if _, err := q.DeleteMessageBatch(ctx, qi.URL, entries); err == nil {
+		t.Error("expected chaos error on DeleteMessageBatch")
+	}
+}

--- a/chaos/wrappers_monitoring.go
+++ b/chaos/wrappers_monitoring.go
@@ -1,0 +1,72 @@
+package chaos
+
+import (
+	"context"
+
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+// chaosMonitoring wraps a monitoring driver. Hot-path: metric and alarm CRUD.
+// Notification channels and alarm history delegate through.
+type chaosMonitoring struct {
+	mondriver.Monitoring
+	engine *Engine
+}
+
+// WrapMonitoring returns a monitoring driver that consults engine on metric
+// and alarm calls.
+func WrapMonitoring(inner mondriver.Monitoring, engine *Engine) mondriver.Monitoring {
+	return &chaosMonitoring{Monitoring: inner, engine: engine}
+}
+
+func (c *chaosMonitoring) PutMetricData(ctx context.Context, data []mondriver.MetricDatum) error {
+	if err := applyChaos(ctx, c.engine, "monitoring", "PutMetricData"); err != nil {
+		return err
+	}
+
+	return c.Monitoring.PutMetricData(ctx, data)
+}
+
+//nolint:gocritic // input is a value type by interface contract
+func (c *chaosMonitoring) GetMetricData(
+	ctx context.Context, input mondriver.GetMetricInput,
+) (*mondriver.MetricDataResult, error) {
+	if err := applyChaos(ctx, c.engine, "monitoring", "GetMetricData"); err != nil {
+		return nil, err
+	}
+
+	return c.Monitoring.GetMetricData(ctx, input)
+}
+
+func (c *chaosMonitoring) ListMetrics(ctx context.Context, namespace string) ([]string, error) {
+	if err := applyChaos(ctx, c.engine, "monitoring", "ListMetrics"); err != nil {
+		return nil, err
+	}
+
+	return c.Monitoring.ListMetrics(ctx, namespace)
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosMonitoring) CreateAlarm(ctx context.Context, cfg mondriver.AlarmConfig) error {
+	if err := applyChaos(ctx, c.engine, "monitoring", "CreateAlarm"); err != nil {
+		return err
+	}
+
+	return c.Monitoring.CreateAlarm(ctx, cfg)
+}
+
+func (c *chaosMonitoring) DeleteAlarm(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "monitoring", "DeleteAlarm"); err != nil {
+		return err
+	}
+
+	return c.Monitoring.DeleteAlarm(ctx, name)
+}
+
+func (c *chaosMonitoring) DescribeAlarms(ctx context.Context, names []string) ([]mondriver.AlarmInfo, error) {
+	if err := applyChaos(ctx, c.engine, "monitoring", "DescribeAlarms"); err != nil {
+		return nil, err
+	}
+
+	return c.Monitoring.DescribeAlarms(ctx, names)
+}

--- a/chaos/wrappers_monitoring_test.go
+++ b/chaos/wrappers_monitoring_test.go
@@ -1,0 +1,104 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+func newChaosMonitoring(t *testing.T) (mondriver.Monitoring, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapMonitoring(cloudemu.NewAWS().CloudWatch, e), e
+}
+
+func TestWrapMonitoringPutMetricDataChaos(t *testing.T) {
+	m, e := newChaosMonitoring(t)
+	ctx := context.Background()
+	data := []mondriver.MetricDatum{{Namespace: "AWS/EC2", MetricName: "CPU", Value: 1, Timestamp: time.Now()}}
+
+	if err := m.PutMetricData(ctx, data); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("monitoring", time.Hour))
+
+	if err := m.PutMetricData(ctx, data); err == nil {
+		t.Error("expected chaos error on PutMetricData")
+	}
+}
+
+func TestWrapMonitoringGetMetricDataChaos(t *testing.T) {
+	m, e := newChaosMonitoring(t)
+	ctx := context.Background()
+	in := mondriver.GetMetricInput{
+		Namespace: "AWS/EC2", MetricName: "CPU",
+		StartTime: time.Now().Add(-time.Hour), EndTime: time.Now(), Period: 60, Stat: "Average",
+	}
+
+	e.Apply(chaos.ServiceOutage("monitoring", time.Hour))
+
+	if _, err := m.GetMetricData(ctx, in); err == nil {
+		t.Error("expected chaos error on GetMetricData")
+	}
+}
+
+func TestWrapMonitoringListMetricsChaos(t *testing.T) {
+	m, e := newChaosMonitoring(t)
+	ctx := context.Background()
+
+	if _, err := m.ListMetrics(ctx, "AWS/EC2"); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("monitoring", time.Hour))
+
+	if _, err := m.ListMetrics(ctx, "AWS/EC2"); err == nil {
+		t.Error("expected chaos error on ListMetrics")
+	}
+}
+
+func TestWrapMonitoringCreateAlarmChaos(t *testing.T) {
+	m, e := newChaosMonitoring(t)
+	ctx := context.Background()
+	cfg := mondriver.AlarmConfig{
+		Name: "a", Namespace: "AWS/EC2", MetricName: "CPU",
+		ComparisonOperator: "GreaterThanThreshold", Threshold: 80, Period: 60, EvaluationPeriods: 1, Stat: "Average",
+	}
+
+	e.Apply(chaos.ServiceOutage("monitoring", time.Hour))
+
+	if err := m.CreateAlarm(ctx, cfg); err == nil {
+		t.Error("expected chaos error on CreateAlarm")
+	}
+}
+
+func TestWrapMonitoringDeleteAlarmChaos(t *testing.T) {
+	m, e := newChaosMonitoring(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("monitoring", time.Hour))
+
+	if err := m.DeleteAlarm(ctx, "a"); err == nil {
+		t.Error("expected chaos error on DeleteAlarm")
+	}
+}
+
+func TestWrapMonitoringDescribeAlarmsChaos(t *testing.T) {
+	m, e := newChaosMonitoring(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("monitoring", time.Hour))
+
+	if _, err := m.DescribeAlarms(ctx, nil); err == nil {
+		t.Error("expected chaos error on DescribeAlarms")
+	}
+}

--- a/chaos/wrappers_networking.go
+++ b/chaos/wrappers_networking.go
@@ -1,0 +1,115 @@
+package chaos
+
+import (
+	"context"
+
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+)
+
+// chaosNetworking wraps a networking driver. Hot-path: VPC/Subnet/SG CRUD +
+// SG ingress/egress. Peering, NAT, flow logs, route tables, ACLs, IGW, EIP
+// and endpoints delegate through (admin/topology ops).
+type chaosNetworking struct {
+	netdriver.Networking
+	engine *Engine
+}
+
+// WrapNetworking returns a networking driver that consults engine on VPC/
+// Subnet/SecurityGroup data-plane and rule-mutation calls.
+func WrapNetworking(inner netdriver.Networking, engine *Engine) netdriver.Networking {
+	return &chaosNetworking{Networking: inner, engine: engine}
+}
+
+func (c *chaosNetworking) CreateVPC(
+	ctx context.Context, cfg netdriver.VPCConfig,
+) (*netdriver.VPCInfo, error) {
+	if err := applyChaos(ctx, c.engine, "networking", "CreateVPC"); err != nil {
+		return nil, err
+	}
+
+	return c.Networking.CreateVPC(ctx, cfg)
+}
+
+func (c *chaosNetworking) DeleteVPC(ctx context.Context, id string) error {
+	if err := applyChaos(ctx, c.engine, "networking", "DeleteVPC"); err != nil {
+		return err
+	}
+
+	return c.Networking.DeleteVPC(ctx, id)
+}
+
+func (c *chaosNetworking) DescribeVPCs(ctx context.Context, ids []string) ([]netdriver.VPCInfo, error) {
+	if err := applyChaos(ctx, c.engine, "networking", "DescribeVPCs"); err != nil {
+		return nil, err
+	}
+
+	return c.Networking.DescribeVPCs(ctx, ids)
+}
+
+func (c *chaosNetworking) CreateSubnet(
+	ctx context.Context, cfg netdriver.SubnetConfig,
+) (*netdriver.SubnetInfo, error) {
+	if err := applyChaos(ctx, c.engine, "networking", "CreateSubnet"); err != nil {
+		return nil, err
+	}
+
+	return c.Networking.CreateSubnet(ctx, cfg)
+}
+
+func (c *chaosNetworking) DeleteSubnet(ctx context.Context, id string) error {
+	if err := applyChaos(ctx, c.engine, "networking", "DeleteSubnet"); err != nil {
+		return err
+	}
+
+	return c.Networking.DeleteSubnet(ctx, id)
+}
+
+func (c *chaosNetworking) DescribeSubnets(ctx context.Context, ids []string) ([]netdriver.SubnetInfo, error) {
+	if err := applyChaos(ctx, c.engine, "networking", "DescribeSubnets"); err != nil {
+		return nil, err
+	}
+
+	return c.Networking.DescribeSubnets(ctx, ids)
+}
+
+func (c *chaosNetworking) CreateSecurityGroup(
+	ctx context.Context, cfg netdriver.SecurityGroupConfig,
+) (*netdriver.SecurityGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "networking", "CreateSecurityGroup"); err != nil {
+		return nil, err
+	}
+
+	return c.Networking.CreateSecurityGroup(ctx, cfg)
+}
+
+func (c *chaosNetworking) DeleteSecurityGroup(ctx context.Context, id string) error {
+	if err := applyChaos(ctx, c.engine, "networking", "DeleteSecurityGroup"); err != nil {
+		return err
+	}
+
+	return c.Networking.DeleteSecurityGroup(ctx, id)
+}
+
+func (c *chaosNetworking) DescribeSecurityGroups(ctx context.Context, ids []string) ([]netdriver.SecurityGroupInfo, error) {
+	if err := applyChaos(ctx, c.engine, "networking", "DescribeSecurityGroups"); err != nil {
+		return nil, err
+	}
+
+	return c.Networking.DescribeSecurityGroups(ctx, ids)
+}
+
+func (c *chaosNetworking) AddIngressRule(ctx context.Context, groupID string, rule netdriver.SecurityRule) error {
+	if err := applyChaos(ctx, c.engine, "networking", "AddIngressRule"); err != nil {
+		return err
+	}
+
+	return c.Networking.AddIngressRule(ctx, groupID, rule)
+}
+
+func (c *chaosNetworking) AddEgressRule(ctx context.Context, groupID string, rule netdriver.SecurityRule) error {
+	if err := applyChaos(ctx, c.engine, "networking", "AddEgressRule"); err != nil {
+		return err
+	}
+
+	return c.Networking.AddEgressRule(ctx, groupID, rule)
+}

--- a/chaos/wrappers_networking_test.go
+++ b/chaos/wrappers_networking_test.go
@@ -1,0 +1,163 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+)
+
+func newChaosNetworking(t *testing.T) (netdriver.Networking, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapNetworking(cloudemu.NewAWS().VPC, e), e
+}
+
+func TestWrapNetworkingCreateVPCChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+
+	if _, err := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if _, err := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.1.0.0/16"}); err == nil {
+		t.Error("expected chaos error on CreateVPC")
+	}
+}
+
+func TestWrapNetworkingDeleteVPCChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if err := n.DeleteVPC(ctx, v.ID); err == nil {
+		t.Error("expected chaos error on DeleteVPC")
+	}
+}
+
+func TestWrapNetworkingDescribeVPCsChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+
+	if _, err := n.DescribeVPCs(ctx, nil); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if _, err := n.DescribeVPCs(ctx, nil); err == nil {
+		t.Error("expected chaos error on DescribeVPCs")
+	}
+}
+
+func TestWrapNetworkingCreateSubnetChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if _, err := n.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"}); err == nil {
+		t.Error("expected chaos error on CreateSubnet")
+	}
+}
+
+func TestWrapNetworkingDeleteSubnetChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	s, _ := n.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if err := n.DeleteSubnet(ctx, s.ID); err == nil {
+		t.Error("expected chaos error on DeleteSubnet")
+	}
+}
+
+func TestWrapNetworkingDescribeSubnetsChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if _, err := n.DescribeSubnets(ctx, nil); err == nil {
+		t.Error("expected chaos error on DescribeSubnets")
+	}
+}
+
+func TestWrapNetworkingCreateSecurityGroupChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if _, err := n.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "sg", VPCID: v.ID}); err == nil {
+		t.Error("expected chaos error on CreateSecurityGroup")
+	}
+}
+
+func TestWrapNetworkingDeleteSecurityGroupChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	sg, _ := n.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "sg", VPCID: v.ID})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if err := n.DeleteSecurityGroup(ctx, sg.ID); err == nil {
+		t.Error("expected chaos error on DeleteSecurityGroup")
+	}
+}
+
+func TestWrapNetworkingDescribeSecurityGroupsChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	if _, err := n.DescribeSecurityGroups(ctx, nil); err == nil {
+		t.Error("expected chaos error on DescribeSecurityGroups")
+	}
+}
+
+func TestWrapNetworkingAddIngressRuleChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	sg, _ := n.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "sg", VPCID: v.ID})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	rule := netdriver.SecurityRule{Protocol: "tcp", FromPort: 80, ToPort: 80, CIDR: "0.0.0.0/0"}
+	if err := n.AddIngressRule(ctx, sg.ID, rule); err == nil {
+		t.Error("expected chaos error on AddIngressRule")
+	}
+}
+
+func TestWrapNetworkingAddEgressRuleChaos(t *testing.T) {
+	n, e := newChaosNetworking(t)
+	ctx := context.Background()
+	v, _ := n.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	sg, _ := n.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "sg", VPCID: v.ID})
+
+	e.Apply(chaos.ServiceOutage("networking", time.Hour))
+
+	rule := netdriver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "0.0.0.0/0"}
+	if err := n.AddEgressRule(ctx, sg.ID, rule); err == nil {
+		t.Error("expected chaos error on AddEgressRule")
+	}
+}

--- a/chaos/wrappers_notification.go
+++ b/chaos/wrappers_notification.go
@@ -1,0 +1,82 @@
+package chaos
+
+import (
+	"context"
+
+	notifdriver "github.com/stackshy/cloudemu/notification/driver"
+)
+
+// chaosNotification wraps a notification driver. All ops are wrapped — the
+// surface is small and every call is data-plane.
+type chaosNotification struct {
+	notifdriver.Notification
+	engine *Engine
+}
+
+// WrapNotification returns a notification driver that consults engine on
+// every call.
+func WrapNotification(inner notifdriver.Notification, engine *Engine) notifdriver.Notification {
+	return &chaosNotification{Notification: inner, engine: engine}
+}
+
+func (c *chaosNotification) CreateTopic(
+	ctx context.Context, cfg notifdriver.TopicConfig,
+) (*notifdriver.TopicInfo, error) {
+	if err := applyChaos(ctx, c.engine, "notification", "CreateTopic"); err != nil {
+		return nil, err
+	}
+
+	return c.Notification.CreateTopic(ctx, cfg)
+}
+
+func (c *chaosNotification) DeleteTopic(ctx context.Context, id string) error {
+	if err := applyChaos(ctx, c.engine, "notification", "DeleteTopic"); err != nil {
+		return err
+	}
+
+	return c.Notification.DeleteTopic(ctx, id)
+}
+
+func (c *chaosNotification) GetTopic(ctx context.Context, id string) (*notifdriver.TopicInfo, error) {
+	if err := applyChaos(ctx, c.engine, "notification", "GetTopic"); err != nil {
+		return nil, err
+	}
+
+	return c.Notification.GetTopic(ctx, id)
+}
+
+func (c *chaosNotification) ListTopics(ctx context.Context) ([]notifdriver.TopicInfo, error) {
+	if err := applyChaos(ctx, c.engine, "notification", "ListTopics"); err != nil {
+		return nil, err
+	}
+
+	return c.Notification.ListTopics(ctx)
+}
+
+func (c *chaosNotification) Subscribe(
+	ctx context.Context, cfg notifdriver.SubscriptionConfig,
+) (*notifdriver.SubscriptionInfo, error) {
+	if err := applyChaos(ctx, c.engine, "notification", "Subscribe"); err != nil {
+		return nil, err
+	}
+
+	return c.Notification.Subscribe(ctx, cfg)
+}
+
+func (c *chaosNotification) Unsubscribe(ctx context.Context, subscriptionID string) error {
+	if err := applyChaos(ctx, c.engine, "notification", "Unsubscribe"); err != nil {
+		return err
+	}
+
+	return c.Notification.Unsubscribe(ctx, subscriptionID)
+}
+
+func (c *chaosNotification) Publish(
+	ctx context.Context, input notifdriver.PublishInput,
+) (*notifdriver.PublishOutput, error) {
+	if err := applyChaos(ctx, c.engine, "notification", "Publish"); err != nil {
+		return nil, err
+	}
+
+	return c.Notification.Publish(ctx, input)
+}

--- a/chaos/wrappers_notification_test.go
+++ b/chaos/wrappers_notification_test.go
@@ -1,0 +1,107 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	notifdriver "github.com/stackshy/cloudemu/notification/driver"
+)
+
+func newChaosNotification(t *testing.T) (notifdriver.Notification, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapNotification(cloudemu.NewAWS().SNS, e), e
+}
+
+func TestWrapNotificationCreateTopicChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+
+	if _, err := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "ok"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	if _, err := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "fail"}); err == nil {
+		t.Error("expected chaos error on CreateTopic")
+	}
+}
+
+func TestWrapNotificationDeleteTopicChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "del"})
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	if err := n.DeleteTopic(ctx, tp.ID); err == nil {
+		t.Error("expected chaos error on DeleteTopic")
+	}
+}
+
+func TestWrapNotificationGetTopicChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "g"})
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	if _, err := n.GetTopic(ctx, tp.ID); err == nil {
+		t.Error("expected chaos error on GetTopic")
+	}
+}
+
+func TestWrapNotificationListTopicsChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	if _, err := n.ListTopics(ctx); err == nil {
+		t.Error("expected chaos error on ListTopics")
+	}
+}
+
+func TestWrapNotificationSubscribeChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "sub"})
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	cfg := notifdriver.SubscriptionConfig{TopicID: tp.ID, Protocol: "email", Endpoint: "x@y.z"}
+	if _, err := n.Subscribe(ctx, cfg); err == nil {
+		t.Error("expected chaos error on Subscribe")
+	}
+}
+
+func TestWrapNotificationUnsubscribeChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	if err := n.Unsubscribe(ctx, "any-subscription-id"); err == nil {
+		t.Error("expected chaos error on Unsubscribe")
+	}
+}
+
+func TestWrapNotificationPublishChaos(t *testing.T) {
+	n, e := newChaosNotification(t)
+	ctx := context.Background()
+	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "pub"})
+
+	e.Apply(chaos.ServiceOutage("notification", time.Hour))
+
+	if _, err := n.Publish(ctx, notifdriver.PublishInput{TopicID: tp.ID, Message: "hi"}); err == nil {
+		t.Error("expected chaos error on Publish")
+	}
+}

--- a/chaos/wrappers_secrets.go
+++ b/chaos/wrappers_secrets.go
@@ -1,0 +1,83 @@
+package chaos
+
+import (
+	"context"
+
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// chaosSecrets wraps a secrets driver. All ops are wrapped — the surface is
+// small and every call is data-plane.
+type chaosSecrets struct {
+	secretsdriver.Secrets
+	engine *Engine
+}
+
+// WrapSecrets returns a secrets driver that consults engine on every call.
+func WrapSecrets(inner secretsdriver.Secrets, engine *Engine) secretsdriver.Secrets {
+	return &chaosSecrets{Secrets: inner, engine: engine}
+}
+
+func (c *chaosSecrets) CreateSecret(
+	ctx context.Context, cfg secretsdriver.SecretConfig, value []byte,
+) (*secretsdriver.SecretInfo, error) {
+	if err := applyChaos(ctx, c.engine, "secrets", "CreateSecret"); err != nil {
+		return nil, err
+	}
+
+	return c.Secrets.CreateSecret(ctx, cfg, value)
+}
+
+func (c *chaosSecrets) DeleteSecret(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "secrets", "DeleteSecret"); err != nil {
+		return err
+	}
+
+	return c.Secrets.DeleteSecret(ctx, name)
+}
+
+func (c *chaosSecrets) GetSecret(ctx context.Context, name string) (*secretsdriver.SecretInfo, error) {
+	if err := applyChaos(ctx, c.engine, "secrets", "GetSecret"); err != nil {
+		return nil, err
+	}
+
+	return c.Secrets.GetSecret(ctx, name)
+}
+
+func (c *chaosSecrets) ListSecrets(ctx context.Context) ([]secretsdriver.SecretInfo, error) {
+	if err := applyChaos(ctx, c.engine, "secrets", "ListSecrets"); err != nil {
+		return nil, err
+	}
+
+	return c.Secrets.ListSecrets(ctx)
+}
+
+func (c *chaosSecrets) PutSecretValue(
+	ctx context.Context, name string, value []byte,
+) (*secretsdriver.SecretVersion, error) {
+	if err := applyChaos(ctx, c.engine, "secrets", "PutSecretValue"); err != nil {
+		return nil, err
+	}
+
+	return c.Secrets.PutSecretValue(ctx, name, value)
+}
+
+func (c *chaosSecrets) GetSecretValue(
+	ctx context.Context, name, versionID string,
+) (*secretsdriver.SecretVersion, error) {
+	if err := applyChaos(ctx, c.engine, "secrets", "GetSecretValue"); err != nil {
+		return nil, err
+	}
+
+	return c.Secrets.GetSecretValue(ctx, name, versionID)
+}
+
+func (c *chaosSecrets) ListSecretVersions(
+	ctx context.Context, name string,
+) ([]secretsdriver.SecretVersion, error) {
+	if err := applyChaos(ctx, c.engine, "secrets", "ListSecretVersions"); err != nil {
+		return nil, err
+	}
+
+	return c.Secrets.ListSecretVersions(ctx, name)
+}

--- a/chaos/wrappers_secrets_test.go
+++ b/chaos/wrappers_secrets_test.go
@@ -1,0 +1,107 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+)
+
+func newChaosSecrets(t *testing.T) (secretsdriver.Secrets, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapSecrets(cloudemu.NewAWS().SecretsManager, e), e
+}
+
+func TestWrapSecretsCreateSecretChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+
+	if _, err := s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "ok"}, []byte("v")); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if _, err := s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "fail"}, []byte("v")); err == nil {
+		t.Error("expected chaos error on CreateSecret")
+	}
+}
+
+func TestWrapSecretsDeleteSecretChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+	_, _ = s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "del"}, []byte("v"))
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if err := s.DeleteSecret(ctx, "del"); err == nil {
+		t.Error("expected chaos error on DeleteSecret")
+	}
+}
+
+func TestWrapSecretsGetSecretChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+	_, _ = s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "g"}, []byte("v"))
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if _, err := s.GetSecret(ctx, "g"); err == nil {
+		t.Error("expected chaos error on GetSecret")
+	}
+}
+
+func TestWrapSecretsListSecretsChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if _, err := s.ListSecrets(ctx); err == nil {
+		t.Error("expected chaos error on ListSecrets")
+	}
+}
+
+func TestWrapSecretsPutSecretValueChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+	_, _ = s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "p"}, []byte("v"))
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if _, err := s.PutSecretValue(ctx, "p", []byte("v2")); err == nil {
+		t.Error("expected chaos error on PutSecretValue")
+	}
+}
+
+func TestWrapSecretsGetSecretValueChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+	_, _ = s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "gv"}, []byte("v"))
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if _, err := s.GetSecretValue(ctx, "gv", ""); err == nil {
+		t.Error("expected chaos error on GetSecretValue")
+	}
+}
+
+func TestWrapSecretsListSecretVersionsChaos(t *testing.T) {
+	s, e := newChaosSecrets(t)
+	ctx := context.Background()
+	_, _ = s.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "lv"}, []byte("v"))
+
+	e.Apply(chaos.ServiceOutage("secrets", time.Hour))
+
+	if _, err := s.ListSecretVersions(ctx, "lv"); err == nil {
+		t.Error("expected chaos error on ListSecretVersions")
+	}
+}

--- a/chaos/wrappers_serverless.go
+++ b/chaos/wrappers_serverless.go
@@ -1,0 +1,76 @@
+package chaos
+
+import (
+	"context"
+
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// chaosServerless wraps a serverless driver. Hot-path: function CRUD + Invoke.
+// Versions/aliases/layers/concurrency/event source mappings delegate through.
+type chaosServerless struct {
+	serverlessdriver.Serverless
+	engine *Engine
+}
+
+// WrapServerless returns a serverless driver that consults engine on function
+// lifecycle and invocation calls.
+func WrapServerless(inner serverlessdriver.Serverless, engine *Engine) serverlessdriver.Serverless {
+	return &chaosServerless{Serverless: inner, engine: engine}
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosServerless) CreateFunction(
+	ctx context.Context, cfg serverlessdriver.FunctionConfig,
+) (*serverlessdriver.FunctionInfo, error) {
+	if err := applyChaos(ctx, c.engine, "serverless", "CreateFunction"); err != nil {
+		return nil, err
+	}
+
+	return c.Serverless.CreateFunction(ctx, cfg)
+}
+
+func (c *chaosServerless) DeleteFunction(ctx context.Context, name string) error {
+	if err := applyChaos(ctx, c.engine, "serverless", "DeleteFunction"); err != nil {
+		return err
+	}
+
+	return c.Serverless.DeleteFunction(ctx, name)
+}
+
+func (c *chaosServerless) GetFunction(ctx context.Context, name string) (*serverlessdriver.FunctionInfo, error) {
+	if err := applyChaos(ctx, c.engine, "serverless", "GetFunction"); err != nil {
+		return nil, err
+	}
+
+	return c.Serverless.GetFunction(ctx, name)
+}
+
+func (c *chaosServerless) ListFunctions(ctx context.Context) ([]serverlessdriver.FunctionInfo, error) {
+	if err := applyChaos(ctx, c.engine, "serverless", "ListFunctions"); err != nil {
+		return nil, err
+	}
+
+	return c.Serverless.ListFunctions(ctx)
+}
+
+//nolint:gocritic // cfg is a value type by interface contract
+func (c *chaosServerless) UpdateFunction(
+	ctx context.Context, name string, cfg serverlessdriver.FunctionConfig,
+) (*serverlessdriver.FunctionInfo, error) {
+	if err := applyChaos(ctx, c.engine, "serverless", "UpdateFunction"); err != nil {
+		return nil, err
+	}
+
+	return c.Serverless.UpdateFunction(ctx, name, cfg)
+}
+
+func (c *chaosServerless) Invoke(
+	ctx context.Context, input serverlessdriver.InvokeInput,
+) (*serverlessdriver.InvokeOutput, error) {
+	if err := applyChaos(ctx, c.engine, "serverless", "Invoke"); err != nil {
+		return nil, err
+	}
+
+	return c.Serverless.Invoke(ctx, input)
+}

--- a/chaos/wrappers_serverless_test.go
+++ b/chaos/wrappers_serverless_test.go
@@ -1,0 +1,105 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+func newChaosServerless(t *testing.T) (serverlessdriver.Serverless, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapServerless(cloudemu.NewAWS().Lambda, e), e
+}
+
+func TestWrapServerlessCreateFunctionChaos(t *testing.T) {
+	s, e := newChaosServerless(t)
+	ctx := context.Background()
+	cfg := serverlessdriver.FunctionConfig{Name: "fn", Runtime: "go1.x", Handler: "main"}
+
+	if _, err := s.CreateFunction(ctx, cfg); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("serverless", time.Hour))
+
+	cfg.Name = "fn2"
+	if _, err := s.CreateFunction(ctx, cfg); err == nil {
+		t.Error("expected chaos error on CreateFunction")
+	}
+}
+
+func TestWrapServerlessDeleteFunctionChaos(t *testing.T) {
+	s, e := newChaosServerless(t)
+	ctx := context.Background()
+	_, _ = s.CreateFunction(ctx, serverlessdriver.FunctionConfig{Name: "del", Runtime: "go1.x", Handler: "main"})
+
+	e.Apply(chaos.ServiceOutage("serverless", time.Hour))
+
+	if err := s.DeleteFunction(ctx, "del"); err == nil {
+		t.Error("expected chaos error on DeleteFunction")
+	}
+}
+
+func TestWrapServerlessGetFunctionChaos(t *testing.T) {
+	s, e := newChaosServerless(t)
+	ctx := context.Background()
+	_, _ = s.CreateFunction(ctx, serverlessdriver.FunctionConfig{Name: "g", Runtime: "go1.x", Handler: "main"})
+
+	if _, err := s.GetFunction(ctx, "g"); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("serverless", time.Hour))
+
+	if _, err := s.GetFunction(ctx, "g"); err == nil {
+		t.Error("expected chaos error on GetFunction")
+	}
+}
+
+func TestWrapServerlessListFunctionsChaos(t *testing.T) {
+	s, e := newChaosServerless(t)
+	ctx := context.Background()
+
+	if _, err := s.ListFunctions(ctx); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("serverless", time.Hour))
+
+	if _, err := s.ListFunctions(ctx); err == nil {
+		t.Error("expected chaos error on ListFunctions")
+	}
+}
+
+func TestWrapServerlessUpdateFunctionChaos(t *testing.T) {
+	s, e := newChaosServerless(t)
+	ctx := context.Background()
+	_, _ = s.CreateFunction(ctx, serverlessdriver.FunctionConfig{Name: "u", Runtime: "go1.x", Handler: "main"})
+
+	e.Apply(chaos.ServiceOutage("serverless", time.Hour))
+
+	if _, err := s.UpdateFunction(ctx, "u", serverlessdriver.FunctionConfig{Name: "u", Runtime: "go1.x", Handler: "main"}); err == nil {
+		t.Error("expected chaos error on UpdateFunction")
+	}
+}
+
+func TestWrapServerlessInvokeChaos(t *testing.T) {
+	s, e := newChaosServerless(t)
+	ctx := context.Background()
+	_, _ = s.CreateFunction(ctx, serverlessdriver.FunctionConfig{Name: "inv", Runtime: "go1.x", Handler: "main"})
+
+	e.Apply(chaos.ServiceOutage("serverless", time.Hour))
+
+	if _, err := s.Invoke(ctx, serverlessdriver.InvokeInput{FunctionName: "inv", Payload: []byte("{}")}); err == nil {
+		t.Error("expected chaos error on Invoke")
+	}
+}


### PR DESCRIPTION
## What this does

Phase 2 of #104. Extends the chaos engine to wrap the remaining 13 portable services so any service in CloudEmu can be subjected to outage / latency / probabilistic-failure / throttle scenarios.

Phase 1 (#134) shipped wrappers for S3, EC2, DynamoDB. This PR finishes the set.

## What's new

13 new `Wrap*` functions, one per portable service:

| Wrapper | Service tag | Hot-path ops covered |
|---|---|---|
| `WrapServerless` | `serverless` | function CRUD + `Invoke` |
| `WrapNetworking` | `networking` | VPC/Subnet/SG CRUD + ingress/egress rules |
| `WrapMonitoring` | `monitoring` | metric data + alarm CRUD |
| `WrapIAM` | `iam` | user/role/policy CRUD + `CheckPermission` |
| `WrapDNS` | `dns` | zone + record CRUD |
| `WrapLoadBalancer` | `loadbalancer` | LB / target group / target ops |
| `WrapMessageQueue` | `messagequeue` | queue CRUD + send/receive/delete + batch |
| `WrapCache` | `cache` | K/V ops + atomic counters |
| `WrapSecrets` | `secrets` | secret + value ops |
| `WrapLogging` | `logging` | log group CRUD + put/get/filter events |
| `WrapNotification` | `notification` | topic + subscription + `Publish` |
| `WrapContainerRegistry` | `containerregistry` | repo + image CRUD |
| `WrapEventBus` | `eventbus` | bus + rule CRUD + `PutEvents` |

Less-used admin / config ops (e.g. peering, lifecycle policies, layers) delegate through the embedded inner driver without chaos for now — same approach as Phase 1.

## SDK-compat compatibility

Same architectural promise as Phase 1: chaos wraps the **driver interface**, not the API surface. The same wrapped driver works for both the Go API and the SDK-compat HTTP server. As more services gain SDK-compat servers (next initiative — Azure/GCP compute parity), they automatically pick up chaos with no extra wiring.

## Tests

- 13 per-service test files (one per wrapper) covering each wrapped op under `ServiceOutage`.
- 1 consolidated baseline-coverage test file exercising every wrapped op without chaos to cover the success path.
- All existing Phase 1 tests untouched.

## Verified

- `go build ./...` — clean
- `go test ./...` — all 82 packages pass
- `golangci-lint run --timeout=9m ./...` — 0 issues
- `chaos/` coverage: **97.4%** (up from 93%)

## What's coming in later phases

- Phase 2 PR-2: advanced scenarios — slow degradation with jitter, network partition between VPCs, scenario playback.
- Phase 3: pre-built scenarios from real cloud incidents, cascade failure propagation, chaos report.