### PR TITLE
docs: refresh SDK-compat coverage for serverless + message queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,45 +120,60 @@ engine.Apply(chaos.ServiceOutage("storage", 5*time.Second))
 
 Scenarios available today: `ServiceOutage`, `LatencySpike`, `ProbabilisticFailure`, `Throttle`, `Composite`. Works for both Go API and SDK-compat HTTP clients. See [docs/chaos.md](docs/chaos.md).
 
-## Use the Real AWS SDK (no code changes)
+## Use the Real Cloud SDKs (no code changes)
 
-If your app already uses `aws-sdk-go-v2`, you don't have to rewrite anything. cloudemu ships an HTTP server that speaks the real AWS wire protocols. Point the SDK's `BaseEndpoint` at localhost and your production code just works.
+If your app already uses `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go`, you don't have to rewrite anything. cloudemu ships HTTP servers that speak the real wire protocols of all three providers. Point the SDK's endpoint at localhost and your production code just works.
 
 ```go
 import (
     "github.com/stackshy/cloudemu"
-    awsserver "github.com/stackshy/cloudemu/server/aws"
+    awsserver   "github.com/stackshy/cloudemu/server/aws"
+    azureserver "github.com/stackshy/cloudemu/server/azure"
+    gcpserver   "github.com/stackshy/cloudemu/server/gcp"
 )
 
+// AWS
 aws := cloudemu.NewAWS()
-srv := awsserver.New(awsserver.Drivers{
-    S3: aws.S3, DynamoDB: aws.DynamoDB, EC2: aws.EC2,
-})
-ts := httptest.NewServer(srv)
+awsTS := httptest.NewServer(awsserver.New(awsserver.Drivers{
+    S3:     aws.S3,     DynamoDB: aws.DynamoDB, EC2: aws.EC2, VPC: aws.VPC,
+    Lambda: aws.Lambda, SQS:      aws.SQS,      CloudWatch: aws.CloudWatch,
+}))
 
-// Use the REAL aws-sdk-go-v2 client — only the endpoint changes.
+// Azure (TLS — Azure SDK refuses bearer tokens over plain HTTP)
+az := cloudemu.NewAzure()
+azureTS := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{
+    VirtualMachines: az.VirtualMachines, BlobStorage: az.BlobStorage,
+    CosmosDB: az.CosmosDB, Network: az.VNet, Monitor: az.Monitor,
+    Functions: az.Functions, ServiceBus: az.ServiceBus,
+}))
+
+// GCP
+gcp := cloudemu.NewGCP()
+gcpTS := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
+    Compute: gcp.GCE, Networking: gcp.VPC, Storage: gcp.GCS,
+    Firestore: gcp.Firestore, Monitoring: gcp.CloudMonitoring,
+    CloudFunctions: gcp.CloudFunctions, PubSub: gcp.PubSub,
+}))
+
+// Use the REAL SDK clients — only the endpoint changes.
 s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-    o.BaseEndpoint = aws.String(ts.URL)
+    o.BaseEndpoint = aws.String(awsTS.URL)
     o.UsePathStyle = true
 })
 s3Client.PutObject(ctx, &s3.PutObjectInput{...}) // works
 ```
 
-Currently covered:
+Currently covered (lockstep across all 3 providers):
 
-| Service | Operations |
-|---------|-----------|
-| **S3** | CreateBucket, DeleteBucket, ListBuckets, PutObject, GetObject, HeadObject, DeleteObject, ListObjectsV2, CopyObject |
-| **DynamoDB** | CreateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, Query |
-| **EC2** | RunInstances, DescribeInstances (with filters), StartInstances, StopInstances, RebootInstances, TerminateInstances, ModifyInstanceAttribute |
-| **EC2 — VPC & Networking** | CreateVpc, DeleteVpc, DescribeVpcs, CreateSubnet, DeleteSubnet, DescribeSubnets, CreateSecurityGroup, DeleteSecurityGroup, DescribeSecurityGroups, AuthorizeSecurityGroupIngress/Egress, RevokeSecurityGroupIngress/Egress, CreateInternetGateway, AttachInternetGateway, DetachInternetGateway, DescribeInternetGateways, CreateRouteTable, DescribeRouteTables, CreateRoute |
-| **EC2 — EBS & Key Pairs** | CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume, CreateKeyPair, DeleteKeyPair, DescribeKeyPairs |
-| **Auto Scaling** | CreateAutoScalingGroup, Update/Delete/DescribeAutoScalingGroups, SetDesiredCapacity, Put/Delete/ExecutePolicy |
-| **EC2 — Snapshots/AMIs** | Create/Delete/DescribeSnapshots, Create/Deregister/DescribeImages |
-| **EC2 — Spot/Launch Templates** | Request/Cancel/DescribeSpotInstanceRequests, Create/Delete/DescribeLaunchTemplates |
-| **EC2 — NAT/Peering/Flow Logs** | NAT gateways, VPC peering connections, VPC flow logs |
-| **EC2 — Network ACLs** | Create/Delete/DescribeNetworkAcls, Create/DeleteNetworkAclEntry |
-| **CloudWatch** | PutMetricData, GetMetricStatistics, ListMetrics, PutMetricAlarm, Describe/DeleteAlarms (Smithy rpc-v2-cbor) |
+| Domain | AWS | Azure | GCP |
+|--------|-----|-------|-----|
+| **Storage** | S3 | Blob (containers + blobs, copy) | GCS |
+| **Compute** | EC2 (+ VPC/Subnets/SG/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/KeyPairs/AMIs/Snapshots/Spot/LaunchTemplates) | VirtualMachines (+ Disks, Snapshots, Images, SSH keys) | Compute Engine (+ Disks, Snapshots, Images) |
+| **Database** | DynamoDB (CRUD, Query, Scan, Batch, TransactWrite) | Cosmos DB (DBs, containers, documents) | Firestore (commit, batchGet, runQuery) |
+| **Networking** | (in EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
+| **Monitoring** | CloudWatch (Smithy rpc-v2-cbor) | Azure Monitor | Cloud Monitoring (alert policies + time series) |
+| **Serverless** | Lambda (lifecycle + Invoke) | Functions (`Microsoft.Web/sites` + `/api/{name}` invoke) | Cloud Functions v1 (lifecycle + `:call`) |
+| **Message Queue** | SQS (JSON-RPC) | Service Bus (ARM + REST data plane) | Pub/Sub (topics/subs + publish/pull/ack) |
 
 More services land progressively — see [docs/sdk-server.md](docs/sdk-server.md).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ The bottom layer contains the actual mock implementations for each cloud provide
 Sitting above Layer 2 (driver interfaces) are **cross-service engines** that consume driver interfaces directly without going through the portable API. They're peers of each other, not layers in the three-layer stack. Two exist today:
 
 - `topology/` -- reads from compute, networking, and DNS drivers to simulate real network connectivity (`CanConnect`, `TraceRoute`, `Resolve`, security-group and NACL evaluation). See [topology.md](topology.md).
-- `server/` -- exposes driver interfaces over HTTP in each cloud's native SDK wire format, so real `aws-sdk-go-v2` clients work against CloudEmu by only changing `BaseEndpoint`. Currently covers S3, DynamoDB, and EC2 core instance operations. Uses a pluggable `Handler` registry so new services drop in as self-contained packages without touching the core. See [sdk-server.md](sdk-server.md).
+- `server/` -- exposes driver interfaces over HTTP in each cloud's native SDK wire format, so real `aws-sdk-go-v2`, `azure-sdk-for-go`, and `cloud.google.com/go` clients work against CloudEmu by only changing the endpoint. Covers Storage, Compute, Database, Networking, Monitoring, Serverless, and Message Queue across all 3 providers (AWS S3/EC2/DynamoDB/Lambda/SQS/CloudWatch + sibling Azure ARM and GCP REST handlers). Uses a pluggable `Handler` registry so new services drop in as self-contained packages without touching the core. See [sdk-server.md](sdk-server.md).
 
 Both engines depend only on Layer 2 interfaces -- never on concrete provider types -- so they work uniformly across AWS, Azure, and GCP backends.
 
@@ -224,4 +224,24 @@ providers/
         fcm/                          # FCM mock
         artifactregistry/             # Artifact Registry mock
         eventarc/                     # Eventarc mock
+server/                               # SDK-compat HTTP servers (real cloud SDKs work against this)
+    server.go                         # core: Handler interface + dispatcher
+    wire/
+        wire.go                       # shared XML/JSON helpers
+        awsquery/                     # AWS query-protocol helpers
+        azurearm/                     # ARM URL parser + JSON envelope
+        gcprest/                      # GCP REST URL parser + LRO Operation helpers
+    aws/
+        aws.go                        # awsserver.New(Drivers{...})
+        s3/  ec2/  dynamodb/          # S3 REST+XML, EC2 query, DynamoDB JSON-RPC
+        cloudwatch/                   # Smithy rpc-v2-cbor
+        lambda/  sqs/                 # REST + JSON-RPC handlers
+    azure/
+        azure.go                      # azureserver.New(Drivers{...})
+        virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
+        blob/  cosmos/  network/  monitor/  functions/  servicebus/
+    gcp/
+        gcp.go                        # gcpserver.New(Drivers{...})
+        compute/  networks/  gcs/  firestore/  monitoring/
+        cloudfunctions/  pubsub/
 ```

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -1,14 +1,14 @@
 # SDK-Compatible HTTP Server
 
-CloudEmu includes an HTTP server that speaks the real AWS wire protocols. Point the actual `aws-sdk-go-v2` clients at it (via `BaseEndpoint`) and your production code runs unchanged against the in-memory backend.
+CloudEmu includes an HTTP server that speaks the real cloud SDK wire protocols across all three providers — AWS, Azure, and GCP. Point the actual `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go` / `google.golang.org/api` clients at it (via custom endpoint) and your production code runs unchanged against the in-memory backend.
 
-Nothing to mock. No Docker. No accounts. The same SDK calls you'd run against real AWS hit a local `httptest.NewServer` and get back SDK-decodable responses.
+Nothing to mock. No Docker. No accounts. The same SDK calls you'd run against real AWS / Azure / GCP hit a local `httptest.NewServer` and get back SDK-decodable responses.
 
 ## Why
 
-CloudEmu's Go API is great for new code you write for testing. But most real apps already use `aws-sdk-go-v2` directly. Rewriting those call sites just to test against an emulator is friction. The SDK server removes that friction — change the endpoint, done.
+CloudEmu's Go API is great for new code you write for testing. But most real apps already use the official cloud SDKs directly. Rewriting those call sites just to test against an emulator is friction. The SDK-compat server removes that friction — change the endpoint, done.
 
-## Quick start
+## Quick start (AWS)
 
 ```go
 import (
@@ -25,6 +25,10 @@ srv := awsserver.New(awsserver.Drivers{
     S3:       cloud.S3,
     DynamoDB: cloud.DynamoDB,
     EC2:      cloud.EC2,
+    VPC:      cloud.VPC,
+    Lambda:   cloud.Lambda,
+    SQS:      cloud.SQS,
+    CloudWatch: cloud.CloudWatch,
 })
 ts := httptest.NewServer(srv)
 defer ts.Close()
@@ -38,34 +42,122 @@ client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 client.PutObject(ctx, &s3.PutObjectInput{...})
 ```
 
-Region and credentials can be any dummy values — the server doesn't validate signatures.
+## Quick start (Azure)
+
+```go
+import (
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+    "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+    "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+    "github.com/stackshy/cloudemu"
+    azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+cp := cloudemu.NewAzure()
+srv := azureserver.New(azureserver.Drivers{
+    VirtualMachines: cp.VirtualMachines,
+    BlobStorage:     cp.BlobStorage,
+    CosmosDB:        cp.CosmosDB,
+    Network:         cp.VNet,
+    Monitor:         cp.Monitor,
+    Functions:       cp.Functions,
+    ServiceBus:      cp.ServiceBus,
+})
+ts := httptest.NewTLSServer(srv) // Azure SDK requires TLS
+
+opts := &arm.ClientOptions{
+    ClientOptions: azcore.ClientOptions{
+        Cloud: cloud.Configuration{
+            Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+                cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+            },
+        },
+        Transport: ts.Client(),
+    },
+}
+client, _ := armcompute.NewVirtualMachinesClient("sub-1", fakeCred{}, opts)
+```
+
+## Quick start (GCP)
+
+```go
+import (
+    gcpcompute "cloud.google.com/go/compute/apiv1"
+    "github.com/stackshy/cloudemu"
+    gcpserver "github.com/stackshy/cloudemu/server/gcp"
+    "google.golang.org/api/option"
+)
+
+cp := cloudemu.NewGCP()
+srv := gcpserver.New(gcpserver.Drivers{
+    Compute:        cp.GCE,
+    Storage:        cp.GCS,
+    Firestore:      cp.Firestore,
+    Networking:     cp.VPC,
+    Monitoring:     cp.CloudMonitoring,
+    CloudFunctions: cp.CloudFunctions,
+    PubSub:         cp.PubSub,
+})
+ts := httptest.NewServer(srv)
+
+opts := []option.ClientOption{
+    option.WithEndpoint(ts.URL),
+    option.WithoutAuthentication(),
+    option.WithHTTPClient(ts.Client()),
+}
+client, _ := gcpcompute.NewInstancesRESTClient(ctx, opts...)
+```
+
+Region, credentials, and tokens can be any dummy values — the server doesn't validate signatures or AAD tokens.
 
 ## Currently supported
 
+### AWS (`server/aws/`)
+
 | Service | Operations |
 |---------|-----------|
-| **S3** | CreateBucket, DeleteBucket, ListBuckets, PutObject, GetObject, HeadObject, DeleteObject, ListObjectsV2 (with prefix, delimiter, common prefixes, continuation token), CopyObject |
+| **S3** | CreateBucket, DeleteBucket, ListBuckets, PutObject, GetObject, HeadObject, DeleteObject, ListObjectsV2 (prefix, delimiter, common prefixes, continuation token), CopyObject |
 | **DynamoDB** | CreateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, UpdateItem (SET/REMOVE), Query, Scan (with FilterExpression), BatchWriteItem, BatchGetItem, TransactWriteItems |
-| **EC2** | RunInstances (tags, security groups, multi-count), DescribeInstances (filters: `instance-id`, `instance-type`, `instance-state-name`, `tag:*`), StartInstances, StopInstances, RebootInstances, TerminateInstances, ModifyInstanceAttribute |
-| **EC2 — VPC** | CreateVpc, DeleteVpc, DescribeVpcs |
-| **EC2 — Subnet** | CreateSubnet, DeleteSubnet, DescribeSubnets |
-| **EC2 — Security Group** | CreateSecurityGroup, DeleteSecurityGroup, DescribeSecurityGroups, AuthorizeSecurityGroupIngress/Egress, RevokeSecurityGroupIngress/Egress |
-| **EC2 — Internet Gateway** | CreateInternetGateway, AttachInternetGateway, DetachInternetGateway, DescribeInternetGateways |
-| **EC2 — Route Table** | CreateRouteTable, DescribeRouteTables, CreateRoute (gateway/nat-gateway/peering targets) |
-| **EC2 — EBS Volumes** | CreateVolume, DeleteVolume, DescribeVolumes, AttachVolume, DetachVolume |
-| **EC2 — Key Pairs** | CreateKeyPair, DeleteKeyPair, DescribeKeyPairs |
-| **Auto Scaling** | CreateAutoScalingGroup, UpdateAutoScalingGroup, DeleteAutoScalingGroup, DescribeAutoScalingGroups, SetDesiredCapacity, PutScalingPolicy, DeletePolicy, ExecutePolicy |
-| **EC2 — Snapshots** | CreateSnapshot, DeleteSnapshot, DescribeSnapshots |
-| **EC2 — AMIs** | CreateImage, DeregisterImage, DescribeImages |
-| **EC2 — Spot Instances** | RequestSpotInstances, CancelSpotInstanceRequests, DescribeSpotInstanceRequests |
-| **EC2 — Launch Templates** | CreateLaunchTemplate, DeleteLaunchTemplate, DescribeLaunchTemplates |
-| **EC2 — NAT Gateways** | CreateNatGateway, DeleteNatGateway, DescribeNatGateways |
-| **EC2 — VPC Peering** | CreateVpcPeeringConnection, AcceptVpcPeeringConnection, DeleteVpcPeeringConnection, DescribeVpcPeeringConnections |
-| **EC2 — Flow Logs** | CreateFlowLogs, DeleteFlowLogs, DescribeFlowLogs |
-| **EC2 — Network ACLs** | CreateNetworkAcl, DeleteNetworkAcl, DescribeNetworkAcls, CreateNetworkAclEntry, DeleteNetworkAclEntry |
-| **CloudWatch** *(rpc-v2-cbor)* | PutMetricData, GetMetricStatistics, ListMetrics, PutMetricAlarm, DescribeAlarms, DeleteAlarms |
+| **EC2** | RunInstances, DescribeInstances (filters: `instance-id`, `instance-type`, `instance-state-name`, `tag:*`), Start/Stop/Reboot/TerminateInstances, ModifyInstanceAttribute |
+| **EC2 — VPC + Networking** | VPCs, Subnets, Security Groups + ingress/egress rules, Internet Gateways, Route Tables + Routes, NAT Gateways, VPC Peering, Flow Logs, Network ACLs |
+| **EC2 — EBS + Key Pairs** | Volumes (Create/Delete/Describe/Attach/Detach), Key Pairs |
+| **EC2 — Snapshots + AMIs + Spot + Launch Templates** | Snapshots, Images, Spot instance requests, Launch Templates |
+| **Auto Scaling** | CreateAutoScalingGroup, Update/Delete/Describe, SetDesiredCapacity, scaling policies |
+| **Lambda** *(REST + JSON)* | CreateFunction, GetFunction, ListFunctions, DeleteFunction, Invoke (sync) |
+| **SQS** *(JSON-RPC AwsJson1_0)* | CreateQueue, GetQueueUrl, ListQueues, DeleteQueue, SendMessage, ReceiveMessage, DeleteMessage |
+| **CloudWatch** *(Smithy rpc-v2-cbor)* | PutMetricData, GetMetricStatistics, ListMetrics, PutMetricAlarm, DescribeAlarms, DeleteAlarms |
 
-Any operation not in this list returns `501 Not Implemented` or the AWS-style `UnknownOperation` / `InvalidAction` error. The list grows each phase — see the bottom of this page.
+### Azure (`server/azure/`)
+
+All handlers speak ARM JSON over HTTPS unless noted.
+
+| Service | ARM provider / operations |
+|---------|--------------------------|
+| **Virtual Machines** | `Microsoft.Compute/virtualMachines` — CreateOrUpdate, Get, List, Delete, start, powerOff, restart |
+| **Disks / Snapshots / Images / SSH Public Keys** | `Microsoft.Compute/{disks,snapshots,images,sshPublicKeys}` — full CRUD |
+| **Blob Storage** *(data plane)* | Containers + Blobs: Create/Delete/List, PutBlob, GetBlob, DeleteBlob, CopyBlob |
+| **Cosmos DB** *(data plane)* | Databases, Containers, Documents — full CRUD with `x-ms-documentdb-*` headers |
+| **Virtual Network** | `Microsoft.Network/virtualNetworks` — CRUD + subnets |
+| **Azure Monitor** | `microsoft.insights/metricAlerts` and metric data ingest/read |
+| **Functions** | `Microsoft.Web/sites` (Function Apps): CreateOrUpdate, Get, List, Delete + non-ARM `/api/{name}` invoke |
+| **Service Bus** | `Microsoft.ServiceBus/namespaces[/queues]` ARM CRUD + raw-HTTP REST data plane (`POST /{ns}/{queue}/messages`, `DELETE /messages/head`) |
+
+### GCP (`server/gcp/`)
+
+All handlers speak REST + JSON.
+
+| Service | Operations |
+|---------|-----------|
+| **Compute Engine** | Instances + Disks + Snapshots + Images: insert/get/list/delete with LRO envelopes |
+| **Networks** | VPCs, Subnetworks, Firewalls, Routes |
+| **Cloud Storage (GCS)** | Buckets + Objects: create/get/list/delete, upload, download, copy |
+| **Firestore** | Documents + Collections via `:commit`, `:batchGet`, `:runQuery` |
+| **Cloud Monitoring** | Time-series ingest/read, alert policies |
+| **Cloud Functions v1** | Create (LRO), Get, List, Delete (LRO), `:call` (sync invoke) |
+| **Pub/Sub** | Topics + Subscriptions lifecycle, `:publish`, `:pull`, `:acknowledge` |
+
+Any operation not in these lists returns `501 Not Implemented` or the provider's native `UnknownOperation` / `NotImplemented` / `NOT_FOUND` error.
 
 ## How it's wired internally
 
@@ -73,15 +165,23 @@ The server is a tiny core plus a plugin-per-service model. Each service is a sel
 
 ```
 server/
-├── server.go                    # core: Handler interface + Server (≈80 LOC)
+├── server.go                       # core: Handler interface + Server (~80 LOC)
 ├── wire/
-│   ├── wire.go                  # S3/DynamoDB shared helpers (XML, JSON, date)
-│   └── awsquery/                # AWS query-protocol: form decoder + XML envelope
-└── aws/
-    ├── aws.go                   # convenience: New(Drivers{...}) *server.Server
-    ├── s3/                      # S3 REST+XML handler
-    ├── dynamodb/                # DynamoDB JSON-RPC handler
-    └── ec2/                     # EC2 query-protocol handler
+│   ├── wire.go                     # shared XML/JSON helpers
+│   ├── awsquery/                   # AWS query-protocol form decoder + XML envelope
+│   ├── azurearm/                   # ARM URL parser + JSON helpers + error envelope
+│   └── gcprest/                    # GCP REST URL parser + Operation LRO helpers
+├── aws/
+│   ├── aws.go                      # awsserver.New(Drivers{...})
+│   ├── s3/  ec2/  dynamodb/  lambda/  sqs/  cloudwatch/
+├── azure/
+│   ├── azure.go                    # azureserver.New(Drivers{...})
+│   ├── virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
+│   ├── blob/  cosmos/  network/  monitor/  functions/  servicebus/
+└── gcp/
+    ├── gcp.go                      # gcpserver.New(Drivers{...})
+    └── compute/  networks/  gcs/  firestore/  monitoring/
+        cloudfunctions/  pubsub/
 ```
 
 Each handler implements a two-method interface:
@@ -93,40 +193,43 @@ type Handler interface {
 }
 ```
 
-`server.Server` iterates registered handlers and dispatches to the first that claims the request. Adding a new service (Lambda, SQS, Azure Blob, GCS) = a new package + one `Register` call. The core never changes.
+`server.Server` iterates registered handlers and dispatches to the first that claims the request. Adding a new service is one new package + one `Register` call. The core never changes.
 
 ### Protocol detection
 
-Each handler uses a different signal so dispatch is unambiguous:
+Each handler uses a different signal so dispatch is unambiguous within a provider:
 
-| Service | How it's detected |
+| Handler | How it's detected |
 |---------|-------------------|
-| DynamoDB | `X-Amz-Target: DynamoDB_20120810.*` header |
-| EC2 | `Action=…` in URL query or `Content-Type: application/x-www-form-urlencoded` POST |
-| S3 | Fallback (everything else) |
+| AWS DynamoDB | `X-Amz-Target: DynamoDB_20120810.*` header |
+| AWS SQS | `X-Amz-Target: AmazonSQS.*` header |
+| AWS Lambda | URL prefix `/2015-03-31/functions` |
+| AWS EC2 | `Action=…` in URL query or `Content-Type: application/x-www-form-urlencoded` POST |
+| AWS CloudWatch | `Smithy-Protocol: rpc-v2-cbor` header |
+| AWS S3 | Fallback (everything else REST-shaped) |
+| Azure (all ARM) | URL begins with `/subscriptions/{sub}` and matches `Microsoft.<Provider>/<Type>` |
+| Azure Cosmos | URL begins with `/dbs/` (data plane, non-ARM) |
+| Azure Functions invoke | URL begins with `/api/` (non-ARM data plane) |
+| Azure Service Bus data plane | Non-ARM URL ending in `/messages` or `/messages/head` |
+| Azure Blob | Fallback (everything else non-ARM that's REST-shaped) |
+| GCP Compute / Networks | URL prefix `/compute/v1/` |
+| GCP Cloud Functions | `/v1/projects/.../locations/.../functions[/...]` |
+| GCP Pub/Sub | `/v1/projects/.../topics[/...]` or `/v1/projects/.../subscriptions[/...]` |
+| GCP Firestore | `/v1/projects/.../databases/.../documents[/...]` |
+| GCP Cloud Monitoring | `/v3/projects/.../` |
+| GCP GCS | Fallback (`/storage/v1/` and `/{bucket}/{object}` direct-media) |
 
-## Roadmap
+Registration order matters when handlers share a path prefix — `awsserver.New` / `azureserver.New` / `gcpserver.New` register more-specific handlers ahead of catch-alls (S3, Blob, GCS) so first-match-wins resolves correctly.
 
-The EC2 SDK-compat work is Phase 1 of a larger initiative (tracked in [#121](https://github.com/stackshy/cloudemu/issues/121)):
+## Coverage status
 
-| Phase | Scope |
-|-------|-------|
-| 1 (done) | Query-protocol foundation + EC2 core instance ops |
-| 2 (done) | VPC, Subnets, Security Groups, Internet Gateways, Route Tables |
-| 3 (done) | EBS Volumes, Key Pairs |
-| 4 (done) | Auto Scaling Groups + scaling policies |
-| 5 (done) | Snapshots + AMIs |
-| 6 (done) | Spot Instances + Launch Templates |
-| 7 (done) | NAT Gateways + VPC Peering + Flow Logs |
-| 8 (done) | Network ACLs |
-| 3 | EBS Volumes, Key Pairs |
-| 4 | Auto-Scaling Groups + Scaling Policies |
-| 5 | Snapshots, AMIs |
-| 6 | Spot Instances, Launch Templates |
-| 7 | NAT Gateways, VPC Peering, Flow Logs |
-| 8 | Network ACLs |
+| Provider | Domains shipped | Notes |
+|----------|----------------|-------|
+| AWS | Storage, Compute (+ VPC/SG/Subnet/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/Keys/AMIs/Snapshots/Spot/LaunchTemplates), Database, Serverless, Message Queue, Monitoring | The most-mature provider — EC2 was Phase 1 of SDK-compat |
+| Azure | Storage, Compute (+ Disks/Snapshots/Images/SSHKeys), Database, Serverless, Message Queue (ARM only), Networking, Monitoring | Data-plane Service Bus over AMQP is out of scope (use raw-HTTP REST data plane for tests) |
+| GCP | Storage, Compute (+ Disks/Snapshots/Images), Database, Serverless, Message Queue, Networking, Monitoring | All driven via REST (the `cloud.google.com/go/*` clients with `option.WithEndpoint`, or the auto-generated `google.golang.org/api/*` clients) |
 
-After AWS is complete, the sibling `server/azure/` and `server/gcp/` packages will bring the same experience to Azure Blob / Cosmos and GCP GCS / Firestore.
+The remaining 9 service domains (IAM, DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
 
 ## Writing your own handler
 
@@ -147,14 +250,14 @@ srv := server.New()
 srv.Register(&MyHandler{...})
 ```
 
-The `Handler` interface is the only contract — no registration is needed in core CloudEmu. If the handler is generally useful, a PR to add it under `server/aws/<service>` is welcome.
+The `Handler` interface is the only contract — no registration is needed in core CloudEmu. If the handler is generally useful, a PR to add it under `server/<provider>/<service>` is welcome.
 
 ## Limitations
 
-- **No signature validation.** CloudEmu is a local development tool, not a security boundary. Requests are accepted regardless of AWS SigV4 signatures.
-- **No pagination continuation** (S3 listing aside). Adding it as providers grow.
-- **No presigned URLs, no multipart uploads** (yet) for S3.
-- **No `UpdateItem`, `Scan`, `BatchWriteItem`, transactions** (yet) for DynamoDB.
-- **No Auto-Scaling, Spot, Volumes, AMIs** (yet) for EC2 — see roadmap above.
+- **No signature validation.** CloudEmu is a local development tool, not a security boundary. Requests are accepted regardless of AWS SigV4 / Azure AAD / GCP OAuth signatures.
+- **No AMQP for Azure Service Bus.** The modern `azservicebus` SDK uses AMQP exclusively for data plane. ARM control plane is fully supported via `armservicebus`; tests that need send/receive can use the raw-HTTP REST data plane.
+- **GCS direct-media downloads** assume path-style URLs.
+- **DynamoDB / Cosmos / Firestore filters and queries** support common patterns but are not full DSL parsers.
+- **Pagination tokens** are honored where present in the SDK contract; some list operations short-circuit to a single page.
 
-When a client hits an unsupported operation, the server responds with a recognizable AWS error code so failures are easy to diagnose.
+When a client hits an unsupported operation, the server responds with the provider's native error code so failures are easy to diagnose.


### PR DESCRIPTION
## Summary

Catches the documentation up to what's actually shipped. PRs #136-#145 added 16 new SDK-compat handlers across Azure and GCP (compute/storage/database/networking/monitoring/serverless/message queue), but the README and docs still framed the SDK-compat server as AWS-only with an outdated phased roadmap.

## What changed

- **README.md** — replaces the AWS-only "Currently covered" operations table with a cross-provider matrix. The example now shows all 3 server factories (`awsserver.New`, `azureserver.New`, `gcpserver.New`) and notes that Azure requires TLS.
- **docs/sdk-server.md** — full rewrite of the support tables. Adds three sections (AWS / Azure / GCP) listing every shipped handler. Adds Azure and GCP quick-start snippets alongside the existing AWS one. Drops the duplicated Phase 3-8 roadmap stub. Expands the protocol-detection table to cover all 24 currently-registered handlers and explains how registration ordering avoids handler shadowing.
- **docs/architecture.md** — line 51 description (which still said "Currently covers S3, DynamoDB, and EC2 core instance operations") now reflects the full set of shipped domains. The file-structure tree gains a `server/` subtree that lists every existing handler package.

## Out of scope

No code changes. Tests, lint, and build are run as a sanity gate but only `*.md` files are touched.

## Verification

```
go build ./...                              # clean
go vet ./...                                # clean
go test -count=1 ./...                      # all packages green
golangci-lint run --timeout=9m ./...        # 0 issues
```

## Test plan

- [ ] CI confirms doc-only diff doesn't break build/test/lint
- [ ] Render `docs/sdk-server.md` and `docs/architecture.md` on the GitHub UI to verify table formatting