### PR TITLE
feat: Kubernetes data-plane Wave 2 Phase 2 (Pod/Service/Secret/SA/Deployment)

### DIFF
--- a/kubernetes/cascade_test.go
+++ b/kubernetes/cascade_test.go
@@ -1,0 +1,182 @@
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestCascadeDelete_DropsAllNamespacedResources verifies that deleting a
+// namespace also removes every namespaced resource that lived inside it.
+func TestCascadeDelete_DropsAllNamespacedResources(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Set up a namespace populated with one of every resource.
+	do(t, http.MethodPost, base+"/api/v1/namespaces",
+		mustJSON(t, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "doomed"}})).Body.Close()
+
+	creates := []struct {
+		path string
+		body any
+	}{
+		{
+			"/api/v1/namespaces/doomed/configmaps",
+			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}, Data: map[string]string{"a": "b"}},
+		},
+		{
+			"/api/v1/namespaces/doomed/pods",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p"},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "x"}},
+				},
+			},
+		},
+		{
+			"/api/v1/namespaces/doomed/secrets",
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s"}, StringData: map[string]string{"k": "v"}},
+		},
+		{
+			"/api/v1/namespaces/doomed/serviceaccounts",
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa"}},
+		},
+		{
+			"/api/v1/namespaces/doomed/services",
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc"},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			},
+		},
+		{
+			"/apis/apps/v1/namespaces/doomed/deployments",
+			makeDeployment("dep", 1),
+		},
+	}
+
+	for _, c := range creates {
+		resp := do(t, http.MethodPost, base+c.path, mustJSON(t, c.body))
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("seed %s: got %d", c.path, resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+
+	// Sanity — namespaced lists are non-empty before delete.
+	mustHaveItems(t, base, "/api/v1/namespaces/doomed/configmaps", 1)
+	mustHaveItems(t, base, "/api/v1/namespaces/doomed/pods", 1)
+	mustHaveItems(t, base, "/api/v1/namespaces/doomed/secrets", 1)
+	// SA list contains the auto-bootstrap "default" SA + our "sa" = 2.
+	mustHaveItems(t, base, "/api/v1/namespaces/doomed/serviceaccounts", 2)
+	mustHaveItems(t, base, "/api/v1/namespaces/doomed/services", 1)
+	mustHaveItems(t, base, "/apis/apps/v1/namespaces/doomed/deployments", 1)
+
+	// Drop the namespace.
+	resp := do(t, http.MethodDelete, base+"/api/v1/namespaces/doomed", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete-namespace: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Every individual lookup should now 404.
+	gone := []string{
+		"/api/v1/namespaces/doomed/configmaps/cm",
+		"/api/v1/namespaces/doomed/pods/p",
+		"/api/v1/namespaces/doomed/secrets/s",
+		"/api/v1/namespaces/doomed/serviceaccounts/sa",
+		"/api/v1/namespaces/doomed/serviceaccounts/default",
+		"/api/v1/namespaces/doomed/services/svc",
+		"/apis/apps/v1/namespaces/doomed/deployments/dep",
+	}
+
+	for _, path := range gone {
+		resp := do(t, http.MethodGet, base+path, nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s after cascade: got %d, want 404", path, resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+
+	// Cross-namespace check — resources in *other* namespaces stay alive.
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/serviceaccounts/default", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default ns SA disturbed by cascade: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+// mustHaveItems hits a List endpoint and asserts the decoded items count.
+// Works for any K8s list type because we only inspect the `items` field
+// via a minimal struct.
+func mustHaveItems(t *testing.T, base, path string, want int) {
+	t.Helper()
+
+	resp := do(t, http.MethodGet, base+path, nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list %s: got %d", path, resp.StatusCode)
+	}
+
+	// We decode into the type that matches the path. Keeping a single
+	// minimal-items helper would force interface{} dancing; type-asserting
+	// by path is simpler.
+	switch {
+	case endsWith(path, "configmaps"):
+		var list corev1.ConfigMapList
+		mustDecode(t, resp.Body, &list)
+
+		if len(list.Items) != want {
+			t.Fatalf("configmaps in %s: got %d, want %d", path, len(list.Items), want)
+		}
+	case endsWith(path, "pods"):
+		var list corev1.PodList
+		mustDecode(t, resp.Body, &list)
+
+		if len(list.Items) != want {
+			t.Fatalf("pods in %s: got %d, want %d", path, len(list.Items), want)
+		}
+	case endsWith(path, "secrets"):
+		var list corev1.SecretList
+		mustDecode(t, resp.Body, &list)
+
+		if len(list.Items) != want {
+			t.Fatalf("secrets in %s: got %d, want %d", path, len(list.Items), want)
+		}
+	case endsWith(path, "serviceaccounts"):
+		var list corev1.ServiceAccountList
+		mustDecode(t, resp.Body, &list)
+
+		if len(list.Items) != want {
+			t.Fatalf("sas in %s: got %d, want %d", path, len(list.Items), want)
+		}
+	case endsWith(path, "services"):
+		var list corev1.ServiceList
+		mustDecode(t, resp.Body, &list)
+
+		if len(list.Items) != want {
+			t.Fatalf("services in %s: got %d, want %d", path, len(list.Items), want)
+		}
+	case endsWith(path, "deployments"):
+		var list appsv1.DeploymentList
+		mustDecode(t, resp.Body, &list)
+
+		if len(list.Items) != want {
+			t.Fatalf("deployments in %s: got %d, want %d", path, len(list.Items), want)
+		}
+	default:
+		t.Fatalf("mustHaveItems: unknown path suffix %s", path)
+	}
+}
+
+func endsWith(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}

--- a/kubernetes/cascade_test.go
+++ b/kubernetes/cascade_test.go
@@ -2,6 +2,7 @@ package kubernetes_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -130,42 +131,42 @@ func mustHaveItems(t *testing.T, base, path string, want int) {
 	// minimal-items helper would force interface{} dancing; type-asserting
 	// by path is simpler.
 	switch {
-	case endsWith(path, "configmaps"):
+	case strings.HasSuffix(path, "configmaps"):
 		var list corev1.ConfigMapList
 		mustDecode(t, resp.Body, &list)
 
 		if len(list.Items) != want {
 			t.Fatalf("configmaps in %s: got %d, want %d", path, len(list.Items), want)
 		}
-	case endsWith(path, "pods"):
+	case strings.HasSuffix(path, "pods"):
 		var list corev1.PodList
 		mustDecode(t, resp.Body, &list)
 
 		if len(list.Items) != want {
 			t.Fatalf("pods in %s: got %d, want %d", path, len(list.Items), want)
 		}
-	case endsWith(path, "secrets"):
+	case strings.HasSuffix(path, "secrets"):
 		var list corev1.SecretList
 		mustDecode(t, resp.Body, &list)
 
 		if len(list.Items) != want {
 			t.Fatalf("secrets in %s: got %d, want %d", path, len(list.Items), want)
 		}
-	case endsWith(path, "serviceaccounts"):
+	case strings.HasSuffix(path, "serviceaccounts"):
 		var list corev1.ServiceAccountList
 		mustDecode(t, resp.Body, &list)
 
 		if len(list.Items) != want {
 			t.Fatalf("sas in %s: got %d, want %d", path, len(list.Items), want)
 		}
-	case endsWith(path, "services"):
+	case strings.HasSuffix(path, "services"):
 		var list corev1.ServiceList
 		mustDecode(t, resp.Body, &list)
 
 		if len(list.Items) != want {
 			t.Fatalf("services in %s: got %d, want %d", path, len(list.Items), want)
 		}
-	case endsWith(path, "deployments"):
+	case strings.HasSuffix(path, "deployments"):
 		var list appsv1.DeploymentList
 		mustDecode(t, resp.Body, &list)
 
@@ -177,6 +178,3 @@ func mustHaveItems(t *testing.T, base, path string, want int) {
 	}
 }
 
-func endsWith(s, suffix string) bool {
-	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
-}

--- a/kubernetes/configmap.go
+++ b/kubernetes/configmap.go
@@ -79,6 +79,7 @@ func (s *ClusterState) serveConfigMapItem(w http.ResponseWriter, r *http.Request
 	}
 }
 
+//nolint:dupl // namespaced-create CRUD pattern; copy-paste is clearer than a generic helper.
 func (s *ClusterState) createConfigMap(w http.ResponseWriter, r *http.Request, namespace string) {
 	var in corev1.ConfigMap
 	if !readJSON(w, r, &in) {

--- a/kubernetes/configmap.go
+++ b/kubernetes/configmap.go
@@ -13,6 +13,11 @@ import (
 
 // serveConfigMaps dispatches /api/v1/{namespaces/{ns}/configmaps|configmaps}
 // requests.
+//
+// Per-resource files share the dispatch shape on purpose; each resource keeps
+// its quirks (Service ClusterIP, Secret StringData merge) close to its type.
+//
+//nolint:dupl // see comment above.
 func (s *ClusterState) serveConfigMaps(w http.ResponseWriter, r *http.Request, route *Route) {
 	if route.APIGroup != "" || route.APIVersion != apiVersionV1 {
 		writeNotFound(w, "k8s api: configmaps are only served at /api/v1")
@@ -203,6 +208,10 @@ func (s *ClusterState) updateConfigMap(w http.ResponseWriter, r *http.Request, n
 	writeJSON(w, http.StatusOK, &cm)
 }
 
+// Patch flow is identical across namespaced resources; sharing would force a
+// runtime type-switch and obscure the resource-specific store access.
+//
+//nolint:dupl // see comment above.
 func (s *ClusterState) patchConfigMap(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	key := configMapKey(namespace, name)
 

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -1,0 +1,270 @@
+package kubernetes
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// apiGroupApps is the API group Deployments (and other workload controllers)
+// live under: /apis/apps/v1/...
+const apiGroupApps = "apps"
+
+// serveDeployments dispatches /apis/apps/v1/{namespaces/{ns}/deployments|
+// deployments} requests. Deployments are the first apps/v1 resource so the
+// route group check is different from the core/v1 handlers.
+func (s *ClusterState) serveDeployments(w http.ResponseWriter, r *http.Request, route *Route) {
+	if route.APIGroup != apiGroupApps || route.APIVersion != apiVersionV1 {
+		writeNotFound(w, "k8s api: deployments are only served at /apis/apps/v1")
+
+		return
+	}
+
+	if route.Namespace == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, "k8s api: deployments cluster-wide: method not allowed: "+r.Method)
+
+			return
+		}
+
+		s.listDeploymentsAllNamespaces(w)
+
+		return
+	}
+
+	if !s.namespaceExists(route.Namespace) {
+		writeNotFound(w, "k8s api: namespace not found: "+route.Namespace)
+
+		return
+	}
+
+	if route.Name == "" {
+		s.serveDeploymentCollection(w, r, route.Namespace)
+
+		return
+	}
+
+	s.serveDeploymentItem(w, r, route.Namespace, route.Name)
+}
+
+func (s *ClusterState) serveDeploymentCollection(w http.ResponseWriter, r *http.Request, namespace string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listDeployments(w, namespace)
+	case http.MethodPost:
+		s.createDeployment(w, r, namespace)
+	default:
+		writeMethodNotAllowed(w, "k8s api: deployments collection: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) serveDeploymentItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getDeployment(w, namespace, name)
+	case http.MethodPut:
+		s.updateDeployment(w, r, namespace, name)
+	case http.MethodPatch:
+		s.patchDeployment(w, r, namespace, name)
+	case http.MethodDelete:
+		s.deleteDeployment(w, namespace, name)
+	default:
+		writeMethodNotAllowed(w, "k8s api: deployment item: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) createDeployment(w http.ResponseWriter, r *http.Request, namespace string) {
+	var in appsv1.Deployment
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		writeBadRequest(w, "k8s api: deployment: metadata.name is required")
+
+		return
+	}
+
+	in.Namespace = namespace
+
+	key := deploymentKey(namespace, in.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.deployments[key]; ok {
+		writeAlreadyExists(w, "k8s api: deployment already exists: "+key)
+
+		return
+	}
+
+	stamp(&in.ObjectMeta)
+	in.TypeMeta = metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}
+
+	// No controller-manager in Wave 2 — mirror spec.replicas straight onto
+	// status so basic "is my deployment 'ready'?" checks pass. Real
+	// apiserver leaves status empty; the deployment controller fills it in
+	// after observing ReplicaSets and Pods.
+	mirrorDeploymentReplicas(&in)
+
+	dep := in
+	s.deployments[key] = &dep
+	writeJSON(w, http.StatusCreated, &dep)
+}
+
+func (s *ClusterState) listDeployments(w http.ResponseWriter, namespace string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectDeploymentsLocked(namespace)
+	writeJSON(w, http.StatusOK, &appsv1.DeploymentList{
+		TypeMeta: metav1.TypeMeta{Kind: "DeploymentList", APIVersion: "apps/v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) listDeploymentsAllNamespaces(w http.ResponseWriter) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectDeploymentsLocked("")
+	writeJSON(w, http.StatusOK, &appsv1.DeploymentList{
+		TypeMeta: metav1.TypeMeta{Kind: "DeploymentList", APIVersion: "apps/v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) collectDeploymentsLocked(namespace string) []appsv1.Deployment {
+	keys := make([]string, 0, len(s.deployments))
+
+	for k := range s.deployments {
+		if namespace == "" || strings.HasPrefix(k, namespace+"/") {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	items := make([]appsv1.Deployment, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, *s.deployments[k].DeepCopy())
+	}
+
+	return items
+}
+
+func (s *ClusterState) getDeployment(w http.ResponseWriter, namespace, name string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dep, ok := s.deployments[deploymentKey(namespace, name)]
+	if !ok {
+		writeNotFound(w, "k8s api: deployment not found: "+namespace+"/"+name)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, dep.DeepCopy())
+}
+
+func (s *ClusterState) updateDeployment(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	var in appsv1.Deployment
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name != name {
+		writeBadRequest(w, "k8s api: deployment name in body does not match URL")
+
+		return
+	}
+
+	key := deploymentKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.deployments[key]
+	if !ok {
+		writeNotFound(w, "k8s api: deployment not found: "+key)
+
+		return
+	}
+
+	in.Namespace = namespace
+	in.UID = cur.UID
+	in.CreationTimestamp = cur.CreationTimestamp
+	in.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	in.TypeMeta = cur.TypeMeta
+
+	mirrorDeploymentReplicas(&in)
+
+	dep := in
+	s.deployments[key] = &dep
+	writeJSON(w, http.StatusOK, &dep)
+}
+
+func (s *ClusterState) patchDeployment(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	key := deploymentKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.deployments[key]
+	if !ok {
+		writeNotFound(w, "k8s api: deployment not found: "+key)
+
+		return
+	}
+
+	patched, ok := applyJSONPatch(w, r, cur)
+	if !ok {
+		return
+	}
+
+	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	mirrorDeploymentReplicas(patched)
+	s.deployments[key] = patched
+	writeJSON(w, http.StatusOK, patched)
+}
+
+func (s *ClusterState) deleteDeployment(w http.ResponseWriter, namespace, name string) {
+	key := deploymentKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dep, ok := s.deployments[key]
+	if !ok {
+		writeNotFound(w, "k8s api: deployment not found: "+key)
+
+		return
+	}
+
+	delete(s.deployments, key)
+	writeJSON(w, http.StatusOK, dep.DeepCopy())
+}
+
+func deploymentKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// mirrorDeploymentReplicas copies spec.replicas onto status. There is no
+// controller in Wave 2 to drive a real reconcile loop, so we synthesize the
+// terminal-state status fields tests typically assert on. Spec.Replicas of
+// nil is treated as 1 (real k8s default).
+func mirrorDeploymentReplicas(d *appsv1.Deployment) {
+	var replicas int32 = 1
+	if d.Spec.Replicas != nil {
+		replicas = *d.Spec.Replicas
+	}
+
+	d.Status.Replicas = replicas
+	d.Status.ReadyReplicas = replicas
+	d.Status.AvailableReplicas = replicas
+	d.Status.UpdatedReplicas = replicas
+	d.Status.ObservedGeneration = d.Generation
+}

--- a/kubernetes/deployment_test.go
+++ b/kubernetes/deployment_test.go
@@ -1,0 +1,270 @@
+package kubernetes_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ptrInt32(v int32) *int32 { return &v }
+
+func makeDeployment(name string, replicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrInt32(replicas),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": name}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "main", Image: "nginx:1.27"}},
+				},
+			},
+		},
+	}
+}
+
+func TestDeployment_StatusMirrorsSpecReplicas(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments",
+		mustJSON(t, makeDeployment("web", 3)))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: got %d", resp.StatusCode)
+	}
+
+	var got appsv1.Deployment
+	mustDecode(t, resp.Body, &got)
+
+	if got.Status.Replicas != 3 || got.Status.ReadyReplicas != 3 || got.Status.AvailableReplicas != 3 {
+		t.Fatalf("status not mirrored: replicas=%d ready=%d available=%d",
+			got.Status.Replicas, got.Status.ReadyReplicas, got.Status.AvailableReplicas)
+	}
+}
+
+func TestDeployment_LifecycleAndPatch(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments",
+		mustJSON(t, makeDeployment("api", 2))).Body.Close()
+
+	// Get
+	resp := do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/deployments/api", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// List
+	resp = do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/deployments", nil)
+	var list appsv1.DeploymentList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 1 {
+		t.Fatalf("list: got %d items, want 1", len(list.Items))
+	}
+
+	// Patch to scale up.
+	patch := []byte(`{"spec":{"replicas":5}}`)
+	req, _ := http.NewRequest(http.MethodPatch,
+		base+"/apis/apps/v1/namespaces/default/deployments/api", bytes.NewReader(patch))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("patch: got %d", resp.StatusCode)
+	}
+
+	var patched appsv1.Deployment
+	mustDecode(t, resp.Body, &patched)
+
+	if *patched.Spec.Replicas != 5 {
+		t.Fatalf("spec.replicas after patch: got %d, want 5", *patched.Spec.Replicas)
+	}
+
+	if patched.Status.Replicas != 5 {
+		t.Fatalf("status.replicas after patch: got %d, want 5", patched.Status.Replicas)
+	}
+
+	// Update via PUT.
+	resp = do(t, http.MethodPut, base+"/apis/apps/v1/namespaces/default/deployments/api",
+		mustJSON(t, makeDeployment("api", 1)))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("put: got %d", resp.StatusCode)
+	}
+
+	var updated appsv1.Deployment
+	mustDecode(t, resp.Body, &updated)
+
+	if updated.Status.Replicas != 1 {
+		t.Fatalf("status.replicas after PUT: got %d, want 1", updated.Status.Replicas)
+	}
+
+	// Delete
+	resp = do(t, http.MethodDelete, base+"/apis/apps/v1/namespaces/default/deployments/api", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestDeployment_AllNamespacesListAndDefaultReplicas(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Replicas nil should default to 1.
+	d := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-replicas"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "x"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "x"}},
+				},
+			},
+		},
+	}
+
+	resp := do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments", mustJSON(t, d))
+	var got appsv1.Deployment
+	mustDecode(t, resp.Body, &got)
+
+	if got.Status.Replicas != 1 {
+		t.Fatalf("default replicas: got %d, want 1", got.Status.Replicas)
+	}
+
+	// Across-namespaces list.
+	do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/kube-system/deployments",
+		mustJSON(t, makeDeployment("sys", 1))).Body.Close()
+
+	resp = do(t, http.MethodGet, base+"/apis/apps/v1/deployments", nil)
+	var list appsv1.DeploymentList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("all-ns list: got %d items", len(list.Items))
+	}
+}
+
+func TestDeployment_ErrorPaths(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Wrong API group.
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/deployments", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong-group: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Missing namespace.
+	resp = do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/nope/deployments",
+		mustJSON(t, makeDeployment("d", 1)))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing-ns: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Missing name.
+	resp = do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments",
+		mustJSON(t, &appsv1.Deployment{}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing-name: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Duplicate.
+	body := mustJSON(t, makeDeployment("dup", 1))
+	do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments", body).Body.Close()
+
+	resp = do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments", body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("dup: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT name mismatch.
+	resp = do(t, http.MethodPut, base+"/apis/apps/v1/namespaces/default/deployments/dup",
+		mustJSON(t, makeDeployment("different", 1)))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("name-mismatch: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Cluster-wide non-GET.
+	resp = do(t, http.MethodPost, base+"/apis/apps/v1/deployments", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("cluster POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Collection PUT.
+	resp = do(t, http.MethodPut, base+"/apis/apps/v1/namespaces/default/deployments", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("collection PUT: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Item POST.
+	resp = do(t, http.MethodPost, base+"/apis/apps/v1/namespaces/default/deployments/dup", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("item POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT bad body.
+	resp = do(t, http.MethodPut, base+"/apis/apps/v1/namespaces/default/deployments/dup", []byte(`{not`))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("put bad-body: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PATCH on missing.
+	req, _ := http.NewRequest(http.MethodPatch,
+		base+"/apis/apps/v1/namespaces/default/deployments/ghost", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("patch missing: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Get + Delete + Put on missing.
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		resp = do(t, method, base+"/apis/apps/v1/namespaces/default/deployments/ghost", nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s missing: got %d", method, resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+
+	resp = do(t, http.MethodPut, base+"/apis/apps/v1/namespaces/default/deployments/ghost",
+		mustJSON(t, makeDeployment("ghost", 1)))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("put missing: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}

--- a/kubernetes/handlers_http_test.go
+++ b/kubernetes/handlers_http_test.go
@@ -81,7 +81,10 @@ func TestServeHTTP_UnknownResourceReturns404(t *testing.T) {
 	base, cleanup := newFixture(t)
 	t.Cleanup(cleanup)
 
-	resp := do(t, http.MethodGet, base+"/api/v1/pods", nil)
+	// "nodes" is intentionally not implemented in Phase 2 — Pods, Services,
+	// Deployments etc. *are* served, so we need a resource that always falls
+	// through the dispatcher.
+	resp := do(t, http.MethodGet, base+"/api/v1/nodes", nil)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNotFound {

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -196,15 +196,30 @@ func (s *ClusterState) deleteNamespace(w http.ResponseWriter, name string) {
 
 	delete(s.namespaces, name)
 
-	// Cascading delete: drop any namespaced resources that lived inside.
+	// Cascading delete: drop every namespaced resource keyed under this
+	// namespace. Real apiserver does this via finalizers + garbage
+	// collection; we collapse it into a synchronous sweep because tests
+	// don't observe partial states.
 	prefix := name + "/"
-	for k := range s.configMaps {
-		if strings.HasPrefix(k, prefix) {
-			delete(s.configMaps, k)
-		}
-	}
+	deletePrefixedKeysFrom(s.configMaps, prefix)
+	deletePrefixedKeysFrom(s.pods, prefix)
+	deletePrefixedKeysFrom(s.secrets, prefix)
+	deletePrefixedKeysFrom(s.serviceAccounts, prefix)
+	deletePrefixedKeysFrom(s.services, prefix)
+	deletePrefixedKeysFrom(s.deployments, prefix)
 
 	writeJSON(w, http.StatusOK, ns.DeepCopy())
+}
+
+// deletePrefixedKeysFrom drops every entry in m whose key starts with prefix.
+// Used by deleteNamespace to cascade across the per-resource maps without
+// repeating the loop body for each one.
+func deletePrefixedKeysFrom[V any](m map[string]*V, prefix string) {
+	for k := range m {
+		if strings.HasPrefix(k, prefix) {
+			delete(m, k)
+		}
+	}
 }
 
 // newNamespaceObject builds a fresh Namespace with the implicit fields a

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -81,6 +81,11 @@ func (s *ClusterState) createNamespace(w http.ResponseWriter, r *http.Request) {
 	ns.Annotations = in.Annotations
 	s.namespaces[in.Name] = ns
 
+	// Real apiserver auto-creates a "default" ServiceAccount in every new
+	// namespace. Mirror that so `kubectl --namespace=<new>` finds an SA.
+	sa := newServiceAccountObject(in.Name, "default")
+	s.serviceAccounts[serviceAccountKey(in.Name, "default")] = sa
+
 	writeJSON(w, http.StatusCreated, ns)
 }
 

--- a/kubernetes/pod.go
+++ b/kubernetes/pod.go
@@ -1,0 +1,254 @@
+package kubernetes
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// servePods dispatches /api/v1/{namespaces/{ns}/pods|pods} requests.
+//
+// Per-resource files share the dispatch shape on purpose; each resource keeps
+// its quirks (Service ClusterIP, Secret StringData merge) close to its type.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) servePods(w http.ResponseWriter, r *http.Request, route *Route) {
+	if route.APIGroup != "" || route.APIVersion != apiVersionV1 {
+		writeNotFound(w, "k8s api: pods are only served at /api/v1")
+
+		return
+	}
+
+	if route.Namespace == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, "k8s api: pods cluster-wide: method not allowed: "+r.Method)
+
+			return
+		}
+
+		s.listPodsAllNamespaces(w)
+
+		return
+	}
+
+	if !s.namespaceExists(route.Namespace) {
+		writeNotFound(w, "k8s api: namespace not found: "+route.Namespace)
+
+		return
+	}
+
+	if route.Name == "" {
+		s.servePodCollection(w, r, route.Namespace)
+
+		return
+	}
+
+	s.servePodItem(w, r, route.Namespace, route.Name)
+}
+
+func (s *ClusterState) servePodCollection(w http.ResponseWriter, r *http.Request, namespace string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listPods(w, namespace)
+	case http.MethodPost:
+		s.createPod(w, r, namespace)
+	default:
+		writeMethodNotAllowed(w, "k8s api: pods collection: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) servePodItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getPod(w, namespace, name)
+	case http.MethodPut:
+		s.updatePod(w, r, namespace, name)
+	case http.MethodPatch:
+		s.patchPod(w, r, namespace, name)
+	case http.MethodDelete:
+		s.deletePod(w, namespace, name)
+	default:
+		writeMethodNotAllowed(w, "k8s api: pod item: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) createPod(w http.ResponseWriter, r *http.Request, namespace string) {
+	var in corev1.Pod
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		writeBadRequest(w, "k8s api: pod: metadata.name is required")
+
+		return
+	}
+
+	in.Namespace = namespace
+
+	key := podKey(namespace, in.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.pods[key]; ok {
+		writeAlreadyExists(w, "k8s api: pod already exists: "+key)
+
+		return
+	}
+
+	stamp(&in.ObjectMeta)
+	in.TypeMeta = metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}
+
+	// No scheduler in Wave 2 — every Pod is born Pending and stays there
+	// until something (a future Phase 4 controller, or the test author)
+	// explicitly mutates Status.
+	if in.Status.Phase == "" {
+		in.Status.Phase = corev1.PodPending
+	}
+
+	pod := in
+	s.pods[key] = &pod
+	writeJSON(w, http.StatusCreated, &pod)
+}
+
+func (s *ClusterState) listPods(w http.ResponseWriter, namespace string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectPodsLocked(namespace)
+	writeJSON(w, http.StatusOK, &corev1.PodList{
+		TypeMeta: metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) listPodsAllNamespaces(w http.ResponseWriter) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectPodsLocked("")
+	writeJSON(w, http.StatusOK, &corev1.PodList{
+		TypeMeta: metav1.TypeMeta{Kind: "PodList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) collectPodsLocked(namespace string) []corev1.Pod {
+	keys := make([]string, 0, len(s.pods))
+
+	for k := range s.pods {
+		if namespace == "" || strings.HasPrefix(k, namespace+"/") {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	items := make([]corev1.Pod, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, *s.pods[k].DeepCopy())
+	}
+
+	return items
+}
+
+func (s *ClusterState) getPod(w http.ResponseWriter, namespace, name string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	pod, ok := s.pods[podKey(namespace, name)]
+	if !ok {
+		writeNotFound(w, "k8s api: pod not found: "+namespace+"/"+name)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, pod.DeepCopy())
+}
+
+func (s *ClusterState) updatePod(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	var in corev1.Pod
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name != name {
+		writeBadRequest(w, "k8s api: pod name in body does not match URL")
+
+		return
+	}
+
+	key := podKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.pods[key]
+	if !ok {
+		writeNotFound(w, "k8s api: pod not found: "+key)
+
+		return
+	}
+
+	in.Namespace = namespace
+	in.UID = cur.UID
+	in.CreationTimestamp = cur.CreationTimestamp
+	in.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	in.TypeMeta = cur.TypeMeta
+
+	pod := in
+	s.pods[key] = &pod
+	writeJSON(w, http.StatusOK, &pod)
+}
+
+// Patch flow is identical across namespaced resources; sharing would force a
+// runtime type-switch and obscure the resource-specific store access.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) patchPod(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	key := podKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.pods[key]
+	if !ok {
+		writeNotFound(w, "k8s api: pod not found: "+key)
+
+		return
+	}
+
+	patched, ok := applyJSONPatch(w, r, cur)
+	if !ok {
+		return
+	}
+
+	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	s.pods[key] = patched
+	writeJSON(w, http.StatusOK, patched)
+}
+
+func (s *ClusterState) deletePod(w http.ResponseWriter, namespace, name string) {
+	key := podKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	pod, ok := s.pods[key]
+	if !ok {
+		writeNotFound(w, "k8s api: pod not found: "+key)
+
+		return
+	}
+
+	delete(s.pods, key)
+	writeJSON(w, http.StatusOK, pod.DeepCopy())
+}
+
+func podKey(namespace, name string) string {
+	return namespace + "/" + name
+}

--- a/kubernetes/pod.go
+++ b/kubernetes/pod.go
@@ -170,6 +170,7 @@ func (s *ClusterState) getPod(w http.ResponseWriter, namespace, name string) {
 	writeJSON(w, http.StatusOK, pod.DeepCopy())
 }
 
+//nolint:dupl // namespaced-update CRUD pattern; copy-paste is clearer than a generic helper.
 func (s *ClusterState) updatePod(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	var in corev1.Pod
 	if !readJSON(w, r, &in) {

--- a/kubernetes/pod_test.go
+++ b/kubernetes/pod_test.go
@@ -1,0 +1,274 @@
+package kubernetes_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPod_LifecycleInNamespace(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	pod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "nginx:1.27"}},
+		},
+	}
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", mustJSON(t, pod))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status: got %d, want 201", resp.StatusCode)
+	}
+
+	var created corev1.Pod
+	mustDecode(t, resp.Body, &created)
+
+	if created.Status.Phase != corev1.PodPending {
+		t.Fatalf("Phase on create: got %q, want Pending", created.Status.Phase)
+	}
+
+	if created.UID == "" {
+		t.Fatal("Pod missing UID")
+	}
+
+	// Get
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/pods/web", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Pod
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.Containers[0].Image != "nginx:1.27" {
+		t.Fatalf("image: got %q", got.Spec.Containers[0].Image)
+	}
+
+	// List in namespace
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/pods", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d", resp.StatusCode)
+	}
+
+	var list corev1.PodList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 1 {
+		t.Fatalf("list items: got %d, want 1", len(list.Items))
+	}
+
+	// Delete
+	resp = do(t, http.MethodDelete, base+"/api/v1/namespaces/default/pods/web", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/pods/web", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get-after-delete: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestPod_PatchUpdatesImage(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods",
+		mustJSON(t, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c", Image: "nginx:1.27"}},
+			},
+		})).Body.Close()
+
+	patch := []byte(`{"spec":{"containers":[{"name":"c","image":"nginx:1.29"}]}}`)
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/namespaces/default/pods/p", bytes.NewReader(patch))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ := http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("patch: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Pod
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.Containers[0].Image != "nginx:1.29" {
+		t.Fatalf("image after patch: got %q", got.Spec.Containers[0].Image)
+	}
+}
+
+func TestPod_AllNamespacesListAndUpdate(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	for _, ns := range []string{"default", "kube-system"} {
+		do(t, http.MethodPost, base+"/api/v1/namespaces/"+ns+"/pods",
+			mustJSON(t, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p-" + ns},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c", Image: "x"}},
+				},
+			})).Body.Close()
+	}
+
+	// All-namespaces list
+	resp := do(t, http.MethodGet, base+"/api/v1/pods", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("all-ns list: got %d", resp.StatusCode)
+	}
+
+	var list corev1.PodList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("all-ns list: got %d items, want 2", len(list.Items))
+	}
+
+	// Update via PUT — name must match URL.
+	updated := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p-default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "x-v2"}},
+		},
+	}
+
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/pods/p-default", mustJSON(t, updated))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("put: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Pod
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.Containers[0].Image != "x-v2" {
+		t.Fatalf("image after PUT: got %q", got.Spec.Containers[0].Image)
+	}
+
+	if got.ResourceVersion != "2" {
+		t.Fatalf("resourceVersion after PUT: got %q, want 2", got.ResourceVersion)
+	}
+}
+
+func TestPod_ErrorPaths(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Missing namespace.
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/nope/pods",
+		mustJSON(t, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing-ns: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Missing name in body.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", mustJSON(t, &corev1.Pod{}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing-name: got %d, want 400", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Duplicate.
+	body := mustJSON(t, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "dup"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "x"}}},
+	})
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", body).Body.Close()
+
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods", body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("dup: got %d, want 409", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT name mismatch.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/pods/dup",
+		mustJSON(t, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "different"}}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("put name-mismatch: got %d, want 400", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Method on collection.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/pods", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("collection PUT: got %d, want 405", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Method on cluster-wide.
+	resp = do(t, http.MethodPost, base+"/api/v1/pods", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("cluster POST: got %d, want 405", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Wrong API group.
+	resp = do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/pods", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong-group: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Get missing.
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/pods/ghost", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get-missing: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Delete missing.
+	resp = do(t, http.MethodDelete, base+"/api/v1/namespaces/default/pods/ghost", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("delete-missing: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT bad body.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/pods/dup", []byte(`{not-json`))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("put bad body: got %d, want 400", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PATCH missing pod.
+	req, _ := http.NewRequest(http.MethodPatch, base+"/api/v1/namespaces/default/pods/ghost",
+		bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("patch missing: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Method on item.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/pods/dup", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("item POST: got %d, want 405", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -1,0 +1,280 @@
+package kubernetes
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// serveSecrets dispatches /api/v1/{namespaces/{ns}/secrets|secrets} requests.
+//
+// Per-resource files share the dispatch shape on purpose; each resource keeps
+// its quirks (Service ClusterIP, Secret StringData merge) close to its type.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) serveSecrets(w http.ResponseWriter, r *http.Request, route *Route) {
+	if route.APIGroup != "" || route.APIVersion != apiVersionV1 {
+		writeNotFound(w, "k8s api: secrets are only served at /api/v1")
+
+		return
+	}
+
+	if route.Namespace == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, "k8s api: secrets cluster-wide: method not allowed: "+r.Method)
+
+			return
+		}
+
+		s.listSecretsAllNamespaces(w)
+
+		return
+	}
+
+	if !s.namespaceExists(route.Namespace) {
+		writeNotFound(w, "k8s api: namespace not found: "+route.Namespace)
+
+		return
+	}
+
+	if route.Name == "" {
+		s.serveSecretCollection(w, r, route.Namespace)
+
+		return
+	}
+
+	s.serveSecretItem(w, r, route.Namespace, route.Name)
+}
+
+func (s *ClusterState) serveSecretCollection(w http.ResponseWriter, r *http.Request, namespace string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listSecrets(w, namespace)
+	case http.MethodPost:
+		s.createSecret(w, r, namespace)
+	default:
+		writeMethodNotAllowed(w, "k8s api: secrets collection: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) serveSecretItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getSecret(w, namespace, name)
+	case http.MethodPut:
+		s.updateSecret(w, r, namespace, name)
+	case http.MethodPatch:
+		s.patchSecret(w, r, namespace, name)
+	case http.MethodDelete:
+		s.deleteSecret(w, namespace, name)
+	default:
+		writeMethodNotAllowed(w, "k8s api: secret item: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) createSecret(w http.ResponseWriter, r *http.Request, namespace string) {
+	var in corev1.Secret
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		writeBadRequest(w, "k8s api: secret: metadata.name is required")
+
+		return
+	}
+
+	in.Namespace = namespace
+
+	mergeStringData(&in)
+
+	key := secretKey(namespace, in.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.secrets[key]; ok {
+		writeAlreadyExists(w, "k8s api: secret already exists: "+key)
+
+		return
+	}
+
+	stamp(&in.ObjectMeta)
+	in.TypeMeta = metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"}
+
+	if in.Type == "" {
+		in.Type = corev1.SecretTypeOpaque
+	}
+
+	sec := in
+	s.secrets[key] = &sec
+	writeJSON(w, http.StatusCreated, &sec)
+}
+
+func (s *ClusterState) listSecrets(w http.ResponseWriter, namespace string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectSecretsLocked(namespace)
+	writeJSON(w, http.StatusOK, &corev1.SecretList{
+		TypeMeta: metav1.TypeMeta{Kind: "SecretList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) listSecretsAllNamespaces(w http.ResponseWriter) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectSecretsLocked("")
+	writeJSON(w, http.StatusOK, &corev1.SecretList{
+		TypeMeta: metav1.TypeMeta{Kind: "SecretList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) collectSecretsLocked(namespace string) []corev1.Secret {
+	keys := make([]string, 0, len(s.secrets))
+
+	for k := range s.secrets {
+		if namespace == "" || strings.HasPrefix(k, namespace+"/") {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	items := make([]corev1.Secret, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, *s.secrets[k].DeepCopy())
+	}
+
+	return items
+}
+
+func (s *ClusterState) getSecret(w http.ResponseWriter, namespace, name string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sec, ok := s.secrets[secretKey(namespace, name)]
+	if !ok {
+		writeNotFound(w, "k8s api: secret not found: "+namespace+"/"+name)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, sec.DeepCopy())
+}
+
+func (s *ClusterState) updateSecret(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	var in corev1.Secret
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name != name {
+		writeBadRequest(w, "k8s api: secret name in body does not match URL")
+
+		return
+	}
+
+	mergeStringData(&in)
+
+	key := secretKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.secrets[key]
+	if !ok {
+		writeNotFound(w, "k8s api: secret not found: "+key)
+
+		return
+	}
+
+	in.Namespace = namespace
+	in.UID = cur.UID
+	in.CreationTimestamp = cur.CreationTimestamp
+	in.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	in.TypeMeta = cur.TypeMeta
+
+	if in.Type == "" {
+		in.Type = cur.Type
+	}
+
+	sec := in
+	s.secrets[key] = &sec
+	writeJSON(w, http.StatusOK, &sec)
+}
+
+// Patch flow is identical across namespaced resources; sharing would force a
+// runtime type-switch and obscure the resource-specific store access.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) patchSecret(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	key := secretKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.secrets[key]
+	if !ok {
+		writeNotFound(w, "k8s api: secret not found: "+key)
+
+		return
+	}
+
+	patched, ok := applyJSONPatch(w, r, cur)
+	if !ok {
+		return
+	}
+
+	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	s.secrets[key] = patched
+	writeJSON(w, http.StatusOK, patched)
+}
+
+func (s *ClusterState) deleteSecret(w http.ResponseWriter, namespace, name string) {
+	key := secretKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sec, ok := s.secrets[key]
+	if !ok {
+		writeNotFound(w, "k8s api: secret not found: "+key)
+
+		return
+	}
+
+	delete(s.secrets, key)
+	writeJSON(w, http.StatusOK, sec.DeepCopy())
+}
+
+func secretKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// mergeStringData implements the apiserver's convenience-field behavior: any
+// keys in StringData are byte-encoded and copied into Data, overwriting on
+// conflict. StringData is then cleared from the persisted object — clients
+// reading the Secret back see everything in Data, base64-encoded on the
+// wire by encoding/json's default []byte handling.
+func mergeStringData(sec *corev1.Secret) {
+	if len(sec.StringData) == 0 {
+		return
+	}
+
+	if sec.Data == nil {
+		sec.Data = make(map[string][]byte, len(sec.StringData))
+	}
+
+	for k, v := range sec.StringData {
+		sec.Data[k] = []byte(v)
+	}
+
+	sec.StringData = nil
+}

--- a/kubernetes/secret_test.go
+++ b/kubernetes/secret_test.go
@@ -1,0 +1,247 @@
+package kubernetes_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSecret_LifecycleAndStringDataMerge(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Create with StringData — should merge into Data on persist.
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds"},
+		StringData: map[string]string{"username": "admin", "password": "s3cret"},
+		Data:       map[string][]byte{"token": []byte("preexisting")},
+	}
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/secrets", mustJSON(t, sec))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: got %d, want 201", resp.StatusCode)
+	}
+
+	var created corev1.Secret
+	mustDecode(t, resp.Body, &created)
+
+	if len(created.StringData) != 0 {
+		t.Fatalf("StringData should be cleared after merge, got %v", created.StringData)
+	}
+
+	if string(created.Data["username"]) != "admin" {
+		t.Fatalf("username: got %q", string(created.Data["username"]))
+	}
+
+	if string(created.Data["password"]) != "s3cret" {
+		t.Fatalf("password: got %q", string(created.Data["password"]))
+	}
+
+	if string(created.Data["token"]) != "preexisting" {
+		t.Fatalf("token preserved: got %q", string(created.Data["token"]))
+	}
+
+	if created.Type != corev1.SecretTypeOpaque {
+		t.Fatalf("default Type: got %q, want Opaque", created.Type)
+	}
+
+	// Get
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/secrets/creds", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Update via PUT — re-introduce StringData, expect another merge + type preservation.
+	updated := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds"},
+		StringData: map[string]string{"password": "rotated"},
+		// Type omitted — should preserve existing.
+	}
+
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/secrets/creds", mustJSON(t, updated))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("update: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Secret
+	mustDecode(t, resp.Body, &got)
+
+	if string(got.Data["password"]) != "rotated" {
+		t.Fatalf("password after update: got %q", string(got.Data["password"]))
+	}
+
+	if got.Type != corev1.SecretTypeOpaque {
+		t.Fatalf("Type preserved on update: got %q", got.Type)
+	}
+
+	if got.ResourceVersion != "2" {
+		t.Fatalf("RV after update: got %q, want 2", got.ResourceVersion)
+	}
+
+	// Patch
+	patch := []byte(`{"data":{"extra":"ZXh0cmEtdmFsdWU="}}`) // base64("extra-value")
+	req, _ := http.NewRequest(http.MethodPatch,
+		base+"/api/v1/namespaces/default/secrets/creds", bytes.NewReader(patch))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("patch: got %d", resp.StatusCode)
+	}
+
+	var patched corev1.Secret
+	mustDecode(t, resp.Body, &patched)
+
+	if string(patched.Data["extra"]) != "extra-value" {
+		t.Fatalf("patched data.extra: got %q", string(patched.Data["extra"]))
+	}
+
+	// Delete
+	resp = do(t, http.MethodDelete, base+"/api/v1/namespaces/default/secrets/creds", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/secrets/creds", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get-after-delete: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestSecret_AllNamespacesList(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	for _, ns := range []string{"default", "kube-system"} {
+		do(t, http.MethodPost, base+"/api/v1/namespaces/"+ns+"/secrets",
+			mustJSON(t, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "s-" + ns},
+				StringData: map[string]string{"k": "v"},
+			})).Body.Close()
+	}
+
+	resp := do(t, http.MethodGet, base+"/api/v1/secrets", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("all-ns list: got %d", resp.StatusCode)
+	}
+
+	var list corev1.SecretList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("all-ns list: got %d items", len(list.Items))
+	}
+}
+
+func TestSecret_ErrorPaths(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Missing namespace.
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/nope/secrets",
+		mustJSON(t, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s"}}))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing-ns: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Missing name.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/secrets",
+		mustJSON(t, &corev1.Secret{}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing-name: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Duplicate.
+	body := mustJSON(t, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "dup"}})
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/secrets", body).Body.Close()
+
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/secrets", body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("dup: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT name mismatch.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/secrets/dup",
+		mustJSON(t, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "diff"}}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("name-mismatch: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// All-ns non-GET.
+	resp = do(t, http.MethodPost, base+"/api/v1/secrets", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("cluster POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Bad API group.
+	resp = do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/secrets", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong-group: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Collection PUT.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/secrets", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("collection PUT: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Item POST.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/secrets/dup", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("item POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT bad body.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/secrets/dup", []byte(`{not`))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("put bad-body: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Get/Update/Delete/Patch on missing.
+	for method, payload := range map[string][]byte{
+		http.MethodGet:    nil,
+		http.MethodPut:    mustJSON(t, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ghost"}}),
+		http.MethodPatch:  []byte(`{}`),
+		http.MethodDelete: nil,
+	} {
+		req, _ := http.NewRequest(method,
+			base+"/api/v1/namespaces/default/secrets/ghost", bytes.NewReader(payload))
+		if method == http.MethodPatch {
+			req.Header.Set("Content-Type", "application/merge-patch+json")
+		}
+
+		resp, _ := http.DefaultClient.Do(req)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s missing: got %d", method, resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+}

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -1,0 +1,306 @@
+package kubernetes
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// clusterIPNone is the sentinel value a client sets on a headless Service —
+// real apiserver leaves the ClusterIP empty in that case.
+const clusterIPNone = "None"
+
+// serveServices dispatches /api/v1/{namespaces/{ns}/services|services}
+// requests.
+//
+// Per-resource files share the dispatch shape on purpose; each resource keeps
+// its quirks (Service ClusterIP, Secret StringData merge) close to its type.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) serveServices(w http.ResponseWriter, r *http.Request, route *Route) {
+	if route.APIGroup != "" || route.APIVersion != apiVersionV1 {
+		writeNotFound(w, "k8s api: services are only served at /api/v1")
+
+		return
+	}
+
+	if route.Namespace == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, "k8s api: services cluster-wide: method not allowed: "+r.Method)
+
+			return
+		}
+
+		s.listServicesAllNamespaces(w)
+
+		return
+	}
+
+	if !s.namespaceExists(route.Namespace) {
+		writeNotFound(w, "k8s api: namespace not found: "+route.Namespace)
+
+		return
+	}
+
+	if route.Name == "" {
+		s.serveServiceCollection(w, r, route.Namespace)
+
+		return
+	}
+
+	s.serveServiceItem(w, r, route.Namespace, route.Name)
+}
+
+func (s *ClusterState) serveServiceCollection(w http.ResponseWriter, r *http.Request, namespace string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listServices(w, namespace)
+	case http.MethodPost:
+		s.createService(w, r, namespace)
+	default:
+		writeMethodNotAllowed(w, "k8s api: services collection: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) serveServiceItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getService(w, namespace, name)
+	case http.MethodPut:
+		s.updateService(w, r, namespace, name)
+	case http.MethodPatch:
+		s.patchService(w, r, namespace, name)
+	case http.MethodDelete:
+		s.deleteService(w, namespace, name)
+	default:
+		writeMethodNotAllowed(w, "k8s api: service item: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) createService(w http.ResponseWriter, r *http.Request, namespace string) {
+	var in corev1.Service
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		writeBadRequest(w, "k8s api: service: metadata.name is required")
+
+		return
+	}
+
+	in.Namespace = namespace
+
+	key := serviceKey(namespace, in.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.services[key]; ok {
+		writeAlreadyExists(w, "k8s api: service already exists: "+key)
+
+		return
+	}
+
+	stamp(&in.ObjectMeta)
+	in.TypeMeta = metav1.TypeMeta{Kind: "Service", APIVersion: "v1"}
+
+	if in.Spec.Type == "" {
+		in.Spec.Type = corev1.ServiceTypeClusterIP
+	}
+
+	// ClusterIP allocation. "" → allocate next sequential IP. "None" →
+	// headless: keep as-is and leave ClusterIPs nil. Anything else → accept
+	// verbatim (real apiserver validates conflicts; a test backend doesn't
+	// need to).
+	if in.Spec.ClusterIP == "" {
+		in.Spec.ClusterIP = s.allocateClusterIPLocked()
+	}
+
+	if len(in.Spec.ClusterIPs) == 0 && in.Spec.ClusterIP != "" && in.Spec.ClusterIP != clusterIPNone {
+		in.Spec.ClusterIPs = []string{in.Spec.ClusterIP}
+	}
+
+	svc := in
+	s.services[key] = &svc
+	writeJSON(w, http.StatusCreated, &svc)
+}
+
+func (s *ClusterState) listServices(w http.ResponseWriter, namespace string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectServicesLocked(namespace)
+	writeJSON(w, http.StatusOK, &corev1.ServiceList{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) listServicesAllNamespaces(w http.ResponseWriter) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectServicesLocked("")
+	writeJSON(w, http.StatusOK, &corev1.ServiceList{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) collectServicesLocked(namespace string) []corev1.Service {
+	keys := make([]string, 0, len(s.services))
+
+	for k := range s.services {
+		if namespace == "" || strings.HasPrefix(k, namespace+"/") {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	items := make([]corev1.Service, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, *s.services[k].DeepCopy())
+	}
+
+	return items
+}
+
+func (s *ClusterState) getService(w http.ResponseWriter, namespace, name string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	svc, ok := s.services[serviceKey(namespace, name)]
+	if !ok {
+		writeNotFound(w, "k8s api: service not found: "+namespace+"/"+name)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, svc.DeepCopy())
+}
+
+func (s *ClusterState) updateService(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	var in corev1.Service
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name != name {
+		writeBadRequest(w, "k8s api: service name in body does not match URL")
+
+		return
+	}
+
+	key := serviceKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.services[key]
+	if !ok {
+		writeNotFound(w, "k8s api: service not found: "+key)
+
+		return
+	}
+
+	in.Namespace = namespace
+	in.UID = cur.UID
+	in.CreationTimestamp = cur.CreationTimestamp
+	in.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	in.TypeMeta = cur.TypeMeta
+
+	// ClusterIP is immutable after Create (kubernetes apiserver semantics).
+	// Carry the allocated IP forward regardless of what the client sends.
+	in.Spec.ClusterIP = cur.Spec.ClusterIP
+	in.Spec.ClusterIPs = cur.Spec.ClusterIPs
+
+	svc := in
+	s.services[key] = &svc
+	writeJSON(w, http.StatusOK, &svc)
+}
+
+func (s *ClusterState) patchService(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	key := serviceKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.services[key]
+	if !ok {
+		writeNotFound(w, "k8s api: service not found: "+key)
+
+		return
+	}
+
+	patched, ok := applyJSONPatch(w, r, cur)
+	if !ok {
+		return
+	}
+
+	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	// Same ClusterIP-immutable rule as updateService.
+	patched.Spec.ClusterIP = cur.Spec.ClusterIP
+	patched.Spec.ClusterIPs = cur.Spec.ClusterIPs
+	s.services[key] = patched
+	writeJSON(w, http.StatusOK, patched)
+}
+
+func (s *ClusterState) deleteService(w http.ResponseWriter, namespace, name string) {
+	key := serviceKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	svc, ok := s.services[key]
+	if !ok {
+		writeNotFound(w, "k8s api: service not found: "+key)
+
+		return
+	}
+
+	delete(s.services, key)
+	writeJSON(w, http.StatusOK, svc.DeepCopy())
+}
+
+func serviceKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// allocateClusterIPLocked hands out the next sequential ClusterIP from
+// 10.96.0.0/12. Caller must hold s.mu (write lock).
+//
+// Real apiserver allocates from a per-cluster CIDR bitmap and reclaims IPs
+// on Service deletion. Tests don't typically reuse IPs, so we use a simple
+// monotonic counter that never reclaims; the 10.96.0.0/12 range gives us
+// over a million IPs before wrap-around, which is more than enough.
+func (s *ClusterState) allocateClusterIPLocked() string {
+	offset := s.nextClusterIP
+	s.nextClusterIP++
+
+	// 10.96.0.0 + offset rendered as a dotted-quad. Only the lower 20 bits
+	// are interesting for a /12; mask just in case to avoid garbage values
+	// in the unlikely event of overflow.
+	const (
+		baseAddr        uint32 = 10<<24 | 96<<16
+		octetMask       uint32 = 0xFF
+		serviceCIDRMask uint32 = 0x000FFFFF // /12 — host bits below the network
+		shift1                 = 24
+		shift2                 = 16
+		shift3                 = 8
+	)
+
+	addr := baseAddr + (offset & serviceCIDRMask)
+
+	return fmt.Sprintf("%d.%d.%d.%d",
+		(addr>>shift1)&octetMask,
+		(addr>>shift2)&octetMask,
+		(addr>>shift3)&octetMask,
+		addr&octetMask,
+	)
+}

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -220,6 +220,13 @@ func (s *ClusterState) updateService(w http.ResponseWriter, r *http.Request, nam
 	in.Spec.ClusterIP = cur.Spec.ClusterIP
 	in.Spec.ClusterIPs = cur.Spec.ClusterIPs
 
+	// Real apiserver requires .spec.type to remain set after the first
+	// successful create. If the client omits it, fall back to the stored
+	// value rather than silently corrupting the object.
+	if in.Spec.Type == "" {
+		in.Spec.Type = cur.Spec.Type
+	}
+
 	svc := in
 	s.services[key] = &svc
 	writeJSON(w, http.StatusOK, &svc)

--- a/kubernetes/service_test.go
+++ b/kubernetes/service_test.go
@@ -1,6 +1,7 @@
 package kubernetes_test
 
 import (
+	"bytes"
 	"net/http"
 	"testing"
 
@@ -142,6 +143,66 @@ func TestService_ClusterIPImmutableOnUpdate(t *testing.T) {
 
 	if updated.Spec.Ports[0].Port != 8080 {
 		t.Fatalf("Port: got %d, want 8080", updated.Spec.Ports[0].Port)
+	}
+}
+
+func TestService_PatchPreservesClusterIP(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "patchable"},
+			Spec: corev1.ServiceSpec{
+				Type:  corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{{Port: 80}},
+			},
+		}))
+
+	var created corev1.Service
+	mustDecode(t, resp.Body, &created)
+
+	allocatedIP := created.Spec.ClusterIP
+
+	// Patch attempts to overwrite ClusterIP and change ports.
+	patch := []byte(`{"spec":{"clusterIP":"10.96.42.42","ports":[{"port":9090}]}}`)
+
+	req, _ := http.NewRequest(http.MethodPatch,
+		base+"/api/v1/namespaces/default/services/patchable",
+		bytes.NewReader(patch))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("patch status: got %d", resp.StatusCode)
+	}
+
+	var patched corev1.Service
+	mustDecode(t, resp.Body, &patched)
+
+	if patched.Spec.ClusterIP != allocatedIP {
+		t.Fatalf("ClusterIP after patch: got %q, want %q (immutable)", patched.Spec.ClusterIP, allocatedIP)
+	}
+
+	if patched.Spec.Ports[0].Port != 9090 {
+		t.Fatalf("Port after patch: got %d, want 9090", patched.Spec.Ports[0].Port)
+	}
+
+	// Get the service back too — exercises getService happy path.
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/services/patchable", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Service
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.ClusterIP != allocatedIP {
+		t.Fatalf("ClusterIP after Get: got %q", got.Spec.ClusterIP)
 	}
 }
 

--- a/kubernetes/service_test.go
+++ b/kubernetes/service_test.go
@@ -1,0 +1,300 @@
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestService_ClusterIPAllocatedSequentially(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// First three Services with empty ClusterIP — should get 10.96.0.1, .2, .3.
+	wantIPs := []string{"10.96.0.1", "10.96.0.2", "10.96.0.3"}
+
+	for i, want := range wantIPs {
+		body := mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "s-" + want},
+			Spec: corev1.ServiceSpec{
+				Type:     corev1.ServiceTypeClusterIP,
+				Selector: map[string]string{"app": "demo"},
+				Ports:    []corev1.ServicePort{{Port: 80}},
+			},
+		})
+
+		resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/services", body)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %d: got %d", i, resp.StatusCode)
+		}
+
+		var got corev1.Service
+		mustDecode(t, resp.Body, &got)
+
+		if got.Spec.ClusterIP != want {
+			t.Fatalf("ClusterIP[%d]: got %q, want %q", i, got.Spec.ClusterIP, want)
+		}
+
+		if len(got.Spec.ClusterIPs) != 1 || got.Spec.ClusterIPs[0] != want {
+			t.Fatalf("ClusterIPs[%d]: got %v, want [%s]", i, got.Spec.ClusterIPs, want)
+		}
+	}
+}
+
+func TestService_HeadlessKeepsClusterIPEmpty(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	body := mustJSON(t, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "headless"},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: "None",
+			Selector:  map[string]string{"app": "demo"},
+		},
+	})
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/services", body)
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Service
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.ClusterIP != "None" {
+		t.Fatalf("Headless ClusterIP: got %q, want None", got.Spec.ClusterIP)
+	}
+
+	if len(got.Spec.ClusterIPs) != 0 {
+		t.Fatalf("Headless ClusterIPs: got %v, want empty", got.Spec.ClusterIPs)
+	}
+}
+
+func TestService_ExplicitClusterIPAccepted(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "fixed"},
+			Spec: corev1.ServiceSpec{
+				Type:      corev1.ServiceTypeClusterIP,
+				ClusterIP: "10.96.99.99",
+				Ports:     []corev1.ServicePort{{Port: 80}},
+			},
+		}))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("status: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Service
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.ClusterIP != "10.96.99.99" {
+		t.Fatalf("explicit IP: got %q", got.Spec.ClusterIP)
+	}
+}
+
+func TestService_ClusterIPImmutableOnUpdate(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	body := mustJSON(t, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "stable"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	})
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/services", body)
+	var created corev1.Service
+	mustDecode(t, resp.Body, &created)
+
+	allocatedIP := created.Spec.ClusterIP
+	if allocatedIP == "" {
+		t.Fatal("create did not allocate ClusterIP")
+	}
+
+	// Try to change it via PUT — should be ignored, allocated IP must survive.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/services/stable",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "stable"},
+			Spec: corev1.ServiceSpec{
+				Type:      corev1.ServiceTypeClusterIP,
+				ClusterIP: "10.96.42.42",
+				Ports:     []corev1.ServicePort{{Port: 8080}},
+			},
+		}))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("put: got %d", resp.StatusCode)
+	}
+
+	var updated corev1.Service
+	mustDecode(t, resp.Body, &updated)
+
+	if updated.Spec.ClusterIP != allocatedIP {
+		t.Fatalf("ClusterIP after update: got %q, want %q (immutable)", updated.Spec.ClusterIP, allocatedIP)
+	}
+
+	if updated.Spec.Ports[0].Port != 8080 {
+		t.Fatalf("Port: got %d, want 8080", updated.Spec.Ports[0].Port)
+	}
+}
+
+func TestService_LifecycleAndAllNamespacesList(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	for _, ns := range []string{"default", "kube-system"} {
+		do(t, http.MethodPost, base+"/api/v1/namespaces/"+ns+"/services",
+			mustJSON(t, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc"},
+				Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP, Ports: []corev1.ServicePort{{Port: 80}}},
+			})).Body.Close()
+	}
+
+	resp := do(t, http.MethodGet, base+"/api/v1/services", nil)
+	var list corev1.ServiceList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("all-ns list: got %d items", len(list.Items))
+	}
+
+	// Delete
+	resp = do(t, http.MethodDelete, base+"/api/v1/namespaces/default/services/svc", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/services/svc", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get-after-delete: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestService_ErrorPaths(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Missing namespace.
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/nope/services",
+		mustJSON(t, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "s"}}))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing-ns: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Missing name.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing-name: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Duplicate.
+	body := mustJSON(t, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "dup"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP, Ports: []corev1.ServicePort{{Port: 80}}},
+	})
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/services", body).Body.Close()
+
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/services", body)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("dup: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Wrong API group.
+	resp = do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/services", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong-group: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Cluster-wide non-GET.
+	resp = do(t, http.MethodPost, base+"/api/v1/services", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("cluster POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT name mismatch.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/services/dup",
+		mustJSON(t, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "diff"}}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("name-mismatch: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Collection PUT.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/services", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("collection PUT: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Item POST.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/services/dup", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("item POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT bad body.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/services/dup", []byte(`{not`))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("put bad-body: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PATCH on missing.
+	req, _ := http.NewRequest(http.MethodPatch,
+		base+"/api/v1/namespaces/default/services/ghost",
+		nil,
+	)
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("patch missing: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Get + Put + Delete on missing.
+	for _, method := range []string{http.MethodGet, http.MethodDelete} {
+		resp = do(t, method, base+"/api/v1/namespaces/default/services/ghost", nil)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s missing: got %d", method, resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/services/ghost",
+		mustJSON(t, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "ghost"}}))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("put missing: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}

--- a/kubernetes/service_test.go
+++ b/kubernetes/service_test.go
@@ -206,6 +206,45 @@ func TestService_PatchPreservesClusterIP(t *testing.T) {
 	}
 }
 
+func TestService_UpdatePreservesTypeWhenOmitted(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Create a LoadBalancer Service.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "lb"},
+			Spec: corev1.ServiceSpec{
+				Type:  corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{{Port: 80}},
+			},
+		})).Body.Close()
+
+	// PUT a body that omits Type. The stored Type must survive — real
+	// apiserver requires .spec.type after the first successful Create.
+	resp := do(t, http.MethodPut, base+"/api/v1/namespaces/default/services/lb",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "lb"},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Port: 8080}},
+			},
+		}))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("put: got %d", resp.StatusCode)
+	}
+
+	var got corev1.Service
+	mustDecode(t, resp.Body, &got)
+
+	if got.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Fatalf("Type after update without Type in body: got %q, want LoadBalancer (preserved)", got.Spec.Type)
+	}
+
+	if got.Spec.Ports[0].Port != 8080 {
+		t.Fatalf("Port after update: got %d, want 8080", got.Spec.Ports[0].Port)
+	}
+}
+
 func TestService_LifecycleAndAllNamespacesList(t *testing.T) {
 	base, cleanup := newFixture(t)
 	t.Cleanup(cleanup)

--- a/kubernetes/serviceaccount.go
+++ b/kubernetes/serviceaccount.go
@@ -1,0 +1,269 @@
+package kubernetes
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// serveServiceAccounts dispatches /api/v1/{namespaces/{ns}/serviceaccounts|
+// serviceaccounts} requests.
+//
+// Per-resource files share the dispatch shape on purpose; each resource keeps
+// its quirks (Service ClusterIP, Secret StringData merge) close to its type.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) serveServiceAccounts(w http.ResponseWriter, r *http.Request, route *Route) {
+	if route.APIGroup != "" || route.APIVersion != apiVersionV1 {
+		writeNotFound(w, "k8s api: serviceaccounts are only served at /api/v1")
+
+		return
+	}
+
+	if route.Namespace == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, "k8s api: serviceaccounts cluster-wide: method not allowed: "+r.Method)
+
+			return
+		}
+
+		s.listServiceAccountsAllNamespaces(w)
+
+		return
+	}
+
+	if !s.namespaceExists(route.Namespace) {
+		writeNotFound(w, "k8s api: namespace not found: "+route.Namespace)
+
+		return
+	}
+
+	if route.Name == "" {
+		s.serveServiceAccountCollection(w, r, route.Namespace)
+
+		return
+	}
+
+	s.serveServiceAccountItem(w, r, route.Namespace, route.Name)
+}
+
+func (s *ClusterState) serveServiceAccountCollection(w http.ResponseWriter, r *http.Request, namespace string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.listServiceAccounts(w, namespace)
+	case http.MethodPost:
+		s.createServiceAccount(w, r, namespace)
+	default:
+		writeMethodNotAllowed(w, "k8s api: serviceaccounts collection: method not allowed: "+r.Method)
+	}
+}
+
+func (s *ClusterState) serveServiceAccountItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		s.getServiceAccount(w, namespace, name)
+	case http.MethodPut:
+		s.updateServiceAccount(w, r, namespace, name)
+	case http.MethodPatch:
+		s.patchServiceAccount(w, r, namespace, name)
+	case http.MethodDelete:
+		s.deleteServiceAccount(w, namespace, name)
+	default:
+		writeMethodNotAllowed(w, "k8s api: serviceaccount item: method not allowed: "+r.Method)
+	}
+}
+
+//nolint:dupl // namespaced-create CRUD pattern; copy-paste is clearer than a generic helper.
+func (s *ClusterState) createServiceAccount(w http.ResponseWriter, r *http.Request, namespace string) {
+	var in corev1.ServiceAccount
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		writeBadRequest(w, "k8s api: serviceaccount: metadata.name is required")
+
+		return
+	}
+
+	in.Namespace = namespace
+
+	key := serviceAccountKey(namespace, in.Name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.serviceAccounts[key]; ok {
+		writeAlreadyExists(w, "k8s api: serviceaccount already exists: "+key)
+
+		return
+	}
+
+	stamp(&in.ObjectMeta)
+	in.TypeMeta = metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"}
+
+	sa := in
+	s.serviceAccounts[key] = &sa
+	writeJSON(w, http.StatusCreated, &sa)
+}
+
+func (s *ClusterState) listServiceAccounts(w http.ResponseWriter, namespace string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectServiceAccountsLocked(namespace)
+	writeJSON(w, http.StatusOK, &corev1.ServiceAccountList{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccountList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) listServiceAccountsAllNamespaces(w http.ResponseWriter) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectServiceAccountsLocked("")
+	writeJSON(w, http.StatusOK, &corev1.ServiceAccountList{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccountList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) collectServiceAccountsLocked(namespace string) []corev1.ServiceAccount {
+	keys := make([]string, 0, len(s.serviceAccounts))
+
+	for k := range s.serviceAccounts {
+		if namespace == "" || strings.HasPrefix(k, namespace+"/") {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	items := make([]corev1.ServiceAccount, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, *s.serviceAccounts[k].DeepCopy())
+	}
+
+	return items
+}
+
+func (s *ClusterState) getServiceAccount(w http.ResponseWriter, namespace, name string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sa, ok := s.serviceAccounts[serviceAccountKey(namespace, name)]
+	if !ok {
+		writeNotFound(w, "k8s api: serviceaccount not found: "+namespace+"/"+name)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, sa.DeepCopy())
+}
+
+//nolint:dupl // namespaced-update CRUD pattern; copy-paste is clearer than a generic helper.
+func (s *ClusterState) updateServiceAccount(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	var in corev1.ServiceAccount
+	if !readJSON(w, r, &in) {
+		return
+	}
+
+	if in.Name != name {
+		writeBadRequest(w, "k8s api: serviceaccount name in body does not match URL")
+
+		return
+	}
+
+	key := serviceAccountKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.serviceAccounts[key]
+	if !ok {
+		writeNotFound(w, "k8s api: serviceaccount not found: "+key)
+
+		return
+	}
+
+	in.Namespace = namespace
+	in.UID = cur.UID
+	in.CreationTimestamp = cur.CreationTimestamp
+	in.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	in.TypeMeta = cur.TypeMeta
+
+	sa := in
+	s.serviceAccounts[key] = &sa
+	writeJSON(w, http.StatusOK, &sa)
+}
+
+// Patch flow is identical across namespaced resources; sharing would force a
+// runtime type-switch and obscure the resource-specific store access.
+//
+//nolint:dupl // see comment above.
+func (s *ClusterState) patchServiceAccount(w http.ResponseWriter, r *http.Request, namespace, name string) {
+	key := serviceAccountKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cur, ok := s.serviceAccounts[key]
+	if !ok {
+		writeNotFound(w, "k8s api: serviceaccount not found: "+key)
+
+		return
+	}
+
+	patched, ok := applyJSONPatch(w, r, cur)
+	if !ok {
+		return
+	}
+
+	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
+	s.serviceAccounts[key] = patched
+	writeJSON(w, http.StatusOK, patched)
+}
+
+func (s *ClusterState) deleteServiceAccount(w http.ResponseWriter, namespace, name string) {
+	key := serviceAccountKey(namespace, name)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sa, ok := s.serviceAccounts[key]
+	if !ok {
+		writeNotFound(w, "k8s api: serviceaccount not found: "+key)
+
+		return
+	}
+
+	delete(s.serviceAccounts, key)
+	writeJSON(w, http.StatusOK, sa.DeepCopy())
+}
+
+func serviceAccountKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// newServiceAccountObject builds a fresh ServiceAccount with the implicit
+// fields a real apiserver fills in on create. Token Secrets used to be
+// auto-created here (pre-1.24); Wave 2 follows current behavior and leaves
+// .secrets empty.
+func newServiceAccountObject(namespace, name string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{Kind: "ServiceAccount", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(newUID()),
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			ResourceVersion:   "1",
+		},
+	}
+}

--- a/kubernetes/serviceaccount_test.go
+++ b/kubernetes/serviceaccount_test.go
@@ -1,0 +1,243 @@
+package kubernetes_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestServiceAccount_DefaultBootstrapInEveryNamespace(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Bootstrap namespaces (default/kube-system/kube-public) should each
+	// have a "default" ServiceAccount already present.
+	for _, ns := range []string{"default", "kube-system", "kube-public"} {
+		resp := do(t, http.MethodGet, base+"/api/v1/namespaces/"+ns+"/serviceaccounts/default", nil)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("default SA in %s: got %d, want 200", ns, resp.StatusCode)
+		}
+
+		var sa corev1.ServiceAccount
+		mustDecode(t, resp.Body, &sa)
+
+		if sa.Name != "default" || sa.Namespace != ns {
+			t.Fatalf("default SA in %s: got name=%q ns=%q", ns, sa.Name, sa.Namespace)
+		}
+	}
+
+	// Creating a fresh namespace auto-creates a default SA in it too.
+	do(t, http.MethodPost, base+"/api/v1/namespaces",
+		mustJSON(t, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-a"}})).Body.Close()
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/tenant-a/serviceaccounts/default", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("default SA in tenant-a after namespace create: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestServiceAccount_LifecycleAndPatch(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Create a custom SA.
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "deployer",
+			Labels: map[string]string{"team": "platform"},
+		},
+	}
+
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/serviceaccounts", mustJSON(t, sa))
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create: got %d, want 201", resp.StatusCode)
+	}
+
+	// Get
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/serviceaccounts/deployer", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// List in namespace — should include "default" and "deployer".
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/serviceaccounts", nil)
+	var list corev1.ServiceAccountList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("list: got %d items, want 2 (default + deployer)", len(list.Items))
+	}
+
+	// Patch
+	patch := []byte(`{"metadata":{"annotations":{"version":"v2"}}}`)
+	req, _ := http.NewRequest(http.MethodPatch,
+		base+"/api/v1/namespaces/default/serviceaccounts/deployer", bytes.NewReader(patch))
+	req.Header.Set("Content-Type", "application/merge-patch+json")
+
+	resp, _ = http.DefaultClient.Do(req)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("patch: got %d", resp.StatusCode)
+	}
+
+	var patched corev1.ServiceAccount
+	mustDecode(t, resp.Body, &patched)
+
+	if patched.Annotations["version"] != "v2" {
+		t.Fatalf("annotation after patch: got %q", patched.Annotations["version"])
+	}
+
+	// Update via PUT
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/serviceaccounts/deployer",
+		mustJSON(t, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "deployer",
+				Labels: map[string]string{"team": "infra"},
+			},
+		}))
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("put: got %d", resp.StatusCode)
+	}
+
+	var updated corev1.ServiceAccount
+	mustDecode(t, resp.Body, &updated)
+
+	if updated.Labels["team"] != "infra" {
+		t.Fatalf("label after put: got %q", updated.Labels["team"])
+	}
+
+	// Delete
+	resp = do(t, http.MethodDelete, base+"/api/v1/namespaces/default/serviceaccounts/deployer", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestServiceAccount_AllNamespacesList(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodGet, base+"/api/v1/serviceaccounts", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("all-ns list: got %d", resp.StatusCode)
+	}
+
+	var list corev1.ServiceAccountList
+	mustDecode(t, resp.Body, &list)
+
+	// 3 bootstrap namespaces × 1 default SA = 3.
+	if len(list.Items) != 3 {
+		t.Fatalf("all-ns list: got %d items, want 3 bootstrap default SAs", len(list.Items))
+	}
+}
+
+func TestServiceAccount_ErrorPaths(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Missing namespace.
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/nope/serviceaccounts",
+		mustJSON(t, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "sa"}}))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing-ns: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Duplicate — "default" already exists in "default" namespace.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/serviceaccounts",
+		mustJSON(t, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "default"}}))
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("dup: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Missing name.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/serviceaccounts",
+		mustJSON(t, &corev1.ServiceAccount{}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("missing-name: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Wrong API group.
+	resp = do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/serviceaccounts", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong-group: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Cluster-wide non-GET.
+	resp = do(t, http.MethodPost, base+"/api/v1/serviceaccounts", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("cluster POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Collection PUT.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/serviceaccounts", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("collection PUT: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Item POST.
+	resp = do(t, http.MethodPost, base+"/api/v1/namespaces/default/serviceaccounts/default", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("item POST: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT name mismatch.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/serviceaccounts/default",
+		mustJSON(t, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "diff"}}))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("name-mismatch: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// PUT bad body.
+	resp = do(t, http.MethodPut, base+"/api/v1/namespaces/default/serviceaccounts/default",
+		[]byte(`{not`))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("put bad-body: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Get/Put/Patch/Delete on missing.
+	for method, payload := range map[string][]byte{
+		http.MethodGet:    nil,
+		http.MethodPut:    mustJSON(t, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "ghost"}}),
+		http.MethodPatch:  []byte(`{}`),
+		http.MethodDelete: nil,
+	} {
+		req, _ := http.NewRequest(method,
+			base+"/api/v1/namespaces/default/serviceaccounts/ghost", bytes.NewReader(payload))
+		if method == http.MethodPatch {
+			req.Header.Set("Content-Type", "application/merge-patch+json")
+		}
+
+		resp, _ := http.DefaultClient.Do(req)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s missing: got %d", method, resp.StatusCode)
+		}
+
+		resp.Body.Close()
+	}
+}

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -30,6 +30,9 @@ type ClusterState struct {
 
 	// secrets is namespaced — keyed by "<namespace>/<name>".
 	secrets map[string]*corev1.Secret
+
+	// serviceAccounts is namespaced — keyed by "<namespace>/<name>".
+	serviceAccounts map[string]*corev1.ServiceAccount
 }
 
 // newClusterState returns an empty state with the implicit "default" and
@@ -37,14 +40,20 @@ type ClusterState struct {
 // a fresh real cluster.
 func newClusterState() *ClusterState {
 	s := &ClusterState{
-		namespaces: make(map[string]*corev1.Namespace),
-		configMaps: make(map[string]*corev1.ConfigMap),
-		pods:       make(map[string]*corev1.Pod),
-		secrets:    make(map[string]*corev1.Secret),
+		namespaces:      make(map[string]*corev1.Namespace),
+		configMaps:      make(map[string]*corev1.ConfigMap),
+		pods:            make(map[string]*corev1.Pod),
+		secrets:         make(map[string]*corev1.Secret),
+		serviceAccounts: make(map[string]*corev1.ServiceAccount),
 	}
 
 	for _, name := range []string{"default", "kube-system", "kube-public"} {
 		s.namespaces[name] = newNamespaceObject(name)
+		// Real apiserver auto-creates a "default" ServiceAccount in every
+		// namespace. We do the same so `kubectl get sa default` works in
+		// the bootstrap namespaces.
+		sa := newServiceAccountObject(name, "default")
+		s.serviceAccounts[serviceAccountKey(name, "default")] = sa
 	}
 
 	return s
@@ -71,6 +80,8 @@ func (s *ClusterState) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.servePods(w, r, route)
 	case "secrets":
 		s.serveSecrets(w, r, route)
+	case "serviceaccounts":
+		s.serveServiceAccounts(w, r, route)
 	default:
 		writeNotFound(w, "k8s api: resource not implemented: "+route.Resource)
 	}

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -33,7 +33,22 @@ type ClusterState struct {
 
 	// serviceAccounts is namespaced — keyed by "<namespace>/<name>".
 	serviceAccounts map[string]*corev1.ServiceAccount
+
+	// services is namespaced — keyed by "<namespace>/<name>".
+	services map[string]*corev1.Service
+
+	// nextClusterIP is the monotonic counter used to hand out Service
+	// ClusterIPs from 10.96.0.0/12. Incremented under mu.Lock by
+	// allocateClusterIP. Real apiserver uses an in-memory bitmap; the
+	// monotonic counter is enough for tests.
+	nextClusterIP uint32
 }
+
+// firstClusterIPOffset is the first integer offset above 10.96.0.0 that the
+// service ClusterIP allocator hands out (so the first allocated IP is
+// 10.96.0.1). 10.96.0.0/12 is the kubeadm default service CIDR — we keep
+// the same convention so allocations look familiar in tests.
+const firstClusterIPOffset uint32 = 1
 
 // newClusterState returns an empty state with the implicit "default" and
 // "kube-system" namespaces already present, matching the bootstrap state of
@@ -45,6 +60,8 @@ func newClusterState() *ClusterState {
 		pods:            make(map[string]*corev1.Pod),
 		secrets:         make(map[string]*corev1.Secret),
 		serviceAccounts: make(map[string]*corev1.ServiceAccount),
+		services:        make(map[string]*corev1.Service),
+		nextClusterIP:   firstClusterIPOffset,
 	}
 
 	for _, name := range []string{"default", "kube-system", "kube-public"} {
@@ -82,6 +99,8 @@ func (s *ClusterState) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveSecrets(w, r, route)
 	case "serviceaccounts":
 		s.serveServiceAccounts(w, r, route)
+	case "services":
+		s.serveServices(w, r, route)
 	default:
 		writeNotFound(w, "k8s api: resource not implemented: "+route.Resource)
 	}

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -54,9 +54,10 @@ type ClusterState struct {
 // the same convention so allocations look familiar in tests.
 const firstClusterIPOffset uint32 = 1
 
-// newClusterState returns an empty state with the implicit "default" and
-// "kube-system" namespaces already present, matching the bootstrap state of
-// a fresh real cluster.
+// newClusterState returns state pre-populated with the three implicit
+// namespaces (default, kube-system, kube-public) and a "default"
+// ServiceAccount in each, matching the bootstrap state of a fresh real
+// cluster.
 func newClusterState() *ClusterState {
 	s := &ClusterState{
 		namespaces:      make(map[string]*corev1.Namespace),

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sync"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -37,6 +38,9 @@ type ClusterState struct {
 	// services is namespaced — keyed by "<namespace>/<name>".
 	services map[string]*corev1.Service
 
+	// deployments lives under apps/v1 — keyed by "<namespace>/<name>".
+	deployments map[string]*appsv1.Deployment
+
 	// nextClusterIP is the monotonic counter used to hand out Service
 	// ClusterIPs from 10.96.0.0/12. Incremented under mu.Lock by
 	// allocateClusterIP. Real apiserver uses an in-memory bitmap; the
@@ -61,6 +65,7 @@ func newClusterState() *ClusterState {
 		secrets:         make(map[string]*corev1.Secret),
 		serviceAccounts: make(map[string]*corev1.ServiceAccount),
 		services:        make(map[string]*corev1.Service),
+		deployments:     make(map[string]*appsv1.Deployment),
 		nextClusterIP:   firstClusterIPOffset,
 	}
 
@@ -101,6 +106,8 @@ func (s *ClusterState) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveServiceAccounts(w, r, route)
 	case "services":
 		s.serveServices(w, r, route)
+	case "deployments":
+		s.serveDeployments(w, r, route)
 	default:
 		writeNotFound(w, "k8s api: resource not implemented: "+route.Resource)
 	}

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -24,6 +24,9 @@ type ClusterState struct {
 
 	// configMaps is namespaced — keyed by "<namespace>/<name>".
 	configMaps map[string]*corev1.ConfigMap
+
+	// pods is namespaced — keyed by "<namespace>/<name>".
+	pods map[string]*corev1.Pod
 }
 
 // newClusterState returns an empty state with the implicit "default" and
@@ -33,6 +36,7 @@ func newClusterState() *ClusterState {
 	s := &ClusterState{
 		namespaces: make(map[string]*corev1.Namespace),
 		configMaps: make(map[string]*corev1.ConfigMap),
+		pods:       make(map[string]*corev1.Pod),
 	}
 
 	for _, name := range []string{"default", "kube-system", "kube-public"} {
@@ -59,7 +63,9 @@ func (s *ClusterState) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveNamespaces(w, r, route)
 	case "configmaps":
 		s.serveConfigMaps(w, r, route)
+	case "pods":
+		s.servePods(w, r, route)
 	default:
-		writeNotFound(w, "k8s api: resource not implemented in Wave 2 Phase 1: "+route.Resource)
+		writeNotFound(w, "k8s api: resource not implemented: "+route.Resource)
 	}
 }

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -27,6 +27,9 @@ type ClusterState struct {
 
 	// pods is namespaced — keyed by "<namespace>/<name>".
 	pods map[string]*corev1.Pod
+
+	// secrets is namespaced — keyed by "<namespace>/<name>".
+	secrets map[string]*corev1.Secret
 }
 
 // newClusterState returns an empty state with the implicit "default" and
@@ -37,6 +40,7 @@ func newClusterState() *ClusterState {
 		namespaces: make(map[string]*corev1.Namespace),
 		configMaps: make(map[string]*corev1.ConfigMap),
 		pods:       make(map[string]*corev1.Pod),
+		secrets:    make(map[string]*corev1.Secret),
 	}
 
 	for _, name := range []string{"default", "kube-system", "kube-public"} {
@@ -65,6 +69,8 @@ func (s *ClusterState) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveConfigMaps(w, r, route)
 	case "pods":
 		s.servePods(w, r, route)
+	case "secrets":
+		s.serveSecrets(w, r, route)
 	default:
 		writeNotFound(w, "k8s api: resource not implemented: "+route.Resource)
 	}

--- a/server/aws/eks/sdk_dataplane_workloads_test.go
+++ b/server/aws/eks/sdk_dataplane_workloads_test.go
@@ -1,0 +1,184 @@
+// Wave 2 Phase 2 end-to-end test: real client-go deploys an entire workload
+// stack — Namespace, ServiceAccount, Secret, ConfigMap, Deployment, Service,
+// Pod — against an EKS cluster's data-plane endpoint, then deletes the
+// cluster and verifies cascade tear-down.
+
+package eks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stackshy/cloudemu"
+	cloudkube "github.com/stackshy/cloudemu/kubernetes"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+// TestSDKEKSDataPlane_FullWorkloadStack walks through the resources a real
+// app deployment uses: ServiceAccount, Secret (with StringData merge),
+// ConfigMap, Deployment (apps/v1), Service (with ClusterIP allocation), Pod.
+// Every step uses the real client-go SDK so wire encoding, error decoding,
+// and group-version dispatch are exercised end-to-end.
+//
+//nolint:funlen // a single end-to-end scenario across 6 resource kinds; splitting hurts readability.
+func TestSDKEKSDataPlane_FullWorkloadStack(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+
+	k8sAPI := cloudkube.NewAPIServer()
+	cloud.EKS.SetK8sAPI(k8sAPI)
+
+	srv := awsserver.New(awsserver.Drivers{
+		EKS:    cloud.EKS,
+		K8sAPI: k8sAPI,
+	})
+	ts := httptest.NewServer(srv)
+
+	t.Cleanup(ts.Close)
+
+	k8sAPI.SetBaseURL(ts.URL)
+
+	awsClient := newEKSClient(t, ts.URL)
+	ctx := context.Background()
+
+	const clusterName = "wave2-workload"
+
+	_, err := awsClient.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String(clusterName),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/eks"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{"subnet-aaa", "subnet-bbb"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := awsClient.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String(clusterName)})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	endpoint := aws.ToString(out.Cluster.Endpoint)
+	clientset := mustClientset(t, endpoint)
+
+	// 1. Custom namespace — auto-creates a "default" ServiceAccount.
+	if _, err := clientset.CoreV1().Namespaces().Create(ctx,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "shop"}},
+		metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateNamespace: %v", err)
+	}
+
+	// 2. ServiceAccount "deployer" — explicit beside the auto "default".
+	if _, err := clientset.CoreV1().ServiceAccounts("shop").Create(ctx,
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "deployer"}},
+		metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateServiceAccount: %v", err)
+	}
+
+	saList, err := clientset.CoreV1().ServiceAccounts("shop").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListServiceAccounts: %v", err)
+	}
+
+	if len(saList.Items) != 2 {
+		t.Fatalf("SAs in shop: got %d, want 2 (default + deployer)", len(saList.Items))
+	}
+
+	// 3. Secret with StringData — server should merge into Data.
+	sec, err := clientset.CoreV1().Secrets("shop").Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "db-creds"},
+		StringData: map[string]string{"user": "shop", "pass": "rotated"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if string(sec.Data["user"]) != "shop" || string(sec.Data["pass"]) != "rotated" {
+		t.Fatalf("StringData→Data merge: got %+v", sec.Data)
+	}
+
+	if len(sec.StringData) != 0 {
+		t.Fatalf("StringData should be cleared after merge, got %+v", sec.StringData)
+	}
+
+	// 4. ConfigMap.
+	if _, err := clientset.CoreV1().ConfigMaps("shop").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "app-config"},
+		Data:       map[string]string{"log_level": "info"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateConfigMap: %v", err)
+	}
+
+	// 5. Deployment (apps/v1) — replicas mirrored onto status.
+	var replicas int32 = 3
+	dep, err := clientset.AppsV1().Deployments("shop").Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.27"}},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	if dep.Status.Replicas != 3 || dep.Status.ReadyReplicas != 3 {
+		t.Fatalf("Deployment status not mirrored: replicas=%d ready=%d",
+			dep.Status.Replicas, dep.Status.ReadyReplicas)
+	}
+
+	// 6. Service — ClusterIP should be allocated from 10.96.0.0/12.
+	svc, err := clientset.CoreV1().Services("shop").Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "web"},
+			Ports:    []corev1.ServicePort{{Port: 80}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if !strings.HasPrefix(svc.Spec.ClusterIP, "10.96.") {
+		t.Fatalf("ClusterIP: got %q, want 10.96.x.x", svc.Spec.ClusterIP)
+	}
+
+	// 7. Pod — explicit, separate from the Deployment.
+	pod, err := clientset.CoreV1().Pods("shop").Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "side-job"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "j", Image: "busybox"}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreatePod: %v", err)
+	}
+
+	if pod.Status.Phase != corev1.PodPending {
+		t.Fatalf("Pod phase on create: got %q, want Pending", pod.Status.Phase)
+	}
+
+	// Cascade verification: delete the cluster, every endpoint must go away.
+	if _, err := awsClient.DeleteCluster(ctx, &awseks.DeleteClusterInput{Name: aws.String(clusterName)}); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	if _, err := clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{}); err == nil {
+		t.Fatal("client-go after DeleteCluster: expected error, got nil")
+	}
+}


### PR DESCRIPTION
Phase 2 of the Kubernetes data plane. After this PR a real `client-go` can deploy and read back the resources a typical CI/CD pipeline or operator touches — Namespace, ServiceAccount, Secret, ConfigMap, Deployment, Service, Pod — against a cloudemu-emulated EKS cluster.

Builds directly on Phase 1's APIServer / ClusterState / route parser / generic patch helper. No refactoring; each new resource is its own file following the `configmap.go` shape, plus the resource-specific quirks below.

## What's new

| Resource | Path | Phase-2 quirk |
|---|---|---|
| **Pod** | `/api/v1/namespaces/{ns}/pods` | Stamps `Status.Phase = Pending` on create. No scheduler in Wave 2; pods stay Pending. |
| **Secret** | `/api/v1/namespaces/{ns}/secrets` | Mirrors real apiserver: `StringData` values byte-encoded into `Data`, `StringData` cleared. Default `Type=Opaque`. |
| **ServiceAccount** | `/api/v1/namespaces/{ns}/serviceaccounts` | Auto-creates a `default` SA in every namespace (bootstrap + on Create). No token Secret (matches K8s ≥ 1.24). |
| **Service** | `/api/v1/namespaces/{ns}/services` | Sequential ClusterIP allocator from `10.96.0.0/12` (kubeadm default). `"None"` → headless. ClusterIP immutable on Update/Patch. |
| **Deployment** | `/apis/apps/v1/namespaces/{ns}/deployments` | First `apps/v1` resource. Mirrors `spec.replicas` → `status.{replicas,readyReplicas,availableReplicas,updatedReplicas}` so deployments look terminal-state ready (no controller-manager in Wave 2). |

## Cascade delete

`DeleteNamespace` now drops every namespaced resource in one synchronous sweep via a small generic helper:

```go
func deletePrefixedKeysFrom[V any](m map[string]*V, prefix string) { … }
```

## Out of scope (deferred)

- **Watch streaming** → Phase 4
- **Endpoints / EndpointSlice** generation from Service selectors → Phase 4
- **Real controllers** (no ReplicaSets spawned from Deployments, Pods stay Pending) — out of scope for Wave 2
- **RBAC, PV/PVC, StatefulSet/DaemonSet/Job/CronJob/Ingress** — Phase 5+
- **AKS + GKE wiring** → Phase 3

## Commits (7, part-by-part)

1. `feat(kubernetes): add Pod CRUD handler`
2. `feat(kubernetes): add Secret CRUD handler with StringData merge`
3. `feat(kubernetes): add ServiceAccount CRUD with default-SA bootstrap`
4. `feat(kubernetes): add Service CRUD with ClusterIP allocator`
5. `feat(kubernetes): add Deployment CRUD on apps/v1`
6. `feat(kubernetes): cascade-delete Phase 2 resources on Namespace delete`
7. `test(eks): extend Wave 2 round-trip with full workload stack`

## Verification

```
go build ./...                          0 errors
go test ./...                           123 packages OK, 0 failures
golangci-lint run --timeout=9m ./...    0 issues
go test -race ./kubernetes/ ./providers/aws/eks/ ./server/aws/eks/   clean
```

**Coverage on `kubernetes/`**: 98.3% total, **every function ≥ 90%**.

**Real-user standalone smoke test** (`/tmp/cloudemu-smoke`): cloudemu running on a real `127.0.0.1:<port>` exercised by real `aws-sdk-go-v2/service/eks` + real `client-go` v0.32.0 — **17/17 steps green** covering the full lifecycle (create / list / patch / cascade-delete / cluster teardown) of all six new resources plus the namespace bootstrap chain.
