### PR TITLE
fix: crop logo viewBox tight around cloud bounds (kill README backdrop)

### DIFF
--- a/.github/logo.svg
+++ b/.github/logo.svg
@@ -1,6 +1,6 @@
-<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="2 2 29 22" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+    <linearGradient id="g" x1="2" y1="2" x2="31" y2="24" gradientUnits="userSpaceOnUse">
       <stop stop-color="#38bdf8"/>
       <stop offset="1" stop-color="#a855f7"/>
     </linearGradient>


### PR DESCRIPTION
## Summary

The README logo still renders inside a dark rounded backdrop on github.com because the SVG's viewBox \`0 0 32 32\` is bigger than the cloud's actual bounds \`x=2..31, y=2..24\`. GitHub's dark-mode image rendering paints that empty padding as a card.

## Fix

Changed viewBox from \`0 0 32 32\` to \`2 2 29 22\` so the canvas matches the cloud's bounding box exactly. The gradient extents were updated to match (\`x1=2 y1=2 x2=31 y2=24\`) so the gradient still spans the full visible cloud.

No more transparent padding inside the SVG → no more backdrop frame on README / pkg.go.dev.

## Verification

- The SVG renders identically at any size.
- The aspect ratio is now ~29:22 (was 1:1) — the README \`<img width=\"96\">\` will scale to ~96×73, displaying just the cloud.

## Test plan

- [ ] After merge, refresh github.com/stackshy/cloudemu — README logo shows the cloud edge-to-edge with no surrounding card.
- [ ] After Go module proxy refresh, same on pkg.go.dev.