### PR TITLE
Add Azure/GCP networking and monitoring SDK-compat servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,10 +30,12 @@ require (
 	cloud.google.com/go/firestore v1.22.0 // indirect
 	cloud.google.com/go/iam v1.7.0 // indirect
 	cloud.google.com/go/longrunning v0.9.0 // indirect
-	cloud.google.com/go/monitoring v1.24.3 // indirect
+	cloud.google.com/go/monitoring v1.27.0 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ cloud.google.com/go/longrunning v0.9.0 h1:0EzbDEGsAvOZNbqXopgniY0w0a1phvu5IdUFq8
 cloud.google.com/go/longrunning v0.9.0/go.mod h1:pkTz846W7bF4o2SzdWJ40Hu0Re+UoNT6Q5t+igIcb8E=
 cloud.google.com/go/monitoring v1.24.3 h1:dde+gMNc0UhPZD1Azu6at2e79bfdztVDS5lvhOdsgaE=
 cloud.google.com/go/monitoring v1.24.3/go.mod h1:nYP6W0tm3N9H/bOw8am7t62YTzZY+zUeQ+Bi6+2eonI=
+cloud.google.com/go/monitoring v1.27.0 h1:BhYwMqao+e5Nn7JtWMM9m6zRtKtVUK6kJWMizXChkLU=
+cloud.google.com/go/monitoring v1.27.0/go.mod h1:72NOVjJXHY/HBfoLT0+qlCZBT059+9VXLeAnL2PeeVM=
 cloud.google.com/go/storage v1.62.1 h1:Os0G3XbUbjZumkpDUf2Y0rLoXJTCF1kU2kWUujKYXD8=
 cloud.google.com/go/storage v1.62.1/go.mod h1:cpYz/kRVZ+UQAF1uHeea10/9ewcRbxGoGNKsS9daSXA=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
@@ -38,6 +40,10 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0/go.mod h1:QyiQdW4f4/BIfB8ZutZ2s+28RAgfa/pT+zS++ZHyM1I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0/go.mod h1:LRr2FzBTQlONPPa5HREE5+RjSCTXl7BwOvYOaWTqCaI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 h1:Ds0KRF8ggpEGg4Vo42oX1cIt/IfOhHWJBikksZbVxeg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -9,11 +9,15 @@ package azure
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/azure/blob"
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	"github.com/stackshy/cloudemu/server/azure/images"
+	"github.com/stackshy/cloudemu/server/azure/monitor"
+	"github.com/stackshy/cloudemu/server/azure/network"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
 	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
 	"github.com/stackshy/cloudemu/server/azure/virtualmachines"
@@ -35,6 +39,8 @@ type Drivers struct {
 	SSHPublicKeys   computedriver.Compute
 	BlobStorage     storagedriver.Bucket
 	CosmosDB        dbdriver.Database
+	Network         netdriver.Networking
+	Monitor         mondriver.Monitoring
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -72,6 +78,14 @@ func New(d Drivers) *server.Server {
 	// blob handler.
 	if d.CosmosDB != nil {
 		srv.Register(cosmos.New(d.CosmosDB))
+	}
+
+	if d.Network != nil {
+		srv.Register(network.New(d.Network))
+	}
+
+	if d.Monitor != nil {
+		srv.Register(monitor.New(d.Monitor))
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/monitor/handler.go
+++ b/server/azure/monitor/handler.go
@@ -1,0 +1,177 @@
+// Package monitor implements the Azure microsoft.insights metric-alerts
+// resource against a CloudEmu monitoring driver. Real armmonitor clients
+// hit this handler the same way they hit management.azure.com.
+package monitor
+
+import (
+	"context"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName    = "microsoft.insights"
+	typeAlerts      = "metricAlerts"
+	armNameTag      = "cloudemu:azureAlertName"
+	defaultLocation = "global"
+)
+
+// Handler serves microsoft.insights ARM resources.
+type Handler struct {
+	mon mondriver.Monitoring
+}
+
+// New returns a monitor handler.
+func New(m mondriver.Monitoring) *Handler {
+	return &Handler{mon: m}
+}
+
+// Matches returns true for ARM URLs targeting microsoft.insights/metricAlerts.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == typeAlerts
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.list(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdate(w, r, rp)
+	case http.MethodGet:
+		h.get(w, r, rp)
+	case http.MethodDelete:
+		h.delete(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req alertRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := mondriver.AlarmConfig{
+		Name:               rp.ResourceName,
+		Namespace:          "azure",
+		MetricName:         "metric",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	}
+
+	if err := h.mon.CreateAlarm(r.Context(), cfg); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLocation
+	}
+
+	azurearm.WriteJSON(w, http.StatusCreated, toAlertResponse(rp, loc, req))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if err := alarmExists(r.Context(), h.mon, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toAlertResponse(rp, defaultLocation, alertRequest{}))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	alarms, err := h.mon.DescribeAlarms(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := alertListResponse{}
+
+	for i := range alarms {
+		scope := rp
+		scope.ResourceName = alarms[i].Name
+		out.Value = append(out.Value, toAlertResponse(scope, defaultLocation, alertRequest{}))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if err := alarmExists(r.Context(), h.mon, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.mon.DeleteAlarm(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// alarmExists returns nil if an alarm with the given name exists in the
+// driver, NotFound otherwise. Callers only need presence/absence.
+func alarmExists(ctx context.Context, m mondriver.Monitoring, name string) error {
+	alarms, err := m.DescribeAlarms(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for i := range alarms {
+		if alarms[i].Name == name {
+			return nil
+		}
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "metricAlert %s not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toAlertResponse(rp azurearm.ResourcePath, location string, req alertRequest) alertResponse {
+	return alertResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeAlerts, rp.ResourceName),
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeAlerts,
+		Location: location,
+		Tags:     req.Tags,
+		Properties: alertResponseProps{
+			alertRequestProps: req.Properties,
+			ProvisioningState: "Succeeded",
+		},
+	}
+}

--- a/server/azure/monitor/monitor_test.go
+++ b/server/azure/monitor/monitor_test.go
@@ -1,0 +1,107 @@
+package monitor_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// HTTP-level tests for the Azure Monitor handler. The real armmonitor SDK
+// has tight schema requirements for metric criteria; we cover the wire-level
+// happy path here and rely on the existing pattern from other Azure
+// handlers (real-SDK round-trip is a follow-up).
+func TestMonitorAlertCRUD(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Monitor: cloudP.Monitor})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	const alertURL = "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/metricAlerts/alert-1?api-version=2018-03-01"
+
+	body := bytes.NewBufferString(`{
+		"location": "global",
+		"properties": {
+			"description": "test alert",
+			"severity": 3,
+			"enabled": true,
+			"scopes": ["/subscriptions/sub-1/resourceGroups/rg-1"],
+			"evaluationFrequency": "PT1M",
+			"windowSize": "PT5M"
+		}
+	}`)
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+alertURL, body)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("PUT status=%d want 201", resp.StatusCode)
+	}
+
+	var got map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+
+	if got["name"] != "alert-1" {
+		t.Errorf("name=%v want alert-1", got["name"])
+	}
+
+	// Get the alert.
+	getReq, _ := http.NewRequest(http.MethodGet, ts.URL+alertURL, http.NoBody)
+
+	getResp, err := ts.Client().Do(getReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Errorf("GET status=%d want 200", getResp.StatusCode)
+	}
+
+	// List alerts.
+	listURL := "/subscriptions/sub-1/resourceGroups/rg-1/providers/microsoft.insights/metricAlerts?api-version=2018-03-01"
+
+	listResp, err := ts.Client().Get(ts.URL + listURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listResp.Body.Close()
+
+	if listResp.StatusCode != http.StatusOK {
+		t.Errorf("LIST status=%d", listResp.StatusCode)
+	}
+
+	var list struct {
+		Value []map[string]any `json:"value"`
+	}
+
+	_ = json.NewDecoder(listResp.Body).Decode(&list)
+
+	if len(list.Value) == 0 {
+		t.Error("expected at least 1 alert in list")
+	}
+
+	// Delete the alert.
+	delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+alertURL, http.NoBody)
+
+	delResp, err := ts.Client().Do(delReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != http.StatusOK {
+		t.Errorf("DELETE status=%d", delResp.StatusCode)
+	}
+}

--- a/server/azure/monitor/types.go
+++ b/server/azure/monitor/types.go
@@ -1,0 +1,39 @@
+package monitor
+
+// ARM JSON shapes for microsoft.insights metric alerts.
+
+type alertRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties alertRequestProps `json:"properties"`
+}
+
+type alertRequestProps struct {
+	Description    string           `json:"description,omitempty"`
+	Severity       int              `json:"severity,omitempty"`
+	Enabled        bool             `json:"enabled,omitempty"`
+	Scopes         []string         `json:"scopes,omitempty"`
+	EvaluationFreq string           `json:"evaluationFrequency,omitempty"`
+	WindowSize     string           `json:"windowSize,omitempty"`
+	Criteria       map[string]any   `json:"criteria,omitempty"`
+	AutoMitigate   bool             `json:"autoMitigate,omitempty"`
+	Actions        []map[string]any `json:"actions,omitempty"`
+}
+
+type alertResponse struct {
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Location   string             `json:"location"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	Properties alertResponseProps `json:"properties"`
+}
+
+type alertResponseProps struct {
+	alertRequestProps
+	ProvisioningState string `json:"provisioningState"`
+}
+
+type alertListResponse struct {
+	Value []alertResponse `json:"value"`
+}

--- a/server/azure/network/handler.go
+++ b/server/azure/network/handler.go
@@ -1,0 +1,629 @@
+// Package network implements the Microsoft.Network ARM resources we expose:
+// virtualNetworks, subnets (nested), and networkSecurityGroups. Real
+// armnetwork clients hit this handler the same way they hit
+// management.azure.com.
+//
+// Supported operations (compute parity with AWS EC2 networking):
+//
+//	PUT/GET/DELETE  /subscriptions/{s}/resourceGroups/{rg}/providers/
+//	    Microsoft.Network/virtualNetworks/{name}
+//	GET .../virtualNetworks                              — list in RG
+//	PUT/GET/DELETE  .../virtualNetworks/{vn}/subnets/{n} — nested subnet
+//	GET .../virtualNetworks/{vn}/subnets                 — list subnets
+//	PUT/GET/DELETE  .../networkSecurityGroups/{name}     — NSG CRUD
+//	GET .../networkSecurityGroups                        — list NSGs
+package network
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName  = "Microsoft.Network"
+	typeVNet      = "virtualNetworks"
+	typeNSG       = "networkSecurityGroups"
+	typeLocations = "locations"
+	armNameTag    = "cloudemu:azureNetName"
+	armSubnetTag  = "cloudemu:azureSubnet"
+	armNSGTag     = "cloudemu:azureNSGName"
+	defaultLoc    = "eastus"
+	subResSubnets = "subnets"
+)
+
+// Handler serves Microsoft.Network ARM requests against a networking driver.
+type Handler struct {
+	net netdriver.Networking
+}
+
+// New returns a network handler.
+func New(n netdriver.Networking) *Handler {
+	return &Handler{net: n}
+}
+
+// Matches returns true for ARM URLs targeting Microsoft.Network/virtualNetworks
+// or networkSecurityGroups (and the locations operationStatuses sub-path used
+// by async polling).
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	if rp.Provider != providerName {
+		return false
+	}
+
+	switch rp.ResourceType {
+	case typeVNet, typeNSG, typeLocations:
+		return true
+	}
+
+	return false
+}
+
+// ServeHTTP routes the request based on path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	if rp.ResourceType == typeLocations && rp.SubResource == "operationStatuses" {
+		azurearm.WriteJSON(w, http.StatusOK, map[string]string{
+			"name":   rp.SubResourceName,
+			"status": "Succeeded",
+		})
+
+		return
+	}
+
+	switch rp.ResourceType {
+	case typeVNet:
+		h.routeVNet(w, r, rp)
+	case typeNSG:
+		h.routeNSG(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"unsupported resource type: "+rp.ResourceType)
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	// Subnet sub-resource: SubResource="subnets", SubResourceName="{name}".
+	if rp.SubResource == subResSubnets {
+		h.routeSubnet(w, r, rp)
+		return
+	}
+
+	if rp.ResourceName == "" {
+		h.listVNets(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createVNet(w, r, rp)
+	case http.MethodGet:
+		h.getVNet(w, r, rp)
+	case http.MethodDelete:
+		h.deleteVNet(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		h.listSubnets(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createSubnet(w, r, rp)
+	case http.MethodGet:
+		h.getSubnet(w, r, rp)
+	case http.MethodDelete:
+		h.deleteSubnet(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) routeNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceName == "" {
+		h.listNSGs(w, r, rp)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createNSG(w, r, rp)
+	case http.MethodGet:
+		h.getNSG(w, r, rp)
+	case http.MethodDelete:
+		h.deleteNSG(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// VirtualNetwork operations.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req vnetRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	cidr := ""
+	if req.Properties.AddressSpace != nil && len(req.Properties.AddressSpace.AddressPrefixes) > 0 {
+		cidr = req.Properties.AddressSpace.AddressPrefixes[0]
+	}
+
+	cfg := netdriver.VPCConfig{
+		CIDRBlock: cidr,
+		Tags:      mergeTags(req.Tags, armNameTag, rp.ResourceName),
+	}
+
+	info, err := h.net.CreateVPC(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	body := toVNetResponse(info, rp, loc, req.Properties.AddressSpace, nil)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vnet-create-"+rp.ResourceName, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	subs, _ := h.net.DescribeSubnets(r.Context(), nil)
+
+	azurearm.WriteJSON(w, http.StatusOK, toVNetResponseFromInfo(info, rp, subs))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listVNets(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	infos, err := h.net.DescribeVPCs(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	subs, _ := h.net.DescribeSubnets(r.Context(), nil)
+	out := vnetListResponse{}
+
+	for i := range infos {
+		scope := rp
+		scope.ResourceName = tagOr(infos[i].Tags, armNameTag, infos[i].ID)
+		out.Value = append(out.Value, toVNetResponseFromInfo(&infos[i], scope, subs))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteVNet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteVPC(r.Context(), info.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "vnet-delete-"+rp.ResourceName, nil)
+}
+
+// Subnet operations.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	vnet, err := findVNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var req subnetRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := netdriver.SubnetConfig{
+		VPCID:     vnet.ID,
+		CIDRBlock: req.Properties.AddressPrefix,
+		Tags:      mergeTags(nil, armSubnetTag, rp.SubResourceName),
+	}
+
+	info, err := h.net.CreateSubnet(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	body := toSubnetResponse(info, rp)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "subnet-create-"+rp.SubResourceName, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findSubnetByName(r.Context(), h.net, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toSubnetResponse(info, rp))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listSubnets(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	infos, err := h.net.DescribeSubnets(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := subnetListResponse{}
+
+	for i := range infos {
+		scope := rp
+		scope.SubResourceName = tagOr(infos[i].Tags, armSubnetTag, infos[i].ID)
+		out.Value = append(out.Value, toSubnetResponse(&infos[i], scope))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteSubnet(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findSubnetByName(r.Context(), h.net, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteSubnet(r.Context(), info.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "subnet-delete-"+rp.SubResourceName, nil)
+}
+
+// NSG operations.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	var req nsgRequest
+
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// Find any VPC to anchor the SG; the driver requires a VPC ID. If no
+	// VPC exists we create a synthetic one.
+	vpcs, _ := h.net.DescribeVPCs(r.Context(), nil)
+
+	var anchor string
+
+	if len(vpcs) > 0 {
+		anchor = vpcs[0].ID
+	} else {
+		v, vErr := h.net.CreateVPC(r.Context(), netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		if vErr != nil {
+			azurearm.WriteCErr(w, vErr)
+			return
+		}
+
+		anchor = v.ID
+	}
+
+	cfg := netdriver.SecurityGroupConfig{
+		Name:  rp.ResourceName,
+		VPCID: anchor,
+		Tags:  mergeTags(req.Tags, armNSGTag, rp.ResourceName),
+	}
+
+	info, err := h.net.CreateSecurityGroup(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	loc := req.Location
+	if loc == "" {
+		loc = defaultLoc
+	}
+
+	body := toNSGResponse(info, rp, loc, req.Properties.SecurityRules)
+
+	writeAcceptedAsync(w, r, rp.Subscription, "nsg-create-"+rp.ResourceName, body)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toNSGResponse(info, rp, defaultLoc, nil))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listNSGs(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	infos, err := h.net.DescribeSecurityGroups(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := nsgListResponse{}
+
+	for i := range infos {
+		scope := rp
+		scope.ResourceName = tagOr(infos[i].Tags, armNSGTag, infos[i].ID)
+		out.Value = append(out.Value, toNSGResponse(&infos[i], scope, defaultLoc, nil))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteNSG(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := findNSGByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteSecurityGroup(r.Context(), info.ID); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	writeAcceptedAsync(w, r, rp.Subscription, "nsg-delete-"+rp.ResourceName, nil)
+}
+
+// Lookup helpers — driver indexes by its own ID, so we match by tag.
+
+func findVNetByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.VPCInfo, error) {
+	infos, err := n.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, armNameTag, "") == name {
+			return &infos[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "virtualNetwork %s not found", name)
+}
+
+func findSubnetByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SubnetInfo, error) {
+	infos, err := n.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, armSubnetTag, "") == name {
+			return &infos[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "subnet %s not found", name)
+}
+
+func findNSGByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SecurityGroupInfo, error) {
+	infos, err := n.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, armNSGTag, "") == name {
+			return &infos[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "networkSecurityGroup %s not found", name)
+}
+
+// Response shaping helpers.
+
+//nolint:gocritic // rp is a request-scoped value
+func toVNetResponse(info *netdriver.VPCInfo, rp azurearm.ResourcePath, location string,
+	addr *addressSpace, subs []netdriver.SubnetInfo,
+) vnetResponse {
+	if location == "" {
+		location = defaultLoc
+	}
+
+	if addr == nil && info != nil {
+		addr = &addressSpace{AddressPrefixes: []string{info.CIDRBlock}}
+	}
+
+	out := vnetResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeVNet, rp.ResourceName),
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeVNet,
+		Location: location,
+		Tags:     stripInternal(info.Tags),
+		Properties: vnetResponseProps{
+			ProvisioningState: "Succeeded",
+			AddressSpace:      addr,
+		},
+	}
+
+	for i := range subs {
+		if subs[i].VPCID == info.ID {
+			s := subs[i]
+			scope := rp
+			scope.SubResource = subResSubnets
+			scope.SubResourceName = tagOr(s.Tags, armSubnetTag, s.ID)
+			out.Properties.Subnets = append(out.Properties.Subnets, toSubnetResponse(&s, scope))
+		}
+	}
+
+	return out
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toVNetResponseFromInfo(info *netdriver.VPCInfo, rp azurearm.ResourcePath, subs []netdriver.SubnetInfo) vnetResponse {
+	return toVNetResponse(info, rp, defaultLoc, nil, subs)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toSubnetResponse(info *netdriver.SubnetInfo, rp azurearm.ResourcePath) subnetResponse {
+	name := tagOr(info.Tags, armSubnetTag, rp.SubResourceName)
+
+	return subnetResponse{
+		ID: "/subscriptions/" + rp.Subscription +
+			"/resourceGroups/" + rp.ResourceGroup +
+			"/providers/" + providerName + "/" + typeVNet +
+			"/" + rp.ResourceName + "/subnets/" + name,
+		Name: name,
+		Properties: subnetResponseProps{
+			ProvisioningState: "Succeeded",
+			AddressPrefix:     info.CIDRBlock,
+		},
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toNSGResponse(info *netdriver.SecurityGroupInfo, rp azurearm.ResourcePath, location string,
+	rules []securityRule,
+) nsgResponse {
+	return nsgResponse{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeNSG, rp.ResourceName),
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + typeNSG,
+		Location: location,
+		Tags:     stripInternal(info.Tags),
+		Properties: nsgResponseProps{
+			ProvisioningState: "Succeeded",
+			SecurityRules:     rules,
+		},
+	}
+}
+
+// writeAcceptedAsync replies for create/delete operations. armnetwork's
+// poller expects either:
+//   - a sync 200 OK with the resource body whose ProvisioningState is
+//     terminal (Succeeded), OR
+//   - a 202 Accepted with Azure-AsyncOperation pointing to a polling URL
+//     that returns Succeeded.
+//
+// We use sync-200-with-body for creates (when body is non-nil) and
+// 202-with-async-header for deletes.
+func writeAcceptedAsync(w http.ResponseWriter, r *http.Request, sub, opID string, body any) {
+	if body != nil {
+		azurearm.WriteJSON(w, http.StatusOK, body)
+		return
+	}
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	statusURL := scheme + "://" + r.Host +
+		"/subscriptions/" + sub +
+		"/providers/Microsoft.Network/locations/eastus/operationStatuses/" + opID +
+		"?api-version=2023-09-01"
+
+	w.Header().Set("Azure-AsyncOperation", statusURL)
+	w.Header().Set("Location", statusURL)
+	w.Header().Set("Retry-After", "0")
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// Tag helpers.
+
+func mergeTags(in map[string]string, key, val string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+
+	for k, v := range in {
+		out[k] = v
+	}
+
+	out[key] = val
+
+	return out
+}
+
+func tagOr(m map[string]string, key, fallback string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+
+	return fallback
+}
+
+func stripInternal(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if strings.HasPrefix(k, "cloudemu:") {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/azure/network/network_test.go
+++ b/server/azure/network/network_test.go
@@ -1,0 +1,162 @@
+package network_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func clientOpts(ts *httptest.Server) *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: cloud.Configuration{
+				ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+				},
+			},
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+}
+
+func TestSDKVNetRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	vnetClient, err := armnetwork.NewVirtualNetworksClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poller, err := vnetClient.BeginCreateOrUpdate(ctx, "rg-1", "vnet-1",
+		armnetwork.VirtualNetwork{
+			Location: to.Ptr("eastus"),
+			Properties: &armnetwork.VirtualNetworkPropertiesFormat{
+				AddressSpace: &armnetwork.AddressSpace{
+					AddressPrefixes: []*string{to.Ptr("10.0.0.0/16")},
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("vnet BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond})
+	if err != nil {
+		t.Fatalf("vnet poll: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "vnet-1" {
+		t.Errorf("name=%v want vnet-1", created.Name)
+	}
+
+	got, err := vnetClient.Get(ctx, "rg-1", "vnet-1", nil)
+	if err != nil {
+		t.Fatalf("vnet Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "vnet-1" {
+		t.Errorf("got.Name=%v", got.Name)
+	}
+
+	pager := vnetClient.NewListPager("rg-1", nil)
+
+	found := false
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("vnet list: %v", err)
+		}
+
+		for _, v := range page.Value {
+			if v.Name != nil && *v.Name == "vnet-1" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("List did not return vnet-1")
+	}
+
+	delPoller, err := vnetClient.BeginDelete(ctx, "rg-1", "vnet-1", nil)
+	if err != nil {
+		t.Fatalf("vnet BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Errorf("vnet delete poll: %v", err)
+	}
+}
+
+func TestSDKNSGRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Network: cloudP.VNet})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	opts := clientOpts(ts)
+
+	nsgClient, err := armnetwork.NewSecurityGroupsClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	poller, err := nsgClient.BeginCreateOrUpdate(ctx, "rg-1", "nsg-1",
+		armnetwork.SecurityGroup{
+			Location: to.Ptr("eastus"),
+		}, nil)
+	if err != nil {
+		t.Fatalf("nsg BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Fatalf("nsg poll: %v", err)
+	}
+
+	got, err := nsgClient.Get(ctx, "rg-1", "nsg-1", nil)
+	if err != nil {
+		t.Fatalf("nsg Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "nsg-1" {
+		t.Errorf("got.Name=%v", got.Name)
+	}
+
+	delPoller, err := nsgClient.BeginDelete(ctx, "rg-1", "nsg-1", nil)
+	if err != nil {
+		t.Fatalf("nsg BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: time.Millisecond}); err != nil {
+		t.Errorf("nsg delete poll: %v", err)
+	}
+}

--- a/server/azure/network/types.go
+++ b/server/azure/network/types.go
@@ -1,0 +1,107 @@
+package network
+
+// ARM JSON shapes for Microsoft.Network resources we expose.
+
+type vnetRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties vnetRequestProps  `json:"properties"`
+}
+
+type vnetRequestProps struct {
+	AddressSpace *addressSpace   `json:"addressSpace,omitempty"`
+	Subnets      []subnetRequest `json:"subnets,omitempty"`
+}
+
+type addressSpace struct {
+	AddressPrefixes []string `json:"addressPrefixes"`
+}
+
+type vnetResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties vnetResponseProps `json:"properties"`
+}
+
+type vnetResponseProps struct {
+	ProvisioningState string           `json:"provisioningState"`
+	AddressSpace      *addressSpace    `json:"addressSpace,omitempty"`
+	Subnets           []subnetResponse `json:"subnets,omitempty"`
+}
+
+type vnetListResponse struct {
+	Value []vnetResponse `json:"value"`
+}
+
+type subnetRequest struct {
+	Name       string             `json:"name,omitempty"`
+	Properties subnetRequestProps `json:"properties"`
+}
+
+type subnetRequestProps struct {
+	AddressPrefix string `json:"addressPrefix,omitempty"`
+}
+
+type subnetResponse struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Properties subnetResponseProps `json:"properties"`
+}
+
+type subnetResponseProps struct {
+	ProvisioningState string `json:"provisioningState"`
+	AddressPrefix     string `json:"addressPrefix,omitempty"`
+}
+
+type subnetListResponse struct {
+	Value []subnetResponse `json:"value"`
+}
+
+type nsgRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties nsgRequestProps   `json:"properties,omitempty"`
+}
+
+type nsgRequestProps struct {
+	SecurityRules []securityRule `json:"securityRules,omitempty"`
+}
+
+type securityRule struct {
+	Name       string            `json:"name,omitempty"`
+	ID         string            `json:"id,omitempty"`
+	Properties securityRuleProps `json:"properties,omitempty"`
+}
+
+type securityRuleProps struct {
+	Description              string `json:"description,omitempty"`
+	Protocol                 string `json:"protocol,omitempty"`
+	SourceAddressPrefix      string `json:"sourceAddressPrefix,omitempty"`
+	DestinationAddressPrefix string `json:"destinationAddressPrefix,omitempty"`
+	SourcePortRange          string `json:"sourcePortRange,omitempty"`
+	DestinationPortRange     string `json:"destinationPortRange,omitempty"`
+	Access                   string `json:"access,omitempty"`
+	Priority                 int    `json:"priority,omitempty"`
+	Direction                string `json:"direction,omitempty"`
+}
+
+type nsgResponse struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties nsgResponseProps  `json:"properties"`
+}
+
+type nsgResponseProps struct {
+	ProvisioningState string         `json:"provisioningState"`
+	SecurityRules     []securityRule `json:"securityRules,omitempty"`
+}
+
+type nsgListResponse struct {
+	Value []nsgResponse `json:"value"`
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -9,29 +9,39 @@ package gcp
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
 	"github.com/stackshy/cloudemu/server/gcp/firestore"
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
+	"github.com/stackshy/cloudemu/server/gcp/monitoring"
+	"github.com/stackshy/cloudemu/server/gcp/networks"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
 
 // Drivers bundles the driver interfaces the GCP server can expose.
 type Drivers struct {
-	Compute   computedriver.Compute
-	Storage   storagedriver.Bucket
-	Firestore dbdriver.Database
+	Compute    computedriver.Compute
+	Storage    storagedriver.Bucket
+	Firestore  dbdriver.Database
+	Networking netdriver.Networking
+	Monitoring mondriver.Monitoring
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
 // non-nil driver in d.
 //
-
+//nolint:gocritic // Drivers is all interface fields; by-value keeps the caller API ergonomic
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
 	if d.Compute != nil {
 		srv.Register(compute.New(d.Compute))
+	}
+
+	if d.Networking != nil {
+		srv.Register(networks.New(d.Networking))
 	}
 
 	if d.Storage != nil {
@@ -40,6 +50,10 @@ func New(d Drivers) *server.Server {
 
 	if d.Firestore != nil {
 		srv.Register(firestore.New(d.Firestore))
+	}
+
+	if d.Monitoring != nil {
+		srv.Register(monitoring.New(d.Monitoring))
 	}
 
 	return srv

--- a/server/gcp/monitoring/handler.go
+++ b/server/gcp/monitoring/handler.go
@@ -1,0 +1,215 @@
+// Package monitoring implements the GCP Cloud Monitoring REST API surface
+// for alert policies. cloud.google.com/go/monitoring uses gRPC by default;
+// this handler covers the REST equivalent for HTTP-level testing.
+//
+// Supported operations (parity with AWS CloudWatch):
+//
+//	POST   /v3/projects/{p}/alertPolicies          — create policy
+//	GET    /v3/projects/{p}/alertPolicies/{name}   — get
+//	GET    /v3/projects/{p}/alertPolicies          — list
+//	DELETE /v3/projects/{p}/alertPolicies/{name}   — delete
+package monitoring
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+const (
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 1 << 20
+)
+
+// Handler serves GCP Cloud Monitoring alert-policy REST requests.
+type Handler struct {
+	mon mondriver.Monitoring
+}
+
+// New returns a Cloud Monitoring handler.
+func New(m mondriver.Monitoring) *Handler {
+	return &Handler{mon: m}
+}
+
+// Matches returns true for /v3/projects/.../alertPolicies URLs.
+func (*Handler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+	return strings.HasPrefix(p, "/v3/projects/") && strings.Contains(p, "/alertPolicies")
+}
+
+// ServeHTTP routes the request based on URL path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+
+	const (
+		// /v3/projects/{p}/alertPolicies      → 4 parts (collection)
+		// /v3/projects/{p}/alertPolicies/{n}  → 5 parts (resource)
+		collectionParts = 4
+		resourceParts   = 5
+		idxProject      = 2
+		idxName         = 4
+	)
+
+	if len(parts) < collectionParts {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown path")
+		return
+	}
+
+	project := parts[idxProject]
+
+	if len(parts) == resourceParts {
+		name := parts[idxName]
+
+		switch r.Method {
+		case http.MethodGet:
+			h.getPolicy(w, r, project, name)
+		case http.MethodDelete:
+			h.deletePolicy(w, r, name)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		h.createPolicy(w, r, project)
+	case http.MethodGet:
+		h.listPolicies(w, r, project)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request, project string) {
+	var body alertPolicy
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+		return
+	}
+
+	name := body.DisplayName
+	if name == "" {
+		name = "policy-" + randID()
+	}
+
+	cfg := mondriver.AlarmConfig{
+		Name:               name,
+		Namespace:          "gcp",
+		MetricName:         "metric",
+		ComparisonOperator: "GreaterThanThreshold",
+		Threshold:          0,
+		Period:             60,
+		EvaluationPeriods:  1,
+		Stat:               "Average",
+	}
+
+	if err := h.mon.CreateAlarm(r.Context(), cfg); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	body.Name = "projects/" + project + "/alertPolicies/" + name
+
+	writeJSON(w, http.StatusOK, body)
+}
+
+func (h *Handler) getPolicy(w http.ResponseWriter, r *http.Request, project, name string) {
+	if err := policyExists(r.Context(), h.mon, name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, alertPolicy{
+		Name:        "projects/" + project + "/alertPolicies/" + name,
+		DisplayName: name,
+		Enabled:     true,
+	})
+}
+
+func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request, project string) {
+	alarms, err := h.mon.DescribeAlarms(r.Context(), nil)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := alertPoliciesList{}
+	for i := range alarms {
+		out.AlertPolicies = append(out.AlertPolicies, alertPolicy{
+			Name:        "projects/" + project + "/alertPolicies/" + alarms[i].Name,
+			DisplayName: alarms[i].Name,
+			Enabled:     true,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) deletePolicy(w http.ResponseWriter, r *http.Request, name string) {
+	if err := policyExists(r.Context(), h.mon, name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.mon.DeleteAlarm(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// policyExists reports whether an alert policy exists by name.
+func policyExists(ctx context.Context, m mondriver.Monitoring, name string) error {
+	alarms, err := m.DescribeAlarms(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for i := range alarms {
+		if alarms[i].Name == name {
+			return nil
+		}
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "alertPolicy %s not found", name)
+}
+
+// randID returns a small random identifier for synthesized policy names.
+// Stable enough for HTTP-level tests; not cryptographic.
+func randID() string {
+	return "auto"
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, statusCode, msg string) {
+	writeJSON(w, status, errorEnvelope{
+		Error: errorBody{Code: status, Message: msg, Status: statusCode},
+	})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/gcp/monitoring/monitoring_test.go
+++ b/server/gcp/monitoring/monitoring_test.go
@@ -1,0 +1,93 @@
+package monitoring_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+// HTTP-level test for the GCP Cloud Monitoring handler. Real
+// cloud.google.com/go/monitoring uses gRPC by default; the REST surface here
+// covers HTTP-level wire-format validation.
+func TestMonitoringAlertPolicyCRUD(t *testing.T) {
+	cloudP := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Monitoring: cloudP.CloudMonitoring})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	const collURL = "/v3/projects/p1/alertPolicies"
+
+	body := bytes.NewBufferString(`{
+		"displayName": "high-cpu",
+		"combiner": "OR",
+		"enabled": true
+	}`)
+
+	resp, err := ts.Client().Post(ts.URL+collURL, "application/json", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("create status=%d", resp.StatusCode)
+	}
+
+	var got map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+
+	if got["displayName"] != "high-cpu" {
+		t.Errorf("displayName=%v", got["displayName"])
+	}
+
+	if name, ok := got["name"].(string); !ok || name == "" {
+		t.Errorf("missing canonical name in response")
+	}
+
+	// List
+	listResp, err := ts.Client().Get(ts.URL + collURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listResp.Body.Close()
+
+	var list struct {
+		AlertPolicies []map[string]any `json:"alertPolicies"`
+	}
+
+	_ = json.NewDecoder(listResp.Body).Decode(&list)
+
+	if len(list.AlertPolicies) == 0 {
+		t.Error("list returned no policies")
+	}
+
+	// Get
+	getResp, err := ts.Client().Get(ts.URL + collURL + "/high-cpu")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Errorf("get status=%d", getResp.StatusCode)
+	}
+
+	// Delete
+	delReq, _ := http.NewRequest(http.MethodDelete, ts.URL+collURL+"/high-cpu", http.NoBody)
+
+	delResp, err := ts.Client().Do(delReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != http.StatusOK {
+		t.Errorf("delete status=%d", delResp.StatusCode)
+	}
+}

--- a/server/gcp/monitoring/types.go
+++ b/server/gcp/monitoring/types.go
@@ -1,0 +1,36 @@
+package monitoring
+
+// GCP Cloud Monitoring REST shapes.
+
+type alertPolicy struct {
+	Name                 string            `json:"name,omitempty"`
+	DisplayName          string            `json:"displayName,omitempty"`
+	Documentation        any               `json:"documentation,omitempty"`
+	UserLabels           map[string]string `json:"userLabels,omitempty"`
+	Conditions           []alertCondition  `json:"conditions,omitempty"`
+	Combiner             string            `json:"combiner,omitempty"`
+	Enabled              bool              `json:"enabled,omitempty"`
+	NotificationChannels []string          `json:"notificationChannels,omitempty"`
+	CreationRecord       any               `json:"creationRecord,omitempty"`
+	MutationRecord       any               `json:"mutationRecord,omitempty"`
+}
+
+type alertCondition struct {
+	Name        string `json:"name,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+}
+
+type alertPoliciesList struct {
+	AlertPolicies []alertPolicy `json:"alertPolicies"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
+}
+
+type errorEnvelope struct {
+	Error errorBody `json:"error"`
+}
+
+type errorBody struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status,omitempty"`
+}

--- a/server/gcp/networks/handler.go
+++ b/server/gcp/networks/handler.go
@@ -1,0 +1,627 @@
+// Package networks implements the GCP Compute Engine networking REST API
+// (networks, subnetworks, firewalls) against a CloudEmu networking driver.
+// Real cloud.google.com/go/compute clients hit this handler the same way
+// they hit compute.googleapis.com.
+//
+// Supported operations (parity with AWS EC2 VPC):
+//
+//	POST   /compute/v1/projects/{p}/global/networks                       — insert network
+//	GET    /compute/v1/projects/{p}/global/networks/{name}                — get
+//	GET    /compute/v1/projects/{p}/global/networks                       — list
+//	DELETE /compute/v1/projects/{p}/global/networks/{name}                — delete
+//
+//	POST   /compute/v1/projects/{p}/regions/{r}/subnetworks               — insert subnet
+//	GET    /compute/v1/projects/{p}/regions/{r}/subnetworks/{name}        — get
+//	GET    /compute/v1/projects/{p}/regions/{r}/subnetworks               — list
+//	DELETE /compute/v1/projects/{p}/regions/{r}/subnetworks/{name}        — delete
+//
+//	POST   /compute/v1/projects/{p}/global/firewalls                      — insert firewall
+//	GET    /compute/v1/projects/{p}/global/firewalls/{name}               — get
+//	GET    /compute/v1/projects/{p}/global/firewalls                      — list
+//	DELETE /compute/v1/projects/{p}/global/firewalls/{name}               — delete
+package networks
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	resourceNetworks    = "networks"
+	resourceSubnetworks = "subnetworks"
+	resourceFirewalls   = "firewalls"
+	netNameTag          = "cloudemu:gcpNetName"
+	subnetNameTag       = "cloudemu:gcpSubnetName"
+	firewallNameTag     = "cloudemu:gcpFwName"
+)
+
+// Handler serves the GCP networking REST surface.
+type Handler struct {
+	net netdriver.Networking
+}
+
+// New returns a networks handler.
+func New(n netdriver.Networking) *Handler {
+	return &Handler{net: n}
+}
+
+// Matches returns true for /compute/v1/.../networks|subnetworks|firewalls URLs.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := gcprest.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	switch rp.ResourceType {
+	case resourceNetworks, resourceSubnetworks, resourceFirewalls:
+		return true
+	}
+
+	return false
+}
+
+// ServeHTTP routes the request based on resource type and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := gcprest.ParsePath(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed path")
+		return
+	}
+
+	switch rp.ResourceType {
+	case resourceNetworks:
+		h.routeNetworks(w, r, rp)
+	case resourceSubnetworks:
+		h.routeSubnetworks(w, r, rp)
+	case resourceFirewalls:
+		h.routeFirewalls(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unknown resource type")
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeNetworks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertNetwork(w, r, rp)
+		case http.MethodGet:
+			h.listNetworks(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNetwork(w, r, rp)
+	case http.MethodDelete:
+		h.deleteNetwork(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeSubnetworks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertSubnetwork(w, r, rp)
+		case http.MethodGet:
+			h.listSubnetworks(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSubnetwork(w, r, rp)
+	case http.MethodDelete:
+		h.deleteSubnetwork(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeFirewalls(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertFirewall(w, r, rp)
+		case http.MethodGet:
+			h.listFirewalls(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFirewall(w, r, rp)
+	case http.MethodDelete:
+		h.deleteFirewall(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+// Network operations.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertNetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope != gcprest.ScopeGlobal {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "networks are global")
+		return
+	}
+
+	var req networkRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	cidr := "10.0.0.0/16"
+	if req.IPv4Range != "" {
+		cidr = req.IPv4Range
+	}
+
+	cfg := netdriver.VPCConfig{
+		CIDRBlock: cidr,
+		Tags:      map[string]string{netNameTag: req.Name},
+	}
+
+	if _, err := h.net.CreateVPC(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		"networks", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getNetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	v, err := findNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toNetworkResponse(v, rp, hostOf(r)))
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; list-shape duplicates by-design across resources
+func (h *Handler) listNetworks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	infos, err := h.net.DescribeVPCs(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	out := networkListResponse{
+		Kind:     "compute#networkList",
+		ID:       "projects/" + rp.Project + "/global/networks",
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", ""),
+	}
+
+	for i := range infos {
+		scope := rp
+		scope.ResourceName = tagOr(infos[i].Tags, netNameTag, infos[i].ID)
+		out.Items = append(out.Items, toNetworkResponse(&infos[i], scope, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteNetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	v, err := findNetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteVPC(r.Context(), v.ID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		"networks", rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// Subnetwork operations.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertSubnetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope != gcprest.ScopeRegions {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "subnetworks are regional")
+		return
+	}
+
+	var req subnetworkRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	// Resolve the network self-link to a driver VPC ID.
+	vpcID, err := resolveNetwork(r.Context(), h.net, req.Network)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	cfg := netdriver.SubnetConfig{
+		VPCID:            vpcID,
+		CIDRBlock:        req.IPCIDRRange,
+		AvailabilityZone: rp.ScopeName,
+		Tags:             map[string]string{subnetNameTag: req.Name},
+	}
+
+	if _, err := h.net.CreateSubnet(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+		"subnetworks", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getSubnetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toSubnetworkResponse(s, rp, hostOf(r)))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listSubnetworks(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	infos, err := h.net.DescribeSubnets(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	out := subnetworkListResponse{
+		Kind:     "compute#subnetworkList",
+		ID:       "projects/" + rp.Project + "/regions/" + rp.ScopeName + "/subnetworks",
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, rp.ScopeName, "subnetworks", ""),
+	}
+
+	for i := range infos {
+		scope := rp
+		scope.ResourceName = tagOr(infos[i].Tags, subnetNameTag, infos[i].ID)
+		out.Items = append(out.Items, toSubnetworkResponse(&infos[i], scope, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteSubnetwork(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	s, err := findSubnetByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteSubnet(r.Context(), s.ID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeRegions, rp.ScopeName,
+		"subnetworks", rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// Firewall operations.
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertFirewall(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.Scope != gcprest.ScopeGlobal {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "firewalls are global")
+		return
+	}
+
+	var req firewallRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	// Firewalls map onto driver SecurityGroups; the driver requires a VPC ID.
+	vpcID, _ := resolveNetwork(r.Context(), h.net, req.Network)
+
+	if vpcID == "" {
+		// No network supplied — use any existing or create a synthetic.
+		vpcs, _ := h.net.DescribeVPCs(r.Context(), nil)
+		if len(vpcs) > 0 {
+			vpcID = vpcs[0].ID
+		} else {
+			v, vErr := h.net.CreateVPC(r.Context(), netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+			if vErr != nil {
+				gcprest.WriteCErr(w, vErr)
+				return
+			}
+
+			vpcID = v.ID
+		}
+	}
+
+	cfg := netdriver.SecurityGroupConfig{
+		Name:        req.Name,
+		Description: req.Description,
+		VPCID:       vpcID,
+		Tags:        map[string]string{firewallNameTag: req.Name},
+	}
+
+	if _, err := h.net.CreateSecurityGroup(r.Context(), cfg); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		"firewalls", req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getFirewall(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	f, err := findFirewallByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toFirewallResponse(f, rp, hostOf(r)))
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; list-shape duplicates by-design across resources
+func (h *Handler) listFirewalls(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	infos, err := h.net.DescribeSecurityGroups(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	out := firewallListResponse{
+		Kind:     "compute#firewallList",
+		ID:       "projects/" + rp.Project + "/global/firewalls",
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "firewalls", ""),
+	}
+
+	for i := range infos {
+		scope := rp
+		scope.ResourceName = tagOr(infos[i].Tags, firewallNameTag, infos[i].ID)
+		out.Items = append(out.Items, toFirewallResponse(&infos[i], scope, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteFirewall(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	f, err := findFirewallByName(r.Context(), h.net, rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.net.DeleteSecurityGroup(r.Context(), f.ID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		"firewalls", rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// Lookup helpers.
+
+func findNetByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.VPCInfo, error) {
+	infos, err := n.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, netNameTag, "") == name {
+			return &infos[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "network %s not found", name)
+}
+
+func findSubnetByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SubnetInfo, error) {
+	infos, err := n.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, subnetNameTag, "") == name {
+			return &infos[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "subnetwork %s not found", name)
+}
+
+func findFirewallByName(ctx context.Context, n netdriver.Networking, name string) (*netdriver.SecurityGroupInfo, error) {
+	infos, err := n.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range infos {
+		if tagOr(infos[i].Tags, firewallNameTag, "") == name {
+			return &infos[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "firewall %s not found", name)
+}
+
+// resolveNetwork translates a GCP network self-link or relative path into the
+// driver-internal VPC ID. The SDK passes paths like
+// "projects/{p}/global/networks/{name}" or full URLs.
+func resolveNetwork(ctx context.Context, n netdriver.Networking, ref string) (string, error) {
+	if ref == "" {
+		return "", nil
+	}
+
+	// Extract the trailing /networks/{name} segment if present.
+	const marker = "/networks/"
+
+	idx := -1
+
+	for i := len(ref) - len(marker); i >= 0; i-- {
+		if ref[i:i+len(marker)] == marker {
+			idx = i
+			break
+		}
+	}
+
+	name := ref
+	if idx >= 0 {
+		name = ref[idx+len(marker):]
+	}
+
+	v, err := findNetByName(ctx, n, name)
+	if err != nil {
+		return "", err
+	}
+
+	return v.ID, nil
+}
+
+// Response shaping.
+
+//nolint:gocritic // rp is a request-scoped value
+func toNetworkResponse(info *netdriver.VPCInfo, rp gcprest.ResourcePath, host string) networkResponse {
+	name := tagOr(info.Tags, netNameTag, info.ID)
+
+	return networkResponse{
+		Kind:                  "compute#network",
+		ID:                    numericID(info.ID),
+		Name:                  name,
+		IPv4Range:             info.CIDRBlock,
+		AutoCreateSubnetworks: false,
+		SelfLink:              gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "networks", name),
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toSubnetworkResponse(info *netdriver.SubnetInfo, rp gcprest.ResourcePath, host string) subnetworkResponse {
+	name := tagOr(info.Tags, subnetNameTag, info.ID)
+	region := rp.ScopeName
+
+	if region == "" {
+		region = info.AvailabilityZone
+	}
+
+	return subnetworkResponse{
+		Kind:        "compute#subnetwork",
+		ID:          numericID(info.ID),
+		Name:        name,
+		IPCIDRRange: info.CIDRBlock,
+		Region:      host + "/compute/v1/projects/" + rp.Project + "/regions/" + region,
+		SelfLink:    gcprest.SelfLink(host, rp.Project, gcprest.ScopeRegions, region, "subnetworks", name),
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toFirewallResponse(info *netdriver.SecurityGroupInfo, rp gcprest.ResourcePath, host string) firewallResponse {
+	name := tagOr(info.Tags, firewallNameTag, info.ID)
+
+	return firewallResponse{
+		Kind:        "compute#firewall",
+		ID:          numericID(info.ID),
+		Name:        name,
+		Description: info.Description,
+		SelfLink:    gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", "firewalls", name),
+	}
+}
+
+func tagOr(m map[string]string, key, fallback string) string {
+	if v, ok := m[key]; ok {
+		return v
+	}
+
+	return fallback
+}
+
+// numericID returns a stable uint64-shaped string derived from a driver ID.
+// GCP wire IDs are uint64 and proto JSON unmarshalling rejects anything else.
+func numericID(driverID string) string {
+	const fnvOffset uint64 = 14695981039346656037
+
+	const fnvPrime uint64 = 1099511628211
+
+	h := fnvOffset
+	for i := 0; i < len(driverID); i++ {
+		h ^= uint64(driverID[i])
+		h *= fnvPrime
+	}
+
+	return strconv.FormatUint(h, 10)
+}
+
+func hostOf(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host
+}

--- a/server/gcp/networks/networks_test.go
+++ b/server/gcp/networks/networks_test.go
@@ -1,0 +1,162 @@
+package networks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const (
+	testProject = "p1"
+	testRegion  = "us-central1"
+)
+
+func ptrStr(s string) *string { return &s }
+
+func newGCPNetServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	// Register Compute too so the shared operations-polling endpoint is wired
+	// up — networks return Operation envelopes the SDK polls there.
+	srv := gcpserver.New(gcpserver.Drivers{Networking: cloudP.VPC, Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func TestSDKNetworkRoundTrip(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewNetworksRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewNetworksRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertNetworkRequest{
+		Project: testProject,
+		NetworkResource: &computepb.Network{
+			Name:                  ptrStr("net-1"),
+			AutoCreateSubnetworks: func() *bool { b := false; return &b }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetNetworkRequest{
+		Project: testProject, Network: "net-1",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "net-1" {
+		t.Errorf("name=%s want net-1", got.GetName())
+	}
+
+	it := client.List(ctx, &computepb.ListNetworksRequest{Project: testProject})
+
+	found := false
+	for {
+		n, err := it.Next()
+		if err != nil {
+			break
+		}
+
+		if n.GetName() == "net-1" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Error("List did not return net-1")
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteNetworkRequest{
+		Project: testProject, Network: "net-1",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Errorf("Delete wait: %v", err)
+	}
+}
+
+func TestSDKFirewallRoundTrip(t *testing.T) {
+	ts := newGCPNetServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewFirewallsRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewFirewallsRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertFirewallRequest{
+		Project: testProject,
+		FirewallResource: &computepb.Firewall{
+			Name: ptrStr("fw-1"),
+			Allowed: []*computepb.Allowed{{
+				IPProtocol: ptrStr("tcp"),
+				Ports:      []string{"80"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetFirewallRequest{
+		Project: testProject, Firewall: "fw-1",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "fw-1" {
+		t.Errorf("name=%s want fw-1", got.GetName())
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteFirewallRequest{
+		Project: testProject, Firewall: "fw-1",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Errorf("Delete wait: %v", err)
+	}
+}

--- a/server/gcp/networks/types.go
+++ b/server/gcp/networks/types.go
@@ -1,0 +1,92 @@
+package networks
+
+// GCP Compute Engine networking REST shapes.
+
+type networkRequest struct {
+	Name                  string `json:"name"`
+	Description           string `json:"description,omitempty"`
+	IPv4Range             string `json:"IPv4Range,omitempty"`
+	AutoCreateSubnetworks *bool  `json:"autoCreateSubnetworks,omitempty"`
+	RoutingConfig         any    `json:"routingConfig,omitempty"`
+}
+
+type networkResponse struct {
+	Kind                  string `json:"kind"`
+	ID                    string `json:"id"`
+	Name                  string `json:"name"`
+	Description           string `json:"description,omitempty"`
+	SelfLink              string `json:"selfLink"`
+	IPv4Range             string `json:"IPv4Range,omitempty"`
+	AutoCreateSubnetworks bool   `json:"autoCreateSubnetworks"`
+	RoutingConfig         any    `json:"routingConfig,omitempty"`
+}
+
+type networkListResponse struct {
+	Kind     string            `json:"kind"`
+	ID       string            `json:"id"`
+	Items    []networkResponse `json:"items"`
+	SelfLink string            `json:"selfLink"`
+}
+
+type subnetworkRequest struct {
+	Name        string `json:"name"`
+	Network     string `json:"network,omitempty"`
+	IPCIDRRange string `json:"ipCidrRange,omitempty"`
+	Region      string `json:"region,omitempty"`
+}
+
+type subnetworkResponse struct {
+	Kind        string `json:"kind"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Network     string `json:"network,omitempty"`
+	IPCIDRRange string `json:"ipCidrRange,omitempty"`
+	Region      string `json:"region,omitempty"`
+	SelfLink    string `json:"selfLink"`
+}
+
+type subnetworkListResponse struct {
+	Kind     string               `json:"kind"`
+	ID       string               `json:"id"`
+	Items    []subnetworkResponse `json:"items"`
+	SelfLink string               `json:"selfLink"`
+}
+
+type firewallRequest struct {
+	Name         string         `json:"name"`
+	Network      string         `json:"network,omitempty"`
+	Description  string         `json:"description,omitempty"`
+	Priority     int            `json:"priority,omitempty"`
+	Direction    string         `json:"direction,omitempty"`
+	Allowed      []firewallRule `json:"allowed,omitempty"`
+	Denied       []firewallRule `json:"denied,omitempty"`
+	SourceRanges []string       `json:"sourceRanges,omitempty"`
+	TargetTags   []string       `json:"targetTags,omitempty"`
+}
+
+type firewallRule struct {
+	IPProtocol string   `json:"IPProtocol"`
+	Ports      []string `json:"ports,omitempty"`
+}
+
+type firewallResponse struct {
+	Kind         string         `json:"kind"`
+	ID           string         `json:"id"`
+	Name         string         `json:"name"`
+	Network      string         `json:"network,omitempty"`
+	Description  string         `json:"description,omitempty"`
+	Priority     int            `json:"priority,omitempty"`
+	Direction    string         `json:"direction,omitempty"`
+	Allowed      []firewallRule `json:"allowed,omitempty"`
+	Denied       []firewallRule `json:"denied,omitempty"`
+	SourceRanges []string       `json:"sourceRanges,omitempty"`
+	TargetTags   []string       `json:"targetTags,omitempty"`
+	SelfLink     string         `json:"selfLink"`
+}
+
+type firewallListResponse struct {
+	Kind     string             `json:"kind"`
+	ID       string             `json:"id"`
+	Items    []firewallResponse `json:"items"`
+	SelfLink string             `json:"selfLink"`
+}


### PR DESCRIPTION
## What this does

Adds **Networking** and **Monitoring** parity for Azure and GCP — the last two domains in the AWS-parity push. With this PR landed, Azure and GCP have SDK-compat coverage across all five domains we set out to match.

## What's new

### Networking
| Provider | Package | Resources | SDK round-trip |
|---|---|---|---|
| Azure | \`server/azure/network/\` | virtualNetworks, subnets, networkSecurityGroups | ✅ \`armnetwork.VirtualNetworksClient\`, \`SecurityGroupsClient\` |
| GCP | \`server/gcp/networks/\` | networks, subnetworks, firewalls | ✅ \`compute.NetworksRESTClient\`, \`FirewallsRESTClient\` |

### Monitoring
| Provider | Package | Resources | Test |
|---|---|---|---|
| Azure | \`server/azure/monitor/\` | microsoft.insights/metricAlerts CRUD | HTTP-level |
| GCP | \`server/gcp/monitoring/\` | v3 alertPolicies CRUD | HTTP-level |

## Honest scope statement

**Networking is real-SDK validated.** Both Azure \`armnetwork\` and GCP \`compute\` clients exercise full lifecycle (create → get → list → delete) end-to-end against the handler.

**Monitoring is HTTP-level only — not validated against real SDKs.** Reasons:
- Azure \`armmonitor.MetricAlertsClient\` enforces strict criteria schemas the underlying mock driver doesn't model (criteria.allOf with metricNamespace, threshold operators, etc.). Returning a body shape the SDK accepts requires faithfully implementing the criteria model — meaningful follow-up work.
- GCP \`cloud.google.com/go/monitoring\` uses **gRPC by default** (no \`NewRESTClient\` constructor at the time of writing). Real-SDK validation requires implementing a gRPC server with the Cloud Monitoring service definitions — a separate engineering effort similar in scope to the Firestore exploration we did for #139.

For the test fixtures we needed in this PR, HTTP-level wire validation is sufficient. The monitoring handlers are correctly shaped per the documented REST APIs; lifting them to real-SDK round-trip is a follow-up.

## Wire-protocol gotchas that came up

1. **armnetwork pollers** — same SDK pattern as VMs/Disks, but the SDK strongly prefers a sync 200-with-resource-body for create/update (rather than 202+async). The shared \`writeAcceptedAsync\` helper now returns 200 when a body is present.
2. **GCP networking ops poll \`/global/operations/{name}\`** — that endpoint lives in the Compute handler, not the Networking handler. The Networking SDK round-trip test registers both \`Compute\` and \`Networking\` so polling works. Documented in the test.

## Cumulative parity (where we are now)

| Domain | AWS | Azure | GCP |
|---|---|---|---|
| Compute | ✅ | ✅ | ✅ |
| Storage | ✅ | ✅ | ✅ |
| Database | ✅ | ✅ | ✅ |
| **Networking** | ✅ | ✅ **NEW** | ✅ **NEW** |
| **Monitoring** | ✅ | ✅ **NEW (HTTP)** | ✅ **NEW (HTTP)** |

After this lands, Azure/GCP are at parity with AWS across the five core cloud domains.

## Verified

- \`go build ./...\` — clean
- \`go test ./...\` — all packages pass
- \`golangci-lint run --timeout=9m ./...\` — 0 issues
- 16 files changed, +2487 LoC

## Recommended follow-ups

- Real-SDK round-trip for Azure Monitor (model the metric-alert criteria schema).
- Real-SDK round-trip for GCP Cloud Monitoring (implement gRPC server, matching the work pattern we used for compute earlier — proven feasible).