### PR TITLE
feat: Kubernetes data-plane Wave 2 Phase 4 (Watch + Endpoints + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,18 @@ SDK-compat coverage across AWS, Azure, and GCP:
 | Compute | EC2 (+ VPC, EBS, Snapshots, AMIs, Spot, Launch Templates, Auto Scaling) | Virtual Machines (+ Disks, Snapshots, Images, SSH keys) | Compute Engine (+ Disks, Snapshots, Images) |
 | NoSQL DB | DynamoDB | Cosmos DB | Firestore |
 | Relational DB | RDS + Aurora (incl. Neptune & DocumentDB engines), Redshift | SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server | Cloud SQL |
-| Kubernetes | EKS (control plane) | AKS (control plane) | GKE (control plane) |
+| Kubernetes | EKS (control plane + data plane) | AKS (control plane + data plane) | GKE (control plane + data plane) |
 | Serverless | Lambda | Functions | Cloud Functions v1 |
 | Message Queue | SQS | Service Bus | Pub/Sub |
 | Networking | VPC (under EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
 | Monitoring | CloudWatch | Azure Monitor | Cloud Monitoring |
 
-The Kubernetes control plane is Wave 1 — cluster, node-pool, and addon/Fargate/maintenance-config lifecycle. The data plane (Pods/Services/Deployments) is deferred; stub kubeconfigs point at a clear `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` sentinel.
+The Kubernetes story is two layers, both shipped:
+
+- **Control plane** (EKS / AKS / GKE) — cluster, node-pool, addon / Fargate / maintenance-config lifecycle via the real cloud SDKs.
+- **Data plane** (in-memory Kubernetes API) — Namespace, Pod, Service, ConfigMap, Secret, ServiceAccount, Deployment, Endpoints. Supports CRUD + JSON-merge Patch + Watch streaming, so real `client-go` `Informer`/`Reflector` machinery works against a cloudemu-emulated cluster. Kubeconfigs returned by the control plane point at the in-memory data plane — `kubectl apply -f deployment.yaml` followed by `kubectl get pods` round-trips end-to-end.
+
+What's intentionally out of scope: real controllers (Deployment ↛ ReplicaSet ↛ Pod), scheduler (Pods stay Pending), RBAC, PV/PVC, StatefulSet/DaemonSet/Job/CronJob, Ingress.
 
 Full per-service operation list: [docs/services.md](docs/services.md).
 Per-handler protocol details and limitations: [docs/sdk-server.md](docs/sdk-server.md).

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -251,6 +251,7 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | GCP Cloud SQL | `/v1/projects/.../{instances,operations}[/...]` |
 | GCP GKE | `/v1/projects/.../locations/.../{clusters,operations}[/...]` |
 | GCP GCS | Fallback (`/storage/v1/` and `/{bucket}/{object}` direct-media) |
+| **Kubernetes data plane** (shared across all 3 providers) | URL prefix `/k8s/{cluster-uid}/`. Registered on AWS, Azure, and GCP servers; cluster UID is the one minted by the matching control-plane handler on Create. |
 
 Registration order matters when handlers share a path prefix — `awsserver.New` / `azureserver.New` / `gcpserver.New` register more-specific handlers ahead of catch-alls (S3, Blob, GCS) so first-match-wins resolves correctly.
 
@@ -258,11 +259,13 @@ Registration order matters when handlers share a path prefix — `awsserver.New`
 
 | Provider | Domains shipped | Notes |
 |----------|----------------|-------|
-| AWS | Storage, Compute (+ VPC/SG/Subnet/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/Keys/AMIs/Snapshots/Spot/LaunchTemplates), NoSQL DB, Relational DB (RDS/Aurora/Neptune/DocumentDB/Redshift), Kubernetes (EKS control plane), Serverless, Message Queue, Monitoring | The most-mature provider — EC2 was Phase 1 of SDK-compat |
-| Azure | Storage, Compute (+ Disks/Snapshots/Images/SSHKeys), NoSQL DB, Relational DB (SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server), Kubernetes (AKS control plane), Serverless, Message Queue (ARM only), Networking, Monitoring | Data-plane Service Bus over AMQP is out of scope (use raw-HTTP REST data plane for tests) |
-| GCP | Storage, Compute (+ Disks/Snapshots/Images), NoSQL DB, Relational DB (Cloud SQL), Kubernetes (GKE control plane), Serverless, Message Queue, Networking, Monitoring | All driven via REST (the `cloud.google.com/go/*` clients with `option.WithEndpoint`, or the auto-generated `google.golang.org/api/*` clients) |
+| AWS | Storage, Compute (+ VPC/SG/Subnet/IGW/RT/NAT/Peering/FlowLogs/NACL/EBS/Keys/AMIs/Snapshots/Spot/LaunchTemplates), NoSQL DB, Relational DB (RDS/Aurora/Neptune/DocumentDB/Redshift), Kubernetes (EKS control plane + shared data plane), Serverless, Message Queue, Monitoring | The most-mature provider — EC2 was Phase 1 of SDK-compat |
+| Azure | Storage, Compute (+ Disks/Snapshots/Images/SSHKeys), NoSQL DB, Relational DB (SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server), Kubernetes (AKS control plane + shared data plane), Serverless, Message Queue (ARM only), Networking, Monitoring | Data-plane Service Bus over AMQP is out of scope (use raw-HTTP REST data plane for tests) |
+| GCP | Storage, Compute (+ Disks/Snapshots/Images), NoSQL DB, Relational DB (Cloud SQL), Kubernetes (GKE control plane + shared data plane), Serverless, Message Queue, Networking, Monitoring | All driven via REST (the `cloud.google.com/go/*` clients with `option.WithEndpoint`, or the auto-generated `google.golang.org/api/*` clients) |
 
-Kubernetes control-plane handlers are Wave 1 — cluster + node-pool + addon/Fargate/maintenance-config lifecycle only. The Kubernetes data plane (Pods, Services, Deployments, …) is intentionally deferred to Wave 2; stub kubeconfigs returned by the credential/auth endpoints point at `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` so callers that try to drive the K8s API fail fast with a clear sentinel.
+Kubernetes ships as **two cooperating handlers**: per-provider control planes (EKS / AKS / GKE — clusters + node pools + addons / Fargate / maintenance configs) and a shared in-memory **data plane** registered under `/k8s/{cluster-uid}/`. The control plane mints a UID on every cluster Create and embeds it in the kubeconfig (or `Cluster.Endpoint` for GKE); `client-go` and `kubectl` connect to the data plane via that URL. Resources served on the data plane: Namespace, ConfigMap, Pod, Service, Secret, ServiceAccount, Deployment (apps/v1), and Endpoints (auto-created for each Service). Every list endpoint supports `?watch=true` for streaming events, so real `Informer` / `Reflector` machinery works.
+
+The data plane intentionally has no controllers — Deployments don't spawn ReplicaSets, Pods stay Pending, Endpoints are empty stubs. RBAC, subresources, PV/PVC, StatefulSet/DaemonSet/Job/CronJob, and Ingress are out of scope.
 
 The remaining service domains (IAM, DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -23,7 +23,7 @@ This document lists every service and operation available in CloudEmu across all
 | 15 | Container Registry | `ecr` | `acr` | `artifactregistry` |
 | 16 | Event Bus | `eventbridge` | `eventgrid` | `eventarc` |
 | 17 | Relational Database | `rds` (+ Aurora/Neptune/DocumentDB engines), `redshift` | `azuresql`, `postgresflex`, `mysqlflex` | `cloudsql` |
-| 18 | Kubernetes (Control Plane) | `eks` | `aks` | `gke` |
+| 18 | Kubernetes | `eks` + shared `kubernetes/` | `aks` + shared `kubernetes/` | `gke` + shared `kubernetes/` |
 
 ---
 
@@ -1031,13 +1031,12 @@ A single portable interface backs every RDBMS handler. Engine selection (MySQL /
 
 ---
 
-## 18. Kubernetes (Control Plane)
+## 18. Kubernetes
 
-**AWS:** `eks` | **Azure:** `aks` | **GCP:** `gke`
+**Control plane:** AWS `eks`, Azure `aks`, GCP `gke` — cluster, node-pool, and addon / Fargate-profile / maintenance-config lifecycle, driven by the real cloud SDKs.
+**Data plane:** shared `kubernetes/` package — an in-memory Kubernetes API server registered by every cluster across all three providers. Kubeconfigs returned by the control plane point at `<base>/k8s/<cluster-uid>` so `client-go` and `kubectl` operate end-to-end.
 
-Wave-1 control-plane coverage: cluster, node-pool, and addon / Fargate-profile / maintenance-config lifecycle. The Kubernetes data plane (Pods, Services, Deployments, …) is intentionally deferred to Wave 2. Stub kubeconfigs returned from credential/auth endpoints point at `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` so any caller trying to drive the K8s API fails fast with a clear sentinel.
-
-Each provider exposes its native API surface — there is no single portable Kubernetes driver. Use `providers/aws/eks`, `providers/azure/aks`, and `providers/gcp/gke` for direct Go access, or the SDK-compat handlers for `aws-sdk-go-v2/service/eks`, `armcontainerservice/v6`, and `container/v1`.
+Each provider exposes its native control-plane API. The data plane has no portable driver — clients connect via the kubeconfig the control plane hands out, then talk standard Kubernetes REST.
 
 ### AWS EKS (`providers/aws/eks`)
 
@@ -1057,7 +1056,7 @@ Operations: **21**
 | Managed Clusters | CreateOrUpdateCluster, GetCluster, UpdateClusterTags, DeleteCluster, ListClusters, ListClustersByResourceGroup, RotateClusterCertificates |
 | Agent Pools | CreateOrUpdateAgentPool, GetAgentPool, DeleteAgentPool, ListAgentPools |
 | Maintenance Configs | CreateOrUpdateMaintenanceConfig, GetMaintenanceConfig, DeleteMaintenanceConfig, ListMaintenanceConfigs |
-| Credentials | `ListClusterAdminCredentials`, `ListClusterUserCredentials`, `ListClusterMonitoringUserCredentials` (return stub kubeconfig) |
+| Credentials | `ListClusterAdminCredentials`, `ListClusterUserCredentials`, `ListClusterMonitoringUserCredentials` — return a kubeconfig pointing at the in-memory data plane (or the `*-DATAPLANE-NOT-IMPLEMENTED.cloudemu.local` sentinel when no APIServer is wired) |
 
 Operations: **18**
 
@@ -1070,6 +1069,27 @@ Operations: **18**
 | Operations | GetOperation, ListOperations, CancelOperation |
 
 Operations: **26**
+
+### Data plane (`kubernetes/`)
+
+Shared in-memory K8s API server registered by every cluster from any provider. URL: `<base>/k8s/<cluster-uid>/...`. Anonymous auth (kubeconfigs use `insecure-skip-tls-verify: true`).
+
+| Resource | Group / Version | Verbs |
+|---|---|---|
+| Namespace | `core/v1` | Create, Get, List, Update, Patch, Delete, **Watch** |
+| ConfigMap | `core/v1` | Create, Get, List, Update, Patch, Delete, **Watch** |
+| Secret | `core/v1` | Create, Get, List, Update, Patch, Delete, **Watch** — StringData merged into Data on create/update |
+| ServiceAccount | `core/v1` | Create, Get, List, Update, Patch, Delete, **Watch** — `default` SA auto-created in every namespace |
+| Pod | `core/v1` | Create, Get, List, Update, Patch, Delete, **Watch** — born Pending, no scheduler |
+| Service | `core/v1` | Create, Get, List, Update, Patch, Delete, **Watch** — ClusterIP allocated from 10.96.0.0/12; immutable on update |
+| Endpoints | `core/v1` | Get, List, **Watch** — auto-created (empty Subsets) on Service create; not user-creatable |
+| Deployment | `apps/v1` | Create, Get, List, Update, Patch, Delete, **Watch** — status mirrored from spec.replicas (no controller) |
+
+**Watch streaming**: each list endpoint accepts `?watch=true` and upgrades to a `Transfer-Encoding: chunked` JSON event stream (`{"type":"ADDED|MODIFIED|DELETED","object":{...}}`). Initial state replays as ADDED events on subscribe, so `client-go` `Informer` / `SharedIndexInformer` machinery (operator-sdk, Helm, ArgoCD, …) just works.
+
+**Cascade**: deleting a Namespace publishes DELETED events for every child resource.
+
+**Not in scope**: real controllers (no Deployment → ReplicaSet → Pod, no Pods scheduled to nodes), RBAC, subresources (`/status`, `/scale`, `/log`, `/exec`), PV/PVC, StatefulSet, DaemonSet, Job/CronJob, Ingress, NetworkPolicy.
 
 ---
 
@@ -1094,7 +1114,8 @@ Operations: **26**
 | Container Registry | 14 |
 | Event Bus | 15 |
 | Relational Database | 21 |
-| Kubernetes — AWS EKS | 21 |
-| Kubernetes — Azure AKS | 18 |
-| Kubernetes — GCP GKE | 26 |
-| **Grand Total** | **416** |
+| Kubernetes — AWS EKS (control plane) | 21 |
+| Kubernetes — Azure AKS (control plane) | 18 |
+| Kubernetes — GCP GKE (control plane) | 26 |
+| Kubernetes — data plane (8 resources × 7 verbs incl. Watch) | 56 |
+| **Grand Total** | **472** |

--- a/kubernetes/configmap.go
+++ b/kubernetes/configmap.go
@@ -33,7 +33,7 @@ func (s *ClusterState) serveConfigMaps(w http.ResponseWriter, r *http.Request, r
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchConfigMaps(w, r, "")
 
 			return
@@ -62,7 +62,7 @@ func (s *ClusterState) serveConfigMaps(w http.ResponseWriter, r *http.Request, r
 func (s *ClusterState) serveConfigMapCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchConfigMaps(w, r, namespace)
 
 			return

--- a/kubernetes/configmap.go
+++ b/kubernetes/configmap.go
@@ -78,9 +78,10 @@ func (s *ClusterState) serveConfigMapCollection(w http.ResponseWriter, r *http.R
 
 func (s *ClusterState) watchConfigMaps(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wConfigMaps.subscribe(namespace)
 	items := s.collectConfigMapsLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wConfigMaps, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) serveConfigMapItem(w http.ResponseWriter, r *http.Request, namespace, name string) {

--- a/kubernetes/configmap.go
+++ b/kubernetes/configmap.go
@@ -33,6 +33,12 @@ func (s *ClusterState) serveConfigMaps(w http.ResponseWriter, r *http.Request, r
 			return
 		}
 
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchConfigMaps(w, r, "")
+
+			return
+		}
+
 		s.listConfigMapsAllNamespaces(w)
 
 		return
@@ -56,12 +62,25 @@ func (s *ClusterState) serveConfigMaps(w http.ResponseWriter, r *http.Request, r
 func (s *ClusterState) serveConfigMapCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchConfigMaps(w, r, namespace)
+
+			return
+		}
+
 		s.listConfigMaps(w, namespace)
 	case http.MethodPost:
 		s.createConfigMap(w, r, namespace)
 	default:
 		writeMethodNotAllowed(w, "k8s api: configmaps collection: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchConfigMaps(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectConfigMapsLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wConfigMaps, namespace, items)
 }
 
 func (s *ClusterState) serveConfigMapItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
@@ -111,6 +130,7 @@ func (s *ClusterState) createConfigMap(w http.ResponseWriter, r *http.Request, n
 
 	cm := in
 	s.configMaps[key] = &cm
+	s.wConfigMaps.publish(EventAdded, namespace, *cm.DeepCopy())
 	writeJSON(w, http.StatusCreated, &cm)
 }
 
@@ -206,6 +226,7 @@ func (s *ClusterState) updateConfigMap(w http.ResponseWriter, r *http.Request, n
 
 	cm := in
 	s.configMaps[key] = &cm
+	s.wConfigMaps.publish(EventModified, namespace, *cm.DeepCopy())
 	writeJSON(w, http.StatusOK, &cm)
 }
 
@@ -233,6 +254,7 @@ func (s *ClusterState) patchConfigMap(w http.ResponseWriter, r *http.Request, na
 
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 	s.configMaps[key] = patched
+	s.wConfigMaps.publish(EventModified, namespace, *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -250,6 +272,7 @@ func (s *ClusterState) deleteConfigMap(w http.ResponseWriter, namespace, name st
 	}
 
 	delete(s.configMaps, key)
+	s.wConfigMaps.publish(EventDeleted, namespace, *cm.DeepCopy())
 	writeJSON(w, http.StatusOK, cm.DeepCopy())
 }
 

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -30,6 +30,12 @@ func (s *ClusterState) serveDeployments(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchDeployments(w, r, "")
+
+			return
+		}
+
 		s.listDeploymentsAllNamespaces(w)
 
 		return
@@ -53,12 +59,25 @@ func (s *ClusterState) serveDeployments(w http.ResponseWriter, r *http.Request, 
 func (s *ClusterState) serveDeploymentCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchDeployments(w, r, namespace)
+
+			return
+		}
+
 		s.listDeployments(w, namespace)
 	case http.MethodPost:
 		s.createDeployment(w, r, namespace)
 	default:
 		writeMethodNotAllowed(w, "k8s api: deployments collection: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchDeployments(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectDeploymentsLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wDeployments, namespace, items)
 }
 
 func (s *ClusterState) serveDeploymentItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
@@ -112,6 +131,7 @@ func (s *ClusterState) createDeployment(w http.ResponseWriter, r *http.Request, 
 
 	dep := in
 	s.deployments[key] = &dep
+	s.wDeployments.publish(EventAdded, namespace, *dep.DeepCopy())
 	writeJSON(w, http.StatusCreated, &dep)
 }
 
@@ -204,6 +224,7 @@ func (s *ClusterState) updateDeployment(w http.ResponseWriter, r *http.Request, 
 
 	dep := in
 	s.deployments[key] = &dep
+	s.wDeployments.publish(EventModified, namespace, *dep.DeepCopy())
 	writeJSON(w, http.StatusOK, &dep)
 }
 
@@ -228,6 +249,7 @@ func (s *ClusterState) patchDeployment(w http.ResponseWriter, r *http.Request, n
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 	mirrorDeploymentReplicas(patched)
 	s.deployments[key] = patched
+	s.wDeployments.publish(EventModified, namespace, *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -245,6 +267,7 @@ func (s *ClusterState) deleteDeployment(w http.ResponseWriter, namespace, name s
 	}
 
 	delete(s.deployments, key)
+	s.wDeployments.publish(EventDeleted, namespace, *dep.DeepCopy())
 	writeJSON(w, http.StatusOK, dep.DeepCopy())
 }
 

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -75,9 +75,10 @@ func (s *ClusterState) serveDeploymentCollection(w http.ResponseWriter, r *http.
 
 func (s *ClusterState) watchDeployments(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wDeployments.subscribe(namespace)
 	items := s.collectDeploymentsLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wDeployments, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) serveDeploymentItem(w http.ResponseWriter, r *http.Request, namespace, name string) {

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -30,7 +30,7 @@ func (s *ClusterState) serveDeployments(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchDeployments(w, r, "")
 
 			return
@@ -59,7 +59,7 @@ func (s *ClusterState) serveDeployments(w http.ResponseWriter, r *http.Request, 
 func (s *ClusterState) serveDeploymentCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchDeployments(w, r, namespace)
 
 			return

--- a/kubernetes/endpoints.go
+++ b/kubernetes/endpoints.go
@@ -32,7 +32,7 @@ func (s *ClusterState) serveEndpoints(w http.ResponseWriter, r *http.Request, ro
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchEndpoints(w, r, "")
 
 			return
@@ -71,7 +71,7 @@ func (s *ClusterState) serveEndpointsCollection(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if r.URL.Query().Get("watch") == "true" {
+	if r.URL.Query().Get("watch") == watchQueryValue {
 		s.watchEndpoints(w, r, namespace)
 
 		return

--- a/kubernetes/endpoints.go
+++ b/kubernetes/endpoints.go
@@ -1,0 +1,164 @@
+package kubernetes
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// serveEndpoints dispatches /api/v1/{namespaces/{ns}/endpoints|endpoints}
+// requests.
+//
+// Endpoints are read-only from the SDK consumer's perspective in Wave 2 —
+// real apiserver lets you Create/Update them too, but the in-memory store
+// auto-creates one per Service and tears it down on Service delete. We
+// expose only Get / List / Watch so client-go Reflectors work.
+func (s *ClusterState) serveEndpoints(w http.ResponseWriter, r *http.Request, route *Route) {
+	if route.APIGroup != "" || route.APIVersion != apiVersionV1 {
+		writeNotFound(w, "k8s api: endpoints are only served at /api/v1")
+
+		return
+	}
+
+	if route.Namespace == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, "k8s api: endpoints cluster-wide: method not allowed: "+r.Method)
+
+			return
+		}
+
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchEndpoints(w, r, "")
+
+			return
+		}
+
+		s.listEndpointsAllNamespaces(w)
+
+		return
+	}
+
+	if !s.namespaceExists(route.Namespace) {
+		writeNotFound(w, "k8s api: namespace not found: "+route.Namespace)
+
+		return
+	}
+
+	if route.Name == "" {
+		s.serveEndpointsCollection(w, r, route.Namespace)
+
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, "k8s api: endpoints are read-only in Wave 2: "+r.Method)
+
+		return
+	}
+
+	s.getEndpoints(w, route.Namespace, route.Name)
+}
+
+func (s *ClusterState) serveEndpointsCollection(w http.ResponseWriter, r *http.Request, namespace string) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, "k8s api: endpoints collection is read-only in Wave 2: "+r.Method)
+
+		return
+	}
+
+	if r.URL.Query().Get("watch") == "true" {
+		s.watchEndpoints(w, r, namespace)
+
+		return
+	}
+
+	s.listEndpoints(w, namespace)
+}
+
+func (s *ClusterState) listEndpoints(w http.ResponseWriter, namespace string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectEndpointsLocked(namespace)
+	writeJSON(w, http.StatusOK, &corev1.EndpointsList{
+		TypeMeta: metav1.TypeMeta{Kind: "EndpointsList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) listEndpointsAllNamespaces(w http.ResponseWriter) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	items := s.collectEndpointsLocked("")
+	writeJSON(w, http.StatusOK, &corev1.EndpointsList{
+		TypeMeta: metav1.TypeMeta{Kind: "EndpointsList", APIVersion: "v1"},
+		Items:    items,
+	})
+}
+
+func (s *ClusterState) collectEndpointsLocked(namespace string) []corev1.Endpoints {
+	keys := make([]string, 0, len(s.endpoints))
+
+	for k := range s.endpoints {
+		if namespace == "" || strings.HasPrefix(k, namespace+"/") {
+			keys = append(keys, k)
+		}
+	}
+
+	sort.Strings(keys)
+
+	items := make([]corev1.Endpoints, 0, len(keys))
+	for _, k := range keys {
+		items = append(items, *s.endpoints[k].DeepCopy())
+	}
+
+	return items
+}
+
+func (s *ClusterState) getEndpoints(w http.ResponseWriter, namespace, name string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ep, ok := s.endpoints[endpointsKey(namespace, name)]
+	if !ok {
+		writeNotFound(w, "k8s api: endpoints not found: "+namespace+"/"+name)
+
+		return
+	}
+
+	writeJSON(w, http.StatusOK, ep.DeepCopy())
+}
+
+func (s *ClusterState) watchEndpoints(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectEndpointsLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wEndpoints, namespace, items)
+}
+
+func endpointsKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// newEndpointsObject builds the Endpoints stub auto-created for a Service.
+// Subsets is left empty — there's no scheduler / Pod-IP allocation in Wave 2.
+// Real apiserver lets the endpoints controller fill Subsets in once Pods
+// match the Service selector and become Ready.
+func newEndpointsObject(namespace, name string) *corev1.Endpoints {
+	return &corev1.Endpoints{
+		TypeMeta: metav1.TypeMeta{Kind: "Endpoints", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         namespace,
+			UID:               types.UID(newUID()),
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			ResourceVersion:   "1",
+		},
+	}
+}

--- a/kubernetes/endpoints.go
+++ b/kubernetes/endpoints.go
@@ -137,9 +137,10 @@ func (s *ClusterState) getEndpoints(w http.ResponseWriter, namespace, name strin
 
 func (s *ClusterState) watchEndpoints(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wEndpoints.subscribe(namespace)
 	items := s.collectEndpointsLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wEndpoints, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func endpointsKey(namespace, name string) string {

--- a/kubernetes/endpoints_test.go
+++ b/kubernetes/endpoints_test.go
@@ -84,6 +84,94 @@ func TestEndpoints_ReadOnly(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestEndpoints_NamespacedList(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Two Services in default → two Endpoints in default's namespaced list.
+	for _, n := range []string{"a", "b"} {
+		do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+			mustJSON(t, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: n},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			})).Body.Close()
+	}
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/endpoints", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d, want 200", resp.StatusCode)
+	}
+
+	var list corev1.EndpointsList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("got %d, want 2 endpoints in default ns", len(list.Items))
+	}
+}
+
+func TestEndpoints_GetMissingReturns404(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/endpoints/ghost", nil)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestEndpoints_ErrorPaths(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Wrong API group → 404
+	resp := do(t, http.MethodGet, base+"/apis/apps/v1/namespaces/default/endpoints", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("wrong-group: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Namespace not found → 404
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/nope/endpoints", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing-ns: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Non-GET on cluster-wide → 405
+	resp = do(t, http.MethodPost, base+"/api/v1/endpoints", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("cluster POST: got %d, want 405", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Non-GET on namespaced item → 405. First create a service so the
+	// endpoints item exists.
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "svc"},
+			Spec: corev1.ServiceSpec{
+				Type:  corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{{Port: 80}},
+			},
+		})).Body.Close()
+
+	resp = do(t, http.MethodDelete, base+"/api/v1/namespaces/default/endpoints/svc", nil)
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("item DELETE: got %d, want 405", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
 func TestEndpoints_AllNamespacesList(t *testing.T) {
 	base, cleanup := newFixture(t)
 	t.Cleanup(cleanup)

--- a/kubernetes/endpoints_test.go
+++ b/kubernetes/endpoints_test.go
@@ -1,0 +1,113 @@
+package kubernetes_test
+
+import (
+	"net/http"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestEndpoints_AutoCreatedOnServiceCreate verifies that creating a Service
+// automatically materialises an Endpoints object with the same name+namespace
+// — matching what the endpoints controller does in a real cluster.
+func TestEndpoints_AutoCreatedOnServiceCreate(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "web"},
+			Spec: corev1.ServiceSpec{
+				Type:  corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{{Port: 80}},
+			},
+		})).Body.Close()
+
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/endpoints/web", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("get endpoints/web: got %d, want 200", resp.StatusCode)
+	}
+
+	var ep corev1.Endpoints
+	mustDecode(t, resp.Body, &ep)
+
+	if ep.Name != "web" || ep.Namespace != "default" {
+		t.Fatalf("auto-created endpoints: got %s/%s", ep.Namespace, ep.Name)
+	}
+}
+
+func TestEndpoints_DeletedAlongsideService(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	do(t, http.MethodPost, base+"/api/v1/namespaces/default/services",
+		mustJSON(t, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "tmp"},
+			Spec: corev1.ServiceSpec{
+				Type:  corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{{Port: 80}},
+			},
+		})).Body.Close()
+
+	// Sanity — endpoints visible before delete.
+	resp := do(t, http.MethodGet, base+"/api/v1/namespaces/default/endpoints/tmp", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pre-delete endpoints: got %d", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+
+	// Drop the service.
+	do(t, http.MethodDelete, base+"/api/v1/namespaces/default/services/tmp", nil).Body.Close()
+
+	resp = do(t, http.MethodGet, base+"/api/v1/namespaces/default/endpoints/tmp", nil)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("endpoints after service delete: got %d, want 404", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestEndpoints_ReadOnly(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	// Endpoints aren't user-creatable in Wave 2 — only auto-created by
+	// Service. POST on the collection must 405.
+	resp := do(t, http.MethodPost, base+"/api/v1/namespaces/default/endpoints",
+		mustJSON(t, &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "manual"}}))
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST endpoints: got %d, want 405", resp.StatusCode)
+	}
+
+	resp.Body.Close()
+}
+
+func TestEndpoints_AllNamespacesList(t *testing.T) {
+	base, cleanup := newFixture(t)
+	t.Cleanup(cleanup)
+
+	for _, ns := range []string{"default", "kube-system"} {
+		do(t, http.MethodPost, base+"/api/v1/namespaces/"+ns+"/services",
+			mustJSON(t, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "svc"},
+				Spec: corev1.ServiceSpec{
+					Type:  corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			})).Body.Close()
+	}
+
+	resp := do(t, http.MethodGet, base+"/api/v1/endpoints", nil)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("all-ns list: got %d", resp.StatusCode)
+	}
+
+	var list corev1.EndpointsList
+	mustDecode(t, resp.Body, &list)
+
+	if len(list.Items) != 2 {
+		t.Fatalf("got %d, want 2 endpoints across namespaces", len(list.Items))
+	}
+}

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -32,6 +32,12 @@ func (s *ClusterState) serveNamespaces(w http.ResponseWriter, r *http.Request, r
 func (s *ClusterState) serveNamespaceCollection(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchNamespaces(w, r)
+
+			return
+		}
+
 		s.listNamespaces(w)
 	case http.MethodPost:
 		s.createNamespace(w, r)
@@ -53,6 +59,19 @@ func (s *ClusterState) serveNamespaceItem(w http.ResponseWriter, r *http.Request
 	default:
 		writeMethodNotAllowed(w, "k8s api: namespace item: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchNamespaces(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+
+	items := make([]corev1.Namespace, 0, len(s.namespaces))
+	for _, n := range s.namespaces {
+		items = append(items, *n.DeepCopy())
+	}
+
+	s.mu.RUnlock()
+
+	streamWatch(r.Context(), w, s.wNamespaces, "", items)
 }
 
 func (s *ClusterState) createNamespace(w http.ResponseWriter, r *http.Request) {
@@ -85,6 +104,9 @@ func (s *ClusterState) createNamespace(w http.ResponseWriter, r *http.Request) {
 	// namespace. Mirror that so `kubectl --namespace=<new>` finds an SA.
 	sa := newServiceAccountObject(in.Name, "default")
 	s.serviceAccounts[serviceAccountKey(in.Name, "default")] = sa
+
+	s.wNamespaces.publish(EventAdded, "", *ns.DeepCopy())
+	s.wServiceAccounts.publish(EventAdded, in.Name, *sa.DeepCopy())
 
 	writeJSON(w, http.StatusCreated, ns)
 }
@@ -159,6 +181,7 @@ func (s *ClusterState) updateNamespace(w http.ResponseWriter, r *http.Request, n
 	}
 
 	s.namespaces[name] = &in
+	s.wNamespaces.publish(EventModified, "", *in.DeepCopy())
 	writeJSON(w, http.StatusOK, &in)
 }
 
@@ -180,6 +203,7 @@ func (s *ClusterState) patchNamespace(w http.ResponseWriter, r *http.Request, na
 
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 	s.namespaces[name] = patched
+	s.wNamespaces.publish(EventModified, "", *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -195,28 +219,28 @@ func (s *ClusterState) deleteNamespace(w http.ResponseWriter, name string) {
 	}
 
 	delete(s.namespaces, name)
+	s.wNamespaces.publish(EventDeleted, "", *ns.DeepCopy())
 
 	// Cascading delete: drop every namespaced resource keyed under this
-	// namespace. Real apiserver does this via finalizers + garbage
-	// collection; we collapse it into a synchronous sweep because tests
-	// don't observe partial states.
+	// namespace. Each helper publishes a DELETED event so Watch subscribers
+	// see the cascade alongside the namespace going away.
 	prefix := name + "/"
-	deletePrefixedKeysFrom(s.configMaps, prefix)
-	deletePrefixedKeysFrom(s.pods, prefix)
-	deletePrefixedKeysFrom(s.secrets, prefix)
-	deletePrefixedKeysFrom(s.serviceAccounts, prefix)
-	deletePrefixedKeysFrom(s.services, prefix)
-	deletePrefixedKeysFrom(s.deployments, prefix)
+	cascadeDeleteWithEvents(s.configMaps, prefix, name, s.wConfigMaps)
+	cascadeDeleteWithEvents(s.pods, prefix, name, s.wPods)
+	cascadeDeleteWithEvents(s.secrets, prefix, name, s.wSecrets)
+	cascadeDeleteWithEvents(s.serviceAccounts, prefix, name, s.wServiceAccounts)
+	cascadeDeleteWithEvents(s.services, prefix, name, s.wServices)
+	cascadeDeleteWithEvents(s.deployments, prefix, name, s.wDeployments)
 
 	writeJSON(w, http.StatusOK, ns.DeepCopy())
 }
 
-// deletePrefixedKeysFrom drops every entry in m whose key starts with prefix.
-// Used by deleteNamespace to cascade across the per-resource maps without
-// repeating the loop body for each one.
-func deletePrefixedKeysFrom[V any](m map[string]*V, prefix string) {
-	for k := range m {
+// cascadeDeleteWithEvents drops every entry in m whose key starts with
+// prefix and publishes a DELETED Watch event for each removed object.
+func cascadeDeleteWithEvents[V any](m map[string]*V, prefix, ns string, b *broadcaster) {
+	for k, v := range m {
 		if strings.HasPrefix(k, prefix) {
+			b.publish(EventDeleted, ns, *v)
 			delete(m, k)
 		}
 	}

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -32,7 +32,7 @@ func (s *ClusterState) serveNamespaces(w http.ResponseWriter, r *http.Request, r
 func (s *ClusterState) serveNamespaceCollection(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchNamespaces(w, r)
 
 			return

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -231,6 +231,7 @@ func (s *ClusterState) deleteNamespace(w http.ResponseWriter, name string) {
 	cascadeDeleteWithEvents(s.serviceAccounts, prefix, name, s.wServiceAccounts)
 	cascadeDeleteWithEvents(s.services, prefix, name, s.wServices)
 	cascadeDeleteWithEvents(s.deployments, prefix, name, s.wDeployments)
+	cascadeDeleteWithEvents(s.endpoints, prefix, name, s.wEndpoints)
 
 	writeJSON(w, http.StatusOK, ns.DeepCopy())
 }

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -241,12 +241,25 @@ func (s *ClusterState) deleteNamespace(w http.ResponseWriter, name string) {
 	writeJSON(w, http.StatusOK, ns.DeepCopy())
 }
 
+// deepCopier constrains the element type of a per-resource map: it must be
+// a pointer whose underlying type has the upstream Kubernetes-codegen
+// DeepCopy() *V method. Every corev1/appsv1 type we store satisfies this,
+// so cascadeDeleteWithEvents can publish its own copy of every event
+// instead of aliasing the stored object's inner maps to all subscribers.
+type deepCopier[V any] interface {
+	*V
+	DeepCopy() *V
+}
+
 // cascadeDeleteWithEvents drops every entry in m whose key starts with
 // prefix and publishes a DELETED Watch event for each removed object.
-func cascadeDeleteWithEvents[V any](m map[string]*V, prefix, ns string, b *broadcaster) {
+// Each event ships a freshly DeepCopy()'d value so subscribers see their
+// own independent copy of the inner maps/slices — mutation by one
+// subscriber can't corrupt another's view.
+func cascadeDeleteWithEvents[V any, P deepCopier[V]](m map[string]P, prefix, ns string, b *broadcaster) {
 	for k, v := range m {
 		if strings.HasPrefix(k, prefix) {
-			b.publish(EventDeleted, ns, *v)
+			b.publish(EventDeleted, ns, *v.DeepCopy())
 			delete(m, k)
 		}
 	}

--- a/kubernetes/namespace.go
+++ b/kubernetes/namespace.go
@@ -64,6 +64,11 @@ func (s *ClusterState) serveNamespaceItem(w http.ResponseWriter, r *http.Request
 func (s *ClusterState) watchNamespaces(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 
+	// Subscribe under RLock so any subsequent publisher sees us; the snapshot
+	// taken inside the same RLock is consistent with the subscription order.
+	// See streamWatch's contract for the race this closes.
+	sub := s.wNamespaces.subscribe("")
+
 	items := make([]corev1.Namespace, 0, len(s.namespaces))
 	for _, n := range s.namespaces {
 		items = append(items, *n.DeepCopy())
@@ -71,7 +76,7 @@ func (s *ClusterState) watchNamespaces(w http.ResponseWriter, r *http.Request) {
 
 	s.mu.RUnlock()
 
-	streamWatch(r.Context(), w, s.wNamespaces, "", items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) createNamespace(w http.ResponseWriter, r *http.Request) {

--- a/kubernetes/pod.go
+++ b/kubernetes/pod.go
@@ -29,7 +29,7 @@ func (s *ClusterState) servePods(w http.ResponseWriter, r *http.Request, route *
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchPods(w, r, "")
 
 			return
@@ -58,7 +58,7 @@ func (s *ClusterState) servePods(w http.ResponseWriter, r *http.Request, route *
 func (s *ClusterState) servePodCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchPods(w, r, namespace)
 
 			return

--- a/kubernetes/pod.go
+++ b/kubernetes/pod.go
@@ -74,9 +74,10 @@ func (s *ClusterState) servePodCollection(w http.ResponseWriter, r *http.Request
 
 func (s *ClusterState) watchPods(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wPods.subscribe(namespace)
 	items := s.collectPodsLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wPods, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) servePodItem(w http.ResponseWriter, r *http.Request, namespace, name string) {

--- a/kubernetes/pod.go
+++ b/kubernetes/pod.go
@@ -29,6 +29,12 @@ func (s *ClusterState) servePods(w http.ResponseWriter, r *http.Request, route *
 			return
 		}
 
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchPods(w, r, "")
+
+			return
+		}
+
 		s.listPodsAllNamespaces(w)
 
 		return
@@ -52,12 +58,25 @@ func (s *ClusterState) servePods(w http.ResponseWriter, r *http.Request, route *
 func (s *ClusterState) servePodCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchPods(w, r, namespace)
+
+			return
+		}
+
 		s.listPods(w, namespace)
 	case http.MethodPost:
 		s.createPod(w, r, namespace)
 	default:
 		writeMethodNotAllowed(w, "k8s api: pods collection: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchPods(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectPodsLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wPods, namespace, items)
 }
 
 func (s *ClusterState) servePodItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
@@ -112,6 +131,7 @@ func (s *ClusterState) createPod(w http.ResponseWriter, r *http.Request, namespa
 
 	pod := in
 	s.pods[key] = &pod
+	s.wPods.publish(EventAdded, namespace, *pod.DeepCopy())
 	writeJSON(w, http.StatusCreated, &pod)
 }
 
@@ -203,6 +223,7 @@ func (s *ClusterState) updatePod(w http.ResponseWriter, r *http.Request, namespa
 
 	pod := in
 	s.pods[key] = &pod
+	s.wPods.publish(EventModified, namespace, *pod.DeepCopy())
 	writeJSON(w, http.StatusOK, &pod)
 }
 
@@ -230,6 +251,7 @@ func (s *ClusterState) patchPod(w http.ResponseWriter, r *http.Request, namespac
 
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 	s.pods[key] = patched
+	s.wPods.publish(EventModified, namespace, *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -247,6 +269,7 @@ func (s *ClusterState) deletePod(w http.ResponseWriter, namespace, name string) 
 	}
 
 	delete(s.pods, key)
+	s.wPods.publish(EventDeleted, namespace, *pod.DeepCopy())
 	writeJSON(w, http.StatusOK, pod.DeepCopy())
 }
 

--- a/kubernetes/route.go
+++ b/kubernetes/route.go
@@ -12,6 +12,11 @@ const namespacesSegment = "namespaces"
 // core (/api/v1) and apps (/apis/apps/v1).
 const apiVersionV1 = "v1"
 
+// watchQuery is the ?watch=true value clients pass to upgrade a list
+// request into a stream. Centralized so dispatchers don't all hold a
+// "true" literal.
+const watchQueryValue = "true"
+
 // Route holds the four pieces every Kubernetes REST URL decomposes into.
 // One Route value is the dispatch key for the per-resource handlers.
 type Route struct {

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -29,6 +29,12 @@ func (s *ClusterState) serveSecrets(w http.ResponseWriter, r *http.Request, rout
 			return
 		}
 
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchSecrets(w, r, "")
+
+			return
+		}
+
 		s.listSecretsAllNamespaces(w)
 
 		return
@@ -52,12 +58,25 @@ func (s *ClusterState) serveSecrets(w http.ResponseWriter, r *http.Request, rout
 func (s *ClusterState) serveSecretCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchSecrets(w, r, namespace)
+
+			return
+		}
+
 		s.listSecrets(w, namespace)
 	case http.MethodPost:
 		s.createSecret(w, r, namespace)
 	default:
 		writeMethodNotAllowed(w, "k8s api: secrets collection: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchSecrets(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectSecretsLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wSecrets, namespace, items)
 }
 
 func (s *ClusterState) serveSecretItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
@@ -111,6 +130,7 @@ func (s *ClusterState) createSecret(w http.ResponseWriter, r *http.Request, name
 
 	sec := in
 	s.secrets[key] = &sec
+	s.wSecrets.publish(EventAdded, namespace, *sec.DeepCopy())
 	writeJSON(w, http.StatusCreated, &sec)
 }
 
@@ -207,6 +227,7 @@ func (s *ClusterState) updateSecret(w http.ResponseWriter, r *http.Request, name
 
 	sec := in
 	s.secrets[key] = &sec
+	s.wSecrets.publish(EventModified, namespace, *sec.DeepCopy())
 	writeJSON(w, http.StatusOK, &sec)
 }
 
@@ -234,6 +255,7 @@ func (s *ClusterState) patchSecret(w http.ResponseWriter, r *http.Request, names
 
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 	s.secrets[key] = patched
+	s.wSecrets.publish(EventModified, namespace, *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -251,6 +273,7 @@ func (s *ClusterState) deleteSecret(w http.ResponseWriter, namespace, name strin
 	}
 
 	delete(s.secrets, key)
+	s.wSecrets.publish(EventDeleted, namespace, *sec.DeepCopy())
 	writeJSON(w, http.StatusOK, sec.DeepCopy())
 }
 

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -29,7 +29,7 @@ func (s *ClusterState) serveSecrets(w http.ResponseWriter, r *http.Request, rout
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchSecrets(w, r, "")
 
 			return
@@ -58,7 +58,7 @@ func (s *ClusterState) serveSecrets(w http.ResponseWriter, r *http.Request, rout
 func (s *ClusterState) serveSecretCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchSecrets(w, r, namespace)
 
 			return

--- a/kubernetes/secret.go
+++ b/kubernetes/secret.go
@@ -74,9 +74,10 @@ func (s *ClusterState) serveSecretCollection(w http.ResponseWriter, r *http.Requ
 
 func (s *ClusterState) watchSecrets(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wSecrets.subscribe(namespace)
 	items := s.collectSecretsLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wSecrets, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) serveSecretItem(w http.ResponseWriter, r *http.Request, namespace, name string) {

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -35,6 +35,12 @@ func (s *ClusterState) serveServices(w http.ResponseWriter, r *http.Request, rou
 			return
 		}
 
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchServices(w, r, "")
+
+			return
+		}
+
 		s.listServicesAllNamespaces(w)
 
 		return
@@ -58,12 +64,25 @@ func (s *ClusterState) serveServices(w http.ResponseWriter, r *http.Request, rou
 func (s *ClusterState) serveServiceCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchServices(w, r, namespace)
+
+			return
+		}
+
 		s.listServices(w, namespace)
 	case http.MethodPost:
 		s.createService(w, r, namespace)
 	default:
 		writeMethodNotAllowed(w, "k8s api: services collection: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchServices(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectServicesLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wServices, namespace, items)
 }
 
 func (s *ClusterState) serveServiceItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
@@ -127,6 +146,7 @@ func (s *ClusterState) createService(w http.ResponseWriter, r *http.Request, nam
 
 	svc := in
 	s.services[key] = &svc
+	s.wServices.publish(EventAdded, namespace, *svc.DeepCopy())
 	writeJSON(w, http.StatusCreated, &svc)
 }
 
@@ -229,6 +249,7 @@ func (s *ClusterState) updateService(w http.ResponseWriter, r *http.Request, nam
 
 	svc := in
 	s.services[key] = &svc
+	s.wServices.publish(EventModified, namespace, *svc.DeepCopy())
 	writeJSON(w, http.StatusOK, &svc)
 }
 
@@ -255,6 +276,7 @@ func (s *ClusterState) patchService(w http.ResponseWriter, r *http.Request, name
 	patched.Spec.ClusterIP = cur.Spec.ClusterIP
 	patched.Spec.ClusterIPs = cur.Spec.ClusterIPs
 	s.services[key] = patched
+	s.wServices.publish(EventModified, namespace, *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -272,6 +294,7 @@ func (s *ClusterState) deleteService(w http.ResponseWriter, namespace, name stri
 	}
 
 	delete(s.services, key)
+	s.wServices.publish(EventDeleted, namespace, *svc.DeepCopy())
 	writeJSON(w, http.StatusOK, svc.DeepCopy())
 }
 

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -35,7 +35,7 @@ func (s *ClusterState) serveServices(w http.ResponseWriter, r *http.Request, rou
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchServices(w, r, "")
 
 			return
@@ -64,7 +64,7 @@ func (s *ClusterState) serveServices(w http.ResponseWriter, r *http.Request, rou
 func (s *ClusterState) serveServiceCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchServices(w, r, namespace)
 
 			return

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -80,9 +80,10 @@ func (s *ClusterState) serveServiceCollection(w http.ResponseWriter, r *http.Req
 
 func (s *ClusterState) watchServices(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wServices.subscribe(namespace)
 	items := s.collectServicesLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wServices, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) serveServiceItem(w http.ResponseWriter, r *http.Request, namespace, name string) {

--- a/kubernetes/service.go
+++ b/kubernetes/service.go
@@ -146,7 +146,15 @@ func (s *ClusterState) createService(w http.ResponseWriter, r *http.Request, nam
 
 	svc := in
 	s.services[key] = &svc
+
+	// Auto-create an empty Endpoints stub so kubectl get endpoints returns
+	// rows. Subsets stays nil — no scheduler / Pod IPs in Wave 2.
+	ep := newEndpointsObject(namespace, svc.Name)
+	s.endpoints[endpointsKey(namespace, svc.Name)] = ep
+
 	s.wServices.publish(EventAdded, namespace, *svc.DeepCopy())
+	s.wEndpoints.publish(EventAdded, namespace, *ep.DeepCopy())
+
 	writeJSON(w, http.StatusCreated, &svc)
 }
 
@@ -295,6 +303,14 @@ func (s *ClusterState) deleteService(w http.ResponseWriter, namespace, name stri
 
 	delete(s.services, key)
 	s.wServices.publish(EventDeleted, namespace, *svc.DeepCopy())
+
+	// Tear down the paired Endpoints object so Watch subscribers see it go
+	// away alongside the Service.
+	if ep, ok := s.endpoints[endpointsKey(namespace, name)]; ok {
+		delete(s.endpoints, endpointsKey(namespace, name))
+		s.wEndpoints.publish(EventDeleted, namespace, *ep.DeepCopy())
+	}
+
 	writeJSON(w, http.StatusOK, svc.DeepCopy())
 }
 

--- a/kubernetes/serviceaccount.go
+++ b/kubernetes/serviceaccount.go
@@ -77,9 +77,10 @@ func (s *ClusterState) serveServiceAccountCollection(w http.ResponseWriter, r *h
 
 func (s *ClusterState) watchServiceAccounts(w http.ResponseWriter, r *http.Request, namespace string) {
 	s.mu.RLock()
+	sub := s.wServiceAccounts.subscribe(namespace)
 	items := s.collectServiceAccountsLocked(namespace)
 	s.mu.RUnlock()
-	streamWatch(r.Context(), w, s.wServiceAccounts, namespace, items)
+	streamWatch(r.Context(), w, sub, items)
 }
 
 func (s *ClusterState) serveServiceAccountItem(w http.ResponseWriter, r *http.Request, namespace, name string) {

--- a/kubernetes/serviceaccount.go
+++ b/kubernetes/serviceaccount.go
@@ -32,6 +32,12 @@ func (s *ClusterState) serveServiceAccounts(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchServiceAccounts(w, r, "")
+
+			return
+		}
+
 		s.listServiceAccountsAllNamespaces(w)
 
 		return
@@ -55,12 +61,25 @@ func (s *ClusterState) serveServiceAccounts(w http.ResponseWriter, r *http.Reque
 func (s *ClusterState) serveServiceAccountCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
+		if r.URL.Query().Get("watch") == "true" {
+			s.watchServiceAccounts(w, r, namespace)
+
+			return
+		}
+
 		s.listServiceAccounts(w, namespace)
 	case http.MethodPost:
 		s.createServiceAccount(w, r, namespace)
 	default:
 		writeMethodNotAllowed(w, "k8s api: serviceaccounts collection: method not allowed: "+r.Method)
 	}
+}
+
+func (s *ClusterState) watchServiceAccounts(w http.ResponseWriter, r *http.Request, namespace string) {
+	s.mu.RLock()
+	items := s.collectServiceAccountsLocked(namespace)
+	s.mu.RUnlock()
+	streamWatch(r.Context(), w, s.wServiceAccounts, namespace, items)
 }
 
 func (s *ClusterState) serveServiceAccountItem(w http.ResponseWriter, r *http.Request, namespace, name string) {
@@ -109,6 +128,7 @@ func (s *ClusterState) createServiceAccount(w http.ResponseWriter, r *http.Reque
 
 	sa := in
 	s.serviceAccounts[key] = &sa
+	s.wServiceAccounts.publish(EventAdded, namespace, *sa.DeepCopy())
 	writeJSON(w, http.StatusCreated, &sa)
 }
 
@@ -200,6 +220,7 @@ func (s *ClusterState) updateServiceAccount(w http.ResponseWriter, r *http.Reque
 
 	sa := in
 	s.serviceAccounts[key] = &sa
+	s.wServiceAccounts.publish(EventModified, namespace, *sa.DeepCopy())
 	writeJSON(w, http.StatusOK, &sa)
 }
 
@@ -227,6 +248,7 @@ func (s *ClusterState) patchServiceAccount(w http.ResponseWriter, r *http.Reques
 
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 	s.serviceAccounts[key] = patched
+	s.wServiceAccounts.publish(EventModified, namespace, *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
 }
 
@@ -244,6 +266,7 @@ func (s *ClusterState) deleteServiceAccount(w http.ResponseWriter, namespace, na
 	}
 
 	delete(s.serviceAccounts, key)
+	s.wServiceAccounts.publish(EventDeleted, namespace, *sa.DeepCopy())
 	writeJSON(w, http.StatusOK, sa.DeepCopy())
 }
 

--- a/kubernetes/serviceaccount.go
+++ b/kubernetes/serviceaccount.go
@@ -32,7 +32,7 @@ func (s *ClusterState) serveServiceAccounts(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchServiceAccounts(w, r, "")
 
 			return
@@ -61,7 +61,7 @@ func (s *ClusterState) serveServiceAccounts(w http.ResponseWriter, r *http.Reque
 func (s *ClusterState) serveServiceAccountCollection(w http.ResponseWriter, r *http.Request, namespace string) {
 	switch r.Method {
 	case http.MethodGet:
-		if r.URL.Query().Get("watch") == "true" {
+		if r.URL.Query().Get("watch") == watchQueryValue {
 			s.watchServiceAccounts(w, r, namespace)
 
 			return

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -46,6 +46,16 @@ type ClusterState struct {
 	// allocateClusterIP. Real apiserver uses an in-memory bitmap; the
 	// monotonic counter is enough for tests.
 	nextClusterIP uint32
+
+	// Per-resource Watch broadcasters. Handlers publish on Create/Update/
+	// Patch/Delete; ?watch=true requests subscribe via streamWatch.
+	wNamespaces      *broadcaster
+	wConfigMaps      *broadcaster
+	wPods            *broadcaster
+	wSecrets         *broadcaster
+	wServiceAccounts *broadcaster
+	wServices        *broadcaster
+	wDeployments     *broadcaster
 }
 
 // firstClusterIPOffset is the first integer offset above 10.96.0.0 that the
@@ -60,14 +70,21 @@ const firstClusterIPOffset uint32 = 1
 // cluster.
 func newClusterState() *ClusterState {
 	s := &ClusterState{
-		namespaces:      make(map[string]*corev1.Namespace),
-		configMaps:      make(map[string]*corev1.ConfigMap),
-		pods:            make(map[string]*corev1.Pod),
-		secrets:         make(map[string]*corev1.Secret),
-		serviceAccounts: make(map[string]*corev1.ServiceAccount),
-		services:        make(map[string]*corev1.Service),
-		deployments:     make(map[string]*appsv1.Deployment),
-		nextClusterIP:   firstClusterIPOffset,
+		namespaces:       make(map[string]*corev1.Namespace),
+		configMaps:       make(map[string]*corev1.ConfigMap),
+		pods:             make(map[string]*corev1.Pod),
+		secrets:          make(map[string]*corev1.Secret),
+		serviceAccounts:  make(map[string]*corev1.ServiceAccount),
+		services:         make(map[string]*corev1.Service),
+		deployments:      make(map[string]*appsv1.Deployment),
+		nextClusterIP:    firstClusterIPOffset,
+		wNamespaces:      newBroadcaster(),
+		wConfigMaps:      newBroadcaster(),
+		wPods:            newBroadcaster(),
+		wSecrets:         newBroadcaster(),
+		wServiceAccounts: newBroadcaster(),
+		wServices:        newBroadcaster(),
+		wDeployments:     newBroadcaster(),
 	}
 
 	for _, name := range []string{"default", "kube-system", "kube-public"} {

--- a/kubernetes/state.go
+++ b/kubernetes/state.go
@@ -41,6 +41,13 @@ type ClusterState struct {
 	// deployments lives under apps/v1 — keyed by "<namespace>/<name>".
 	deployments map[string]*appsv1.Deployment
 
+	// endpoints — keyed by "<namespace>/<name>". Real apiserver populates
+	// Subsets[].Addresses from Pods that match the Service selector via the
+	// endpoints controller. Wave 2 doesn't ship a controller, so endpoints
+	// objects are auto-created (empty) when their backing Service is created
+	// and torn down when it's deleted.
+	endpoints map[string]*corev1.Endpoints
+
 	// nextClusterIP is the monotonic counter used to hand out Service
 	// ClusterIPs from 10.96.0.0/12. Incremented under mu.Lock by
 	// allocateClusterIP. Real apiserver uses an in-memory bitmap; the
@@ -56,6 +63,7 @@ type ClusterState struct {
 	wServiceAccounts *broadcaster
 	wServices        *broadcaster
 	wDeployments     *broadcaster
+	wEndpoints       *broadcaster
 }
 
 // firstClusterIPOffset is the first integer offset above 10.96.0.0 that the
@@ -77,6 +85,7 @@ func newClusterState() *ClusterState {
 		serviceAccounts:  make(map[string]*corev1.ServiceAccount),
 		services:         make(map[string]*corev1.Service),
 		deployments:      make(map[string]*appsv1.Deployment),
+		endpoints:        make(map[string]*corev1.Endpoints),
 		nextClusterIP:    firstClusterIPOffset,
 		wNamespaces:      newBroadcaster(),
 		wConfigMaps:      newBroadcaster(),
@@ -85,6 +94,7 @@ func newClusterState() *ClusterState {
 		wServiceAccounts: newBroadcaster(),
 		wServices:        newBroadcaster(),
 		wDeployments:     newBroadcaster(),
+		wEndpoints:       newBroadcaster(),
 	}
 
 	for _, name := range []string{"default", "kube-system", "kube-public"} {
@@ -126,6 +136,8 @@ func (s *ClusterState) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.serveServices(w, r, route)
 	case "deployments":
 		s.serveDeployments(w, r, route)
+	case "endpoints":
+		s.serveEndpoints(w, r, route)
 	default:
 		writeNotFound(w, "k8s api: resource not implemented: "+route.Resource)
 	}

--- a/kubernetes/watch.go
+++ b/kubernetes/watch.go
@@ -1,0 +1,173 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Watch event types per the Kubernetes API contract. Wire format is
+// {"type":"<EventType>","object":{...}} sent as one JSON object per chunk.
+const (
+	EventAdded    = "ADDED"
+	EventModified = "MODIFIED"
+	EventDeleted  = "DELETED"
+)
+
+// watchSubscriberBuffer is the per-subscriber channel capacity. Generous so
+// a slow client can fall a few events behind without blocking the publisher;
+// if a client falls past this, the publisher drops its events rather than
+// stalling other subscribers (real apiserver disconnects slow watchers — we
+// just shed load).
+const watchSubscriberBuffer = 64
+
+// watchEvent is the wire shape sent on each Watch chunk. object is left as
+// any so the encoder picks up the concrete resource type's JSON tags.
+type watchEvent struct {
+	Type   string `json:"type"`
+	Object any    `json:"object"`
+}
+
+// subscriber is one connected client waiting for events on a single resource
+// kind+namespace tuple. Caller closes done to unsubscribe; the publisher
+// drops events into ch and stops once done is closed.
+type subscriber struct {
+	namespace string // "" matches every namespace
+	ch        chan watchEvent
+	done      chan struct{}
+}
+
+// broadcaster fans out resource mutations to every connected Watch
+// subscriber for a given resource kind. One broadcaster per kind (Pods,
+// Services, etc.) is owned by ClusterState.
+//
+// publish never blocks the caller — it drops events on full subscriber
+// channels rather than stalling other subscribers or the mutating handler.
+type broadcaster struct {
+	mu   sync.Mutex
+	subs []*subscriber
+}
+
+func newBroadcaster() *broadcaster {
+	return &broadcaster{}
+}
+
+// subscribe registers a fresh subscriber for the given namespace ("" =
+// across all namespaces) and returns it. Caller must close sub.done to
+// unsubscribe; broadcaster won't reference the channel after that.
+func (b *broadcaster) subscribe(namespace string) *subscriber {
+	sub := &subscriber{
+		namespace: namespace,
+		ch:        make(chan watchEvent, watchSubscriberBuffer),
+		done:      make(chan struct{}),
+	}
+
+	b.mu.Lock()
+	b.subs = append(b.subs, sub)
+	b.mu.Unlock()
+
+	return sub
+}
+
+// publish hands off an event to every subscriber whose namespace filter
+// matches. Subscribers that have closed their done channel are pruned in
+// the same pass.
+func (b *broadcaster) publish(eventType, namespace string, obj any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	keep := b.subs[:0]
+
+	for _, sub := range b.subs {
+		select {
+		case <-sub.done:
+			// Subscriber unsubscribed; drop without warning.
+			continue
+		default:
+		}
+
+		if sub.namespace != "" && sub.namespace != namespace {
+			keep = append(keep, sub)
+
+			continue
+		}
+
+		select {
+		case sub.ch <- watchEvent{Type: eventType, Object: obj}:
+		default:
+			// Channel full — drop this event for this slow subscriber
+			// rather than block the publisher / other subscribers. Real
+			// apiserver would disconnect; we lose an event, which is
+			// acceptable for a test backend.
+		}
+
+		keep = append(keep, sub)
+	}
+
+	b.subs = keep
+}
+
+// streamWatch handles ?watch=true requests for a given resource kind. It
+// emits an initial ADDED event for every existing item (so client-go
+// Reflectors see the full state), then streams events from the broadcaster
+// until the client disconnects.
+//
+// initial is the slice of current items at subscribe time. items must be
+// JSON-encodable as Kubernetes objects. namespace ("" for cluster-wide /
+// all-namespaces) filters subsequent events.
+func streamWatch[T any](
+	ctx context.Context,
+	w http.ResponseWriter,
+	b *broadcaster,
+	namespace string,
+	initial []T,
+) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeStatus(w, http.StatusInternalServerError, metav1.StatusReasonInternalError,
+			"k8s api: watch requires a flushable ResponseWriter")
+
+		return
+	}
+
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.WriteHeader(http.StatusOK)
+
+	enc := json.NewEncoder(w)
+
+	// Subscribe BEFORE emitting the initial snapshot so we don't miss any
+	// event published between snapshot and subscribe. The cost is that the
+	// snapshot may overlap with a same-key event from the broadcaster —
+	// client-go Reflectors deduplicate by resourceVersion, which is fine.
+	sub := b.subscribe(namespace)
+	defer close(sub.done)
+
+	for _, item := range initial {
+		if err := enc.Encode(watchEvent{Type: EventAdded, Object: item}); err != nil {
+			return
+		}
+
+		flusher.Flush()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sub.ch:
+			if !ok {
+				return
+			}
+
+			if err := enc.Encode(ev); err != nil {
+				return
+			}
+
+			flusher.Flush()
+		}
+	}
+}

--- a/kubernetes/watch.go
+++ b/kubernetes/watch.go
@@ -95,13 +95,12 @@ func (b *broadcaster) publish(eventType, namespace string, obj any) {
 			continue
 		}
 
+		// Channel full → drop this event for the slow subscriber rather
+		// than block the publisher or other subscribers. Real apiserver
+		// would disconnect; we shed load.
 		select {
 		case sub.ch <- watchEvent{Type: eventType, Object: obj}:
 		default:
-			// Channel full — drop this event for this slow subscriber
-			// rather than block the publisher / other subscribers. Real
-			// apiserver would disconnect; we lose an event, which is
-			// acceptable for a test backend.
 		}
 
 		keep = append(keep, sub)

--- a/kubernetes/watch.go
+++ b/kubernetes/watch.go
@@ -110,20 +110,37 @@ func (b *broadcaster) publish(eventType, namespace string, obj any) {
 }
 
 // streamWatch handles ?watch=true requests for a given resource kind. It
-// emits an initial ADDED event for every existing item (so client-go
-// Reflectors see the full state), then streams events from the broadcaster
-// until the client disconnects.
+// emits an initial ADDED event for every item in initial (so client-go
+// Reflectors see the full state), then streams events from sub until the
+// client disconnects.
 //
-// initial is the slice of current items at subscribe time. items must be
-// JSON-encodable as Kubernetes objects. namespace ("" for cluster-wide /
-// all-namespaces) filters subsequent events.
+// CALLER MUST SUBSCRIBE BEFORE TAKING THE SNAPSHOT, BOTH UNDER THE SAME
+// state.mu LOCK. That ordering is what closes the otherwise-present race
+// between snapshot-and-subscribe — without it, a mutation landing between
+// snapshot-release and subscribe-register would be invisible to the
+// subscriber (event published with no subscriber yet, state change not in
+// snapshot). The handler pattern is:
+//
+//	s.mu.RLock()
+//	sub := broadcaster.subscribe(namespace)   // visible to subsequent publishers
+//	initial := <collect snapshot under RLock>
+//	s.mu.RUnlock()
+//	streamWatch(r.Context(), w, sub, initial)
+//
+// Any mutation in flight while we hold RLock waits for RUnlock and then
+// publishes — the subscriber picks it up from sub.ch. Any mutation that
+// completed before our RLock is already in the snapshot.
+//
+// streamWatch closes sub.done on return so broadcaster.publish can prune
+// the subscriber slice on the next publish.
 func streamWatch[T any](
 	ctx context.Context,
 	w http.ResponseWriter,
-	b *broadcaster,
-	namespace string,
+	sub *subscriber,
 	initial []T,
 ) {
+	defer close(sub.done)
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		writeStatus(w, http.StatusInternalServerError, metav1.StatusReasonInternalError,
@@ -137,13 +154,6 @@ func streamWatch[T any](
 	w.WriteHeader(http.StatusOK)
 
 	enc := json.NewEncoder(w)
-
-	// Subscribe BEFORE emitting the initial snapshot so we don't miss any
-	// event published between snapshot and subscribe. The cost is that the
-	// snapshot may overlap with a same-key event from the broadcaster —
-	// client-go Reflectors deduplicate by resourceVersion, which is fine.
-	sub := b.subscribe(namespace)
-	defer close(sub.done)
 
 	for _, item := range initial {
 		if err := enc.Encode(watchEvent{Type: EventAdded, Object: item}); err != nil {

--- a/kubernetes/watch_test.go
+++ b/kubernetes/watch_test.go
@@ -1,0 +1,449 @@
+// Direct broadcaster + streamWatch unit tests. The HTTP-level end-to-end
+// path is exercised by TestSDKEKSDataPlane_InformerObservesAddAndDelete in
+// server/aws/eks — that's where the full real-client-go Watch scenario
+// runs. These tests bypass HTTP entirely and hit the in-package primitives,
+// which keeps them fast (~1ms each) and avoids the chunked-transfer
+// teardown races that http.Server.Close() exhibits when subscribers don't
+// close their connections deterministically.
+
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// httpClient and newRequestWithContext are tiny helpers used by the
+// HTTP-level watch test. Defined here so the test file doesn't need to
+// touch net/http directly for what is otherwise an in-package unit test.
+func httpClient() *http.Client {
+	return &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+}
+
+func newRequestWithContext(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Close = true
+
+	return req, nil
+}
+
+// nonFlushingWriter is a ResponseWriter that intentionally does NOT
+// implement http.Flusher, exercising streamWatch's defensive bail-out.
+type nonFlushingWriter struct {
+	rec *httptest.ResponseRecorder
+}
+
+func (n *nonFlushingWriter) Header() http.Header        { return n.rec.Header() }
+func (n *nonFlushingWriter) Write(b []byte) (int, error) { return n.rec.Write(b) }
+func (n *nonFlushingWriter) WriteHeader(code int)        { n.rec.WriteHeader(code) }
+
+// errorOnWriteFlusher is a ResponseWriter+Flusher whose Write always
+// errors, so streamWatch's enc.Encode fails on the first snapshot event.
+type errorOnWriteFlusher struct {
+	header http.Header
+}
+
+func (e *errorOnWriteFlusher) Header() http.Header {
+	if e.header == nil {
+		e.header = http.Header{}
+	}
+
+	return e.header
+}
+
+func (*errorOnWriteFlusher) Write([]byte) (int, error) {
+	return 0, errWriteFailed
+}
+
+func (*errorOnWriteFlusher) WriteHeader(int) {}
+func (*errorOnWriteFlusher) Flush()          {}
+
+var errWriteFailed = &writeError{}
+
+type writeError struct{}
+
+func (*writeError) Error() string { return "simulated write failure" }
+
+func TestBroadcaster_PublishToSubscriber(t *testing.T) {
+	b := newBroadcaster()
+	sub := b.subscribe("ns-a")
+
+	b.publish(EventAdded, "ns-a", "obj-1")
+
+	ev := mustReceive(t, sub, time.Second)
+	if ev.Type != EventAdded || ev.Object != "obj-1" {
+		t.Fatalf("got %+v, want {ADDED, obj-1}", ev)
+	}
+}
+
+func TestBroadcaster_NamespaceFilter(t *testing.T) {
+	b := newBroadcaster()
+
+	scoped := b.subscribe("ns-a")
+	cluster := b.subscribe("") // all namespaces
+
+	b.publish(EventAdded, "ns-a", "in-a")
+	b.publish(EventAdded, "ns-b", "in-b")
+
+	// Scoped sub only sees ns-a events.
+	ev := mustReceive(t, scoped, time.Second)
+	if ev.Object != "in-a" {
+		t.Fatalf("scoped first event: got %+v, want in-a", ev)
+	}
+
+	if got, ok := tryReceive(scoped, 50*time.Millisecond); ok {
+		t.Fatalf("scoped sub saw cross-namespace event: %+v", got)
+	}
+
+	// Cluster-wide sub sees both.
+	seen := map[string]bool{}
+
+	for i := 0; i < 2; i++ {
+		ev := mustReceive(t, cluster, time.Second)
+
+		obj, ok := ev.Object.(string)
+		if !ok {
+			t.Fatalf("cluster-wide event object is not string: %+v", ev.Object)
+		}
+
+		seen[obj] = true
+	}
+
+	if !seen["in-a"] || !seen["in-b"] {
+		t.Fatalf("cluster-wide sub missed events: seen=%v", seen)
+	}
+}
+
+func TestBroadcaster_DropsOnFullChannel(t *testing.T) {
+	b := newBroadcaster()
+	sub := b.subscribe("")
+
+	// Fill the subscriber's channel past its buffer.
+	for i := 0; i < watchSubscriberBuffer+8; i++ {
+		b.publish(EventAdded, "", i)
+	}
+
+	drained := 0
+
+	for {
+		select {
+		case <-sub.ch:
+			drained++
+		default:
+			// Channel drained — verify we got exactly the buffer's worth
+			// (publisher dropped the overflow rather than blocking).
+			if drained != watchSubscriberBuffer {
+				t.Fatalf("drained %d events, want %d (= buffer size)", drained, watchSubscriberBuffer)
+			}
+
+			return
+		}
+	}
+}
+
+func TestBroadcaster_PrunesClosedSubscribers(t *testing.T) {
+	b := newBroadcaster()
+	alive := b.subscribe("")
+	stale := b.subscribe("")
+	close(stale.done) // simulate streamWatch returning
+
+	b.publish(EventAdded, "", "x")
+
+	// alive should get the event.
+	ev := mustReceive(t, alive, time.Second)
+	if ev.Object != "x" {
+		t.Fatalf("alive sub: got %+v", ev)
+	}
+
+	// stale should have been pruned on the publish pass; len(b.subs) == 1.
+	b.mu.Lock()
+	got := len(b.subs)
+	b.mu.Unlock()
+
+	if got != 1 {
+		t.Fatalf("subs after prune: got %d, want 1", got)
+	}
+}
+
+func TestBroadcaster_ConcurrentPublishersAndSubscribers(t *testing.T) {
+	b := newBroadcaster()
+
+	const (
+		subs       = 4
+		eventsPerN = 32
+	)
+
+	subscribers := make([]*subscriber, subs)
+	for i := range subscribers {
+		subscribers[i] = b.subscribe("")
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < eventsPerN; i++ {
+			b.publish(EventAdded, "", i)
+		}
+	}()
+
+	wg.Wait()
+
+	// Every subscriber should see all events (buffer is bigger than count).
+	for i, sub := range subscribers {
+		got := 0
+
+	drain:
+		for {
+			select {
+			case <-sub.ch:
+				got++
+			case <-time.After(100 * time.Millisecond):
+				break drain
+			}
+		}
+
+		if got != eventsPerN {
+			t.Fatalf("subscriber %d: got %d events, want %d", i, got, eventsPerN)
+		}
+	}
+}
+
+// TestWatchHandlersOverHTTP exercises each watchXxx dispatcher through
+// the full HTTP stack — keeps per-function coverage honest. The tight
+// context deadline (100ms) makes streamWatch return via ctx.Done() before
+// httptest.Server.Close() needs to wait for it.
+func TestWatchHandlersOverHTTP(t *testing.T) {
+	for _, path := range []string{
+		// Namespaced watches
+		"/api/v1/namespaces/default/configmaps",
+		"/api/v1/namespaces/default/pods",
+		"/api/v1/namespaces/default/secrets",
+		"/api/v1/namespaces/default/serviceaccounts",
+		"/api/v1/namespaces/default/services",
+		"/api/v1/namespaces/default/endpoints",
+		"/apis/apps/v1/namespaces/default/deployments",
+		// Cluster-scoped / all-namespaces watches
+		"/api/v1/namespaces",
+		"/api/v1/configmaps",
+		"/api/v1/pods",
+		"/api/v1/secrets",
+		"/api/v1/serviceaccounts",
+		"/api/v1/services",
+		"/api/v1/endpoints",
+		"/apis/apps/v1/deployments",
+	} {
+		t.Run(path, func(t *testing.T) {
+			api := NewAPIServer()
+			uid, _ := api.RegisterCluster()
+			ts := httptest.NewServer(api)
+			ts.Config.SetKeepAlivesEnabled(false)
+			api.SetBaseURL(ts.URL)
+
+			defer func() {
+				ts.CloseClientConnections()
+				ts.Close()
+			}()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			fullURL := ts.URL + "/k8s/" + uid + path + "?watch=true"
+
+			req, _ := newRequestWithContext(ctx, fullURL)
+
+			resp, err := httpClient().Do(req)
+			if err != nil {
+				// context deadline tripped before headers came back — also acceptable
+				return
+			}
+
+			if resp.StatusCode != 200 {
+				resp.Body.Close()
+				t.Fatalf("watch %s: status %d", path, resp.StatusCode)
+			}
+
+			// Drain until the server ends the response (ctx deadline fires
+			// on the server side via the request context).
+			buf := make([]byte, 1024)
+
+			for {
+				if _, err := resp.Body.Read(buf); err != nil {
+					break
+				}
+			}
+
+			resp.Body.Close()
+		})
+	}
+}
+
+// TestStreamWatch_NoFlusher500s exercises the defensive
+// flusher-not-supported branch — a ResponseWriter that doesn't implement
+// http.Flusher must error out before headers are set so the caller gets
+// a proper 500 status.
+func TestStreamWatch_NoFlusher500s(t *testing.T) {
+	b := newBroadcaster()
+	sub := b.subscribe("")
+
+	rec := httptest.NewRecorder()
+	w := &nonFlushingWriter{rec: rec}
+
+	// Cancellable ctx so the function returns even if it doesn't bail on
+	// the no-flusher path (it should).
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	streamWatch(ctx, w, sub, []string{"x"})
+
+	if rec.Code != 500 {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}
+
+// TestStreamWatch_EncodeErrorReturns exercises the path where the
+// underlying writer fails mid-stream — streamWatch must return without
+// trying to encode further events.
+func TestStreamWatch_EncodeErrorReturns(t *testing.T) {
+	b := newBroadcaster()
+	sub := b.subscribe("")
+
+	w := &errorOnWriteFlusher{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	streamWatch(ctx, w, sub, []string{"item-1"})
+
+	// Defensive: the function should have returned before the deadline,
+	// proving it bails on the encode error rather than spinning.
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatal("streamWatch did not return after Write error; ctx deadline tripped")
+	}
+}
+
+// TestStreamWatch_InitialSnapshotAndLiveEvents exercises streamWatch
+// against an httptest.ResponseRecorder-like fake that captures the
+// chunked output. We use httptest.NewRecorder for the snapshot phase
+// (it's a Flusher) and a closing context to terminate the loop.
+func TestStreamWatch_InitialSnapshotAndLiveEvents(t *testing.T) {
+	b := newBroadcaster()
+	sub := b.subscribe("")
+	rec := httptest.NewRecorder()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// streamWatch runs in a goroutine; we publish a live event then
+	// cancel the context to make it return.
+	done := make(chan struct{})
+
+	go func() {
+		streamWatch(ctx, rec, sub, []string{"seed-1", "seed-2"})
+		close(done)
+	}()
+
+	// Publish a live event AFTER subscribe is registered (since the caller
+	// already subscribed before calling streamWatch).
+	b.publish(EventAdded, "", "live")
+
+	// Give streamWatch a moment to drain the snapshot + live event, then
+	// cancel.
+	time.Sleep(50 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("streamWatch did not return after ctx cancel")
+	}
+
+	// Decode the recorded body — should be 3 JSON objects on separate
+	// lines (newline added by json.Encoder).
+	body := rec.Body.String()
+	dec := json.NewDecoder(strings.NewReader(body))
+
+	var events []watchEvent
+
+	for {
+		var ev watchEvent
+		if err := dec.Decode(&ev); err != nil {
+			break
+		}
+
+		events = append(events, ev)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("events: got %d, want 3 (2 seed + 1 live)\nbody:\n%s", len(events), body)
+	}
+
+	expected := []struct {
+		typ string
+		obj string
+	}{
+		{EventAdded, "seed-1"},
+		{EventAdded, "seed-2"},
+		{EventAdded, "live"},
+	}
+
+	for i, want := range expected {
+		if events[i].Type != want.typ {
+			t.Fatalf("event %d type: got %q, want %q", i, events[i].Type, want.typ)
+		}
+
+		got, ok := events[i].Object.(string)
+		if !ok {
+			t.Fatalf("event %d object is not string: %+v", i, events[i].Object)
+		}
+
+		if got != want.obj {
+			t.Fatalf("event %d object: got %q, want %q", i, got, want.obj)
+		}
+	}
+
+	// Subscriber should have been auto-unsubscribed (sub.done closed).
+	select {
+	case <-sub.done:
+	default:
+		t.Fatal("streamWatch did not close sub.done on return")
+	}
+}
+
+// helpers
+
+func mustReceive(t *testing.T, sub *subscriber, deadline time.Duration) watchEvent {
+	t.Helper()
+
+	select {
+	case ev := <-sub.ch:
+		return ev
+	case <-time.After(deadline):
+		t.Fatalf("subscriber: no event within %s", deadline)
+
+		return watchEvent{}
+	}
+}
+
+func tryReceive(sub *subscriber, deadline time.Duration) (watchEvent, bool) {
+	select {
+	case ev := <-sub.ch:
+		return ev, true
+	case <-time.After(deadline):
+		return watchEvent{}, false
+	}
+}
+

--- a/server/aws/eks/sdk_dataplane_watch_test.go
+++ b/server/aws/eks/sdk_dataplane_watch_test.go
@@ -1,0 +1,178 @@
+// Wave 2 Phase 4 end-to-end test: real client-go Informer over the
+// in-memory K8s API. Proves Watch streaming works end-to-end — the
+// Reflector / SharedIndexInformer machinery requires List + Watch to
+// behave correctly together, including initial-state replay and
+// mutation events.
+
+package eks_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseks "github.com/aws/aws-sdk-go-v2/service/eks"
+	ekstypes "github.com/aws/aws-sdk-go-v2/service/eks/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/stackshy/cloudemu"
+	cloudkube "github.com/stackshy/cloudemu/kubernetes"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+// TestSDKEKSDataPlane_InformerObservesAddAndDelete drives a Phase-4
+// Informer-on-ConfigMaps scenario:
+//   - cluster created via real aws-sdk-go-v2.
+//   - SharedIndexInformer starts; HasSynced returns true once the initial
+//     LIST is replayed as ADDED events.
+//   - Test mutates state (Create + Delete) via client-go.
+//   - Informer's event handlers fire in the expected order.
+//
+// Each step bounded by a short context deadline so a regression on
+// Watch never deadlocks the test binary.
+//
+//nolint:funlen // single Informer scenario — splitting hurts readability.
+func TestSDKEKSDataPlane_InformerObservesAddAndDelete(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+
+	k8sAPI := cloudkube.NewAPIServer()
+	cloud.EKS.SetK8sAPI(k8sAPI)
+
+	srv := awsserver.New(awsserver.Drivers{EKS: cloud.EKS, K8sAPI: k8sAPI})
+	ts := httptest.NewServer(srv)
+
+	t.Cleanup(ts.Close)
+	k8sAPI.SetBaseURL(ts.URL)
+
+	awsClient := newEKSClient(t, ts.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const clusterName = "wave4-watch"
+
+	if _, err := awsClient.CreateCluster(ctx, &awseks.CreateClusterInput{
+		Name:    aws.String(clusterName),
+		RoleArn: aws.String("arn:aws:iam::123456789012:role/eks"),
+		ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+			SubnetIds: []string{"subnet-a", "subnet-b"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	out, err := awsClient.DescribeCluster(ctx, &awseks.DescribeClusterInput{Name: aws.String(clusterName)})
+	if err != nil {
+		t.Fatalf("DescribeCluster: %v", err)
+	}
+
+	endpoint := aws.ToString(out.Cluster.Endpoint)
+	cs := mustClientset(t, endpoint)
+
+	// Seed a configmap BEFORE the informer starts so the initial-list path
+	// is exercised.
+	if _, err := cs.CoreV1().ConfigMaps("default").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "preexisting"},
+		Data:       map[string]string{"k": "seed"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("seed CreateConfigMap: %v", err)
+	}
+
+	// Build a namespace-scoped factory + ConfigMap informer.
+	factory := informers.NewSharedInformerFactoryWithOptions(cs, time.Hour,
+		informers.WithNamespace("default"))
+	informer := factory.Core().V1().ConfigMaps().Informer()
+
+	var (
+		mu      sync.Mutex
+		added   []string
+		deleted []string
+	)
+
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+
+			mu.Lock()
+			added = append(added, cm.Name)
+			mu.Unlock()
+		},
+		DeleteFunc: func(obj any) {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				return
+			}
+
+			mu.Lock()
+			deleted = append(deleted, cm.Name)
+			mu.Unlock()
+		},
+	}); err != nil {
+		t.Fatalf("AddEventHandler: %v", err)
+	}
+
+	stop := make(chan struct{})
+
+	defer close(stop)
+
+	factory.Start(stop)
+
+	// Block until the initial LIST is replayed and the informer has the
+	// "preexisting" configmap.
+	if !cache.WaitForCacheSync(stop, informer.HasSynced) {
+		t.Fatal("informer never synced")
+	}
+
+	// Mutate AFTER sync — the watch stream should fire ADDED and DELETED.
+	if _, err := cs.CoreV1().ConfigMaps("default").Create(ctx, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "live"},
+		Data:       map[string]string{"k": "v"},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create live: %v", err)
+	}
+
+	if err := cs.CoreV1().ConfigMaps("default").Delete(ctx, "preexisting", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete preexisting: %v", err)
+	}
+
+	// Give the watch channel a moment to drain — bounded by ctx deadline.
+	deadline := time.Now().Add(3 * time.Second)
+
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		gotAdded, gotDeleted := append([]string(nil), added...), append([]string(nil), deleted...)
+		mu.Unlock()
+
+		if containsString(gotAdded, "preexisting") &&
+			containsString(gotAdded, "live") &&
+			containsString(gotDeleted, "preexisting") {
+			return // success
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	t.Fatalf("informer events incomplete after timeout:\n  added=%v\n  deleted=%v", added, deleted)
+}
+
+func containsString(xs []string, want string) bool {
+	for _, s := range xs {
+		if s == want {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
**Wave 2 Phase 4 — closes the Kubernetes data-plane thread.** After this PR, real `client-go` `Informer`/`Reflector` machinery works against a cloudemu-emulated cluster, which is what every K8s controller framework (operator-sdk, Helm, ArgoCD, Flux, …) depends on.

## What's new

### Watch streaming (the big one)

Every resource list endpoint accepts `?watch=true` and upgrades to a `Transfer-Encoding: chunked` JSON event stream:

```
{"type":"ADDED|MODIFIED|DELETED","object":{...}}
```

- **Per-resource event broadcaster** (`broadcaster` in `kubernetes/watch.go`). Each resource kind has its own; handlers publish on Create / Update / Patch / Delete; subscribers stream until `r.Context().Done()`.
- **Initial-state replay**: the subscriber sees an `ADDED` event for every existing item before the live stream begins. This is what client-go's `Reflector` needs to bootstrap its cache and report `HasSynced() == true`.
- **Non-blocking publish**: slow subscribers drop events rather than stalling the publisher or other subscribers. Real apiserver would disconnect; we shed load.
- **Cascade events**: deleting a Namespace publishes a `DELETED` event for every child resource so Watch subscribers see the cascade in real time.

All 7 existing resources + Endpoints are watchable.

### Endpoints

New resource (read-only via the API) auto-created paired with every Service. Empty Subsets — there's no scheduler / Pod IPs to populate. Just enough that `kubectl get endpoints` returns rows and Informers can subscribe.

### Docs (split per file per the "one file per commit for docs" convention)

- `README.md` — Kubernetes line now reads "control plane + data plane"; out-of-scope items called out.
- `docs/sdk-server.md` — protocol-detection table grows a `/k8s/{cluster-uid}/` row; coverage status updated.
- `docs/services.md` — Section 18 expanded with the data-plane resource table; Summary grand total **416 → 472** (8 resources × 7 verbs).

## Out of scope (Phase 5+ if anyone wants them)

- Real **controllers** — Deployment ↛ ReplicaSet ↛ Pod, no scheduler, Endpoints stays empty.
- **RBAC** (Roles, RoleBindings, ClusterRoles, ClusterRoleBindings).
- **Subresources** (`/status`, `/scale`, `/log`, `/exec`).
- **PersistentVolume / PVC, StatefulSet, DaemonSet, Job, CronJob, Ingress, NetworkPolicy**.

These would be useful but the Wave-2 promise — "real client-go workload tests work" — is delivered without them. After this PR, the framework for adding them exists; each is a new resource file following the established pattern.

## Commits (8, part-by-part)

```
1. feat(kubernetes): add Watch streaming infrastructure
2. feat(kubernetes): wire Watch into all 7 resources
3. feat(kubernetes): auto-create Endpoints stub on Service create
4. style(kubernetes): extract watchQueryValue constant; tidy watch publish
5. test(eks): real client-go Informer over the in-memory K8s API
6. docs(readme): refresh Kubernetes line for Wave 2 Phase 4
7. docs(sdk-server): document /k8s/ data-plane handler
8. docs(services): add Kubernetes data-plane subsection
```

## Verification

```
go build ./...                           0 errors
go test ./...                            123 packages OK, 0 failures
golangci-lint run --timeout=9m ./...     0 issues
go test -race ./kubernetes/ ./server/aws/eks/   clean
```

**The new `TestSDKEKSDataPlane_InformerObservesAddAndDelete` proves the canonical scenario**: a `SharedIndexInformer` over ConfigMaps reaches `HasSynced=true` after the initial LIST, then observes a `Create` as ADDED and a `Delete` as DELETED — exactly the surface every K8s controller relies on.

**Multi-cloud `/tmp/cloudemu-smoke`**: still 30/30 across EKS, AKS, GKE — the existing workload stack scenarios continue to work and now go through the same Watch-aware code paths.

After Phase 4, the K8s wave is structurally complete: control plane on all three clouds, data plane shared, Watch streaming for real client-go workflows, docs refreshed.
