### PR TITLE
docs: refresh README + docs for v1.6.2 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,246 +11,117 @@
   <a href="https://pkg.go.dev/github.com/stackshy/cloudemu"><img src="https://pkg.go.dev/badge/github.com/stackshy/cloudemu.svg" alt="Go Reference"></a>
   <a href="https://goreportcard.com/report/github.com/stackshy/cloudemu"><img src="https://goreportcard.com/badge/github.com/stackshy/cloudemu" alt="Go Report Card"></a>
   <a href="https://github.com/stackshy/cloudemu/blob/development/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
-  <a href="https://github.com/stackshy/cloudemu/actions"><img src="https://img.shields.io/github/actions/workflow/status/stackshy/cloudemu/go.yml?branch=development&label=tests" alt="Tests"></a>
   <img src="https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white" alt="Go Version">
   <img src="https://img.shields.io/badge/providers-AWS_|_Azure_|_GCP-orange" alt="Providers">
   <img src="https://img.shields.io/badge/cost-$0-brightgreen" alt="Zero Cost">
-  <a href="https://cloudemu.vercel.app"><img src="https://img.shields.io/badge/docs-cloudemu.vercel.app-blueviolet" alt="Documentation"></a>
 </p>
 
 ---
 
-cloudemu is a Go library that emulates cloud services entirely in memory. No real cloud accounts, no Docker, no network calls. Import the package, create a provider, and test your cloud code instantly.
+## What it does
 
-```go
-aws := cloudemu.NewAWS()
-azure := cloudemu.NewAzure()
-gcp := cloudemu.NewGCP()
-```
+cloudemu emulates AWS, Azure, and GCP cloud services entirely in memory, so you can test cloud-dependent code without real accounts, Docker, or network calls.
 
-## Installation
+It ships two surfaces you can mix and match:
+
+- **SDK-compat HTTP server** — point the real `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go` clients at a local endpoint and they just work. No code changes in your app.
+- **Go API** — typed in-memory mocks (`aws.S3`, `azure.VirtualMachines`, `gcp.GCE`, …) for tests written against cloudemu directly.
+
+## Install
 
 ```bash
 go get github.com/stackshy/cloudemu
 ```
 
-Requires Go 1.25.0+.
+Requires Go 1.25+.
 
-## The Problem
+## How it works (SDK-compat)
 
-Testing cloud-dependent code is painful. You either pay for real accounts, wrestle with heavy emulators that need Docker, or write incomplete mocks from scratch.
-
-| Approach | Cost | Speed | Offline |
-|----------|------|-------|---------|
-| Real cloud (AWS/Azure/GCP) | $$$ | Slow (seconds) | No |
-| LocalStack / Emulators | $ | Medium (100ms+) | Yes |
-| **cloudemu** | **Free** | **Fast (~10ms)** | **Yes** |
-
-## How It Works
-
-cloudemu provides mock implementations of cloud services that behave like the real thing. Each provider (AWS, Azure, GCP) gives you typed access to all supported services. You call the same operations you'd call in production — create resources, read data, manage lifecycle — and cloudemu handles it in memory with realistic behavior.
-
-### Example: EC2 Compute
-
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-
-    "github.com/stackshy/cloudemu"
-    "github.com/stackshy/cloudemu/compute/driver"
-)
-
-func main() {
-    ctx := context.Background()
-    aws := cloudemu.NewAWS()
-
-    // Launch 2 instances — they start in "pending" and transition to "running"
-    instances, _ := aws.EC2.RunInstances(ctx, driver.InstanceConfig{
-        ImageID:      "ami-0abcdef1234567890",
-        InstanceType: "t2.micro",
-        Tags:         map[string]string{"env": "test"},
-    }, 2)
-
-    fmt.Println(instances[0].State) // "running"
-    fmt.Println(instances[0].ID)    // "i-00000001"
-
-    // Stop an instance — state machine enforces valid transitions
-    _ = aws.EC2.StopInstances(ctx, []string{instances[0].ID})
-
-    // Describe to check state
-    desc, _ := aws.EC2.DescribeInstances(ctx, []string{instances[0].ID}, nil)
-    fmt.Println(desc[0].State) // "stopped"
-
-    // Terminate
-    _ = aws.EC2.TerminateInstances(ctx, []string{instances[0].ID})
-
-    // Trying to stop a terminated instance returns an error — just like real EC2
-    err := aws.EC2.StopInstances(ctx, []string{instances[0].ID})
-    fmt.Println(err) // "cannot stop instance: invalid transition"
-}
-```
-
-This same pattern works across all services and all three providers. Replace `aws.EC2` with `azure.VirtualMachines` or `gcp.GCE` and the code behaves identically.
-
-## What Makes It Realistic
-
-cloudemu goes beyond basic CRUD mocks. It reproduces real cloud behaviors so your tests catch real issues:
-
-- **State Machines** — VMs enforce valid lifecycle transitions (`pending → running → stopped → terminated`). Illegal transitions return errors.
-- **Auto-Metrics** — Launching a VM automatically pushes CPU, Network, and Disk metrics to the monitoring service. Stop/start/terminate emit corresponding metric values.
-- **Alarm Evaluation** — Push metric data and alarms automatically transition between `OK` and `ALARM` based on threshold comparison.
-- **IAM Policy Evaluation** — Parses JSON policy documents with wildcard matching. Explicit `Deny` overrides `Allow`.
-- **FIFO Deduplication** — FIFO queues enforce 5-minute deduplication windows.
-- **Dead-Letter Queues** — Messages exceeding max receive count move to the DLQ automatically.
-- **TTL Expiry** — Cached items and database records expire after their TTL. Lazy cleanup on read.
-- **Stream/Change Feed** — Database mutations produce stream records (INSERT/MODIFY/REMOVE).
-- **Numeric-Aware Comparisons** — Database filters compare `"10" > "9"` correctly using numeric ordering.
-
-## Chaos Engineering — Test Your App Against Cloud Failure
-
-CloudEmu can deliberately fail or slow down services in controlled, time-bounded windows, so retry logic, timeouts, and graceful-degradation paths in your code can actually be exercised.
-
-```go
-engine := chaos.New(config.RealClock{})
-chaosS3 := chaos.WrapBucket(cloud.S3, engine)
-
-// Run your app against this S3...
-engine.Apply(chaos.ServiceOutage("storage", 5*time.Second))
-// ...calls fail for 5 seconds, then recover automatically.
-```
-
-Scenarios available today: `ServiceOutage`, `LatencySpike`, `ProbabilisticFailure`, `Throttle`, `Composite`. Works for both Go API and SDK-compat HTTP clients. See [docs/chaos.md](docs/chaos.md).
-
-## Use the Real Cloud SDKs (no code changes)
-
-If your app already uses `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go`, you don't have to rewrite anything. cloudemu ships HTTP servers that speak the real wire protocols of all three providers. Point the SDK's endpoint at localhost and your production code just works.
+Most apps already use the official cloud SDKs. cloudemu speaks the same wire protocols (AWS Query/JSON/Smithy, Azure ARM, GCP REST) over a local `httptest.NewServer`. Change the SDK endpoint, and the same production code runs against an in-memory backend.
 
 ```go
 import (
+    "net/http/httptest"
+
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/service/s3"
     "github.com/stackshy/cloudemu"
-    awsserver   "github.com/stackshy/cloudemu/server/aws"
-    azureserver "github.com/stackshy/cloudemu/server/azure"
-    gcpserver   "github.com/stackshy/cloudemu/server/gcp"
+    awsserver "github.com/stackshy/cloudemu/server/aws"
 )
 
-// AWS
-aws := cloudemu.NewAWS()
-awsTS := httptest.NewServer(awsserver.New(awsserver.Drivers{
-    S3:     aws.S3,     DynamoDB: aws.DynamoDB, EC2: aws.EC2, VPC: aws.VPC,
-    Lambda: aws.Lambda, SQS:      aws.SQS,      CloudWatch: aws.CloudWatch,
+cloud := cloudemu.NewAWS()
+ts := httptest.NewServer(awsserver.New(awsserver.Drivers{
+    S3:       cloud.S3,
+    DynamoDB: cloud.DynamoDB,
+    EC2:      cloud.EC2,
+    RDS:      cloud.RDS,
+    EKS:      cloud.EKS,
+    // …leave fields nil to omit a service
 }))
+defer ts.Close()
 
-// Azure (TLS — Azure SDK refuses bearer tokens over plain HTTP)
-az := cloudemu.NewAzure()
-azureTS := httptest.NewTLSServer(azureserver.New(azureserver.Drivers{
-    VirtualMachines: az.VirtualMachines, BlobStorage: az.BlobStorage,
-    CosmosDB: az.CosmosDB, Network: az.VNet, Monitor: az.Monitor,
-    Functions: az.Functions, ServiceBus: az.ServiceBus,
-}))
-
-// GCP
-gcp := cloudemu.NewGCP()
-gcpTS := httptest.NewServer(gcpserver.New(gcpserver.Drivers{
-    Compute: gcp.GCE, Networking: gcp.VPC, Storage: gcp.GCS,
-    Firestore: gcp.Firestore, Monitoring: gcp.CloudMonitoring,
-    CloudFunctions: gcp.CloudFunctions, PubSub: gcp.PubSub,
-}))
-
-// Use the REAL SDK clients — only the endpoint changes.
-s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-    o.BaseEndpoint = aws.String(awsTS.URL)
+client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String(ts.URL)
     o.UsePathStyle = true
 })
-s3Client.PutObject(ctx, &s3.PutObjectInput{...}) // works
+
+client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory backend
 ```
 
-Currently covered (lockstep across all 3 providers):
+Equivalent setups for Azure (`azureserver.New`) and GCP (`gcpserver.New`) are in [docs/sdk-server.md](docs/sdk-server.md).
+
+## Or use the Go API directly
+
+```go
+aws := cloudemu.NewAWS()
+
+instances, _ := aws.EC2.RunInstances(ctx, driver.InstanceConfig{
+    ImageID:      "ami-0abcdef1234567890",
+    InstanceType: "t2.micro",
+}, 2)
+
+_ = aws.EC2.StopInstances(ctx, []string{instances[0].ID})
+
+desc, _ := aws.EC2.DescribeInstances(ctx, []string{instances[0].ID}, nil)
+// desc[0].State == "stopped"
+```
+
+The same pattern works across all services and all three providers — swap `aws.EC2` for `azure.VirtualMachines` or `gcp.GCE`.
+
+## What's supported
+
+SDK-compat coverage across AWS, Azure, and GCP:
 
 | Domain | AWS | Azure | GCP |
-|--------|-----|-------|-----|
-| **Storage** | S3 | Blob (containers + blobs, copy) | GCS |
-| **Compute** | EC2 (+ VPC/Subnets/SG/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/KeyPairs/AMIs/Snapshots/Spot/LaunchTemplates) | VirtualMachines (+ Disks, Snapshots, Images, SSH keys) | Compute Engine (+ Disks, Snapshots, Images) |
-| **Database** | DynamoDB (CRUD, Query, Scan, Batch, TransactWrite) | Cosmos DB (DBs, containers, documents) | Firestore (commit, batchGet, runQuery) |
-| **Networking** | (in EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
-| **Monitoring** | CloudWatch (Smithy rpc-v2-cbor) | Azure Monitor | Cloud Monitoring (alert policies + time series) |
-| **Serverless** | Lambda (lifecycle + Invoke) | Functions (`Microsoft.Web/sites` + `/api/{name}` invoke) | Cloud Functions v1 (lifecycle + `:call`) |
-| **Message Queue** | SQS (JSON-RPC) | Service Bus (ARM + REST data plane) | Pub/Sub (topics/subs + publish/pull/ack) |
+|---|---|---|---|
+| Storage | S3 | Blob Storage | GCS |
+| Compute | EC2 (+ VPC, EBS, Snapshots, AMIs, Spot, Launch Templates, Auto Scaling) | Virtual Machines (+ Disks, Snapshots, Images, SSH keys) | Compute Engine (+ Disks, Snapshots, Images) |
+| NoSQL DB | DynamoDB | Cosmos DB | Firestore |
+| Relational DB | RDS + Aurora (incl. Neptune & DocumentDB engines), Redshift | SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server | Cloud SQL |
+| Kubernetes | EKS (control plane) | AKS (control plane) | GKE (control plane) |
+| Serverless | Lambda | Functions | Cloud Functions v1 |
+| Message Queue | SQS | Service Bus | Pub/Sub |
+| Networking | VPC (under EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
+| Monitoring | CloudWatch | Azure Monitor | Cloud Monitoring |
 
-More services land progressively — see [docs/sdk-server.md](docs/sdk-server.md).
+The Kubernetes control plane is Wave 1 — cluster, node-pool, and addon/Fargate/maintenance-config lifecycle. The data plane (Pods/Services/Deployments) is deferred; stub kubeconfigs point at a clear `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` sentinel.
 
-## Cross-Cutting Features
+Full per-service operation list: [docs/services.md](docs/services.md).
+Per-handler protocol details and limitations: [docs/sdk-server.md](docs/sdk-server.md).
 
-Every service can be wrapped with a portable API layer that adds test-oriented features:
+## More
 
-```go
-bucket := storage.NewBucket(aws.S3,
-    storage.WithRecorder(rec),              // record every API call
-    storage.WithMetrics(mc),                // track call counts and durations
-    storage.WithErrorInjection(inj),        // simulate cloud failures
-    storage.WithRateLimiter(limiter),       // simulate API throttling
-    storage.WithLatency(5*time.Millisecond),// simulate network delay
-)
-```
+- [docs/getting-started.md](docs/getting-started.md) — set up a test in 5 minutes
+- [docs/architecture.md](docs/architecture.md) — three-layer design, factory wiring
+- [docs/features.md](docs/features.md) — auto-metrics, alarm evaluation, IAM policy evaluation, FIFO dedup, error injection, fake clock
+- [docs/chaos.md](docs/chaos.md) — deliberately fail or slow down services to test retry/timeout paths
+- [docs/topology.md](docs/topology.md) — network connectivity simulation across VPC, peering, SGs, ACLs
 
-| Feature | What It Does |
-|---------|-------------|
-| **Call Recording** | Capture every API call with inputs, outputs, errors, and timing |
-| **Error Injection** | Simulate failures: always, every Nth call, probabilistic, or first N calls |
-| **Rate Limiting** | Token bucket limiter that returns `Throttled` errors when exhausted |
-| **Metrics Collection** | Track `calls_total`, `call_duration`, `errors_total` per operation |
-| **Fake Clock** | Control time for deterministic testing of TTL, dedup, alarms |
-| **Latency Simulation** | Add delays to test timeout handling |
-
-## Configuration
-
-```go
-aws := cloudemu.NewAWS(
-    config.WithRegion("eu-west-1"),
-    config.WithAccountID("999888777666"),
-    config.WithClock(config.NewFakeClock(time.Now())),
-)
-```
-
-## Error Handling
-
-All operations return errors with canonical codes. Use helper functions to check types:
-
-```go
-import cerrors "github.com/stackshy/cloudemu/errors"
-
-_, err := aws.S3.GetObject(ctx, "bucket", "missing-key")
-if cerrors.IsNotFound(err) {
-    // handle missing resource
-}
-
-// Codes: NotFound, AlreadyExists, InvalidArgument,
-//        FailedPrecondition, PermissionDenied, Throttled
-```
-
-## Architecture
-
-Three-layer design inspired by Go CDK, plus pluggable cross-service engines:
-
-```
-SDK-Compat Server  →  point real aws-sdk-go-v2 at localhost (server/)
-Topology Engine    →  simulate network connectivity (topology/)
-        ↓ both consume the same contract ↓
-Portable API       →  recording, metrics, rate limiting, error injection
-Driver Interface   →  minimal Go interfaces per service
-Provider Mocks     →  in-memory backends (AWS/Azure/GCP) using generic memstore
-```
-
-All mocks are backed by a generic, thread-safe `memstore.Store[V]`. Services emit cloud-native metrics to the monitoring service, so you can query metrics via `GetMetricData` the same way you would with real CloudWatch, Azure Monitor, or Cloud Monitoring. The SDK-compat server and topology engine sit above the driver layer as separate consumers — new services plug in without touching the core.
-
-## Running Tests
+## Tests
 
 ```bash
-go build ./...   # compile
-go vet ./...     # static analysis
-go test -v ./... # run all tests
+go build ./...
+go test ./...
 ```
 
 ## License

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,11 @@
 # CloudEmu Documentation
 
-CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides mock implementations of 16 cloud services across AWS, Azure, and GCP -- designed for testing and development without real cloud accounts, Docker, or network calls.
+CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides mock implementations of cloud services across AWS, Azure, and GCP -- designed for testing and development without real cloud accounts, Docker, or network calls.
 
 ## Table of Contents
 
 - [Architecture](architecture.md) -- Three-layer design, package structure, cross-service wiring
-- [Services](services.md) -- Complete provider resource reference with all operations for 16 services
+- [Services](services.md) -- Complete provider resource reference with all operations across every supported service
 - [Features](features.md) -- Cross-cutting features: auto-metrics, alarm evaluation, IAM policy checking, FIFO dedup, cost tracking, and more
 - [SDK Server](sdk-server.md) -- SDK-compatible HTTP server (use the real aws-sdk-go-v2 against CloudEmu)
 - [Topology](topology.md) -- Network topology simulation engine
@@ -16,7 +16,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 | Topic | Link |
 |-------|------|
 | Creating an AWS provider | [Getting Started](getting-started.md#creating-providers) |
-| All 16 service operations | [Services Reference](services.md#master-table) |
+| All service operations | [Services Reference](services.md#master-table) |
 | Using real AWS SDK clients | [SDK Server](sdk-server.md) |
 | Auto-metric generation | [Features](features.md#1-auto-metric-generation) |
 | Error injection and rate limiting | [Features](features.md#8-portable-api-cross-cutting-concerns) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ Each provider has a factory function (`New()`) in its top-level package (`provid
 
 1. Accepts functional `config.Option` values for configuration (clock, region, account ID, etc.)
 2. Creates `config.Options` from the functional options
-3. Instantiates all 16 service mocks, passing the shared options to each
+3. Instantiates every service mock, passing the shared options to each
 4. Wires cross-service dependencies (e.g., compute to monitoring)
 5. Returns the `Provider` struct with all services accessible as public fields
 
@@ -89,7 +89,7 @@ aws := cloudemu.NewAWS(
     config.WithAccountID("123456789012"),
 )
 
-// All 16 services are ready to use
+// All services are ready to use
 aws.S3.CreateBucket(ctx, "my-bucket")
 aws.EC2.RunInstances(ctx, instanceConfig, 1)
 aws.DynamoDB.CreateTable(ctx, tableConfig)
@@ -169,9 +169,13 @@ containerregistry/
     driver/driver.go                  # ContainerRegistry interface
 eventbus/
     driver/driver.go                  # EventBus interface
+relationaldb/
+    driver/driver.go                  # Relational DB interface (RDS, Aurora, Neptune,
+                                      # DocumentDB, Redshift, Azure SQL, Postgres/MySQL
+                                      # Flexible Server, Cloud SQL)
 providers/
     aws/
-        aws.go                        # AWS factory (wires all 16 services)
+        aws.go                        # AWS factory (wires all services)
         s3/                           # S3 mock
         ec2/                          # EC2 mock
         dynamodb/                     # DynamoDB mock
@@ -188,8 +192,12 @@ providers/
         sns/                          # SNS mock
         ecr/                          # ECR mock
         eventbridge/                  # EventBridge mock
+        rds/                          # RDS mock (Aurora + Neptune + DocumentDB engines)
+        redshift/                     # Redshift mock
+        eks/                          # EKS control-plane mock (clusters, node groups,
+                                      # Fargate profiles, addons)
     azure/
-        azure.go                      # Azure factory (wires all 16 services)
+        azure.go                      # Azure factory (wires all services)
         blobstorage/                  # Blob Storage mock
         virtualmachines/              # Virtual Machines mock
         cosmosdb/                     # Cosmos DB mock
@@ -206,8 +214,13 @@ providers/
         notificationhubs/             # Notification Hubs mock
         acr/                          # ACR mock
         eventgrid/                    # Event Grid mock
+        azuresql/                     # Azure SQL Database mock
+        postgresflex/                 # Azure PostgreSQL Flexible Server mock
+        mysqlflex/                    # Azure MySQL Flexible Server mock
+        aks/                          # AKS control-plane mock (managed clusters,
+                                      # agent pools, maintenance configs)
     gcp/
-        gcp.go                        # GCP factory (wires all 16 services)
+        gcp.go                        # GCP factory (wires all services)
         gcs/                          # GCS mock
         gce/                          # GCE mock
         firestore/                    # Firestore mock
@@ -224,6 +237,9 @@ providers/
         fcm/                          # FCM mock
         artifactregistry/             # Artifact Registry mock
         eventarc/                     # Eventarc mock
+        cloudsql/                     # Cloud SQL mock
+        gke/                          # GKE control-plane mock (clusters, node pools,
+                                      # operations)
 server/                               # SDK-compat HTTP servers (real cloud SDKs work against this)
     server.go                         # core: Handler interface + dispatcher
     wire/
@@ -236,12 +252,18 @@ server/                               # SDK-compat HTTP servers (real cloud SDKs
         s3/  ec2/  dynamodb/          # S3 REST+XML, EC2 query, DynamoDB JSON-RPC
         cloudwatch/                   # Smithy rpc-v2-cbor
         lambda/  sqs/                 # REST + JSON-RPC handlers
+        rds/  redshift/               # query-protocol relational DB handlers
+        eks/                          # REST EKS control-plane handler
     azure/
         azure.go                      # azureserver.New(Drivers{...})
         virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
         blob/  cosmos/  network/  monitor/  functions/  servicebus/
+        azuresql/  postgresflex/  mysqlflex/   # ARM relational DB handlers
+        aks/                          # ARM AKS control-plane handler
     gcp/
         gcp.go                        # gcpserver.New(Drivers{...})
         compute/  networks/  gcs/  firestore/  monitoring/
         cloudfunctions/  pubsub/
+        cloudsql/                     # REST Cloud SQL handler
+        gke/                          # REST GKE control-plane handler
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ Requires Go 1.25.0 or later.
 
 ## Creating Providers
 
-CloudEmu provides three top-level factory functions, one per cloud provider. Each returns a provider struct with all 16 services ready to use.
+CloudEmu provides three top-level factory functions, one per cloud provider. Each returns a provider struct with every supported service ready to use.
 
 ### AWS
 
@@ -27,11 +27,12 @@ func main() {
     ctx := context.Background()
     aws := cloudemu.NewAWS()
 
-    // All 16 services are available:
+    // All services are available, e.g.:
     // aws.S3, aws.EC2, aws.DynamoDB, aws.Lambda, aws.VPC,
     // aws.CloudWatch, aws.IAM, aws.Route53, aws.ELB, aws.SQS,
     // aws.ElastiCache, aws.SecretsManager, aws.CloudWatchLogs,
-    // aws.SNS, aws.ECR, aws.EventBridge
+    // aws.SNS, aws.ECR, aws.EventBridge,
+    // aws.RDS, aws.Redshift, aws.EKS
     _ = ctx
 }
 ```

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -22,13 +22,16 @@ import (
 
 cloud := cloudemu.NewAWS()
 srv := awsserver.New(awsserver.Drivers{
-    S3:       cloud.S3,
-    DynamoDB: cloud.DynamoDB,
-    EC2:      cloud.EC2,
-    VPC:      cloud.VPC,
-    Lambda:   cloud.Lambda,
-    SQS:      cloud.SQS,
+    S3:         cloud.S3,
+    DynamoDB:   cloud.DynamoDB,
+    EC2:        cloud.EC2,
+    VPC:        cloud.VPC,
+    Lambda:     cloud.Lambda,
+    SQS:        cloud.SQS,
     CloudWatch: cloud.CloudWatch,
+    RDS:        cloud.RDS,
+    Redshift:   cloud.Redshift,
+    EKS:        cloud.EKS,
 })
 ts := httptest.NewServer(srv)
 defer ts.Close()
@@ -63,6 +66,10 @@ srv := azureserver.New(azureserver.Drivers{
     Monitor:         cp.Monitor,
     Functions:       cp.Functions,
     ServiceBus:      cp.ServiceBus,
+    SQL:             cp.SQL,
+    PostgresFlex:    cp.PostgresFlex,
+    MySQLFlex:       cp.MySQLFlex,
+    AKS:             cp.AKS,
 })
 ts := httptest.NewTLSServer(srv) // Azure SDK requires TLS
 
@@ -98,6 +105,8 @@ srv := gcpserver.New(gcpserver.Drivers{
     Monitoring:     cp.CloudMonitoring,
     CloudFunctions: cp.CloudFunctions,
     PubSub:         cp.PubSub,
+    CloudSQL:       cp.CloudSQL,
+    GKE:            cp.GKE,
 })
 ts := httptest.NewServer(srv)
 
@@ -127,6 +136,9 @@ Region, credentials, and tokens can be any dummy values — the server doesn't v
 | **Lambda** *(REST + JSON)* | CreateFunction, GetFunction, ListFunctions, DeleteFunction, Invoke (sync) |
 | **SQS** *(JSON-RPC AwsJson1_0)* | CreateQueue, GetQueueUrl, ListQueues, DeleteQueue, SendMessage, ReceiveMessage, DeleteMessage |
 | **CloudWatch** *(Smithy rpc-v2-cbor)* | PutMetricData, GetMetricStatistics, ListMetrics, PutMetricAlarm, DescribeAlarms, DeleteAlarms |
+| **RDS / Aurora** *(query protocol)* | DBInstances (Create/Describe/Modify/Delete/Start/Stop/Reboot), DBClusters (Create/Describe/Modify/Delete/Start/Stop), DBSnapshots + DBClusterSnapshots (Create/Describe/Delete/Restore). One handler also serves the **Neptune** and **DocumentDB** engines — both reuse the same `aws-sdk-go-v2/service/{neptune,docdb}` client surface. |
+| **Redshift** *(query protocol)* | CreateCluster, DescribeClusters, ModifyCluster, DeleteCluster, RebootCluster, CreateClusterSnapshot, DescribeClusterSnapshots, DeleteClusterSnapshot, RestoreFromClusterSnapshot |
+| **EKS** *(REST + JSON)* | Clusters (Create/Describe/List/UpdateConfig/UpdateVersion/Delete), NodeGroups (Create/Describe/List/UpdateConfig/UpdateVersion/Delete), Fargate Profiles (Create/Describe/List/Delete), Addons (Create/Describe/List/Update/Delete). Stub kubeconfig only — data plane deferred to Wave 2. |
 
 ### Azure (`server/azure/`)
 
@@ -142,6 +154,10 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **Azure Monitor** | `microsoft.insights/metricAlerts` and metric data ingest/read |
 | **Functions** | `Microsoft.Web/sites` (Function Apps): CreateOrUpdate, Get, List, Delete + non-ARM `/api/{name}` invoke |
 | **Service Bus** | `Microsoft.ServiceBus/namespaces[/queues]` ARM CRUD + raw-HTTP REST data plane (`POST /{ns}/{queue}/messages`, `DELETE /messages/head`) |
+| **SQL Database** | `Microsoft.Sql/servers[/databases]` — servers and databases, full CRUD lifecycle |
+| **PostgreSQL Flexible Server** | `Microsoft.DBforPostgreSQL/flexibleServers` — full CRUD lifecycle |
+| **MySQL Flexible Server** | `Microsoft.DBforMySQL/flexibleServers` — full CRUD lifecycle |
+| **AKS** | `Microsoft.ContainerService/managedClusters` — ManagedClusters (CreateOrUpdate, Get, UpdateTags, Delete, List/ListByResourceGroup), AgentPools (CreateOrUpdate, Get, Delete, List), MaintenanceConfigurations (CreateOrUpdate, Get, Delete, List), ListClusterAdmin/User/MonitoringUser Credentials, RotateClusterCertificates. Stub kubeconfig only — data plane deferred to Wave 2. |
 
 ### GCP (`server/gcp/`)
 
@@ -156,6 +172,8 @@ All handlers speak REST + JSON.
 | **Cloud Monitoring** | Time-series ingest/read, alert policies |
 | **Cloud Functions v1** | Create (LRO), Get, List, Delete (LRO), `:call` (sync invoke) |
 | **Pub/Sub** | Topics + Subscriptions lifecycle, `:publish`, `:pull`, `:acknowledge` |
+| **Cloud SQL** | Instances (insert/get/list/patch/delete/start/stop/restart) + Operations (get/list) — supports the `sqladmin/v1` SDK |
+| **GKE** | Clusters (Create/Get/List/Update/Delete + `:setLogging`/`:setMonitoring`/`:setMasterAuth`/`:setLegacyAbac`/`:setNetworkPolicy`/`:setMaintenancePolicy`/`:setResourceLabels`/`:startIpRotation`/`:completeIpRotation`), NodePools (Create/Get/List/Update/Delete + `:setSize`/`:setAutoscaling`/`:setManagement`/`:rollback`), Operations (Get/List/`:cancel`). Stub kubeconfig only — data plane deferred to Wave 2. |
 
 Any operation not in these lists returns `501 Not Implemented` or the provider's native `UnknownOperation` / `NotImplemented` / `NOT_FOUND` error.
 
@@ -174,14 +192,20 @@ server/
 ├── aws/
 │   ├── aws.go                      # awsserver.New(Drivers{...})
 │   ├── s3/  ec2/  dynamodb/  lambda/  sqs/  cloudwatch/
+│   ├── rds/  redshift/             # query-protocol relational DB handlers
+│   └── eks/                        # REST EKS control-plane handler
 ├── azure/
 │   ├── azure.go                    # azureserver.New(Drivers{...})
 │   ├── virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
 │   ├── blob/  cosmos/  network/  monitor/  functions/  servicebus/
+│   ├── azuresql/  postgresflex/  mysqlflex/   # ARM relational DB handlers
+│   └── aks/                        # ARM AKS control-plane handler
 └── gcp/
     ├── gcp.go                      # gcpserver.New(Drivers{...})
-    └── compute/  networks/  gcs/  firestore/  monitoring/
-        cloudfunctions/  pubsub/
+    ├── compute/  networks/  gcs/  firestore/  monitoring/
+    ├── cloudfunctions/  pubsub/
+    ├── cloudsql/                   # REST Cloud SQL handler
+    └── gke/                        # REST GKE control-plane handler
 ```
 
 Each handler implements a two-method interface:
@@ -204,10 +228,17 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | AWS DynamoDB | `X-Amz-Target: DynamoDB_20120810.*` header |
 | AWS SQS | `X-Amz-Target: AmazonSQS.*` header |
 | AWS Lambda | URL prefix `/2015-03-31/functions` |
+| AWS EKS | URL prefix `/clusters` |
+| AWS RDS | Form-encoded POST whose `Action=` is a known RDS operation (registered before EC2) |
+| AWS Redshift | Form-encoded POST whose `Action=` is a known Redshift operation (registered before EC2) |
 | AWS EC2 | `Action=…` in URL query or `Content-Type: application/x-www-form-urlencoded` POST |
 | AWS CloudWatch | `Smithy-Protocol: rpc-v2-cbor` header |
 | AWS S3 | Fallback (everything else REST-shaped) |
 | Azure (all ARM) | URL begins with `/subscriptions/{sub}` and matches `Microsoft.<Provider>/<Type>` |
+| Azure SQL | ARM provider `Microsoft.Sql` |
+| Azure PostgreSQL Flexible | ARM provider `Microsoft.DBforPostgreSQL/flexibleServers` |
+| Azure MySQL Flexible | ARM provider `Microsoft.DBforMySQL/flexibleServers` |
+| Azure AKS | ARM provider `Microsoft.ContainerService/managedClusters` |
 | Azure Cosmos | URL begins with `/dbs/` (data plane, non-ARM) |
 | Azure Functions invoke | URL begins with `/api/` (non-ARM data plane) |
 | Azure Service Bus data plane | Non-ARM URL ending in `/messages` or `/messages/head` |
@@ -217,6 +248,8 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | GCP Pub/Sub | `/v1/projects/.../topics[/...]` or `/v1/projects/.../subscriptions[/...]` |
 | GCP Firestore | `/v1/projects/.../databases/.../documents[/...]` |
 | GCP Cloud Monitoring | `/v3/projects/.../` |
+| GCP Cloud SQL | `/v1/projects/.../{instances,operations}[/...]` |
+| GCP GKE | `/v1/projects/.../locations/.../{clusters,operations}[/...]` |
 | GCP GCS | Fallback (`/storage/v1/` and `/{bucket}/{object}` direct-media) |
 
 Registration order matters when handlers share a path prefix — `awsserver.New` / `azureserver.New` / `gcpserver.New` register more-specific handlers ahead of catch-alls (S3, Blob, GCS) so first-match-wins resolves correctly.
@@ -225,11 +258,13 @@ Registration order matters when handlers share a path prefix — `awsserver.New`
 
 | Provider | Domains shipped | Notes |
 |----------|----------------|-------|
-| AWS | Storage, Compute (+ VPC/SG/Subnet/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/Keys/AMIs/Snapshots/Spot/LaunchTemplates), Database, Serverless, Message Queue, Monitoring | The most-mature provider — EC2 was Phase 1 of SDK-compat |
-| Azure | Storage, Compute (+ Disks/Snapshots/Images/SSHKeys), Database, Serverless, Message Queue (ARM only), Networking, Monitoring | Data-plane Service Bus over AMQP is out of scope (use raw-HTTP REST data plane for tests) |
-| GCP | Storage, Compute (+ Disks/Snapshots/Images), Database, Serverless, Message Queue, Networking, Monitoring | All driven via REST (the `cloud.google.com/go/*` clients with `option.WithEndpoint`, or the auto-generated `google.golang.org/api/*` clients) |
+| AWS | Storage, Compute (+ VPC/SG/Subnet/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/Keys/AMIs/Snapshots/Spot/LaunchTemplates), NoSQL DB, Relational DB (RDS/Aurora/Neptune/DocumentDB/Redshift), Kubernetes (EKS control plane), Serverless, Message Queue, Monitoring | The most-mature provider — EC2 was Phase 1 of SDK-compat |
+| Azure | Storage, Compute (+ Disks/Snapshots/Images/SSHKeys), NoSQL DB, Relational DB (SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server), Kubernetes (AKS control plane), Serverless, Message Queue (ARM only), Networking, Monitoring | Data-plane Service Bus over AMQP is out of scope (use raw-HTTP REST data plane for tests) |
+| GCP | Storage, Compute (+ Disks/Snapshots/Images), NoSQL DB, Relational DB (Cloud SQL), Kubernetes (GKE control plane), Serverless, Message Queue, Networking, Monitoring | All driven via REST (the `cloud.google.com/go/*` clients with `option.WithEndpoint`, or the auto-generated `google.golang.org/api/*` clients) |
 
-The remaining 9 service domains (IAM, DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
+Kubernetes control-plane handlers are Wave 1 — cluster + node-pool + addon/Fargate/maintenance-config lifecycle only. The Kubernetes data plane (Pods, Services, Deployments, …) is intentionally deferred to Wave 2; stub kubeconfigs returned by the credential/auth endpoints point at `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` so callers that try to drive the K8s API fail fast with a clear sentinel.
+
+The remaining service domains (IAM, DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
 
 ## Writing your own handler
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -22,6 +22,8 @@ This document lists every service and operation available in CloudEmu across all
 | 14 | Notification | `sns` | `notificationhubs` | `fcm` |
 | 15 | Container Registry | `ecr` | `acr` | `artifactregistry` |
 | 16 | Event Bus | `eventbridge` | `eventgrid` | `eventarc` |
+| 17 | Relational Database | `rds` (+ Aurora/Neptune/DocumentDB engines), `redshift` | `azuresql`, `postgresflex`, `mysqlflex` | `cloudsql` |
+| 18 | Kubernetes (Control Plane) | `eks` | `aks` | `gke` |
 
 ---
 
@@ -977,6 +979,100 @@ This document lists every service and operation available in CloudEmu across all
 
 ---
 
+## 17. Relational Database
+
+**Driver interface:** `relationaldb/driver/driver.go`
+**AWS:** `rds` (covers Aurora, Neptune, and DocumentDB engines), `redshift` | **Azure:** `azuresql`, `postgresflex`, `mysqlflex` | **GCP:** `cloudsql`
+
+A single portable interface backs every RDBMS handler. Engine selection (MySQL / PostgreSQL / Aurora / Neptune / DocumentDB / Redshift / Cloud SQL / Azure SQL / …) is a field on the input config, not a separate driver.
+
+### Instance Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateInstance` | `(ctx, InstanceConfig) (*Instance, error)` |
+| `DescribeInstances` | `(ctx, ids) ([]Instance, error)` |
+| `ModifyInstance` | `(ctx, id, ModifyInstanceInput) (*Instance, error)` |
+| `DeleteInstance` | `(ctx, id) error` |
+| `StartInstance` | `(ctx, id) error` |
+| `StopInstance` | `(ctx, id) error` |
+| `RebootInstance` | `(ctx, id) error` |
+
+### Cluster Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateCluster` | `(ctx, ClusterConfig) (*Cluster, error)` |
+| `DescribeClusters` | `(ctx, ids) ([]Cluster, error)` |
+| `ModifyCluster` | `(ctx, id, ModifyInstanceInput) (*Cluster, error)` |
+| `DeleteCluster` | `(ctx, id) error` |
+| `StartCluster` | `(ctx, id) error` |
+| `StopCluster` | `(ctx, id) error` |
+
+### Snapshot Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSnapshot` | `(ctx, SnapshotConfig) (*Snapshot, error)` |
+| `DescribeSnapshots` | `(ctx, ids, instanceID) ([]Snapshot, error)` |
+| `DeleteSnapshot` | `(ctx, id) error` |
+| `RestoreInstanceFromSnapshot` | `(ctx, RestoreInstanceInput) (*Instance, error)` |
+
+### Cluster Snapshot Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateClusterSnapshot` | `(ctx, ClusterSnapshotConfig) (*ClusterSnapshot, error)` |
+| `DescribeClusterSnapshots` | `(ctx, ids, clusterID) ([]ClusterSnapshot, error)` |
+| `DeleteClusterSnapshot` | `(ctx, id) error` |
+| `RestoreClusterFromSnapshot` | `(ctx, RestoreClusterInput) (*Cluster, error)` |
+
+**Total: 21 operations**
+
+---
+
+## 18. Kubernetes (Control Plane)
+
+**AWS:** `eks` | **Azure:** `aks` | **GCP:** `gke`
+
+Wave-1 control-plane coverage: cluster, node-pool, and addon / Fargate-profile / maintenance-config lifecycle. The Kubernetes data plane (Pods, Services, Deployments, …) is intentionally deferred to Wave 2. Stub kubeconfigs returned from credential/auth endpoints point at `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` so any caller trying to drive the K8s API fails fast with a clear sentinel.
+
+Each provider exposes its native API surface — there is no single portable Kubernetes driver. Use `providers/aws/eks`, `providers/azure/aks`, and `providers/gcp/gke` for direct Go access, or the SDK-compat handlers for `aws-sdk-go-v2/service/eks`, `armcontainerservice/v6`, and `container/v1`.
+
+### AWS EKS (`providers/aws/eks`)
+
+| Resource | Operations |
+|----------|-----------|
+| Clusters | CreateCluster, DescribeCluster, ListClusters, UpdateClusterConfig, UpdateClusterVersion, DeleteCluster |
+| Node Groups | CreateNodegroup, DescribeNodegroup, ListNodegroups, UpdateNodegroupConfig, UpdateNodegroupVersion, DeleteNodegroup |
+| Fargate Profiles | CreateFargateProfile, DescribeFargateProfile, ListFargateProfiles, DeleteFargateProfile |
+| Addons | CreateAddon, DescribeAddon, ListAddons, UpdateAddon, DeleteAddon |
+
+Operations: **21**
+
+### Azure AKS (`providers/azure/aks`)
+
+| Resource | Operations |
+|----------|-----------|
+| Managed Clusters | CreateOrUpdateCluster, GetCluster, UpdateClusterTags, DeleteCluster, ListClusters, ListClustersByResourceGroup, RotateClusterCertificates |
+| Agent Pools | CreateOrUpdateAgentPool, GetAgentPool, DeleteAgentPool, ListAgentPools |
+| Maintenance Configs | CreateOrUpdateMaintenanceConfig, GetMaintenanceConfig, DeleteMaintenanceConfig, ListMaintenanceConfigs |
+| Credentials | `ListClusterAdminCredentials`, `ListClusterUserCredentials`, `ListClusterMonitoringUserCredentials` (return stub kubeconfig) |
+
+Operations: **18**
+
+### GCP GKE (`providers/gcp/gke`)
+
+| Resource | Operations |
+|----------|-----------|
+| Clusters | CreateCluster, GetCluster, ListClusters, UpdateCluster, DeleteCluster, SetClusterLogging, SetClusterMonitoring, SetMasterAuth, SetLegacyAbac, SetNetworkPolicy, SetMaintenancePolicy, SetResourceLabels, StartIPRotation, CompleteIPRotation |
+| Node Pools | CreateNodePool, GetNodePool, ListNodePools, UpdateNodePool, DeleteNodePool, SetNodePoolSize, SetNodePoolAutoscaling, SetNodePoolManagement, RollbackNodePool |
+| Operations | GetOperation, ListOperations, CancelOperation |
+
+Operations: **26**
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -997,4 +1093,8 @@ This document lists every service and operation available in CloudEmu across all
 | Notification | 8 |
 | Container Registry | 14 |
 | Event Bus | 15 |
-| **Grand Total** | **330** |
+| Relational Database | 21 |
+| Kubernetes — AWS EKS | 21 |
+| Kubernetes — Azure AKS | 18 |
+| Kubernetes — GCP GKE | 26 |
+| **Grand Total** | **416** |


### PR DESCRIPTION
Refresh the in-repo docs to cover the v1.6.2 resources (relational databases + Kubernetes control plane) and tighten the README.

Changes (one commit per file):

- `README.md` — restructured for clarity. Leads with what cloudemu does, an SDK-compat snippet, the Go API as an alternative, and a single coverage table. Stripped the long bullet sections; deeper material now links to `docs/`.
- `docs/sdk-server.md` — added Quick-Start `Drivers` fields and 9 new rows to the per-provider coverage tables (AWS RDS/Aurora/Neptune/DocumentDB, Redshift, EKS; Azure SQL, PostgreSQL Flexible, MySQL Flexible, AKS; GCP Cloud SQL, GKE). Added protocol-detection entries and updated the Coverage status summary.
- `docs/services.md` — Master Table rows 17 and 18, plus two new sections:
  - **17. Relational Database** — 21 operations on the unified `relationaldb/driver` interface (used by RDS, Redshift, Cloud SQL, Azure SQL, Postgres-Flex, MySQL-Flex).
  - **18. Kubernetes (Control Plane)** — per-provider operation tables for EKS, AKS, and GKE. Wave-1 control-plane only; data plane is deferred and the kubeconfig sentinel is called out.
  - Summary recalculated (330 → 416).
- `docs/architecture.md` — File Structure block updated with the new `relationaldb/`, `providers/{aws,azure,gcp}/...`, and `server/{aws,azure,gcp}/...` packages.
- `docs/getting-started.md` — provider example comments include RDS/Redshift/EKS; "16 services" phrasing generalized.
- `docs/README.md` — same generalization for the docs index.

Docs-only — `go build ./...` and `go test ./...` (122 packages) still pass.
