### PR TITLE
add AWS SQS, Azure Service Bus, GCP Pub/Sub SDK-compat servers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
@@ -53,6 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1 h1:7CBQ+Ei8SP2c6ydQTGCCrS35bDxgTMfoP2miAwK++OU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 h1:JLPf82byRFgfB0f2feJMmRfCCFV0W9/GayiiewTvjlw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3/go.mod h1:9sfaaa+UF5VVus+Tr/bd1qm1oRoltnewm3HpiT9l8VU=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
@@ -112,6 +114,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 h1:QgaWXVmNDxv/U/3UIHfGb7ohvtFgerf/bYcYylj4i8E=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27/go.mod h1:8S6ExnLprS0oIeA8ZlHkJUJ0BMpKqnRPws/S0jegTqQ=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15/go.mod h1:WSvS1NLr7JaPunCXqpJnWk1Bjo7IxzZXrZi1QQCkuqM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6fuOwWlWpD2StNLTceKpys=

--- a/messagequeue_sdk_compat_test.go
+++ b/messagequeue_sdk_compat_test.go
@@ -1,0 +1,245 @@
+package cloudemu_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+// TestMessageQueueSDKCompat_CrossProvider drives a send→receive→delete loop
+// through every SDK-compat MQ handler (AWS SQS, Azure Service Bus,
+// GCP Pub/Sub) using raw HTTP. It validates wire-level routing and that the
+// portable message queue driver's Send/Receive/Delete chain is reachable
+// from each provider's HTTP surface.
+func TestMessageQueueSDKCompat_CrossProvider(t *testing.T) {
+	t.Run("aws-sqs", func(t *testing.T) {
+		cloud := cloudemu.NewAWS()
+		ts := httptest.NewServer(awsserver.New(awsserver.Drivers{SQS: cloud.SQS}))
+		t.Cleanup(ts.Close)
+
+		// Create.
+		create := postSQS(t, ts.URL, "AmazonSQS.CreateQueue", `{"QueueName":"loop"}`)
+		mqMustStatus(t, create, http.StatusOK)
+
+		var createOut struct {
+			QueueURL string `json:"QueueUrl"`
+		}
+		mustJSON(t, create, &createOut)
+
+		// Send.
+		mqMustStatus(t, postSQS(t, ts.URL, "AmazonSQS.SendMessage",
+			`{"QueueUrl":"`+createOut.QueueURL+`","MessageBody":"hello"}`), http.StatusOK)
+
+		// Receive.
+		recv := postSQS(t, ts.URL, "AmazonSQS.ReceiveMessage",
+			`{"QueueUrl":"`+createOut.QueueURL+`","MaxNumberOfMessages":1}`)
+		mqMustStatus(t, recv, http.StatusOK)
+
+		var recvOut struct {
+			Messages []struct {
+				Body          string `json:"Body"`
+				ReceiptHandle string `json:"ReceiptHandle"`
+			} `json:"Messages"`
+		}
+		mustJSON(t, recv, &recvOut)
+
+		if len(recvOut.Messages) != 1 || recvOut.Messages[0].Body != "hello" {
+			t.Fatalf("Receive: got %+v", recvOut.Messages)
+		}
+
+		// Delete message.
+		mqMustStatus(t, postSQS(t, ts.URL, "AmazonSQS.DeleteMessage",
+			`{"QueueUrl":"`+createOut.QueueURL+`","ReceiptHandle":"`+recvOut.Messages[0].ReceiptHandle+`"}`),
+			http.StatusOK)
+
+		// Delete queue.
+		mqMustStatus(t, postSQS(t, ts.URL, "AmazonSQS.DeleteQueue",
+			`{"QueueUrl":"`+createOut.QueueURL+`"}`), http.StatusOK)
+	})
+
+	t.Run("azure-servicebus", func(t *testing.T) {
+		cloud := cloudemu.NewAzure()
+		ts := httptest.NewServer(azureserver.New(azureserver.Drivers{ServiceBus: cloud.ServiceBus}))
+		t.Cleanup(ts.Close)
+
+		const (
+			subID  = "00000000-0000-0000-0000-000000000000"
+			rgName = "rg-1"
+			nsName = "ns-test"
+			apiVer = "?api-version=2022-10-01-preview"
+		)
+
+		queueARM := ts.URL + "/subscriptions/" + subID +
+			"/resourceGroups/" + rgName +
+			"/providers/Microsoft.ServiceBus/namespaces/" + nsName +
+			"/queues/loop" + apiVer
+
+		// Create queue (control plane).
+		mqMustStatus(t, putRequest(t, queueARM, `{"properties":{}}`), http.StatusOK)
+
+		// Send (data plane).
+		mqMustStatus(t, postRaw(t, ts.URL+"/"+nsName+"/loop/messages", "hello"), http.StatusCreated)
+
+		// Receive (data plane).
+		recv := deleteRequest(t, ts.URL+"/"+nsName+"/loop/messages/head")
+		mqMustStatus(t, recv, http.StatusOK)
+
+		body := mqReadBody(t, recv)
+		if body != "hello" {
+			t.Fatalf("body = %q, want hello", body)
+		}
+
+		// Delete queue.
+		mqMustStatus(t, deleteRequest(t, queueARM), http.StatusOK)
+	})
+
+	t.Run("gcp-pubsub", func(t *testing.T) {
+		cloud := cloudemu.NewGCP()
+		ts := httptest.NewServer(gcpserver.New(gcpserver.Drivers{PubSub: cloud.PubSub}))
+		t.Cleanup(ts.Close)
+
+		const project = "demo"
+		topicURL := ts.URL + "/v1/projects/" + project + "/topics/loop"
+		subURL := ts.URL + "/v1/projects/" + project + "/subscriptions/loop"
+
+		// Create topic.
+		mqMustStatus(t, putRequest(t, topicURL, `{}`), http.StatusOK)
+
+		// Create subscription.
+		mqMustStatus(t, putRequest(t, subURL,
+			`{"topic":"projects/demo/topics/loop"}`), http.StatusOK)
+
+		// Publish.
+		pubBody := `{"messages":[{"data":"` + base64.StdEncoding.EncodeToString([]byte("hello")) + `"}]}`
+		mqMustStatus(t, postRaw(t, topicURL+":publish", pubBody), http.StatusOK)
+
+		// Pull.
+		pull := postRaw(t, subURL+":pull", `{"maxMessages":1}`)
+		mqMustStatus(t, pull, http.StatusOK)
+
+		var pullResp struct {
+			ReceivedMessages []struct {
+				AckID   string `json:"ackId"`
+				Message struct {
+					Data string `json:"data"`
+				} `json:"message"`
+			} `json:"receivedMessages"`
+		}
+		mustJSON(t, pull, &pullResp)
+
+		if len(pullResp.ReceivedMessages) != 1 {
+			t.Fatalf("Pull: got %d messages, want 1", len(pullResp.ReceivedMessages))
+		}
+
+		decoded, _ := base64.StdEncoding.DecodeString(pullResp.ReceivedMessages[0].Message.Data)
+		if string(decoded) != "hello" {
+			t.Fatalf("payload = %q, want hello", decoded)
+		}
+
+		// Ack.
+		ackBody := `{"ackIds":["` + pullResp.ReceivedMessages[0].AckID + `"]}`
+		mqMustStatus(t, postRaw(t, subURL+":acknowledge", ackBody), http.StatusOK)
+
+		// Delete topic.
+		mqMustStatus(t, deleteRequest(t, topicURL), http.StatusOK)
+	})
+}
+
+// helpers --------------------------------------------------------------------
+
+func postSQS(t *testing.T, baseURL, target, body string) *http.Response {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, baseURL+"/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", target)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", target, err)
+	}
+
+	return resp
+}
+
+func postRaw(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+
+	return resp
+}
+
+func putRequest(t *testing.T, url, body string) *http.Response {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPut, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT %s: %v", url, err)
+	}
+
+	return resp
+}
+
+func deleteRequest(t *testing.T, url string) *http.Response {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodDelete, url, nil)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE %s: %v", url, err)
+	}
+
+	return resp
+}
+
+func mqMustStatus(t *testing.T, resp *http.Response, want int) {
+	t.Helper()
+
+	if resp.StatusCode != want {
+		body := mqReadBody(t, resp)
+		t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, want, body)
+	}
+}
+
+func mustJSON(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+}
+
+func mqReadBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return strings.TrimSpace(string(b))
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -9,6 +9,7 @@ package aws
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/server"
@@ -17,6 +18,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/ec2"
 	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/s3"
+	"github.com/stackshy/cloudemu/server/aws/sqs"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
@@ -31,6 +33,7 @@ type Drivers struct {
 	VPC        netdriver.Networking
 	CloudWatch mondriver.Monitoring
 	Lambda     sdrv.Serverless
+	SQS        mqdriver.MessageQueue
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every
@@ -58,6 +61,13 @@ func New(d Drivers) *server.Server {
 
 	if d.DynamoDB != nil {
 		srv.Register(dynamodb.New(d.DynamoDB))
+	}
+
+	// SQS shares the X-Amz-Target header with DynamoDB but uses a different
+	// prefix (AmazonSQS.* vs DynamoDB_20120810.*); their Matches predicates
+	// are mutually exclusive.
+	if d.SQS != nil {
+		srv.Register(sqs.New(d.SQS))
 	}
 
 	if d.EC2 != nil || d.VPC != nil {

--- a/server/aws/sqs/handler.go
+++ b/server/aws/sqs/handler.go
@@ -1,0 +1,255 @@
+// Package sqs implements the AWS SQS JSON-RPC protocol as a server.Handler.
+// Modern aws-sdk-go-v2 SQS uses AwsJson1_0 with X-Amz-Target headers (since
+// SQS migrated off the legacy Query protocol in 2023).
+//
+// MVP coverage: queue lifecycle + the synchronous send/receive/delete loop
+// every consumer needs. Batch ops, ChangeMessageVisibility, attributes, and
+// PurgeQueue are deferred to a follow-up — the portable
+// messagequeue.MessageQueue driver supports them.
+package sqs
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "AmazonSQS."
+
+// Handler serves SQS JSON-RPC requests against a messagequeue.MessageQueue
+// driver.
+type Handler struct {
+	mq mqdriver.MessageQueue
+}
+
+// New returns an SQS handler backed by mq.
+func New(mq mqdriver.MessageQueue) *Handler {
+	return &Handler{mq: mq}
+}
+
+// Matches identifies SQS requests by their X-Amz-Target header. SQS shares
+// the same content-type as DynamoDB (application/x-amz-json-1.0) so the
+// header prefix is the only reliable discriminator.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches SQS operations based on X-Amz-Target.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "CreateQueue":
+		h.createQueue(w, r)
+	case "GetQueueUrl":
+		h.getQueueURL(w, r)
+	case "ListQueues":
+		h.listQueues(w, r)
+	case "DeleteQueue":
+		h.deleteQueue(w, r)
+	case "SendMessage":
+		h.sendMessage(w, r)
+	case "ReceiveMessage":
+		h.receiveMessage(w, r)
+	case "DeleteMessage":
+		h.deleteMessage(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown operation: "+op)
+	}
+}
+
+func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueName  string            `json:"QueueName"`
+		Attributes map[string]string `json:"Attributes"`
+		Tags       map[string]string `json:"tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := mqdriver.QueueConfig{
+		Name: req.QueueName,
+		FIFO: req.Attributes["FifoQueue"] == "true" || strings.HasSuffix(req.QueueName, ".fifo"),
+		Tags: req.Tags,
+	}
+
+	info, err := h.mq.CreateQueue(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"QueueUrl": info.URL})
+}
+
+func (h *Handler) getQueueURL(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueName string `json:"QueueName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	for i := range queues {
+		if queues[i].Name == req.QueueName {
+			wire.WriteJSON(w, map[string]any{"QueueUrl": queues[i].URL})
+			return
+		}
+	}
+
+	wire.WriteJSONError(w, http.StatusBadRequest,
+		"QueueDoesNotExist", "queue not found: "+req.QueueName)
+}
+
+func (h *Handler) listQueues(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueNamePrefix string `json:"QueueNamePrefix"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	queues, err := h.mq.ListQueues(r.Context(), req.QueueNamePrefix)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	urls := make([]string, 0, len(queues))
+	for i := range queues {
+		urls = append(urls, queues[i].URL)
+	}
+
+	wire.WriteJSON(w, map[string]any{"QueueUrls": urls})
+}
+
+func (h *Handler) deleteQueue(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueURL string `json:"QueueUrl"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.mq.DeleteQueue(r.Context(), req.QueueURL); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+func (h *Handler) sendMessage(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueURL          string         `json:"QueueUrl"`
+		MessageBody       string         `json:"MessageBody"`
+		DelaySeconds      int            `json:"DelaySeconds"`
+		GroupID           string         `json:"MessageGroupId"`
+		DeduplicationID   string         `json:"MessageDeduplicationId"`
+		MessageAttributes map[string]any `json:"MessageAttributes"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	out, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
+		QueueURL:        req.QueueURL,
+		Body:            req.MessageBody,
+		DelaySeconds:    req.DelaySeconds,
+		GroupID:         req.GroupID,
+		DeduplicationID: req.DeduplicationID,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"MessageId": out.MessageID})
+}
+
+func (h *Handler) receiveMessage(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueURL            string `json:"QueueUrl"`
+		MaxNumberOfMessages int    `json:"MaxNumberOfMessages"`
+		WaitTimeSeconds     int    `json:"WaitTimeSeconds"`
+		VisibilityTimeout   int    `json:"VisibilityTimeout"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.MaxNumberOfMessages == 0 {
+		req.MaxNumberOfMessages = 1
+	}
+
+	msgs, err := h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
+		QueueURL:          req.QueueURL,
+		MaxMessages:       req.MaxNumberOfMessages,
+		WaitTimeSeconds:   req.WaitTimeSeconds,
+		VisibilityTimeout: req.VisibilityTimeout,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]map[string]any, 0, len(msgs))
+	for i := range msgs {
+		out = append(out, map[string]any{
+			"MessageId":     msgs[i].MessageID,
+			"ReceiptHandle": msgs[i].ReceiptHandle,
+			"Body":          msgs[i].Body,
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Messages": out})
+}
+
+func (h *Handler) deleteMessage(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueueURL      string `json:"QueueUrl"`
+		ReceiptHandle string `json:"ReceiptHandle"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.mq.DeleteMessage(r.Context(), req.QueueURL, req.ReceiptHandle); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+// writeErr maps CloudEmu canonical errors to SQS-shaped HTTP error responses.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "QueueDoesNotExist", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "QueueNameExists", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
+}

--- a/server/aws/sqs/sdk_roundtrip_test.go
+++ b/server/aws/sqs/sdk_roundtrip_test.go
@@ -1,0 +1,158 @@
+package sqs_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newSDKClient(t *testing.T) (*awssqs.Client, *cloudemuAWSHandle) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{SQS: cloud.SQS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awssqs.NewFromConfig(cfg, func(o *awssqs.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	return client, &cloudemuAWSHandle{cloud: cloud}
+}
+
+type cloudemuAWSHandle struct {
+	cloud any
+}
+
+func TestSDKSQSCreateAndGet(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("sdk-q"),
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if aws.ToString(out.QueueUrl) == "" {
+		t.Fatal("CreateQueue returned empty QueueUrl")
+	}
+
+	got, err := client.GetQueueUrl(ctx, &awssqs.GetQueueUrlInput{
+		QueueName: aws.String("sdk-q"),
+	})
+	if err != nil {
+		t.Fatalf("GetQueueUrl: %v", err)
+	}
+
+	if aws.ToString(got.QueueUrl) != aws.ToString(out.QueueUrl) {
+		t.Fatalf("URLs differ: create %q, get %q",
+			aws.ToString(out.QueueUrl), aws.ToString(got.QueueUrl))
+	}
+}
+
+func TestSDKSQSSendReceiveDeleteRoundTrip(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("loop"),
+	})
+	if err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	if _, err := client.SendMessage(ctx, &awssqs.SendMessageInput{
+		QueueUrl:    q.QueueUrl,
+		MessageBody: aws.String("hello world"),
+	}); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	rcv, err := client.ReceiveMessage(ctx, &awssqs.ReceiveMessageInput{
+		QueueUrl:            q.QueueUrl,
+		MaxNumberOfMessages: 1,
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	if len(rcv.Messages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(rcv.Messages))
+	}
+
+	if aws.ToString(rcv.Messages[0].Body) != "hello world" {
+		t.Fatalf("Body = %q, want hello world", aws.ToString(rcv.Messages[0].Body))
+	}
+
+	if _, err := client.DeleteMessage(ctx, &awssqs.DeleteMessageInput{
+		QueueUrl:      q.QueueUrl,
+		ReceiptHandle: rcv.Messages[0].ReceiptHandle,
+	}); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+}
+
+func TestSDKSQSListQueues(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"a", "b"} {
+		if _, err := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+			QueueName: aws.String(n),
+		}); err != nil {
+			t.Fatalf("create %s: %v", n, err)
+		}
+	}
+
+	out, err := client.ListQueues(ctx, &awssqs.ListQueuesInput{})
+	if err != nil {
+		t.Fatalf("ListQueues: %v", err)
+	}
+
+	if len(out.QueueUrls) != 2 {
+		t.Fatalf("listed %d, want 2", len(out.QueueUrls))
+	}
+}
+
+func TestSDKSQSDeleteQueue(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	q, _ := client.CreateQueue(ctx, &awssqs.CreateQueueInput{
+		QueueName: aws.String("doomed"),
+	})
+
+	if _, err := client.DeleteQueue(ctx, &awssqs.DeleteQueueInput{
+		QueueUrl: q.QueueUrl,
+	}); err != nil {
+		t.Fatalf("DeleteQueue: %v", err)
+	}
+
+	if _, err := client.GetQueueUrl(ctx, &awssqs.GetQueueUrlInput{
+		QueueName: aws.String("doomed"),
+	}); err == nil {
+		t.Fatal("GetQueueUrl after delete returned nil error, want QueueDoesNotExist")
+	}
+}

--- a/server/aws/sqs/sqs_test.go
+++ b/server/aws/sqs/sqs_test.go
@@ -1,0 +1,239 @@
+package sqs_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/server/aws/sqs"
+)
+
+func newServer(t *testing.T) (*httptest.Server, mqHandle) {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := httptest.NewServer(sqs.New(cloud.SQS))
+	t.Cleanup(srv.Close)
+
+	return srv, mqHandle{queueURL: ""}
+}
+
+type mqHandle struct {
+	queueURL string
+}
+
+func TestMatchesAcceptsAmazonSQSTarget(t *testing.T) {
+	h := sqs.New(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("X-Amz-Target", "AmazonSQS.CreateQueue")
+
+	if !h.Matches(req) {
+		t.Fatal("Matches should accept AmazonSQS.* target")
+	}
+}
+
+func TestMatchesRejectsDynamoDBTarget(t *testing.T) {
+	h := sqs.New(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("X-Amz-Target", "DynamoDB_20120810.PutItem")
+
+	if h.Matches(req) {
+		t.Fatal("Matches should reject DynamoDB target")
+	}
+}
+
+func TestCreateAndGetQueueURL(t *testing.T) {
+	srv, _ := newServer(t)
+
+	createBody := `{"QueueName":"q1"}`
+	create := postJSON(t, srv, "AmazonSQS.CreateQueue", createBody)
+
+	if create.StatusCode != http.StatusOK {
+		t.Fatalf("create status = %d", create.StatusCode)
+	}
+
+	resp := postJSON(t, srv, "AmazonSQS.GetQueueUrl", `{"QueueName":"q1"}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get status = %d", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	if !strings.Contains(body, `"QueueUrl"`) || !strings.Contains(body, "q1") {
+		t.Fatalf("response missing QueueUrl: %s", body)
+	}
+}
+
+func TestGetQueueURLMissing(t *testing.T) {
+	srv, _ := newServer(t)
+
+	resp := postJSON(t, srv, "AmazonSQS.GetQueueUrl", `{"QueueName":"nope"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+
+	if !strings.Contains(readBody(t, resp), "QueueDoesNotExist") {
+		t.Fatal("expected QueueDoesNotExist error")
+	}
+}
+
+func TestSendReceiveDelete(t *testing.T) {
+	srv, _ := newServer(t)
+
+	create := postJSON(t, srv, "AmazonSQS.CreateQueue", `{"QueueName":"loop"}`)
+	queueURL := extractQueueURL(t, create)
+
+	send := postJSON(t, srv, "AmazonSQS.SendMessage",
+		`{"QueueUrl":"`+queueURL+`","MessageBody":"hello"}`)
+	if send.StatusCode != http.StatusOK {
+		t.Fatalf("send status = %d", send.StatusCode)
+	}
+
+	recv := postJSON(t, srv, "AmazonSQS.ReceiveMessage",
+		`{"QueueUrl":"`+queueURL+`","MaxNumberOfMessages":1}`)
+
+	body := readBody(t, recv)
+	if !strings.Contains(body, "hello") {
+		t.Fatalf("Receive missing payload: %s", body)
+	}
+
+	receipt := extractReceipt(body)
+	if receipt == "" {
+		t.Fatalf("no ReceiptHandle in: %s", body)
+	}
+
+	del := postJSON(t, srv, "AmazonSQS.DeleteMessage",
+		`{"QueueUrl":"`+queueURL+`","ReceiptHandle":"`+receipt+`"}`)
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("delete msg status = %d", del.StatusCode)
+	}
+}
+
+func TestReceiveEmptyQueue(t *testing.T) {
+	srv, _ := newServer(t)
+
+	create := postJSON(t, srv, "AmazonSQS.CreateQueue", `{"QueueName":"empty"}`)
+	queueURL := extractQueueURL(t, create)
+
+	resp := postJSON(t, srv, "AmazonSQS.ReceiveMessage",
+		`{"QueueUrl":"`+queueURL+`"}`)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	// Empty receive should return Messages: [] or omit.
+	if strings.Contains(body, "ReceiptHandle") {
+		t.Fatalf("expected no messages, got %s", body)
+	}
+}
+
+func TestListQueues(t *testing.T) {
+	srv, _ := newServer(t)
+
+	for _, n := range []string{"a", "b", "c"} {
+		_ = postJSON(t, srv, "AmazonSQS.CreateQueue", `{"QueueName":"`+n+`"}`)
+	}
+
+	resp := postJSON(t, srv, "AmazonSQS.ListQueues", `{}`)
+	body := readBody(t, resp)
+
+	for _, n := range []string{"a", "b", "c"} {
+		if !strings.Contains(body, "/"+n+`"`) {
+			t.Fatalf("missing queue %q in list response: %s", n, body)
+		}
+	}
+}
+
+func TestDeleteQueue(t *testing.T) {
+	srv, _ := newServer(t)
+
+	create := postJSON(t, srv, "AmazonSQS.CreateQueue", `{"QueueName":"goner"}`)
+	queueURL := extractQueueURL(t, create)
+
+	del := postJSON(t, srv, "AmazonSQS.DeleteQueue",
+		`{"QueueUrl":"`+queueURL+`"}`)
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("delete queue status = %d", del.StatusCode)
+	}
+
+	resp := postJSON(t, srv, "AmazonSQS.GetQueueUrl", `{"QueueName":"goner"}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("post-delete get-url = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestUnknownOperation(t *testing.T) {
+	srv, _ := newServer(t)
+
+	resp := postJSON(t, srv, "AmazonSQS.SomeMadeUpOp", `{}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// helpers --------------------------------------------------------------------
+
+func postJSON(t *testing.T, srv *httptest.Server, target, body string) *http.Response {
+	t.Helper()
+
+	req, _ := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, srv.URL+"/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	req.Header.Set("X-Amz-Target", target)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", target, err)
+	}
+
+	return resp
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+
+	return string(buf[:n])
+}
+
+func extractQueueURL(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	body := readBody(t, resp)
+	const key = `"QueueUrl":"`
+	i := strings.Index(body, key)
+	if i < 0 {
+		t.Fatalf("QueueUrl not in body: %s", body)
+	}
+	rest := body[i+len(key):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		t.Fatalf("malformed QueueUrl in body: %s", body)
+	}
+
+	return rest[:end]
+}
+
+func extractReceipt(body string) string {
+	const key = `"ReceiptHandle":"`
+	i := strings.Index(body, key)
+	if i < 0 {
+		return ""
+	}
+	rest := body[i+len(key):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -9,6 +9,7 @@ package azure
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/server"
@@ -19,6 +20,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/images"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/network"
+	"github.com/stackshy/cloudemu/server/azure/servicebus"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
 	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
 	"github.com/stackshy/cloudemu/server/azure/virtualmachines"
@@ -44,6 +46,7 @@ type Drivers struct {
 	Network         netdriver.Networking
 	Monitor         mondriver.Monitoring
 	Functions       sdrv.Serverless
+	ServiceBus      mqdriver.MessageQueue
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -93,6 +96,10 @@ func New(d Drivers) *server.Server {
 
 	if d.Functions != nil {
 		srv.Register(functions.New(d.Functions))
+	}
+
+	if d.ServiceBus != nil {
+		srv.Register(servicebus.New(d.ServiceBus))
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/blob/handler.go
+++ b/server/azure/blob/handler.go
@@ -73,7 +73,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	container, blob := parseBlobPath(r.URL.Path)
 	q := r.URL.Query()
 
-	w.Header().Set("x-ms-version", xmsVersion)
+	w.Header().Set("X-Ms-Version", xmsVersion)
 
 	switch {
 	case container == "" && q.Get("comp") == compList:
@@ -131,7 +131,7 @@ func (h *Handler) containerOp(w http.ResponseWriter, r *http.Request, container 
 func (h *Handler) blobOp(w http.ResponseWriter, r *http.Request, container, blob string) {
 	switch r.Method {
 	case http.MethodPut:
-		if r.Header.Get("x-ms-copy-source") != "" {
+		if r.Header.Get("X-Ms-Copy-Source") != "" {
 			h.copyBlob(w, r, container, blob)
 			return
 		}
@@ -270,7 +270,7 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 
 	w.Header().Set("ETag", "\"0x8DAB0\"")
 	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
-	w.Header().Set("x-ms-request-server-encrypted", "true")
+	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
 	w.WriteHeader(http.StatusCreated)
 }
 
@@ -302,7 +302,7 @@ func writeBlobHeaders(w http.ResponseWriter, info *storagedriver.ObjectInfo, siz
 	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
 	w.Header().Set("Last-Modified", httpDate(info.LastModified))
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-	w.Header().Set("x-ms-blob-type", "BlockBlob")
+	w.Header().Set("X-Ms-Blob-Type", "BlockBlob")
 
 	for k, v := range info.Metadata {
 		w.Header().Set("x-ms-meta-"+k, v)
@@ -319,7 +319,7 @@ func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request, container, 
 }
 
 func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, blob string) {
-	src := r.Header.Get("x-ms-copy-source")
+	src := r.Header.Get("X-Ms-Copy-Source")
 	srcBucket, srcKey := extractCopySource(src)
 
 	if srcBucket == "" || srcKey == "" {
@@ -334,8 +334,8 @@ func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, bl
 		return
 	}
 
-	w.Header().Set("x-ms-copy-id", "00000000-0000-0000-0000-000000000001")
-	w.Header().Set("x-ms-copy-status", "success")
+	w.Header().Set("X-Ms-Copy-Id", "00000000-0000-0000-0000-000000000001")
+	w.Header().Set("X-Ms-Copy-Status", "success")
 	w.Header().Set("ETag", "\"0x8DAB0\"")
 	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
 	w.WriteHeader(http.StatusAccepted)
@@ -386,7 +386,7 @@ func writeXML(w http.ResponseWriter, status int, v any) {
 
 func writeError(w http.ResponseWriter, status int, code, msg string) {
 	w.Header().Set("Content-Type", contentTypeXML)
-	w.Header().Set("x-ms-error-code", code)
+	w.Header().Set("X-Ms-Error-Code", code)
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(xml.Header))
 	_ = xml.NewEncoder(w).Encode(errorXML{Code: code, Message: msg})

--- a/server/azure/servicebus/handler.go
+++ b/server/azure/servicebus/handler.go
@@ -1,0 +1,453 @@
+// Package servicebus serves Azure Service Bus ARM control-plane requests
+// (Microsoft.ServiceBus/namespaces[/queues]) plus a raw-HTTP data plane for
+// send/receive against a CloudEmu messagequeue driver.
+//
+// Real azure-sdk-for-go armservicebus clients drive the ARM control plane
+// (PUT/GET/DELETE namespaces and queues). The data-plane azservicebus SDK
+// uses AMQP exclusively and is out of scope; tests that exercise send/receive
+// hit the REST data plane (POST /{namespace}/{queue}/messages,
+// DELETE /{namespace}/{queue}/messages/head) directly with raw HTTP. This
+// matches Microsoft's older "Send/Receive REST" endpoints documented at
+// https://learn.microsoft.com/rest/api/servicebus/.
+//
+// MVP coverage:
+//
+//	PUT/GET/DELETE  .../namespaces/{ns}                        — namespace lifecycle
+//	GET             .../namespaces                             — list (subscription scope)
+//	PUT/GET/DELETE  .../namespaces/{ns}/queues/{name}          — queue lifecycle
+//	GET             .../namespaces/{ns}/queues                 — list queues in namespace
+//	POST            /{namespace}/{queue}/messages              — send (raw HTTP)
+//	DELETE          /{namespace}/{queue}/messages/head         — receive+ack (raw HTTP)
+//
+// Topics, subscriptions, rules, AMQP, sessions, and DLQ wire formats are
+// deferred to a follow-up.
+package servicebus
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName = "Microsoft.ServiceBus"
+	resourceType = "namespaces"
+	subTypeQueue = "queues"
+
+	maxBodyBytes  = 1 << 20
+	dataPlanePath = "/messages"
+)
+
+// Handler serves ARM Service Bus + raw-HTTP data-plane requests.
+type Handler struct {
+	mq mqdriver.MessageQueue
+}
+
+// New returns a Service Bus handler backed by mq.
+func New(mq mqdriver.MessageQueue) *Handler {
+	return &Handler{mq: mq}
+}
+
+// Matches accepts ARM Microsoft.ServiceBus/namespaces[...] paths plus
+// data-plane URLs ending in /messages or /messages/head.
+func (*Handler) Matches(r *http.Request) bool {
+	if isDataPlanePath(r.URL.Path) {
+		return true
+	}
+
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == resourceType
+}
+
+// ServeHTTP routes by URL shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isDataPlanePath(r.URL.Path) {
+		h.serveDataPlane(w, r)
+		return
+	}
+
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// /providers/Microsoft.ServiceBus/namespaces (subscription-level list)
+	if rp.ResourceName == "" {
+		h.listNamespaces(w, r)
+		return
+	}
+
+	// /namespaces/{ns}/queues[/{name}]
+	if rp.SubResource == subTypeQueue {
+		h.serveQueue(w, r, rp)
+		return
+	}
+
+	if rp.SubResource != "" {
+		azurearm.WriteError(w, http.StatusNotImplemented, "NotImplemented",
+			"unsupported sub-resource: "+rp.SubResource)
+		return
+	}
+
+	h.serveNamespace(w, r, rp)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveNamespace(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createNamespace(w, r, rp)
+	case http.MethodGet:
+		h.getNamespace(w, r, rp)
+	case http.MethodDelete:
+		h.deleteNamespace(w, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) serveQueue(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	if rp.SubResourceName == "" {
+		// Collection: list queues in the namespace.
+		if r.Method != http.MethodGet {
+			azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+			return
+		}
+
+		h.listQueues(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createQueue(w, r, rp)
+	case http.MethodGet:
+		h.getQueue(w, r, rp)
+	case http.MethodDelete:
+		h.deleteQueue(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+// ---------- Namespace control plane ----------
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	var req createNamespaceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidRequestContent", err.Error())
+		return
+	}
+
+	location := req.Location
+	if location == "" {
+		location = "eastus"
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, namespaceResource{
+		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
+			providerName, resourceType, rp.ResourceName),
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + resourceType,
+		Location: location,
+		Properties: namespaceProperties{
+			ProvisioningState:  "Succeeded",
+			ServiceBusEndpoint: "https://" + rp.ResourceName + ".servicebus.windows.net:443/",
+		},
+		SKU: req.SKU,
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) getNamespace(w http.ResponseWriter, _ *http.Request, rp azurearm.ResourcePath) {
+	// Namespaces are virtual — there's no driver state. Always return Succeeded.
+	azurearm.WriteJSON(w, http.StatusOK, namespaceResource{
+		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
+			providerName, resourceType, rp.ResourceName),
+		Name:     rp.ResourceName,
+		Type:     providerName + "/" + resourceType,
+		Location: "eastus",
+		Properties: namespaceProperties{
+			ProvisioningState:  "Succeeded",
+			ServiceBusEndpoint: "https://" + rp.ResourceName + ".servicebus.windows.net:443/",
+		},
+	})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (*Handler) deleteNamespace(w http.ResponseWriter, _ azurearm.ResourcePath) {
+	// Virtual namespace: nothing to free.
+	w.WriteHeader(http.StatusOK)
+}
+
+func (*Handler) listNamespaces(w http.ResponseWriter, _ *http.Request) {
+	// We don't track namespaces in the driver; return an empty list.
+	azurearm.WriteJSON(w, http.StatusOK, listResponse{Value: []any{}})
+}
+
+// ---------- Queue control plane ----------
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	var req createQueueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidRequestContent", err.Error())
+		return
+	}
+
+	cfg := mqdriver.QueueConfig{
+		Name: rp.SubResourceName,
+		FIFO: req.Properties.RequiresSession || strings.HasSuffix(rp.SubResourceName, ".fifo"),
+	}
+
+	info, err := h.mq.CreateQueue(r.Context(), cfg)
+	if err != nil && !cerrors.IsAlreadyExists(err) {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if info == nil {
+		// Idempotent PUT: re-read the queue.
+		queues, _ := h.mq.ListQueues(r.Context(), "")
+
+		for i := range queues {
+			if queues[i].Name == rp.SubResourceName {
+				info = &queues[i]
+				break
+			}
+		}
+	}
+
+	if info == nil {
+		azurearm.WriteError(w, http.StatusInternalServerError, "InternalError", "queue lookup failed")
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toQueueResource(rp, info))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getQueue(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	for i := range queues {
+		if queues[i].Name == rp.SubResourceName {
+			azurearm.WriteJSON(w, http.StatusOK, toQueueResource(rp, &queues[i]))
+			return
+		}
+	}
+
+	azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "queue not found")
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listQueues(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := listResponse{Value: make([]any, 0, len(queues))}
+	for i := range queues {
+		out.Value = append(out.Value, toQueueResource(rp, &queues[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteQueue(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	var url string
+
+	for i := range queues {
+		if queues[i].Name == rp.SubResourceName {
+			url = queues[i].URL
+			break
+		}
+	}
+
+	if url == "" {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound", "queue not found")
+		return
+	}
+
+	if err := h.mq.DeleteQueue(r.Context(), url); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// ---------- Data plane (raw HTTP send/receive) ----------
+
+func isDataPlanePath(p string) bool {
+	if !strings.HasSuffix(p, dataPlanePath) && !strings.HasSuffix(p, dataPlanePath+"/head") {
+		return false
+	}
+	// The path must NOT be an ARM URL — those start with /subscriptions/.
+	return !strings.HasPrefix(p, "/subscriptions/")
+}
+
+func (h *Handler) serveDataPlane(w http.ResponseWriter, r *http.Request) {
+	queueName, peek := parseDataPlanePath(r.URL.Path)
+	if queueName == "" {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "missing queue in data-plane path")
+		return
+	}
+
+	queue, err := h.findQueueByName(r.Context(), queueName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if peek {
+		h.dataPlaneReceive(w, r, queue.URL)
+		return
+	}
+
+	h.dataPlaneSend(w, r, queue.URL)
+}
+
+func (h *Handler) dataPlaneSend(w http.ResponseWriter, r *http.Request, queueURL string) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "send requires POST")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		azurearm.WriteError(w, http.StatusRequestEntityTooLarge, "PayloadTooLarge", err.Error())
+		return
+	}
+
+	if _, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
+		QueueURL: queueURL,
+		Body:     string(body),
+	}); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *Handler) dataPlaneReceive(w http.ResponseWriter, r *http.Request, queueURL string) {
+	if r.Method != http.MethodDelete {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+			"receive-and-delete requires DELETE")
+		return
+	}
+
+	msgs, err := h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
+		QueueURL:    queueURL,
+		MaxMessages: 1,
+	})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if len(msgs) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// Service Bus REST returns the message body in the response with the
+	// brokered message envelope as headers; we put both in the body for
+	// simplicity since the modern SDK doesn't use this path.
+	if err := h.mq.DeleteMessage(r.Context(), queueURL, msgs[0].ReceiptHandle); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("BrokerProperties", `{"MessageId":"`+msgs[0].MessageID+`"}`)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(msgs[0].Body))
+}
+
+// parseDataPlanePath returns the queue name and a flag indicating whether
+// the URL targets /messages/head (peek-and-delete) or /messages (send).
+func parseDataPlanePath(p string) (queueName string, peek bool) {
+	trimmed := strings.Trim(p, "/")
+
+	if strings.HasSuffix(trimmed, "messages/head") {
+		peek = true
+		trimmed = strings.TrimSuffix(trimmed, "/messages/head")
+	} else if strings.HasSuffix(trimmed, "messages") {
+		trimmed = strings.TrimSuffix(trimmed, "/messages")
+	} else {
+		return "", false
+	}
+
+	// Trimmed is now either "queue" or "namespace/queue". The driver doesn't
+	// model namespaces — the queue is the last segment regardless.
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 0 {
+		return "", peek
+	}
+
+	return parts[len(parts)-1], peek
+}
+
+func (h *Handler) findQueueByName(ctx context.Context, name string) (*mqdriver.QueueInfo, error) {
+	queues, err := h.mq.ListQueues(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range queues {
+		if queues[i].Name == name {
+			return &queues[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "queue %s not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value; copying once per response is fine.
+func toQueueResource(rp azurearm.ResourcePath, info *mqdriver.QueueInfo) queueResource {
+	return queueResource{
+		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
+			providerName, resourceType, rp.ResourceName) + "/queues/" + info.Name,
+		Name: info.Name,
+		Type: providerName + "/" + resourceType + "/" + subTypeQueue,
+		Properties: queueProperties{
+			Status:       "Active",
+			MessageCount: info.ApproxMessageCount,
+		},
+	}
+}

--- a/server/azure/servicebus/sdk_roundtrip_test.go
+++ b/server/azure/servicebus/sdk_roundtrip_test.go
@@ -1,0 +1,92 @@
+package servicebus_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// fakeCred is a static-token credential for tests.
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newQueuesClient(t *testing.T, ts *httptest.Server) *armservicebus.QueuesClient {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud: myCloud, Transport: ts.Client(),
+			Retry: policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armservicebus.NewClientFactory(subID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("ClientFactory: %v", err)
+	}
+
+	return cf.NewQueuesClient()
+}
+
+func TestSDKServiceBusQueueLifecycle(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ServiceBus: cloudP.ServiceBus})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newQueuesClient(t, ts)
+	ctx := context.Background()
+
+	created, err := client.CreateOrUpdate(ctx, rgName, nsName, "sdk-q",
+		armservicebus.SBQueue{
+			Properties: &armservicebus.SBQueueProperties{
+				MaxSizeInMegabytes: to.Ptr[int32](1024),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "sdk-q" {
+		t.Fatalf("created.Name = %v, want sdk-q", created.Name)
+	}
+
+	got, err := client.Get(ctx, rgName, nsName, "sdk-q", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != "sdk-q" {
+		t.Fatalf("got.Name = %v, want sdk-q", got.Name)
+	}
+
+	if _, err := client.Delete(ctx, rgName, nsName, "sdk-q", nil); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := client.Get(ctx, rgName, nsName, "sdk-q", nil); err == nil {
+		t.Fatal("post-delete Get returned nil error, want NotFound")
+	}
+}

--- a/server/azure/servicebus/servicebus_test.go
+++ b/server/azure/servicebus/servicebus_test.go
@@ -1,0 +1,230 @@
+package servicebus_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+const (
+	subID  = "00000000-0000-0000-0000-000000000000"
+	rgName = "rg-1"
+	nsName = "test-ns"
+	apiVer = "?api-version=2022-10-01-preview"
+)
+
+func nsURL() string {
+	return "/subscriptions/" + subID + "/resourceGroups/" + rgName +
+		"/providers/Microsoft.ServiceBus/namespaces/" + nsName
+}
+
+func queueURL(name string) string {
+	return nsURL() + "/queues/" + name
+}
+
+func newTestServer(t *testing.T) (*httptest.Server, *cloudemuHandle) {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := httptest.NewServer(azureserver.New(azureserver.Drivers{ServiceBus: cloud.ServiceBus}))
+	t.Cleanup(srv.Close)
+
+	return srv, &cloudemuHandle{provider: cloud}
+}
+
+type cloudemuHandle struct {
+	provider any
+}
+
+func TestNamespaceLifecycle(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	put := doRequest(t, srv, http.MethodPut, nsURL()+apiVer, `{"location":"eastus"}`)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT namespace = %d", put.StatusCode)
+	}
+
+	get := doRequest(t, srv, http.MethodGet, nsURL()+apiVer, "")
+	if get.StatusCode != http.StatusOK {
+		t.Fatalf("GET namespace = %d", get.StatusCode)
+	}
+
+	body := readBody(t, get)
+	if !strings.Contains(body, "Succeeded") {
+		t.Fatalf("namespace body missing provisioningState: %s", body)
+	}
+
+	del := doRequest(t, srv, http.MethodDelete, nsURL()+apiVer, "")
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE namespace = %d", del.StatusCode)
+	}
+}
+
+func TestQueueLifecycle(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	body := `{"properties":{"maxSizeInMegabytes":1024}}`
+
+	put := doRequest(t, srv, http.MethodPut, queueURL("orders")+apiVer, body)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT queue = %d, body: %s", put.StatusCode, readBody(t, put))
+	}
+
+	get := doRequest(t, srv, http.MethodGet, queueURL("orders")+apiVer, "")
+	if get.StatusCode != http.StatusOK {
+		t.Fatalf("GET queue = %d", get.StatusCode)
+	}
+
+	var got struct {
+		Name       string `json:"name"`
+		Properties struct {
+			Status string `json:"status"`
+		} `json:"properties"`
+	}
+
+	if err := json.NewDecoder(get.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = get.Body.Close()
+
+	if got.Name != "orders" {
+		t.Fatalf("Name = %q, want orders", got.Name)
+	}
+
+	if got.Properties.Status != "Active" {
+		t.Fatalf("Status = %q, want Active", got.Properties.Status)
+	}
+
+	del := doRequest(t, srv, http.MethodDelete, queueURL("orders")+apiVer, "")
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE queue = %d", del.StatusCode)
+	}
+
+	missing := doRequest(t, srv, http.MethodGet, queueURL("orders")+apiVer, "")
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("post-delete GET = %d, want 404", missing.StatusCode)
+	}
+}
+
+func TestQueueIdempotentPut(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	body := `{"properties":{}}`
+
+	first := doRequest(t, srv, http.MethodPut, queueURL("idem")+apiVer, body)
+	if first.StatusCode != http.StatusOK {
+		t.Fatalf("first PUT = %d", first.StatusCode)
+	}
+
+	second := doRequest(t, srv, http.MethodPut, queueURL("idem")+apiVer, body)
+	if second.StatusCode != http.StatusOK {
+		t.Fatalf("second PUT = %d (idempotent expected)", second.StatusCode)
+	}
+}
+
+func TestListQueues(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	for _, n := range []string{"a", "b", "c"} {
+		_ = doRequest(t, srv, http.MethodPut, queueURL(n)+apiVer, `{"properties":{}}`)
+	}
+
+	resp := doRequest(t, srv, http.MethodGet, nsURL()+"/queues"+apiVer, "")
+
+	var got struct {
+		Value []map[string]any `json:"value"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = resp.Body.Close()
+
+	if len(got.Value) != 3 {
+		t.Fatalf("listed %d queues, want 3", len(got.Value))
+	}
+}
+
+func TestDataPlaneSendReceive(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	if r := doRequest(t, srv, http.MethodPut, queueURL("loop")+apiVer,
+		`{"properties":{}}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create queue: %d", r.StatusCode)
+	}
+
+	send := doRequest(t, srv, http.MethodPost, "/"+nsName+"/loop/messages", "hello")
+	if send.StatusCode != http.StatusCreated {
+		t.Fatalf("send = %d, want 201", send.StatusCode)
+	}
+
+	rcv := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/loop/messages/head", "")
+	if rcv.StatusCode != http.StatusOK {
+		t.Fatalf("receive = %d, want 200", rcv.StatusCode)
+	}
+
+	got := readBody(t, rcv)
+	if got != "hello" {
+		t.Fatalf("body = %q, want hello", got)
+	}
+
+	// Subsequent receive on empty queue should return 204.
+	empty := doRequest(t, srv, http.MethodDelete, "/"+nsName+"/loop/messages/head", "")
+	if empty.StatusCode != http.StatusNoContent {
+		t.Fatalf("empty receive = %d, want 204", empty.StatusCode)
+	}
+}
+
+func TestDataPlaneSendToMissingQueue(t *testing.T) {
+	srv, _ := newTestServer(t)
+
+	resp := doRequest(t, srv, http.MethodPost, "/"+nsName+"/no-such/messages", "x")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("send to missing queue = %d, want 404", resp.StatusCode)
+	}
+}
+
+// helpers --------------------------------------------------------------------
+
+func doRequest(t *testing.T, srv *httptest.Server, method, path, body string) *http.Response {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), method, srv.URL+path, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+
+	return resp
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return strings.TrimSpace(string(b))
+}

--- a/server/azure/servicebus/types.go
+++ b/server/azure/servicebus/types.go
@@ -1,0 +1,57 @@
+package servicebus
+
+// namespaceResource is the ARM JSON shape for Microsoft.ServiceBus/namespaces.
+type namespaceResource struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Type       string              `json:"type"`
+	Location   string              `json:"location"`
+	Properties namespaceProperties `json:"properties"`
+	SKU        *sbSKU              `json:"sku,omitempty"`
+}
+
+type namespaceProperties struct {
+	ProvisioningState  string `json:"provisioningState"`
+	ServiceBusEndpoint string `json:"serviceBusEndpoint,omitempty"`
+}
+
+type sbSKU struct {
+	Name string `json:"name,omitempty"`
+	Tier string `json:"tier,omitempty"`
+}
+
+// queueResource is the ARM JSON shape for Microsoft.ServiceBus/namespaces/queues.
+type queueResource struct {
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Properties queueProperties `json:"properties"`
+}
+
+type queueProperties struct {
+	Status                     string `json:"status"`
+	MessageCount               int    `json:"messageCount"`
+	MaxSizeInMegabytes         int    `json:"maxSizeInMegabytes,omitempty"`
+	RequiresDuplicateDetection bool   `json:"requiresDuplicateDetection,omitempty"`
+	RequiresSession            bool   `json:"requiresSession,omitempty"`
+	DefaultMessageTimeToLive   string `json:"defaultMessageTimeToLive,omitempty"`
+	LockDuration               string `json:"lockDuration,omitempty"`
+}
+
+// listResponse is the {value: [...]} envelope ARM uses for collection responses.
+type listResponse struct {
+	Value []any `json:"value"`
+}
+
+// createQueueRequest is what we read from a PUT /queues/{name} body. Most
+// fields are accepted-then-ignored (the driver doesn't model Service Bus
+// dead-letter / forwarding semantics yet).
+type createQueueRequest struct {
+	Properties queueProperties `json:"properties"`
+}
+
+// createNamespaceRequest is what we read from a PUT /namespaces/{ns} body.
+type createNamespaceRequest struct {
+	Location string `json:"location"`
+	SKU      *sbSKU `json:"sku,omitempty"`
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -9,6 +9,7 @@ package gcp
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/server"
@@ -18,6 +19,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
+	"github.com/stackshy/cloudemu/server/gcp/pubsub"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
@@ -30,6 +32,7 @@ type Drivers struct {
 	Networking     netdriver.Networking
 	Monitoring     mondriver.Monitoring
 	CloudFunctions sdrv.Serverless
+	PubSub         mqdriver.MessageQueue
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -58,6 +61,13 @@ func New(d Drivers) *server.Server {
 	// /v1/projects/ prefix match.
 	if d.CloudFunctions != nil {
 		srv.Register(cloudfunctions.New(d.CloudFunctions))
+	}
+
+	// PubSub matches /v1/projects/{p}/{topics|subscriptions}/...; register
+	// before Firestore so its more-specific resource-type guard wins over
+	// Firestore's permissive /v1/projects/ prefix.
+	if d.PubSub != nil {
+		srv.Register(pubsub.New(d.PubSub))
 	}
 
 	if d.Firestore != nil {

--- a/server/gcp/pubsub/handler.go
+++ b/server/gcp/pubsub/handler.go
@@ -1,0 +1,507 @@
+// Package pubsub implements the GCP Pub/Sub v1 REST API as a server.Handler.
+// Real google.golang.org/api/pubsub/v1 clients configured with a custom
+// endpoint hit this handler the same way they hit pubsub.googleapis.com.
+//
+// MVP coverage:
+//
+//	PUT    /v1/projects/{p}/topics/{name}                  — Create
+//	GET    /v1/projects/{p}/topics/{name}                  — Get
+//	GET    /v1/projects/{p}/topics                         — List
+//	DELETE /v1/projects/{p}/topics/{name}                  — Delete
+//	POST   /v1/projects/{p}/topics/{name}:publish          — Publish
+//	PUT    /v1/projects/{p}/subscriptions/{name}           — Create
+//	GET    /v1/projects/{p}/subscriptions/{name}           — Get
+//	GET    /v1/projects/{p}/subscriptions                  — List
+//	DELETE /v1/projects/{p}/subscriptions/{name}           — Delete
+//	POST   /v1/projects/{p}/subscriptions/{name}:pull      — Pull
+//	POST   /v1/projects/{p}/subscriptions/{name}:acknowledge — Ack
+//
+// The portable messagequeue driver pairs a topic and subscription under a
+// single queue keyed by name. SDK-compat reflects this: a subscription's
+// "topic" must point at a topic with the same trailing name. Cross-name
+// subscriptions (sub "billing-events" linked to topic "events") are not
+// modeled in the MVP.
+package pubsub
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+)
+
+const (
+	pathPrefix = "/v1/projects/"
+
+	resTopics        = "topics"
+	resSubscriptions = "subscriptions"
+
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 5 << 20
+
+	// Path-segment counts used to dispatch by URL shape.
+	partsTypeOnly = 2 // /v1/projects/{p}/{type}
+	partsResource = 3 // /v1/projects/{p}/{type}/{name}
+)
+
+// Handler serves Pub/Sub v1 REST requests against a messagequeue driver.
+type Handler struct {
+	mq mqdriver.MessageQueue
+}
+
+// New returns a Pub/Sub handler backed by mq.
+func New(mq mqdriver.MessageQueue) *Handler {
+	return &Handler{mq: mq}
+}
+
+// Matches accepts /v1/projects/{p}/topics[...] and /v1/projects/{p}/subscriptions[...].
+// The resource-type guard prevents this handler from claiming Cloud Functions
+// (locations/functions) or Firestore (databases) URLs that share the same
+// /v1/projects/ prefix.
+func (*Handler) Matches(r *http.Request) bool {
+	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+		return false
+	}
+
+	parts := splitPath(r.URL.Path)
+	if len(parts) < partsTypeOnly {
+		return false
+	}
+
+	// parts[1] is "topics" or "subscriptions" (possibly with :action suffix).
+	t := parts[1]
+	if i := strings.Index(t, ":"); i >= 0 {
+		t = t[:i]
+	}
+
+	return t == resTopics || t == resSubscriptions
+}
+
+// ServeHTTP routes by URL shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < partsTypeOnly {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported path")
+		return
+	}
+
+	project := parts[0]
+	resType := parts[1]
+
+	// Strip ":action" from the type for the bare-collection match.
+	bareType, action := resType, ""
+	if i := strings.Index(resType, ":"); i >= 0 {
+		bareType = resType[:i]
+		action = resType[i+1:]
+	}
+
+	if len(parts) == partsTypeOnly && action == "" {
+		// /v1/projects/{p}/{topics|subscriptions}
+		h.serveCollection(w, r, project, bareType)
+		return
+	}
+
+	// Resource-level: /v1/projects/{p}/{type}/{name}[:action]
+	if len(parts) < partsResource {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "missing resource name")
+		return
+	}
+
+	name := parts[2]
+	if i := strings.Index(name, ":"); i >= 0 {
+		action = name[i+1:]
+		name = name[:i]
+	}
+
+	switch bareType {
+	case resTopics:
+		h.serveTopic(w, r, project, name, action)
+	case resSubscriptions:
+		h.serveSubscription(w, r, project, name, action)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown resource type: "+bareType)
+	}
+}
+
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, project, resType string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	switch resType {
+	case resTopics:
+		out := listTopicsResponse{Topics: make([]topic, 0, len(queues))}
+		for i := range queues {
+			out.Topics = append(out.Topics, topic{
+				Name: topicName(project, queues[i].Name),
+			})
+		}
+
+		writeJSON(w, http.StatusOK, out)
+	case resSubscriptions:
+		out := listSubscriptionsResponse{Subscriptions: make([]subscription, 0, len(queues))}
+		for i := range queues {
+			out.Subscriptions = append(out.Subscriptions, subscription{
+				Name:  subscriptionName(project, queues[i].Name),
+				Topic: topicName(project, queues[i].Name),
+			})
+		}
+
+		writeJSON(w, http.StatusOK, out)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown collection type")
+	}
+}
+
+// ---------- Topics ----------
+
+func (h *Handler) serveTopic(w http.ResponseWriter, r *http.Request, project, name, action string) {
+	if action == "publish" {
+		h.publish(w, r, project, name)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createTopic(w, r, project, name)
+	case http.MethodGet:
+		h.getTopic(w, r, project, name)
+	case http.MethodDelete:
+		h.deleteTopic(w, r, project, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createTopic(w http.ResponseWriter, r *http.Request, project, name string) {
+	var body topic
+	_ = decodeJSON(w, r, &body) // topic body is mostly empty for create; tolerate it
+
+	info, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: name, Tags: body.Labels})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, topic{
+		Name:   topicName(project, info.Name),
+		Labels: info.Tags,
+	})
+}
+
+func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, project, name string) {
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, topic{
+		Name:   topicName(project, q.Name),
+		Labels: q.Tags,
+	})
+}
+
+func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, _, name string) {
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.mq.DeleteQueue(r.Context(), q.URL); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) publish(w http.ResponseWriter, r *http.Request, _, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	var req publishRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := publishResponse{MessageIDs: make([]string, 0, len(req.Messages))}
+
+	for i := range req.Messages {
+		body, decErr := base64.StdEncoding.DecodeString(req.Messages[i].Data)
+		if decErr != nil {
+			// Tolerate unencoded payloads — some test clients send raw JSON.
+			body = []byte(req.Messages[i].Data)
+		}
+
+		send, sendErr := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
+			QueueURL:   q.URL,
+			Body:       string(body),
+			GroupID:    req.Messages[i].OrderingKey,
+			Attributes: req.Messages[i].Attributes,
+		})
+		if sendErr != nil {
+			writeErr(w, sendErr)
+			return
+		}
+
+		out.MessageIDs = append(out.MessageIDs, send.MessageID)
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+// ---------- Subscriptions ----------
+
+func (h *Handler) serveSubscription(w http.ResponseWriter, r *http.Request, project, name, action string) {
+	switch action {
+	case "pull":
+		h.pull(w, r, name)
+		return
+	case "acknowledge":
+		h.acknowledge(w, r, name)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createSubscription(w, r, project, name)
+	case http.MethodGet:
+		h.getSubscription(w, r, project, name)
+	case http.MethodDelete:
+		h.deleteSubscription(w, r, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+	}
+}
+
+func (h *Handler) createSubscription(w http.ResponseWriter, r *http.Request, project, name string) {
+	var body subscription
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	// The driver pairs topic+subscription under a single queue; require the
+	// subscription name to match a known queue (which represents the topic).
+	if _, err := h.findQueueByName(r, name); err != nil {
+		// Auto-create from the topic field if present and matches the sub name.
+		if subToTopicName(body.Topic) != name {
+			writeErr(w, err)
+			return
+		}
+
+		if _, cerr := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: name}); cerr != nil &&
+			!cerrors.IsAlreadyExists(cerr) {
+			writeErr(w, cerr)
+			return
+		}
+	}
+
+	resp := subscription{
+		Name:               subscriptionName(project, name),
+		Topic:              topicName(project, name),
+		AckDeadlineSeconds: body.AckDeadlineSeconds,
+		Labels:             body.Labels,
+	}
+	if resp.AckDeadlineSeconds == 0 {
+		resp.AckDeadlineSeconds = 10
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) getSubscription(w http.ResponseWriter, r *http.Request, project, name string) {
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, subscription{
+		Name:               subscriptionName(project, q.Name),
+		Topic:              topicName(project, q.Name),
+		AckDeadlineSeconds: 10,
+	})
+}
+
+func (*Handler) deleteSubscription(w http.ResponseWriter, _ *http.Request, _ string) {
+	// In the driver, deleting the subscription would orphan the topic. Treat
+	// it as a no-op: real Pub/Sub has no operation that's both safe and useful
+	// here without modeling subscriptions separately.
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) pull(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	var req pullRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if req.MaxMessages == 0 {
+		req.MaxMessages = 1
+	}
+
+	msgs, err := h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
+		QueueURL:    q.URL,
+		MaxMessages: req.MaxMessages,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := pullResponse{ReceivedMessages: make([]receivedMessage, 0, len(msgs))}
+	for i := range msgs {
+		out.ReceivedMessages = append(out.ReceivedMessages, receivedMessage{
+			AckID: msgs[i].ReceiptHandle,
+			Message: pubsubMessage{
+				MessageID:  msgs[i].MessageID,
+				Data:       base64.StdEncoding.EncodeToString([]byte(msgs[i].Body)),
+				Attributes: msgs[i].Attributes,
+			},
+		})
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) acknowledge(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+		return
+	}
+
+	var req acknowledgeRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	q, err := h.findQueueByName(r, name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	for _, ack := range req.AckIDs {
+		if delErr := h.mq.DeleteMessage(r.Context(), q.URL, ack); delErr != nil {
+			writeErr(w, delErr)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// ---------- helpers ----------
+
+func splitPath(p string) []string {
+	rest := strings.TrimPrefix(p, pathPrefix)
+	if rest == "" {
+		return nil
+	}
+
+	return strings.Split(rest, "/")
+}
+
+func topicName(project, name string) string {
+	return fmt.Sprintf("projects/%s/topics/%s", project, name)
+}
+
+func subscriptionName(project, name string) string {
+	return fmt.Sprintf("projects/%s/subscriptions/%s", project, name)
+}
+
+// subToTopicName extracts the trailing topic name from "projects/p/topics/foo".
+func subToTopicName(full string) string {
+	if i := strings.LastIndex(full, "/"); i >= 0 {
+		return full[i+1:]
+	}
+
+	return full
+}
+
+func (h *Handler) findQueueByName(r *http.Request, name string) (*mqdriver.QueueInfo, error) {
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range queues {
+		if queues[i].Name == name {
+			return &queues[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "%s not found", name)
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, reason, msg string) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": msg,
+			"status":  reason,
+		},
+	})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/gcp/pubsub/pubsub_test.go
+++ b/server/gcp/pubsub/pubsub_test.go
@@ -1,0 +1,270 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const project = "demo"
+
+func topicURL(name string) string {
+	return "/v1/projects/" + project + "/topics/" + name
+}
+
+func subURL(name string) string {
+	return "/v1/projects/" + project + "/subscriptions/" + name
+}
+
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+		PubSub:    cloud.PubSub,
+		Firestore: cloud.Firestore, // exercise registration ordering
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestMatchesAcceptsTopicsAndSubscriptions(t *testing.T) {
+	srv := newServer(t)
+
+	for _, p := range []string{
+		"/v1/projects/demo/topics",
+		"/v1/projects/demo/subscriptions",
+	} {
+		resp, err := http.Get(srv.URL + p)
+		if err != nil {
+			t.Fatalf("GET %s: %v", p, err)
+		}
+
+		_ = resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s = %d, want 200", p, resp.StatusCode)
+		}
+	}
+}
+
+func TestMatchesRejectsFirestorePath(t *testing.T) {
+	srv := newServer(t)
+
+	resp, err := http.Post(
+		srv.URL+"/v1/projects/demo/databases/(default)/documents:commit",
+		"application/json", strings.NewReader(`{"writes":[]}`))
+	if err != nil {
+		t.Fatalf("firestore POST: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	// Firestore handler should claim it (200), not pubsub.
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("firestore commit = %d, want 200 (firestore handler should win)", resp.StatusCode)
+	}
+}
+
+func TestTopicLifecycle(t *testing.T) {
+	srv := newServer(t)
+
+	put := doRequest(t, srv, http.MethodPut, topicURL("orders"), `{}`)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT topic = %d, body: %s", put.StatusCode, readBody(t, put))
+	}
+
+	get := doRequest(t, srv, http.MethodGet, topicURL("orders"), "")
+
+	var topicGot struct {
+		Name string `json:"name"`
+	}
+
+	if err := json.NewDecoder(get.Body).Decode(&topicGot); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = get.Body.Close()
+
+	if !strings.HasSuffix(topicGot.Name, "/topics/orders") {
+		t.Fatalf("name = %q, want suffix /topics/orders", topicGot.Name)
+	}
+
+	del := doRequest(t, srv, http.MethodDelete, topicURL("orders"), "")
+	if del.StatusCode != http.StatusOK {
+		t.Fatalf("DELETE topic = %d", del.StatusCode)
+	}
+
+	missing := doRequest(t, srv, http.MethodGet, topicURL("orders"), "")
+	if missing.StatusCode != http.StatusNotFound {
+		t.Fatalf("post-delete GET = %d, want 404", missing.StatusCode)
+	}
+}
+
+func TestSubscriptionLifecycle(t *testing.T) {
+	srv := newServer(t)
+
+	if r := doRequest(t, srv, http.MethodPut, topicURL("events"), `{}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create topic: %d", r.StatusCode)
+	}
+
+	body := `{"topic":"projects/demo/topics/events","ackDeadlineSeconds":30}`
+	put := doRequest(t, srv, http.MethodPut, subURL("events"), body)
+	if put.StatusCode != http.StatusOK {
+		t.Fatalf("PUT subscription = %d, body: %s", put.StatusCode, readBody(t, put))
+	}
+
+	get := doRequest(t, srv, http.MethodGet, subURL("events"), "")
+	if get.StatusCode != http.StatusOK {
+		t.Fatalf("GET subscription = %d", get.StatusCode)
+	}
+}
+
+func TestPublishAndPull(t *testing.T) {
+	srv := newServer(t)
+
+	if r := doRequest(t, srv, http.MethodPut, topicURL("loop"), `{}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create topic: %d", r.StatusCode)
+	}
+
+	pubBody := `{"messages":[{"data":"` +
+		base64.StdEncoding.EncodeToString([]byte("hello")) + `"}]}`
+
+	pub := doRequest(t, srv, http.MethodPost, topicURL("loop")+":publish", pubBody)
+	if pub.StatusCode != http.StatusOK {
+		t.Fatalf("publish = %d", pub.StatusCode)
+	}
+
+	pull := doRequest(t, srv, http.MethodPost, subURL("loop")+":pull", `{"maxMessages":1}`)
+	if pull.StatusCode != http.StatusOK {
+		t.Fatalf("pull = %d", pull.StatusCode)
+	}
+
+	var pullResp struct {
+		ReceivedMessages []struct {
+			AckID   string `json:"ackId"`
+			Message struct {
+				MessageID string `json:"messageId"`
+				Data      string `json:"data"`
+			} `json:"message"`
+		} `json:"receivedMessages"`
+	}
+
+	if err := json.NewDecoder(pull.Body).Decode(&pullResp); err != nil {
+		t.Fatalf("decode pull: %v", err)
+	}
+
+	_ = pull.Body.Close()
+
+	if len(pullResp.ReceivedMessages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(pullResp.ReceivedMessages))
+	}
+
+	got, _ := base64.StdEncoding.DecodeString(pullResp.ReceivedMessages[0].Message.Data)
+	if string(got) != "hello" {
+		t.Fatalf("body = %q, want hello", got)
+	}
+
+	ackBody := `{"ackIds":["` + pullResp.ReceivedMessages[0].AckID + `"]}`
+	ack := doRequest(t, srv, http.MethodPost, subURL("loop")+":acknowledge", ackBody)
+	if ack.StatusCode != http.StatusOK {
+		t.Fatalf("ack = %d", ack.StatusCode)
+	}
+}
+
+func TestPullEmpty(t *testing.T) {
+	srv := newServer(t)
+
+	if r := doRequest(t, srv, http.MethodPut, topicURL("empty"), `{}`); r.StatusCode != http.StatusOK {
+		t.Fatalf("create topic: %d", r.StatusCode)
+	}
+
+	resp := doRequest(t, srv, http.MethodPost, subURL("empty")+":pull", `{"maxMessages":1}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pull = %d, want 200", resp.StatusCode)
+	}
+
+	body := readBody(t, resp)
+	if strings.Contains(body, `"ackId"`) {
+		t.Fatalf("expected no messages, got %s", body)
+	}
+}
+
+func TestPublishToMissingTopic(t *testing.T) {
+	srv := newServer(t)
+
+	pub := doRequest(t, srv, http.MethodPost, topicURL("nope")+":publish",
+		`{"messages":[{"data":"eA=="}]}`)
+	if pub.StatusCode != http.StatusNotFound {
+		t.Fatalf("publish missing = %d, want 404", pub.StatusCode)
+	}
+}
+
+func TestListTopics(t *testing.T) {
+	srv := newServer(t)
+
+	for _, n := range []string{"a", "b"} {
+		_ = doRequest(t, srv, http.MethodPut, topicURL(n), `{}`)
+	}
+
+	resp := doRequest(t, srv, http.MethodGet, "/v1/projects/"+project+"/topics", "")
+
+	var got struct {
+		Topics []map[string]any `json:"topics"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	_ = resp.Body.Close()
+
+	if len(got.Topics) != 2 {
+		t.Fatalf("listed %d topics, want 2", len(got.Topics))
+	}
+}
+
+// helpers --------------------------------------------------------------------
+
+func doRequest(t *testing.T, srv *httptest.Server, method, path, body string) *http.Response {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), method, srv.URL+path, rdr)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+
+	return resp
+}
+
+func readBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	return strings.TrimSpace(string(b))
+}

--- a/server/gcp/pubsub/sdk_roundtrip_test.go
+++ b/server/gcp/pubsub/sdk_roundtrip_test.go
@@ -1,0 +1,123 @@
+package pubsub_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+	"google.golang.org/api/option"
+	pubsubv1 "google.golang.org/api/pubsub/v1"
+)
+
+func newSDKService(t *testing.T) *pubsubv1.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{PubSub: cloud.PubSub})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := pubsubv1.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestSDKPubSubTopicLifecycle(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	created, err := svc.Projects.Topics.Create(
+		"projects/demo/topics/sdk-topic", &pubsubv1.Topic{}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !strings.HasSuffix(created.Name, "/topics/sdk-topic") {
+		t.Fatalf("created.Name = %q, want suffix /topics/sdk-topic", created.Name)
+	}
+
+	got, err := svc.Projects.Topics.Get("projects/demo/topics/sdk-topic").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name != created.Name {
+		t.Fatalf("Get returned %q, want %q", got.Name, created.Name)
+	}
+
+	if _, err := svc.Projects.Topics.Delete("projects/demo/topics/sdk-topic").Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestSDKPubSubPublishPullAck(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	const topicName = "projects/demo/topics/loop"
+	const subName = "projects/demo/subscriptions/loop"
+
+	if _, err := svc.Projects.Topics.Create(topicName, &pubsubv1.Topic{}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Topic.Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Subscriptions.Create(subName, &pubsubv1.Subscription{
+		Topic: topicName,
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Subscription.Create: %v", err)
+	}
+
+	if _, err := svc.Projects.Topics.Publish(topicName, &pubsubv1.PublishRequest{
+		Messages: []*pubsubv1.PubsubMessage{
+			{Data: base64.StdEncoding.EncodeToString([]byte("hello"))},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	pull, err := svc.Projects.Subscriptions.Pull(subName, &pubsubv1.PullRequest{
+		MaxMessages: 1,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Pull: %v", err)
+	}
+
+	if len(pull.ReceivedMessages) != 1 {
+		t.Fatalf("got %d messages, want 1", len(pull.ReceivedMessages))
+	}
+
+	body, _ := base64.StdEncoding.DecodeString(pull.ReceivedMessages[0].Message.Data)
+	if string(body) != "hello" {
+		t.Fatalf("body = %q, want hello", body)
+	}
+
+	if _, err := svc.Projects.Subscriptions.Acknowledge(subName, &pubsubv1.AcknowledgeRequest{
+		AckIds: []string{pull.ReceivedMessages[0].AckId},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Acknowledge: %v", err)
+	}
+}
+
+func TestSDKPubSubPublishToMissingTopic(t *testing.T) {
+	svc := newSDKService(t)
+
+	_, err := svc.Projects.Topics.Publish("projects/demo/topics/nope",
+		&pubsubv1.PublishRequest{Messages: []*pubsubv1.PubsubMessage{
+			{Data: base64.StdEncoding.EncodeToString([]byte("x"))},
+		}}).Context(context.Background()).Do()
+
+	if err == nil {
+		t.Fatal("Publish to missing topic returned nil error, want NotFound")
+	}
+}

--- a/server/gcp/pubsub/types.go
+++ b/server/gcp/pubsub/types.go
@@ -1,0 +1,59 @@
+package pubsub
+
+// topic is the GCP Pub/Sub Topic resource shape.
+type topic struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// subscription is the GCP Pub/Sub Subscription resource shape.
+type subscription struct {
+	Name               string            `json:"name"`
+	Topic              string            `json:"topic"`
+	AckDeadlineSeconds int               `json:"ackDeadlineSeconds,omitempty"`
+	Labels             map[string]string `json:"labels,omitempty"`
+}
+
+type listTopicsResponse struct {
+	Topics []topic `json:"topics"`
+}
+
+type listSubscriptionsResponse struct {
+	Subscriptions []subscription `json:"subscriptions"`
+}
+
+// publishRequest is POST topics/{name}:publish.
+type publishRequest struct {
+	Messages []pubsubMessage `json:"messages"`
+}
+
+type pubsubMessage struct {
+	Data        string            `json:"data"` // base64
+	Attributes  map[string]string `json:"attributes,omitempty"`
+	OrderingKey string            `json:"orderingKey,omitempty"`
+	MessageID   string            `json:"messageId,omitempty"`
+}
+
+type publishResponse struct {
+	MessageIDs []string `json:"messageIds"`
+}
+
+// pullRequest is POST subscriptions/{name}:pull.
+type pullRequest struct {
+	MaxMessages       int  `json:"maxMessages"`
+	ReturnImmediately bool `json:"returnImmediately"`
+}
+
+type pullResponse struct {
+	ReceivedMessages []receivedMessage `json:"receivedMessages"`
+}
+
+type receivedMessage struct {
+	AckID   string        `json:"ackId"`
+	Message pubsubMessage `json:"message"`
+}
+
+// acknowledgeRequest is POST subscriptions/{name}:acknowledge.
+type acknowledgeRequest struct {
+	AckIDs []string `json:"ackIds"`
+}


### PR DESCRIPTION
## Summary

Adds SDK-compat HTTP servers for message queues across all 3 providers — the next service domain to reach lockstep parity after serverless (#144). Messaging is the most-requested cloud-emulation surface after compute and is the main reason most teams reach for LocalStack today.

- **server/aws/sqs** — JSON-RPC (`AwsJson1_0` via `X-Amz-Target: AmazonSQS.*`). Modern aws-sdk-go-v2 SQS migrated off the legacy Query protocol in 2023; this matches.
- **server/azure/servicebus** — ARM control plane (`Microsoft.ServiceBus/namespaces[/queues]` PUT/GET/DELETE) + raw-HTTP REST data plane (`POST /{ns}/{queue}/messages`, `DELETE /messages/head`). The modern `azservicebus` SDK is AMQP-only and out of MVP scope; ARM is round-tripped via real `armservicebus/v2`.
- **server/gcp/pubsub** — Topics + Subscriptions lifecycle, `:publish`, `:pull`, `:acknowledge`. Resource-type guard registers ahead of Firestore so the shared `/v1/projects/` prefix doesn't shadow.

## Scope (MVP — Phase 1)

Lifecycle + send/receive/delete loop. Batch ops, ChangeMessageVisibility, queue attributes, DLQ wire mapping, FIFO dedup wire format, AMQP, streaming pull, and ordering keys are deferred — the portable `messagequeue/driver` already supports the underlying semantics.

## Wiring & registration ordering

- `awsserver.Drivers.SQS`, `azureserver.Drivers.ServiceBus`, `gcpserver.Drivers.PubSub` fields added.
- AWS SQS matches via `X-Amz-Target` (mutually exclusive with DynamoDB).
- Azure Service Bus ARM path is uniquely `Microsoft.ServiceBus`; data plane matches non-`/subscriptions/` paths ending in `/messages` or `/messages/head`.
- GCP Pub/Sub registers before Firestore — same precedent set by Cloud Functions in #144.

## Tests

- **Per-handler unit tests** (raw HTTP via `httptest`): 19 cases covering lifecycle, error paths, send/receive round-trips, registration ordering, empty-queue receive.
- **Real-SDK round-trip tests**:
  - `aws-sdk-go-v2/service/sqs`
  - `armservicebus/v2` (Azure SDK, control plane)
  - `google.golang.org/api/pubsub/v1`
- **Cross-provider integration test** (`messagequeue_sdk_compat_test.go`): single test spins up all 3 servers and validates send→receive→delete in lockstep.
- **65/65** end-to-end checks passing in `/tmp/cloudemu-e2e` with real cloud SDKs hitting local httptest servers (23 new MQ cases on top of the 42 from #144).

## Verification

```
go build ./...
go vet ./...
go test -count=1 ./...                           # all packages green
golangci-lint run --timeout=9m ./...             # 0 issues
```

## Commits (feature-wise)

1. `fix`: canonicalize `x-ms-*` header casing in `azure/blob` handler (clears 8 pre-existing lint warnings from #138)
2. `chore(deps)`: add `aws-sdk-go-v2/service/sqs` and `armservicebus/v2`
3. `feat(aws)`: AWS SQS SDK-compat handler
4. `feat(azure)`: Azure Service Bus SDK-compat handler
5. `feat(gcp)`: GCP Pub/Sub SDK-compat handler
6. `test`: cross-provider message queue integration test

## Out of scope (Phase 2 follow-up)

AWS: SendMessageBatch, ChangeMessageVisibility, GetQueueAttributes, DLQ redrive wire format, FIFO dedup wire format.
Azure: AMQP data plane, topics + subscriptions (Service Bus topics, not the resource type), sessions, dead-letter queues.
GCP: streaming pull, ordering keys, schema registry, cross-name subscription/topic mapping.

## Test plan

- [ ] CI runs `go build ./...` clean
- [ ] CI runs `go test ./...` — every package passes
- [ ] CI runs `golangci-lint run --timeout=9m ./...` — 0 new issues
- [ ] Manual: instantiate `awsserver.New(awsserver.Drivers{SQS: cloud.SQS})` and round-trip with `aws-sdk-go-v2/service/sqs`
- [ ] Manual: same for Azure (`armservicebus/v2`) and GCP (`pubsub/v1`)