### PR TITLE
feat(azure): IAM SDK-compat handler

### DIFF
--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -161,6 +161,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **PostgreSQL Flexible Server** | `Microsoft.DBforPostgreSQL/flexibleServers` — full CRUD lifecycle |
 | **MySQL Flexible Server** | `Microsoft.DBforMySQL/flexibleServers` — full CRUD lifecycle |
 | **AKS** | `Microsoft.ContainerService/managedClusters` — ManagedClusters (CreateOrUpdate, Get, UpdateTags, Delete, List/ListByResourceGroup), AgentPools (CreateOrUpdate, Get, Delete, List), MaintenanceConfigurations (CreateOrUpdate, Get, Delete, List), ListClusterAdmin/User/MonitoringUser Credentials, RotateClusterCertificates. Stub kubeconfig only — data plane deferred to Wave 2. |
+| **IAM (armauthorization)** | `Microsoft.Authorization` — RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete) at any scope (subscription, resource group, resource, management group). Real `armauthorization` SDK clients round-trip end-to-end. Microsoft Graph (users/groups) is out of scope — deferred to a future handler. |
 | **Resource Graph** | `Microsoft.ResourceGraph` — `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` with a KQL-shaped query over the cross-service inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
 
 ### GCP (`server/gcp/`)

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	cloud.google.com/go/monitoring v1.27.0 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6Xu
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0 h1:FErSe/vQGefbSuVwBV9JlrRXgG1uOFyW6TCXERX89s4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0/go.mod h1:3rnszxfW8gCLRhoFPgvfXhwSzLam4cHQZ50SugID/sg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3 h1:puJogXZNILDxFHrXTSgjF9P7lgJkr37hr31h5r7CC7I=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3/go.mod h1:ZCM0BEa95+Ov7zRyPZS40SY1pFANErtVgERanZHtgcg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0 h1:LkHbJbgF3YyvC53aqYGR+wWQDn2Rdp9AQdGndf9QvY4=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0/go.mod h1:QyiQdW4f4/BIfB8ZutZ2s+28RAgfa/pT+zS++ZHyM1I=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5 v5.0.0 h1:5n7dPVqsWfVKw+ZiEKSd3Kzu7gwBkbEBkeXb8rgaE9Q=
@@ -68,6 +70,7 @@ github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBAD
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 h1:4iB+IesclUXdP0ICgAabvq2FYLXrJWKx1fJQ+GxSo3Y=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 h1:UnDZ/zFfG1JhH/DqxIZYU/1CUAlTUScoXD/LcM2Ykk8=
@@ -189,6 +192,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -9,6 +9,7 @@ package azure
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
@@ -22,6 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	"github.com/stackshy/cloudemu/server/azure/functions"
+	azureiamhandler "github.com/stackshy/cloudemu/server/azure/iam"
 	"github.com/stackshy/cloudemu/server/azure/images"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
@@ -59,6 +61,7 @@ type Drivers struct {
 	PostgresFlex    rdbdriver.RelationalDB
 	MySQLFlex       rdbdriver.RelationalDB
 	AKS             aksserver.Backend
+	IAM             iamdriver.IAM
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -165,6 +168,13 @@ func New(d Drivers) *server.Server {
 	// unconstrained relative to the resource handlers above.
 	if d.ResourceDiscovery != nil {
 		srv.Register(resourcegraph.New(d.ResourceDiscovery, d.SubscriptionID))
+	}
+
+	// IAM matches /providers/Microsoft.Authorization/role{Definitions,Assignments}
+	// at any scope — distinct from every other ARM provider name, so
+	// registration order is unconstrained.
+	if d.IAM != nil {
+		srv.Register(azureiamhandler.New(d.IAM))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	"github.com/stackshy/cloudemu/server/azure/functions"
-	azureiamhandler "github.com/stackshy/cloudemu/server/azure/iam"
+	"github.com/stackshy/cloudemu/server/azure/iam"
 	"github.com/stackshy/cloudemu/server/azure/images"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
@@ -174,7 +174,7 @@ func New(d Drivers) *server.Server {
 	// at any scope — distinct from every other ARM provider name, so
 	// registration order is unconstrained.
 	if d.IAM != nil {
-		srv.Register(azureiamhandler.New(d.IAM))
+		srv.Register(iam.New(d.IAM))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/iam/assignments.go
+++ b/server/azure/iam/assignments.go
@@ -61,11 +61,13 @@ func (s *assignmentStore) delete(id string) (roleAssignmentEnvelope, bool) {
 	return env, true
 }
 
-// listAtScope returns every assignment whose stored scope starts with the
-// query scope. Real Azure list-at-scope returns assignments AT the scope and
-// at all ancestor scopes; we implement a simpler "prefix or exact match"
-// that's correct for the typical narrow scope-equality case and a reasonable
-// approximation otherwise.
+// listAtScope returns assignments visible from the query scope. Real Azure
+// RoleAssignments.ListForScope returns assignments AT the queried scope and
+// at all ANCESTOR scopes (because permissions inherit downward) — it does
+// NOT return assignments at descendant scopes. We mirror that direction so
+// emulator tests get the same narrowing they'd see against real Azure.
+//
+// An empty or root ("/") query returns everything.
 func (s *assignmentStore) listAtScope(scope string) []roleAssignmentEnvelope {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -76,7 +78,6 @@ func (s *assignmentStore) listAtScope(scope string) []roleAssignmentEnvelope {
 		env := s.items[id]
 		if scope == "" || scope == "/" ||
 			env.Properties.Scope == scope ||
-			strings.HasPrefix(env.Properties.Scope, scope+"/") ||
 			strings.HasPrefix(scope, env.Properties.Scope+"/") {
 			out = append(out, env)
 		}

--- a/server/azure/iam/assignments.go
+++ b/server/azure/iam/assignments.go
@@ -1,0 +1,86 @@
+package iam
+
+import (
+	"strings"
+	"sync"
+)
+
+// assignmentStore is a thread-safe in-memory store for Azure RoleAssignments.
+// We cannot back this through the shared iamdriver.IAM because the AWS-shaped
+// driver has no equivalent concept (it carries Users + Roles + Policies,
+// whereas an Azure RoleAssignment is a (principal, roleDefinition, scope)
+// triple). Keeping a small dedicated store here is the simplest path that
+// matches real Azure semantics.
+type assignmentStore struct {
+	mu sync.RWMutex
+	// items is keyed by assignment id (the {id} segment of the URL — a GUID
+	// in real Azure, but we treat it as an opaque string).
+	items map[string]roleAssignmentEnvelope
+}
+
+func newAssignmentStore() *assignmentStore {
+	return &assignmentStore{items: map[string]roleAssignmentEnvelope{}}
+}
+
+// put inserts or updates an assignment. Returns the stored envelope.
+// env is passed by pointer because the envelope is wider than the gocritic
+// hugeParam threshold; the function only stores a copy.
+func (s *assignmentStore) put(env *roleAssignmentEnvelope) roleAssignmentEnvelope {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.items[env.Name] = *env
+
+	return *env
+}
+
+// get returns the assignment with the given id, or (_, false) if absent.
+func (s *assignmentStore) get(id string) (roleAssignmentEnvelope, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	env, ok := s.items[id]
+
+	return env, ok
+}
+
+// delete removes an assignment. Returns the deleted envelope so the caller
+// can echo it back per Azure semantics (DELETE returns 200 with the prior
+// resource), and ok=false if it wasn't there.
+func (s *assignmentStore) delete(id string) (roleAssignmentEnvelope, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	env, ok := s.items[id]
+	if !ok {
+		return roleAssignmentEnvelope{}, false
+	}
+
+	delete(s.items, id)
+
+	return env, true
+}
+
+// listAtScope returns every assignment whose stored scope starts with the
+// query scope. Real Azure list-at-scope returns assignments AT the scope and
+// at all ancestor scopes; we implement a simpler "prefix or exact match"
+// that's correct for the typical narrow scope-equality case and a reasonable
+// approximation otherwise.
+func (s *assignmentStore) listAtScope(scope string) []roleAssignmentEnvelope {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	out := make([]roleAssignmentEnvelope, 0, len(s.items))
+
+	for id := range s.items {
+		env := s.items[id]
+		if scope == "" || scope == "/" ||
+			env.Properties.Scope == scope ||
+			strings.HasPrefix(env.Properties.Scope, scope+"/") ||
+			strings.HasPrefix(scope, env.Properties.Scope+"/") {
+			out = append(out, env)
+		}
+	}
+
+	return out
+}

--- a/server/azure/iam/errors_sdk_test.go
+++ b/server/azure/iam/errors_sdk_test.go
@@ -1,0 +1,152 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+)
+
+// armauthorization surfaces handler errors as *azcore.ResponseError. The
+// tests in this file lock in the StatusCode contract for each error path so
+// regressions on the JSON envelope or the wire status surface immediately.
+
+func TestSDKAzureIAMRoleDefinitionNotFoundIsTyped(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	_, err := roleDefs.Get(ctx, testScope, "missing-role-id", nil)
+	if err == nil {
+		t.Fatalf("Get on missing role definition: expected error, got nil")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected *azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.StatusCode != 404 {
+		t.Fatalf("got status %d, want 404", respErr.StatusCode)
+	}
+}
+
+func TestSDKAzureIAMRoleAssignmentNotFoundIsTyped(t *testing.T) {
+	_, roleAssigns := newSDKClients(t)
+	ctx := context.Background()
+
+	_, err := roleAssigns.Get(ctx, testScope, "missing-assignment-id", nil)
+	if err == nil {
+		t.Fatalf("Get on missing role assignment: expected error, got nil")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected *azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.StatusCode != 404 {
+		t.Fatalf("got status %d, want 404", respErr.StatusCode)
+	}
+}
+
+func TestSDKAzureIAMCreateAssignmentMissingPrincipalIsRejected(t *testing.T) {
+	_, roleAssigns := newSDKClients(t)
+	ctx := context.Background()
+
+	_, err := roleAssigns.Create(ctx, testScope, "any-id",
+		armauthorization.RoleAssignmentCreateParameters{
+			Properties: &armauthorization.RoleAssignmentProperties{
+				RoleDefinitionID: to.Ptr(testScope +
+					"/providers/Microsoft.Authorization/roleDefinitions/some-role"),
+				// PrincipalID omitted on purpose
+			},
+		}, nil)
+	if err == nil {
+		t.Fatalf("Create without principalId: expected error, got nil")
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("expected *azcore.ResponseError, got %T: %v", err, err)
+	}
+
+	if respErr.StatusCode != 400 {
+		t.Fatalf("got status %d, want 400", respErr.StatusCode)
+	}
+}
+
+// TestSDKAzureIAMUpdateReplacesStoredValue exercises the create-then-update
+// path on a single role definition. Both PUTs must succeed, and a subsequent
+// GET must return the second PUT's values — confirming the upsert path in
+// CreateOrUpdate actually replaces (rather than silently keeping the
+// original). Status code is always 201 for this specific endpoint per the
+// Azure REST spec — see the comment in createOrUpdateRoleDefinition.
+func TestSDKAzureIAMUpdateReplacesStoredValue(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	const roleID = "11111111-aaaa-bbbb-cccc-222222222222"
+
+	def := armauthorization.RoleDefinition{
+		Properties: &armauthorization.RoleDefinitionProperties{
+			RoleName: to.Ptr("v1"),
+			RoleType: to.Ptr("CustomRole"),
+		},
+	}
+
+	// First PUT — create.
+	if _, err := roleDefs.CreateOrUpdate(ctx, testScope, roleID, def, nil); err != nil {
+		t.Fatalf("first CreateOrUpdate: %v", err)
+	}
+
+	// Second PUT — update. Round-trip a different role name so we know the
+	// update actually replaced the stored value.
+	def.Properties.RoleName = to.Ptr("v2")
+	if _, err := roleDefs.CreateOrUpdate(ctx, testScope, roleID, def, nil); err != nil {
+		t.Fatalf("second CreateOrUpdate (update): %v", err)
+	}
+
+	got, err := roleDefs.Get(ctx, testScope, roleID, nil)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.RoleName == nil ||
+		*got.Properties.RoleName != "v2" {
+		t.Fatalf("update did not replace role: got %+v", got.Properties)
+	}
+}
+
+// TestSDKAzureIAMDeleteReturnsResource verifies the handler echoes the
+// deleted resource back in the body of DELETE — real Azure semantics.
+func TestSDKAzureIAMDeleteReturnsResource(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	const roleID = "33333333-dddd-eeee-ffff-444444444444"
+
+	if _, err := roleDefs.CreateOrUpdate(ctx, testScope, roleID,
+		armauthorization.RoleDefinition{
+			Properties: &armauthorization.RoleDefinitionProperties{
+				RoleName: to.Ptr("about-to-be-deleted"),
+				RoleType: to.Ptr("CustomRole"),
+			},
+		}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+
+	deleted, err := roleDefs.Delete(ctx, testScope, roleID, nil)
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if deleted.RoleDefinition.Properties == nil ||
+		deleted.RoleDefinition.Properties.RoleName == nil ||
+		*deleted.RoleDefinition.Properties.RoleName != "about-to-be-deleted" {
+		t.Fatalf("Delete did not echo the prior resource: got %+v",
+			deleted.RoleDefinition)
+	}
+}

--- a/server/azure/iam/handler.go
+++ b/server/azure/iam/handler.go
@@ -1,0 +1,147 @@
+// Package iam implements the Azure Microsoft.Authorization ARM REST API as
+// a server.Handler. Real azure-sdk-for-go armauthorization clients pointed
+// at this server can CRUD RoleDefinitions and RoleAssignments end-to-end.
+//
+// Coverage (api-version 2022-04-01):
+//
+//	PUT    /{scope}/providers/Microsoft.Authorization/roleDefinitions/{id}   — CreateOrUpdate
+//	GET    /{scope}/providers/Microsoft.Authorization/roleDefinitions/{id}   — Get
+//	DELETE /{scope}/providers/Microsoft.Authorization/roleDefinitions/{id}   — Delete
+//	GET    /{scope}/providers/Microsoft.Authorization/roleDefinitions        — List
+//	PUT    /{scope}/providers/Microsoft.Authorization/roleAssignments/{id}   — Create
+//	GET    /{scope}/providers/Microsoft.Authorization/roleAssignments/{id}   — Get
+//	DELETE /{scope}/providers/Microsoft.Authorization/roleAssignments/{id}   — Delete
+//	GET    /{scope}/providers/Microsoft.Authorization/roleAssignments        — List at scope
+//
+// Scope can be subscription, resource-group, resource, or
+// management-group — anything that appears before /providers/Microsoft.Authorization
+// in the URL. The handler treats it as an opaque string.
+//
+// RoleDefinitions back through the shared iamdriver.IAM (each Azure role
+// definition is stored as a driver Role with AssumeRolePolicyDoc holding the
+// ARM properties JSON). RoleAssignments live in an in-handler store —
+// Azure's RoleAssignment shape (principal + role + scope) does not map onto
+// the AWS-shaped driver interface.
+package iam
+
+import (
+	"net/http"
+	"strings"
+
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+)
+
+const (
+	// providerSegment is the lower-case marker we search for in URLs.
+	// Real SDKs vary in case, so URL matching always lower-cases the path.
+	providerSegment       = "/providers/microsoft.authorization/"
+	roleDefinitionsSuffix = "roledefinitions"
+	roleAssignmentsSuffix = "roleassignments"
+
+	// providerSegmentCanonical is the cased segment we embed in returned
+	// resource IDs so SDK consumers see Microsoft's canonical capitalization
+	// (some downstream tooling does case-sensitive checks on the id field).
+	providerSegmentCanonical = "/providers/Microsoft.Authorization/"
+	roleDefinitionsCanonical = "roleDefinitions"
+	roleAssignmentsCanonical = "roleAssignments"
+)
+
+// Handler serves Microsoft.Authorization ARM RBAC requests.
+type Handler struct {
+	iam         iamdriver.IAM
+	assignments *assignmentStore
+}
+
+// New returns a handler backed by drv for role definitions, with an empty
+// in-memory store for role assignments.
+func New(drv iamdriver.IAM) *Handler {
+	return &Handler{
+		iam:         drv,
+		assignments: newAssignmentStore(),
+	}
+}
+
+// Matches claims any path containing /providers/Microsoft.Authorization/
+// followed by roleDefinitions or roleAssignments. Comparisons are
+// case-insensitive because Azure SDK URL templates sometimes lower-case the
+// resource type.
+func (*Handler) Matches(r *http.Request) bool {
+	lower := strings.ToLower(r.URL.Path)
+
+	idx := strings.Index(lower, providerSegment)
+	if idx < 0 {
+		return false
+	}
+
+	tail := lower[idx+len(providerSegment):]
+
+	return strings.HasPrefix(tail, roleDefinitionsSuffix) ||
+		strings.HasPrefix(tail, roleAssignmentsSuffix)
+}
+
+// ServeHTTP routes by resource type (definitions vs assignments) and HTTP verb.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scope, kind, id, ok := parseAuthPath(r.URL.Path)
+	if !ok {
+		writeARMError(w, http.StatusBadRequest, "InvalidPath",
+			"malformed Microsoft.Authorization path")
+		return
+	}
+
+	switch kind {
+	case roleDefinitionsSuffix:
+		h.serveRoleDefinitions(w, r, scope, id)
+	case roleAssignmentsSuffix:
+		h.serveRoleAssignments(w, r, scope, id)
+	default:
+		writeARMError(w, http.StatusNotFound, "ResourceNotFound",
+			"unknown Microsoft.Authorization resource: "+kind)
+	}
+}
+
+// parseAuthPath splits a Microsoft.Authorization URL into (scope, kind, id).
+//
+//   - scope is everything before "/providers/Microsoft.Authorization/" — the
+//     RBAC scope (subscription, resource group, resource, management group, …),
+//     normalized to start with a leading "/" and with any trailing slash trimmed.
+//   - kind is "roledefinitions" or "roleassignments" (lower-case).
+//   - id is the {id} segment, or "" for a collection (list) request.
+//
+// Returns ok=false if the path doesn't match the expected shape.
+func parseAuthPath(urlPath string) (scope, kind, id string, ok bool) {
+	lower := strings.ToLower(urlPath)
+
+	idx := strings.Index(lower, providerSegment)
+	if idx < 0 {
+		return "", "", "", false
+	}
+
+	scope = normalizeScope(urlPath[:idx])
+
+	tail := strings.TrimRight(urlPath[idx+len(providerSegment):], "/")
+	parts := strings.SplitN(tail, "/", 2) //nolint:mnd // splitting "kind/id" at most once
+	kind = strings.ToLower(parts[0])
+
+	if len(parts) > 1 {
+		id = parts[1]
+	}
+
+	return scope, kind, id, true
+}
+
+// normalizeScope canonicalizes the chunk of an ARM URL that precedes the
+// /providers/Microsoft.Authorization/ segment. Trailing slashes are trimmed,
+// a leading slash is added so callers always see a path-rooted scope, and
+// the empty path becomes "/" (subscription-less root for tenant-scoped ops).
+func normalizeScope(raw string) string {
+	trimmed := strings.TrimRight(raw, "/")
+	if trimmed == "" {
+		return "/"
+	}
+
+	if !strings.HasPrefix(trimmed, "/") {
+		return "/" + trimmed
+	}
+
+	return trimmed
+}

--- a/server/azure/iam/operations.go
+++ b/server/azure/iam/operations.go
@@ -1,0 +1,362 @@
+package iam
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+)
+
+const maxBodyBytes = 1 << 20
+
+// --- Role Definitions ---
+
+// serveRoleDefinitions dispatches PUT/GET/DELETE by verb. id is "" for a
+// collection (list) request.
+func (h *Handler) serveRoleDefinitions(w http.ResponseWriter, r *http.Request, scope, id string) {
+	switch r.Method {
+	case http.MethodPut:
+		if id == "" {
+			writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+				"PUT requires a role definition id")
+			return
+		}
+
+		h.createOrUpdateRoleDefinition(w, r, scope, id)
+	case http.MethodGet:
+		if id == "" {
+			h.listRoleDefinitions(w, r, scope)
+			return
+		}
+
+		h.getRoleDefinition(w, r, id)
+	case http.MethodDelete:
+		if id == "" {
+			writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+				"DELETE requires a role definition id")
+			return
+		}
+
+		h.deleteRoleDefinition(w, r, id)
+	default:
+		writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+			"unsupported verb on roleDefinitions: "+r.Method)
+	}
+}
+
+func (h *Handler) createOrUpdateRoleDefinition(
+	w http.ResponseWriter, r *http.Request, scope, id string,
+) {
+	var in createOrUpdateRoleDefinitionInput
+	if !decodeJSONBody(w, r, &in) {
+		return
+	}
+
+	props := in.Properties
+	if props.Type == "" {
+		props.Type = "CustomRole"
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	props.CreatedOn = now
+	props.UpdatedOn = now
+
+	if len(props.AssignableScopes) == 0 {
+		props.AssignableScopes = []string{scope}
+	}
+
+	propsJSON, err := json.Marshal(props)
+	if err != nil {
+		writeARMError(w, http.StatusInternalServerError, "InternalError",
+			"could not encode role definition properties: "+err.Error())
+		return
+	}
+
+	// Upsert: try create first, fall back to delete+create on AlreadyExists
+	// so subsequent PUTs to the same id behave as updates per ARM semantics.
+	if _, err := h.iam.CreateRole(r.Context(), iamdriver.RoleConfig{
+		Name:                id,
+		AssumeRolePolicyDoc: string(propsJSON),
+		Path:                scope,
+	}); err != nil {
+		if !cerrors.IsAlreadyExists(err) {
+			writeCErr(w, err)
+			return
+		}
+
+		if delErr := h.iam.DeleteRole(r.Context(), id); delErr != nil {
+			writeCErr(w, delErr)
+			return
+		}
+
+		if _, err := h.iam.CreateRole(r.Context(), iamdriver.RoleConfig{
+			Name:                id,
+			AssumeRolePolicyDoc: string(propsJSON),
+			Path:                scope,
+		}); err != nil {
+			writeCErr(w, err)
+			return
+		}
+	}
+
+	writeARMJSON(w, http.StatusCreated,
+		buildRoleDefinitionEnvelope(scope, id, &props))
+}
+
+func (h *Handler) getRoleDefinition(w http.ResponseWriter, r *http.Request, id string) {
+	role, err := h.iam.GetRole(r.Context(), id)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	scope := role.Path
+
+	props, perr := decodeRoleProperties(role.AssumeRolePolicyDoc)
+	if perr != nil {
+		writeARMError(w, http.StatusInternalServerError, "InternalError",
+			"could not decode stored role definition: "+perr.Error())
+		return
+	}
+
+	writeARMJSON(w, http.StatusOK, buildRoleDefinitionEnvelope(scope, id, &props))
+}
+
+func (h *Handler) listRoleDefinitions(w http.ResponseWriter, r *http.Request, scope string) {
+	roles, err := h.iam.ListRoles(r.Context())
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	out := roleDefinitionList{Value: make([]roleDefinitionEnvelope, 0, len(roles))}
+
+	for i := range roles {
+		role := &roles[i]
+		if !scopeMatches(scope, role.Path) {
+			continue
+		}
+
+		props, perr := decodeRoleProperties(role.AssumeRolePolicyDoc)
+		if perr != nil {
+			continue
+		}
+
+		out.Value = append(out.Value,
+			buildRoleDefinitionEnvelope(role.Path, role.Name, &props))
+	}
+
+	writeARMJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) deleteRoleDefinition(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.iam.DeleteRole(r.Context(), id); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- Role Assignments ---
+
+func (h *Handler) serveRoleAssignments(w http.ResponseWriter, r *http.Request, scope, id string) {
+	switch r.Method {
+	case http.MethodPut:
+		if id == "" {
+			writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+				"PUT requires a role assignment id")
+			return
+		}
+
+		h.createRoleAssignment(w, r, scope, id)
+	case http.MethodGet:
+		if id == "" {
+			h.listRoleAssignments(w, scope)
+			return
+		}
+
+		h.getRoleAssignment(w, scope, id)
+	case http.MethodDelete:
+		if id == "" {
+			writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+				"DELETE requires a role assignment id")
+			return
+		}
+
+		h.deleteRoleAssignment(w, scope, id)
+	default:
+		writeARMError(w, http.StatusMethodNotAllowed, "MethodNotAllowed",
+			"unsupported verb on roleAssignments: "+r.Method)
+	}
+}
+
+func (h *Handler) createRoleAssignment(
+	w http.ResponseWriter, r *http.Request, scope, id string,
+) {
+	var in createRoleAssignmentInput
+	if !decodeJSONBody(w, r, &in) {
+		return
+	}
+
+	props := in.Properties
+
+	if props.RoleDefinitionID == "" {
+		writeARMError(w, http.StatusBadRequest, "MissingProperty",
+			"properties.roleDefinitionId is required")
+		return
+	}
+
+	if props.PrincipalID == "" {
+		writeARMError(w, http.StatusBadRequest, "MissingProperty",
+			"properties.principalId is required")
+		return
+	}
+
+	if props.Scope == "" {
+		props.Scope = scope
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	props.CreatedOn = now
+	props.UpdatedOn = now
+
+	env := roleAssignmentEnvelope{
+		ID:         scope + providerSegmentCanonical + roleAssignmentsCanonical + "/" + id,
+		Name:       id,
+		Type:       typeRoleAssignment,
+		Properties: props,
+	}
+
+	stored := h.assignments.put(&env)
+	writeARMJSON(w, http.StatusCreated, stored)
+}
+
+func (h *Handler) getRoleAssignment(w http.ResponseWriter, scope, id string) {
+	env, ok := h.assignments.get(id)
+	if !ok {
+		writeARMError(w, http.StatusNotFound, "RoleAssignmentNotFound",
+			"role assignment "+id+" not found")
+		return
+	}
+	// Rewrite the ID with the requested scope so the SDK round-trips the
+	// caller's path back unchanged.
+	env.ID = scope + providerSegmentCanonical + roleAssignmentsCanonical + "/" + id
+
+	writeARMJSON(w, http.StatusOK, env)
+}
+
+func (h *Handler) listRoleAssignments(w http.ResponseWriter, scope string) {
+	items := h.assignments.listAtScope(scope)
+	writeARMJSON(w, http.StatusOK, roleAssignmentList{Value: items})
+}
+
+func (h *Handler) deleteRoleAssignment(w http.ResponseWriter, scope, id string) {
+	env, ok := h.assignments.delete(id)
+	if !ok {
+		writeARMError(w, http.StatusNotFound, "RoleAssignmentNotFound",
+			"role assignment "+id+" not found")
+		return
+	}
+
+	env.ID = scope + providerSegmentCanonical + roleAssignmentsCanonical + "/" + id
+
+	writeARMJSON(w, http.StatusOK, env)
+}
+
+// --- helpers ---
+
+// buildRoleDefinitionEnvelope returns the ARM JSON envelope for a single
+// role definition. props is passed by pointer because the struct is wider
+// than the gocritic hugeParam threshold; the function dereferences once.
+func buildRoleDefinitionEnvelope(
+	scope, id string, props *roleDefinitionProperties,
+) roleDefinitionEnvelope {
+	return roleDefinitionEnvelope{
+		ID:         scope + providerSegmentCanonical + roleDefinitionsCanonical + "/" + id,
+		Name:       id,
+		Type:       typeRoleDefinition,
+		Properties: *props,
+	}
+}
+
+// decodeRoleProperties extracts the properties JSON we stashed in
+// AssumeRolePolicyDoc during create. Empty doc returns a zero-value
+// properties struct so listing pre-existing driver roles (created via the
+// portable API rather than this handler) doesn't surface as an error.
+func decodeRoleProperties(doc string) (roleDefinitionProperties, error) {
+	if doc == "" {
+		return roleDefinitionProperties{}, nil
+	}
+
+	var props roleDefinitionProperties
+	if err := json.Unmarshal([]byte(doc), &props); err != nil {
+		return roleDefinitionProperties{}, err
+	}
+
+	return props, nil
+}
+
+// scopeMatches returns true when a stored role's scope is acceptable for a
+// query scope. Empty query returns everything (azure SDK calls this with no
+// scope for "list all in subscription"). Exact-match or ancestor prefix is
+// allowed; we err on the permissive side rather than mirror Azure's exact
+// inheritance semantics, which the SDK doesn't enforce client-side.
+func scopeMatches(query, stored string) bool {
+	if query == "" || query == "/" {
+		return true
+	}
+
+	if stored == "" || query == stored {
+		return true
+	}
+
+	if strings.HasPrefix(query, stored+"/") {
+		return true
+	}
+
+	return strings.HasPrefix(stored, query+"/")
+}
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	defer func() { _ = r.Body.Close() }()
+
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeARMError(w, http.StatusBadRequest, "InvalidBody",
+			"could not read request body: "+err.Error())
+		return false
+	}
+
+	if len(raw) == 0 {
+		writeARMError(w, http.StatusBadRequest, "InvalidBody", "empty request body")
+		return false
+	}
+
+	if err := json.Unmarshal(raw, v); err != nil {
+		writeARMError(w, http.StatusBadRequest, "InvalidBody",
+			"could not parse JSON body: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+// writeCErr maps canonical cloudemu errors to ARM JSON error responses.
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeARMError(w, http.StatusNotFound, "ResourceNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeARMError(w, http.StatusConflict, "ResourceAlreadyExists", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeARMError(w, http.StatusBadRequest, "InvalidArgument", err.Error())
+	default:
+		writeARMError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
+}

--- a/server/azure/iam/operations.go
+++ b/server/azure/iam/operations.go
@@ -78,6 +78,16 @@ func (h *Handler) createOrUpdateRoleDefinition(
 
 	// Upsert: try create first, fall back to delete+create on AlreadyExists
 	// so subsequent PUTs to the same id behave as updates per ARM semantics.
+	//
+	// Caveat: the delete+create dance is not atomic — a concurrent reader
+	// between the two driver calls observes NotFound. The driver lacks an
+	// Update entry point, so this is the simplest workaround. Real ARM does
+	// an atomic upsert.
+	//
+	// Status code: armauthorization roleDefinitions.CreateOrUpdate models
+	// only 201 Created as success (per the Azure REST API spec for this
+	// specific endpoint — unlike e.g. managedClusters which returns 200 on
+	// update). So we always return 201 regardless of create-vs-update.
 	if _, err := h.iam.CreateRole(r.Context(), iamdriver.RoleConfig{
 		Name:                id,
 		AssumeRolePolicyDoc: string(propsJSON),
@@ -153,13 +163,32 @@ func (h *Handler) listRoleDefinitions(w http.ResponseWriter, r *http.Request, sc
 	writeARMJSON(w, http.StatusOK, out)
 }
 
+// deleteRoleDefinition deletes the role and echoes back the prior resource,
+// matching real Azure semantics (the SDK's RoleDefinitionsClientDeleteResponse
+// carries a RoleDefinition body).
 func (h *Handler) deleteRoleDefinition(w http.ResponseWriter, r *http.Request, id string) {
+	role, err := h.iam.GetRole(r.Context(), id)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	priorScope := role.Path
+
+	priorProps, perr := decodeRoleProperties(role.AssumeRolePolicyDoc)
+	if perr != nil {
+		writeARMError(w, http.StatusInternalServerError, "InternalError",
+			"could not decode stored role definition: "+perr.Error())
+		return
+	}
+
 	if err := h.iam.DeleteRole(r.Context(), id); err != nil {
 		writeCErr(w, err)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	writeARMJSON(w, http.StatusOK,
+		buildRoleDefinitionEnvelope(priorScope, id, &priorProps))
 }
 
 // --- Role Assignments ---

--- a/server/azure/iam/sdk_roundtrip_test.go
+++ b/server/azure/iam/sdk_roundtrip_test.go
@@ -1,0 +1,204 @@
+package iam_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+const (
+	testSubscription = "11111111-1111-1111-1111-111111111111"
+	testScope        = "/subscriptions/" + testSubscription
+)
+
+func newSDKClients(t *testing.T) (
+	*armauthorization.RoleDefinitionsClient,
+	*armauthorization.RoleAssignmentsClient,
+) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{IAM: cloudP.IAM})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armauthorization.NewClientFactory(testSubscription, fakeCred{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return cf.NewRoleDefinitionsClient(), cf.NewRoleAssignmentsClient()
+}
+
+func TestSDKAzureIAMRoleDefinitionLifecycle(t *testing.T) {
+	roleDefs, _ := newSDKClients(t)
+	ctx := context.Background()
+
+	const roleID = "aaaaaaaa-1111-1111-1111-111111111111"
+
+	created, err := roleDefs.CreateOrUpdate(ctx, testScope, roleID, armauthorization.RoleDefinition{
+		Properties: &armauthorization.RoleDefinitionProperties{
+			RoleName:    to.Ptr("Custom Reader"),
+			Description: to.Ptr("Read-only access to a small set of resources"),
+			RoleType:    to.Ptr("CustomRole"),
+			Permissions: []*armauthorization.Permission{
+				{
+					Actions:    []*string{to.Ptr("Microsoft.Compute/virtualMachines/read")},
+					NotActions: []*string{},
+				},
+			},
+			AssignableScopes: []*string{to.Ptr(testScope)},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate role definition: %v", err)
+	}
+
+	if got := getStringPtr(created.Properties.RoleName); got != "Custom Reader" {
+		t.Fatalf("got RoleName %q, want Custom Reader", got)
+	}
+
+	got, err := roleDefs.Get(ctx, testScope, roleID, nil)
+	if err != nil {
+		t.Fatalf("Get role definition: %v", err)
+	}
+
+	if got.Properties == nil || getStringPtr(got.Properties.RoleName) != "Custom Reader" {
+		t.Fatalf("Get returned wrong role: %+v", got.Properties)
+	}
+
+	pager := roleDefs.NewListPager(testScope, nil)
+
+	var count int
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListPager.NextPage: %v", err)
+		}
+		count += len(page.Value)
+	}
+
+	if count != 1 {
+		t.Fatalf("list returned %d role definitions, want 1", count)
+	}
+
+	if _, err := roleDefs.Delete(ctx, testScope, roleID, nil); err != nil {
+		t.Fatalf("Delete role definition: %v", err)
+	}
+
+	if _, err := roleDefs.Get(ctx, testScope, roleID, nil); err == nil {
+		t.Fatalf("Get after Delete: expected error, got nil")
+	}
+}
+
+func TestSDKAzureIAMRoleAssignmentLifecycle(t *testing.T) {
+	roleDefs, roleAssigns := newSDKClients(t)
+	ctx := context.Background()
+
+	const (
+		roleDefID    = "bbbbbbbb-2222-2222-2222-222222222222"
+		assignmentID = "cccccccc-3333-3333-3333-333333333333"
+		principalID  = "dddddddd-4444-4444-4444-444444444444"
+	)
+
+	if _, err := roleDefs.CreateOrUpdate(ctx, testScope, roleDefID, armauthorization.RoleDefinition{
+		Properties: &armauthorization.RoleDefinitionProperties{
+			RoleName: to.Ptr("Reader"),
+			RoleType: to.Ptr("CustomRole"),
+		},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate role definition (for assignment): %v", err)
+	}
+
+	roleDefArmID := testScope + "/providers/Microsoft.Authorization/roleDefinitions/" + roleDefID
+
+	created, err := roleAssigns.Create(ctx, testScope, assignmentID, armauthorization.RoleAssignmentCreateParameters{
+		Properties: &armauthorization.RoleAssignmentProperties{
+			RoleDefinitionID: to.Ptr(roleDefArmID),
+			PrincipalID:      to.Ptr(principalID),
+			PrincipalType:    to.Ptr(armauthorization.PrincipalTypeUser),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Create role assignment: %v", err)
+	}
+
+	if got := getStringPtr(created.Properties.PrincipalID); got != principalID {
+		t.Fatalf("got principalId %q, want %s", got, principalID)
+	}
+
+	got, err := roleAssigns.Get(ctx, testScope, assignmentID, nil)
+	if err != nil {
+		t.Fatalf("Get role assignment: %v", err)
+	}
+
+	if got.Properties == nil || getStringPtr(got.Properties.PrincipalID) != principalID {
+		t.Fatalf("Get returned wrong principal: %+v", got.Properties)
+	}
+
+	pager := roleAssigns.NewListForScopePager(testScope, nil)
+
+	var count int
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("NewListForScopePager.NextPage: %v", err)
+		}
+		count += len(page.Value)
+	}
+
+	if count != 1 {
+		t.Fatalf("list returned %d role assignments, want 1", count)
+	}
+
+	if _, err := roleAssigns.Delete(ctx, testScope, assignmentID, nil); err != nil {
+		t.Fatalf("Delete role assignment: %v", err)
+	}
+
+	if _, err := roleAssigns.Get(ctx, testScope, assignmentID, nil); err == nil {
+		t.Fatalf("Get after Delete: expected error, got nil")
+	}
+}
+
+func getStringPtr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/server/azure/iam/types.go
+++ b/server/azure/iam/types.go
@@ -1,0 +1,103 @@
+package iam
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// armErrorEnvelope is the ARM error JSON shape every SDK expects on a non-2xx
+// response: {"error": {"code": "...", "message": "..."}}.
+type armErrorEnvelope struct {
+	Error armErrorBody `json:"error"`
+}
+
+type armErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func writeARMError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(armErrorEnvelope{
+		Error: armErrorBody{Code: code, Message: msg},
+	})
+}
+
+func writeARMJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// Resource type identifiers used in the ARM "type" field of envelopes.
+const (
+	typeRoleDefinition = "Microsoft.Authorization/roleDefinitions"
+	typeRoleAssignment = "Microsoft.Authorization/roleAssignments"
+)
+
+// permission is the {actions, notActions, dataActions, notDataActions} bag
+// inside a RoleDefinition.properties.permissions[] entry.
+type permission struct {
+	Actions        []string `json:"actions,omitempty"`
+	NotActions     []string `json:"notActions,omitempty"`
+	DataActions    []string `json:"dataActions,omitempty"`
+	NotDataActions []string `json:"notDataActions,omitempty"`
+}
+
+// roleDefinitionProperties is the ARM properties block for a RoleDefinition.
+type roleDefinitionProperties struct {
+	RoleName         string       `json:"roleName"`
+	Description      string       `json:"description,omitempty"`
+	Type             string       `json:"type,omitempty"` // "CustomRole" or "BuiltInRole"
+	Permissions      []permission `json:"permissions,omitempty"`
+	AssignableScopes []string     `json:"assignableScopes,omitempty"`
+	CreatedOn        string       `json:"createdOn,omitempty"`
+	UpdatedOn        string       `json:"updatedOn,omitempty"`
+}
+
+// roleDefinitionEnvelope is the full ARM envelope returned on GET/PUT.
+type roleDefinitionEnvelope struct {
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name"` // the {id} segment of the URL
+	Type       string                   `json:"type"` // typeRoleDefinition
+	Properties roleDefinitionProperties `json:"properties"`
+}
+
+// roleDefinitionList is the ARM paged-list shape returned on a collection GET.
+// NextLink is omitted (single page only).
+type roleDefinitionList struct {
+	Value []roleDefinitionEnvelope `json:"value"`
+}
+
+// roleAssignmentProperties is the ARM properties block for a RoleAssignment.
+type roleAssignmentProperties struct {
+	RoleDefinitionID string `json:"roleDefinitionId"`
+	PrincipalID      string `json:"principalId"`
+	PrincipalType    string `json:"principalType,omitempty"`
+	Scope            string `json:"scope,omitempty"`
+	Description      string `json:"description,omitempty"`
+	CreatedOn        string `json:"createdOn,omitempty"`
+	UpdatedOn        string `json:"updatedOn,omitempty"`
+}
+
+type roleAssignmentEnvelope struct {
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name"` // the {id} segment of the URL
+	Type       string                   `json:"type"` // typeRoleAssignment
+	Properties roleAssignmentProperties `json:"properties"`
+}
+
+type roleAssignmentList struct {
+	Value []roleAssignmentEnvelope `json:"value"`
+}
+
+// createOrUpdateRoleDefinitionInput is the request body for PUT roleDefinitions.
+type createOrUpdateRoleDefinitionInput struct {
+	Properties roleDefinitionProperties `json:"properties"`
+}
+
+// createRoleAssignmentInput is the request body for PUT roleAssignments.
+type createRoleAssignmentInput struct {
+	Properties roleAssignmentProperties `json:"properties"`
+}


### PR DESCRIPTION
## Feature

- New server/azure/iam package serves the Microsoft.Authorization ARM REST API on top of the shared in-memory IAM driver. Real azure-sdk-for-go armauthorization clients connect by pointing their cloud configuration at the SDK server and round-trip end-to-end.
- Covers eight endpoints across two ARM resource types: RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete). Scope is opaque so subscription, resource group, resource, and management group scopes all work uniformly.
- RoleDefinitions back through the shared iamdriver.IAM (each Azure definition is stored as a driver Role with the ARM properties block embedded as JSON), so role definitions created through the SDK are visible to portable consumers of azure.IAM.ListRoles. RoleAssignments live in a small handler-local store because Azure's principal plus role plus scope triple does not map onto the AWS-shaped driver interface.
- Handler registers in azureserver.New alongside the other ARM handlers. The path /providers/Microsoft.Authorization/role[Definitions|Assignments] is unique to this provider so dispatch order is unconstrained. Returned resource IDs use the canonical Microsoft.Authorization capitalization regardless of incoming URL casing.
- Real-SDK roundtrip tests exercise both the RoleDefinition and RoleAssignment lifecycle end to end against an httptest TLS server, asserting list and get round-trip the values the SDK sent.
- Microsoft Graph (Users, Groups, Service Principals) is intentionally out of scope and is documented as such in docs/sdk-server.md alongside the new handler table row.