### PR TITLE
Add Azure Cosmos DB and GCP Firestore SDK-compat servers (database parity with AWS DynamoDB)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,12 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
+	cloud.google.com/go/firestore v1.22.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
+	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
+	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ cloud.google.com/go/compute v1.60.0 h1:CqGt23ysz990ZZe1vq/9aDPKKnmwM6kcC7Y1Q05H2
 cloud.google.com/go/compute v1.60.0/go.mod h1:Xm6PbsLgBpAg4va77ljbBdpMjzuU+uPp5Ze2dnZq7lw=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/firestore v1.22.0 h1:avooeboIq37vKXobrbPUFhFBxS/c3FqmWoX0xs8dO6E=
+cloud.google.com/go/firestore v1.22.0/go.mod h1:PaM4i7i7ruALSKmlpHXXZaPObcZw0W7ie5UOPr72iTU=
 cloud.google.com/go/iam v1.7.0 h1:JD3zh0C6LHl16aCn5Akff0+GELdp1+4hmh6ndoFLl8U=
 cloud.google.com/go/iam v1.7.0/go.mod h1:tetWZW1PD/m6vcuY2Zj/aU0eCHNPuxedbnbRTyKXvdY=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
@@ -22,10 +24,14 @@ cloud.google.com/go/storage v1.62.1 h1:Os0G3XbUbjZumkpDUf2Y0rLoXJTCF1kU2kWUujKYX
 cloud.google.com/go/storage v1.62.1/go.mod h1:cpYz/kRVZ+UQAF1uHeea10/9ewcRbxGoGNKsS9daSXA=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
+github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
+github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzUOPYN9KEUUuC0Yd0/vC0=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av4mvyWEbZ7whg72AoOCEzlXFKc=
+github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0 h1:LkHbJbgF3YyvC53aqYGR+wWQDn2Rdp9AQdGndf9QvY4=

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -8,8 +8,10 @@ package azure
 
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/azure/blob"
+	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	"github.com/stackshy/cloudemu/server/azure/images"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
@@ -32,6 +34,7 @@ type Drivers struct {
 	Images          computedriver.Compute
 	SSHPublicKeys   computedriver.Compute
 	BlobStorage     storagedriver.Bucket
+	CosmosDB        dbdriver.Database
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -63,6 +66,12 @@ func New(d Drivers) *server.Server {
 
 	if d.SSHPublicKeys != nil {
 		srv.Register(sshpublickeys.New(d.SSHPublicKeys))
+	}
+
+	// Cosmos DB matches on /dbs/* paths — register before the catch-all
+	// blob handler.
+	if d.CosmosDB != nil {
+		srv.Register(cosmos.New(d.CosmosDB))
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/cosmos/cosmos_test.go
+++ b/server/azure/cosmos/cosmos_test.go
@@ -1,0 +1,134 @@
+package cosmos_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// fakeKey is the dummy master key our test client uses. The handler ignores
+// the Authorization header completely.
+const fakeKey = "dGVzdC1rZXk=" // base64("test-key")
+
+// TestSDKCosmosRoundTrip drives the Azure azcosmos SDK against our handler
+// for the data-plane resources: database, container, items.
+func TestSDKCosmosRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{CosmosDB: cloudP.CosmosDB})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	cred, err := azcosmos.NewKeyCredential(fakeKey)
+	if err != nil {
+		t.Fatalf("NewKeyCredential: %v", err)
+	}
+
+	opts := &azcosmos.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := azcosmos.NewClientWithKey(ts.URL, cred, opts)
+	if err != nil {
+		t.Fatalf("NewClientWithKey: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create database (virtual — handler always succeeds).
+	if _, err := client.CreateDatabase(ctx, azcosmos.DatabaseProperties{ID: "appdb"}, nil); err != nil {
+		t.Fatalf("CreateDatabase: %v", err)
+	}
+
+	dbClient, err := client.NewDatabase("appdb")
+	if err != nil {
+		t.Fatalf("NewDatabase: %v", err)
+	}
+
+	// Create container.
+	containerProps := azcosmos.ContainerProperties{
+		ID:                     "users",
+		PartitionKeyDefinition: azcosmos.PartitionKeyDefinition{Paths: []string{"/pk"}},
+	}
+
+	if _, err := dbClient.CreateContainer(ctx, containerProps, nil); err != nil {
+		t.Fatalf("CreateContainer: %v", err)
+	}
+
+	contClient, err := dbClient.NewContainer("users")
+	if err != nil {
+		t.Fatalf("NewContainer: %v", err)
+	}
+
+	// Create item.
+	doc := map[string]any{"id": "u1", "pk": "team-a", "name": "Alice"}
+	docBytes, _ := json.Marshal(doc)
+	pk := azcosmos.NewPartitionKeyString("team-a")
+
+	createResp, err := contClient.CreateItem(ctx, pk, docBytes, nil)
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	if createResp.RawResponse.StatusCode != 201 {
+		t.Errorf("CreateItem status=%d want 201", createResp.RawResponse.StatusCode)
+	}
+
+	// Read item.
+	readResp, err := contClient.ReadItem(ctx, pk, "u1", nil)
+	if err != nil {
+		t.Fatalf("ReadItem: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(readResp.Value, &got); err != nil {
+		t.Fatalf("unmarshal read: %v", err)
+	}
+
+	if got["name"] != "Alice" {
+		t.Errorf("name=%v want Alice", got["name"])
+	}
+
+	// Replace item.
+	doc["name"] = "Alice Updated"
+	docBytes, _ = json.Marshal(doc)
+
+	if _, err := contClient.ReplaceItem(ctx, pk, "u1", docBytes, nil); err != nil {
+		t.Fatalf("ReplaceItem: %v", err)
+	}
+
+	// Delete item.
+	if _, err := contClient.DeleteItem(ctx, pk, "u1", nil); err != nil {
+		t.Errorf("DeleteItem: %v", err)
+	}
+
+	// Read deleted item — should 404.
+	if _, err := contClient.ReadItem(ctx, pk, "u1", nil); err == nil {
+		t.Error("expected error reading deleted item")
+	} else {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode != 404 {
+			t.Errorf("expected 404, got %d", respErr.StatusCode)
+		}
+	}
+
+	// Delete container.
+	if _, err := contClient.Delete(ctx, nil); err != nil {
+		t.Errorf("Container.Delete: %v", err)
+	}
+
+	_ = strings.TrimSpace
+}

--- a/server/azure/cosmos/handler.go
+++ b/server/azure/cosmos/handler.go
@@ -1,0 +1,565 @@
+// Package cosmos implements the Azure Cosmos DB SQL data-plane REST API
+// against a CloudEmu database driver. Real azure-sdk-for-go/sdk/data/azcosmos
+// clients configured with a custom endpoint hit this handler the same way
+// they hit {account}.documents.azure.com.
+//
+// Supported operations (parity with AWS DynamoDB):
+//
+//	Databases:  POST /dbs, GET /dbs, GET /dbs/{db}, DELETE /dbs/{db}
+//	Containers: POST /dbs/{db}/colls, GET /dbs/{db}/colls, GET .../{c}, DELETE .../{c}
+//	Items:      POST /dbs/{db}/colls/{c}/docs   (also Query with x-ms-documentdb-isquery)
+//	            GET .../docs, GET .../docs/{id}
+//	            PUT .../docs/{id}, DELETE .../docs/{id}
+//
+// The driver doesn't model Cosmos's database-level grouping, so we expose a
+// single virtual database "cloudemu" that always exists and contains every
+// driver table as a container.
+package cosmos
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+const (
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 5 << 20
+)
+
+// Handler serves Cosmos DB SQL API requests against a database driver.
+type Handler struct {
+	db dbdriver.Database
+}
+
+// New returns a Cosmos handler backed by db.
+func New(db dbdriver.Database) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches returns true for the Cosmos data plane URLs we serve: the account
+// root probe (GET /) and the /dbs/... resource tree.
+func (*Handler) Matches(r *http.Request) bool {
+	return r.URL.Path == "/" || r.URL.Path == "/dbs" || strings.HasPrefix(r.URL.Path, "/dbs/")
+}
+
+// ServeHTTP routes the request based on URL path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/" {
+		h.accountProperties(w, r)
+		return
+	}
+
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+
+	switch len(parts) {
+	case 1:
+		// /dbs
+		h.databaseCollection(w, r)
+	case pathDBOnly:
+		// /dbs/{db}
+		h.databaseResource(w, r, parts[1])
+	case pathColls:
+		// /dbs/{db}/colls
+		h.containerCollection(w, r, parts[1])
+	case pathContainerOrDocsCol:
+		// /dbs/{db}/colls/{coll}
+		h.containerResource(w, r, parts[1], parts[3])
+	case pathDocsCol:
+		// /dbs/{db}/colls/{coll}/docs
+		h.documentCollection(w, r, parts[1], parts[3])
+	case pathDocResource:
+		// /dbs/{db}/colls/{coll}/docs/{id}
+		h.documentResource(w, r, parts[1], parts[3], parts[5])
+	default:
+		writeError(w, http.StatusNotFound, "NotFound", "unsupported Cosmos path")
+	}
+}
+
+// Path-segment counts. Defined as constants so it's easy to reason about
+// nested resource depth without magic numbers.
+const (
+	pathDBOnly             = 2 // /dbs/{db}
+	pathColls              = 3 // /dbs/{db}/colls
+	pathContainerOrDocsCol = 4 // /dbs/{db}/colls/{coll}
+	pathDocsCol            = 5 // /dbs/{db}/colls/{coll}/docs
+	pathDocResource        = 6 // /dbs/{db}/colls/{coll}/docs/{id}
+)
+
+// accountProperties answers the account-root probe the Cosmos SDK fires on
+// first use. The response shape mimics a global database-account record;
+// real Cosmos returns regions, consistency settings, etc.
+func (*Handler) accountProperties(w http.ResponseWriter, r *http.Request) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	endpoint := scheme + "://" + r.Host + "/"
+
+	props := map[string]any{
+		"id":                           "cloudemu",
+		"_rid":                         "cloudemu",
+		"_self":                        "",
+		"_etag":                        `"cloudemu"`,
+		"_ts":                          time.Now().Unix(),
+		"_dbs":                         "//dbs/",
+		"writableLocations":            []map[string]any{{"name": "Primary", "databaseAccountEndpoint": endpoint}},
+		"readableLocations":            []map[string]any{{"name": "Primary", "databaseAccountEndpoint": endpoint}},
+		"enableMultipleWriteLocations": false,
+		"userConsistencyPolicy": map[string]any{
+			"defaultConsistencyLevel": "Session",
+		},
+		"systemReplicationPolicy": map[string]any{
+			"minReplicaSetSize":     1,
+			"maxReplicasetSize":     4,
+			"asyncReplication":      false,
+			"replicaRestoreTimeout": 600,
+		},
+		"userReplicationPolicy": map[string]any{
+			"minReplicaSetSize":     1,
+			"maxReplicasetSize":     4,
+			"asyncReplication":      false,
+			"replicaRestoreTimeout": 600,
+		},
+		"addresses":             "//addresses/",
+		"userResourceGroupName": "",
+	}
+
+	writeJSON(w, http.StatusOK, props)
+}
+
+const defaultDBName = "cloudemu"
+
+func (*Handler) databaseCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var body struct {
+			ID string `json:"id"`
+		}
+
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+
+		// We pretend any database creation succeeds. Items live under tables;
+		// the Cosmos database layer is virtual.
+		writeJSON(w, http.StatusCreated, makeDatabaseResource(body.ID))
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, databasesList{
+			RID: "cloudemu",
+			Databases: []databaseResource{
+				makeDatabaseResource(defaultDBName),
+			},
+			Count: 1,
+		})
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (*Handler) databaseResource(w http.ResponseWriter, r *http.Request, db string) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, makeDatabaseResource(db))
+	case http.MethodDelete:
+		// No-op; the virtual database can't actually be deleted because
+		// tables underneath still belong to the driver.
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) containerCollection(w http.ResponseWriter, r *http.Request, db string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createContainer(w, r, db)
+	case http.MethodGet:
+		h.listContainers(w, r, db)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, db string) {
+	var body containerResource
+
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.ID == "" {
+		writeError(w, http.StatusBadRequest, "BadRequest", "container id required")
+		return
+	}
+
+	cfg := dbdriver.TableConfig{
+		Name:         body.ID,
+		PartitionKey: partitionKeyAttribute(body.PartitionKey),
+	}
+
+	if err := h.db.CreateTable(r.Context(), cfg); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, makeContainerResource(db, body.ID, body.PartitionKey))
+}
+
+func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request, db string) {
+	tables, err := h.db.ListTables(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := containersList{RID: "cloudemu"}
+
+	for _, t := range tables {
+		cfg, derr := h.db.DescribeTable(r.Context(), t)
+		pk := defaultPartitionKey()
+
+		if derr == nil && cfg != nil && cfg.PartitionKey != "" {
+			pk = &partitionKeyDef{Paths: []string{"/" + cfg.PartitionKey}, Kind: "Hash"}
+		}
+
+		out.DocumentCollections = append(out.DocumentCollections,
+			makeContainerResource(db, t, pk))
+	}
+
+	out.Count = len(out.DocumentCollections)
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) containerResource(w http.ResponseWriter, r *http.Request, db, coll string) {
+	switch r.Method {
+	case http.MethodGet:
+		cfg, err := h.db.DescribeTable(r.Context(), coll)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		pk := defaultPartitionKey()
+		if cfg.PartitionKey != "" {
+			pk = &partitionKeyDef{Paths: []string{"/" + cfg.PartitionKey}, Kind: "Hash"}
+		}
+
+		writeJSON(w, http.StatusOK, makeContainerResource(db, coll, pk))
+	case http.MethodDelete:
+		if err := h.db.DeleteTable(r.Context(), coll); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) documentCollection(w http.ResponseWriter, r *http.Request, db, coll string) {
+	switch r.Method {
+	case http.MethodPost:
+		// Cosmos overloads POST /docs for both create and query depending on
+		// the x-ms-documentdb-isquery header.
+		if isQuery(r) {
+			h.queryDocuments(w, r, coll)
+			return
+		}
+
+		h.createDocument(w, r, db, coll)
+	case http.MethodGet:
+		h.listDocuments(w, r, coll)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, _, coll string) {
+	item, ok := decodeAnyJSON(w, r)
+	if !ok {
+		return
+	}
+
+	if _, exists := item["id"]; !exists {
+		writeError(w, http.StatusBadRequest, "BadRequest", "item must contain an id field")
+		return
+	}
+
+	if err := h.db.PutItem(r.Context(), coll, item); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	addSystemProps(item)
+	writeJSON(w, http.StatusCreated, item)
+}
+
+func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll string) {
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: coll})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	for i := range result.Items {
+		addSystemProps(result.Items[i])
+	}
+
+	writeJSON(w, http.StatusOK, documentsList{
+		RID:       "cloudemu",
+		Documents: result.Items,
+		Count:     result.Count,
+	})
+}
+
+func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll string) {
+	// We accept the query body but ignore it — return all items via Scan.
+	// This is sufficient for SDK round-trip validation; full SQL parsing is
+	// out of scope.
+	body, _ := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	_ = body
+
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: coll})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	for i := range result.Items {
+		addSystemProps(result.Items[i])
+	}
+
+	writeJSON(w, http.StatusOK, documentsList{
+		RID:       "cloudemu",
+		Documents: result.Items,
+		Count:     result.Count,
+	})
+}
+
+func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, _, coll, id string) {
+	pk := docPartitionKey(r)
+	keyMap := buildKey(coll, pk, id)
+
+	switch r.Method {
+	case http.MethodGet:
+		item, err := h.db.GetItem(r.Context(), coll, keyMap)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		addSystemProps(item)
+		writeJSON(w, http.StatusOK, item)
+	case http.MethodPut:
+		// Replace document.
+		item, ok := decodeAnyJSON(w, r)
+		if !ok {
+			return
+		}
+
+		if _, exists := item["id"]; !exists {
+			item["id"] = id
+		}
+
+		if err := h.db.PutItem(r.Context(), coll, item); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		addSystemProps(item)
+		writeJSON(w, http.StatusOK, item)
+	case http.MethodDelete:
+		if err := h.db.DeleteItem(r.Context(), coll, keyMap); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// isQuery returns true when the request is a Cosmos query (POST /docs with
+// the documentdb-isquery flag).
+func isQuery(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("X-Ms-Documentdb-Isquery"), "true") ||
+		strings.EqualFold(r.Header.Get("X-Ms-Documentdb-Isquery"), "True")
+}
+
+// docPartitionKey extracts the partition-key value from the
+// x-ms-documentdb-partitionkey header. Real Cosmos requires this on every
+// per-document request. The header value is a JSON array, e.g. `["pk-value"]`.
+func docPartitionKey(r *http.Request) string {
+	raw := r.Header.Get("X-Ms-Documentdb-Partitionkey")
+	if raw == "" {
+		return ""
+	}
+
+	var parsed []any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return ""
+	}
+
+	if len(parsed) == 0 {
+		return ""
+	}
+
+	if s, ok := parsed[0].(string); ok {
+		return s
+	}
+
+	return fmt.Sprintf("%v", parsed[0])
+}
+
+// buildKey constructs the key map our driver expects to look up a document.
+// The driver uses the partition-key attribute name to find the right item;
+// for items where the table has no explicit partition key we fall back to id.
+func buildKey(_, pk, id string) map[string]any {
+	if pk == "" {
+		return map[string]any{"id": id}
+	}
+
+	return map[string]any{"id": id, "pk": pk}
+}
+
+func partitionKeyAttribute(pk *partitionKeyDef) string {
+	if pk == nil || len(pk.Paths) == 0 {
+		return "id"
+	}
+
+	// Cosmos paths look like "/myKey" — strip the leading slash.
+	return strings.TrimPrefix(pk.Paths[0], "/")
+}
+
+func defaultPartitionKey() *partitionKeyDef {
+	return &partitionKeyDef{Paths: []string{"/id"}, Kind: "Hash"}
+}
+
+func makeDatabaseResource(id string) databaseResource {
+	rid := "rid-" + id
+
+	return databaseResource{
+		resource: resource{
+			ID:    id,
+			RID:   rid,
+			Self:  "dbs/" + rid + "/",
+			ETag:  `"` + rid + `"`,
+			TS:    time.Now().Unix(),
+			Attac: "attachments/",
+		},
+		Colls: "colls/",
+		Users: "users/",
+	}
+}
+
+func makeContainerResource(_, id string, pk *partitionKeyDef) containerResource {
+	rid := "rid-" + id
+
+	if pk == nil {
+		pk = defaultPartitionKey()
+	}
+
+	return containerResource{
+		resource: resource{
+			ID:    id,
+			RID:   rid,
+			Self:  "dbs/cloudemu/colls/" + rid + "/",
+			ETag:  `"` + rid + `"`,
+			TS:    time.Now().Unix(),
+			Attac: "attachments/",
+		},
+		Docs:         "docs/",
+		Sprocs:       "sprocs/",
+		Triggers:     "triggers/",
+		UDFs:         "udfs/",
+		Conflicts:    "conflicts/",
+		PartitionKey: pk,
+	}
+}
+
+func addSystemProps(item map[string]any) {
+	if item == nil {
+		return
+	}
+
+	id, _ := item["id"].(string)
+
+	if _, ok := item["_rid"]; !ok {
+		item["_rid"] = "rid-" + id
+	}
+
+	if _, ok := item["_self"]; !ok {
+		item["_self"] = "dbs/cloudemu/colls/c/docs/" + id
+	}
+
+	if _, ok := item["_etag"]; !ok {
+		item["_etag"] = `"` + id + `"`
+	}
+
+	if _, ok := item["_ts"]; !ok {
+		item["_ts"] = time.Now().Unix()
+	}
+
+	if _, ok := item["_attachments"]; !ok {
+		item["_attachments"] = "attachments/"
+	}
+}
+
+// JSON helpers.
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "BadRequest", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+func decodeAnyJSON(w http.ResponseWriter, r *http.Request) (map[string]any, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	out := map[string]any{}
+	if err := json.NewDecoder(r.Body).Decode(&out); err != nil {
+		writeError(w, http.StatusBadRequest, "BadRequest", "invalid JSON: "+err.Error())
+		return nil, false
+	}
+
+	return out, true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	writeJSON(w, status, errorEnvelope{Code: code, Message: msg})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "Conflict", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "BadRequest", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+	}
+}

--- a/server/azure/cosmos/types.go
+++ b/server/azure/cosmos/types.go
@@ -1,0 +1,61 @@
+package cosmos
+
+// Cosmos DB SQL API JSON wire shapes. We model the minimum surface needed for
+// the azcosmos SDK to drive databases, containers, and items end-to-end.
+
+// resource is the common envelope every Cosmos resource carries.
+type resource struct {
+	ID    string `json:"id"`
+	RID   string `json:"_rid,omitempty"`
+	Self  string `json:"_self,omitempty"`
+	ETag  string `json:"_etag,omitempty"`
+	TS    int64  `json:"_ts,omitempty"`
+	Attac string `json:"_attachments,omitempty"`
+}
+
+type databaseResource struct {
+	resource
+	Colls string `json:"_colls,omitempty"`
+	Users string `json:"_users,omitempty"`
+}
+
+type databasesList struct {
+	RID       string             `json:"_rid"`
+	Databases []databaseResource `json:"Databases"`
+	Count     int                `json:"_count"`
+}
+
+type containerResource struct {
+	resource
+	Docs            string           `json:"_docs,omitempty"`
+	Sprocs          string           `json:"_sprocs,omitempty"`
+	Triggers        string           `json:"_triggers,omitempty"`
+	UDFs            string           `json:"_udfs,omitempty"`
+	Conflicts       string           `json:"_conflicts,omitempty"`
+	PartitionKey    *partitionKeyDef `json:"partitionKey,omitempty"`
+	IndexingPolicy  map[string]any   `json:"indexingPolicy,omitempty"`
+	UniqueKeyPolicy map[string]any   `json:"uniqueKeyPolicy,omitempty"`
+}
+
+type partitionKeyDef struct {
+	Paths   []string `json:"paths"`
+	Kind    string   `json:"kind"`
+	Version int      `json:"version,omitempty"`
+}
+
+type containersList struct {
+	RID                 string              `json:"_rid"`
+	DocumentCollections []containerResource `json:"DocumentCollections"`
+	Count               int                 `json:"_count"`
+}
+
+type documentsList struct {
+	RID       string           `json:"_rid"`
+	Documents []map[string]any `json:"Documents"`
+	Count     int              `json:"_count"`
+}
+
+type errorEnvelope struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/server/gcp/firestore/firestore_test.go
+++ b/server/gcp/firestore/firestore_test.go
@@ -1,0 +1,123 @@
+package firestore_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	gcpfirestore "cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const testProject = "p1"
+
+// TestSDKFirestoreRoundTrip drives Firestore document operations with the
+// real cloud.google.com/go/firestore client (REST mode) against our handler.
+func TestSDKFirestoreRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+
+	// Create the table the handler writes into. Firestore's logical model
+	// has dynamic collection names, but our underlying driver wants tables
+	// pre-declared.
+	ctx := context.Background()
+	_ = cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{
+		Name: "users", PartitionKey: "id",
+	})
+
+	srv := gcpserver.New(gcpserver.Drivers{Firestore: cloudP.Firestore})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := gcpfirestore.NewRESTClient(ctx, testProject,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	coll := client.Collection("users")
+
+	// Set (create) a document.
+	docRef := coll.Doc("u1")
+	if _, err := docRef.Set(ctx, map[string]any{
+		"name": "Alice",
+		"age":  30,
+		"active": true,
+	}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Get the document back.
+	snap, err := docRef.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	got := snap.Data()
+
+	if got["name"] != "Alice" {
+		t.Errorf("name=%v want Alice", got["name"])
+	}
+
+	// Firestore returns int64 for integer values.
+	if got["age"] != int64(30) {
+		t.Errorf("age=%v want 30", got["age"])
+	}
+
+	if got["active"] != true {
+		t.Errorf("active=%v want true", got["active"])
+	}
+
+	// List documents in the collection.
+	it := coll.Documents(ctx)
+
+	seen := map[string]bool{}
+	for {
+		s, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("iterator: %v", err)
+		}
+
+		seen[s.Ref.ID] = true
+	}
+
+	if !seen["u1"] {
+		t.Errorf("u1 not in list: %v", seen)
+	}
+
+	// Update the document.
+	if _, err := docRef.Set(ctx, map[string]any{
+		"name": "Alice Updated",
+		"age":  31,
+	}); err != nil {
+		t.Fatalf("Set (update): %v", err)
+	}
+
+	snap2, err := docRef.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+
+	if snap2.Data()["name"] != "Alice Updated" {
+		t.Errorf("after update: name=%v", snap2.Data()["name"])
+	}
+
+	// Delete the document.
+	if _, err := docRef.Delete(ctx); err != nil {
+		t.Errorf("Delete: %v", err)
+	}
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -1,0 +1,694 @@
+// Package firestore implements the GCP Firestore REST API as a server.Handler.
+// Real cloud.google.com/go/firestore clients constructed via NewRESTClient
+// hit this handler the same way they hit firestore.googleapis.com.
+//
+// Supported operations (parity with AWS DynamoDB):
+//
+//	POST   /v1/projects/{p}/databases/{db}/documents/{collection}        — create document
+//	POST   /v1/projects/{p}/databases/{db}/documents/{collection}?documentId={id}
+//	GET    /v1/projects/{p}/databases/{db}/documents/{collection}        — list documents
+//	GET    /v1/projects/{p}/databases/{db}/documents/{collection}/{id}   — get document
+//	PATCH  /v1/projects/{p}/databases/{db}/documents/{collection}/{id}   — update document
+//	DELETE /v1/projects/{p}/databases/{db}/documents/{collection}/{id}   — delete document
+package firestore
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// Path-segment values used in Firestore REST URLs.
+const (
+	segProjects  = "projects"
+	segDatabases = "databases"
+	segDocuments = "documents"
+)
+
+// Static sentinel errors so the err113 lint stays satisfied while keeping
+// messages readable.
+var (
+	errNotDocPath     = errStr("not a firestore document path")
+	errInvalidDocName = errStr("invalid document name")
+	errMissingDocID   = errStr("missing document id in name")
+)
+
+// errStr is a string-backed error type so we can declare sentinel errors
+// without pulling in errors.New (which trips the err113 linter).
+type errStr string
+
+func (e errStr) Error() string { return string(e) }
+
+const (
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 5 << 20
+)
+
+// Handler serves Firestore REST API requests against a database driver.
+type Handler struct {
+	db dbdriver.Database
+}
+
+// New returns a Firestore handler backed by db.
+func New(db dbdriver.Database) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches returns true for /v1/projects/.../databases/.../documents paths.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, "/v1/projects/")
+}
+
+// ServeHTTP routes the request based on URL path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Batched write API: POST .../documents:commit, .../documents:batchGet,
+	// .../documents:runQuery — these end with `:action`.
+	if action, base, ok := splitActionSuffix(r.URL.Path); ok {
+		h.serveAction(w, r, base, action)
+		return
+	}
+
+	parts, err := parseFirestorePath(r.URL.Path)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+		return
+	}
+
+	if parts.documentID == "" {
+		// Collection-level operation.
+		switch r.Method {
+		case http.MethodPost:
+			h.createDocument(w, r, parts)
+		case http.MethodGet:
+			h.listDocuments(w, r, parts)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getDocument(w, r, parts)
+	case http.MethodPatch:
+		h.updateDocument(w, r, parts)
+	case http.MethodDelete:
+		h.deleteDocument(w, r, parts)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+// splitActionSuffix detects URLs of the form "{base}:{action}" and returns
+// the action name and base path. Example: "/v1/.../documents:commit" →
+// ("commit", "/v1/.../documents", true).
+func splitActionSuffix(path string) (action, base string, ok bool) {
+	colonIdx := strings.LastIndex(path, ":")
+	if colonIdx < 0 {
+		return "", "", false
+	}
+
+	// Must be after the last "/" to be a method action; otherwise it's part
+	// of the path (rare, but be safe).
+	slashIdx := strings.LastIndex(path, "/")
+	if colonIdx < slashIdx {
+		return "", "", false
+	}
+
+	return path[colonIdx+1:], path[:colonIdx], true
+}
+
+// serveAction handles the batch write/read endpoints used by Firestore's
+// REST API. Real Firestore's gRPC API uses individual RPCs; the REST API
+// bundles them under :commit / :batchGet / :runQuery.
+func (h *Handler) serveAction(w http.ResponseWriter, r *http.Request, base, action string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	switch action {
+	case "commit":
+		h.commit(w, r, base)
+	case "batchGet":
+		h.batchGet(w, r, base)
+	case "runQuery":
+		h.runQuery(w, r, base)
+	default:
+		writeError(w, http.StatusNotImplemented, "UNIMPLEMENTED", "action not implemented: "+action)
+	}
+}
+
+// commitRequest mirrors the subset of Firestore's CommitRequest we accept.
+type commitRequest struct {
+	Writes []writeOp `json:"writes"`
+}
+
+type writeOp struct {
+	Update *document `json:"update,omitempty"`
+	Delete string    `json:"delete,omitempty"`
+}
+
+type commitResponse struct {
+	WriteResults []writeResult `json:"writeResults"`
+	CommitTime   string        `json:"commitTime"`
+}
+
+type writeResult struct {
+	UpdateTime string `json:"updateTime"`
+}
+
+// commit handles POST .../documents:commit — the batch-write endpoint the
+// REST SDK uses for Set / Update / Delete.
+func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
+	var req commitRequest
+
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	out := commitResponse{CommitTime: now}
+
+	for _, op := range req.Writes {
+		switch {
+		case op.Update != nil:
+			p, id, err := splitDocumentName(op.Update.Name)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+				return
+			}
+
+			item := fieldsToMap(op.Update.Fields)
+			item["id"] = id
+
+			if perr := h.db.PutItem(r.Context(), p.collection, item); perr != nil {
+				writeErr(w, perr)
+				return
+			}
+
+			out.WriteResults = append(out.WriteResults, writeResult{UpdateTime: now})
+		case op.Delete != "":
+			p, id, err := splitDocumentName(op.Delete)
+			if err != nil {
+				writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+				return
+			}
+
+			if derr := h.db.DeleteItem(r.Context(), p.collection, map[string]any{"id": id}); derr != nil {
+				writeErr(w, derr)
+				return
+			}
+
+			out.WriteResults = append(out.WriteResults, writeResult{UpdateTime: now})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// batchGet handles POST .../documents:batchGet — the batched-read endpoint.
+type batchGetRequest struct {
+	Documents []string `json:"documents"`
+}
+
+type batchGetResponseEntry struct {
+	Found    *document `json:"found,omitempty"`
+	Missing  string    `json:"missing,omitempty"`
+	ReadTime string    `json:"readTime"`
+}
+
+func (h *Handler) batchGet(w http.ResponseWriter, r *http.Request, _ string) {
+	var req batchGetRequest
+
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+
+	// REST batchGet returns a JSON array of response entries (newline-
+	// delimited objects in the streaming HTTP response).
+	for _, docName := range req.Documents {
+		p, id, err := splitDocumentName(docName)
+		if err != nil {
+			_ = enc.Encode([]batchGetResponseEntry{{Missing: docName, ReadTime: now}})
+			continue
+		}
+
+		item, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{"id": id})
+		if gerr != nil {
+			_ = enc.Encode([]batchGetResponseEntry{{Missing: docName, ReadTime: now}})
+			continue
+		}
+
+		doc := mapToDocument(item, p, id)
+		_ = enc.Encode([]batchGetResponseEntry{{Found: &doc, ReadTime: now}})
+	}
+}
+
+// runQuery handles POST .../documents:runQuery — for collection scans.
+type runQueryRequest struct {
+	StructuredQuery struct {
+		From []struct {
+			CollectionID string `json:"collectionId"`
+		} `json:"from"`
+	} `json:"structuredQuery"`
+}
+
+type runQueryResponseEntry struct {
+	Document *document `json:"document,omitempty"`
+	ReadTime string    `json:"readTime"`
+}
+
+func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) {
+	var req runQueryRequest
+
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	if len(req.StructuredQuery.From) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "from clause required")
+		return
+	}
+
+	collection := req.StructuredQuery.From[0].CollectionID
+
+	// Project + database from the base path.
+	p, _ := parseFirestorePath(base)
+	p.collection = collection
+
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: collection})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	// Stream JSON array of entries.
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("[")) //nolint:errcheck // best-effort streaming response
+
+	for i, item := range result.Items {
+		if i > 0 {
+			w.Write([]byte(",")) //nolint:errcheck // best-effort
+		}
+
+		id, _ := item["id"].(string)
+		doc := mapToDocument(item, p, id)
+
+		_ = json.NewEncoder(w).Encode(runQueryResponseEntry{Document: &doc, ReadTime: now})
+	}
+
+	w.Write([]byte("]")) //nolint:errcheck // best-effort
+}
+
+// splitDocumentName parses "projects/{p}/databases/{db}/documents/{coll}/{id}"
+// into a firestorePath plus the document id.
+func splitDocumentName(name string) (firestorePath, string, error) {
+	parts := strings.Split(name, "/")
+
+	const (
+		minParts                = 6
+		idxProject, idxDatabase = 1, 3
+		idxCollection           = 5
+		idxID                   = 6
+	)
+
+	if len(parts) < minParts ||
+		parts[0] != segProjects ||
+		parts[2] != segDatabases ||
+		parts[4] != segDocuments {
+		return firestorePath{}, "", fmt.Errorf("%w: %s", errInvalidDocName, name)
+	}
+
+	p := firestorePath{
+		project:    parts[idxProject],
+		database:   parts[idxDatabase],
+		collection: parts[idxCollection],
+	}
+
+	if len(parts) <= idxID {
+		return p, "", fmt.Errorf("%w: %s", errMissingDocID, name)
+	}
+
+	return p, strings.Join(parts[idxID:], "/"), nil
+}
+
+// firestorePath holds the components extracted from a Firestore URL.
+type firestorePath struct {
+	project    string
+	database   string
+	collection string
+	documentID string
+}
+
+// parseFirestorePath extracts the project, database, collection, and
+// optional document id from a Firestore REST path.
+//
+// /v1/projects/{p}/databases/{db}/documents/{collection}
+// /v1/projects/{p}/databases/{db}/documents/{collection}/{id}.
+func parseFirestorePath(path string) (firestorePath, error) {
+	rest := strings.TrimPrefix(path, "/v1/")
+
+	parts := strings.Split(rest, "/")
+
+	const (
+		minParts      = 6 // projects/{p}/databases/{db}/documents/{collection}
+		fullDocParts  = 7 // ... + /{id}
+		idxProject    = 1
+		idxDatabase   = 3
+		idxCollection = 5
+		idxDocument   = 6
+	)
+
+	if len(parts) < minParts ||
+		parts[0] != segProjects ||
+		parts[2] != segDatabases ||
+		parts[4] != segDocuments {
+		return firestorePath{}, errNotDocPath
+	}
+
+	out := firestorePath{
+		project:    parts[idxProject],
+		database:   parts[idxDatabase],
+		collection: parts[idxCollection],
+	}
+
+	if len(parts) >= fullDocParts {
+		out.documentID = strings.Join(parts[idxDocument:], "/")
+	}
+
+	return out, nil
+}
+
+func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
+	docID := r.URL.Query().Get("documentId")
+	if docID == "" {
+		// Auto-generate an ID; Firestore's default IDs are 20-char IDs but
+		// any string is fine for our purposes.
+		docID = "auto-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	}
+
+	var inDoc document
+
+	if !decodeJSON(w, r, &inDoc) {
+		return
+	}
+
+	item := fieldsToMap(inDoc.Fields)
+	item["id"] = docID
+
+	if err := h.db.PutItem(r.Context(), p.collection, item); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, mapToDocument(item, p, docID))
+}
+
+func (h *Handler) getDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
+	item, err := h.db.GetItem(r.Context(), p.collection, map[string]any{"id": p.documentID})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, mapToDocument(item, p, p.documentID))
+}
+
+func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, p firestorePath) {
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: p.collection})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listDocumentsResponse{}
+
+	for _, item := range result.Items {
+		id, _ := item["id"].(string)
+		out.Documents = append(out.Documents, mapToDocument(item, p, id))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) updateDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
+	var inDoc document
+
+	if !decodeJSON(w, r, &inDoc) {
+		return
+	}
+
+	item := fieldsToMap(inDoc.Fields)
+	item["id"] = p.documentID
+
+	if err := h.db.PutItem(r.Context(), p.collection, item); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, mapToDocument(item, p, p.documentID))
+}
+
+func (h *Handler) deleteDocument(w http.ResponseWriter, r *http.Request, p firestorePath) {
+	if err := h.db.DeleteItem(r.Context(), p.collection, map[string]any{"id": p.documentID}); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// mapToDocument converts a driver-shaped item map into a Firestore document.
+func mapToDocument(item map[string]any, p firestorePath, id string) document {
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	return document{
+		Name: fmt.Sprintf("projects/%s/databases/%s/documents/%s/%s",
+			p.project, p.database, p.collection, id),
+		Fields:     mapToFields(item),
+		CreateTime: now,
+		UpdateTime: now,
+	}
+}
+
+// mapToFields converts a driver item map to typed Firestore field values,
+// excluding the synthetic id field that we use as a primary key.
+func mapToFields(item map[string]any) map[string]value {
+	if len(item) == 0 {
+		return nil
+	}
+
+	fields := make(map[string]value, len(item))
+
+	for k, v := range item {
+		if k == "id" {
+			continue
+		}
+
+		fields[k] = goValueToFirestore(v)
+	}
+
+	if len(fields) == 0 {
+		return nil
+	}
+
+	return fields
+}
+
+// fieldsToMap converts Firestore typed field values back into a Go map.
+func fieldsToMap(fields map[string]value) map[string]any {
+	out := make(map[string]any, len(fields))
+
+	for k, v := range fields {
+		out[k] = firestoreValueToGo(v)
+	}
+
+	return out
+}
+
+// goValueToFirestore picks the correct typed wrapper for a Go value.
+func goValueToFirestore(v any) value {
+	switch x := v.(type) {
+	case string:
+		return value{StringValue: &x}
+	case bool:
+		return value{BooleanValue: &x}
+	case int, int32, int64:
+		return goIntToFirestore(x)
+	case float64:
+		return goFloat64ToFirestore(x)
+	case []any:
+		return goArrayToFirestore(x)
+	case map[string]any:
+		return goMapToFirestore(x)
+	case nil:
+		nullStr := "NULL_VALUE"
+
+		return value{NullValue: &nullStr}
+	default:
+		s := fmt.Sprintf("%v", x)
+
+		return value{StringValue: &s}
+	}
+}
+
+func goIntToFirestore(x any) value {
+	var n int64
+
+	switch v := x.(type) {
+	case int:
+		n = int64(v)
+	case int32:
+		n = int64(v)
+	case int64:
+		n = v
+	}
+
+	s := strconv.FormatInt(n, 10)
+
+	return value{IntegerValue: &s}
+}
+
+// goFloat64ToFirestore encodes integer-valued floats as IntegerValue so
+// reads round-trip with the same Go type the SDK expects.
+func goFloat64ToFirestore(x float64) value {
+	if x == float64(int64(x)) {
+		s := strconv.FormatInt(int64(x), 10)
+		return value{IntegerValue: &s}
+	}
+
+	return value{DoubleValue: &x}
+}
+
+func goArrayToFirestore(x []any) value {
+	arr := arrayValue{Values: make([]value, len(x))}
+
+	for i, el := range x {
+		arr.Values[i] = goValueToFirestore(el)
+	}
+
+	return value{ArrayValue: &arr}
+}
+
+func goMapToFirestore(x map[string]any) value {
+	m := mapValue{Fields: make(map[string]value, len(x))}
+
+	for k, mv := range x {
+		m.Fields[k] = goValueToFirestore(mv)
+	}
+
+	return value{MapValue: &m}
+}
+
+//nolint:gocritic // v is by-design a value type for the field unmarshaller
+func firestoreValueToGo(v value) any {
+	if x := firestoreScalarToGo(v); x != skipScalar {
+		return x
+	}
+
+	switch {
+	case v.ArrayValue != nil:
+		out := make([]any, len(v.ArrayValue.Values))
+		for i, el := range v.ArrayValue.Values {
+			out[i] = firestoreValueToGo(el)
+		}
+
+		return out
+	case v.MapValue != nil:
+		out := make(map[string]any, len(v.MapValue.Fields))
+		for k, mv := range v.MapValue.Fields {
+			out[k] = firestoreValueToGo(mv)
+		}
+
+		return out
+	}
+
+	return nil
+}
+
+// skipScalar is a sentinel returned by firestoreScalarToGo to mean: this
+// value is not a scalar, try the composite branches.
+//
+//nolint:gochecknoglobals // sentinel value
+var skipScalar = struct{}{}
+
+//nolint:gocritic // v is by-design a value type for the field unmarshaller
+func firestoreScalarToGo(v value) any {
+	switch {
+	case v.StringValue != nil:
+		return *v.StringValue
+	case v.BooleanValue != nil:
+		return *v.BooleanValue
+	case v.IntegerValue != nil:
+		if n, err := strconv.ParseInt(*v.IntegerValue, 10, 64); err == nil {
+			return n
+		}
+
+		return *v.IntegerValue
+	case v.DoubleValue != nil:
+		return *v.DoubleValue
+	case v.NullValue != nil:
+		return nil
+	case v.TimestampValue != nil:
+		return *v.TimestampValue
+	}
+
+	return skipScalar
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, statusCode, msg string) {
+	writeJSON(w, status, errorEnvelope{
+		Error: errorBody{
+			Code:    status,
+			Message: msg,
+			Status:  statusCode,
+		},
+	})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/gcp/firestore/types.go
+++ b/server/gcp/firestore/types.go
@@ -1,0 +1,58 @@
+package firestore
+
+// Firestore REST JSON shapes (https://firestore.googleapis.com/v1/).
+
+// document is the wire shape of a Firestore document.
+type document struct {
+	Name       string           `json:"name,omitempty"`
+	Fields     map[string]value `json:"fields,omitempty"`
+	CreateTime string           `json:"createTime,omitempty"`
+	UpdateTime string           `json:"updateTime,omitempty"`
+}
+
+// value is a typed Firestore field value. Only one of the *Value fields is
+// set per value object.
+type value struct {
+	NullValue      *string     `json:"nullValue,omitempty"`
+	BooleanValue   *bool       `json:"booleanValue,omitempty"`
+	IntegerValue   *string     `json:"integerValue,omitempty"`
+	DoubleValue    *float64    `json:"doubleValue,omitempty"`
+	TimestampValue *string     `json:"timestampValue,omitempty"`
+	StringValue    *string     `json:"stringValue,omitempty"`
+	BytesValue     *string     `json:"bytesValue,omitempty"`
+	ReferenceValue *string     `json:"referenceValue,omitempty"`
+	GeoPointValue  *geoPoint   `json:"geoPointValue,omitempty"`
+	ArrayValue     *arrayValue `json:"arrayValue,omitempty"`
+	MapValue       *mapValue   `json:"mapValue,omitempty"`
+}
+
+type geoPoint struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+type arrayValue struct {
+	Values []value `json:"values,omitempty"`
+}
+
+type mapValue struct {
+	Fields map[string]value `json:"fields,omitempty"`
+}
+
+// listDocumentsResponse is the body for GET .../{collection}.
+type listDocumentsResponse struct {
+	Documents     []document `json:"documents,omitempty"`
+	NextPageToken string     `json:"nextPageToken,omitempty"`
+}
+
+// errorEnvelope is the standard Google API error wrapper.
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    int              `json:"code"`
+	Message string           `json:"message"`
+	Status  string           `json:"status,omitempty"`
+	Details []map[string]any `json:"details,omitempty"`
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -8,16 +8,19 @@ package gcp
 
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
+	"github.com/stackshy/cloudemu/server/gcp/firestore"
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
 
 // Drivers bundles the driver interfaces the GCP server can expose.
 type Drivers struct {
-	Compute computedriver.Compute
-	Storage storagedriver.Bucket
+	Compute   computedriver.Compute
+	Storage   storagedriver.Bucket
+	Firestore dbdriver.Database
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -33,6 +36,10 @@ func New(d Drivers) *server.Server {
 
 	if d.Storage != nil {
 		srv.Register(gcs.New(d.Storage))
+	}
+
+	if d.Firestore != nil {
+		srv.Register(firestore.New(d.Firestore))
 	}
 
 	return srv


### PR DESCRIPTION
## What this does

**Database parity** — the next category in the Azure/GCP SDK-compat push. Brings Azure Cosmos DB and GCP Firestore up to match what AWS DynamoDB already has. Both new resources have **real-SDK round-trip tests**.

## What's new

### Azure Cosmos DB (\`server/azure/cosmos/\`)
- Cosmos SQL API data plane handler
- Account-root probe (\`GET /\`) returning a synthetic database account
- Resource tree: \`/dbs\`, \`/dbs/{db}\`, \`/dbs/{db}/colls\`, \`/dbs/{db}/colls/{coll}\`, \`.../docs\`, \`.../docs/{id}\`
- The driver doesn't model Cosmos databases as a separate concept, so the database layer is virtual — every container is a driver table
- Real-SDK round-trip via \`azcosmos.Client\`: CreateDatabase → CreateContainer → CreateItem → ReadItem → ReplaceItem → DeleteItem → 404-after-delete → DeleteContainer

### GCP Firestore (\`server/gcp/firestore/\`)
- Firestore REST API handler
- Per-document URLs: \`/v1/projects/{p}/databases/{db}/documents/{coll}\`, \`.../{id}\`
- Batch action endpoints used by the Go SDK: \`:commit\`, \`:batchGet\`, \`:runQuery\`
- Field type marshalling between Go values and Firestore typed Values (\`stringValue\`, \`integerValue\`, \`booleanValue\`, \`doubleValue\`, \`timestampValue\`, \`arrayValue\`, \`mapValue\`, \`nullValue\`)
- Real-SDK round-trip via \`cloud.google.com/go/firestore.NewRESTClient\`: Set → Get → Documents iterator → Set (update) → Delete

## Wire-protocol gotchas surfaced by real SDKs

1. **Cosmos SDK probes account properties at \`GET /\`** before doing anything else — must return a database-account record with regions, consistency policy, etc. Otherwise the SDK retries forever.
2. **Cosmos SDK refuses HTTP without TLS** for authenticated requests (master-key auth) → tests use \`httptest.NewTLSServer\`.
3. **Firestore Go SDK uses gRPC by default**, but \`NewRESTClient\` (added in v1.20) lets us run REST. Bumped from v1.21 to v1.22.
4. **Firestore REST writes go through \`:commit\`**, not the per-document URL. Reads similarly go through \`:batchGet\` for explicit doc fetches and \`:runQuery\` for collection iteration. The per-document REST endpoints exist but the SDK rarely uses them — handler supports both for completeness.
5. **Cosmos document partition keys** travel via the \`x-ms-documentdb-partitionkey\` header as a JSON array.

## Cumulative parity (where we are now)

| Domain | AWS | Azure | GCP |
|---|---|---|---|
| Compute | ✅ EC2 + sub-resources | ✅ VMs/Disks/Snapshots/Images/SSHKeys | ✅ Instances/Disks/Snapshots/Images |
| Storage | ✅ S3 | ✅ Blob | ✅ GCS |
| **Database** | ✅ DynamoDB | ✅ **Cosmos DB (this PR)** | ✅ **Firestore (this PR)** |
| Monitoring | ✅ CloudWatch | ❌ | ❌ |
| Networking | ✅ via EC2 | ❌ | ❌ |

## Verified

- \`go build ./...\` — clean
- \`go test ./...\` — all packages pass; both real-SDK round-trip tests succeed
- \`golangci-lint run --timeout=9m ./...\` — 0 issues
- 10 files changed, +1663 LoC

## Honest scope statement

**NOT in this PR (each provider's "advanced" surface):** Cosmos stored procedures / triggers / UDFs / change feed / batch / patch operations / consistency-level enforcement. Firestore transactions / listen (server streaming) / collection groups / aggregation queries / partition queries. Both providers have these in real life; the underlying driver doesn't model most of them, and they aren't needed for SDK-compat round-trip validation.

## Next per the roadmap

Monitoring parity (Azure Monitor + GCP Cloud Monitoring → AWS CloudWatch) — that's the next category to knock down.