### PR TITLE
fix: register GCS handler last so it doesn't shadow Firestore/Monitoring

### DIFF
--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -32,6 +32,12 @@ type Drivers struct {
 // New returns a server that speaks GCP's REST JSON wire protocol for every
 // non-nil driver in d.
 //
+// GCS's Matches() also accepts /{bucket}/{object} for direct-media downloads,
+// which is broad enough to swallow Firestore and Cloud Monitoring traffic if
+// it registers first. Register more-specific handlers (compute, networks,
+// firestore, monitoring) ahead of GCS so first-match-wins keeps each on the
+// correct package.
+//
 //nolint:gocritic // Drivers is all interface fields; by-value keeps the caller API ergonomic
 func New(d Drivers) *server.Server {
 	srv := server.New()
@@ -44,16 +50,16 @@ func New(d Drivers) *server.Server {
 		srv.Register(networks.New(d.Networking))
 	}
 
-	if d.Storage != nil {
-		srv.Register(gcs.New(d.Storage))
-	}
-
 	if d.Firestore != nil {
 		srv.Register(firestore.New(d.Firestore))
 	}
 
 	if d.Monitoring != nil {
 		srv.Register(monitoring.New(d.Monitoring))
+	}
+
+	if d.Storage != nil {
+		srv.Register(gcs.New(d.Storage))
 	}
 
 	return srv


### PR DESCRIPTION
## What

When users wire up multiple GCP drivers in a single \`gcpserver.New(...)\` call, requests to Firestore (\`/v1/...\`) and Cloud Monitoring (\`/v3/...\`) were getting a \`405 Method Not Allowed\` from the GCS handler instead of reaching their intended handlers.

## Why this happened

\`server/gcp/gcs/handler.go\`'s \`Matches()\` accepts both the JSON-API prefix and direct-media paths of the form \`/{bucket}/{object}\` (the GCS SDK's \`Reader.NewRangeReader\` hits these without the \`/storage/v1/\` prefix). That direct-media branch is permissive enough to also match \`/v1/projects/...\` and \`/v3/projects/...\`, so when GCS was registered before Firestore or Monitoring, first-match-wins routed their traffic to GCS, which 405'd the methods.

## How I found it

End-to-end smoke test: spun up a server with all GCP drivers wired (\`Compute\`, \`Networking\`, \`Storage\`, \`Firestore\`, \`Monitoring\`) and drove each one with its real SDK. Firestore and Monitoring failed with \`405\` from the GCS handler.

## Fix

Reorder registration in \`server/gcp/gcp.go\` so GCS is the **last** handler — every other handler matches a more specific path prefix and now wins. GCS remains the catch-all (which is the correct shape since direct-media URLs are unprefixed).

## Verification

- \`go test ./server/... -count=1\` — all packages pass
- \`golangci-lint run --timeout=9m ./...\` — 0 issues
- E2E simulation against a server with all 5 GCP drivers wired — **16/16 SDK round-trips pass** (was 14/16 before)

## Impact

Any user who creates a \`gcpserver.New(...)\` with both \`Storage\` and either \`Firestore\` or \`Monitoring\` populated would have hit this. Existing tests passed because each test wires a single driver in isolation, masking the ordering issue.