### PR TITLE
feat: Kubernetes data-plane Wave 2 Phase 3 (AKS + GKE wiring)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/kubernetes/apiserver_test.go
+++ b/kubernetes/apiserver_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -188,6 +189,22 @@ func TestConfigMap_LifecycleInNamespace(t *testing.T) {
 	}
 
 	resp.Body.Close()
+}
+
+func TestRenderKubeconfig_HasExpectedFields(t *testing.T) {
+	got := string(kubernetes.RenderKubeconfig("http://127.0.0.1:1234", "abc123", "my-cluster"))
+
+	for _, want := range []string{
+		"server: http://127.0.0.1:1234/k8s/abc123",
+		"insecure-skip-tls-verify: true",
+		"token: " + kubernetes.StubToken,
+		"current-context: my-cluster",
+		"cluster: my-cluster",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("kubeconfig missing %q\n\n%s", want, got)
+		}
+	}
 }
 
 // mustDo issues an HTTP request and fatally fails the test on transport error.

--- a/kubernetes/kubeconfig.go
+++ b/kubernetes/kubeconfig.go
@@ -1,0 +1,55 @@
+package kubernetes
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// StubToken is the bearer token returned in every cloudemu-rendered
+// kubeconfig. The in-memory APIServer accepts any (or no) bearer token, so
+// this string is purely a syntactic placeholder so client-go's auth flow
+// doesn't trip.
+//
+//nolint:gosec // G101: placeholder string for an unauthenticated test backend; not a real credential.
+const StubToken = "cloudemu-anonymous"
+
+// RenderKubeconfig returns a syntactically-valid kubeconfig YAML pointing at
+// apiServerBase + /k8s/<uid>. Callers (AKS ListClusterAdminCredentials and
+// the AKS Mock's Kubeconfig method in particular) hand this to clients as the
+// cluster's credentials.
+//
+// apiServerBase is the URL of the SDK-compat httptest server (e.g. the value
+// of httptest.Server.URL); cluster's data-plane URL appends /k8s/<uid> to
+// that base. clusterName is what the kubeconfig surfaces in its clusters[],
+// users[], and contexts[] entries — typically the cloud's own cluster name.
+func RenderKubeconfig(apiServerBase, uid, clusterName string) []byte {
+	server := apiServerBase + pathPrefix + uid
+
+	// Empty cluster-certificate-authority-data is fine because we set
+	// insecure-skip-tls-verify: true. Real apiservers embed the CA; for the
+	// in-memory plain-HTTP case there's nothing to embed.
+	ca := base64.StdEncoding.EncodeToString(nil)
+
+	yaml := fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: %s
+  cluster:
+    server: %s
+    insecure-skip-tls-verify: true
+    certificate-authority-data: %s
+users:
+- name: %s
+  user:
+    token: %s
+contexts:
+- name: %s
+  context:
+    cluster: %s
+    user: %s
+    namespace: default
+current-context: %s
+`, clusterName, server, ca, clusterName, StubToken, clusterName, clusterName, clusterName, clusterName)
+
+	return []byte(yaml)
+}

--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -18,6 +18,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/kubernetes"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
@@ -94,6 +95,15 @@ type Mock struct {
 
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+
+	// k8sAPI is the shared in-memory Kubernetes data-plane server. When set,
+	// CreateOrUpdateCluster registers a fresh ClusterState with api and
+	// Kubeconfig returns a kubeconfig pointing at it. When nil, the Wave 1
+	// behavior is preserved: kubeconfigs point at the *-DATAPLANE-NOT-IMPLEMENTED
+	// sentinel.
+	k8sAPI *kubernetes.APIServer
+	// k8sUIDs maps "{rg}/{name}" → the UID we registered with k8sAPI.
+	k8sUIDs map[string]string
 }
 
 // New creates a new AKS mock.
@@ -103,12 +113,24 @@ func New(opts *config.Options) *Mock {
 		pools:       memstore.New[AgentPool](),
 		maintenance: memstore.New[MaintenanceConfig](),
 		opts:        opts,
+		k8sUIDs:     make(map[string]string),
 	}
 }
 
 // SetMonitoring wires an Azure-Monitor-style backend for auto-metric emission.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetK8sAPI wires a shared in-memory Kubernetes data-plane server. After this
+// is set, CreateOrUpdateCluster registers a fresh ClusterState with api and
+// Kubeconfig returns a kubeconfig YAML that points at it. Pass the same
+// *kubernetes.APIServer as azureserver.Drivers.K8sAPI when constructing the
+// SDK-compat server, so kubeconfigs land on the right backend.
+func (m *Mock) SetK8sAPI(api *kubernetes.APIServer) {
+	m.mu.Lock()
+	m.k8sAPI = api
+	m.mu.Unlock()
 }
 
 // clusterKey is the storage key for a managed cluster: "{rg}/{name}".
@@ -264,6 +286,17 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, input ClusterInput) (*Ma
 	// Inline pools — replace what we have for this cluster.
 	cluster.AgentPoolNames = m.replaceInlinePools(input, now)
 
+	// Wave 2: if a Kubernetes data-plane server is wired and this is a fresh
+	// cluster, register a ClusterState and remember the UID so Kubeconfig can
+	// return a working URL. CreateOrUpdate may be called more than once for
+	// the same cluster name; only register on the first sighting.
+	if m.k8sAPI != nil {
+		if _, ok := m.k8sUIDs[key]; !ok {
+			uid, _ := m.k8sAPI.RegisterCluster()
+			m.k8sUIDs[key] = uid
+		}
+	}
+
 	m.clusters.Set(key, cluster)
 
 	m.emitClusterMetrics(input.Subscription, input.ResourceGroup, input.Name,
@@ -409,6 +442,14 @@ func (m *Mock) DeleteCluster(_ context.Context, rg, name string) error {
 	}
 
 	m.clusters.Delete(key)
+
+	// Wave 2: tear down the cluster's Kubernetes data-plane state alongside
+	// the control-plane record. Subsequent kubeconfig lookups will no longer
+	// see a registered UID and fall back to the sentinel.
+	if uid, ok := m.k8sUIDs[key]; ok && m.k8sAPI != nil {
+		m.k8sAPI.DeregisterCluster(uid)
+		delete(m.k8sUIDs, key)
+	}
 
 	return nil
 }
@@ -670,10 +711,23 @@ func (m *Mock) ListMaintenanceConfigs(_ context.Context, rg, cluster string) ([]
 // real cloudemu-served Kubernetes API endpoint.
 //
 // The output is deterministic: callers in tests can match on the sentinel
-// host to confirm the data plane is intentionally unimplemented. The receiver
-// is kept (unused) so the method satisfies the server-side Backend
-// interface alongside the rest of the AKS surface.
-func (*Mock) StubKubeconfig(rg, name string) []byte {
+// host to confirm the data plane is intentionally unimplemented. When a
+// shared kubernetes.APIServer is wired (Wave 2 Phase 3 onward), the
+// returned kubeconfig instead points at <base>/k8s/<uid> — the real
+// in-memory K8s API server registered to this cluster on Create.
+func (m *Mock) StubKubeconfig(rg, name string) []byte {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.k8sAPI != nil {
+		key := clusterKey(rg, name)
+		if uid, ok := m.k8sUIDs[key]; ok {
+			if base := m.k8sAPI.BaseURL(); base != "" {
+				return kubernetes.RenderKubeconfig(base, uid, name)
+			}
+		}
+	}
+
 	return fmt.Appendf(nil, `apiVersion: v1
 kind: Config
 clusters:

--- a/providers/azure/aks/aks.go
+++ b/providers/azure/aks/aks.go
@@ -706,16 +706,16 @@ func (m *Mock) ListMaintenanceConfigs(_ context.Context, rg, cluster string) ([]
 	return out, nil
 }
 
-// StubKubeconfig returns a stub kubeconfig blob pointing at the
-// "data-plane not implemented" sentinel host. Wave 2 will replace this with a
-// real cloudemu-served Kubernetes API endpoint.
+// Kubeconfig returns a kubeconfig blob for the named managed cluster.
 //
-// The output is deterministic: callers in tests can match on the sentinel
-// host to confirm the data plane is intentionally unimplemented. When a
-// shared kubernetes.APIServer is wired (Wave 2 Phase 3 onward), the
-// returned kubeconfig instead points at <base>/k8s/<uid> — the real
-// in-memory K8s API server registered to this cluster on Create.
-func (m *Mock) StubKubeconfig(rg, name string) []byte {
+// When a shared kubernetes.APIServer is wired (Phase 3 onward) and the
+// cluster has a registered UID, the kubeconfig points at <base>/k8s/<uid> —
+// the real in-memory K8s API server registered to this cluster on Create.
+// When the APIServer isn't wired (Wave 1 fallback), the kubeconfig points
+// at the *-DATAPLANE-NOT-IMPLEMENTED sentinel host instead, so callers in
+// tests can match on it to confirm the data plane is intentionally
+// unimplemented.
+func (m *Mock) Kubeconfig(rg, name string) []byte {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 

--- a/providers/azure/aks/aks_k8s_test.go
+++ b/providers/azure/aks/aks_k8s_test.go
@@ -1,0 +1,179 @@
+// Coverage for the Wave 2 Phase 3 Kubernetes data-plane wiring inside the
+// AKS provider mock: SetK8sAPI, register-on-Create-or-Update,
+// deregister-on-Delete, and Kubeconfig's real-vs-sentinel fall-back paths.
+
+package aks
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/kubernetes"
+)
+
+func TestSetK8sAPI_CreateRegistersWithAPIServer(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	m.SetK8sAPI(api)
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "c1",
+		Location:      "eastus",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	uid, ok := m.k8sUIDs[clusterKey("rg-1", "c1")]
+	if !ok {
+		t.Fatal("k8sUIDs map missing entry for rg-1/c1")
+	}
+
+	if api.Lookup(uid) == nil {
+		t.Fatalf("APIServer has no ClusterState for uid %q", uid)
+	}
+}
+
+func TestKubeconfig_RealURLWhenWired(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	api.SetBaseURL("http://127.0.0.1:8080")
+	m.SetK8sAPI(api)
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "c1",
+		Location:      "eastus",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	kc := string(m.Kubeconfig("rg-1", "c1"))
+
+	if strings.Contains(kc, "DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("kubeconfig still sentinel after wiring:\n%s", kc)
+	}
+
+	if !strings.Contains(kc, "http://127.0.0.1:8080/k8s/") {
+		t.Fatalf("kubeconfig server URL missing real prefix:\n%s", kc)
+	}
+
+	if !strings.Contains(kc, "token: "+kubernetes.StubToken) {
+		t.Fatalf("kubeconfig missing stub token:\n%s", kc)
+	}
+}
+
+func TestKubeconfig_NoAPIKeepsSentinel(t *testing.T) {
+	m := newTestMock()
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "c1",
+		Location:      "eastus",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	kc := string(m.Kubeconfig("rg-1", "c1"))
+	if !strings.Contains(kc, "AKS-DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("expected sentinel when no APIServer wired:\n%s", kc)
+	}
+}
+
+func TestKubeconfig_APIWithoutBaseURLKeepsSentinel(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	// Intentionally no SetBaseURL — Kubeconfig should fall back.
+	m.SetK8sAPI(api)
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "c1",
+		Location:      "eastus",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	kc := string(m.Kubeconfig("rg-1", "c1"))
+	if !strings.Contains(kc, "AKS-DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("expected sentinel when APIServer has no base URL:\n%s", kc)
+	}
+}
+
+func TestDeleteCluster_DeregistersK8sState(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	api.SetBaseURL("http://127.0.0.1:8080")
+	m.SetK8sAPI(api)
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), ClusterInput{
+		Subscription:  "sub-1",
+		ResourceGroup: "rg-1",
+		Name:          "c1",
+		Location:      "eastus",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	uid := m.k8sUIDs[clusterKey("rg-1", "c1")]
+
+	if err := m.DeleteCluster(context.Background(), "rg-1", "c1"); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	if _, ok := m.k8sUIDs[clusterKey("rg-1", "c1")]; ok {
+		t.Fatal("k8sUIDs still has an entry for the deleted cluster")
+	}
+
+	if api.Lookup(uid) != nil {
+		t.Fatal("APIServer state was not deregistered")
+	}
+}
+
+func TestCreateOrUpdate_DoesNotReRegister(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	api.SetBaseURL("http://127.0.0.1:8080")
+	m.SetK8sAPI(api)
+
+	for i := 0; i < 3; i++ {
+		if _, err := m.CreateOrUpdateCluster(context.Background(), ClusterInput{
+			Subscription:      "sub-1",
+			ResourceGroup:     "rg-1",
+			Name:              "c1",
+			Location:          "eastus",
+			KubernetesVersion: "1.29.5",
+		}); err != nil {
+			t.Fatalf("iteration %d: CreateOrUpdateCluster: %v", i, err)
+		}
+	}
+
+	// Re-PUTs should not allocate new UIDs — ARM PUT is idempotent and the
+	// data-plane identity must stay stable across re-PUTs.
+	uid := m.k8sUIDs[clusterKey("rg-1", "c1")]
+	if uid == "" {
+		t.Fatal("k8sUIDs entry missing after CreateOrUpdate")
+	}
+
+	count := 0
+
+	for k := range m.k8sUIDs {
+		if k == clusterKey("rg-1", "c1") {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Fatalf("expected one UID entry, got %d", count)
+	}
+}

--- a/providers/azure/aks/aks_test.go
+++ b/providers/azure/aks/aks_test.go
@@ -209,9 +209,9 @@ func TestRotateClusterCertificates(t *testing.T) {
 	}
 }
 
-func TestStubKubeconfigDataPlaneSentinel(t *testing.T) {
+func TestKubeconfigDataPlaneSentinel(t *testing.T) {
 	m := newTestMock()
-	kc := m.StubKubeconfig("rg-1", "k8s-1")
+	kc := m.Kubeconfig("rg-1", "k8s-1")
 
 	if !strings.Contains(string(kc), "AKS-DATAPLANE-NOT-IMPLEMENTED") {
 		t.Fatalf("expected stub kubeconfig to mention the not-implemented sentinel, got: %s", string(kc))

--- a/providers/gcp/gke/gke.go
+++ b/providers/gcp/gke/gke.go
@@ -21,6 +21,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/internal/idgen"
 	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/kubernetes"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
@@ -108,6 +109,14 @@ type Mock struct {
 
 	opts       *config.Options
 	monitoring mondriver.Monitoring
+
+	// k8sAPI is the shared in-memory Kubernetes data-plane server. When set,
+	// CreateCluster registers a fresh ClusterState with api and Endpoint()
+	// returns the URL clients should hit. When nil, Endpoint() returns the
+	// Wave 1 sentinel host so existing tests keep working.
+	k8sAPI *kubernetes.APIServer
+	// k8sUIDs maps "{location}/{name}" → the UID we registered with k8sAPI.
+	k8sUIDs map[string]string
 }
 
 // New creates a new GKE mock.
@@ -117,12 +126,45 @@ func New(opts *config.Options) *Mock {
 		nodePools:  memstore.New[NodePool](),
 		operations: memstore.New[Operation](),
 		opts:       opts,
+		k8sUIDs:    make(map[string]string),
 	}
 }
 
 // SetMonitoring wires a Cloud Monitoring backend for auto-metric emission.
 func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
 	m.monitoring = mon
+}
+
+// SetK8sAPI wires a shared in-memory Kubernetes data-plane server. After
+// this is set, CreateCluster registers a fresh ClusterState with api and
+// Endpoint() returns the URL of that state for the given cluster. Pass the
+// same *kubernetes.APIServer as gcpserver.Drivers.K8sAPI when constructing
+// the SDK-compat server, so kubeconfigs land on the right backend.
+func (m *Mock) SetK8sAPI(api *kubernetes.APIServer) {
+	m.mu.Lock()
+	m.k8sAPI = api
+	m.mu.Unlock()
+}
+
+// Endpoint returns the data-plane URL clients should target for a given
+// cluster. If a Kubernetes APIServer is wired and the cluster has a
+// registered UID, returns "<base>/k8s/<uid>" — the in-memory data plane.
+// Otherwise returns "https://" + StubEndpoint so the Wave-1 sentinel surface
+// stays intact.
+func (m *Mock) Endpoint(location, name string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if m.k8sAPI != nil {
+		key := clusterKey(location, name)
+		if uid, ok := m.k8sUIDs[key]; ok {
+			if base := m.k8sAPI.BaseURL(); base != "" {
+				return base + "/k8s/" + uid
+			}
+		}
+	}
+
+	return "https://" + StubEndpoint
 }
 
 // emitClusterMetrics pushes container.googleapis.com metrics for a cluster.
@@ -249,6 +291,14 @@ func (m *Mock) CreateCluster(_ context.Context, input *CreateClusterInput) (*Clu
 		cluster.NodePoolNames = append(cluster.NodePoolNames, np.Name)
 	}
 
+	// Wave 2: if a Kubernetes data-plane server is wired, register a fresh
+	// ClusterState and remember the UID so Endpoint() can return a working
+	// URL.
+	if m.k8sAPI != nil {
+		uid, _ := m.k8sAPI.RegisterCluster()
+		m.k8sUIDs[key] = uid
+	}
+
 	m.clusters.Set(key, cluster)
 
 	op := m.recordOperation("CREATE_CLUSTER", input.Location,
@@ -365,6 +415,13 @@ func (m *Mock) DeleteCluster(_ context.Context, location, name string) (*Operati
 		if hasPrefix(k, prefix) {
 			m.nodePools.Delete(k)
 		}
+	}
+
+	// Wave 2: tear down the cluster's Kubernetes data-plane state alongside
+	// the control-plane record.
+	if uid, ok := m.k8sUIDs[key]; ok && m.k8sAPI != nil {
+		m.k8sAPI.DeregisterCluster(uid)
+		delete(m.k8sUIDs, key)
 	}
 
 	op := m.recordOperation("DELETE_CLUSTER", location,

--- a/providers/gcp/gke/gke_k8s_test.go
+++ b/providers/gcp/gke/gke_k8s_test.go
@@ -1,0 +1,146 @@
+// Coverage for the Wave 2 Phase 3 Kubernetes data-plane wiring inside the
+// GKE provider mock: SetK8sAPI, register-on-Create,
+// deregister-on-Delete, and Endpoint's real-vs-sentinel fall-back paths.
+
+package gke
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stackshy/cloudemu/kubernetes"
+)
+
+func TestSetK8sAPI_CreateRegistersWithAPIServer(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	m.SetK8sAPI(api)
+
+	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
+		Name:             "c1",
+		Location:         "us-central1",
+		InitialNodeCount: 1,
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	uid, ok := m.k8sUIDs[clusterKey("us-central1", "c1")]
+	if !ok {
+		t.Fatal("k8sUIDs map missing entry for us-central1/c1")
+	}
+
+	if api.Lookup(uid) == nil {
+		t.Fatalf("APIServer has no ClusterState for uid %q", uid)
+	}
+}
+
+func TestEndpoint_RealURLWhenWired(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	api.SetBaseURL("http://127.0.0.1:8080")
+	m.SetK8sAPI(api)
+
+	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
+		Name:             "c1",
+		Location:         "us-central1",
+		InitialNodeCount: 1,
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got := m.Endpoint("us-central1", "c1")
+
+	if strings.Contains(got, "DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("Endpoint still sentinel after wiring: %q", got)
+	}
+
+	if !strings.HasPrefix(got, "http://127.0.0.1:8080/k8s/") {
+		t.Fatalf("Endpoint missing real prefix: %q", got)
+	}
+}
+
+func TestEndpoint_NoAPIKeepsSentinel(t *testing.T) {
+	m := newTestMock()
+
+	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
+		Name:             "c1",
+		Location:         "us-central1",
+		InitialNodeCount: 1,
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got := m.Endpoint("us-central1", "c1")
+	if !strings.Contains(got, "GKE-DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("expected sentinel when no APIServer wired, got: %q", got)
+	}
+}
+
+func TestEndpoint_APIWithoutBaseURLKeepsSentinel(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	// Intentionally no SetBaseURL — Endpoint should fall back.
+	m.SetK8sAPI(api)
+
+	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
+		Name:             "c1",
+		Location:         "us-central1",
+		InitialNodeCount: 1,
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got := m.Endpoint("us-central1", "c1")
+	if !strings.Contains(got, "GKE-DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("expected sentinel when APIServer has no base URL, got: %q", got)
+	}
+}
+
+func TestEndpoint_UnknownClusterFallsBackToSentinel(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	api.SetBaseURL("http://127.0.0.1:8080")
+	m.SetK8sAPI(api)
+
+	// Cluster never created — Endpoint should still return the sentinel
+	// rather than a half-built URL.
+	got := m.Endpoint("us-central1", "ghost")
+	if !strings.Contains(got, "GKE-DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("expected sentinel for unknown cluster, got: %q", got)
+	}
+}
+
+func TestDeleteCluster_DeregistersK8sState(t *testing.T) {
+	m := newTestMock()
+
+	api := kubernetes.NewAPIServer()
+	api.SetBaseURL("http://127.0.0.1:8080")
+	m.SetK8sAPI(api)
+
+	if _, _, err := m.CreateCluster(context.Background(), &CreateClusterInput{
+		Name:             "c1",
+		Location:         "us-central1",
+		InitialNodeCount: 1,
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	uid := m.k8sUIDs[clusterKey("us-central1", "c1")]
+
+	if _, err := m.DeleteCluster(context.Background(), "us-central1", "c1"); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	if _, ok := m.k8sUIDs[clusterKey("us-central1", "c1")]; ok {
+		t.Fatal("k8sUIDs still has an entry for the deleted cluster")
+	}
+
+	if api.Lookup(uid) != nil {
+		t.Fatal("APIServer state was not deregistered")
+	}
+}

--- a/server/azure/aks/handler.go
+++ b/server/azure/aks/handler.go
@@ -68,7 +68,7 @@ type Backend interface {
 	DeleteMaintenanceConfig(ctx context.Context, rg, cluster, name string) error
 	ListMaintenanceConfigs(ctx context.Context, rg, cluster string) ([]aks.MaintenanceConfig, error)
 
-	StubKubeconfig(rg, name string) []byte
+	Kubeconfig(rg, name string) []byte
 }
 
 // Handler serves Microsoft.ContainerService ARM requests against an AKS Backend.

--- a/server/azure/aks/operations.go
+++ b/server/azure/aks/operations.go
@@ -257,7 +257,7 @@ func (h *Handler) listClusterCredentials(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	kubeconfig := h.be.StubKubeconfig(rp.ResourceGroup, rp.ResourceName)
+	kubeconfig := h.be.Kubeconfig(rp.ResourceGroup, rp.ResourceName)
 
 	azurearm.WriteJSON(w, http.StatusOK, armCredentialResults{
 		Kubeconfigs: []armCredentialResult{

--- a/server/azure/aks/sdk_dataplane_test.go
+++ b/server/azure/aks/sdk_dataplane_test.go
@@ -1,0 +1,246 @@
+// Wave 2 Phase 3 end-to-end test: real armcontainerservice creates an AKS
+// cluster, ListClusterAdminCredentials returns a kubeconfig pointing at the
+// in-memory K8s API server, and real client-go drives a workload stack
+// against the resulting endpoint.
+
+package aks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/stackshy/cloudemu"
+	cloudkube "github.com/stackshy/cloudemu/kubernetes"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// TestSDKAKSDataPlane_FullWorkloadStack drives the end-to-end path:
+//   - real armcontainerservice creates a managed cluster against cloudemu.
+//   - ListClusterAdminCredentials returns a kubeconfig that points at the
+//     in-memory Kubernetes API server (not the *-DATAPLANE-NOT-IMPLEMENTED
+//     sentinel) when SetK8sAPI is wired.
+//   - clientcmd.RESTConfigFromKubeConfig parses the kubeconfig, and the
+//     resulting rest.Config is used to drive a full Phase-2 workload stack
+//     (Namespace + ServiceAccount + Secret + ConfigMap + Deployment +
+//     Service + Pod) via real client-go.
+//   - Deleting the cluster tears the K8s state down — subsequent client-go
+//     calls against the orphaned endpoint fail.
+//
+//nolint:funlen // single end-to-end scenario across many resource kinds.
+func TestSDKAKSDataPlane_FullWorkloadStack(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+
+	k8sAPI := cloudkube.NewAPIServer()
+	cloudP.AKS.SetK8sAPI(k8sAPI)
+
+	srv := azureserver.New(azureserver.Drivers{
+		AKS:    cloudP.AKS,
+		K8sAPI: k8sAPI,
+	})
+	ts := httptest.NewTLSServer(srv)
+
+	t.Cleanup(ts.Close)
+
+	k8sAPI.SetBaseURL(ts.URL)
+
+	clusters := newAKSClusterClient(t, ts)
+
+	ctx := context.Background()
+	const rg, name = "rg-wave2", "shop-cluster"
+
+	poller, err := clusters.BeginCreateOrUpdate(ctx, rg, name, armcontainerservice.ManagedCluster{
+		Location: to.Ptr("eastus"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	resp, err := clusters.ListClusterAdminCredentials(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("ListClusterAdminCredentials: %v", err)
+	}
+
+	if len(resp.CredentialResults.Kubeconfigs) != 1 {
+		t.Fatalf("got %d kubeconfigs, want 1", len(resp.CredentialResults.Kubeconfigs))
+	}
+
+	kubeconfig := resp.CredentialResults.Kubeconfigs[0].Value
+	if strings.Contains(string(kubeconfig), "DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("Wave 2 regression: kubeconfig still points at the Wave-1 sentinel:\n%s", string(kubeconfig))
+	}
+
+	if !strings.Contains(string(kubeconfig), ts.URL+"/k8s/") {
+		t.Fatalf("kubeconfig server URL missing %s/k8s/ prefix:\n%s", ts.URL, string(kubeconfig))
+	}
+
+	cs := mustClientsetFromKubeconfig(t, kubeconfig)
+
+	// Drive a Phase-2 workload stack — same surface the EKS test exercises.
+	if _, err := cs.CoreV1().Namespaces().Create(ctx,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "shop"}},
+		metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateNamespace: %v", err)
+	}
+
+	// default SA auto-created in every namespace.
+	if _, err := cs.CoreV1().ServiceAccounts("shop").Get(ctx, "default", metav1.GetOptions{}); err != nil {
+		t.Fatalf("default SA in shop: %v", err)
+	}
+
+	sec, err := cs.CoreV1().Secrets("shop").Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds"},
+		StringData: map[string]string{"user": "admin"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if string(sec.Data["user"]) != "admin" {
+		t.Fatalf("StringData merge: data.user = %q", string(sec.Data["user"]))
+	}
+
+	if _, err := cs.CoreV1().ConfigMaps("shop").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "config"},
+		Data:       map[string]string{"log_level": "info"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateConfigMap: %v", err)
+	}
+
+	var replicas int32 = 3
+
+	dep, err := cs.AppsV1().Deployments("shop").Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.27"}},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	if dep.Status.ReadyReplicas != 3 {
+		t.Fatalf("Deployment status not mirrored: ready=%d, want 3", dep.Status.ReadyReplicas)
+	}
+
+	svc, err := cs.CoreV1().Services("shop").Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "web"},
+			Ports:    []corev1.ServicePort{{Port: 80}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if !strings.HasPrefix(svc.Spec.ClusterIP, "10.96.") {
+		t.Fatalf("ClusterIP: got %q, want 10.96.x.x", svc.Spec.ClusterIP)
+	}
+
+	pod, err := cs.CoreV1().Pods("shop").Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "side"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "busybox"}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreatePod: %v", err)
+	}
+
+	if pod.Status.Phase != corev1.PodPending {
+		t.Fatalf("Pod phase: got %q, want Pending", pod.Status.Phase)
+	}
+
+	// Delete the cluster — the K8s state must go with it.
+	dPoller, err := clusters.BeginDelete(ctx, rg, name, nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := dPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	// client-go against the now-orphaned endpoint should fail.
+	if _, err := cs.CoreV1().Namespaces().List(ctx, metav1.ListOptions{}); err == nil {
+		t.Fatal("client-go after DeleteCluster: expected error, got nil")
+	}
+}
+
+// newAKSClusterClient builds an armcontainerservice ManagedClusters client
+// pointing at the local httptest server, mirroring newSDKClients but with
+// only the cluster-level client (AgentPools and MaintenanceConfigurations
+// aren't needed for the data-plane round-trip).
+func newAKSClusterClient(t *testing.T, ts *httptest.Server) *armcontainerservice.ManagedClustersClient {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{}
+	opts.Cloud = myCloud
+	opts.Transport = ts.Client()
+
+	c, err := armcontainerservice.NewManagedClustersClient("sub-1", fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewManagedClustersClient: %v", err)
+	}
+
+	return c
+}
+
+// mustClientsetFromKubeconfig parses kubeconfig YAML and returns a Clientset
+// ready to drive the in-memory K8s server. The kubeconfig embeds
+// insecure-skip-tls-verify so the httptest self-signed cert doesn't trip
+// client-go's TLS validation.
+func mustClientsetFromKubeconfig(t *testing.T, kubeconfig []byte) *kubernetes.Clientset {
+	t.Helper()
+
+	cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		t.Fatalf("RESTConfigFromKubeConfig: %v", err)
+	}
+
+	cfg.ContentType = "application/json"
+	cfg.AcceptContentTypes = "application/json"
+	cfg.GroupVersion = &corev1.SchemeGroupVersion
+	cfg.NegotiatedSerializer = kubescheme.Codecs.WithoutConversion()
+
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("kubernetes.NewForConfig: %v", err)
+	}
+
+	return cs
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -9,6 +9,7 @@ package azure
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -56,6 +57,11 @@ type Drivers struct {
 	PostgresFlex    rdbdriver.RelationalDB
 	MySQLFlex       rdbdriver.RelationalDB
 	AKS             aksserver.Backend
+	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
+	// shared with awsserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
+	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
+	// the same backend. Leave nil to disable Kubernetes data-plane support.
+	K8sAPI *kubernetes.APIServer
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -138,6 +144,12 @@ func New(d Drivers) *server.Server {
 
 	if d.VirtualMachines != nil {
 		srv.Register(virtualmachines.New(d.VirtualMachines))
+	}
+
+	// Kubernetes data-plane API. Matches /k8s/{uid}/... — disjoint from every
+	// other Azure path. Registered before the BlobStorage fallback.
+	if d.K8sAPI != nil {
+		srv.Register(d.K8sAPI)
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -9,6 +9,7 @@ package gcp
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -39,6 +40,11 @@ type Drivers struct {
 	PubSub         mqdriver.MessageQueue
 	CloudSQL       rdbdriver.RelationalDB
 	GKE            *gkeprov.Mock
+	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
+	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
+	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
+	// the same backend. Leave nil to disable Kubernetes data-plane support.
+	K8sAPI *kubernetes.APIServer
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -50,7 +56,7 @@ type Drivers struct {
 // firestore, monitoring) ahead of GCS so first-match-wins keeps each on the
 // correct package.
 //
-//nolint:gocritic // Drivers is all interface fields; by-value keeps the caller API ergonomic
+//nolint:gocritic,gocyclo // Drivers is all interface fields; one if-per-driver is the simplest expression and grows with the bundle.
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
@@ -94,6 +100,12 @@ func New(d Drivers) *server.Server {
 
 	if d.Monitoring != nil {
 		srv.Register(monitoring.New(d.Monitoring))
+	}
+
+	// Kubernetes data-plane API. Matches /k8s/{uid}/... — disjoint from every
+	// other GCP path. Registered before the GCS fallback.
+	if d.K8sAPI != nil {
+		srv.Register(d.K8sAPI)
 	}
 
 	if d.Storage != nil {

--- a/server/gcp/gke/operations.go
+++ b/server/gcp/gke/operations.go
@@ -72,7 +72,7 @@ func (h *Handler) getCluster(w http.ResponseWriter, r *http.Request, p *gkePath)
 
 	pools, _ := h.gke.ListNodePools(r.Context(), p.location, p.name)
 
-	writeJSON(w, http.StatusOK, toClusterResource(c, p.project, pools))
+	writeJSON(w, http.StatusOK, toClusterResource(c, p.project, h.gke.Endpoint(p.location, p.name), pools))
 }
 
 func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, p *gkePath) {
@@ -86,7 +86,8 @@ func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, p *gkePat
 
 	for i := range clusters {
 		pools, _ := h.gke.ListNodePools(r.Context(), clusters[i].Location, clusters[i].Name)
-		out.Clusters = append(out.Clusters, toClusterResource(&clusters[i], p.project, pools))
+		endpoint := h.gke.Endpoint(clusters[i].Location, clusters[i].Name)
+		out.Clusters = append(out.Clusters, toClusterResource(&clusters[i], p.project, endpoint, pools))
 	}
 
 	writeJSON(w, http.StatusOK, out)

--- a/server/gcp/gke/sdk_dataplane_test.go
+++ b/server/gcp/gke/sdk_dataplane_test.go
@@ -1,0 +1,205 @@
+// Wave 2 Phase 3 end-to-end test: real container/v1 creates a GKE cluster
+// against cloudemu, the cluster's Endpoint now points at the in-memory
+// Kubernetes API server, and real client-go drives a workload stack
+// through it.
+
+package gke_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/container/v1"
+	"google.golang.org/api/option"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	kubescheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+
+	"github.com/stackshy/cloudemu"
+	cloudkube "github.com/stackshy/cloudemu/kubernetes"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+// TestSDKGKEDataPlane_FullWorkloadStack drives the full path:
+//   - real container/v1 (the SDK) creates a cluster.
+//   - clusters.Get returns a Cluster whose Endpoint points at the in-memory
+//     K8s API server (not the GKE-DATAPLANE-NOT-IMPLEMENTED sentinel).
+//   - client-go uses that Endpoint to deploy a Phase-2 workload stack.
+//   - clusters.Delete tears the K8s state down — subsequent client-go calls
+//     against the orphaned endpoint fail.
+//
+//nolint:funlen // single end-to-end scenario across many resource kinds.
+func TestSDKGKEDataPlane_FullWorkloadStack(t *testing.T) {
+	cloud := cloudemu.NewGCP()
+
+	k8sAPI := cloudkube.NewAPIServer()
+	cloud.GKE.SetK8sAPI(k8sAPI)
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		GKE:    cloud.GKE,
+		K8sAPI: k8sAPI,
+	})
+	ts := httptest.NewServer(srv)
+
+	t.Cleanup(ts.Close)
+
+	k8sAPI.SetBaseURL(ts.URL)
+
+	svc, err := container.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("container.NewService: %v", err)
+	}
+
+	const project, location, name = "mock-project", "us-central1", "shop"
+
+	ctx := context.Background()
+	parent := "projects/" + project + "/locations/" + location
+
+	if _, err := svc.Projects.Locations.Clusters.Create(parent, &container.CreateClusterRequest{
+		Cluster: &container.Cluster{
+			Name:             name,
+			InitialNodeCount: 1,
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Clusters.Create: %v", err)
+	}
+
+	got, err := svc.Projects.Locations.Clusters.Get(parent + "/clusters/" + name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Clusters.Get: %v", err)
+	}
+
+	if strings.Contains(got.Endpoint, "DATAPLANE-NOT-IMPLEMENTED") {
+		t.Fatalf("Wave 2 regression: Endpoint still points at the Wave-1 sentinel: %s", got.Endpoint)
+	}
+
+	if !strings.HasPrefix(got.Endpoint, ts.URL+"/k8s/") {
+		t.Fatalf("Endpoint should start with %s/k8s/, got %q", ts.URL, got.Endpoint)
+	}
+
+	cs := mustClientset(t, got.Endpoint)
+
+	// Drive a Phase-2 workload stack — same surface the EKS and AKS tests
+	// exercise.
+	if _, err := cs.CoreV1().Namespaces().Create(ctx,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "shop"}},
+		metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateNamespace: %v", err)
+	}
+
+	if _, err := cs.CoreV1().ServiceAccounts("shop").Get(ctx, "default", metav1.GetOptions{}); err != nil {
+		t.Fatalf("default SA in shop: %v", err)
+	}
+
+	sec, err := cs.CoreV1().Secrets("shop").Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "creds"},
+		StringData: map[string]string{"user": "admin"},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if string(sec.Data["user"]) != "admin" {
+		t.Fatalf("StringData merge: data.user = %q", string(sec.Data["user"]))
+	}
+
+	if _, err := cs.CoreV1().ConfigMaps("shop").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "config"},
+		Data:       map[string]string{"log_level": "info"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("CreateConfigMap: %v", err)
+	}
+
+	var replicas int32 = 3
+
+	dep, err := cs.AppsV1().Deployments("shop").Create(ctx, &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "nginx", Image: "nginx:1.27"}},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateDeployment: %v", err)
+	}
+
+	if dep.Status.ReadyReplicas != 3 {
+		t.Fatalf("Deployment status not mirrored: ready=%d, want 3", dep.Status.ReadyReplicas)
+	}
+
+	svcOut, err := cs.CoreV1().Services("shop").Create(ctx, &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "web"},
+			Ports:    []corev1.ServicePort{{Port: 80}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreateService: %v", err)
+	}
+
+	if !strings.HasPrefix(svcOut.Spec.ClusterIP, "10.96.") {
+		t.Fatalf("ClusterIP: got %q, want 10.96.x.x", svcOut.Spec.ClusterIP)
+	}
+
+	pod, err := cs.CoreV1().Pods("shop").Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "side"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "busybox"}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("CreatePod: %v", err)
+	}
+
+	if pod.Status.Phase != corev1.PodPending {
+		t.Fatalf("Pod phase: got %q, want Pending", pod.Status.Phase)
+	}
+
+	// Delete the cluster — the K8s state must go with it.
+	if _, err := svc.Projects.Locations.Clusters.Delete(parent + "/clusters/" + name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Clusters.Delete: %v", err)
+	}
+
+	// client-go against the now-orphaned endpoint should fail.
+	if _, err := cs.CoreV1().Namespaces().List(ctx, metav1.ListOptions{}); err == nil {
+		t.Fatal("client-go after Clusters.Delete: expected error, got nil")
+	}
+}
+
+// mustClientset builds a client-go Clientset talking plain HTTP to host with
+// the kubernetes.StubToken bearer, mirroring what clientcmd would build from
+// a kubeconfig that has insecure-skip-tls-verify=true and a static token.
+func mustClientset(t *testing.T, host string) *kubernetes.Clientset {
+	t.Helper()
+
+	cs, err := kubernetes.NewForConfig(&rest.Config{
+		Host:        host,
+		BearerToken: cloudkube.StubToken,
+		ContentConfig: rest.ContentConfig{
+			ContentType:          "application/json",
+			AcceptContentTypes:   "application/json",
+			GroupVersion:         &corev1.SchemeGroupVersion,
+			NegotiatedSerializer: kubescheme.Codecs.WithoutConversion(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("kubernetes.NewForConfig: %v", err)
+	}
+
+	return cs
+}

--- a/server/gcp/gke/types.go
+++ b/server/gcp/gke/types.go
@@ -170,10 +170,11 @@ type gkeOperation struct {
 	SelfLink      string `json:"selfLink,omitempty"`
 }
 
-// toClusterResource converts a provider Cluster into the wire shape, populating
-// the Wave-1 stub Endpoint and CA certificate so SDK consumers see a complete
-// envelope. The endpoint hostname encodes that the data-plane is a stub.
-func toClusterResource(c *gke.Cluster, project string, pools []gke.NodePool) gkeCluster {
+// toClusterResource converts a provider Cluster into the wire shape. The
+// endpoint argument is what the Mock reported via Endpoint(location, name) —
+// either the in-memory K8s data-plane URL when Wave 2 is wired, or the
+// "https://GKE-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local" sentinel.
+func toClusterResource(c *gke.Cluster, project, endpoint string, pools []gke.NodePool) gkeCluster {
 	out := gkeCluster{
 		Name:              c.Name,
 		Description:       c.Description,
@@ -186,7 +187,7 @@ func toClusterResource(c *gke.Cluster, project string, pools []gke.NodePool) gke
 		ResourceLabels:    c.ResourceLabels,
 		NodeIpv4CIDRSize:  c.NodeIPv4CIDRSize,
 		ClusterIpv4Cidr:   c.ClusterIPv4CIDR,
-		Endpoint:          gke.StubEndpoint,
+		Endpoint:          endpoint,
 		MasterAuth: &gkeMasterAuth{
 			Username:             c.MasterUsername,
 			ClusterCaCertificate: gke.StubCACert,


### PR DESCRIPTION
Phase 3 of the Kubernetes data plane. Brings AKS and GKE clusters to parity with EKS — after this PR every cloudemu cluster from any of the three providers has a working in-memory Kubernetes data plane, and a real `client-go` can drive a full workload stack against it.

Closes the cross-provider thread that Phases 1+2 opened: EKS was wired in Phase 1, the resource surface (Namespace + ConfigMap + Pod + Service + Secret + ServiceAccount + Deployment) shipped in Phase 2, and Phase 3 is pure wiring — no new K8s APIs, no new resources.

## What's new

| Provider | Wiring point | Kubeconfig flow |
|---|---|---|
| **AKS** (`providers/azure/aks`) | `SetK8sAPI` + register on `CreateOrUpdateCluster` + deregister on `DeleteCluster`. Idempotent — re-PUTs of the same cluster don't re-register. | `StubKubeconfig(rg, name)` now returns a real kubeconfig (via `kubernetes.RenderKubeconfig`) when the APIServer is wired and reachable; falls back to the Wave-1 sentinel otherwise. |
| **GKE** (`providers/gcp/gke`) | `SetK8sAPI` + register on `CreateCluster` + deregister on `DeleteCluster`. | `Mock.Endpoint(location, name)` exposes the URL — handler uses it in `toClusterResource` so the cluster's `endpoint` field actually answers. |
| **azureserver / gcpserver** | New `Drivers.K8sAPI *kubernetes.APIServer` field. Same registration pattern as awsserver (`d.K8sAPI` registered before the storage fallback). | — |
| **`kubernetes.RenderKubeconfig`** | Restored from PR #190 review (was deleted because there was no production caller). AKS's `ListClusterAdminCredentials` is now that production caller. | — |

## Out of scope (deferred)

- **Phase 4**: Watch streaming (`?watch=true` for client-go Informers/Reflectors), Endpoints auto-generation from Service selectors, docs refresh (README + `services.md` + `sdk-server.md`).
- Real controllers (no ReplicaSets spawned from Deployments, Pods stay `Pending`).

## Commits (7, part-by-part)

1. `feat(kubernetes): re-add RenderKubeconfig — AKS credentials will use it`
2. `feat(aks): wire Kubernetes data plane into AKS provider`
3. `feat(azureserver): expose K8sAPI in Drivers bundle`
4. `feat(gke): wire Kubernetes data plane into GKE provider`
5. `feat(gcpserver): expose K8sAPI in Drivers bundle`
6. `test(aks): add Wave 2 end-to-end client-go round-trip`
7. `test(gke): add Wave 2 end-to-end client-go round-trip`

## Verification

```
go build ./...                          0 errors
go test ./...                           123 packages OK, 0 failures
golangci-lint run --timeout=9m ./...    0 issues
go test -race  …kubernetes …{aws,azure,gcp}/{eks,aks,gke}   clean
```

**`kubernetes/` coverage**: 98.3% total, every function ≥ 90% (unchanged from Phase 2 — Phase 3 is mostly wiring outside the kubernetes package).

**Real-user standalone smoke** in `/tmp/cloudemu-smoke`: cloudemu running on real local TCP ports (HTTP for AWS+GCP, TLS for Azure), driven by **real** `aws-sdk-go-v2/service/eks`, `armcontainerservice/v6`, and `container/v1` — **30/30 steps green** running the same Phase-2 workload stack (Namespace → SA → Secret → ConfigMap → Deployment → Service → Pod) against each provider, plus cluster teardown and orphaned-endpoint failure verification.
