### PR TITLE
feat(azuresql): add Azure SQL Database SDK-compat handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.1.1/go.mod h1:c/wcGeGx5FUPbM/JltUYHZcKmigwyVLJlDq+4HdtXaw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 h1:JLPf82byRFgfB0f2feJMmRfCCFV0W9/GayiiewTvjlw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3/go.mod h1:9sfaaa+UF5VVus+Tr/bd1qm1oRoltnewm3HpiT9l8VU=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087deZ0kP1RUg4pU7w9U9xpUedTCbOtz+mnd0+hrkQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/azure/azureiam"
 	"github.com/stackshy/cloudemu/providers/azure/azurelb"
 	"github.com/stackshy/cloudemu/providers/azure/azuremonitor"
+	"github.com/stackshy/cloudemu/providers/azure/azuresql"
 	"github.com/stackshy/cloudemu/providers/azure/blobstorage"
 	"github.com/stackshy/cloudemu/providers/azure/cosmosdb"
 	"github.com/stackshy/cloudemu/providers/azure/eventgrid"
@@ -39,6 +40,7 @@ type Provider struct {
 	NotificationHubs *notificationhubs.Mock
 	ACR              *acr.Mock
 	EventGrid        *eventgrid.Mock
+	SQL              *azuresql.Mock
 }
 
 // New creates a new Azure provider with all mock services.
@@ -61,6 +63,7 @@ func New(opts ...config.Option) *Provider {
 		NotificationHubs: notificationhubs.New(o),
 		ACR:              acr.New(o),
 		EventGrid:        eventgrid.New(o),
+		SQL:              azuresql.New(o),
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
 	p.BlobStorage.SetMonitoring(p.Monitor)
@@ -72,6 +75,7 @@ func New(opts ...config.Option) *Provider {
 	p.NotificationHubs.SetMonitoring(p.Monitor)
 	p.ACR.SetMonitoring(p.Monitor)
 	p.EventGrid.SetMonitoring(p.Monitor)
+	p.SQL.SetMonitoring(p.Monitor)
 
 	return p
 }

--- a/providers/azure/azuresql/azuresql.go
+++ b/providers/azure/azuresql/azuresql.go
@@ -1,0 +1,711 @@
+// Package azuresql provides an in-memory mock of Microsoft.Sql (Azure SQL
+// Database). It implements relationaldb/driver.RelationalDB so the same
+// backend serves both the portable API (relationaldb.DB) and the SDK-compat
+// HTTP layer.
+//
+// Mapping into the relationaldb shape:
+//
+//   - Cluster                 → Microsoft.Sql logical server (a connection
+//     endpoint that groups databases, billed per-DB).
+//   - Instance with ClusterID → A database under that server. The instance ID
+//     in the portable API is the DB name; the
+//     ClusterID is the server name.
+//   - Snapshot                → A database long-term retention backup.
+//   - ClusterSnapshot         → Not supported (Azure SQL has no server-level
+//     snapshots). Cluster-snapshot methods return
+//     InvalidArgument.
+//
+// Lifecycle: Azure SQL databases are "always on" — there is no native
+// start/stop API. The mock still tracks state transitions so portable-API
+// users can drive Start/Stop and observe deterministic behavior; the
+// transitions don't affect the ARM-visible state.
+package azuresql
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	rdsdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+)
+
+const (
+	defaultPort        = 1433
+	defaultStorageGB   = 32
+	defaultStorageType = "GeneralPurpose"
+	defaultSKU         = "GP_S_Gen5_2"
+	armProvider        = "Microsoft.Sql"
+	cpuMetricRunning   = 0.25
+	cpuMetricStopped   = 0.0
+	dtuRunning         = 50.0
+)
+
+var _ rdsdriver.RelationalDB = (*Mock)(nil)
+
+// Mock is the in-memory Azure SQL implementation.
+type Mock struct {
+	mu sync.RWMutex
+
+	// clusters key = server name
+	clusters *memstore.Store[rdsdriver.Cluster]
+	// instances key = "server/database"
+	instances *memstore.Store[rdsdriver.Instance]
+	// snapshots key = snapshot id
+	snapshots *memstore.Store[rdsdriver.Snapshot]
+
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new Azure SQL mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		clusters:  memstore.New[rdsdriver.Cluster](),
+		instances: memstore.New[rdsdriver.Instance](),
+		snapshots: memstore.New[rdsdriver.Snapshot](),
+		opts:      opts,
+	}
+}
+
+// SetMonitoring wires an Azure-Monitor-style backend for auto-metric emission.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+// emitDatabaseMetrics emits Microsoft.Sql/servers/databases-shaped metrics.
+func (m *Mock) emitDatabaseMetrics(server, database string, cpuFrac, dtu float64) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	resourceID := serverDatabaseResourceID(m.opts.Region, server, database)
+	dims := map[string]string{"resourceId": resourceID}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{
+		{Namespace: "Microsoft.Sql/servers/databases", MetricName: "cpu_percent",
+			Value: cpuFrac * 100, Unit: "Percent", Dimensions: dims, Timestamp: now},
+		{Namespace: "Microsoft.Sql/servers/databases", MetricName: "dtu_consumption_percent",
+			Value: dtu, Unit: "Percent", Dimensions: dims, Timestamp: now},
+		{Namespace: "Microsoft.Sql/servers/databases", MetricName: "storage_percent",
+			Value: 25, Unit: "Percent", Dimensions: dims, Timestamp: now},
+		{Namespace: "Microsoft.Sql/servers/databases", MetricName: "connection_successful",
+			Value: 5, Unit: "Count", Dimensions: dims, Timestamp: now},
+		{Namespace: "Microsoft.Sql/servers/databases", MetricName: "connection_failed",
+			Value: 0, Unit: "Count", Dimensions: dims, Timestamp: now},
+	})
+}
+
+// serverDatabaseResourceID constructs the canonical Azure resource ID for a
+// (server, database) pair.
+func serverDatabaseResourceID(region, server, database string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/servers/%s/databases/%s",
+		region, region, armProvider, server, database)
+}
+
+// instanceKey is the storage key used for an instance in the relationaldb
+// model: "{server}/{database}". Encoding the server in the key is what lets
+// the same database name exist under different servers without collision.
+func instanceKey(server, database string) string {
+	return server + "/" + database
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+// CreateInstance creates a new database under an existing logical server.
+//
+//nolint:gocritic // cfg matches the driver interface signature.
+func (m *Mock) CreateInstance(_ context.Context, cfg rdsdriver.InstanceConfig) (*rdsdriver.Instance, error) {
+	if cfg.ID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "database name is required")
+	}
+
+	if cfg.ClusterID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"ClusterID (Azure SQL logical server) is required to create a database")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	server, ok := m.clusters.Get(cfg.ClusterID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Azure SQL server %q not found", cfg.ClusterID)
+	}
+
+	key := instanceKey(cfg.ClusterID, cfg.ID)
+	if _, ok := m.instances.Get(key); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"database %q already exists on server %q", cfg.ID, cfg.ClusterID)
+	}
+
+	storage := cfg.AllocatedStorage
+	if storage == 0 {
+		storage = defaultStorageGB
+	}
+
+	storageType := cfg.StorageType
+	if storageType == "" {
+		storageType = defaultStorageType
+	}
+
+	sku := cfg.InstanceClass
+	if sku == "" {
+		sku = defaultSKU
+	}
+
+	inst := rdsdriver.Instance{
+		ID:               cfg.ID,
+		ARN:              serverDatabaseResourceID(m.opts.Region, cfg.ClusterID, cfg.ID),
+		Engine:           "SQLServer",
+		EngineVersion:    cfg.EngineVersion,
+		InstanceClass:    sku,
+		AllocatedStorage: storage,
+		StorageType:      storageType,
+		Endpoint:         cfg.ClusterID + ".database.windows.net",
+		Port:             defaultPort,
+		State:            rdsdriver.StateAvailable,
+		ClusterID:        cfg.ClusterID,
+		AvailabilityZone: server.SubnetGroupName, // re-use as region carrier
+		CreatedAt:        m.opts.Clock.Now().UTC(),
+		Tags:             copyTags(cfg.Tags),
+	}
+
+	m.instances.Set(key, inst)
+
+	server.Members = append(server.Members, cfg.ID)
+	m.clusters.Set(cfg.ClusterID, server)
+
+	m.emitDatabaseMetrics(cfg.ClusterID, cfg.ID, cpuMetricRunning, dtuRunning)
+
+	out := inst
+
+	return &out, nil
+}
+
+// DescribeInstances returns instances. With ids empty: all databases across
+// all servers. With ids set: each id may be either bare "{database}" (resolved
+// against the unique server, ambiguity error otherwise) or the composite
+// "{server}/{database}".
+func (m *Mock) DescribeInstances(_ context.Context, ids []string) ([]rdsdriver.Instance, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(ids) == 0 {
+		all := m.instances.All()
+		out := make([]rdsdriver.Instance, 0, len(all))
+
+		//nolint:gocritic // map values are large structs; copy is unavoidable when materializing the result slice.
+		for _, v := range all {
+			out = append(out, v)
+		}
+
+		return out, nil
+	}
+
+	out := make([]rdsdriver.Instance, 0, len(ids))
+
+	for _, id := range ids {
+		inst, err := m.lookupInstance(id)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, inst)
+	}
+
+	return out, nil
+}
+
+// lookupInstance resolves an id (either "{server}/{db}" or just "{db}") to an
+// Instance. Bare names are accepted only when a single matching database
+// exists across all servers. Caller must hold m.mu (read or write).
+func (m *Mock) lookupInstance(id string) (rdsdriver.Instance, error) {
+	if inst, ok := m.instances.Get(id); ok {
+		return inst, nil
+	}
+
+	matches := m.instances.Filter(func(_ string, inst rdsdriver.Instance) bool {
+		return inst.ID == id
+	})
+
+	switch len(matches) {
+	case 0:
+		return rdsdriver.Instance{}, cerrors.Newf(cerrors.NotFound, "database %q not found", id)
+	case 1:
+		//nolint:gocritic // single iteration to extract the only match; copy unavoidable.
+		for _, v := range matches {
+			return v, nil
+		}
+	}
+
+	return rdsdriver.Instance{}, cerrors.Newf(cerrors.InvalidArgument,
+		"database name %q is ambiguous across servers; pass {server}/{database}", id)
+}
+
+// ModifyInstance applies the supplied changes to a database.
+func (m *Mock) ModifyInstance(
+	_ context.Context, id string, input rdsdriver.ModifyInstanceInput,
+) (*rdsdriver.Instance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, err := m.lookupInstance(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if input.InstanceClass != "" {
+		inst.InstanceClass = input.InstanceClass
+	}
+
+	if input.AllocatedStorage > 0 {
+		inst.AllocatedStorage = input.AllocatedStorage
+	}
+
+	if input.EngineVersion != "" {
+		inst.EngineVersion = input.EngineVersion
+	}
+
+	if input.Tags != nil {
+		inst.Tags = copyTags(input.Tags)
+	}
+
+	m.instances.Set(instanceKey(inst.ClusterID, inst.ID), inst)
+
+	out := inst
+
+	return &out, nil
+}
+
+// DeleteInstance removes a database.
+func (m *Mock) DeleteInstance(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, err := m.lookupInstance(id)
+	if err != nil {
+		return err
+	}
+
+	m.instances.Delete(instanceKey(inst.ClusterID, inst.ID))
+
+	cluster, ok := m.clusters.Get(inst.ClusterID)
+	if ok {
+		cluster.Members = removeString(cluster.Members, inst.ID)
+		m.clusters.Set(inst.ClusterID, cluster)
+	}
+
+	return nil
+}
+
+// StartInstance flips a database to available state. Azure SQL doesn't have a
+// native start endpoint, so this is observable only via the portable API.
+func (m *Mock) StartInstance(_ context.Context, id string) error {
+	return m.transitionInstance(id, rdsdriver.StateStopped, rdsdriver.StateAvailable, cpuMetricRunning, dtuRunning, "start")
+}
+
+// StopInstance flips a database to stopped state.
+func (m *Mock) StopInstance(_ context.Context, id string) error {
+	return m.transitionInstance(id, rdsdriver.StateAvailable, rdsdriver.StateStopped, cpuMetricStopped, 0, "stop")
+}
+
+// RebootInstance is a no-op state-wise; emits a fresh metric tick.
+func (m *Mock) RebootInstance(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, err := m.lookupInstance(id)
+	if err != nil {
+		return err
+	}
+
+	if inst.State != rdsdriver.StateAvailable {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"database %q is in state %q; reboot requires %q", id, inst.State, rdsdriver.StateAvailable)
+	}
+
+	m.emitDatabaseMetrics(inst.ClusterID, inst.ID, cpuMetricRunning, dtuRunning)
+
+	return nil
+}
+
+func (m *Mock) transitionInstance(id, from, to string, cpu, dtu float64, verb string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, err := m.lookupInstance(id)
+	if err != nil {
+		return err
+	}
+
+	if inst.State == to {
+		return nil // idempotent
+	}
+
+	if inst.State != from {
+		return cerrors.Newf(cerrors.FailedPrecondition,
+			"database %q is in state %q; %s requires %q", id, inst.State, verb, from)
+	}
+
+	inst.State = to
+	m.instances.Set(instanceKey(inst.ClusterID, inst.ID), inst)
+
+	m.emitDatabaseMetrics(inst.ClusterID, inst.ID, cpu, dtu)
+
+	return nil
+}
+
+// CreateCluster creates an Azure SQL logical server.
+//
+//nolint:gocritic // cfg matches the driver interface signature.
+func (m *Mock) CreateCluster(_ context.Context, cfg rdsdriver.ClusterConfig) (*rdsdriver.Cluster, error) {
+	if cfg.ID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "server name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.clusters.Get(cfg.ID); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "Azure SQL server %q already exists", cfg.ID)
+	}
+
+	cluster := rdsdriver.Cluster{
+		ID:             cfg.ID,
+		ARN:            idgen.AzureID(m.opts.Region, m.opts.Region, armProvider, "servers", cfg.ID),
+		Engine:         "SQLServer",
+		EngineVersion:  cfg.EngineVersion,
+		MasterUsername: cfg.MasterUsername,
+		Endpoint:       cfg.ID + ".database.windows.net",
+		Port:           defaultPort,
+		State:          rdsdriver.StateAvailable,
+		// Stash region in SubnetGroupName since the field exists; consumers
+		// can read it back from there.
+		SubnetGroupName: m.opts.Region,
+		CreatedAt:       m.opts.Clock.Now().UTC(),
+		Tags:            copyTags(cfg.Tags),
+	}
+
+	m.clusters.Set(cfg.ID, cluster)
+
+	out := cluster
+
+	return &out, nil
+}
+
+// DescribeClusters returns servers (or all if ids empty).
+func (m *Mock) DescribeClusters(_ context.Context, ids []string) ([]rdsdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(ids) == 0 {
+		all := m.clusters.All()
+		out := make([]rdsdriver.Cluster, 0, len(all))
+
+		//nolint:gocritic // map values are large structs; copy is unavoidable when materializing the result slice.
+		for _, v := range all {
+			out = append(out, v)
+		}
+
+		return out, nil
+	}
+
+	out := make([]rdsdriver.Cluster, 0, len(ids))
+
+	for _, id := range ids {
+		cluster, ok := m.clusters.Get(id)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "Azure SQL server %q not found", id)
+		}
+
+		out = append(out, cluster)
+	}
+
+	return out, nil
+}
+
+// ModifyCluster updates server-level fields (admin password reset, version).
+func (m *Mock) ModifyCluster(
+	_ context.Context, id string, input rdsdriver.ModifyInstanceInput,
+) (*rdsdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, ok := m.clusters.Get(id)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "Azure SQL server %q not found", id)
+	}
+
+	if input.EngineVersion != "" {
+		cluster.EngineVersion = input.EngineVersion
+	}
+
+	if input.Tags != nil {
+		cluster.Tags = copyTags(input.Tags)
+	}
+
+	m.clusters.Set(id, cluster)
+
+	out := cluster
+
+	return &out, nil
+}
+
+// DeleteCluster removes a server. Real Azure cascade-deletes child databases;
+// the mock matches that behavior so tests don't have to manually clean up.
+func (m *Mock) DeleteCluster(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cluster, ok := m.clusters.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "Azure SQL server %q not found", id)
+	}
+
+	for _, member := range cluster.Members {
+		m.instances.Delete(instanceKey(id, member))
+	}
+
+	m.clusters.Delete(id)
+
+	return nil
+}
+
+// StartCluster / StopCluster are no-ops on Azure SQL servers. They aren't
+// "started" / "stopped" the way RDS clusters are; the underlying databases
+// are independently controlled.
+func (*Mock) StartCluster(_ context.Context, _ string) error { return nil }
+
+// StopCluster is a no-op on Azure SQL servers.
+func (*Mock) StopCluster(_ context.Context, _ string) error { return nil }
+
+// CreateSnapshot creates a long-term retention backup of a database.
+func (m *Mock) CreateSnapshot(_ context.Context, cfg rdsdriver.SnapshotConfig) (*rdsdriver.Snapshot, error) {
+	if cfg.ID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "snapshot id is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, err := m.lookupInstance(cfg.InstanceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, ok := m.snapshots.Get(cfg.ID); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "backup %q already exists", cfg.ID)
+	}
+
+	snap := rdsdriver.Snapshot{
+		ID:               cfg.ID,
+		ARN:              idgen.AzureID(m.opts.Region, m.opts.Region, armProvider, "longTermRetentionBackups", cfg.ID),
+		InstanceID:       instanceKey(inst.ClusterID, inst.ID),
+		Engine:           inst.Engine,
+		EngineVersion:    inst.EngineVersion,
+		AllocatedStorage: inst.AllocatedStorage,
+		State:            rdsdriver.SnapshotAvailable,
+		CreatedAt:        m.opts.Clock.Now().UTC(),
+		Tags:             copyTags(cfg.Tags),
+	}
+
+	m.snapshots.Set(cfg.ID, snap)
+
+	out := snap
+
+	return &out, nil
+}
+
+// DescribeSnapshots returns snapshots filtered by ids and/or instance.
+func (m *Mock) DescribeSnapshots(
+	_ context.Context, ids []string, instanceID string,
+) ([]rdsdriver.Snapshot, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.snapshots.All()
+	idSet := stringSet(ids)
+
+	out := make([]rdsdriver.Snapshot, 0, len(all))
+
+	//nolint:gocritic // map values are sized for accuracy; copy is unavoidable when materializing the result slice.
+	for _, snap := range all {
+		if instanceID != "" && snap.InstanceID != instanceID {
+			continue
+		}
+
+		if len(idSet) > 0 {
+			if _, ok := idSet[snap.ID]; !ok {
+				continue
+			}
+		}
+
+		out = append(out, snap)
+	}
+
+	return out, nil
+}
+
+// DeleteSnapshot removes a backup.
+func (m *Mock) DeleteSnapshot(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.snapshots.Delete(id) {
+		return cerrors.Newf(cerrors.NotFound, "backup %q not found", id)
+	}
+
+	return nil
+}
+
+// RestoreInstanceFromSnapshot creates a new database from a backup.
+func (m *Mock) RestoreInstanceFromSnapshot(
+	_ context.Context, input rdsdriver.RestoreInstanceInput,
+) (*rdsdriver.Instance, error) {
+	if input.NewInstanceID == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "new database id is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snap, ok := m.snapshots.Get(input.SnapshotID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "backup %q not found", input.SnapshotID)
+	}
+
+	// NewInstanceID can be either bare ("db1") or composite ("server/db1").
+	// In bare form the snapshot's source server is reused.
+	server, dbName := splitInstanceKey(input.NewInstanceID)
+
+	if server == "" {
+		// Pull source server from snapshot key.
+		srv, _ := splitInstanceKey(snap.InstanceID)
+		server = srv
+	}
+
+	if _, exists := m.clusters.Get(server); !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "Azure SQL server %q not found", server)
+	}
+
+	key := instanceKey(server, dbName)
+	if _, exists := m.instances.Get(key); exists {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"database %q already exists on server %q", dbName, server)
+	}
+
+	sku := input.InstanceClass
+	if sku == "" {
+		sku = defaultSKU
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	inst := rdsdriver.Instance{
+		ID:               dbName,
+		ARN:              serverDatabaseResourceID(m.opts.Region, server, dbName),
+		Engine:           snap.Engine,
+		EngineVersion:    snap.EngineVersion,
+		InstanceClass:    sku,
+		AllocatedStorage: snap.AllocatedStorage,
+		StorageType:      defaultStorageType,
+		Endpoint:         server + ".database.windows.net",
+		Port:             defaultPort,
+		State:            rdsdriver.StateAvailable,
+		ClusterID:        server,
+		CreatedAt:        now,
+		Tags:             copyTags(input.Tags),
+	}
+
+	m.instances.Set(key, inst)
+
+	cluster, ok := m.clusters.Get(server)
+	if ok {
+		cluster.Members = append(cluster.Members, dbName)
+		m.clusters.Set(server, cluster)
+	}
+
+	m.emitDatabaseMetrics(server, dbName, cpuMetricRunning, dtuRunning)
+
+	out := inst
+
+	return &out, nil
+}
+
+// CreateClusterSnapshot is unsupported on Azure SQL.
+func (*Mock) CreateClusterSnapshot(
+	_ context.Context, _ rdsdriver.ClusterSnapshotConfig,
+) (*rdsdriver.ClusterSnapshot, error) {
+	return nil, cerrors.New(cerrors.InvalidArgument,
+		"Azure SQL does not support server-level snapshots; backups are per-database")
+}
+
+// DescribeClusterSnapshots returns an empty list — Azure SQL has none.
+func (*Mock) DescribeClusterSnapshots(
+	_ context.Context, _ []string, _ string,
+) ([]rdsdriver.ClusterSnapshot, error) {
+	return []rdsdriver.ClusterSnapshot{}, nil
+}
+
+// DeleteClusterSnapshot is unsupported on Azure SQL.
+func (*Mock) DeleteClusterSnapshot(_ context.Context, _ string) error {
+	return cerrors.New(cerrors.InvalidArgument, "Azure SQL does not support server-level snapshots")
+}
+
+// RestoreClusterFromSnapshot is unsupported on Azure SQL.
+func (*Mock) RestoreClusterFromSnapshot(
+	_ context.Context, _ rdsdriver.RestoreClusterInput,
+) (*rdsdriver.Cluster, error) {
+	return nil, cerrors.New(cerrors.InvalidArgument,
+		"Azure SQL does not support server-level snapshot restore")
+}
+
+func splitInstanceKey(id string) (server, database string) {
+	for i, ch := range id {
+		if ch == '/' {
+			return id[:i], id[i+1:]
+		}
+	}
+
+	return "", id
+}
+
+func removeString(slice []string, target string) []string {
+	for i, v := range slice {
+		if v == target {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+
+	return slice
+}
+
+func stringSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		out[v] = struct{}{}
+	}
+
+	return out
+}

--- a/providers/azure/azuresql/azuresql_test.go
+++ b/providers/azure/azuresql/azuresql_test.go
@@ -1,0 +1,247 @@
+package azuresql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	rdsdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("eastus"),
+	)
+
+	return New(opts)
+}
+
+func TestServerLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cluster, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{
+		ID:             "srv1",
+		MasterUsername: "admin",
+		EngineVersion:  "12.0",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "srv1", cluster.ID)
+	assertEqual(t, "available", cluster.State)
+	assertNotEmpty(t, cluster.Endpoint)
+
+	// Listing.
+	list, err := m.DescribeClusters(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+
+	// Modify.
+	updated, err := m.ModifyCluster(ctx, "srv1", rdsdriver.ModifyInstanceInput{
+		EngineVersion: "12.1",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "12.1", updated.EngineVersion)
+
+	requireNoError(t, m.DeleteCluster(ctx, "srv1"))
+
+	if _, err := m.DescribeClusters(ctx, []string{"srv1"}); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestDatabaseRequiresServer(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:     "db1",
+		Engine: "SQLServer",
+	}); err == nil {
+		t.Fatal("expected error: database without ClusterID")
+	}
+
+	if _, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:        "db1",
+		ClusterID: "ghost",
+		Engine:    "SQLServer",
+	}); err == nil {
+		t.Fatal("expected error: database with non-existent server")
+	}
+}
+
+func TestDatabaseLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"})
+	requireNoError(t, err)
+
+	inst, err := m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:               "appdb",
+		ClusterID:        "srv1",
+		Engine:           "SQLServer",
+		AllocatedStorage: 100,
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "appdb", inst.ID)
+	assertEqual(t, "srv1", inst.ClusterID)
+	assertEqual(t, 100, inst.AllocatedStorage)
+	assertEqual(t, 1433, inst.Port)
+
+	// Bare-name lookup works when there's exactly one match.
+	insts, err := m.DescribeInstances(ctx, []string{"appdb"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(insts))
+
+	// Composite-key lookup also works.
+	insts, err = m.DescribeInstances(ctx, []string{"srv1/appdb"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(insts))
+
+	// State transitions via portable API.
+	requireNoError(t, m.StopInstance(ctx, "srv1/appdb"))
+	requireNoError(t, m.StartInstance(ctx, "srv1/appdb"))
+	requireNoError(t, m.RebootInstance(ctx, "srv1/appdb"))
+
+	requireNoError(t, m.DeleteInstance(ctx, "srv1/appdb"))
+}
+
+func TestAmbiguousDatabaseName(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv-a"})
+	requireNoError(t, err)
+	_, err = m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv-b"})
+	requireNoError(t, err)
+
+	_, err = m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "main", ClusterID: "srv-a"})
+	requireNoError(t, err)
+	_, err = m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "main", ClusterID: "srv-b"})
+	requireNoError(t, err)
+
+	// Bare "main" is ambiguous now.
+	if _, err := m.DescribeInstances(ctx, []string{"main"}); err == nil {
+		t.Fatal("expected ambiguity error for bare 'main'")
+	}
+
+	// Composite resolves cleanly.
+	insts, err := m.DescribeInstances(ctx, []string{"srv-a/main"})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(insts))
+}
+
+func TestCascadeDeleteServer(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"})
+	requireNoError(t, err)
+
+	_, err = m.CreateInstance(ctx, rdsdriver.InstanceConfig{ID: "db1", ClusterID: "srv1"})
+	requireNoError(t, err)
+
+	requireNoError(t, m.DeleteCluster(ctx, "srv1"))
+
+	insts, err := m.DescribeInstances(ctx, nil)
+	requireNoError(t, err)
+	assertEqual(t, 0, len(insts))
+}
+
+func TestSnapshotAndRestore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, rdsdriver.ClusterConfig{ID: "srv1"})
+	requireNoError(t, err)
+
+	_, err = m.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID: "src", ClusterID: "srv1", AllocatedStorage: 50,
+	})
+	requireNoError(t, err)
+
+	snap, err := m.CreateSnapshot(ctx, rdsdriver.SnapshotConfig{
+		ID:         "backup-1",
+		InstanceID: "srv1/src",
+	})
+	requireNoError(t, err)
+
+	assertEqual(t, "available", snap.State)
+	assertEqual(t, 50, snap.AllocatedStorage)
+
+	// Restore into the same server with a different name.
+	restored, err := m.RestoreInstanceFromSnapshot(ctx, rdsdriver.RestoreInstanceInput{
+		NewInstanceID: "srv1/restored",
+		SnapshotID:    "backup-1",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "restored", restored.ID)
+	assertEqual(t, "srv1", restored.ClusterID)
+	assertEqual(t, 50, restored.AllocatedStorage)
+
+	// Bare new-instance ID inherits the source server.
+	bareRestored, err := m.RestoreInstanceFromSnapshot(ctx, rdsdriver.RestoreInstanceInput{
+		NewInstanceID: "bare-restored",
+		SnapshotID:    "backup-1",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "srv1", bareRestored.ClusterID)
+
+	requireNoError(t, m.DeleteSnapshot(ctx, "backup-1"))
+}
+
+func TestClusterSnapshotsUnsupported(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateClusterSnapshot(ctx, rdsdriver.ClusterSnapshotConfig{
+		ID: "x", ClusterID: "y",
+	}); err == nil {
+		t.Fatal("expected unsupported")
+	}
+
+	csnaps, err := m.DescribeClusterSnapshots(ctx, nil, "")
+	requireNoError(t, err)
+	assertEqual(t, 0, len(csnaps))
+}
+
+func TestStartStopClusterIsNoop(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// Both pass on a non-existent server — Azure SQL doesn't have explicit
+	// server-level start/stop, so we keep these calls inert.
+	requireNoError(t, m.StartCluster(ctx, "nonexistent"))
+	requireNoError(t, m.StopCluster(ctx, "nonexistent"))
+}
+
+// Hand-rolled helpers per CLAUDE.md.
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -12,7 +12,9 @@ import (
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/azuresql"
 	"github.com/stackshy/cloudemu/server/azure/blob"
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/disks"
@@ -47,6 +49,7 @@ type Drivers struct {
 	Monitor         mondriver.Monitoring
 	Functions       sdrv.Serverless
 	ServiceBus      mqdriver.MessageQueue
+	SQL             rdbdriver.RelationalDB
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -100,6 +103,12 @@ func New(d Drivers) *server.Server {
 
 	if d.ServiceBus != nil {
 		srv.Register(servicebus.New(d.ServiceBus))
+	}
+
+	// Microsoft.Sql provider — distinct ARM provider name from compute and
+	// network so registration order is unconstrained.
+	if d.SQL != nil {
+		srv.Register(azuresql.New(d.SQL))
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/azuresql/handler.go
+++ b/server/azure/azuresql/handler.go
@@ -1,0 +1,133 @@
+// Package azuresql implements the Azure SQL Database (Microsoft.Sql) ARM
+// REST API as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql clients
+// configured with a custom endpoint hit this handler the same way they hit
+// management.azure.com.
+//
+// MVP coverage:
+//
+//	PUT    .../providers/Microsoft.Sql/servers/{s}                      — Create or update server
+//	GET    .../providers/Microsoft.Sql/servers/{s}                      — Get server
+//	DELETE .../providers/Microsoft.Sql/servers/{s}                      — Delete server (cascade-deletes databases)
+//	GET    .../providers/Microsoft.Sql/servers                          — List servers in RG
+//	PUT    .../providers/Microsoft.Sql/servers/{s}/databases/{d}        — Create or update database
+//	PATCH  .../providers/Microsoft.Sql/servers/{s}/databases/{d}        — Update database
+//	GET    .../providers/Microsoft.Sql/servers/{s}/databases/{d}        — Get database
+//	DELETE .../providers/Microsoft.Sql/servers/{s}/databases/{d}        — Delete database
+//	GET    .../providers/Microsoft.Sql/servers/{s}/databases            — List databases on a server
+//
+// Mutating ops return 200 OK with the resource body inline so the SDK's LRO
+// poller terminates on the first response.
+package azuresql
+
+import (
+	"net/http"
+
+	rdsdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName         = "Microsoft.Sql"
+	resourceServers      = "servers"
+	subResourceDatabases = "databases"
+)
+
+// Handler serves Microsoft.Sql ARM requests against a relationaldb driver.
+type Handler struct {
+	db rdsdriver.RelationalDB
+}
+
+// New returns an Azure SQL handler backed by db.
+func New(db rdsdriver.RelationalDB) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches returns true for ARM Microsoft.Sql server/database paths.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == resourceServers
+}
+
+// ServeHTTP routes the request based on path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// Database-scoped: .../servers/{srv}/databases[/{db}]
+	if rp.SubResource == subResourceDatabases {
+		h.serveDatabaseRoute(w, r, &rp)
+		return
+	}
+
+	// Server-scoped or list.
+	if rp.ResourceName == "" {
+		h.serveServerCollection(w, r, &rp)
+		return
+	}
+
+	h.serveServer(w, r, &rp)
+}
+
+func (h *Handler) serveServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateServer(w, r, rp)
+	case http.MethodGet:
+		h.getServer(w, r, rp)
+	case http.MethodPatch:
+		h.updateServer(w, r, rp)
+	case http.MethodDelete:
+		h.deleteServer(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveServerCollection(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.listServers(w, r, rp)
+}
+
+func (h *Handler) serveDatabaseRoute(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	// rp.ResourceName is the server name; rp.SubResourceName is the database
+	// name (or empty for the collection).
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listDatabases(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateDatabase(w, r, rp)
+	case http.MethodPatch:
+		h.updateDatabase(w, r, rp)
+	case http.MethodGet:
+		h.getDatabase(w, r, rp)
+	case http.MethodDelete:
+		h.deleteDatabase(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/azuresql/operations.go
+++ b/server/azure/azuresql/operations.go
@@ -1,0 +1,237 @@
+package azuresql
+
+import (
+	"net/http"
+
+	rdsdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// ---- Server (logical) ops ----
+
+func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armServer
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := rdsdriver.ClusterConfig{
+		ID:             rp.ResourceName,
+		Engine:         "SQLServer",
+		MasterUsername: stringFrom(body.Properties, func(p *armServerProps) string { return p.AdministratorLogin }),
+		MasterUserPassword: stringFrom(body.Properties, func(p *armServerProps) string {
+			return p.AdministratorLoginPassword
+		}),
+		EngineVersion: stringFrom(body.Properties, func(p *armServerProps) string { return p.Version }),
+		Tags:          body.Tags,
+	}
+
+	cluster, err := h.db.CreateCluster(r.Context(), cfg)
+	if err != nil {
+		// Idempotent PUT: if the server already exists, treat as a get.
+		existing, getErr := h.db.DescribeClusters(r.Context(), []string{rp.ResourceName})
+		if getErr != nil || len(existing) != 1 {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		cluster = &existing[0]
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMServer(cluster, rp.Subscription, rp.ResourceGroup))
+}
+
+func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armServer
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	input := rdsdriver.ModifyInstanceInput{
+		EngineVersion: stringFrom(body.Properties, func(p *armServerProps) string { return p.Version }),
+		Tags:          body.Tags,
+	}
+
+	cluster, err := h.db.ModifyCluster(r.Context(), rp.ResourceName, input)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMServer(cluster, rp.Subscription, rp.ResourceGroup))
+}
+
+func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	clusters, err := h.db.DescribeClusters(r.Context(), []string{rp.ResourceName})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMServer(&clusters[0], rp.Subscription, rp.ResourceGroup))
+}
+
+func (h *Handler) deleteServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.db.DeleteCluster(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	clusters, err := h.db.DescribeClusters(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armServer, 0, len(clusters))
+	for i := range clusters {
+		out = append(out, toARMServer(&clusters[i], rp.Subscription, rp.ResourceGroup))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armList[armServer]{Value: out})
+}
+
+// ---- Database ops ----
+
+//nolint:gocyclo // sequential field defaulting + restore path keeps the body linear.
+func (h *Handler) createOrUpdateDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armDatabase
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	server := rp.ResourceName
+	dbName := rp.SubResourceName
+
+	// Restore path: createMode=Restore + sourceDatabaseId.
+	if body.Properties != nil && body.Properties.CreateMode == "Restore" {
+		input := rdsdriver.RestoreInstanceInput{
+			NewInstanceID: server + "/" + dbName,
+			SnapshotID:    body.Properties.SourceDatabaseID,
+		}
+
+		if body.SKU != nil {
+			input.InstanceClass = body.SKU.Name
+		}
+
+		inst, err := h.db.RestoreInstanceFromSnapshot(r.Context(), input)
+		if err != nil {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(inst, rp.Subscription, rp.ResourceGroup))
+
+		return
+	}
+
+	cfg := rdsdriver.InstanceConfig{
+		ID:               dbName,
+		ClusterID:        server,
+		Engine:           "SQLServer",
+		AvailabilityZone: body.Location,
+		Tags:             body.Tags,
+	}
+
+	if body.SKU != nil {
+		cfg.InstanceClass = body.SKU.Name
+	}
+
+	if body.Properties != nil && body.Properties.MaxSizeBytes > 0 {
+		cfg.AllocatedStorage = int(body.Properties.MaxSizeBytes / (1 << 30))
+	}
+
+	inst, err := h.db.CreateInstance(r.Context(), cfg)
+	if err != nil {
+		// Idempotent PUT: if the database already exists, fall back to a get.
+		existing, getErr := h.db.DescribeInstances(r.Context(), []string{server + "/" + dbName})
+		if getErr != nil || len(existing) != 1 {
+			azurearm.WriteCErr(w, err)
+			return
+		}
+
+		inst = &existing[0]
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(inst, rp.Subscription, rp.ResourceGroup))
+}
+
+func (h *Handler) updateDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body armDatabase
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	input := rdsdriver.ModifyInstanceInput{
+		Tags: body.Tags,
+	}
+
+	if body.SKU != nil {
+		input.InstanceClass = body.SKU.Name
+	}
+
+	if body.Properties != nil && body.Properties.MaxSizeBytes > 0 {
+		input.AllocatedStorage = int(body.Properties.MaxSizeBytes / (1 << 30))
+	}
+
+	inst, err := h.db.ModifyInstance(r.Context(), rp.ResourceName+"/"+rp.SubResourceName, input)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(inst, rp.Subscription, rp.ResourceGroup))
+}
+
+func (h *Handler) getDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	insts, err := h.db.DescribeInstances(r.Context(), []string{rp.ResourceName + "/" + rp.SubResourceName})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMDatabase(&insts[0], rp.Subscription, rp.ResourceGroup))
+}
+
+func (h *Handler) deleteDatabase(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.db.DeleteInstance(r.Context(), rp.ResourceName+"/"+rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listDatabases(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	all, err := h.db.DescribeInstances(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armDatabase, 0)
+
+	for i := range all {
+		if all[i].ClusterID != rp.ResourceName {
+			continue
+		}
+
+		out = append(out, toARMDatabase(&all[i], rp.Subscription, rp.ResourceGroup))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armList[armDatabase]{Value: out})
+}
+
+// stringFrom returns f(p) when p is non-nil, else "". A small helper that
+// keeps body decoders compact when most fields are pointer-deref accesses.
+func stringFrom[T any](p *T, f func(*T) string) string {
+	if p == nil {
+		return ""
+	}
+
+	return f(p)
+}

--- a/server/azure/azuresql/sdk_roundtrip_test.go
+++ b/server/azure/azuresql/sdk_roundtrip_test.go
@@ -1,0 +1,227 @@
+package azuresql_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newSDKClients(t *testing.T) (*armsql.ServersClient, *armsql.DatabasesClient) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{SQL: cloudP.SQL})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armsql.NewClientFactory("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cf.NewServersClient(), cf.NewDatabasesClient()
+}
+
+func TestSDKAzureSQLServerLifecycle(t *testing.T) {
+	servers, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armsql.ServerProperties{
+			AdministratorLogin:         to.Ptr("admin"),
+			AdministratorLoginPassword: to.Ptr("Sup3rs3cret!"),
+			Version:                    to.Ptr("12.0"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	resp, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if resp.Server.Name == nil || *resp.Server.Name != "srv1" {
+		t.Fatalf("got name %v, want srv1", resp.Server.Name)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "srv1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Server.Properties == nil ||
+		got.Server.Properties.FullyQualifiedDomainName == nil ||
+		*got.Server.Properties.FullyQualifiedDomainName == "" {
+		t.Fatal("expected FullyQualifiedDomainName set")
+	}
+
+	// List under the resource group.
+	pager := servers.NewListByResourceGroupPager("rg-1", nil)
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(page.Value) != 1 {
+		t.Fatalf("got %d servers, want 1", len(page.Value))
+	}
+
+	delPoller, err := servers.BeginDelete(ctx, "rg-1", "srv1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	if _, err := servers.Get(ctx, "rg-1", "srv1", nil); err == nil {
+		t.Fatal("expected NotFound after Delete")
+	}
+}
+
+func TestSDKAzureSQLDatabaseLifecycle(t *testing.T) {
+	servers, dbs := newSDKClients(t)
+	ctx := context.Background()
+
+	// Need a server first.
+	srvPoller, err := servers.BeginCreateOrUpdate(ctx, "rg-1", "srv1", armsql.Server{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("Server BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := srvPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Server PollUntilDone: %v", err)
+	}
+
+	// Create database.
+	dbPoller, err := dbs.BeginCreateOrUpdate(ctx, "rg-1", "srv1", "appdb", armsql.Database{
+		Location: to.Ptr("eastus"),
+		SKU:      &armsql.SKU{Name: to.Ptr("S0")},
+		Properties: &armsql.DatabaseProperties{
+			MaxSizeBytes: to.Ptr(int64(50) * (1 << 30)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("DB BeginCreateOrUpdate: %v", err)
+	}
+
+	dbResp, err := dbPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("DB PollUntilDone: %v", err)
+	}
+
+	if dbResp.Database.Name == nil || *dbResp.Database.Name != "appdb" {
+		t.Fatalf("got db name %v, want appdb", dbResp.Database.Name)
+	}
+
+	if dbResp.Database.SKU == nil || *dbResp.Database.SKU.Name != "S0" {
+		t.Fatal("expected SKU=S0 on response")
+	}
+
+	// Get.
+	got, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Database.Properties == nil || got.Database.Properties.Status == nil {
+		t.Fatal("expected Status set")
+	}
+
+	if *got.Database.Properties.Status != "Online" {
+		t.Fatalf("expected Online, got %q", *got.Database.Properties.Status)
+	}
+
+	// PATCH (resize).
+	patchPoller, err := dbs.BeginUpdate(ctx, "rg-1", "srv1", "appdb", armsql.DatabaseUpdate{
+		SKU: &armsql.SKU{Name: to.Ptr("S2")},
+		Properties: &armsql.DatabaseUpdateProperties{
+			MaxSizeBytes: to.Ptr(int64(100) * (1 << 30)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	if _, err := patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update PollUntilDone: %v", err)
+	}
+
+	got, err = dbs.Get(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("Get after patch: %v", err)
+	}
+
+	if got.Database.SKU == nil || *got.Database.SKU.Name != "S2" {
+		t.Fatalf("expected sku S2 after patch")
+	}
+
+	// List.
+	pager := dbs.NewListByServerPager("rg-1", "srv1", nil)
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("DB List: %v", err)
+	}
+
+	if len(page.Value) != 1 {
+		t.Fatalf("got %d databases, want 1", len(page.Value))
+	}
+
+	// Delete.
+	delPoller, err := dbs.BeginDelete(ctx, "rg-1", "srv1", "appdb", nil)
+	if err != nil {
+		t.Fatalf("DB BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("DB delete poll: %v", err)
+	}
+
+	if _, err := dbs.Get(ctx, "rg-1", "srv1", "appdb", nil); err == nil {
+		t.Fatal("expected NotFound after DB delete")
+	}
+}

--- a/server/azure/azuresql/types.go
+++ b/server/azure/azuresql/types.go
@@ -1,0 +1,132 @@
+package azuresql
+
+import (
+	rdsdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+)
+
+// Azure SQL Database.status enum values used in ARM responses.
+const (
+	dbStatusOnline   = "Online"
+	dbStatusPaused   = "Paused"
+	dbStatusCreating = "Creating"
+	dbStatusDeleting = "Deleting"
+)
+
+// armServer is the JSON shape Azure ARM expects for Microsoft.Sql/servers.
+type armServer struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Location   string            `json:"location,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties *armServerProps   `json:"properties,omitempty"`
+}
+
+type armServerProps struct {
+	AdministratorLogin         string `json:"administratorLogin,omitempty"`
+	AdministratorLoginPassword string `json:"administratorLoginPassword,omitempty"`
+	Version                    string `json:"version,omitempty"`
+	State                      string `json:"state,omitempty"`
+	FullyQualifiedDomainName   string `json:"fullyQualifiedDomainName,omitempty"`
+}
+
+// armDatabase is the JSON shape Azure ARM expects for
+// Microsoft.Sql/servers/databases.
+type armDatabase struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Location   string            `json:"location,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	SKU        *armSKU           `json:"sku,omitempty"`
+	Properties *armDatabaseProps `json:"properties,omitempty"`
+}
+
+type armSKU struct {
+	Name     string `json:"name,omitempty"`
+	Tier     string `json:"tier,omitempty"`
+	Capacity int    `json:"capacity,omitempty"`
+}
+
+type armDatabaseProps struct {
+	Status                      string `json:"status,omitempty"`
+	CreateMode                  string `json:"createMode,omitempty"`
+	SourceDatabaseID            string `json:"sourceDatabaseId,omitempty"`
+	RestorePointInTime          string `json:"restorePointInTime,omitempty"`
+	MaxSizeBytes                int64  `json:"maxSizeBytes,omitempty"`
+	Collation                   string `json:"collation,omitempty"`
+	DatabaseID                  string `json:"databaseId,omitempty"`
+	CurrentServiceObjectiveName string `json:"currentServiceObjectiveName,omitempty"`
+}
+
+// armList is the ARM list-response envelope.
+type armList[T any] struct {
+	Value    []T    `json:"value"`
+	NextLink string `json:"nextLink,omitempty"`
+}
+
+// toARMServer converts a portable Cluster (logical server) to ARM JSON.
+func toARMServer(cluster *rdsdriver.Cluster, subscription, resourceGroup string) armServer {
+	return armServer{
+		ID:   armServerID(subscription, resourceGroup, cluster.ID),
+		Name: cluster.ID,
+		Type: providerName + "/servers",
+		// Region is stashed in SubnetGroupName by the provider.
+		Location: cluster.SubnetGroupName,
+		Tags:     cluster.Tags,
+		Properties: &armServerProps{
+			AdministratorLogin:       cluster.MasterUsername,
+			Version:                  cluster.EngineVersion,
+			State:                    "Ready",
+			FullyQualifiedDomainName: cluster.Endpoint,
+		},
+	}
+}
+
+// toARMDatabase converts a portable Instance (database) to ARM JSON.
+func toARMDatabase(inst *rdsdriver.Instance, subscription, resourceGroup string) armDatabase {
+	return armDatabase{
+		ID:       armDatabaseID(subscription, resourceGroup, inst.ClusterID, inst.ID),
+		Name:     inst.ID,
+		Type:     providerName + "/servers/databases",
+		Location: inst.AvailabilityZone,
+		Tags:     inst.Tags,
+		SKU: &armSKU{
+			Name: inst.InstanceClass,
+		},
+		Properties: &armDatabaseProps{
+			Status:                      databaseStatus(inst.State),
+			MaxSizeBytes:                int64(inst.AllocatedStorage) * (1 << 30),
+			Collation:                   "SQL_Latin1_General_CP1_CI_AS",
+			DatabaseID:                  inst.ARN,
+			CurrentServiceObjectiveName: inst.InstanceClass,
+		},
+	}
+}
+
+func armServerID(subscription, resourceGroup, server string) string {
+	return "/subscriptions/" + subscription +
+		"/resourceGroups/" + resourceGroup +
+		"/providers/" + providerName + "/servers/" + server
+}
+
+func armDatabaseID(subscription, resourceGroup, server, database string) string {
+	return armServerID(subscription, resourceGroup, server) + "/databases/" + database
+}
+
+// databaseStatus maps the portable lifecycle to the Azure SQL Database.status
+// enum (Online, Offline, Restoring, Creating, Disabled).
+func databaseStatus(state string) string {
+	switch state {
+	case rdsdriver.StateAvailable:
+		return dbStatusOnline
+	case rdsdriver.StateStopped:
+		return dbStatusPaused
+	case rdsdriver.StateCreating:
+		return dbStatusCreating
+	case rdsdriver.StateDeleting:
+		return dbStatusDeleting
+	default:
+		return dbStatusOnline
+	}
+}


### PR DESCRIPTION
Closes #167.

## Summary
Adds an SDK-compat handler so the real `github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql` client works against cloudemu. Completes the relational-DB trio after AWS RDS (#154) and GCP Cloud SQL (#168).

## What's in
- `providers/azure/azuresql/` — in-memory mock implementing `relationaldb/driver.RelationalDB`. Mapping:
  - `Cluster` → Microsoft.Sql logical server
  - `Instance` with `ClusterID` → database under that server (composite ID `{server}/{database}`)
  - `Snapshot` → long-term retention backup
  - `ClusterSnapshot` → unsupported (no equivalent in Azure SQL)
  
  Server delete cascade-deletes child databases to match real Azure behavior. Bare-name database lookup works when unambiguous; composite-key lookup always works. Emits `Microsoft.Sql/servers/databases` metrics on lifecycle transitions.
- `server/azure/azuresql/` — ARM REST handler for the Microsoft.Sql provider. Routes server CRUD + database CRUD/list under `/subscriptions/{s}/resourceGroups/{rg}/providers/Microsoft.Sql/servers/...` Supports idempotent PUT (existing resource → return current state) and `createMode=Restore` via the standard PUT-with-source path.
- Wired into `providers/azure/azure.go` (`p.SQL` + `SetMonitoring`) and `server/azure/azure.go` Drivers bundle. The `Microsoft.Sql` provider name is distinct from `Microsoft.Compute`/`Microsoft.Network`/etc., so registration order is unconstrained.

## Operations implemented
Servers: CreateOrUpdate, Get, Update, Delete (cascade), ListByResourceGroup
Databases: CreateOrUpdate, Get, Update (PATCH), Delete, ListByServer, restore via createMode=Restore

## Tests
- Provider unit tests with hand-rolled require/assert helpers (no testify): server lifecycle, database requires server, database lifecycle, ambiguous bare-name lookup, cascade delete, snapshot+restore, cluster-snapshots unsupported.
- SDK round-trip tests using real `armsql.ServersClient` and `armsql.DatabasesClient` against `httptest.NewTLSServer`. Covers BeginCreateOrUpdate (LRO), Get, ListByResourceGroup, BeginDelete, BeginUpdate (PATCH), full DB lifecycle.
- End-to-end smoke test from a tmp module driving the real SDK against the cloudemu HTTPS server: 13/13 steps pass, including idempotent PUT and cascade-delete verification.

## Verification
- `go build ./...` clean
- `go test ./...` all packages green
- `golangci-lint run --timeout=9m ./...` 0 issues across the entire project

## Test plan
- [ ] `go test ./providers/azure/azuresql/... ./server/azure/azuresql/...`
- [ ] `go test ./...` full suite stays green
- [ ] `golangci-lint run --timeout=9m ./...` reports 0 issues
- [ ] Drive a real `armsql` ServersClient + DatabasesClient at the cloudemu server and confirm CreateOrUpdate/Get/Update/Delete + cascade-delete round-trip