### PR TITLE
feat(gke): add GCP GKE SDK-compat handler — control plane (#169)

### DIFF
--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/gcp/gcplb"
 	"github.com/stackshy/cloudemu/providers/gcp/gcpvpc"
 	"github.com/stackshy/cloudemu/providers/gcp/gcs"
+	"github.com/stackshy/cloudemu/providers/gcp/gke"
 	"github.com/stackshy/cloudemu/providers/gcp/memorystore"
 	"github.com/stackshy/cloudemu/providers/gcp/pubsub"
 	"github.com/stackshy/cloudemu/providers/gcp/secretmanager"
@@ -41,6 +42,7 @@ type Provider struct {
 	ArtifactRegistry *artifactregistry.Mock
 	Eventarc         *eventarc.Mock
 	CloudSQL         *cloudsql.Mock
+	GKE              *gke.Mock
 }
 
 // New creates a new GCP provider with all mock services.
@@ -64,6 +66,7 @@ func New(opts ...config.Option) *Provider {
 		ArtifactRegistry: artifactregistry.New(o),
 		Eventarc:         eventarc.New(o),
 		CloudSQL:         cloudsql.New(o),
+		GKE:              gke.New(o),
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 	p.GCS.SetMonitoring(p.CloudMonitoring)
@@ -76,6 +79,7 @@ func New(opts ...config.Option) *Provider {
 	p.ArtifactRegistry.SetMonitoring(p.CloudMonitoring)
 	p.Eventarc.SetMonitoring(p.CloudMonitoring)
 	p.CloudSQL.SetMonitoring(p.CloudMonitoring)
+	p.GKE.SetMonitoring(p.CloudMonitoring)
 
 	return p
 }

--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -1,0 +1,754 @@
+// Package gke provides an in-memory mock of GCP Kubernetes Engine (GKE).
+//
+// Wave 1 covers only the GKE control-plane: Clusters, NodePools, and the
+// long-running Operations they emit. The Kubernetes data-plane API
+// (Deployments, StatefulSets, Pods, Services) is intentionally out of scope
+// and will be wired up in Wave 2 alongside a Kubernetes API server stub.
+//
+// To reflect that, GetCluster returns a stub Endpoint
+// (https://GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local) and a stub CA
+// certificate so that tooling like `gcloud container clusters get-credentials`
+// can render a kubeconfig — actual API calls against the kubeconfig will fail
+// until Wave 2 lands.
+package gke
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+// Stub values used in Cluster responses until the Kubernetes data-plane
+// arrives in Wave 2.
+const (
+	StubEndpoint    = "GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local"
+	StubCACert      = "MIIBkTCB+wIJAOdjUjcyKZUyMA0GCSqGSIb3DQEBBQUAMA0xCzAJBgNVBAYTAlVT" // dummy base64 blob
+	StubMasterVer   = "1.30.0-gke.0"
+	stubNodeVersion = "1.30.0-gke.0"
+)
+
+const (
+	cpuMetricRunning   = 0.25
+	memMetricRunning   = 1024.0 * 1024.0 * 256.0 // 256 MiB
+	defaultNodeCount   = 1
+	defaultMachineType = "e2-medium"
+	defaultDiskSizeGB  = 100
+)
+
+// Cluster is the in-memory representation of a GKE cluster. The shape mirrors
+// only the fields the SDK round-trip cares about; the handler layer maps
+// these to the wire shape google.golang.org/api/container/v1.Cluster expects.
+type Cluster struct {
+	Name              string
+	Location          string
+	Description       string
+	Network           string
+	Subnetwork        string
+	InitialNodeCount  int64
+	NodeIPv4CIDRSize  int64
+	ClusterIPv4CIDR   string
+	LoggingService    string
+	MonitoringService string
+	LegacyAbacEnabled bool
+	NetworkPolicy     bool
+	MasterUsername    string
+	ResourceLabels    map[string]string
+	MaintenanceWindow string // RFC-3339 daily window encoding; empty = none.
+	IPRotationActive  bool
+	NodePoolNames     []string
+	Status            string
+	CreatedAt         time.Time
+}
+
+// NodePool is the in-memory representation of a GKE node pool.
+type NodePool struct {
+	Name              string
+	ClusterName       string
+	Location          string
+	NodeCount         int64
+	MachineType       string
+	DiskSizeGB        int64
+	Version           string
+	AutoscalingMin    int64
+	AutoscalingMax    int64
+	AutoscalingOn     bool
+	AutoUpgrade       bool
+	AutoRepair        bool
+	Status            string
+	UpgradeRolledBack bool
+	CreatedAt         time.Time
+}
+
+// Operation tracks GKE long-running operations. The mock completes every
+// operation immediately (status=DONE) so SDK pollers terminate on the first
+// poll.
+type Operation struct {
+	Name          string
+	Location      string
+	OperationType string
+	Status        string
+	TargetLink    string
+	StartTime     time.Time
+	EndTime       time.Time
+}
+
+// Mock is the in-memory GKE backend.
+type Mock struct {
+	mu sync.RWMutex
+
+	clusters   *memstore.Store[Cluster]
+	nodePools  *memstore.Store[NodePool] // keyed by clusterName + "/" + nodePoolName
+	operations *memstore.Store[Operation]
+
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new GKE mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		clusters:   memstore.New[Cluster](),
+		nodePools:  memstore.New[NodePool](),
+		operations: memstore.New[Operation](),
+		opts:       opts,
+	}
+}
+
+// SetMonitoring wires a Cloud Monitoring backend for auto-metric emission.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+// emitClusterMetrics pushes container.googleapis.com metrics for a cluster.
+// Real GKE samples per-container/per-node metrics; the mock emits a single
+// representative datum per metric per cluster so SDK consumers see traffic.
+func (m *Mock) emitClusterMetrics(clusterName string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	dims := map[string]string{
+		"project_id":   m.opts.ProjectID,
+		"cluster_name": clusterName,
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{
+		{Namespace: "container.googleapis.com", MetricName: "container/cpu/usage_time",
+			Value: cpuMetricRunning, Unit: "s", Dimensions: dims, Timestamp: now},
+		{Namespace: "container.googleapis.com", MetricName: "container/memory/used_bytes",
+			Value: memMetricRunning, Unit: "By", Dimensions: dims, Timestamp: now},
+		{Namespace: "container.googleapis.com", MetricName: "node/count",
+			Value: 1, Unit: "1", Dimensions: dims, Timestamp: now},
+	})
+}
+
+func (m *Mock) recordOperation(opType, location, target string) Operation {
+	now := m.opts.Clock.Now().UTC()
+	op := Operation{
+		Name:          idgen.GenerateID("operation-"),
+		Location:      location,
+		OperationType: opType,
+		Status:        "DONE",
+		TargetLink:    target,
+		StartTime:     now,
+		EndTime:       now,
+	}
+	m.operations.Set(op.Name, op)
+
+	return op
+}
+
+// CreateClusterInput captures the subset of CreateCluster we honor.
+type CreateClusterInput struct {
+	Name              string
+	Location          string
+	Description       string
+	Network           string
+	Subnetwork        string
+	InitialNodeCount  int64
+	LoggingService    string
+	MonitoringService string
+	ResourceLabels    map[string]string
+	NodePools         []NodePoolSpec
+}
+
+// NodePoolSpec captures the node-pool fields we keep when bootstrapping a
+// cluster from a CreateClusterRequest.
+type NodePoolSpec struct {
+	Name             string
+	InitialNodeCount int64
+	MachineType      string
+	DiskSizeGB       int64
+	Version          string
+	AutoscalingMin   int64
+	AutoscalingMax   int64
+	AutoscalingOn    bool
+}
+
+// CreateCluster registers a new cluster and any nested node pools.
+func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Cluster, *Operation, error) {
+	if input.Name == "" {
+		return nil, nil, cerrors.New(cerrors.InvalidArgument, "cluster name is required")
+	}
+
+	if input.Location == "" {
+		input.Location = m.opts.Region
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(input.Location, input.Name)
+	if _, ok := m.clusters.Get(key); ok {
+		return nil, nil, cerrors.Newf(cerrors.AlreadyExists, "cluster %q already exists", input.Name)
+	}
+
+	cluster := Cluster{
+		Name:              input.Name,
+		Location:          input.Location,
+		Description:       input.Description,
+		Network:           defaultIfEmpty(input.Network, "default"),
+		Subnetwork:        defaultIfEmpty(input.Subnetwork, "default"),
+		InitialNodeCount:  input.InitialNodeCount,
+		NodeIPv4CIDRSize:  24,
+		ClusterIPv4CIDR:   "10.0.0.0/14",
+		LoggingService:    defaultIfEmpty(input.LoggingService, "logging.googleapis.com/kubernetes"),
+		MonitoringService: defaultIfEmpty(input.MonitoringService, "monitoring.googleapis.com/kubernetes"),
+		ResourceLabels:    copyLabels(input.ResourceLabels),
+		Status:            "RUNNING",
+		CreatedAt:         m.opts.Clock.Now().UTC(),
+	}
+
+	// Bootstrap default node pool when none specified — matches real GKE.
+	pools := input.NodePools
+	if len(pools) == 0 {
+		count := input.InitialNodeCount
+		if count == 0 {
+			count = defaultNodeCount
+		}
+
+		pools = []NodePoolSpec{{
+			Name:             "default-pool",
+			InitialNodeCount: count,
+			MachineType:      defaultMachineType,
+			DiskSizeGB:       defaultDiskSizeGB,
+			Version:          stubNodeVersion,
+		}}
+	}
+
+	for i := range pools {
+		np := nodePoolFromSpec(&pools[i], input.Name, input.Location, m.opts.Clock.Now().UTC())
+		m.nodePools.Set(nodePoolKey(input.Location, input.Name, np.Name), np)
+		cluster.NodePoolNames = append(cluster.NodePoolNames, np.Name)
+	}
+
+	m.clusters.Set(key, cluster)
+
+	op := m.recordOperation("CREATE_CLUSTER", input.Location,
+		"projects/"+m.opts.ProjectID+"/locations/"+input.Location+"/clusters/"+input.Name)
+
+	m.emitClusterMetrics(input.Name)
+
+	out := cluster
+
+	return &out, &op, nil
+}
+
+func nodePoolFromSpec(spec *NodePoolSpec, clusterName, location string, now time.Time) NodePool {
+	count := spec.InitialNodeCount
+	if count == 0 {
+		count = defaultNodeCount
+	}
+
+	return NodePool{
+		Name:           spec.Name,
+		ClusterName:    clusterName,
+		Location:       location,
+		NodeCount:      count,
+		MachineType:    defaultIfEmpty(spec.MachineType, defaultMachineType),
+		DiskSizeGB:     defaultIfZero(spec.DiskSizeGB, defaultDiskSizeGB),
+		Version:        defaultIfEmpty(spec.Version, stubNodeVersion),
+		AutoscalingMin: spec.AutoscalingMin,
+		AutoscalingMax: spec.AutoscalingMax,
+		AutoscalingOn:  spec.AutoscalingOn,
+		AutoUpgrade:    true,
+		AutoRepair:     true,
+		Status:         "RUNNING",
+		CreatedAt:      now,
+	}
+}
+
+// GetCluster returns a single cluster by location+name.
+func (m *Mock) GetCluster(_ context.Context, location, name string) (*Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	c, ok := m.clusters.Get(clusterKey(location, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", name, location)
+	}
+
+	out := c
+
+	return &out, nil
+}
+
+// ListClusters returns clusters in a location ("-" for all locations).
+func (m *Mock) ListClusters(_ context.Context, location string) ([]Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.clusters.All()
+	out := make([]Cluster, 0, len(all))
+
+	//nolint:gocritic // map values are sized for accuracy.
+	for _, c := range all {
+		if location != "" && location != "-" && c.Location != location {
+			continue
+		}
+
+		out = append(out, c)
+	}
+
+	return out, nil
+}
+
+// UpdateClusterInput is the subset of UpdateCluster we honor.
+type UpdateClusterInput struct {
+	LoggingService    string
+	MonitoringService string
+	NodeVersion       string
+	MasterVersion     string
+	ResourceLabels    map[string]string
+}
+
+// UpdateCluster applies a partial update.
+func (m *Mock) UpdateCluster(
+	_ context.Context, location, name string, input UpdateClusterInput,
+) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		if input.LoggingService != "" {
+			c.LoggingService = input.LoggingService
+		}
+
+		if input.MonitoringService != "" {
+			c.MonitoringService = input.MonitoringService
+		}
+
+		if input.ResourceLabels != nil {
+			c.ResourceLabels = copyLabels(input.ResourceLabels)
+		}
+	})
+}
+
+// DeleteCluster removes a cluster and its node pools.
+func (m *Mock) DeleteCluster(_ context.Context, location, name string) (*Operation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(location, name)
+	if !m.clusters.Has(key) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", name, location)
+	}
+
+	m.clusters.Delete(key)
+
+	prefix := location + "/" + name + "/"
+	for _, k := range m.nodePools.Keys() {
+		if hasPrefix(k, prefix) {
+			m.nodePools.Delete(k)
+		}
+	}
+
+	op := m.recordOperation("DELETE_CLUSTER", location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+name)
+
+	return &op, nil
+}
+
+// SetClusterLogging implements :setLogging (logging-service URI).
+func (m *Mock) SetClusterLogging(_ context.Context, location, name, service string) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.LoggingService = service
+	})
+}
+
+// SetClusterMonitoring implements :setMonitoring (monitoring-service URI).
+func (m *Mock) SetClusterMonitoring(_ context.Context, location, name, service string) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.MonitoringService = service
+	})
+}
+
+// SetMasterAuth implements :setMasterAuth (basic-auth username/password).
+func (m *Mock) SetMasterAuth(_ context.Context, location, name, username string) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.MasterUsername = username
+	})
+}
+
+// SetLegacyAbac implements :setLegacyAbac.
+func (m *Mock) SetLegacyAbac(_ context.Context, location, name string, enabled bool) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.LegacyAbacEnabled = enabled
+	})
+}
+
+// SetNetworkPolicy implements :setNetworkPolicy.
+func (m *Mock) SetNetworkPolicy(_ context.Context, location, name string, enabled bool) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.NetworkPolicy = enabled
+	})
+}
+
+// SetMaintenancePolicy implements :setMaintenancePolicy.
+func (m *Mock) SetMaintenancePolicy(_ context.Context, location, name, window string) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.MaintenanceWindow = window
+	})
+}
+
+// SetResourceLabels implements :setResourceLabels.
+func (m *Mock) SetResourceLabels(
+	_ context.Context, location, name string, labels map[string]string,
+) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.ResourceLabels = copyLabels(labels)
+	})
+}
+
+// StartIPRotation implements :startIpRotation.
+func (m *Mock) StartIPRotation(_ context.Context, location, name string) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.IPRotationActive = true
+	})
+}
+
+// CompleteIPRotation implements :completeIpRotation.
+func (m *Mock) CompleteIPRotation(_ context.Context, location, name string) (*Operation, error) {
+	return m.mutateCluster(location, name, func(c *Cluster) {
+		c.IPRotationActive = false
+	})
+}
+
+func (m *Mock) mutateCluster(
+	location, name string, fn func(*Cluster),
+) (*Operation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(location, name)
+
+	c, ok := m.clusters.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", name, location)
+	}
+
+	fn(&c)
+
+	m.clusters.Set(key, c)
+
+	op := m.recordOperation("UPDATE_CLUSTER", location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+name)
+
+	return &op, nil
+}
+
+// CreateNodePool registers a new node pool inside an existing cluster.
+func (m *Mock) CreateNodePool(
+	_ context.Context, location, clusterName string, spec *NodePoolSpec,
+) (*NodePool, *Operation, error) {
+	if spec.Name == "" {
+		return nil, nil, cerrors.New(cerrors.InvalidArgument, "node pool name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cKey := clusterKey(location, clusterName)
+
+	cluster, ok := m.clusters.Get(cKey)
+	if !ok {
+		return nil, nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found in %q", clusterName, location)
+	}
+
+	npKey := nodePoolKey(location, clusterName, spec.Name)
+	if _, exists := m.nodePools.Get(npKey); exists {
+		return nil, nil, cerrors.Newf(cerrors.AlreadyExists, "node pool %q already exists in cluster %q", spec.Name, clusterName)
+	}
+
+	np := nodePoolFromSpec(spec, clusterName, location, m.opts.Clock.Now().UTC())
+	m.nodePools.Set(npKey, np)
+
+	cluster.NodePoolNames = append(cluster.NodePoolNames, np.Name)
+	m.clusters.Set(cKey, cluster)
+
+	op := m.recordOperation("CREATE_NODE_POOL", location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+spec.Name)
+
+	out := np
+
+	return &out, &op, nil
+}
+
+// GetNodePool returns one node pool.
+func (m *Mock) GetNodePool(_ context.Context, location, clusterName, name string) (*NodePool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	np, ok := m.nodePools.Get(nodePoolKey(location, clusterName, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "node pool %q not found in cluster %q", name, clusterName)
+	}
+
+	out := np
+
+	return &out, nil
+}
+
+// ListNodePools returns all node pools in a cluster.
+func (m *Mock) ListNodePools(_ context.Context, location, clusterName string) ([]NodePool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	prefix := location + "/" + clusterName + "/"
+	all := m.nodePools.All()
+
+	out := make([]NodePool, 0, len(all))
+
+	//nolint:gocritic // map values are sized for accuracy.
+	for k, np := range all {
+		if hasPrefix(k, prefix) {
+			out = append(out, np)
+		}
+	}
+
+	return out, nil
+}
+
+// UpdateNodePoolInput captures the subset of UpdateNodePool we honor.
+type UpdateNodePoolInput struct {
+	NodeVersion string
+	MachineType string
+	DiskSizeGB  int64
+}
+
+// UpdateNodePool applies a partial update.
+func (m *Mock) UpdateNodePool(
+	_ context.Context, location, clusterName, name string, input UpdateNodePoolInput,
+) (*Operation, error) {
+	return m.mutateNodePool(location, clusterName, name, "UPGRADE_NODES", func(np *NodePool) {
+		if input.NodeVersion != "" {
+			np.Version = input.NodeVersion
+		}
+
+		if input.MachineType != "" {
+			np.MachineType = input.MachineType
+		}
+
+		if input.DiskSizeGB > 0 {
+			np.DiskSizeGB = input.DiskSizeGB
+		}
+	})
+}
+
+// DeleteNodePool removes a node pool.
+func (m *Mock) DeleteNodePool(_ context.Context, location, clusterName, name string) (*Operation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	npKey := nodePoolKey(location, clusterName, name)
+	if !m.nodePools.Has(npKey) {
+		return nil, cerrors.Newf(cerrors.NotFound, "node pool %q not found in cluster %q", name, clusterName)
+	}
+
+	m.nodePools.Delete(npKey)
+
+	if cluster, ok := m.clusters.Get(clusterKey(location, clusterName)); ok {
+		cluster.NodePoolNames = removeString(cluster.NodePoolNames, name)
+		m.clusters.Set(clusterKey(location, clusterName), cluster)
+	}
+
+	op := m.recordOperation("DELETE_NODE_POOL", location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name)
+
+	return &op, nil
+}
+
+// SetNodePoolSize resizes a node pool to count nodes.
+func (m *Mock) SetNodePoolSize(
+	_ context.Context, location, clusterName, name string, count int64,
+) (*Operation, error) {
+	return m.mutateNodePool(location, clusterName, name, "SET_NODE_POOL_SIZE", func(np *NodePool) {
+		np.NodeCount = count
+	})
+}
+
+// SetNodePoolAutoscaling toggles autoscaling and bounds.
+func (m *Mock) SetNodePoolAutoscaling(
+	_ context.Context, location, clusterName, name string, on bool, minNodes, maxNodes int64,
+) (*Operation, error) {
+	return m.mutateNodePool(location, clusterName, name, "UPDATE_CLUSTER", func(np *NodePool) {
+		np.AutoscalingOn = on
+		np.AutoscalingMin = minNodes
+		np.AutoscalingMax = maxNodes
+	})
+}
+
+// SetNodePoolManagement toggles auto-upgrade and auto-repair.
+func (m *Mock) SetNodePoolManagement(
+	_ context.Context, location, clusterName, name string, autoUpgrade, autoRepair bool,
+) (*Operation, error) {
+	return m.mutateNodePool(location, clusterName, name, "SET_NODE_POOL_MANAGEMENT", func(np *NodePool) {
+		np.AutoUpgrade = autoUpgrade
+		np.AutoRepair = autoRepair
+	})
+}
+
+// RollbackNodePool flags an in-progress upgrade as rolled back.
+func (m *Mock) RollbackNodePool(_ context.Context, location, clusterName, name string) (*Operation, error) {
+	return m.mutateNodePool(location, clusterName, name, "UPGRADE_NODES", func(np *NodePool) {
+		np.UpgradeRolledBack = true
+	})
+}
+
+func (m *Mock) mutateNodePool(
+	location, clusterName, name, opType string, fn func(*NodePool),
+) (*Operation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := nodePoolKey(location, clusterName, name)
+
+	np, ok := m.nodePools.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "node pool %q not found in cluster %q", name, clusterName)
+	}
+
+	fn(&np)
+	m.nodePools.Set(key, np)
+
+	op := m.recordOperation(opType, location,
+		"projects/"+m.opts.ProjectID+"/locations/"+location+"/clusters/"+clusterName+"/nodePools/"+name)
+
+	return &op, nil
+}
+
+// GetOperation returns one previously-recorded operation. The location is
+// part of the SDK URL but operation names are globally unique in the mock,
+// so the parameter is unused — kept for parity with the SDK signature.
+func (m *Mock) GetOperation(_ context.Context, _, name string) (*Operation, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	op, ok := m.operations.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "operation %q not found", name)
+	}
+
+	out := op
+
+	return &out, nil
+}
+
+// ListOperations returns all operations in a location ("-" for all).
+func (m *Mock) ListOperations(_ context.Context, location string) ([]Operation, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.operations.All()
+	out := make([]Operation, 0, len(all))
+
+	//nolint:gocritic // map values are sized for accuracy.
+	for _, op := range all {
+		if location != "" && location != "-" && op.Location != location {
+			continue
+		}
+
+		out = append(out, op)
+	}
+
+	return out, nil
+}
+
+// CancelOperation marks a recorded operation as canceled. Real GKE cancels
+// long-running ops; the mock's ops are already DONE so this is a no-op for
+// state purposes — we still record the request returned an OK envelope. The
+// location is part of the SDK URL but operation names are globally unique in
+// the mock, so the parameter is unused — kept for parity with the SDK.
+func (m *Mock) CancelOperation(_ context.Context, _, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	op, ok := m.operations.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "operation %q not found", name)
+	}
+
+	op.Status = "ABORTING"
+	m.operations.Set(name, op)
+
+	return nil
+}
+
+// helpers
+
+func clusterKey(location, name string) string {
+	return location + "/" + name
+}
+
+func nodePoolKey(location, clusterName, name string) string {
+	return location + "/" + clusterName + "/" + name
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func defaultIfEmpty(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+
+	return v
+}
+
+func defaultIfZero(v, fallback int64) int64 {
+	if v == 0 {
+		return fallback
+	}
+
+	return v
+}
+
+func copyLabels(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func removeString(items []string, target string) []string {
+	out := items[:0]
+
+	for _, s := range items {
+		if s != target {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}

--- a/providers/gcp/gke/gke_test.go
+++ b/providers/gcp/gke/gke_test.go
@@ -1,0 +1,354 @@
+package gke
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-central1"),
+		config.WithProjectID("mock-project"),
+	)
+
+	return New(opts)
+}
+
+func TestCreateCluster(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     CreateClusterInput
+		expectErr bool
+	}{
+		{
+			name: "minimal",
+			input: CreateClusterInput{
+				Name:     "prod",
+				Location: "us-central1",
+			},
+		},
+		{
+			name: "with explicit node pool",
+			input: CreateClusterInput{
+				Name:     "with-np",
+				Location: "us-central1",
+				NodePools: []NodePoolSpec{
+					{Name: "primary", InitialNodeCount: 3, MachineType: "e2-standard-4"},
+				},
+			},
+		},
+		{
+			name:      "missing name",
+			input:     CreateClusterInput{Location: "us-central1"},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestMock()
+
+			c, op, err := m.CreateCluster(context.Background(), &tc.input)
+			assertError(t, err, tc.expectErr)
+
+			if tc.expectErr {
+				return
+			}
+
+			assertEqual(t, tc.input.Name, c.Name)
+			assertEqual(t, "RUNNING", c.Status)
+			assertEqual(t, "DONE", op.Status)
+
+			if len(c.NodePoolNames) == 0 {
+				t.Fatal("expected at least one node pool")
+			}
+		})
+	}
+}
+
+func TestClusterDuplicateRejected(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "p1", Location: "us-central1"})
+	requireNoError(t, err)
+
+	if _, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "p1", Location: "us-central1"}); err == nil {
+		t.Fatal("expected AlreadyExists error on duplicate cluster")
+	}
+}
+
+func TestGetListUpdateDeleteCluster(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "alpha", Location: "us-central1"})
+	requireNoError(t, err)
+
+	got, err := m.GetCluster(ctx, "us-central1", "alpha")
+	requireNoError(t, err)
+	assertEqual(t, "alpha", got.Name)
+
+	if _, err := m.GetCluster(ctx, "us-central1", "missing"); err == nil {
+		t.Fatal("expected NotFound for missing cluster")
+	}
+
+	clusters, err := m.ListClusters(ctx, "-")
+	requireNoError(t, err)
+	assertEqual(t, 1, len(clusters))
+
+	_, err = m.UpdateCluster(ctx, "us-central1", "alpha", UpdateClusterInput{
+		LoggingService: "none",
+		ResourceLabels: map[string]string{"env": "prod"},
+	})
+	requireNoError(t, err)
+
+	got, _ = m.GetCluster(ctx, "us-central1", "alpha")
+	assertEqual(t, "none", got.LoggingService)
+	assertEqual(t, "prod", got.ResourceLabels["env"])
+
+	_, err = m.DeleteCluster(ctx, "us-central1", "alpha")
+	requireNoError(t, err)
+
+	if _, err := m.GetCluster(ctx, "us-central1", "alpha"); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestClusterSetters(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	loc, name := "us-central1", "tweaks"
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: name, Location: loc})
+	requireNoError(t, err)
+
+	if _, err := m.SetClusterLogging(ctx, loc, name, "logging.googleapis.com/kubernetes"); err != nil {
+		t.Fatalf("SetClusterLogging: %v", err)
+	}
+
+	if _, err := m.SetClusterMonitoring(ctx, loc, name, "monitoring.googleapis.com/kubernetes"); err != nil {
+		t.Fatalf("SetClusterMonitoring: %v", err)
+	}
+
+	if _, err := m.SetMasterAuth(ctx, loc, name, "admin"); err != nil {
+		t.Fatalf("SetMasterAuth: %v", err)
+	}
+
+	if _, err := m.SetLegacyAbac(ctx, loc, name, true); err != nil {
+		t.Fatalf("SetLegacyAbac: %v", err)
+	}
+
+	if _, err := m.SetNetworkPolicy(ctx, loc, name, true); err != nil {
+		t.Fatalf("SetNetworkPolicy: %v", err)
+	}
+
+	if _, err := m.SetMaintenancePolicy(ctx, loc, name, "03:00"); err != nil {
+		t.Fatalf("SetMaintenancePolicy: %v", err)
+	}
+
+	if _, err := m.SetResourceLabels(ctx, loc, name, map[string]string{"team": "core"}); err != nil {
+		t.Fatalf("SetResourceLabels: %v", err)
+	}
+
+	if _, err := m.StartIPRotation(ctx, loc, name); err != nil {
+		t.Fatalf("StartIPRotation: %v", err)
+	}
+
+	got, _ := m.GetCluster(ctx, loc, name)
+	assertEqual(t, true, got.LegacyAbacEnabled)
+	assertEqual(t, true, got.NetworkPolicy)
+	assertEqual(t, "03:00", got.MaintenanceWindow)
+	assertEqual(t, "admin", got.MasterUsername)
+	assertEqual(t, "core", got.ResourceLabels["team"])
+	assertEqual(t, true, got.IPRotationActive)
+
+	if _, err := m.CompleteIPRotation(ctx, loc, name); err != nil {
+		t.Fatalf("CompleteIPRotation: %v", err)
+	}
+
+	got, _ = m.GetCluster(ctx, loc, name)
+	assertEqual(t, false, got.IPRotationActive)
+}
+
+func TestNodePoolLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	loc, cName := "us-central1", "host"
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: cName, Location: loc})
+	requireNoError(t, err)
+
+	_, _, err = m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{
+		Name:             "extra",
+		InitialNodeCount: 2,
+		MachineType:      "e2-standard-4",
+	})
+	requireNoError(t, err)
+
+	if _, _, err := m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{Name: "extra"}); err == nil {
+		t.Fatal("expected AlreadyExists on duplicate pool")
+	}
+
+	pool, err := m.GetNodePool(ctx, loc, cName, "extra")
+	requireNoError(t, err)
+	assertEqual(t, int64(2), pool.NodeCount)
+	assertEqual(t, "e2-standard-4", pool.MachineType)
+
+	pools, err := m.ListNodePools(ctx, loc, cName)
+	requireNoError(t, err)
+
+	if len(pools) != 2 {
+		t.Fatalf("expected 2 pools (default + extra), got %d", len(pools))
+	}
+
+	if _, err := m.SetNodePoolSize(ctx, loc, cName, "extra", 5); err != nil {
+		t.Fatalf("SetNodePoolSize: %v", err)
+	}
+
+	pool, _ = m.GetNodePool(ctx, loc, cName, "extra")
+	assertEqual(t, int64(5), pool.NodeCount)
+
+	if _, err := m.SetNodePoolAutoscaling(ctx, loc, cName, "extra", true, 1, 10); err != nil {
+		t.Fatalf("SetNodePoolAutoscaling: %v", err)
+	}
+
+	pool, _ = m.GetNodePool(ctx, loc, cName, "extra")
+	assertEqual(t, true, pool.AutoscalingOn)
+	assertEqual(t, int64(1), pool.AutoscalingMin)
+	assertEqual(t, int64(10), pool.AutoscalingMax)
+
+	if _, err := m.SetNodePoolManagement(ctx, loc, cName, "extra", false, false); err != nil {
+		t.Fatalf("SetNodePoolManagement: %v", err)
+	}
+
+	pool, _ = m.GetNodePool(ctx, loc, cName, "extra")
+	assertEqual(t, false, pool.AutoUpgrade)
+	assertEqual(t, false, pool.AutoRepair)
+
+	if _, err := m.UpdateNodePool(ctx, loc, cName, "extra", UpdateNodePoolInput{
+		NodeVersion: "1.31.0-gke.0",
+		MachineType: "e2-standard-8",
+	}); err != nil {
+		t.Fatalf("UpdateNodePool: %v", err)
+	}
+
+	pool, _ = m.GetNodePool(ctx, loc, cName, "extra")
+	assertEqual(t, "1.31.0-gke.0", pool.Version)
+	assertEqual(t, "e2-standard-8", pool.MachineType)
+
+	if _, err := m.RollbackNodePool(ctx, loc, cName, "extra"); err != nil {
+		t.Fatalf("RollbackNodePool: %v", err)
+	}
+
+	pool, _ = m.GetNodePool(ctx, loc, cName, "extra")
+	assertEqual(t, true, pool.UpgradeRolledBack)
+
+	if _, err := m.DeleteNodePool(ctx, loc, cName, "extra"); err != nil {
+		t.Fatalf("DeleteNodePool: %v", err)
+	}
+
+	if _, err := m.GetNodePool(ctx, loc, cName, "extra"); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+func TestNodePoolErrorPaths(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, _, err := m.CreateNodePool(ctx, "us-central1", "missing", &NodePoolSpec{Name: "x"}); err == nil {
+		t.Fatal("expected NotFound when cluster missing")
+	}
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "host", Location: "us-central1"})
+	requireNoError(t, err)
+
+	if _, _, err := m.CreateNodePool(ctx, "us-central1", "host", &NodePoolSpec{}); err == nil {
+		t.Fatal("expected InvalidArgument when name empty")
+	}
+}
+
+func TestOperations(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, op, err := m.CreateCluster(ctx, &CreateClusterInput{Name: "p", Location: "us-central1"})
+	requireNoError(t, err)
+
+	got, err := m.GetOperation(ctx, "us-central1", op.Name)
+	requireNoError(t, err)
+	assertEqual(t, op.Name, got.Name)
+	assertEqual(t, "DONE", got.Status)
+
+	ops, err := m.ListOperations(ctx, "us-central1")
+	requireNoError(t, err)
+
+	if len(ops) == 0 {
+		t.Fatal("expected at least one operation")
+	}
+
+	if err := m.CancelOperation(ctx, "us-central1", op.Name); err != nil {
+		t.Fatalf("CancelOperation: %v", err)
+	}
+
+	got, _ = m.GetOperation(ctx, "us-central1", op.Name)
+	assertEqual(t, "ABORTING", got.Status)
+
+	if err := m.CancelOperation(ctx, "us-central1", "missing"); err == nil {
+		t.Fatal("expected NotFound on cancel of missing op")
+	}
+}
+
+func TestCascadingDelete(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	loc, cName := "us-central1", "host"
+
+	_, _, err := m.CreateCluster(ctx, &CreateClusterInput{Name: cName, Location: loc})
+	requireNoError(t, err)
+
+	_, _, err = m.CreateNodePool(ctx, loc, cName, &NodePoolSpec{Name: "extra"})
+	requireNoError(t, err)
+
+	_, err = m.DeleteCluster(ctx, loc, cName)
+	requireNoError(t, err)
+
+	if _, err := m.GetNodePool(ctx, loc, cName, "extra"); err == nil {
+		t.Fatal("expected node pools to be deleted along with cluster")
+	}
+}
+
+// Hand-rolled helpers per CLAUDE.md (provider tests don't use testify).
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertError(t *testing.T, err error, expectErr bool) {
+	t.Helper()
+
+	switch {
+	case expectErr && err == nil:
+		t.Fatal("expected error, got nil")
+	case !expectErr && err != nil:
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func assertEqual(t *testing.T, expected, actual any) {
+	t.Helper()
+
+	if expected != actual {
+		t.Errorf("expected %v, got %v", expected, actual)
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -12,6 +12,7 @@ import (
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	gkeprov "github.com/stackshy/cloudemu/providers/gcp/gke"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
@@ -19,6 +20,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/compute"
 	"github.com/stackshy/cloudemu/server/gcp/firestore"
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
+	"github.com/stackshy/cloudemu/server/gcp/gke"
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
@@ -36,6 +38,7 @@ type Drivers struct {
 	CloudFunctions sdrv.Serverless
 	PubSub         mqdriver.MessageQueue
 	CloudSQL       rdbdriver.RelationalDB
+	GKE            *gkeprov.Mock
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -77,6 +80,12 @@ func New(d Drivers) *server.Server {
 	// /v1/projects/ space as Firestore, so register first.
 	if d.CloudSQL != nil {
 		srv.Register(cloudsql.New(d.CloudSQL))
+	}
+
+	// GKE matches /v1/projects/{p}/locations/{l}/{clusters|operations}/...;
+	// same /v1/projects/ space as Firestore, so register first.
+	if d.GKE != nil {
+		srv.Register(gke.New(d.GKE))
 	}
 
 	if d.Firestore != nil {

--- a/server/gcp/gke/handler.go
+++ b/server/gcp/gke/handler.go
@@ -1,0 +1,361 @@
+// Package gke implements the GCP Kubernetes Engine (Container) API as a
+// server.Handler. Real google.golang.org/api/container/v1 clients configured
+// with a custom endpoint hit this handler the same way they hit
+// container.googleapis.com.
+//
+// Wave-1 coverage (control plane only):
+//
+//	POST   /v1/projects/{p}/locations/{l}/clusters
+//	GET    /v1/projects/{p}/locations/{l}/clusters
+//	GET    /v1/projects/{p}/locations/{l}/clusters/{c}
+//	PUT    /v1/projects/{p}/locations/{l}/clusters/{c}
+//	DELETE /v1/projects/{p}/locations/{l}/clusters/{c}
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setLogging
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setMonitoring
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setMasterAuth
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setLegacyAbac
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setNetworkPolicy
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setMaintenancePolicy
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:setResourceLabels
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:startIpRotation
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}:completeIpRotation
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools
+//	GET    /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools
+//	GET    /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}
+//	PUT    /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}
+//	DELETE /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}:setSize
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}:setAutoscaling
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}:setManagement
+//	POST   /v1/projects/{p}/locations/{l}/clusters/{c}/nodePools/{n}:rollback
+//	GET    /v1/projects/{p}/locations/{l}/operations
+//	GET    /v1/projects/{p}/locations/{l}/operations/{op}
+//	POST   /v1/projects/{p}/locations/{l}/operations/{op}:cancel
+//
+// All mutating endpoints return Operation envelopes with status=DONE so SDK
+// pollers terminate on the first response. Cluster.Endpoint and
+// MasterAuth.ClusterCaCertificate carry stub values — see provider/gcp/gke
+// for the Wave-2 deferral note.
+//
+// The /v1/projects/{p}/locations/{l}/ prefix is shared with Cloud Functions
+// (functions/) and Cloud SQL (/v1/projects/{p}/instances). Matches narrows on
+// the 4th segment so this handler claims ONLY clusters/operations URLs.
+package gke
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/providers/gcp/gke"
+)
+
+const (
+	pathPrefix      = "/v1/projects/"
+	contentTypeJSON = "application/json"
+	maxBodyBytes    = 1 << 20
+
+	resourceClusters   = "clusters"
+	resourceNodePools  = "nodePools"
+	resourceOperations = "operations"
+	locationsSeg       = "locations"
+
+	// actionResX values tag the resource an action applies to.
+	actionResCluster    = "cluster"
+	actionResNodePool   = "nodePool"
+	actionResOperation  = "operation"
+	actionResCollection = "collection"
+)
+
+// Handler serves GKE container-API REST requests against a gke.Mock backend.
+type Handler struct {
+	gke *gke.Mock
+}
+
+// New returns a GKE handler backed by m.
+func New(m *gke.Mock) *Handler {
+	return &Handler{gke: m}
+}
+
+// Matches accepts /v1/projects/{p}/locations/{l}/{clusters|operations}/...
+// paths. Anything else (functions, instances, databases) belongs to a
+// different handler and falls through.
+func (*Handler) Matches(r *http.Request) bool {
+	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+		return false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
+
+	const (
+		idxScope    = 1 // "locations"
+		idxResource = 3 // "clusters" | "operations"
+	)
+
+	if len(parts) <= idxResource {
+		return false
+	}
+
+	if parts[idxScope] != locationsSeg {
+		return false
+	}
+
+	res := parts[idxResource]
+	if i := strings.Index(res, ":"); i >= 0 {
+		res = res[:i]
+	}
+
+	return res == resourceClusters || res == resourceOperations
+}
+
+// gkePath holds the parsed components of a GKE URL.
+type gkePath struct {
+	project   string
+	location  string
+	resource  string // "clusters" or "operations"
+	name      string // cluster name or operation name
+	subRes    string // "nodePools" when present
+	subName   string // node-pool name
+	action    string // ":setLogging", ":setSize", ":cancel", etc. (no leading colon)
+	actionRes string // resource the action applies to: "cluster" or "nodePool" or "operation"
+}
+
+// parsePath splits a GKE URL into a gkePath. Returns ok=false on malformed.
+//
+
+func parsePath(urlPath string) (gkePath, bool) {
+	rest := strings.TrimPrefix(urlPath, pathPrefix)
+
+	parts := strings.Split(rest, "/")
+
+	const (
+		minParts    = 4 // {project}/locations/{location}/{resource}
+		idxProject  = 0
+		idxScope    = 1
+		idxLocation = 2
+		idxResource = 3
+		idxName     = 4
+		idxSubRes   = 5
+		idxSubName  = 6
+	)
+
+	if len(parts) < minParts || parts[idxScope] != locationsSeg {
+		return gkePath{}, false
+	}
+
+	out := gkePath{
+		project:  parts[idxProject],
+		location: parts[idxLocation],
+		resource: parts[idxResource],
+	}
+
+	// 4th segment may be "{resource}:{action}" for collection-level actions
+	// (none today, but keep symmetry with cloudfunctions).
+	if base, action, ok := splitColon(out.resource); ok {
+		out.resource = base
+		out.action = action
+		out.actionRes = actionResCollection
+	}
+
+	if len(parts) > idxName {
+		parseNameSegment(&out, parts[idxName])
+	}
+
+	if len(parts) > idxSubRes {
+		out.subRes = parts[idxSubRes]
+	}
+
+	if len(parts) > idxSubName {
+		parseSubNameSegment(&out, parts[idxSubName])
+	}
+
+	return out, true
+}
+
+func parseNameSegment(out *gkePath, seg string) {
+	base, action, ok := splitColon(seg)
+	if !ok {
+		out.name = seg
+		return
+	}
+
+	out.name = base
+	out.action = action
+
+	if out.resource == resourceOperations {
+		out.actionRes = actionResOperation
+	} else {
+		out.actionRes = actionResCluster
+	}
+}
+
+func parseSubNameSegment(out *gkePath, seg string) {
+	base, action, ok := splitColon(seg)
+	if !ok {
+		out.subName = seg
+		return
+	}
+
+	out.subName = base
+	out.action = action
+	out.actionRes = actionResNodePool
+}
+
+func splitColon(s string) (base, action string, ok bool) {
+	i := strings.LastIndex(s, ":")
+	if i < 0 {
+		return s, "", false
+	}
+
+	return s[:i], s[i+1:], true
+}
+
+// ServeHTTP routes based on the parsed path.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p, ok := parsePath(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "malformed path")
+		return
+	}
+
+	switch p.resource {
+	case resourceClusters:
+		h.serveClusters(w, r, &p)
+	case resourceOperations:
+		h.serveOperations(w, r, &p)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported resource: "+p.resource)
+	}
+}
+
+func (h *Handler) serveClusters(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if p.action != "" && p.actionRes == actionResCluster {
+		h.clusterAction(w, r, p)
+		return
+	}
+
+	if p.subRes == resourceNodePools {
+		h.serveNodePools(w, r, p)
+		return
+	}
+
+	if p.name == "" {
+		h.serveClusterCollection(w, r, p)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCluster(w, r, p)
+	case http.MethodPut:
+		h.updateCluster(w, r, p)
+	case http.MethodDelete:
+		h.deleteCluster(w, r, p)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveClusterCollection(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createCluster(w, r, p)
+	case http.MethodGet:
+		h.listClusters(w, r, p)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveNodePools(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if p.action != "" && p.actionRes == actionResNodePool {
+		h.nodePoolAction(w, r, p)
+		return
+	}
+
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.createNodePool(w, r, p)
+		case http.MethodGet:
+			h.listNodePools(w, r, p)
+		default:
+			writeMethodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNodePool(w, r, p)
+	case http.MethodPut:
+		h.updateNodePool(w, r, p)
+	case http.MethodDelete:
+		h.deleteNodePool(w, r, p)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveOperations(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if p.action == "cancel" && p.actionRes == actionResOperation {
+		h.cancelOperation(w, r, p)
+		return
+	}
+
+	if p.name == "" {
+		h.listOperations(w, r, p)
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	op, err := h.gke.GetOperation(r.Context(), p.location, p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) cancelOperation(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	if err := h.gke.CancelOperation(r.Context(), p.location, p.name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+func (h *Handler) listOperations(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	ops, err := h.gke.ListOperations(r.Context(), p.location)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listOperationsResp{Operations: make([]gkeOperation, 0, len(ops))}
+	for i := range ops {
+		out.Operations = append(out.Operations, toOperationResource(&ops[i], p.project))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "method not allowed")
+}

--- a/server/gcp/gke/operations.go
+++ b/server/gcp/gke/operations.go
@@ -1,0 +1,469 @@
+package gke
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/providers/gcp/gke"
+)
+
+func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body createClusterReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.Cluster == nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "cluster body required")
+		return
+	}
+
+	in := gke.CreateClusterInput{
+		Name:              body.Cluster.Name,
+		Location:          p.location,
+		Description:       body.Cluster.Description,
+		Network:           body.Cluster.Network,
+		Subnetwork:        body.Cluster.Subnetwork,
+		InitialNodeCount:  body.Cluster.InitialNodeCount,
+		LoggingService:    body.Cluster.LoggingService,
+		MonitoringService: body.Cluster.MonitoringService,
+		ResourceLabels:    body.Cluster.ResourceLabels,
+	}
+
+	for i := range body.Cluster.NodePools {
+		in.NodePools = append(in.NodePools, nodePoolSpecFromWire(&body.Cluster.NodePools[i]))
+	}
+
+	_, op, err := h.gke.CreateCluster(r.Context(), &in)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func nodePoolSpecFromWire(np *gkeNodePool) gke.NodePoolSpec {
+	spec := gke.NodePoolSpec{
+		Name:             np.Name,
+		InitialNodeCount: np.InitialNodeCount,
+		Version:          np.Version,
+	}
+
+	if np.Config != nil {
+		spec.MachineType = np.Config.MachineType
+		spec.DiskSizeGB = np.Config.DiskSizeGb
+	}
+
+	if np.Autoscaling != nil {
+		spec.AutoscalingOn = np.Autoscaling.Enabled
+		spec.AutoscalingMin = np.Autoscaling.MinNodeCount
+		spec.AutoscalingMax = np.Autoscaling.MaxNodeCount
+	}
+
+	return spec
+}
+
+func (h *Handler) getCluster(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	c, err := h.gke.GetCluster(r.Context(), p.location, p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	pools, _ := h.gke.ListNodePools(r.Context(), p.location, p.name)
+
+	writeJSON(w, http.StatusOK, toClusterResource(c, p.project, pools))
+}
+
+func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	clusters, err := h.gke.ListClusters(r.Context(), p.location)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listClustersResp{Clusters: make([]gkeCluster, 0, len(clusters))}
+
+	for i := range clusters {
+		pools, _ := h.gke.ListNodePools(r.Context(), clusters[i].Location, clusters[i].Name)
+		out.Clusters = append(out.Clusters, toClusterResource(&clusters[i], p.project, pools))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body updateClusterReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	in := gke.UpdateClusterInput{}
+
+	if body.Update != nil {
+		in.NodeVersion = body.Update.DesiredNodeVersion
+		in.MasterVersion = body.Update.DesiredMasterVersion
+		in.LoggingService = body.Update.DesiredLoggingService
+		in.MonitoringService = body.Update.DesiredMonitoringService
+		in.ResourceLabels = body.Update.DesiredResourceLabels
+	}
+
+	op, err := h.gke.UpdateCluster(r.Context(), p.location, p.name, in)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	op, err := h.gke.DeleteCluster(r.Context(), p.location, p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+//nolint:gocyclo // single switch over GKE cluster :setX actions; flat dispatch is clearest.
+func (h *Handler) clusterAction(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	switch p.action {
+	case "setLogging":
+		h.setLogging(w, r, p)
+	case "setMonitoring":
+		h.setMonitoring(w, r, p)
+	case "setMasterAuth":
+		h.setMasterAuth(w, r, p)
+	case "setLegacyAbac":
+		h.setLegacyAbac(w, r, p)
+	case "setNetworkPolicy":
+		h.setNetworkPolicy(w, r, p)
+	case "setMaintenancePolicy":
+		h.setMaintenancePolicy(w, r, p)
+	case "setResourceLabels":
+		h.setResourceLabels(w, r, p)
+	case "startIpRotation":
+		h.startIPRotation(w, r, p)
+	case "completeIpRotation":
+		h.completeIPRotation(w, r, p)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported action: "+p.action)
+	}
+}
+
+func (h *Handler) setLogging(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setLoggingReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	op, err := h.gke.SetClusterLogging(r.Context(), p.location, p.name, body.LoggingService)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setMonitoring(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setMonitoringReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	op, err := h.gke.SetClusterMonitoring(r.Context(), p.location, p.name, body.MonitoringService)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setMasterAuth(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setMasterAuthReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	username := ""
+	if body.Update != nil {
+		username = body.Update.Username
+	}
+
+	op, err := h.gke.SetMasterAuth(r.Context(), p.location, p.name, username)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setLegacyAbac(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setLegacyAbacReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	op, err := h.gke.SetLegacyAbac(r.Context(), p.location, p.name, body.Enabled)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setNetworkPolicy(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setNetworkPolicyReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	enabled := false
+	if body.NetworkPolicy != nil {
+		enabled = body.NetworkPolicy.Enabled
+	}
+
+	op, err := h.gke.SetNetworkPolicy(r.Context(), p.location, p.name, enabled)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setMaintenancePolicy(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setMaintenancePolicyReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	window := ""
+	if body.MaintenancePolicy != nil &&
+		body.MaintenancePolicy.Window != nil &&
+		body.MaintenancePolicy.Window.DailyMaintenanceWindow != nil {
+		window = body.MaintenancePolicy.Window.DailyMaintenanceWindow.StartTime
+	}
+
+	op, err := h.gke.SetMaintenancePolicy(r.Context(), p.location, p.name, window)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setResourceLabels(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setLabelsReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	op, err := h.gke.SetResourceLabels(r.Context(), p.location, p.name, body.ResourceLabels)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) startIPRotation(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	op, err := h.gke.StartIPRotation(r.Context(), p.location, p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) completeIPRotation(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	op, err := h.gke.CompleteIPRotation(r.Context(), p.location, p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+// node-pool routes
+
+func (h *Handler) createNodePool(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body createNodePoolReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	if body.NodePool == nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "nodePool body required")
+		return
+	}
+
+	spec := nodePoolSpecFromWire(body.NodePool)
+
+	_, op, err := h.gke.CreateNodePool(r.Context(), p.location, p.name, &spec)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) getNodePool(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	np, err := h.gke.GetNodePool(r.Context(), p.location, p.name, p.subName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toNodePoolResource(np, p.project))
+}
+
+func (h *Handler) listNodePools(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	pools, err := h.gke.ListNodePools(r.Context(), p.location, p.name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listNodePoolsResp{NodePools: make([]gkeNodePool, 0, len(pools))}
+	for i := range pools {
+		out.NodePools = append(out.NodePools, toNodePoolResource(&pools[i], p.project))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) updateNodePool(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body updateNodePoolReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	in := gke.UpdateNodePoolInput{
+		NodeVersion: body.NodeVersion,
+		MachineType: body.MachineType,
+		DiskSizeGB:  body.DiskSizeGb,
+	}
+
+	op, err := h.gke.UpdateNodePool(r.Context(), p.location, p.name, p.subName, in)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) deleteNodePool(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	op, err := h.gke.DeleteNodePool(r.Context(), p.location, p.name, p.subName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) nodePoolAction(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	switch p.action {
+	case "setSize":
+		h.setNodePoolSize(w, r, p)
+	case "setAutoscaling":
+		h.setNodePoolAutoscaling(w, r, p)
+	case "setManagement":
+		h.setNodePoolManagement(w, r, p)
+	case "rollback":
+		h.rollbackNodePool(w, r, p)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unsupported node-pool action: "+p.action)
+	}
+}
+
+func (h *Handler) setNodePoolSize(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setNodePoolSizeReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	op, err := h.gke.SetNodePoolSize(r.Context(), p.location, p.name, p.subName, body.NodeCount)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setNodePoolAutoscaling(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setNodePoolAutoscalingReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	on, minN, maxN := false, int64(0), int64(0)
+	if body.Autoscaling != nil {
+		on = body.Autoscaling.Enabled
+		minN = body.Autoscaling.MinNodeCount
+		maxN = body.Autoscaling.MaxNodeCount
+	}
+
+	op, err := h.gke.SetNodePoolAutoscaling(r.Context(), p.location, p.name, p.subName, on, minN, maxN)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) setNodePoolManagement(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	var body setNodePoolManagementReq
+	if !decodeJSON(w, r, &body) {
+		return
+	}
+
+	autoUpgrade, autoRepair := false, false
+	if body.Management != nil {
+		autoUpgrade = body.Management.AutoUpgrade
+		autoRepair = body.Management.AutoRepair
+	}
+
+	op, err := h.gke.SetNodePoolManagement(r.Context(), p.location, p.name, p.subName, autoUpgrade, autoRepair)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}
+
+func (h *Handler) rollbackNodePool(w http.ResponseWriter, r *http.Request, p *gkePath) {
+	op, err := h.gke.RollbackNodePool(r.Context(), p.location, p.name, p.subName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOperationResource(op, p.project))
+}

--- a/server/gcp/gke/sdk_roundtrip_test.go
+++ b/server/gcp/gke/sdk_roundtrip_test.go
@@ -1,0 +1,352 @@
+package gke_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gkeprov "github.com/stackshy/cloudemu/providers/gcp/gke"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+func newSDKClient(t *testing.T) (*container.Service, string) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{
+		GKE: cloud.GKE,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := container.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("container.NewService: %v", err)
+	}
+
+	return svc, "mock-project"
+}
+
+func parent(project, location string) string {
+	return "projects/" + project + "/locations/" + location
+}
+
+func clusterName(project, location, cluster string) string {
+	return parent(project, location) + "/clusters/" + cluster
+}
+
+func nodePoolName(project, location, cluster, pool string) string {
+	return clusterName(project, location, cluster) + "/nodePools/" + pool
+}
+
+func TestSDKGKECreateGetList(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	op, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{
+			Name:             "prod",
+			InitialNodeCount: 3,
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Create: %v", err)
+	}
+
+	if op.Status != "DONE" {
+		t.Fatalf("got op status %q, want DONE", op.Status)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "prod")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get: %v", err)
+	}
+
+	if got.Name != "prod" {
+		t.Fatalf("got name %q, want prod", got.Name)
+	}
+
+	if got.Status != "RUNNING" {
+		t.Fatalf("got status %q, want RUNNING", got.Status)
+	}
+
+	if !strings.Contains(got.Endpoint, gkeprov.StubEndpoint) {
+		t.Fatalf("expected Wave-2 stub endpoint, got %q", got.Endpoint)
+	}
+
+	if got.MasterAuth == nil || got.MasterAuth.ClusterCaCertificate == "" {
+		t.Fatal("expected non-empty stub clusterCaCertificate")
+	}
+
+	if len(got.NodePools) == 0 {
+		t.Fatal("expected default node pool to be present")
+	}
+
+	list, err := svc.Projects.Locations.Clusters.List(parent(project, loc)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.List: %v", err)
+	}
+
+	if len(list.Clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(list.Clusters))
+	}
+}
+
+func TestSDKGKEUpdateAndDelete(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "alpha"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.Update(clusterName(project, loc, "alpha"),
+		&container.UpdateClusterRequest{
+			Update: &container.ClusterUpdate{
+				DesiredLoggingService:    "none",
+				DesiredMonitoringService: "none",
+			},
+		}).Context(ctx).Do(); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.SetResourceLabels(clusterName(project, loc, "alpha"),
+		&container.SetLabelsRequest{ResourceLabels: map[string]string{"env": "test"}}).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("setResourceLabels: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "alpha")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+
+	if got.LoggingService != "none" {
+		t.Fatalf("got logging %q, want none", got.LoggingService)
+	}
+
+	if got.ResourceLabels["env"] != "test" {
+		t.Fatalf("got label env=%q, want test", got.ResourceLabels["env"])
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.Delete(clusterName(project, loc, "alpha")).Context(ctx).Do(); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.Get(clusterName(project, loc, "alpha")).Context(ctx).Do(); err == nil {
+		t.Fatal("expected NotFound after delete")
+	}
+}
+
+//nolint:funlen // exercises every cluster-level :setX endpoint.
+func TestSDKGKEClusterSetters(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	cname := clusterName(project, loc, "tweaks")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "tweaks"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	calls := []struct {
+		name string
+		fn   func() error
+	}{
+		{"setLogging", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetLogging(cname, &container.SetLoggingServiceRequest{
+				LoggingService: "logging.googleapis.com/kubernetes",
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"setMonitoring", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetMonitoring(cname, &container.SetMonitoringServiceRequest{
+				MonitoringService: "monitoring.googleapis.com/kubernetes",
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"setMasterAuth", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetMasterAuth(cname, &container.SetMasterAuthRequest{
+				Action: "SET_USERNAME",
+				Update: &container.MasterAuth{Username: "admin"},
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"setLegacyAbac", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetLegacyAbac(cname, &container.SetLegacyAbacRequest{
+				Enabled: true,
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"setNetworkPolicy", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetNetworkPolicy(cname, &container.SetNetworkPolicyRequest{
+				NetworkPolicy: &container.NetworkPolicy{Enabled: true},
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"setMaintenancePolicy", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetMaintenancePolicy(cname, &container.SetMaintenancePolicyRequest{
+				MaintenancePolicy: &container.MaintenancePolicy{
+					Window: &container.MaintenanceWindow{
+						DailyMaintenanceWindow: &container.DailyMaintenanceWindow{StartTime: "03:00"},
+					},
+				},
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"setResourceLabels", func() error {
+			_, err := svc.Projects.Locations.Clusters.SetResourceLabels(cname, &container.SetLabelsRequest{
+				ResourceLabels: map[string]string{"team": "core"},
+			}).Context(ctx).Do()
+			return err
+		}},
+		{"startIpRotation", func() error {
+			_, err := svc.Projects.Locations.Clusters.StartIpRotation(cname, &container.StartIPRotationRequest{}).Context(ctx).Do()
+			return err
+		}},
+		{"completeIpRotation", func() error {
+			_, err := svc.Projects.Locations.Clusters.CompleteIpRotation(cname, &container.CompleteIPRotationRequest{}).Context(ctx).Do()
+			return err
+		}},
+	}
+
+	for _, c := range calls {
+		if err := c.fn(); err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+	}
+}
+
+func TestSDKGKENodePools(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+	parentClus := clusterName(project, loc, "host")
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "host"},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("create cluster: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Create(parentClus, &container.CreateNodePoolRequest{
+		NodePool: &container.NodePool{
+			Name:             "extra",
+			InitialNodeCount: 2,
+			Config:           &container.NodeConfig{MachineType: "e2-standard-4", DiskSizeGb: 50},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("nodepool create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.NodePools.Get(nodePoolName(project, loc, "host", "extra")).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool get: %v", err)
+	}
+
+	if got.Name != "extra" {
+		t.Fatalf("got %q, want extra", got.Name)
+	}
+
+	if got.InitialNodeCount != 2 {
+		t.Fatalf("got count %d, want 2", got.InitialNodeCount)
+	}
+
+	list, err := svc.Projects.Locations.Clusters.NodePools.List(parentClus).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("nodepool list: %v", err)
+	}
+
+	if len(list.NodePools) != 2 { // default-pool + extra
+		t.Fatalf("got %d pools, want 2", len(list.NodePools))
+	}
+
+	npFull := nodePoolName(project, loc, "host", "extra")
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.SetSize(npFull, &container.SetNodePoolSizeRequest{
+		NodeCount: 5,
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("setSize: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.SetAutoscaling(npFull, &container.SetNodePoolAutoscalingRequest{
+		Autoscaling: &container.NodePoolAutoscaling{Enabled: true, MinNodeCount: 1, MaxNodeCount: 10},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("setAutoscaling: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.SetManagement(npFull, &container.SetNodePoolManagementRequest{
+		Management: &container.NodeManagement{AutoUpgrade: false, AutoRepair: false},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("setManagement: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Update(npFull, &container.UpdateNodePoolRequest{
+		NodeVersion: "1.31.0-gke.0",
+		MachineType: "e2-standard-8",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Rollback(npFull, &container.RollbackNodePoolUpgradeRequest{}).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	if _, err := svc.Projects.Locations.Clusters.NodePools.Delete(npFull).Context(ctx).Do(); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestSDKGKEOperations(t *testing.T) {
+	svc, project := newSDKClient(t)
+	ctx := context.Background()
+	loc := "us-central1"
+
+	op, err := svc.Projects.Locations.Clusters.Create(parent(project, loc), &container.CreateClusterRequest{
+		Cluster: &container.Cluster{Name: "prod"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Operations.Get(parent(project, loc) + "/operations/" + op.Name).
+		Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("operations.get: %v", err)
+	}
+
+	if got.Status != "DONE" {
+		t.Fatalf("got status %q, want DONE", got.Status)
+	}
+
+	list, err := svc.Projects.Locations.Operations.List(parent(project, loc)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("operations.list: %v", err)
+	}
+
+	if len(list.Operations) == 0 {
+		t.Fatal("expected at least one operation")
+	}
+
+	if _, err := svc.Projects.Locations.Operations.Cancel(parent(project, loc)+"/operations/"+op.Name,
+		&container.CancelOperationRequest{}).Context(ctx).Do(); err != nil {
+		t.Fatalf("operations.cancel: %v", err)
+	}
+}

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -1,0 +1,290 @@
+package gke
+
+import (
+	"encoding/json"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/providers/gcp/gke"
+)
+
+// gkeCluster mirrors google.golang.org/api/container/v1.Cluster's wire shape
+// for the fields we honor. Anything we don't care about round-trips as zero
+// values via the standard json package.
+type gkeCluster struct {
+	Name              string            `json:"name,omitempty"`
+	Description       string            `json:"description,omitempty"`
+	Location          string            `json:"location,omitempty"`
+	Network           string            `json:"network,omitempty"`
+	Subnetwork        string            `json:"subnetwork,omitempty"`
+	InitialNodeCount  int64             `json:"initialNodeCount,omitempty"`
+	LoggingService    string            `json:"loggingService,omitempty"`
+	MonitoringService string            `json:"monitoringService,omitempty"`
+	ResourceLabels    map[string]string `json:"resourceLabels,omitempty"`
+	NodePools         []gkeNodePool     `json:"nodePools,omitempty"`
+	NodeIpv4CIDRSize  int64             `json:"nodeIpv4CidrSize,omitempty"`
+	ClusterIpv4Cidr   string            `json:"clusterIpv4Cidr,omitempty"`
+	Endpoint          string            `json:"endpoint,omitempty"`
+	MasterAuth        *gkeMasterAuth    `json:"masterAuth,omitempty"`
+	Status            string            `json:"status,omitempty"`
+	SelfLink          string            `json:"selfLink,omitempty"`
+	CurrentMasterVer  string            `json:"currentMasterVersion,omitempty"`
+	CurrentNodeVer    string            `json:"currentNodeVersion,omitempty"`
+	CreateTime        string            `json:"createTime,omitempty"`
+}
+
+type gkeMasterAuth struct {
+	Username                string `json:"username,omitempty"`
+	ClusterCaCertificate    string `json:"clusterCaCertificate,omitempty"`
+	ClientCertificate       string `json:"clientCertificate,omitempty"`
+	ClientKey               string `json:"clientKey,omitempty"`
+	ClientCertificateConfig any    `json:"clientCertificateConfig,omitempty"`
+}
+
+type gkeNodePool struct {
+	Name             string             `json:"name,omitempty"`
+	Version          string             `json:"version,omitempty"`
+	InitialNodeCount int64              `json:"initialNodeCount,omitempty"`
+	Locations        []string           `json:"locations,omitempty"`
+	Config           *gkeNodeConfig     `json:"config,omitempty"`
+	Autoscaling      *gkeAutoscaling    `json:"autoscaling,omitempty"`
+	Management       *gkeNodeManagement `json:"management,omitempty"`
+	Status           string             `json:"status,omitempty"`
+	SelfLink         string             `json:"selfLink,omitempty"`
+}
+
+type gkeNodeConfig struct {
+	MachineType string `json:"machineType,omitempty"`
+	DiskSizeGb  int64  `json:"diskSizeGb,omitempty"`
+}
+
+type gkeAutoscaling struct {
+	Enabled      bool  `json:"enabled,omitempty"`
+	MinNodeCount int64 `json:"minNodeCount,omitempty"`
+	MaxNodeCount int64 `json:"maxNodeCount,omitempty"`
+}
+
+type gkeNodeManagement struct {
+	AutoUpgrade bool `json:"autoUpgrade,omitempty"`
+	AutoRepair  bool `json:"autoRepair,omitempty"`
+}
+
+// Request envelopes — only the fields we read are listed here.
+
+type createClusterReq struct {
+	Cluster *gkeCluster `json:"cluster,omitempty"`
+}
+
+type updateClusterReq struct {
+	Update *struct {
+		DesiredNodeVersion       string            `json:"desiredNodeVersion,omitempty"`
+		DesiredMasterVersion     string            `json:"desiredMasterVersion,omitempty"`
+		DesiredLoggingService    string            `json:"desiredLoggingService,omitempty"`
+		DesiredMonitoringService string            `json:"desiredMonitoringService,omitempty"`
+		DesiredResourceLabels    map[string]string `json:"desiredResourceLabels,omitempty"`
+	} `json:"update,omitempty"`
+}
+
+type setLoggingReq struct {
+	LoggingService string `json:"loggingService,omitempty"`
+}
+
+type setMonitoringReq struct {
+	MonitoringService string `json:"monitoringService,omitempty"`
+}
+
+type setMasterAuthReq struct {
+	Action string `json:"action,omitempty"`
+	Update *struct {
+		Username string `json:"username,omitempty"`
+		Password string `json:"password,omitempty"`
+	} `json:"update,omitempty"`
+}
+
+type setLegacyAbacReq struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+type setNetworkPolicyReq struct {
+	NetworkPolicy *struct {
+		Enabled bool `json:"enabled,omitempty"`
+	} `json:"networkPolicy,omitempty"`
+}
+
+type setMaintenancePolicyReq struct {
+	MaintenancePolicy *struct {
+		Window *struct {
+			DailyMaintenanceWindow *struct {
+				StartTime string `json:"startTime,omitempty"`
+			} `json:"dailyMaintenanceWindow,omitempty"`
+		} `json:"window,omitempty"`
+	} `json:"maintenancePolicy,omitempty"`
+}
+
+type setLabelsReq struct {
+	ResourceLabels map[string]string `json:"resourceLabels,omitempty"`
+}
+
+type createNodePoolReq struct {
+	NodePool *gkeNodePool `json:"nodePool,omitempty"`
+}
+
+type updateNodePoolReq struct {
+	NodeVersion string `json:"nodeVersion,omitempty"`
+	MachineType string `json:"machineType,omitempty"`
+	DiskSizeGb  int64  `json:"diskSizeGb,omitempty"`
+}
+
+type setNodePoolSizeReq struct {
+	NodeCount int64 `json:"nodeCount,omitempty"`
+}
+
+type setNodePoolAutoscalingReq struct {
+	Autoscaling *gkeAutoscaling `json:"autoscaling,omitempty"`
+}
+
+type setNodePoolManagementReq struct {
+	Management *gkeNodeManagement `json:"management,omitempty"`
+}
+
+type listClustersResp struct {
+	Clusters []gkeCluster `json:"clusters"`
+}
+
+type listNodePoolsResp struct {
+	NodePools []gkeNodePool `json:"nodePools"`
+}
+
+type listOperationsResp struct {
+	Operations []gkeOperation `json:"operations"`
+}
+
+type gkeOperation struct {
+	Name          string `json:"name,omitempty"`
+	OperationType string `json:"operationType,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Location      string `json:"location,omitempty"`
+	TargetLink    string `json:"targetLink,omitempty"`
+	StartTime     string `json:"startTime,omitempty"`
+	EndTime       string `json:"endTime,omitempty"`
+	SelfLink      string `json:"selfLink,omitempty"`
+}
+
+// toClusterResource converts a provider Cluster into the wire shape, populating
+// the Wave-1 stub Endpoint and CA certificate so SDK consumers see a complete
+// envelope. The endpoint hostname encodes that the data-plane is a stub.
+func toClusterResource(c *gke.Cluster, project string, pools []gke.NodePool) gkeCluster {
+	out := gkeCluster{
+		Name:              c.Name,
+		Description:       c.Description,
+		Location:          c.Location,
+		Network:           c.Network,
+		Subnetwork:        c.Subnetwork,
+		InitialNodeCount:  c.InitialNodeCount,
+		LoggingService:    c.LoggingService,
+		MonitoringService: c.MonitoringService,
+		ResourceLabels:    c.ResourceLabels,
+		NodeIpv4CIDRSize:  c.NodeIPv4CIDRSize,
+		ClusterIpv4Cidr:   c.ClusterIPv4CIDR,
+		Endpoint:          gke.StubEndpoint,
+		MasterAuth: &gkeMasterAuth{
+			Username:             c.MasterUsername,
+			ClusterCaCertificate: gke.StubCACert,
+		},
+		Status:           c.Status,
+		CurrentMasterVer: gke.StubMasterVer,
+		CurrentNodeVer:   gke.StubMasterVer,
+		SelfLink:         "projects/" + project + "/locations/" + c.Location + "/clusters/" + c.Name,
+		CreateTime:       c.CreatedAt.Format("2006-01-02T15:04:05.000Z"),
+	}
+
+	for i := range pools {
+		out.NodePools = append(out.NodePools, toNodePoolResource(&pools[i], project))
+	}
+
+	return out
+}
+
+func toNodePoolResource(np *gke.NodePool, project string) gkeNodePool {
+	out := gkeNodePool{
+		Name:             np.Name,
+		Version:          np.Version,
+		InitialNodeCount: np.NodeCount,
+		Config: &gkeNodeConfig{
+			MachineType: np.MachineType,
+			DiskSizeGb:  np.DiskSizeGB,
+		},
+		Management: &gkeNodeManagement{
+			AutoUpgrade: np.AutoUpgrade,
+			AutoRepair:  np.AutoRepair,
+		},
+		Status: np.Status,
+		SelfLink: "projects/" + project + "/locations/" + np.Location +
+			"/clusters/" + np.ClusterName + "/nodePools/" + np.Name,
+	}
+
+	if np.AutoscalingOn || np.AutoscalingMin > 0 || np.AutoscalingMax > 0 {
+		out.Autoscaling = &gkeAutoscaling{
+			Enabled:      np.AutoscalingOn,
+			MinNodeCount: np.AutoscalingMin,
+			MaxNodeCount: np.AutoscalingMax,
+		}
+	}
+
+	return out
+}
+
+func toOperationResource(op *gke.Operation, project string) gkeOperation {
+	return gkeOperation{
+		Name:          op.Name,
+		OperationType: op.OperationType,
+		Status:        op.Status,
+		Location:      op.Location,
+		TargetLink:    op.TargetLink,
+		StartTime:     op.StartTime.Format("2006-01-02T15:04:05.000Z"),
+		EndTime:       op.EndTime.Format("2006-01-02T15:04:05.000Z"),
+		SelfLink:      "projects/" + project + "/locations/" + op.Location + "/operations/" + op.Name,
+	}
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, reason, msg string) {
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"message": msg,
+			"status":  reason,
+		},
+	})
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusConflict, "FAILED_PRECONDITION", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}


### PR DESCRIPTION
Closes #169.

## Scope (Wave 1 — control plane only; data-plane deferred to Wave 2)

This PR ships only the GKE control-plane SDK surface. The Kubernetes data-plane API (Deployments, StatefulSets, Pods, Services) is intentionally out of scope and will land in Wave 2 alongside a Kubernetes API server stub. To keep `gcloud container clusters get-credentials` ergonomic, GetCluster returns a stub `endpoint` (`GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local`) and a stub `masterAuth.clusterCaCertificate` — actual API calls against the rendered kubeconfig will fail until Wave 2 lands.

## What's in

- `providers/gcp/gke/` — in-memory mock backing Clusters, NodePools, and Operations. Uses `memstore.Store[V]`, `cerrors`, `idgen.GCPID`. Emits `container.googleapis.com` metrics (CPU, memory, node count) on cluster creation.
- `server/gcp/gke/` — REST handler implementing the container.googleapis.com SDK surface. Mutations return DONE Operation envelopes so SDK pollers terminate on the first response.
- Wiring: `providers/gcp/gcp.go` initializes `GKE *gke.Mock` and calls `SetMonitoring(p.CloudMonitoring)`; `server/gcp/gcp.go` registers the handler before Firestore (same `/v1/projects/` namespace, narrowed by 4th-segment guard so it claims only `clusters`/`operations`).

## Operations implemented

- **Clusters**: Create, Get, List, Update, Delete, `:setLogging`, `:setMonitoring`, `:setMasterAuth`, `:setLegacyAbac`, `:setNetworkPolicy`, `:setMaintenancePolicy`, `:setResourceLabels`, `:startIpRotation`, `:completeIpRotation`.
- **NodePools**: Create, Get, List, Update, Delete, `:setSize`, `:setAutoscaling`, `:setManagement`, `:rollback`.
- **Operations**: Get, List, `:cancel`.

## Tests

- `providers/gcp/gke/gke_test.go` — provider mock unit tests using hand-rolled require/assert helpers (no testify).
- `server/gcp/gke/sdk_roundtrip_test.go` — real `google.golang.org/api/container/v1` client wired against `httptest.NewServer(srv)` with `option.WithEndpoint(ts.URL)` + `option.WithoutAuthentication()`. Covers cluster lifecycle, every cluster-level setter, full node-pool lifecycle, and operations (get/list/cancel).

## Verification

- `go build ./...` — clean.
- `go test ./...` — all 118 packages pass.
- `golangci-lint run --timeout=9m ./...` — 0 issues.

## Test plan

- [x] Provider tests pass for cluster lifecycle, node-pool lifecycle, cluster setters, cascading delete, and operations.
- [x] SDK round-trip tests pass with the real `container/v1` client against the in-memory server.
- [x] Handler dispatch leaves Cloud SQL, Cloud Functions, Pub/Sub, and Firestore traffic on `/v1/projects/` undisturbed.
- [ ] Manual smoke: point a `container.NewService` client at a `cloudemu` server and exercise `gcloud container clusters list` via the SDK.