### PR TITLE
feat(resourcediscovery): Phase 1 foundation — database tagging API + cross-service engine

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -293,3 +293,31 @@ func (db *Database) ListIndexes(ctx context.Context, table string) ([]driver.Ind
 
 	return out.([]driver.IndexInfo), nil
 }
+
+func (db *Database) TagResource(ctx context.Context, table string, tags map[string]string) error {
+	_, err := db.do(ctx, "TagResource", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.TagResource(ctx, table, tags)
+	})
+
+	return err
+}
+
+func (db *Database) UntagResource(ctx context.Context, table string, tagKeys []string) error {
+	_, err := db.do(ctx, "UntagResource", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.UntagResource(ctx, table, tagKeys)
+	})
+
+	return err
+}
+
+func (db *Database) ListTagsOfResource(ctx context.Context, table string) (map[string]string, error) {
+	out, err := db.do(ctx, "ListTagsOfResource", map[string]any{"table": table}, func() (any, error) {
+		return db.driver.ListTagsOfResource(ctx, table)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(map[string]string), nil
+}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -726,3 +726,36 @@ func TestListIndexesPortable(t *testing.T) {
 		require.Error(t, listErr)
 	})
 }
+
+func TestTaggingPortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	require.NoError(t, db.CreateTable(ctx, driver.TableConfig{Name: "tag-table", PartitionKey: "pk"}))
+
+	t.Run("tag and list", func(t *testing.T) {
+		require.NoError(t, db.TagResource(ctx, "tag-table", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := db.ListTagsOfResource(ctx, "tag-table")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		require.NoError(t, db.UntagResource(ctx, "tag-table", []string{"env"}))
+
+		got, err := db.ListTagsOfResource(ctx, "tag-table")
+		require.NoError(t, err)
+		_, hasEnv := got["env"]
+		assert.False(t, hasEnv)
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("missing table errors", func(t *testing.T) {
+		require.Error(t, db.TagResource(ctx, "no-table", map[string]string{"k": "v"}))
+		require.Error(t, db.UntagResource(ctx, "no-table", []string{"k"}))
+		_, err := db.ListTagsOfResource(ctx, "no-table")
+		require.Error(t, err)
+	})
+}

--- a/database/driver/driver.go
+++ b/database/driver/driver.go
@@ -148,4 +148,9 @@ type Database interface {
 	DeleteIndex(ctx context.Context, table, indexName string) error
 	DescribeIndex(ctx context.Context, table, indexName string) (*IndexInfo, error)
 	ListIndexes(ctx context.Context, table string) ([]IndexInfo, error)
+
+	// Tagging
+	TagResource(ctx context.Context, table string, tags map[string]string) error
+	UntagResource(ctx context.Context, table string, tagKeys []string) error
+	ListTagsOfResource(ctx context.Context, table string) (map[string]string, error)
 }

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -22,29 +22,31 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/sns"
 	"github.com/stackshy/cloudemu/providers/aws/sqs"
 	"github.com/stackshy/cloudemu/providers/aws/vpc"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
 // Provider holds all AWS mock services.
 type Provider struct {
-	S3             *s3.Mock
-	EC2            *ec2.Mock
-	DynamoDB       *dynamodb.Mock
-	Lambda         *lambda.Mock
-	VPC            *vpc.Mock
-	CloudWatch     *cloudwatch.Mock
-	IAM            *awsiam.Mock
-	Route53        *route53.Mock
-	ELB            *elb.Mock
-	SQS            *sqs.Mock
-	ElastiCache    *elasticache.Mock
-	SecretsManager *secretsmanager.Mock
-	CloudWatchLogs *cloudwatchlogs.Mock
-	SNS            *sns.Mock
-	ECR            *ecr.Mock
-	EventBridge    *eventbridge.Mock
-	RDS            *rds.Mock
-	Redshift       *redshift.Mock
-	EKS            *eks.Mock
+	S3                *s3.Mock
+	EC2               *ec2.Mock
+	DynamoDB          *dynamodb.Mock
+	Lambda            *lambda.Mock
+	VPC               *vpc.Mock
+	CloudWatch        *cloudwatch.Mock
+	IAM               *awsiam.Mock
+	Route53           *route53.Mock
+	ELB               *elb.Mock
+	SQS               *sqs.Mock
+	ElastiCache       *elasticache.Mock
+	SecretsManager    *secretsmanager.Mock
+	CloudWatchLogs    *cloudwatchlogs.Mock
+	SNS               *sns.Mock
+	ECR               *ecr.Mock
+	EventBridge       *eventbridge.Mock
+	RDS               *rds.Mock
+	Redshift          *redshift.Mock
+	EKS               *eks.Mock
+	ResourceDiscovery *resourcediscovery.Engine
 }
 
 // New creates a new AWS provider with all mock services.
@@ -84,6 +86,17 @@ func New(opts ...config.Option) *Provider {
 	p.RDS.SetMonitoring(p.CloudWatch)
 	p.Redshift.SetMonitoring(p.CloudWatch)
 	p.EKS.SetMonitoring(p.CloudWatch)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderAWS, o.AccountID, o.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.EC2,
+			Networking: p.VPC,
+			Storage:    p.S3,
+			Database:   p.DynamoDB,
+			Serverless: p.Lambda,
+		},
+	)
 
 	return p
 }

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -48,6 +48,7 @@ type tableData struct {
 	streamConfig  driver.StreamConfig
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
+	tags          map[string]string
 }
 
 // Mock is an in-memory mock implementation of DynamoDB.
@@ -868,4 +869,61 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 	}
 
 	return indexes, nil
+}
+
+// TagResource sets or replaces tag key/values on a table. Existing keys not
+// present in tags are preserved; existing keys present in tags are overwritten.
+func (m *Mock) TagResource(_ context.Context, table string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if td.tags == nil {
+		td.tags = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		td.tags[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes the given tag keys from a table. Unknown keys are ignored.
+func (m *Mock) UntagResource(_ context.Context, table string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	for _, k := range tagKeys {
+		delete(td.tags, k)
+	}
+
+	return nil
+}
+
+// ListTagsOfResource returns a copy of the tag map for a table.
+func (m *Mock) ListTagsOfResource(_ context.Context, table string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	out := make(map[string]string, len(td.tags))
+	for k, v := range td.tags {
+		out[k] = v
+	}
+
+	return out, nil
 }

--- a/providers/aws/dynamodb/dynamodb_test.go
+++ b/providers/aws/dynamodb/dynamodb_test.go
@@ -682,6 +682,80 @@ func TestDynamoDBMetricsEmission(t *testing.T) {
 	})
 }
 
+func TestTagging(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("tag and list", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+
+		err := m.TagResource(ctx, "tbl", map[string]string{"env": "prod", "team": "data"})
+		requireNoError(t, err)
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got))
+		assertEqual(t, "prod", got["env"])
+		assertEqual(t, "data", got["team"])
+	})
+
+	t.Run("tag merges with existing", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "stage", "owner": "alice"}))
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, 3, len(got))
+		assertEqual(t, "prod", got["env"])
+		assertEqual(t, "alice", got["owner"])
+		assertEqual(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "prod", "team": "data"}))
+		requireNoError(t, m.UntagResource(ctx, "tbl", []string{"env", "missing"}))
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, 1, len(got))
+		assertEqual(t, "data", got["team"])
+	})
+
+	t.Run("list returns copy", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "prod"}))
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+
+		got["env"] = "mutated"
+
+		fresh, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, "prod", fresh["env"])
+	})
+
+	t.Run("missing table errors", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.TagResource(ctx, "nope", map[string]string{"k": "v"})
+		assertError(t, err, true)
+
+		err = m.UntagResource(ctx, "nope", []string{"k"})
+		assertError(t, err, true)
+
+		_, err = m.ListTagsOfResource(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/azure/servicebus"
 	"github.com/stackshy/cloudemu/providers/azure/virtualmachines"
 	"github.com/stackshy/cloudemu/providers/azure/vnet"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
 // Provider holds all Azure mock services.
@@ -47,6 +48,8 @@ type Provider struct {
 	PostgresFlex     *postgresflex.Mock
 	MySQLFlex        *mysqlflex.Mock
 	AKS              *aks.Mock
+
+	ResourceDiscovery *resourcediscovery.Engine
 }
 
 // New creates a new Azure provider with all mock services.
@@ -88,6 +91,17 @@ func New(opts ...config.Option) *Provider {
 	p.PostgresFlex.SetMonitoring(p.Monitor)
 	p.MySQLFlex.SetMonitoring(p.Monitor)
 	p.AKS.SetMonitoring(p.Monitor)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderAzure, o.AccountID, o.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.VirtualMachines,
+			Networking: p.VNet,
+			Storage:    p.BlobStorage,
+			Database:   p.CosmosDB,
+			Serverless: p.Functions,
+		},
+	)
 
 	return p
 }

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -50,6 +50,7 @@ type tableData struct {
 	streamConfig  driver.StreamConfig
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
+	tags          map[string]string
 }
 
 // Mock is an in-memory mock implementation of Azure Cosmos DB.
@@ -882,4 +883,61 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 	}
 
 	return indexes, nil
+}
+
+// TagResource sets or replaces tag key/values on a container. Existing keys
+// not present in tags are preserved; existing keys present in tags are overwritten.
+func (m *Mock) TagResource(_ context.Context, table string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	if td.tags == nil {
+		td.tags = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		td.tags[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes the given tag keys from a container. Unknown keys are ignored.
+func (m *Mock) UntagResource(_ context.Context, table string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	for _, k := range tagKeys {
+		delete(td.tags, k)
+	}
+
+	return nil
+}
+
+// ListTagsOfResource returns a copy of the tag map for a container.
+func (m *Mock) ListTagsOfResource(_ context.Context, table string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	out := make(map[string]string, len(td.tags))
+	for k, v := range td.tags {
+		out[k] = v
+	}
+
+	return out, nil
 }

--- a/providers/azure/cosmosdb/cosmosdb_test.go
+++ b/providers/azure/cosmosdb/cosmosdb_test.go
@@ -891,3 +891,71 @@ func TestUpdateItemEmitsMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, mon.hasMetric("Microsoft.DocumentDB/databaseAccounts", "TotalRequests"))
 }
+
+func TestTagging(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("tag and list", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "data", got["team"])
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("tag merges with existing", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "stage", "owner": "alice"}))
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "alice", got["owner"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod", "team": "data"}))
+		require.NoError(t, m.UntagResource(ctx, "users", []string{"env", "missing"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("list returns copy", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		got["env"] = "mutated"
+
+		fresh, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", fresh["env"])
+	})
+
+	t.Run("missing container errors", func(t *testing.T) {
+		m := newTestMock()
+
+		require.Error(t, m.TagResource(ctx, "nope", map[string]string{"k": "v"}))
+		require.Error(t, m.UntagResource(ctx, "nope", []string{"k"}))
+		_, err := m.ListTagsOfResource(ctx, "nope")
+		require.Error(t, err)
+	})
+}

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -50,6 +50,7 @@ type collectionData struct {
 	streamConfig  driver.StreamConfig
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
+	labels        map[string]string
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Firestore.
@@ -863,4 +864,64 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 	}
 
 	return indexes, nil
+}
+
+// TagResource sets or replaces label key/values on a collection. GCP terms
+// these "labels"; the cross-cloud driver interface calls the method TagResource.
+// Existing labels not present in tags are preserved; existing labels present
+// in tags are overwritten.
+func (m *Mock) TagResource(_ context.Context, table string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	if cd.labels == nil {
+		cd.labels = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		cd.labels[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes the given label keys from a collection. Unknown keys
+// are ignored.
+func (m *Mock) UntagResource(_ context.Context, table string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	for _, k := range tagKeys {
+		delete(cd.labels, k)
+	}
+
+	return nil
+}
+
+// ListTagsOfResource returns a copy of the label map for a collection.
+func (m *Mock) ListTagsOfResource(_ context.Context, table string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	out := make(map[string]string, len(cd.labels))
+	for k, v := range cd.labels {
+		out[k] = v
+	}
+
+	return out, nil
 }

--- a/providers/gcp/firestore/firestore_test.go
+++ b/providers/gcp/firestore/firestore_test.go
@@ -1163,3 +1163,75 @@ func TestUpdateItemEmitsMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, mon.data["firestore.googleapis.com/document/write_count"])
 }
+
+func TestTagging(t *testing.T) {
+	ctx := context.Background()
+
+	createColl := func(m *Mock, name string) {
+		require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: name, PartitionKey: "pk"}))
+	}
+
+	t.Run("tag and list", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("tag merges with existing", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "stage", "owner": "alice"}))
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "alice", got["owner"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod", "team": "data"}))
+		require.NoError(t, m.UntagResource(ctx, "coll", []string{"env", "missing"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("list returns copy", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		got["env"] = "mutated"
+
+		fresh, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", fresh["env"])
+	})
+
+	t.Run("missing collection errors", func(t *testing.T) {
+		m := newTestMock()
+
+		require.Error(t, m.TagResource(ctx, "nope", map[string]string{"k": "v"}))
+		require.Error(t, m.UntagResource(ctx, "nope", []string{"k"}))
+		_, err := m.ListTagsOfResource(ctx, "nope")
+		require.Error(t, err)
+	})
+}

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/gcp/memorystore"
 	"github.com/stackshy/cloudemu/providers/gcp/pubsub"
 	"github.com/stackshy/cloudemu/providers/gcp/secretmanager"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
 // Provider holds all GCP mock services.
@@ -43,6 +44,8 @@ type Provider struct {
 	Eventarc         *eventarc.Mock
 	CloudSQL         *cloudsql.Mock
 	GKE              *gke.Mock
+
+	ResourceDiscovery *resourcediscovery.Engine
 }
 
 // New creates a new GCP provider with all mock services.
@@ -80,6 +83,17 @@ func New(opts ...config.Option) *Provider {
 	p.Eventarc.SetMonitoring(p.CloudMonitoring)
 	p.CloudSQL.SetMonitoring(p.CloudMonitoring)
 	p.GKE.SetMonitoring(p.CloudMonitoring)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderGCP, o.ProjectID, o.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.GCE,
+			Networking: p.VPC,
+			Storage:    p.GCS,
+			Database:   p.Firestore,
+			Serverless: p.CloudFunctions,
+		},
+	)
 
 	return p
 }

--- a/resourcediscovery/arn.go
+++ b/resourcediscovery/arn.go
@@ -1,0 +1,116 @@
+package resourcediscovery
+
+import (
+	"fmt"
+
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+// Per-provider ARN/URN builders. These produce best-effort canonical
+// identifiers — enough for resource discovery output, not necessarily
+// byte-equal to what each service's own driver would emit when it owns
+// the canonical ID. Phases 2-4 may refine these as the SDK-compat
+// handlers expose the exact strings real clients expect.
+
+const azureDefaultResourceGroup = "default"
+
+// Network resource kind constants used by per-provider ARN routing.
+const (
+	netKindVPC           = "vpc"
+	netKindSubnet        = "subnet"
+	netKindSecurityGroup = "security-group"
+)
+
+func (e *Engine) computeInstanceARN(id string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("ec2", e.region, e.accountID, "instance/"+id)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Compute", "virtualMachines", id)
+	case ProviderGCP:
+		return id
+	default:
+		return id
+	}
+}
+
+func (e *Engine) networkARN(kind, id string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("ec2", e.region, e.accountID, kind+"/"+id)
+	case ProviderAzure:
+		azureType := azureNetworkType(kind)
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Network", azureType, id)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, gcpNetworkCollection(kind), id)
+	default:
+		return id
+	}
+}
+
+func azureNetworkType(kind string) string {
+	switch kind {
+	case netKindVPC:
+		return "virtualNetworks"
+	case netKindSubnet:
+		return "subnets"
+	case netKindSecurityGroup:
+		return "networkSecurityGroups"
+	default:
+		return kind
+	}
+}
+
+func gcpNetworkCollection(kind string) string {
+	switch kind {
+	case netKindVPC:
+		return "networks"
+	case netKindSubnet:
+		return "subnetworks"
+	case netKindSecurityGroup:
+		return "firewalls"
+	default:
+		return kind
+	}
+}
+
+func (e *Engine) storageBucketARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return fmt.Sprintf("arn:aws:s3:::%s", name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Storage",
+			"storageAccounts/default/blobServices/default/containers", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "buckets", name)
+	default:
+		return name
+	}
+}
+
+func (e *Engine) databaseTableARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("dynamodb", e.region, e.accountID, "table/"+name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.DocumentDB",
+			"databaseAccounts/default/sqlDatabases/default/containers", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "databases/(default)/collections", name)
+	default:
+		return name
+	}
+}
+
+func (e *Engine) serverlessFunctionARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("lambda", e.region, e.accountID, "function:"+name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Web", "sites", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "locations/"+e.region+"/functions", name)
+	default:
+		return name
+	}
+}

--- a/resourcediscovery/engine.go
+++ b/resourcediscovery/engine.go
@@ -1,0 +1,108 @@
+package resourcediscovery
+
+import (
+	"context"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+)
+
+// Drivers bundles the per-service drivers the engine reads from. Any field
+// may be nil — the matching walker is skipped in that case. This keeps the
+// engine usable in partial test wirings and during the staged rollout of
+// per-service walkers in later phases.
+type Drivers struct {
+	Compute    computedriver.Compute
+	Networking netdriver.Networking
+	Storage    storagedriver.Bucket
+	Database   dbdriver.Database
+	Serverless serverlessdriver.Serverless
+}
+
+// Engine walks all configured service drivers and returns a normalized
+// cross-service resource inventory.
+type Engine struct {
+	provider  string
+	accountID string
+	region    string
+	drivers   Drivers
+}
+
+// New constructs an Engine. provider is one of "aws", "azure", "gcp".
+// accountID is the AWS account ID, Azure subscription ID, or GCP project ID;
+// it is embedded in the ARN/URN of each returned Resource. region is the
+// default region used when a driver does not carry per-resource regions.
+// drivers is passed by pointer because the struct is wider than the
+// gocritic hugeParam threshold; passing nil for any field skips that walker.
+func New(provider, accountID, region string, drivers *Drivers) *Engine {
+	var d Drivers
+	if drivers != nil {
+		d = *drivers
+	}
+
+	return &Engine{
+		provider:  provider,
+		accountID: accountID,
+		region:    region,
+		drivers:   d,
+	}
+}
+
+// ListAll walks every configured driver and returns the merged inventory.
+// Nil drivers are skipped silently. The first walker error short-circuits
+// the rest.
+func (e *Engine) ListAll(ctx context.Context) ([]Resource, error) {
+	return e.List(ctx, Query{})
+}
+
+// List walks every configured driver and returns resources matching q.
+// Filtering happens after collection — walkers always return their full set
+// so tag/region resolution is consistent regardless of query shape.
+func (e *Engine) List(ctx context.Context, q Query) ([]Resource, error) {
+	var out []Resource
+
+	for _, walk := range e.walkers() {
+		batch, err := walk(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range batch {
+			if q.matches(&batch[i]) {
+				out = append(out, batch[i])
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// walkers returns the active walker functions, skipping any whose driver is nil.
+func (e *Engine) walkers() []func(context.Context) ([]Resource, error) {
+	var ws []func(context.Context) ([]Resource, error)
+
+	if e.drivers.Compute != nil {
+		ws = append(ws, e.walkCompute)
+	}
+
+	if e.drivers.Networking != nil {
+		ws = append(ws, e.walkNetworking)
+	}
+
+	if e.drivers.Storage != nil {
+		ws = append(ws, e.walkStorage)
+	}
+
+	if e.drivers.Database != nil {
+		ws = append(ws, e.walkDatabase)
+	}
+
+	if e.drivers.Serverless != nil {
+		ws = append(ws, e.walkServerless)
+	}
+
+	return ws
+}

--- a/resourcediscovery/engine_test.go
+++ b/resourcediscovery/engine_test.go
@@ -2,6 +2,7 @@ package resourcediscovery
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	"github.com/stackshy/cloudemu/config"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
 	"github.com/stackshy/cloudemu/providers/aws/ec2"
@@ -16,6 +18,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/s3"
 	"github.com/stackshy/cloudemu/providers/aws/vpc"
 	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -262,4 +265,107 @@ func groupByType(rs []Resource) map[string][]Resource {
 		out[r.Type] = append(out[r.Type], r)
 	}
 	return out
+}
+
+// failingDatabase wraps a real Database driver and forces ListTables (or
+// ListTagsOfResource, if set) to return the supplied error. All other
+// methods delegate to the embedded interface.
+type failingDatabase struct {
+	dbdriver.Database
+	listErr    error
+	listTagErr error
+}
+
+func (f *failingDatabase) ListTables(ctx context.Context) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.Database.ListTables(ctx)
+}
+
+func (f *failingDatabase) ListTagsOfResource(ctx context.Context, table string) (map[string]string, error) {
+	if f.listTagErr != nil {
+		return nil, f.listTagErr
+	}
+	return f.Database.ListTagsOfResource(ctx, table)
+}
+
+// failingStorage wraps a real Storage driver and forces GetBucketTagging
+// to return the supplied error.
+type failingStorage struct {
+	storagedriver.Bucket
+	tagErr error
+}
+
+func (f *failingStorage) GetBucketTagging(ctx context.Context, bucket string) (map[string]string, error) {
+	if f.tagErr != nil {
+		return nil, f.tagErr
+	}
+	return f.Bucket.GetBucketTagging(ctx, bucket)
+}
+
+func TestWalkerErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	t.Run("ListTables error wraps with walker name", func(t *testing.T) {
+		sentinel := errors.New("listtables blew up")
+		db := &failingDatabase{Database: dynamodb.New(opts), listErr: sentinel}
+
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: db})
+		_, err := eng.ListAll(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel, "sentinel should propagate via %%w")
+		assert.Contains(t, err.Error(), "walkDatabase", "error should be wrapped with walker name")
+	})
+
+	t.Run("non-NotFound tag-lookup error propagates", func(t *testing.T) {
+		sentinel := errors.New("tagging service unavailable")
+
+		realDB := dynamodb.New(opts)
+		require.NoError(t, realDB.CreateTable(ctx, dbdriver.TableConfig{Name: "t1", PartitionKey: "pk"}))
+
+		db := &failingDatabase{Database: realDB, listTagErr: sentinel}
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: db})
+
+		_, err := eng.ListAll(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel)
+		assert.Contains(t, err.Error(), `"t1"`, "error should name the resource that failed")
+	})
+
+	t.Run("NotFound tag-lookup is treated as race and resource is skipped", func(t *testing.T) {
+		realDB := dynamodb.New(opts)
+		require.NoError(t, realDB.CreateTable(ctx, dbdriver.TableConfig{Name: "alive", PartitionKey: "pk"}))
+
+		// Force every ListTagsOfResource to look like the table was deleted
+		// mid-walk. The walker should drop the resource silently rather
+		// than failing the whole ListAll.
+		db := &failingDatabase{
+			Database:   realDB,
+			listTagErr: cerrors.Newf(cerrors.NotFound, "table gone"),
+		}
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: db})
+
+		out, err := eng.ListAll(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, out, "race-disappeared resources should be skipped, not surfaced")
+	})
+
+	t.Run("storage tag-lookup error propagates", func(t *testing.T) {
+		sentinel := errors.New("s3 tagging timeout")
+
+		realS3 := s3.New(opts)
+		require.NoError(t, realS3.CreateBucket(ctx, "bkt"))
+
+		bkt := &failingStorage{Bucket: realS3, tagErr: sentinel}
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Storage: bkt})
+
+		_, err := eng.ListAll(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel)
+		assert.Contains(t, err.Error(), `"bkt"`)
+	})
 }

--- a/resourcediscovery/engine_test.go
+++ b/resourcediscovery/engine_test.go
@@ -1,0 +1,265 @@
+package resourcediscovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/config"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
+	"github.com/stackshy/cloudemu/providers/aws/ec2"
+	"github.com/stackshy/cloudemu/providers/aws/lambda"
+	"github.com/stackshy/cloudemu/providers/aws/s3"
+	"github.com/stackshy/cloudemu/providers/aws/vpc"
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fixture struct {
+	engine *Engine
+	ec2    *ec2.Mock
+	vpc    *vpc.Mock
+	s3     *s3.Mock
+	ddb    *dynamodb.Mock
+	lambda *lambda.Mock
+}
+
+func newAWSFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	ec2Mock := ec2.New(opts)
+	vpcMock := vpc.New(opts)
+	s3Mock := s3.New(opts)
+	ddbMock := dynamodb.New(opts)
+	lambdaMock := lambda.New(opts)
+
+	eng := New(ProviderAWS, "123456789012", "us-east-1", &Drivers{
+		Compute:    ec2Mock,
+		Networking: vpcMock,
+		Storage:    s3Mock,
+		Database:   ddbMock,
+		Serverless: lambdaMock,
+	})
+
+	return &fixture{
+		engine: eng,
+		ec2:    ec2Mock,
+		vpc:    vpcMock,
+		s3:     s3Mock,
+		ddb:    ddbMock,
+		lambda: lambdaMock,
+	}
+}
+
+func TestNew(t *testing.T) {
+	eng := New(ProviderAWS, "acct", "us-east-1", nil)
+	require.NotNil(t, eng)
+	assert.Equal(t, ProviderAWS, eng.provider)
+}
+
+func TestListAllEmpty(t *testing.T) {
+	f := newAWSFixture(t)
+
+	out, err := f.engine.ListAll(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestListAllAcrossServices(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, map[string]string{"env": "prod"})
+	seedVPC(t, f, map[string]string{"env": "prod"})
+	seedS3(t, f, "data-bucket", map[string]string{"env": "stage"})
+	seedDDB(t, f, "users", map[string]string{"env": "prod", "team": "core"})
+	seedLambda(t, f, "handler", map[string]string{"env": "stage"})
+
+	out, err := f.engine.ListAll(ctx)
+	require.NoError(t, err)
+
+	byType := groupByType(out)
+	assert.Len(t, byType[TypeInstance], 1, "compute instance")
+	assert.Len(t, byType[TypeVPC], 1, "vpc")
+	assert.Len(t, byType[TypeBucket], 1, "bucket")
+	assert.Len(t, byType[TypeTable], 1, "table")
+	assert.Len(t, byType[TypeFunction], 1, "function")
+}
+
+func TestListWithQueryFilters(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, map[string]string{"env": "prod"})
+	seedDDB(t, f, "users", map[string]string{"env": "prod"})
+	seedDDB(t, f, "stage-cache", map[string]string{"env": "stage"})
+
+	t.Run("by service", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Service: ServiceDatabase})
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		for _, r := range got {
+			assert.Equal(t, ServiceDatabase, r.Service)
+		}
+	})
+
+	t.Run("by type", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Type: TypeInstance})
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, TypeInstance, got[0].Type)
+	})
+
+	t.Run("by tag key+value", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Tags: map[string]string{"env": "prod"}})
+		require.NoError(t, err)
+		assert.Len(t, got, 2, "expected compute + users table")
+	})
+
+	t.Run("by tag key only", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Tags: map[string]string{"env": ""}})
+		require.NoError(t, err)
+		assert.Len(t, got, 3, "all 3 carry env tag")
+	})
+}
+
+func TestSearchByTag(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedDDB(t, f, "prod-tbl", map[string]string{"env": "prod"})
+	seedDDB(t, f, "stage-tbl", map[string]string{"env": "stage"})
+
+	got, err := f.engine.SearchByTag(ctx, "env", "prod")
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "prod-tbl", got[0].ID)
+}
+
+func TestGetTagKeysAndValues(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, map[string]string{"env": "prod", "team": "core"})
+	seedDDB(t, f, "tbl", map[string]string{"env": "stage"})
+
+	keys, err := f.engine.GetTagKeys(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"env", "team"}, keys)
+
+	envValues, err := f.engine.GetTagValues(ctx, "env")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod", "stage"}, envValues)
+
+	missing, err := f.engine.GetTagValues(ctx, "missing")
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+}
+
+func TestARNShapes(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, nil)
+	seedVPC(t, f, nil)
+	seedS3(t, f, "my-bkt", nil)
+	seedDDB(t, f, "my-tbl", nil)
+	seedLambda(t, f, "my-fn", nil)
+
+	out, err := f.engine.ListAll(ctx)
+	require.NoError(t, err)
+
+	for _, r := range out {
+		switch r.Type {
+		case TypeInstance:
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:instance/"),
+				"unexpected instance ARN: %s", r.ARN)
+		case TypeVPC:
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:vpc/"),
+				"unexpected VPC ARN: %s", r.ARN)
+		case TypeBucket:
+			assert.Equal(t, "arn:aws:s3:::my-bkt", r.ARN)
+		case TypeTable:
+			assert.Equal(t, "arn:aws:dynamodb:us-east-1:123456789012:table/my-tbl", r.ARN)
+		case TypeFunction:
+			// Lambda mock builds its own ARN; we just require non-empty.
+			assert.NotEmpty(t, r.ARN)
+		default:
+			t.Fatalf("unexpected resource type: %s", r.Type)
+		}
+	}
+}
+
+func TestNilDriversSkipped(t *testing.T) {
+	ctx := context.Background()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	ddbMock := dynamodb.New(opts)
+
+	eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: ddbMock})
+	require.NoError(t, ddbMock.CreateTable(ctx, dbdriver.TableConfig{Name: "only", PartitionKey: "pk"}))
+
+	out, err := eng.ListAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.Equal(t, ServiceDatabase, out[0].Service)
+}
+
+func seedCompute(t *testing.T, f *fixture, tags map[string]string) {
+	t.Helper()
+	_, err := f.ec2.RunInstances(context.Background(), computedriver.InstanceConfig{
+		ImageID: "ami-1", InstanceType: "t2.micro", Tags: tags,
+	}, 1)
+	require.NoError(t, err)
+}
+
+func seedVPC(t *testing.T, f *fixture, tags map[string]string) {
+	t.Helper()
+	_, err := f.vpc.CreateVPC(context.Background(), netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: tags,
+	})
+	require.NoError(t, err)
+}
+
+func seedS3(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, f.s3.CreateBucket(ctx, name))
+	if len(tags) > 0 {
+		require.NoError(t, f.s3.PutBucketTagging(ctx, name, tags))
+	}
+}
+
+func seedDDB(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, f.ddb.CreateTable(ctx, dbdriver.TableConfig{Name: name, PartitionKey: "pk"}))
+	if len(tags) > 0 {
+		require.NoError(t, f.ddb.TagResource(ctx, name, tags))
+	}
+}
+
+func seedLambda(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	_, err := f.lambda.CreateFunction(context.Background(), serverlessdriver.FunctionConfig{
+		Name: name, Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30, Tags: tags,
+	})
+	require.NoError(t, err)
+}
+
+func groupByType(rs []Resource) map[string][]Resource {
+	out := make(map[string][]Resource)
+	for _, r := range rs {
+		out[r.Type] = append(out[r.Type], r)
+	}
+	return out
+}

--- a/resourcediscovery/search.go
+++ b/resourcediscovery/search.go
@@ -1,0 +1,64 @@
+package resourcediscovery
+
+import (
+	"context"
+	"sort"
+)
+
+// SearchByTag returns every resource carrying tag key. If value is non-empty,
+// the tag's value must also match exactly.
+func (e *Engine) SearchByTag(ctx context.Context, key, value string) ([]Resource, error) {
+	return e.List(ctx, Query{Tags: map[string]string{key: value}})
+}
+
+// GetTagKeys returns the deduplicated, sorted set of tag keys present on
+// any resource across the engine's drivers.
+func (e *Engine) GetTagKeys(ctx context.Context) ([]string, error) {
+	all, err := e.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{})
+
+	for i := range all {
+		for k := range all[i].Tags {
+			set[k] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// GetTagValues returns the deduplicated, sorted set of values seen for the
+// given tag key across every resource.
+func (e *Engine) GetTagValues(ctx context.Context, key string) ([]string, error) {
+	all, err := e.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{})
+
+	for i := range all {
+		if v, ok := all[i].Tags[key]; ok {
+			set[v] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}

--- a/resourcediscovery/types.go
+++ b/resourcediscovery/types.go
@@ -1,0 +1,75 @@
+// Package resourcediscovery is a cross-service inventory engine. It reads
+// from existing service drivers (compute, networking, storage, database,
+// serverless) and returns a normalized view of every resource a provider
+// holds, with tags resolved per service.
+//
+// The engine follows the topology package as a precedent: it owns no state,
+// constructs from driver interfaces, and is query-driven. It is the
+// foundation for the SDK-compat handlers in the AWS Resource Explorer +
+// Resource Groups Tagging API, Azure Resource Graph, and GCP Cloud Asset
+// Inventory packages.
+package resourcediscovery
+
+import "time"
+
+// Resource is the normalized cross-cloud resource shape. Every walker emits
+// resources in this form so callers can filter, search, and tag-query
+// uniformly regardless of provider or service.
+type Resource struct {
+	Provider  string
+	Service   string
+	Type      string
+	ID        string
+	ARN       string
+	Region    string
+	Tags      map[string]string
+	CreatedAt time.Time
+}
+
+// Query filters a list operation. All non-empty fields must match. Tags match
+// on key presence and (if value is non-empty) equality.
+type Query struct {
+	Service string
+	Type    string
+	Region  string
+	Tags    map[string]string
+}
+
+// matches returns true if r satisfies every non-empty field of q.
+func (q Query) matches(r *Resource) bool {
+	if !fieldMatch(q.Service, r.Service) {
+		return false
+	}
+
+	if !fieldMatch(q.Type, r.Type) {
+		return false
+	}
+
+	if !fieldMatch(q.Region, r.Region) {
+		return false
+	}
+
+	return tagsMatch(q.Tags, r.Tags)
+}
+
+// fieldMatch returns true when want is empty (no filter) or equals got.
+func fieldMatch(want, got string) bool {
+	return want == "" || want == got
+}
+
+// tagsMatch returns true when every required key is present, and any
+// non-empty required value equals the actual value.
+func tagsMatch(required, actual map[string]string) bool {
+	for k, v := range required {
+		got, ok := actual[k]
+		if !ok {
+			return false
+		}
+
+		if v != "" && got != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/resourcediscovery/walkers.go
+++ b/resourcediscovery/walkers.go
@@ -1,0 +1,203 @@
+package resourcediscovery
+
+import (
+	"context"
+	"fmt"
+)
+
+// Provider name constants used for routing per-provider ARN construction.
+const (
+	ProviderAWS   = "aws"
+	ProviderAzure = "azure"
+	ProviderGCP   = "gcp"
+)
+
+// Service name constants embedded in Resource.Service. These are the
+// portable-API service identifiers, not provider-specific names. Callers
+// translate to per-provider service names at the SDK boundary.
+const (
+	ServiceCompute    = "compute"
+	ServiceNetworking = "networking"
+	ServiceStorage    = "storage"
+	ServiceDatabase   = "database"
+	ServiceServerless = "serverless"
+)
+
+// Resource type constants emitted by the walkers.
+const (
+	TypeInstance      = "Instance"
+	TypeVPC           = "VPC"
+	TypeSubnet        = "Subnet"
+	TypeSecurityGroup = "SecurityGroup"
+	TypeBucket        = "Bucket"
+	TypeTable         = "Table"
+	TypeFunction      = "Function"
+)
+
+func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
+	instances, err := e.drivers.Compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkCompute: %w", err)
+	}
+
+	out := make([]Resource, 0, len(instances))
+	for i := range instances {
+		out = append(out, Resource{
+			Provider: e.provider,
+			Service:  ServiceCompute,
+			Type:     TypeInstance,
+			ID:       instances[i].ID,
+			ARN:      e.computeInstanceARN(instances[i].ID),
+			Region:   e.region,
+			Tags:     copyTags(instances[i].Tags),
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
+	out := []Resource{}
+
+	vpcs, err := e.drivers.Networking.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkNetworking vpcs: %w", err)
+	}
+
+	for _, v := range vpcs {
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypeVPC,
+			ID:     v.ID,
+			ARN:    e.networkARN(netKindVPC, v.ID),
+			Region: e.region, Tags: copyTags(v.Tags),
+		})
+	}
+
+	subnets, err := e.drivers.Networking.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkNetworking subnets: %w", err)
+	}
+
+	for _, s := range subnets {
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypeSubnet,
+			ID:     s.ID,
+			ARN:    e.networkARN(netKindSubnet, s.ID),
+			Region: e.region, Tags: copyTags(s.Tags),
+		})
+	}
+
+	sgs, err := e.drivers.Networking.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkNetworking sgs: %w", err)
+	}
+
+	for _, sg := range sgs {
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypeSecurityGroup,
+			ID:     sg.ID,
+			ARN:    e.networkARN(netKindSecurityGroup, sg.ID),
+			Region: e.region, Tags: copyTags(sg.Tags),
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkStorage(ctx context.Context) ([]Resource, error) {
+	buckets, err := e.drivers.Storage.ListBuckets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkStorage: %w", err)
+	}
+
+	out := make([]Resource, 0, len(buckets))
+
+	for _, b := range buckets {
+		tags, tagErr := e.drivers.Storage.GetBucketTagging(ctx, b.Name)
+		if tagErr != nil {
+			// Buckets without tags surface a NotFound from the tagging API
+			// in real S3 — treat as "no tags" rather than failing the walk.
+			tags = nil
+		}
+
+		region := b.Region
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceStorage, Type: TypeBucket,
+			ID:     b.Name,
+			ARN:    e.storageBucketARN(b.Name),
+			Region: region, Tags: tags,
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkDatabase(ctx context.Context) ([]Resource, error) {
+	tables, err := e.drivers.Database.ListTables(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkDatabase: %w", err)
+	}
+
+	out := make([]Resource, 0, len(tables))
+
+	for _, name := range tables {
+		tags, tagErr := e.drivers.Database.ListTagsOfResource(ctx, name)
+		if tagErr != nil {
+			tags = nil
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceDatabase, Type: TypeTable,
+			ID:     name,
+			ARN:    e.databaseTableARN(name),
+			Region: e.region, Tags: tags,
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkServerless(ctx context.Context) ([]Resource, error) {
+	fns, err := e.drivers.Serverless.ListFunctions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkServerless: %w", err)
+	}
+
+	out := make([]Resource, 0, len(fns))
+
+	for i := range fns {
+		// FunctionInfo carries a populated ARN — use it directly rather than
+		// re-deriving, so the value matches what the function's own service
+		// returned.
+		arn := fns[i].ARN
+		if arn == "" {
+			arn = e.serverlessFunctionARN(fns[i].Name)
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceServerless, Type: TypeFunction,
+			ID:     fns[i].Name,
+			ARN:    arn,
+			Region: e.region, Tags: copyTags(fns[i].Tags),
+		})
+	}
+
+	return out, nil
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}

--- a/resourcediscovery/walkers.go
+++ b/resourcediscovery/walkers.go
@@ -3,6 +3,8 @@ package resourcediscovery
 import (
 	"context"
 	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
 )
 
 // Provider name constants used for routing per-provider ARN construction.
@@ -115,9 +117,14 @@ func (e *Engine) walkStorage(ctx context.Context) ([]Resource, error) {
 	for _, b := range buckets {
 		tags, tagErr := e.drivers.Storage.GetBucketTagging(ctx, b.Name)
 		if tagErr != nil {
-			// Buckets without tags surface a NotFound from the tagging API
-			// in real S3 — treat as "no tags" rather than failing the walk.
-			tags = nil
+			// NotFound means the bucket was deleted between ListBuckets and
+			// this tagging lookup. Skip it from the inventory; any other
+			// error is real and must propagate.
+			if cerrors.IsNotFound(tagErr) {
+				continue
+			}
+
+			return nil, fmt.Errorf("walkStorage tags %q: %w", b.Name, tagErr)
 		}
 
 		region := b.Region
@@ -147,7 +154,14 @@ func (e *Engine) walkDatabase(ctx context.Context) ([]Resource, error) {
 	for _, name := range tables {
 		tags, tagErr := e.drivers.Database.ListTagsOfResource(ctx, name)
 		if tagErr != nil {
-			tags = nil
+			// Race window: table was deleted between ListTables and the
+			// tagging lookup. Skip the now-gone resource. Any other error
+			// is real and must propagate.
+			if cerrors.IsNotFound(tagErr) {
+				continue
+			}
+
+			return nil, fmt.Errorf("walkDatabase tags %q: %w", name, tagErr)
 		}
 
 		out = append(out, Resource{


### PR DESCRIPTION
## Summary

Phase 1 foundation for the resource discovery trio (#170 AWS Resource Explorer + Resource Groups Tagging, #171 Azure Resource Graph, #172 GCP Cloud Asset Inventory). Ships the tag-surface fixes and the shared cross-service inventory engine that the per-provider SDK-compat HTTP handlers in Phases 2–4 will consume.

## What this PR ships

**1. Database tagging API.** Real DynamoDB / CosmosDB / Firestore use separate `TagResource` / `UntagResource` / `ListTagsOfResource` methods (not a `Tags` field on `TableConfig`). Added to `database/driver/driver.go`, implemented across all three providers with thread-safe per-table tag storage, surfaced through the portable `database/database.go` wrapper.

Storage tagging (S3 / Blob / GCS bucket + object tagging) was already complete in the driver — no change needed; resource discovery just walks `ListBuckets → GetBucketTagging` like real S3.

**2. `resourcediscovery/` package.** New cross-service inventory engine, modeled on `topology/`: owns no state, constructed from driver interfaces, query-driven.

- Normalized `Resource` shape: `{Provider, Service, Type, ID, ARN, Region, Tags, CreatedAt}`
- Walkers for Compute, Networking (VPCs/Subnets/SGs), Storage, Database, Serverless
- Per-provider ARN/URN construction (AWS ARNs, Azure resource IDs, GCP self-links) via `internal/idgen`
- Query API: `ListAll`, `List(Query)`, `SearchByTag`, `GetTagKeys`, `GetTagValues`
- Nil-driver-safe — passing nil for any field skips that walker

**3. Provider wiring.** Each `Provider` (AWS / Azure / GCP) now exposes `ResourceDiscovery *resourcediscovery.Engine`, constructed in `New()` with that provider's drivers and `opts.AccountID` (or `opts.ProjectID` for GCP) + `opts.Region`.

## Scope decisions

- Phase 1 covers 5 services (compute, networking, storage, database, serverless) — enough to prove the cross-service walk pattern and exercise both inline-tag (compute/networking/serverless) and lookup-tag (storage/database) flows.
- Additional services (IAM, DNS, LB, MQ, Cache, Secrets, Logging, Notification, Container Registry, Event Bus) can be added in later phases as the per-provider SDK handlers need them.

## Out of scope (deferred to Phases 2–4)

- AWS `resourceexplorer2` + `resourcegroupstaggingapi` SDK-compat HTTP handlers (#170)
- Azure `armresourcegraph` SDK-compat HTTP handler (#171)
- GCP `cloudasset/v1` SDK-compat HTTP handler (#172)
- KQL subset evaluator (Azure handler concern)
- Cross-account / cross-subscription discovery

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [x] `golangci-lint run --timeout=9m ./...` 0 issues
- [x] Database tagging: tag/list/merge/replace/untag/missing-resource error paths covered on AWS, Azure, GCP
- [x] Engine: cross-service ListAll, Query filters (service/type/region/tag-key/tag-key+value), SearchByTag, GetTagKeys, GetTagValues, ARN shapes, nil-driver-skip