### PR TITLE
docs: document cross-service resource discovery feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ SDK-compat coverage across AWS, Azure, and GCP:
 | Message Queue | SQS | Service Bus | Pub/Sub |
 | Networking | VPC (under EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
 | Monitoring | CloudWatch | Azure Monitor | Cloud Monitoring |
+| Resource Discovery | Resource Explorer + Resource Groups Tagging API | Resource Graph | Cloud Asset Inventory |
 
 The Kubernetes story is two layers, both shipped:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -369,3 +369,64 @@ clock.Set(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
 - **Auto-metrics** -- Backfill datapoints are generated at 1-minute intervals from `clock.Now()`. FakeClock ensures predictable timestamps.
 - **TTL evaluation** -- Database TTL checks compare item timestamps against the clock.
 - **Resource timestamps** -- All `CreatedAt`, `LastModified`, and similar fields use the clock.
+
+---
+
+## 10. Cross-Service Resource Discovery
+
+CloudEmu ships a cross-service inventory engine (`resourcediscovery/`) that walks every service driver a provider holds and returns a single normalized view of what exists. It sits next to the `topology/` engine as a peer of the portable API — it owns no state, constructs from driver interfaces, and is purely query-driven.
+
+The engine is the foundation for three SDK-compat handlers that speak the real cloud inventory APIs: **AWS Resource Explorer 2 + Resource Groups Tagging API**, **Azure Resource Graph**, and **GCP Cloud Asset Inventory**. A tag set through any one of those paths is immediately visible through the others, and through the engine's own `SearchByTag`.
+
+### Provider wiring
+
+Every provider factory wires the engine automatically. No setup required:
+
+```go
+aws := cloudemu.NewAWS(config.WithAccountID("123456789012"), config.WithRegion("us-west-2"))
+
+all, _ := aws.ResourceDiscovery.ListAll(ctx)
+// returns Resource{Provider, Service, Type, ID, ARN, Region, Tags, CreatedAt}
+// for every bucket, instance, VPC, subnet, security group, table, and function
+```
+
+The same field exists on Azure and GCP providers (`azure.ResourceDiscovery`, `gcp.ResourceDiscovery`). Internally, the engine reads from the existing Compute, Networking, Storage, Database, and Serverless drivers — any field that's nil is silently skipped, so partial test wirings work.
+
+### Engine API
+
+| Operation | Purpose |
+|-----------|---------|
+| `ListAll(ctx)` | Every resource the provider currently holds |
+| `List(ctx, Query)` | Filter by `Services`, `Type`, `Region`, and `Tags` (any-of for `Services`; AND across all non-empty fields) |
+| `SearchByTag(ctx, key, value)` | Every resource whose `Tags[key] == value` |
+| `GetTagKeys(ctx)` | Distinct tag keys across the inventory |
+| `GetTagValues(ctx, key)` | Distinct values for a key |
+| `TagResourceByARN(ctx, arn, tags)` | Apply tags to a resource addressed by canonical ARN/URN |
+| `UntagResourceByARN(ctx, arn, keys)` | Remove tag keys from a resource addressed by canonical ARN/URN |
+
+The `Resource` struct is uniform across clouds:
+
+```go
+type Resource struct {
+    Provider  string            // "aws" | "azure" | "gcp"
+    Service   string            // "compute" | "storage" | "networking" | "database" | "serverless"
+    Type      string            // e.g. "instance", "bucket", "vpc", "table", "function"
+    ID        string
+    ARN       string            // AWS ARN, Azure resource ID, or GCP //-prefixed URN
+    Region    string
+    Tags      map[string]string
+    CreatedAt time.Time
+}
+```
+
+### SDK-compat surfaces
+
+The engine drives three handlers, each registered on its provider's SDK-compat server. They all read from (and write tags through) the same engine, so the choice between them is purely about which SDK the calling code already speaks.
+
+| Cloud | Handler | What real SDK clients see |
+|-------|---------|--------------------------|
+| AWS | `server/aws/resourceexplorer2` + `server/aws/resourcegroupstaggingapi` | `resourceexplorer2.Search`, `resourcegroupstaggingapi.GetResources/TagResources/UntagResources/GetTagKeys/GetTagValues` |
+| Azure | `server/azure/resourcegraph` | `armresourcegraph.Resources` — KQL-shaped query over the unified inventory |
+| GCP | `server/gcp/cloudasset` | `cloudasset.SearchAllResources`, `assets.List`, `ExportAssets`, Feeds CRUD, `Operations.Get` |
+
+See [services.md — Resource Discovery](services.md#19-resource-discovery) for the full per-handler operation list and [sdk-server.md](sdk-server.md) for the wire protocols.

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -139,6 +139,8 @@ Region, credentials, and tokens can be any dummy values — the server doesn't v
 | **RDS / Aurora** *(query protocol)* | DBInstances (Create/Describe/Modify/Delete/Start/Stop/Reboot), DBClusters (Create/Describe/Modify/Delete/Start/Stop), DBSnapshots + DBClusterSnapshots (Create/Describe/Delete/Restore). One handler also serves the **Neptune** and **DocumentDB** engines — both reuse the same `aws-sdk-go-v2/service/{neptune,docdb}` client surface. |
 | **Redshift** *(query protocol)* | CreateCluster, DescribeClusters, ModifyCluster, DeleteCluster, RebootCluster, CreateClusterSnapshot, DescribeClusterSnapshots, DeleteClusterSnapshot, RestoreFromClusterSnapshot |
 | **EKS** *(REST + JSON)* | Clusters (Create/Describe/List/UpdateConfig/UpdateVersion/Delete), NodeGroups (Create/Describe/List/UpdateConfig/UpdateVersion/Delete), Fargate Profiles (Create/Describe/List/Delete), Addons (Create/Describe/List/Update/Delete). Stub kubeconfig only — data plane deferred to Wave 2. |
+| **Resource Explorer 2** *(JSON)* | Search — free-text plus filter expression over the cross-service inventory; results include ARN, resource type, region, owning account, and tags |
+| **Resource Groups Tagging API** *(JSON-RPC)* | GetResources (filter by `ResourceTypeFilters` + `TagFilters`, paginated), TagResources, UntagResources, GetTagKeys, GetTagValues |
 
 ### Azure (`server/azure/`)
 
@@ -158,6 +160,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **PostgreSQL Flexible Server** | `Microsoft.DBforPostgreSQL/flexibleServers` — full CRUD lifecycle |
 | **MySQL Flexible Server** | `Microsoft.DBforMySQL/flexibleServers` — full CRUD lifecycle |
 | **AKS** | `Microsoft.ContainerService/managedClusters` — ManagedClusters (CreateOrUpdate, Get, UpdateTags, Delete, List/ListByResourceGroup), AgentPools (CreateOrUpdate, Get, Delete, List), MaintenanceConfigurations (CreateOrUpdate, Get, Delete, List), ListClusterAdmin/User/MonitoringUser Credentials, RotateClusterCertificates. Stub kubeconfig only — data plane deferred to Wave 2. |
+| **Resource Graph** | `Microsoft.ResourceGraph` — `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` with a KQL-shaped query over the cross-service inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
 
 ### GCP (`server/gcp/`)
 
@@ -174,6 +177,7 @@ All handlers speak REST + JSON.
 | **Pub/Sub** | Topics + Subscriptions lifecycle, `:publish`, `:pull`, `:acknowledge` |
 | **Cloud SQL** | Instances (insert/get/list/patch/delete/start/stop/restart) + Operations (get/list) — supports the `sqladmin/v1` SDK |
 | **GKE** | Clusters (Create/Get/List/Update/Delete + `:setLogging`/`:setMonitoring`/`:setMasterAuth`/`:setLegacyAbac`/`:setNetworkPolicy`/`:setMaintenancePolicy`/`:setResourceLabels`/`:startIpRotation`/`:completeIpRotation`), NodePools (Create/Get/List/Update/Delete + `:setSize`/`:setAutoscaling`/`:setManagement`/`:rollback`), Operations (Get/List/`:cancel`). Stub kubeconfig only — data plane deferred to Wave 2. |
+| **Cloud Asset Inventory** | `assets.list` (filter by `assetTypes[]`), `searchAllResources` (query + asset-type filter), `searchAllIamPolicies` (returns empty — out of scope), `exportAssets` (sync; inline results in the returned Operation), `batchGetAssetsHistory`, Feeds (create/list/get/patch/delete), `operations.get`. Resource names returned as GCP-shaped `//service/path` URNs. |
 
 Any operation not in these lists returns `501 Not Implemented` or the provider's native `UnknownOperation` / `NotImplemented` / `NOT_FOUND` error.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -24,6 +24,7 @@ This document lists every service and operation available in CloudEmu across all
 | 16 | Event Bus | `eventbridge` | `eventgrid` | `eventarc` |
 | 17 | Relational Database | `rds` (+ Aurora/Neptune/DocumentDB engines), `redshift` | `azuresql`, `postgresflex`, `mysqlflex` | `cloudsql` |
 | 18 | Kubernetes | `eks` + shared `kubernetes/` | `aks` + shared `kubernetes/` | `gke` + shared `kubernetes/` |
+| 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
 
 ---
 
@@ -1093,6 +1094,61 @@ Shared in-memory K8s API server registered by every cluster from any provider. U
 
 ---
 
+## 19. Resource Discovery
+
+**Engine:** `resourcediscovery/` — a cross-service inventory engine that walks the Compute, Networking, Storage, Database, and Serverless drivers of any provider and returns a normalized `Resource` view (provider, service, type, ID, ARN/URN, region, tags, created-at). Auto-wired by every provider factory and exposed as `Provider.ResourceDiscovery`.
+
+**SDK-compat handlers:** AWS Resource Explorer Two + Resource Groups Tagging API, Azure Resource Graph, and GCP Cloud Asset Inventory. All three sit on top of the same engine, so a tag written through any one path is visible through the others.
+
+### Engine (`resourcediscovery/`)
+
+| Operation | Signature |
+|-----------|-----------|
+| `New` | `(provider, accountID, region string, drivers *Drivers) *Engine` |
+| `ListAll` | `(ctx) ([]Resource, error)` |
+| `List` | `(ctx, Query) ([]Resource, error)` — filter by `Services`, `Type`, `Region`, `Tags` |
+| `SearchByTag` | `(ctx, key, value string) ([]Resource, error)` |
+| `GetTagKeys` | `(ctx) ([]string, error)` |
+| `GetTagValues` | `(ctx, key string) ([]string, error)` |
+| `TagResourceByARN` | `(ctx, arn string, tags map[string]string) error` |
+| `UntagResourceByARN` | `(ctx, arn string, keys []string) error` |
+
+### AWS — Resource Explorer 2 (`server/aws/resourceexplorer2`)
+
+| Operation | Notes |
+|-----------|-------|
+| `Search` | Free-text + filter expression over the unified inventory; returns ARN, resource type, region, owning account, tags |
+
+### AWS — Resource Groups Tagging API (`server/aws/resourcegroupstaggingapi`)
+
+| Operation | Notes |
+|-----------|-------|
+| `GetResources` | Filter by `ResourceTypeFilters` and `TagFilters`; pagination via `PaginationToken` |
+| `TagResources` | Apply a tag set to one or more ARNs in a single call |
+| `UntagResources` | Remove tag keys from one or more ARNs in a single call |
+| `GetTagKeys` | All tag keys across the inventory |
+| `GetTagValues` | All values for a given tag key |
+
+### Azure — Resource Graph (`server/azure/resourcegraph`)
+
+| Operation | Notes |
+|-----------|-------|
+| `Resources` | `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` — KQL-shaped query over the unified inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
+
+### GCP — Cloud Asset Inventory (`server/gcp/cloudasset`)
+
+| Resource | Operations |
+|----------|-----------|
+| Assets | `assets.list` (filter by `assetTypes[]`), `searchAllResources` (query string + asset-type filter), `searchAllIamPolicies` (returns empty — out of scope) |
+| Export | `exportAssets` — synchronous, returns an `Operation` with inline results |
+| Feeds | `feeds.create`, `feeds.list`, `feeds.get`, `feeds.patch`, `feeds.delete` |
+| Operations | `operations.get` — fetches cached `exportAssets` results |
+| Batch | `batchGetAssetsHistory` |
+
+Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups Tagging 5** + **Azure Resource Graph 1** + **GCP Cloud Asset 11** = **26**
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -1118,4 +1174,5 @@ Shared in-memory K8s API server registered by every cluster from any provider. U
 | Kubernetes — Azure AKS (control plane) | 18 |
 | Kubernetes — GCP GKE (control plane) | 26 |
 | Kubernetes — data plane (8 resources × 7 verbs incl. Watch) | 56 |
-| **Grand Total** | **472** |
+| Resource Discovery (engine + AWS + Azure + GCP handlers) | 26 |
+| **Grand Total** | **498** |


### PR DESCRIPTION
## Feature

- README adds a Resource Discovery row to the supported services table so the cross-service inventory engine and its three SDK-compat handlers are visible from the project landing page.
- Services reference gains a master-table row, a dedicated Resource Discovery section, and Summary-table accounting that documents the engine plus per-handler operations across AWS Resource Explorer Two and Resource Groups Tagging API, Azure Resource Graph, and GCP Cloud Asset Inventory.
- SDK-compat server reference lists the new Resource Explorer Two, Resource Groups Tagging API, Resource Graph, and Cloud Asset Inventory handlers under their respective provider tables with wire-protocol notes.
- Features document gains a Cross-Service Resource Discovery section covering the engine API, provider wiring, the normalized Resource shape, and the SDK-compat surfaces it powers.