### PR TITLE
fix(ec2): StartInstances/StopInstances idempotent on target state (closes #152)

### DIFF
--- a/providers/aws/ec2/ec2.go
+++ b/providers/aws/ec2/ec2.go
@@ -29,6 +29,12 @@ type lifecycleTransition struct {
 	finalState        string
 	metricValues      []float64
 	errVerb           string
+	// idempotentStates are states where the operation is a no-op rather than
+	// an error. Real AWS EC2 documents StartInstances on a running instance
+	// and StopInstances on a stopped instance as idempotent — they return
+	// 200 with currentState equal to previousState rather than
+	// IncorrectInstanceState.
+	idempotentStates []string
 }
 
 var (
@@ -40,12 +46,14 @@ var (
 		finalState:        compute.StateRunning,
 		metricValues:      runningMetricValues,
 		errVerb:           "start",
+		idempotentStates:  []string{compute.StateRunning, compute.StatePending},
 	}
 	stopTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateStopping,
 		finalState:        compute.StateStopped,
 		metricValues:      zeroMetricValues,
 		errVerb:           "stop",
+		idempotentStates:  []string{compute.StateStopped, compute.StateStopping},
 	}
 	rebootTransition = lifecycleTransition{ //nolint:gochecknoglobals // package-level config
 		intermediateState: compute.StateRestarting,
@@ -234,11 +242,19 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 	return results, nil
 }
 
+//nolint:gocritic // t is a small read-only config; copying once per call is fine.
 func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t lifecycleTransition) error {
 	for _, id := range instanceIDs {
 		inst, ok := m.instances.Get(id)
 		if !ok {
 			return cerrors.Newf(cerrors.NotFound, "instance %q not found", id)
+		}
+
+		// Real AWS EC2 documents Start/Stop as idempotent on the target
+		// state. Skip the state machine and return success without changing
+		// state when we're already there.
+		if isIdempotent(inst.State, t.idempotentStates) {
+			continue
 		}
 
 		if err := m.sm.Transition(id, t.intermediateState); err != nil {
@@ -253,6 +269,16 @@ func (m *Mock) transitionInstances(ctx context.Context, instanceIDs []string, t 
 	}
 
 	return nil
+}
+
+func isIdempotent(state string, idempotentStates []string) bool {
+	for _, s := range idempotentStates {
+		if state == s {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (m *Mock) StartInstances(ctx context.Context, instanceIDs []string) error {

--- a/providers/aws/ec2/ec2_test.go
+++ b/providers/aws/ec2/ec2_test.go
@@ -129,8 +129,29 @@ func TestStartInstances(t *testing.T) {
 		assertEqual(t, compute.StateRunning, result[0].State)
 	})
 
+	t.Run("idempotent on already running", func(t *testing.T) {
+		// Real AWS EC2 returns 200 OK with currentState=running when
+		// StartInstances is called on an already-running instance.
+		err := m.StartInstances(ctx, []string{id})
+		requireNoError(t, err)
+
+		result, _ := m.DescribeInstances(ctx, []string{id}, nil)
+		assertEqual(t, compute.StateRunning, result[0].State)
+	})
+
 	t.Run("not found", func(t *testing.T) {
 		err := m.StartInstances(ctx, []string{"i-nonexistent"})
+		assertError(t, err, true)
+	})
+
+	t.Run("rejects start on terminated", func(t *testing.T) {
+		// Real AWS rejects starting a terminated instance —
+		// the strict-state behavior is intentional here.
+		instances, _ := m.RunInstances(ctx, defaultConfig(), 1)
+		termID := instances[0].ID
+		_ = m.TerminateInstances(ctx, []string{termID})
+
+		err := m.StartInstances(ctx, []string{termID})
 		assertError(t, err, true)
 	})
 }
@@ -150,8 +171,24 @@ func TestStopInstances(t *testing.T) {
 		assertEqual(t, compute.StateStopped, result[0].State)
 	})
 
-	t.Run("cannot stop already stopped", func(t *testing.T) {
+	t.Run("idempotent on already stopped", func(t *testing.T) {
+		// Real AWS EC2 returns 200 OK with currentState=stopped when
+		// StopInstances is called on an already-stopped instance.
 		err := m.StopInstances(ctx, []string{id})
+		requireNoError(t, err)
+
+		result, _ := m.DescribeInstances(ctx, []string{id}, nil)
+		assertEqual(t, compute.StateStopped, result[0].State)
+	})
+
+	t.Run("rejects stop on terminated", func(t *testing.T) {
+		// Real AWS rejects stopping a terminated instance —
+		// strict-state behavior is intentional here.
+		instances, _ := m.RunInstances(ctx, defaultConfig(), 1)
+		termID := instances[0].ID
+		_ = m.TerminateInstances(ctx, []string{termID})
+
+		err := m.StopInstances(ctx, []string{termID})
 		assertError(t, err, true)
 	})
 }

--- a/server/aws/ec2_test.go
+++ b/server/aws/ec2_test.go
@@ -318,6 +318,73 @@ func TestEC2StartInstancesUnknownIDReturnsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestEC2StartInstancesIdempotentOnRunning verifies AWS-documented idempotent
+// behavior: calling StartInstances on an already-running instance returns
+// 200 with currentState=running rather than IncorrectInstanceState.
+//
+// Issue: https://github.com/stackshy/cloudemu/issues/152
+func TestEC2StartInstancesIdempotentOnRunning(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-idem"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+
+	// Instance is already running. Real AWS treats this as a no-op.
+	out, err := client.StartInstances(ctx, &ec2.StartInstancesInput{
+		InstanceIds: []string{id},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.StartingInstances, 1)
+
+	desc, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{id},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ec2types.InstanceStateNameRunning,
+		desc.Reservations[0].Instances[0].State.Name)
+}
+
+// TestEC2StopInstancesIdempotentOnStopped verifies the stopped-side of the
+// same AWS-documented idempotent behavior.
+func TestEC2StopInstancesIdempotentOnStopped(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	run, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId: aws.String("ami-idem-stop"), InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount: aws.Int32(1), MaxCount: aws.Int32(1),
+	})
+	require.NoError(t, err)
+
+	id := aws.ToString(run.Instances[0].InstanceId)
+
+	// First stop transitions running → stopped.
+	_, err = client.StopInstances(ctx, &ec2.StopInstancesInput{
+		InstanceIds: []string{id},
+	})
+	require.NoError(t, err)
+
+	// Second stop on already-stopped instance is a no-op in real AWS.
+	out, err := client.StopInstances(ctx, &ec2.StopInstancesInput{
+		InstanceIds: []string{id},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.StoppingInstances, 1)
+
+	desc, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{id},
+	})
+	require.NoError(t, err)
+	require.Equal(t, ec2types.InstanceStateNameStopped,
+		desc.Reservations[0].Instances[0].State.Name)
+}
+
 func TestEC2ModifyInstanceAttributeType(t *testing.T) {
 	client := newEC2Client(t)
 	ctx := context.Background()


### PR DESCRIPTION
Closes #152.

Summary
- Real AWS EC2 documents StartInstances on a running instance and StopInstances on a stopped instance as idempotent no-ops; cloudemu was rejecting both with HTTP 400 IncorrectInstanceState. This breaks production code relying on the documented idempotency (retry loops, schedulers, circuit breakers).

Fix
- Added idempotentStates to lifecycleTransition (only populated for start and stop). transitionInstances now skips the state machine entirely when an instance is already in one of those states for the requested operation; the call returns success and the state is unchanged.
- Strict-state behavior is preserved for genuinely illegal transitions (terminated → start, terminated → stop) and for reboot / terminate, which keep their existing semantics.

Tests
- providers/aws/ec2/ec2_test.go: added "idempotent on already running" and "idempotent on already stopped" sub-tests; added explicit "rejects start on terminated" and "rejects stop on terminated" sub-tests so the strict cases stay covered.
- server/aws/ec2_test.go: added two SDK round-trip tests (TestEC2StartInstancesIdempotentOnRunning, TestEC2StopInstancesIdempotentOnStopped) that drive the real aws-sdk-go-v2/service/ec2 client against awsserver and verify the documented AWS behavior end-to-end.

Verification
- go build ./... clean.
- go vet ./... clean.
- go test -count=1 ./... — all packages green.
- golangci-lint run --timeout=9m ./... — 0 issues.

Out of scope
- Terminate idempotency (real AWS treats Terminate on terminated as a no-op too) is not changed in this PR. The reporter scoped #152 to Start/Stop; happy to file a follow-up if a maintainer wants Terminate to match.