### PR TITLE
add AWS Lambda, Azure Functions, GCP Cloud Functions SDK-compat servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/aws/aws-sdk-go-v2 v1.41.6
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1
@@ -34,15 +34,16 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 // indirect
@@ -50,11 +51,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.25.0 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0 h1:FErSe/vQGefbSuVwBV9JlrRXgG1uOFyW6TCXERX89s4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0/go.mod h1:3rnszxfW8gCLRhoFPgvfXhwSzLam4cHQZ50SugID/sg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0 h1:LkHbJbgF3YyvC53aqYGR+wWQDn2Rdp9AQdGndf9QvY4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0/go.mod h1:QyiQdW4f4/BIfB8ZutZ2s+28RAgfa/pT+zS++ZHyM1I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
@@ -62,8 +64,12 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
 github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10 h1:gx1AwW1Iyk9Z9dD9F4akX5gnN3QZwUB20GGKH/I+Rho=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.10/go.mod h1:qqY157uZoqm5OXq/amuaBJyC9hgBCBQnsaWnPe905GY=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
@@ -72,8 +78,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -96,6 +106,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22 h1:PUmZeJU6
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.22/go.mod h1:nO6egFBoAaoXze24a2C0NjQCvdpk8OueRoYimvEB9jo=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
@@ -108,6 +120,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBU
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
 github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
 github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -15,7 +15,9 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
 	"github.com/stackshy/cloudemu/server/aws/ec2"
+	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/s3"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
 
@@ -28,6 +30,7 @@ type Drivers struct {
 	EC2        computedriver.Compute
 	VPC        netdriver.Networking
 	CloudWatch mondriver.Monitoring
+	Lambda     sdrv.Serverless
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every
@@ -39,6 +42,8 @@ type Drivers struct {
 //   - EC2 matches on Action= (form-encoded POST or query string). The EC2
 //     handler also serves VPC and Auto Scaling ops since real AWS uses the
 //     same query-protocol endpoint for all of them.
+//   - Lambda matches on the /2015-03-31/functions path prefix and must
+//     register before S3 so its REST URLs aren't swallowed by the catch-all.
 //   - S3 is the REST fallback.
 //
 // keeps the caller API ergonomic (awsserver.New(Drivers{...})).
@@ -57,6 +62,10 @@ func New(d Drivers) *server.Server {
 
 	if d.EC2 != nil || d.VPC != nil {
 		srv.Register(ec2.New(d.EC2, d.VPC))
+	}
+
+	if d.Lambda != nil {
+		srv.Register(lambda.New(d.Lambda))
 	}
 
 	if d.S3 != nil {

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -1,0 +1,288 @@
+// Package lambda implements the AWS Lambda REST+JSON control-plane protocol
+// as a server.Handler. Point a real aws-sdk-go-v2 Lambda client at a Server
+// registered with this handler and operations work against an in-memory
+// serverless driver.
+//
+// MVP coverage: CreateFunction, GetFunction, ListFunctions, DeleteFunction,
+// Invoke (synchronous). Versions, aliases, layers, concurrency configs, and
+// event source mappings are not yet wired through — the driver supports them
+// but the wire surface is deferred to a follow-up.
+package lambda
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// pathPrefix is the Lambda API version prefix every control-plane URL starts
+// with. We match on this so the handler doesn't accidentally swallow generic
+// REST traffic that should fall through to the S3 catch-all.
+const pathPrefix = "/2015-03-31/functions"
+
+const (
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 6 << 20 // 6 MiB — Lambda's sync invocation payload limit.
+)
+
+// Handler serves AWS Lambda REST requests against a serverless.Serverless
+// driver.
+type Handler struct {
+	fn sdrv.Serverless
+}
+
+// New returns a Lambda handler backed by fn.
+func New(fn sdrv.Serverless) *Handler {
+	return &Handler{fn: fn}
+}
+
+// Matches returns true for any URL under /2015-03-31/functions — that's the
+// Lambda control-plane prefix the SDK uses for every operation in our MVP.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, pathPrefix)
+}
+
+// ServeHTTP dispatches Lambda operations based on path shape and method.
+//
+//	/2015-03-31/functions                       GET=list, POST=create
+//	/2015-03-31/functions/{name}                GET=get, DELETE=delete
+//	/2015-03-31/functions/{name}/invocations    POST=invoke
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, pathPrefix)
+	rest = strings.TrimPrefix(rest, "/")
+
+	if rest == "" {
+		h.serveCollection(w, r)
+		return
+	}
+
+	parts := strings.Split(rest, "/")
+	name := parts[0]
+
+	const (
+		partsResource = 1 // /functions/{name}
+		partsInvoke   = 2 // /functions/{name}/invocations
+	)
+
+	switch len(parts) {
+	case partsResource:
+		h.serveResource(w, r, name)
+	case partsInvoke:
+		if parts[1] == "invocations" {
+			h.serveInvoke(w, r, name)
+			return
+		}
+
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+	default:
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+	}
+}
+
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.list(w, r)
+	case http.MethodPost:
+		h.create(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+	}
+}
+
+func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, r, name)
+	case http.MethodDelete:
+		h.delete(w, r, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+	}
+}
+
+func (h *Handler) serveInvoke(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+		return
+	}
+
+	h.invoke(w, r, name)
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createFunctionRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := sdrv.FunctionConfig{
+		Name:    req.FunctionName,
+		Runtime: req.Runtime,
+		Handler: req.Handler,
+		Memory:  req.MemorySize,
+		Timeout: req.Timeout,
+		Tags:    req.Tags,
+	}
+	if req.Environment != nil {
+		cfg.Environment = req.Environment.Variables
+	}
+
+	info, err := h.fn.CreateFunction(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, toConfiguration(info))
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, name string) {
+	info, err := h.fn.GetFunction(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, functionResource{
+		Configuration: toConfiguration(info),
+		Code: codeLocation{
+			RepositoryType: "S3",
+			Location:       "https://cloudemu-mock/" + name,
+		},
+		Tags: info.Tags,
+	})
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	infos, err := h.fn.ListFunctions(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listFunctionsResponse{Functions: make([]functionConfiguration, 0, len(infos))}
+	for i := range infos {
+		out.Functions = append(out.Functions, toConfiguration(&infos[i]))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, name string) {
+	if err := h.fn.DeleteFunction(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusRequestEntityTooLarge, "RequestEntityTooLargeException", err.Error())
+		return
+	}
+
+	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
+		FunctionName: name,
+		Payload:      payload,
+		InvokeType:   r.Header.Get("X-Amz-Invocation-Type"),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentTypeJSON)
+
+	if out.Error != "" {
+		// Lambda surfaces handler errors via the X-Amz-Function-Error header
+		// while still returning HTTP 200 with the error payload as the body.
+		w.Header().Set("X-Amz-Function-Error", "Unhandled")
+
+		body, jerr := json.Marshal(map[string]string{
+			"errorType":    "HandlerError",
+			"errorMessage": out.Error,
+		})
+		if jerr != nil {
+			body = []byte(`{"errorMessage":"unknown error"}`)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out.Payload)
+}
+
+func toConfiguration(info *sdrv.FunctionInfo) functionConfiguration {
+	cfg := functionConfiguration{
+		FunctionName: info.Name,
+		FunctionArn:  info.ARN,
+		Runtime:      info.Runtime,
+		Handler:      info.Handler,
+		MemorySize:   info.Memory,
+		Timeout:      info.Timeout,
+		LastModified: info.LastModified,
+		State:        info.State,
+		PackageType:  "Zip",
+	}
+
+	if len(info.Environment) > 0 {
+		cfg.Environment = &envEnvelope{Variables: info.Environment}
+	}
+
+	return cfg
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidRequestContentException", err.Error())
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, errType, msg string) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("X-Amzn-Errortype", errType)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"Type":    errType,
+		"Message": msg,
+		"message": msg,
+	})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ResourceConflictException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidParameterValueException", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "ServiceException", err.Error())
+	}
+}

--- a/server/aws/lambda/lambda_test.go
+++ b/server/aws/lambda/lambda_test.go
@@ -1,0 +1,340 @@
+package lambda_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	awsprov "github.com/stackshy/cloudemu/providers/aws"
+	"github.com/stackshy/cloudemu/server/aws/lambda"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+func newServer(t *testing.T) (*httptest.Server, *awsprov.Provider) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := httptest.NewServer(lambda.New(cloud.Lambda))
+
+	t.Cleanup(srv.Close)
+
+	return srv, cloud
+}
+
+func TestMatchesPathPrefix(t *testing.T) {
+	h := lambda.New(nil)
+
+	want := []string{
+		"/2015-03-31/functions",
+		"/2015-03-31/functions/foo",
+		"/2015-03-31/functions/foo/invocations",
+	}
+
+	for _, p := range want {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		if !h.Matches(req) {
+			t.Fatalf("Matches(%q) = false, want true", p)
+		}
+	}
+}
+
+func TestMatchesRejectsUnrelatedPaths(t *testing.T) {
+	h := lambda.New(nil)
+
+	skip := []string{"/", "/bucket/key", "/2020-08-31/functions"}
+
+	for _, p := range skip {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		if h.Matches(req) {
+			t.Fatalf("Matches(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestCreateAndGetFunction(t *testing.T) {
+	srv, _ := newServer(t)
+
+	body := `{"FunctionName":"hello","Runtime":"go1.x","Handler":"main","MemorySize":128,"Timeout":30}`
+
+	resp := postJSON(t, srv.URL+"/2015-03-31/functions", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d, want 201", resp.StatusCode)
+	}
+
+	getResp, err := http.Get(srv.URL + "/2015-03-31/functions/hello")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("get status = %d, want 200", getResp.StatusCode)
+	}
+
+	var got struct {
+		Configuration functionShape `json:"Configuration"`
+	}
+
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Configuration.FunctionName != "hello" {
+		t.Fatalf("FunctionName = %q, want hello", got.Configuration.FunctionName)
+	}
+
+	if got.Configuration.Runtime != "go1.x" {
+		t.Fatalf("Runtime = %q, want go1.x", got.Configuration.Runtime)
+	}
+
+	if !strings.Contains(got.Configuration.FunctionArn, ":function:hello") {
+		t.Fatalf("FunctionArn = %q, want contains :function:hello", got.Configuration.FunctionArn)
+	}
+}
+
+func TestGetMissingFunctionReturns404(t *testing.T) {
+	srv, _ := newServer(t)
+
+	resp, err := http.Get(srv.URL + "/2015-03-31/functions/missing")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+
+	if got := resp.Header.Get("X-Amzn-Errortype"); got != "ResourceNotFoundException" {
+		t.Fatalf("errortype = %q, want ResourceNotFoundException", got)
+	}
+}
+
+func TestCreateDuplicateReturnsConflict(t *testing.T) {
+	srv, _ := newServer(t)
+
+	body := `{"FunctionName":"dup","Runtime":"python3.11","Handler":"app.handler"}`
+
+	first := postJSON(t, srv.URL+"/2015-03-31/functions", body)
+	if first.StatusCode != http.StatusCreated {
+		t.Fatalf("first create = %d, want 201", first.StatusCode)
+	}
+
+	second := postJSON(t, srv.URL+"/2015-03-31/functions", body)
+	if second.StatusCode != http.StatusConflict {
+		t.Fatalf("second create = %d, want 409", second.StatusCode)
+	}
+}
+
+func TestListFunctions(t *testing.T) {
+	srv, _ := newServer(t)
+
+	for _, name := range []string{"a", "b", "c"} {
+		body := `{"FunctionName":"` + name + `","Runtime":"go1.x"}`
+
+		resp := postJSON(t, srv.URL+"/2015-03-31/functions", body)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %s: %d", name, resp.StatusCode)
+		}
+	}
+
+	resp, err := http.Get(srv.URL + "/2015-03-31/functions")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	var got struct {
+		Functions []functionShape `json:"Functions"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(got.Functions) != 3 {
+		t.Fatalf("Functions count = %d, want 3", len(got.Functions))
+	}
+}
+
+func TestDeleteFunction(t *testing.T) {
+	srv, _ := newServer(t)
+
+	body := `{"FunctionName":"goner","Runtime":"go1.x"}`
+	if r := postJSON(t, srv.URL+"/2015-03-31/functions", body); r.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d", r.StatusCode)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodDelete, srv.URL+"/2015-03-31/functions/goner", nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", resp.StatusCode)
+	}
+
+	gone, err := http.Get(srv.URL + "/2015-03-31/functions/goner")
+	if err != nil {
+		t.Fatalf("post-delete get: %v", err)
+	}
+
+	defer gone.Body.Close()
+
+	if gone.StatusCode != http.StatusNotFound {
+		t.Fatalf("post-delete get = %d, want 404", gone.StatusCode)
+	}
+}
+
+func TestInvokeReturnsHandlerPayload(t *testing.T) {
+	srv, cloud := newServer(t)
+
+	body := `{"FunctionName":"echo","Runtime":"go1.x"}`
+	if r := postJSON(t, srv.URL+"/2015-03-31/functions", body); r.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d", r.StatusCode)
+	}
+
+	cloud.Lambda.RegisterHandler("echo", func(_ context.Context, payload []byte) ([]byte, error) {
+		return append([]byte(`{"echo":`), append(payload, '}')...), nil
+	})
+
+	resp, err := http.Post(srv.URL+"/2015-03-31/functions/echo/invocations",
+		"application/json", bytes.NewReader([]byte(`"hi"`)))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	got, _ := io.ReadAll(resp.Body)
+	if string(got) != `{"echo":"hi"}` {
+		t.Fatalf("body = %q, want {\"echo\":\"hi\"}", string(got))
+	}
+
+	if resp.Header.Get("X-Amz-Function-Error") != "" {
+		t.Fatalf("unexpected X-Amz-Function-Error header on success")
+	}
+}
+
+func TestInvokeMissingHandlerSignalsError(t *testing.T) {
+	srv, _ := newServer(t)
+
+	if r := postJSON(t, srv.URL+"/2015-03-31/functions",
+		`{"FunctionName":"nohandler","Runtime":"go1.x"}`); r.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d", r.StatusCode)
+	}
+
+	resp, err := http.Post(srv.URL+"/2015-03-31/functions/nohandler/invocations",
+		"application/json", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.Header.Get("X-Amz-Function-Error") == "" {
+		t.Fatal("expected X-Amz-Function-Error on no-handler invoke")
+	}
+}
+
+func TestInvokeOnMissingFunctionReturns404(t *testing.T) {
+	srv, _ := newServer(t)
+
+	resp, err := http.Post(srv.URL+"/2015-03-31/functions/missing/invocations",
+		"application/json", bytes.NewReader([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("invoke: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestEnvironmentRoundTrip(t *testing.T) {
+	srv, _ := newServer(t)
+
+	body := `{"FunctionName":"envfn","Runtime":"go1.x","Environment":{"Variables":{"K":"V"}}}`
+	if r := postJSON(t, srv.URL+"/2015-03-31/functions", body); r.StatusCode != http.StatusCreated {
+		t.Fatalf("create: %d", r.StatusCode)
+	}
+
+	getResp, err := http.Get(srv.URL + "/2015-03-31/functions/envfn")
+	if err != nil {
+		t.Fatalf("get envfn: %v", err)
+	}
+
+	defer getResp.Body.Close()
+
+	var got struct {
+		Configuration functionShape `json:"Configuration"`
+	}
+
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if got.Configuration.Environment == nil ||
+		got.Configuration.Environment.Variables["K"] != "V" {
+		t.Fatalf("environment not preserved: %+v", got.Configuration.Environment)
+	}
+}
+
+// TestDriverNilDoesNotPanic guards against a regression where the handler
+// might dereference a nil driver during routing.
+func TestDriverNilDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+
+	_ = lambda.New(stubDriver{})
+}
+
+type stubDriver struct{ sdrv.Serverless }
+
+// Helpers --------------------------------------------------------------------
+
+type envShape struct {
+	Variables map[string]string `json:"Variables"`
+}
+
+type functionShape struct {
+	FunctionName string    `json:"FunctionName"`
+	FunctionArn  string    `json:"FunctionArn"`
+	Runtime      string    `json:"Runtime"`
+	Handler      string    `json:"Handler"`
+	Environment  *envShape `json:"Environment"`
+}
+
+func postJSON(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+
+	return resp
+}

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -1,0 +1,158 @@
+package lambda_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awslambda "github.com/aws/aws-sdk-go-v2/service/lambda"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/stackshy/cloudemu"
+	awsprovider "github.com/stackshy/cloudemu/providers/aws"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newSDKClient(t *testing.T) (*awslambda.Client, *awsprovider.Provider) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{Lambda: cloud.Lambda})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awslambda.NewFromConfig(cfg, func(o *awslambda.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	return client, cloud
+}
+
+func TestSDKLambdaCreateGetDelete(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("hello"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		MemorySize:   aws.Int32(128),
+		Timeout:      aws.Int32(30),
+		Code: &lambdatypes.FunctionCode{
+			ZipFile: []byte("fake-zip"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	got, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{
+		FunctionName: aws.String("hello"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+
+	if got.Configuration == nil || aws.ToString(got.Configuration.FunctionName) != "hello" {
+		t.Fatalf("got %+v, want FunctionName=hello", got.Configuration)
+	}
+
+	if aws.ToString(got.Configuration.Handler) != "main" {
+		t.Fatalf("Handler = %q, want main", aws.ToString(got.Configuration.Handler))
+	}
+
+	if got.Configuration.MemorySize == nil || *got.Configuration.MemorySize != 128 {
+		t.Fatalf("MemorySize = %v, want 128", got.Configuration.MemorySize)
+	}
+
+	list, err := client.ListFunctions(ctx, &awslambda.ListFunctionsInput{})
+	if err != nil {
+		t.Fatalf("ListFunctions: %v", err)
+	}
+
+	if len(list.Functions) != 1 || aws.ToString(list.Functions[0].FunctionName) != "hello" {
+		t.Fatalf("Functions = %+v, want one named hello", list.Functions)
+	}
+
+	if _, err := client.DeleteFunction(ctx, &awslambda.DeleteFunctionInput{
+		FunctionName: aws.String("hello"),
+	}); err != nil {
+		t.Fatalf("DeleteFunction: %v", err)
+	}
+
+	if _, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{
+		FunctionName: aws.String("hello"),
+	}); err == nil {
+		t.Fatal("GetFunction after delete returned nil error, want NotFound")
+	}
+}
+
+func TestSDKLambdaInvoke(t *testing.T) {
+	client, cloud := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("echo"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	cloud.Lambda.RegisterHandler("echo", func(_ context.Context, payload []byte) ([]byte, error) {
+		out := append([]byte(`{"echoed":`), payload...)
+		out = append(out, '}')
+
+		return out, nil
+	})
+
+	resp, err := client.Invoke(ctx, &awslambda.InvokeInput{
+		FunctionName: aws.String("echo"),
+		Payload:      []byte(`"hi"`),
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+
+	if got := string(resp.Payload); got != `{"echoed":"hi"}` {
+		t.Fatalf("Payload = %q, want {\"echoed\":\"hi\"}", got)
+	}
+
+	if resp.FunctionError != nil && *resp.FunctionError != "" {
+		t.Fatalf("FunctionError = %q, want empty", *resp.FunctionError)
+	}
+
+	// Read+exhaust to simulate a real client clean-up — guards against any
+	// surprises if Invoke ever returns a streaming body.
+	_, _ = io.ReadAll(bytes.NewReader(resp.Payload))
+}
+
+func TestSDKLambdaInvokeOnMissingFunction(t *testing.T) {
+	client, _ := newSDKClient(t)
+
+	_, err := client.Invoke(context.Background(), &awslambda.InvokeInput{
+		FunctionName: aws.String("nope"),
+		Payload:      []byte(`{}`),
+	})
+	if err == nil {
+		t.Fatal("Invoke on missing function returned nil error, want NotFound")
+	}
+}

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -1,0 +1,59 @@
+package lambda
+
+// envEnvelope is the AWS Lambda Environment shape: {"Variables": {k: v}}.
+type envEnvelope struct {
+	Variables map[string]string `json:"Variables,omitempty"`
+}
+
+// functionConfiguration is the response body shared by Create / Get / Update.
+// Field set is the minimum the AWS SDK populates for a function description.
+type functionConfiguration struct {
+	FunctionName string       `json:"FunctionName"`
+	FunctionArn  string       `json:"FunctionArn"`
+	Runtime      string       `json:"Runtime,omitempty"`
+	Role         string       `json:"Role,omitempty"`
+	Handler      string       `json:"Handler,omitempty"`
+	Description  string       `json:"Description,omitempty"`
+	MemorySize   int          `json:"MemorySize,omitempty"`
+	Timeout      int          `json:"Timeout,omitempty"`
+	LastModified string       `json:"LastModified,omitempty"`
+	State        string       `json:"State,omitempty"`
+	CodeSha256   string       `json:"CodeSha256,omitempty"`
+	Environment  *envEnvelope `json:"Environment,omitempty"`
+	PackageType  string       `json:"PackageType,omitempty"`
+}
+
+// functionResource is the shape returned by GetFunction:
+// {Configuration, Code, Tags}. Code is a placeholder since the driver
+// doesn't persist deployment artifacts.
+type functionResource struct {
+	Configuration functionConfiguration `json:"Configuration"`
+	Code          codeLocation          `json:"Code,omitempty"`
+	Tags          map[string]string     `json:"Tags,omitempty"`
+}
+
+type codeLocation struct {
+	RepositoryType string `json:"RepositoryType,omitempty"`
+	Location       string `json:"Location,omitempty"`
+}
+
+// listFunctionsResponse is the ListFunctions response envelope.
+type listFunctionsResponse struct {
+	Functions []functionConfiguration `json:"Functions"`
+}
+
+// createFunctionRequest captures the fields we read from a CreateFunction body.
+// We deliberately ignore Code, Role (no IAM evaluation), VPCConfig, etc — the
+// portable driver doesn't model them.
+type createFunctionRequest struct {
+	FunctionName string            `json:"FunctionName"`
+	Runtime      string            `json:"Runtime"`
+	Role         string            `json:"Role"`
+	Handler      string            `json:"Handler"`
+	Description  string            `json:"Description"`
+	MemorySize   int               `json:"MemorySize"`
+	Timeout      int               `json:"Timeout"`
+	Environment  *envEnvelope      `json:"Environment"`
+	Tags         map[string]string `json:"Tags"`
+	PackageType  string            `json:"PackageType"`
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -15,12 +15,14 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/blob"
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/disks"
+	"github.com/stackshy/cloudemu/server/azure/functions"
 	"github.com/stackshy/cloudemu/server/azure/images"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/network"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
 	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
 	"github.com/stackshy/cloudemu/server/azure/virtualmachines"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
 
@@ -41,6 +43,7 @@ type Drivers struct {
 	CosmosDB        dbdriver.Database
 	Network         netdriver.Networking
 	Monitor         mondriver.Monitoring
+	Functions       sdrv.Serverless
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -51,13 +54,13 @@ type Drivers struct {
 // so handlers can register independently — virtualMachines doesn't conflict
 // with future blob storage or networking handlers.
 //
-//nolint:gocritic // Drivers is all interface fields; by-value keeps the caller API ergonomic
+//nolint:gocritic,gocyclo // Drivers is all interface fields; one if-per-driver is the simplest expression
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
-	// Register more-specific resource handlers first so their resourceType
-	// match wins over virtualMachines (which also accepts the locations
-	// sub-path used for async-operation polling).
+	// Register more-specific compute resource handlers first so their
+	// resourceType match wins over virtualMachines (which also accepts the
+	// locations sub-path used for async-operation polling).
 	if d.Disks != nil {
 		srv.Register(disks.New(d.Disks))
 	}
@@ -86,6 +89,10 @@ func New(d Drivers) *server.Server {
 
 	if d.Monitor != nil {
 		srv.Register(monitor.New(d.Monitor))
+	}
+
+	if d.Functions != nil {
+		srv.Register(functions.New(d.Functions))
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/functions/functions_test.go
+++ b/server/azure/functions/functions_test.go
@@ -1,0 +1,270 @@
+package functions_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+const (
+	subID  = "00000000-0000-0000-0000-000000000000"
+	rgName = "test-rg"
+
+	apiVer = "?api-version=2022-03-01"
+)
+
+func sitesURL(name string) string {
+	return "/subscriptions/" + subID +
+		"/resourceGroups/" + rgName +
+		"/providers/Microsoft.Web/sites/" + name
+}
+
+func collectionURL() string {
+	return "/subscriptions/" + subID +
+		"/resourceGroups/" + rgName +
+		"/providers/Microsoft.Web/sites"
+}
+
+func TestMatches_AcceptsArmAndApiPaths(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+	t.Cleanup(srv.Close)
+
+	cases := []struct {
+		method, url string
+		wantStatus  int
+	}{
+		{http.MethodGet, sitesURL("missing") + apiVer, http.StatusNotFound},
+		{http.MethodGet, collectionURL() + apiVer, http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		req, _ := http.NewRequestWithContext(context.Background(), tc.method, srv.URL+tc.url, nil)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", tc.method, tc.url, err)
+		}
+
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != tc.wantStatus {
+			t.Fatalf("%s %s status = %d, want %d", tc.method, tc.url, resp.StatusCode, tc.wantStatus)
+		}
+	}
+}
+
+func TestPutGetDeleteSiteRoundTrip(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+	t.Cleanup(srv.Close)
+
+	body := `{
+        "kind":"functionapp",
+        "location":"westus",
+        "tags":{"env":"test"},
+        "properties":{
+            "siteConfig":{
+                "linuxFxVersion":"Python|3.10",
+                "appSettings":[{"name":"K","value":"V"}]
+            },
+            "httpsOnly":true
+        }
+    }`
+
+	put := doRequest(t, srv, http.MethodPut, sitesURL("hello")+apiVer, body)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200; body=%s", put.StatusCode, readBody(t, put))
+	}
+
+	got := doRequest(t, srv, http.MethodGet, sitesURL("hello")+apiVer, "")
+	if got.StatusCode != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", got.StatusCode)
+	}
+
+	var site siteShape
+
+	if err := json.NewDecoder(got.Body).Decode(&site); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = got.Body.Close()
+
+	if site.Name != "hello" {
+		t.Fatalf("Name = %q, want hello", site.Name)
+	}
+
+	if site.Kind != "functionapp" {
+		t.Fatalf("Kind = %q, want functionapp", site.Kind)
+	}
+
+	if site.Properties.SiteConfig.LinuxFxVersion != "Python|3.10" {
+		t.Fatalf("LinuxFxVersion = %q", site.Properties.SiteConfig.LinuxFxVersion)
+	}
+
+	if !strings.Contains(site.ID, "/Microsoft.Web/sites/hello") {
+		t.Fatalf("ID = %q, want path containing /Microsoft.Web/sites/hello", site.ID)
+	}
+
+	del := doRequest(t, srv, http.MethodDelete, sitesURL("hello")+apiVer, "")
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE status = %d, want 200", del.StatusCode)
+	}
+
+	missing := doRequest(t, srv, http.MethodGet, sitesURL("hello")+apiVer, "")
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("post-delete GET = %d, want 404", missing.StatusCode)
+	}
+}
+
+func TestList(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+	t.Cleanup(srv.Close)
+
+	for _, n := range []string{"a", "b", "c"} {
+		body := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`
+
+		resp := doRequest(t, srv, http.MethodPut, sitesURL(n)+apiVer, body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("PUT %s = %d", n, resp.StatusCode)
+		}
+	}
+
+	resp := doRequest(t, srv, http.MethodGet, collectionURL()+apiVer, "")
+
+	var got struct {
+		Value []siteShape `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = resp.Body.Close()
+
+	if len(got.Value) != 3 {
+		t.Fatalf("len(value) = %d, want 3", len(got.Value))
+	}
+}
+
+func TestPutIsIdempotent(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+	t.Cleanup(srv.Close)
+
+	body := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{"linuxFxVersion":"Node|18"}}}`
+
+	first := doRequest(t, srv, http.MethodPut, sitesURL("idem")+apiVer, body)
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first PUT = %d", first.StatusCode)
+	}
+
+	body2 := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{"linuxFxVersion":"Node|20"}}}`
+
+	second := doRequest(t, srv, http.MethodPut, sitesURL("idem")+apiVer, body2)
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("second PUT = %d, want 200 (idempotent)", second.StatusCode)
+	}
+
+	got := doRequest(t, srv, http.MethodGet, sitesURL("idem")+apiVer, "")
+
+	var site siteShape
+	if err := json.NewDecoder(got.Body).Decode(&site); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = got.Body.Close()
+
+	if site.Properties.SiteConfig.LinuxFxVersion != "Node|20" {
+		t.Fatalf("LinuxFxVersion = %q, want Node|20 (after update)",
+			site.Properties.SiteConfig.LinuxFxVersion)
+	}
+}
+
+func TestInvokeRunsRegisteredHandler(t *testing.T) {
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+	t.Cleanup(srv.Close)
+
+	body := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{}}}`
+	if r := doRequest(t, srv, http.MethodPut, sitesURL("echo")+apiVer, body); r.StatusCode != http.StatusOK {
+		t.Fatalf("PUT echo = %d", r.StatusCode)
+	}
+
+	cloud.Functions.RegisterHandler("echo", func(_ context.Context, payload []byte) ([]byte, error) {
+		return append([]byte(`{"got":`), append(payload, '}')...), nil
+	})
+
+	resp := doRequest(t, srv, http.MethodPost, "/api/echo", `"hello"`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("invoke status = %d, want 200", resp.StatusCode)
+	}
+
+	out := readBody(t, resp)
+	if out != `{"got":"hello"}` {
+		t.Fatalf("body = %q, want {\"got\":\"hello\"}", out)
+	}
+}
+
+// helpers --------------------------------------------------------------------
+
+type siteShape struct {
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Kind       string             `json:"kind"`
+	Properties sitePropertiesView `json:"properties"`
+}
+
+type sitePropertiesView struct {
+	State           string         `json:"state"`
+	HostNames       []string       `json:"hostNames"`
+	DefaultHostName string         `json:"defaultHostName"`
+	SiteConfig      siteConfigView `json:"siteConfig"`
+}
+
+type siteConfigView struct {
+	LinuxFxVersion string `json:"linuxFxVersion"`
+}
+
+func doRequest(t *testing.T, srv *httptest.Server, method, path, body string) *http.Response {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), method, srv.URL+path, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+
+	return resp
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return strings.TrimSpace(string(b))
+}
+

--- a/server/azure/functions/handler.go
+++ b/server/azure/functions/handler.go
@@ -1,0 +1,309 @@
+// Package functions serves Azure ARM Microsoft.Web/sites (Function Apps)
+// requests against a CloudEmu serverless driver. Real azure-sdk-for-go
+// armappservice clients configured with a custom endpoint hit this handler
+// the same way they hit management.azure.com.
+//
+// MVP coverage:
+//
+//	PUT    .../sites/{name}      — CreateOrUpdate
+//	GET    .../sites/{name}      — Get
+//	GET    .../sites             — List in resource group / subscription
+//	DELETE .../sites/{name}      — Delete
+//	POST   /api/{name}           — Synchronous invoke (non-ARM, mirrors how
+//	                               real Function Apps are hit at
+//	                               <app>.azurewebsites.net/api/<name>)
+//
+// Versions, slots, deployment, scaling, and Kudu/SCM endpoints are deferred.
+package functions
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+const (
+	providerName = "Microsoft.Web"
+	resourceType = "sites"
+
+	functionAppKind  = "functionapp"
+	defaultLocation  = "eastus"
+	invokePathPrefix = "/api/"
+	maxInvokeBytes   = 1 << 20 // 1 MiB
+	maxControlBytes  = 1 << 20
+)
+
+// Handler serves ARM JSON requests for Microsoft.Web/sites and direct invoke
+// requests at /api/{name}.
+type Handler struct {
+	fn sdrv.Serverless
+}
+
+// New returns a Functions handler backed by fn.
+func New(fn sdrv.Serverless) *Handler {
+	return &Handler{fn: fn}
+}
+
+// Matches accepts ARM Microsoft.Web/sites paths plus the non-ARM /api/{name}
+// invoke shape.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, invokePathPrefix) {
+		return true
+	}
+
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == resourceType
+}
+
+// ServeHTTP routes requests by URL shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, invokePathPrefix) {
+		h.serveInvoke(w, r)
+		return
+	}
+
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	switch {
+	case rp.ResourceName != "":
+		h.serveResource(w, r, rp)
+	default:
+		h.serveCollection(w, r, rp)
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value; copying is cheap.
+func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdate(w, r, rp)
+	case http.MethodGet:
+		h.get(w, r, rp)
+	case http.MethodDelete:
+		h.delete(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value; copying is cheap.
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	h.list(w, r, rp)
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.ResourceGroup == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing resourceGroups segment")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxControlBytes)
+
+	var req createSiteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidRequestContent", err.Error())
+		return
+	}
+
+	cfg := sdrv.FunctionConfig{
+		Name:        rp.ResourceName,
+		Runtime:     req.Properties.SiteConfig.LinuxFxVersion,
+		Tags:        req.Tags,
+		Environment: appSettingsToMap(req.Properties.SiteConfig.AppSettings),
+	}
+
+	info, err := upsertFunction(r, h.fn, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, req))
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	info, err := h.fn.GetFunction(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toSiteResource(rp, info, createSiteRequest{}))
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) list(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	infos, err := h.fn.ListFunctions(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]siteResource, 0, len(infos))
+
+	for i := range infos {
+		scope := rp
+		scope.ResourceName = infos[i].Name
+		out = append(out, toSiteResource(scope, &infos[i], createSiteRequest{}))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, siteListResponse{Value: out})
+}
+
+//nolint:gocritic // rp travels the dispatch chain once per request.
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if err := h.fn.DeleteFunction(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) serveInvoke(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "invoke requires POST")
+		return
+	}
+
+	name := strings.TrimPrefix(r.URL.Path, invokePathPrefix)
+	if name == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing function name")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxInvokeBytes)
+
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		azurearm.WriteError(w, http.StatusRequestEntityTooLarge, "PayloadTooLarge", err.Error())
+		return
+	}
+
+	out, ierr := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
+		FunctionName: name,
+		Payload:      payload,
+		InvokeType:   "RequestResponse",
+	})
+	if ierr != nil {
+		azurearm.WriteCErr(w, ierr)
+		return
+	}
+
+	if out.Error != "" {
+		// Real Azure Functions return 500 + plain-text error body when the
+		// handler throws.
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(out.Error))
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out.Payload)
+}
+
+// upsertFunction creates the function on first call and updates it on subsequent
+// calls — ARM PUT is idempotent and SDKs use it for both.
+//
+//nolint:gocritic // cfg is the canonical request payload; copying once per PUT is fine.
+func upsertFunction(r *http.Request, fn sdrv.Serverless, cfg sdrv.FunctionConfig) (*sdrv.FunctionInfo, error) {
+	info, err := fn.CreateFunction(r.Context(), cfg)
+	if err == nil {
+		return info, nil
+	}
+
+	if !cerrors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	return fn.UpdateFunction(r.Context(), cfg.Name, cfg)
+}
+
+//nolint:gocritic // rp is request-scoped.
+func toSiteResource(rp azurearm.ResourcePath, info *sdrv.FunctionInfo, req createSiteRequest) siteResource {
+	location := req.Location
+	if location == "" {
+		location = defaultLocation
+	}
+
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
+		providerName, resourceType, rp.ResourceName)
+
+	hostName := info.Name + ".azurewebsites.net"
+
+	settings := req.Properties.SiteConfig.AppSettings
+	if len(settings) == 0 {
+		settings = mapToAppSettings(info.Environment)
+	}
+
+	return siteResource{
+		ID:       id,
+		Name:     info.Name,
+		Type:     providerName + "/" + resourceType,
+		Kind:     functionAppKind,
+		Location: location,
+		Tags:     info.Tags,
+		Properties: siteProperties{
+			State:           "Running",
+			HostNames:       []string{hostName},
+			DefaultHostName: hostName,
+			SiteConfig: siteConfig{
+				LinuxFxVersion: info.Runtime,
+				AppSettings:    settings,
+			},
+			ServerFarmID:        req.Properties.ServerFarmID,
+			HTTPSOnly:           req.Properties.HTTPSOnly,
+			Reserved:            req.Properties.Reserved,
+			LastModifiedTimeUtc: time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+}
+
+func appSettingsToMap(settings []nameValue) map[string]string {
+	if len(settings) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(settings))
+	for _, kv := range settings {
+		out[kv.Name] = kv.Value
+	}
+
+	return out
+}
+
+func mapToAppSettings(env map[string]string) []nameValue {
+	if len(env) == 0 {
+		return nil
+	}
+
+	out := make([]nameValue, 0, len(env))
+	for k, v := range env {
+		out = append(out, nameValue{Name: k, Value: v})
+	}
+
+	return out
+}

--- a/server/azure/functions/sdk_roundtrip_test.go
+++ b/server/azure/functions/sdk_roundtrip_test.go
@@ -1,0 +1,130 @@
+package functions_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3"
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// fakeCred is a static-token credential for tests. The handler ignores the
+// Authorization header but the SDK still demands a TokenCredential.
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newWebAppsClient(t *testing.T, ts *httptest.Server) *armappservice.WebAppsClient {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	clientFactory, err := armappservice.NewClientFactory(subID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewClientFactory: %v", err)
+	}
+
+	return clientFactory.NewWebAppsClient()
+}
+
+func TestSDKAzureFunctionsCreateGetDelete(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Functions: cloudP.Functions})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newWebAppsClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rgName, "sdk-fn",
+		armappservice.Site{
+			Kind:     to.Ptr("functionapp"),
+			Location: to.Ptr("eastus"),
+			Properties: &armappservice.SiteProperties{
+				HTTPSOnly: to.Ptr(true),
+				SiteConfig: &armappservice.SiteConfig{
+					LinuxFxVersion: to.Ptr("Python|3.10"),
+				},
+			},
+		},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, &runtimePollerOptions)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "sdk-fn" {
+		t.Fatalf("created Name = %v, want sdk-fn", created.Name)
+	}
+
+	if created.Kind == nil || *created.Kind != "functionapp" {
+		t.Fatalf("created Kind = %v, want functionapp", created.Kind)
+	}
+
+	got, err := client.Get(ctx, rgName, "sdk-fn", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "sdk-fn" {
+		t.Fatalf("got Name = %v, want sdk-fn", got.Name)
+	}
+
+	if got.Properties == nil ||
+		got.Properties.SiteConfig == nil ||
+		got.Properties.SiteConfig.LinuxFxVersion == nil ||
+		*got.Properties.SiteConfig.LinuxFxVersion != "Python|3.10" {
+		t.Fatalf("LinuxFxVersion not preserved: %+v", got.Properties)
+	}
+
+	if _, err := client.Delete(ctx, rgName, "sdk-fn", nil); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := client.Get(ctx, rgName, "sdk-fn", nil); err == nil {
+		t.Fatal("post-delete Get returned nil error, want NotFound")
+	}
+}
+
+// runtimePollerOptions is a zero-frequency poll override so the SDK doesn't
+// sleep between status polls in tests.
+//
+//nolint:gochecknoglobals // exported only to test files in this package.
+var runtimePollerOptions = pollerOptionsZeroFrequency()
+
+func pollerOptionsZeroFrequency() runtime.PollUntilDoneOptions {
+	return runtime.PollUntilDoneOptions{Frequency: time.Millisecond}
+}

--- a/server/azure/functions/types.go
+++ b/server/azure/functions/types.go
@@ -1,0 +1,64 @@
+package functions
+
+// siteResource is the ARM JSON shape for Microsoft.Web/sites returned to the
+// SDK. We populate the fields a Functions client needs to navigate the site
+// (id, name, type, kind, location, basic properties) and skip the long tail
+// of feature flags real App Service surfaces.
+type siteResource struct {
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Kind       string            `json:"kind"`
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties siteProperties    `json:"properties"`
+}
+
+type siteProperties struct {
+	State               string            `json:"state"`
+	HostNames           []string          `json:"hostNames"`
+	DefaultHostName     string            `json:"defaultHostName"`
+	SiteConfig          siteConfig        `json:"siteConfig"`
+	Reserved            bool              `json:"reserved,omitempty"`
+	ServerFarmID        string            `json:"serverFarmId,omitempty"`
+	HTTPSOnly           bool              `json:"httpsOnly,omitempty"`
+	Tags                map[string]string `json:"tags,omitempty"`
+	LastModifiedTimeUtc string            `json:"lastModifiedTimeUtc,omitempty"`
+}
+
+type siteConfig struct {
+	LinuxFxVersion      string      `json:"linuxFxVersion,omitempty"`
+	NetFrameworkVersion string      `json:"netFrameworkVersion,omitempty"`
+	AppSettings         []nameValue `json:"appSettings,omitempty"`
+}
+
+type nameValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// siteListResponse is the {value: [...]} envelope ARM uses for collection responses.
+type siteListResponse struct {
+	Value []siteResource `json:"value"`
+}
+
+// createSiteRequest captures the fields we read from a PUT body. Real Azure
+// accepts dozens of properties; the driver only models the basics.
+type createSiteRequest struct {
+	Kind       string               `json:"kind"`
+	Location   string               `json:"location"`
+	Tags       map[string]string    `json:"tags"`
+	Properties createSiteProperties `json:"properties"`
+}
+
+type createSiteProperties struct {
+	SiteConfig   createSiteConfig `json:"siteConfig"`
+	Reserved     bool             `json:"reserved"`
+	ServerFarmID string           `json:"serverFarmId"`
+	HTTPSOnly    bool             `json:"httpsOnly"`
+}
+
+type createSiteConfig struct {
+	LinuxFxVersion string      `json:"linuxFxVersion"`
+	AppSettings    []nameValue `json:"appSettings"`
+}

--- a/server/gcp/cloudfunctions/cloudfunctions_test.go
+++ b/server/gcp/cloudfunctions/cloudfunctions_test.go
@@ -1,0 +1,290 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const (
+	project  = "demo-project"
+	location = "us-central1"
+)
+
+func functionsURL() string {
+	return "/v1/projects/" + project + "/locations/" + location + "/functions"
+}
+
+func TestMatchesAcceptsLocationsFunctions(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions}))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + functionsURL())
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestMatchesRejectsFirestorePath(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+		CloudFunctions: cloud.CloudFunctions,
+		Firestore:      cloud.Firestore,
+	}))
+	t.Cleanup(srv.Close)
+
+	// Firestore path must NOT be claimed by cloudfunctions.
+	body := strings.NewReader(`{"writes":[]}`)
+
+	resp, err := http.Post(
+		srv.URL+"/v1/projects/"+project+"/databases/(default)/documents:commit",
+		"application/json", body,
+	)
+	if err != nil {
+		t.Fatalf("POST firestore: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	// Expect Firestore handler to claim it (200 OK with empty writeResults).
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("firestore commit status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestCreateGetDeleteRoundTrip(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions}))
+	t.Cleanup(srv.Close)
+
+	body := `{
+        "name":"projects/demo-project/locations/us-central1/functions/hello",
+        "runtime":"go121",
+        "entryPoint":"Hello",
+        "availableMemoryMb":256,
+        "timeout":"60s",
+        "labels":{"env":"test"}
+    }`
+
+	createResp, err := http.Post(srv.URL+functionsURL(), "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	defer createResp.Body.Close()
+
+	if createResp.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d, want 200", createResp.StatusCode)
+	}
+
+	var op operationShape
+
+	if err := json.NewDecoder(createResp.Body).Decode(&op); err != nil {
+		t.Fatalf("decode op: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("op.Done = false, want true (LRO returns immediately)")
+	}
+
+	if !strings.Contains(op.Name, "operations/create-hello") {
+		t.Fatalf("op name = %q, want contains operations/create-hello", op.Name)
+	}
+
+	getResp, err := http.Get(srv.URL + functionsURL() + "/hello")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Fatalf("get status = %d, want 200", getResp.StatusCode)
+	}
+
+	var fn cloudFunctionShape
+
+	if err := json.NewDecoder(getResp.Body).Decode(&fn); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+
+	if fn.Runtime != "go121" {
+		t.Fatalf("runtime = %q, want go121", fn.Runtime)
+	}
+
+	if fn.EntryPoint != "Hello" {
+		t.Fatalf("entryPoint = %q, want Hello", fn.EntryPoint)
+	}
+
+	if fn.AvailableMemory != 256 {
+		t.Fatalf("availableMemoryMb = %d, want 256", fn.AvailableMemory)
+	}
+
+	if fn.Timeout != "60s" {
+		t.Fatalf("timeout = %q, want 60s", fn.Timeout)
+	}
+
+	delReq, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodDelete, srv.URL+functionsURL()+"/hello", nil)
+
+	delResp, err := http.DefaultClient.Do(delReq)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status = %d", delResp.StatusCode)
+	}
+
+	missing, err := http.Get(srv.URL + functionsURL() + "/hello")
+	if err != nil {
+		t.Fatalf("post-delete get: %v", err)
+	}
+
+	defer missing.Body.Close()
+
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("post-delete get = %d, want 404", missing.StatusCode)
+	}
+}
+
+func TestList(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions}))
+	t.Cleanup(srv.Close)
+
+	for _, n := range []string{"a", "b"} {
+		body := `{"name":"projects/demo-project/locations/us-central1/functions/` + n + `","runtime":"go121"}`
+
+		resp, err := http.Post(srv.URL+functionsURL(), "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("create %s: %v", n, err)
+		}
+
+		_ = resp.Body.Close()
+	}
+
+	resp, err := http.Get(srv.URL + functionsURL())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	var got struct {
+		Functions []cloudFunctionShape `json:"functions"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(got.Functions) != 2 {
+		t.Fatalf("len(functions) = %d, want 2", len(got.Functions))
+	}
+}
+
+func TestCallInvokesHandler(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions}))
+	t.Cleanup(srv.Close)
+
+	body := `{"name":"projects/demo-project/locations/us-central1/functions/echo","runtime":"go121"}`
+	if r, _ := http.Post(srv.URL+functionsURL(), "application/json", strings.NewReader(body)); r != nil {
+		_ = r.Body.Close()
+	}
+
+	cloud.CloudFunctions.RegisterHandler("echo", func(_ context.Context, payload []byte) ([]byte, error) {
+		return []byte("got:" + string(payload)), nil
+	})
+
+	resp, err := http.Post(
+		srv.URL+functionsURL()+"/echo:call",
+		"application/json",
+		strings.NewReader(`{"data":"hello"}`),
+	)
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	out, _ := io.ReadAll(resp.Body)
+
+	var cr struct {
+		Result string `json:"result"`
+		Error  string `json:"error"`
+	}
+
+	if err := json.Unmarshal(out, &cr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if cr.Error != "" {
+		t.Fatalf("call error = %q, want empty", cr.Error)
+	}
+
+	if cr.Result != "got:hello" {
+		t.Fatalf("result = %q, want got:hello", cr.Result)
+	}
+}
+
+func TestOperationPoll(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions}))
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/operations/some-op-id")
+	if err != nil {
+		t.Fatalf("op poll: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	var op operationShape
+
+	if err := json.NewDecoder(resp.Body).Decode(&op); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("op.Done = false, want true")
+	}
+}
+
+// helpers --------------------------------------------------------------------
+
+type operationShape struct {
+	Name string `json:"name"`
+	Done bool   `json:"done"`
+}
+
+type cloudFunctionShape struct {
+	Name            string            `json:"name"`
+	Status          string            `json:"status"`
+	Runtime         string            `json:"runtime"`
+	EntryPoint      string            `json:"entryPoint"`
+	AvailableMemory int               `json:"availableMemoryMb"`
+	Timeout         string            `json:"timeout"`
+	Labels          map[string]string `json:"labels"`
+}

--- a/server/gcp/cloudfunctions/handler.go
+++ b/server/gcp/cloudfunctions/handler.go
@@ -1,0 +1,472 @@
+// Package cloudfunctions implements the GCP Cloud Functions v1 REST API as
+// a server.Handler. Real cloud.google.com/go/functions/apiv1 clients
+// configured with a custom endpoint hit this handler the same way they hit
+// cloudfunctions.googleapis.com.
+//
+// MVP coverage:
+//
+//	POST   /v1/projects/{p}/locations/{l}/functions             — Create (LRO)
+//	GET    /v1/projects/{p}/locations/{l}/functions/{name}      — Get
+//	GET    /v1/projects/{p}/locations/{l}/functions             — List
+//	DELETE /v1/projects/{p}/locations/{l}/functions/{name}      — Delete (LRO)
+//	POST   /v1/projects/{p}/locations/{l}/functions/{name}:call — Synchronous invoke
+//	GET    /v1/operations/{op}                                  — Poll an LRO
+//
+// All mutating endpoints return Operation envelopes with done=true so SDK
+// pollers terminate on the first response.
+package cloudfunctions
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+const (
+	pathPrefix      = "/v1/projects/"
+	functionsSeg    = "functions"
+	locationsSeg    = "locations"
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 5 << 20
+)
+
+// Handler serves GCP Cloud Functions v1 REST requests against a serverless
+// driver.
+type Handler struct {
+	fn sdrv.Serverless
+}
+
+// New returns a Cloud Functions handler backed by fn.
+func New(fn sdrv.Serverless) *Handler {
+	return &Handler{fn: fn}
+}
+
+// Matches accepts paths that look like Cloud Functions v1: either an LRO poll
+// (/v1/operations/...) or a /v1/projects/{p}/locations/{l}/functions[/...]
+// path. The locations+functions segment guards us from shadowing Firestore's
+// /v1/projects/{p}/databases/... URLs.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, "/v1/operations/") {
+		return true
+	}
+
+	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+		return false
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, pathPrefix)
+
+	// rest is "{project}/locations/{location}/functions[/...]"
+	parts := strings.Split(rest, "/")
+
+	const (
+		idxScope = 1 // locations
+		idxType  = 3 // functions
+	)
+
+	if len(parts) <= idxType {
+		return false
+	}
+
+	if parts[idxScope] != locationsSeg {
+		return false
+	}
+
+	// Strip ":action" suffix from the last segment for the type-equality check.
+	typePart := parts[idxType]
+	if i := strings.Index(typePart, ":"); i >= 0 {
+		typePart = typePart[:i]
+	}
+
+	return typePart == functionsSeg
+}
+
+// ServeHTTP routes requests by URL shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/v1/operations/") {
+		h.serveOperation(w, r)
+		return
+	}
+
+	parts, ok := parseFunctionsPath(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported path")
+		return
+	}
+
+	if parts.action == "call" && parts.name != "" {
+		h.serveCall(w, r, parts)
+		return
+	}
+
+	if parts.name != "" {
+		h.serveResource(w, r, parts)
+		return
+	}
+
+	h.serveCollection(w, r, parts)
+}
+
+func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, p functionPath) {
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, r, p)
+	case http.MethodPatch:
+		h.update(w, r, p)
+	case http.MethodDelete:
+		h.delete(w, r, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, p functionPath) {
+	switch r.Method {
+	case http.MethodPost:
+		h.create(w, r, p)
+	case http.MethodGet:
+		h.list(w, r, p)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+// serveOperation answers GET /v1/operations/{name}. We always return done=true
+// because mutations are synchronous in the mock; a poll is just an echo.
+func (*Handler) serveOperation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	opName := strings.TrimPrefix(r.URL.Path, "/v1/")
+	writeJSON(w, http.StatusOK, operation{Name: opName, Done: true})
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request, p functionPath) {
+	// Real Cloud Functions accepts the function name in either the body or as a
+	// "?functionId=" query parameter. SDKs use the body.
+	var body cloudFunction
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	name := lastSegment(body.Name)
+	if name == "" {
+		name = r.URL.Query().Get("functionId")
+	}
+
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "function name required")
+		return
+	}
+
+	cfg := sdrv.FunctionConfig{
+		Name:        name,
+		Runtime:     body.Runtime,
+		Handler:     body.EntryPoint,
+		Memory:      body.AvailableMemory,
+		Tags:        body.Labels,
+		Environment: body.EnvVariables,
+		Timeout:     parseTimeoutSeconds(body.Timeout),
+	}
+
+	info, err := h.fn.CreateFunction(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resource := toCloudFunction(info, p)
+
+	writeJSON(w, http.StatusOK, operation{
+		Name:     "operations/create-" + name + "-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		Done:     true,
+		Response: resourceAsResponse(resource, "CloudFunction"),
+	})
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request, p functionPath) {
+	info, err := h.fn.GetFunction(r.Context(), p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toCloudFunction(info, p))
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request, p functionPath) {
+	infos, err := h.fn.ListFunctions(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listFunctionsResponse{Functions: make([]cloudFunction, 0, len(infos))}
+	for i := range infos {
+		out.Functions = append(out.Functions, toCloudFunction(&infos[i], p))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, p functionPath) {
+	var body cloudFunction
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := sdrv.FunctionConfig{
+		Name:        p.name,
+		Runtime:     body.Runtime,
+		Handler:     body.EntryPoint,
+		Memory:      body.AvailableMemory,
+		Tags:        body.Labels,
+		Environment: body.EnvVariables,
+		Timeout:     parseTimeoutSeconds(body.Timeout),
+	}
+
+	info, err := h.fn.UpdateFunction(r.Context(), p.name, cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resource := toCloudFunction(info, p)
+	writeJSON(w, http.StatusOK, operation{
+		Name:     "operations/update-" + p.name,
+		Done:     true,
+		Response: resourceAsResponse(resource, "CloudFunction"),
+	})
+}
+
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request, p functionPath) {
+	if err := h.fn.DeleteFunction(r.Context(), p.name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, operation{
+		Name: "operations/delete-" + p.name,
+		Done: true,
+	})
+}
+
+func (h *Handler) serveCall(w http.ResponseWriter, r *http.Request, p functionPath) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	var req callRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	out, err := h.fn.Invoke(r.Context(), sdrv.InvokeInput{
+		FunctionName: p.name,
+		Payload:      []byte(req.Data),
+		InvokeType:   "RequestResponse",
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resp := callResponse{
+		ExecutionID: strconv.FormatInt(time.Now().UnixNano(), 10),
+	}
+
+	if out.Error != "" {
+		resp.Error = out.Error
+	} else {
+		resp.Result = string(out.Payload)
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// functionPath holds the components of a Cloud Functions URL.
+type functionPath struct {
+	project  string
+	location string
+	name     string
+	action   string // "call", etc.
+}
+
+// fullName returns the canonical resource name "projects/{p}/locations/{l}/functions/{n}".
+func (p functionPath) fullName() string {
+	return "projects/" + p.project + "/locations/" + p.location + "/functions/" + p.name
+}
+
+// parseFunctionsPath extracts components from a Cloud Functions v1 URL.
+//
+//	/v1/projects/{p}/locations/{l}/functions
+//	/v1/projects/{p}/locations/{l}/functions/{name}
+//	/v1/projects/{p}/locations/{l}/functions/{name}:{action}
+func parseFunctionsPath(path string) (functionPath, bool) {
+	rest := strings.TrimPrefix(path, pathPrefix)
+
+	parts := strings.Split(rest, "/")
+
+	const (
+		minParts    = 4 // {project}/locations/{location}/functions
+		idxProject  = 0
+		idxScope    = 1
+		idxLocation = 2
+		idxType     = 3
+		idxName     = 4
+	)
+
+	if len(parts) < minParts || parts[idxScope] != locationsSeg {
+		return functionPath{}, false
+	}
+
+	typePart := parts[idxType]
+	if typePart != functionsSeg {
+		// Could be "functions:action" with no name on the collection.
+		base, action, hasAction := splitColon(typePart)
+		if !hasAction || base != functionsSeg {
+			return functionPath{}, false
+		}
+
+		return functionPath{
+			project: parts[idxProject], location: parts[idxLocation], action: action,
+		}, true
+	}
+
+	out := functionPath{
+		project:  parts[idxProject],
+		location: parts[idxLocation],
+	}
+
+	if len(parts) > idxName {
+		nameWithAction := strings.Join(parts[idxName:], "/")
+		if base, action, ok := splitColon(nameWithAction); ok {
+			out.name = base
+			out.action = action
+		} else {
+			out.name = nameWithAction
+		}
+	}
+
+	return out, true
+}
+
+func splitColon(s string) (base, action string, ok bool) {
+	i := strings.LastIndex(s, ":")
+	if i < 0 {
+		return s, "", false
+	}
+
+	return s[:i], s[i+1:], true
+}
+
+func lastSegment(name string) string {
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		return name[i+1:]
+	}
+
+	return name
+}
+
+func parseTimeoutSeconds(t string) int {
+	t = strings.TrimSuffix(t, "s")
+
+	n, err := strconv.Atoi(t)
+	if err != nil {
+		return 0
+	}
+
+	return n
+}
+
+func toCloudFunction(info *sdrv.FunctionInfo, p functionPath) cloudFunction {
+	scope := p
+	scope.name = info.Name
+
+	cf := cloudFunction{
+		Name:            scope.fullName(),
+		Status:          "ACTIVE",
+		Runtime:         info.Runtime,
+		EntryPoint:      info.Handler,
+		AvailableMemory: info.Memory,
+		Labels:          info.Tags,
+		EnvVariables:    info.Environment,
+		UpdateTime:      info.LastModified,
+		VersionID:       "1",
+	}
+
+	if info.Timeout > 0 {
+		cf.Timeout = strconv.Itoa(info.Timeout) + "s"
+	}
+
+	return cf
+}
+
+//nolint:gocritic // cf is the response body shape; one copy per LRO response is fine.
+func resourceAsResponse(cf cloudFunction, kind string) map[string]any {
+	b, err := json.Marshal(cf)
+	if err != nil {
+		return nil
+	}
+
+	out := map[string]any{
+		"@type": "type.googleapis.com/google.cloud.functions.v1." + kind,
+	}
+
+	var fields map[string]any
+	_ = json.Unmarshal(b, &fields)
+
+	for k, v := range fields {
+		out[k] = v
+	}
+
+	return out
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, reason, msg string) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": msg,
+			"status":  reason,
+		},
+	})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/gcp/cloudfunctions/sdk_roundtrip_test.go
+++ b/server/gcp/cloudfunctions/sdk_roundtrip_test.go
@@ -1,0 +1,144 @@
+package cloudfunctions_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+	"google.golang.org/api/cloudfunctions/v1"
+	"google.golang.org/api/option"
+)
+
+func newGCPSDKService(t *testing.T) *cloudfunctions.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := cloudfunctions.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestSDKCloudFunctionsCreateGetListDelete(t *testing.T) {
+	svc := newGCPSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/demo/locations/us-central1"
+
+	op, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:              parent + "/functions/hello",
+		Runtime:           "go121",
+		EntryPoint:        "Hello",
+		AvailableMemoryMb: 128,
+		Timeout:           "60s",
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatal("Create operation not done")
+	}
+
+	got, err := svc.Projects.Locations.Functions.Get(parent + "/functions/hello").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Runtime != "go121" {
+		t.Fatalf("Runtime = %q, want go121", got.Runtime)
+	}
+
+	if got.EntryPoint != "Hello" {
+		t.Fatalf("EntryPoint = %q, want Hello", got.EntryPoint)
+	}
+
+	if got.AvailableMemoryMb != 128 {
+		t.Fatalf("AvailableMemoryMb = %d, want 128", got.AvailableMemoryMb)
+	}
+
+	if !strings.HasSuffix(got.Name, "/functions/hello") {
+		t.Fatalf("Name = %q, want suffix /functions/hello", got.Name)
+	}
+
+	listResp, err := svc.Projects.Locations.Functions.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(listResp.Functions) != 1 {
+		t.Fatalf("listed %d functions, want 1", len(listResp.Functions))
+	}
+
+	delOp, err := svc.Projects.Locations.Functions.Delete(parent + "/functions/hello").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if !delOp.Done {
+		t.Fatal("Delete operation not done")
+	}
+
+	if _, err := svc.Projects.Locations.Functions.Get(parent + "/functions/hello").
+		Context(ctx).Do(); err == nil {
+		t.Fatal("post-delete Get returned nil error, want NotFound")
+	}
+}
+
+func TestSDKCloudFunctionsCall(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudFunctions: cloud.CloudFunctions})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := cloudfunctions.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	parent := "projects/demo/locations/us-central1"
+
+	if _, err := svc.Projects.Locations.Functions.Create(parent, &cloudfunctions.CloudFunction{
+		Name:    parent + "/functions/echo",
+		Runtime: "go121",
+	}).Context(context.Background()).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	cloud.CloudFunctions.RegisterHandler("echo", func(_ context.Context, payload []byte) ([]byte, error) {
+		return []byte("got:" + string(payload)), nil
+	})
+
+	resp, err := svc.Projects.Locations.Functions.Call(
+		parent+"/functions/echo",
+		&cloudfunctions.CallFunctionRequest{Data: "hello"},
+	).Context(context.Background()).Do()
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	if resp.Result != "got:hello" {
+		t.Fatalf("Result = %q, want got:hello", resp.Result)
+	}
+
+	if resp.Error != "" {
+		t.Fatalf("Error = %q, want empty", resp.Error)
+	}
+}

--- a/server/gcp/cloudfunctions/types.go
+++ b/server/gcp/cloudfunctions/types.go
@@ -1,0 +1,57 @@
+package cloudfunctions
+
+// cloudFunction is the v1 GCP Cloud Functions resource shape returned by
+// Get / Create / Update.
+type cloudFunction struct {
+	Name             string            `json:"name"`
+	Description      string            `json:"description,omitempty"`
+	SourceArchiveURL string            `json:"sourceArchiveUrl,omitempty"`
+	HTTPSTrigger     *httpsTrigger     `json:"httpsTrigger,omitempty"`
+	Status           string            `json:"status"`
+	EntryPoint       string            `json:"entryPoint,omitempty"`
+	Runtime          string            `json:"runtime,omitempty"`
+	Timeout          string            `json:"timeout,omitempty"`
+	AvailableMemory  int               `json:"availableMemoryMb,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	EnvVariables     map[string]string `json:"environmentVariables,omitempty"`
+	UpdateTime       string            `json:"updateTime,omitempty"`
+	VersionID        string            `json:"versionId,omitempty"`
+}
+
+type httpsTrigger struct {
+	URL string `json:"url"`
+}
+
+// listFunctionsResponse is the {functions: [...]} envelope returned by
+// projects.locations.functions.list.
+type listFunctionsResponse struct {
+	Functions []cloudFunction `json:"functions"`
+}
+
+// operation is the google.longrunning.Operation envelope used by mutating
+// endpoints. Real GCP returns done=false initially and clients poll; our mock
+// returns done=true immediately so SDKs see completion on the first call.
+type operation struct {
+	Name     string         `json:"name"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+	Done     bool           `json:"done"`
+	Response map[string]any `json:"response,omitempty"`
+	Error    *opError       `json:"error,omitempty"`
+}
+
+type opError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// callRequest is the body of POST functions/{name}:call.
+type callRequest struct {
+	Data string `json:"data"`
+}
+
+// callResponse is the body of a successful :call.
+type callResponse struct {
+	ExecutionID string `json:"executionId"`
+	Result      string `json:"result,omitempty"`
+	Error       string `json:"error,omitempty"`
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -12,21 +12,24 @@ import (
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
 	"github.com/stackshy/cloudemu/server/gcp/firestore"
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
 
 // Drivers bundles the driver interfaces the GCP server can expose.
 type Drivers struct {
-	Compute    computedriver.Compute
-	Storage    storagedriver.Bucket
-	Firestore  dbdriver.Database
-	Networking netdriver.Networking
-	Monitoring mondriver.Monitoring
+	Compute        computedriver.Compute
+	Storage        storagedriver.Bucket
+	Firestore      dbdriver.Database
+	Networking     netdriver.Networking
+	Monitoring     mondriver.Monitoring
+	CloudFunctions sdrv.Serverless
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -48,6 +51,13 @@ func New(d Drivers) *server.Server {
 
 	if d.Networking != nil {
 		srv.Register(networks.New(d.Networking))
+	}
+
+	// CloudFunctions matches /v1/projects/{p}/locations/{l}/functions paths
+	// before Firestore so the locations+functions guard wins over Firestore's
+	// /v1/projects/ prefix match.
+	if d.CloudFunctions != nil {
+		srv.Register(cloudfunctions.New(d.CloudFunctions))
 	}
 
 	if d.Firestore != nil {

--- a/serverless_sdk_compat_test.go
+++ b/serverless_sdk_compat_test.go
@@ -1,0 +1,189 @@
+package cloudemu_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+	sdrv "github.com/stackshy/cloudemu/serverless/driver"
+)
+
+// TestServerlessSDKCompat_CrossProvider verifies that all 3 provider-specific
+// SDK-compat servers (AWS Lambda, Azure Functions, GCP Cloud Functions) are
+// properly registered through their respective server factories and serve
+// the same lifecycle (create → invoke → delete) when driven over HTTP.
+//
+// The test uses raw HTTP rather than each cloud's official SDK so it
+// verifies the wire-format paths in the same place that
+// SetMonitoring-style cross-service wiring is asserted.
+func TestServerlessSDKCompat_CrossProvider(t *testing.T) {
+	t.Run("aws", func(t *testing.T) {
+		cloud := cloudemu.NewAWS()
+		ts := httptest.NewServer(awsserver.New(awsserver.Drivers{Lambda: cloud.Lambda}))
+		t.Cleanup(ts.Close)
+
+		registerEcho(cloud.Lambda, "echo")
+
+		// Create.
+		body := `{"FunctionName":"echo","Runtime":"go1.x","Handler":"main"}`
+		mustStatus(t, postJSON(t, ts.URL+"/2015-03-31/functions", body), http.StatusCreated)
+
+		// Invoke.
+		invoke := postJSON(t, ts.URL+"/2015-03-31/functions/echo/invocations", `"hi"`)
+		mustStatus(t, invoke, http.StatusOK)
+
+		got := readBody(t, invoke)
+		if got != `{"echoed":"hi"}` {
+			t.Fatalf("invoke body = %q, want {\"echoed\":\"hi\"}", got)
+		}
+
+		// Delete.
+		mustStatus(t, mustDelete(t, ts.URL+"/2015-03-31/functions/echo"), http.StatusNoContent)
+	})
+
+	t.Run("azure", func(t *testing.T) {
+		cloud := cloudemu.NewAzure()
+		ts := httptest.NewServer(azureserver.New(azureserver.Drivers{Functions: cloud.Functions}))
+		t.Cleanup(ts.Close)
+
+		registerEcho(cloud.Functions, "echo")
+
+		const (
+			subID  = "00000000-0000-0000-0000-000000000000"
+			rgName = "rg-test"
+			apiVer = "?api-version=2022-03-01"
+		)
+		baseURL := ts.URL + "/subscriptions/" + subID +
+			"/resourceGroups/" + rgName +
+			"/providers/Microsoft.Web/sites/echo"
+
+		body := `{"kind":"functionapp","location":"eastus","properties":{"siteConfig":{"linuxFxVersion":"Python|3.10"}}}`
+		mustStatus(t, putJSON(t, baseURL+apiVer, body), http.StatusOK)
+
+		// Invoke via the non-ARM /api/{name} surface.
+		invoke := postJSON(t, ts.URL+"/api/echo", `"hi"`)
+		mustStatus(t, invoke, http.StatusOK)
+
+		got := readBody(t, invoke)
+		if got != `{"echoed":"hi"}` {
+			t.Fatalf("invoke body = %q, want {\"echoed\":\"hi\"}", got)
+		}
+
+		mustStatus(t, mustDelete(t, baseURL+apiVer), http.StatusOK)
+	})
+
+	t.Run("gcp", func(t *testing.T) {
+		cloud := cloudemu.NewGCP()
+		ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+			CloudFunctions: cloud.CloudFunctions,
+			Firestore:      cloud.Firestore, // exercise registration ordering
+		}))
+		t.Cleanup(ts.Close)
+
+		registerEcho(cloud.CloudFunctions, "echo")
+
+		base := ts.URL + "/v1/projects/demo/locations/us-central1/functions"
+
+		body := `{"name":"projects/demo/locations/us-central1/functions/echo","runtime":"go121","entryPoint":"H"}`
+		mustStatus(t, postJSON(t, base, body), http.StatusOK)
+
+		// :call invoke. The `data` field carries the raw payload as a string,
+		// so we send the JSON literal "hi" (with embedded quotes) to match
+		// the AWS/Azure shape the echo handler produces.
+		invoke := postJSON(t, base+"/echo:call", `{"data":"\"hi\""}`)
+		mustStatus(t, invoke, http.StatusOK)
+
+		var cr struct {
+			Result string `json:"result"`
+			Error  string `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(readBody(t, invoke)), &cr); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		if cr.Result != `{"echoed":"hi"}` {
+			t.Fatalf("call result = %q, want {\"echoed\":\"hi\"}", cr.Result)
+		}
+
+		mustStatus(t, mustDelete(t, base+"/echo"), http.StatusOK)
+	})
+}
+
+// registerEcho wires a deterministic handler so all 3 provider tests can
+// assert the same expected output.
+func registerEcho(fn sdrv.Serverless, name string) {
+	fn.RegisterHandler(name, func(_ context.Context, payload []byte) ([]byte, error) {
+		out := append([]byte(`{"echoed":`), payload...)
+		out = append(out, '}')
+		return out, nil
+	})
+}
+
+func postJSON(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+
+	return resp
+}
+
+func putJSON(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPut, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT %s: %v", url, err)
+	}
+
+	return resp
+}
+
+func mustDelete(t *testing.T, url string) *http.Response {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+
+	return resp
+}
+
+func mustStatus(t *testing.T, resp *http.Response, want int) {
+	t.Helper()
+
+	if resp.StatusCode != want {
+		body := readBody(t, resp)
+		t.Fatalf("status = %d, want %d; body = %s", resp.StatusCode, want, body)
+	}
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return strings.TrimSpace(string(b))
+}


### PR DESCRIPTION
## Summary

Adds SDK-compat HTTP servers for serverless across all 3 providers, achieving lockstep parity with the storage / database / networking / monitoring work shipped in #138–#140.

- **server/aws/lambda** — REST + JSON, mounts under `/2015-03-31/functions`. `awsserver.Drivers.Lambda` field.
- **server/azure/functions** — ARM `Microsoft.Web/sites` + non-ARM `/api/{name}` invoke surface. `azureserver.Drivers.Functions` field.
- **server/gcp/cloudfunctions** — v1 REST under `/v1/projects/{p}/locations/{l}/functions` with LRO envelopes (done=true). `gcpserver.Drivers.CloudFunctions` field.

## Scope (MVP — Phase 1)

CreateFunction, GetFunction, ListFunctions, DeleteFunction, synchronous Invoke. Versions, aliases, layers, concurrency configs, event source mappings are deferred to a follow-up PR — the portable `serverless/driver` already supports them but the wire surface is not wired through yet.

## Registration ordering

- AWS Lambda registers before S3 (S3 is the REST catch-all)
- GCP Cloud Functions registers before Firestore (both share `/v1/projects/...`; the locations+functions guard wins)
- Azure Functions registers before BlobStorage (Blob is the data-plane catch-all)

## Tests

- **Per-handler unit tests** (raw HTTP via `httptest`) — lifecycle, error cases, invoke success/failure, registration ordering
- **Real-SDK round-trip tests** with the official cloud SDKs:
  - `aws-sdk-go-v2/service/lambda`
  - `armappservice/v3` (Azure SDK)
  - `google.golang.org/api/cloudfunctions/v1`
- **Cross-provider integration test** (`serverless_sdk_compat_test.go`) drives create→invoke→delete on all 3 servers in lockstep

42-case end-to-end simulation in `/tmp/cloudemu-e2e` (separate harness) drives every branch — create, duplicate, get, get-missing, list, update, invoke success, invoke handler-error, invoke missing, delete, post-delete-get, env round-trip, operation poll — with the real SDKs and passes 42/42.

## Verification

```
go build ./...
go vet ./...
go test ./...                     # all green
golangci-lint run --timeout=9m ./...   # only 8 pre-existing canonicalheader issues in server/azure/blob (PR #138)
```

## New dependencies (test-only)

Production code only depends on the existing `serverless/driver` interface. The new SDK packages are referenced exclusively in `*_test.go`:

- `github.com/aws/aws-sdk-go-v2/service/lambda`
- `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3`
- `google.golang.org/api/cloudfunctions/v1` (already transitively available; now a direct dep)

## Test plan

- [ ] CI runs `go build ./...` clean
- [ ] CI runs `go test ./...` — all 30+ packages green
- [ ] CI runs `golangci-lint run --timeout=9m ./...` — no new issues
- [ ] Manual: instantiate `awsserver.New(awsserver.Drivers{Lambda: cloud.Lambda})` and round-trip with `aws-sdk-go-v2/service/lambda`
- [ ] Manual: same for Azure (`armappservice/v3`) and GCP (`cloudfunctions/v1`)