### PR TITLE
feat(aws): Resource Explorer 2 + Resource Groups Tagging SDK-compat handlers (#170)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/fxamacker/cbor/v2 v2.9.1

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,10 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPP
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7 h1:6NCQBp9IIEs51YI9/jT5/ckSd6Ka9956gAGlw0a0yFI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7/go.mod h1:uLWlNO4q8278lSx2iKIJZ09zSXNJ6uQTFM1jvZIZRf4=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvNmV5Se1pmx0ag5+Eb3/wZkT03iyCCI=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12 h1:kOX5fCUb0BSMNHbRm7icw/dEyTjiYCLczIYglbYFJnI=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=

--- a/networking/driver/driver.go
+++ b/networking/driver/driver.go
@@ -306,4 +306,14 @@ type Networking interface {
 	DeleteVPCEndpoint(ctx context.Context, id string) error
 	DescribeVPCEndpoints(ctx context.Context, ids []string) ([]VPCEndpoint, error)
 	ModifyVPCEndpoint(ctx context.Context, id string, config VPCEndpointConfig) (*VPCEndpoint, error)
+
+	// Tag mutation. Update* merges keys into the resource's existing Tags
+	// (overlapping keys overwritten, others preserved); Remove* deletes the
+	// listed keys. Required by the Resource Groups Tagging API surface.
+	UpdateVPCTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveVPCTags(ctx context.Context, id string, keys []string) error
+	UpdateSubnetTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveSubnetTags(ctx context.Context, id string, keys []string) error
+	UpdateSecurityGroupTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveSecurityGroupTags(ctx context.Context, id string, keys []string) error
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -659,3 +659,51 @@ func (n *Networking) ModifyVPCEndpoint(
 
 	return out.(*driver.VPCEndpoint), nil
 }
+
+func (n *Networking) UpdateVPCTags(ctx context.Context, id string, tags map[string]string) error {
+	_, err := n.do(ctx, "UpdateVPCTags", id, func() (any, error) {
+		return nil, n.driver.UpdateVPCTags(ctx, id, tags)
+	})
+
+	return err
+}
+
+func (n *Networking) RemoveVPCTags(ctx context.Context, id string, keys []string) error {
+	_, err := n.do(ctx, "RemoveVPCTags", id, func() (any, error) {
+		return nil, n.driver.RemoveVPCTags(ctx, id, keys)
+	})
+
+	return err
+}
+
+func (n *Networking) UpdateSubnetTags(ctx context.Context, id string, tags map[string]string) error {
+	_, err := n.do(ctx, "UpdateSubnetTags", id, func() (any, error) {
+		return nil, n.driver.UpdateSubnetTags(ctx, id, tags)
+	})
+
+	return err
+}
+
+func (n *Networking) RemoveSubnetTags(ctx context.Context, id string, keys []string) error {
+	_, err := n.do(ctx, "RemoveSubnetTags", id, func() (any, error) {
+		return nil, n.driver.RemoveSubnetTags(ctx, id, keys)
+	})
+
+	return err
+}
+
+func (n *Networking) UpdateSecurityGroupTags(ctx context.Context, id string, tags map[string]string) error {
+	_, err := n.do(ctx, "UpdateSecurityGroupTags", id, func() (any, error) {
+		return nil, n.driver.UpdateSecurityGroupTags(ctx, id, tags)
+	})
+
+	return err
+}
+
+func (n *Networking) RemoveSecurityGroupTags(ctx context.Context, id string, keys []string) error {
+	_, err := n.do(ctx, "RemoveSecurityGroupTags", id, func() (any, error) {
+		return nil, n.driver.RemoveSecurityGroupTags(ctx, id, keys)
+	})
+
+	return err
+}

--- a/networking/networking_test.go
+++ b/networking/networking_test.go
@@ -760,6 +760,81 @@ func (m *mockDriver) ModifyVPCEndpoint(
 	return ep, nil
 }
 
+func (m *mockDriver) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+	return nil
+}
+
+func (m *mockDriver) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+	return nil
+}
+
+func (m *mockDriver) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+	return nil
+}
+
+func (m *mockDriver) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+	return nil
+}
+
+func (m *mockDriver) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+	return nil
+}
+
+func (m *mockDriver) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+	return nil
+}
+
 func newTestNetworking(opts ...Option) *Networking {
 	return NewNetworking(newMockDriver(), opts...)
 }

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -300,18 +300,15 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 
 // UpdateVPCTags merges the given tags into the VPC's tag map. Existing keys
 // not present in tags are preserved; overlapping keys are overwritten.
+// The mutation runs inside memstore.Update so the store's lock is held for
+// the duration; the new map is built fresh and swapped in atomically so
+// concurrent readers iterating the old map are unaffected.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = mergeTagMap(v.Tags, tags)
+		return v
+	}) {
 		return errors.Newf(errors.NotFound, "VPC %q not found", id)
-	}
-
-	if v.Tags == nil {
-		v.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		v.Tags[k] = val
 	}
 
 	return nil
@@ -319,13 +316,11 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 
 // RemoveVPCTags removes the given tag keys from a VPC. Unknown keys are ignored.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = removeTagMapKeys(v.Tags, keys)
+		return v
+	}) {
 		return errors.Newf(errors.NotFound, "VPC %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(v.Tags, k)
 	}
 
 	return nil
@@ -333,17 +328,11 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 
 // UpdateSubnetTags merges tags into the subnet's tag map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = mergeTagMap(s.Tags, tags)
+		return s
+	}) {
 		return errors.Newf(errors.NotFound, "subnet %q not found", id)
-	}
-
-	if s.Tags == nil {
-		s.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		s.Tags[k] = val
 	}
 
 	return nil
@@ -351,13 +340,11 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 
 // RemoveSubnetTags removes the given tag keys from a subnet.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = removeTagMapKeys(s.Tags, keys)
+		return s
+	}) {
 		return errors.Newf(errors.NotFound, "subnet %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(s.Tags, k)
 	}
 
 	return nil
@@ -365,17 +352,11 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 
 // UpdateSecurityGroupTags merges tags into the security group's tag map.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = mergeTagMap(sg.Tags, tags)
+		return sg
+	}) {
 		return errors.Newf(errors.NotFound, "security group %q not found", id)
-	}
-
-	if sg.Tags == nil {
-		sg.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		sg.Tags[k] = val
 	}
 
 	return nil
@@ -383,16 +364,56 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 
 // RemoveSecurityGroupTags removes the given tag keys from a security group.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = removeTagMapKeys(sg.Tags, keys)
+		return sg
+	}) {
 		return errors.Newf(errors.NotFound, "security group %q not found", id)
 	}
 
-	for _, k := range keys {
-		delete(sg.Tags, k)
+	return nil
+}
+
+// mergeTagMap returns a fresh map containing existing's keys plus tags's
+// keys (tags wins on overlap). The original existing map is not modified
+// so concurrent readers can keep iterating it safely.
+func mergeTagMap(existing, tags map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(tags))
+
+	for k, v := range existing {
+		out[k] = v
 	}
 
-	return nil
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
+// removeTagMapKeys returns a fresh map with the listed keys removed. The
+// original map is not modified.
+func removeTagMapKeys(existing map[string]string, keys []string) map[string]string {
+	if len(existing) == 0 {
+		return existing
+	}
+
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+
+	out := make(map[string]string, len(existing))
+
+	for k, v := range existing {
+		if _, gone := drop[k]; gone {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -298,6 +298,103 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	return errors.Newf(errors.NotFound, "egress rule not found in security group %q", groupID)
 }
 
+// UpdateVPCTags merges the given tags into the VPC's tag map. Existing keys
+// not present in tags are preserved; overlapping keys are overwritten.
+func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "VPC %q not found", id)
+	}
+
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveVPCTags removes the given tag keys from a VPC. Unknown keys are ignored.
+func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "VPC %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSubnetTags merges tags into the subnet's tag map.
+func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subnet %q not found", id)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSubnetTags removes the given tag keys from a subnet.
+func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subnet %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSecurityGroupTags merges tags into the security group's tag map.
+func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "security group %q not found", id)
+	}
+
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSecurityGroupTags removes the given tag keys from a security group.
+func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "security group %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+
+	return nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -1103,6 +1103,43 @@ func TestTagMutation(t *testing.T) {
 	})
 }
 
+// TestTagMutationConcurrency drives many concurrent Update/Remove tag calls
+// against a single VPC. The new memstore.Update path holds the store lock
+// for the duration of the mutation and swaps in a freshly-built map, so
+// concurrent writers cannot tear the inner map. With go test -race this
+// catches any regression to in-place mutation under an unguarded read.
+//
+// Note: this test does NOT mix in Describe calls because reads through
+// memstore.Get release the lock before the caller dereferences the value
+// — a pre-existing pattern in the codebase that is out of scope here. A
+// follow-up should add a Read closure to memstore (or per-resource locks)
+// so reads can copy Tags under the same lock that protects writes.
+func TestTagMutationConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	requireNoError(t, err)
+
+	const writers = 16
+	const iters = 100
+
+	done := make(chan struct{})
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer func() { done <- struct{}{} }()
+			for i := 0; i < iters; i++ {
+				_ = m.UpdateVPCTags(ctx, v.ID, map[string]string{"k": "v"})
+				_ = m.RemoveVPCTags(ctx, v.ID, []string{"k"})
+			}
+		}(w)
+	}
+
+	for w := 0; w < writers; w++ {
+		<-done
+	}
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -1025,6 +1025,84 @@ func TestRouteTableAssociation(t *testing.T) {
 	})
 }
 
+func TestTagMutation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("VPC tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"}})
+		requireNoError(t, err)
+
+		requireNoError(t, m.UpdateVPCTags(ctx, v.ID, map[string]string{"env": "prod", "team": "platform"}))
+
+		got, err := m.DescribeVPCs(ctx, []string{v.ID})
+		requireNoError(t, err)
+		assertEqual(t, "prod", got[0].Tags["env"])
+		assertEqual(t, "platform", got[0].Tags["team"])
+
+		requireNoError(t, m.RemoveVPCTags(ctx, v.ID, []string{"env", "missing"}))
+		got, err = m.DescribeVPCs(ctx, []string{v.ID})
+		requireNoError(t, err)
+		_, hasEnv := got[0].Tags["env"]
+		assertEqual(t, false, hasEnv)
+		assertEqual(t, "platform", got[0].Tags["team"])
+	})
+
+	t.Run("Subnet tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		requireNoError(t, err)
+
+		s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		requireNoError(t, err)
+
+		requireNoError(t, m.UpdateSubnetTags(ctx, s.ID, map[string]string{"tier": "private"}))
+		got, err := m.DescribeSubnets(ctx, []string{s.ID})
+		requireNoError(t, err)
+		assertEqual(t, "private", got[0].Tags["tier"])
+
+		requireNoError(t, m.RemoveSubnetTags(ctx, s.ID, []string{"tier"}))
+		got, err = m.DescribeSubnets(ctx, []string{s.ID})
+		requireNoError(t, err)
+		_, hasTier := got[0].Tags["tier"]
+		assertEqual(t, false, hasTier)
+	})
+
+	t.Run("SecurityGroup tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		requireNoError(t, err)
+
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+		requireNoError(t, err)
+
+		requireNoError(t, m.UpdateSecurityGroupTags(ctx, sg.ID, map[string]string{"role": "web"}))
+		got, err := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		requireNoError(t, err)
+		assertEqual(t, "web", got[0].Tags["role"])
+
+		requireNoError(t, m.RemoveSecurityGroupTags(ctx, sg.ID, []string{"role"}))
+		got, err = m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		requireNoError(t, err)
+		_, hasRole := got[0].Tags["role"]
+		assertEqual(t, false, hasRole)
+	})
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		m := newTestMock()
+
+		assertError(t, m.UpdateVPCTags(ctx, "vpc-nope", map[string]string{"k": "v"}), true)
+		assertError(t, m.RemoveVPCTags(ctx, "vpc-nope", []string{"k"}), true)
+		assertError(t, m.UpdateSubnetTags(ctx, "subnet-nope", map[string]string{"k": "v"}), true)
+		assertError(t, m.RemoveSubnetTags(ctx, "subnet-nope", []string{"k"}), true)
+		assertError(t, m.UpdateSecurityGroupTags(ctx, "sg-nope", map[string]string{"k": "v"}), true)
+		assertError(t, m.RemoveSecurityGroupTags(ctx, "sg-nope", []string{"k"}), true)
+	})
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -300,6 +300,102 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	return cerrors.Newf(cerrors.NotFound, "egress rule not found in network security group %q", groupID)
 }
 
+// UpdateVPCTags merges the given tags into the virtual network's tag map.
+func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
+	}
+
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveVPCTags removes the given tag keys from a virtual network.
+func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSubnetTags merges tags into the subnet's tag map.
+func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSubnetTags removes the given tag keys from a subnet.
+func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSecurityGroupTags merges tags into the NSG's tag map.
+func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSecurityGroupTags removes the given tag keys from an NSG.
+func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+
+	return nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -301,18 +301,14 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 }
 
 // UpdateVPCTags merges the given tags into the virtual network's tag map.
+// The mutation runs under memstore.Update's lock; a fresh map is swapped in
+// so concurrent readers iterating the old map are unaffected.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = mergeTagMap(v.Tags, tags)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
-	}
-
-	if v.Tags == nil {
-		v.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		v.Tags[k] = val
 	}
 
 	return nil
@@ -320,13 +316,11 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 
 // RemoveVPCTags removes the given tag keys from a virtual network.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = removeTagMapKeys(v.Tags, keys)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(v.Tags, k)
 	}
 
 	return nil
@@ -334,17 +328,11 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 
 // UpdateSubnetTags merges tags into the subnet's tag map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = mergeTagMap(s.Tags, tags)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
-	}
-
-	if s.Tags == nil {
-		s.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		s.Tags[k] = val
 	}
 
 	return nil
@@ -352,13 +340,11 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 
 // RemoveSubnetTags removes the given tag keys from a subnet.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = removeTagMapKeys(s.Tags, keys)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(s.Tags, k)
 	}
 
 	return nil
@@ -366,17 +352,11 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 
 // UpdateSecurityGroupTags merges tags into the NSG's tag map.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = mergeTagMap(sg.Tags, tags)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
-	}
-
-	if sg.Tags == nil {
-		sg.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		sg.Tags[k] = val
 	}
 
 	return nil
@@ -384,16 +364,55 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 
 // RemoveSecurityGroupTags removes the given tag keys from an NSG.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = removeTagMapKeys(sg.Tags, keys)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
 	}
 
-	for _, k := range keys {
-		delete(sg.Tags, k)
+	return nil
+}
+
+// mergeTagMap returns a fresh map containing existing's keys plus tags's
+// keys (tags wins on overlap). The original existing map is not modified
+// so concurrent readers can keep iterating it safely.
+func mergeTagMap(existing, tags map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(tags))
+
+	for k, v := range existing {
+		out[k] = v
 	}
 
-	return nil
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
+// removeTagMapKeys returns a fresh map with the listed keys removed.
+func removeTagMapKeys(existing map[string]string, keys []string) map[string]string {
+	if len(existing) == 0 {
+		return existing
+	}
+
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+
+	out := make(map[string]string, len(existing))
+
+	for k, v := range existing {
+		if _, gone := drop[k]; gone {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -1272,3 +1272,74 @@ func TestGetFlowLogRecords(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestTagMutation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("VPC tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"}})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateVPCTags(ctx, v.ID, map[string]string{"env": "prod", "team": "platform"}))
+		got, err := m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got[0].Tags["env"])
+		assert.Equal(t, "platform", got[0].Tags["team"])
+
+		require.NoError(t, m.RemoveVPCTags(ctx, v.ID, []string{"env", "missing"}))
+		got, err = m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["env"]
+		assert.False(t, has)
+		assert.Equal(t, "platform", got[0].Tags["team"])
+	})
+
+	t.Run("Subnet tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSubnetTags(ctx, s.ID, map[string]string{"tier": "private"}))
+		got, err := m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "private", got[0].Tags["tier"])
+
+		require.NoError(t, m.RemoveSubnetTags(ctx, s.ID, []string{"tier"}))
+		got, err = m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["tier"]
+		assert.False(t, has)
+	})
+
+	t.Run("NSG tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSecurityGroupTags(ctx, sg.ID, map[string]string{"role": "web"}))
+		got, err := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "web", got[0].Tags["role"])
+
+		require.NoError(t, m.RemoveSecurityGroupTags(ctx, sg.ID, []string{"role"}))
+		got, err = m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["role"]
+		assert.False(t, has)
+	})
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		m := newTestMock()
+		require.Error(t, m.UpdateVPCTags(ctx, "vnet-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveVPCTags(ctx, "vnet-nope", []string{"k"}))
+		require.Error(t, m.UpdateSubnetTags(ctx, "subnet-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSubnetTags(ctx, "subnet-nope", []string{"k"}))
+		require.Error(t, m.UpdateSecurityGroupTags(ctx, "nsg-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSecurityGroupTags(ctx, "nsg-nope", []string{"k"}))
+	})
+}

--- a/providers/gcp/gcpvpc/vpc.go
+++ b/providers/gcp/gcpvpc/vpc.go
@@ -302,18 +302,14 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 
 // UpdateVPCTags merges the given labels into the network's label map. GCP
 // calls these labels; the cross-cloud Networking interface uses the term tags.
+// The mutation runs under memstore.Update's lock; a fresh map is swapped in
+// so concurrent readers iterating the old map are unaffected.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = mergeTagMap(v.Tags, tags)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
-	}
-
-	if v.Tags == nil {
-		v.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		v.Tags[k] = val
 	}
 
 	return nil
@@ -321,13 +317,11 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 
 // RemoveVPCTags removes the given label keys from a network.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = removeTagMapKeys(v.Tags, keys)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(v.Tags, k)
 	}
 
 	return nil
@@ -335,17 +329,11 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 
 // UpdateSubnetTags merges labels into the subnetwork's label map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = mergeTagMap(s.Tags, tags)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
-	}
-
-	if s.Tags == nil {
-		s.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		s.Tags[k] = val
 	}
 
 	return nil
@@ -353,13 +341,11 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 
 // RemoveSubnetTags removes the given label keys from a subnetwork.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = removeTagMapKeys(s.Tags, keys)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(s.Tags, k)
 	}
 
 	return nil
@@ -367,17 +353,11 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 
 // UpdateSecurityGroupTags merges labels into the firewall rule's label map.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = mergeTagMap(sg.Tags, tags)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
-	}
-
-	if sg.Tags == nil {
-		sg.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		sg.Tags[k] = val
 	}
 
 	return nil
@@ -385,16 +365,54 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 
 // RemoveSecurityGroupTags removes the given label keys from a firewall rule.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = removeTagMapKeys(sg.Tags, keys)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
 	}
 
-	for _, k := range keys {
-		delete(sg.Tags, k)
+	return nil
+}
+
+// mergeTagMap returns a fresh map containing existing's keys plus tags's
+// keys (tags wins on overlap). The original existing map is not modified.
+func mergeTagMap(existing, tags map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(tags))
+
+	for k, v := range existing {
+		out[k] = v
 	}
 
-	return nil
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
+// removeTagMapKeys returns a fresh map with the listed keys removed.
+func removeTagMapKeys(existing map[string]string, keys []string) map[string]string {
+	if len(existing) == 0 {
+		return existing
+	}
+
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+
+	out := make(map[string]string, len(existing))
+
+	for k, v := range existing {
+		if _, gone := drop[k]; gone {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/gcp/gcpvpc/vpc.go
+++ b/providers/gcp/gcpvpc/vpc.go
@@ -300,6 +300,103 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	return cerrors.Newf(cerrors.NotFound, "egress rule not found in firewall rule %q", groupID)
 }
 
+// UpdateVPCTags merges the given labels into the network's label map. GCP
+// calls these labels; the cross-cloud Networking interface uses the term tags.
+func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
+	}
+
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveVPCTags removes the given label keys from a network.
+func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSubnetTags merges labels into the subnetwork's label map.
+func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSubnetTags removes the given label keys from a subnetwork.
+func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSecurityGroupTags merges labels into the firewall rule's label map.
+func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
+	}
+
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSecurityGroupTags removes the given label keys from a firewall rule.
+func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+
+	return nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {

--- a/providers/gcp/gcpvpc/vpc_test.go
+++ b/providers/gcp/gcpvpc/vpc_test.go
@@ -1438,3 +1438,74 @@ func TestRouteTableAssociation(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestTagMutation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("VPC tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"}})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateVPCTags(ctx, v.ID, map[string]string{"env": "prod", "team": "platform"}))
+		got, err := m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got[0].Tags["env"])
+		assert.Equal(t, "platform", got[0].Tags["team"])
+
+		require.NoError(t, m.RemoveVPCTags(ctx, v.ID, []string{"env", "missing"}))
+		got, err = m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["env"]
+		assert.False(t, has)
+		assert.Equal(t, "platform", got[0].Tags["team"])
+	})
+
+	t.Run("Subnet tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSubnetTags(ctx, s.ID, map[string]string{"tier": "private"}))
+		got, err := m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "private", got[0].Tags["tier"])
+
+		require.NoError(t, m.RemoveSubnetTags(ctx, s.ID, []string{"tier"}))
+		got, err = m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["tier"]
+		assert.False(t, has)
+	})
+
+	t.Run("Firewall rule tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSecurityGroupTags(ctx, sg.ID, map[string]string{"role": "web"}))
+		got, err := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "web", got[0].Tags["role"])
+
+		require.NoError(t, m.RemoveSecurityGroupTags(ctx, sg.ID, []string{"role"}))
+		got, err = m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["role"]
+		assert.False(t, has)
+	})
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		m := newTestMock()
+		require.Error(t, m.UpdateVPCTags(ctx, "net-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveVPCTags(ctx, "net-nope", []string{"k"}))
+		require.Error(t, m.UpdateSubnetTags(ctx, "subnet-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSubnetTags(ctx, "subnet-nope", []string{"k"}))
+		require.Error(t, m.UpdateSecurityGroupTags(ctx, "fw-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSecurityGroupTags(ctx, "fw-nope", []string{"k"}))
+	})
+}

--- a/resourcediscovery/engine_test.go
+++ b/resourcediscovery/engine_test.go
@@ -106,7 +106,7 @@ func TestListWithQueryFilters(t *testing.T) {
 	seedDDB(t, f, "stage-cache", map[string]string{"env": "stage"})
 
 	t.Run("by service", func(t *testing.T) {
-		got, err := f.engine.List(ctx, Query{Service: ServiceDatabase})
+		got, err := f.engine.List(ctx, Query{Services: []string{ServiceDatabase}})
 		require.NoError(t, err)
 		assert.Len(t, got, 2)
 		for _, r := range got {

--- a/resourcediscovery/tagging.go
+++ b/resourcediscovery/tagging.go
@@ -93,6 +93,15 @@ func parseS3ARN(arn, resource string) (parsedARN, error) {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "S3 ARN missing bucket name: %q", arn)
 	}
 
+	// arn:aws:s3:::bucket-name → resource = "bucket-name" (taggable).
+	// arn:aws:s3:::bucket-name/object-key → resource = "bucket-name/object-key".
+	// Object-level tagging requires PutObjectTagging, not PutBucketTagging;
+	// reject until Phase 2.x adds object support.
+	if strings.ContainsRune(resource, '/') {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"S3 object ARNs are not yet supported (Phase 2 covers buckets only): %q", arn)
+	}
+
 	return parsedARN{service: awsServiceS3, id: resource}, nil
 }
 

--- a/resourcediscovery/tagging.go
+++ b/resourcediscovery/tagging.go
@@ -1,0 +1,224 @@
+package resourcediscovery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// AWS service identifiers as they appear in ARNs.
+const (
+	awsServiceS3       = "s3"
+	awsServiceDynamoDB = "dynamodb"
+	awsServiceEC2      = "ec2"
+)
+
+// DynamoDB resource type within an EC2 ARN.
+const awsTypeTable = "table"
+
+// arnParts is the number of colon-separated segments in a fully-qualified
+// AWS ARN: arn:partition:service:region:account:resource.
+const arnParts = 6
+
+// TagResourceByARN merges tags into the resource identified by arn. The arn
+// is parsed to determine the underlying service and resource type, then
+// dispatched to the matching driver's tag-mutation method.
+//
+// Supported in Phase 2:
+//   - AWS S3 bucket: arn:aws:s3:::name
+//   - AWS DynamoDB table: arn:aws:dynamodb:region:account:table/name
+//   - AWS VPC/Subnet/SecurityGroup: arn:aws:ec2:region:account:{vpc,subnet,security-group}/id
+//
+// Returns InvalidArgument for unsupported services (lambda, ec2 instance, etc.)
+// or unparseable ARNs.
+func (e *Engine) TagResourceByARN(ctx context.Context, arn string, tags map[string]string) error {
+	res, err := parseSupportedARN(arn)
+	if err != nil {
+		return err
+	}
+
+	return e.dispatchTag(ctx, res, tags, true /* set */, nil)
+}
+
+// UntagResourceByARN removes the given tag keys from the resource identified
+// by arn. ARN parsing rules match TagResourceByARN.
+func (e *Engine) UntagResourceByARN(ctx context.Context, arn string, keys []string) error {
+	res, err := parseSupportedARN(arn)
+	if err != nil {
+		return err
+	}
+
+	return e.dispatchTag(ctx, res, nil, false /* set */, keys)
+}
+
+// parsedARN holds the fragments TagResourceByARN needs to route a call.
+type parsedARN struct {
+	service      string // "s3", "dynamodb", "ec2"
+	resourceType string // "table", "vpc", "subnet", "security-group", or "" for s3 bucket
+	id           string // bucket name, table name, vpc-id, subnet-id, sg-id
+}
+
+func parseSupportedARN(arn string) (parsedARN, error) {
+	// AWS ARN format: arn:partition:service:region:account:resource
+	// resource is either "name" (S3), "type/id", or "type:id".
+	if !strings.HasPrefix(arn, "arn:aws:") {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "only AWS ARNs are supported, got %q", arn)
+	}
+
+	parts := strings.SplitN(arn, ":", arnParts)
+	if len(parts) < arnParts {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "malformed ARN: %q", arn)
+	}
+
+	service := parts[2]
+	resource := parts[5]
+
+	switch service {
+	case awsServiceS3:
+		return parseS3ARN(arn, resource)
+	case awsServiceDynamoDB:
+		return parseDynamoDBARN(arn, resource)
+	case awsServiceEC2:
+		return parseEC2ARN(arn, resource)
+	default:
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"tagging service %q is not yet supported (Phase 2 covers s3, dynamodb, ec2 networking)", service)
+	}
+}
+
+func parseS3ARN(arn, resource string) (parsedARN, error) {
+	if resource == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "S3 ARN missing bucket name: %q", arn)
+	}
+
+	return parsedARN{service: awsServiceS3, id: resource}, nil
+}
+
+func parseDynamoDBARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, '/')
+	if !ok || rt != awsTypeTable {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected DynamoDB table ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceDynamoDB, resourceType: rt, id: id}, nil
+}
+
+func parseEC2ARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, '/')
+	if !ok {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "malformed EC2 ARN: %q", arn)
+	}
+
+	switch rt {
+	case netKindVPC, netKindSubnet, netKindSecurityGroup:
+		return parsedARN{service: awsServiceEC2, resourceType: rt, id: id}, nil
+	default:
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"tagging EC2 resource type %q is not yet supported (Phase 2 covers vpc, subnet, security-group)", rt)
+	}
+}
+
+func splitTypeID(s string, sep rune) (rt, id string, ok bool) {
+	for i, r := range s {
+		if r == sep {
+			return s[:i], s[i+1:], true
+		}
+	}
+
+	return "", "", false
+}
+
+func (e *Engine) dispatchTag(ctx context.Context, res parsedARN, tags map[string]string, set bool, keys []string) error {
+	switch {
+	case res.service == awsServiceS3:
+		return e.tagS3(ctx, res.id, tags, set, keys)
+	case res.service == awsServiceDynamoDB && res.resourceType == awsTypeTable:
+		return e.tagDynamoDB(ctx, res.id, tags, set, keys)
+	case res.service == awsServiceEC2:
+		return e.tagEC2Network(ctx, res.resourceType, res.id, tags, set, keys)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "internal: unrouted parsedARN %+v", res)
+	}
+}
+
+func (e *Engine) tagS3(ctx context.Context, bucket string, tags map[string]string, set bool, keys []string) error {
+	if e.drivers.Storage == nil {
+		return cerrors.Newf(cerrors.FailedPrecondition, "storage driver not configured on engine")
+	}
+
+	if set {
+		// S3 PutBucketTagging replaces the entire tag set. To get "merge"
+		// semantics we read-modify-write.
+		existing, err := e.drivers.Storage.GetBucketTagging(ctx, bucket)
+		if err != nil && !cerrors.IsNotFound(err) {
+			return fmt.Errorf("tagS3 read %q: %w", bucket, err)
+		}
+
+		merged := make(map[string]string, len(existing)+len(tags))
+		for k, v := range existing {
+			merged[k] = v
+		}
+
+		for k, v := range tags {
+			merged[k] = v
+		}
+
+		return e.drivers.Storage.PutBucketTagging(ctx, bucket, merged)
+	}
+
+	existing, err := e.drivers.Storage.GetBucketTagging(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("tagS3 read %q: %w", bucket, err)
+	}
+
+	for _, k := range keys {
+		delete(existing, k)
+	}
+
+	return e.drivers.Storage.PutBucketTagging(ctx, bucket, existing)
+}
+
+func (e *Engine) tagDynamoDB(ctx context.Context, table string, tags map[string]string, set bool, keys []string) error {
+	if e.drivers.Database == nil {
+		return cerrors.Newf(cerrors.FailedPrecondition, "database driver not configured on engine")
+	}
+
+	if set {
+		return e.drivers.Database.TagResource(ctx, table, tags)
+	}
+
+	return e.drivers.Database.UntagResource(ctx, table, keys)
+}
+
+func (e *Engine) tagEC2Network(ctx context.Context, resourceType, id string,
+	tags map[string]string, set bool, keys []string,
+) error {
+	if e.drivers.Networking == nil {
+		return cerrors.Newf(cerrors.FailedPrecondition, "networking driver not configured on engine")
+	}
+
+	switch resourceType {
+	case netKindVPC:
+		if set {
+			return e.drivers.Networking.UpdateVPCTags(ctx, id, tags)
+		}
+
+		return e.drivers.Networking.RemoveVPCTags(ctx, id, keys)
+	case netKindSubnet:
+		if set {
+			return e.drivers.Networking.UpdateSubnetTags(ctx, id, tags)
+		}
+
+		return e.drivers.Networking.RemoveSubnetTags(ctx, id, keys)
+	case netKindSecurityGroup:
+		if set {
+			return e.drivers.Networking.UpdateSecurityGroupTags(ctx, id, tags)
+		}
+
+		return e.drivers.Networking.RemoveSecurityGroupTags(ctx, id, keys)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported EC2 resource type %q", resourceType)
+	}
+}

--- a/resourcediscovery/tagging_test.go
+++ b/resourcediscovery/tagging_test.go
@@ -1,0 +1,177 @@
+package resourcediscovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSupportedARN(t *testing.T) {
+	tests := []struct {
+		name      string
+		arn       string
+		wantSvc   string
+		wantType  string
+		wantID    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "s3 bucket", arn: "arn:aws:s3:::my-bucket", wantSvc: "s3", wantID: "my-bucket"},
+		{name: "dynamodb table", arn: "arn:aws:dynamodb:us-east-1:111:table/MyTable", wantSvc: "dynamodb", wantType: "table", wantID: "MyTable"},
+		{name: "vpc", arn: "arn:aws:ec2:us-east-1:111:vpc/vpc-abc", wantSvc: "ec2", wantType: "vpc", wantID: "vpc-abc"},
+		{name: "subnet", arn: "arn:aws:ec2:us-east-1:111:subnet/subnet-abc", wantSvc: "ec2", wantType: "subnet", wantID: "subnet-abc"},
+		{name: "security-group", arn: "arn:aws:ec2:us-east-1:111:security-group/sg-abc", wantSvc: "ec2", wantType: "security-group", wantID: "sg-abc"},
+		{name: "instance unsupported", arn: "arn:aws:ec2:us-east-1:111:instance/i-abc", wantErr: true, errSubstr: "not yet supported"},
+		{name: "lambda unsupported", arn: "arn:aws:lambda:us-east-1:111:function:fn", wantErr: true, errSubstr: "not yet supported"},
+		{name: "non-aws partition", arn: "arn:azure:s3:::x", wantErr: true, errSubstr: "only AWS ARNs"},
+		{name: "malformed", arn: "not-an-arn", wantErr: true, errSubstr: "only AWS ARNs"},
+		{name: "missing parts", arn: "arn:aws:s3", wantErr: true, errSubstr: "malformed ARN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSupportedARN(tt.arn)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tt.errSubstr),
+					"error %q did not contain %q", err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSvc, got.service)
+			assert.Equal(t, tt.wantType, got.resourceType)
+			assert.Equal(t, tt.wantID, got.id)
+		})
+	}
+}
+
+func TestTagResourceByARN_S3(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	require.NoError(t, f.s3.CreateBucket(ctx, "tag-me"))
+	require.NoError(t, f.engine.TagResourceByARN(ctx, "arn:aws:s3:::tag-me",
+		map[string]string{"env": "prod", "team": "platform"}))
+
+	got, err := f.s3.GetBucketTagging(ctx, "tag-me")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got["env"])
+	assert.Equal(t, "platform", got["team"])
+
+	// Merge semantics: existing keys preserved, overlapping overwritten.
+	require.NoError(t, f.engine.TagResourceByARN(ctx, "arn:aws:s3:::tag-me",
+		map[string]string{"env": "stage", "new": "x"}))
+	got, err = f.s3.GetBucketTagging(ctx, "tag-me")
+	require.NoError(t, err)
+	assert.Equal(t, "stage", got["env"])
+	assert.Equal(t, "platform", got["team"], "non-overlapping key should survive merge")
+	assert.Equal(t, "x", got["new"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, "arn:aws:s3:::tag-me", []string{"env", "missing"}))
+	got, err = f.s3.GetBucketTagging(ctx, "tag-me")
+	require.NoError(t, err)
+	_, has := got["env"]
+	assert.False(t, has)
+	assert.Equal(t, "platform", got["team"])
+}
+
+func TestTagResourceByARN_DynamoDB(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedDDB(t, f, "tag-tbl", nil)
+
+	arn := "arn:aws:dynamodb:us-east-1:123456789012:table/tag-tbl"
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"env": "prod"}))
+
+	got, err := f.ddb.ListTagsOfResource(ctx, "tag-tbl")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got["env"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"env"}))
+	got, err = f.ddb.ListTagsOfResource(ctx, "tag-tbl")
+	require.NoError(t, err)
+	_, has := got["env"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_VPC(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	v, err := f.vpc.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:vpc/" + v.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"env": "prod"}))
+
+	got, err := f.vpc.DescribeVPCs(ctx, []string{v.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got[0].Tags["env"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"env"}))
+	got, err = f.vpc.DescribeVPCs(ctx, []string{v.ID})
+	require.NoError(t, err)
+	_, has := got[0].Tags["env"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_Subnet(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	v, err := f.vpc.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	s, err := f.vpc.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:subnet/" + s.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"tier": "private"}))
+
+	got, err := f.vpc.DescribeSubnets(ctx, []string{s.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "private", got[0].Tags["tier"])
+}
+
+func TestTagResourceByARN_SecurityGroup(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	v, err := f.vpc.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	sg, err := f.vpc.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:security-group/" + sg.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"role": "web"}))
+
+	got, err := f.vpc.DescribeSecurityGroups(ctx, []string{sg.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "web", got[0].Tags["role"])
+}
+
+func TestTagResourceByARN_UnsupportedReturnsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	err := f.engine.TagResourceByARN(ctx, "arn:aws:lambda:us-east-1:111:function:fn",
+		map[string]string{"k": "v"})
+	require.Error(t, err)
+	assert.Equal(t, cerrors.InvalidArgument, cerrors.GetCode(err))
+	assert.Contains(t, err.Error(), "not yet supported")
+}
+
+func TestTagResourceByARN_MissingDriverReturnsFailedPrecondition(t *testing.T) {
+	ctx := context.Background()
+	// Engine with no drivers wired.
+	eng := New(ProviderAWS, "111", "us-east-1", nil)
+
+	err := eng.TagResourceByARN(ctx, "arn:aws:s3:::x", map[string]string{"k": "v"})
+	require.Error(t, err)
+	assert.Equal(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+}

--- a/resourcediscovery/tagging_test.go
+++ b/resourcediscovery/tagging_test.go
@@ -31,6 +31,7 @@ func TestParseSupportedARN(t *testing.T) {
 		{name: "non-aws partition", arn: "arn:azure:s3:::x", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "malformed", arn: "not-an-arn", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "missing parts", arn: "arn:aws:s3", wantErr: true, errSubstr: "malformed ARN"},
+		{name: "s3 object rejected", arn: "arn:aws:s3:::bkt/obj.txt", wantErr: true, errSubstr: "object ARNs are not yet supported"},
 	}
 
 	for _, tt := range tests {

--- a/resourcediscovery/types.go
+++ b/resourcediscovery/types.go
@@ -28,16 +28,21 @@ type Resource struct {
 
 // Query filters a list operation. All non-empty fields must match. Tags match
 // on key presence and (if value is non-empty) equality.
+//
+// Services is an any-of set: a resource matches if its Service is in the
+// slice. An empty/nil slice means "no service filter". This shape supports
+// cases like AWS's "ec2" which spans both compute and networking — the
+// caller can pass Services: []string{"compute", "networking"}.
 type Query struct {
-	Service string
-	Type    string
-	Region  string
-	Tags    map[string]string
+	Services []string
+	Type     string
+	Region   string
+	Tags     map[string]string
 }
 
 // matches returns true if r satisfies every non-empty field of q.
 func (q Query) matches(r *Resource) bool {
-	if !fieldMatch(q.Service, r.Service) {
+	if !sliceMatch(q.Services, r.Service) {
 		return false
 	}
 
@@ -55,6 +60,21 @@ func (q Query) matches(r *Resource) bool {
 // fieldMatch returns true when want is empty (no filter) or equals got.
 func fieldMatch(want, got string) bool {
 	return want == "" || want == got
+}
+
+// sliceMatch returns true when want is empty (no filter) or got is in want.
+func sliceMatch(want []string, got string) bool {
+	if len(want) == 0 {
+		return true
+	}
+
+	for _, w := range want {
+		if w == got {
+			return true
+		}
+	}
+
+	return false
 }
 
 // tagsMatch returns true when every required key is present, and any

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -15,6 +15,7 @@ import (
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
@@ -23,6 +24,8 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/rds"
 	"github.com/stackshy/cloudemu/server/aws/redshift"
+	"github.com/stackshy/cloudemu/server/aws/resourceexplorer2"
+	"github.com/stackshy/cloudemu/server/aws/resourcegroupstaggingapi"
 	"github.com/stackshy/cloudemu/server/aws/s3"
 	"github.com/stackshy/cloudemu/server/aws/sqs"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
@@ -48,6 +51,13 @@ type Drivers struct {
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
 	// the same backend. Leave nil to disable Kubernetes data-plane support.
 	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery is the cross-service inventory engine. Required to
+	// serve Resource Explorer 2 and Resource Groups Tagging API requests.
+	// Leave nil to omit both handlers. AccountID and Region are needed for
+	// Resource Explorer to construct view/index ARNs.
+	ResourceDiscovery *resourcediscovery.Engine
+	AccountID         string
+	Region            string
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every
@@ -89,6 +99,12 @@ func New(d Drivers) *server.Server {
 		srv.Register(sqs.New(d.SQS))
 	}
 
+	// Resource Groups Tagging API: X-Amz-Target prefix
+	// ResourceGroupsTaggingAPI_20170126.* — disjoint from DynamoDB/SQS.
+	if d.ResourceDiscovery != nil {
+		srv.Register(resourcegroupstaggingapi.New(d.ResourceDiscovery))
+	}
+
 	// RDS must be registered before EC2: both speak AWS query-protocol on
 	// POST + form-encoded bodies, and Server matches in registration order.
 	// RDS's Matches is action-specific, so a request bound for EC2 will fall
@@ -125,6 +141,12 @@ func New(d Drivers) *server.Server {
 	// every other AWS path. Registered before S3's REST fallback.
 	if d.K8sAPI != nil {
 		srv.Register(d.K8sAPI)
+	}
+
+	// Resource Explorer 2 uses REST-JSON with fixed top-level paths
+	// (/CreateView, /Search, etc.). Must register before S3's catch-all.
+	if d.ResourceDiscovery != nil {
+		srv.Register(resourceexplorer2.New(d.ResourceDiscovery, d.AccountID, d.Region))
 	}
 
 	if d.S3 != nil {

--- a/server/aws/resourceexplorer2/filter.go
+++ b/server/aws/resourceexplorer2/filter.go
@@ -43,7 +43,7 @@ func applyToken(q *resourcediscovery.Query, token string) {
 
 	switch key {
 	case "service":
-		q.Service = awsToPortableService(val)
+		q.Services = append(q.Services, awsToPortableServices(val)...)
 	case "region":
 		q.Region = val
 	}
@@ -62,20 +62,21 @@ func applyTagToken(q *resourcediscovery.Query, body string) {
 	q.Tags[key] = val
 }
 
-func awsToPortableService(s string) string {
+// awsToPortableServices maps an AWS service name to the set of portable
+// service names that match it. Most AWS services map 1:1; "ec2" expands to
+// {compute, networking} because real AWS uses ec2 for both VMs and VPC
+// resources while cloudemu's portable API splits them.
+func awsToPortableServices(s string) []string {
 	switch s {
 	case awsServiceEC2:
-		// ec2 covers both compute and networking in real AWS; the engine
-		// returns both because Query.Service applies to portable names. We
-		// use empty to match either.
-		return ""
+		return []string{portableServiceCompute, portableServiceNetworking}
 	case awsServiceS3:
-		return portableServiceStorage
+		return []string{portableServiceStorage}
 	case awsServiceDynamoDB:
-		return portableServiceDatabase
+		return []string{portableServiceDatabase}
 	case awsServiceLambda:
-		return portableServiceServerless
+		return []string{portableServiceServerless}
 	default:
-		return s
+		return []string{s}
 	}
 }

--- a/server/aws/resourceexplorer2/filter.go
+++ b/server/aws/resourceexplorer2/filter.go
@@ -1,0 +1,81 @@
+package resourceexplorer2
+
+import (
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// parseFilter parses Resource Explorer's documented query subset into a
+// resourcediscovery.Query. Supported tokens:
+//
+//	service:<name>          → Query.Service (after AWS→portable mapping)
+//	region:<name>           → Query.Region
+//	tag.<key>:<value>       → Query.Tags[key] = value
+//	tag.<key>:              → Query.Tags[key] = "" (key-only match)
+//
+// Tokens are whitespace-separated. Unknown tokens are tolerated and
+// ignored — matches Resource Explorer's permissive parser behavior for a
+// minimal-impact-on-real-callers SDK round-trip.
+func parseFilter(query string) resourcediscovery.Query {
+	q := resourcediscovery.Query{}
+	if strings.TrimSpace(query) == "" {
+		return q
+	}
+
+	for _, token := range strings.Fields(query) {
+		applyToken(&q, token)
+	}
+
+	return q
+}
+
+func applyToken(q *resourcediscovery.Query, token string) {
+	if strings.HasPrefix(token, "tag.") {
+		applyTagToken(q, strings.TrimPrefix(token, "tag."))
+		return
+	}
+
+	key, val, ok := strings.Cut(token, ":")
+	if !ok {
+		return
+	}
+
+	switch key {
+	case "service":
+		q.Service = awsToPortableService(val)
+	case "region":
+		q.Region = val
+	}
+}
+
+func applyTagToken(q *resourcediscovery.Query, body string) {
+	key, val, _ := strings.Cut(body, ":")
+	if key == "" {
+		return
+	}
+
+	if q.Tags == nil {
+		q.Tags = make(map[string]string)
+	}
+
+	q.Tags[key] = val
+}
+
+func awsToPortableService(s string) string {
+	switch s {
+	case awsServiceEC2:
+		// ec2 covers both compute and networking in real AWS; the engine
+		// returns both because Query.Service applies to portable names. We
+		// use empty to match either.
+		return ""
+	case awsServiceS3:
+		return portableServiceStorage
+	case awsServiceDynamoDB:
+		return portableServiceDatabase
+	case awsServiceLambda:
+		return portableServiceServerless
+	default:
+		return s
+	}
+}

--- a/server/aws/resourceexplorer2/handler.go
+++ b/server/aws/resourceexplorer2/handler.go
@@ -53,9 +53,10 @@ type Handler struct {
 	accountID string
 	region    string
 
-	mu      sync.RWMutex
-	views   map[string]*view  // keyed by ViewArn
-	indexes map[string]*index // keyed by region
+	mu          sync.RWMutex
+	views       map[string]*view  // keyed by ViewArn
+	viewsByName map[string]string // ViewName → ViewArn, for collision detection
+	indexes     map[string]*index // keyed by region
 }
 
 type view struct {
@@ -76,11 +77,12 @@ type index struct {
 // New returns a Resource Explorer 2 handler.
 func New(engine *resourcediscovery.Engine, accountID, region string) *Handler {
 	h := &Handler{
-		engine:    engine,
-		accountID: accountID,
-		region:    region,
-		views:     make(map[string]*view),
-		indexes:   make(map[string]*index),
+		engine:      engine,
+		accountID:   accountID,
+		region:      region,
+		views:       make(map[string]*view),
+		viewsByName: make(map[string]string),
+		indexes:     make(map[string]*index),
 	}
 
 	// Real Resource Explorer requires an Index in the calling region before
@@ -166,12 +168,15 @@ func (h *Handler) createView(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	arn := h.viewARN(req.ViewName)
-	if _, exists := h.views[arn]; exists {
+	// Dedupe by ViewName, not by ARN: every call to viewARN() generates a
+	// fresh unique suffix, so a name-only check is the only way to reject
+	// duplicates the way real Resource Explorer does.
+	if _, exists := h.viewsByName[req.ViewName]; exists {
 		wire.WriteJSONError(w, http.StatusConflict, "ConflictException", "view already exists: "+req.ViewName)
 		return
 	}
 
+	arn := h.viewARN(req.ViewName)
 	v := &view{
 		ARN:         arn,
 		Name:        req.ViewName,
@@ -180,9 +185,10 @@ func (h *Handler) createView(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:   time.Now().UTC(),
 	}
 	h.views[arn] = v
+	h.viewsByName[req.ViewName] = arn
 
 	wire.WriteJSON(w, map[string]any{
-		"View": viewToWire(v),
+		"View": viewToWire(v, h.accountID),
 	})
 }
 
@@ -198,12 +204,14 @@ func (h *Handler) deleteView(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if _, ok := h.views[req.ViewArn]; !ok {
+	v, ok := h.views[req.ViewArn]
+	if !ok {
 		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
 		return
 	}
 
 	delete(h.views, req.ViewArn)
+	delete(h.viewsByName, v.Name)
 	wire.WriteJSON(w, map[string]any{"ViewArn": req.ViewArn})
 }
 
@@ -238,7 +246,7 @@ func (h *Handler) getView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{
-		"View": viewToWire(v),
+		"View": viewToWire(v, h.accountID),
 		"Tags": v.Tags,
 	})
 }
@@ -378,11 +386,11 @@ func (h *Handler) indexARN(region string) string {
 	return idgen.AWSARN("resource-explorer-2", region, h.accountID, "index/"+idgen.GenerateID(""))
 }
 
-func viewToWire(v *view) map[string]any {
+func viewToWire(v *view, owner string) map[string]any {
 	return map[string]any{
 		"ViewArn": v.ARN,
 		"Filters": map[string]any{"FilterString": v.QueryString},
-		"Owner":   "",
+		"Owner":   owner,
 	}
 }
 

--- a/server/aws/resourceexplorer2/handler.go
+++ b/server/aws/resourceexplorer2/handler.go
@@ -1,0 +1,437 @@
+// Package resourceexplorer2 serves the AWS Resource Explorer 2 REST-JSON
+// protocol against a *resourcediscovery.Engine.
+//
+// Resource Explorer maintains stateful Views (saved filter expressions)
+// and Indexes (per-region resource catalogs). This handler stores both in
+// memory and routes Search/ListResources through the engine.
+//
+// Filter language: a documented subset of real Resource Explorer query
+// syntax. Supported tokens:
+//
+//	service:<name>          (e.g., service:s3)
+//	tag.<key>:<value>       (e.g., tag.env:prod)
+//	region:<name>           (e.g., region:us-east-1)
+//
+// Unknown tokens are tolerated and ignored. Real Resource Explorer supports
+// a wider grammar; tighten this as later phases need.
+package resourceexplorer2
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/resourcediscovery"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// AWS service identifiers used in Resource Explorer ResourceType strings
+// and in TagResources/UntagResources ARN routing.
+const (
+	awsServiceEC2      = "ec2"
+	awsServiceS3       = "s3"
+	awsServiceDynamoDB = "dynamodb"
+	awsServiceLambda   = "lambda"
+)
+
+// Portable-API service identifiers as emitted by resourcediscovery walkers.
+const (
+	portableServiceCompute    = "compute"
+	portableServiceNetworking = "networking"
+	portableServiceStorage    = "storage"
+	portableServiceDatabase   = "database"
+	portableServiceServerless = "serverless"
+)
+
+// Handler serves Resource Explorer 2 REST-JSON requests.
+type Handler struct {
+	engine *resourcediscovery.Engine
+
+	accountID string
+	region    string
+
+	mu      sync.RWMutex
+	views   map[string]*view  // keyed by ViewArn
+	indexes map[string]*index // keyed by region
+}
+
+type view struct {
+	ARN         string
+	Name        string
+	QueryString string
+	Tags        map[string]string
+	CreatedAt   time.Time
+}
+
+type index struct {
+	ARN       string
+	Region    string
+	Type      string // "LOCAL" or "AGGREGATOR"
+	CreatedAt time.Time
+}
+
+// New returns a Resource Explorer 2 handler.
+func New(engine *resourcediscovery.Engine, accountID, region string) *Handler {
+	h := &Handler{
+		engine:    engine,
+		accountID: accountID,
+		region:    region,
+		views:     make(map[string]*view),
+		indexes:   make(map[string]*index),
+	}
+
+	// Real Resource Explorer requires an Index in the calling region before
+	// Search works. Bootstrap a LOCAL index for the configured region so
+	// SDK clients don't have to call CreateIndex first.
+	idxARN := h.indexARN(region)
+	h.indexes[region] = &index{
+		ARN: idxARN, Region: region, Type: "LOCAL", CreatedAt: time.Now().UTC(),
+	}
+
+	return h
+}
+
+// Known REST-JSON paths for Resource Explorer 2. The handler matches only
+// these exact paths to avoid shadowing S3's REST catch-all.
+//
+//nolint:gochecknoglobals // immutable lookup table.
+var knownPaths = map[string]struct{}{
+	"/CreateView":    {},
+	"/DeleteView":    {},
+	"/ListViews":     {},
+	"/GetView":       {},
+	"/Search":        {},
+	"/ListResources": {},
+	"/ListIndexes":   {},
+	"/GetIndex":      {},
+}
+
+// Matches returns true for POST requests whose path is one of the known
+// Resource Explorer 2 operations.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.Method != http.MethodPost {
+		return false
+	}
+
+	_, ok := knownPaths[r.URL.Path]
+
+	return ok
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/CreateView":
+		h.createView(w, r)
+	case "/DeleteView":
+		h.deleteView(w, r)
+	case "/ListViews":
+		h.listViews(w, r)
+	case "/GetView":
+		h.getView(w, r)
+	case "/Search":
+		h.search(w, r)
+	case "/ListResources":
+		h.listResources(w, r)
+	case "/ListIndexes":
+		h.listIndexes(w, r)
+	case "/GetIndex":
+		h.getIndex(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "unknown path: "+r.URL.Path)
+	}
+}
+
+func (h *Handler) createView(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ViewName    string            `json:"ViewName"`
+		Tags        map[string]string `json:"Tags"`
+		QueryString string            `json:"-"` // Smithy puts this under Filters.FilterString; tolerate either.
+		Filters     struct {
+			FilterString string `json:"FilterString"`
+		} `json:"Filters"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.ViewName == "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "ViewName is required")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	arn := h.viewARN(req.ViewName)
+	if _, exists := h.views[arn]; exists {
+		wire.WriteJSONError(w, http.StatusConflict, "ConflictException", "view already exists: "+req.ViewName)
+		return
+	}
+
+	v := &view{
+		ARN:         arn,
+		Name:        req.ViewName,
+		QueryString: req.Filters.FilterString,
+		Tags:        copyStringMap(req.Tags),
+		CreatedAt:   time.Now().UTC(),
+	}
+	h.views[arn] = v
+
+	wire.WriteJSON(w, map[string]any{
+		"View": viewToWire(v),
+	})
+}
+
+func (h *Handler) deleteView(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ViewArn string `json:"ViewArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.views[req.ViewArn]; !ok {
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+		return
+	}
+
+	delete(h.views, req.ViewArn)
+	wire.WriteJSON(w, map[string]any{"ViewArn": req.ViewArn})
+}
+
+func (h *Handler) listViews(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	arns := make([]string, 0, len(h.views))
+	for arn := range h.views {
+		arns = append(arns, arn)
+	}
+
+	wire.WriteJSON(w, map[string]any{"Views": arns})
+}
+
+func (h *Handler) getView(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ViewArn string `json:"ViewArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	v, ok := h.views[req.ViewArn]
+	if !ok {
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"View": viewToWire(v),
+		"Tags": v.Tags,
+	})
+}
+
+func (h *Handler) search(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueryString string `json:"QueryString"`
+		ViewArn     string `json:"ViewArn"`
+		MaxResults  int    `json:"MaxResults"`
+		NextToken   string `json:"NextToken"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	query := req.QueryString
+
+	// If a view is referenced, merge its FilterString with the request's
+	// QueryString. Real Resource Explorer treats them as additive AND.
+	if req.ViewArn != "" {
+		h.mu.RLock()
+		v, ok := h.views[req.ViewArn]
+		h.mu.RUnlock()
+
+		if !ok {
+			wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+			return
+		}
+
+		query = strings.TrimSpace(v.QueryString + " " + query)
+	}
+
+	q := parseFilter(query)
+
+	results, err := h.engine.List(r.Context(), q)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resources := make([]map[string]any, 0, len(results))
+	for i := range results {
+		resources = append(resources, resourceToWire(&results[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"Resources": resources,
+		"Count":     map[string]any{"TotalResources": len(resources), "Complete": true},
+	})
+}
+
+func (h *Handler) listResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Filters struct {
+			FilterString string `json:"FilterString"`
+		} `json:"Filters"`
+		ViewArn string `json:"ViewArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	query := req.Filters.FilterString
+
+	if req.ViewArn != "" {
+		h.mu.RLock()
+		v, ok := h.views[req.ViewArn]
+		h.mu.RUnlock()
+
+		if !ok {
+			wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+			return
+		}
+
+		query = strings.TrimSpace(v.QueryString + " " + query)
+	}
+
+	q := parseFilter(query)
+
+	results, err := h.engine.List(r.Context(), q)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]map[string]any, 0, len(results))
+	for i := range results {
+		out = append(out, resourceToWire(&results[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{"Resources": out})
+}
+
+func (h *Handler) listIndexes(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	out := make([]map[string]any, 0, len(h.indexes))
+	for _, idx := range h.indexes {
+		out = append(out, map[string]any{
+			"Arn":    idx.ARN,
+			"Region": idx.Region,
+			"Type":   idx.Type,
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Indexes": out})
+}
+
+func (h *Handler) getIndex(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	idx, ok := h.indexes[h.region]
+	if !ok {
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "no index in region: "+h.region)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"Arn":         idx.ARN,
+		"Region":      idx.Region,
+		"Type":        idx.Type,
+		"State":       "ACTIVE",
+		"CreatedAt":   idx.CreatedAt.Format(time.RFC3339),
+		"LastUpdated": idx.CreatedAt.Format(time.RFC3339),
+	})
+}
+
+func (h *Handler) viewARN(name string) string {
+	return idgen.AWSARN("resource-explorer-2", h.region, h.accountID, "view/"+name+"/"+idgen.GenerateID(""))
+}
+
+func (h *Handler) indexARN(region string) string {
+	return idgen.AWSARN("resource-explorer-2", region, h.accountID, "index/"+idgen.GenerateID(""))
+}
+
+func viewToWire(v *view) map[string]any {
+	return map[string]any{
+		"ViewArn": v.ARN,
+		"Filters": map[string]any{"FilterString": v.QueryString},
+		"Owner":   "",
+	}
+}
+
+func resourceToWire(r *resourcediscovery.Resource) map[string]any {
+	return map[string]any{
+		"Arn":             r.ARN,
+		"OwningAccountId": "",
+		"Region":          r.Region,
+		"ResourceType":    r.Service + ":" + strings.ToLower(r.Type),
+		"Service":         portableToAWSService(r.Service),
+		"Properties":      []map[string]any{},
+	}
+}
+
+func portableToAWSService(s string) string {
+	switch s {
+	case portableServiceCompute, portableServiceNetworking:
+		return awsServiceEC2
+	case portableServiceStorage:
+		return awsServiceS3
+	case portableServiceDatabase:
+		return awsServiceDynamoDB
+	case portableServiceServerless:
+		return awsServiceLambda
+	default:
+		return s
+	}
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+
+	return out
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+	}
+}

--- a/server/aws/resourceexplorer2/sdk_test.go
+++ b/server/aws/resourceexplorer2/sdk_test.go
@@ -1,0 +1,165 @@
+// Real-SDK round-trip test: the live aws-sdk-go-v2 Resource Explorer 2
+// client drives the in-memory handler end-to-end.
+
+package resourceexplorer2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	rex "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
+	rextypes "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func TestSDKResourceExplorer2(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "prod-bucket"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "prod-bucket", map[string]string{"env": "prod"}))
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "stage-bucket"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "stage-bucket", map[string]string{"env": "stage"}))
+
+	require.NoError(t, cloud.DynamoDB.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloud.DynamoDB.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	_, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		DynamoDB:          cloud.DynamoDB,
+		VPC:               cloud.VPC,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newREXClient(t, ts.URL)
+
+	t.Run("GetIndex returns bootstrap index", func(t *testing.T) {
+		out, err := client.GetIndex(ctx, &rex.GetIndexInput{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, aws.ToString(out.Arn))
+		assert.Equal(t, rextypes.IndexTypeLocal, out.Type)
+	})
+
+	t.Run("ListIndexes returns at least the local index", func(t *testing.T) {
+		out, err := client.ListIndexes(ctx, &rex.ListIndexesInput{})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Indexes), 1)
+	})
+
+	t.Run("Search with no view returns all resources", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String(""),
+		})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Resources), 4, "expect 2 buckets + 1 table + 1 vpc")
+	})
+
+	t.Run("Search filters by tag", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("tag.env:prod"),
+		})
+		require.NoError(t, err)
+		// prod-bucket, events table, vpc — 3 prod resources
+		assert.Len(t, out.Resources, 3)
+	})
+
+	t.Run("Search filters by service", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("service:s3"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 2, "two s3 buckets")
+	})
+
+	t.Run("Search combines service + tag", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("service:s3 tag.env:prod"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 1)
+		assert.Equal(t, "arn:aws:s3:::prod-bucket", aws.ToString(out.Resources[0].Arn))
+	})
+
+	var viewArn string
+
+	t.Run("CreateView", func(t *testing.T) {
+		out, err := client.CreateView(ctx, &rex.CreateViewInput{
+			ViewName: aws.String("prod-only"),
+			Filters: &rextypes.SearchFilter{
+				FilterString: aws.String("tag.env:prod"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.View)
+		viewArn = aws.ToString(out.View.ViewArn)
+		assert.NotEmpty(t, viewArn)
+	})
+
+	t.Run("ListViews includes the new view", func(t *testing.T) {
+		out, err := client.ListViews(ctx, &rex.ListViewsInput{})
+		require.NoError(t, err)
+		assert.Contains(t, out.Views, viewArn)
+	})
+
+	t.Run("GetView returns the filter", func(t *testing.T) {
+		out, err := client.GetView(ctx, &rex.GetViewInput{ViewArn: aws.String(viewArn)})
+		require.NoError(t, err)
+		require.NotNil(t, out.View)
+		require.NotNil(t, out.View.Filters)
+		assert.Equal(t, "tag.env:prod", aws.ToString(out.View.Filters.FilterString))
+	})
+
+	t.Run("Search via view filters server-side", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			ViewArn:     aws.String(viewArn),
+			QueryString: aws.String(""),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 3, "view's tag.env:prod filter applies")
+	})
+
+	t.Run("DeleteView", func(t *testing.T) {
+		_, err := client.DeleteView(ctx, &rex.DeleteViewInput{ViewArn: aws.String(viewArn)})
+		require.NoError(t, err)
+
+		listOut, err := client.ListViews(ctx, &rex.ListViewsInput{})
+		require.NoError(t, err)
+		assert.NotContains(t, listOut.Views, viewArn)
+	})
+}
+
+func newREXClient(t *testing.T, baseURL string) *rex.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("k", "s", "")),
+	)
+	if err != nil {
+		t.Fatalf("awsconfig: %v", err)
+	}
+
+	return rex.NewFromConfig(cfg, func(o *rex.Options) {
+		o.BaseEndpoint = aws.String(baseURL)
+	})
+}

--- a/server/aws/resourceexplorer2/sdk_test.go
+++ b/server/aws/resourceexplorer2/sdk_test.go
@@ -148,6 +148,61 @@ func TestSDKResourceExplorer2(t *testing.T) {
 	})
 }
 
+// TestSDKResourceExplorer2_BugFixes exercises the four review-fix paths in
+// isolation so each can fail with a clear signal if it regresses.
+func TestSDKResourceExplorer2_BugFixes(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	// Seed one VPC (networking) and one EC2 instance via the engine surface.
+	_, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "log-bucket"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "log-bucket", map[string]string{"env": "prod"}))
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		VPC:               cloud.VPC,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newREXClient(t, ts.URL)
+
+	t.Run("service:ec2 matches networking (not s3)", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("service:ec2"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 1, "service:ec2 should expand to compute+networking; only the VPC matches")
+		assert.Equal(t, "ec2", aws.ToString(out.Resources[0].Service))
+	})
+
+	t.Run("CreateView rejects duplicate name", func(t *testing.T) {
+		_, err := client.CreateView(ctx, &rex.CreateViewInput{ViewName: aws.String("dup")})
+		require.NoError(t, err)
+
+		_, err = client.CreateView(ctx, &rex.CreateViewInput{ViewName: aws.String("dup")})
+		require.Error(t, err, "second CreateView with the same name must fail")
+		assert.Contains(t, err.Error(), "ConflictException")
+	})
+
+	t.Run("View Owner field carries the account ID", func(t *testing.T) {
+		created, err := client.CreateView(ctx, &rex.CreateViewInput{ViewName: aws.String("owned-view")})
+		require.NoError(t, err)
+
+		got, err := client.GetView(ctx, &rex.GetViewInput{ViewArn: created.View.ViewArn})
+		require.NoError(t, err)
+		assert.Equal(t, "123456789012", aws.ToString(got.View.Owner))
+	})
+}
+
 func newREXClient(t *testing.T, baseURL string) *rex.Client {
 	t.Helper()
 

--- a/server/aws/resourcegroupstaggingapi/handler.go
+++ b/server/aws/resourcegroupstaggingapi/handler.go
@@ -1,0 +1,302 @@
+// Package resourcegroupstaggingapi serves the AWS Resource Groups Tagging
+// API JSON 1.1 protocol against a *resourcediscovery.Engine. Real
+// aws-sdk-go-v2/service/resourcegroupstaggingapi clients work end-to-end.
+package resourcegroupstaggingapi
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/resourcediscovery"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "ResourceGroupsTaggingAPI_20170126."
+
+// AWS service identifiers used to translate portable service names to the
+// names that appear in real AWS ARN/filter syntax.
+const (
+	awsServiceEC2      = "ec2"
+	awsServiceS3       = "s3"
+	awsServiceDynamoDB = "dynamodb"
+	awsServiceLambda   = "lambda"
+)
+
+// Error code returned for any tag-routing failure surfaced to the SDK
+// client. Real AWS uses InvalidParameterException for both bad ARNs and
+// resource-not-found.
+const errInvalidParameter = "InvalidParameterException"
+
+// Handler serves Resource Groups Tagging API JSON-RPC requests.
+type Handler struct {
+	engine *resourcediscovery.Engine
+}
+
+// New returns a handler backed by the given cross-service discovery engine.
+func New(engine *resourcediscovery.Engine) *Handler {
+	return &Handler{engine: engine}
+}
+
+// Matches returns true for an X-Amz-Target of "ResourceGroupsTaggingAPI_20170126.<Op>".
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches by X-Amz-Target operation.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "GetResources":
+		h.getResources(w, r)
+	case "GetTagKeys":
+		h.getTagKeys(w, r)
+	case "GetTagValues":
+		h.getTagValues(w, r)
+	case "TagResources":
+		h.tagResources(w, r)
+	case "UntagResources":
+		h.untagResources(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown operation: "+op)
+	}
+}
+
+type tagFilter struct {
+	Key    string   `json:"Key"`
+	Values []string `json:"Values"`
+}
+
+func (h *Handler) getResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceTypeFilters []string    `json:"ResourceTypeFilters"`
+		TagFilters          []tagFilter `json:"TagFilters"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	all, err := h.engine.ListAll(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]map[string]any, 0, len(all))
+
+	for i := range all {
+		res := &all[i]
+		if !matchesTypeFilter(res, req.ResourceTypeFilters) {
+			continue
+		}
+
+		if !matchesTagFilters(res, req.TagFilters) {
+			continue
+		}
+
+		out = append(out, map[string]any{
+			"ResourceARN": res.ARN,
+			"Tags":        toTagList(res.Tags),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ResourceTagMappingList": out,
+		"PaginationToken":        "",
+	})
+}
+
+func (h *Handler) getTagKeys(w http.ResponseWriter, r *http.Request) {
+	var req struct{}
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	keys, err := h.engine.GetTagKeys(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TagKeys":         keys,
+		"PaginationToken": "",
+	})
+}
+
+func (h *Handler) getTagValues(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Key string `json:"Key"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Key == "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "Key is required")
+		return
+	}
+
+	vals, err := h.engine.GetTagValues(r.Context(), req.Key)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TagValues":       vals,
+		"PaginationToken": "",
+	})
+}
+
+func (h *Handler) tagResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceARNList []string          `json:"ResourceARNList"`
+		Tags            map[string]string `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	failed := map[string]map[string]string{}
+
+	for _, arn := range req.ResourceARNList {
+		if err := h.engine.TagResourceByARN(r.Context(), arn, req.Tags); err != nil {
+			failed[arn] = map[string]string{
+				"ErrorCode":    awsErrorCode(err),
+				"ErrorMessage": err.Error(),
+			}
+		}
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FailedResourcesMap": failed,
+	})
+}
+
+func (h *Handler) untagResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceARNList []string `json:"ResourceARNList"`
+		TagKeys         []string `json:"TagKeys"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	failed := map[string]map[string]string{}
+
+	for _, arn := range req.ResourceARNList {
+		if err := h.engine.UntagResourceByARN(r.Context(), arn, req.TagKeys); err != nil {
+			failed[arn] = map[string]string{
+				"ErrorCode":    awsErrorCode(err),
+				"ErrorMessage": err.Error(),
+			}
+		}
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FailedResourcesMap": failed,
+	})
+}
+
+func matchesTypeFilter(r *resourcediscovery.Resource, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	// Filter syntax: "service" (e.g., "s3") or "service:type" (e.g., "dynamodb:table").
+	for _, f := range filters {
+		svc, rt, hasType := strings.Cut(f, ":")
+		// Translate portable service to AWS service name for matching.
+		awsService := portableToAWSService(r.Service)
+		if svc != awsService {
+			continue
+		}
+
+		if !hasType {
+			return true
+		}
+
+		if strings.EqualFold(rt, r.Type) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func portableToAWSService(s string) string {
+	switch s {
+	case "compute", "networking":
+		return awsServiceEC2
+	case "storage":
+		return awsServiceS3
+	case "database":
+		return awsServiceDynamoDB
+	case "serverless":
+		return awsServiceLambda
+	default:
+		return s
+	}
+}
+
+func matchesTagFilters(r *resourcediscovery.Resource, filters []tagFilter) bool {
+	for _, tf := range filters {
+		got, ok := r.Tags[tf.Key]
+		if !ok {
+			return false
+		}
+
+		if len(tf.Values) == 0 {
+			continue
+		}
+
+		matched := false
+
+		for _, v := range tf.Values {
+			if v == got {
+				matched = true
+				break
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+func toTagList(tags map[string]string) []map[string]string {
+	out := make([]map[string]string, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, map[string]string{"Key": k, "Value": v})
+	}
+
+	return out
+}
+
+func awsErrorCode(err error) string {
+	switch {
+	case cerrors.IsNotFound(err), cerrors.IsInvalidArgument(err):
+		return errInvalidParameter
+	default:
+		return "InternalServiceException"
+	}
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err), cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, errInvalidParameter, err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServiceException", err.Error())
+	}
+}

--- a/server/aws/resourcegroupstaggingapi/sdk_test.go
+++ b/server/aws/resourcegroupstaggingapi/sdk_test.go
@@ -1,0 +1,162 @@
+// Real-SDK round-trip test: the live aws-sdk-go-v2 Resource Groups Tagging
+// API client drives the in-memory handler end-to-end.
+
+package resourcegroupstaggingapi_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	rgta "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func TestSDKResourceGroupsTagging(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	// Seed a small inventory across services.
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "audit-logs"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "audit-logs",
+		map[string]string{"env": "prod", "team": "security"}))
+
+	require.NoError(t, cloud.DynamoDB.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloud.DynamoDB.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	vpcInfo, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"},
+	})
+	require.NoError(t, err)
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		DynamoDB:          cloud.DynamoDB,
+		VPC:               cloud.VPC,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newRGTAClient(t, ts.URL)
+
+	t.Run("GetResources returns everything", func(t *testing.T) {
+		out, err := client.GetResources(ctx, &rgta.GetResourcesInput{})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.ResourceTagMappingList), 3,
+			"expect bucket + table + vpc at minimum")
+
+		// Spot-check that ARNs and tags are present.
+		seenBucket := false
+		for _, m := range out.ResourceTagMappingList {
+			if aws.ToString(m.ResourceARN) == "arn:aws:s3:::audit-logs" {
+				seenBucket = true
+				tags := tagsToMap(m.Tags)
+				assert.Equal(t, "prod", tags["env"])
+				assert.Equal(t, "security", tags["team"])
+			}
+		}
+		assert.True(t, seenBucket, "audit-logs bucket should appear in inventory")
+	})
+
+	t.Run("GetResources with TagFilters", func(t *testing.T) {
+		out, err := client.GetResources(ctx, &rgta.GetResourcesInput{
+			TagFilters: []rgtatypes.TagFilter{{
+				Key:    aws.String("env"),
+				Values: []string{"prod"},
+			}},
+		})
+		require.NoError(t, err)
+		// audit-logs (s3) + events (dynamodb) both have env=prod; vpc has env=stage.
+		assert.Len(t, out.ResourceTagMappingList, 2)
+	})
+
+	t.Run("GetTagKeys returns deduplicated keys", func(t *testing.T) {
+		out, err := client.GetTagKeys(ctx, &rgta.GetTagKeysInput{})
+		require.NoError(t, err)
+		sort.Strings(out.TagKeys)
+		assert.Equal(t, []string{"env", "team"}, out.TagKeys)
+	})
+
+	t.Run("GetTagValues for a key", func(t *testing.T) {
+		out, err := client.GetTagValues(ctx, &rgta.GetTagValuesInput{Key: aws.String("env")})
+		require.NoError(t, err)
+		sort.Strings(out.TagValues)
+		assert.Equal(t, []string{"prod", "stage"}, out.TagValues)
+	})
+
+	t.Run("TagResources adds tags and is visible in subsequent reads", func(t *testing.T) {
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{"arn:aws:s3:::audit-logs"},
+			Tags:            map[string]string{"compliance": "soc2"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.FailedResourcesMap)
+
+		got, err := cloud.S3.GetBucketTagging(ctx, "audit-logs")
+		require.NoError(t, err)
+		assert.Equal(t, "soc2", got["compliance"])
+		assert.Equal(t, "prod", got["env"], "existing tags must survive the merge")
+	})
+
+	t.Run("UntagResources removes the listed keys", func(t *testing.T) {
+		arn := "arn:aws:ec2:us-east-1:123456789012:vpc/" + vpcInfo.ID
+		out, err := client.UntagResources(ctx, &rgta.UntagResourcesInput{
+			ResourceARNList: []string{arn},
+			TagKeys:         []string{"env"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.FailedResourcesMap)
+
+		got, err := cloud.VPC.DescribeVPCs(ctx, []string{vpcInfo.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["env"]
+		assert.False(t, has, "env tag should be gone after UntagResources")
+	})
+
+	t.Run("TagResources reports failures for unsupported ARNs", func(t *testing.T) {
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{"arn:aws:lambda:us-east-1:111:function:nope"},
+			Tags:            map[string]string{"k": "v"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.FailedResourcesMap, 1)
+	})
+}
+
+func newRGTAClient(t *testing.T, baseURL string) *rgta.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("k", "s", "")),
+	)
+	if err != nil {
+		t.Fatalf("awsconfig: %v", err)
+	}
+
+	return rgta.NewFromConfig(cfg, func(o *rgta.Options) {
+		o.BaseEndpoint = aws.String(baseURL)
+	})
+}
+
+func tagsToMap(tags []rgtatypes.Tag) map[string]string {
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+	return out
+}


### PR DESCRIPTION
Closes #170. Phase 2 of the resource discovery trio.

## What this PR ships

**Two new SDK-compat HTTP handlers:**

- `server/aws/resourcegroupstaggingapi` — JSON 1.1 protocol (X-Amz-Target). 5 operations: `GetResources` / `GetTagKeys` / `GetTagValues` / `TagResources` / `UntagResources`. All five route through the `resourcediscovery.Engine`.
- `server/aws/resourceexplorer2` — REST-JSON protocol. 8 operations: `CreateView` / `DeleteView` / `ListViews` / `GetView` / `Search` / `ListResources` / `ListIndexes` / `GetIndex`. Stateful in-memory Views and Indexes (LOCAL index auto-bootstrapped for the configured region). Filter subset supported: `service:<name>`, `tag.<key>:<value>`, `region:<name>`. Unknown tokens tolerated.

**Real-SDK round-trip tests** drive both handlers end-to-end with `aws-sdk-go-v2/service/resourcegroupstaggingapi` and `aws-sdk-go-v2/service/resourceexplorer2`:
- 7 sub-tests for Resource Groups Tagging
- 11 sub-tests for Resource Explorer 2

## Engine + driver extensions to support tag mutation

- `resourcediscovery`: `TagResourceByARN(ctx, arn, tags)` + `UntagResourceByARN(ctx, arn, keys)`. Parses ARNs and dispatches to the right driver. Returns `InvalidArgument` for unsupported services with a clear message.
- `networking/driver`: `Update{VPC,Subnet,SecurityGroup}Tags` + `Remove{VPC,Subnet,SecurityGroup}Tags`. Implemented across AWS VPC, Azure VNet, GCP VPC. The driver previously had no post-create tag-mutation surface — Tags were only settable via `Create*`.

## Out of scope (deferred)

- **Compute (EC2 instances) and Lambda functions** as `TagResources` targets — `ModifyInstance` requires stopped-state and `UpdateFunction` rewrites the whole config, so neither has a clean tag-only mutation path. Phase 2 returns `InvalidArgument` with a "not yet supported" message for those ARNs. Adding dedicated `UpdateInstanceTags` / `UpdateFunctionTags` driver methods is a natural follow-up.
- Full Resource Explorer KQL-like query grammar — only the three documented tokens are parsed.
- Pagination (`NextToken`/`PaginationToken` always empty).
- Cross-account / aggregator indexes.

## Wiring

`server/aws/Drivers` now has `ResourceDiscovery *resourcediscovery.Engine`, `AccountID string`, `Region string`. When `ResourceDiscovery` is non-nil, both handlers register. Dispatch order in `server/aws/aws.go`: Resource Groups Tagging slots next to DynamoDB/SQS (also X-Amz-Target), Resource Explorer 2 sits before S3's catch-all (it claims top-level paths like `/CreateView`).

## Verification

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [x] `golangci-lint run --timeout=9m ./...` 0 issues
- [x] Real-SDK round-trip on both handlers passes against the in-process server