### PR TITLE
fix(awsquery): dual-shape error envelope so RDS/Redshift/Neptune/DocDB SDKs see typed errors

### DIFF
--- a/server/wire/awsquery/awsquery.go
+++ b/server/wire/awsquery/awsquery.go
@@ -196,11 +196,23 @@ func WriteXMLResponse(w http.ResponseWriter, v any) {
 	_ = xml.NewEncoder(w).Encode(v)
 }
 
-// ErrorResponse is the AWS-style XML error body.
+// ErrorResponse is the AWS-style XML error body. It emits BOTH the EC2 query
+// shape (<Errors><Error>...</Error></Errors>) and the standard query shape
+// (<Error>...</Error> at the response root) so that:
+//
+//   - EC2 SDK (which parses xml:"Errors>Error>Code") finds the wrapped form.
+//   - RDS / Redshift / Neptune / DocumentDB SDKs (which parse xml:"Error>Code"
+//     against a wrappedErrorResponse) find the unwrapped form.
+//
+// The duplication is harmless: each SDK matches its own shape via XPath-style
+// xml tags and ignores the other.
 type ErrorResponse struct {
 	XMLName   xml.Name `xml:"Response"`
-	RequestID string   `xml:"RequestID"`
 	Errors    []Error  `xml:"Errors>Error"`
+	Error     Error    `xml:"Error"`
+	RequestID string   `xml:"RequestID"`
+	//nolint:revive,stylecheck,staticcheck // SDKs literally look for "RequestId", not "RequestID"; the second field is intentional.
+	RequestId string `xml:"RequestId"`
 }
 
 // Error is one error entry.
@@ -209,14 +221,18 @@ type Error struct {
 	Message string `xml:"Message"`
 }
 
-// WriteXMLError writes an AWS-style XML error response.
+// WriteXMLError writes an AWS-style XML error response. The response shape is
+// compatible with both the EC2 query SDK and the standard query SDKs (RDS,
+// Redshift, Neptune, DocumentDB).
 func WriteXMLError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "text/xml")
 	w.WriteHeader(status)
 	fmt.Fprint(w, xml.Header)
 
 	_ = xml.NewEncoder(w).Encode(ErrorResponse{
-		RequestID: RequestID,
 		Errors:    []Error{{Code: code, Message: message}},
+		Error:     Error{Code: code, Message: message},
+		RequestID: RequestID,
+		RequestId: RequestID,
 	})
 }


### PR DESCRIPTION
## Summary
Discovered during prod-readiness end-to-end testing: every server-side error returned to the AWS SDKs for RDS, Redshift, Neptune, and DocumentDB came through as \`UnknownError\` instead of the typed exception (\`ClusterAlreadyExistsFault\`, \`DBInstanceNotFound\`, etc.). Apps relying on \`errors.As(&typedErr)\` would never match.

## Root cause
\`awsquery.WriteXMLError\` emitted only the EC2-shaped envelope (\`<Response><Errors><Error>...</Error></Errors></Response>\`). EC2 SDK parses this via \`xml:"Errors>Error>Code"\`. RDS / Redshift / Neptune / DocumentDB SDKs use the *standard* query shape and look for \`xml:"Error>Code"\` directly under the response root — they couldn't find Code/Message inside the nested wrapper.

## Fix
Emit both shapes inside the same \`<Response>\` element:

- \`<Errors><Error>...</Error></Errors>\` — EC2 SDK path
- \`<Error>...</Error>\` (sibling, top-level) — standard query SDK path
- \`<RequestID>\` and \`<RequestId>\` (both casings, SDKs differ)

Each SDK's XML decoder picks its own shape; the duplicate is inert for the other parser.

## Verification
- \`go build ./...\` clean
- \`go test ./...\` all packages green
- \`golangci-lint run --timeout=9m ./...\` 0 issues
- 74/74 EC2-side regression checks still pass (\`/tmp/cloudemu-e2e\`)
- 50/50 prod-readiness checks pass (\`/tmp/cloudemu-prod-readiness\`), including:
  - Redshift duplicate \`CreateCluster\` now correctly surfaces a typed conflict error
  - RDS / Neptune / DocDB NotFound paths now surface typed errors
  - EC2 routing precedence test (combined RDS+Redshift+EC2 server) still works

## Test plan
- [ ] \`go test ./...\` stays green
- [ ] \`golangci-lint run --timeout=9m ./...\` reports 0 issues
- [ ] EC2 SDK test (e.g. NotFound on \`DescribeInstances\` with bogus id) still receives the typed exception
- [ ] RDS / Redshift / Neptune / DocDB SDK tests now receive typed exceptions for duplicates and NotFounds