### PR TITLE
feat: AWS Bedrock guardrails, provisioned throughput & invocation logging SDK-compat

### DIFF
--- a/bedrock/bedrock.go
+++ b/bedrock/bedrock.go
@@ -206,3 +206,135 @@ func (b *Bedrock) Converse(ctx context.Context, in driver.ConverseInput) (*drive
 
 	return out.(*driver.ConverseOutput), nil
 }
+
+// CreateGuardrail creates a content guardrail.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (b *Bedrock) CreateGuardrail(ctx context.Context, cfg driver.GuardrailConfig) (*driver.Guardrail, error) {
+	out, err := b.do(ctx, "CreateGuardrail", cfg, func() (any, error) { return b.driver.CreateGuardrail(ctx, cfg) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Guardrail), nil
+}
+
+// GetGuardrail retrieves a guardrail by identifier and optional version.
+func (b *Bedrock) GetGuardrail(ctx context.Context, identifier, version string) (*driver.Guardrail, error) {
+	out, err := b.do(ctx, "GetGuardrail", identifier, func() (any, error) { return b.driver.GetGuardrail(ctx, identifier, version) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Guardrail), nil
+}
+
+// ListGuardrails lists all guardrails.
+func (b *Bedrock) ListGuardrails(ctx context.Context) ([]driver.Guardrail, error) {
+	out, err := b.do(ctx, "ListGuardrails", nil, func() (any, error) { return b.driver.ListGuardrails(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Guardrail), nil
+}
+
+// UpdateGuardrail updates a guardrail's mutable fields.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (b *Bedrock) UpdateGuardrail(ctx context.Context, identifier string, cfg driver.GuardrailConfig) (*driver.Guardrail, error) {
+	out, err := b.do(ctx, "UpdateGuardrail", identifier, func() (any, error) { return b.driver.UpdateGuardrail(ctx, identifier, cfg) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Guardrail), nil
+}
+
+// DeleteGuardrail deletes a guardrail.
+func (b *Bedrock) DeleteGuardrail(ctx context.Context, identifier string) error {
+	_, err := b.do(ctx, "DeleteGuardrail", identifier, func() (any, error) { return nil, b.driver.DeleteGuardrail(ctx, identifier) })
+
+	return err
+}
+
+// CreateProvisionedModelThroughput provisions throughput for a model.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (b *Bedrock) CreateProvisionedModelThroughput(
+	ctx context.Context, cfg driver.ProvisionedThroughputConfig,
+) (*driver.ProvisionedThroughput, error) {
+	out, err := b.do(ctx, "CreateProvisionedModelThroughput", cfg, func() (any, error) {
+		return b.driver.CreateProvisionedModelThroughput(ctx, cfg)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ProvisionedThroughput), nil
+}
+
+// GetProvisionedModelThroughput retrieves provisioned throughput by identifier.
+func (b *Bedrock) GetProvisionedModelThroughput(ctx context.Context, identifier string) (*driver.ProvisionedThroughput, error) {
+	out, err := b.do(ctx, "GetProvisionedModelThroughput", identifier, func() (any, error) {
+		return b.driver.GetProvisionedModelThroughput(ctx, identifier)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ProvisionedThroughput), nil
+}
+
+// ListProvisionedModelThroughputs lists all provisioned throughputs.
+func (b *Bedrock) ListProvisionedModelThroughputs(ctx context.Context) ([]driver.ProvisionedThroughput, error) {
+	out, err := b.do(ctx, "ListProvisionedModelThroughputs", nil, func() (any, error) {
+		return b.driver.ListProvisionedModelThroughputs(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.ProvisionedThroughput), nil
+}
+
+// DeleteProvisionedModelThroughput deletes provisioned throughput by identifier.
+func (b *Bedrock) DeleteProvisionedModelThroughput(ctx context.Context, identifier string) error {
+	_, err := b.do(ctx, "DeleteProvisionedModelThroughput", identifier, func() (any, error) {
+		return nil, b.driver.DeleteProvisionedModelThroughput(ctx, identifier)
+	})
+
+	return err
+}
+
+// PutModelInvocationLoggingConfiguration sets the invocation logging config.
+func (b *Bedrock) PutModelInvocationLoggingConfiguration(ctx context.Context, cfg driver.LoggingConfig) error {
+	_, err := b.do(ctx, "PutModelInvocationLoggingConfiguration", cfg, func() (any, error) {
+		return nil, b.driver.PutModelInvocationLoggingConfiguration(ctx, cfg)
+	})
+
+	return err
+}
+
+// GetModelInvocationLoggingConfiguration returns the invocation logging config.
+func (b *Bedrock) GetModelInvocationLoggingConfiguration(ctx context.Context) (*driver.LoggingConfig, error) {
+	out, err := b.do(ctx, "GetModelInvocationLoggingConfiguration", nil, func() (any, error) {
+		return b.driver.GetModelInvocationLoggingConfiguration(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, _ := out.(*driver.LoggingConfig)
+
+	return cfg, nil
+}
+
+// DeleteModelInvocationLoggingConfiguration clears the invocation logging config.
+func (b *Bedrock) DeleteModelInvocationLoggingConfiguration(ctx context.Context) error {
+	_, err := b.do(ctx, "DeleteModelInvocationLoggingConfiguration", nil, func() (any, error) {
+		return nil, b.driver.DeleteModelInvocationLoggingConfiguration(ctx)
+	})
+
+	return err
+}

--- a/bedrock/bedrock_test.go
+++ b/bedrock/bedrock_test.go
@@ -150,3 +150,53 @@ func TestWithRateLimiter(t *testing.T) {
 	_, err = b.ListFoundationModels(context.Background())
 	require.Error(t, err)
 }
+
+func TestManagementWrappers(t *testing.T) {
+	b := newTestBedrock()
+	ctx := context.Background()
+
+	g, err := b.CreateGuardrail(ctx, driver.GuardrailConfig{
+		Name:                    "gr-1",
+		BlockedInputMessaging:   "in",
+		BlockedOutputsMessaging: "out",
+	})
+	require.NoError(t, err)
+	require.Equal(t, driver.GuardrailReady, g.Status)
+
+	_, err = b.GetGuardrail(ctx, g.ID, "")
+	require.NoError(t, err)
+
+	gs, err := b.ListGuardrails(ctx)
+	require.NoError(t, err)
+	require.Len(t, gs, 1)
+
+	require.NoError(t, b.DeleteGuardrail(ctx, g.ID))
+
+	pt, err := b.CreateProvisionedModelThroughput(ctx, driver.ProvisionedThroughputConfig{
+		ProvisionedModelName: "pt-1",
+		ModelID:              titanModel,
+		ModelUnits:           1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, driver.ProvisionedInService, pt.Status)
+
+	_, err = b.GetProvisionedModelThroughput(ctx, "pt-1")
+	require.NoError(t, err)
+
+	pts, err := b.ListProvisionedModelThroughputs(ctx)
+	require.NoError(t, err)
+	require.Len(t, pts, 1)
+
+	require.NoError(t, b.DeleteProvisionedModelThroughput(ctx, "pt-1"))
+
+	require.NoError(t, b.PutModelInvocationLoggingConfiguration(ctx, driver.LoggingConfig{
+		TextDataDeliveryEnabled: true,
+		S3:                      &driver.S3LoggingConfig{BucketName: "logs"},
+	}))
+
+	lc, err := b.GetModelInvocationLoggingConfiguration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, lc)
+
+	require.NoError(t, b.DeleteModelInvocationLoggingConfiguration(ctx))
+}

--- a/bedrock/driver/driver.go
+++ b/bedrock/driver/driver.go
@@ -141,9 +141,100 @@ type ConverseOutput struct {
 	LatencyMs    int
 }
 
+// Guardrail status values.
+const (
+	GuardrailReady    = "READY"
+	GuardrailCreating = "CREATING"
+	GuardrailUpdating = "UPDATING"
+	GuardrailFailed   = "FAILED"
+)
+
+// Provisioned throughput status values.
+const (
+	ProvisionedCreating  = "Creating"
+	ProvisionedInService = "InService"
+	ProvisionedUpdating  = "Updating"
+	ProvisionedFailed    = "Failed"
+)
+
+// GuardrailConfig describes a guardrail to create or update.
+type GuardrailConfig struct {
+	Name                    string
+	Description             string
+	BlockedInputMessaging   string
+	BlockedOutputsMessaging string
+	KMSKeyID                string
+	ClientRequestToken      string
+	Tags                    map[string]string
+}
+
+// Guardrail describes a content guardrail.
+type Guardrail struct {
+	ID                      string
+	ARN                     string
+	Name                    string
+	Description             string
+	Version                 string
+	Status                  string
+	BlockedInputMessaging   string
+	BlockedOutputsMessaging string
+	KMSKeyARN               string
+	CreatedAt               string
+	UpdatedAt               string
+}
+
+// ProvisionedThroughputConfig describes a provisioned-throughput purchase.
+type ProvisionedThroughputConfig struct {
+	ProvisionedModelName string
+	ModelID              string
+	ModelUnits           int
+	CommitmentDuration   string
+	ClientRequestToken   string
+	Tags                 map[string]string
+}
+
+// ProvisionedThroughput describes provisioned model throughput.
+type ProvisionedThroughput struct {
+	ARN                string
+	Name               string
+	ModelARN           string
+	DesiredModelARN    string
+	FoundationModelARN string
+	ModelUnits         int
+	DesiredModelUnits  int
+	Status             string
+	CommitmentDuration string
+	CreationTime       string
+	LastModifiedTime   string
+}
+
+// S3LoggingConfig is an S3 delivery target for invocation logs.
+type S3LoggingConfig struct {
+	BucketName string
+	KeyPrefix  string
+}
+
+// CloudWatchLoggingConfig is a CloudWatch Logs delivery target.
+type CloudWatchLoggingConfig struct {
+	LogGroupName        string
+	RoleARN             string
+	LargeDataDeliveryS3 *S3LoggingConfig
+}
+
+// LoggingConfig is the model-invocation logging configuration.
+type LoggingConfig struct {
+	TextDataDeliveryEnabled      bool
+	ImageDataDeliveryEnabled     bool
+	EmbeddingDataDeliveryEnabled bool
+	VideoDataDeliveryEnabled     bool
+	S3                           *S3LoggingConfig
+	CloudWatch                   *CloudWatchLoggingConfig
+}
+
 // Bedrock is the interface that foundation-model service implementations must
 // satisfy. It spans the control plane (model catalog, customization jobs,
-// custom models) and the runtime (InvokeModel, Converse).
+// custom models, guardrails, provisioned throughput, invocation logging) and
+// the runtime (InvokeModel, Converse).
 type Bedrock interface {
 	ListFoundationModels(ctx context.Context) ([]FoundationModel, error)
 	GetFoundationModel(ctx context.Context, modelID string) (*FoundationModel, error)
@@ -158,4 +249,19 @@ type Bedrock interface {
 
 	InvokeModel(ctx context.Context, in InvokeModelInput) (*InvokeModelResult, error)
 	Converse(ctx context.Context, in ConverseInput) (*ConverseOutput, error)
+
+	CreateGuardrail(ctx context.Context, cfg GuardrailConfig) (*Guardrail, error)
+	GetGuardrail(ctx context.Context, identifier, version string) (*Guardrail, error)
+	ListGuardrails(ctx context.Context) ([]Guardrail, error)
+	UpdateGuardrail(ctx context.Context, identifier string, cfg GuardrailConfig) (*Guardrail, error)
+	DeleteGuardrail(ctx context.Context, identifier string) error
+
+	CreateProvisionedModelThroughput(ctx context.Context, cfg ProvisionedThroughputConfig) (*ProvisionedThroughput, error)
+	GetProvisionedModelThroughput(ctx context.Context, identifier string) (*ProvisionedThroughput, error)
+	ListProvisionedModelThroughputs(ctx context.Context) ([]ProvisionedThroughput, error)
+	DeleteProvisionedModelThroughput(ctx context.Context, identifier string) error
+
+	PutModelInvocationLoggingConfiguration(ctx context.Context, cfg LoggingConfig) error
+	GetModelInvocationLoggingConfiguration(ctx context.Context) (*LoggingConfig, error)
+	DeleteModelInvocationLoggingConfiguration(ctx context.Context) error
 }

--- a/providers/aws/bedrock/bedrock.go
+++ b/providers/aws/bedrock/bedrock.go
@@ -6,6 +6,7 @@ package bedrock
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/bedrock/driver"
@@ -20,20 +21,27 @@ var _ driver.Bedrock = (*Mock)(nil)
 
 // Mock is an in-memory mock implementation of the AWS Bedrock service.
 type Mock struct {
-	foundation []driver.FoundationModel
-	jobs       *memstore.Store[*driver.CustomizationJob]
-	models     *memstore.Store[*driver.CustomModel]
-	opts       *config.Options
+	foundation  []driver.FoundationModel
+	jobs        *memstore.Store[*driver.CustomizationJob]
+	models      *memstore.Store[*driver.CustomModel]
+	guardrails  *memstore.Store[*driver.Guardrail]
+	provisioned *memstore.Store[*driver.ProvisionedThroughput]
+	opts        *config.Options
+
+	logMu   sync.RWMutex
+	logging *driver.LoggingConfig
 }
 
 // New creates a new Bedrock mock seeded with a realistic foundation-model
 // catalog.
 func New(opts *config.Options) *Mock {
 	return &Mock{
-		foundation: seedFoundationModels(opts.Region),
-		jobs:       memstore.New[*driver.CustomizationJob](),
-		models:     memstore.New[*driver.CustomModel](),
-		opts:       opts,
+		foundation:  seedFoundationModels(opts.Region),
+		jobs:        memstore.New[*driver.CustomizationJob](),
+		models:      memstore.New[*driver.CustomModel](),
+		guardrails:  memstore.New[*driver.Guardrail](),
+		provisioned: memstore.New[*driver.ProvisionedThroughput](),
+		opts:        opts,
 	}
 }
 

--- a/providers/aws/bedrock/management.go
+++ b/providers/aws/bedrock/management.go
@@ -92,7 +92,14 @@ func (m *Mock) UpdateGuardrail(_ context.Context, identifier string, cfg driver.
 	updated.BlockedInputMessaging = orDefault(cfg.BlockedInputMessaging, g.BlockedInputMessaging)
 	updated.BlockedOutputsMessaging = orDefault(cfg.BlockedOutputsMessaging, g.BlockedOutputsMessaging)
 	updated.UpdatedAt = m.now()
-	m.guardrails.Set(g.Name, &updated)
+
+	// Guardrails are keyed by name; re-key when an update renames one so
+	// lookups by the new name keep working.
+	if updated.Name != g.Name {
+		m.guardrails.Delete(g.Name)
+	}
+
+	m.guardrails.Set(updated.Name, &updated)
 
 	result := updated
 

--- a/providers/aws/bedrock/management.go
+++ b/providers/aws/bedrock/management.go
@@ -1,0 +1,296 @@
+package bedrock
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/bedrock/driver"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+// guardrailDraftVersion is the working version assigned to a freshly created
+// guardrail, matching the real Bedrock "DRAFT" version.
+const guardrailDraftVersion = "DRAFT"
+
+// --- Guardrails ---
+
+// CreateGuardrail creates a guardrail in the READY state.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) CreateGuardrail(_ context.Context, cfg driver.GuardrailConfig) (*driver.Guardrail, error) {
+	if err := validateGuardrailConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	if m.guardrails.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "guardrail %q already exists", cfg.Name)
+	}
+
+	id := idgen.GenerateID("gr-")
+	now := m.now()
+	g := &driver.Guardrail{
+		ID:                      id,
+		ARN:                     idgen.AWSARN("bedrock", m.opts.Region, m.opts.AccountID, "guardrail/"+id),
+		Name:                    cfg.Name,
+		Description:             cfg.Description,
+		Version:                 guardrailDraftVersion,
+		Status:                  driver.GuardrailReady,
+		BlockedInputMessaging:   cfg.BlockedInputMessaging,
+		BlockedOutputsMessaging: cfg.BlockedOutputsMessaging,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+
+	if cfg.KMSKeyID != "" {
+		g.KMSKeyARN = cfg.KMSKeyID
+	}
+
+	m.guardrails.Set(cfg.Name, g)
+
+	result := *g
+
+	return &result, nil
+}
+
+// GetGuardrail returns a guardrail by name or ARN. version is ignored (only
+// the working version is modeled).
+func (m *Mock) GetGuardrail(_ context.Context, identifier, _ string) (*driver.Guardrail, error) {
+	g := m.findGuardrail(identifier)
+	if g == nil {
+		return nil, errors.Newf(errors.NotFound, "guardrail %q not found", identifier)
+	}
+
+	result := *g
+
+	return &result, nil
+}
+
+// ListGuardrails lists all guardrails.
+func (m *Mock) ListGuardrails(_ context.Context) ([]driver.Guardrail, error) {
+	all := m.guardrails.All()
+	out := make([]driver.Guardrail, 0, len(all))
+
+	for _, g := range all {
+		out = append(out, *g)
+	}
+
+	return out, nil
+}
+
+// UpdateGuardrail updates a guardrail's mutable fields.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) UpdateGuardrail(_ context.Context, identifier string, cfg driver.GuardrailConfig) (*driver.Guardrail, error) {
+	g := m.findGuardrail(identifier)
+	if g == nil {
+		return nil, errors.Newf(errors.NotFound, "guardrail %q not found", identifier)
+	}
+
+	updated := *g
+	updated.Name = orDefault(cfg.Name, g.Name)
+	updated.Description = cfg.Description
+	updated.BlockedInputMessaging = orDefault(cfg.BlockedInputMessaging, g.BlockedInputMessaging)
+	updated.BlockedOutputsMessaging = orDefault(cfg.BlockedOutputsMessaging, g.BlockedOutputsMessaging)
+	updated.UpdatedAt = m.now()
+	m.guardrails.Set(g.Name, &updated)
+
+	result := updated
+
+	return &result, nil
+}
+
+// DeleteGuardrail deletes a guardrail by name or ARN.
+func (m *Mock) DeleteGuardrail(_ context.Context, identifier string) error {
+	g := m.findGuardrail(identifier)
+	if g == nil {
+		return errors.Newf(errors.NotFound, "guardrail %q not found", identifier)
+	}
+
+	m.guardrails.Delete(g.Name)
+
+	return nil
+}
+
+func (m *Mock) findGuardrail(id string) *driver.Guardrail {
+	if g, ok := m.guardrails.Get(id); ok {
+		return g
+	}
+
+	for _, g := range m.guardrails.All() {
+		if g.ID == id || g.ARN == id {
+			return g
+		}
+	}
+
+	return nil
+}
+
+func validateGuardrailConfig(cfg driver.GuardrailConfig) error { //nolint:gocritic // cfg by value matches interface
+	switch {
+	case cfg.Name == "":
+		return errors.New(errors.InvalidArgument, "name is required")
+	case cfg.BlockedInputMessaging == "":
+		return errors.New(errors.InvalidArgument, "blockedInputMessaging is required")
+	case cfg.BlockedOutputsMessaging == "":
+		return errors.New(errors.InvalidArgument, "blockedOutputsMessaging is required")
+	default:
+		return nil
+	}
+}
+
+// --- Provisioned model throughput ---
+
+// CreateProvisionedModelThroughput provisions throughput for a model in the
+// InService state.
+//
+//nolint:gocritic // cfg matches the driver interface signature; copied once on entry.
+func (m *Mock) CreateProvisionedModelThroughput(
+	_ context.Context, cfg driver.ProvisionedThroughputConfig,
+) (*driver.ProvisionedThroughput, error) {
+	switch {
+	case cfg.ProvisionedModelName == "":
+		return nil, errors.New(errors.InvalidArgument, "provisionedModelName is required")
+	case cfg.ModelID == "":
+		return nil, errors.New(errors.InvalidArgument, "modelId is required")
+	case cfg.ModelUnits <= 0:
+		return nil, errors.New(errors.InvalidArgument, "modelUnits must be positive")
+	}
+
+	modelARN := m.resolveModelARN(cfg.ModelID)
+	if modelARN == "" {
+		return nil, errors.Newf(errors.InvalidArgument, "model %q not found", cfg.ModelID)
+	}
+
+	if m.provisioned.Has(cfg.ProvisionedModelName) {
+		return nil, errors.Newf(errors.AlreadyExists, "provisioned model %q already exists", cfg.ProvisionedModelName)
+	}
+
+	now := m.now()
+	pt := &driver.ProvisionedThroughput{
+		ARN:                idgen.AWSARN("bedrock", m.opts.Region, m.opts.AccountID, "provisioned-model/"+idgen.GenerateID("")),
+		Name:               cfg.ProvisionedModelName,
+		ModelARN:           modelARN,
+		DesiredModelARN:    modelARN,
+		FoundationModelARN: modelARN,
+		ModelUnits:         cfg.ModelUnits,
+		DesiredModelUnits:  cfg.ModelUnits,
+		Status:             driver.ProvisionedInService,
+		CommitmentDuration: cfg.CommitmentDuration,
+		CreationTime:       now,
+		LastModifiedTime:   now,
+	}
+	m.provisioned.Set(cfg.ProvisionedModelName, pt)
+
+	result := *pt
+
+	return &result, nil
+}
+
+// GetProvisionedModelThroughput returns a provisioned throughput by name or ARN.
+func (m *Mock) GetProvisionedModelThroughput(_ context.Context, identifier string) (*driver.ProvisionedThroughput, error) {
+	pt := m.findProvisioned(identifier)
+	if pt == nil {
+		return nil, errors.Newf(errors.NotFound, "provisioned model %q not found", identifier)
+	}
+
+	result := *pt
+
+	return &result, nil
+}
+
+// ListProvisionedModelThroughputs lists all provisioned throughputs.
+func (m *Mock) ListProvisionedModelThroughputs(_ context.Context) ([]driver.ProvisionedThroughput, error) {
+	all := m.provisioned.All()
+	out := make([]driver.ProvisionedThroughput, 0, len(all))
+
+	for _, pt := range all {
+		out = append(out, *pt)
+	}
+
+	return out, nil
+}
+
+// DeleteProvisionedModelThroughput deletes a provisioned throughput by name or ARN.
+func (m *Mock) DeleteProvisionedModelThroughput(_ context.Context, identifier string) error {
+	pt := m.findProvisioned(identifier)
+	if pt == nil {
+		return errors.Newf(errors.NotFound, "provisioned model %q not found", identifier)
+	}
+
+	m.provisioned.Delete(pt.Name)
+
+	return nil
+}
+
+func (m *Mock) findProvisioned(id string) *driver.ProvisionedThroughput {
+	if pt, ok := m.provisioned.Get(id); ok {
+		return pt
+	}
+
+	for _, pt := range m.provisioned.All() {
+		if pt.ARN == id {
+			return pt
+		}
+	}
+
+	return nil
+}
+
+// resolveModelARN returns the ARN of a foundation or custom model, or "" if
+// the identifier names neither.
+func (m *Mock) resolveModelARN(id string) string {
+	if fm := m.findFoundation(id); fm != nil {
+		return fm.ModelARN
+	}
+
+	if cm := m.findCustom(id); cm != nil {
+		return cm.ModelARN
+	}
+
+	return ""
+}
+
+// --- Model invocation logging ---
+
+// PutModelInvocationLoggingConfiguration sets the invocation logging config.
+func (m *Mock) PutModelInvocationLoggingConfiguration(_ context.Context, cfg driver.LoggingConfig) error {
+	stored := cfg
+
+	m.logMu.Lock()
+	m.logging = &stored
+	m.logMu.Unlock()
+
+	return nil
+}
+
+// GetModelInvocationLoggingConfiguration returns the invocation logging config,
+// or nil if none is set.
+func (m *Mock) GetModelInvocationLoggingConfiguration(_ context.Context) (*driver.LoggingConfig, error) {
+	m.logMu.RLock()
+	defer m.logMu.RUnlock()
+
+	if m.logging == nil {
+		return nil, nil //nolint:nilnil // an unset logging config is a valid, non-error result
+	}
+
+	result := *m.logging
+
+	return &result, nil
+}
+
+// DeleteModelInvocationLoggingConfiguration clears the invocation logging config.
+func (m *Mock) DeleteModelInvocationLoggingConfiguration(_ context.Context) error {
+	m.logMu.Lock()
+	m.logging = nil
+	m.logMu.Unlock()
+
+	return nil
+}
+
+func orDefault(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+
+	return v
+}

--- a/providers/aws/bedrock/management_test.go
+++ b/providers/aws/bedrock/management_test.go
@@ -1,0 +1,152 @@
+package bedrock
+
+import (
+	"context"
+	"testing"
+
+	bedrockdriver "github.com/stackshy/cloudemu/bedrock/driver"
+)
+
+func newGuardrail(t *testing.T, m *Mock, name string) *bedrockdriver.Guardrail {
+	t.Helper()
+
+	g, err := m.CreateGuardrail(context.Background(), bedrockdriver.GuardrailConfig{
+		Name:                    name,
+		BlockedInputMessaging:   "blocked in",
+		BlockedOutputsMessaging: "blocked out",
+	})
+	requireNoError(t, err)
+
+	return g
+}
+
+func TestGuardrailLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	g := newGuardrail(t, m, "gr-1")
+	assertNotEmpty(t, g.ID)
+	assertNotEmpty(t, g.ARN)
+	assertEqual(t, bedrockdriver.GuardrailReady, g.Status)
+
+	got, err := m.GetGuardrail(ctx, g.ID, "")
+	requireNoError(t, err)
+	assertEqual(t, "gr-1", got.Name)
+
+	// lookup by ARN works too
+	_, err = m.GetGuardrail(ctx, g.ARN, "")
+	requireNoError(t, err)
+
+	list, err := m.ListGuardrails(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+
+	upd, err := m.UpdateGuardrail(ctx, g.ID, bedrockdriver.GuardrailConfig{
+		Name:                    "gr-1",
+		BlockedInputMessaging:   "new in",
+		BlockedOutputsMessaging: "new out",
+	})
+	requireNoError(t, err)
+	assertEqual(t, "new in", upd.BlockedInputMessaging)
+
+	requireNoError(t, m.DeleteGuardrail(ctx, g.ID))
+
+	_, err = m.GetGuardrail(ctx, g.ID, "")
+	assertError(t, err, true)
+}
+
+func TestGuardrailValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateGuardrail(ctx, bedrockdriver.GuardrailConfig{BlockedInputMessaging: "x", BlockedOutputsMessaging: "y"})
+	assertError(t, err, true)
+
+	_, err = m.CreateGuardrail(ctx, bedrockdriver.GuardrailConfig{Name: "g", BlockedOutputsMessaging: "y"})
+	assertError(t, err, true)
+
+	newGuardrail(t, m, "dup")
+	_, err = m.CreateGuardrail(ctx, bedrockdriver.GuardrailConfig{
+		Name: "dup", BlockedInputMessaging: "x", BlockedOutputsMessaging: "y",
+	})
+	assertError(t, err, true)
+}
+
+func TestProvisionedThroughputLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	pt, err := m.CreateProvisionedModelThroughput(ctx, bedrockdriver.ProvisionedThroughputConfig{
+		ProvisionedModelName: "pt-1",
+		ModelID:              titanModel,
+		ModelUnits:           2,
+	})
+	requireNoError(t, err)
+	assertEqual(t, bedrockdriver.ProvisionedInService, pt.Status)
+	assertNotEmpty(t, pt.ARN)
+	assertEqual(t, 2, pt.ModelUnits)
+
+	got, err := m.GetProvisionedModelThroughput(ctx, "pt-1")
+	requireNoError(t, err)
+	assertNotEmpty(t, got.FoundationModelARN)
+
+	// by ARN
+	_, err = m.GetProvisionedModelThroughput(ctx, pt.ARN)
+	requireNoError(t, err)
+
+	list, err := m.ListProvisionedModelThroughputs(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+
+	requireNoError(t, m.DeleteProvisionedModelThroughput(ctx, "pt-1"))
+
+	_, err = m.GetProvisionedModelThroughput(ctx, "pt-1")
+	assertError(t, err, true)
+}
+
+func TestProvisionedThroughputValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateProvisionedModelThroughput(ctx, bedrockdriver.ProvisionedThroughputConfig{
+		ProvisionedModelName: "pt", ModelID: titanModel, ModelUnits: 0,
+	})
+	assertError(t, err, true)
+
+	_, err = m.CreateProvisionedModelThroughput(ctx, bedrockdriver.ProvisionedThroughputConfig{
+		ProvisionedModelName: "pt", ModelID: "nope.unknown-v1", ModelUnits: 1,
+	})
+	assertError(t, err, true)
+}
+
+func TestModelInvocationLogging(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	// Unset → nil, no error.
+	cfg, err := m.GetModelInvocationLoggingConfiguration(ctx)
+	requireNoError(t, err)
+	if cfg != nil {
+		t.Fatalf("expected nil logging config, got %+v", cfg)
+	}
+
+	requireNoError(t, m.PutModelInvocationLoggingConfiguration(ctx, bedrockdriver.LoggingConfig{
+		TextDataDeliveryEnabled: true,
+		S3:                      &bedrockdriver.S3LoggingConfig{BucketName: "logs", KeyPrefix: "p/"},
+	}))
+
+	cfg, err = m.GetModelInvocationLoggingConfiguration(ctx)
+	requireNoError(t, err)
+	if cfg == nil || cfg.S3 == nil {
+		t.Fatal("expected logging config with S3")
+	}
+	assertEqual(t, "logs", cfg.S3.BucketName)
+
+	requireNoError(t, m.DeleteModelInvocationLoggingConfiguration(ctx))
+
+	cfg, err = m.GetModelInvocationLoggingConfiguration(ctx)
+	requireNoError(t, err)
+	if cfg != nil {
+		t.Fatalf("expected nil after delete, got %+v", cfg)
+	}
+}

--- a/providers/aws/bedrock/management_test.go
+++ b/providers/aws/bedrock/management_test.go
@@ -55,6 +55,32 @@ func TestGuardrailLifecycle(t *testing.T) {
 	assertError(t, err, true)
 }
 
+func TestGuardrailRenameRekeys(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	g := newGuardrail(t, m, "gr-old")
+
+	_, err := m.UpdateGuardrail(ctx, g.ID, bedrockdriver.GuardrailConfig{
+		Name:                    "gr-new",
+		BlockedInputMessaging:   "in",
+		BlockedOutputsMessaging: "out",
+	})
+	requireNoError(t, err)
+
+	// Lookup by the new name must succeed; the old name must be gone.
+	got, err := m.GetGuardrail(ctx, "gr-new", "")
+	requireNoError(t, err)
+	assertEqual(t, "gr-new", got.Name)
+
+	_, err = m.GetGuardrail(ctx, "gr-old", "")
+	assertError(t, err, true)
+
+	list, err := m.ListGuardrails(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(list))
+}
+
 func TestGuardrailValidation(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/server/aws/bedrock/handler.go
+++ b/server/aws/bedrock/handler.go
@@ -38,6 +38,11 @@ const (
 	prefixCustom     = "/custom-models"
 	prefixRuntime    = "/model/"
 
+	prefixGuardrails    = "/guardrails"
+	prefixProvisioned   = "/provisioned-model-throughput"
+	pathProvisionedList = "/provisioned-model-throughputs"
+	pathLogging         = "/logging/modelinvocations"
+
 	actionInvoke   = "invoke"
 	actionConverse = "converse"
 )
@@ -52,14 +57,26 @@ func New(drv bedrockdriver.Bedrock) *Handler {
 	return &Handler{bedrock: drv}
 }
 
+// collectionPrefixes are the URL prefixes that own both a collection path and
+// a "/{id}" resource path.
+//
+//nolint:gochecknoglobals // immutable routing table shared by Matches and ServeHTTP
+var collectionPrefixes = []string{prefixFoundation, prefixJobs, prefixCustom, prefixGuardrails, prefixProvisioned}
+
+// claims reports whether path p belongs to this handler.
+func claims(p string) bool {
+	for _, pre := range collectionPrefixes {
+		if p == pre || strings.HasPrefix(p, pre+"/") {
+			return true
+		}
+	}
+
+	return strings.HasPrefix(p, prefixRuntime) || p == pathProvisionedList || p == pathLogging
+}
+
 // Matches claims the Bedrock control-plane and runtime URL prefixes.
 func (*Handler) Matches(r *http.Request) bool {
-	p := r.URL.Path
-
-	return p == prefixFoundation || strings.HasPrefix(p, prefixFoundation+"/") ||
-		p == prefixJobs || strings.HasPrefix(p, prefixJobs+"/") ||
-		p == prefixCustom || strings.HasPrefix(p, prefixCustom+"/") ||
-		strings.HasPrefix(p, prefixRuntime)
+	return claims(r.URL.Path)
 }
 
 // ServeHTTP routes by URL prefix.
@@ -76,7 +93,101 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case strings.HasPrefix(p, prefixRuntime):
 		h.serveRuntime(w, r, strings.TrimPrefix(p, prefixRuntime))
 	default:
+		h.serveManagement(w, r, p)
+	}
+}
+
+// serveManagement routes the guardrail, provisioned-throughput, and invocation
+// logging surfaces. Split out of ServeHTTP to keep each dispatcher small.
+func (h *Handler) serveManagement(w http.ResponseWriter, r *http.Request, p string) {
+	switch {
+	case p == pathProvisionedList:
+		h.serveProvisionedList(w, r)
+	case p == prefixProvisioned || strings.HasPrefix(p, prefixProvisioned+"/"):
+		h.serveProvisioned(w, r, strings.TrimPrefix(strings.TrimPrefix(p, prefixProvisioned), "/"))
+	case p == prefixGuardrails || strings.HasPrefix(p, prefixGuardrails+"/"):
+		h.serveGuardrails(w, r, strings.TrimPrefix(strings.TrimPrefix(p, prefixGuardrails), "/"))
+	case p == pathLogging:
+		h.serveLogging(w, r)
+	default:
 		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported path: "+p)
+	}
+}
+
+// serveGuardrails handles /guardrails[/{id}].
+func (h *Handler) serveGuardrails(w http.ResponseWriter, r *http.Request, id string) {
+	if id == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.createGuardrail(w, r)
+		case http.MethodGet:
+			h.listGuardrails(w, r)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getGuardrail(w, r, id)
+	case http.MethodPut:
+		h.updateGuardrail(w, r, id)
+	case http.MethodDelete:
+		h.deleteGuardrail(w, r, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveProvisioned handles /provisioned-model-throughput[/{id}]. The bare path
+// is create-only (POST); listing uses the plural path.
+func (h *Handler) serveProvisioned(w http.ResponseWriter, r *http.Request, id string) {
+	if id == "" {
+		if r.Method != http.MethodPost {
+			methodNotAllowed(w)
+
+			return
+		}
+
+		h.createProvisioned(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getProvisioned(w, r, id)
+	case http.MethodDelete:
+		h.deleteProvisioned(w, r, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveProvisionedList handles GET /provisioned-model-throughputs.
+func (h *Handler) serveProvisionedList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	h.listProvisioned(w, r)
+}
+
+// serveLogging handles /logging/modelinvocations.
+func (h *Handler) serveLogging(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPut:
+		h.putLogging(w, r)
+	case http.MethodGet:
+		h.getLogging(w, r)
+	case http.MethodDelete:
+		h.deleteLogging(w, r)
+	default:
+		methodNotAllowed(w)
 	}
 }
 

--- a/server/aws/bedrock/management.go
+++ b/server/aws/bedrock/management.go
@@ -1,0 +1,429 @@
+package bedrock
+
+import (
+	"net/http"
+
+	bedrockdriver "github.com/stackshy/cloudemu/bedrock/driver"
+)
+
+// --- wire types ---
+
+type tagPair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type createGuardrailRequest struct {
+	Name                    string    `json:"name"`
+	Description             string    `json:"description"`
+	BlockedInputMessaging   string    `json:"blockedInputMessaging"`
+	BlockedOutputsMessaging string    `json:"blockedOutputsMessaging"`
+	KMSKeyID                string    `json:"kmsKeyId"`
+	ClientRequestToken      string    `json:"clientRequestToken"`
+	Tags                    []tagPair `json:"tags"`
+}
+
+type createGuardrailResponse struct {
+	GuardrailID  string `json:"guardrailId"`
+	GuardrailARN string `json:"guardrailArn"`
+	Version      string `json:"version"`
+	CreatedAt    string `json:"createdAt,omitempty"`
+}
+
+type guardrailJSON struct {
+	Name                    string `json:"name"`
+	Description             string `json:"description,omitempty"`
+	GuardrailID             string `json:"guardrailId"`
+	GuardrailARN            string `json:"guardrailArn"`
+	Version                 string `json:"version"`
+	Status                  string `json:"status"`
+	BlockedInputMessaging   string `json:"blockedInputMessaging,omitempty"`
+	BlockedOutputsMessaging string `json:"blockedOutputsMessaging,omitempty"`
+	KMSKeyARN               string `json:"kmsKeyArn,omitempty"`
+	CreatedAt               string `json:"createdAt,omitempty"`
+	UpdatedAt               string `json:"updatedAt,omitempty"`
+}
+
+type guardrailSummaryJSON struct {
+	ID          string `json:"id"`
+	ARN         string `json:"arn"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version"`
+	Status      string `json:"status"`
+	CreatedAt   string `json:"createdAt,omitempty"`
+	UpdatedAt   string `json:"updatedAt,omitempty"`
+}
+
+type listGuardrailsResponse struct {
+	Guardrails []guardrailSummaryJSON `json:"guardrails"`
+	NextToken  string                 `json:"nextToken,omitempty"`
+}
+
+type updateGuardrailResponse struct {
+	GuardrailID  string `json:"guardrailId"`
+	GuardrailARN string `json:"guardrailArn"`
+	Version      string `json:"version"`
+	UpdatedAt    string `json:"updatedAt,omitempty"`
+}
+
+type createProvisionedRequest struct {
+	ProvisionedModelName string    `json:"provisionedModelName"`
+	ModelID              string    `json:"modelId"`
+	ModelUnits           int       `json:"modelUnits"`
+	CommitmentDuration   string    `json:"commitmentDuration"`
+	ClientRequestToken   string    `json:"clientRequestToken"`
+	Tags                 []tagPair `json:"tags"`
+}
+
+type createProvisionedResponse struct {
+	ProvisionedModelARN string `json:"provisionedModelArn"`
+}
+
+type provisionedJSON struct {
+	ProvisionedModelName string `json:"provisionedModelName"`
+	ProvisionedModelARN  string `json:"provisionedModelArn"`
+	ModelARN             string `json:"modelArn"`
+	DesiredModelARN      string `json:"desiredModelArn"`
+	FoundationModelARN   string `json:"foundationModelArn"`
+	ModelUnits           int    `json:"modelUnits"`
+	DesiredModelUnits    int    `json:"desiredModelUnits"`
+	Status               string `json:"status"`
+	CommitmentDuration   string `json:"commitmentDuration,omitempty"`
+	CreationTime         string `json:"creationTime,omitempty"`
+	LastModifiedTime     string `json:"lastModifiedTime,omitempty"`
+}
+
+type listProvisionedResponse struct {
+	ProvisionedModelSummaries []provisionedJSON `json:"provisionedModelSummaries"`
+	NextToken                 string            `json:"nextToken,omitempty"`
+}
+
+type s3ConfigJSON struct {
+	BucketName string `json:"bucketName"`
+	KeyPrefix  string `json:"keyPrefix,omitempty"`
+}
+
+type cloudWatchConfigJSON struct {
+	LogGroupName              string        `json:"logGroupName"`
+	RoleArn                   string        `json:"roleArn"`
+	LargeDataDeliveryS3Config *s3ConfigJSON `json:"largeDataDeliveryS3Config,omitempty"`
+}
+
+type loggingConfigJSON struct {
+	TextDataDeliveryEnabled      bool                  `json:"textDataDeliveryEnabled"`
+	ImageDataDeliveryEnabled     bool                  `json:"imageDataDeliveryEnabled"`
+	EmbeddingDataDeliveryEnabled bool                  `json:"embeddingDataDeliveryEnabled"`
+	VideoDataDeliveryEnabled     bool                  `json:"videoDataDeliveryEnabled"`
+	S3Config                     *s3ConfigJSON         `json:"s3Config,omitempty"`
+	CloudWatchConfig             *cloudWatchConfigJSON `json:"cloudWatchConfig,omitempty"`
+}
+
+type putLoggingRequest struct {
+	LoggingConfig loggingConfigJSON `json:"loggingConfig"`
+}
+
+type getLoggingResponse struct {
+	LoggingConfig *loggingConfigJSON `json:"loggingConfig,omitempty"`
+}
+
+// --- guardrail operations ---
+
+func (h *Handler) createGuardrail(w http.ResponseWriter, r *http.Request) {
+	var in createGuardrailRequest
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+
+	g, err := h.bedrock.CreateGuardrail(r.Context(), bedrockdriver.GuardrailConfig{
+		Name:                    in.Name,
+		Description:             in.Description,
+		BlockedInputMessaging:   in.BlockedInputMessaging,
+		BlockedOutputsMessaging: in.BlockedOutputsMessaging,
+		KMSKeyID:                in.KMSKeyID,
+		ClientRequestToken:      in.ClientRequestToken,
+		Tags:                    tagsToMap(in.Tags),
+	})
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, createGuardrailResponse{
+		GuardrailID: g.ID, GuardrailARN: g.ARN, Version: g.Version, CreatedAt: g.CreatedAt,
+	})
+}
+
+func (h *Handler) getGuardrail(w http.ResponseWriter, r *http.Request, id string) {
+	g, err := h.bedrock.GetGuardrail(r.Context(), id, r.URL.Query().Get("guardrailVersion"))
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, toGuardrailJSON(g))
+}
+
+func (h *Handler) listGuardrails(w http.ResponseWriter, r *http.Request) {
+	gs, err := h.bedrock.ListGuardrails(r.Context())
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	out := make([]guardrailSummaryJSON, 0, len(gs))
+	for i := range gs {
+		out = append(out, toGuardrailSummaryJSON(&gs[i]))
+	}
+
+	writeJSON(w, listGuardrailsResponse{Guardrails: out})
+}
+
+func (h *Handler) updateGuardrail(w http.ResponseWriter, r *http.Request, id string) {
+	var in createGuardrailRequest
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+
+	g, err := h.bedrock.UpdateGuardrail(r.Context(), id, bedrockdriver.GuardrailConfig{
+		Name:                    in.Name,
+		Description:             in.Description,
+		BlockedInputMessaging:   in.BlockedInputMessaging,
+		BlockedOutputsMessaging: in.BlockedOutputsMessaging,
+		KMSKeyID:                in.KMSKeyID,
+	})
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, updateGuardrailResponse{
+		GuardrailID: g.ID, GuardrailARN: g.ARN, Version: g.Version, UpdatedAt: g.UpdatedAt,
+	})
+}
+
+func (h *Handler) deleteGuardrail(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.bedrock.DeleteGuardrail(r.Context(), id); err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// --- provisioned throughput operations ---
+
+func (h *Handler) createProvisioned(w http.ResponseWriter, r *http.Request) {
+	var in createProvisionedRequest
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+
+	pt, err := h.bedrock.CreateProvisionedModelThroughput(r.Context(), bedrockdriver.ProvisionedThroughputConfig{
+		ProvisionedModelName: in.ProvisionedModelName,
+		ModelID:              in.ModelID,
+		ModelUnits:           in.ModelUnits,
+		CommitmentDuration:   in.CommitmentDuration,
+		ClientRequestToken:   in.ClientRequestToken,
+		Tags:                 tagsToMap(in.Tags),
+	})
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, createProvisionedResponse{ProvisionedModelARN: pt.ARN})
+}
+
+func (h *Handler) getProvisioned(w http.ResponseWriter, r *http.Request, id string) {
+	pt, err := h.bedrock.GetProvisionedModelThroughput(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, toProvisionedJSON(pt))
+}
+
+func (h *Handler) listProvisioned(w http.ResponseWriter, r *http.Request) {
+	pts, err := h.bedrock.ListProvisionedModelThroughputs(r.Context())
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	out := make([]provisionedJSON, 0, len(pts))
+	for i := range pts {
+		out = append(out, toProvisionedJSON(&pts[i]))
+	}
+
+	writeJSON(w, listProvisionedResponse{ProvisionedModelSummaries: out})
+}
+
+func (h *Handler) deleteProvisioned(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.bedrock.DeleteProvisionedModelThroughput(r.Context(), id); err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// --- model invocation logging operations ---
+
+func (h *Handler) putLogging(w http.ResponseWriter, r *http.Request) {
+	var in putLoggingRequest
+	if !decodeJSON(w, r, &in) {
+		return
+	}
+
+	if err := h.bedrock.PutModelInvocationLoggingConfiguration(r.Context(), toDriverLogging(in.LoggingConfig)); err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func (h *Handler) getLogging(w http.ResponseWriter, r *http.Request) {
+	cfg, err := h.bedrock.GetModelInvocationLoggingConfiguration(r.Context())
+	if err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	if cfg == nil {
+		writeJSON(w, getLoggingResponse{})
+
+		return
+	}
+
+	wire := toLoggingJSON(cfg)
+	writeJSON(w, getLoggingResponse{LoggingConfig: &wire})
+}
+
+func (h *Handler) deleteLogging(w http.ResponseWriter, r *http.Request) {
+	if err := h.bedrock.DeleteModelInvocationLoggingConfiguration(r.Context()); err != nil {
+		writeErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// --- converters ---
+
+func toGuardrailJSON(g *bedrockdriver.Guardrail) guardrailJSON {
+	return guardrailJSON{
+		Name:                    g.Name,
+		Description:             g.Description,
+		GuardrailID:             g.ID,
+		GuardrailARN:            g.ARN,
+		Version:                 g.Version,
+		Status:                  g.Status,
+		BlockedInputMessaging:   g.BlockedInputMessaging,
+		BlockedOutputsMessaging: g.BlockedOutputsMessaging,
+		KMSKeyARN:               g.KMSKeyARN,
+		CreatedAt:               g.CreatedAt,
+		UpdatedAt:               g.UpdatedAt,
+	}
+}
+
+func toGuardrailSummaryJSON(g *bedrockdriver.Guardrail) guardrailSummaryJSON {
+	return guardrailSummaryJSON{
+		ID: g.ID, ARN: g.ARN, Name: g.Name, Description: g.Description,
+		Version: g.Version, Status: g.Status, CreatedAt: g.CreatedAt, UpdatedAt: g.UpdatedAt,
+	}
+}
+
+func toProvisionedJSON(pt *bedrockdriver.ProvisionedThroughput) provisionedJSON {
+	return provisionedJSON{
+		ProvisionedModelName: pt.Name,
+		ProvisionedModelARN:  pt.ARN,
+		ModelARN:             pt.ModelARN,
+		DesiredModelARN:      pt.DesiredModelARN,
+		FoundationModelARN:   pt.FoundationModelARN,
+		ModelUnits:           pt.ModelUnits,
+		DesiredModelUnits:    pt.DesiredModelUnits,
+		Status:               pt.Status,
+		CommitmentDuration:   pt.CommitmentDuration,
+		CreationTime:         pt.CreationTime,
+		LastModifiedTime:     pt.LastModifiedTime,
+	}
+}
+
+func toDriverLogging(in loggingConfigJSON) bedrockdriver.LoggingConfig {
+	out := bedrockdriver.LoggingConfig{
+		TextDataDeliveryEnabled:      in.TextDataDeliveryEnabled,
+		ImageDataDeliveryEnabled:     in.ImageDataDeliveryEnabled,
+		EmbeddingDataDeliveryEnabled: in.EmbeddingDataDeliveryEnabled,
+		VideoDataDeliveryEnabled:     in.VideoDataDeliveryEnabled,
+	}
+
+	if in.S3Config != nil {
+		out.S3 = &bedrockdriver.S3LoggingConfig{BucketName: in.S3Config.BucketName, KeyPrefix: in.S3Config.KeyPrefix}
+	}
+
+	if in.CloudWatchConfig != nil {
+		cw := &bedrockdriver.CloudWatchLoggingConfig{
+			LogGroupName: in.CloudWatchConfig.LogGroupName,
+			RoleARN:      in.CloudWatchConfig.RoleArn,
+		}
+		if s3 := in.CloudWatchConfig.LargeDataDeliveryS3Config; s3 != nil {
+			cw.LargeDataDeliveryS3 = &bedrockdriver.S3LoggingConfig{BucketName: s3.BucketName, KeyPrefix: s3.KeyPrefix}
+		}
+
+		out.CloudWatch = cw
+	}
+
+	return out
+}
+
+func toLoggingJSON(in *bedrockdriver.LoggingConfig) loggingConfigJSON {
+	out := loggingConfigJSON{
+		TextDataDeliveryEnabled:      in.TextDataDeliveryEnabled,
+		ImageDataDeliveryEnabled:     in.ImageDataDeliveryEnabled,
+		EmbeddingDataDeliveryEnabled: in.EmbeddingDataDeliveryEnabled,
+		VideoDataDeliveryEnabled:     in.VideoDataDeliveryEnabled,
+	}
+
+	if in.S3 != nil {
+		out.S3Config = &s3ConfigJSON{BucketName: in.S3.BucketName, KeyPrefix: in.S3.KeyPrefix}
+	}
+
+	if in.CloudWatch != nil {
+		cw := &cloudWatchConfigJSON{LogGroupName: in.CloudWatch.LogGroupName, RoleArn: in.CloudWatch.RoleARN}
+		if s3 := in.CloudWatch.LargeDataDeliveryS3; s3 != nil {
+			cw.LargeDataDeliveryS3Config = &s3ConfigJSON{BucketName: s3.BucketName, KeyPrefix: s3.KeyPrefix}
+		}
+
+		out.CloudWatchConfig = cw
+	}
+
+	return out
+}
+
+func tagsToMap(tags []tagPair) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}

--- a/server/aws/bedrock/sdk_roundtrip_test.go
+++ b/server/aws/bedrock/sdk_roundtrip_test.go
@@ -302,3 +302,145 @@ func TestSDKConverse(t *testing.T) {
 		t.Fatalf("expected non-zero token usage, got %+v", out.Usage)
 	}
 }
+
+func TestSDKGuardrailLifecycle(t *testing.T) {
+	client := newControlClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateGuardrail(ctx, &awsbedrock.CreateGuardrailInput{
+		Name:                    aws.String("gr-1"),
+		Description:             aws.String("test guardrail"),
+		BlockedInputMessaging:   aws.String("blocked input"),
+		BlockedOutputsMessaging: aws.String("blocked output"),
+	})
+	if err != nil {
+		t.Fatalf("CreateGuardrail: %v", err)
+	}
+
+	if aws.ToString(created.GuardrailId) == "" || aws.ToString(created.GuardrailArn) == "" {
+		t.Fatalf("expected guardrail id + arn, got %+v", created)
+	}
+
+	got, err := client.GetGuardrail(ctx, &awsbedrock.GetGuardrailInput{
+		GuardrailIdentifier: created.GuardrailId,
+	})
+	if err != nil {
+		t.Fatalf("GetGuardrail: %v", err)
+	}
+
+	if got.Status != bedrocktypes.GuardrailStatusReady {
+		t.Fatalf("got status %q, want READY", got.Status)
+	}
+
+	list, err := client.ListGuardrails(ctx, &awsbedrock.ListGuardrailsInput{})
+	if err != nil {
+		t.Fatalf("ListGuardrails: %v", err)
+	}
+
+	if len(list.Guardrails) != 1 {
+		t.Fatalf("got %d guardrails, want 1", len(list.Guardrails))
+	}
+
+	if _, err = client.UpdateGuardrail(ctx, &awsbedrock.UpdateGuardrailInput{
+		GuardrailIdentifier:     created.GuardrailId,
+		Name:                    aws.String("gr-1"),
+		BlockedInputMessaging:   aws.String("updated input"),
+		BlockedOutputsMessaging: aws.String("updated output"),
+	}); err != nil {
+		t.Fatalf("UpdateGuardrail: %v", err)
+	}
+
+	if _, err = client.DeleteGuardrail(ctx, &awsbedrock.DeleteGuardrailInput{
+		GuardrailIdentifier: created.GuardrailId,
+	}); err != nil {
+		t.Fatalf("DeleteGuardrail: %v", err)
+	}
+
+	_, err = client.GetGuardrail(ctx, &awsbedrock.GetGuardrailInput{GuardrailIdentifier: created.GuardrailId})
+	if err == nil {
+		t.Fatal("expected error after delete")
+	}
+}
+
+func TestSDKProvisionedThroughputLifecycle(t *testing.T) {
+	client := newControlClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateProvisionedModelThroughput(ctx, &awsbedrock.CreateProvisionedModelThroughputInput{
+		ProvisionedModelName: aws.String("pt-1"),
+		ModelId:              aws.String(claudeModel),
+		ModelUnits:           aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("CreateProvisionedModelThroughput: %v", err)
+	}
+
+	got, err := client.GetProvisionedModelThroughput(ctx, &awsbedrock.GetProvisionedModelThroughputInput{
+		ProvisionedModelId: aws.String("pt-1"),
+	})
+	if err != nil {
+		t.Fatalf("GetProvisionedModelThroughput: %v", err)
+	}
+
+	if got.Status != bedrocktypes.ProvisionedModelStatusInService {
+		t.Fatalf("got status %q, want InService", got.Status)
+	}
+
+	list, err := client.ListProvisionedModelThroughputs(ctx, &awsbedrock.ListProvisionedModelThroughputsInput{})
+	if err != nil {
+		t.Fatalf("ListProvisionedModelThroughputs: %v", err)
+	}
+
+	if len(list.ProvisionedModelSummaries) != 1 {
+		t.Fatalf("got %d summaries, want 1", len(list.ProvisionedModelSummaries))
+	}
+
+	if _, err = client.DeleteProvisionedModelThroughput(ctx, &awsbedrock.DeleteProvisionedModelThroughputInput{
+		ProvisionedModelId: aws.String(aws.ToString(created.ProvisionedModelArn)),
+	}); err != nil {
+		t.Fatalf("DeleteProvisionedModelThroughput: %v", err)
+	}
+}
+
+func TestSDKModelInvocationLogging(t *testing.T) {
+	client := newControlClient(t)
+	ctx := context.Background()
+
+	_, err := client.PutModelInvocationLoggingConfiguration(ctx, &awsbedrock.PutModelInvocationLoggingConfigurationInput{
+		LoggingConfig: &bedrocktypes.LoggingConfig{
+			TextDataDeliveryEnabled: aws.Bool(true),
+			S3Config: &bedrocktypes.S3Config{
+				BucketName: aws.String("my-logs"),
+				KeyPrefix:  aws.String("bedrock/"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PutModelInvocationLoggingConfiguration: %v", err)
+	}
+
+	got, err := client.GetModelInvocationLoggingConfiguration(ctx, &awsbedrock.GetModelInvocationLoggingConfigurationInput{})
+	if err != nil {
+		t.Fatalf("GetModelInvocationLoggingConfiguration: %v", err)
+	}
+
+	if got.LoggingConfig == nil || got.LoggingConfig.S3Config == nil ||
+		aws.ToString(got.LoggingConfig.S3Config.BucketName) != "my-logs" {
+		t.Fatalf("unexpected logging config: %+v", got.LoggingConfig)
+	}
+
+	if _, err = client.DeleteModelInvocationLoggingConfiguration(ctx,
+		&awsbedrock.DeleteModelInvocationLoggingConfigurationInput{}); err != nil {
+		t.Fatalf("DeleteModelInvocationLoggingConfiguration: %v", err)
+	}
+
+	after, err := client.GetModelInvocationLoggingConfiguration(ctx,
+		&awsbedrock.GetModelInvocationLoggingConfigurationInput{})
+	if err != nil {
+		t.Fatalf("GetModelInvocationLoggingConfiguration after delete: %v", err)
+	}
+
+	if after.LoggingConfig != nil {
+		t.Fatalf("expected nil logging config after delete, got %+v", after.LoggingConfig)
+	}
+}


### PR DESCRIPTION
Closes #207.

## Summary
Extends the AWS Bedrock SDK-compat handler (built in #160) with the remaining control-plane management surface, end-to-end compatible with the real `aws-sdk-go-v2/service/bedrock` client.

## What's included
- **Guardrails**: CreateGuardrail, GetGuardrail, ListGuardrails, UpdateGuardrail, DeleteGuardrail (synchronous READY state, DRAFT version, name/ARN lookup).
- **Provisioned model throughput**: CreateProvisionedModelThroughput, GetProvisionedModelThroughput, ListProvisionedModelThroughputs, DeleteProvisionedModelThroughput (synchronous InService, model resolved against the foundation/custom catalog).
- **Model invocation logging**: Put/Get/DeleteModelInvocationLoggingConfiguration (S3 + CloudWatch delivery config).
- Added across all layers: driver interface, portable wrapper, in-memory provider (`management.go`), and restJson1 server handler routing (`/guardrails`, `/provisioned-model-throughput[s]`, `/logging/modelinvocations`).

## Tests
- Provider-level and portable-level unit tests.
- SDK roundtrip tests driving the real bedrock client: guardrail lifecycle, provisioned-throughput lifecycle, and invocation-logging put/get/delete.

`go build ./...`, `go test ./...`, and `golangci-lint run` all pass.