### PR TITLE
feat(gcp): IAM SDK-compat handler

### DIFF
--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -180,6 +180,7 @@ All handlers speak REST + JSON.
 | **Cloud SQL** | Instances (insert/get/list/patch/delete/start/stop/restart) + Operations (get/list) — supports the `sqladmin/v1` SDK |
 | **GKE** | Clusters (Create/Get/List/Update/Delete + `:setLogging`/`:setMonitoring`/`:setMasterAuth`/`:setLegacyAbac`/`:setNetworkPolicy`/`:setMaintenancePolicy`/`:setResourceLabels`/`:startIpRotation`/`:completeIpRotation`), NodePools (Create/Get/List/Update/Delete + `:setSize`/`:setAutoscaling`/`:setManagement`/`:rollback`), Operations (Get/List/`:cancel`). Stub kubeconfig only — data plane deferred to Wave 2. |
 | **Cloud Asset Inventory** | `assets.list` (filter by `assetTypes[]`), `searchAllResources` (query + asset-type filter), `searchAllIamPolicies` (returns empty — out of scope), `exportAssets` (sync; inline results in the returned Operation), `batchGetAssetsHistory`, Feeds (create/list/get/patch/delete), `operations.get`. Resource names returned as GCP-shaped `//service/path` URNs. |
+| **IAM (iam.googleapis.com v1)** | ServiceAccounts (Create/Get/List/Delete/Patch), custom Roles (Create/Get/List/Delete/Patch), ServiceAccountKeys (Create/Get/List/Delete). Real `google.golang.org/api/iam/v1` clients round-trip end-to-end; errors surface as typed `*googleapi.Error`. Resource-level `getIamPolicy`/`setIamPolicy` bindings on individual GCP resources are out of scope. |
 
 Any operation not in these lists returns `501 Not Implemented` or the provider's native `UnknownOperation` / `NotImplemented` / `NOT_FOUND` error.
 

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -9,6 +9,7 @@ package gcp
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
@@ -24,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/firestore"
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
 	"github.com/stackshy/cloudemu/server/gcp/gke"
+	"github.com/stackshy/cloudemu/server/gcp/iam"
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
@@ -42,6 +44,7 @@ type Drivers struct {
 	PubSub         mqdriver.MessageQueue
 	CloudSQL       rdbdriver.RelationalDB
 	GKE            *gkeprov.Mock
+	IAM            iamdriver.IAM
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -109,6 +112,16 @@ func New(d Drivers) *server.Server {
 	// suffix custom methods that share the same prefix.
 	if d.ResourceDiscovery != nil {
 		srv.Register(cloudasset.New(d.ResourceDiscovery, d.ProjectID))
+	}
+
+	// IAM matches /v1/projects/{p}/{serviceAccounts|roles}[/…] — its
+	// resource-type guard is disjoint from Firestore (which serves
+	// /v1/projects/{p}/databases/…) and from CloudFunctions / PubSub /
+	// CloudSQL / GKE / CloudAsset, so registration order is unconstrained
+	// among the /v1/projects/ family. Registered before Firestore for
+	// consistency with the pattern above.
+	if d.IAM != nil {
+		srv.Register(iam.New(d.IAM))
 	}
 
 	if d.Firestore != nil {

--- a/server/gcp/iam/errors_sdk_test.go
+++ b/server/gcp/iam/errors_sdk_test.go
@@ -1,0 +1,182 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	iamv1 "google.golang.org/api/iam/v1"
+)
+
+// google.golang.org/api/iam/v1 surfaces handler errors as *googleapi.Error.
+// This file locks in the StatusCode contract for the paths the main
+// lifecycle tests don't cover.
+
+func assertGoogleAPIError(t *testing.T, err error, wantCode int) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+
+	if apiErr.Code != wantCode {
+		t.Fatalf("got HTTP %d, want %d", apiErr.Code, wantCode)
+	}
+}
+
+func TestSDKGCPIAMRoleNotFoundIsTyped(t *testing.T) {
+	svc := newSDKService(t)
+
+	_, err := svc.Projects.Roles.Get(
+		"projects/" + testProject + "/roles/no-such-role",
+	).Context(context.Background()).Do()
+
+	assertGoogleAPIError(t, err, 404)
+}
+
+func TestSDKGCPIAMKeyNotFoundIsTyped(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+	if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "key-test",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("CreateServiceAccount: %v", err)
+	}
+
+	email := "key-test@" + testProject + ".iam.gserviceaccount.com"
+
+	_, err := svc.Projects.ServiceAccounts.Keys.Get(
+		"projects/-/serviceAccounts/" + email + "/keys/no-such-key",
+	).Context(ctx).Do()
+
+	assertGoogleAPIError(t, err, 404)
+}
+
+func TestSDKGCPIAMDuplicateServiceAccountIsConflict(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "dupe",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	_, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "dupe",
+	}).Context(ctx).Do()
+
+	assertGoogleAPIError(t, err, 409)
+}
+
+// TestSDKGCPIAMPatchActuallyReplaces verifies the Patch wire-shape decode
+// works: the SDK wraps the payload in {"serviceAccount": {...}, "updateMask":
+// "..."}, and a previous version of the handler decoded into a bare
+// serviceAccount struct which silently dropped every field. This test would
+// have caught that regression.
+func TestSDKGCPIAMPatchActuallyReplaces(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "patcher",
+		ServiceAccount: &iamv1.ServiceAccount{
+			DisplayName: "before",
+			Description: "old description",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	email := "patcher@" + testProject + ".iam.gserviceaccount.com"
+	saResource := "projects/-/serviceAccounts/" + email
+
+	if _, err := svc.Projects.ServiceAccounts.Patch(saResource,
+		&iamv1.PatchServiceAccountRequest{
+			ServiceAccount: &iamv1.ServiceAccount{
+				DisplayName: "after",
+				Description: "new description",
+			},
+			UpdateMask: "displayName,description",
+		},
+	).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	got, err := svc.Projects.ServiceAccounts.Get(saResource).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get after Patch: %v", err)
+	}
+
+	if got.DisplayName != "after" {
+		t.Fatalf("got displayName %q, want after", got.DisplayName)
+	}
+
+	if got.Description != "new description" {
+		t.Fatalf("got description %q, want new description", got.Description)
+	}
+}
+
+// TestSDKGCPIAMPatchPreservesProjectThroughWildcard verifies that a PATCH
+// using the projects/- wildcard URL preserves the SA's original project
+// rather than moving the SA into a "-" project bucket — which would then
+// vanish from list under the real project.
+func TestSDKGCPIAMPatchPreservesProjectThroughWildcard(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "wildcard-patch",
+		ServiceAccount: &iamv1.ServiceAccount{
+			DisplayName: "original",
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	email := "wildcard-patch@" + testProject + ".iam.gserviceaccount.com"
+
+	if _, err := svc.Projects.ServiceAccounts.Patch(
+		"projects/-/serviceAccounts/"+email,
+		&iamv1.PatchServiceAccountRequest{
+			ServiceAccount: &iamv1.ServiceAccount{DisplayName: "patched"},
+			UpdateMask:     "displayName",
+		},
+	).Context(ctx).Do(); err != nil {
+		t.Fatalf("Patch via wildcard: %v", err)
+	}
+
+	// The SA must still surface under the real project after a wildcard
+	// patch — proving updateServiceAccount preserved the stored project.
+	list, err := svc.Projects.ServiceAccounts.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	found := false
+	for _, a := range list.Accounts {
+		if a.Email == email {
+			found = true
+			if a.DisplayName != "patched" {
+				t.Fatalf("got displayName %q, want patched", a.DisplayName)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("SA disappeared from project listing after wildcard patch")
+	}
+}

--- a/server/gcp/iam/handler.go
+++ b/server/gcp/iam/handler.go
@@ -153,8 +153,8 @@ func (h *Handler) routeServiceAccounts(w http.ResponseWriter, r *http.Request, r
 		case http.MethodGet:
 			h.getServiceAccount(w, r, rt.project, rt.name)
 		case http.MethodDelete:
-			h.deleteServiceAccount(w, r, rt.project, rt.name)
-		case http.MethodPatch, http.MethodPut:
+			h.deleteServiceAccount(w, r, rt.name)
+		case http.MethodPatch:
 			h.updateServiceAccount(w, r, rt.project, rt.name)
 		default:
 			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
@@ -186,7 +186,7 @@ func (h *Handler) routeServiceAccountKeys(w http.ResponseWriter, r *http.Request
 		case http.MethodGet:
 			h.getKey(w, r, rt.project, rt.name, rt.subName)
 		case http.MethodDelete:
-			h.deleteKey(w, r, rt.project, rt.name, rt.subName)
+			h.deleteKey(w, r, rt.name, rt.subName)
 		default:
 			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
 				"unsupported verb on key: "+r.Method)
@@ -212,7 +212,7 @@ func (h *Handler) routeRoles(w http.ResponseWriter, r *http.Request, rt *route) 
 			h.getRole(w, r, rt.project, rt.name)
 		case http.MethodDelete:
 			h.deleteRole(w, r, rt.project, rt.name)
-		case http.MethodPatch, http.MethodPut:
+		case http.MethodPatch:
 			h.updateRole(w, r, rt.project, rt.name)
 		default:
 			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",

--- a/server/gcp/iam/handler.go
+++ b/server/gcp/iam/handler.go
@@ -1,0 +1,222 @@
+// Package iam implements the GCP iam.googleapis.com v1 REST API as a
+// server.Handler. Real google.golang.org/api/iam/v1 clients pointed at this
+// server CRUD ServiceAccounts, custom Roles, and ServiceAccountKeys
+// end-to-end.
+//
+// MVP coverage (v1 REST):
+//
+//	POST   /v1/projects/{p}/serviceAccounts                                       — Create SA
+//	GET    /v1/projects/{p}/serviceAccounts/{email}                               — Get SA
+//	GET    /v1/projects/{p}/serviceAccounts                                       — List SAs
+//	DELETE /v1/projects/{p}/serviceAccounts/{email}                               — Delete SA
+//	PATCH  /v1/projects/{p}/serviceAccounts/{email}                               — Update SA
+//	POST   /v1/projects/{p}/serviceAccounts/{email}/keys                          — Create key
+//	GET    /v1/projects/{p}/serviceAccounts/{email}/keys/{keyId}                  — Get key
+//	GET    /v1/projects/{p}/serviceAccounts/{email}/keys                          — List keys
+//	DELETE /v1/projects/{p}/serviceAccounts/{email}/keys/{keyId}                  — Delete key
+//	POST   /v1/projects/{p}/roles                                                 — Create role
+//	GET    /v1/projects/{p}/roles/{roleId}                                        — Get role
+//	GET    /v1/projects/{p}/roles                                                 — List roles
+//	DELETE /v1/projects/{p}/roles/{roleId}                                        — Delete role
+//	PATCH  /v1/projects/{p}/roles/{roleId}                                        — Update role
+//
+// All state lives in the shared iamdriver.IAM:
+//
+//   - Driver Users back ServiceAccounts (driver User.Name == SA email).
+//   - Driver Roles back custom Roles (the SA-style Permissions list is
+//     stashed in AssumeRolePolicyDoc as JSON).
+//   - Driver AccessKeys back SA Keys (AccessKey.UserName == SA email,
+//     AccessKeyID == key id).
+//
+// Resource-level IAM policy bindings (getIamPolicy / setIamPolicy on
+// projects, buckets, etc.) are out of scope — those live on individual
+// resources, not on iam.googleapis.com itself.
+package iam
+
+import (
+	"net/http"
+	"strings"
+
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+)
+
+const (
+	pathPrefix         = "/v1/projects/"
+	serviceAccountsSeg = "serviceAccounts"
+	rolesSeg           = "roles"
+	keysSeg            = "keys"
+)
+
+// Handler serves iam.googleapis.com v1 REST requests against the IAM driver.
+type Handler struct {
+	iam iamdriver.IAM
+}
+
+// New returns an IAM handler backed by drv.
+func New(drv iamdriver.IAM) *Handler {
+	return &Handler{iam: drv}
+}
+
+// Matches returns true for any /v1/projects/{p}/{serviceAccounts|roles}[/…]
+// path. The catch-all match is safe because the GCP server registers more
+// specific handlers (compute, networks, gcs, …) ahead of this one — there's
+// no other IAM handler in the GCP namespace that this would shadow.
+func (*Handler) Matches(r *http.Request) bool {
+	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+		return false
+	}
+
+	tail := strings.TrimPrefix(r.URL.Path, pathPrefix)
+
+	parts := strings.Split(tail, "/")
+	// parts: [project, kind, …]
+	if len(parts) < 2 { //nolint:mnd // need at least project + kind
+		return false
+	}
+
+	return parts[1] == serviceAccountsSeg || parts[1] == rolesSeg
+}
+
+// route is the parsed shape of an IAM URL after the /v1/projects/{p}/ prefix.
+type route struct {
+	project string
+	kind    string // serviceAccountsSeg or rolesSeg
+	name    string // SA email or role id, or "" for a collection
+	subKind string // keysSeg, or "" for non-key paths
+	subName string // key id, or "" for the collection
+}
+
+// parseRoute splits the URL after /v1/projects/. Returns ok=false if the
+// shape doesn't match what the IAM v1 SDK emits.
+func parseRoute(urlPath string) (route, bool) {
+	tail := strings.TrimPrefix(urlPath, pathPrefix)
+	tail = strings.TrimRight(tail, "/")
+
+	parts := strings.Split(tail, "/")
+	if len(parts) < 2 { //nolint:mnd // need at least project + kind
+		return route{}, false
+	}
+
+	r := route{project: parts[0], kind: parts[1]}
+
+	if len(parts) >= 3 { //nolint:mnd // optional resource name segment
+		r.name = parts[2]
+	}
+
+	if len(parts) >= 4 { //nolint:mnd // optional sub-resource (keys)
+		r.subKind = parts[3]
+	}
+
+	if len(parts) >= 5 { //nolint:mnd // optional sub-resource name (key id)
+		r.subName = parts[4]
+	}
+
+	return r, true
+}
+
+// ServeHTTP routes by URL shape and HTTP verb.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalidArgument", "malformed IAM v1 path")
+		return
+	}
+
+	switch rt.kind {
+	case serviceAccountsSeg:
+		h.routeServiceAccounts(w, r, &rt)
+	case rolesSeg:
+		h.routeRoles(w, r, &rt)
+	default:
+		writeError(w, http.StatusNotFound, "notFound",
+			"unknown IAM resource: "+rt.kind)
+	}
+}
+
+// routeServiceAccounts dispatches the /serviceAccounts/* surface.
+func (h *Handler) routeServiceAccounts(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch {
+	// Collection: POST create, GET list.
+	case rt.name == "":
+		switch r.Method {
+		case http.MethodPost:
+			h.createServiceAccount(w, r, rt.project)
+		case http.MethodGet:
+			h.listServiceAccounts(w, r, rt.project)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+				"unsupported verb on serviceAccounts collection: "+r.Method)
+		}
+	// Single SA: GET / DELETE / PATCH.
+	case rt.subKind == "":
+		switch r.Method {
+		case http.MethodGet:
+			h.getServiceAccount(w, r, rt.project, rt.name)
+		case http.MethodDelete:
+			h.deleteServiceAccount(w, r, rt.project, rt.name)
+		case http.MethodPatch, http.MethodPut:
+			h.updateServiceAccount(w, r, rt.project, rt.name)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+				"unsupported verb on serviceAccount: "+r.Method)
+		}
+	// SA keys sub-resource.
+	case rt.subKind == keysSeg:
+		h.routeServiceAccountKeys(w, r, rt)
+	default:
+		writeError(w, http.StatusNotFound, "notFound",
+			"unknown serviceAccount sub-resource: "+rt.subKind)
+	}
+}
+
+func (h *Handler) routeServiceAccountKeys(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch rt.subName {
+	case "":
+		switch r.Method {
+		case http.MethodPost:
+			h.createKey(w, r, rt.project, rt.name)
+		case http.MethodGet:
+			h.listKeys(w, r, rt.project, rt.name)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+				"unsupported verb on keys collection: "+r.Method)
+		}
+	default:
+		switch r.Method {
+		case http.MethodGet:
+			h.getKey(w, r, rt.project, rt.name, rt.subName)
+		case http.MethodDelete:
+			h.deleteKey(w, r, rt.project, rt.name, rt.subName)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+				"unsupported verb on key: "+r.Method)
+		}
+	}
+}
+
+func (h *Handler) routeRoles(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch rt.name {
+	case "":
+		switch r.Method {
+		case http.MethodPost:
+			h.createRole(w, r, rt.project)
+		case http.MethodGet:
+			h.listRoles(w, r, rt.project)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+				"unsupported verb on roles collection: "+r.Method)
+		}
+	default:
+		switch r.Method {
+		case http.MethodGet:
+			h.getRole(w, r, rt.project, rt.name)
+		case http.MethodDelete:
+			h.deleteRole(w, r, rt.project, rt.name)
+		case http.MethodPatch, http.MethodPut:
+			h.updateRole(w, r, rt.project, rt.name)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed",
+				"unsupported verb on role: "+r.Method)
+		}
+	}
+}

--- a/server/gcp/iam/operations.go
+++ b/server/gcp/iam/operations.go
@@ -55,6 +55,10 @@ func (h *Handler) getServiceAccount(w http.ResponseWriter, r *http.Request, proj
 	writeJSON(w, toServiceAccountJSON(project, email, &sa))
 }
 
+// listServiceAccounts returns SAs at the given project. A literal "-" in the
+// project segment is the GCP-wide wildcard meaning "every project the caller
+// can see" — we treat it as match-all because there's no concept of caller
+// identity in the emulator.
 func (h *Handler) listServiceAccounts(w http.ResponseWriter, r *http.Request, project string) {
 	users, err := h.iam.ListUsers(r.Context())
 	if err != nil {
@@ -62,24 +66,31 @@ func (h *Handler) listServiceAccounts(w http.ResponseWriter, r *http.Request, pr
 		return
 	}
 
+	wildcard := project == "-"
 	out := listServiceAccountsResponse{Accounts: make([]serviceAccount, 0, len(users))}
 
 	for i := range users {
 		u := &users[i]
-		if u.Path != project {
+		if !wildcard && u.Path != project {
 			continue
 		}
 
+		// When responding to a wildcard query, render each SA against its
+		// own real project; the URL "-" never appears in the returned name.
+		responseProject := project
+		if wildcard {
+			responseProject = u.Path
+		}
+
 		sa := saFromUser(u)
-		out.Accounts = append(out.Accounts, toServiceAccountJSON(project, u.Name, &sa))
+		out.Accounts = append(out.Accounts,
+			toServiceAccountJSON(responseProject, u.Name, &sa))
 	}
 
 	writeJSON(w, out)
 }
 
-func (h *Handler) deleteServiceAccount(w http.ResponseWriter, r *http.Request, project, email string) {
-	_ = project
-
+func (h *Handler) deleteServiceAccount(w http.ResponseWriter, r *http.Request, email string) {
 	if err := h.iam.DeleteUser(r.Context(), email); err != nil {
 		writeCErr(w, err)
 		return
@@ -89,14 +100,37 @@ func (h *Handler) deleteServiceAccount(w http.ResponseWriter, r *http.Request, p
 	writeJSON(w, struct{}{})
 }
 
+// updateServiceAccount handles PATCH .../serviceAccounts/{email}. The GCP
+// SDK wraps the payload as {"serviceAccount": {...}, "updateMask": "..."} —
+// decoding into a bare serviceAccount silently loses every field, so we
+// must decode the wrapper. updateMask itself is ignored; the emulator
+// always full-replaces.
+//
+// When the URL uses the wildcard project segment "projects/-/...", project
+// arrives as "-". We look up the existing SA first and reuse its stored
+// project for the re-create so the SA doesn't move to a synthetic "-"
+// project bucket that would later disappear from listServiceAccounts.
+//
+// The Delete+Create dance is non-atomic — a concurrent reader between the
+// two driver calls observes NotFound. The driver lacks an Update entry
+// point so this is the simplest workaround.
 func (h *Handler) updateServiceAccount(w http.ResponseWriter, r *http.Request, project, email string) {
-	var in serviceAccount
+	var in patchServiceAccountRequest
 	if !decodeJSONBody(w, r, &in) {
 		return
 	}
 
-	// The driver has no Update, so we do a destructive replace. Tags carry
-	// the displayName / description we re-store.
+	storedProject := project
+	if storedProject == "-" {
+		existing, err := h.iam.GetUser(r.Context(), email)
+		if err != nil {
+			writeCErr(w, err)
+			return
+		}
+
+		storedProject = existing.Path
+	}
+
 	if err := h.iam.DeleteUser(r.Context(), email); err != nil {
 		writeCErr(w, err)
 		return
@@ -104,17 +138,17 @@ func (h *Handler) updateServiceAccount(w http.ResponseWriter, r *http.Request, p
 
 	if _, err := h.iam.CreateUser(r.Context(), iamdriver.UserConfig{
 		Name: email,
-		Path: project,
+		Path: storedProject,
 		Tags: map[string]string{
-			"displayName": in.DisplayName,
-			"description": in.Description,
+			"displayName": in.ServiceAccount.DisplayName,
+			"description": in.ServiceAccount.Description,
 		},
 	}); err != nil {
 		writeCErr(w, err)
 		return
 	}
 
-	writeJSON(w, toServiceAccountJSON(project, email, &in))
+	writeJSON(w, toServiceAccountJSON(storedProject, email, &in.ServiceAccount))
 }
 
 // --- Roles ---
@@ -189,11 +223,11 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, project stri
 			continue
 		}
 
-		props, perr := decodeRoleProps(dr.AssumeRolePolicyDoc)
-		if perr != nil {
-			continue
-		}
-
+		// If the stored doc is malformed (e.g. a portable test stashed a
+		// non-JSON value via the shared driver), emit the role with just
+		// its name rather than silently dropping it from the list — the
+		// underlying entry exists and the caller should see something.
+		props, _ := decodeRoleProps(dr.AssumeRolePolicyDoc)
 		out.Roles = append(out.Roles, toRoleJSON(project, dr.Name, &props))
 	}
 
@@ -201,8 +235,6 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, project stri
 }
 
 func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
-	_ = project
-
 	dr, err := h.iam.GetRole(r.Context(), roleID)
 	if err != nil {
 		writeCErr(w, err)
@@ -227,6 +259,13 @@ func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, project, ro
 	writeJSON(w, out)
 }
 
+// updateRole handles PATCH .../roles/{roleId}. Unlike SA Patch the role
+// payload is the bare resource body, with updateMask passed as a ?updateMask=
+// query parameter — we ignore the mask (emulator always full-replaces).
+//
+// The Delete+Create dance is non-atomic — a concurrent reader between the
+// two driver calls observes NotFound. The driver lacks an Update entry
+// point so this is the simplest workaround.
 func (h *Handler) updateRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
 	var in role
 	if !decodeJSONBody(w, r, &in) {
@@ -317,9 +356,7 @@ func (h *Handler) listKeys(w http.ResponseWriter, r *http.Request, project, emai
 	writeJSON(w, out)
 }
 
-func (h *Handler) deleteKey(w http.ResponseWriter, r *http.Request, project, email, keyID string) {
-	_ = project
-
+func (h *Handler) deleteKey(w http.ResponseWriter, r *http.Request, email, keyID string) {
 	if err := h.iam.DeleteAccessKey(r.Context(), email, keyID); err != nil {
 		writeCErr(w, err)
 		return

--- a/server/gcp/iam/operations.go
+++ b/server/gcp/iam/operations.go
@@ -1,0 +1,459 @@
+package iam
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	iamdriver "github.com/stackshy/cloudemu/iam/driver"
+)
+
+const maxBodyBytes = 1 << 20
+
+// --- ServiceAccounts ---
+
+func (h *Handler) createServiceAccount(w http.ResponseWriter, r *http.Request, project string) {
+	var in createServiceAccountRequest
+	if !decodeJSONBody(w, r, &in) {
+		return
+	}
+
+	if in.AccountID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"accountId is required")
+		return
+	}
+
+	email := buildSAEmail(in.AccountID, project)
+
+	// Persist as a driver User. The SA email is the natural primary key.
+	if _, err := h.iam.CreateUser(r.Context(), iamdriver.UserConfig{
+		Name: email,
+		Path: project,
+		Tags: map[string]string{
+			"displayName": in.ServiceAccount.DisplayName,
+			"description": in.ServiceAccount.Description,
+		},
+	}); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, toServiceAccountJSON(project, email, &in.ServiceAccount))
+}
+
+func (h *Handler) getServiceAccount(w http.ResponseWriter, r *http.Request, project, email string) {
+	user, err := h.iam.GetUser(r.Context(), email)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	sa := saFromUser(user)
+	writeJSON(w, toServiceAccountJSON(project, email, &sa))
+}
+
+func (h *Handler) listServiceAccounts(w http.ResponseWriter, r *http.Request, project string) {
+	users, err := h.iam.ListUsers(r.Context())
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	out := listServiceAccountsResponse{Accounts: make([]serviceAccount, 0, len(users))}
+
+	for i := range users {
+		u := &users[i]
+		if u.Path != project {
+			continue
+		}
+
+		sa := saFromUser(u)
+		out.Accounts = append(out.Accounts, toServiceAccountJSON(project, u.Name, &sa))
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) deleteServiceAccount(w http.ResponseWriter, r *http.Request, project, email string) {
+	_ = project
+
+	if err := h.iam.DeleteUser(r.Context(), email); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// GCP returns an empty body with 200 on successful SA delete.
+	writeJSON(w, struct{}{})
+}
+
+func (h *Handler) updateServiceAccount(w http.ResponseWriter, r *http.Request, project, email string) {
+	var in serviceAccount
+	if !decodeJSONBody(w, r, &in) {
+		return
+	}
+
+	// The driver has no Update, so we do a destructive replace. Tags carry
+	// the displayName / description we re-store.
+	if err := h.iam.DeleteUser(r.Context(), email); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if _, err := h.iam.CreateUser(r.Context(), iamdriver.UserConfig{
+		Name: email,
+		Path: project,
+		Tags: map[string]string{
+			"displayName": in.DisplayName,
+			"description": in.Description,
+		},
+	}); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, toServiceAccountJSON(project, email, &in))
+}
+
+// --- Roles ---
+
+func (h *Handler) createRole(w http.ResponseWriter, r *http.Request, project string) {
+	var in createRoleRequest
+	if !decodeJSONBody(w, r, &in) {
+		return
+	}
+
+	if in.RoleID == "" {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"roleId is required")
+		return
+	}
+
+	props := roleProps{
+		Title:               in.Role.Title,
+		Description:         in.Role.Description,
+		IncludedPermissions: in.Role.IncludedPermissions,
+		Stage:               in.Role.Stage,
+	}
+
+	propsJSON, err := json.Marshal(props)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL",
+			"could not encode role props: "+err.Error())
+		return
+	}
+
+	if _, err := h.iam.CreateRole(r.Context(), iamdriver.RoleConfig{
+		Name:                in.RoleID,
+		Path:                project,
+		AssumeRolePolicyDoc: string(propsJSON),
+	}); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, toRoleJSON(project, in.RoleID, &props))
+}
+
+func (h *Handler) getRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
+	dr, err := h.iam.GetRole(r.Context(), roleID)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	props, perr := decodeRoleProps(dr.AssumeRolePolicyDoc)
+	if perr != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL",
+			"could not decode stored role props: "+perr.Error())
+		return
+	}
+
+	writeJSON(w, toRoleJSON(project, roleID, &props))
+}
+
+func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, project string) {
+	roles, err := h.iam.ListRoles(r.Context())
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	out := listRolesResponse{Roles: make([]role, 0, len(roles))}
+
+	for i := range roles {
+		dr := &roles[i]
+		if dr.Path != project {
+			continue
+		}
+
+		props, perr := decodeRoleProps(dr.AssumeRolePolicyDoc)
+		if perr != nil {
+			continue
+		}
+
+		out.Roles = append(out.Roles, toRoleJSON(project, dr.Name, &props))
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
+	_ = project
+
+	dr, err := h.iam.GetRole(r.Context(), roleID)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	props, perr := decodeRoleProps(dr.AssumeRolePolicyDoc)
+	if perr != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL",
+			"could not decode stored role props: "+perr.Error())
+		return
+	}
+
+	if err := h.iam.DeleteRole(r.Context(), roleID); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// GCP marks the role as deleted in the echoed body.
+	out := toRoleJSON(project, roleID, &props)
+	out.Deleted = true
+	writeJSON(w, out)
+}
+
+func (h *Handler) updateRole(w http.ResponseWriter, r *http.Request, project, roleID string) {
+	var in role
+	if !decodeJSONBody(w, r, &in) {
+		return
+	}
+
+	props := roleProps{
+		Title:               in.Title,
+		Description:         in.Description,
+		IncludedPermissions: in.IncludedPermissions,
+		Stage:               in.Stage,
+	}
+
+	propsJSON, err := json.Marshal(props)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "INTERNAL",
+			"could not encode role props: "+err.Error())
+		return
+	}
+
+	if err := h.iam.DeleteRole(r.Context(), roleID); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if _, err := h.iam.CreateRole(r.Context(), iamdriver.RoleConfig{
+		Name:                roleID,
+		Path:                project,
+		AssumeRolePolicyDoc: string(propsJSON),
+	}); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, toRoleJSON(project, roleID, &props))
+}
+
+// --- Service Account Keys ---
+
+func (h *Handler) createKey(w http.ResponseWriter, r *http.Request, project, email string) {
+	// SDK sometimes sends an empty body, sometimes a body with key algorithm
+	// hints we don't honor — accept either.
+	_ = drainBody(r)
+
+	k, err := h.iam.CreateAccessKey(r.Context(), iamdriver.AccessKeyConfig{
+		UserName: email,
+	})
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, toKeyJSON(project, email, k.AccessKeyID, k.SecretAccessKey))
+}
+
+func (h *Handler) getKey(w http.ResponseWriter, r *http.Request, project, email, keyID string) {
+	keys, err := h.iam.ListAccessKeys(r.Context(), email)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	for i := range keys {
+		if keys[i].AccessKeyID == keyID {
+			// Empty private-key body on GET — GCP only returns the private
+			// material once at create time.
+			writeJSON(w, toKeyJSON(project, email, keyID, ""))
+			return
+		}
+	}
+
+	writeError(w, http.StatusNotFound, "NOT_FOUND",
+		"service account key "+keyID+" not found")
+}
+
+func (h *Handler) listKeys(w http.ResponseWriter, r *http.Request, project, email string) {
+	keys, err := h.iam.ListAccessKeys(r.Context(), email)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	out := listKeysResponse{Keys: make([]serviceAccountKey, 0, len(keys))}
+	for i := range keys {
+		out.Keys = append(out.Keys, toKeyJSON(project, email, keys[i].AccessKeyID, ""))
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) deleteKey(w http.ResponseWriter, r *http.Request, project, email, keyID string) {
+	_ = project
+
+	if err := h.iam.DeleteAccessKey(r.Context(), email, keyID); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// --- helpers ---
+
+// buildSAEmail constructs a GCP-shaped service account email. Real GCP
+// derives the domain from the project ID; we follow the same convention so
+// returned values look like the real thing.
+func buildSAEmail(accountID, project string) string {
+	return accountID + "@" + project + ".iam.gserviceaccount.com"
+}
+
+// saFromUser reconstructs the wire-shape ServiceAccount from a driver User.
+// DisplayName + Description come back via the tags we stashed at create.
+func saFromUser(u *iamdriver.UserInfo) serviceAccount {
+	out := serviceAccount{}
+
+	if u.Tags != nil {
+		out.DisplayName = u.Tags["displayName"]
+		out.Description = u.Tags["description"]
+	}
+
+	return out
+}
+
+// toServiceAccountJSON fills the wire envelope with derived fields the
+// driver doesn't carry. The "name" field is always the resource path; email
+// is the same as the URL segment.
+func toServiceAccountJSON(project, email string, sa *serviceAccount) serviceAccount {
+	out := *sa
+	out.Name = "projects/" + project + "/serviceAccounts/" + email
+	out.ProjectID = project
+	out.Email = email
+
+	if out.UniqueID == "" {
+		// Stable synthetic ID derived from the email so tests can match it.
+		out.UniqueID = "uid-" + strings.ReplaceAll(email, "@", "-")
+	}
+
+	return out
+}
+
+// toRoleJSON builds the wire envelope for a custom role. The "name" field
+// is the canonical resource path.
+func toRoleJSON(project, roleID string, props *roleProps) role {
+	return role{
+		Name:                "projects/" + project + "/roles/" + roleID,
+		Title:               props.Title,
+		Description:         props.Description,
+		IncludedPermissions: props.IncludedPermissions,
+		Stage:               props.Stage,
+	}
+}
+
+// toKeyJSON builds the wire envelope for a service-account key. private is
+// only populated on create (GCP returns the private key material exactly
+// once); GET / LIST pass an empty string.
+func toKeyJSON(project, email, keyID, private string) serviceAccountKey {
+	return serviceAccountKey{
+		Name: "projects/" + project + "/serviceAccounts/" + email +
+			"/keys/" + keyID,
+		PrivateKeyType: "TYPE_GOOGLE_CREDENTIALS_FILE",
+		KeyAlgorithm:   "KEY_ALG_RSA_2048",
+		PrivateKeyData: private,
+		KeyOrigin:      "GOOGLE_PROVIDED",
+		KeyType:        "USER_MANAGED",
+	}
+}
+
+func decodeRoleProps(doc string) (roleProps, error) {
+	if doc == "" {
+		return roleProps{}, nil
+	}
+
+	var props roleProps
+	if err := json.Unmarshal([]byte(doc), &props); err != nil {
+		return roleProps{}, err
+	}
+
+	return props, nil
+}
+
+func decodeJSONBody(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	defer func() { _ = r.Body.Close() }()
+
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"could not read request body: "+err.Error())
+		return false
+	}
+
+	if len(raw) == 0 {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"empty request body")
+		return false
+	}
+
+	if err := json.Unmarshal(raw, v); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			"could not parse JSON body: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+// drainBody reads and discards the body so the connection isn't left in
+// a half-read state. Used by endpoints that don't need request data.
+func drainBody(r *http.Request) error {
+	r.Body = http.MaxBytesReader(nil, r.Body, maxBodyBytes)
+	defer func() { _ = r.Body.Close() }()
+
+	_, err := io.Copy(io.Discard, r.Body)
+
+	return err
+}
+
+// writeCErr maps canonical cloudemu errors to GCP JSON error envelopes.
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "ALREADY_EXISTS", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/gcp/iam/sdk_roundtrip_test.go
+++ b/server/gcp/iam/sdk_roundtrip_test.go
@@ -1,0 +1,217 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+	"google.golang.org/api/googleapi"
+	iamv1 "google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+)
+
+const (
+	testProject = "demo-project"
+)
+
+func newSDKService(t *testing.T) *iamv1.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{IAM: cloud.IAM})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := iamv1.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("iamv1.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestSDKGCPIAMServiceAccountLifecycle(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	created, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "ci-deployer",
+		ServiceAccount: &iamv1.ServiceAccount{
+			DisplayName: "CI Deployer",
+			Description: "Used by CI to deploy",
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	wantEmail := "ci-deployer@" + testProject + ".iam.gserviceaccount.com"
+	if created.Email != wantEmail {
+		t.Fatalf("got email %q, want %q", created.Email, wantEmail)
+	}
+
+	if created.DisplayName != "CI Deployer" {
+		t.Fatalf("got displayName %q, want CI Deployer", created.DisplayName)
+	}
+
+	got, err := svc.Projects.ServiceAccounts.Get(
+		"projects/-/serviceAccounts/" + wantEmail,
+	).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Email != wantEmail {
+		t.Fatalf("Get returned email %q, want %q", got.Email, wantEmail)
+	}
+
+	list, err := svc.Projects.ServiceAccounts.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(list.Accounts) != 1 {
+		t.Fatalf("List returned %d accounts, want 1", len(list.Accounts))
+	}
+
+	if _, err := svc.Projects.ServiceAccounts.Delete(
+		"projects/-/serviceAccounts/" + wantEmail,
+	).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := svc.Projects.ServiceAccounts.Get(
+		"projects/-/serviceAccounts/" + wantEmail,
+	).Context(ctx).Do(); err == nil {
+		t.Fatalf("Get after Delete: expected error, got nil")
+	}
+}
+
+func TestSDKGCPIAMRoleLifecycle(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	created, err := svc.Projects.Roles.Create(parent, &iamv1.CreateRoleRequest{
+		RoleId: "customViewer",
+		Role: &iamv1.Role{
+			Title:       "Custom Viewer",
+			Description: "Read-only access",
+			IncludedPermissions: []string{
+				"compute.instances.list",
+				"compute.instances.get",
+			},
+			Stage: "GA",
+		},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	wantName := parent + "/roles/customViewer"
+	if created.Name != wantName {
+		t.Fatalf("got name %q, want %q", created.Name, wantName)
+	}
+
+	if len(created.IncludedPermissions) != 2 {
+		t.Fatalf("got %d permissions, want 2", len(created.IncludedPermissions))
+	}
+
+	got, err := svc.Projects.Roles.Get(wantName).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Title != "Custom Viewer" {
+		t.Fatalf("Get returned title %q, want Custom Viewer", got.Title)
+	}
+
+	list, err := svc.Projects.Roles.List(parent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(list.Roles) != 1 {
+		t.Fatalf("List returned %d roles, want 1", len(list.Roles))
+	}
+
+	if _, err := svc.Projects.Roles.Delete(wantName).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestSDKGCPIAMServiceAccountKeysLifecycle(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	parent := "projects/" + testProject
+
+	if _, err := svc.Projects.ServiceAccounts.Create(parent, &iamv1.CreateServiceAccountRequest{
+		AccountId: "key-owner",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("CreateServiceAccount: %v", err)
+	}
+
+	email := "key-owner@" + testProject + ".iam.gserviceaccount.com"
+	saResource := "projects/-/serviceAccounts/" + email
+
+	createdKey, err := svc.Projects.ServiceAccounts.Keys.Create(saResource,
+		&iamv1.CreateServiceAccountKeyRequest{},
+	).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.Create: %v", err)
+	}
+
+	if createdKey.Name == "" {
+		t.Fatalf("Keys.Create returned empty name")
+	}
+
+	if createdKey.PrivateKeyData == "" {
+		t.Fatalf("Keys.Create did not return PrivateKeyData (real GCP returns it once)")
+	}
+
+	listed, err := svc.Projects.ServiceAccounts.Keys.List(saResource).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Keys.List: %v", err)
+	}
+
+	if len(listed.Keys) != 1 {
+		t.Fatalf("Keys.List returned %d keys, want 1", len(listed.Keys))
+	}
+
+	if _, err := svc.Projects.ServiceAccounts.Keys.Delete(createdKey.Name).
+		Context(ctx).Do(); err != nil {
+		t.Fatalf("Keys.Delete: %v", err)
+	}
+}
+
+func TestSDKGCPIAMNotFoundIsTyped(t *testing.T) {
+	svc := newSDKService(t)
+	ctx := context.Background()
+
+	_, err := svc.Projects.ServiceAccounts.Get(
+		"projects/-/serviceAccounts/ghost@demo-project.iam.gserviceaccount.com",
+	).Context(ctx).Do()
+	if err == nil {
+		t.Fatalf("Get on missing SA: expected error, got nil")
+	}
+
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *googleapi.Error, got %T: %v", err, err)
+	}
+
+	if apiErr.Code != 404 {
+		t.Fatalf("got HTTP %d, want 404", apiErr.Code)
+	}
+}

--- a/server/gcp/iam/types.go
+++ b/server/gcp/iam/types.go
@@ -29,6 +29,16 @@ type createServiceAccountRequest struct {
 	ServiceAccount serviceAccount `json:"serviceAccount"`
 }
 
+// patchServiceAccountRequest is the PATCH body for ServiceAccounts.Patch.
+// The SDK wraps the resource in this envelope and adds an updateMask telling
+// the server which fields to touch. We ignore the mask (emulator always
+// full-replaces) but must decode the wrapper to find the resource at all —
+// the wrapper field is mandatory.
+type patchServiceAccountRequest struct {
+	ServiceAccount serviceAccount `json:"serviceAccount"`
+	UpdateMask     string         `json:"updateMask,omitempty"`
+}
+
 // listServiceAccountsResponse is the wire shape for the SA list response.
 type listServiceAccountsResponse struct {
 	Accounts      []serviceAccount `json:"accounts"`

--- a/server/gcp/iam/types.go
+++ b/server/gcp/iam/types.go
@@ -1,0 +1,123 @@
+package iam
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const contentTypeJSON = "application/json"
+
+// --- ServiceAccount ---
+
+// serviceAccount mirrors the GCP iam.googleapis.com v1 ServiceAccount JSON.
+// Fields are populated from a driver UserInfo plus the project the request
+// was scoped to.
+type serviceAccount struct {
+	Name           string `json:"name"`
+	ProjectID      string `json:"projectId,omitempty"`
+	UniqueID       string `json:"uniqueId,omitempty"`
+	Email          string `json:"email,omitempty"`
+	DisplayName    string `json:"displayName,omitempty"`
+	Description    string `json:"description,omitempty"`
+	OAuth2ClientID string `json:"oauth2ClientId,omitempty"`
+	Etag           string `json:"etag,omitempty"`
+}
+
+// createServiceAccountRequest is the POST body for ServiceAccounts.Create.
+type createServiceAccountRequest struct {
+	AccountID      string         `json:"accountId"`
+	ServiceAccount serviceAccount `json:"serviceAccount"`
+}
+
+// listServiceAccountsResponse is the wire shape for the SA list response.
+type listServiceAccountsResponse struct {
+	Accounts      []serviceAccount `json:"accounts"`
+	NextPageToken string           `json:"nextPageToken,omitempty"`
+}
+
+// --- Role ---
+
+// role mirrors the GCP iam.googleapis.com v1 Role JSON. The driver only
+// carries name + path + permissions doc; everything else is reconstructed
+// from the request payload.
+type role struct {
+	Name                string   `json:"name"`
+	Title               string   `json:"title,omitempty"`
+	Description         string   `json:"description,omitempty"`
+	IncludedPermissions []string `json:"includedPermissions,omitempty"`
+	Stage               string   `json:"stage,omitempty"`
+	Etag                string   `json:"etag,omitempty"`
+	Deleted             bool     `json:"deleted,omitempty"`
+}
+
+// createRoleRequest is the POST body for Roles.Create.
+type createRoleRequest struct {
+	RoleID string `json:"roleId"`
+	Role   role   `json:"role"`
+}
+
+// listRolesResponse is the wire shape for the role list response.
+type listRolesResponse struct {
+	Roles         []role `json:"roles"`
+	NextPageToken string `json:"nextPageToken,omitempty"`
+}
+
+// roleProps is the JSON shape we stash in driver Role.AssumeRolePolicyDoc.
+// The driver field has no native place for GCP-style permissions, so we
+// serialize the GCP-specific properties block as JSON.
+type roleProps struct {
+	Title               string   `json:"title,omitempty"`
+	Description         string   `json:"description,omitempty"`
+	IncludedPermissions []string `json:"includedPermissions,omitempty"`
+	Stage               string   `json:"stage,omitempty"`
+}
+
+// --- ServiceAccountKey ---
+
+// serviceAccountKey mirrors the GCP v1 ServiceAccountKey JSON.
+type serviceAccountKey struct {
+	Name            string `json:"name"`
+	PrivateKeyType  string `json:"privateKeyType,omitempty"`
+	KeyAlgorithm    string `json:"keyAlgorithm,omitempty"`
+	PrivateKeyData  string `json:"privateKeyData,omitempty"`
+	PublicKeyData   string `json:"publicKeyData,omitempty"`
+	ValidAfterTime  string `json:"validAfterTime,omitempty"`
+	ValidBeforeTime string `json:"validBeforeTime,omitempty"`
+	KeyOrigin       string `json:"keyOrigin,omitempty"`
+	KeyType         string `json:"keyType,omitempty"`
+}
+
+// listKeysResponse is the wire shape for the SA key list response.
+type listKeysResponse struct {
+	Keys []serviceAccountKey `json:"keys"`
+}
+
+// --- error envelope ---
+
+// gcpError is the JSON shape every GCP API client expects for non-2xx
+// responses: {"error": {"code": 404, "message": "...", "status": "NOT_FOUND"}}.
+type gcpError struct {
+	Error gcpErrorBody `json:"error"`
+}
+
+type gcpErrorBody struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status,omitempty"`
+}
+
+// writeJSON writes v as a 200 OK JSON response. The IAM handler always
+// returns 200 on success; non-2xx flows go through writeError.
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, statusStr, msg string) {
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(gcpError{
+		Error: gcpErrorBody{Code: status, Message: msg, Status: statusStr},
+	})
+}


### PR DESCRIPTION
## Feature

- New server/gcp/iam package serves the iam.googleapis.com v1 REST API on top of the shared in-memory IAM driver. Real google.golang.org/api/iam/v1 clients connect by pointing at the SDK server and round-trip end-to-end with errors surfaced as typed googleapi.Error.
- Covers thirteen REST endpoints across three resource groups: ServiceAccounts (Create, Get, List, Delete, Patch), custom Roles (Create, Get, List, Delete, Patch), and ServiceAccountKeys (Create, Get, List, Delete). All under /v1/projects/{p}/serviceAccounts and /v1/projects/{p}/roles.
- Cleanest cross-cloud driver mapping yet: ServiceAccount stores through the driver User (the SA email is the natural primary key), custom Role stores through the driver Role with the GCP-style permissions list serialized as JSON in AssumeRolePolicyDoc, and ServiceAccountKey stores through the driver AccessKey with the SA email as the owning user.
- Service account emails are minted with the canonical GCP shape `{accountId}@{project}.iam.gserviceaccount.com`; resource names use the canonical projects/{p}/... path; SA keys return private key material only on create per real GCP semantics.
- Handler registers in gcpserver.New alongside the other /v1/projects/ family handlers. The serviceAccounts and roles resource-type guards are disjoint from every other GCP service so registration order is unconstrained among the family.
- Real-SDK roundtrip tests exercise the full lifecycle of each resource group plus a typed-error path (Get on missing SA surfaces as *googleapi.Error with Code 404).
- Resource-level IAM policy bindings (getIamPolicy / setIamPolicy on individual GCP resources) are intentionally out of scope and documented as such in docs/sdk-server.md.