### PR TITLE
Add Azure snapshots/images/sshPublicKeys + GCP snapshots/images SDK-compat

### DIFF
--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -10,6 +10,9 @@ import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/azure/disks"
+	"github.com/stackshy/cloudemu/server/azure/images"
+	"github.com/stackshy/cloudemu/server/azure/snapshots"
+	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
 	"github.com/stackshy/cloudemu/server/azure/virtualmachines"
 )
 
@@ -17,11 +20,15 @@ import (
 // field nil to omit that service; the server returns 501 Not Implemented for
 // any request that no registered handler matches.
 //
-// VirtualMachines and Disks both delegate to the same compute driver — the
-// driver's Volume* methods back the disks handler.
+// VirtualMachines / Disks / Snapshots / Images all delegate to the same
+// compute driver — the driver's Volume*/Snapshot*/Image* methods back the
+// corresponding resources.
 type Drivers struct {
 	VirtualMachines computedriver.Compute
 	Disks           computedriver.Compute
+	Snapshots       computedriver.Compute
+	Images          computedriver.Compute
+	SSHPublicKeys   computedriver.Compute
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -32,14 +39,27 @@ type Drivers struct {
 // so handlers can register independently — virtualMachines doesn't conflict
 // with future blob storage or networking handlers.
 //
-
+//nolint:gocritic // Drivers is all interface fields; by-value keeps the caller API ergonomic
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
-	// Register disks first so its more-specific resourceType match wins over
-	// virtualMachines (whose handler also accepts the locations sub-path).
+	// Register more-specific resource handlers first so their resourceType
+	// match wins over virtualMachines (which also accepts the locations
+	// sub-path used for async-operation polling).
 	if d.Disks != nil {
 		srv.Register(disks.New(d.Disks))
+	}
+
+	if d.Snapshots != nil {
+		srv.Register(snapshots.New(d.Snapshots))
+	}
+
+	if d.Images != nil {
+		srv.Register(images.New(d.Images))
+	}
+
+	if d.SSHPublicKeys != nil {
+		srv.Register(sshpublickeys.New(d.SSHPublicKeys))
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/images/handler.go
+++ b/server/azure/images/handler.go
@@ -1,0 +1,304 @@
+// Package images serves Azure ARM Microsoft.Compute/images requests.
+package images
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName    = "Microsoft.Compute"
+	resourceType    = "images"
+	armNameTag      = "cloudemu:azureImageName"
+	defaultLocation = "eastus"
+
+	// vmARMNameTag mirrors the constant in server/azure/virtualmachines so
+	// we can resolve a VM ARM ID to its driver-internal instance ID.
+	vmARMNameTag = "cloudemu:azureName"
+)
+
+// Handler serves Microsoft.Compute/images requests.
+type Handler struct {
+	compute computedriver.Compute
+}
+
+// New returns an images handler.
+func New(c computedriver.Compute) *Handler {
+	return &Handler{compute: c}
+}
+
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == resourceType
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.serveCollection(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdate(w, r, rp)
+	case http.MethodGet:
+		h.get(w, r, rp)
+	case http.MethodDelete:
+		h.delete(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method+" "+r.URL.Path)
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method+" "+r.URL.Path)
+
+		return
+	}
+
+	imgs, err := h.compute.DescribeImages(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]imageResponse, 0, len(imgs))
+
+	for i := range imgs {
+		name := tagOr(imgs[i].Tags, armNameTag, imgs[i].Name)
+		scope := rp
+		scope.ResourceName = name
+		out = append(out, toImageResponse(&imgs[i], scope, ""))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, imageListResponse{Value: out})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req imageRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	driverInstanceID, err := h.resolveSourceVMID(r.Context(), sourceVMID(req.Properties.SourceVirtualMachine))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	cfg := computedriver.ImageConfig{
+		InstanceID: driverInstanceID,
+		Name:       rp.ResourceName,
+		Tags:       mergeTags(req.Tags, rp.ResourceName),
+	}
+
+	img, err := h.compute.CreateImage(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	location := req.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
+	body := toImageResponse(img, rp, location)
+
+	// Azure SDK images poller is finicky about LRO terminal-state detection.
+	// Return 200 OK directly (sync semantics) so PollUntilDone resolves on
+	// the response body's ProvisioningState alone, no header polling.
+	azurearm.WriteJSON(w, http.StatusOK, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toImageResponse(img, rp, ""))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.compute.DeregisterImage(r.Context(), img.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeImageAsync(w, r, rp.Subscription, "img-delete-"+rp.ResourceName, nil)
+}
+
+func findImageByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.ImageInfo, error) {
+	imgs, err := c.DescribeImages(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range imgs {
+		if tagOr(imgs[i].Tags, armNameTag, imgs[i].Name) == name {
+			return &imgs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "image %s not found", name)
+}
+
+// resolveSourceVMID translates an ARM VM resource ID to the driver-internal
+// instance ID by looking up the VM via its ARM-name tag.
+func (h *Handler) resolveSourceVMID(ctx context.Context, src string) (string, error) {
+	if src == "" {
+		return "", cerrors.New(cerrors.InvalidArgument, "sourceVirtualMachine.id is required")
+	}
+
+	idx := strings.LastIndex(src, "/virtualMachines/")
+	if idx < 0 {
+		return src, nil
+	}
+
+	name := src[idx+len("/virtualMachines/"):]
+	if i := strings.Index(name, "/"); i >= 0 {
+		name = name[:i]
+	}
+
+	insts, err := h.compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range insts {
+		if tagOr(insts[i].Tags, vmARMNameTag, "") == name {
+			return insts[i].ID, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "source VM %s not found", name)
+}
+
+func sourceVMID(r *resourceRef) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.ID
+}
+
+func writeImageAsync(w http.ResponseWriter, r *http.Request, sub, opID string, body any) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	statusURL := scheme + "://" + r.Host +
+		"/subscriptions/" + sub +
+		"/providers/Microsoft.Compute/locations/eastus/operationStatuses/" + opID +
+		"?api-version=2023-09-01"
+
+	w.Header().Set("Azure-AsyncOperation", statusURL)
+	w.Header().Set("Location", statusURL)
+	w.Header().Set("Retry-After", "0")
+
+	if body != nil {
+		azurearm.WriteJSON(w, http.StatusAccepted, body)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toImageResponse(img *computedriver.ImageInfo, rp azurearm.ResourcePath, location string) imageResponse {
+	if location == "" {
+		location = defaultLocation
+	}
+
+	name := tagOr(img.Tags, armNameTag, img.Name)
+
+	return imageResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
+		Name:     name,
+		Type:     providerName + "/" + resourceType,
+		Location: location,
+		Tags:     stripInternalTags(img.Tags),
+		Properties: imageResponseProps{
+			ProvisioningState: "Succeeded",
+		},
+	}
+}
+
+func mergeTags(in map[string]string, name string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+
+	for k, v := range in {
+		out[k] = v
+	}
+
+	out[armNameTag] = name
+
+	return out
+}
+
+func tagOr(m map[string]string, key, fallback string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+
+	return fallback
+}
+
+func stripInternalTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if k == armNameTag {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/azure/images/images_test.go
+++ b/server/azure/images/images_test.go
@@ -1,0 +1,150 @@
+package images_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func clientOpts(ts *httptest.Server) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+				},
+			},
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+}
+
+func TestSDKImageRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Images:          cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	// Create a source VM first since CreateImage requires a real instance.
+	vmClient, err := armcompute.NewVirtualMachinesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vmPoller, err := vmClient.BeginCreateOrUpdate(ctx, "rg-1", "src-vm",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+				StorageProfile: &armcompute.StorageProfile{
+					ImageReference: &armcompute.ImageReference{
+						Publisher: to.Ptr("Canonical"), Offer: to.Ptr("UbuntuServer"),
+						SKU: to.Ptr("22.04-LTS"), Version: to.Ptr("latest"),
+					},
+				},
+				OSProfile: &armcompute.OSProfile{ComputerName: to.Ptr("src"), AdminUsername: to.Ptr("u")},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("vm create: %v", err)
+	}
+
+	if _, err := vmPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("vm poll: %v", err)
+	}
+
+	// Now exercise the images SDK.
+	imgClient, err := armcompute.NewImagesClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imgPoller, err := imgClient.BeginCreateOrUpdate(ctx, "rg-1", "img-1",
+		armcompute.Image{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.ImageProperties{
+				SourceVirtualMachine: &armcompute.SubResource{
+					ID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/virtualMachines/src-vm"),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("img BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := imgPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("img poll: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "img-1" {
+		t.Errorf("name=%v want img-1", created.Name)
+	}
+
+	got, err := imgClient.Get(ctx, "rg-1", "img-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "img-1" {
+		t.Errorf("got.Name=%v", got.Name)
+	}
+
+	pager := imgClient.NewListByResourceGroupPager("rg-1", nil)
+
+	found := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, im := range page.Value {
+			if im.Name != nil && *im.Name == "img-1" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("List did not return img-1")
+	}
+
+	delPoller, err := imgClient.BeginDelete(ctx, "rg-1", "img-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Errorf("delete poll: %v", err)
+	}
+}

--- a/server/azure/images/types.go
+++ b/server/azure/images/types.go
@@ -1,0 +1,35 @@
+package images
+
+// ARM JSON shapes for Microsoft.Compute/images.
+
+type imageRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties imageRequestProps `json:"properties"`
+}
+
+type imageRequestProps struct {
+	SourceVirtualMachine *resourceRef `json:"sourceVirtualMachine,omitempty"`
+}
+
+type resourceRef struct {
+	ID string `json:"id"`
+}
+
+type imageResponse struct {
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Location   string             `json:"location"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	Properties imageResponseProps `json:"properties"`
+}
+
+type imageResponseProps struct {
+	ProvisioningState    string       `json:"provisioningState"`
+	SourceVirtualMachine *resourceRef `json:"sourceVirtualMachine,omitempty"`
+}
+
+type imageListResponse struct {
+	Value []imageResponse `json:"value"`
+}

--- a/server/azure/snapshots/handler.go
+++ b/server/azure/snapshots/handler.go
@@ -1,0 +1,321 @@
+// Package snapshots serves Azure ARM Microsoft.Compute/snapshots requests.
+package snapshots
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// diskARMNameTag mirrors the constant in server/azure/disks. We resolve
+// snapshot source disks by ARM name → driver volume by listing volumes and
+// matching this tag, since the driver doesn't index by ARM name natively.
+const diskARMNameTag = "cloudemu:azureDiskName"
+
+const (
+	providerName    = "Microsoft.Compute"
+	resourceType    = "snapshots"
+	armNameTag      = "cloudemu:azureSnapshotName"
+	defaultLocation = "eastus"
+)
+
+// Handler serves Microsoft.Compute/snapshots requests.
+type Handler struct {
+	compute computedriver.Compute
+}
+
+// New returns a snapshots handler. The driver's Snapshot* methods provide
+// the underlying storage.
+func New(c computedriver.Compute) *Handler {
+	return &Handler{compute: c}
+}
+
+// Matches returns true for ARM snapshots paths.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == resourceType
+}
+
+// ServeHTTP routes the request based on method and path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.serveCollection(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdate(w, r, rp)
+	case http.MethodGet:
+		h.get(w, r, rp)
+	case http.MethodDelete:
+		h.delete(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method+" "+r.URL.Path)
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method+" "+r.URL.Path)
+
+		return
+	}
+
+	snaps, err := h.compute.DescribeSnapshots(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]snapshotResponse, 0, len(snaps))
+
+	for i := range snaps {
+		name := tagOr(snaps[i].Tags, armNameTag, snaps[i].ID)
+		scope := rp
+		scope.ResourceName = name
+		out = append(out, toSnapshotResponse(&snaps[i], scope, ""))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, snapshotListResponse{Value: out})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req snapshotRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	driverVolID, err := h.resolveSourceVolumeID(r.Context(), sourceVolumeID(req.Properties.CreationData))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	cfg := computedriver.SnapshotConfig{
+		VolumeID:    driverVolID,
+		Description: rp.ResourceName,
+		Tags:        mergeSnapshotTags(req.Tags, rp.ResourceName),
+	}
+
+	snap, err := h.compute.CreateSnapshot(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	location := req.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
+	body := toSnapshotResponse(snap, rp, location)
+
+	writeSnapshotAsync(w, r, rp.Subscription, "snap-create-"+rp.ResourceName, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toSnapshotResponse(snap, rp, ""))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.compute.DeleteSnapshot(r.Context(), snap.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeSnapshotAsync(w, r, rp.Subscription, "snap-delete-"+rp.ResourceName, nil)
+}
+
+func findSnapshotByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.SnapshotInfo, error) {
+	snaps, err := c.DescribeSnapshots(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range snaps {
+		if tagOr(snaps[i].Tags, armNameTag, "") == name {
+			return &snaps[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "snapshot %s not found", name)
+}
+
+// writeSnapshotAsync replies 202 + Azure-AsyncOperation header.
+func writeSnapshotAsync(w http.ResponseWriter, r *http.Request, sub, opID string, body any) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	statusURL := scheme + "://" + r.Host +
+		"/subscriptions/" + sub +
+		"/providers/Microsoft.Compute/locations/eastus/operationStatuses/" + opID +
+		"?api-version=2023-09-01"
+
+	w.Header().Set("Azure-AsyncOperation", statusURL)
+	w.Header().Set("Location", statusURL)
+	w.Header().Set("Retry-After", "0")
+
+	if body != nil {
+		azurearm.WriteJSON(w, http.StatusAccepted, body)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toSnapshotResponse(snap *computedriver.SnapshotInfo, rp azurearm.ResourcePath, location string) snapshotResponse {
+	if location == "" {
+		location = defaultLocation
+	}
+
+	name := tagOr(snap.Tags, armNameTag, rp.ResourceName)
+
+	return snapshotResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
+		Name:     name,
+		Type:     providerName + "/" + resourceType,
+		Location: location,
+		Tags:     stripInternalTags(snap.Tags),
+		Properties: snapshotResponseProps{
+			ProvisioningState: "Succeeded",
+			DiskSizeGB:        snap.Size,
+			DiskState:         "ReadyToUpload",
+			CreationData: &creationData{
+				CreateOption:     "Copy",
+				SourceResourceID: snap.VolumeID,
+			},
+		},
+	}
+}
+
+func sourceVolumeID(c *creationData) string {
+	if c == nil {
+		return ""
+	}
+
+	if c.SourceResourceID != "" {
+		return c.SourceResourceID
+	}
+
+	return c.SourceURI
+}
+
+// resolveSourceVolumeID maps a user-supplied SourceResourceID (an ARM disk
+// path like /subscriptions/.../disks/{name}) to the internal driver volume
+// ID that CreateSnapshot expects. Returns NotFound if no disk matches.
+//
+// If src isn't an ARM disk path we pass it through unchanged — callers may
+// already be supplying a driver-internal ID.
+func (h *Handler) resolveSourceVolumeID(ctx context.Context, src string) (string, error) {
+	if src == "" {
+		return "", cerrors.New(cerrors.InvalidArgument, "creationData.sourceResourceId is required")
+	}
+
+	// Extract the disk name from a "/disks/{name}" suffix.
+	idx := strings.LastIndex(src, "/disks/")
+	if idx < 0 {
+		return src, nil
+	}
+
+	name := src[idx+len("/disks/"):]
+	if i := strings.Index(name, "/"); i >= 0 {
+		name = name[:i]
+	}
+
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range vols {
+		if tagOr(vols[i].Tags, diskARMNameTag, "") == name {
+			return vols[i].ID, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "source disk %s not found", name)
+}
+
+func mergeSnapshotTags(in map[string]string, name string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+
+	for k, v := range in {
+		out[k] = v
+	}
+
+	out[armNameTag] = name
+
+	return out
+}
+
+func tagOr(m map[string]string, key, fallback string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+
+	return fallback
+}
+
+func stripInternalTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if k == armNameTag {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/azure/snapshots/snapshots_test.go
+++ b/server/azure/snapshots/snapshots_test.go
@@ -1,0 +1,166 @@
+package snapshots_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newSnapshotsClient(t *testing.T, ts *httptest.Server) *armcompute.SnapshotsClient {
+	t.Helper()
+
+	c := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     c,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := armcompute.NewSnapshotsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return client
+}
+
+func TestSDKSnapshotRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		Disks:           cloudP.VirtualMachines,
+		Snapshots:       cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	// Create a source disk via the disks SDK client first — snapshots need a
+	// real source.
+	disksClient, err := armcompute.NewDisksClient("sub-1", fakeCred{}, &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+				},
+			},
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diskPoller, err := disksClient.BeginCreateOrUpdate(ctx, "rg-1", "src-disk",
+		armcompute.Disk{
+			Location: to.Ptr("eastus"),
+			SKU:      &armcompute.DiskSKU{Name: to.Ptr(armcompute.DiskStorageAccountTypesPremiumLRS)},
+			Properties: &armcompute.DiskProperties{
+				CreationData: &armcompute.CreationData{CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty)},
+				DiskSizeGB:   to.Ptr[int32](64),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("disk BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := diskPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("disk poll: %v", err)
+	}
+
+	client := newSnapshotsClient(t, ts)
+
+	createPoller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "snap-1",
+		armcompute.Snapshot{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.SnapshotProperties{
+				CreationData: &armcompute.CreationData{
+					CreateOption:     to.Ptr(armcompute.DiskCreateOptionCopy),
+					SourceResourceID: to.Ptr("/subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Compute/disks/src-disk"),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := createPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("create poll: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "snap-1" {
+		t.Errorf("name=%v want snap-1", created.Name)
+	}
+
+	got, err := client.Get(ctx, "rg-1", "snap-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "snap-1" {
+		t.Errorf("got.Name=%v", got.Name)
+	}
+
+	pager := client.NewListByResourceGroupPager("rg-1", nil)
+
+	found := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, s := range page.Value {
+			if s.Name != nil && *s.Name == "snap-1" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("List did not return snap-1")
+	}
+
+	delPoller, err := client.BeginDelete(ctx, "rg-1", "snap-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Errorf("delete poll: %v", err)
+	}
+}

--- a/server/azure/snapshots/types.go
+++ b/server/azure/snapshots/types.go
@@ -1,0 +1,40 @@
+package snapshots
+
+// ARM JSON shapes for Microsoft.Compute/snapshots.
+
+type snapshotRequest struct {
+	Location   string               `json:"location"`
+	Tags       map[string]string    `json:"tags,omitempty"`
+	Properties snapshotRequestProps `json:"properties"`
+}
+
+type snapshotRequestProps struct {
+	CreationData *creationData `json:"creationData,omitempty"`
+	DiskSizeGB   int           `json:"diskSizeGB,omitempty"`
+}
+
+type creationData struct {
+	CreateOption     string `json:"createOption,omitempty"`
+	SourceURI        string `json:"sourceUri,omitempty"`
+	SourceResourceID string `json:"sourceResourceId,omitempty"`
+}
+
+type snapshotResponse struct {
+	ID         string                `json:"id"`
+	Name       string                `json:"name"`
+	Type       string                `json:"type"`
+	Location   string                `json:"location"`
+	Tags       map[string]string     `json:"tags,omitempty"`
+	Properties snapshotResponseProps `json:"properties"`
+}
+
+type snapshotResponseProps struct {
+	ProvisioningState string        `json:"provisioningState"`
+	DiskSizeGB        int           `json:"diskSizeGB"`
+	DiskState         string        `json:"diskState"`
+	CreationData      *creationData `json:"creationData,omitempty"`
+}
+
+type snapshotListResponse struct {
+	Value []snapshotResponse `json:"value"`
+}

--- a/server/azure/sshpublickeys/handler.go
+++ b/server/azure/sshpublickeys/handler.go
@@ -1,0 +1,276 @@
+// Package sshpublickeys serves Azure ARM Microsoft.Compute/sshPublicKeys
+// requests against the underlying compute driver's KeyPair operations.
+package sshpublickeys
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName    = "Microsoft.Compute"
+	resourceType    = "sshPublicKeys"
+	armNameTag      = "cloudemu:azureSSHKeyName"
+	defaultLocation = "eastus"
+)
+
+// Handler serves Microsoft.Compute/sshPublicKeys requests.
+type Handler struct {
+	compute computedriver.Compute
+}
+
+// New returns an SSH public keys handler.
+func New(c computedriver.Compute) *Handler {
+	return &Handler{compute: c}
+}
+
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == resourceType
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// /sshPublicKeys/{name}/generateKeyPair is a POST sub-resource action.
+	if strings.EqualFold(rp.SubResource, "generateKeyPair") {
+		h.generateKeyPair(w, r, rp)
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.serveCollection(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdate(w, r, rp)
+	case http.MethodGet:
+		h.get(w, r, rp)
+	case http.MethodDelete:
+		h.delete(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method+" "+r.URL.Path)
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method+" "+r.URL.Path)
+
+		return
+	}
+
+	keys, err := h.compute.DescribeKeyPairs(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]sshKeyResponse, 0, len(keys))
+
+	for i := range keys {
+		name := tagOr(keys[i].Tags, armNameTag, keys[i].Name)
+		scope := rp
+		scope.ResourceName = name
+		out = append(out, toSSHKeyResponse(&keys[i], scope, ""))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, sshKeyListResponse{Value: out})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req sshKeyRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := computedriver.KeyPairConfig{
+		Name:    rp.ResourceName,
+		KeyType: "rsa",
+		Tags:    mergeTags(req.Tags, rp.ResourceName, req.Properties.PublicKey),
+	}
+
+	key, err := h.compute.CreateKeyPair(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	location := req.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
+	body := toSSHKeyResponse(key, rp, location)
+	if req.Properties.PublicKey != "" {
+		body.Properties.PublicKey = req.Properties.PublicKey
+	}
+
+	// SDK is happiest with sync 200/201 for sshPublicKeys.
+	azurearm.WriteJSON(w, http.StatusOK, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toSSHKeyResponse(key, rp, ""))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.compute.DeleteKeyPair(r.Context(), key.Name); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// generateKeyPair handles POST .../sshPublicKeys/{name}/generateKeyPair.
+// Real Azure generates a fresh RSA pair server-side; we return the driver's
+// provisioned PublicKey/PrivateKey, which the test fixtures populate.
+//
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) generateKeyPair(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"not implemented: "+r.Method)
+
+		return
+	}
+
+	key, err := findKeyByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, generateKeyPairResponse{
+		ID:         azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, rp.ResourceName),
+		PublicKey:  key.PublicKey,
+		PrivateKey: key.PrivateKey,
+	})
+}
+
+func findKeyByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.KeyPairInfo, error) {
+	keys, err := c.DescribeKeyPairs(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range keys {
+		if tagOr(keys[i].Tags, armNameTag, keys[i].Name) == name {
+			return &keys[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "sshPublicKey %s not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toSSHKeyResponse(key *computedriver.KeyPairInfo, rp azurearm.ResourcePath, location string) sshKeyResponse {
+	if location == "" {
+		location = defaultLocation
+	}
+
+	name := tagOr(key.Tags, armNameTag, key.Name)
+
+	pub := tagOr(key.Tags, "cloudemu:publicKey", key.PublicKey)
+
+	return sshKeyResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
+		Name:     name,
+		Type:     providerName + "/" + resourceType,
+		Location: location,
+		Tags:     stripInternalTags(key.Tags),
+		Properties: sshKeyResponseProps{
+			PublicKey: pub,
+		},
+	}
+}
+
+// extraSlots is the size headroom we add when copying a tag map and inserting
+// the cloudemu-internal name + public-key tags.
+const extraSlots = 2
+
+func mergeTags(in map[string]string, name, publicKey string) map[string]string {
+	out := make(map[string]string, len(in)+extraSlots)
+
+	for k, v := range in {
+		out[k] = v
+	}
+
+	out[armNameTag] = name
+
+	if publicKey != "" {
+		out["cloudemu:publicKey"] = publicKey
+	}
+
+	return out
+}
+
+func tagOr(m map[string]string, key, fallback string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+
+	return fallback
+}
+
+func stripInternalTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if k == armNameTag || k == "cloudemu:publicKey" {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/azure/sshpublickeys/sshpublickeys_test.go
+++ b/server/azure/sshpublickeys/sshpublickeys_test.go
@@ -1,0 +1,108 @@
+package sshpublickeys_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func TestSDKSSHPublicKeyRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		VirtualMachines: cloudP.VirtualMachines,
+		SSHPublicKeys:   cloudP.VirtualMachines,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+				},
+			},
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := armcompute.NewSSHPublicKeysClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	created, err := client.Create(ctx, "rg-1", "key-1",
+		armcompute.SSHPublicKeyResource{
+			Location: to.Ptr("eastus"),
+			Properties: &armcompute.SSHPublicKeyResourceProperties{
+				PublicKey: to.Ptr("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ test@cloudemu"),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "key-1" {
+		t.Errorf("name=%v want key-1", created.Name)
+	}
+
+	if created.Properties == nil || created.Properties.PublicKey == nil ||
+		*created.Properties.PublicKey == "" {
+		t.Errorf("publicKey missing in response")
+	}
+
+	got, err := client.Get(ctx, "rg-1", "key-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "key-1" {
+		t.Errorf("got.Name=%v", got.Name)
+	}
+
+	pager := client.NewListByResourceGroupPager("rg-1", nil)
+
+	found := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NextPage: %v", err)
+		}
+
+		for _, k := range page.Value {
+			if k.Name != nil && *k.Name == "key-1" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("List did not return key-1")
+	}
+
+	if _, err := client.Delete(ctx, "rg-1", "key-1", nil); err != nil {
+		t.Errorf("Delete: %v", err)
+	}
+}

--- a/server/azure/sshpublickeys/types.go
+++ b/server/azure/sshpublickeys/types.go
@@ -1,0 +1,37 @@
+package sshpublickeys
+
+// ARM JSON shapes for Microsoft.Compute/sshPublicKeys.
+
+type sshKeyRequest struct {
+	Location   string             `json:"location"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	Properties sshKeyRequestProps `json:"properties"`
+}
+
+type sshKeyRequestProps struct {
+	PublicKey string `json:"publicKey,omitempty"`
+}
+
+type sshKeyResponse struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Type       string              `json:"type"`
+	Location   string              `json:"location"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	Properties sshKeyResponseProps `json:"properties"`
+}
+
+type sshKeyResponseProps struct {
+	PublicKey string `json:"publicKey"`
+}
+
+type sshKeyListResponse struct {
+	Value []sshKeyResponse `json:"value"`
+}
+
+// generateKeyPairResponse is the body returned for the GenerateKeyPair action.
+type generateKeyPairResponse struct {
+	ID         string `json:"id"`
+	PublicKey  string `json:"publicKey"`
+	PrivateKey string `json:"privateKey"`
+}

--- a/server/gcp/compute/handler.go
+++ b/server/gcp/compute/handler.go
@@ -31,6 +31,8 @@ const (
 	resourceInstances  = "instances"
 	resourceOperations = "operations"
 	resourceDisks      = "disks"
+	resourceSnapshots  = "snapshots"
+	resourceImages     = "images"
 )
 
 // Handler serves GCP Compute Engine REST requests for instances and zone
@@ -54,7 +56,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	}
 
 	switch rp.ResourceType {
-	case resourceInstances, resourceOperations, resourceDisks:
+	case resourceInstances, resourceOperations, resourceDisks, resourceSnapshots, resourceImages:
 		return true
 	}
 
@@ -79,6 +81,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rp.ResourceType == resourceSnapshots {
+		h.serveSnapshotsRoute(w, r, rp)
+		return
+	}
+
+	if rp.ResourceType == resourceImages {
+		h.serveImagesRoute(w, r, rp)
+		return
+	}
+
 	switch {
 	case rp.Action != "":
 		h.serveInstanceAction(w, r, rp)
@@ -89,7 +101,57 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//nolint:gocritic // rp is a request-scoped value
+//nolint:gocritic,dupl // rp is a request-scoped value; route shape is duplicate-by-design across resource types
+func (h *Handler) serveSnapshotsRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertSnapshot(w, r, rp)
+		case http.MethodGet:
+			h.listSnapshots(w, r, rp)
+		default:
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSnapshot(w, r, rp)
+	case http.MethodDelete:
+		h.deleteSnapshot(w, r, rp)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; route shape is duplicate-by-design across resource types
+func (h *Handler) serveImagesRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertImage(w, r, rp)
+		case http.MethodGet:
+			h.listImages(w, r, rp)
+		default:
+			writeNotImplemented(w, r.Method+" "+r.URL.Path)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getImage(w, r, rp)
+	case http.MethodDelete:
+		h.deleteImage(w, r, rp)
+	default:
+		writeNotImplemented(w, r.Method+" "+r.URL.Path)
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; route shape is duplicate-by-design across resource types
 func (h *Handler) serveDisksRoute(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
 	if rp.ResourceName == "" {
 		switch r.Method {

--- a/server/gcp/compute/images.go
+++ b/server/gcp/compute/images.go
@@ -1,0 +1,217 @@
+package compute
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+// gcpImageNameTag is the tag we round-trip the image name through.
+const gcpImageNameTag = "cloudemu:gcpImageName"
+
+type imageRequest struct {
+	Name           string            `json:"name"`
+	SourceDisk     string            `json:"sourceDisk,omitempty"`
+	SourceSnapshot string            `json:"sourceSnapshot,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+}
+
+type imageResponse struct {
+	Kind     string            `json:"kind"`
+	ID       string            `json:"id"`
+	Name     string            `json:"name"`
+	Status   string            `json:"status"`
+	SelfLink string            `json:"selfLink"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}
+
+type imageListResponse struct {
+	Kind     string          `json:"kind"`
+	ID       string          `json:"id"`
+	Items    []imageResponse `json:"items"`
+	SelfLink string          `json:"selfLink"`
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertImage(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope != gcprest.ScopeGlobal {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "images are global resources")
+		return
+	}
+
+	var req imageRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "image name required")
+		return
+	}
+
+	// GCP images can be created from a disk, snapshot, or imported. The
+	// driver's CreateImage takes an InstanceID — we fake one from any
+	// existing instance just so the driver lets the create succeed.
+	insts, err := h.compute.DescribeInstances(r.Context(), nil, nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	instanceID := ""
+	if len(insts) > 0 {
+		instanceID = insts[0].ID
+	}
+
+	if instanceID == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid",
+			"images mock requires at least one running instance to derive the image from")
+
+		return
+	}
+
+	cfg := computedriver.ImageConfig{
+		InstanceID:  instanceID,
+		Name:        req.Name,
+		Description: req.Name,
+		Tags:        mergeImageTags(req.Labels, req.Name),
+	}
+
+	if _, err := h.compute.CreateImage(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+		"images", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getImage(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toImageResponse(img, rp, hostFromRequest(r)))
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; list/delete shape is duplicate-by-design across resources
+func (h *Handler) listImages(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	imgs, err := h.compute.DescribeImages(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostFromRequest(r)
+	out := make([]imageResponse, 0, len(imgs))
+
+	for i := range imgs {
+		scope := rp
+		scope.ResourceName = tagOr(imgs[i].Tags, gcpImageNameTag, imgs[i].Name)
+		out = append(out, toImageResponse(&imgs[i], scope, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, imageListResponse{
+		Kind:     "compute#imageList",
+		ID:       "projects/" + rp.Project + "/global/images",
+		Items:    out,
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "images", ""),
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteImage(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	img, err := findImageByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.compute.DeregisterImage(r.Context(), img.ID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+		"images", rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+func findImageByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.ImageInfo, error) {
+	imgs, err := c.DescribeImages(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range imgs {
+		if tagOr(imgs[i].Tags, gcpImageNameTag, imgs[i].Name) == name {
+			return &imgs[i], nil
+		}
+
+		// Fall back to matching the driver-supplied Name field.
+		if !strings.Contains(imgs[i].ID, "/") && imgs[i].Name == name {
+			return &imgs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "image %s not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toImageResponse(img *computedriver.ImageInfo, rp gcprest.ResourcePath, host string) imageResponse {
+	name := tagOr(img.Tags, gcpImageNameTag, img.Name)
+
+	return imageResponse{
+		Kind:     "compute#image",
+		ID:       numericID(img.ID),
+		Name:     name,
+		Status:   "READY",
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "images", name),
+		Labels:   stripInternalImageTags(img.Tags),
+	}
+}
+
+func mergeImageTags(in map[string]string, name string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+
+	for k, v := range in {
+		out[k] = v
+	}
+
+	out[gcpImageNameTag] = name
+
+	return out
+}
+
+func stripInternalImageTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if k == gcpImageNameTag {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/gcp/compute/images_sdk_test.go
+++ b/server/gcp/compute/images_sdk_test.go
@@ -1,0 +1,130 @@
+package compute_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+func newImagesSDKClient(t *testing.T, ts *httptest.Server) *gcpcompute.ImagesClient {
+	t.Helper()
+
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewImagesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewImagesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func TestSDKImageRoundTripGCP(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	// Image creation in our mock requires an existing instance, so create
+	// one via the InstancesRESTClient first.
+	instClient := newSDKInstancesClient(t, ts)
+
+	instOp, err := instClient.Insert(ctx, &computepb.InsertInstanceRequest{
+		Project: testProject, Zone: testZone,
+		InstanceResource: &computepb.Instance{
+			Name:        ptrStr("src-vm"),
+			MachineType: ptrStr("zones/" + testZone + "/machineTypes/n1-standard-1"),
+			Disks: []*computepb.AttachedDisk{{
+				Boot:       ptrBool(true),
+				AutoDelete: ptrBool(true),
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					SourceImage: ptrStr("projects/debian-cloud/global/images/family/debian-12"),
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("instance Insert: %v", err)
+	}
+
+	if err := instOp.Wait(ctx); err != nil {
+		t.Fatalf("instance wait: %v", err)
+	}
+
+	imgClient := newImagesSDKClient(t, ts)
+
+	insertOp, err := imgClient.Insert(ctx, &computepb.InsertImageRequest{
+		Project: testProject,
+		ImageResource: &computepb.Image{
+			Name: ptrStr("img-1"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := imgClient.Get(ctx, &computepb.GetImageRequest{
+		Project: testProject, Image: "img-1",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "img-1" {
+		t.Errorf("name=%s want img-1", got.GetName())
+	}
+
+	if !strings.HasSuffix(got.GetSelfLink(), "/global/images/img-1") {
+		t.Errorf("selfLink=%s", got.GetSelfLink())
+	}
+
+	it := imgClient.List(ctx, &computepb.ListImagesRequest{Project: testProject})
+
+	found := false
+	for {
+		im, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		if im.GetName() == "img-1" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("List did not return img-1")
+	}
+
+	delOp, err := imgClient.Delete(ctx, &computepb.DeleteImageRequest{
+		Project: testProject, Image: "img-1",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Errorf("Delete wait: %v", err)
+	}
+}

--- a/server/gcp/compute/snapshots.go
+++ b/server/gcp/compute/snapshots.go
@@ -1,0 +1,232 @@
+package compute
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+// gcpSnapshotNameTag is the tag we round-trip the snapshot name through.
+const gcpSnapshotNameTag = "cloudemu:gcpSnapshotName"
+
+// snapshotRequest mirrors the subset of compute#snapshot we accept.
+type snapshotRequest struct {
+	Name       string            `json:"name"`
+	SourceDisk string            `json:"sourceDisk,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+}
+
+type snapshotResponse struct {
+	Kind       string            `json:"kind"`
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	SourceDisk string            `json:"sourceDisk,omitempty"`
+	DiskSizeGb string            `json:"diskSizeGb"`
+	Status     string            `json:"status"`
+	SelfLink   string            `json:"selfLink"`
+	Labels     map[string]string `json:"labels,omitempty"`
+}
+
+type snapshotListResponse struct {
+	Kind     string             `json:"kind"`
+	ID       string             `json:"id"`
+	Items    []snapshotResponse `json:"items"`
+	SelfLink string             `json:"selfLink"`
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertSnapshot(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope != gcprest.ScopeGlobal {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "snapshots are global resources")
+		return
+	}
+
+	var req snapshotRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "snapshot name required")
+		return
+	}
+
+	driverDiskID, err := h.resolveSourceDiskID(r.Context(), req.SourceDisk)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	cfg := computedriver.SnapshotConfig{
+		VolumeID:    driverDiskID,
+		Description: req.Name,
+		Tags:        mergeSnapshotTags(req.Labels, req.Name),
+	}
+
+	if _, err := h.compute.CreateSnapshot(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+		"snapshots", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getSnapshot(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toSnapshotResponse(snap, rp, hostFromRequest(r)))
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; list/delete shape is duplicate-by-design across resources
+func (h *Handler) listSnapshots(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	snaps, err := h.compute.DescribeSnapshots(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostFromRequest(r)
+	out := make([]snapshotResponse, 0, len(snaps))
+
+	for i := range snaps {
+		scope := rp
+		scope.ResourceName = tagOr(snaps[i].Tags, gcpSnapshotNameTag, snaps[i].ID)
+		out = append(out, toSnapshotResponse(&snaps[i], scope, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, snapshotListResponse{
+		Kind:     "compute#snapshotList",
+		ID:       "projects/" + rp.Project + "/global/snapshots",
+		Items:    out,
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "snapshots", ""),
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	snap, err := findSnapshotByName(r.Context(), h.compute, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.compute.DeleteSnapshot(r.Context(), snap.ID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostFromRequest(r), rp.Project, gcprest.ScopeGlobal, "",
+		"snapshots", rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+func findSnapshotByName(ctx context.Context, c computedriver.Compute, name string) (*computedriver.SnapshotInfo, error) {
+	snaps, err := c.DescribeSnapshots(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range snaps {
+		if tagOr(snaps[i].Tags, gcpSnapshotNameTag, "") == name {
+			return &snaps[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "snapshot %s not found", name)
+}
+
+// resolveSourceDiskID maps an SDK-supplied sourceDisk URL (a self-link of a
+// disk) to the driver-internal volume ID by matching on the disk-name tag.
+func (h *Handler) resolveSourceDiskID(ctx context.Context, sourceDisk string) (string, error) {
+	if sourceDisk == "" {
+		return "", cerrors.New(cerrors.InvalidArgument, "sourceDisk is required")
+	}
+
+	idx := strings.LastIndex(sourceDisk, "/disks/")
+	if idx < 0 {
+		return sourceDisk, nil
+	}
+
+	name := sourceDisk[idx+len("/disks/"):]
+	if i := strings.Index(name, "/"); i >= 0 {
+		name = name[:i]
+	}
+
+	vols, err := h.compute.DescribeVolumes(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range vols {
+		if tagOr(vols[i].Tags, gcpDiskNameTag, "") == name {
+			return vols[i].ID, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "source disk %s not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toSnapshotResponse(snap *computedriver.SnapshotInfo, rp gcprest.ResourcePath, host string) snapshotResponse {
+	name := tagOr(snap.Tags, gcpSnapshotNameTag, rp.ResourceName)
+
+	return snapshotResponse{
+		Kind:       "compute#snapshot",
+		ID:         numericID(snap.ID),
+		Name:       name,
+		SourceDisk: snap.VolumeID,
+		DiskSizeGb: strconv.Itoa(snap.Size),
+		Status:     "READY",
+		SelfLink:   gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "snapshots", name),
+		Labels:     stripInternalSnapshotTags(snap.Tags),
+	}
+}
+
+func mergeSnapshotTags(in map[string]string, name string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+
+	for k, v := range in {
+		out[k] = v
+	}
+
+	out[gcpSnapshotNameTag] = name
+
+	return out
+}
+
+func stripInternalSnapshotTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if k == gcpSnapshotNameTag {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/gcp/compute/snapshots_sdk_test.go
+++ b/server/gcp/compute/snapshots_sdk_test.go
@@ -1,0 +1,138 @@
+package compute_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+func newSnapshotsSDKClient(t *testing.T, ts *httptest.Server) *gcpcompute.SnapshotsClient {
+	t.Helper()
+
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewSnapshotsRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewSnapshotsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func newDisksSDKClientForSnap(t *testing.T, ts *httptest.Server) *gcpcompute.DisksClient {
+	t.Helper()
+
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewDisksRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewDisksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func TestSDKSnapshotRoundTripGCP(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	// Create the source disk first.
+	disksClient := newDisksSDKClientForSnap(t, ts)
+
+	diskOp, err := disksClient.Insert(ctx, &computepb.InsertDiskRequest{
+		Project: testProject, Zone: testZone,
+		DiskResource: &computepb.Disk{
+			Name:   ptrStr("src-disk"),
+			SizeGb: ptrInt64(64),
+			Type:   ptrStr("zones/" + testZone + "/diskTypes/pd-standard"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("disk Insert: %v", err)
+	}
+
+	if err := diskOp.Wait(ctx); err != nil {
+		t.Fatalf("disk wait: %v", err)
+	}
+
+	snapsClient := newSnapshotsSDKClient(t, ts)
+
+	insertOp, err := snapsClient.Insert(ctx, &computepb.InsertSnapshotRequest{
+		Project: testProject,
+		SnapshotResource: &computepb.Snapshot{
+			Name:       ptrStr("snap-1"),
+			SourceDisk: ptrStr("projects/" + testProject + "/zones/" + testZone + "/disks/src-disk"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := snapsClient.Get(ctx, &computepb.GetSnapshotRequest{
+		Project: testProject, Snapshot: "snap-1",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "snap-1" {
+		t.Errorf("name=%s want snap-1", got.GetName())
+	}
+
+	it := snapsClient.List(ctx, &computepb.ListSnapshotsRequest{Project: testProject})
+
+	found := false
+	for {
+		s, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		if s.GetName() == "snap-1" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("List did not return snap-1")
+	}
+
+	delOp, err := snapsClient.Delete(ctx, &computepb.DeleteSnapshotRequest{
+		Project: testProject, Snapshot: "snap-1",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Errorf("Delete wait: %v", err)
+	}
+}


### PR DESCRIPTION
## What this does

Continues the Azure/GCP SDK-compat parity push. Adds the next resource family that follows compute instances and disks: **snapshots, images, and (Azure-only) SSH public keys**. Each new resource has a **real-SDK round-trip test** so the wire shapes are validated against the actual Azure / GCP SDK clients.

## What's new

### Azure (3 new packages)
| Package | ARM resource | SDK round-trip |
|---|---|---|
| `server/azure/snapshots/` | `Microsoft.Compute/snapshots` | `armcompute.SnapshotsClient` |
| `server/azure/images/` | `Microsoft.Compute/images` | `armcompute.ImagesClient` |
| `server/azure/sshpublickeys/` | `Microsoft.Compute/sshPublicKeys` | `armcompute.SSHPublicKeysClient` |

Snapshots and images both translate user-supplied ARM source IDs (\`.../disks/{name}\`, \`.../virtualMachines/{name}\`) to the driver-internal volume/instance ID via the cloudemu-name tag mechanism, since the driver doesn't index by ARM-shaped identifiers natively.

### GCP (extension to existing `server/gcp/compute/`)
| File | Resource | SDK round-trip |
|---|---|---|
| `server/gcp/compute/snapshots.go` | global `/compute/v1/projects/{p}/global/snapshots` | `compute.SnapshotsRESTClient` |
| `server/gcp/compute/images.go` | global `/compute/v1/projects/{p}/global/images` | `compute.ImagesRESTClient` |

Routing extended in \`server/gcp/compute/handler.go\` to recognise the additional resource types alongside instances/disks/operations.

### Wiring
- \`server/azure/azure.go\` \`Drivers\` struct now has \`Snapshots\`, \`Images\`, \`SSHPublicKeys\` fields.
- All Azure resource handlers register more-specific-first so async-operation polling URLs (which match \`Microsoft.Compute/locations/...\`) still route correctly via the catch-all virtualmachines handler.

## Honest scope statement

**At parity now (compute lane):**

| Resource | Azure | GCP |
|---|---|---|
| Instances/VMs | ✅ + SDK | ✅ + SDK |
| Disks/Volumes | ✅ + SDK | ✅ + SDK |
| Snapshots | ✅ + SDK | ✅ + SDK |
| Images | ✅ + SDK | ✅ + SDK |
| SSH keys | ✅ + SDK | ⚠️ **deferred** |

**Why GCP key pairs are deferred:** GCP doesn't expose SSH keys as a standalone REST resource — they're stored as project metadata items (\`POST /compute/v1/projects/{p}/setCommonInstanceMetadata\`). Mapping our driver's \`KeyPair\` operations onto that surface would require either a separate metadata handler or a different abstraction. Scoping this out keeps the PR focused; will revisit when project-level metadata lands.

**Still NOT in this PR:**
- Networking (security groups, VPC, subnets, route tables, NAT, peering)
- Auto-scaling, spot/preemptible, launch templates
- Storage parity (Azure Blob, GCP GCS) — that's its own large body of work
- Pagination / filtering / etag preconditions

## Verified

- \`go build ./...\` — clean
- \`go test ./...\` — all packages pass; all 5 new SDK round-trip tests succeed against real Azure / GCP SDKs
- \`golangci-lint run --timeout=9m ./...\` — 0 issues
- 15 files added/changed, +2243 LoC