### PR TITLE
feat(eks): add AWS EKS SDK-compat handler — control plane (#184)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
+	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1/go.mod h1:wHrWCwhXZrl2PuCP5t36UTacy9fCHDJ+vw1r3qxTL5M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 h1:9nfacm+uWgbdPaOplvJjxN50qgthexb7GOR/97ygc5o=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
+github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
+github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 h1:JRaIgADQS/U6uXDqlPiefP32yXTda7Kqfx+LgspooZM=

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
 	"github.com/stackshy/cloudemu/providers/aws/ec2"
 	"github.com/stackshy/cloudemu/providers/aws/ecr"
+	"github.com/stackshy/cloudemu/providers/aws/eks"
 	"github.com/stackshy/cloudemu/providers/aws/elasticache"
 	"github.com/stackshy/cloudemu/providers/aws/elb"
 	"github.com/stackshy/cloudemu/providers/aws/eventbridge"
@@ -43,6 +44,7 @@ type Provider struct {
 	EventBridge    *eventbridge.Mock
 	RDS            *rds.Mock
 	Redshift       *redshift.Mock
+	EKS            *eks.Mock
 }
 
 // New creates a new AWS provider with all mock services.
@@ -67,6 +69,7 @@ func New(opts ...config.Option) *Provider {
 		EventBridge:    eventbridge.New(o),
 		RDS:            rds.New(o),
 		Redshift:       redshift.New(o),
+		EKS:            eks.New(o),
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
 	p.S3.SetMonitoring(p.CloudWatch)
@@ -80,6 +83,7 @@ func New(opts ...config.Option) *Provider {
 	p.EventBridge.SetMonitoring(p.CloudWatch)
 	p.RDS.SetMonitoring(p.CloudWatch)
 	p.Redshift.SetMonitoring(p.CloudWatch)
+	p.EKS.SetMonitoring(p.CloudWatch)
 
 	return p
 }

--- a/providers/aws/eks/driver/driver.go
+++ b/providers/aws/eks/driver/driver.go
@@ -1,0 +1,226 @@
+// Package driver defines the interface for AWS EKS control-plane mocks.
+//
+// Wave 1 covers the cloud-side EKS surface only: clusters, managed node
+// groups, Fargate profiles, and add-ons. The Kubernetes data plane
+// (Deployments, Pods, Services, …) is explicitly out of scope and will
+// be Wave 2 — when it lands, the cluster Endpoint and CertificateAuthority
+// fields will point at a real in-process apiserver instead of the
+// placeholder values returned today.
+//
+// The shape is intentionally service-local: EKS has no cross-cloud
+// equivalent that warrants a portable abstraction yet, so this lives next
+// to the provider implementation rather than in a top-level package.
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// Cluster lifecycle states. Mirrors the AWS EKS ClusterStatus enum.
+const (
+	ClusterStatusCreating = "CREATING"
+	ClusterStatusActive   = "ACTIVE"
+	ClusterStatusDeleting = "DELETING"
+	ClusterStatusUpdating = "UPDATING"
+)
+
+// Nodegroup lifecycle states.
+const (
+	NodegroupStatusCreating = "CREATING"
+	NodegroupStatusActive   = "ACTIVE"
+	NodegroupStatusUpdating = "UPDATING"
+	NodegroupStatusDeleting = "DELETING"
+)
+
+// FargateProfile lifecycle states.
+const (
+	FargateProfileStatusCreating = "CREATING"
+	FargateProfileStatusActive   = "ACTIVE"
+	FargateProfileStatusDeleting = "DELETING"
+)
+
+// Addon lifecycle states.
+const (
+	AddonStatusCreating = "CREATING"
+	AddonStatusActive   = "ACTIVE"
+	AddonStatusUpdating = "UPDATING"
+	AddonStatusDeleting = "DELETING"
+)
+
+// VPCConfig captures the subset of EKS VPC configuration the mock retains.
+type VPCConfig struct {
+	SubnetIDs             []string
+	SecurityGroupIDs      []string
+	EndpointPublicAccess  bool
+	EndpointPrivateAccess bool
+	PublicAccessCidrs     []string
+}
+
+// ClusterConfig configures a new EKS cluster.
+type ClusterConfig struct {
+	Name      string
+	Version   string
+	RoleArn   string
+	VPCConfig VPCConfig
+	Tags      map[string]string
+}
+
+// Cluster is the mock-side representation of an EKS cluster.
+type Cluster struct {
+	Name                 string
+	ARN                  string
+	Version              string
+	PlatformVersion      string
+	RoleArn              string
+	Endpoint             string
+	CertificateAuthority string
+	Status               string
+	VPCConfig            VPCConfig
+	Tags                 map[string]string
+	CreatedAt            time.Time
+}
+
+// ClusterUpdate is returned by mutating cluster ops; SDKs poll this via
+// DescribeUpdate but Wave 1 returns done=true immediately.
+type ClusterUpdate struct {
+	ID        string
+	Type      string // VersionUpdate, EndpointAccessUpdate, …
+	Status    string // InProgress, Failed, Canceled, Successful
+	CreatedAt time.Time
+}
+
+// NodegroupScalingConfig captures Auto Scaling sizing for a nodegroup.
+type NodegroupScalingConfig struct {
+	MinSize     int
+	MaxSize     int
+	DesiredSize int
+}
+
+// NodegroupConfig configures a new managed node group.
+type NodegroupConfig struct {
+	ClusterName    string
+	NodegroupName  string
+	NodeRole       string
+	Subnets        []string
+	InstanceTypes  []string
+	AmiType        string
+	CapacityType   string
+	DiskSize       int
+	Version        string
+	ReleaseVersion string
+	ScalingConfig  NodegroupScalingConfig
+	Labels         map[string]string
+	Tags           map[string]string
+}
+
+// Nodegroup is the mock-side representation of a managed node group.
+type Nodegroup struct {
+	ClusterName    string
+	NodegroupName  string
+	ARN            string
+	NodeRole       string
+	Subnets        []string
+	InstanceTypes  []string
+	AmiType        string
+	CapacityType   string
+	DiskSize       int
+	Version        string
+	ReleaseVersion string
+	ScalingConfig  NodegroupScalingConfig
+	Status         string
+	Labels         map[string]string
+	Tags           map[string]string
+	CreatedAt      time.Time
+}
+
+// FargateProfileSelector matches Pods to a Fargate profile.
+type FargateProfileSelector struct {
+	Namespace string
+	Labels    map[string]string
+}
+
+// FargateProfileConfig configures a new Fargate profile.
+type FargateProfileConfig struct {
+	ClusterName        string
+	FargateProfileName string
+	PodExecutionRole   string
+	Subnets            []string
+	Selectors          []FargateProfileSelector
+	Tags               map[string]string
+}
+
+// FargateProfile is the mock-side representation of a Fargate profile.
+type FargateProfile struct {
+	ClusterName        string
+	FargateProfileName string
+	ARN                string
+	PodExecutionRole   string
+	Subnets            []string
+	Selectors          []FargateProfileSelector
+	Status             string
+	Tags               map[string]string
+	CreatedAt          time.Time
+}
+
+// AddonConfig configures a new cluster add-on.
+type AddonConfig struct {
+	ClusterName           string
+	AddonName             string
+	AddonVersion          string
+	ServiceAccountRoleArn string
+	ConfigurationValues   string
+	Tags                  map[string]string
+}
+
+// Addon is the mock-side representation of a cluster add-on.
+type Addon struct {
+	ClusterName           string
+	AddonName             string
+	AddonVersion          string
+	ARN                   string
+	ServiceAccountRoleArn string
+	ConfigurationValues   string
+	Status                string
+	Tags                  map[string]string
+	CreatedAt             time.Time
+	ModifiedAt            time.Time
+}
+
+// EKS is the interface implemented by the EKS provider mock. It mirrors the
+// AWS EKS API operations the SDK-compat handler needs to serve real clients.
+type EKS interface {
+	// Clusters
+	CreateCluster(ctx context.Context, cfg ClusterConfig) (*Cluster, error)
+	DescribeCluster(ctx context.Context, name string) (*Cluster, error)
+	ListClusters(ctx context.Context) ([]string, error)
+	UpdateClusterConfig(ctx context.Context, name string, cfg VPCConfig, tags map[string]string) (*ClusterUpdate, error)
+	UpdateClusterVersion(ctx context.Context, name, version string) (*ClusterUpdate, error)
+	DeleteCluster(ctx context.Context, name string) (*Cluster, error)
+
+	// Node groups
+	CreateNodegroup(ctx context.Context, cfg NodegroupConfig) (*Nodegroup, error)
+	DescribeNodegroup(ctx context.Context, clusterName, nodegroupName string) (*Nodegroup, error)
+	ListNodegroups(ctx context.Context, clusterName string) ([]string, error)
+	UpdateNodegroupConfig(
+		ctx context.Context, clusterName, nodegroupName string,
+		scaling *NodegroupScalingConfig, labels map[string]string,
+	) (*ClusterUpdate, error)
+	UpdateNodegroupVersion(
+		ctx context.Context, clusterName, nodegroupName, version, releaseVersion string,
+	) (*ClusterUpdate, error)
+	DeleteNodegroup(ctx context.Context, clusterName, nodegroupName string) (*Nodegroup, error)
+
+	// Fargate profiles
+	CreateFargateProfile(ctx context.Context, cfg FargateProfileConfig) (*FargateProfile, error)
+	DescribeFargateProfile(ctx context.Context, clusterName, profileName string) (*FargateProfile, error)
+	ListFargateProfiles(ctx context.Context, clusterName string) ([]string, error)
+	DeleteFargateProfile(ctx context.Context, clusterName, profileName string) (*FargateProfile, error)
+
+	// Add-ons
+	CreateAddon(ctx context.Context, cfg AddonConfig) (*Addon, error)
+	DescribeAddon(ctx context.Context, clusterName, addonName string) (*Addon, error)
+	ListAddons(ctx context.Context, clusterName string) ([]string, error)
+	UpdateAddon(ctx context.Context, cfg AddonConfig) (*ClusterUpdate, error)
+	DeleteAddon(ctx context.Context, clusterName, addonName string) (*Addon, error)
+}

--- a/providers/aws/eks/eks.go
+++ b/providers/aws/eks/eks.go
@@ -1,0 +1,812 @@
+// Package eks provides an in-memory mock of AWS EKS — Wave 1 covers the
+// control plane only (clusters, managed node groups, Fargate profiles, and
+// add-ons). The Kubernetes data plane is out of scope and will be Wave 2;
+// for now the cluster Endpoint and CertificateAuthority fields return
+// placeholder values so kubeconfig generation works syntactically without
+// a real apiserver.
+//
+// The mock implements eks/driver.EKS so the same backend serves both the
+// SDK-compat HTTP handler in server/aws/eks and any direct programmatic
+// access from Go test code.
+package eks
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
+)
+
+// Wave 1 placeholder for the cluster API server endpoint. Wave 2 will swap
+// in a real per-cluster apiserver address.
+const (
+	wavePlaceholderEndpoint = "https://EKS-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local"
+	defaultPlatformVersion  = "eks.1"
+	namespaceEKS            = "AWS/EKS"
+)
+
+// CloudWatch-style metric values emitted on cluster create. The numbers are
+// arbitrary running-cluster defaults; the goal is for monitoring assertions
+// to find populated datapoints, not to model real load.
+const (
+	metricClusterCPU       = 25.0
+	metricClusterMemory    = 40.0
+	metricClusterPods      = 5.0
+	metricClusterNodes     = 2.0
+	metricClusterAPIErrors = 0.0
+)
+
+var _ eksdriver.EKS = (*Mock)(nil)
+
+// Mock is the in-memory AWS EKS implementation.
+type Mock struct {
+	mu sync.RWMutex
+
+	clusters        *memstore.Store[eksdriver.Cluster]
+	nodegroups      *memstore.Store[eksdriver.Nodegroup]
+	fargateProfiles *memstore.Store[eksdriver.FargateProfile]
+	addons          *memstore.Store[eksdriver.Addon]
+
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new AWS EKS mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		clusters:        memstore.New[eksdriver.Cluster](),
+		nodegroups:      memstore.New[eksdriver.Nodegroup](),
+		fargateProfiles: memstore.New[eksdriver.FargateProfile](),
+		addons:          memstore.New[eksdriver.Addon](),
+		opts:            opts,
+	}
+}
+
+// SetMonitoring wires a CloudWatch-style backend for auto-metric emission.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+// nodegroupKey uniquely identifies a nodegroup across clusters.
+func nodegroupKey(clusterName, nodegroupName string) string {
+	return clusterName + "/" + nodegroupName
+}
+
+// fargateKey uniquely identifies a Fargate profile across clusters.
+func fargateKey(clusterName, profileName string) string {
+	return clusterName + "/" + profileName
+}
+
+// addonKey uniquely identifies an add-on across clusters.
+func addonKey(clusterName, addonName string) string {
+	return clusterName + "/" + addonName
+}
+
+// stubCertificate returns a placeholder base64 CA blob. Real EKS returns a
+// PEM-encoded x509 cert; SDK clients only base64-decode it for the
+// kubeconfig, so a deterministic stub is enough for Wave 1.
+func stubCertificate() string {
+	const placeholder = "-----BEGIN CERTIFICATE-----\nMIICloudemuStubCertificate\n-----END CERTIFICATE-----\n"
+
+	return base64.StdEncoding.EncodeToString([]byte(placeholder))
+}
+
+func newUpdateID() string {
+	var b [16]byte
+
+	if _, err := rand.Read(b[:]); err != nil {
+		// rand.Read on Linux/macOS uses getrandom(2)/arc4random(3); both are
+		// effectively infallible. Falling back to a fixed string keeps the
+		// caller signature simple if it ever does fail.
+		return "00000000-0000-0000-0000-000000000000"
+	}
+
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		hex.EncodeToString(b[0:4]),
+		hex.EncodeToString(b[4:6]),
+		hex.EncodeToString(b[6:8]),
+		hex.EncodeToString(b[8:10]),
+		hex.EncodeToString(b[10:16]),
+	)
+}
+
+func (m *Mock) clusterARN(name string) string {
+	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID, "cluster/"+name)
+}
+
+func (m *Mock) nodegroupARN(clusterName, nodegroupName string) string {
+	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID,
+		"nodegroup/"+clusterName+"/"+nodegroupName)
+}
+
+func (m *Mock) fargateARN(clusterName, profileName string) string {
+	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID,
+		"fargateprofile/"+clusterName+"/"+profileName)
+}
+
+func (m *Mock) addonARN(clusterName, addonName string) string {
+	return idgen.AWSARN("eks", m.opts.Region, m.opts.AccountID,
+		"addon/"+clusterName+"/"+addonName)
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func copyStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+
+	out := make([]string, len(src))
+	copy(out, src)
+
+	return out
+}
+
+func (m *Mock) emitClusterMetrics(name string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	dims := map[string]string{"ClusterName": name}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{
+		{
+			Namespace: namespaceEKS, MetricName: "CPUUtilization", Value: metricClusterCPU,
+			Unit: "Percent", Dimensions: dims, Timestamp: now,
+		},
+		{
+			Namespace: namespaceEKS, MetricName: "MemoryUtilization", Value: metricClusterMemory,
+			Unit: "Percent", Dimensions: dims, Timestamp: now,
+		},
+		{
+			Namespace: namespaceEKS, MetricName: "cluster_node_count", Value: metricClusterNodes,
+			Unit: "Count", Dimensions: dims, Timestamp: now,
+		},
+		{
+			Namespace: namespaceEKS, MetricName: "cluster_pod_count", Value: metricClusterPods,
+			Unit: "Count", Dimensions: dims, Timestamp: now,
+		},
+		{
+			Namespace: namespaceEKS, MetricName: "apiserver_request_total", Value: metricClusterAPIErrors,
+			Unit: "Count", Dimensions: dims, Timestamp: now,
+		},
+	})
+}
+
+// CreateCluster creates a new cluster.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) CreateCluster(_ context.Context, cfg eksdriver.ClusterConfig) (*eksdriver.Cluster, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "cluster name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.clusters.Get(cfg.Name); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "cluster %q already exists", cfg.Name)
+	}
+
+	cluster := eksdriver.Cluster{
+		Name:                 cfg.Name,
+		ARN:                  m.clusterARN(cfg.Name),
+		Version:              cfg.Version,
+		PlatformVersion:      defaultPlatformVersion,
+		RoleArn:              cfg.RoleArn,
+		Endpoint:             wavePlaceholderEndpoint,
+		CertificateAuthority: stubCertificate(),
+		Status:               eksdriver.ClusterStatusActive,
+		VPCConfig: eksdriver.VPCConfig{
+			SubnetIDs:             copyStrings(cfg.VPCConfig.SubnetIDs),
+			SecurityGroupIDs:      copyStrings(cfg.VPCConfig.SecurityGroupIDs),
+			EndpointPublicAccess:  cfg.VPCConfig.EndpointPublicAccess,
+			EndpointPrivateAccess: cfg.VPCConfig.EndpointPrivateAccess,
+			PublicAccessCidrs:     copyStrings(cfg.VPCConfig.PublicAccessCidrs),
+		},
+		Tags:      copyTags(cfg.Tags),
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}
+
+	m.clusters.Set(cfg.Name, cluster)
+
+	m.emitClusterMetrics(cfg.Name)
+
+	out := cluster
+
+	return &out, nil
+}
+
+// DescribeCluster looks up a cluster by name.
+func (m *Mock) DescribeCluster(_ context.Context, name string) (*eksdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	}
+
+	out := c
+
+	return &out, nil
+}
+
+// ListClusters returns the names of all clusters.
+func (m *Mock) ListClusters(_ context.Context) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.clusters.Keys(), nil
+}
+
+// UpdateClusterConfig records a logical update for VPC config / logging /
+// tags. Wave 1 applies the changes synchronously and returns a Successful
+// update so SDK pollers terminate immediately.
+//
+//nolint:gocritic // cfg matches the driver interface signature; one copy on entry is fine.
+func (m *Mock) UpdateClusterConfig(
+	_ context.Context, name string, cfg eksdriver.VPCConfig, tags map[string]string,
+) (*eksdriver.ClusterUpdate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	}
+
+	if len(cfg.SubnetIDs) > 0 {
+		c.VPCConfig.SubnetIDs = copyStrings(cfg.SubnetIDs)
+	}
+
+	if len(cfg.SecurityGroupIDs) > 0 {
+		c.VPCConfig.SecurityGroupIDs = copyStrings(cfg.SecurityGroupIDs)
+	}
+
+	if len(cfg.PublicAccessCidrs) > 0 {
+		c.VPCConfig.PublicAccessCidrs = copyStrings(cfg.PublicAccessCidrs)
+	}
+
+	c.VPCConfig.EndpointPublicAccess = cfg.EndpointPublicAccess
+	c.VPCConfig.EndpointPrivateAccess = cfg.EndpointPrivateAccess
+
+	if tags != nil {
+		c.Tags = copyTags(tags)
+	}
+
+	m.clusters.Set(name, c)
+
+	return &eksdriver.ClusterUpdate{
+		ID:        newUpdateID(),
+		Type:      "EndpointAccessUpdate",
+		Status:    "Successful",
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}, nil
+}
+
+// UpdateClusterVersion bumps the Kubernetes version of an existing cluster.
+func (m *Mock) UpdateClusterVersion(_ context.Context, name, version string) (*eksdriver.ClusterUpdate, error) {
+	if version == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "version is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	}
+
+	c.Version = version
+	m.clusters.Set(name, c)
+
+	return &eksdriver.ClusterUpdate{
+		ID:        newUpdateID(),
+		Type:      "VersionUpdate",
+		Status:    "Successful",
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}, nil
+}
+
+// DeleteCluster removes a cluster (only if no nodegroups, Fargate profiles,
+// or add-ons remain attached, matching real EKS behavior).
+//
+
+func (m *Mock) DeleteCluster(_ context.Context, name string) (*eksdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	}
+
+	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
+	for _, ng := range m.nodegroups.All() {
+		if ng.ClusterName == name {
+			return nil, cerrors.Newf(cerrors.FailedPrecondition,
+				"cluster %q still has nodegroup %q attached", name, ng.NodegroupName)
+		}
+	}
+
+	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
+	for _, fp := range m.fargateProfiles.All() {
+		if fp.ClusterName == name {
+			return nil, cerrors.Newf(cerrors.FailedPrecondition,
+				"cluster %q still has Fargate profile %q attached", name, fp.FargateProfileName)
+		}
+	}
+
+	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
+	for _, ad := range m.addons.All() {
+		if ad.ClusterName == name {
+			return nil, cerrors.Newf(cerrors.FailedPrecondition,
+				"cluster %q still has add-on %q installed", name, ad.AddonName)
+		}
+	}
+
+	c.Status = eksdriver.ClusterStatusDeleting
+
+	m.clusters.Delete(name)
+
+	out := c
+
+	return &out, nil
+}
+
+// CreateNodegroup creates a new managed node group.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) CreateNodegroup(_ context.Context, cfg eksdriver.NodegroupConfig) (*eksdriver.Nodegroup, error) {
+	if cfg.ClusterName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "clusterName is required")
+	}
+
+	if cfg.NodegroupName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "nodegroupName is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.clusters.Get(cfg.ClusterName); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
+	}
+
+	key := nodegroupKey(cfg.ClusterName, cfg.NodegroupName)
+	if _, ok := m.nodegroups.Get(key); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"nodegroup %q already exists in cluster %q", cfg.NodegroupName, cfg.ClusterName)
+	}
+
+	ng := eksdriver.Nodegroup{
+		ClusterName:    cfg.ClusterName,
+		NodegroupName:  cfg.NodegroupName,
+		ARN:            m.nodegroupARN(cfg.ClusterName, cfg.NodegroupName),
+		NodeRole:       cfg.NodeRole,
+		Subnets:        copyStrings(cfg.Subnets),
+		InstanceTypes:  copyStrings(cfg.InstanceTypes),
+		AmiType:        cfg.AmiType,
+		CapacityType:   cfg.CapacityType,
+		DiskSize:       cfg.DiskSize,
+		Version:        cfg.Version,
+		ReleaseVersion: cfg.ReleaseVersion,
+		ScalingConfig:  cfg.ScalingConfig,
+		Status:         eksdriver.NodegroupStatusActive,
+		Labels:         copyTags(cfg.Labels),
+		Tags:           copyTags(cfg.Tags),
+		CreatedAt:      m.opts.Clock.Now().UTC(),
+	}
+
+	m.nodegroups.Set(key, ng)
+
+	out := ng
+
+	return &out, nil
+}
+
+// DescribeNodegroup looks up a nodegroup by cluster + name.
+func (m *Mock) DescribeNodegroup(_ context.Context, clusterName, nodegroupName string) (*eksdriver.Nodegroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ng, ok := m.nodegroups.Get(nodegroupKey(clusterName, nodegroupName))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
+	}
+
+	out := ng
+
+	return &out, nil
+}
+
+// ListNodegroups returns the names of all nodegroups in a cluster.
+func (m *Mock) ListNodegroups(_ context.Context, clusterName string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if _, ok := m.clusters.Get(clusterName); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
+	}
+
+	out := make([]string, 0)
+
+	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
+	for _, ng := range m.nodegroups.All() {
+		if ng.ClusterName == clusterName {
+			out = append(out, ng.NodegroupName)
+		}
+	}
+
+	return out, nil
+}
+
+// UpdateNodegroupConfig applies scaling and label changes to a nodegroup.
+func (m *Mock) UpdateNodegroupConfig(
+	_ context.Context, clusterName, nodegroupName string,
+	scaling *eksdriver.NodegroupScalingConfig, labels map[string]string,
+) (*eksdriver.ClusterUpdate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := nodegroupKey(clusterName, nodegroupName)
+
+	ng, ok := m.nodegroups.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
+	}
+
+	if scaling != nil {
+		ng.ScalingConfig = *scaling
+	}
+
+	if labels != nil {
+		ng.Labels = copyTags(labels)
+	}
+
+	m.nodegroups.Set(key, ng)
+
+	return &eksdriver.ClusterUpdate{
+		ID:        newUpdateID(),
+		Type:      "ConfigUpdate",
+		Status:    "Successful",
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}, nil
+}
+
+// UpdateNodegroupVersion bumps the Kubernetes version of a nodegroup.
+func (m *Mock) UpdateNodegroupVersion(
+	_ context.Context, clusterName, nodegroupName, version, releaseVersion string,
+) (*eksdriver.ClusterUpdate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := nodegroupKey(clusterName, nodegroupName)
+
+	ng, ok := m.nodegroups.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
+	}
+
+	if version != "" {
+		ng.Version = version
+	}
+
+	if releaseVersion != "" {
+		ng.ReleaseVersion = releaseVersion
+	}
+
+	m.nodegroups.Set(key, ng)
+
+	return &eksdriver.ClusterUpdate{
+		ID:        newUpdateID(),
+		Type:      "VersionUpdate",
+		Status:    "Successful",
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}, nil
+}
+
+// DeleteNodegroup removes a nodegroup.
+func (m *Mock) DeleteNodegroup(_ context.Context, clusterName, nodegroupName string) (*eksdriver.Nodegroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := nodegroupKey(clusterName, nodegroupName)
+
+	ng, ok := m.nodegroups.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"nodegroup %q not found in cluster %q", nodegroupName, clusterName)
+	}
+
+	ng.Status = eksdriver.NodegroupStatusDeleting
+
+	m.nodegroups.Delete(key)
+
+	out := ng
+
+	return &out, nil
+}
+
+// CreateFargateProfile creates a new Fargate profile in the named cluster.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) CreateFargateProfile(
+	_ context.Context, cfg eksdriver.FargateProfileConfig,
+) (*eksdriver.FargateProfile, error) {
+	if cfg.ClusterName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "clusterName is required")
+	}
+
+	if cfg.FargateProfileName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "fargateProfileName is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.clusters.Get(cfg.ClusterName); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
+	}
+
+	key := fargateKey(cfg.ClusterName, cfg.FargateProfileName)
+	if _, ok := m.fargateProfiles.Get(key); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"Fargate profile %q already exists in cluster %q", cfg.FargateProfileName, cfg.ClusterName)
+	}
+
+	fp := eksdriver.FargateProfile{
+		ClusterName:        cfg.ClusterName,
+		FargateProfileName: cfg.FargateProfileName,
+		ARN:                m.fargateARN(cfg.ClusterName, cfg.FargateProfileName),
+		PodExecutionRole:   cfg.PodExecutionRole,
+		Subnets:            copyStrings(cfg.Subnets),
+		Selectors:          append([]eksdriver.FargateProfileSelector(nil), cfg.Selectors...),
+		Status:             eksdriver.FargateProfileStatusActive,
+		Tags:               copyTags(cfg.Tags),
+		CreatedAt:          m.opts.Clock.Now().UTC(),
+	}
+
+	m.fargateProfiles.Set(key, fp)
+
+	out := fp
+
+	return &out, nil
+}
+
+// DescribeFargateProfile looks up a profile by cluster + name.
+func (m *Mock) DescribeFargateProfile(
+	_ context.Context, clusterName, profileName string,
+) (*eksdriver.FargateProfile, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	fp, ok := m.fargateProfiles.Get(fargateKey(clusterName, profileName))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"Fargate profile %q not found in cluster %q", profileName, clusterName)
+	}
+
+	out := fp
+
+	return &out, nil
+}
+
+// ListFargateProfiles returns the names of all profiles in a cluster.
+func (m *Mock) ListFargateProfiles(_ context.Context, clusterName string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if _, ok := m.clusters.Get(clusterName); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
+	}
+
+	out := make([]string, 0)
+
+	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
+	for _, fp := range m.fargateProfiles.All() {
+		if fp.ClusterName == clusterName {
+			out = append(out, fp.FargateProfileName)
+		}
+	}
+
+	return out, nil
+}
+
+// DeleteFargateProfile removes a Fargate profile.
+func (m *Mock) DeleteFargateProfile(
+	_ context.Context, clusterName, profileName string,
+) (*eksdriver.FargateProfile, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := fargateKey(clusterName, profileName)
+
+	fp, ok := m.fargateProfiles.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"Fargate profile %q not found in cluster %q", profileName, clusterName)
+	}
+
+	fp.Status = eksdriver.FargateProfileStatusDeleting
+
+	m.fargateProfiles.Delete(key)
+
+	out := fp
+
+	return &out, nil
+}
+
+// CreateAddon installs a new add-on on a cluster.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) CreateAddon(_ context.Context, cfg eksdriver.AddonConfig) (*eksdriver.Addon, error) {
+	if cfg.ClusterName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "clusterName is required")
+	}
+
+	if cfg.AddonName == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "addonName is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.clusters.Get(cfg.ClusterName); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
+	}
+
+	key := addonKey(cfg.ClusterName, cfg.AddonName)
+	if _, ok := m.addons.Get(key); ok {
+		return nil, cerrors.Newf(cerrors.AlreadyExists,
+			"add-on %q already installed on cluster %q", cfg.AddonName, cfg.ClusterName)
+	}
+
+	now := m.opts.Clock.Now().UTC()
+
+	ad := eksdriver.Addon{
+		ClusterName:           cfg.ClusterName,
+		AddonName:             cfg.AddonName,
+		AddonVersion:          cfg.AddonVersion,
+		ARN:                   m.addonARN(cfg.ClusterName, cfg.AddonName),
+		ServiceAccountRoleArn: cfg.ServiceAccountRoleArn,
+		ConfigurationValues:   cfg.ConfigurationValues,
+		Status:                eksdriver.AddonStatusActive,
+		Tags:                  copyTags(cfg.Tags),
+		CreatedAt:             now,
+		ModifiedAt:            now,
+	}
+
+	m.addons.Set(key, ad)
+
+	out := ad
+
+	return &out, nil
+}
+
+// DescribeAddon looks up an add-on by cluster + name.
+func (m *Mock) DescribeAddon(_ context.Context, clusterName, addonName string) (*eksdriver.Addon, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ad, ok := m.addons.Get(addonKey(clusterName, addonName))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"add-on %q not found on cluster %q", addonName, clusterName)
+	}
+
+	out := ad
+
+	return &out, nil
+}
+
+// ListAddons returns the names of all add-ons installed on a cluster.
+func (m *Mock) ListAddons(_ context.Context, clusterName string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if _, ok := m.clusters.Get(clusterName); !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
+	}
+
+	out := make([]string, 0)
+
+	//nolint:gocritic // Store.All copies values out anyway; the per-iter copy here is no extra cost.
+	for _, ad := range m.addons.All() {
+		if ad.ClusterName == clusterName {
+			out = append(out, ad.AddonName)
+		}
+	}
+
+	return out, nil
+}
+
+// UpdateAddon updates an installed add-on (version, configuration, etc.).
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) UpdateAddon(_ context.Context, cfg eksdriver.AddonConfig) (*eksdriver.ClusterUpdate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := addonKey(cfg.ClusterName, cfg.AddonName)
+
+	ad, ok := m.addons.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"add-on %q not found on cluster %q", cfg.AddonName, cfg.ClusterName)
+	}
+
+	if cfg.AddonVersion != "" {
+		ad.AddonVersion = cfg.AddonVersion
+	}
+
+	if cfg.ServiceAccountRoleArn != "" {
+		ad.ServiceAccountRoleArn = cfg.ServiceAccountRoleArn
+	}
+
+	if cfg.ConfigurationValues != "" {
+		ad.ConfigurationValues = cfg.ConfigurationValues
+	}
+
+	if cfg.Tags != nil {
+		ad.Tags = copyTags(cfg.Tags)
+	}
+
+	ad.ModifiedAt = m.opts.Clock.Now().UTC()
+	m.addons.Set(key, ad)
+
+	return &eksdriver.ClusterUpdate{
+		ID:        newUpdateID(),
+		Type:      "AddonUpdate",
+		Status:    "Successful",
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}, nil
+}
+
+// DeleteAddon removes an add-on from a cluster.
+func (m *Mock) DeleteAddon(_ context.Context, clusterName, addonName string) (*eksdriver.Addon, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := addonKey(clusterName, addonName)
+
+	ad, ok := m.addons.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound,
+			"add-on %q not found on cluster %q", addonName, clusterName)
+	}
+
+	ad.Status = eksdriver.AddonStatusDeleting
+
+	m.addons.Delete(key)
+
+	out := ad
+
+	return &out, nil
+}

--- a/providers/aws/eks/eks_test.go
+++ b/providers/aws/eks/eks_test.go
@@ -1,0 +1,351 @@
+package eks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+	)
+
+	return New(opts)
+}
+
+func TestCreateCluster(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       eksdriver.ClusterConfig
+		expectErr bool
+	}{
+		{
+			name: "success",
+			cfg: eksdriver.ClusterConfig{
+				Name:    "my-cluster",
+				Version: "1.30",
+				RoleArn: "arn:aws:iam::123456789012:role/eks-cluster",
+				VPCConfig: eksdriver.VPCConfig{
+					SubnetIDs: []string{"subnet-1", "subnet-2"},
+				},
+			},
+		},
+		{
+			name:      "missing name",
+			cfg:       eksdriver.ClusterConfig{Version: "1.30"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			cluster, err := m.CreateCluster(context.Background(), tc.cfg)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, tc.cfg.Name, cluster.Name)
+			assertEqual(t, "ACTIVE", cluster.Status)
+			assertNotEmpty(t, cluster.ARN)
+			assertNotEmpty(t, cluster.Endpoint)
+			assertNotEmpty(t, cluster.CertificateAuthority)
+		})
+	}
+}
+
+func TestCreateCluster_Duplicate(t *testing.T) {
+	m := newTestMock()
+	cfg := eksdriver.ClusterConfig{Name: "c1", Version: "1.30"}
+
+	_, err := m.CreateCluster(context.Background(), cfg)
+	requireNoError(t, err)
+
+	if _, err := m.CreateCluster(context.Background(), cfg); err == nil {
+		t.Fatal("expected duplicate error, got nil")
+	}
+}
+
+func TestClusterLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	requireNoError(t, err)
+
+	got, err := m.DescribeCluster(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, "c1", got.Name)
+
+	names, err := m.ListClusters(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(names))
+
+	upd, err := m.UpdateClusterVersion(ctx, "c1", "1.31")
+	requireNoError(t, err)
+	assertEqual(t, "Successful", upd.Status)
+
+	got, err = m.DescribeCluster(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, "1.31", got.Version)
+
+	_, err = m.UpdateClusterConfig(ctx, "c1",
+		eksdriver.VPCConfig{EndpointPublicAccess: true, PublicAccessCidrs: []string{"0.0.0.0/0"}},
+		map[string]string{"env": "dev"})
+	requireNoError(t, err)
+
+	got, err = m.DescribeCluster(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, true, got.VPCConfig.EndpointPublicAccess)
+	assertEqual(t, "dev", got.Tags["env"])
+
+	deleted, err := m.DeleteCluster(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, "DELETING", deleted.Status)
+
+	if _, err := m.DescribeCluster(ctx, "c1"); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestUpdateCluster_NotFound(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.UpdateClusterVersion(ctx, "missing", "1.30"); err == nil {
+		t.Fatal("expected error for missing cluster")
+	}
+
+	if _, err := m.UpdateClusterConfig(ctx, "missing", eksdriver.VPCConfig{}, nil); err == nil {
+		t.Fatal("expected error for missing cluster")
+	}
+}
+
+func TestNodegroupLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	requireNoError(t, err)
+
+	ng, err := m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName:   "c1",
+		NodegroupName: "ng1",
+		NodeRole:      "arn:aws:iam::123456789012:role/eks-node",
+		Subnets:       []string{"subnet-1"},
+		ScalingConfig: eksdriver.NodegroupScalingConfig{MinSize: 1, MaxSize: 3, DesiredSize: 2},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "ACTIVE", ng.Status)
+	assertNotEmpty(t, ng.ARN)
+
+	got, err := m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, "ng1", got.NodegroupName)
+
+	names, err := m.ListNodegroups(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(names))
+
+	upd, err := m.UpdateNodegroupConfig(ctx, "c1", "ng1",
+		&eksdriver.NodegroupScalingConfig{MinSize: 2, MaxSize: 5, DesiredSize: 3}, nil)
+	requireNoError(t, err)
+	assertEqual(t, "Successful", upd.Status)
+
+	got, err = m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, 3, got.ScalingConfig.DesiredSize)
+
+	_, err = m.UpdateNodegroupVersion(ctx, "c1", "ng1", "1.31", "")
+	requireNoError(t, err)
+
+	got, err = m.DescribeNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+	assertEqual(t, "1.31", got.Version)
+
+	_, err = m.DeleteNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+
+	if _, err := m.DescribeNodegroup(ctx, "c1", "ng1"); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestCreateNodegroup_ClusterMustExist(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreateNodegroup(context.Background(), eksdriver.NodegroupConfig{
+		ClusterName:   "missing",
+		NodegroupName: "ng1",
+	})
+	if err == nil {
+		t.Fatal("expected NotFound when cluster missing")
+	}
+}
+
+func TestFargateProfileLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	requireNoError(t, err)
+
+	fp, err := m.CreateFargateProfile(ctx, eksdriver.FargateProfileConfig{
+		ClusterName:        "c1",
+		FargateProfileName: "fp1",
+		PodExecutionRole:   "arn:aws:iam::123456789012:role/fargate",
+		Selectors:          []eksdriver.FargateProfileSelector{{Namespace: "default"}},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "ACTIVE", fp.Status)
+	assertNotEmpty(t, fp.ARN)
+
+	got, err := m.DescribeFargateProfile(ctx, "c1", "fp1")
+	requireNoError(t, err)
+	assertEqual(t, "fp1", got.FargateProfileName)
+
+	names, err := m.ListFargateProfiles(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(names))
+
+	_, err = m.DeleteFargateProfile(ctx, "c1", "fp1")
+	requireNoError(t, err)
+
+	if _, err := m.DescribeFargateProfile(ctx, "c1", "fp1"); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestAddonLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	requireNoError(t, err)
+
+	ad, err := m.CreateAddon(ctx, eksdriver.AddonConfig{
+		ClusterName:  "c1",
+		AddonName:    "vpc-cni",
+		AddonVersion: "v1.0",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "ACTIVE", ad.Status)
+	assertNotEmpty(t, ad.ARN)
+
+	got, err := m.DescribeAddon(ctx, "c1", "vpc-cni")
+	requireNoError(t, err)
+	assertEqual(t, "v1.0", got.AddonVersion)
+
+	names, err := m.ListAddons(ctx, "c1")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(names))
+
+	upd, err := m.UpdateAddon(ctx, eksdriver.AddonConfig{
+		ClusterName: "c1", AddonName: "vpc-cni", AddonVersion: "v2.0",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "Successful", upd.Status)
+
+	got, err = m.DescribeAddon(ctx, "c1", "vpc-cni")
+	requireNoError(t, err)
+	assertEqual(t, "v2.0", got.AddonVersion)
+
+	_, err = m.DeleteAddon(ctx, "c1", "vpc-cni")
+	requireNoError(t, err)
+
+	if _, err := m.DescribeAddon(ctx, "c1", "vpc-cni"); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+// DeleteCluster must fail until child nodegroups, profiles, and addons are
+// all cleared — matching real EKS behaviour.
+func TestDeleteCluster_RejectsAttachedChildren(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateCluster(ctx, eksdriver.ClusterConfig{Name: "c1", Version: "1.30"})
+	requireNoError(t, err)
+
+	_, err = m.CreateNodegroup(ctx, eksdriver.NodegroupConfig{ClusterName: "c1", NodegroupName: "ng1"})
+	requireNoError(t, err)
+
+	if _, err := m.DeleteCluster(ctx, "c1"); err == nil {
+		t.Fatal("expected DeleteCluster to reject when nodegroup attached")
+	}
+
+	_, err = m.DeleteNodegroup(ctx, "c1", "ng1")
+	requireNoError(t, err)
+
+	_, err = m.CreateFargateProfile(ctx, eksdriver.FargateProfileConfig{ClusterName: "c1", FargateProfileName: "fp1"})
+	requireNoError(t, err)
+
+	if _, err := m.DeleteCluster(ctx, "c1"); err == nil {
+		t.Fatal("expected DeleteCluster to reject when Fargate profile attached")
+	}
+
+	_, err = m.DeleteFargateProfile(ctx, "c1", "fp1")
+	requireNoError(t, err)
+
+	_, err = m.CreateAddon(ctx, eksdriver.AddonConfig{ClusterName: "c1", AddonName: "vpc-cni"})
+	requireNoError(t, err)
+
+	if _, err := m.DeleteCluster(ctx, "c1"); err == nil {
+		t.Fatal("expected DeleteCluster to reject when addon attached")
+	}
+
+	_, err = m.DeleteAddon(ctx, "c1", "vpc-cni")
+	requireNoError(t, err)
+
+	_, err = m.DeleteCluster(ctx, "c1")
+	requireNoError(t, err)
+}
+
+// requireNoError fails the test immediately if err is non-nil.
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// assertError asserts that err matches the expectErr expectation.
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error, got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// assertEqual asserts that expected and actual are equal.
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}
+
+// assertNotEmpty asserts that s is non-empty.
+func assertNotEmpty(t *testing.T, s string) {
+	t.Helper()
+
+	if s == "" {
+		t.Error("expected non-empty string")
+	}
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -12,11 +12,13 @@ import (
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
 	"github.com/stackshy/cloudemu/server/aws/ec2"
+	"github.com/stackshy/cloudemu/server/aws/eks"
 	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/rds"
 	"github.com/stackshy/cloudemu/server/aws/redshift"
@@ -39,6 +41,7 @@ type Drivers struct {
 	SQS        mqdriver.MessageQueue
 	RDS        rdbdriver.RelationalDB
 	Redshift   rdbdriver.RelationalDB
+	EKS        eksdriver.EKS
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every
@@ -59,7 +62,7 @@ type Drivers struct {
 //
 // keeps the caller API ergonomic (awsserver.New(Drivers{...})).
 //
-//nolint:gocritic // Drivers is all interface fields (pointer-width); by-value
+//nolint:gocritic,gocyclo // Drivers is by-value for ergonomics; the dispatch is one if-per-driver and grows with the bundle.
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
@@ -100,6 +103,14 @@ func New(d Drivers) *server.Server {
 
 	if d.Lambda != nil {
 		srv.Register(lambda.New(d.Lambda))
+	}
+
+	// EKS is a REST/JSON service rooted at /clusters. It must register
+	// before S3 because S3 is the permissive REST fallback that would
+	// otherwise claim the same path. EKS's Matches predicate is rooted
+	// at /clusters specifically so it doesn't shadow other REST URLs.
+	if d.EKS != nil {
+		srv.Register(eks.New(d.EKS))
 	}
 
 	if d.S3 != nil {

--- a/server/aws/eks/errors.go
+++ b/server/aws/eks/errors.go
@@ -1,0 +1,43 @@
+package eks
+
+import (
+	"encoding/json"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// errorBody is the JSON body shape EKS returns for failures. The SDK reads
+// the X-Amzn-ErrorType header for routing and falls back to the body's
+// type/code field if absent.
+type errorBody struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message"`
+}
+
+// writeError writes a REST/JSON error response with the given HTTP status,
+// EKS-shaped error type, and message. The X-Amzn-ErrorType header is the
+// canonical signal the SDK reads to map to a typed exception.
+func writeError(w http.ResponseWriter, status int, errType, msg string) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("X-Amzn-ErrorType", errType)
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(errorBody{Code: errType, Message: msg})
+}
+
+// writeErr maps cloudemu canonical errors to EKS-shaped error responses.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ResourceInUseException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusBadRequest, "InvalidRequestException", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "ServerException", err.Error())
+	}
+}

--- a/server/aws/eks/handler.go
+++ b/server/aws/eks/handler.go
@@ -1,0 +1,300 @@
+// Package eks implements the AWS EKS REST/JSON control-plane API as a
+// server.Handler. Point the real aws-sdk-go-v2/service/eks client at a
+// Server registered with this handler and CreateCluster, CreateNodegroup,
+// CreateFargateProfile, CreateAddon, and their friends work against an
+// in-memory EKS driver.
+//
+// Wave 1 covers control-plane resources only; the Kubernetes data plane
+// (Pods, Deployments, Services, …) is out of scope and is deferred to
+// Wave 2. Until Wave 2 ships, the cluster Endpoint field returns a
+// placeholder URL and the CertificateAuthority field returns a stub PEM,
+// so kubeconfig generation works syntactically without a real apiserver.
+//
+// EKS uses REST/JSON (not the AWS query protocol). URL paths follow the
+// shape the SDK emits, e.g. POST /clusters, POST
+// /clusters/{name}/node-groups, POST /clusters/{name}/addons/{addon}/update.
+// The handler's Matches predicate is rooted at /clusters so it does not
+// shadow the catch-all S3 handler that may be registered alongside.
+package eks
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
+)
+
+const (
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 5 << 20
+
+	pathPrefix = "/clusters"
+
+	// segNodeGroups, segFargateProfiles, segAddons are the EKS sub-resource
+	// path segments. Real SDK kebab-cases them (note "node-groups" with a
+	// hyphen; the JSON body field is camelCase "nodegroupName").
+	segNodeGroups      = "node-groups"
+	segFargateProfiles = "fargate-profiles"
+	segAddons          = "addons"
+	segUpdates         = "updates"
+	segUpdateConfig    = "update-config"
+	segUpdateVersion   = "update-version"
+	segUpdate          = "update"
+)
+
+// Path-segment counts the dispatcher branches on. Naming each one keeps the
+// switch inside ServeHTTP free of magic numbers.
+const (
+	pathSegsCluster            = 1 // /clusters/{name}
+	pathSegsClusterSubresource = 2 // /clusters/{name}/{action}
+	pathSegsChildResource      = 3 // /clusters/{name}/{kind}/{child}
+	pathSegsChildAction        = 4 // /clusters/{name}/{kind}/{child}/{action}
+)
+
+// Handler serves AWS EKS REST/JSON requests against an EKS driver.
+type Handler struct {
+	eks eksdriver.EKS
+}
+
+// New returns an EKS handler backed by the supplied driver.
+func New(eks eksdriver.EKS) *Handler {
+	return &Handler{eks: eks}
+}
+
+// Matches claims any request rooted at /clusters or exactly /clusters. The
+// predicate is intentionally narrow: it rejects anything outside that path
+// so the catch-all S3 handler can serve unrelated REST URLs without
+// interference.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.URL.Path == pathPrefix {
+		return true
+	}
+
+	return strings.HasPrefix(r.URL.Path, pathPrefix+"/")
+}
+
+// ServeHTTP routes EKS requests by URL shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+
+	switch len(parts) {
+	case 0:
+		// /clusters — collection.
+		h.serveClustersCollection(w, r)
+
+	case pathSegsCluster:
+		// /clusters/{name} — cluster resource.
+		h.serveCluster(w, r, parts[0])
+
+	case pathSegsClusterSubresource:
+		// /clusters/{name}/{action} — cluster sub-resource.
+		h.serveClusterSubresource(w, r, parts[0], parts[1])
+
+	case pathSegsChildResource:
+		// /clusters/{name}/{kind}/{child} — child resource.
+		h.serveChildResource(w, r, parts[0], parts[1], parts[2])
+
+	case pathSegsChildAction:
+		// /clusters/{name}/{kind}/{child}/{action} — child action.
+		h.serveChildAction(w, r, parts[0], parts[1], parts[2], parts[3])
+
+	default:
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported path: "+r.URL.Path)
+	}
+}
+
+func (h *Handler) serveClustersCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createCluster(w, r)
+	case http.MethodGet:
+		h.listClusters(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveCluster(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.describeCluster(w, r, name)
+	case http.MethodDelete:
+		h.deleteCluster(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveClusterSubresource(w http.ResponseWriter, r *http.Request, name, action string) {
+	switch action {
+	case segUpdateConfig:
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w)
+
+			return
+		}
+
+		h.updateClusterConfig(w, r, name)
+
+	case segUpdates:
+		// UpdateClusterVersion goes here; the SDK posts to /clusters/{n}/updates.
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w)
+
+			return
+		}
+
+		h.updateClusterVersion(w, r, name)
+
+	case segNodeGroups:
+		h.serveNodegroupsCollection(w, r, name)
+
+	case segFargateProfiles:
+		h.serveFargateCollection(w, r, name)
+
+	case segAddons:
+		h.serveAddonsCollection(w, r, name)
+
+	default:
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException",
+			"unknown cluster sub-resource: "+action)
+	}
+}
+
+func (h *Handler) serveNodegroupsCollection(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createNodegroup(w, r, name)
+	case http.MethodGet:
+		h.listNodegroups(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveFargateCollection(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createFargateProfile(w, r, name)
+	case http.MethodGet:
+		h.listFargateProfiles(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveAddonsCollection(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createAddon(w, r, name)
+	case http.MethodGet:
+		h.listAddons(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveChildResource(w http.ResponseWriter, r *http.Request, clusterName, kind, child string) {
+	switch kind {
+	case segNodeGroups:
+		h.serveNodegroup(w, r, clusterName, child)
+	case segFargateProfiles:
+		h.serveFargateProfile(w, r, clusterName, child)
+	case segAddons:
+		h.serveAddon(w, r, clusterName, child)
+	default:
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException",
+			"unknown child resource: "+kind)
+	}
+}
+
+func (h *Handler) serveNodegroup(w http.ResponseWriter, r *http.Request, clusterName, ngName string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.describeNodegroup(w, r, clusterName, ngName)
+	case http.MethodDelete:
+		h.deleteNodegroup(w, r, clusterName, ngName)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveFargateProfile(w http.ResponseWriter, r *http.Request, clusterName, profileName string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.describeFargateProfile(w, r, clusterName, profileName)
+	case http.MethodDelete:
+		h.deleteFargateProfile(w, r, clusterName, profileName)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveAddon(w http.ResponseWriter, r *http.Request, clusterName, addonName string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.describeAddon(w, r, clusterName, addonName)
+	case http.MethodDelete:
+		h.deleteAddon(w, r, clusterName, addonName)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveChildAction(w http.ResponseWriter, r *http.Request, clusterName, kind, child, action string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	switch {
+	case kind == segNodeGroups && action == segUpdateConfig:
+		h.updateNodegroupConfig(w, r, clusterName, child)
+	case kind == segNodeGroups && action == segUpdateVersion:
+		h.updateNodegroupVersion(w, r, clusterName, child)
+	case kind == segAddons && action == segUpdate:
+		h.updateAddon(w, r, clusterName, child)
+	default:
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException",
+			"unknown child action: "+kind+"/"+action)
+	}
+}
+
+// splitPath strips the /clusters prefix and splits the remainder. The
+// returned slice is empty for the bare /clusters URL.
+func splitPath(p string) []string {
+	rest := strings.TrimPrefix(p, pathPrefix)
+	rest = strings.TrimPrefix(rest, "/")
+
+	if rest == "" {
+		return nil
+	}
+
+	return strings.Split(rest, "/")
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidParameterException", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+// writeJSON encodes v as the JSON response body. Real EKS only ever returns
+// 200 on success (errors go through writeError), so the status is fixed.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/server/aws/eks/operations.go
+++ b/server/aws/eks/operations.go
@@ -1,0 +1,538 @@
+package eks
+
+import (
+	"math"
+	"net/http"
+
+	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
+)
+
+// safeInt32 narrows an int to int32, clamping at math.MaxInt32 / math.MinInt32.
+// EKS scaling and disk-size fields are int32 on the wire; the driver uses int
+// for ergonomics. A direct int->int32 cast would trip gosec G115; explicit
+// clamping makes the truncation behavior deliberate.
+func safeInt32(v int) int32 {
+	switch {
+	case v > math.MaxInt32:
+		return math.MaxInt32
+	case v < math.MinInt32:
+		return math.MinInt32
+	default:
+		return int32(v)
+	}
+}
+
+// Cluster operations.
+
+func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request) {
+	var body createClusterRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := eksdriver.ClusterConfig{
+		Name:    body.Name,
+		Version: body.Version,
+		RoleArn: body.RoleArn,
+		Tags:    body.Tags,
+	}
+
+	if body.ResourcesVpcConfig != nil {
+		cfg.VPCConfig = vpcRequestToDriver(body.ResourcesVpcConfig)
+	}
+
+	cluster, err := h.eks.CreateCluster(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, clusterEnvelope{Cluster: toClusterJSON(cluster)})
+}
+
+func (h *Handler) describeCluster(w http.ResponseWriter, r *http.Request, name string) {
+	cluster, err := h.eks.DescribeCluster(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, clusterEnvelope{Cluster: toClusterJSON(cluster)})
+}
+
+func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request) {
+	names, err := h.eks.ListClusters(r.Context())
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, listClustersResponse{Clusters: names})
+}
+
+func (h *Handler) updateClusterConfig(w http.ResponseWriter, r *http.Request, name string) {
+	var body updateClusterConfigRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	var vpc eksdriver.VPCConfig
+	if body.ResourcesVpcConfig != nil {
+		vpc = vpcRequestToDriver(body.ResourcesVpcConfig)
+	}
+
+	upd, err := h.eks.UpdateClusterConfig(r.Context(), name, vpc, body.Tags)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, updateEnvelope{Update: toUpdateJSON(upd)})
+}
+
+func (h *Handler) updateClusterVersion(w http.ResponseWriter, r *http.Request, name string) {
+	var body updateClusterVersionRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	upd, err := h.eks.UpdateClusterVersion(r.Context(), name, body.Version)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, updateEnvelope{Update: toUpdateJSON(upd)})
+}
+
+func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request, name string) {
+	cluster, err := h.eks.DeleteCluster(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, clusterEnvelope{Cluster: toClusterJSON(cluster)})
+}
+
+// Nodegroup operations.
+
+func (h *Handler) createNodegroup(w http.ResponseWriter, r *http.Request, clusterName string) {
+	var body createNodegroupRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := eksdriver.NodegroupConfig{
+		ClusterName:    clusterName,
+		NodegroupName:  body.NodegroupName,
+		NodeRole:       body.NodeRole,
+		Subnets:        body.Subnets,
+		InstanceTypes:  body.InstanceTypes,
+		AmiType:        body.AmiType,
+		CapacityType:   body.CapacityType,
+		Version:        body.Version,
+		ReleaseVersion: body.ReleaseVersion,
+		Labels:         body.Labels,
+		Tags:           body.Tags,
+	}
+
+	if body.DiskSize != nil {
+		cfg.DiskSize = int(*body.DiskSize)
+	}
+
+	if body.ScalingConfig != nil {
+		cfg.ScalingConfig = scalingFromJSON(body.ScalingConfig)
+	}
+
+	ng, err := h.eks.CreateNodegroup(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nodegroupEnvelope{Nodegroup: toNodegroupJSON(ng)})
+}
+
+func (h *Handler) describeNodegroup(w http.ResponseWriter, r *http.Request, clusterName, ngName string) {
+	ng, err := h.eks.DescribeNodegroup(r.Context(), clusterName, ngName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nodegroupEnvelope{Nodegroup: toNodegroupJSON(ng)})
+}
+
+func (h *Handler) listNodegroups(w http.ResponseWriter, r *http.Request, clusterName string) {
+	names, err := h.eks.ListNodegroups(r.Context(), clusterName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, listNodegroupsResponse{Nodegroups: names})
+}
+
+func (h *Handler) updateNodegroupConfig(w http.ResponseWriter, r *http.Request, clusterName, ngName string) {
+	var body updateNodegroupConfigRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	var (
+		scaling *eksdriver.NodegroupScalingConfig
+		labels  map[string]string
+	)
+
+	if body.ScalingConfig != nil {
+		s := scalingFromJSON(body.ScalingConfig)
+		scaling = &s
+	}
+
+	if body.Labels != nil {
+		labels = body.Labels.AddOrUpdateLabels
+	}
+
+	upd, err := h.eks.UpdateNodegroupConfig(r.Context(), clusterName, ngName, scaling, labels)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, updateEnvelope{Update: toUpdateJSON(upd)})
+}
+
+func (h *Handler) updateNodegroupVersion(w http.ResponseWriter, r *http.Request, clusterName, ngName string) {
+	var body updateNodegroupVersionRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	upd, err := h.eks.UpdateNodegroupVersion(r.Context(), clusterName, ngName, body.Version, body.ReleaseVersion)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, updateEnvelope{Update: toUpdateJSON(upd)})
+}
+
+func (h *Handler) deleteNodegroup(w http.ResponseWriter, r *http.Request, clusterName, ngName string) {
+	ng, err := h.eks.DeleteNodegroup(r.Context(), clusterName, ngName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nodegroupEnvelope{Nodegroup: toNodegroupJSON(ng)})
+}
+
+// Fargate profile operations.
+
+func (h *Handler) createFargateProfile(w http.ResponseWriter, r *http.Request, clusterName string) {
+	var body createFargateProfileRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := eksdriver.FargateProfileConfig{
+		ClusterName:        clusterName,
+		FargateProfileName: body.FargateProfileName,
+		PodExecutionRole:   body.PodExecutionRoleArn,
+		Subnets:            body.Subnets,
+		Tags:               body.Tags,
+	}
+
+	for _, s := range body.Selectors {
+		cfg.Selectors = append(cfg.Selectors, eksdriver.FargateProfileSelector{
+			Namespace: s.Namespace,
+			Labels:    s.Labels,
+		})
+	}
+
+	fp, err := h.eks.CreateFargateProfile(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, fargateProfileEnvelope{FargateProfile: toFargateProfileJSON(fp)})
+}
+
+func (h *Handler) describeFargateProfile(w http.ResponseWriter, r *http.Request, clusterName, profileName string) {
+	fp, err := h.eks.DescribeFargateProfile(r.Context(), clusterName, profileName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, fargateProfileEnvelope{FargateProfile: toFargateProfileJSON(fp)})
+}
+
+func (h *Handler) listFargateProfiles(w http.ResponseWriter, r *http.Request, clusterName string) {
+	names, err := h.eks.ListFargateProfiles(r.Context(), clusterName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, listFargateProfilesResponse{FargateProfileNames: names})
+}
+
+func (h *Handler) deleteFargateProfile(w http.ResponseWriter, r *http.Request, clusterName, profileName string) {
+	fp, err := h.eks.DeleteFargateProfile(r.Context(), clusterName, profileName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, fargateProfileEnvelope{FargateProfile: toFargateProfileJSON(fp)})
+}
+
+// Add-on operations.
+
+func (h *Handler) createAddon(w http.ResponseWriter, r *http.Request, clusterName string) {
+	var body createAddonRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := eksdriver.AddonConfig{
+		ClusterName:           clusterName,
+		AddonName:             body.AddonName,
+		AddonVersion:          body.AddonVersion,
+		ServiceAccountRoleArn: body.ServiceAccountRoleArn,
+		ConfigurationValues:   body.ConfigurationValues,
+		Tags:                  body.Tags,
+	}
+
+	ad, err := h.eks.CreateAddon(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, addonEnvelope{Addon: toAddonJSON(ad)})
+}
+
+func (h *Handler) describeAddon(w http.ResponseWriter, r *http.Request, clusterName, addonName string) {
+	ad, err := h.eks.DescribeAddon(r.Context(), clusterName, addonName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, addonEnvelope{Addon: toAddonJSON(ad)})
+}
+
+func (h *Handler) listAddons(w http.ResponseWriter, r *http.Request, clusterName string) {
+	names, err := h.eks.ListAddons(r.Context(), clusterName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, listAddonsResponse{Addons: names})
+}
+
+func (h *Handler) updateAddon(w http.ResponseWriter, r *http.Request, clusterName, addonName string) {
+	var body updateAddonRequest
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := eksdriver.AddonConfig{
+		ClusterName:           clusterName,
+		AddonName:             addonName,
+		AddonVersion:          body.AddonVersion,
+		ServiceAccountRoleArn: body.ServiceAccountRoleArn,
+		ConfigurationValues:   body.ConfigurationValues,
+	}
+
+	upd, err := h.eks.UpdateAddon(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, updateEnvelope{Update: toUpdateJSON(upd)})
+}
+
+func (h *Handler) deleteAddon(w http.ResponseWriter, r *http.Request, clusterName, addonName string) {
+	ad, err := h.eks.DeleteAddon(r.Context(), clusterName, addonName)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, addonEnvelope{Addon: toAddonJSON(ad)})
+}
+
+// Conversion helpers.
+
+func vpcRequestToDriver(v *vpcConfigRequest) eksdriver.VPCConfig {
+	out := eksdriver.VPCConfig{
+		SubnetIDs:         v.SubnetIDs,
+		SecurityGroupIDs:  v.SecurityGroupIDs,
+		PublicAccessCidrs: v.PublicAccessCidrs,
+	}
+
+	if v.EndpointPublicAccess != nil {
+		out.EndpointPublicAccess = *v.EndpointPublicAccess
+	}
+
+	if v.EndpointPrivateAccess != nil {
+		out.EndpointPrivateAccess = *v.EndpointPrivateAccess
+	}
+
+	return out
+}
+
+func scalingFromJSON(s *nodegroupScalingConfigJSON) eksdriver.NodegroupScalingConfig {
+	out := eksdriver.NodegroupScalingConfig{}
+
+	if s.MinSize != nil {
+		out.MinSize = int(*s.MinSize)
+	}
+
+	if s.MaxSize != nil {
+		out.MaxSize = int(*s.MaxSize)
+	}
+
+	if s.DesiredSize != nil {
+		out.DesiredSize = int(*s.DesiredSize)
+	}
+
+	return out
+}
+
+func toClusterJSON(c *eksdriver.Cluster) clusterJSON {
+	out := clusterJSON{
+		Name:            c.Name,
+		Arn:             c.ARN,
+		CreatedAt:       epochSeconds(c.CreatedAt),
+		Version:         c.Version,
+		Endpoint:        c.Endpoint,
+		RoleArn:         c.RoleArn,
+		Status:          c.Status,
+		PlatformVersion: c.PlatformVersion,
+		Tags:            c.Tags,
+		ResourcesVpcConfig: &vpcConfigResponse{
+			SubnetIDs:             c.VPCConfig.SubnetIDs,
+			SecurityGroupIDs:      c.VPCConfig.SecurityGroupIDs,
+			EndpointPublicAccess:  c.VPCConfig.EndpointPublicAccess,
+			EndpointPrivateAccess: c.VPCConfig.EndpointPrivateAccess,
+			PublicAccessCidrs:     c.VPCConfig.PublicAccessCidrs,
+		},
+	}
+
+	if c.CertificateAuthority != "" {
+		out.CertificateAuthority = &certificate{Data: c.CertificateAuthority}
+	}
+
+	return out
+}
+
+func toNodegroupJSON(n *eksdriver.Nodegroup) nodegroupJSON {
+	minSize := safeInt32(n.ScalingConfig.MinSize)
+	maxSize := safeInt32(n.ScalingConfig.MaxSize)
+	desired := safeInt32(n.ScalingConfig.DesiredSize)
+	disk := safeInt32(n.DiskSize)
+
+	out := nodegroupJSON{
+		NodegroupName:  n.NodegroupName,
+		NodegroupArn:   n.ARN,
+		ClusterName:    n.ClusterName,
+		Version:        n.Version,
+		ReleaseVersion: n.ReleaseVersion,
+		CreatedAt:      epochSeconds(n.CreatedAt),
+		ModifiedAt:     epochSeconds(n.CreatedAt),
+		Status:         n.Status,
+		CapacityType:   n.CapacityType,
+		ScalingConfig: &nodegroupScalingConfigJSON{
+			MinSize:     &minSize,
+			MaxSize:     &maxSize,
+			DesiredSize: &desired,
+		},
+		InstanceTypes: n.InstanceTypes,
+		Subnets:       n.Subnets,
+		AmiType:       n.AmiType,
+		NodeRole:      n.NodeRole,
+		Labels:        n.Labels,
+		Tags:          n.Tags,
+	}
+
+	if n.DiskSize > 0 {
+		out.DiskSize = &disk
+	}
+
+	return out
+}
+
+func toFargateProfileJSON(fp *eksdriver.FargateProfile) fargateProfileJSON {
+	out := fargateProfileJSON{
+		FargateProfileName:  fp.FargateProfileName,
+		FargateProfileArn:   fp.ARN,
+		ClusterName:         fp.ClusterName,
+		CreatedAt:           epochSeconds(fp.CreatedAt),
+		PodExecutionRoleArn: fp.PodExecutionRole,
+		Subnets:             fp.Subnets,
+		Status:              fp.Status,
+		Tags:                fp.Tags,
+	}
+
+	for _, s := range fp.Selectors {
+		out.Selectors = append(out.Selectors, fargateProfileSelectorJSON{
+			Namespace: s.Namespace,
+			Labels:    s.Labels,
+		})
+	}
+
+	return out
+}
+
+func toAddonJSON(ad *eksdriver.Addon) addonJSON {
+	return addonJSON{
+		AddonName:             ad.AddonName,
+		ClusterName:           ad.ClusterName,
+		Status:                ad.Status,
+		AddonVersion:          ad.AddonVersion,
+		AddonArn:              ad.ARN,
+		CreatedAt:             epochSeconds(ad.CreatedAt),
+		ModifiedAt:            epochSeconds(ad.ModifiedAt),
+		ServiceAccountRoleArn: ad.ServiceAccountRoleArn,
+		ConfigurationValues:   ad.ConfigurationValues,
+		Tags:                  ad.Tags,
+	}
+}
+
+func toUpdateJSON(u *eksdriver.ClusterUpdate) updateJSON {
+	return updateJSON{
+		ID:        u.ID,
+		Type:      u.Type,
+		Status:    u.Status,
+		CreatedAt: epochSeconds(u.CreatedAt),
+	}
+}

--- a/server/aws/eks/sdk_roundtrip_test.go
+++ b/server/aws/eks/sdk_roundtrip_test.go
@@ -1,0 +1,398 @@
+package eks_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newSDKClient(t *testing.T) *awseks.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		EKS: cloud.EKS,
+		// S3 included so we exercise routing precedence — EKS must claim
+		// /clusters paths before the catch-all S3 handler sees them.
+		S3: cloud.S3,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awseks.NewFromConfig(cfg, func(o *awseks.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKEKSClusterLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String("c1"),
+		Version: aws.String("1.30"),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/eks-cluster"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{"subnet-1", "subnet-2"},
+		},
+		Tags: map[string]string{"env": "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if aws.ToString(out.Cluster.Name) != "c1" {
+		t.Fatalf("got name %q, want c1", aws.ToString(out.Cluster.Name))
+	}
+
+	if out.Cluster.Status != ekstypes.ClusterStatusActive {
+		t.Fatalf("got status %q, want ACTIVE", out.Cluster.Status)
+	}
+
+	if aws.ToString(out.Cluster.Endpoint) == "" {
+		t.Fatal("expected endpoint to be set (placeholder for Wave 1)")
+	}
+
+	if out.Cluster.CertificateAuthority == nil || aws.ToString(out.Cluster.CertificateAuthority.Data) == "" {
+		t.Fatal("expected stub certificate-authority data")
+	}
+
+	got, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	if aws.ToString(got.Cluster.Version) != "1.30" {
+		t.Fatalf("got version %q, want 1.30", aws.ToString(got.Cluster.Version))
+	}
+
+	list, err := client.ListClusters(ctx, &awseks.ListClustersInput{})
+	if err != nil {
+		t.Fatalf("ListClusters: %v", err)
+	}
+
+	if len(list.Clusters) != 1 || list.Clusters[0] != "c1" {
+		t.Fatalf("got %v, want [c1]", list.Clusters)
+	}
+
+	upd, err := client.UpdateClusterVersion(ctx, &awseks.UpdateClusterVersionInput{
+		Name:    aws.String("c1"),
+		Version: aws.String("1.31"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateClusterVersion: %v", err)
+	}
+
+	if upd.Update == nil || aws.ToString(upd.Update.Id) == "" {
+		t.Fatal("expected update with non-empty id")
+	}
+
+	got, err = client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("DescribeCluster after update: %v", err)
+	}
+
+	if aws.ToString(got.Cluster.Version) != "1.31" {
+		t.Fatalf("version did not apply: got %q", aws.ToString(got.Cluster.Version))
+	}
+
+	pubAccess := true
+
+	_, err = client.UpdateClusterConfig(ctx, &awseks.UpdateClusterConfigInput{
+		Name: aws.String("c1"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			EndpointPublicAccess: &pubAccess,
+			PublicAccessCidrs:    []string{"0.0.0.0/0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateClusterConfig: %v", err)
+	}
+
+	if _, err := client.DeleteCluster(ctx, &awseks.DeleteClusterInput{Name: aws.String("c1")}); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	if _, err := client.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String("c1")}); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestSDKEKSNodegroupLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String("c1"),
+		Version: aws.String("1.30"),
+		RoleArn: aws.String("arn:aws:iam::1:role/r"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{"subnet-1"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	minSize := int32(1)
+	maxSize := int32(3)
+	desired := int32(2)
+
+	out, err := client.CreateNodegroup(ctx, &awseks.CreateNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		NodeRole:      aws.String("arn:aws:iam::1:role/r"),
+		Subnets:       []string{"subnet-1"},
+		ScalingConfig: &ekstypes.NodegroupScalingConfig{
+			MinSize:     &minSize,
+			MaxSize:     &maxSize,
+			DesiredSize: &desired,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	if out.Nodegroup.Status != ekstypes.NodegroupStatusActive {
+		t.Fatalf("got status %q, want ACTIVE", out.Nodegroup.Status)
+	}
+
+	got, err := client.DescribeNodegroup(ctx, &awseks.DescribeNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeNodegroup: %v", err)
+	}
+
+	if got.Nodegroup.ScalingConfig == nil || aws.ToInt32(got.Nodegroup.ScalingConfig.DesiredSize) != 2 {
+		t.Fatal("expected desired size 2 to round-trip")
+	}
+
+	list, err := client.ListNodegroups(ctx, &awseks.ListNodegroupsInput{ClusterName: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("ListNodegroups: %v", err)
+	}
+
+	if len(list.Nodegroups) != 1 || list.Nodegroups[0] != "ng1" {
+		t.Fatalf("got %v, want [ng1]", list.Nodegroups)
+	}
+
+	newDesired := int32(3)
+
+	if _, err := client.UpdateNodegroupConfig(ctx, &awseks.UpdateNodegroupConfigInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		ScalingConfig: &ekstypes.NodegroupScalingConfig{DesiredSize: &newDesired},
+	}); err != nil {
+		t.Fatalf("UpdateNodegroupConfig: %v", err)
+	}
+
+	if _, err := client.UpdateNodegroupVersion(ctx, &awseks.UpdateNodegroupVersionInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+		Version:       aws.String("1.31"),
+	}); err != nil {
+		t.Fatalf("UpdateNodegroupVersion: %v", err)
+	}
+
+	if _, err := client.DeleteNodegroup(ctx, &awseks.DeleteNodegroupInput{
+		ClusterName:   aws.String("c1"),
+		NodegroupName: aws.String("ng1"),
+	}); err != nil {
+		t.Fatalf("DeleteNodegroup: %v", err)
+	}
+}
+
+func TestSDKEKSFargateProfileLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		Version:            aws.String("1.30"),
+		RoleArn:            aws.String("arn:aws:iam::1:role/r"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.CreateFargateProfile(ctx, &awseks.CreateFargateProfileInput{
+		ClusterName:         aws.String("c1"),
+		FargateProfileName:  aws.String("fp1"),
+		PodExecutionRoleArn: aws.String("arn:aws:iam::1:role/fargate"),
+		Selectors: []ekstypes.FargateProfileSelector{
+			{Namespace: aws.String("default")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateFargateProfile: %v", err)
+	}
+
+	if out.FargateProfile.Status != ekstypes.FargateProfileStatusActive {
+		t.Fatalf("got status %q, want ACTIVE", out.FargateProfile.Status)
+	}
+
+	got, err := client.DescribeFargateProfile(ctx, &awseks.DescribeFargateProfileInput{
+		ClusterName:        aws.String("c1"),
+		FargateProfileName: aws.String("fp1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeFargateProfile: %v", err)
+	}
+
+	if aws.ToString(got.FargateProfile.FargateProfileName) != "fp1" {
+		t.Fatalf("got name %q, want fp1", aws.ToString(got.FargateProfile.FargateProfileName))
+	}
+
+	list, err := client.ListFargateProfiles(ctx, &awseks.ListFargateProfilesInput{ClusterName: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("ListFargateProfiles: %v", err)
+	}
+
+	if len(list.FargateProfileNames) != 1 {
+		t.Fatalf("got %d profiles, want 1", len(list.FargateProfileNames))
+	}
+
+	if _, err := client.DeleteFargateProfile(ctx, &awseks.DeleteFargateProfileInput{
+		ClusterName:        aws.String("c1"),
+		FargateProfileName: aws.String("fp1"),
+	}); err != nil {
+		t.Fatalf("DeleteFargateProfile: %v", err)
+	}
+}
+
+func TestSDKEKSAddonLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:               aws.String("c1"),
+		Version:            aws.String("1.30"),
+		RoleArn:            aws.String("arn:aws:iam::1:role/r"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{SubnetIds: []string{"subnet-1"}},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := client.CreateAddon(ctx, &awseks.CreateAddonInput{
+		ClusterName:  aws.String("c1"),
+		AddonName:    aws.String("vpc-cni"),
+		AddonVersion: aws.String("v1.0.0"),
+	})
+	if err != nil {
+		t.Fatalf("CreateAddon: %v", err)
+	}
+
+	if out.Addon.Status != ekstypes.AddonStatusActive {
+		t.Fatalf("got status %q, want ACTIVE", out.Addon.Status)
+	}
+
+	got, err := client.DescribeAddon(ctx, &awseks.DescribeAddonInput{
+		ClusterName: aws.String("c1"),
+		AddonName:   aws.String("vpc-cni"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddon: %v", err)
+	}
+
+	if aws.ToString(got.Addon.AddonVersion) != "v1.0.0" {
+		t.Fatalf("got version %q, want v1.0.0", aws.ToString(got.Addon.AddonVersion))
+	}
+
+	list, err := client.ListAddons(ctx, &awseks.ListAddonsInput{ClusterName: aws.String("c1")})
+	if err != nil {
+		t.Fatalf("ListAddons: %v", err)
+	}
+
+	if len(list.Addons) != 1 {
+		t.Fatalf("got %d addons, want 1", len(list.Addons))
+	}
+
+	if _, err := client.UpdateAddon(ctx, &awseks.UpdateAddonInput{
+		ClusterName:  aws.String("c1"),
+		AddonName:    aws.String("vpc-cni"),
+		AddonVersion: aws.String("v2.0.0"),
+	}); err != nil {
+		t.Fatalf("UpdateAddon: %v", err)
+	}
+
+	got, err = client.DescribeAddon(ctx, &awseks.DescribeAddonInput{
+		ClusterName: aws.String("c1"),
+		AddonName:   aws.String("vpc-cni"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAddon after update: %v", err)
+	}
+
+	if aws.ToString(got.Addon.AddonVersion) != "v2.0.0" {
+		t.Fatalf("update did not apply: got %q", aws.ToString(got.Addon.AddonVersion))
+	}
+
+	if _, err := client.DeleteAddon(ctx, &awseks.DeleteAddonInput{
+		ClusterName: aws.String("c1"),
+		AddonName:   aws.String("vpc-cni"),
+	}); err != nil {
+		t.Fatalf("DeleteAddon: %v", err)
+	}
+}
+
+// Sanity check: when both EKS and S3 are wired, an S3 request still reaches
+// the S3 handler — EKS's Matches must be rooted at /clusters specifically.
+func TestSDKEKSRoutingDoesNotShadowS3(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EKS: cloud.EKS, S3: cloud.S3})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	// A bare GET / is a list-buckets request; that should hit S3, not EKS.
+	resp, err := ts.Client().Get(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.Header.Get("X-Amzn-ErrorType") == "ResourceNotFoundException" {
+		t.Fatal("EKS handler shadowed an S3 request")
+	}
+}
+
+// Error mapping: an unknown cluster yields ResourceNotFoundException so the
+// SDK's typed-error middleware can map it correctly.
+func TestSDKEKSDescribeMissingClusterReturnsTypedError(t *testing.T) {
+	client := newSDKClient(t)
+
+	_, err := client.DescribeCluster(context.Background(), &awseks.DescribeClusterInput{
+		Name: aws.String("does-not-exist"),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	var notFound *ekstypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected ResourceNotFoundException, got %T: %v", err, err)
+	}
+}

--- a/server/aws/eks/types.go
+++ b/server/aws/eks/types.go
@@ -1,0 +1,239 @@
+package eks
+
+import "time"
+
+// JSON shapes for AWS EKS REST/JSON requests and responses. Field names use
+// camelCase to match what the real aws-sdk-go-v2 EKS client emits.
+//
+// Pointer/optional fields use omitempty so absent values round-trip cleanly.
+
+// vpcConfigRequest is the request body shape for VPC config in
+// CreateCluster and UpdateClusterConfig.
+type vpcConfigRequest struct {
+	SubnetIDs             []string `json:"subnetIds,omitempty"`
+	SecurityGroupIDs      []string `json:"securityGroupIds,omitempty"`
+	EndpointPublicAccess  *bool    `json:"endpointPublicAccess,omitempty"`
+	EndpointPrivateAccess *bool    `json:"endpointPrivateAccess,omitempty"`
+	PublicAccessCidrs     []string `json:"publicAccessCidrs,omitempty"`
+}
+
+// vpcConfigResponse is the response shape EKS returns for VPC config.
+type vpcConfigResponse struct {
+	SubnetIDs              []string `json:"subnetIds"`
+	SecurityGroupIDs       []string `json:"securityGroupIds"`
+	ClusterSecurityGroupID string   `json:"clusterSecurityGroupId,omitempty"`
+	VpcID                  string   `json:"vpcId,omitempty"`
+	EndpointPublicAccess   bool     `json:"endpointPublicAccess"`
+	EndpointPrivateAccess  bool     `json:"endpointPrivateAccess"`
+	PublicAccessCidrs      []string `json:"publicAccessCidrs,omitempty"`
+}
+
+// certificate carries the base64 CA blob used in kubeconfig generation.
+type certificate struct {
+	Data string `json:"data"`
+}
+
+// clusterJSON is the EKS cluster resource shape.
+type clusterJSON struct {
+	Name                 string             `json:"name"`
+	Arn                  string             `json:"arn"`
+	CreatedAt            float64            `json:"createdAt"`
+	Version              string             `json:"version,omitempty"`
+	Endpoint             string             `json:"endpoint,omitempty"`
+	RoleArn              string             `json:"roleArn,omitempty"`
+	ResourcesVpcConfig   *vpcConfigResponse `json:"resourcesVpcConfig,omitempty"`
+	Status               string             `json:"status"`
+	CertificateAuthority *certificate       `json:"certificateAuthority,omitempty"`
+	PlatformVersion      string             `json:"platformVersion,omitempty"`
+	Tags                 map[string]string  `json:"tags,omitempty"`
+}
+
+// nodegroupScalingConfigJSON mirrors the SDK shape for nodegroup scaling.
+type nodegroupScalingConfigJSON struct {
+	MinSize     *int32 `json:"minSize,omitempty"`
+	MaxSize     *int32 `json:"maxSize,omitempty"`
+	DesiredSize *int32 `json:"desiredSize,omitempty"`
+}
+
+// nodegroupJSON is the EKS nodegroup resource shape.
+type nodegroupJSON struct {
+	NodegroupName  string                      `json:"nodegroupName"`
+	NodegroupArn   string                      `json:"nodegroupArn"`
+	ClusterName    string                      `json:"clusterName"`
+	Version        string                      `json:"version,omitempty"`
+	ReleaseVersion string                      `json:"releaseVersion,omitempty"`
+	CreatedAt      float64                     `json:"createdAt"`
+	ModifiedAt     float64                     `json:"modifiedAt"`
+	Status         string                      `json:"status"`
+	CapacityType   string                      `json:"capacityType,omitempty"`
+	ScalingConfig  *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	InstanceTypes  []string                    `json:"instanceTypes,omitempty"`
+	Subnets        []string                    `json:"subnets,omitempty"`
+	AmiType        string                      `json:"amiType,omitempty"`
+	NodeRole       string                      `json:"nodeRole,omitempty"`
+	Labels         map[string]string           `json:"labels,omitempty"`
+	DiskSize       *int32                      `json:"diskSize,omitempty"`
+	Tags           map[string]string           `json:"tags,omitempty"`
+}
+
+// fargateProfileSelectorJSON matches Pods to a Fargate profile.
+type fargateProfileSelectorJSON struct {
+	Namespace string            `json:"namespace,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+// fargateProfileJSON is the EKS Fargate profile resource shape.
+type fargateProfileJSON struct {
+	FargateProfileName  string                       `json:"fargateProfileName"`
+	FargateProfileArn   string                       `json:"fargateProfileArn"`
+	ClusterName         string                       `json:"clusterName"`
+	CreatedAt           float64                      `json:"createdAt"`
+	PodExecutionRoleArn string                       `json:"podExecutionRoleArn,omitempty"`
+	Subnets             []string                     `json:"subnets,omitempty"`
+	Selectors           []fargateProfileSelectorJSON `json:"selectors,omitempty"`
+	Status              string                       `json:"status"`
+	Tags                map[string]string            `json:"tags,omitempty"`
+}
+
+// addonJSON is the EKS addon resource shape.
+type addonJSON struct {
+	AddonName             string            `json:"addonName"`
+	ClusterName           string            `json:"clusterName"`
+	Status                string            `json:"status"`
+	AddonVersion          string            `json:"addonVersion,omitempty"`
+	AddonArn              string            `json:"addonArn,omitempty"`
+	CreatedAt             float64           `json:"createdAt"`
+	ModifiedAt            float64           `json:"modifiedAt"`
+	ServiceAccountRoleArn string            `json:"serviceAccountRoleArn,omitempty"`
+	ConfigurationValues   string            `json:"configurationValues,omitempty"`
+	Tags                  map[string]string `json:"tags,omitempty"`
+}
+
+// updateJSON is the EKS Update envelope returned from update operations.
+type updateJSON struct {
+	ID        string  `json:"id"`
+	Type      string  `json:"type,omitempty"`
+	Status    string  `json:"status,omitempty"`
+	CreatedAt float64 `json:"createdAt"`
+}
+
+// Request bodies decoded from POST/PUT JSON.
+
+type createClusterRequest struct {
+	Name               string            `json:"name"`
+	Version            string            `json:"version,omitempty"`
+	RoleArn            string            `json:"roleArn,omitempty"`
+	ResourcesVpcConfig *vpcConfigRequest `json:"resourcesVpcConfig,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty"`
+}
+
+type updateClusterConfigRequest struct {
+	ResourcesVpcConfig *vpcConfigRequest `json:"resourcesVpcConfig,omitempty"`
+	Tags               map[string]string `json:"tags,omitempty"`
+}
+
+type updateClusterVersionRequest struct {
+	Version string `json:"version,omitempty"`
+}
+
+type createNodegroupRequest struct {
+	NodegroupName  string                      `json:"nodegroupName"`
+	NodeRole       string                      `json:"nodeRole,omitempty"`
+	Subnets        []string                    `json:"subnets,omitempty"`
+	InstanceTypes  []string                    `json:"instanceTypes,omitempty"`
+	AmiType        string                      `json:"amiType,omitempty"`
+	CapacityType   string                      `json:"capacityType,omitempty"`
+	DiskSize       *int32                      `json:"diskSize,omitempty"`
+	Version        string                      `json:"version,omitempty"`
+	ReleaseVersion string                      `json:"releaseVersion,omitempty"`
+	ScalingConfig  *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	Labels         map[string]string           `json:"labels,omitempty"`
+	Tags           map[string]string           `json:"tags,omitempty"`
+}
+
+type updateNodegroupConfigRequest struct {
+	ScalingConfig *nodegroupScalingConfigJSON `json:"scalingConfig,omitempty"`
+	Labels        *labelsUpdate               `json:"labels,omitempty"`
+}
+
+// labelsUpdate is the request shape for nodegroup label changes; the SDK
+// sends addOrUpdateLabels and removeLabels separately. The mock applies
+// addOrUpdateLabels and ignores removeLabels for Wave 1.
+type labelsUpdate struct {
+	AddOrUpdateLabels map[string]string `json:"addOrUpdateLabels,omitempty"`
+	RemoveLabels      []string          `json:"removeLabels,omitempty"`
+}
+
+type updateNodegroupVersionRequest struct {
+	Version        string `json:"version,omitempty"`
+	ReleaseVersion string `json:"releaseVersion,omitempty"`
+}
+
+type createFargateProfileRequest struct {
+	FargateProfileName  string                       `json:"fargateProfileName"`
+	PodExecutionRoleArn string                       `json:"podExecutionRoleArn,omitempty"`
+	Subnets             []string                     `json:"subnets,omitempty"`
+	Selectors           []fargateProfileSelectorJSON `json:"selectors,omitempty"`
+	Tags                map[string]string            `json:"tags,omitempty"`
+}
+
+type createAddonRequest struct {
+	AddonName             string            `json:"addonName"`
+	AddonVersion          string            `json:"addonVersion,omitempty"`
+	ServiceAccountRoleArn string            `json:"serviceAccountRoleArn,omitempty"`
+	ConfigurationValues   string            `json:"configurationValues,omitempty"`
+	Tags                  map[string]string `json:"tags,omitempty"`
+}
+
+type updateAddonRequest struct {
+	AddonVersion          string `json:"addonVersion,omitempty"`
+	ServiceAccountRoleArn string `json:"serviceAccountRoleArn,omitempty"`
+	ConfigurationValues   string `json:"configurationValues,omitempty"`
+}
+
+// Response envelopes.
+
+type clusterEnvelope struct {
+	Cluster clusterJSON `json:"cluster"`
+}
+
+type nodegroupEnvelope struct {
+	Nodegroup nodegroupJSON `json:"nodegroup"`
+}
+
+type fargateProfileEnvelope struct {
+	FargateProfile fargateProfileJSON `json:"fargateProfile"`
+}
+
+type addonEnvelope struct {
+	Addon addonJSON `json:"addon"`
+}
+
+type updateEnvelope struct {
+	Update updateJSON `json:"update"`
+}
+
+type listClustersResponse struct {
+	Clusters []string `json:"clusters"`
+}
+
+type listNodegroupsResponse struct {
+	Nodegroups []string `json:"nodegroups"`
+}
+
+type listFargateProfilesResponse struct {
+	FargateProfileNames []string `json:"fargateProfileNames"`
+}
+
+type listAddonsResponse struct {
+	Addons []string `json:"addons"`
+}
+
+// nanosPerSecond converts UnixNano to fractional seconds (the EKS wire format).
+const nanosPerSecond = 1_000_000_000.0
+
+// epochSeconds converts a Go time.Time to the AWS-style fractional epoch
+// seconds the EKS REST/JSON SDK expects.
+func epochSeconds(t time.Time) float64 {
+	return float64(t.UnixNano()) / nanosPerSecond
+}


### PR DESCRIPTION
Closes #184.

## Scope (Wave 1 — control plane only; data-plane deferred to Wave 2)
This PR adds an in-memory mock and SDK-compatible HTTP handler for the **cloud-side EKS control plane**. The Kubernetes data plane (Deployments, StatefulSets, Pods, Services, …) is explicitly out of scope and will be Wave 2.

For now, `DescribeCluster` returns a placeholder `Endpoint` (`https://EKS-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local`) and a stub base64 `CertificateAuthority`, so `aws eks update-kubeconfig` produces a syntactically-valid kubeconfig — Wave 2 will populate these with a real apiserver address.

## What's in
- `providers/aws/eks/` — in-memory mock implementing a service-local `eks/driver.EKS` interface, backed by `memstore.Store[V]`. Emits `AWS/EKS` CloudWatch metrics (CPUUtilization, MemoryUtilization, cluster_node_count, cluster_pod_count, apiserver_request_total) on cluster create.
- `providers/aws/eks/driver/` — driver interface (cluster, nodegroup, Fargate profile, addon types).
- `server/aws/eks/` — REST/JSON handler matching the real `aws-sdk-go-v2/service/eks` URL shape, registered before S3 so its narrow `/clusters` predicate does not shadow the catch-all REST handler.
- Wire-up in `providers/aws/aws.go` (factory + `SetMonitoring`) and `server/aws/aws.go` (Drivers bundle + handler registration).

## Operations implemented
- **Clusters:** CreateCluster, DescribeCluster, ListClusters, UpdateClusterConfig, UpdateClusterVersion, DeleteCluster
- **Node groups:** CreateNodegroup, DescribeNodegroup, ListNodegroups, UpdateNodegroupConfig, UpdateNodegroupVersion, DeleteNodegroup
- **Fargate profiles:** CreateFargateProfile, DescribeFargateProfile, ListFargateProfiles, DeleteFargateProfile
- **Addons:** CreateAddon, DescribeAddon, ListAddons, UpdateAddon, DeleteAddon

URL paths were probed against the real SDK to avoid guesswork — note `UpdateClusterVersion` posts to `/clusters/{n}/updates` (not `/update-version`) and `UpdateAddon` posts to `/clusters/{n}/addons/{a}/update`.

## Tests
- `providers/aws/eks/eks_test.go` — hand-rolled require/assert helpers; covers cluster + nodegroup + Fargate + addon lifecycle, duplicate rejection, NotFound on missing parents, and DeleteCluster rejecting attached children.
- `server/aws/eks/sdk_roundtrip_test.go` — drives the real `aws-sdk-go-v2/service/eks` client against the in-memory server. Covers all four resource lifecycles, typed-error mapping (`ResourceNotFoundException`), and routing precedence (S3 still gets `GET /` when both EKS and S3 are wired).

## Verification
```
go build ./...                          # 0 errors
go test ./...                           # all packages pass
golangci-lint run --timeout=9m ./...    # 0 issues
```

## Test plan
- [ ] `go test ./providers/aws/eks/... ./server/aws/eks/...` passes
- [ ] `go test ./...` passes
- [ ] `golangci-lint run --timeout=9m ./...` reports 0 issues
- [ ] Real `aws-sdk-go-v2/service/eks` client successfully creates, describes, lists, updates, and deletes a cluster + nodegroup + Fargate profile + addon against the cloudemu-backed server
- [ ] When wired alongside S3, an EKS request hits the EKS handler and a non-EKS REST request still hits S3 (no shadowing)