### PR TITLE
feat(gcp): Cloud Asset Inventory v1 SDK-compat handler (#172)

### DIFF
--- a/server/gcp/cloudasset/filter.go
+++ b/server/gcp/cloudasset/filter.go
@@ -1,0 +1,235 @@
+// Package cloudasset serves the GCP Cloud Asset Inventory v1 REST API
+// against a *resourcediscovery.Engine.
+//
+// Filter syntax (documented subset of the real Cloud Asset filter
+// expression):
+//
+//	service:storage.googleapis.com      service:compute.googleapis.com
+//	assetType:storage.googleapis.com/Bucket
+//	location:us-east1                    location:us-central1
+//	labels.env:prod                      tags.env:prod
+//
+// Multiple terms are whitespace-separated and AND-composed. Unknown keys
+// are tolerated and ignored (matches Cloud Asset's permissive behavior
+// for unknown fields). Contradictory terms (two distinct services in the
+// same query, or two values for the same label) flip ForceEmpty so the
+// handler short-circuits to an empty result — a single resource cannot
+// belong to two services or hold two values for one label, so the real
+// API would also return zero rows.
+package cloudasset
+
+import (
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// GCP service identifiers as they appear in Cloud Asset assetType strings.
+const (
+	gcpServiceCompute        = "compute.googleapis.com"
+	gcpServiceStorage        = "storage.googleapis.com"
+	gcpServiceFirestore      = "firestore.googleapis.com"
+	gcpServiceCloudFunctions = "cloudfunctions.googleapis.com"
+)
+
+// Fully-qualified GCP asset type strings — used in both directions
+// (parsing assetType filters AND emitting type in response rows).
+const (
+	atComputeInstance = "compute.googleapis.com/Instance"
+	atNetwork         = "compute.googleapis.com/Network"
+	atSubnetwork      = "compute.googleapis.com/Subnetwork"
+	atFirewall        = "compute.googleapis.com/Firewall"
+	atStorageBucket   = "storage.googleapis.com/Bucket"
+	atFirestoreDB     = "firestore.googleapis.com/Database"
+	atFirestoreColl   = "firestore.googleapis.com/Collection"
+	atCloudFunction   = "cloudfunctions.googleapis.com/Function"
+	atCloudFunctionV1 = "cloudfunctions.googleapis.com/CloudFunction"
+)
+
+// Portable service identifiers as emitted by resourcediscovery walkers.
+const (
+	portableCompute    = "compute"
+	portableNetworking = "networking"
+	portableStorage    = "storage"
+	portableDatabase   = "database"
+	portableServerless = "serverless"
+)
+
+// parsedFilter is the result of filter parsing — an engine Query plus
+// any caller-detected contradictions.
+type parsedFilter struct {
+	Query      resourcediscovery.Query
+	ForceEmpty bool
+
+	serviceSet bool
+	typeSet    bool
+	labelFirst map[string]string
+}
+
+// parseFilter converts a Cloud Asset filter expression into a Query.
+// Empty filter returns a zero Query (matches all). Unknown tokens are
+// silently ignored.
+func parseFilter(expr string) parsedFilter {
+	out := parsedFilter{}
+	if strings.TrimSpace(expr) == "" {
+		return out
+	}
+
+	for _, token := range strings.Fields(expr) {
+		applyToken(&out, token)
+	}
+
+	return out
+}
+
+func applyToken(out *parsedFilter, token string) {
+	key, val, ok := strings.Cut(token, ":")
+	if !ok || val == "" {
+		return
+	}
+
+	switch {
+	case key == "service":
+		applyService(out, val)
+	case key == "assetType":
+		applyAssetType(out, val)
+	case key == "location":
+		out.Query.Region = val
+	case strings.HasPrefix(key, "labels."):
+		addLabel(out, strings.TrimPrefix(key, "labels."), val)
+	case strings.HasPrefix(key, "tags."):
+		addLabel(out, strings.TrimPrefix(key, "tags."), val)
+	}
+}
+
+func applyService(out *parsedFilter, service string) {
+	if out.serviceSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.serviceSet = true
+
+	svc := gcpServiceToPortable(service)
+	if svc == "" {
+		return
+	}
+
+	out.Query.Services = expandPortableService(svc)
+}
+
+func applyAssetType(out *parsedFilter, assetType string) {
+	if out.typeSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.typeSet = true
+
+	svc, typ := mapGCPAssetType(assetType)
+	if svc != "" {
+		out.Query.Services = []string{svc}
+	}
+
+	if typ != "" {
+		out.Query.Type = typ
+	}
+}
+
+func addLabel(out *parsedFilter, key, value string) {
+	if prev, seen := out.labelFirst[key]; seen && prev != value {
+		out.ForceEmpty = true
+		return
+	}
+
+	if out.labelFirst == nil {
+		out.labelFirst = make(map[string]string)
+	}
+
+	out.labelFirst[key] = value
+
+	if out.Query.Tags == nil {
+		out.Query.Tags = make(map[string]string)
+	}
+
+	out.Query.Tags[key] = value
+}
+
+// gcpServiceToPortable maps a GCP service name (storage.googleapis.com)
+// to the portable service identifier. compute.googleapis.com is special:
+// it spans both portable "compute" and "networking" — the caller uses
+// expandPortableService to get the right Services set.
+func gcpServiceToPortable(service string) string {
+	switch service {
+	case gcpServiceCompute:
+		// caller should expand
+		return portableCompute
+	case gcpServiceStorage:
+		return portableStorage
+	case gcpServiceFirestore:
+		return portableDatabase
+	case gcpServiceCloudFunctions:
+		return portableServerless
+	default:
+		return ""
+	}
+}
+
+// expandPortableService turns a portable service into the slice the engine
+// matcher expects. compute.googleapis.com covers both VMs and networking
+// resources in real GCP, so a service:compute.googleapis.com filter must
+// match both portable services.
+func expandPortableService(svc string) []string {
+	if svc == portableCompute {
+		return []string{portableCompute, portableNetworking}
+	}
+
+	return []string{svc}
+}
+
+// mapGCPAssetType translates a fully-qualified GCP asset type
+// (compute.googleapis.com/Instance) to the portable (service, type) pair
+// the engine uses. Returns ("", "") for unmapped types.
+func mapGCPAssetType(assetType string) (service, typ string) {
+	switch assetType {
+	case atComputeInstance:
+		return portableCompute, "Instance"
+	case atNetwork:
+		return portableNetworking, "VPC"
+	case atSubnetwork:
+		return portableNetworking, "Subnet"
+	case atFirewall:
+		return portableNetworking, "SecurityGroup"
+	case atStorageBucket:
+		return portableStorage, "Bucket"
+	case atFirestoreDB, atFirestoreColl:
+		return portableDatabase, "Table"
+	case atCloudFunction, atCloudFunctionV1:
+		return portableServerless, "Function"
+	default:
+		return "", ""
+	}
+}
+
+// portableToGCPAssetType is the inverse — turns the engine's (service,
+// type) pair into the canonical GCP assetType string the API emits.
+func portableToGCPAssetType(service, typ string) string {
+	switch service + "/" + typ {
+	case portableCompute + "/Instance":
+		return atComputeInstance
+	case portableNetworking + "/VPC":
+		return atNetwork
+	case portableNetworking + "/Subnet":
+		return atSubnetwork
+	case portableNetworking + "/SecurityGroup":
+		return atFirewall
+	case portableStorage + "/Bucket":
+		return atStorageBucket
+	case portableDatabase + "/Table":
+		return atFirestoreDB
+	case portableServerless + "/Function":
+		return atCloudFunction
+	default:
+		return service + "/" + typ
+	}
+}

--- a/server/gcp/cloudasset/filter.go
+++ b/server/gcp/cloudasset/filter.go
@@ -115,7 +115,18 @@ func applyService(out *parsedFilter, service string) {
 		return
 	}
 
-	out.Query.Services = expandPortableService(svc)
+	newServices := expandPortableService(svc)
+
+	// Cross-clause contradiction: if an earlier assetType: pinned a
+	// narrower service set, a service: clause that doesn't overlap means
+	// "this resource must belong to two different services" — impossible,
+	// so flag ForceEmpty.
+	if out.typeSet && len(out.Query.Services) > 0 && !servicesIntersect(out.Query.Services, newServices) {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.Query.Services = newServices
 }
 
 func applyAssetType(out *parsedFilter, assetType string) {
@@ -128,12 +139,39 @@ func applyAssetType(out *parsedFilter, assetType string) {
 
 	svc, typ := mapGCPAssetType(assetType)
 	if svc != "" {
-		out.Query.Services = []string{svc}
+		newServices := []string{svc}
+
+		// Cross-clause contradiction: same idea as applyService — if a
+		// service: clause already narrowed Services and the new assetType
+		// belongs to a different service, no resource can satisfy both.
+		if out.serviceSet && len(out.Query.Services) > 0 && !servicesIntersect(out.Query.Services, newServices) {
+			out.ForceEmpty = true
+			return
+		}
+
+		out.Query.Services = newServices
 	}
 
 	if typ != "" {
 		out.Query.Type = typ
 	}
+}
+
+// servicesIntersect returns true when the two service-name sets share at
+// least one element. Used by the cross-clause contradiction checks above.
+func servicesIntersect(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+
+	for _, s := range b {
+		if _, ok := set[s]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addLabel(out *parsedFilter, key, value string) {

--- a/server/gcp/cloudasset/filter_test.go
+++ b/server/gcp/cloudasset/filter_test.go
@@ -96,12 +96,55 @@ func TestParseFilter_ForceEmpty(t *testing.T) {
 			name: "label vs tag conflict on same key",
 			expr: "labels.env:prod tags.env:stage",
 		},
+		{
+			name: "service then assetType cross-contradiction",
+			expr: "service:compute.googleapis.com assetType:storage.googleapis.com/Bucket",
+		},
+		{
+			name: "assetType then service cross-contradiction",
+			expr: "assetType:firestore.googleapis.com/Database service:storage.googleapis.com",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseFilter(tt.expr)
 			assert.True(t, got.ForceEmpty, "expected ForceEmpty for %q", tt.expr)
+		})
+	}
+}
+
+// TestParseFilter_ServiceAssetTypeAgreement verifies that compatible
+// service + assetType pairs are NOT flagged. compute.googleapis.com
+// covers both portable compute and networking — Instance + Network +
+// Subnetwork + Firewall all belong to that service.
+func TestParseFilter_ServiceAssetTypeAgreement(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "compute service + Instance assetType",
+			expr: "service:compute.googleapis.com assetType:compute.googleapis.com/Instance",
+		},
+		{
+			name: "compute service + Network assetType",
+			expr: "service:compute.googleapis.com assetType:compute.googleapis.com/Network",
+		},
+		{
+			name: "storage service + Bucket assetType",
+			expr: "service:storage.googleapis.com assetType:storage.googleapis.com/Bucket",
+		},
+		{
+			name: "reverse order: assetType then matching service",
+			expr: "assetType:compute.googleapis.com/Instance service:compute.googleapis.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilter(tt.expr)
+			assert.False(t, got.ForceEmpty, "agreeing service+assetType must not trip ForceEmpty: %q", tt.expr)
 		})
 	}
 }

--- a/server/gcp/cloudasset/filter_test.go
+++ b/server/gcp/cloudasset/filter_test.go
@@ -1,0 +1,153 @@
+package cloudasset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		wantSvcs []string
+		wantType string
+		wantRegn string
+		wantTags map[string]string
+	}{
+		{
+			name: "empty",
+			expr: "",
+		},
+		{
+			name:     "service compute expands to compute+networking",
+			expr:     "service:compute.googleapis.com",
+			wantSvcs: []string{"compute", "networking"},
+		},
+		{
+			name:     "service storage",
+			expr:     "service:storage.googleapis.com",
+			wantSvcs: []string{"storage"},
+		},
+		{
+			name:     "assetType pins service and type",
+			expr:     "assetType:storage.googleapis.com/Bucket",
+			wantSvcs: []string{"storage"},
+			wantType: "Bucket",
+		},
+		{
+			name:     "location",
+			expr:     "location:us-central1",
+			wantRegn: "us-central1",
+		},
+		{
+			name:     "labels prefix",
+			expr:     "labels.env:prod",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "tags prefix",
+			expr:     "tags.env:prod",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "service + label + location",
+			expr:     "service:storage.googleapis.com labels.env:prod location:us-east1",
+			wantSvcs: []string{"storage"},
+			wantRegn: "us-east1",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name: "unknown key ignored",
+			expr: "unknown:value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilter(tt.expr)
+			assert.Equal(t, tt.wantSvcs, got.Query.Services)
+			assert.Equal(t, tt.wantType, got.Query.Type)
+			assert.Equal(t, tt.wantRegn, got.Query.Region)
+			assert.Equal(t, tt.wantTags, got.Query.Tags)
+			assert.False(t, got.ForceEmpty, "non-contradictory filter must not trip ForceEmpty")
+		})
+	}
+}
+
+func TestParseFilter_ForceEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "two different services",
+			expr: "service:compute.googleapis.com service:storage.googleapis.com",
+		},
+		{
+			name: "two different assetTypes",
+			expr: "assetType:storage.googleapis.com/Bucket assetType:firestore.googleapis.com/Database",
+		},
+		{
+			name: "conflicting label values for same key",
+			expr: "labels.env:prod labels.env:stage",
+		},
+		{
+			name: "label vs tag conflict on same key",
+			expr: "labels.env:prod tags.env:stage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilter(tt.expr)
+			assert.True(t, got.ForceEmpty, "expected ForceEmpty for %q", tt.expr)
+		})
+	}
+}
+
+func TestMapGCPAssetType(t *testing.T) {
+	tests := []struct {
+		assetType string
+		wantSvc   string
+		wantType  string
+	}{
+		{"compute.googleapis.com/Instance", "compute", "Instance"},
+		{"compute.googleapis.com/Network", "networking", "VPC"},
+		{"compute.googleapis.com/Subnetwork", "networking", "Subnet"},
+		{"compute.googleapis.com/Firewall", "networking", "SecurityGroup"},
+		{"storage.googleapis.com/Bucket", "storage", "Bucket"},
+		{"firestore.googleapis.com/Database", "database", "Table"},
+		{"cloudfunctions.googleapis.com/Function", "serverless", "Function"},
+		{"unknown.googleapis.com/Widget", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.assetType, func(t *testing.T) {
+			svc, typ := mapGCPAssetType(tt.assetType)
+			assert.Equal(t, tt.wantSvc, svc)
+			assert.Equal(t, tt.wantType, typ)
+		})
+	}
+}
+
+func TestPortableToGCPAssetType_Roundtrip(t *testing.T) {
+	cases := []struct {
+		svc  string
+		typ  string
+		want string
+	}{
+		{"compute", "Instance", "compute.googleapis.com/Instance"},
+		{"networking", "VPC", "compute.googleapis.com/Network"},
+		{"networking", "Subnet", "compute.googleapis.com/Subnetwork"},
+		{"networking", "SecurityGroup", "compute.googleapis.com/Firewall"},
+		{"storage", "Bucket", "storage.googleapis.com/Bucket"},
+		{"database", "Table", "firestore.googleapis.com/Database"},
+		{"serverless", "Function", "cloudfunctions.googleapis.com/Function"},
+	}
+
+	for _, c := range cases {
+		got := portableToGCPAssetType(c.svc, c.typ)
+		assert.Equal(t, c.want, got)
+	}
+}

--- a/server/gcp/cloudasset/handler.go
+++ b/server/gcp/cloudasset/handler.go
@@ -49,8 +49,9 @@ type Handler struct {
 	engine    *resourcediscovery.Engine
 	projectID string
 
-	mu    sync.RWMutex
-	feeds map[string]*feed // keyed by full feed name (projects/X/feeds/Y)
+	mu         sync.RWMutex
+	feeds      map[string]*feed          // keyed by full feed name (projects/X/feeds/Y)
+	operations map[string]map[string]any // keyed by op name; caches completed export results
 }
 
 type feed struct {
@@ -73,11 +74,17 @@ func New(engine *resourcediscovery.Engine, projectID string) *Handler {
 	}
 
 	return &Handler{
-		engine:    engine,
-		projectID: projectID,
-		feeds:     make(map[string]*feed),
+		engine:     engine,
+		projectID:  projectID,
+		feeds:      make(map[string]*feed),
+		operations: make(map[string]map[string]any),
 	}
 }
+
+// operationNamePrefix tags operation IDs we own so the Operations.Get
+// path matcher (very broadly /v1/.../operations/...) only claims ours and
+// not the GCE/compute operations served by other handlers.
+const operationNamePrefix = "cloudemu-export-"
 
 // Matches accepts paths that are unambiguously Cloud Asset. We match
 // narrowly to avoid shadowing other GCP REST handlers (firestore claims
@@ -93,6 +100,13 @@ func (*Handler) Matches(r *http.Request) bool {
 		if _, ok := customMethods[p[i+1:]]; ok {
 			return true
 		}
+	}
+
+	// /v1/{parent}/operations/cloudemu-export-... — claim only operation
+	// names this package creates; other handlers (compute, networks)
+	// serve their own /operations/ paths.
+	if strings.Contains(p, "/operations/"+operationNamePrefix) {
+		return true
 	}
 
 	// /v1/{parent}/assets or /v1/{parent}/feeds[/{id}]
@@ -130,9 +144,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// /v1/{parent}/operations/cloudemu-export-... — the result of an
+	// earlier exportAssets call. Cached in h.operations.
+	if before, id, ok := segmentBeforeLast(p, "/operations/"); ok && strings.HasPrefix(id, operationNamePrefix) {
+		h.getOperation(w, r, stripAPIPrefix(before)+"/operations/"+id)
+		return
+	}
+
 	// /v1/{parent}/feeds/{id} — derive the canonical feed name without /v1/.
 	if before, id, ok := segmentBeforeLast(p, "/feeds/"); ok {
+		if strings.ContainsRune(id, '/') {
+			writeError(w, http.StatusNotFound, "NOT_FOUND",
+				"feed id cannot contain '/': "+id)
+
+			return
+		}
+
 		h.serveFeedItem(w, r, stripAPIPrefix(before)+"/feeds/"+id)
+
 		return
 	}
 
@@ -227,36 +256,60 @@ func (*Handler) searchAllIamPolicies(w http.ResponseWriter, _ *http.Request, _ s
 
 // ----- exportAssets -----
 
-func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, _ string) {
+func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, scope string) {
 	body := readJSONBody(r)
 
 	parsed := parseFilter(strOrEmpty(body["filter"]))
-	if parsed.ForceEmpty {
-		writeJSON(w, http.StatusOK, completedExportOperation(nil))
-		return
+
+	var results []resourcediscovery.Resource
+
+	if !parsed.ForceEmpty {
+		var err error
+
+		results, err = h.engine.List(r.Context(), parsed.Query)
+		if err != nil {
+			writeCErr(w, err)
+			return
+		}
 	}
 
-	results, err := h.engine.List(r.Context(), parsed.Query)
-	if err != nil {
-		writeCErr(w, err)
-		return
+	op := h.buildAndCacheExportOperation(scope, results)
+	writeJSON(w, http.StatusOK, op)
+}
+
+// buildAndCacheExportOperation creates the LRO response and caches it under
+// its name so a subsequent Operations.Get can find it. The operation is
+// scope-prefixed (projects/X/operations/cloudemu-export-...) so the path
+// matcher in ServeHTTP routes the poll back to this handler.
+func (h *Handler) buildAndCacheExportOperation(scope string, results []resourcediscovery.Resource) map[string]any {
+	if scope == "" {
+		scope = "projects/" + h.projectID
 	}
 
-	writeJSON(w, http.StatusOK, completedExportOperation(results))
+	name := scope + "/operations/" + operationNamePrefix + strconv.FormatInt(time.Now().UnixNano(), 10)
+	op := completedExportOperation(name, results)
+
+	h.mu.Lock()
+	h.operations[name] = op
+	h.mu.Unlock()
+
+	return op
 }
 
 // completedExportOperation builds the synchronous LRO response shape.
-// Real Cloud Asset returns an operation name that the caller polls; the
-// mock returns done=true with the asset list inline so SDK calls that
-// expect the operation to be ready immediately work without polling.
-func completedExportOperation(results []resourcediscovery.Resource) map[string]any {
+// Real Cloud Asset is async — it returns an operation name that the
+// caller polls via Operations.Get. The mock returns done=true with the
+// asset list inline so most callers (which call .Do() and check Done)
+// work without polling, AND caches the response under name so callers
+// that DO poll via Operations.Get find a matching entry.
+func completedExportOperation(name string, results []resourcediscovery.Resource) map[string]any {
 	assets := make([]map[string]any, 0, len(results))
 	for i := range results {
 		assets = append(assets, resourceToAsset(&results[i]))
 	}
 
 	return map[string]any{
-		"name": "operations/cloudemu-export-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		"name": name,
 		"done": true,
 		"metadata": map[string]any{
 			"@type": "type.googleapis.com/google.cloud.asset.v1.ExportAssetsRequest",
@@ -268,6 +321,22 @@ func completedExportOperation(results []resourcediscovery.Resource) map[string]a
 			"outputUriPrefix": "cloudemu://in-memory",
 		},
 	}
+}
+
+// getOperation serves Operations.Get for export operations cached by an
+// earlier exportAssets call. Method is implicitly GET; we don't enforce
+// because the dispatch already routed here for any verb on this path.
+func (h *Handler) getOperation(w http.ResponseWriter, _ *http.Request, name string) {
+	h.mu.RLock()
+	op, ok := h.operations[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "operation not found: "+name)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, op)
 }
 
 // ----- batchGetAssetsHistory -----

--- a/server/gcp/cloudasset/handler.go
+++ b/server/gcp/cloudasset/handler.go
@@ -1,0 +1,759 @@
+package cloudasset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// Path prefix shared by every Cloud Asset operation.
+const apiPrefix = "/v1/"
+
+// Custom-method names that may appear after a colon in the URL — e.g.,
+// /v1/projects/X:searchAllResources.
+const (
+	methodSearchAllResources    = "searchAllResources"
+	methodSearchAllIamPolicies  = "searchAllIamPolicies"
+	methodExportAssets          = "exportAssets"
+	methodBatchGetAssetsHistory = "batchGetAssetsHistory"
+)
+
+// Body size cap for any JSON request — matches the firestore handler.
+const maxBodyBytes = 5 << 20
+
+// Custom-method dispatch table. Immutable; declared as a package-level
+// var because Go does not allow const maps.
+//
+//nolint:gochecknoglobals // immutable lookup set.
+var customMethods = map[string]struct{}{
+	methodSearchAllResources:    {},
+	methodSearchAllIamPolicies:  {},
+	methodExportAssets:          {},
+	methodBatchGetAssetsHistory: {},
+}
+
+// Sentinel feed error so handler tests can match exactly without %w wrap.
+var errFeedNotFound = errors.New("feed not found")
+
+// Handler serves Cloud Asset Inventory v1 REST requests.
+type Handler struct {
+	engine    *resourcediscovery.Engine
+	projectID string
+
+	mu    sync.RWMutex
+	feeds map[string]*feed // keyed by full feed name (projects/X/feeds/Y)
+}
+
+type feed struct {
+	Name        string            `json:"name"`
+	AssetNames  []string          `json:"assetNames,omitempty"`
+	AssetTypes  []string          `json:"assetTypes,omitempty"`
+	ContentType string            `json:"contentType,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	FeedOutput  map[string]any    `json:"feedOutputConfig,omitempty"`
+	Condition   map[string]any    `json:"condition,omitempty"`
+}
+
+// New returns a Cloud Asset handler backed by engine. projectID is used
+// for feed-name validation and asset scoping; if empty, the engine's own
+// AccountID (which holds the GCP project ID for GCP engines) is used so
+// callers don't have to repeat it.
+func New(engine *resourcediscovery.Engine, projectID string) *Handler {
+	if projectID == "" && engine != nil {
+		projectID = engine.AccountID()
+	}
+
+	return &Handler{
+		engine:    engine,
+		projectID: projectID,
+		feeds:     make(map[string]*feed),
+	}
+}
+
+// Matches accepts paths that are unambiguously Cloud Asset. We match
+// narrowly to avoid shadowing other GCP REST handlers (firestore claims
+// /v1/projects/ broadly), so registration order is forgiving.
+func (*Handler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+	if !strings.HasPrefix(p, apiPrefix) {
+		return false
+	}
+
+	// Custom methods (colon syntax): /v1/{scope}:method.
+	if i := strings.LastIndexByte(p, ':'); i > len(apiPrefix) {
+		if _, ok := customMethods[p[i+1:]]; ok {
+			return true
+		}
+	}
+
+	// /v1/{parent}/assets or /v1/{parent}/feeds[/{id}]
+	return pathHasSegment(p, "assets") || pathHasSegment(p, "feeds")
+}
+
+func pathHasSegment(p, seg string) bool {
+	for _, part := range strings.Split(p, "/") {
+		if part == seg {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+
+	if i := strings.LastIndexByte(p, ':'); i > len(apiPrefix) {
+		method := p[i+1:]
+		scope := stripAPIPrefix(p[:i])
+		h.serveCustomMethod(w, r, scope, method)
+
+		return
+	}
+
+	if endsWith, parent := segmentSuffix(p, "/assets"); endsWith {
+		h.listAssets(w, r, stripAPIPrefix(parent))
+		return
+	}
+
+	if endsWith, parent := segmentSuffix(p, "/feeds"); endsWith {
+		h.serveFeedsCollection(w, r, stripAPIPrefix(parent))
+		return
+	}
+
+	// /v1/{parent}/feeds/{id} — derive the canonical feed name without /v1/.
+	if before, id, ok := segmentBeforeLast(p, "/feeds/"); ok {
+		h.serveFeedItem(w, r, stripAPIPrefix(before)+"/feeds/"+id)
+		return
+	}
+
+	writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown Cloud Asset path: "+p)
+}
+
+// stripAPIPrefix removes the leading "/v1/" so derived names match the
+// canonical GCP shape (projects/X/feeds/Y, not /v1/projects/X/feeds/Y).
+func stripAPIPrefix(p string) string {
+	return strings.TrimPrefix(p, apiPrefix)
+}
+
+// expectedMethod returns the HTTP method the real Cloud Asset API uses for
+// each custom method. Search and history are GETs; export is a POST
+// long-running operation.
+func expectedMethod(method string) string {
+	if method == methodExportAssets {
+		return http.MethodPost
+	}
+
+	return http.MethodGet
+}
+
+func (h *Handler) serveCustomMethod(w http.ResponseWriter, r *http.Request, scope, method string) {
+	if want := expectedMethod(method); r.Method != want {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+			want+" required for "+method)
+
+		return
+	}
+
+	switch method {
+	case methodSearchAllResources:
+		h.searchAllResources(w, r, scope)
+	case methodSearchAllIamPolicies:
+		h.searchAllIamPolicies(w, r, scope)
+	case methodExportAssets:
+		h.exportAssets(w, r, scope)
+	case methodBatchGetAssetsHistory:
+		h.batchGetAssetsHistory(w, r, scope)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+method)
+	}
+}
+
+// ----- searchAllResources -----
+
+func (h *Handler) searchAllResources(w http.ResponseWriter, r *http.Request, _ string) {
+	// Real Cloud Asset takes filter as a query param OR body field. Support
+	// both; body wins if both supplied.
+	body := readJSONBody(r)
+
+	filter := r.URL.Query().Get("query")
+	if v, ok := body["query"].(string); ok && v != "" {
+		filter = v
+	}
+
+	pageSize := intParam(r, body, "pageSize")
+
+	parsed := parseFilter(filter)
+	if parsed.ForceEmpty {
+		writeJSON(w, http.StatusOK, map[string]any{"results": []any{}})
+		return
+	}
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if pageSize > 0 && pageSize < len(results) {
+		results = results[:pageSize]
+	}
+
+	out := make([]map[string]any, 0, len(results))
+	for i := range results {
+		out = append(out, resourceToSearchResult(&results[i], h.projectID))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"results": out})
+}
+
+// ----- searchAllIamPolicies -----
+
+func (*Handler) searchAllIamPolicies(w http.ResponseWriter, _ *http.Request, _ string) {
+	// IAM policy walking is out of scope for Phase 4 — the engine doesn't
+	// expose iam driver state. Return empty so callers can probe the API
+	// without erroring out.
+	writeJSON(w, http.StatusOK, map[string]any{"results": []any{}})
+}
+
+// ----- exportAssets -----
+
+func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, _ string) {
+	body := readJSONBody(r)
+
+	parsed := parseFilter(strOrEmpty(body["filter"]))
+	if parsed.ForceEmpty {
+		writeJSON(w, http.StatusOK, completedExportOperation(nil))
+		return
+	}
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, completedExportOperation(results))
+}
+
+// completedExportOperation builds the synchronous LRO response shape.
+// Real Cloud Asset returns an operation name that the caller polls; the
+// mock returns done=true with the asset list inline so SDK calls that
+// expect the operation to be ready immediately work without polling.
+func completedExportOperation(results []resourcediscovery.Resource) map[string]any {
+	assets := make([]map[string]any, 0, len(results))
+	for i := range results {
+		assets = append(assets, resourceToAsset(&results[i]))
+	}
+
+	return map[string]any{
+		"name": "operations/cloudemu-export-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		"done": true,
+		"metadata": map[string]any{
+			"@type": "type.googleapis.com/google.cloud.asset.v1.ExportAssetsRequest",
+		},
+		"response": map[string]any{
+			"@type":           "type.googleapis.com/google.cloud.asset.v1.ExportAssetsResponse",
+			"readTime":        time.Now().UTC().Format(time.RFC3339Nano),
+			"assets":          assets,
+			"outputUriPrefix": "cloudemu://in-memory",
+		},
+	}
+}
+
+// ----- batchGetAssetsHistory -----
+
+func (h *Handler) batchGetAssetsHistory(w http.ResponseWriter, r *http.Request, _ string) {
+	body := readJSONBody(r)
+
+	parsed := parseFilter(strOrEmpty(body["filter"]))
+	if parsed.ForceEmpty {
+		writeJSON(w, http.StatusOK, map[string]any{"assets": []any{}})
+		return
+	}
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// Real API returns TemporalAsset entries with window timestamps; the
+	// mock has no time-travel, so each asset gets a single window starting
+	// at the read time.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	out := make([]map[string]any, 0, len(results))
+	for i := range results {
+		out = append(out, map[string]any{
+			"window": map[string]any{"startTime": now, "endTime": now},
+			"asset":  resourceToAsset(&results[i]),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"assets": out})
+}
+
+// ----- assets.list -----
+//
+// Real assets.list does not take a free-form filter expression. The SDK
+// surfaces it as repeated assetTypes={...} query params plus pageSize.
+// We honor assetTypes (any-of match) and ignore contentType / readTime
+// since the mock has no time-travel or per-content-type projections.
+
+func (h *Handler) listAssets(w http.ResponseWriter, r *http.Request, _ string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "GET required for assets.list")
+		return
+	}
+
+	assetTypes := r.URL.Query()["assetTypes"]
+	pageSize := intParam(r, nil, "pageSize")
+
+	allResults, err := h.collectAssetsForTypes(r.Context(), assetTypes)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if pageSize > 0 && pageSize < len(allResults) {
+		allResults = allResults[:pageSize]
+	}
+
+	out := make([]map[string]any, 0, len(allResults))
+	for i := range allResults {
+		out = append(out, resourceToAsset(&allResults[i]))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"assets":   out,
+		"readTime": nowRFC(),
+	})
+}
+
+// collectAssetsForTypes runs one engine query per assetType filter and
+// merges the results. If no assetTypes are supplied, returns the full
+// inventory in a single query.
+func (h *Handler) collectAssetsForTypes(ctx context.Context, assetTypes []string) ([]resourcediscovery.Resource, error) {
+	if len(assetTypes) == 0 {
+		return h.engine.ListAll(ctx)
+	}
+
+	var all []resourcediscovery.Resource
+
+	for _, at := range assetTypes {
+		svc, typ := mapGCPAssetType(at)
+		if svc == "" {
+			continue
+		}
+
+		batch, err := h.engine.List(ctx, resourcediscovery.Query{
+			Services: []string{svc},
+			Type:     typ,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, batch...)
+	}
+
+	return all, nil
+}
+
+// ----- Feeds collection (POST create, GET list) -----
+
+func (h *Handler) serveFeedsCollection(w http.ResponseWriter, r *http.Request, parent string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createFeed(w, r, parent)
+	case http.MethodGet:
+		h.listFeeds(w, r, parent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+			"only POST and GET are supported on the feeds collection")
+	}
+}
+
+func (h *Handler) createFeed(w http.ResponseWriter, r *http.Request, parent string) {
+	body := readJSONBody(r)
+
+	feedID := strOrEmpty(body["feedId"])
+	if feedID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "feedId is required")
+		return
+	}
+
+	feedBody, _ := body["feed"].(map[string]any)
+	name := parent + "/feeds/" + feedID
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, exists := h.feeds[name]; exists {
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", "feed already exists: "+name)
+		return
+	}
+
+	f := feedFromBody(feedBody)
+	f.Name = name
+	h.feeds[name] = f
+
+	writeJSON(w, http.StatusOK, feedToWire(f))
+}
+
+func (h *Handler) listFeeds(w http.ResponseWriter, _ *http.Request, parent string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	prefix := parent + "/feeds/"
+	out := make([]map[string]any, 0)
+
+	for name, f := range h.feeds {
+		if strings.HasPrefix(name, prefix) {
+			out = append(out, feedToWire(f))
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"feeds": out})
+}
+
+// ----- Feed item (GET, PATCH, DELETE) -----
+
+func (h *Handler) serveFeedItem(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeed(w, name)
+	case http.MethodPatch:
+		h.patchFeed(w, r, name)
+	case http.MethodDelete:
+		h.deleteFeed(w, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+			"only GET, PATCH, DELETE are supported on a feed item")
+	}
+}
+
+func (h *Handler) getFeed(w http.ResponseWriter, name string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	f, ok := h.feeds[name]
+	if !ok {
+		writeNotFound(w, name)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, feedToWire(f))
+}
+
+func (h *Handler) patchFeed(w http.ResponseWriter, r *http.Request, name string) {
+	body := readJSONBody(r)
+
+	// The PATCH body is an UpdateFeedRequest: { "feed": {...}, "updateMask": ... }.
+	// Unwrap the inner feed before merging so partial updates land on the
+	// right fields.
+	feedBody, _ := body["feed"].(map[string]any)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	f, ok := h.feeds[name]
+	if !ok {
+		writeNotFound(w, name)
+		return
+	}
+
+	mergeFeed(f, feedBody)
+	writeJSON(w, http.StatusOK, feedToWire(f))
+}
+
+func (h *Handler) deleteFeed(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.feeds[name]; !ok {
+		writeNotFound(w, name)
+		return
+	}
+
+	delete(h.feeds, name)
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// ----- helpers -----
+
+func writeNotFound(w http.ResponseWriter, name string) {
+	writeError(w, http.StatusNotFound, "NOT_FOUND", errFeedNotFound.Error()+": "+name)
+}
+
+// segmentSuffix reports whether p ends with the given /segment.
+// Returns ok and the path before the suffix.
+func segmentSuffix(p, suffix string) (ok bool, before string) {
+	if !strings.HasSuffix(p, suffix) {
+		return false, ""
+	}
+
+	return true, strings.TrimSuffix(p, suffix)
+}
+
+// segmentBeforeLast splits p around the LAST occurrence of marker.
+// Returns the part before, the part after, and ok=true if found.
+func segmentBeforeLast(p, marker string) (before, after string, ok bool) {
+	i := strings.LastIndex(p, marker)
+	if i < 0 {
+		return "", "", false
+	}
+
+	return p[:i], p[i+len(marker):], true
+}
+
+func readJSONBody(r *http.Request) map[string]any {
+	out := map[string]any{}
+	if r.Body == nil {
+		return out
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil || len(raw) == 0 {
+		return out
+	}
+
+	_ = json.Unmarshal(raw, &out)
+
+	return out
+}
+
+func strOrEmpty(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func intParam(r *http.Request, body map[string]any, key string) int {
+	if v, ok := body[key]; ok {
+		switch n := v.(type) {
+		case float64:
+			return int(n)
+		case int:
+			return n
+		}
+	}
+
+	if s := r.URL.Query().Get(key); s != "" {
+		n, err := strconv.Atoi(s)
+		if err == nil {
+			return n
+		}
+	}
+
+	return 0
+}
+
+func nowRFC() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+// resourceToSearchResult formats one Resource for the searchAllResources
+// response. GCP uses a "name" of //service/path.
+func resourceToSearchResult(r *resourcediscovery.Resource, project string) map[string]any {
+	return map[string]any{
+		"name":        gcpResourceName(r),
+		"assetType":   portableToGCPAssetType(r.Service, r.Type),
+		"project":     "projects/" + project,
+		"location":    r.Region,
+		"displayName": r.ID,
+		"labels":      labelsOrEmpty(r.Tags),
+	}
+}
+
+// resourceToAsset formats one Resource for the exportAssets / batchGet
+// response shape: { name, asset_type, resource: {...} }.
+func resourceToAsset(r *resourcediscovery.Resource) map[string]any {
+	return map[string]any{
+		"name":      gcpResourceName(r),
+		"assetType": portableToGCPAssetType(r.Service, r.Type),
+		"resource": map[string]any{
+			"version":              "v1",
+			"discoveryDocumentUri": "",
+			"discoveryName":        r.Type,
+			"location":             r.Region,
+			"data":                 map[string]any{"id": r.ID, "labels": labelsOrEmpty(r.Tags)},
+		},
+	}
+}
+
+// gcpResourceName builds the //service/path identifier GCP uses for assets.
+// For most resources the engine's ARN is already a GCP self-link
+// (projects/.../...), so prefix with the service host.
+func gcpResourceName(r *resourcediscovery.Resource) string {
+	host := portableServiceHost(r.Service)
+	if !strings.HasPrefix(r.ARN, "//") {
+		return "//" + host + "/" + r.ARN
+	}
+
+	return r.ARN
+}
+
+func portableServiceHost(service string) string {
+	switch service {
+	case portableCompute, portableNetworking:
+		return gcpServiceCompute
+	case portableStorage:
+		return gcpServiceStorage
+	case portableDatabase:
+		return gcpServiceFirestore
+	case portableServerless:
+		return gcpServiceCloudFunctions
+	default:
+		return service + ".googleapis.com"
+	}
+}
+
+func labelsOrEmpty(t map[string]string) map[string]string {
+	if t == nil {
+		return map[string]string{}
+	}
+
+	return t
+}
+
+func feedFromBody(body map[string]any) *feed {
+	f := &feed{}
+	if body == nil {
+		return f
+	}
+
+	mergeFeed(f, body)
+
+	return f
+}
+
+func mergeFeed(f *feed, body map[string]any) {
+	if v, ok := body["assetNames"].([]any); ok {
+		f.AssetNames = toStringSlice(v)
+	}
+
+	if v, ok := body["assetTypes"].([]any); ok {
+		f.AssetTypes = toStringSlice(v)
+	}
+
+	if v, ok := body["contentType"].(string); ok {
+		f.ContentType = v
+	}
+
+	if v, ok := body["labels"].(map[string]any); ok {
+		f.Labels = toStringMap(v)
+	}
+
+	if v, ok := body["feedOutputConfig"].(map[string]any); ok {
+		f.FeedOutput = v
+	}
+
+	if v, ok := body["condition"].(map[string]any); ok {
+		f.Condition = v
+	}
+}
+
+func toStringSlice(in []any) []string {
+	out := make([]string, 0, len(in))
+
+	for _, v := range in {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+func toStringMap(in map[string]any) map[string]string {
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+
+	return out
+}
+
+func feedToWire(f *feed) map[string]any {
+	out := map[string]any{
+		"name": f.Name,
+	}
+
+	if len(f.AssetNames) > 0 {
+		out["assetNames"] = f.AssetNames
+	}
+
+	if len(f.AssetTypes) > 0 {
+		out["assetTypes"] = f.AssetTypes
+	}
+
+	if f.ContentType != "" {
+		out["contentType"] = f.ContentType
+	}
+
+	if f.Labels != nil {
+		out["labels"] = f.Labels
+	}
+
+	if f.FeedOutput != nil {
+		out["feedOutputConfig"] = f.FeedOutput
+	}
+
+	if f.Condition != nil {
+		out["condition"] = f.Condition
+	}
+
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError emits a googleapi-shaped error. The status code (e.g.
+// ALREADY_EXISTS) is also prefixed onto the message so callers using
+// substring matching against the SDK's error.Error() string can still
+// recognize it — the googleapi error helper surfaces message, not status.
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	combined := code + ": " + msg
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"status":  code,
+			"message": combined,
+		},
+	})
+}
+
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}
+
+// Compile-time check the handler implements the dispatch interface.
+var _ interface {
+	Matches(*http.Request) bool
+	http.Handler
+} = (*Handler)(nil)

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -1,0 +1,258 @@
+// Real-SDK round-trip test: the live google.golang.org/api/cloudasset/v1
+// REST client drives the in-memory handler end-to-end.
+
+package cloudasset_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/cloudasset/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+func TestSDKCloudAsset(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "my-test-project"
+
+	// Seed inventory across services.
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "audit-logs"))
+	require.NoError(t, cloudP.GCS.PutBucketTagging(ctx, "audit-logs",
+		map[string]string{"env": "prod", "team": "security"}))
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "stage-logs"))
+	require.NoError(t, cloudP.GCS.PutBucketTagging(ctx, "stage-logs",
+		map[string]string{"env": "stage"}))
+
+	require.NoError(t, cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloudP.Firestore.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	_, err := cloudP.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		Firestore:         cloudP.Firestore,
+		Networking:        cloudP.VPC,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	scope := "projects/" + projectID
+
+	t.Run("searchAllResources returns everything when filter is empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Do()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Results), 4, "expect 2 buckets + 1 table + 1 vpc")
+	})
+
+	t.Run("searchAllResources filters by service", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("service:storage.googleapis.com").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Results, 2)
+		for _, r := range out.Results {
+			assert.Equal(t, "storage.googleapis.com/Bucket", r.AssetType)
+		}
+	})
+
+	t.Run("searchAllResources filters by label", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("labels.env:prod").Do()
+		require.NoError(t, err)
+		// audit-logs bucket + events table + VPC — 3 prod resources.
+		assert.Len(t, out.Results, 3)
+	})
+
+	t.Run("searchAllResources combines service + label", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("service:storage.googleapis.com labels.env:prod").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Results, 1)
+		assert.Equal(t, "audit-logs", out.Results[0].DisplayName)
+	})
+
+	t.Run("searchAllResources: contradiction returns empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("service:storage.googleapis.com service:firestore.googleapis.com").Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("searchAllResources: conflicting label values returns empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("labels.env:prod labels.env:stage").Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("searchAllIamPolicies returns empty (out of scope)", func(t *testing.T) {
+		out, err := client.V1.SearchAllIamPolicies(scope).Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("assets.list returns full inventory", func(t *testing.T) {
+		out, err := client.Assets.List(scope).Do()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Assets), 4)
+	})
+
+	t.Run("assets.list with assetTypes narrows results", func(t *testing.T) {
+		out, err := client.Assets.List(scope).
+			AssetTypes("firestore.googleapis.com/Database").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Assets, 1)
+	})
+
+	t.Run("assets.list with multiple assetTypes is any-of", func(t *testing.T) {
+		out, err := client.Assets.List(scope).
+			AssetTypes("firestore.googleapis.com/Database", "storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		// 1 firestore + 2 buckets = 3
+		assert.Len(t, out.Assets, 3)
+	})
+
+	t.Run("exportAssets returns sync operation with results inline", func(t *testing.T) {
+		op, err := client.V1.ExportAssets(scope, &cloudasset.ExportAssetsRequest{}).Do()
+		require.NoError(t, err)
+		assert.True(t, op.Done)
+		require.NotNil(t, op.Response)
+		assert.Contains(t, string(op.Response), "audit-logs")
+	})
+
+	t.Run("returned resource names are GCP-shaped (//service/path)", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("assetType:storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		require.NotEmpty(t, out.Results)
+		for _, r := range out.Results {
+			assert.True(t, strings.HasPrefix(r.Name, "//storage.googleapis.com/"),
+				"bucket name should start with //storage.googleapis.com/, got %q", r.Name)
+		}
+	})
+
+	// ----- Feeds CRUD -----
+	feedID := "audit-feed"
+	feedName := scope + "/feeds/" + feedID
+
+	t.Run("Feeds.Create", func(t *testing.T) {
+		created, err := client.Feeds.Create(scope, &cloudasset.CreateFeedRequest{
+			FeedId: feedID,
+			Feed: &cloudasset.Feed{
+				AssetTypes:  []string{"storage.googleapis.com/Bucket"},
+				ContentType: "RESOURCE",
+				FeedOutputConfig: &cloudasset.FeedOutputConfig{
+					PubsubDestination: &cloudasset.PubsubDestination{
+						Topic: "projects/" + projectID + "/topics/asset-changes",
+					},
+				},
+			},
+		}).Do()
+		require.NoError(t, err)
+		assert.Equal(t, feedName, created.Name)
+	})
+
+	t.Run("Feeds.Create duplicate fails with ALREADY_EXISTS", func(t *testing.T) {
+		_, err := client.Feeds.Create(scope, &cloudasset.CreateFeedRequest{
+			FeedId: feedID,
+			Feed:   &cloudasset.Feed{},
+		}).Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ALREADY_EXISTS")
+	})
+
+	t.Run("Feeds.List includes the new feed", func(t *testing.T) {
+		out, err := client.Feeds.List(scope).Do()
+		require.NoError(t, err)
+		var names []string
+		for _, f := range out.Feeds {
+			names = append(names, f.Name)
+		}
+		assert.Contains(t, names, feedName)
+	})
+
+	t.Run("Feeds.Get returns the stored feed", func(t *testing.T) {
+		got, err := client.Feeds.Get(feedName).Do()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"storage.googleapis.com/Bucket"}, got.AssetTypes)
+	})
+
+	t.Run("Feeds.Patch updates the feed", func(t *testing.T) {
+		patched, err := client.Feeds.Patch(feedName, &cloudasset.UpdateFeedRequest{
+			Feed: &cloudasset.Feed{
+				AssetTypes: []string{
+					"storage.googleapis.com/Bucket",
+					"firestore.googleapis.com/Database",
+				},
+			},
+		}).Do()
+		require.NoError(t, err)
+		assert.Len(t, patched.AssetTypes, 2)
+	})
+
+	t.Run("Feeds.Delete removes the feed", func(t *testing.T) {
+		_, err := client.Feeds.Delete(feedName).Do()
+		require.NoError(t, err)
+
+		out, err := client.Feeds.List(scope).Do()
+		require.NoError(t, err)
+		var names []string
+		for _, f := range out.Feeds {
+			names = append(names, f.Name)
+		}
+		assert.NotContains(t, names, feedName)
+	})
+
+	t.Run("Feeds.Get on deleted feed returns NOT_FOUND", func(t *testing.T) {
+		_, err := client.Feeds.Get(feedName).Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+}
+
+// TestEmptyProjectIDFallsBackToEngine confirms the Phase-3-style fallback:
+// callers wiring ResourceDiscovery without ProjectID get the engine's own
+// project ID, not a silently-empty handler.
+func TestEmptyProjectIDFallsBackToEngine(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "bkt"))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		// ProjectID intentionally omitted.
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	// Use the engine's accountID as scope; the handler must accept it.
+	scope := "projects/" + cloudP.ResourceDiscovery.AccountID()
+	out, err := client.V1.SearchAllResources(scope).Do()
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.Results)
+}

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -256,3 +256,108 @@ func TestEmptyProjectIDFallsBackToEngine(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, out.Results)
 }
+
+// TestSDKCloudAsset_BugFixes pins the three issues called out in the
+// PR #198 review so they cannot silently regress.
+func TestSDKCloudAsset_BugFixes(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "my-test-project"
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "bkt"))
+	require.NoError(t, cloudP.GCS.PutBucketTagging(ctx, "bkt", map[string]string{"env": "prod"}))
+	require.NoError(t, cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: "tbl", PartitionKey: "pk"}))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		Firestore:         cloudP.Firestore,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	scope := "projects/" + projectID
+
+	t.Run("Bug 1: service vs assetType contradiction returns empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("service:compute.googleapis.com assetType:storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results,
+			"compute service + Bucket assetType is impossible — must yield zero")
+	})
+
+	t.Run("Bug 1: agreeing service+assetType still returns results", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("service:storage.googleapis.com assetType:storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Results, 1)
+	})
+
+	t.Run("Bug 2: Operations.Get returns cached export result", func(t *testing.T) {
+		// Trigger an export — caches the operation under its name.
+		op, err := client.V1.ExportAssets(scope, &cloudasset.ExportAssetsRequest{}).Do()
+		require.NoError(t, err)
+		require.NotEmpty(t, op.Name, "operation must have a non-empty name to be pollable")
+
+		// Now poll via Operations.Get. Before the fix this 404'd.
+		polled, err := client.Operations.Get(op.Name).Do()
+		require.NoError(t, err, "Operations.Get must find the cached export op")
+		assert.True(t, polled.Done)
+		assert.Equal(t, op.Name, polled.Name)
+		assert.NotEmpty(t, polled.Response, "polled op must carry the response payload")
+	})
+
+	t.Run("Bug 2: Operations.Get on unknown name still 404s", func(t *testing.T) {
+		_, err := client.Operations.Get("projects/" + projectID + "/operations/cloudemu-export-bogus").Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+
+	t.Run("Bug 3: feed id containing '/' is rejected", func(t *testing.T) {
+		// Construct a malformed feed name. The SDK's Get builds the URL
+		// from the name as-is.
+		_, err := client.Feeds.Get(scope + "/feeds/nested/path").Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+}
+
+// TestSDKCloudAsset_BatchGetAssetsHistory fills the coverage gap from the
+// review — the endpoint was implemented but not exercised by any test.
+func TestSDKCloudAsset_BatchGetAssetsHistory(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "history-test"
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "h-bkt"))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	out, err := client.V1.BatchGetAssetsHistory("projects/" + projectID).Do()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(out.Assets), 1,
+		"batchGetAssetsHistory should return the current snapshot wrapped in a temporal-asset entry")
+	for _, a := range out.Assets {
+		require.NotNil(t, a.Window, "each TemporalAsset must carry a window")
+		assert.NotEmpty(t, a.Window.StartTime)
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -15,7 +15,9 @@ import (
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	gkeprov "github.com/stackshy/cloudemu/providers/gcp/gke"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
@@ -45,6 +47,13 @@ type Drivers struct {
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
 	// the same backend. Leave nil to disable Kubernetes data-plane support.
 	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery is the cross-service inventory engine. Required to
+	// serve Cloud Asset Inventory (cloudasset/v1) requests. Leave nil to
+	// omit the handler. ProjectID is used for feed-name validation; if
+	// empty the engine's own AccountID (GCP project ID for GCP engines)
+	// is used as the fallback.
+	ResourceDiscovery *resourcediscovery.Engine
+	ProjectID         string
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -92,6 +101,14 @@ func New(d Drivers) *server.Server {
 	// same /v1/projects/ space as Firestore, so register first.
 	if d.GKE != nil {
 		srv.Register(gke.New(d.GKE))
+	}
+
+	// Cloud Asset Inventory matches /v1/{scope}:method and /v1/{parent}/
+	// {assets,feeds} paths. Register before Firestore: Firestore's Matches
+	// is /v1/projects/ broadly, which would otherwise swallow the colon-
+	// suffix custom methods that share the same prefix.
+	if d.ResourceDiscovery != nil {
+		srv.Register(cloudasset.New(d.ResourceDiscovery, d.ProjectID))
 	}
 
 	if d.Firestore != nil {


### PR DESCRIPTION
Closes #172. **Phase 4 of the resource discovery trio — final piece.** Real `google.golang.org/api/cloudasset/v1` clients drive the in-memory handler end-to-end.

After this merges, the trio is complete:
- ✅ AWS Resource Explorer + Resource Groups Tagging (#170, PR #196)
- ✅ Azure Resource Graph (#171, PR #197)
- ✅ GCP Cloud Asset Inventory (#172, this PR)

## What this PR ships

**`server/gcp/cloudasset`** — REST/JSON handler with 10 operations.

**Custom-method endpoints** (colon syntax at `/v1/{scope}:method`):

| Method | HTTP | Behavior |
|---|---|---|
| `searchAllResources` | GET | Filter → `engine.List` |
| `searchAllIamPolicies` | GET | Returns empty (IAM walking out of scope; documented) |
| `exportAssets` | POST | Synchronous `done=true` LRO with assets inline |
| `batchGetAssetsHistory` | GET | Current snapshot wrapped in a single-window `TemporalAsset` |

**Resource endpoints:**
- `GET /v1/{parent}/assets` — narrowed by repeated `?assetTypes=` (any-of, multi-query merge in handler)

**Feeds CRUD** (stateful, in-memory):
- `POST /v1/{parent}/feeds` (dedupes by feed name)
- `GET /v1/{parent}/feeds` (list)
- `GET /v1/{name}` (get)
- `PATCH /v1/{name}` (partial update, unwraps `UpdateFeedRequest.feed`)
- `DELETE /v1/{name}`

## Filter language

Documented subset of the real GCP filter expression (key:value, AND-composed):

```
service:storage.googleapis.com        // → {storage}
service:compute.googleapis.com        // → {compute, networking}
assetType:storage.googleapis.com/Bucket
location:us-central1
labels.env:prod                       // also: tags.env:prod
```

**Same `ForceEmpty` contradiction detection as the Azure KQL parser** (PR #197): `service:X service:Y` and `labels.env:prod labels.env:stage` both yield zero results — real GCP AND semantics. Unknown keys are tolerated and ignored.

## Wiring (`server/gcp/gcp.go`)

`Drivers` gains `ResourceDiscovery *resourcediscovery.Engine` and `ProjectID string`. Handler registers **before** firestore — firestore's `Matches` is the broad `/v1/projects/` prefix, so cloudasset must claim its colon-suffix and `/assets`, `/feeds` paths first. Empty `ProjectID` falls back to `engine.AccountID()` (same fallback pattern as Phase 3).

## Out of scope (deferred)

- **IAM policy walking** — `searchAllIamPolicies` returns empty; the engine doesn't expose iam driver state. Documented.
- **Async export polling** — `exportAssets` returns `done=true` with assets inline. Real callers that immediately read `op.Response` work; pollers don't crash but get done state on first call.
- **Per-content-type projections** (`RESOURCE` vs `IAM_POLICY` vs `ORG_POLICY`) — handler always emits the resource shape.
- **organizations/{id}** and **folders/{id}** scopes — accepted but treated as the single project's inventory.

## Verification

- [x] `go build ./...` clean
- [x] `go test ./...` all pass
- [x] `golangci-lint run --timeout=9m ./...` 0 issues
- [x] **18 real-SDK round-trip sub-tests** via `google.golang.org/api/cloudasset/v1`: search by service, by label, by assetType, contradiction detection, multi-value assetTypes any-of, GCP-shaped `//service/path` names, full Feeds CRUD lifecycle including dedupe and `NOT_FOUND` on deleted feeds
- [x] **9 KQL/filter parser cases + ForceEmpty contradiction tests + assetType translation table**
- [x] **TestEmptyProjectIDFallsBackToEngine** — same fallback pattern as the Azure handler