### PR TITLE
feat(azure): Resource Graph SDK-compat handler (#171)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 h1:HzqcSJWx32XQdr8KtxAu/SZJj0PqDo9tKf2YGPdynV0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0/go.mod h1:nKcJObAisSPDrO9lMuuCBoYY7Ki7ADt8p6XmBhpKNTk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 h1:JLPf82byRFgfB0f2feJMmRfCCFV0W9/GayiiewTvjlw=

--- a/resourcediscovery/engine.go
+++ b/resourcediscovery/engine.go
@@ -51,6 +51,20 @@ func New(provider, accountID, region string, drivers *Drivers) *Engine {
 	}
 }
 
+// AccountID returns the AWS account ID, Azure subscription ID, or GCP
+// project ID the engine was constructed with. Exposed so handlers built on
+// top of the engine (Resource Explorer, Resource Graph, Cloud Asset
+// Inventory) don't have to ask their callers to supply the same value a
+// second time when wiring up the server.
+func (e *Engine) AccountID() string {
+	return e.accountID
+}
+
+// Region returns the default region the engine was constructed with.
+func (e *Engine) Region() string {
+	return e.region
+}
+
 // ListAll walks every configured driver and returns the merged inventory.
 // Nil drivers are skipped silently. The first walker error short-circuits
 // the rest.

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -14,6 +14,7 @@ import (
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
 	aksserver "github.com/stackshy/cloudemu/server/azure/aks"
 	"github.com/stackshy/cloudemu/server/azure/azuresql"
@@ -26,6 +27,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
 	"github.com/stackshy/cloudemu/server/azure/network"
 	"github.com/stackshy/cloudemu/server/azure/postgresflex"
+	"github.com/stackshy/cloudemu/server/azure/resourcegraph"
 	"github.com/stackshy/cloudemu/server/azure/servicebus"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
 	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
@@ -62,6 +64,12 @@ type Drivers struct {
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
 	// the same backend. Leave nil to disable Kubernetes data-plane support.
 	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery is the cross-service inventory engine. Required to
+	// serve Azure Resource Graph (armresourcegraph) requests. Leave nil to
+	// omit the handler. SubscriptionID is needed for the subscription-scoping
+	// check on incoming queries.
+	ResourceDiscovery *resourcediscovery.Engine
+	SubscriptionID    string
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -150,6 +158,13 @@ func New(d Drivers) *server.Server {
 	// other Azure path. Registered before the BlobStorage fallback.
 	if d.K8sAPI != nil {
 		srv.Register(d.K8sAPI)
+	}
+
+	// Resource Graph matches /providers/Microsoft.ResourceGraph/... —
+	// distinct from any service-scoped ARM URL, so registration order is
+	// unconstrained relative to the resource handlers above.
+	if d.ResourceDiscovery != nil {
+		srv.Register(resourcegraph.New(d.ResourceDiscovery, d.SubscriptionID))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -1,0 +1,264 @@
+package resourcegraph
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// Path prefixes this handler serves. The Resource Graph provider sits at a
+// well-known ARM URL; the API-version query string is varied across SDK
+// releases so we ignore it for matching.
+const (
+	pathResources       = "/providers/Microsoft.ResourceGraph/resources"
+	pathResourcesHistry = "/providers/Microsoft.ResourceGraph/resourcesHistory"
+	pathOperations      = "/providers/Microsoft.ResourceGraph/operations"
+)
+
+// Handler serves Azure Resource Graph ARM-JSON requests.
+type Handler struct {
+	engine         *resourcediscovery.Engine
+	subscriptionID string
+}
+
+// New returns a Resource Graph handler backed by engine. subscriptionID is
+// returned in resource IDs and validated against the request's subscriptions
+// list (a request whose subscriptions field is set but does not include this
+// ID returns an empty result rather than an error).
+func New(engine *resourcediscovery.Engine, subscriptionID string) *Handler {
+	return &Handler{engine: engine, subscriptionID: subscriptionID}
+}
+
+// Matches accepts ARM requests targeting Microsoft.ResourceGraph. The
+// resourcesHistory and operations paths are also routed here.
+func (*Handler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+
+	return strings.HasPrefix(p, pathResources) ||
+		strings.HasPrefix(p, pathResourcesHistry) ||
+		strings.HasPrefix(p, pathOperations)
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, pathOperations):
+		h.listOperations(w, r)
+	case strings.HasPrefix(r.URL.Path, pathResourcesHistry):
+		h.queryResourcesHistory(w, r)
+	case strings.HasPrefix(r.URL.Path, pathResources):
+		h.queryResources(w, r)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown Resource Graph path: "+r.URL.Path)
+	}
+}
+
+type queryRequest struct {
+	Subscriptions []string `json:"subscriptions"`
+	Query         string   `json:"query"`
+	Options       struct {
+		Top  int `json:"$top"`
+		Skip int `json:"$skip"`
+	} `json:"options"`
+}
+
+func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "POST required")
+		return
+	}
+
+	var req queryRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if !h.subscriptionAllowed(req.Subscriptions) {
+		azurearm.WriteJSON(w, http.StatusOK, emptyResponse())
+		return
+	}
+
+	parsed := parseKQL(req.Query)
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	results = applyLimit(results, parsed.Limit, req.Options.Top, req.Options.Skip)
+
+	data := make([]map[string]any, 0, len(results))
+	for i := range results {
+		data = append(data, resourceToWire(&results[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"totalRecords":    len(data),
+		"count":           len(data),
+		"data":            data,
+		"facets":          []any{},
+		"resultTruncated": "false",
+	})
+}
+
+// queryResourcesHistory returns the current inventory as a single point-in-time
+// snapshot. The mock has no time-travel state; real Resource Graph History
+// requires Azure Diagnostic Settings to be configured, which is out of scope.
+func (h *Handler) queryResourcesHistory(w http.ResponseWriter, r *http.Request) {
+	h.queryResources(w, r)
+}
+
+// listOperations returns the descriptors for the three ops this handler
+// supports. Real Resource Graph returns many more (private link, etc.); we
+// surface only the ones a discovery-focused caller exercises.
+func (*Handler) listOperations(w http.ResponseWriter, _ *http.Request) {
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"value": []map[string]any{
+			operationDescriptor("Microsoft.ResourceGraph/resources/read",
+				"resources", "Query", "Submits a Resource Graph query."),
+			operationDescriptor("Microsoft.ResourceGraph/resourcesHistory/read",
+				"resourcesHistory", "Query history", "Submits a Resource Graph history query."),
+			operationDescriptor("Microsoft.ResourceGraph/operations/read",
+				"operations", "List", "Lists supported Resource Graph operations."),
+		},
+	})
+}
+
+func operationDescriptor(name, resource, op, desc string) map[string]any {
+	return map[string]any{
+		"name": name,
+		"display": map[string]string{
+			"provider":    "Microsoft.ResourceGraph",
+			"resource":    resource,
+			"operation":   op,
+			"description": desc,
+		},
+	}
+}
+
+// subscriptionAllowed returns true if the request's subscription list is
+// empty (caller doesn't care about scoping) or includes this handler's
+// subscription ID. Mismatch returns an empty result rather than an error,
+// matching real Resource Graph behavior when the caller scopes to
+// subscriptions they can't see.
+func (h *Handler) subscriptionAllowed(reqSubs []string) bool {
+	if len(reqSubs) == 0 {
+		return true
+	}
+
+	for _, s := range reqSubs {
+		if s == h.subscriptionID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func emptyResponse() map[string]any {
+	return map[string]any{
+		"totalRecords":    0,
+		"count":           0,
+		"data":            []any{},
+		"facets":          []any{},
+		"resultTruncated": "false",
+	}
+}
+
+// applyLimit applies the caller-specified $top/$skip and any `| limit N` /
+// `| take N` from the KQL. The smaller of the two limits wins; $skip is
+// applied before slicing.
+func applyLimit(results []resourcediscovery.Resource, kqlLimit, top, skip int) []resourcediscovery.Resource {
+	if skip > 0 {
+		if skip >= len(results) {
+			return nil
+		}
+
+		results = results[skip:]
+	}
+
+	limit := top
+	if kqlLimit > 0 && (limit == 0 || kqlLimit < limit) {
+		limit = kqlLimit
+	}
+
+	if limit > 0 && limit < len(results) {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+// resourceToWire formats one Resource into the Azure Resource Graph row
+// shape: { id, name, type, location, resourceGroup, subscriptionId, tags }.
+// The portable Type is translated back to the canonical Azure type string.
+func resourceToWire(r *resourcediscovery.Resource) map[string]any {
+	out := map[string]any{
+		"id":             r.ARN,
+		"name":           r.ID,
+		"type":           portableToAzureType(r.Service, r.Type),
+		"location":       r.Region,
+		"resourceGroup":  "default",
+		"subscriptionId": extractSubscription(r.ARN),
+		"tags":           tagsOrEmpty(r.Tags),
+	}
+
+	return out
+}
+
+func tagsOrEmpty(tags map[string]string) map[string]string {
+	if tags == nil {
+		return map[string]string{}
+	}
+
+	return tags
+}
+
+// extractSubscription pulls /subscriptions/<id>/... out of an Azure resource
+// ID. Returns empty string for non-conforming IDs.
+func extractSubscription(arn string) string {
+	const prefix = "/subscriptions/"
+	if !strings.HasPrefix(arn, prefix) {
+		return ""
+	}
+
+	rest := arn[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+
+	return rest
+}
+
+// portableToAzureType is the inverse of mapAzureType — it turns the engine's
+// (service, type) pair back into the dotted Azure type string a real ARG
+// response carries.
+func portableToAzureType(service, typ string) string {
+	switch service + "/" + typ {
+	case "compute/Instance":
+		return "microsoft.compute/virtualmachines"
+	case "networking/VPC":
+		return "microsoft.network/virtualnetworks"
+	case "networking/Subnet":
+		return "microsoft.network/subnets"
+	case "networking/SecurityGroup":
+		return "microsoft.network/networksecuritygroups"
+	case "storage/Bucket":
+		return "microsoft.storage/storageaccounts"
+	case "database/Table":
+		return "microsoft.documentdb/databaseaccounts"
+	case "serverless/Function":
+		return "microsoft.web/sites"
+	default:
+		return strings.ToLower(service + "/" + typ)
+	}
+}
+
+// Compile-time check that Handler implements the Matches+ServeHTTP pair the
+// dispatch chain expects.
+var _ interface {
+	Matches(*http.Request) bool
+	http.Handler
+} = (*Handler)(nil)

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -12,9 +12,9 @@ import (
 // well-known ARM URL; the API-version query string is varied across SDK
 // releases so we ignore it for matching.
 const (
-	pathResources       = "/providers/Microsoft.ResourceGraph/resources"
-	pathResourcesHistry = "/providers/Microsoft.ResourceGraph/resourcesHistory"
-	pathOperations      = "/providers/Microsoft.ResourceGraph/operations"
+	pathResources        = "/providers/Microsoft.ResourceGraph/resources"
+	pathResourcesHistory = "/providers/Microsoft.ResourceGraph/resourcesHistory"
+	pathOperations       = "/providers/Microsoft.ResourceGraph/operations"
 )
 
 // Handler serves Azure Resource Graph ARM-JSON requests.
@@ -24,30 +24,40 @@ type Handler struct {
 }
 
 // New returns a Resource Graph handler backed by engine. subscriptionID is
-// returned in resource IDs and validated against the request's subscriptions
-// list (a request whose subscriptions field is set but does not include this
-// ID returns an empty result rather than an error).
+// validated against the request's subscriptions list (a request whose
+// subscriptions field is set but does not include this ID returns an empty
+// result rather than an error). If subscriptionID is empty, the engine's
+// own AccountID is used — that's the same value the engine was built with
+// when it constructed Azure-shaped resource IDs, so the two stay aligned
+// without callers having to pass the ID twice.
 func New(engine *resourcediscovery.Engine, subscriptionID string) *Handler {
+	if subscriptionID == "" && engine != nil {
+		subscriptionID = engine.AccountID()
+	}
+
 	return &Handler{engine: engine, subscriptionID: subscriptionID}
 }
 
-// Matches accepts ARM requests targeting Microsoft.ResourceGraph. The
-// resourcesHistory and operations paths are also routed here.
+// Matches accepts ARM requests targeting Microsoft.ResourceGraph. Uses
+// exact path equality, not prefix match, so /resources cannot shadow
+// /resourcesHistory (the longer path starts with the shorter one).
+// r.URL.Path strips the query string, so api-version is not in the way.
 func (*Handler) Matches(r *http.Request) bool {
-	p := r.URL.Path
-
-	return strings.HasPrefix(p, pathResources) ||
-		strings.HasPrefix(p, pathResourcesHistry) ||
-		strings.HasPrefix(p, pathOperations)
+	switch r.URL.Path {
+	case pathResources, pathResourcesHistory, pathOperations:
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch {
-	case strings.HasPrefix(r.URL.Path, pathOperations):
+	switch r.URL.Path {
+	case pathOperations:
 		h.listOperations(w, r)
-	case strings.HasPrefix(r.URL.Path, pathResourcesHistry):
+	case pathResourcesHistory:
 		h.queryResourcesHistory(w, r)
-	case strings.HasPrefix(r.URL.Path, pathResources):
+	case pathResources:
 		h.queryResources(w, r)
 	default:
 		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown Resource Graph path: "+r.URL.Path)
@@ -80,6 +90,13 @@ func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parsed := parseKQL(req.Query)
+
+	// Contradiction in chained where-clauses (e.g. two type filters AND-ed
+	// together) — short-circuit before hitting the engine. See parsedKQL.
+	if parsed.ForceEmpty {
+		azurearm.WriteJSON(w, http.StatusOK, emptyResponse())
+		return
+	}
 
 	results, err := h.engine.List(r.Context(), parsed.Query)
 	if err != nil {

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -1,0 +1,203 @@
+// Package resourcegraph serves Azure Resource Graph (armresourcegraph) REST
+// requests against a *resourcediscovery.Engine.
+//
+// Resource Graph queries use Kusto Query Language (KQL), a rich
+// data-analytics grammar. This handler implements a documented subset that
+// covers the queries real callers make for inventory/discovery:
+//
+//	Resources
+//	| where type == 'microsoft.compute/virtualmachines'
+//	| where type =~ 'microsoft.network/virtualnetworks'
+//	| where resourceGroup == 'rg-prod'
+//	| where location == 'eastus'
+//	| where tags['env'] == 'prod'
+//	| where tags.env == 'prod'
+//	| project id, type, name              (column selection: ignored, full
+//	                                        records returned)
+//	| limit 100                           (also: | take 100)
+//
+// Unknown tokens and unsupported clauses are tolerated: the parser logs
+// them away and continues with the constraints it did understand. Real
+// Resource Graph would reject malformed queries; the stub favors returning
+// some result over a 400 so SDK callers that probe with unknown queries
+// don't blow up.
+package resourcegraph
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// Canonical Azure resource type strings used by Resource Graph query syntax
+// and emitted in response rows.
+const (
+	azureTypeVM      = "microsoft.compute/virtualmachines"
+	azureTypeVNet    = "microsoft.network/virtualnetworks"
+	azureTypeSubnet  = "microsoft.network/subnets"
+	azureTypeSubnetN = "microsoft.network/virtualnetworks/subnets"
+	azureTypeNSG     = "microsoft.network/networksecuritygroups"
+	azureTypeStorage = "microsoft.storage/storageaccounts"
+	azureTypeStoCnt  = "microsoft.storage/storageaccounts/blobservices/containers"
+	azureTypeCosmos  = "microsoft.documentdb/databaseaccounts"
+	azureTypeCosmosC = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
+	azureTypeWebSite = "microsoft.web/sites"
+)
+
+// Portable service identifiers as emitted by the resourcediscovery walkers.
+const (
+	portableCompute    = "compute"
+	portableNetworking = "networking"
+	portableStorage    = "storage"
+	portableDatabase   = "database"
+	portableServerless = "serverless"
+)
+
+// parsedKQL is the result of KQL parsing — an engine Query plus the limit
+// extracted from `| limit N` / `| take N` (0 means no caller-specified limit).
+type parsedKQL struct {
+	Query resourcediscovery.Query
+	Limit int
+}
+
+// Pre-compiled KQL predicate regexes. Compiled once at package load; safe
+// for concurrent use.
+//
+
+var (
+	// type == 'X' / type =~ 'X' / type == "X".
+	reWhereType = regexp.MustCompile(`(?i)^\s*type\s*(==|=~)\s*['"]([^'"]+)['"]\s*$`)
+	// resourceGroup == 'X'.
+	reWhereRG = regexp.MustCompile(`(?i)^\s*resourceGroup\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// location == 'X'.
+	reWhereLocation = regexp.MustCompile(`(?i)^\s*location\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// tags['k'] == 'v' / tags["k"] == "v".
+	reWhereTagsBracket = regexp.MustCompile(`(?i)^\s*tags\s*\[\s*['"]([^'"]+)['"]\s*\]\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// tags.k == 'v'.
+	reWhereTagsDot = regexp.MustCompile(`(?i)^\s*tags\.([A-Za-z0-9_-]+)\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// limit N / take N.
+	reLimit = regexp.MustCompile(`(?i)^\s*(limit|take)\s+(\d+)\s*$`)
+)
+
+// parseKQL splits the query on `|` and applies each clause to a Query under
+// construction. Always returns a valid parsedKQL; unrecognized clauses
+// (project, summarize, join, …) are silently ignored — the stub favors
+// returning some result over a 400 on syntax we don't model yet.
+func parseKQL(query string) parsedKQL {
+	out := parsedKQL{}
+
+	clauses := strings.Split(query, "|")
+	for _, raw := range clauses {
+		clause := strings.TrimSpace(raw)
+		if clause == "" {
+			continue
+		}
+
+		applyClause(&out, clause)
+	}
+
+	return out
+}
+
+func applyClause(out *parsedKQL, clause string) {
+	// Drop the leading "Resources" table reference; it's the only one we
+	// support and it carries no constraint.
+	if strings.EqualFold(clause, "Resources") {
+		return
+	}
+
+	if strings.HasPrefix(strings.ToLower(clause), "where ") {
+		applyWhere(out, strings.TrimSpace(clause[len("where "):]))
+		return
+	}
+
+	if m := reLimit.FindStringSubmatch(clause); m != nil {
+		if n, err := strconv.Atoi(m[2]); err == nil {
+			out.Limit = n
+		}
+
+		return
+	}
+}
+
+// applyWhere routes a single "where" predicate to the matching field on the
+// engine Query. Unknown predicates are tolerated and left untouched — see
+// parseKQL's package-level comment for the rationale.
+func applyWhere(out *parsedKQL, body string) {
+	if m := reWhereType.FindStringSubmatch(body); m != nil {
+		applyType(out, m[2])
+		return
+	}
+
+	if m := reWhereRG.FindStringSubmatch(body); m != nil {
+		// The engine does not track resource groups; every Azure resource
+		// is bucketed under a single "default" group. Filtering by RG is
+		// therefore a no-op here — documented limitation; revisit if the
+		// engine grows real RG awareness.
+		_ = m
+		return
+	}
+
+	if m := reWhereLocation.FindStringSubmatch(body); m != nil {
+		out.Query.Region = m[1]
+		return
+	}
+
+	if m := reWhereTagsBracket.FindStringSubmatch(body); m != nil {
+		addTag(out, m[1], m[2])
+		return
+	}
+
+	if m := reWhereTagsDot.FindStringSubmatch(body); m != nil {
+		addTag(out, m[1], m[2])
+		return
+	}
+}
+
+// applyType maps an Azure type string to portable Service + Type. Lower-case
+// before matching since Azure types are case-insensitive in KQL.
+func applyType(out *parsedKQL, azureType string) {
+	svc, typ := mapAzureType(strings.ToLower(azureType))
+	if svc != "" {
+		out.Query.Services = append(out.Query.Services, svc)
+	}
+
+	if typ != "" {
+		out.Query.Type = typ
+	}
+}
+
+func addTag(out *parsedKQL, key, value string) {
+	if out.Query.Tags == nil {
+		out.Query.Tags = make(map[string]string)
+	}
+
+	out.Query.Tags[key] = value
+}
+
+// mapAzureType translates a fully-qualified Azure resource type to the
+// portable (service, type) pair the engine uses. Returns ("", "") for
+// unmapped types so the filter is treated as match-none rather than
+// match-all.
+func mapAzureType(azureType string) (service, typ string) {
+	switch azureType {
+	case azureTypeVM:
+		return portableCompute, "Instance"
+	case azureTypeVNet:
+		return portableNetworking, "VPC"
+	case azureTypeSubnet, azureTypeSubnetN:
+		return portableNetworking, "Subnet"
+	case azureTypeNSG:
+		return portableNetworking, "SecurityGroup"
+	case azureTypeStorage, azureTypeStoCnt:
+		return portableStorage, "Bucket"
+	case azureTypeCosmos, azureTypeCosmosC:
+		return portableDatabase, "Table"
+	case azureTypeWebSite:
+		return portableServerless, "Function"
+	default:
+		return "", ""
+	}
+}

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -57,9 +57,20 @@ const (
 
 // parsedKQL is the result of KQL parsing — an engine Query plus the limit
 // extracted from `| limit N` / `| take N` (0 means no caller-specified limit).
+//
+// ForceEmpty is set when the parser detects a contradiction in chained
+// where-clauses (e.g. two different type filters AND-ed together). Real KQL
+// `where type == 'X' | where type == 'Y'` returns zero rows because a single
+// resource cannot have two types; the engine matcher would otherwise OR-merge
+// the two values via the Services slice, so we short-circuit at the handler.
 type parsedKQL struct {
-	Query resourcediscovery.Query
-	Limit int
+	Query      resourcediscovery.Query
+	Limit      int
+	ForceEmpty bool
+
+	// internal tracking — used by applyType / addTag to detect conflicts.
+	typeSet     bool
+	tagFirstVal map[string]string
 }
 
 // Pre-compiled KQL predicate regexes. Compiled once at package load; safe
@@ -157,11 +168,21 @@ func applyWhere(out *parsedKQL, body string) {
 }
 
 // applyType maps an Azure type string to portable Service + Type. Lower-case
-// before matching since Azure types are case-insensitive in KQL.
+// before matching since Azure types are case-insensitive in KQL. A second
+// type clause is treated as an AND contradiction — real KQL would yield
+// zero rows because a resource cannot have two types — so ForceEmpty is
+// flipped and later short-circuits the handler.
 func applyType(out *parsedKQL, azureType string) {
+	if out.typeSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.typeSet = true
+
 	svc, typ := mapAzureType(strings.ToLower(azureType))
 	if svc != "" {
-		out.Query.Services = append(out.Query.Services, svc)
+		out.Query.Services = []string{svc}
 	}
 
 	if typ != "" {
@@ -169,7 +190,21 @@ func applyType(out *parsedKQL, azureType string) {
 	}
 }
 
+// addTag records a tag predicate. Repeating the same key with a different
+// value is a KQL contradiction (a single tag cannot hold two values at
+// once); flips ForceEmpty so the handler returns an empty result.
 func addTag(out *parsedKQL, key, value string) {
+	if prev, seen := out.tagFirstVal[key]; seen && prev != value {
+		out.ForceEmpty = true
+		return
+	}
+
+	if out.tagFirstVal == nil {
+		out.tagFirstVal = make(map[string]string)
+	}
+
+	out.tagFirstVal[key] = value
+
 	if out.Query.Tags == nil {
 		out.Query.Tags = make(map[string]string)
 	}

--- a/server/azure/resourcegraph/kql_test.go
+++ b/server/azure/resourcegraph/kql_test.go
@@ -1,0 +1,124 @@
+package resourcegraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseKQL(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantSvcs  []string
+		wantType  string
+		wantRegn  string
+		wantTags  map[string]string
+		wantLimit int
+	}{
+		{
+			name:     "empty query",
+			query:    "",
+			wantSvcs: nil,
+		},
+		{
+			name:     "only Resources",
+			query:    "Resources",
+			wantSvcs: nil,
+		},
+		{
+			name:     "type equality",
+			query:    "Resources | where type == 'microsoft.compute/virtualmachines'",
+			wantSvcs: []string{"compute"},
+			wantType: "Instance",
+		},
+		{
+			name:     "type case-insensitive equality",
+			query:    "Resources | where type =~ 'Microsoft.Network/VirtualNetworks'",
+			wantSvcs: []string{"networking"},
+			wantType: "VPC",
+		},
+		{
+			name:     "location",
+			query:    "Resources | where location == 'eastus'",
+			wantRegn: "eastus",
+		},
+		{
+			name:     "tag bracket",
+			query:    "Resources | where tags['env'] == 'prod'",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "tag dot",
+			query:    "Resources | where tags.env == 'prod'",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "type + tag combined",
+			query:    "Resources | where type == 'microsoft.storage/storageaccounts' | where tags['env'] == 'prod'",
+			wantSvcs: []string{"storage"},
+			wantType: "Bucket",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:      "limit clause",
+			query:     "Resources | limit 50",
+			wantLimit: 50,
+		},
+		{
+			name:      "take clause",
+			query:     "Resources | take 10",
+			wantLimit: 10,
+		},
+		{
+			name:     "project clause ignored",
+			query:    "Resources | where type == 'microsoft.web/sites' | project id, name",
+			wantSvcs: []string{"serverless"},
+			wantType: "Function",
+		},
+		{
+			name:  "resourceGroup is a no-op",
+			query: "Resources | where resourceGroup == 'mygroup'",
+		},
+		{
+			name:  "unknown predicate tolerated",
+			query: "Resources | where sku.tier == 'Premium'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKQL(tt.query)
+			assert.Equal(t, tt.wantSvcs, got.Query.Services)
+			assert.Equal(t, tt.wantType, got.Query.Type)
+			assert.Equal(t, tt.wantRegn, got.Query.Region)
+			assert.Equal(t, tt.wantTags, got.Query.Tags)
+			assert.Equal(t, tt.wantLimit, got.Limit)
+		})
+	}
+}
+
+func TestMapAzureType(t *testing.T) {
+	tests := []struct {
+		azureType string
+		wantSvc   string
+		wantType  string
+	}{
+		{"microsoft.compute/virtualmachines", "compute", "Instance"},
+		{"microsoft.network/virtualnetworks", "networking", "VPC"},
+		{"microsoft.network/subnets", "networking", "Subnet"},
+		{"microsoft.network/networksecuritygroups", "networking", "SecurityGroup"},
+		{"microsoft.storage/storageaccounts", "storage", "Bucket"},
+		{"microsoft.documentdb/databaseaccounts", "database", "Table"},
+		{"microsoft.web/sites", "serverless", "Function"},
+		{"microsoft.unknown/widgets", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.azureType, func(t *testing.T) {
+			svc, typ := mapAzureType(tt.azureType)
+			assert.Equal(t, tt.wantSvc, svc)
+			assert.Equal(t, tt.wantType, typ)
+		})
+	}
+}

--- a/server/azure/resourcegraph/kql_test.go
+++ b/server/azure/resourcegraph/kql_test.go
@@ -122,3 +122,68 @@ func TestMapAzureType(t *testing.T) {
 		})
 	}
 }
+
+// TestParseKQL_ForceEmpty pins the AND-semantics fix: contradictory
+// chained where-clauses must surface ForceEmpty so the handler can return
+// zero rows. Real KQL would also yield zero — a resource cannot
+// simultaneously have two distinct types or two different tag values for
+// the same key.
+func TestParseKQL_ForceEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "two different type filters",
+			query: "Resources | where type == 'microsoft.compute/virtualmachines' | where type == 'microsoft.storage/storageaccounts'",
+		},
+		{
+			name:  "same type filter twice (still flagged — second clause is redundant by design)",
+			query: "Resources | where type == 'microsoft.compute/virtualmachines' | where type == 'microsoft.compute/virtualmachines'",
+		},
+		{
+			name:  "conflicting tag values for same key",
+			query: "Resources | where tags['env'] == 'prod' | where tags['env'] == 'stage'",
+		},
+		{
+			name:  "tag dot syntax conflicts with bracket syntax on same key",
+			query: "Resources | where tags['env'] == 'prod' | where tags.env == 'stage'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKQL(tt.query)
+			assert.True(t, got.ForceEmpty, "expected ForceEmpty for contradictory query: %q", tt.query)
+		})
+	}
+}
+
+// TestParseKQL_NoFalsePositiveForceEmpty makes sure agreeing/compatible
+// chained clauses do NOT trip the contradiction sentinel.
+func TestParseKQL_NoFalsePositiveForceEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "type + unrelated tag",
+			query: "Resources | where type == 'microsoft.compute/virtualmachines' | where tags['env'] == 'prod'",
+		},
+		{
+			name:  "two tag filters on different keys",
+			query: "Resources | where tags['env'] == 'prod' | where tags['team'] == 'data'",
+		},
+		{
+			name:  "same tag key+value repeated",
+			query: "Resources | where tags['env'] == 'prod' | where tags['env'] == 'prod'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKQL(tt.query)
+			assert.False(t, got.ForceEmpty, "ForceEmpty must not trip for compatible query: %q", tt.query)
+		})
+	}
+}

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -1,0 +1,189 @@
+// Real-SDK round-trip test: the live azure-sdk-for-go
+// armresourcegraph client drives the in-memory handler end-to-end.
+
+package resourcegraph_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func TestSDKResourceGraph(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "audit-logs"))
+	require.NoError(t, cloudP.BlobStorage.PutBucketTagging(ctx, "audit-logs",
+		map[string]string{"env": "prod", "team": "security"}))
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "stage-logs"))
+	require.NoError(t, cloudP.BlobStorage.PutBucketTagging(ctx, "stage-logs",
+		map[string]string{"env": "stage"}))
+
+	require.NoError(t, cloudP.CosmosDB.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloudP.CosmosDB.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	_, err := cloudP.VNet.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := azureserver.New(azureserver.Drivers{
+		BlobStorage:       cloudP.BlobStorage,
+		CosmosDB:          cloudP.CosmosDB,
+		Network:           cloudP.VNet,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	t.Run("query all resources", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+
+		data, ok := out.Data.([]any)
+		require.True(t, ok, "expected []any data, got %T", out.Data)
+		assert.GreaterOrEqual(t, len(data), 4, "expect 2 buckets + 1 table + 1 vnet")
+	})
+
+	t.Run("filter by type", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.storage/storageaccounts'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2, "two storage accounts")
+	})
+
+	t.Run("filter by type and tag", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.storage/storageaccounts' | where tags['env'] == 'prod'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 1)
+
+		row := data[0].(map[string]any)
+		assert.Equal(t, "audit-logs", row["name"])
+		assert.Equal(t, "microsoft.storage/storageaccounts", row["type"])
+
+		tags := row["tags"].(map[string]any)
+		assert.Equal(t, "prod", tags["env"])
+	})
+
+	t.Run("case-insensitive type match", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type =~ 'Microsoft.Network/VirtualNetworks'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 1, "the one VNet we seeded")
+	})
+
+	t.Run("subscription scoping — wrong sub returns empty", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query:         to.Ptr("Resources"),
+			Subscriptions: []*string{to.Ptr("some-other-sub")},
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
+
+	t.Run("limit clause caps results", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | limit 1"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 1)
+	})
+
+	t.Run("$top option caps results", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+			Options: &armresourcegraph.QueryRequestOptions{
+				Top: to.Ptr(int32(2)),
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2)
+	})
+
+	t.Run("returned resource IDs are Azure-shaped", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.network/virtualnetworks'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1)
+
+		row := data[0].(map[string]any)
+		id := row["id"].(string)
+		assert.Contains(t, id, "/subscriptions/123456789012/")
+		assert.Contains(t, id, "Microsoft.Network")
+		assert.Equal(t, "123456789012", row["subscriptionId"])
+	})
+}
+
+func newResourceGraphClient(t *testing.T, ts *httptest.Server) *armresourcegraph.Client {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armresourcegraph.NewClientFactory(fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cf.NewClient()
+}

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -187,3 +187,98 @@ func newResourceGraphClient(t *testing.T, ts *httptest.Server) *armresourcegraph
 
 	return cf.NewClient()
 }
+
+// TestSDKResourceGraph_BugFixes pins the three issues called out in the
+// PR #197 review so they cannot silently regress.
+func TestSDKResourceGraph_BugFixes(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "bkt"))
+	require.NoError(t, cloudP.BlobStorage.PutBucketTagging(ctx, "bkt",
+		map[string]string{"env": "prod"}))
+
+	_, err := cloudP.VNet.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	t.Run("Bug 1: contradictory type filters return empty (AND, not OR)", func(t *testing.T) {
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			SubscriptionID:    "123456789012",
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.compute/virtualmachines' | where type == 'microsoft.storage/storageaccounts'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords, "AND of two distinct types must yield zero")
+	})
+
+	t.Run("Bug 1: conflicting tag values for same key return empty", func(t *testing.T) {
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			SubscriptionID:    "123456789012",
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where tags['env'] == 'prod' | where tags['env'] == 'stage'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
+
+	t.Run("Bug 3: empty SubscriptionID falls back to engine.AccountID", func(t *testing.T) {
+		// Wire the server WITHOUT explicit SubscriptionID. Scoped queries
+		// for the engine's account ID should still work.
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			// SubscriptionID intentionally omitted.
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query:         to.Ptr("Resources"),
+			Subscriptions: []*string{to.Ptr(cloudP.ResourceDiscovery.AccountID())},
+		}, nil)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, *out.TotalRecords, int64(1),
+			"with SubscriptionID omitted, the handler must fall back to engine.AccountID() so scoped queries still match")
+	})
+
+	t.Run("Bug 2: /resources prefix does not shadow /resourcesHistory routing", func(t *testing.T) {
+		// Smoke-test the shadow case via the real client: ResourcesHistory
+		// must route to its own handler (which delegates back to
+		// queryResources today, but the dispatch path is distinct).
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			SubscriptionID:    "123456789012",
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.ResourcesHistory(ctx, armresourcegraph.ResourcesHistoryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+	})
+}


### PR DESCRIPTION
Closes #171. Phase 3 of the resource discovery trio. Real `azure-sdk-for-go` `armresourcegraph` clients drive the in-memory handler end-to-end.

## What this PR ships

**`server/azure/resourcegraph`** — ARM REST/JSON handler at `/providers/Microsoft.ResourceGraph/{resources,resourcesHistory,operations}`:

- **POST Resources.query** — main entry point; parses KQL, calls `engine.List`, returns the Azure ARG row shape.
- **POST ResourcesHistory.queryResourcesHistory** — returns current state as a single point-in-time snapshot. The mock has no time-travel; real history needs Azure Diagnostic Settings (out of scope).
- **GET Operations** — returns descriptors for the three supported ops.

**KQL subset parser** (`kql.go`) — documented subset that covers what real discovery callers send:

```kql
Resources
| where type == 'microsoft.compute/virtualmachines'
| where type =~ 'Microsoft.Network/VirtualNetworks'     // case-insensitive
| where location == 'eastus'
| where tags['env'] == 'prod'
| where tags.env == 'prod'
| project id, name                                       // ignored
| limit 100                                              // also: take
```

Unknown predicates and `resourceGroup` filters are tolerated and no-op'd — the stub favors returning some result over a 400 on syntax we don't model.

**Subscription scoping** — requests with a `Subscriptions` list that doesn't include the handler's `SubscriptionID` return an empty result rather than 4xx, matching real ARG behavior when callers scope to subscriptions they can't see.

**`$top` / `$skip` request options** compose with KQL `limit` / `take` — smaller cap wins.

## Out of scope (deferred)

- **Resource-group filtering** — the engine doesn't track RG; every Azure resource is bucketed under "default". `where resourceGroup == 'rg'` is a no-op.
- **Tag-set mutation via ARG** — Resource Graph is read-only; for tag writes, use `resourcegroupstaggingapi` (AWS-shaped) or a future ARM tag operation.
- **Full KQL grammar** — joins, summarize, mv-expand, ranges, etc. Document-only.
- **Diagnostic-settings-backed history** — `resourcesHistory` returns current snapshot.

## Wiring

`server/azure/Drivers` gains `ResourceDiscovery *resourcediscovery.Engine` and `SubscriptionID string`. Handler registers when `ResourceDiscovery` is non-nil; its path-prefix `Matches` is disjoint from every other Azure ARM URL so registration order is unconstrained.

## Verification

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [x] `golangci-lint run --timeout=9m ./...` 0 issues
- [x] Real `armresourcegraph` round-trip: 8 sub-tests covering query-all, filter-by-type, type+tag, case-insensitive match, subscription scoping, limit, `\$top`, Azure-shaped resource ID validation
- [x] KQL parser: 13 clause-shape table-driven tests + the full Azure type translation table