### PR TITLE
add cloudemu logo and show it at the top of README

### DIFF
--- a/.github/logo.svg
+++ b/.github/logo.svg
@@ -1,0 +1,18 @@
+<svg width="128" height="128" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="g" x1="2" y1="6" x2="30" y2="28" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#38bdf8"/>
+      <stop offset="1" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <circle cx="10" cy="17" r="5.5" fill="url(#g)"/>
+    <circle cx="16" cy="13" r="6.5" fill="url(#g)"/>
+    <circle cx="22" cy="16" r="5" fill="url(#g)"/>
+    <rect x="9" y="18" width="14" height="6" rx="3" fill="url(#g)"/>
+  </g>
+  <path d="M11.5 19.5L16 21L20.5 19.5" stroke="white" stroke-opacity="0.7" stroke-width="0.9" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="11.5" cy="19.5" r="1.35" fill="white"/>
+  <circle cx="16" cy="21" r="1.35" fill="white"/>
+  <circle cx="20.5" cy="19.5" r="1.35" fill="white"/>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 <p align="center">
+  <img src="https://raw.githubusercontent.com/stackshy/cloudemu/development/.github/logo.svg" alt="cloudemu" width="96" height="96" />
+</p>
+
+<p align="center">
   <h1 align="center">cloudemu</h1>
   <p align="center"><b>Zero-Cost In-Memory Cloud Emulation for Go</b></p>
 </p>


### PR DESCRIPTION
## Summary

Adds the cloudemu brand mark to the repo and surfaces it at the top of the README, so the logo shows up on GitHub and on pkg.go.dev.

## Design

Cloud silhouette holding three connected nodes — represents the three providers (AWS, Azure, GCP) emulated inside cloudemu. Uses the same \`sky-400 → violet-500\` gradient that's already used in the docs hero highlight, so the logo, the docs, and the package READMEs all share one brand system.

The same SVG is used by the docs site (\`stackshy/cloudemu-docs\`) at \`public/logo.svg\` and \`app/icon.svg\`.

## What's added

- \`.github/logo.svg\` — the brand mark, served via raw.githubusercontent so pkg.go.dev (which requires absolute image URLs) renders it.
- \`README.md\` — an \`<img>\` block at the top centers the 96px logo above the existing title + tagline.

## Test plan

- [ ] GitHub renders the logo at the top of the repo's README on github.com.
- [ ] pkg.go.dev renders the logo on https://pkg.go.dev/github.com/stackshy/cloudemu after the PR is merged into \`development\`.