### PR TITLE
release: v1.6.4

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -293,3 +293,31 @@ func (db *Database) ListIndexes(ctx context.Context, table string) ([]driver.Ind
 
 	return out.([]driver.IndexInfo), nil
 }
+
+func (db *Database) TagResource(ctx context.Context, table string, tags map[string]string) error {
+	_, err := db.do(ctx, "TagResource", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.TagResource(ctx, table, tags)
+	})
+
+	return err
+}
+
+func (db *Database) UntagResource(ctx context.Context, table string, tagKeys []string) error {
+	_, err := db.do(ctx, "UntagResource", map[string]any{"table": table}, func() (any, error) {
+		return nil, db.driver.UntagResource(ctx, table, tagKeys)
+	})
+
+	return err
+}
+
+func (db *Database) ListTagsOfResource(ctx context.Context, table string) (map[string]string, error) {
+	out, err := db.do(ctx, "ListTagsOfResource", map[string]any{"table": table}, func() (any, error) {
+		return db.driver.ListTagsOfResource(ctx, table)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(map[string]string), nil
+}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -726,3 +726,36 @@ func TestListIndexesPortable(t *testing.T) {
 		require.Error(t, listErr)
 	})
 }
+
+func TestTaggingPortable(t *testing.T) {
+	db, _ := newTestDatabase()
+	ctx := context.Background()
+
+	require.NoError(t, db.CreateTable(ctx, driver.TableConfig{Name: "tag-table", PartitionKey: "pk"}))
+
+	t.Run("tag and list", func(t *testing.T) {
+		require.NoError(t, db.TagResource(ctx, "tag-table", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := db.ListTagsOfResource(ctx, "tag-table")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		require.NoError(t, db.UntagResource(ctx, "tag-table", []string{"env"}))
+
+		got, err := db.ListTagsOfResource(ctx, "tag-table")
+		require.NoError(t, err)
+		_, hasEnv := got["env"]
+		assert.False(t, hasEnv)
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("missing table errors", func(t *testing.T) {
+		require.Error(t, db.TagResource(ctx, "no-table", map[string]string{"k": "v"}))
+		require.Error(t, db.UntagResource(ctx, "no-table", []string{"k"}))
+		_, err := db.ListTagsOfResource(ctx, "no-table")
+		require.Error(t, err)
+	})
+}

--- a/database/driver/driver.go
+++ b/database/driver/driver.go
@@ -148,4 +148,9 @@ type Database interface {
 	DeleteIndex(ctx context.Context, table, indexName string) error
 	DescribeIndex(ctx context.Context, table, indexName string) (*IndexInfo, error)
 	ListIndexes(ctx context.Context, table string) ([]IndexInfo, error)
+
+	// Tagging
+	TagResource(ctx context.Context, table string, tags map[string]string) error
+	UntagResource(ctx context.Context, table string, tagKeys []string) error
+	ListTagsOfResource(ctx context.Context, table string) (map[string]string, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7
+	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/fxamacker/cbor/v2 v2.9.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 h1:HzqcSJWx32XQdr8KtxAu/SZJj0PqDo9tKf2YGPdynV0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0/go.mod h1:nKcJObAisSPDrO9lMuuCBoYY7Ki7ADt8p6XmBhpKNTk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3 h1:JLPf82byRFgfB0f2feJMmRfCCFV0W9/GayiiewTvjlw=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,10 @@ github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPP
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7 h1:6NCQBp9IIEs51YI9/jT5/ckSd6Ka9956gAGlw0a0yFI=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7/go.mod h1:uLWlNO4q8278lSx2iKIJZ09zSXNJ6uQTFM1jvZIZRf4=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvNmV5Se1pmx0ag5+Eb3/wZkT03iyCCI=
+github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12 h1:kOX5fCUb0BSMNHbRm7icw/dEyTjiYCLczIYglbYFJnI=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=

--- a/networking/driver/driver.go
+++ b/networking/driver/driver.go
@@ -306,4 +306,14 @@ type Networking interface {
 	DeleteVPCEndpoint(ctx context.Context, id string) error
 	DescribeVPCEndpoints(ctx context.Context, ids []string) ([]VPCEndpoint, error)
 	ModifyVPCEndpoint(ctx context.Context, id string, config VPCEndpointConfig) (*VPCEndpoint, error)
+
+	// Tag mutation. Update* merges keys into the resource's existing Tags
+	// (overlapping keys overwritten, others preserved); Remove* deletes the
+	// listed keys. Required by the Resource Groups Tagging API surface.
+	UpdateVPCTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveVPCTags(ctx context.Context, id string, keys []string) error
+	UpdateSubnetTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveSubnetTags(ctx context.Context, id string, keys []string) error
+	UpdateSecurityGroupTags(ctx context.Context, id string, tags map[string]string) error
+	RemoveSecurityGroupTags(ctx context.Context, id string, keys []string) error
 }

--- a/networking/networking.go
+++ b/networking/networking.go
@@ -659,3 +659,51 @@ func (n *Networking) ModifyVPCEndpoint(
 
 	return out.(*driver.VPCEndpoint), nil
 }
+
+func (n *Networking) UpdateVPCTags(ctx context.Context, id string, tags map[string]string) error {
+	_, err := n.do(ctx, "UpdateVPCTags", id, func() (any, error) {
+		return nil, n.driver.UpdateVPCTags(ctx, id, tags)
+	})
+
+	return err
+}
+
+func (n *Networking) RemoveVPCTags(ctx context.Context, id string, keys []string) error {
+	_, err := n.do(ctx, "RemoveVPCTags", id, func() (any, error) {
+		return nil, n.driver.RemoveVPCTags(ctx, id, keys)
+	})
+
+	return err
+}
+
+func (n *Networking) UpdateSubnetTags(ctx context.Context, id string, tags map[string]string) error {
+	_, err := n.do(ctx, "UpdateSubnetTags", id, func() (any, error) {
+		return nil, n.driver.UpdateSubnetTags(ctx, id, tags)
+	})
+
+	return err
+}
+
+func (n *Networking) RemoveSubnetTags(ctx context.Context, id string, keys []string) error {
+	_, err := n.do(ctx, "RemoveSubnetTags", id, func() (any, error) {
+		return nil, n.driver.RemoveSubnetTags(ctx, id, keys)
+	})
+
+	return err
+}
+
+func (n *Networking) UpdateSecurityGroupTags(ctx context.Context, id string, tags map[string]string) error {
+	_, err := n.do(ctx, "UpdateSecurityGroupTags", id, func() (any, error) {
+		return nil, n.driver.UpdateSecurityGroupTags(ctx, id, tags)
+	})
+
+	return err
+}
+
+func (n *Networking) RemoveSecurityGroupTags(ctx context.Context, id string, keys []string) error {
+	_, err := n.do(ctx, "RemoveSecurityGroupTags", id, func() (any, error) {
+		return nil, n.driver.RemoveSecurityGroupTags(ctx, id, keys)
+	})
+
+	return err
+}

--- a/networking/networking_test.go
+++ b/networking/networking_test.go
@@ -760,6 +760,81 @@ func (m *mockDriver) ModifyVPCEndpoint(
 	return ep, nil
 }
 
+func (m *mockDriver) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+	return nil
+}
+
+func (m *mockDriver) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+	return nil
+}
+
+func (m *mockDriver) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+	return nil
+}
+
+func (m *mockDriver) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+	return nil
+}
+
+func (m *mockDriver) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+	return nil
+}
+
+func (m *mockDriver) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+	return nil
+}
+
 func newTestNetworking(opts ...Option) *Networking {
 	return NewNetworking(newMockDriver(), opts...)
 }

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -22,29 +22,31 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/sns"
 	"github.com/stackshy/cloudemu/providers/aws/sqs"
 	"github.com/stackshy/cloudemu/providers/aws/vpc"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
 // Provider holds all AWS mock services.
 type Provider struct {
-	S3             *s3.Mock
-	EC2            *ec2.Mock
-	DynamoDB       *dynamodb.Mock
-	Lambda         *lambda.Mock
-	VPC            *vpc.Mock
-	CloudWatch     *cloudwatch.Mock
-	IAM            *awsiam.Mock
-	Route53        *route53.Mock
-	ELB            *elb.Mock
-	SQS            *sqs.Mock
-	ElastiCache    *elasticache.Mock
-	SecretsManager *secretsmanager.Mock
-	CloudWatchLogs *cloudwatchlogs.Mock
-	SNS            *sns.Mock
-	ECR            *ecr.Mock
-	EventBridge    *eventbridge.Mock
-	RDS            *rds.Mock
-	Redshift       *redshift.Mock
-	EKS            *eks.Mock
+	S3                *s3.Mock
+	EC2               *ec2.Mock
+	DynamoDB          *dynamodb.Mock
+	Lambda            *lambda.Mock
+	VPC               *vpc.Mock
+	CloudWatch        *cloudwatch.Mock
+	IAM               *awsiam.Mock
+	Route53           *route53.Mock
+	ELB               *elb.Mock
+	SQS               *sqs.Mock
+	ElastiCache       *elasticache.Mock
+	SecretsManager    *secretsmanager.Mock
+	CloudWatchLogs    *cloudwatchlogs.Mock
+	SNS               *sns.Mock
+	ECR               *ecr.Mock
+	EventBridge       *eventbridge.Mock
+	RDS               *rds.Mock
+	Redshift          *redshift.Mock
+	EKS               *eks.Mock
+	ResourceDiscovery *resourcediscovery.Engine
 }
 
 // New creates a new AWS provider with all mock services.
@@ -84,6 +86,17 @@ func New(opts ...config.Option) *Provider {
 	p.RDS.SetMonitoring(p.CloudWatch)
 	p.Redshift.SetMonitoring(p.CloudWatch)
 	p.EKS.SetMonitoring(p.CloudWatch)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderAWS, o.AccountID, o.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.EC2,
+			Networking: p.VPC,
+			Storage:    p.S3,
+			Database:   p.DynamoDB,
+			Serverless: p.Lambda,
+		},
+	)
 
 	return p
 }

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -48,6 +48,7 @@ type tableData struct {
 	streamConfig  driver.StreamConfig
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
+	tags          map[string]string
 }
 
 // Mock is an in-memory mock implementation of DynamoDB.
@@ -868,4 +869,61 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 	}
 
 	return indexes, nil
+}
+
+// TagResource sets or replaces tag key/values on a table. Existing keys not
+// present in tags are preserved; existing keys present in tags are overwritten.
+func (m *Mock) TagResource(_ context.Context, table string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if td.tags == nil {
+		td.tags = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		td.tags[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes the given tag keys from a table. Unknown keys are ignored.
+func (m *Mock) UntagResource(_ context.Context, table string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	for _, k := range tagKeys {
+		delete(td.tags, k)
+	}
+
+	return nil
+}
+
+// ListTagsOfResource returns a copy of the tag map for a table.
+func (m *Mock) ListTagsOfResource(_ context.Context, table string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	out := make(map[string]string, len(td.tags))
+	for k, v := range td.tags {
+		out[k] = v
+	}
+
+	return out, nil
 }

--- a/providers/aws/dynamodb/dynamodb_test.go
+++ b/providers/aws/dynamodb/dynamodb_test.go
@@ -682,6 +682,80 @@ func TestDynamoDBMetricsEmission(t *testing.T) {
 	})
 }
 
+func TestTagging(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("tag and list", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+
+		err := m.TagResource(ctx, "tbl", map[string]string{"env": "prod", "team": "data"})
+		requireNoError(t, err)
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, 2, len(got))
+		assertEqual(t, "prod", got["env"])
+		assertEqual(t, "data", got["team"])
+	})
+
+	t.Run("tag merges with existing", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "stage", "owner": "alice"}))
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, 3, len(got))
+		assertEqual(t, "prod", got["env"])
+		assertEqual(t, "alice", got["owner"])
+		assertEqual(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "prod", "team": "data"}))
+		requireNoError(t, m.UntagResource(ctx, "tbl", []string{"env", "missing"}))
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, 1, len(got))
+		assertEqual(t, "data", got["team"])
+	})
+
+	t.Run("list returns copy", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(m, "tbl")
+		requireNoError(t, m.TagResource(ctx, "tbl", map[string]string{"env": "prod"}))
+
+		got, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+
+		got["env"] = "mutated"
+
+		fresh, err := m.ListTagsOfResource(ctx, "tbl")
+		requireNoError(t, err)
+		assertEqual(t, "prod", fresh["env"])
+	})
+
+	t.Run("missing table errors", func(t *testing.T) {
+		m := newTestMock()
+
+		err := m.TagResource(ctx, "nope", map[string]string{"k": "v"})
+		assertError(t, err, true)
+
+		err = m.UntagResource(ctx, "nope", []string{"k"})
+		assertError(t, err, true)
+
+		_, err = m.ListTagsOfResource(ctx, "nope")
+		assertError(t, err, true)
+	})
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -300,18 +300,15 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 
 // UpdateVPCTags merges the given tags into the VPC's tag map. Existing keys
 // not present in tags are preserved; overlapping keys are overwritten.
+// The mutation runs inside memstore.Update so the store's lock is held for
+// the duration; the new map is built fresh and swapped in atomically so
+// concurrent readers iterating the old map are unaffected.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = mergeTagMap(v.Tags, tags)
+		return v
+	}) {
 		return errors.Newf(errors.NotFound, "VPC %q not found", id)
-	}
-
-	if v.Tags == nil {
-		v.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		v.Tags[k] = val
 	}
 
 	return nil
@@ -319,13 +316,11 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 
 // RemoveVPCTags removes the given tag keys from a VPC. Unknown keys are ignored.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = removeTagMapKeys(v.Tags, keys)
+		return v
+	}) {
 		return errors.Newf(errors.NotFound, "VPC %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(v.Tags, k)
 	}
 
 	return nil
@@ -333,17 +328,11 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 
 // UpdateSubnetTags merges tags into the subnet's tag map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = mergeTagMap(s.Tags, tags)
+		return s
+	}) {
 		return errors.Newf(errors.NotFound, "subnet %q not found", id)
-	}
-
-	if s.Tags == nil {
-		s.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		s.Tags[k] = val
 	}
 
 	return nil
@@ -351,13 +340,11 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 
 // RemoveSubnetTags removes the given tag keys from a subnet.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = removeTagMapKeys(s.Tags, keys)
+		return s
+	}) {
 		return errors.Newf(errors.NotFound, "subnet %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(s.Tags, k)
 	}
 
 	return nil
@@ -365,17 +352,11 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 
 // UpdateSecurityGroupTags merges tags into the security group's tag map.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = mergeTagMap(sg.Tags, tags)
+		return sg
+	}) {
 		return errors.Newf(errors.NotFound, "security group %q not found", id)
-	}
-
-	if sg.Tags == nil {
-		sg.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		sg.Tags[k] = val
 	}
 
 	return nil
@@ -383,16 +364,56 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 
 // RemoveSecurityGroupTags removes the given tag keys from a security group.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = removeTagMapKeys(sg.Tags, keys)
+		return sg
+	}) {
 		return errors.Newf(errors.NotFound, "security group %q not found", id)
 	}
 
-	for _, k := range keys {
-		delete(sg.Tags, k)
+	return nil
+}
+
+// mergeTagMap returns a fresh map containing existing's keys plus tags's
+// keys (tags wins on overlap). The original existing map is not modified
+// so concurrent readers can keep iterating it safely.
+func mergeTagMap(existing, tags map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(tags))
+
+	for k, v := range existing {
+		out[k] = v
 	}
 
-	return nil
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
+// removeTagMapKeys returns a fresh map with the listed keys removed. The
+// original map is not modified.
+func removeTagMapKeys(existing map[string]string, keys []string) map[string]string {
+	if len(existing) == 0 {
+		return existing
+	}
+
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+
+	out := make(map[string]string, len(existing))
+
+	for k, v := range existing {
+		if _, gone := drop[k]; gone {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -298,6 +298,103 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	return errors.Newf(errors.NotFound, "egress rule not found in security group %q", groupID)
 }
 
+// UpdateVPCTags merges the given tags into the VPC's tag map. Existing keys
+// not present in tags are preserved; overlapping keys are overwritten.
+func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "VPC %q not found", id)
+	}
+
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveVPCTags removes the given tag keys from a VPC. Unknown keys are ignored.
+func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "VPC %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSubnetTags merges tags into the subnet's tag map.
+func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subnet %q not found", id)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSubnetTags removes the given tag keys from a subnet.
+func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subnet %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSecurityGroupTags merges tags into the security group's tag map.
+func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "security group %q not found", id)
+	}
+
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSecurityGroupTags removes the given tag keys from a security group.
+func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "security group %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+
+	return nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -1103,6 +1103,43 @@ func TestTagMutation(t *testing.T) {
 	})
 }
 
+// TestTagMutationConcurrency drives many concurrent Update/Remove tag calls
+// against a single VPC. The new memstore.Update path holds the store lock
+// for the duration of the mutation and swaps in a freshly-built map, so
+// concurrent writers cannot tear the inner map. With go test -race this
+// catches any regression to in-place mutation under an unguarded read.
+//
+// Note: this test does NOT mix in Describe calls because reads through
+// memstore.Get release the lock before the caller dereferences the value
+// — a pre-existing pattern in the codebase that is out of scope here. A
+// follow-up should add a Read closure to memstore (or per-resource locks)
+// so reads can copy Tags under the same lock that protects writes.
+func TestTagMutationConcurrency(t *testing.T) {
+	ctx := context.Background()
+	m := newTestMock()
+
+	v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	requireNoError(t, err)
+
+	const writers = 16
+	const iters = 100
+
+	done := make(chan struct{})
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer func() { done <- struct{}{} }()
+			for i := 0; i < iters; i++ {
+				_ = m.UpdateVPCTags(ctx, v.ID, map[string]string{"k": "v"})
+				_ = m.RemoveVPCTags(ctx, v.ID, []string{"k"})
+			}
+		}(w)
+	}
+
+	for w := 0; w < writers; w++ {
+		<-done
+	}
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -1025,6 +1025,84 @@ func TestRouteTableAssociation(t *testing.T) {
 	})
 }
 
+func TestTagMutation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("VPC tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"}})
+		requireNoError(t, err)
+
+		requireNoError(t, m.UpdateVPCTags(ctx, v.ID, map[string]string{"env": "prod", "team": "platform"}))
+
+		got, err := m.DescribeVPCs(ctx, []string{v.ID})
+		requireNoError(t, err)
+		assertEqual(t, "prod", got[0].Tags["env"])
+		assertEqual(t, "platform", got[0].Tags["team"])
+
+		requireNoError(t, m.RemoveVPCTags(ctx, v.ID, []string{"env", "missing"}))
+		got, err = m.DescribeVPCs(ctx, []string{v.ID})
+		requireNoError(t, err)
+		_, hasEnv := got[0].Tags["env"]
+		assertEqual(t, false, hasEnv)
+		assertEqual(t, "platform", got[0].Tags["team"])
+	})
+
+	t.Run("Subnet tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		requireNoError(t, err)
+
+		s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		requireNoError(t, err)
+
+		requireNoError(t, m.UpdateSubnetTags(ctx, s.ID, map[string]string{"tier": "private"}))
+		got, err := m.DescribeSubnets(ctx, []string{s.ID})
+		requireNoError(t, err)
+		assertEqual(t, "private", got[0].Tags["tier"])
+
+		requireNoError(t, m.RemoveSubnetTags(ctx, s.ID, []string{"tier"}))
+		got, err = m.DescribeSubnets(ctx, []string{s.ID})
+		requireNoError(t, err)
+		_, hasTier := got[0].Tags["tier"]
+		assertEqual(t, false, hasTier)
+	})
+
+	t.Run("SecurityGroup tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		requireNoError(t, err)
+
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+		requireNoError(t, err)
+
+		requireNoError(t, m.UpdateSecurityGroupTags(ctx, sg.ID, map[string]string{"role": "web"}))
+		got, err := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		requireNoError(t, err)
+		assertEqual(t, "web", got[0].Tags["role"])
+
+		requireNoError(t, m.RemoveSecurityGroupTags(ctx, sg.ID, []string{"role"}))
+		got, err = m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		requireNoError(t, err)
+		_, hasRole := got[0].Tags["role"]
+		assertEqual(t, false, hasRole)
+	})
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		m := newTestMock()
+
+		assertError(t, m.UpdateVPCTags(ctx, "vpc-nope", map[string]string{"k": "v"}), true)
+		assertError(t, m.RemoveVPCTags(ctx, "vpc-nope", []string{"k"}), true)
+		assertError(t, m.UpdateSubnetTags(ctx, "subnet-nope", map[string]string{"k": "v"}), true)
+		assertError(t, m.RemoveSubnetTags(ctx, "subnet-nope", []string{"k"}), true)
+		assertError(t, m.UpdateSecurityGroupTags(ctx, "sg-nope", map[string]string{"k": "v"}), true)
+		assertError(t, m.RemoveSecurityGroupTags(ctx, "sg-nope", []string{"k"}), true)
+	})
+}
+
 func requireNoError(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/azure/servicebus"
 	"github.com/stackshy/cloudemu/providers/azure/virtualmachines"
 	"github.com/stackshy/cloudemu/providers/azure/vnet"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
 // Provider holds all Azure mock services.
@@ -47,6 +48,8 @@ type Provider struct {
 	PostgresFlex     *postgresflex.Mock
 	MySQLFlex        *mysqlflex.Mock
 	AKS              *aks.Mock
+
+	ResourceDiscovery *resourcediscovery.Engine
 }
 
 // New creates a new Azure provider with all mock services.
@@ -88,6 +91,17 @@ func New(opts ...config.Option) *Provider {
 	p.PostgresFlex.SetMonitoring(p.Monitor)
 	p.MySQLFlex.SetMonitoring(p.Monitor)
 	p.AKS.SetMonitoring(p.Monitor)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderAzure, o.AccountID, o.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.VirtualMachines,
+			Networking: p.VNet,
+			Storage:    p.BlobStorage,
+			Database:   p.CosmosDB,
+			Serverless: p.Functions,
+		},
+	)
 
 	return p
 }

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -50,6 +50,7 @@ type tableData struct {
 	streamConfig  driver.StreamConfig
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
+	tags          map[string]string
 }
 
 // Mock is an in-memory mock implementation of Azure Cosmos DB.
@@ -882,4 +883,61 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 	}
 
 	return indexes, nil
+}
+
+// TagResource sets or replaces tag key/values on a container. Existing keys
+// not present in tags are preserved; existing keys present in tags are overwritten.
+func (m *Mock) TagResource(_ context.Context, table string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	if td.tags == nil {
+		td.tags = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		td.tags[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes the given tag keys from a container. Unknown keys are ignored.
+func (m *Mock) UntagResource(_ context.Context, table string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	for _, k := range tagKeys {
+		delete(td.tags, k)
+	}
+
+	return nil
+}
+
+// ListTagsOfResource returns a copy of the tag map for a container.
+func (m *Mock) ListTagsOfResource(_ context.Context, table string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %s not found", table)
+	}
+
+	out := make(map[string]string, len(td.tags))
+	for k, v := range td.tags {
+		out[k] = v
+	}
+
+	return out, nil
 }

--- a/providers/azure/cosmosdb/cosmosdb_test.go
+++ b/providers/azure/cosmosdb/cosmosdb_test.go
@@ -891,3 +891,71 @@ func TestUpdateItemEmitsMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, mon.hasMetric("Microsoft.DocumentDB/databaseAccounts", "TotalRequests"))
 }
+
+func TestTagging(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("tag and list", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "data", got["team"])
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("tag merges with existing", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "stage", "owner": "alice"}))
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "alice", got["owner"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod", "team": "data"}))
+		require.NoError(t, m.UntagResource(ctx, "users", []string{"env", "missing"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("list returns copy", func(t *testing.T) {
+		m := newTestMock()
+		createTestTable(t, m)
+		require.NoError(t, m.TagResource(ctx, "users", map[string]string{"env": "prod"}))
+
+		got, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		got["env"] = "mutated"
+
+		fresh, err := m.ListTagsOfResource(ctx, "users")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", fresh["env"])
+	})
+
+	t.Run("missing container errors", func(t *testing.T) {
+		m := newTestMock()
+
+		require.Error(t, m.TagResource(ctx, "nope", map[string]string{"k": "v"}))
+		require.Error(t, m.UntagResource(ctx, "nope", []string{"k"}))
+		_, err := m.ListTagsOfResource(ctx, "nope")
+		require.Error(t, err)
+	})
+}

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -300,6 +300,102 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	return cerrors.Newf(cerrors.NotFound, "egress rule not found in network security group %q", groupID)
 }
 
+// UpdateVPCTags merges the given tags into the virtual network's tag map.
+func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
+	}
+
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveVPCTags removes the given tag keys from a virtual network.
+func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSubnetTags merges tags into the subnet's tag map.
+func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSubnetTags removes the given tag keys from a subnet.
+func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSecurityGroupTags merges tags into the NSG's tag map.
+func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSecurityGroupTags removes the given tag keys from an NSG.
+func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+
+	return nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {

--- a/providers/azure/vnet/vnet.go
+++ b/providers/azure/vnet/vnet.go
@@ -301,18 +301,14 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 }
 
 // UpdateVPCTags merges the given tags into the virtual network's tag map.
+// The mutation runs under memstore.Update's lock; a fresh map is swapped in
+// so concurrent readers iterating the old map are unaffected.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = mergeTagMap(v.Tags, tags)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
-	}
-
-	if v.Tags == nil {
-		v.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		v.Tags[k] = val
 	}
 
 	return nil
@@ -320,13 +316,11 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 
 // RemoveVPCTags removes the given tag keys from a virtual network.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = removeTagMapKeys(v.Tags, keys)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "virtual network %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(v.Tags, k)
 	}
 
 	return nil
@@ -334,17 +328,11 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 
 // UpdateSubnetTags merges tags into the subnet's tag map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = mergeTagMap(s.Tags, tags)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
-	}
-
-	if s.Tags == nil {
-		s.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		s.Tags[k] = val
 	}
 
 	return nil
@@ -352,13 +340,11 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 
 // RemoveSubnetTags removes the given tag keys from a subnet.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = removeTagMapKeys(s.Tags, keys)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnet %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(s.Tags, k)
 	}
 
 	return nil
@@ -366,17 +352,11 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 
 // UpdateSecurityGroupTags merges tags into the NSG's tag map.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = mergeTagMap(sg.Tags, tags)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
-	}
-
-	if sg.Tags == nil {
-		sg.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		sg.Tags[k] = val
 	}
 
 	return nil
@@ -384,16 +364,55 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 
 // RemoveSecurityGroupTags removes the given tag keys from an NSG.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = removeTagMapKeys(sg.Tags, keys)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network security group %q not found", id)
 	}
 
-	for _, k := range keys {
-		delete(sg.Tags, k)
+	return nil
+}
+
+// mergeTagMap returns a fresh map containing existing's keys plus tags's
+// keys (tags wins on overlap). The original existing map is not modified
+// so concurrent readers can keep iterating it safely.
+func mergeTagMap(existing, tags map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(tags))
+
+	for k, v := range existing {
+		out[k] = v
 	}
 
-	return nil
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
+// removeTagMapKeys returns a fresh map with the listed keys removed.
+func removeTagMapKeys(existing map[string]string, keys []string) map[string]string {
+	if len(existing) == 0 {
+		return existing
+	}
+
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+
+	out := make(map[string]string, len(existing))
+
+	for k, v := range existing {
+		if _, gone := drop[k]; gone {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/azure/vnet/vnet_test.go
+++ b/providers/azure/vnet/vnet_test.go
@@ -1272,3 +1272,74 @@ func TestGetFlowLogRecords(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestTagMutation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("VPC tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"}})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateVPCTags(ctx, v.ID, map[string]string{"env": "prod", "team": "platform"}))
+		got, err := m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got[0].Tags["env"])
+		assert.Equal(t, "platform", got[0].Tags["team"])
+
+		require.NoError(t, m.RemoveVPCTags(ctx, v.ID, []string{"env", "missing"}))
+		got, err = m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["env"]
+		assert.False(t, has)
+		assert.Equal(t, "platform", got[0].Tags["team"])
+	})
+
+	t.Run("Subnet tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSubnetTags(ctx, s.ID, map[string]string{"tier": "private"}))
+		got, err := m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "private", got[0].Tags["tier"])
+
+		require.NoError(t, m.RemoveSubnetTags(ctx, s.ID, []string{"tier"}))
+		got, err = m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["tier"]
+		assert.False(t, has)
+	})
+
+	t.Run("NSG tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSecurityGroupTags(ctx, sg.ID, map[string]string{"role": "web"}))
+		got, err := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "web", got[0].Tags["role"])
+
+		require.NoError(t, m.RemoveSecurityGroupTags(ctx, sg.ID, []string{"role"}))
+		got, err = m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["role"]
+		assert.False(t, has)
+	})
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		m := newTestMock()
+		require.Error(t, m.UpdateVPCTags(ctx, "vnet-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveVPCTags(ctx, "vnet-nope", []string{"k"}))
+		require.Error(t, m.UpdateSubnetTags(ctx, "subnet-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSubnetTags(ctx, "subnet-nope", []string{"k"}))
+		require.Error(t, m.UpdateSecurityGroupTags(ctx, "nsg-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSecurityGroupTags(ctx, "nsg-nope", []string{"k"}))
+	})
+}

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -50,6 +50,7 @@ type collectionData struct {
 	streamConfig  driver.StreamConfig
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
+	labels        map[string]string
 }
 
 // Mock is an in-memory mock implementation of Google Cloud Firestore.
@@ -863,4 +864,64 @@ func (m *Mock) ListIndexes(_ context.Context, table string) ([]driver.IndexInfo,
 	}
 
 	return indexes, nil
+}
+
+// TagResource sets or replaces label key/values on a collection. GCP terms
+// these "labels"; the cross-cloud driver interface calls the method TagResource.
+// Existing labels not present in tags are preserved; existing labels present
+// in tags are overwritten.
+func (m *Mock) TagResource(_ context.Context, table string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	if cd.labels == nil {
+		cd.labels = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		cd.labels[k] = v
+	}
+
+	return nil
+}
+
+// UntagResource removes the given label keys from a collection. Unknown keys
+// are ignored.
+func (m *Mock) UntagResource(_ context.Context, table string, tagKeys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	for _, k := range tagKeys {
+		delete(cd.labels, k)
+	}
+
+	return nil
+}
+
+// ListTagsOfResource returns a copy of the label map for a collection.
+func (m *Mock) ListTagsOfResource(_ context.Context, table string) (map[string]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cd, exists := m.collections[table]
+	if !exists {
+		return nil, cerrors.Newf(cerrors.NotFound, "collection %s not found", table)
+	}
+
+	out := make(map[string]string, len(cd.labels))
+	for k, v := range cd.labels {
+		out[k] = v
+	}
+
+	return out, nil
 }

--- a/providers/gcp/firestore/firestore_test.go
+++ b/providers/gcp/firestore/firestore_test.go
@@ -1163,3 +1163,75 @@ func TestUpdateItemEmitsMetrics(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, mon.data["firestore.googleapis.com/document/write_count"])
 }
+
+func TestTagging(t *testing.T) {
+	ctx := context.Background()
+
+	createColl := func(m *Mock, name string) {
+		require.NoError(t, m.CreateTable(ctx, driver.TableConfig{Name: name, PartitionKey: "pk"}))
+	}
+
+	t.Run("tag and list", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("tag merges with existing", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "stage", "owner": "alice"}))
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod", "team": "data"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Len(t, got, 3)
+		assert.Equal(t, "prod", got["env"])
+		assert.Equal(t, "alice", got["owner"])
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("untag removes keys", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod", "team": "data"}))
+		require.NoError(t, m.UntagResource(ctx, "coll", []string{"env", "missing"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "data", got["team"])
+	})
+
+	t.Run("list returns copy", func(t *testing.T) {
+		m := newTestMock()
+		createColl(m, "coll")
+		require.NoError(t, m.TagResource(ctx, "coll", map[string]string{"env": "prod"}))
+
+		got, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		got["env"] = "mutated"
+
+		fresh, err := m.ListTagsOfResource(ctx, "coll")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", fresh["env"])
+	})
+
+	t.Run("missing collection errors", func(t *testing.T) {
+		m := newTestMock()
+
+		require.Error(t, m.TagResource(ctx, "nope", map[string]string{"k": "v"}))
+		require.Error(t, m.UntagResource(ctx, "nope", []string{"k"}))
+		_, err := m.ListTagsOfResource(ctx, "nope")
+		require.Error(t, err)
+	})
+}

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/gcp/memorystore"
 	"github.com/stackshy/cloudemu/providers/gcp/pubsub"
 	"github.com/stackshy/cloudemu/providers/gcp/secretmanager"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
 // Provider holds all GCP mock services.
@@ -43,6 +44,8 @@ type Provider struct {
 	Eventarc         *eventarc.Mock
 	CloudSQL         *cloudsql.Mock
 	GKE              *gke.Mock
+
+	ResourceDiscovery *resourcediscovery.Engine
 }
 
 // New creates a new GCP provider with all mock services.
@@ -80,6 +83,17 @@ func New(opts ...config.Option) *Provider {
 	p.Eventarc.SetMonitoring(p.CloudMonitoring)
 	p.CloudSQL.SetMonitoring(p.CloudMonitoring)
 	p.GKE.SetMonitoring(p.CloudMonitoring)
+
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderGCP, o.ProjectID, o.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.GCE,
+			Networking: p.VPC,
+			Storage:    p.GCS,
+			Database:   p.Firestore,
+			Serverless: p.CloudFunctions,
+		},
+	)
 
 	return p
 }

--- a/providers/gcp/gcpvpc/vpc.go
+++ b/providers/gcp/gcpvpc/vpc.go
@@ -302,18 +302,14 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 
 // UpdateVPCTags merges the given labels into the network's label map. GCP
 // calls these labels; the cross-cloud Networking interface uses the term tags.
+// The mutation runs under memstore.Update's lock; a fresh map is swapped in
+// so concurrent readers iterating the old map are unaffected.
 func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = mergeTagMap(v.Tags, tags)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
-	}
-
-	if v.Tags == nil {
-		v.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		v.Tags[k] = val
 	}
 
 	return nil
@@ -321,13 +317,11 @@ func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]strin
 
 // RemoveVPCTags removes the given label keys from a network.
 func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
-	v, ok := m.vpcs.Get(id)
-	if !ok {
+	if !m.vpcs.Update(id, func(v *vpcData) *vpcData {
+		v.Tags = removeTagMapKeys(v.Tags, keys)
+		return v
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(v.Tags, k)
 	}
 
 	return nil
@@ -335,17 +329,11 @@ func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error 
 
 // UpdateSubnetTags merges labels into the subnetwork's label map.
 func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = mergeTagMap(s.Tags, tags)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
-	}
-
-	if s.Tags == nil {
-		s.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		s.Tags[k] = val
 	}
 
 	return nil
@@ -353,13 +341,11 @@ func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]st
 
 // RemoveSubnetTags removes the given label keys from a subnetwork.
 func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
-	s, ok := m.subnets.Get(id)
-	if !ok {
+	if !m.subnets.Update(id, func(s *subnetData) *subnetData {
+		s.Tags = removeTagMapKeys(s.Tags, keys)
+		return s
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
-	}
-
-	for _, k := range keys {
-		delete(s.Tags, k)
 	}
 
 	return nil
@@ -367,17 +353,11 @@ func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) err
 
 // UpdateSecurityGroupTags merges labels into the firewall rule's label map.
 func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = mergeTagMap(sg.Tags, tags)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
-	}
-
-	if sg.Tags == nil {
-		sg.Tags = make(map[string]string, len(tags))
-	}
-
-	for k, val := range tags {
-		sg.Tags[k] = val
 	}
 
 	return nil
@@ -385,16 +365,54 @@ func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[st
 
 // RemoveSecurityGroupTags removes the given label keys from a firewall rule.
 func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
-	sg, ok := m.securityGroups.Get(id)
-	if !ok {
+	if !m.securityGroups.Update(id, func(sg *sgData) *sgData {
+		sg.Tags = removeTagMapKeys(sg.Tags, keys)
+		return sg
+	}) {
 		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
 	}
 
-	for _, k := range keys {
-		delete(sg.Tags, k)
+	return nil
+}
+
+// mergeTagMap returns a fresh map containing existing's keys plus tags's
+// keys (tags wins on overlap). The original existing map is not modified.
+func mergeTagMap(existing, tags map[string]string) map[string]string {
+	out := make(map[string]string, len(existing)+len(tags))
+
+	for k, v := range existing {
+		out[k] = v
 	}
 
-	return nil
+	for k, v := range tags {
+		out[k] = v
+	}
+
+	return out
+}
+
+// removeTagMapKeys returns a fresh map with the listed keys removed.
+func removeTagMapKeys(existing map[string]string, keys []string) map[string]string {
+	if len(existing) == 0 {
+		return existing
+	}
+
+	drop := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		drop[k] = struct{}{}
+	}
+
+	out := make(map[string]string, len(existing))
+
+	for k, v := range existing {
+		if _, gone := drop[k]; gone {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	return out
 }
 
 // copyTags creates a shallow copy of a tags map.

--- a/providers/gcp/gcpvpc/vpc.go
+++ b/providers/gcp/gcpvpc/vpc.go
@@ -300,6 +300,103 @@ func (m *Mock) RemoveEgressRule(_ context.Context, groupID string, rule driver.S
 	return cerrors.Newf(cerrors.NotFound, "egress rule not found in firewall rule %q", groupID)
 }
 
+// UpdateVPCTags merges the given labels into the network's label map. GCP
+// calls these labels; the cross-cloud Networking interface uses the term tags.
+func (m *Mock) UpdateVPCTags(_ context.Context, id string, tags map[string]string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
+	}
+
+	if v.Tags == nil {
+		v.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		v.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveVPCTags removes the given label keys from a network.
+func (m *Mock) RemoveVPCTags(_ context.Context, id string, keys []string) error {
+	v, ok := m.vpcs.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "network %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(v.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSubnetTags merges labels into the subnetwork's label map.
+func (m *Mock) UpdateSubnetTags(_ context.Context, id string, tags map[string]string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
+	}
+
+	if s.Tags == nil {
+		s.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		s.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSubnetTags removes the given label keys from a subnetwork.
+func (m *Mock) RemoveSubnetTags(_ context.Context, id string, keys []string) error {
+	s, ok := m.subnets.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "subnetwork %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(s.Tags, k)
+	}
+
+	return nil
+}
+
+// UpdateSecurityGroupTags merges labels into the firewall rule's label map.
+func (m *Mock) UpdateSecurityGroupTags(_ context.Context, id string, tags map[string]string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
+	}
+
+	if sg.Tags == nil {
+		sg.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, val := range tags {
+		sg.Tags[k] = val
+	}
+
+	return nil
+}
+
+// RemoveSecurityGroupTags removes the given label keys from a firewall rule.
+func (m *Mock) RemoveSecurityGroupTags(_ context.Context, id string, keys []string) error {
+	sg, ok := m.securityGroups.Get(id)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", id)
+	}
+
+	for _, k := range keys {
+		delete(sg.Tags, k)
+	}
+
+	return nil
+}
+
 // copyTags creates a shallow copy of a tags map.
 func copyTags(tags map[string]string) map[string]string {
 	if tags == nil {

--- a/providers/gcp/gcpvpc/vpc_test.go
+++ b/providers/gcp/gcpvpc/vpc_test.go
@@ -1438,3 +1438,74 @@ func TestRouteTableAssociation(t *testing.T) {
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
+
+func TestTagMutation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("VPC tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"}})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateVPCTags(ctx, v.ID, map[string]string{"env": "prod", "team": "platform"}))
+		got, err := m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "prod", got[0].Tags["env"])
+		assert.Equal(t, "platform", got[0].Tags["team"])
+
+		require.NoError(t, m.RemoveVPCTags(ctx, v.ID, []string{"env", "missing"}))
+		got, err = m.DescribeVPCs(ctx, []string{v.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["env"]
+		assert.False(t, has)
+		assert.Equal(t, "platform", got[0].Tags["team"])
+	})
+
+	t.Run("Subnet tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSubnetTags(ctx, s.ID, map[string]string{"tier": "private"}))
+		got, err := m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "private", got[0].Tags["tier"])
+
+		require.NoError(t, m.RemoveSubnetTags(ctx, s.ID, []string{"tier"}))
+		got, err = m.DescribeSubnets(ctx, []string{s.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["tier"]
+		assert.False(t, has)
+	})
+
+	t.Run("Firewall rule tags update + remove", func(t *testing.T) {
+		m := newTestMock()
+		v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+		require.NoError(t, err)
+		sg, err := m.CreateSecurityGroup(ctx, driver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+		require.NoError(t, err)
+
+		require.NoError(t, m.UpdateSecurityGroupTags(ctx, sg.ID, map[string]string{"role": "web"}))
+		got, err := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		assert.Equal(t, "web", got[0].Tags["role"])
+
+		require.NoError(t, m.RemoveSecurityGroupTags(ctx, sg.ID, []string{"role"}))
+		got, err = m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["role"]
+		assert.False(t, has)
+	})
+
+	t.Run("missing resource errors", func(t *testing.T) {
+		m := newTestMock()
+		require.Error(t, m.UpdateVPCTags(ctx, "net-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveVPCTags(ctx, "net-nope", []string{"k"}))
+		require.Error(t, m.UpdateSubnetTags(ctx, "subnet-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSubnetTags(ctx, "subnet-nope", []string{"k"}))
+		require.Error(t, m.UpdateSecurityGroupTags(ctx, "fw-nope", map[string]string{"k": "v"}))
+		require.Error(t, m.RemoveSecurityGroupTags(ctx, "fw-nope", []string{"k"}))
+	})
+}

--- a/resourcediscovery/arn.go
+++ b/resourcediscovery/arn.go
@@ -1,0 +1,116 @@
+package resourcediscovery
+
+import (
+	"fmt"
+
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+// Per-provider ARN/URN builders. These produce best-effort canonical
+// identifiers — enough for resource discovery output, not necessarily
+// byte-equal to what each service's own driver would emit when it owns
+// the canonical ID. Phases 2-4 may refine these as the SDK-compat
+// handlers expose the exact strings real clients expect.
+
+const azureDefaultResourceGroup = "default"
+
+// Network resource kind constants used by per-provider ARN routing.
+const (
+	netKindVPC           = "vpc"
+	netKindSubnet        = "subnet"
+	netKindSecurityGroup = "security-group"
+)
+
+func (e *Engine) computeInstanceARN(id string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("ec2", e.region, e.accountID, "instance/"+id)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Compute", "virtualMachines", id)
+	case ProviderGCP:
+		return id
+	default:
+		return id
+	}
+}
+
+func (e *Engine) networkARN(kind, id string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("ec2", e.region, e.accountID, kind+"/"+id)
+	case ProviderAzure:
+		azureType := azureNetworkType(kind)
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Network", azureType, id)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, gcpNetworkCollection(kind), id)
+	default:
+		return id
+	}
+}
+
+func azureNetworkType(kind string) string {
+	switch kind {
+	case netKindVPC:
+		return "virtualNetworks"
+	case netKindSubnet:
+		return "subnets"
+	case netKindSecurityGroup:
+		return "networkSecurityGroups"
+	default:
+		return kind
+	}
+}
+
+func gcpNetworkCollection(kind string) string {
+	switch kind {
+	case netKindVPC:
+		return "networks"
+	case netKindSubnet:
+		return "subnetworks"
+	case netKindSecurityGroup:
+		return "firewalls"
+	default:
+		return kind
+	}
+}
+
+func (e *Engine) storageBucketARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return fmt.Sprintf("arn:aws:s3:::%s", name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Storage",
+			"storageAccounts/default/blobServices/default/containers", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "buckets", name)
+	default:
+		return name
+	}
+}
+
+func (e *Engine) databaseTableARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("dynamodb", e.region, e.accountID, "table/"+name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.DocumentDB",
+			"databaseAccounts/default/sqlDatabases/default/containers", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "databases/(default)/collections", name)
+	default:
+		return name
+	}
+}
+
+func (e *Engine) serverlessFunctionARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("lambda", e.region, e.accountID, "function:"+name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Web", "sites", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "locations/"+e.region+"/functions", name)
+	default:
+		return name
+	}
+}

--- a/resourcediscovery/engine.go
+++ b/resourcediscovery/engine.go
@@ -1,0 +1,108 @@
+package resourcediscovery
+
+import (
+	"context"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+)
+
+// Drivers bundles the per-service drivers the engine reads from. Any field
+// may be nil — the matching walker is skipped in that case. This keeps the
+// engine usable in partial test wirings and during the staged rollout of
+// per-service walkers in later phases.
+type Drivers struct {
+	Compute    computedriver.Compute
+	Networking netdriver.Networking
+	Storage    storagedriver.Bucket
+	Database   dbdriver.Database
+	Serverless serverlessdriver.Serverless
+}
+
+// Engine walks all configured service drivers and returns a normalized
+// cross-service resource inventory.
+type Engine struct {
+	provider  string
+	accountID string
+	region    string
+	drivers   Drivers
+}
+
+// New constructs an Engine. provider is one of "aws", "azure", "gcp".
+// accountID is the AWS account ID, Azure subscription ID, or GCP project ID;
+// it is embedded in the ARN/URN of each returned Resource. region is the
+// default region used when a driver does not carry per-resource regions.
+// drivers is passed by pointer because the struct is wider than the
+// gocritic hugeParam threshold; passing nil for any field skips that walker.
+func New(provider, accountID, region string, drivers *Drivers) *Engine {
+	var d Drivers
+	if drivers != nil {
+		d = *drivers
+	}
+
+	return &Engine{
+		provider:  provider,
+		accountID: accountID,
+		region:    region,
+		drivers:   d,
+	}
+}
+
+// ListAll walks every configured driver and returns the merged inventory.
+// Nil drivers are skipped silently. The first walker error short-circuits
+// the rest.
+func (e *Engine) ListAll(ctx context.Context) ([]Resource, error) {
+	return e.List(ctx, Query{})
+}
+
+// List walks every configured driver and returns resources matching q.
+// Filtering happens after collection — walkers always return their full set
+// so tag/region resolution is consistent regardless of query shape.
+func (e *Engine) List(ctx context.Context, q Query) ([]Resource, error) {
+	var out []Resource
+
+	for _, walk := range e.walkers() {
+		batch, err := walk(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range batch {
+			if q.matches(&batch[i]) {
+				out = append(out, batch[i])
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// walkers returns the active walker functions, skipping any whose driver is nil.
+func (e *Engine) walkers() []func(context.Context) ([]Resource, error) {
+	var ws []func(context.Context) ([]Resource, error)
+
+	if e.drivers.Compute != nil {
+		ws = append(ws, e.walkCompute)
+	}
+
+	if e.drivers.Networking != nil {
+		ws = append(ws, e.walkNetworking)
+	}
+
+	if e.drivers.Storage != nil {
+		ws = append(ws, e.walkStorage)
+	}
+
+	if e.drivers.Database != nil {
+		ws = append(ws, e.walkDatabase)
+	}
+
+	if e.drivers.Serverless != nil {
+		ws = append(ws, e.walkServerless)
+	}
+
+	return ws
+}

--- a/resourcediscovery/engine.go
+++ b/resourcediscovery/engine.go
@@ -51,6 +51,20 @@ func New(provider, accountID, region string, drivers *Drivers) *Engine {
 	}
 }
 
+// AccountID returns the AWS account ID, Azure subscription ID, or GCP
+// project ID the engine was constructed with. Exposed so handlers built on
+// top of the engine (Resource Explorer, Resource Graph, Cloud Asset
+// Inventory) don't have to ask their callers to supply the same value a
+// second time when wiring up the server.
+func (e *Engine) AccountID() string {
+	return e.accountID
+}
+
+// Region returns the default region the engine was constructed with.
+func (e *Engine) Region() string {
+	return e.region
+}
+
 // ListAll walks every configured driver and returns the merged inventory.
 // Nil drivers are skipped silently. The first walker error short-circuits
 // the rest.

--- a/resourcediscovery/engine_test.go
+++ b/resourcediscovery/engine_test.go
@@ -2,6 +2,7 @@ package resourcediscovery
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	"github.com/stackshy/cloudemu/config"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
 	"github.com/stackshy/cloudemu/providers/aws/ec2"
@@ -16,6 +18,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/s3"
 	"github.com/stackshy/cloudemu/providers/aws/vpc"
 	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -262,4 +265,107 @@ func groupByType(rs []Resource) map[string][]Resource {
 		out[r.Type] = append(out[r.Type], r)
 	}
 	return out
+}
+
+// failingDatabase wraps a real Database driver and forces ListTables (or
+// ListTagsOfResource, if set) to return the supplied error. All other
+// methods delegate to the embedded interface.
+type failingDatabase struct {
+	dbdriver.Database
+	listErr    error
+	listTagErr error
+}
+
+func (f *failingDatabase) ListTables(ctx context.Context) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.Database.ListTables(ctx)
+}
+
+func (f *failingDatabase) ListTagsOfResource(ctx context.Context, table string) (map[string]string, error) {
+	if f.listTagErr != nil {
+		return nil, f.listTagErr
+	}
+	return f.Database.ListTagsOfResource(ctx, table)
+}
+
+// failingStorage wraps a real Storage driver and forces GetBucketTagging
+// to return the supplied error.
+type failingStorage struct {
+	storagedriver.Bucket
+	tagErr error
+}
+
+func (f *failingStorage) GetBucketTagging(ctx context.Context, bucket string) (map[string]string, error) {
+	if f.tagErr != nil {
+		return nil, f.tagErr
+	}
+	return f.Bucket.GetBucketTagging(ctx, bucket)
+}
+
+func TestWalkerErrorPropagation(t *testing.T) {
+	ctx := context.Background()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	t.Run("ListTables error wraps with walker name", func(t *testing.T) {
+		sentinel := errors.New("listtables blew up")
+		db := &failingDatabase{Database: dynamodb.New(opts), listErr: sentinel}
+
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: db})
+		_, err := eng.ListAll(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel, "sentinel should propagate via %%w")
+		assert.Contains(t, err.Error(), "walkDatabase", "error should be wrapped with walker name")
+	})
+
+	t.Run("non-NotFound tag-lookup error propagates", func(t *testing.T) {
+		sentinel := errors.New("tagging service unavailable")
+
+		realDB := dynamodb.New(opts)
+		require.NoError(t, realDB.CreateTable(ctx, dbdriver.TableConfig{Name: "t1", PartitionKey: "pk"}))
+
+		db := &failingDatabase{Database: realDB, listTagErr: sentinel}
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: db})
+
+		_, err := eng.ListAll(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel)
+		assert.Contains(t, err.Error(), `"t1"`, "error should name the resource that failed")
+	})
+
+	t.Run("NotFound tag-lookup is treated as race and resource is skipped", func(t *testing.T) {
+		realDB := dynamodb.New(opts)
+		require.NoError(t, realDB.CreateTable(ctx, dbdriver.TableConfig{Name: "alive", PartitionKey: "pk"}))
+
+		// Force every ListTagsOfResource to look like the table was deleted
+		// mid-walk. The walker should drop the resource silently rather
+		// than failing the whole ListAll.
+		db := &failingDatabase{
+			Database:   realDB,
+			listTagErr: cerrors.Newf(cerrors.NotFound, "table gone"),
+		}
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: db})
+
+		out, err := eng.ListAll(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, out, "race-disappeared resources should be skipped, not surfaced")
+	})
+
+	t.Run("storage tag-lookup error propagates", func(t *testing.T) {
+		sentinel := errors.New("s3 tagging timeout")
+
+		realS3 := s3.New(opts)
+		require.NoError(t, realS3.CreateBucket(ctx, "bkt"))
+
+		bkt := &failingStorage{Bucket: realS3, tagErr: sentinel}
+		eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Storage: bkt})
+
+		_, err := eng.ListAll(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel)
+		assert.Contains(t, err.Error(), `"bkt"`)
+	})
 }

--- a/resourcediscovery/engine_test.go
+++ b/resourcediscovery/engine_test.go
@@ -1,0 +1,265 @@
+package resourcediscovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	"github.com/stackshy/cloudemu/config"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stackshy/cloudemu/providers/aws/dynamodb"
+	"github.com/stackshy/cloudemu/providers/aws/ec2"
+	"github.com/stackshy/cloudemu/providers/aws/lambda"
+	"github.com/stackshy/cloudemu/providers/aws/s3"
+	"github.com/stackshy/cloudemu/providers/aws/vpc"
+	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fixture struct {
+	engine *Engine
+	ec2    *ec2.Mock
+	vpc    *vpc.Mock
+	s3     *s3.Mock
+	ddb    *dynamodb.Mock
+	lambda *lambda.Mock
+}
+
+func newAWSFixture(t *testing.T) *fixture {
+	t.Helper()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+
+	ec2Mock := ec2.New(opts)
+	vpcMock := vpc.New(opts)
+	s3Mock := s3.New(opts)
+	ddbMock := dynamodb.New(opts)
+	lambdaMock := lambda.New(opts)
+
+	eng := New(ProviderAWS, "123456789012", "us-east-1", &Drivers{
+		Compute:    ec2Mock,
+		Networking: vpcMock,
+		Storage:    s3Mock,
+		Database:   ddbMock,
+		Serverless: lambdaMock,
+	})
+
+	return &fixture{
+		engine: eng,
+		ec2:    ec2Mock,
+		vpc:    vpcMock,
+		s3:     s3Mock,
+		ddb:    ddbMock,
+		lambda: lambdaMock,
+	}
+}
+
+func TestNew(t *testing.T) {
+	eng := New(ProviderAWS, "acct", "us-east-1", nil)
+	require.NotNil(t, eng)
+	assert.Equal(t, ProviderAWS, eng.provider)
+}
+
+func TestListAllEmpty(t *testing.T) {
+	f := newAWSFixture(t)
+
+	out, err := f.engine.ListAll(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestListAllAcrossServices(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, map[string]string{"env": "prod"})
+	seedVPC(t, f, map[string]string{"env": "prod"})
+	seedS3(t, f, "data-bucket", map[string]string{"env": "stage"})
+	seedDDB(t, f, "users", map[string]string{"env": "prod", "team": "core"})
+	seedLambda(t, f, "handler", map[string]string{"env": "stage"})
+
+	out, err := f.engine.ListAll(ctx)
+	require.NoError(t, err)
+
+	byType := groupByType(out)
+	assert.Len(t, byType[TypeInstance], 1, "compute instance")
+	assert.Len(t, byType[TypeVPC], 1, "vpc")
+	assert.Len(t, byType[TypeBucket], 1, "bucket")
+	assert.Len(t, byType[TypeTable], 1, "table")
+	assert.Len(t, byType[TypeFunction], 1, "function")
+}
+
+func TestListWithQueryFilters(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, map[string]string{"env": "prod"})
+	seedDDB(t, f, "users", map[string]string{"env": "prod"})
+	seedDDB(t, f, "stage-cache", map[string]string{"env": "stage"})
+
+	t.Run("by service", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Service: ServiceDatabase})
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+		for _, r := range got {
+			assert.Equal(t, ServiceDatabase, r.Service)
+		}
+	})
+
+	t.Run("by type", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Type: TypeInstance})
+		require.NoError(t, err)
+		assert.Len(t, got, 1)
+		assert.Equal(t, TypeInstance, got[0].Type)
+	})
+
+	t.Run("by tag key+value", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Tags: map[string]string{"env": "prod"}})
+		require.NoError(t, err)
+		assert.Len(t, got, 2, "expected compute + users table")
+	})
+
+	t.Run("by tag key only", func(t *testing.T) {
+		got, err := f.engine.List(ctx, Query{Tags: map[string]string{"env": ""}})
+		require.NoError(t, err)
+		assert.Len(t, got, 3, "all 3 carry env tag")
+	})
+}
+
+func TestSearchByTag(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedDDB(t, f, "prod-tbl", map[string]string{"env": "prod"})
+	seedDDB(t, f, "stage-tbl", map[string]string{"env": "stage"})
+
+	got, err := f.engine.SearchByTag(ctx, "env", "prod")
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "prod-tbl", got[0].ID)
+}
+
+func TestGetTagKeysAndValues(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, map[string]string{"env": "prod", "team": "core"})
+	seedDDB(t, f, "tbl", map[string]string{"env": "stage"})
+
+	keys, err := f.engine.GetTagKeys(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"env", "team"}, keys)
+
+	envValues, err := f.engine.GetTagValues(ctx, "env")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"prod", "stage"}, envValues)
+
+	missing, err := f.engine.GetTagValues(ctx, "missing")
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+}
+
+func TestARNShapes(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedCompute(t, f, nil)
+	seedVPC(t, f, nil)
+	seedS3(t, f, "my-bkt", nil)
+	seedDDB(t, f, "my-tbl", nil)
+	seedLambda(t, f, "my-fn", nil)
+
+	out, err := f.engine.ListAll(ctx)
+	require.NoError(t, err)
+
+	for _, r := range out {
+		switch r.Type {
+		case TypeInstance:
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:instance/"),
+				"unexpected instance ARN: %s", r.ARN)
+		case TypeVPC:
+			assert.True(t, strings.HasPrefix(r.ARN, "arn:aws:ec2:us-east-1:123456789012:vpc/"),
+				"unexpected VPC ARN: %s", r.ARN)
+		case TypeBucket:
+			assert.Equal(t, "arn:aws:s3:::my-bkt", r.ARN)
+		case TypeTable:
+			assert.Equal(t, "arn:aws:dynamodb:us-east-1:123456789012:table/my-tbl", r.ARN)
+		case TypeFunction:
+			// Lambda mock builds its own ARN; we just require non-empty.
+			assert.NotEmpty(t, r.ARN)
+		default:
+			t.Fatalf("unexpected resource type: %s", r.Type)
+		}
+	}
+}
+
+func TestNilDriversSkipped(t *testing.T) {
+	ctx := context.Background()
+
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	ddbMock := dynamodb.New(opts)
+
+	eng := New(ProviderAWS, "acct", "us-east-1", &Drivers{Database: ddbMock})
+	require.NoError(t, ddbMock.CreateTable(ctx, dbdriver.TableConfig{Name: "only", PartitionKey: "pk"}))
+
+	out, err := eng.ListAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.Equal(t, ServiceDatabase, out[0].Service)
+}
+
+func seedCompute(t *testing.T, f *fixture, tags map[string]string) {
+	t.Helper()
+	_, err := f.ec2.RunInstances(context.Background(), computedriver.InstanceConfig{
+		ImageID: "ami-1", InstanceType: "t2.micro", Tags: tags,
+	}, 1)
+	require.NoError(t, err)
+}
+
+func seedVPC(t *testing.T, f *fixture, tags map[string]string) {
+	t.Helper()
+	_, err := f.vpc.CreateVPC(context.Background(), netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: tags,
+	})
+	require.NoError(t, err)
+}
+
+func seedS3(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, f.s3.CreateBucket(ctx, name))
+	if len(tags) > 0 {
+		require.NoError(t, f.s3.PutBucketTagging(ctx, name, tags))
+	}
+}
+
+func seedDDB(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, f.ddb.CreateTable(ctx, dbdriver.TableConfig{Name: name, PartitionKey: "pk"}))
+	if len(tags) > 0 {
+		require.NoError(t, f.ddb.TagResource(ctx, name, tags))
+	}
+}
+
+func seedLambda(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	_, err := f.lambda.CreateFunction(context.Background(), serverlessdriver.FunctionConfig{
+		Name: name, Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30, Tags: tags,
+	})
+	require.NoError(t, err)
+}
+
+func groupByType(rs []Resource) map[string][]Resource {
+	out := make(map[string][]Resource)
+	for _, r := range rs {
+		out[r.Type] = append(out[r.Type], r)
+	}
+	return out
+}

--- a/resourcediscovery/engine_test.go
+++ b/resourcediscovery/engine_test.go
@@ -106,7 +106,7 @@ func TestListWithQueryFilters(t *testing.T) {
 	seedDDB(t, f, "stage-cache", map[string]string{"env": "stage"})
 
 	t.Run("by service", func(t *testing.T) {
-		got, err := f.engine.List(ctx, Query{Service: ServiceDatabase})
+		got, err := f.engine.List(ctx, Query{Services: []string{ServiceDatabase}})
 		require.NoError(t, err)
 		assert.Len(t, got, 2)
 		for _, r := range got {

--- a/resourcediscovery/search.go
+++ b/resourcediscovery/search.go
@@ -1,0 +1,64 @@
+package resourcediscovery
+
+import (
+	"context"
+	"sort"
+)
+
+// SearchByTag returns every resource carrying tag key. If value is non-empty,
+// the tag's value must also match exactly.
+func (e *Engine) SearchByTag(ctx context.Context, key, value string) ([]Resource, error) {
+	return e.List(ctx, Query{Tags: map[string]string{key: value}})
+}
+
+// GetTagKeys returns the deduplicated, sorted set of tag keys present on
+// any resource across the engine's drivers.
+func (e *Engine) GetTagKeys(ctx context.Context) ([]string, error) {
+	all, err := e.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{})
+
+	for i := range all {
+		for k := range all[i].Tags {
+			set[k] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}
+
+// GetTagValues returns the deduplicated, sorted set of values seen for the
+// given tag key across every resource.
+func (e *Engine) GetTagValues(ctx context.Context, key string) ([]string, error) {
+	all, err := e.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	set := make(map[string]struct{})
+
+	for i := range all {
+		if v, ok := all[i].Tags[key]; ok {
+			set[v] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+
+	sort.Strings(out)
+
+	return out, nil
+}

--- a/resourcediscovery/tagging.go
+++ b/resourcediscovery/tagging.go
@@ -93,6 +93,15 @@ func parseS3ARN(arn, resource string) (parsedARN, error) {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "S3 ARN missing bucket name: %q", arn)
 	}
 
+	// arn:aws:s3:::bucket-name → resource = "bucket-name" (taggable).
+	// arn:aws:s3:::bucket-name/object-key → resource = "bucket-name/object-key".
+	// Object-level tagging requires PutObjectTagging, not PutBucketTagging;
+	// reject until Phase 2.x adds object support.
+	if strings.ContainsRune(resource, '/') {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"S3 object ARNs are not yet supported (Phase 2 covers buckets only): %q", arn)
+	}
+
 	return parsedARN{service: awsServiceS3, id: resource}, nil
 }
 

--- a/resourcediscovery/tagging.go
+++ b/resourcediscovery/tagging.go
@@ -1,0 +1,224 @@
+package resourcediscovery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// AWS service identifiers as they appear in ARNs.
+const (
+	awsServiceS3       = "s3"
+	awsServiceDynamoDB = "dynamodb"
+	awsServiceEC2      = "ec2"
+)
+
+// DynamoDB resource type within an EC2 ARN.
+const awsTypeTable = "table"
+
+// arnParts is the number of colon-separated segments in a fully-qualified
+// AWS ARN: arn:partition:service:region:account:resource.
+const arnParts = 6
+
+// TagResourceByARN merges tags into the resource identified by arn. The arn
+// is parsed to determine the underlying service and resource type, then
+// dispatched to the matching driver's tag-mutation method.
+//
+// Supported in Phase 2:
+//   - AWS S3 bucket: arn:aws:s3:::name
+//   - AWS DynamoDB table: arn:aws:dynamodb:region:account:table/name
+//   - AWS VPC/Subnet/SecurityGroup: arn:aws:ec2:region:account:{vpc,subnet,security-group}/id
+//
+// Returns InvalidArgument for unsupported services (lambda, ec2 instance, etc.)
+// or unparseable ARNs.
+func (e *Engine) TagResourceByARN(ctx context.Context, arn string, tags map[string]string) error {
+	res, err := parseSupportedARN(arn)
+	if err != nil {
+		return err
+	}
+
+	return e.dispatchTag(ctx, res, tags, true /* set */, nil)
+}
+
+// UntagResourceByARN removes the given tag keys from the resource identified
+// by arn. ARN parsing rules match TagResourceByARN.
+func (e *Engine) UntagResourceByARN(ctx context.Context, arn string, keys []string) error {
+	res, err := parseSupportedARN(arn)
+	if err != nil {
+		return err
+	}
+
+	return e.dispatchTag(ctx, res, nil, false /* set */, keys)
+}
+
+// parsedARN holds the fragments TagResourceByARN needs to route a call.
+type parsedARN struct {
+	service      string // "s3", "dynamodb", "ec2"
+	resourceType string // "table", "vpc", "subnet", "security-group", or "" for s3 bucket
+	id           string // bucket name, table name, vpc-id, subnet-id, sg-id
+}
+
+func parseSupportedARN(arn string) (parsedARN, error) {
+	// AWS ARN format: arn:partition:service:region:account:resource
+	// resource is either "name" (S3), "type/id", or "type:id".
+	if !strings.HasPrefix(arn, "arn:aws:") {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "only AWS ARNs are supported, got %q", arn)
+	}
+
+	parts := strings.SplitN(arn, ":", arnParts)
+	if len(parts) < arnParts {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "malformed ARN: %q", arn)
+	}
+
+	service := parts[2]
+	resource := parts[5]
+
+	switch service {
+	case awsServiceS3:
+		return parseS3ARN(arn, resource)
+	case awsServiceDynamoDB:
+		return parseDynamoDBARN(arn, resource)
+	case awsServiceEC2:
+		return parseEC2ARN(arn, resource)
+	default:
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"tagging service %q is not yet supported (Phase 2 covers s3, dynamodb, ec2 networking)", service)
+	}
+}
+
+func parseS3ARN(arn, resource string) (parsedARN, error) {
+	if resource == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "S3 ARN missing bucket name: %q", arn)
+	}
+
+	return parsedARN{service: awsServiceS3, id: resource}, nil
+}
+
+func parseDynamoDBARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, '/')
+	if !ok || rt != awsTypeTable {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected DynamoDB table ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceDynamoDB, resourceType: rt, id: id}, nil
+}
+
+func parseEC2ARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, '/')
+	if !ok {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "malformed EC2 ARN: %q", arn)
+	}
+
+	switch rt {
+	case netKindVPC, netKindSubnet, netKindSecurityGroup:
+		return parsedARN{service: awsServiceEC2, resourceType: rt, id: id}, nil
+	default:
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
+			"tagging EC2 resource type %q is not yet supported (Phase 2 covers vpc, subnet, security-group)", rt)
+	}
+}
+
+func splitTypeID(s string, sep rune) (rt, id string, ok bool) {
+	for i, r := range s {
+		if r == sep {
+			return s[:i], s[i+1:], true
+		}
+	}
+
+	return "", "", false
+}
+
+func (e *Engine) dispatchTag(ctx context.Context, res parsedARN, tags map[string]string, set bool, keys []string) error {
+	switch {
+	case res.service == awsServiceS3:
+		return e.tagS3(ctx, res.id, tags, set, keys)
+	case res.service == awsServiceDynamoDB && res.resourceType == awsTypeTable:
+		return e.tagDynamoDB(ctx, res.id, tags, set, keys)
+	case res.service == awsServiceEC2:
+		return e.tagEC2Network(ctx, res.resourceType, res.id, tags, set, keys)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "internal: unrouted parsedARN %+v", res)
+	}
+}
+
+func (e *Engine) tagS3(ctx context.Context, bucket string, tags map[string]string, set bool, keys []string) error {
+	if e.drivers.Storage == nil {
+		return cerrors.Newf(cerrors.FailedPrecondition, "storage driver not configured on engine")
+	}
+
+	if set {
+		// S3 PutBucketTagging replaces the entire tag set. To get "merge"
+		// semantics we read-modify-write.
+		existing, err := e.drivers.Storage.GetBucketTagging(ctx, bucket)
+		if err != nil && !cerrors.IsNotFound(err) {
+			return fmt.Errorf("tagS3 read %q: %w", bucket, err)
+		}
+
+		merged := make(map[string]string, len(existing)+len(tags))
+		for k, v := range existing {
+			merged[k] = v
+		}
+
+		for k, v := range tags {
+			merged[k] = v
+		}
+
+		return e.drivers.Storage.PutBucketTagging(ctx, bucket, merged)
+	}
+
+	existing, err := e.drivers.Storage.GetBucketTagging(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("tagS3 read %q: %w", bucket, err)
+	}
+
+	for _, k := range keys {
+		delete(existing, k)
+	}
+
+	return e.drivers.Storage.PutBucketTagging(ctx, bucket, existing)
+}
+
+func (e *Engine) tagDynamoDB(ctx context.Context, table string, tags map[string]string, set bool, keys []string) error {
+	if e.drivers.Database == nil {
+		return cerrors.Newf(cerrors.FailedPrecondition, "database driver not configured on engine")
+	}
+
+	if set {
+		return e.drivers.Database.TagResource(ctx, table, tags)
+	}
+
+	return e.drivers.Database.UntagResource(ctx, table, keys)
+}
+
+func (e *Engine) tagEC2Network(ctx context.Context, resourceType, id string,
+	tags map[string]string, set bool, keys []string,
+) error {
+	if e.drivers.Networking == nil {
+		return cerrors.Newf(cerrors.FailedPrecondition, "networking driver not configured on engine")
+	}
+
+	switch resourceType {
+	case netKindVPC:
+		if set {
+			return e.drivers.Networking.UpdateVPCTags(ctx, id, tags)
+		}
+
+		return e.drivers.Networking.RemoveVPCTags(ctx, id, keys)
+	case netKindSubnet:
+		if set {
+			return e.drivers.Networking.UpdateSubnetTags(ctx, id, tags)
+		}
+
+		return e.drivers.Networking.RemoveSubnetTags(ctx, id, keys)
+	case netKindSecurityGroup:
+		if set {
+			return e.drivers.Networking.UpdateSecurityGroupTags(ctx, id, tags)
+		}
+
+		return e.drivers.Networking.RemoveSecurityGroupTags(ctx, id, keys)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported EC2 resource type %q", resourceType)
+	}
+}

--- a/resourcediscovery/tagging_test.go
+++ b/resourcediscovery/tagging_test.go
@@ -1,0 +1,177 @@
+package resourcediscovery
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSupportedARN(t *testing.T) {
+	tests := []struct {
+		name      string
+		arn       string
+		wantSvc   string
+		wantType  string
+		wantID    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{name: "s3 bucket", arn: "arn:aws:s3:::my-bucket", wantSvc: "s3", wantID: "my-bucket"},
+		{name: "dynamodb table", arn: "arn:aws:dynamodb:us-east-1:111:table/MyTable", wantSvc: "dynamodb", wantType: "table", wantID: "MyTable"},
+		{name: "vpc", arn: "arn:aws:ec2:us-east-1:111:vpc/vpc-abc", wantSvc: "ec2", wantType: "vpc", wantID: "vpc-abc"},
+		{name: "subnet", arn: "arn:aws:ec2:us-east-1:111:subnet/subnet-abc", wantSvc: "ec2", wantType: "subnet", wantID: "subnet-abc"},
+		{name: "security-group", arn: "arn:aws:ec2:us-east-1:111:security-group/sg-abc", wantSvc: "ec2", wantType: "security-group", wantID: "sg-abc"},
+		{name: "instance unsupported", arn: "arn:aws:ec2:us-east-1:111:instance/i-abc", wantErr: true, errSubstr: "not yet supported"},
+		{name: "lambda unsupported", arn: "arn:aws:lambda:us-east-1:111:function:fn", wantErr: true, errSubstr: "not yet supported"},
+		{name: "non-aws partition", arn: "arn:azure:s3:::x", wantErr: true, errSubstr: "only AWS ARNs"},
+		{name: "malformed", arn: "not-an-arn", wantErr: true, errSubstr: "only AWS ARNs"},
+		{name: "missing parts", arn: "arn:aws:s3", wantErr: true, errSubstr: "malformed ARN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSupportedARN(tt.arn)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tt.errSubstr),
+					"error %q did not contain %q", err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSvc, got.service)
+			assert.Equal(t, tt.wantType, got.resourceType)
+			assert.Equal(t, tt.wantID, got.id)
+		})
+	}
+}
+
+func TestTagResourceByARN_S3(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	require.NoError(t, f.s3.CreateBucket(ctx, "tag-me"))
+	require.NoError(t, f.engine.TagResourceByARN(ctx, "arn:aws:s3:::tag-me",
+		map[string]string{"env": "prod", "team": "platform"}))
+
+	got, err := f.s3.GetBucketTagging(ctx, "tag-me")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got["env"])
+	assert.Equal(t, "platform", got["team"])
+
+	// Merge semantics: existing keys preserved, overlapping overwritten.
+	require.NoError(t, f.engine.TagResourceByARN(ctx, "arn:aws:s3:::tag-me",
+		map[string]string{"env": "stage", "new": "x"}))
+	got, err = f.s3.GetBucketTagging(ctx, "tag-me")
+	require.NoError(t, err)
+	assert.Equal(t, "stage", got["env"])
+	assert.Equal(t, "platform", got["team"], "non-overlapping key should survive merge")
+	assert.Equal(t, "x", got["new"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, "arn:aws:s3:::tag-me", []string{"env", "missing"}))
+	got, err = f.s3.GetBucketTagging(ctx, "tag-me")
+	require.NoError(t, err)
+	_, has := got["env"]
+	assert.False(t, has)
+	assert.Equal(t, "platform", got["team"])
+}
+
+func TestTagResourceByARN_DynamoDB(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedDDB(t, f, "tag-tbl", nil)
+
+	arn := "arn:aws:dynamodb:us-east-1:123456789012:table/tag-tbl"
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"env": "prod"}))
+
+	got, err := f.ddb.ListTagsOfResource(ctx, "tag-tbl")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got["env"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"env"}))
+	got, err = f.ddb.ListTagsOfResource(ctx, "tag-tbl")
+	require.NoError(t, err)
+	_, has := got["env"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_VPC(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	v, err := f.vpc.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:vpc/" + v.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"env": "prod"}))
+
+	got, err := f.vpc.DescribeVPCs(ctx, []string{v.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got[0].Tags["env"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"env"}))
+	got, err = f.vpc.DescribeVPCs(ctx, []string{v.ID})
+	require.NoError(t, err)
+	_, has := got[0].Tags["env"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_Subnet(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	v, err := f.vpc.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	s, err := f.vpc.CreateSubnet(ctx, netdriver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:subnet/" + s.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"tier": "private"}))
+
+	got, err := f.vpc.DescribeSubnets(ctx, []string{s.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "private", got[0].Tags["tier"])
+}
+
+func TestTagResourceByARN_SecurityGroup(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	v, err := f.vpc.CreateVPC(ctx, netdriver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	require.NoError(t, err)
+	sg, err := f.vpc.CreateSecurityGroup(ctx, netdriver.SecurityGroupConfig{Name: "web", VPCID: v.ID})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:security-group/" + sg.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"role": "web"}))
+
+	got, err := f.vpc.DescribeSecurityGroups(ctx, []string{sg.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "web", got[0].Tags["role"])
+}
+
+func TestTagResourceByARN_UnsupportedReturnsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	err := f.engine.TagResourceByARN(ctx, "arn:aws:lambda:us-east-1:111:function:fn",
+		map[string]string{"k": "v"})
+	require.Error(t, err)
+	assert.Equal(t, cerrors.InvalidArgument, cerrors.GetCode(err))
+	assert.Contains(t, err.Error(), "not yet supported")
+}
+
+func TestTagResourceByARN_MissingDriverReturnsFailedPrecondition(t *testing.T) {
+	ctx := context.Background()
+	// Engine with no drivers wired.
+	eng := New(ProviderAWS, "111", "us-east-1", nil)
+
+	err := eng.TagResourceByARN(ctx, "arn:aws:s3:::x", map[string]string{"k": "v"})
+	require.Error(t, err)
+	assert.Equal(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+}

--- a/resourcediscovery/tagging_test.go
+++ b/resourcediscovery/tagging_test.go
@@ -31,6 +31,7 @@ func TestParseSupportedARN(t *testing.T) {
 		{name: "non-aws partition", arn: "arn:azure:s3:::x", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "malformed", arn: "not-an-arn", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "missing parts", arn: "arn:aws:s3", wantErr: true, errSubstr: "malformed ARN"},
+		{name: "s3 object rejected", arn: "arn:aws:s3:::bkt/obj.txt", wantErr: true, errSubstr: "object ARNs are not yet supported"},
 	}
 
 	for _, tt := range tests {

--- a/resourcediscovery/types.go
+++ b/resourcediscovery/types.go
@@ -1,0 +1,75 @@
+// Package resourcediscovery is a cross-service inventory engine. It reads
+// from existing service drivers (compute, networking, storage, database,
+// serverless) and returns a normalized view of every resource a provider
+// holds, with tags resolved per service.
+//
+// The engine follows the topology package as a precedent: it owns no state,
+// constructs from driver interfaces, and is query-driven. It is the
+// foundation for the SDK-compat handlers in the AWS Resource Explorer +
+// Resource Groups Tagging API, Azure Resource Graph, and GCP Cloud Asset
+// Inventory packages.
+package resourcediscovery
+
+import "time"
+
+// Resource is the normalized cross-cloud resource shape. Every walker emits
+// resources in this form so callers can filter, search, and tag-query
+// uniformly regardless of provider or service.
+type Resource struct {
+	Provider  string
+	Service   string
+	Type      string
+	ID        string
+	ARN       string
+	Region    string
+	Tags      map[string]string
+	CreatedAt time.Time
+}
+
+// Query filters a list operation. All non-empty fields must match. Tags match
+// on key presence and (if value is non-empty) equality.
+type Query struct {
+	Service string
+	Type    string
+	Region  string
+	Tags    map[string]string
+}
+
+// matches returns true if r satisfies every non-empty field of q.
+func (q Query) matches(r *Resource) bool {
+	if !fieldMatch(q.Service, r.Service) {
+		return false
+	}
+
+	if !fieldMatch(q.Type, r.Type) {
+		return false
+	}
+
+	if !fieldMatch(q.Region, r.Region) {
+		return false
+	}
+
+	return tagsMatch(q.Tags, r.Tags)
+}
+
+// fieldMatch returns true when want is empty (no filter) or equals got.
+func fieldMatch(want, got string) bool {
+	return want == "" || want == got
+}
+
+// tagsMatch returns true when every required key is present, and any
+// non-empty required value equals the actual value.
+func tagsMatch(required, actual map[string]string) bool {
+	for k, v := range required {
+		got, ok := actual[k]
+		if !ok {
+			return false
+		}
+
+		if v != "" && got != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/resourcediscovery/types.go
+++ b/resourcediscovery/types.go
@@ -28,16 +28,21 @@ type Resource struct {
 
 // Query filters a list operation. All non-empty fields must match. Tags match
 // on key presence and (if value is non-empty) equality.
+//
+// Services is an any-of set: a resource matches if its Service is in the
+// slice. An empty/nil slice means "no service filter". This shape supports
+// cases like AWS's "ec2" which spans both compute and networking — the
+// caller can pass Services: []string{"compute", "networking"}.
 type Query struct {
-	Service string
-	Type    string
-	Region  string
-	Tags    map[string]string
+	Services []string
+	Type     string
+	Region   string
+	Tags     map[string]string
 }
 
 // matches returns true if r satisfies every non-empty field of q.
 func (q Query) matches(r *Resource) bool {
-	if !fieldMatch(q.Service, r.Service) {
+	if !sliceMatch(q.Services, r.Service) {
 		return false
 	}
 
@@ -55,6 +60,21 @@ func (q Query) matches(r *Resource) bool {
 // fieldMatch returns true when want is empty (no filter) or equals got.
 func fieldMatch(want, got string) bool {
 	return want == "" || want == got
+}
+
+// sliceMatch returns true when want is empty (no filter) or got is in want.
+func sliceMatch(want []string, got string) bool {
+	if len(want) == 0 {
+		return true
+	}
+
+	for _, w := range want {
+		if w == got {
+			return true
+		}
+	}
+
+	return false
 }
 
 // tagsMatch returns true when every required key is present, and any

--- a/resourcediscovery/walkers.go
+++ b/resourcediscovery/walkers.go
@@ -1,0 +1,203 @@
+package resourcediscovery
+
+import (
+	"context"
+	"fmt"
+)
+
+// Provider name constants used for routing per-provider ARN construction.
+const (
+	ProviderAWS   = "aws"
+	ProviderAzure = "azure"
+	ProviderGCP   = "gcp"
+)
+
+// Service name constants embedded in Resource.Service. These are the
+// portable-API service identifiers, not provider-specific names. Callers
+// translate to per-provider service names at the SDK boundary.
+const (
+	ServiceCompute    = "compute"
+	ServiceNetworking = "networking"
+	ServiceStorage    = "storage"
+	ServiceDatabase   = "database"
+	ServiceServerless = "serverless"
+)
+
+// Resource type constants emitted by the walkers.
+const (
+	TypeInstance      = "Instance"
+	TypeVPC           = "VPC"
+	TypeSubnet        = "Subnet"
+	TypeSecurityGroup = "SecurityGroup"
+	TypeBucket        = "Bucket"
+	TypeTable         = "Table"
+	TypeFunction      = "Function"
+)
+
+func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
+	instances, err := e.drivers.Compute.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkCompute: %w", err)
+	}
+
+	out := make([]Resource, 0, len(instances))
+	for i := range instances {
+		out = append(out, Resource{
+			Provider: e.provider,
+			Service:  ServiceCompute,
+			Type:     TypeInstance,
+			ID:       instances[i].ID,
+			ARN:      e.computeInstanceARN(instances[i].ID),
+			Region:   e.region,
+			Tags:     copyTags(instances[i].Tags),
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkNetworking(ctx context.Context) ([]Resource, error) {
+	out := []Resource{}
+
+	vpcs, err := e.drivers.Networking.DescribeVPCs(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkNetworking vpcs: %w", err)
+	}
+
+	for _, v := range vpcs {
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypeVPC,
+			ID:     v.ID,
+			ARN:    e.networkARN(netKindVPC, v.ID),
+			Region: e.region, Tags: copyTags(v.Tags),
+		})
+	}
+
+	subnets, err := e.drivers.Networking.DescribeSubnets(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkNetworking subnets: %w", err)
+	}
+
+	for _, s := range subnets {
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypeSubnet,
+			ID:     s.ID,
+			ARN:    e.networkARN(netKindSubnet, s.ID),
+			Region: e.region, Tags: copyTags(s.Tags),
+		})
+	}
+
+	sgs, err := e.drivers.Networking.DescribeSecurityGroups(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("walkNetworking sgs: %w", err)
+	}
+
+	for _, sg := range sgs {
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceNetworking, Type: TypeSecurityGroup,
+			ID:     sg.ID,
+			ARN:    e.networkARN(netKindSecurityGroup, sg.ID),
+			Region: e.region, Tags: copyTags(sg.Tags),
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkStorage(ctx context.Context) ([]Resource, error) {
+	buckets, err := e.drivers.Storage.ListBuckets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkStorage: %w", err)
+	}
+
+	out := make([]Resource, 0, len(buckets))
+
+	for _, b := range buckets {
+		tags, tagErr := e.drivers.Storage.GetBucketTagging(ctx, b.Name)
+		if tagErr != nil {
+			// Buckets without tags surface a NotFound from the tagging API
+			// in real S3 — treat as "no tags" rather than failing the walk.
+			tags = nil
+		}
+
+		region := b.Region
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceStorage, Type: TypeBucket,
+			ID:     b.Name,
+			ARN:    e.storageBucketARN(b.Name),
+			Region: region, Tags: tags,
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkDatabase(ctx context.Context) ([]Resource, error) {
+	tables, err := e.drivers.Database.ListTables(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkDatabase: %w", err)
+	}
+
+	out := make([]Resource, 0, len(tables))
+
+	for _, name := range tables {
+		tags, tagErr := e.drivers.Database.ListTagsOfResource(ctx, name)
+		if tagErr != nil {
+			tags = nil
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceDatabase, Type: TypeTable,
+			ID:     name,
+			ARN:    e.databaseTableARN(name),
+			Region: e.region, Tags: tags,
+		})
+	}
+
+	return out, nil
+}
+
+func (e *Engine) walkServerless(ctx context.Context) ([]Resource, error) {
+	fns, err := e.drivers.Serverless.ListFunctions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkServerless: %w", err)
+	}
+
+	out := make([]Resource, 0, len(fns))
+
+	for i := range fns {
+		// FunctionInfo carries a populated ARN — use it directly rather than
+		// re-deriving, so the value matches what the function's own service
+		// returned.
+		arn := fns[i].ARN
+		if arn == "" {
+			arn = e.serverlessFunctionARN(fns[i].Name)
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceServerless, Type: TypeFunction,
+			ID:     fns[i].Name,
+			ARN:    arn,
+			Region: e.region, Tags: copyTags(fns[i].Tags),
+		})
+	}
+
+	return out, nil
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}

--- a/resourcediscovery/walkers.go
+++ b/resourcediscovery/walkers.go
@@ -3,6 +3,8 @@ package resourcediscovery
 import (
 	"context"
 	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
 )
 
 // Provider name constants used for routing per-provider ARN construction.
@@ -115,9 +117,14 @@ func (e *Engine) walkStorage(ctx context.Context) ([]Resource, error) {
 	for _, b := range buckets {
 		tags, tagErr := e.drivers.Storage.GetBucketTagging(ctx, b.Name)
 		if tagErr != nil {
-			// Buckets without tags surface a NotFound from the tagging API
-			// in real S3 — treat as "no tags" rather than failing the walk.
-			tags = nil
+			// NotFound means the bucket was deleted between ListBuckets and
+			// this tagging lookup. Skip it from the inventory; any other
+			// error is real and must propagate.
+			if cerrors.IsNotFound(tagErr) {
+				continue
+			}
+
+			return nil, fmt.Errorf("walkStorage tags %q: %w", b.Name, tagErr)
 		}
 
 		region := b.Region
@@ -147,7 +154,14 @@ func (e *Engine) walkDatabase(ctx context.Context) ([]Resource, error) {
 	for _, name := range tables {
 		tags, tagErr := e.drivers.Database.ListTagsOfResource(ctx, name)
 		if tagErr != nil {
-			tags = nil
+			// Race window: table was deleted between ListTables and the
+			// tagging lookup. Skip the now-gone resource. Any other error
+			// is real and must propagate.
+			if cerrors.IsNotFound(tagErr) {
+				continue
+			}
+
+			return nil, fmt.Errorf("walkDatabase tags %q: %w", name, tagErr)
 		}
 
 		out = append(out, Resource{

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -15,6 +15,7 @@ import (
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
@@ -23,6 +24,8 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/rds"
 	"github.com/stackshy/cloudemu/server/aws/redshift"
+	"github.com/stackshy/cloudemu/server/aws/resourceexplorer2"
+	"github.com/stackshy/cloudemu/server/aws/resourcegroupstaggingapi"
 	"github.com/stackshy/cloudemu/server/aws/s3"
 	"github.com/stackshy/cloudemu/server/aws/sqs"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
@@ -48,6 +51,13 @@ type Drivers struct {
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
 	// the same backend. Leave nil to disable Kubernetes data-plane support.
 	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery is the cross-service inventory engine. Required to
+	// serve Resource Explorer 2 and Resource Groups Tagging API requests.
+	// Leave nil to omit both handlers. AccountID and Region are needed for
+	// Resource Explorer to construct view/index ARNs.
+	ResourceDiscovery *resourcediscovery.Engine
+	AccountID         string
+	Region            string
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every
@@ -89,6 +99,12 @@ func New(d Drivers) *server.Server {
 		srv.Register(sqs.New(d.SQS))
 	}
 
+	// Resource Groups Tagging API: X-Amz-Target prefix
+	// ResourceGroupsTaggingAPI_20170126.* — disjoint from DynamoDB/SQS.
+	if d.ResourceDiscovery != nil {
+		srv.Register(resourcegroupstaggingapi.New(d.ResourceDiscovery))
+	}
+
 	// RDS must be registered before EC2: both speak AWS query-protocol on
 	// POST + form-encoded bodies, and Server matches in registration order.
 	// RDS's Matches is action-specific, so a request bound for EC2 will fall
@@ -125,6 +141,12 @@ func New(d Drivers) *server.Server {
 	// every other AWS path. Registered before S3's REST fallback.
 	if d.K8sAPI != nil {
 		srv.Register(d.K8sAPI)
+	}
+
+	// Resource Explorer 2 uses REST-JSON with fixed top-level paths
+	// (/CreateView, /Search, etc.). Must register before S3's catch-all.
+	if d.ResourceDiscovery != nil {
+		srv.Register(resourceexplorer2.New(d.ResourceDiscovery, d.AccountID, d.Region))
 	}
 
 	if d.S3 != nil {

--- a/server/aws/resourceexplorer2/filter.go
+++ b/server/aws/resourceexplorer2/filter.go
@@ -43,7 +43,7 @@ func applyToken(q *resourcediscovery.Query, token string) {
 
 	switch key {
 	case "service":
-		q.Service = awsToPortableService(val)
+		q.Services = append(q.Services, awsToPortableServices(val)...)
 	case "region":
 		q.Region = val
 	}
@@ -62,20 +62,21 @@ func applyTagToken(q *resourcediscovery.Query, body string) {
 	q.Tags[key] = val
 }
 
-func awsToPortableService(s string) string {
+// awsToPortableServices maps an AWS service name to the set of portable
+// service names that match it. Most AWS services map 1:1; "ec2" expands to
+// {compute, networking} because real AWS uses ec2 for both VMs and VPC
+// resources while cloudemu's portable API splits them.
+func awsToPortableServices(s string) []string {
 	switch s {
 	case awsServiceEC2:
-		// ec2 covers both compute and networking in real AWS; the engine
-		// returns both because Query.Service applies to portable names. We
-		// use empty to match either.
-		return ""
+		return []string{portableServiceCompute, portableServiceNetworking}
 	case awsServiceS3:
-		return portableServiceStorage
+		return []string{portableServiceStorage}
 	case awsServiceDynamoDB:
-		return portableServiceDatabase
+		return []string{portableServiceDatabase}
 	case awsServiceLambda:
-		return portableServiceServerless
+		return []string{portableServiceServerless}
 	default:
-		return s
+		return []string{s}
 	}
 }

--- a/server/aws/resourceexplorer2/filter.go
+++ b/server/aws/resourceexplorer2/filter.go
@@ -1,0 +1,81 @@
+package resourceexplorer2
+
+import (
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// parseFilter parses Resource Explorer's documented query subset into a
+// resourcediscovery.Query. Supported tokens:
+//
+//	service:<name>          → Query.Service (after AWS→portable mapping)
+//	region:<name>           → Query.Region
+//	tag.<key>:<value>       → Query.Tags[key] = value
+//	tag.<key>:              → Query.Tags[key] = "" (key-only match)
+//
+// Tokens are whitespace-separated. Unknown tokens are tolerated and
+// ignored — matches Resource Explorer's permissive parser behavior for a
+// minimal-impact-on-real-callers SDK round-trip.
+func parseFilter(query string) resourcediscovery.Query {
+	q := resourcediscovery.Query{}
+	if strings.TrimSpace(query) == "" {
+		return q
+	}
+
+	for _, token := range strings.Fields(query) {
+		applyToken(&q, token)
+	}
+
+	return q
+}
+
+func applyToken(q *resourcediscovery.Query, token string) {
+	if strings.HasPrefix(token, "tag.") {
+		applyTagToken(q, strings.TrimPrefix(token, "tag."))
+		return
+	}
+
+	key, val, ok := strings.Cut(token, ":")
+	if !ok {
+		return
+	}
+
+	switch key {
+	case "service":
+		q.Service = awsToPortableService(val)
+	case "region":
+		q.Region = val
+	}
+}
+
+func applyTagToken(q *resourcediscovery.Query, body string) {
+	key, val, _ := strings.Cut(body, ":")
+	if key == "" {
+		return
+	}
+
+	if q.Tags == nil {
+		q.Tags = make(map[string]string)
+	}
+
+	q.Tags[key] = val
+}
+
+func awsToPortableService(s string) string {
+	switch s {
+	case awsServiceEC2:
+		// ec2 covers both compute and networking in real AWS; the engine
+		// returns both because Query.Service applies to portable names. We
+		// use empty to match either.
+		return ""
+	case awsServiceS3:
+		return portableServiceStorage
+	case awsServiceDynamoDB:
+		return portableServiceDatabase
+	case awsServiceLambda:
+		return portableServiceServerless
+	default:
+		return s
+	}
+}

--- a/server/aws/resourceexplorer2/handler.go
+++ b/server/aws/resourceexplorer2/handler.go
@@ -53,9 +53,10 @@ type Handler struct {
 	accountID string
 	region    string
 
-	mu      sync.RWMutex
-	views   map[string]*view  // keyed by ViewArn
-	indexes map[string]*index // keyed by region
+	mu          sync.RWMutex
+	views       map[string]*view  // keyed by ViewArn
+	viewsByName map[string]string // ViewName → ViewArn, for collision detection
+	indexes     map[string]*index // keyed by region
 }
 
 type view struct {
@@ -76,11 +77,12 @@ type index struct {
 // New returns a Resource Explorer 2 handler.
 func New(engine *resourcediscovery.Engine, accountID, region string) *Handler {
 	h := &Handler{
-		engine:    engine,
-		accountID: accountID,
-		region:    region,
-		views:     make(map[string]*view),
-		indexes:   make(map[string]*index),
+		engine:      engine,
+		accountID:   accountID,
+		region:      region,
+		views:       make(map[string]*view),
+		viewsByName: make(map[string]string),
+		indexes:     make(map[string]*index),
 	}
 
 	// Real Resource Explorer requires an Index in the calling region before
@@ -166,12 +168,15 @@ func (h *Handler) createView(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	arn := h.viewARN(req.ViewName)
-	if _, exists := h.views[arn]; exists {
+	// Dedupe by ViewName, not by ARN: every call to viewARN() generates a
+	// fresh unique suffix, so a name-only check is the only way to reject
+	// duplicates the way real Resource Explorer does.
+	if _, exists := h.viewsByName[req.ViewName]; exists {
 		wire.WriteJSONError(w, http.StatusConflict, "ConflictException", "view already exists: "+req.ViewName)
 		return
 	}
 
+	arn := h.viewARN(req.ViewName)
 	v := &view{
 		ARN:         arn,
 		Name:        req.ViewName,
@@ -180,9 +185,10 @@ func (h *Handler) createView(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:   time.Now().UTC(),
 	}
 	h.views[arn] = v
+	h.viewsByName[req.ViewName] = arn
 
 	wire.WriteJSON(w, map[string]any{
-		"View": viewToWire(v),
+		"View": viewToWire(v, h.accountID),
 	})
 }
 
@@ -198,12 +204,14 @@ func (h *Handler) deleteView(w http.ResponseWriter, r *http.Request) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if _, ok := h.views[req.ViewArn]; !ok {
+	v, ok := h.views[req.ViewArn]
+	if !ok {
 		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
 		return
 	}
 
 	delete(h.views, req.ViewArn)
+	delete(h.viewsByName, v.Name)
 	wire.WriteJSON(w, map[string]any{"ViewArn": req.ViewArn})
 }
 
@@ -238,7 +246,7 @@ func (h *Handler) getView(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, map[string]any{
-		"View": viewToWire(v),
+		"View": viewToWire(v, h.accountID),
 		"Tags": v.Tags,
 	})
 }
@@ -378,11 +386,11 @@ func (h *Handler) indexARN(region string) string {
 	return idgen.AWSARN("resource-explorer-2", region, h.accountID, "index/"+idgen.GenerateID(""))
 }
 
-func viewToWire(v *view) map[string]any {
+func viewToWire(v *view, owner string) map[string]any {
 	return map[string]any{
 		"ViewArn": v.ARN,
 		"Filters": map[string]any{"FilterString": v.QueryString},
-		"Owner":   "",
+		"Owner":   owner,
 	}
 }
 

--- a/server/aws/resourceexplorer2/handler.go
+++ b/server/aws/resourceexplorer2/handler.go
@@ -1,0 +1,437 @@
+// Package resourceexplorer2 serves the AWS Resource Explorer 2 REST-JSON
+// protocol against a *resourcediscovery.Engine.
+//
+// Resource Explorer maintains stateful Views (saved filter expressions)
+// and Indexes (per-region resource catalogs). This handler stores both in
+// memory and routes Search/ListResources through the engine.
+//
+// Filter language: a documented subset of real Resource Explorer query
+// syntax. Supported tokens:
+//
+//	service:<name>          (e.g., service:s3)
+//	tag.<key>:<value>       (e.g., tag.env:prod)
+//	region:<name>           (e.g., region:us-east-1)
+//
+// Unknown tokens are tolerated and ignored. Real Resource Explorer supports
+// a wider grammar; tighten this as later phases need.
+package resourceexplorer2
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/resourcediscovery"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// AWS service identifiers used in Resource Explorer ResourceType strings
+// and in TagResources/UntagResources ARN routing.
+const (
+	awsServiceEC2      = "ec2"
+	awsServiceS3       = "s3"
+	awsServiceDynamoDB = "dynamodb"
+	awsServiceLambda   = "lambda"
+)
+
+// Portable-API service identifiers as emitted by resourcediscovery walkers.
+const (
+	portableServiceCompute    = "compute"
+	portableServiceNetworking = "networking"
+	portableServiceStorage    = "storage"
+	portableServiceDatabase   = "database"
+	portableServiceServerless = "serverless"
+)
+
+// Handler serves Resource Explorer 2 REST-JSON requests.
+type Handler struct {
+	engine *resourcediscovery.Engine
+
+	accountID string
+	region    string
+
+	mu      sync.RWMutex
+	views   map[string]*view  // keyed by ViewArn
+	indexes map[string]*index // keyed by region
+}
+
+type view struct {
+	ARN         string
+	Name        string
+	QueryString string
+	Tags        map[string]string
+	CreatedAt   time.Time
+}
+
+type index struct {
+	ARN       string
+	Region    string
+	Type      string // "LOCAL" or "AGGREGATOR"
+	CreatedAt time.Time
+}
+
+// New returns a Resource Explorer 2 handler.
+func New(engine *resourcediscovery.Engine, accountID, region string) *Handler {
+	h := &Handler{
+		engine:    engine,
+		accountID: accountID,
+		region:    region,
+		views:     make(map[string]*view),
+		indexes:   make(map[string]*index),
+	}
+
+	// Real Resource Explorer requires an Index in the calling region before
+	// Search works. Bootstrap a LOCAL index for the configured region so
+	// SDK clients don't have to call CreateIndex first.
+	idxARN := h.indexARN(region)
+	h.indexes[region] = &index{
+		ARN: idxARN, Region: region, Type: "LOCAL", CreatedAt: time.Now().UTC(),
+	}
+
+	return h
+}
+
+// Known REST-JSON paths for Resource Explorer 2. The handler matches only
+// these exact paths to avoid shadowing S3's REST catch-all.
+//
+//nolint:gochecknoglobals // immutable lookup table.
+var knownPaths = map[string]struct{}{
+	"/CreateView":    {},
+	"/DeleteView":    {},
+	"/ListViews":     {},
+	"/GetView":       {},
+	"/Search":        {},
+	"/ListResources": {},
+	"/ListIndexes":   {},
+	"/GetIndex":      {},
+}
+
+// Matches returns true for POST requests whose path is one of the known
+// Resource Explorer 2 operations.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.Method != http.MethodPost {
+		return false
+	}
+
+	_, ok := knownPaths[r.URL.Path]
+
+	return ok
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/CreateView":
+		h.createView(w, r)
+	case "/DeleteView":
+		h.deleteView(w, r)
+	case "/ListViews":
+		h.listViews(w, r)
+	case "/GetView":
+		h.getView(w, r)
+	case "/Search":
+		h.search(w, r)
+	case "/ListResources":
+		h.listResources(w, r)
+	case "/ListIndexes":
+		h.listIndexes(w, r)
+	case "/GetIndex":
+		h.getIndex(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "unknown path: "+r.URL.Path)
+	}
+}
+
+func (h *Handler) createView(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ViewName    string            `json:"ViewName"`
+		Tags        map[string]string `json:"Tags"`
+		QueryString string            `json:"-"` // Smithy puts this under Filters.FilterString; tolerate either.
+		Filters     struct {
+			FilterString string `json:"FilterString"`
+		} `json:"Filters"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.ViewName == "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "ViewName is required")
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	arn := h.viewARN(req.ViewName)
+	if _, exists := h.views[arn]; exists {
+		wire.WriteJSONError(w, http.StatusConflict, "ConflictException", "view already exists: "+req.ViewName)
+		return
+	}
+
+	v := &view{
+		ARN:         arn,
+		Name:        req.ViewName,
+		QueryString: req.Filters.FilterString,
+		Tags:        copyStringMap(req.Tags),
+		CreatedAt:   time.Now().UTC(),
+	}
+	h.views[arn] = v
+
+	wire.WriteJSON(w, map[string]any{
+		"View": viewToWire(v),
+	})
+}
+
+func (h *Handler) deleteView(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ViewArn string `json:"ViewArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.views[req.ViewArn]; !ok {
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+		return
+	}
+
+	delete(h.views, req.ViewArn)
+	wire.WriteJSON(w, map[string]any{"ViewArn": req.ViewArn})
+}
+
+func (h *Handler) listViews(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	arns := make([]string, 0, len(h.views))
+	for arn := range h.views {
+		arns = append(arns, arn)
+	}
+
+	wire.WriteJSON(w, map[string]any{"Views": arns})
+}
+
+func (h *Handler) getView(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ViewArn string `json:"ViewArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	v, ok := h.views[req.ViewArn]
+	if !ok {
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"View": viewToWire(v),
+		"Tags": v.Tags,
+	})
+}
+
+func (h *Handler) search(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		QueryString string `json:"QueryString"`
+		ViewArn     string `json:"ViewArn"`
+		MaxResults  int    `json:"MaxResults"`
+		NextToken   string `json:"NextToken"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	query := req.QueryString
+
+	// If a view is referenced, merge its FilterString with the request's
+	// QueryString. Real Resource Explorer treats them as additive AND.
+	if req.ViewArn != "" {
+		h.mu.RLock()
+		v, ok := h.views[req.ViewArn]
+		h.mu.RUnlock()
+
+		if !ok {
+			wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+			return
+		}
+
+		query = strings.TrimSpace(v.QueryString + " " + query)
+	}
+
+	q := parseFilter(query)
+
+	results, err := h.engine.List(r.Context(), q)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resources := make([]map[string]any, 0, len(results))
+	for i := range results {
+		resources = append(resources, resourceToWire(&results[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"Resources": resources,
+		"Count":     map[string]any{"TotalResources": len(resources), "Complete": true},
+	})
+}
+
+func (h *Handler) listResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Filters struct {
+			FilterString string `json:"FilterString"`
+		} `json:"Filters"`
+		ViewArn string `json:"ViewArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	query := req.Filters.FilterString
+
+	if req.ViewArn != "" {
+		h.mu.RLock()
+		v, ok := h.views[req.ViewArn]
+		h.mu.RUnlock()
+
+		if !ok {
+			wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "view not found: "+req.ViewArn)
+			return
+		}
+
+		query = strings.TrimSpace(v.QueryString + " " + query)
+	}
+
+	q := parseFilter(query)
+
+	results, err := h.engine.List(r.Context(), q)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]map[string]any, 0, len(results))
+	for i := range results {
+		out = append(out, resourceToWire(&results[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{"Resources": out})
+}
+
+func (h *Handler) listIndexes(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	out := make([]map[string]any, 0, len(h.indexes))
+	for _, idx := range h.indexes {
+		out = append(out, map[string]any{
+			"Arn":    idx.ARN,
+			"Region": idx.Region,
+			"Type":   idx.Type,
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Indexes": out})
+}
+
+func (h *Handler) getIndex(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	idx, ok := h.indexes[h.region]
+	if !ok {
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", "no index in region: "+h.region)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"Arn":         idx.ARN,
+		"Region":      idx.Region,
+		"Type":        idx.Type,
+		"State":       "ACTIVE",
+		"CreatedAt":   idx.CreatedAt.Format(time.RFC3339),
+		"LastUpdated": idx.CreatedAt.Format(time.RFC3339),
+	})
+}
+
+func (h *Handler) viewARN(name string) string {
+	return idgen.AWSARN("resource-explorer-2", h.region, h.accountID, "view/"+name+"/"+idgen.GenerateID(""))
+}
+
+func (h *Handler) indexARN(region string) string {
+	return idgen.AWSARN("resource-explorer-2", region, h.accountID, "index/"+idgen.GenerateID(""))
+}
+
+func viewToWire(v *view) map[string]any {
+	return map[string]any{
+		"ViewArn": v.ARN,
+		"Filters": map[string]any{"FilterString": v.QueryString},
+		"Owner":   "",
+	}
+}
+
+func resourceToWire(r *resourcediscovery.Resource) map[string]any {
+	return map[string]any{
+		"Arn":             r.ARN,
+		"OwningAccountId": "",
+		"Region":          r.Region,
+		"ResourceType":    r.Service + ":" + strings.ToLower(r.Type),
+		"Service":         portableToAWSService(r.Service),
+		"Properties":      []map[string]any{},
+	}
+}
+
+func portableToAWSService(s string) string {
+	switch s {
+	case portableServiceCompute, portableServiceNetworking:
+		return awsServiceEC2
+	case portableServiceStorage:
+		return awsServiceS3
+	case portableServiceDatabase:
+		return awsServiceDynamoDB
+	case portableServiceServerless:
+		return awsServiceLambda
+	default:
+		return s
+	}
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+
+	return out
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFoundException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+	}
+}

--- a/server/aws/resourceexplorer2/sdk_test.go
+++ b/server/aws/resourceexplorer2/sdk_test.go
@@ -1,0 +1,165 @@
+// Real-SDK round-trip test: the live aws-sdk-go-v2 Resource Explorer 2
+// client drives the in-memory handler end-to-end.
+
+package resourceexplorer2_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	rex "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
+	rextypes "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func TestSDKResourceExplorer2(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "prod-bucket"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "prod-bucket", map[string]string{"env": "prod"}))
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "stage-bucket"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "stage-bucket", map[string]string{"env": "stage"}))
+
+	require.NoError(t, cloud.DynamoDB.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloud.DynamoDB.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	_, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		DynamoDB:          cloud.DynamoDB,
+		VPC:               cloud.VPC,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newREXClient(t, ts.URL)
+
+	t.Run("GetIndex returns bootstrap index", func(t *testing.T) {
+		out, err := client.GetIndex(ctx, &rex.GetIndexInput{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, aws.ToString(out.Arn))
+		assert.Equal(t, rextypes.IndexTypeLocal, out.Type)
+	})
+
+	t.Run("ListIndexes returns at least the local index", func(t *testing.T) {
+		out, err := client.ListIndexes(ctx, &rex.ListIndexesInput{})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Indexes), 1)
+	})
+
+	t.Run("Search with no view returns all resources", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String(""),
+		})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Resources), 4, "expect 2 buckets + 1 table + 1 vpc")
+	})
+
+	t.Run("Search filters by tag", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("tag.env:prod"),
+		})
+		require.NoError(t, err)
+		// prod-bucket, events table, vpc — 3 prod resources
+		assert.Len(t, out.Resources, 3)
+	})
+
+	t.Run("Search filters by service", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("service:s3"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 2, "two s3 buckets")
+	})
+
+	t.Run("Search combines service + tag", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("service:s3 tag.env:prod"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 1)
+		assert.Equal(t, "arn:aws:s3:::prod-bucket", aws.ToString(out.Resources[0].Arn))
+	})
+
+	var viewArn string
+
+	t.Run("CreateView", func(t *testing.T) {
+		out, err := client.CreateView(ctx, &rex.CreateViewInput{
+			ViewName: aws.String("prod-only"),
+			Filters: &rextypes.SearchFilter{
+				FilterString: aws.String("tag.env:prod"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.View)
+		viewArn = aws.ToString(out.View.ViewArn)
+		assert.NotEmpty(t, viewArn)
+	})
+
+	t.Run("ListViews includes the new view", func(t *testing.T) {
+		out, err := client.ListViews(ctx, &rex.ListViewsInput{})
+		require.NoError(t, err)
+		assert.Contains(t, out.Views, viewArn)
+	})
+
+	t.Run("GetView returns the filter", func(t *testing.T) {
+		out, err := client.GetView(ctx, &rex.GetViewInput{ViewArn: aws.String(viewArn)})
+		require.NoError(t, err)
+		require.NotNil(t, out.View)
+		require.NotNil(t, out.View.Filters)
+		assert.Equal(t, "tag.env:prod", aws.ToString(out.View.Filters.FilterString))
+	})
+
+	t.Run("Search via view filters server-side", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			ViewArn:     aws.String(viewArn),
+			QueryString: aws.String(""),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 3, "view's tag.env:prod filter applies")
+	})
+
+	t.Run("DeleteView", func(t *testing.T) {
+		_, err := client.DeleteView(ctx, &rex.DeleteViewInput{ViewArn: aws.String(viewArn)})
+		require.NoError(t, err)
+
+		listOut, err := client.ListViews(ctx, &rex.ListViewsInput{})
+		require.NoError(t, err)
+		assert.NotContains(t, listOut.Views, viewArn)
+	})
+}
+
+func newREXClient(t *testing.T, baseURL string) *rex.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("k", "s", "")),
+	)
+	if err != nil {
+		t.Fatalf("awsconfig: %v", err)
+	}
+
+	return rex.NewFromConfig(cfg, func(o *rex.Options) {
+		o.BaseEndpoint = aws.String(baseURL)
+	})
+}

--- a/server/aws/resourceexplorer2/sdk_test.go
+++ b/server/aws/resourceexplorer2/sdk_test.go
@@ -148,6 +148,61 @@ func TestSDKResourceExplorer2(t *testing.T) {
 	})
 }
 
+// TestSDKResourceExplorer2_BugFixes exercises the four review-fix paths in
+// isolation so each can fail with a clear signal if it regresses.
+func TestSDKResourceExplorer2_BugFixes(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	// Seed one VPC (networking) and one EC2 instance via the engine surface.
+	_, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "log-bucket"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "log-bucket", map[string]string{"env": "prod"}))
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		VPC:               cloud.VPC,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newREXClient(t, ts.URL)
+
+	t.Run("service:ec2 matches networking (not s3)", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{
+			QueryString: aws.String("service:ec2"),
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 1, "service:ec2 should expand to compute+networking; only the VPC matches")
+		assert.Equal(t, "ec2", aws.ToString(out.Resources[0].Service))
+	})
+
+	t.Run("CreateView rejects duplicate name", func(t *testing.T) {
+		_, err := client.CreateView(ctx, &rex.CreateViewInput{ViewName: aws.String("dup")})
+		require.NoError(t, err)
+
+		_, err = client.CreateView(ctx, &rex.CreateViewInput{ViewName: aws.String("dup")})
+		require.Error(t, err, "second CreateView with the same name must fail")
+		assert.Contains(t, err.Error(), "ConflictException")
+	})
+
+	t.Run("View Owner field carries the account ID", func(t *testing.T) {
+		created, err := client.CreateView(ctx, &rex.CreateViewInput{ViewName: aws.String("owned-view")})
+		require.NoError(t, err)
+
+		got, err := client.GetView(ctx, &rex.GetViewInput{ViewArn: created.View.ViewArn})
+		require.NoError(t, err)
+		assert.Equal(t, "123456789012", aws.ToString(got.View.Owner))
+	})
+}
+
 func newREXClient(t *testing.T, baseURL string) *rex.Client {
 	t.Helper()
 

--- a/server/aws/resourcegroupstaggingapi/handler.go
+++ b/server/aws/resourcegroupstaggingapi/handler.go
@@ -1,0 +1,302 @@
+// Package resourcegroupstaggingapi serves the AWS Resource Groups Tagging
+// API JSON 1.1 protocol against a *resourcediscovery.Engine. Real
+// aws-sdk-go-v2/service/resourcegroupstaggingapi clients work end-to-end.
+package resourcegroupstaggingapi
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/resourcediscovery"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "ResourceGroupsTaggingAPI_20170126."
+
+// AWS service identifiers used to translate portable service names to the
+// names that appear in real AWS ARN/filter syntax.
+const (
+	awsServiceEC2      = "ec2"
+	awsServiceS3       = "s3"
+	awsServiceDynamoDB = "dynamodb"
+	awsServiceLambda   = "lambda"
+)
+
+// Error code returned for any tag-routing failure surfaced to the SDK
+// client. Real AWS uses InvalidParameterException for both bad ARNs and
+// resource-not-found.
+const errInvalidParameter = "InvalidParameterException"
+
+// Handler serves Resource Groups Tagging API JSON-RPC requests.
+type Handler struct {
+	engine *resourcediscovery.Engine
+}
+
+// New returns a handler backed by the given cross-service discovery engine.
+func New(engine *resourcediscovery.Engine) *Handler {
+	return &Handler{engine: engine}
+}
+
+// Matches returns true for an X-Amz-Target of "ResourceGroupsTaggingAPI_20170126.<Op>".
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches by X-Amz-Target operation.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "GetResources":
+		h.getResources(w, r)
+	case "GetTagKeys":
+		h.getTagKeys(w, r)
+	case "GetTagValues":
+		h.getTagValues(w, r)
+	case "TagResources":
+		h.tagResources(w, r)
+	case "UntagResources":
+		h.untagResources(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown operation: "+op)
+	}
+}
+
+type tagFilter struct {
+	Key    string   `json:"Key"`
+	Values []string `json:"Values"`
+}
+
+func (h *Handler) getResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceTypeFilters []string    `json:"ResourceTypeFilters"`
+		TagFilters          []tagFilter `json:"TagFilters"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	all, err := h.engine.ListAll(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]map[string]any, 0, len(all))
+
+	for i := range all {
+		res := &all[i]
+		if !matchesTypeFilter(res, req.ResourceTypeFilters) {
+			continue
+		}
+
+		if !matchesTagFilters(res, req.TagFilters) {
+			continue
+		}
+
+		out = append(out, map[string]any{
+			"ResourceARN": res.ARN,
+			"Tags":        toTagList(res.Tags),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ResourceTagMappingList": out,
+		"PaginationToken":        "",
+	})
+}
+
+func (h *Handler) getTagKeys(w http.ResponseWriter, r *http.Request) {
+	var req struct{}
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	keys, err := h.engine.GetTagKeys(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TagKeys":         keys,
+		"PaginationToken": "",
+	})
+}
+
+func (h *Handler) getTagValues(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Key string `json:"Key"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Key == "" {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "Key is required")
+		return
+	}
+
+	vals, err := h.engine.GetTagValues(r.Context(), req.Key)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TagValues":       vals,
+		"PaginationToken": "",
+	})
+}
+
+func (h *Handler) tagResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceARNList []string          `json:"ResourceARNList"`
+		Tags            map[string]string `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	failed := map[string]map[string]string{}
+
+	for _, arn := range req.ResourceARNList {
+		if err := h.engine.TagResourceByARN(r.Context(), arn, req.Tags); err != nil {
+			failed[arn] = map[string]string{
+				"ErrorCode":    awsErrorCode(err),
+				"ErrorMessage": err.Error(),
+			}
+		}
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FailedResourcesMap": failed,
+	})
+}
+
+func (h *Handler) untagResources(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceARNList []string `json:"ResourceARNList"`
+		TagKeys         []string `json:"TagKeys"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	failed := map[string]map[string]string{}
+
+	for _, arn := range req.ResourceARNList {
+		if err := h.engine.UntagResourceByARN(r.Context(), arn, req.TagKeys); err != nil {
+			failed[arn] = map[string]string{
+				"ErrorCode":    awsErrorCode(err),
+				"ErrorMessage": err.Error(),
+			}
+		}
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FailedResourcesMap": failed,
+	})
+}
+
+func matchesTypeFilter(r *resourcediscovery.Resource, filters []string) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	// Filter syntax: "service" (e.g., "s3") or "service:type" (e.g., "dynamodb:table").
+	for _, f := range filters {
+		svc, rt, hasType := strings.Cut(f, ":")
+		// Translate portable service to AWS service name for matching.
+		awsService := portableToAWSService(r.Service)
+		if svc != awsService {
+			continue
+		}
+
+		if !hasType {
+			return true
+		}
+
+		if strings.EqualFold(rt, r.Type) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func portableToAWSService(s string) string {
+	switch s {
+	case "compute", "networking":
+		return awsServiceEC2
+	case "storage":
+		return awsServiceS3
+	case "database":
+		return awsServiceDynamoDB
+	case "serverless":
+		return awsServiceLambda
+	default:
+		return s
+	}
+}
+
+func matchesTagFilters(r *resourcediscovery.Resource, filters []tagFilter) bool {
+	for _, tf := range filters {
+		got, ok := r.Tags[tf.Key]
+		if !ok {
+			return false
+		}
+
+		if len(tf.Values) == 0 {
+			continue
+		}
+
+		matched := false
+
+		for _, v := range tf.Values {
+			if v == got {
+				matched = true
+				break
+			}
+		}
+
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+func toTagList(tags map[string]string) []map[string]string {
+	out := make([]map[string]string, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, map[string]string{"Key": k, "Value": v})
+	}
+
+	return out
+}
+
+func awsErrorCode(err error) string {
+	switch {
+	case cerrors.IsNotFound(err), cerrors.IsInvalidArgument(err):
+		return errInvalidParameter
+	default:
+		return "InternalServiceException"
+	}
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err), cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, errInvalidParameter, err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServiceException", err.Error())
+	}
+}

--- a/server/aws/resourcegroupstaggingapi/sdk_test.go
+++ b/server/aws/resourcegroupstaggingapi/sdk_test.go
@@ -1,0 +1,162 @@
+// Real-SDK round-trip test: the live aws-sdk-go-v2 Resource Groups Tagging
+// API client drives the in-memory handler end-to-end.
+
+package resourcegroupstaggingapi_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	rgta "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func TestSDKResourceGroupsTagging(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	// Seed a small inventory across services.
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "audit-logs"))
+	require.NoError(t, cloud.S3.PutBucketTagging(ctx, "audit-logs",
+		map[string]string{"env": "prod", "team": "security"}))
+
+	require.NoError(t, cloud.DynamoDB.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloud.DynamoDB.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	vpcInfo, err := cloud.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "stage"},
+	})
+	require.NoError(t, err)
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		DynamoDB:          cloud.DynamoDB,
+		VPC:               cloud.VPC,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newRGTAClient(t, ts.URL)
+
+	t.Run("GetResources returns everything", func(t *testing.T) {
+		out, err := client.GetResources(ctx, &rgta.GetResourcesInput{})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.ResourceTagMappingList), 3,
+			"expect bucket + table + vpc at minimum")
+
+		// Spot-check that ARNs and tags are present.
+		seenBucket := false
+		for _, m := range out.ResourceTagMappingList {
+			if aws.ToString(m.ResourceARN) == "arn:aws:s3:::audit-logs" {
+				seenBucket = true
+				tags := tagsToMap(m.Tags)
+				assert.Equal(t, "prod", tags["env"])
+				assert.Equal(t, "security", tags["team"])
+			}
+		}
+		assert.True(t, seenBucket, "audit-logs bucket should appear in inventory")
+	})
+
+	t.Run("GetResources with TagFilters", func(t *testing.T) {
+		out, err := client.GetResources(ctx, &rgta.GetResourcesInput{
+			TagFilters: []rgtatypes.TagFilter{{
+				Key:    aws.String("env"),
+				Values: []string{"prod"},
+			}},
+		})
+		require.NoError(t, err)
+		// audit-logs (s3) + events (dynamodb) both have env=prod; vpc has env=stage.
+		assert.Len(t, out.ResourceTagMappingList, 2)
+	})
+
+	t.Run("GetTagKeys returns deduplicated keys", func(t *testing.T) {
+		out, err := client.GetTagKeys(ctx, &rgta.GetTagKeysInput{})
+		require.NoError(t, err)
+		sort.Strings(out.TagKeys)
+		assert.Equal(t, []string{"env", "team"}, out.TagKeys)
+	})
+
+	t.Run("GetTagValues for a key", func(t *testing.T) {
+		out, err := client.GetTagValues(ctx, &rgta.GetTagValuesInput{Key: aws.String("env")})
+		require.NoError(t, err)
+		sort.Strings(out.TagValues)
+		assert.Equal(t, []string{"prod", "stage"}, out.TagValues)
+	})
+
+	t.Run("TagResources adds tags and is visible in subsequent reads", func(t *testing.T) {
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{"arn:aws:s3:::audit-logs"},
+			Tags:            map[string]string{"compliance": "soc2"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.FailedResourcesMap)
+
+		got, err := cloud.S3.GetBucketTagging(ctx, "audit-logs")
+		require.NoError(t, err)
+		assert.Equal(t, "soc2", got["compliance"])
+		assert.Equal(t, "prod", got["env"], "existing tags must survive the merge")
+	})
+
+	t.Run("UntagResources removes the listed keys", func(t *testing.T) {
+		arn := "arn:aws:ec2:us-east-1:123456789012:vpc/" + vpcInfo.ID
+		out, err := client.UntagResources(ctx, &rgta.UntagResourcesInput{
+			ResourceARNList: []string{arn},
+			TagKeys:         []string{"env"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.FailedResourcesMap)
+
+		got, err := cloud.VPC.DescribeVPCs(ctx, []string{vpcInfo.ID})
+		require.NoError(t, err)
+		_, has := got[0].Tags["env"]
+		assert.False(t, has, "env tag should be gone after UntagResources")
+	})
+
+	t.Run("TagResources reports failures for unsupported ARNs", func(t *testing.T) {
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{"arn:aws:lambda:us-east-1:111:function:nope"},
+			Tags:            map[string]string{"k": "v"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, out.FailedResourcesMap, 1)
+	})
+}
+
+func newRGTAClient(t *testing.T, baseURL string) *rgta.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("k", "s", "")),
+	)
+	if err != nil {
+		t.Fatalf("awsconfig: %v", err)
+	}
+
+	return rgta.NewFromConfig(cfg, func(o *rgta.Options) {
+		o.BaseEndpoint = aws.String(baseURL)
+	})
+}
+
+func tagsToMap(tags []rgtatypes.Tag) map[string]string {
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+	return out
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -14,6 +14,7 @@ import (
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
 	aksserver "github.com/stackshy/cloudemu/server/azure/aks"
 	"github.com/stackshy/cloudemu/server/azure/azuresql"
@@ -26,6 +27,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
 	"github.com/stackshy/cloudemu/server/azure/network"
 	"github.com/stackshy/cloudemu/server/azure/postgresflex"
+	"github.com/stackshy/cloudemu/server/azure/resourcegraph"
 	"github.com/stackshy/cloudemu/server/azure/servicebus"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
 	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
@@ -62,6 +64,12 @@ type Drivers struct {
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
 	// the same backend. Leave nil to disable Kubernetes data-plane support.
 	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery is the cross-service inventory engine. Required to
+	// serve Azure Resource Graph (armresourcegraph) requests. Leave nil to
+	// omit the handler. SubscriptionID is needed for the subscription-scoping
+	// check on incoming queries.
+	ResourceDiscovery *resourcediscovery.Engine
+	SubscriptionID    string
 }
 
 // New returns a server that speaks the Azure ARM JSON wire protocol for every
@@ -150,6 +158,13 @@ func New(d Drivers) *server.Server {
 	// other Azure path. Registered before the BlobStorage fallback.
 	if d.K8sAPI != nil {
 		srv.Register(d.K8sAPI)
+	}
+
+	// Resource Graph matches /providers/Microsoft.ResourceGraph/... —
+	// distinct from any service-scoped ARM URL, so registration order is
+	// unconstrained relative to the resource handlers above.
+	if d.ResourceDiscovery != nil {
+		srv.Register(resourcegraph.New(d.ResourceDiscovery, d.SubscriptionID))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -1,0 +1,264 @@
+package resourcegraph
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// Path prefixes this handler serves. The Resource Graph provider sits at a
+// well-known ARM URL; the API-version query string is varied across SDK
+// releases so we ignore it for matching.
+const (
+	pathResources       = "/providers/Microsoft.ResourceGraph/resources"
+	pathResourcesHistry = "/providers/Microsoft.ResourceGraph/resourcesHistory"
+	pathOperations      = "/providers/Microsoft.ResourceGraph/operations"
+)
+
+// Handler serves Azure Resource Graph ARM-JSON requests.
+type Handler struct {
+	engine         *resourcediscovery.Engine
+	subscriptionID string
+}
+
+// New returns a Resource Graph handler backed by engine. subscriptionID is
+// returned in resource IDs and validated against the request's subscriptions
+// list (a request whose subscriptions field is set but does not include this
+// ID returns an empty result rather than an error).
+func New(engine *resourcediscovery.Engine, subscriptionID string) *Handler {
+	return &Handler{engine: engine, subscriptionID: subscriptionID}
+}
+
+// Matches accepts ARM requests targeting Microsoft.ResourceGraph. The
+// resourcesHistory and operations paths are also routed here.
+func (*Handler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+
+	return strings.HasPrefix(p, pathResources) ||
+		strings.HasPrefix(p, pathResourcesHistry) ||
+		strings.HasPrefix(p, pathOperations)
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, pathOperations):
+		h.listOperations(w, r)
+	case strings.HasPrefix(r.URL.Path, pathResourcesHistry):
+		h.queryResourcesHistory(w, r)
+	case strings.HasPrefix(r.URL.Path, pathResources):
+		h.queryResources(w, r)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown Resource Graph path: "+r.URL.Path)
+	}
+}
+
+type queryRequest struct {
+	Subscriptions []string `json:"subscriptions"`
+	Query         string   `json:"query"`
+	Options       struct {
+		Top  int `json:"$top"`
+		Skip int `json:"$skip"`
+	} `json:"options"`
+}
+
+func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "POST required")
+		return
+	}
+
+	var req queryRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if !h.subscriptionAllowed(req.Subscriptions) {
+		azurearm.WriteJSON(w, http.StatusOK, emptyResponse())
+		return
+	}
+
+	parsed := parseKQL(req.Query)
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	results = applyLimit(results, parsed.Limit, req.Options.Top, req.Options.Skip)
+
+	data := make([]map[string]any, 0, len(results))
+	for i := range results {
+		data = append(data, resourceToWire(&results[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"totalRecords":    len(data),
+		"count":           len(data),
+		"data":            data,
+		"facets":          []any{},
+		"resultTruncated": "false",
+	})
+}
+
+// queryResourcesHistory returns the current inventory as a single point-in-time
+// snapshot. The mock has no time-travel state; real Resource Graph History
+// requires Azure Diagnostic Settings to be configured, which is out of scope.
+func (h *Handler) queryResourcesHistory(w http.ResponseWriter, r *http.Request) {
+	h.queryResources(w, r)
+}
+
+// listOperations returns the descriptors for the three ops this handler
+// supports. Real Resource Graph returns many more (private link, etc.); we
+// surface only the ones a discovery-focused caller exercises.
+func (*Handler) listOperations(w http.ResponseWriter, _ *http.Request) {
+	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
+		"value": []map[string]any{
+			operationDescriptor("Microsoft.ResourceGraph/resources/read",
+				"resources", "Query", "Submits a Resource Graph query."),
+			operationDescriptor("Microsoft.ResourceGraph/resourcesHistory/read",
+				"resourcesHistory", "Query history", "Submits a Resource Graph history query."),
+			operationDescriptor("Microsoft.ResourceGraph/operations/read",
+				"operations", "List", "Lists supported Resource Graph operations."),
+		},
+	})
+}
+
+func operationDescriptor(name, resource, op, desc string) map[string]any {
+	return map[string]any{
+		"name": name,
+		"display": map[string]string{
+			"provider":    "Microsoft.ResourceGraph",
+			"resource":    resource,
+			"operation":   op,
+			"description": desc,
+		},
+	}
+}
+
+// subscriptionAllowed returns true if the request's subscription list is
+// empty (caller doesn't care about scoping) or includes this handler's
+// subscription ID. Mismatch returns an empty result rather than an error,
+// matching real Resource Graph behavior when the caller scopes to
+// subscriptions they can't see.
+func (h *Handler) subscriptionAllowed(reqSubs []string) bool {
+	if len(reqSubs) == 0 {
+		return true
+	}
+
+	for _, s := range reqSubs {
+		if s == h.subscriptionID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func emptyResponse() map[string]any {
+	return map[string]any{
+		"totalRecords":    0,
+		"count":           0,
+		"data":            []any{},
+		"facets":          []any{},
+		"resultTruncated": "false",
+	}
+}
+
+// applyLimit applies the caller-specified $top/$skip and any `| limit N` /
+// `| take N` from the KQL. The smaller of the two limits wins; $skip is
+// applied before slicing.
+func applyLimit(results []resourcediscovery.Resource, kqlLimit, top, skip int) []resourcediscovery.Resource {
+	if skip > 0 {
+		if skip >= len(results) {
+			return nil
+		}
+
+		results = results[skip:]
+	}
+
+	limit := top
+	if kqlLimit > 0 && (limit == 0 || kqlLimit < limit) {
+		limit = kqlLimit
+	}
+
+	if limit > 0 && limit < len(results) {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+// resourceToWire formats one Resource into the Azure Resource Graph row
+// shape: { id, name, type, location, resourceGroup, subscriptionId, tags }.
+// The portable Type is translated back to the canonical Azure type string.
+func resourceToWire(r *resourcediscovery.Resource) map[string]any {
+	out := map[string]any{
+		"id":             r.ARN,
+		"name":           r.ID,
+		"type":           portableToAzureType(r.Service, r.Type),
+		"location":       r.Region,
+		"resourceGroup":  "default",
+		"subscriptionId": extractSubscription(r.ARN),
+		"tags":           tagsOrEmpty(r.Tags),
+	}
+
+	return out
+}
+
+func tagsOrEmpty(tags map[string]string) map[string]string {
+	if tags == nil {
+		return map[string]string{}
+	}
+
+	return tags
+}
+
+// extractSubscription pulls /subscriptions/<id>/... out of an Azure resource
+// ID. Returns empty string for non-conforming IDs.
+func extractSubscription(arn string) string {
+	const prefix = "/subscriptions/"
+	if !strings.HasPrefix(arn, prefix) {
+		return ""
+	}
+
+	rest := arn[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+
+	return rest
+}
+
+// portableToAzureType is the inverse of mapAzureType — it turns the engine's
+// (service, type) pair back into the dotted Azure type string a real ARG
+// response carries.
+func portableToAzureType(service, typ string) string {
+	switch service + "/" + typ {
+	case "compute/Instance":
+		return "microsoft.compute/virtualmachines"
+	case "networking/VPC":
+		return "microsoft.network/virtualnetworks"
+	case "networking/Subnet":
+		return "microsoft.network/subnets"
+	case "networking/SecurityGroup":
+		return "microsoft.network/networksecuritygroups"
+	case "storage/Bucket":
+		return "microsoft.storage/storageaccounts"
+	case "database/Table":
+		return "microsoft.documentdb/databaseaccounts"
+	case "serverless/Function":
+		return "microsoft.web/sites"
+	default:
+		return strings.ToLower(service + "/" + typ)
+	}
+}
+
+// Compile-time check that Handler implements the Matches+ServeHTTP pair the
+// dispatch chain expects.
+var _ interface {
+	Matches(*http.Request) bool
+	http.Handler
+} = (*Handler)(nil)

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -12,9 +12,9 @@ import (
 // well-known ARM URL; the API-version query string is varied across SDK
 // releases so we ignore it for matching.
 const (
-	pathResources       = "/providers/Microsoft.ResourceGraph/resources"
-	pathResourcesHistry = "/providers/Microsoft.ResourceGraph/resourcesHistory"
-	pathOperations      = "/providers/Microsoft.ResourceGraph/operations"
+	pathResources        = "/providers/Microsoft.ResourceGraph/resources"
+	pathResourcesHistory = "/providers/Microsoft.ResourceGraph/resourcesHistory"
+	pathOperations       = "/providers/Microsoft.ResourceGraph/operations"
 )
 
 // Handler serves Azure Resource Graph ARM-JSON requests.
@@ -24,30 +24,40 @@ type Handler struct {
 }
 
 // New returns a Resource Graph handler backed by engine. subscriptionID is
-// returned in resource IDs and validated against the request's subscriptions
-// list (a request whose subscriptions field is set but does not include this
-// ID returns an empty result rather than an error).
+// validated against the request's subscriptions list (a request whose
+// subscriptions field is set but does not include this ID returns an empty
+// result rather than an error). If subscriptionID is empty, the engine's
+// own AccountID is used — that's the same value the engine was built with
+// when it constructed Azure-shaped resource IDs, so the two stay aligned
+// without callers having to pass the ID twice.
 func New(engine *resourcediscovery.Engine, subscriptionID string) *Handler {
+	if subscriptionID == "" && engine != nil {
+		subscriptionID = engine.AccountID()
+	}
+
 	return &Handler{engine: engine, subscriptionID: subscriptionID}
 }
 
-// Matches accepts ARM requests targeting Microsoft.ResourceGraph. The
-// resourcesHistory and operations paths are also routed here.
+// Matches accepts ARM requests targeting Microsoft.ResourceGraph. Uses
+// exact path equality, not prefix match, so /resources cannot shadow
+// /resourcesHistory (the longer path starts with the shorter one).
+// r.URL.Path strips the query string, so api-version is not in the way.
 func (*Handler) Matches(r *http.Request) bool {
-	p := r.URL.Path
-
-	return strings.HasPrefix(p, pathResources) ||
-		strings.HasPrefix(p, pathResourcesHistry) ||
-		strings.HasPrefix(p, pathOperations)
+	switch r.URL.Path {
+	case pathResources, pathResourcesHistory, pathOperations:
+		return true
+	default:
+		return false
+	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch {
-	case strings.HasPrefix(r.URL.Path, pathOperations):
+	switch r.URL.Path {
+	case pathOperations:
 		h.listOperations(w, r)
-	case strings.HasPrefix(r.URL.Path, pathResourcesHistry):
+	case pathResourcesHistory:
 		h.queryResourcesHistory(w, r)
-	case strings.HasPrefix(r.URL.Path, pathResources):
+	case pathResources:
 		h.queryResources(w, r)
 	default:
 		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unknown Resource Graph path: "+r.URL.Path)
@@ -80,6 +90,13 @@ func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parsed := parseKQL(req.Query)
+
+	// Contradiction in chained where-clauses (e.g. two type filters AND-ed
+	// together) — short-circuit before hitting the engine. See parsedKQL.
+	if parsed.ForceEmpty {
+		azurearm.WriteJSON(w, http.StatusOK, emptyResponse())
+		return
+	}
 
 	results, err := h.engine.List(r.Context(), parsed.Query)
 	if err != nil {

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -1,0 +1,203 @@
+// Package resourcegraph serves Azure Resource Graph (armresourcegraph) REST
+// requests against a *resourcediscovery.Engine.
+//
+// Resource Graph queries use Kusto Query Language (KQL), a rich
+// data-analytics grammar. This handler implements a documented subset that
+// covers the queries real callers make for inventory/discovery:
+//
+//	Resources
+//	| where type == 'microsoft.compute/virtualmachines'
+//	| where type =~ 'microsoft.network/virtualnetworks'
+//	| where resourceGroup == 'rg-prod'
+//	| where location == 'eastus'
+//	| where tags['env'] == 'prod'
+//	| where tags.env == 'prod'
+//	| project id, type, name              (column selection: ignored, full
+//	                                        records returned)
+//	| limit 100                           (also: | take 100)
+//
+// Unknown tokens and unsupported clauses are tolerated: the parser logs
+// them away and continues with the constraints it did understand. Real
+// Resource Graph would reject malformed queries; the stub favors returning
+// some result over a 400 so SDK callers that probe with unknown queries
+// don't blow up.
+package resourcegraph
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// Canonical Azure resource type strings used by Resource Graph query syntax
+// and emitted in response rows.
+const (
+	azureTypeVM      = "microsoft.compute/virtualmachines"
+	azureTypeVNet    = "microsoft.network/virtualnetworks"
+	azureTypeSubnet  = "microsoft.network/subnets"
+	azureTypeSubnetN = "microsoft.network/virtualnetworks/subnets"
+	azureTypeNSG     = "microsoft.network/networksecuritygroups"
+	azureTypeStorage = "microsoft.storage/storageaccounts"
+	azureTypeStoCnt  = "microsoft.storage/storageaccounts/blobservices/containers"
+	azureTypeCosmos  = "microsoft.documentdb/databaseaccounts"
+	azureTypeCosmosC = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
+	azureTypeWebSite = "microsoft.web/sites"
+)
+
+// Portable service identifiers as emitted by the resourcediscovery walkers.
+const (
+	portableCompute    = "compute"
+	portableNetworking = "networking"
+	portableStorage    = "storage"
+	portableDatabase   = "database"
+	portableServerless = "serverless"
+)
+
+// parsedKQL is the result of KQL parsing — an engine Query plus the limit
+// extracted from `| limit N` / `| take N` (0 means no caller-specified limit).
+type parsedKQL struct {
+	Query resourcediscovery.Query
+	Limit int
+}
+
+// Pre-compiled KQL predicate regexes. Compiled once at package load; safe
+// for concurrent use.
+//
+
+var (
+	// type == 'X' / type =~ 'X' / type == "X".
+	reWhereType = regexp.MustCompile(`(?i)^\s*type\s*(==|=~)\s*['"]([^'"]+)['"]\s*$`)
+	// resourceGroup == 'X'.
+	reWhereRG = regexp.MustCompile(`(?i)^\s*resourceGroup\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// location == 'X'.
+	reWhereLocation = regexp.MustCompile(`(?i)^\s*location\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// tags['k'] == 'v' / tags["k"] == "v".
+	reWhereTagsBracket = regexp.MustCompile(`(?i)^\s*tags\s*\[\s*['"]([^'"]+)['"]\s*\]\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// tags.k == 'v'.
+	reWhereTagsDot = regexp.MustCompile(`(?i)^\s*tags\.([A-Za-z0-9_-]+)\s*==\s*['"]([^'"]+)['"]\s*$`)
+	// limit N / take N.
+	reLimit = regexp.MustCompile(`(?i)^\s*(limit|take)\s+(\d+)\s*$`)
+)
+
+// parseKQL splits the query on `|` and applies each clause to a Query under
+// construction. Always returns a valid parsedKQL; unrecognized clauses
+// (project, summarize, join, …) are silently ignored — the stub favors
+// returning some result over a 400 on syntax we don't model yet.
+func parseKQL(query string) parsedKQL {
+	out := parsedKQL{}
+
+	clauses := strings.Split(query, "|")
+	for _, raw := range clauses {
+		clause := strings.TrimSpace(raw)
+		if clause == "" {
+			continue
+		}
+
+		applyClause(&out, clause)
+	}
+
+	return out
+}
+
+func applyClause(out *parsedKQL, clause string) {
+	// Drop the leading "Resources" table reference; it's the only one we
+	// support and it carries no constraint.
+	if strings.EqualFold(clause, "Resources") {
+		return
+	}
+
+	if strings.HasPrefix(strings.ToLower(clause), "where ") {
+		applyWhere(out, strings.TrimSpace(clause[len("where "):]))
+		return
+	}
+
+	if m := reLimit.FindStringSubmatch(clause); m != nil {
+		if n, err := strconv.Atoi(m[2]); err == nil {
+			out.Limit = n
+		}
+
+		return
+	}
+}
+
+// applyWhere routes a single "where" predicate to the matching field on the
+// engine Query. Unknown predicates are tolerated and left untouched — see
+// parseKQL's package-level comment for the rationale.
+func applyWhere(out *parsedKQL, body string) {
+	if m := reWhereType.FindStringSubmatch(body); m != nil {
+		applyType(out, m[2])
+		return
+	}
+
+	if m := reWhereRG.FindStringSubmatch(body); m != nil {
+		// The engine does not track resource groups; every Azure resource
+		// is bucketed under a single "default" group. Filtering by RG is
+		// therefore a no-op here — documented limitation; revisit if the
+		// engine grows real RG awareness.
+		_ = m
+		return
+	}
+
+	if m := reWhereLocation.FindStringSubmatch(body); m != nil {
+		out.Query.Region = m[1]
+		return
+	}
+
+	if m := reWhereTagsBracket.FindStringSubmatch(body); m != nil {
+		addTag(out, m[1], m[2])
+		return
+	}
+
+	if m := reWhereTagsDot.FindStringSubmatch(body); m != nil {
+		addTag(out, m[1], m[2])
+		return
+	}
+}
+
+// applyType maps an Azure type string to portable Service + Type. Lower-case
+// before matching since Azure types are case-insensitive in KQL.
+func applyType(out *parsedKQL, azureType string) {
+	svc, typ := mapAzureType(strings.ToLower(azureType))
+	if svc != "" {
+		out.Query.Services = append(out.Query.Services, svc)
+	}
+
+	if typ != "" {
+		out.Query.Type = typ
+	}
+}
+
+func addTag(out *parsedKQL, key, value string) {
+	if out.Query.Tags == nil {
+		out.Query.Tags = make(map[string]string)
+	}
+
+	out.Query.Tags[key] = value
+}
+
+// mapAzureType translates a fully-qualified Azure resource type to the
+// portable (service, type) pair the engine uses. Returns ("", "") for
+// unmapped types so the filter is treated as match-none rather than
+// match-all.
+func mapAzureType(azureType string) (service, typ string) {
+	switch azureType {
+	case azureTypeVM:
+		return portableCompute, "Instance"
+	case azureTypeVNet:
+		return portableNetworking, "VPC"
+	case azureTypeSubnet, azureTypeSubnetN:
+		return portableNetworking, "Subnet"
+	case azureTypeNSG:
+		return portableNetworking, "SecurityGroup"
+	case azureTypeStorage, azureTypeStoCnt:
+		return portableStorage, "Bucket"
+	case azureTypeCosmos, azureTypeCosmosC:
+		return portableDatabase, "Table"
+	case azureTypeWebSite:
+		return portableServerless, "Function"
+	default:
+		return "", ""
+	}
+}

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -57,9 +57,20 @@ const (
 
 // parsedKQL is the result of KQL parsing — an engine Query plus the limit
 // extracted from `| limit N` / `| take N` (0 means no caller-specified limit).
+//
+// ForceEmpty is set when the parser detects a contradiction in chained
+// where-clauses (e.g. two different type filters AND-ed together). Real KQL
+// `where type == 'X' | where type == 'Y'` returns zero rows because a single
+// resource cannot have two types; the engine matcher would otherwise OR-merge
+// the two values via the Services slice, so we short-circuit at the handler.
 type parsedKQL struct {
-	Query resourcediscovery.Query
-	Limit int
+	Query      resourcediscovery.Query
+	Limit      int
+	ForceEmpty bool
+
+	// internal tracking — used by applyType / addTag to detect conflicts.
+	typeSet     bool
+	tagFirstVal map[string]string
 }
 
 // Pre-compiled KQL predicate regexes. Compiled once at package load; safe
@@ -157,11 +168,21 @@ func applyWhere(out *parsedKQL, body string) {
 }
 
 // applyType maps an Azure type string to portable Service + Type. Lower-case
-// before matching since Azure types are case-insensitive in KQL.
+// before matching since Azure types are case-insensitive in KQL. A second
+// type clause is treated as an AND contradiction — real KQL would yield
+// zero rows because a resource cannot have two types — so ForceEmpty is
+// flipped and later short-circuits the handler.
 func applyType(out *parsedKQL, azureType string) {
+	if out.typeSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.typeSet = true
+
 	svc, typ := mapAzureType(strings.ToLower(azureType))
 	if svc != "" {
-		out.Query.Services = append(out.Query.Services, svc)
+		out.Query.Services = []string{svc}
 	}
 
 	if typ != "" {
@@ -169,7 +190,21 @@ func applyType(out *parsedKQL, azureType string) {
 	}
 }
 
+// addTag records a tag predicate. Repeating the same key with a different
+// value is a KQL contradiction (a single tag cannot hold two values at
+// once); flips ForceEmpty so the handler returns an empty result.
 func addTag(out *parsedKQL, key, value string) {
+	if prev, seen := out.tagFirstVal[key]; seen && prev != value {
+		out.ForceEmpty = true
+		return
+	}
+
+	if out.tagFirstVal == nil {
+		out.tagFirstVal = make(map[string]string)
+	}
+
+	out.tagFirstVal[key] = value
+
 	if out.Query.Tags == nil {
 		out.Query.Tags = make(map[string]string)
 	}

--- a/server/azure/resourcegraph/kql_test.go
+++ b/server/azure/resourcegraph/kql_test.go
@@ -1,0 +1,124 @@
+package resourcegraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseKQL(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantSvcs  []string
+		wantType  string
+		wantRegn  string
+		wantTags  map[string]string
+		wantLimit int
+	}{
+		{
+			name:     "empty query",
+			query:    "",
+			wantSvcs: nil,
+		},
+		{
+			name:     "only Resources",
+			query:    "Resources",
+			wantSvcs: nil,
+		},
+		{
+			name:     "type equality",
+			query:    "Resources | where type == 'microsoft.compute/virtualmachines'",
+			wantSvcs: []string{"compute"},
+			wantType: "Instance",
+		},
+		{
+			name:     "type case-insensitive equality",
+			query:    "Resources | where type =~ 'Microsoft.Network/VirtualNetworks'",
+			wantSvcs: []string{"networking"},
+			wantType: "VPC",
+		},
+		{
+			name:     "location",
+			query:    "Resources | where location == 'eastus'",
+			wantRegn: "eastus",
+		},
+		{
+			name:     "tag bracket",
+			query:    "Resources | where tags['env'] == 'prod'",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "tag dot",
+			query:    "Resources | where tags.env == 'prod'",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "type + tag combined",
+			query:    "Resources | where type == 'microsoft.storage/storageaccounts' | where tags['env'] == 'prod'",
+			wantSvcs: []string{"storage"},
+			wantType: "Bucket",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:      "limit clause",
+			query:     "Resources | limit 50",
+			wantLimit: 50,
+		},
+		{
+			name:      "take clause",
+			query:     "Resources | take 10",
+			wantLimit: 10,
+		},
+		{
+			name:     "project clause ignored",
+			query:    "Resources | where type == 'microsoft.web/sites' | project id, name",
+			wantSvcs: []string{"serverless"},
+			wantType: "Function",
+		},
+		{
+			name:  "resourceGroup is a no-op",
+			query: "Resources | where resourceGroup == 'mygroup'",
+		},
+		{
+			name:  "unknown predicate tolerated",
+			query: "Resources | where sku.tier == 'Premium'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKQL(tt.query)
+			assert.Equal(t, tt.wantSvcs, got.Query.Services)
+			assert.Equal(t, tt.wantType, got.Query.Type)
+			assert.Equal(t, tt.wantRegn, got.Query.Region)
+			assert.Equal(t, tt.wantTags, got.Query.Tags)
+			assert.Equal(t, tt.wantLimit, got.Limit)
+		})
+	}
+}
+
+func TestMapAzureType(t *testing.T) {
+	tests := []struct {
+		azureType string
+		wantSvc   string
+		wantType  string
+	}{
+		{"microsoft.compute/virtualmachines", "compute", "Instance"},
+		{"microsoft.network/virtualnetworks", "networking", "VPC"},
+		{"microsoft.network/subnets", "networking", "Subnet"},
+		{"microsoft.network/networksecuritygroups", "networking", "SecurityGroup"},
+		{"microsoft.storage/storageaccounts", "storage", "Bucket"},
+		{"microsoft.documentdb/databaseaccounts", "database", "Table"},
+		{"microsoft.web/sites", "serverless", "Function"},
+		{"microsoft.unknown/widgets", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.azureType, func(t *testing.T) {
+			svc, typ := mapAzureType(tt.azureType)
+			assert.Equal(t, tt.wantSvc, svc)
+			assert.Equal(t, tt.wantType, typ)
+		})
+	}
+}

--- a/server/azure/resourcegraph/kql_test.go
+++ b/server/azure/resourcegraph/kql_test.go
@@ -122,3 +122,68 @@ func TestMapAzureType(t *testing.T) {
 		})
 	}
 }
+
+// TestParseKQL_ForceEmpty pins the AND-semantics fix: contradictory
+// chained where-clauses must surface ForceEmpty so the handler can return
+// zero rows. Real KQL would also yield zero — a resource cannot
+// simultaneously have two distinct types or two different tag values for
+// the same key.
+func TestParseKQL_ForceEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "two different type filters",
+			query: "Resources | where type == 'microsoft.compute/virtualmachines' | where type == 'microsoft.storage/storageaccounts'",
+		},
+		{
+			name:  "same type filter twice (still flagged — second clause is redundant by design)",
+			query: "Resources | where type == 'microsoft.compute/virtualmachines' | where type == 'microsoft.compute/virtualmachines'",
+		},
+		{
+			name:  "conflicting tag values for same key",
+			query: "Resources | where tags['env'] == 'prod' | where tags['env'] == 'stage'",
+		},
+		{
+			name:  "tag dot syntax conflicts with bracket syntax on same key",
+			query: "Resources | where tags['env'] == 'prod' | where tags.env == 'stage'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKQL(tt.query)
+			assert.True(t, got.ForceEmpty, "expected ForceEmpty for contradictory query: %q", tt.query)
+		})
+	}
+}
+
+// TestParseKQL_NoFalsePositiveForceEmpty makes sure agreeing/compatible
+// chained clauses do NOT trip the contradiction sentinel.
+func TestParseKQL_NoFalsePositiveForceEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "type + unrelated tag",
+			query: "Resources | where type == 'microsoft.compute/virtualmachines' | where tags['env'] == 'prod'",
+		},
+		{
+			name:  "two tag filters on different keys",
+			query: "Resources | where tags['env'] == 'prod' | where tags['team'] == 'data'",
+		},
+		{
+			name:  "same tag key+value repeated",
+			query: "Resources | where tags['env'] == 'prod' | where tags['env'] == 'prod'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKQL(tt.query)
+			assert.False(t, got.ForceEmpty, "ForceEmpty must not trip for compatible query: %q", tt.query)
+		})
+	}
+}

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -1,0 +1,189 @@
+// Real-SDK round-trip test: the live azure-sdk-for-go
+// armresourcegraph client drives the in-memory handler end-to-end.
+
+package resourcegraph_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func TestSDKResourceGraph(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "audit-logs"))
+	require.NoError(t, cloudP.BlobStorage.PutBucketTagging(ctx, "audit-logs",
+		map[string]string{"env": "prod", "team": "security"}))
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "stage-logs"))
+	require.NoError(t, cloudP.BlobStorage.PutBucketTagging(ctx, "stage-logs",
+		map[string]string{"env": "stage"}))
+
+	require.NoError(t, cloudP.CosmosDB.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloudP.CosmosDB.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	_, err := cloudP.VNet.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := azureserver.New(azureserver.Drivers{
+		BlobStorage:       cloudP.BlobStorage,
+		CosmosDB:          cloudP.CosmosDB,
+		Network:           cloudP.VNet,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	t.Run("query all resources", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+
+		data, ok := out.Data.([]any)
+		require.True(t, ok, "expected []any data, got %T", out.Data)
+		assert.GreaterOrEqual(t, len(data), 4, "expect 2 buckets + 1 table + 1 vnet")
+	})
+
+	t.Run("filter by type", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.storage/storageaccounts'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2, "two storage accounts")
+	})
+
+	t.Run("filter by type and tag", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.storage/storageaccounts' | where tags['env'] == 'prod'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 1)
+
+		row := data[0].(map[string]any)
+		assert.Equal(t, "audit-logs", row["name"])
+		assert.Equal(t, "microsoft.storage/storageaccounts", row["type"])
+
+		tags := row["tags"].(map[string]any)
+		assert.Equal(t, "prod", tags["env"])
+	})
+
+	t.Run("case-insensitive type match", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type =~ 'Microsoft.Network/VirtualNetworks'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 1, "the one VNet we seeded")
+	})
+
+	t.Run("subscription scoping — wrong sub returns empty", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query:         to.Ptr("Resources"),
+			Subscriptions: []*string{to.Ptr("some-other-sub")},
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
+
+	t.Run("limit clause caps results", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | limit 1"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 1)
+	})
+
+	t.Run("$top option caps results", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+			Options: &armresourcegraph.QueryRequestOptions{
+				Top: to.Ptr(int32(2)),
+			},
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2)
+	})
+
+	t.Run("returned resource IDs are Azure-shaped", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.network/virtualnetworks'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1)
+
+		row := data[0].(map[string]any)
+		id := row["id"].(string)
+		assert.Contains(t, id, "/subscriptions/123456789012/")
+		assert.Contains(t, id, "Microsoft.Network")
+		assert.Equal(t, "123456789012", row["subscriptionId"])
+	})
+}
+
+func newResourceGraphClient(t *testing.T, ts *httptest.Server) *armresourcegraph.Client {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armresourcegraph.NewClientFactory(fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cf.NewClient()
+}

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -187,3 +187,98 @@ func newResourceGraphClient(t *testing.T, ts *httptest.Server) *armresourcegraph
 
 	return cf.NewClient()
 }
+
+// TestSDKResourceGraph_BugFixes pins the three issues called out in the
+// PR #197 review so they cannot silently regress.
+func TestSDKResourceGraph_BugFixes(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "bkt"))
+	require.NoError(t, cloudP.BlobStorage.PutBucketTagging(ctx, "bkt",
+		map[string]string{"env": "prod"}))
+
+	_, err := cloudP.VNet.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	t.Run("Bug 1: contradictory type filters return empty (AND, not OR)", func(t *testing.T) {
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			SubscriptionID:    "123456789012",
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.compute/virtualmachines' | where type == 'microsoft.storage/storageaccounts'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords, "AND of two distinct types must yield zero")
+	})
+
+	t.Run("Bug 1: conflicting tag values for same key return empty", func(t *testing.T) {
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			SubscriptionID:    "123456789012",
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where tags['env'] == 'prod' | where tags['env'] == 'stage'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
+
+	t.Run("Bug 3: empty SubscriptionID falls back to engine.AccountID", func(t *testing.T) {
+		// Wire the server WITHOUT explicit SubscriptionID. Scoped queries
+		// for the engine's account ID should still work.
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			// SubscriptionID intentionally omitted.
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query:         to.Ptr("Resources"),
+			Subscriptions: []*string{to.Ptr(cloudP.ResourceDiscovery.AccountID())},
+		}, nil)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, *out.TotalRecords, int64(1),
+			"with SubscriptionID omitted, the handler must fall back to engine.AccountID() so scoped queries still match")
+	})
+
+	t.Run("Bug 2: /resources prefix does not shadow /resourcesHistory routing", func(t *testing.T) {
+		// Smoke-test the shadow case via the real client: ResourcesHistory
+		// must route to its own handler (which delegates back to
+		// queryResources today, but the dispatch path is distinct).
+		srv := azureserver.New(azureserver.Drivers{
+			BlobStorage:       cloudP.BlobStorage,
+			Network:           cloudP.VNet,
+			ResourceDiscovery: cloudP.ResourceDiscovery,
+			SubscriptionID:    "123456789012",
+		})
+		ts := httptest.NewTLSServer(srv)
+		t.Cleanup(ts.Close)
+
+		client := newResourceGraphClient(t, ts)
+		out, err := client.ResourcesHistory(ctx, armresourcegraph.ResourcesHistoryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+	})
+}

--- a/server/gcp/cloudasset/filter.go
+++ b/server/gcp/cloudasset/filter.go
@@ -1,0 +1,235 @@
+// Package cloudasset serves the GCP Cloud Asset Inventory v1 REST API
+// against a *resourcediscovery.Engine.
+//
+// Filter syntax (documented subset of the real Cloud Asset filter
+// expression):
+//
+//	service:storage.googleapis.com      service:compute.googleapis.com
+//	assetType:storage.googleapis.com/Bucket
+//	location:us-east1                    location:us-central1
+//	labels.env:prod                      tags.env:prod
+//
+// Multiple terms are whitespace-separated and AND-composed. Unknown keys
+// are tolerated and ignored (matches Cloud Asset's permissive behavior
+// for unknown fields). Contradictory terms (two distinct services in the
+// same query, or two values for the same label) flip ForceEmpty so the
+// handler short-circuits to an empty result — a single resource cannot
+// belong to two services or hold two values for one label, so the real
+// API would also return zero rows.
+package cloudasset
+
+import (
+	"strings"
+
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// GCP service identifiers as they appear in Cloud Asset assetType strings.
+const (
+	gcpServiceCompute        = "compute.googleapis.com"
+	gcpServiceStorage        = "storage.googleapis.com"
+	gcpServiceFirestore      = "firestore.googleapis.com"
+	gcpServiceCloudFunctions = "cloudfunctions.googleapis.com"
+)
+
+// Fully-qualified GCP asset type strings — used in both directions
+// (parsing assetType filters AND emitting type in response rows).
+const (
+	atComputeInstance = "compute.googleapis.com/Instance"
+	atNetwork         = "compute.googleapis.com/Network"
+	atSubnetwork      = "compute.googleapis.com/Subnetwork"
+	atFirewall        = "compute.googleapis.com/Firewall"
+	atStorageBucket   = "storage.googleapis.com/Bucket"
+	atFirestoreDB     = "firestore.googleapis.com/Database"
+	atFirestoreColl   = "firestore.googleapis.com/Collection"
+	atCloudFunction   = "cloudfunctions.googleapis.com/Function"
+	atCloudFunctionV1 = "cloudfunctions.googleapis.com/CloudFunction"
+)
+
+// Portable service identifiers as emitted by resourcediscovery walkers.
+const (
+	portableCompute    = "compute"
+	portableNetworking = "networking"
+	portableStorage    = "storage"
+	portableDatabase   = "database"
+	portableServerless = "serverless"
+)
+
+// parsedFilter is the result of filter parsing — an engine Query plus
+// any caller-detected contradictions.
+type parsedFilter struct {
+	Query      resourcediscovery.Query
+	ForceEmpty bool
+
+	serviceSet bool
+	typeSet    bool
+	labelFirst map[string]string
+}
+
+// parseFilter converts a Cloud Asset filter expression into a Query.
+// Empty filter returns a zero Query (matches all). Unknown tokens are
+// silently ignored.
+func parseFilter(expr string) parsedFilter {
+	out := parsedFilter{}
+	if strings.TrimSpace(expr) == "" {
+		return out
+	}
+
+	for _, token := range strings.Fields(expr) {
+		applyToken(&out, token)
+	}
+
+	return out
+}
+
+func applyToken(out *parsedFilter, token string) {
+	key, val, ok := strings.Cut(token, ":")
+	if !ok || val == "" {
+		return
+	}
+
+	switch {
+	case key == "service":
+		applyService(out, val)
+	case key == "assetType":
+		applyAssetType(out, val)
+	case key == "location":
+		out.Query.Region = val
+	case strings.HasPrefix(key, "labels."):
+		addLabel(out, strings.TrimPrefix(key, "labels."), val)
+	case strings.HasPrefix(key, "tags."):
+		addLabel(out, strings.TrimPrefix(key, "tags."), val)
+	}
+}
+
+func applyService(out *parsedFilter, service string) {
+	if out.serviceSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.serviceSet = true
+
+	svc := gcpServiceToPortable(service)
+	if svc == "" {
+		return
+	}
+
+	out.Query.Services = expandPortableService(svc)
+}
+
+func applyAssetType(out *parsedFilter, assetType string) {
+	if out.typeSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.typeSet = true
+
+	svc, typ := mapGCPAssetType(assetType)
+	if svc != "" {
+		out.Query.Services = []string{svc}
+	}
+
+	if typ != "" {
+		out.Query.Type = typ
+	}
+}
+
+func addLabel(out *parsedFilter, key, value string) {
+	if prev, seen := out.labelFirst[key]; seen && prev != value {
+		out.ForceEmpty = true
+		return
+	}
+
+	if out.labelFirst == nil {
+		out.labelFirst = make(map[string]string)
+	}
+
+	out.labelFirst[key] = value
+
+	if out.Query.Tags == nil {
+		out.Query.Tags = make(map[string]string)
+	}
+
+	out.Query.Tags[key] = value
+}
+
+// gcpServiceToPortable maps a GCP service name (storage.googleapis.com)
+// to the portable service identifier. compute.googleapis.com is special:
+// it spans both portable "compute" and "networking" — the caller uses
+// expandPortableService to get the right Services set.
+func gcpServiceToPortable(service string) string {
+	switch service {
+	case gcpServiceCompute:
+		// caller should expand
+		return portableCompute
+	case gcpServiceStorage:
+		return portableStorage
+	case gcpServiceFirestore:
+		return portableDatabase
+	case gcpServiceCloudFunctions:
+		return portableServerless
+	default:
+		return ""
+	}
+}
+
+// expandPortableService turns a portable service into the slice the engine
+// matcher expects. compute.googleapis.com covers both VMs and networking
+// resources in real GCP, so a service:compute.googleapis.com filter must
+// match both portable services.
+func expandPortableService(svc string) []string {
+	if svc == portableCompute {
+		return []string{portableCompute, portableNetworking}
+	}
+
+	return []string{svc}
+}
+
+// mapGCPAssetType translates a fully-qualified GCP asset type
+// (compute.googleapis.com/Instance) to the portable (service, type) pair
+// the engine uses. Returns ("", "") for unmapped types.
+func mapGCPAssetType(assetType string) (service, typ string) {
+	switch assetType {
+	case atComputeInstance:
+		return portableCompute, "Instance"
+	case atNetwork:
+		return portableNetworking, "VPC"
+	case atSubnetwork:
+		return portableNetworking, "Subnet"
+	case atFirewall:
+		return portableNetworking, "SecurityGroup"
+	case atStorageBucket:
+		return portableStorage, "Bucket"
+	case atFirestoreDB, atFirestoreColl:
+		return portableDatabase, "Table"
+	case atCloudFunction, atCloudFunctionV1:
+		return portableServerless, "Function"
+	default:
+		return "", ""
+	}
+}
+
+// portableToGCPAssetType is the inverse — turns the engine's (service,
+// type) pair into the canonical GCP assetType string the API emits.
+func portableToGCPAssetType(service, typ string) string {
+	switch service + "/" + typ {
+	case portableCompute + "/Instance":
+		return atComputeInstance
+	case portableNetworking + "/VPC":
+		return atNetwork
+	case portableNetworking + "/Subnet":
+		return atSubnetwork
+	case portableNetworking + "/SecurityGroup":
+		return atFirewall
+	case portableStorage + "/Bucket":
+		return atStorageBucket
+	case portableDatabase + "/Table":
+		return atFirestoreDB
+	case portableServerless + "/Function":
+		return atCloudFunction
+	default:
+		return service + "/" + typ
+	}
+}

--- a/server/gcp/cloudasset/filter.go
+++ b/server/gcp/cloudasset/filter.go
@@ -115,7 +115,18 @@ func applyService(out *parsedFilter, service string) {
 		return
 	}
 
-	out.Query.Services = expandPortableService(svc)
+	newServices := expandPortableService(svc)
+
+	// Cross-clause contradiction: if an earlier assetType: pinned a
+	// narrower service set, a service: clause that doesn't overlap means
+	// "this resource must belong to two different services" — impossible,
+	// so flag ForceEmpty.
+	if out.typeSet && len(out.Query.Services) > 0 && !servicesIntersect(out.Query.Services, newServices) {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.Query.Services = newServices
 }
 
 func applyAssetType(out *parsedFilter, assetType string) {
@@ -128,12 +139,39 @@ func applyAssetType(out *parsedFilter, assetType string) {
 
 	svc, typ := mapGCPAssetType(assetType)
 	if svc != "" {
-		out.Query.Services = []string{svc}
+		newServices := []string{svc}
+
+		// Cross-clause contradiction: same idea as applyService — if a
+		// service: clause already narrowed Services and the new assetType
+		// belongs to a different service, no resource can satisfy both.
+		if out.serviceSet && len(out.Query.Services) > 0 && !servicesIntersect(out.Query.Services, newServices) {
+			out.ForceEmpty = true
+			return
+		}
+
+		out.Query.Services = newServices
 	}
 
 	if typ != "" {
 		out.Query.Type = typ
 	}
+}
+
+// servicesIntersect returns true when the two service-name sets share at
+// least one element. Used by the cross-clause contradiction checks above.
+func servicesIntersect(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+
+	for _, s := range b {
+		if _, ok := set[s]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 func addLabel(out *parsedFilter, key, value string) {

--- a/server/gcp/cloudasset/filter_test.go
+++ b/server/gcp/cloudasset/filter_test.go
@@ -96,12 +96,55 @@ func TestParseFilter_ForceEmpty(t *testing.T) {
 			name: "label vs tag conflict on same key",
 			expr: "labels.env:prod tags.env:stage",
 		},
+		{
+			name: "service then assetType cross-contradiction",
+			expr: "service:compute.googleapis.com assetType:storage.googleapis.com/Bucket",
+		},
+		{
+			name: "assetType then service cross-contradiction",
+			expr: "assetType:firestore.googleapis.com/Database service:storage.googleapis.com",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := parseFilter(tt.expr)
 			assert.True(t, got.ForceEmpty, "expected ForceEmpty for %q", tt.expr)
+		})
+	}
+}
+
+// TestParseFilter_ServiceAssetTypeAgreement verifies that compatible
+// service + assetType pairs are NOT flagged. compute.googleapis.com
+// covers both portable compute and networking — Instance + Network +
+// Subnetwork + Firewall all belong to that service.
+func TestParseFilter_ServiceAssetTypeAgreement(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "compute service + Instance assetType",
+			expr: "service:compute.googleapis.com assetType:compute.googleapis.com/Instance",
+		},
+		{
+			name: "compute service + Network assetType",
+			expr: "service:compute.googleapis.com assetType:compute.googleapis.com/Network",
+		},
+		{
+			name: "storage service + Bucket assetType",
+			expr: "service:storage.googleapis.com assetType:storage.googleapis.com/Bucket",
+		},
+		{
+			name: "reverse order: assetType then matching service",
+			expr: "assetType:compute.googleapis.com/Instance service:compute.googleapis.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilter(tt.expr)
+			assert.False(t, got.ForceEmpty, "agreeing service+assetType must not trip ForceEmpty: %q", tt.expr)
 		})
 	}
 }

--- a/server/gcp/cloudasset/filter_test.go
+++ b/server/gcp/cloudasset/filter_test.go
@@ -1,0 +1,153 @@
+package cloudasset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		expr     string
+		wantSvcs []string
+		wantType string
+		wantRegn string
+		wantTags map[string]string
+	}{
+		{
+			name: "empty",
+			expr: "",
+		},
+		{
+			name:     "service compute expands to compute+networking",
+			expr:     "service:compute.googleapis.com",
+			wantSvcs: []string{"compute", "networking"},
+		},
+		{
+			name:     "service storage",
+			expr:     "service:storage.googleapis.com",
+			wantSvcs: []string{"storage"},
+		},
+		{
+			name:     "assetType pins service and type",
+			expr:     "assetType:storage.googleapis.com/Bucket",
+			wantSvcs: []string{"storage"},
+			wantType: "Bucket",
+		},
+		{
+			name:     "location",
+			expr:     "location:us-central1",
+			wantRegn: "us-central1",
+		},
+		{
+			name:     "labels prefix",
+			expr:     "labels.env:prod",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "tags prefix",
+			expr:     "tags.env:prod",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name:     "service + label + location",
+			expr:     "service:storage.googleapis.com labels.env:prod location:us-east1",
+			wantSvcs: []string{"storage"},
+			wantRegn: "us-east1",
+			wantTags: map[string]string{"env": "prod"},
+		},
+		{
+			name: "unknown key ignored",
+			expr: "unknown:value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilter(tt.expr)
+			assert.Equal(t, tt.wantSvcs, got.Query.Services)
+			assert.Equal(t, tt.wantType, got.Query.Type)
+			assert.Equal(t, tt.wantRegn, got.Query.Region)
+			assert.Equal(t, tt.wantTags, got.Query.Tags)
+			assert.False(t, got.ForceEmpty, "non-contradictory filter must not trip ForceEmpty")
+		})
+	}
+}
+
+func TestParseFilter_ForceEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{
+			name: "two different services",
+			expr: "service:compute.googleapis.com service:storage.googleapis.com",
+		},
+		{
+			name: "two different assetTypes",
+			expr: "assetType:storage.googleapis.com/Bucket assetType:firestore.googleapis.com/Database",
+		},
+		{
+			name: "conflicting label values for same key",
+			expr: "labels.env:prod labels.env:stage",
+		},
+		{
+			name: "label vs tag conflict on same key",
+			expr: "labels.env:prod tags.env:stage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseFilter(tt.expr)
+			assert.True(t, got.ForceEmpty, "expected ForceEmpty for %q", tt.expr)
+		})
+	}
+}
+
+func TestMapGCPAssetType(t *testing.T) {
+	tests := []struct {
+		assetType string
+		wantSvc   string
+		wantType  string
+	}{
+		{"compute.googleapis.com/Instance", "compute", "Instance"},
+		{"compute.googleapis.com/Network", "networking", "VPC"},
+		{"compute.googleapis.com/Subnetwork", "networking", "Subnet"},
+		{"compute.googleapis.com/Firewall", "networking", "SecurityGroup"},
+		{"storage.googleapis.com/Bucket", "storage", "Bucket"},
+		{"firestore.googleapis.com/Database", "database", "Table"},
+		{"cloudfunctions.googleapis.com/Function", "serverless", "Function"},
+		{"unknown.googleapis.com/Widget", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.assetType, func(t *testing.T) {
+			svc, typ := mapGCPAssetType(tt.assetType)
+			assert.Equal(t, tt.wantSvc, svc)
+			assert.Equal(t, tt.wantType, typ)
+		})
+	}
+}
+
+func TestPortableToGCPAssetType_Roundtrip(t *testing.T) {
+	cases := []struct {
+		svc  string
+		typ  string
+		want string
+	}{
+		{"compute", "Instance", "compute.googleapis.com/Instance"},
+		{"networking", "VPC", "compute.googleapis.com/Network"},
+		{"networking", "Subnet", "compute.googleapis.com/Subnetwork"},
+		{"networking", "SecurityGroup", "compute.googleapis.com/Firewall"},
+		{"storage", "Bucket", "storage.googleapis.com/Bucket"},
+		{"database", "Table", "firestore.googleapis.com/Database"},
+		{"serverless", "Function", "cloudfunctions.googleapis.com/Function"},
+	}
+
+	for _, c := range cases {
+		got := portableToGCPAssetType(c.svc, c.typ)
+		assert.Equal(t, c.want, got)
+	}
+}

--- a/server/gcp/cloudasset/handler.go
+++ b/server/gcp/cloudasset/handler.go
@@ -49,8 +49,9 @@ type Handler struct {
 	engine    *resourcediscovery.Engine
 	projectID string
 
-	mu    sync.RWMutex
-	feeds map[string]*feed // keyed by full feed name (projects/X/feeds/Y)
+	mu         sync.RWMutex
+	feeds      map[string]*feed          // keyed by full feed name (projects/X/feeds/Y)
+	operations map[string]map[string]any // keyed by op name; caches completed export results
 }
 
 type feed struct {
@@ -73,11 +74,17 @@ func New(engine *resourcediscovery.Engine, projectID string) *Handler {
 	}
 
 	return &Handler{
-		engine:    engine,
-		projectID: projectID,
-		feeds:     make(map[string]*feed),
+		engine:     engine,
+		projectID:  projectID,
+		feeds:      make(map[string]*feed),
+		operations: make(map[string]map[string]any),
 	}
 }
+
+// operationNamePrefix tags operation IDs we own so the Operations.Get
+// path matcher (very broadly /v1/.../operations/...) only claims ours and
+// not the GCE/compute operations served by other handlers.
+const operationNamePrefix = "cloudemu-export-"
 
 // Matches accepts paths that are unambiguously Cloud Asset. We match
 // narrowly to avoid shadowing other GCP REST handlers (firestore claims
@@ -93,6 +100,13 @@ func (*Handler) Matches(r *http.Request) bool {
 		if _, ok := customMethods[p[i+1:]]; ok {
 			return true
 		}
+	}
+
+	// /v1/{parent}/operations/cloudemu-export-... — claim only operation
+	// names this package creates; other handlers (compute, networks)
+	// serve their own /operations/ paths.
+	if strings.Contains(p, "/operations/"+operationNamePrefix) {
+		return true
 	}
 
 	// /v1/{parent}/assets or /v1/{parent}/feeds[/{id}]
@@ -130,9 +144,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// /v1/{parent}/operations/cloudemu-export-... — the result of an
+	// earlier exportAssets call. Cached in h.operations.
+	if before, id, ok := segmentBeforeLast(p, "/operations/"); ok && strings.HasPrefix(id, operationNamePrefix) {
+		h.getOperation(w, r, stripAPIPrefix(before)+"/operations/"+id)
+		return
+	}
+
 	// /v1/{parent}/feeds/{id} — derive the canonical feed name without /v1/.
 	if before, id, ok := segmentBeforeLast(p, "/feeds/"); ok {
+		if strings.ContainsRune(id, '/') {
+			writeError(w, http.StatusNotFound, "NOT_FOUND",
+				"feed id cannot contain '/': "+id)
+
+			return
+		}
+
 		h.serveFeedItem(w, r, stripAPIPrefix(before)+"/feeds/"+id)
+
 		return
 	}
 
@@ -227,36 +256,60 @@ func (*Handler) searchAllIamPolicies(w http.ResponseWriter, _ *http.Request, _ s
 
 // ----- exportAssets -----
 
-func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, _ string) {
+func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, scope string) {
 	body := readJSONBody(r)
 
 	parsed := parseFilter(strOrEmpty(body["filter"]))
-	if parsed.ForceEmpty {
-		writeJSON(w, http.StatusOK, completedExportOperation(nil))
-		return
+
+	var results []resourcediscovery.Resource
+
+	if !parsed.ForceEmpty {
+		var err error
+
+		results, err = h.engine.List(r.Context(), parsed.Query)
+		if err != nil {
+			writeCErr(w, err)
+			return
+		}
 	}
 
-	results, err := h.engine.List(r.Context(), parsed.Query)
-	if err != nil {
-		writeCErr(w, err)
-		return
+	op := h.buildAndCacheExportOperation(scope, results)
+	writeJSON(w, http.StatusOK, op)
+}
+
+// buildAndCacheExportOperation creates the LRO response and caches it under
+// its name so a subsequent Operations.Get can find it. The operation is
+// scope-prefixed (projects/X/operations/cloudemu-export-...) so the path
+// matcher in ServeHTTP routes the poll back to this handler.
+func (h *Handler) buildAndCacheExportOperation(scope string, results []resourcediscovery.Resource) map[string]any {
+	if scope == "" {
+		scope = "projects/" + h.projectID
 	}
 
-	writeJSON(w, http.StatusOK, completedExportOperation(results))
+	name := scope + "/operations/" + operationNamePrefix + strconv.FormatInt(time.Now().UnixNano(), 10)
+	op := completedExportOperation(name, results)
+
+	h.mu.Lock()
+	h.operations[name] = op
+	h.mu.Unlock()
+
+	return op
 }
 
 // completedExportOperation builds the synchronous LRO response shape.
-// Real Cloud Asset returns an operation name that the caller polls; the
-// mock returns done=true with the asset list inline so SDK calls that
-// expect the operation to be ready immediately work without polling.
-func completedExportOperation(results []resourcediscovery.Resource) map[string]any {
+// Real Cloud Asset is async — it returns an operation name that the
+// caller polls via Operations.Get. The mock returns done=true with the
+// asset list inline so most callers (which call .Do() and check Done)
+// work without polling, AND caches the response under name so callers
+// that DO poll via Operations.Get find a matching entry.
+func completedExportOperation(name string, results []resourcediscovery.Resource) map[string]any {
 	assets := make([]map[string]any, 0, len(results))
 	for i := range results {
 		assets = append(assets, resourceToAsset(&results[i]))
 	}
 
 	return map[string]any{
-		"name": "operations/cloudemu-export-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		"name": name,
 		"done": true,
 		"metadata": map[string]any{
 			"@type": "type.googleapis.com/google.cloud.asset.v1.ExportAssetsRequest",
@@ -268,6 +321,22 @@ func completedExportOperation(results []resourcediscovery.Resource) map[string]a
 			"outputUriPrefix": "cloudemu://in-memory",
 		},
 	}
+}
+
+// getOperation serves Operations.Get for export operations cached by an
+// earlier exportAssets call. Method is implicitly GET; we don't enforce
+// because the dispatch already routed here for any verb on this path.
+func (h *Handler) getOperation(w http.ResponseWriter, _ *http.Request, name string) {
+	h.mu.RLock()
+	op, ok := h.operations[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "operation not found: "+name)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, op)
 }
 
 // ----- batchGetAssetsHistory -----

--- a/server/gcp/cloudasset/handler.go
+++ b/server/gcp/cloudasset/handler.go
@@ -1,0 +1,759 @@
+package cloudasset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/resourcediscovery"
+)
+
+// Path prefix shared by every Cloud Asset operation.
+const apiPrefix = "/v1/"
+
+// Custom-method names that may appear after a colon in the URL — e.g.,
+// /v1/projects/X:searchAllResources.
+const (
+	methodSearchAllResources    = "searchAllResources"
+	methodSearchAllIamPolicies  = "searchAllIamPolicies"
+	methodExportAssets          = "exportAssets"
+	methodBatchGetAssetsHistory = "batchGetAssetsHistory"
+)
+
+// Body size cap for any JSON request — matches the firestore handler.
+const maxBodyBytes = 5 << 20
+
+// Custom-method dispatch table. Immutable; declared as a package-level
+// var because Go does not allow const maps.
+//
+//nolint:gochecknoglobals // immutable lookup set.
+var customMethods = map[string]struct{}{
+	methodSearchAllResources:    {},
+	methodSearchAllIamPolicies:  {},
+	methodExportAssets:          {},
+	methodBatchGetAssetsHistory: {},
+}
+
+// Sentinel feed error so handler tests can match exactly without %w wrap.
+var errFeedNotFound = errors.New("feed not found")
+
+// Handler serves Cloud Asset Inventory v1 REST requests.
+type Handler struct {
+	engine    *resourcediscovery.Engine
+	projectID string
+
+	mu    sync.RWMutex
+	feeds map[string]*feed // keyed by full feed name (projects/X/feeds/Y)
+}
+
+type feed struct {
+	Name        string            `json:"name"`
+	AssetNames  []string          `json:"assetNames,omitempty"`
+	AssetTypes  []string          `json:"assetTypes,omitempty"`
+	ContentType string            `json:"contentType,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	FeedOutput  map[string]any    `json:"feedOutputConfig,omitempty"`
+	Condition   map[string]any    `json:"condition,omitempty"`
+}
+
+// New returns a Cloud Asset handler backed by engine. projectID is used
+// for feed-name validation and asset scoping; if empty, the engine's own
+// AccountID (which holds the GCP project ID for GCP engines) is used so
+// callers don't have to repeat it.
+func New(engine *resourcediscovery.Engine, projectID string) *Handler {
+	if projectID == "" && engine != nil {
+		projectID = engine.AccountID()
+	}
+
+	return &Handler{
+		engine:    engine,
+		projectID: projectID,
+		feeds:     make(map[string]*feed),
+	}
+}
+
+// Matches accepts paths that are unambiguously Cloud Asset. We match
+// narrowly to avoid shadowing other GCP REST handlers (firestore claims
+// /v1/projects/ broadly), so registration order is forgiving.
+func (*Handler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+	if !strings.HasPrefix(p, apiPrefix) {
+		return false
+	}
+
+	// Custom methods (colon syntax): /v1/{scope}:method.
+	if i := strings.LastIndexByte(p, ':'); i > len(apiPrefix) {
+		if _, ok := customMethods[p[i+1:]]; ok {
+			return true
+		}
+	}
+
+	// /v1/{parent}/assets or /v1/{parent}/feeds[/{id}]
+	return pathHasSegment(p, "assets") || pathHasSegment(p, "feeds")
+}
+
+func pathHasSegment(p, seg string) bool {
+	for _, part := range strings.Split(p, "/") {
+		if part == seg {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p := r.URL.Path
+
+	if i := strings.LastIndexByte(p, ':'); i > len(apiPrefix) {
+		method := p[i+1:]
+		scope := stripAPIPrefix(p[:i])
+		h.serveCustomMethod(w, r, scope, method)
+
+		return
+	}
+
+	if endsWith, parent := segmentSuffix(p, "/assets"); endsWith {
+		h.listAssets(w, r, stripAPIPrefix(parent))
+		return
+	}
+
+	if endsWith, parent := segmentSuffix(p, "/feeds"); endsWith {
+		h.serveFeedsCollection(w, r, stripAPIPrefix(parent))
+		return
+	}
+
+	// /v1/{parent}/feeds/{id} — derive the canonical feed name without /v1/.
+	if before, id, ok := segmentBeforeLast(p, "/feeds/"); ok {
+		h.serveFeedItem(w, r, stripAPIPrefix(before)+"/feeds/"+id)
+		return
+	}
+
+	writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown Cloud Asset path: "+p)
+}
+
+// stripAPIPrefix removes the leading "/v1/" so derived names match the
+// canonical GCP shape (projects/X/feeds/Y, not /v1/projects/X/feeds/Y).
+func stripAPIPrefix(p string) string {
+	return strings.TrimPrefix(p, apiPrefix)
+}
+
+// expectedMethod returns the HTTP method the real Cloud Asset API uses for
+// each custom method. Search and history are GETs; export is a POST
+// long-running operation.
+func expectedMethod(method string) string {
+	if method == methodExportAssets {
+		return http.MethodPost
+	}
+
+	return http.MethodGet
+}
+
+func (h *Handler) serveCustomMethod(w http.ResponseWriter, r *http.Request, scope, method string) {
+	if want := expectedMethod(method); r.Method != want {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+			want+" required for "+method)
+
+		return
+	}
+
+	switch method {
+	case methodSearchAllResources:
+		h.searchAllResources(w, r, scope)
+	case methodSearchAllIamPolicies:
+		h.searchAllIamPolicies(w, r, scope)
+	case methodExportAssets:
+		h.exportAssets(w, r, scope)
+	case methodBatchGetAssetsHistory:
+		h.batchGetAssetsHistory(w, r, scope)
+	default:
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "unknown method: "+method)
+	}
+}
+
+// ----- searchAllResources -----
+
+func (h *Handler) searchAllResources(w http.ResponseWriter, r *http.Request, _ string) {
+	// Real Cloud Asset takes filter as a query param OR body field. Support
+	// both; body wins if both supplied.
+	body := readJSONBody(r)
+
+	filter := r.URL.Query().Get("query")
+	if v, ok := body["query"].(string); ok && v != "" {
+		filter = v
+	}
+
+	pageSize := intParam(r, body, "pageSize")
+
+	parsed := parseFilter(filter)
+	if parsed.ForceEmpty {
+		writeJSON(w, http.StatusOK, map[string]any{"results": []any{}})
+		return
+	}
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if pageSize > 0 && pageSize < len(results) {
+		results = results[:pageSize]
+	}
+
+	out := make([]map[string]any, 0, len(results))
+	for i := range results {
+		out = append(out, resourceToSearchResult(&results[i], h.projectID))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"results": out})
+}
+
+// ----- searchAllIamPolicies -----
+
+func (*Handler) searchAllIamPolicies(w http.ResponseWriter, _ *http.Request, _ string) {
+	// IAM policy walking is out of scope for Phase 4 — the engine doesn't
+	// expose iam driver state. Return empty so callers can probe the API
+	// without erroring out.
+	writeJSON(w, http.StatusOK, map[string]any{"results": []any{}})
+}
+
+// ----- exportAssets -----
+
+func (h *Handler) exportAssets(w http.ResponseWriter, r *http.Request, _ string) {
+	body := readJSONBody(r)
+
+	parsed := parseFilter(strOrEmpty(body["filter"]))
+	if parsed.ForceEmpty {
+		writeJSON(w, http.StatusOK, completedExportOperation(nil))
+		return
+	}
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, completedExportOperation(results))
+}
+
+// completedExportOperation builds the synchronous LRO response shape.
+// Real Cloud Asset returns an operation name that the caller polls; the
+// mock returns done=true with the asset list inline so SDK calls that
+// expect the operation to be ready immediately work without polling.
+func completedExportOperation(results []resourcediscovery.Resource) map[string]any {
+	assets := make([]map[string]any, 0, len(results))
+	for i := range results {
+		assets = append(assets, resourceToAsset(&results[i]))
+	}
+
+	return map[string]any{
+		"name": "operations/cloudemu-export-" + strconv.FormatInt(time.Now().UnixNano(), 10),
+		"done": true,
+		"metadata": map[string]any{
+			"@type": "type.googleapis.com/google.cloud.asset.v1.ExportAssetsRequest",
+		},
+		"response": map[string]any{
+			"@type":           "type.googleapis.com/google.cloud.asset.v1.ExportAssetsResponse",
+			"readTime":        time.Now().UTC().Format(time.RFC3339Nano),
+			"assets":          assets,
+			"outputUriPrefix": "cloudemu://in-memory",
+		},
+	}
+}
+
+// ----- batchGetAssetsHistory -----
+
+func (h *Handler) batchGetAssetsHistory(w http.ResponseWriter, r *http.Request, _ string) {
+	body := readJSONBody(r)
+
+	parsed := parseFilter(strOrEmpty(body["filter"]))
+	if parsed.ForceEmpty {
+		writeJSON(w, http.StatusOK, map[string]any{"assets": []any{}})
+		return
+	}
+
+	results, err := h.engine.List(r.Context(), parsed.Query)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// Real API returns TemporalAsset entries with window timestamps; the
+	// mock has no time-travel, so each asset gets a single window starting
+	// at the read time.
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+
+	out := make([]map[string]any, 0, len(results))
+	for i := range results {
+		out = append(out, map[string]any{
+			"window": map[string]any{"startTime": now, "endTime": now},
+			"asset":  resourceToAsset(&results[i]),
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"assets": out})
+}
+
+// ----- assets.list -----
+//
+// Real assets.list does not take a free-form filter expression. The SDK
+// surfaces it as repeated assetTypes={...} query params plus pageSize.
+// We honor assetTypes (any-of match) and ignore contentType / readTime
+// since the mock has no time-travel or per-content-type projections.
+
+func (h *Handler) listAssets(w http.ResponseWriter, r *http.Request, _ string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "GET required for assets.list")
+		return
+	}
+
+	assetTypes := r.URL.Query()["assetTypes"]
+	pageSize := intParam(r, nil, "pageSize")
+
+	allResults, err := h.collectAssetsForTypes(r.Context(), assetTypes)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if pageSize > 0 && pageSize < len(allResults) {
+		allResults = allResults[:pageSize]
+	}
+
+	out := make([]map[string]any, 0, len(allResults))
+	for i := range allResults {
+		out = append(out, resourceToAsset(&allResults[i]))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"assets":   out,
+		"readTime": nowRFC(),
+	})
+}
+
+// collectAssetsForTypes runs one engine query per assetType filter and
+// merges the results. If no assetTypes are supplied, returns the full
+// inventory in a single query.
+func (h *Handler) collectAssetsForTypes(ctx context.Context, assetTypes []string) ([]resourcediscovery.Resource, error) {
+	if len(assetTypes) == 0 {
+		return h.engine.ListAll(ctx)
+	}
+
+	var all []resourcediscovery.Resource
+
+	for _, at := range assetTypes {
+		svc, typ := mapGCPAssetType(at)
+		if svc == "" {
+			continue
+		}
+
+		batch, err := h.engine.List(ctx, resourcediscovery.Query{
+			Services: []string{svc},
+			Type:     typ,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, batch...)
+	}
+
+	return all, nil
+}
+
+// ----- Feeds collection (POST create, GET list) -----
+
+func (h *Handler) serveFeedsCollection(w http.ResponseWriter, r *http.Request, parent string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createFeed(w, r, parent)
+	case http.MethodGet:
+		h.listFeeds(w, r, parent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+			"only POST and GET are supported on the feeds collection")
+	}
+}
+
+func (h *Handler) createFeed(w http.ResponseWriter, r *http.Request, parent string) {
+	body := readJSONBody(r)
+
+	feedID := strOrEmpty(body["feedId"])
+	if feedID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "feedId is required")
+		return
+	}
+
+	feedBody, _ := body["feed"].(map[string]any)
+	name := parent + "/feeds/" + feedID
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, exists := h.feeds[name]; exists {
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", "feed already exists: "+name)
+		return
+	}
+
+	f := feedFromBody(feedBody)
+	f.Name = name
+	h.feeds[name] = f
+
+	writeJSON(w, http.StatusOK, feedToWire(f))
+}
+
+func (h *Handler) listFeeds(w http.ResponseWriter, _ *http.Request, parent string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	prefix := parent + "/feeds/"
+	out := make([]map[string]any, 0)
+
+	for name, f := range h.feeds {
+		if strings.HasPrefix(name, prefix) {
+			out = append(out, feedToWire(f))
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"feeds": out})
+}
+
+// ----- Feed item (GET, PATCH, DELETE) -----
+
+func (h *Handler) serveFeedItem(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeed(w, name)
+	case http.MethodPatch:
+		h.patchFeed(w, r, name)
+	case http.MethodDelete:
+		h.deleteFeed(w, name)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED",
+			"only GET, PATCH, DELETE are supported on a feed item")
+	}
+}
+
+func (h *Handler) getFeed(w http.ResponseWriter, name string) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	f, ok := h.feeds[name]
+	if !ok {
+		writeNotFound(w, name)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, feedToWire(f))
+}
+
+func (h *Handler) patchFeed(w http.ResponseWriter, r *http.Request, name string) {
+	body := readJSONBody(r)
+
+	// The PATCH body is an UpdateFeedRequest: { "feed": {...}, "updateMask": ... }.
+	// Unwrap the inner feed before merging so partial updates land on the
+	// right fields.
+	feedBody, _ := body["feed"].(map[string]any)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	f, ok := h.feeds[name]
+	if !ok {
+		writeNotFound(w, name)
+		return
+	}
+
+	mergeFeed(f, feedBody)
+	writeJSON(w, http.StatusOK, feedToWire(f))
+}
+
+func (h *Handler) deleteFeed(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.feeds[name]; !ok {
+		writeNotFound(w, name)
+		return
+	}
+
+	delete(h.feeds, name)
+	writeJSON(w, http.StatusOK, map[string]any{})
+}
+
+// ----- helpers -----
+
+func writeNotFound(w http.ResponseWriter, name string) {
+	writeError(w, http.StatusNotFound, "NOT_FOUND", errFeedNotFound.Error()+": "+name)
+}
+
+// segmentSuffix reports whether p ends with the given /segment.
+// Returns ok and the path before the suffix.
+func segmentSuffix(p, suffix string) (ok bool, before string) {
+	if !strings.HasSuffix(p, suffix) {
+		return false, ""
+	}
+
+	return true, strings.TrimSuffix(p, suffix)
+}
+
+// segmentBeforeLast splits p around the LAST occurrence of marker.
+// Returns the part before, the part after, and ok=true if found.
+func segmentBeforeLast(p, marker string) (before, after string, ok bool) {
+	i := strings.LastIndex(p, marker)
+	if i < 0 {
+		return "", "", false
+	}
+
+	return p[:i], p[i+len(marker):], true
+}
+
+func readJSONBody(r *http.Request) map[string]any {
+	out := map[string]any{}
+	if r.Body == nil {
+		return out
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil || len(raw) == 0 {
+		return out
+	}
+
+	_ = json.Unmarshal(raw, &out)
+
+	return out
+}
+
+func strOrEmpty(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func intParam(r *http.Request, body map[string]any, key string) int {
+	if v, ok := body[key]; ok {
+		switch n := v.(type) {
+		case float64:
+			return int(n)
+		case int:
+			return n
+		}
+	}
+
+	if s := r.URL.Query().Get(key); s != "" {
+		n, err := strconv.Atoi(s)
+		if err == nil {
+			return n
+		}
+	}
+
+	return 0
+}
+
+func nowRFC() string {
+	return time.Now().UTC().Format(time.RFC3339Nano)
+}
+
+// resourceToSearchResult formats one Resource for the searchAllResources
+// response. GCP uses a "name" of //service/path.
+func resourceToSearchResult(r *resourcediscovery.Resource, project string) map[string]any {
+	return map[string]any{
+		"name":        gcpResourceName(r),
+		"assetType":   portableToGCPAssetType(r.Service, r.Type),
+		"project":     "projects/" + project,
+		"location":    r.Region,
+		"displayName": r.ID,
+		"labels":      labelsOrEmpty(r.Tags),
+	}
+}
+
+// resourceToAsset formats one Resource for the exportAssets / batchGet
+// response shape: { name, asset_type, resource: {...} }.
+func resourceToAsset(r *resourcediscovery.Resource) map[string]any {
+	return map[string]any{
+		"name":      gcpResourceName(r),
+		"assetType": portableToGCPAssetType(r.Service, r.Type),
+		"resource": map[string]any{
+			"version":              "v1",
+			"discoveryDocumentUri": "",
+			"discoveryName":        r.Type,
+			"location":             r.Region,
+			"data":                 map[string]any{"id": r.ID, "labels": labelsOrEmpty(r.Tags)},
+		},
+	}
+}
+
+// gcpResourceName builds the //service/path identifier GCP uses for assets.
+// For most resources the engine's ARN is already a GCP self-link
+// (projects/.../...), so prefix with the service host.
+func gcpResourceName(r *resourcediscovery.Resource) string {
+	host := portableServiceHost(r.Service)
+	if !strings.HasPrefix(r.ARN, "//") {
+		return "//" + host + "/" + r.ARN
+	}
+
+	return r.ARN
+}
+
+func portableServiceHost(service string) string {
+	switch service {
+	case portableCompute, portableNetworking:
+		return gcpServiceCompute
+	case portableStorage:
+		return gcpServiceStorage
+	case portableDatabase:
+		return gcpServiceFirestore
+	case portableServerless:
+		return gcpServiceCloudFunctions
+	default:
+		return service + ".googleapis.com"
+	}
+}
+
+func labelsOrEmpty(t map[string]string) map[string]string {
+	if t == nil {
+		return map[string]string{}
+	}
+
+	return t
+}
+
+func feedFromBody(body map[string]any) *feed {
+	f := &feed{}
+	if body == nil {
+		return f
+	}
+
+	mergeFeed(f, body)
+
+	return f
+}
+
+func mergeFeed(f *feed, body map[string]any) {
+	if v, ok := body["assetNames"].([]any); ok {
+		f.AssetNames = toStringSlice(v)
+	}
+
+	if v, ok := body["assetTypes"].([]any); ok {
+		f.AssetTypes = toStringSlice(v)
+	}
+
+	if v, ok := body["contentType"].(string); ok {
+		f.ContentType = v
+	}
+
+	if v, ok := body["labels"].(map[string]any); ok {
+		f.Labels = toStringMap(v)
+	}
+
+	if v, ok := body["feedOutputConfig"].(map[string]any); ok {
+		f.FeedOutput = v
+	}
+
+	if v, ok := body["condition"].(map[string]any); ok {
+		f.Condition = v
+	}
+}
+
+func toStringSlice(in []any) []string {
+	out := make([]string, 0, len(in))
+
+	for _, v := range in {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+func toStringMap(in map[string]any) map[string]string {
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+
+	return out
+}
+
+func feedToWire(f *feed) map[string]any {
+	out := map[string]any{
+		"name": f.Name,
+	}
+
+	if len(f.AssetNames) > 0 {
+		out["assetNames"] = f.AssetNames
+	}
+
+	if len(f.AssetTypes) > 0 {
+		out["assetTypes"] = f.AssetTypes
+	}
+
+	if f.ContentType != "" {
+		out["contentType"] = f.ContentType
+	}
+
+	if f.Labels != nil {
+		out["labels"] = f.Labels
+	}
+
+	if f.FeedOutput != nil {
+		out["feedOutputConfig"] = f.FeedOutput
+	}
+
+	if f.Condition != nil {
+		out["condition"] = f.Condition
+	}
+
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeError emits a googleapi-shaped error. The status code (e.g.
+// ALREADY_EXISTS) is also prefixed onto the message so callers using
+// substring matching against the SDK's error.Error() string can still
+// recognize it — the googleapi error helper surfaces message, not status.
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	combined := code + ": " + msg
+	writeJSON(w, status, map[string]any{
+		"error": map[string]any{
+			"code":    status,
+			"status":  code,
+			"message": combined,
+		},
+	})
+}
+
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}
+
+// Compile-time check the handler implements the dispatch interface.
+var _ interface {
+	Matches(*http.Request) bool
+	http.Handler
+} = (*Handler)(nil)

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -1,0 +1,258 @@
+// Real-SDK round-trip test: the live google.golang.org/api/cloudasset/v1
+// REST client drives the in-memory handler end-to-end.
+
+package cloudasset_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/cloudasset/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	netdriver "github.com/stackshy/cloudemu/networking/driver"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+func TestSDKCloudAsset(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "my-test-project"
+
+	// Seed inventory across services.
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "audit-logs"))
+	require.NoError(t, cloudP.GCS.PutBucketTagging(ctx, "audit-logs",
+		map[string]string{"env": "prod", "team": "security"}))
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "stage-logs"))
+	require.NoError(t, cloudP.GCS.PutBucketTagging(ctx, "stage-logs",
+		map[string]string{"env": "stage"}))
+
+	require.NoError(t, cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: "events", PartitionKey: "pk"}))
+	require.NoError(t, cloudP.Firestore.TagResource(ctx, "events", map[string]string{"env": "prod"}))
+
+	_, err := cloudP.VPC.CreateVPC(ctx, netdriver.VPCConfig{
+		CIDRBlock: "10.0.0.0/16", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		Firestore:         cloudP.Firestore,
+		Networking:        cloudP.VPC,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	scope := "projects/" + projectID
+
+	t.Run("searchAllResources returns everything when filter is empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Do()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Results), 4, "expect 2 buckets + 1 table + 1 vpc")
+	})
+
+	t.Run("searchAllResources filters by service", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("service:storage.googleapis.com").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Results, 2)
+		for _, r := range out.Results {
+			assert.Equal(t, "storage.googleapis.com/Bucket", r.AssetType)
+		}
+	})
+
+	t.Run("searchAllResources filters by label", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("labels.env:prod").Do()
+		require.NoError(t, err)
+		// audit-logs bucket + events table + VPC — 3 prod resources.
+		assert.Len(t, out.Results, 3)
+	})
+
+	t.Run("searchAllResources combines service + label", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("service:storage.googleapis.com labels.env:prod").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Results, 1)
+		assert.Equal(t, "audit-logs", out.Results[0].DisplayName)
+	})
+
+	t.Run("searchAllResources: contradiction returns empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("service:storage.googleapis.com service:firestore.googleapis.com").Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("searchAllResources: conflicting label values returns empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Query("labels.env:prod labels.env:stage").Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("searchAllIamPolicies returns empty (out of scope)", func(t *testing.T) {
+		out, err := client.V1.SearchAllIamPolicies(scope).Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results)
+	})
+
+	t.Run("assets.list returns full inventory", func(t *testing.T) {
+		out, err := client.Assets.List(scope).Do()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Assets), 4)
+	})
+
+	t.Run("assets.list with assetTypes narrows results", func(t *testing.T) {
+		out, err := client.Assets.List(scope).
+			AssetTypes("firestore.googleapis.com/Database").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Assets, 1)
+	})
+
+	t.Run("assets.list with multiple assetTypes is any-of", func(t *testing.T) {
+		out, err := client.Assets.List(scope).
+			AssetTypes("firestore.googleapis.com/Database", "storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		// 1 firestore + 2 buckets = 3
+		assert.Len(t, out.Assets, 3)
+	})
+
+	t.Run("exportAssets returns sync operation with results inline", func(t *testing.T) {
+		op, err := client.V1.ExportAssets(scope, &cloudasset.ExportAssetsRequest{}).Do()
+		require.NoError(t, err)
+		assert.True(t, op.Done)
+		require.NotNil(t, op.Response)
+		assert.Contains(t, string(op.Response), "audit-logs")
+	})
+
+	t.Run("returned resource names are GCP-shaped (//service/path)", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("assetType:storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		require.NotEmpty(t, out.Results)
+		for _, r := range out.Results {
+			assert.True(t, strings.HasPrefix(r.Name, "//storage.googleapis.com/"),
+				"bucket name should start with //storage.googleapis.com/, got %q", r.Name)
+		}
+	})
+
+	// ----- Feeds CRUD -----
+	feedID := "audit-feed"
+	feedName := scope + "/feeds/" + feedID
+
+	t.Run("Feeds.Create", func(t *testing.T) {
+		created, err := client.Feeds.Create(scope, &cloudasset.CreateFeedRequest{
+			FeedId: feedID,
+			Feed: &cloudasset.Feed{
+				AssetTypes:  []string{"storage.googleapis.com/Bucket"},
+				ContentType: "RESOURCE",
+				FeedOutputConfig: &cloudasset.FeedOutputConfig{
+					PubsubDestination: &cloudasset.PubsubDestination{
+						Topic: "projects/" + projectID + "/topics/asset-changes",
+					},
+				},
+			},
+		}).Do()
+		require.NoError(t, err)
+		assert.Equal(t, feedName, created.Name)
+	})
+
+	t.Run("Feeds.Create duplicate fails with ALREADY_EXISTS", func(t *testing.T) {
+		_, err := client.Feeds.Create(scope, &cloudasset.CreateFeedRequest{
+			FeedId: feedID,
+			Feed:   &cloudasset.Feed{},
+		}).Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ALREADY_EXISTS")
+	})
+
+	t.Run("Feeds.List includes the new feed", func(t *testing.T) {
+		out, err := client.Feeds.List(scope).Do()
+		require.NoError(t, err)
+		var names []string
+		for _, f := range out.Feeds {
+			names = append(names, f.Name)
+		}
+		assert.Contains(t, names, feedName)
+	})
+
+	t.Run("Feeds.Get returns the stored feed", func(t *testing.T) {
+		got, err := client.Feeds.Get(feedName).Do()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"storage.googleapis.com/Bucket"}, got.AssetTypes)
+	})
+
+	t.Run("Feeds.Patch updates the feed", func(t *testing.T) {
+		patched, err := client.Feeds.Patch(feedName, &cloudasset.UpdateFeedRequest{
+			Feed: &cloudasset.Feed{
+				AssetTypes: []string{
+					"storage.googleapis.com/Bucket",
+					"firestore.googleapis.com/Database",
+				},
+			},
+		}).Do()
+		require.NoError(t, err)
+		assert.Len(t, patched.AssetTypes, 2)
+	})
+
+	t.Run("Feeds.Delete removes the feed", func(t *testing.T) {
+		_, err := client.Feeds.Delete(feedName).Do()
+		require.NoError(t, err)
+
+		out, err := client.Feeds.List(scope).Do()
+		require.NoError(t, err)
+		var names []string
+		for _, f := range out.Feeds {
+			names = append(names, f.Name)
+		}
+		assert.NotContains(t, names, feedName)
+	})
+
+	t.Run("Feeds.Get on deleted feed returns NOT_FOUND", func(t *testing.T) {
+		_, err := client.Feeds.Get(feedName).Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+}
+
+// TestEmptyProjectIDFallsBackToEngine confirms the Phase-3-style fallback:
+// callers wiring ResourceDiscovery without ProjectID get the engine's own
+// project ID, not a silently-empty handler.
+func TestEmptyProjectIDFallsBackToEngine(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "bkt"))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		// ProjectID intentionally omitted.
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	// Use the engine's accountID as scope; the handler must accept it.
+	scope := "projects/" + cloudP.ResourceDiscovery.AccountID()
+	out, err := client.V1.SearchAllResources(scope).Do()
+	require.NoError(t, err)
+	assert.NotEmpty(t, out.Results)
+}

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -256,3 +256,108 @@ func TestEmptyProjectIDFallsBackToEngine(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, out.Results)
 }
+
+// TestSDKCloudAsset_BugFixes pins the three issues called out in the
+// PR #198 review so they cannot silently regress.
+func TestSDKCloudAsset_BugFixes(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "my-test-project"
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "bkt"))
+	require.NoError(t, cloudP.GCS.PutBucketTagging(ctx, "bkt", map[string]string{"env": "prod"}))
+	require.NoError(t, cloudP.Firestore.CreateTable(ctx, dbdriver.TableConfig{Name: "tbl", PartitionKey: "pk"}))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		Firestore:         cloudP.Firestore,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	scope := "projects/" + projectID
+
+	t.Run("Bug 1: service vs assetType contradiction returns empty", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("service:compute.googleapis.com assetType:storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		assert.Empty(t, out.Results,
+			"compute service + Bucket assetType is impossible — must yield zero")
+	})
+
+	t.Run("Bug 1: agreeing service+assetType still returns results", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("service:storage.googleapis.com assetType:storage.googleapis.com/Bucket").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Results, 1)
+	})
+
+	t.Run("Bug 2: Operations.Get returns cached export result", func(t *testing.T) {
+		// Trigger an export — caches the operation under its name.
+		op, err := client.V1.ExportAssets(scope, &cloudasset.ExportAssetsRequest{}).Do()
+		require.NoError(t, err)
+		require.NotEmpty(t, op.Name, "operation must have a non-empty name to be pollable")
+
+		// Now poll via Operations.Get. Before the fix this 404'd.
+		polled, err := client.Operations.Get(op.Name).Do()
+		require.NoError(t, err, "Operations.Get must find the cached export op")
+		assert.True(t, polled.Done)
+		assert.Equal(t, op.Name, polled.Name)
+		assert.NotEmpty(t, polled.Response, "polled op must carry the response payload")
+	})
+
+	t.Run("Bug 2: Operations.Get on unknown name still 404s", func(t *testing.T) {
+		_, err := client.Operations.Get("projects/" + projectID + "/operations/cloudemu-export-bogus").Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+
+	t.Run("Bug 3: feed id containing '/' is rejected", func(t *testing.T) {
+		// Construct a malformed feed name. The SDK's Get builds the URL
+		// from the name as-is.
+		_, err := client.Feeds.Get(scope + "/feeds/nested/path").Do()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+}
+
+// TestSDKCloudAsset_BatchGetAssetsHistory fills the coverage gap from the
+// review — the endpoint was implemented but not exercised by any test.
+func TestSDKCloudAsset_BatchGetAssetsHistory(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "history-test"
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "h-bkt"))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	out, err := client.V1.BatchGetAssetsHistory("projects/" + projectID).Do()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(out.Assets), 1,
+		"batchGetAssetsHistory should return the current snapshot wrapped in a temporal-asset entry")
+	for _, a := range out.Assets {
+		require.NotNil(t, a.Window, "each TemporalAsset must carry a window")
+		assert.NotEmpty(t, a.Window.StartTime)
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -15,7 +15,9 @@ import (
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	gkeprov "github.com/stackshy/cloudemu/providers/gcp/gke"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
+	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
@@ -45,6 +47,13 @@ type Drivers struct {
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
 	// the same backend. Leave nil to disable Kubernetes data-plane support.
 	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery is the cross-service inventory engine. Required to
+	// serve Cloud Asset Inventory (cloudasset/v1) requests. Leave nil to
+	// omit the handler. ProjectID is used for feed-name validation; if
+	// empty the engine's own AccountID (GCP project ID for GCP engines)
+	// is used as the fallback.
+	ResourceDiscovery *resourcediscovery.Engine
+	ProjectID         string
 }
 
 // New returns a server that speaks GCP's REST JSON wire protocol for every
@@ -92,6 +101,14 @@ func New(d Drivers) *server.Server {
 	// same /v1/projects/ space as Firestore, so register first.
 	if d.GKE != nil {
 		srv.Register(gke.New(d.GKE))
+	}
+
+	// Cloud Asset Inventory matches /v1/{scope}:method and /v1/{parent}/
+	// {assets,feeds} paths. Register before Firestore: Firestore's Matches
+	// is /v1/projects/ broadly, which would otherwise swallow the colon-
+	// suffix custom methods that share the same prefix.
+	if d.ResourceDiscovery != nil {
+		srv.Register(cloudasset.New(d.ResourceDiscovery, d.ProjectID))
 	}
 
 	if d.Firestore != nil {


### PR DESCRIPTION

## Feature

- Cross-service ResourceDiscovery engine that aggregates and queries resources across compute, storage, database, networking, and serverless from a single inventory surface.
- AWS Resource Explorer Two and Resource Groups Tagging SDK-compat handlers wired through the gateway.
- Azure Resource Graph SDK-compat handler with KQL-shaped query support over the unified inventory.
- GCP Cloud Asset Inventory SDK-compat handler covering searchAllResources, assets list, exportAssets, feeds, and operations.

## Enhancement

- Database service exposes TagResource, UntagResource, and ListTagsOfResource so tagged resources flow into the discovery engine.
- Networking service exposes UpdateTags and RemoveTags on VPC, Subnet, and SecurityGroup.
- ResourceDiscovery exposes TagResourceByARN and UntagResourceByARN for tag operations addressed by canonical resource identifier.
- ResourceDiscovery engine wired into the AWS, Azure, and GCP provider factories so every service surfaces inventory entries automatically.

## Fixed

- ResourceDiscovery now only swallows NotFound on tag lookups; all other lookup errors propagate to the caller.
- Addressed review feedback in the AWS Resource Explorer and Resource Groups Tagging handlers.
- Addressed review feedback in the Azure Resource Graph handler.
- Addressed review feedback in the GCP Cloud Asset Inventory handler.
