### PR TITLE
v1.7.2

### DIFF
--- a/databricks/dataplane.go
+++ b/databricks/dataplane.go
@@ -444,3 +444,101 @@ func (d *DataPlane) AllClusterLibraryStatuses(ctx context.Context) ([]driver.Clu
 
 	return out.([]driver.ClusterLibraryStatuses), nil
 }
+
+// ResizeCluster changes a cluster's worker count or autoscale bounds.
+func (d *DataPlane) ResizeCluster(ctx context.Context, id string, numWorkers, autoscaleMin, autoscaleMax int32) error {
+	_, err := d.do(ctx, "ResizeCluster", id, func() (any, error) {
+		return nil, d.driver.ResizeCluster(ctx, id, numWorkers, autoscaleMin, autoscaleMax)
+	})
+
+	return err
+}
+
+// PinCluster pins a cluster.
+func (d *DataPlane) PinCluster(ctx context.Context, id string) error {
+	_, err := d.do(ctx, "PinCluster", id, func() (any, error) { return nil, d.driver.PinCluster(ctx, id) })
+
+	return err
+}
+
+// UnpinCluster unpins a cluster.
+func (d *DataPlane) UnpinCluster(ctx context.Context, id string) error {
+	_, err := d.do(ctx, "UnpinCluster", id, func() (any, error) { return nil, d.driver.UnpinCluster(ctx, id) })
+
+	return err
+}
+
+// ListNodeTypes returns the available node-type catalog.
+func (d *DataPlane) ListNodeTypes(ctx context.Context) ([]driver.NodeType, error) {
+	out, err := d.do(ctx, "ListNodeTypes", nil, func() (any, error) { return d.driver.ListNodeTypes(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.NodeType), nil
+}
+
+// ListSparkVersions returns the available runtime versions.
+func (d *DataPlane) ListSparkVersions(ctx context.Context) ([]driver.SparkVersion, error) {
+	out, err := d.do(ctx, "ListSparkVersions", nil, func() (any, error) { return d.driver.ListSparkVersions(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.SparkVersion), nil
+}
+
+// ListZones returns the availability zones and the default zone.
+func (d *DataPlane) ListZones(ctx context.Context) (zones []string, defaultZone string, err error) {
+	type zonesResult struct {
+		zones       []string
+		defaultZone string
+	}
+
+	out, err := d.do(ctx, "ListZones", nil, func() (any, error) {
+		zs, def, zErr := d.driver.ListZones(ctx)
+
+		return zonesResult{zones: zs, defaultZone: def}, zErr
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	res := out.(zonesResult)
+
+	return res.zones, res.defaultZone, nil
+}
+
+// SubmitRun submits a one-time run and returns its ID.
+func (d *DataPlane) SubmitRun(ctx context.Context, runName string) (int64, error) {
+	out, err := d.do(ctx, "SubmitRun", runName, func() (any, error) { return d.driver.SubmitRun(ctx, runName) })
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(int64), nil
+}
+
+// CancelAllRuns cancels all runs for a job.
+func (d *DataPlane) CancelAllRuns(ctx context.Context, jobID int64) error {
+	_, err := d.do(ctx, "CancelAllRuns", jobID, func() (any, error) { return nil, d.driver.CancelAllRuns(ctx, jobID) })
+
+	return err
+}
+
+// DeleteRun deletes a run by ID.
+func (d *DataPlane) DeleteRun(ctx context.Context, runID int64) error {
+	_, err := d.do(ctx, "DeleteRun", runID, func() (any, error) { return nil, d.driver.DeleteRun(ctx, runID) })
+
+	return err
+}
+
+// RepairRun repairs a run and returns the repair ID.
+func (d *DataPlane) RepairRun(ctx context.Context, runID int64) (int64, error) {
+	out, err := d.do(ctx, "RepairRun", runID, func() (any, error) { return d.driver.RepairRun(ctx, runID) })
+	if err != nil {
+		return 0, err
+	}
+
+	return out.(int64), nil
+}

--- a/databricks/dataplane.go
+++ b/databricks/dataplane.go
@@ -317,3 +317,130 @@ func (d *DataPlane) UpdatePermissions(
 
 	return out.(*driver.ObjectPermissions), nil
 }
+
+// GetRun retrieves a job run by ID.
+func (d *DataPlane) GetRun(ctx context.Context, runID int64) (*driver.Run, error) {
+	out, err := d.do(ctx, "GetRun", runID, func() (any, error) { return d.driver.GetRun(ctx, runID) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.Run), nil
+}
+
+// ListRuns lists runs, optionally filtered by job ID (0 = all).
+func (d *DataPlane) ListRuns(ctx context.Context, jobID int64) ([]driver.Run, error) {
+	out, err := d.do(ctx, "ListRuns", jobID, func() (any, error) { return d.driver.ListRuns(ctx, jobID) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.Run), nil
+}
+
+// CancelRun cancels a job run.
+func (d *DataPlane) CancelRun(ctx context.Context, runID int64) error {
+	_, err := d.do(ctx, "CancelRun", runID, func() (any, error) { return nil, d.driver.CancelRun(ctx, runID) })
+
+	return err
+}
+
+// GetRunOutput retrieves a run's output.
+func (d *DataPlane) GetRunOutput(ctx context.Context, runID int64) (*driver.RunOutput, error) {
+	out, err := d.do(ctx, "GetRunOutput", runID, func() (any, error) { return d.driver.GetRunOutput(ctx, runID) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.RunOutput), nil
+}
+
+// CreateClusterPolicy creates a cluster policy.
+func (d *DataPlane) CreateClusterPolicy(ctx context.Context, cfg driver.ClusterPolicyConfig) (*driver.ClusterPolicy, error) {
+	out, err := d.do(ctx, "CreateClusterPolicy", cfg, func() (any, error) { return d.driver.CreateClusterPolicy(ctx, cfg) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ClusterPolicy), nil
+}
+
+// GetClusterPolicy retrieves a cluster policy by ID.
+func (d *DataPlane) GetClusterPolicy(ctx context.Context, policyID string) (*driver.ClusterPolicy, error) {
+	out, err := d.do(ctx, "GetClusterPolicy", policyID, func() (any, error) { return d.driver.GetClusterPolicy(ctx, policyID) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.ClusterPolicy), nil
+}
+
+// EditClusterPolicy updates a cluster policy.
+func (d *DataPlane) EditClusterPolicy(ctx context.Context, policyID string, cfg driver.ClusterPolicyConfig) error {
+	_, err := d.do(ctx, "EditClusterPolicy", policyID, func() (any, error) {
+		return nil, d.driver.EditClusterPolicy(ctx, policyID, cfg)
+	})
+
+	return err
+}
+
+// DeleteClusterPolicy deletes a cluster policy by ID.
+func (d *DataPlane) DeleteClusterPolicy(ctx context.Context, policyID string) error {
+	_, err := d.do(ctx, "DeleteClusterPolicy", policyID, func() (any, error) {
+		return nil, d.driver.DeleteClusterPolicy(ctx, policyID)
+	})
+
+	return err
+}
+
+// ListClusterPolicies lists all cluster policies.
+func (d *DataPlane) ListClusterPolicies(ctx context.Context) ([]driver.ClusterPolicy, error) {
+	out, err := d.do(ctx, "ListClusterPolicies", nil, func() (any, error) { return d.driver.ListClusterPolicies(ctx) })
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.ClusterPolicy), nil
+}
+
+// InstallLibraries installs libraries on a cluster.
+func (d *DataPlane) InstallLibraries(ctx context.Context, clusterID string, libs []driver.LibrarySpec) error {
+	_, err := d.do(ctx, "InstallLibraries", clusterID, func() (any, error) {
+		return nil, d.driver.InstallLibraries(ctx, clusterID, libs)
+	})
+
+	return err
+}
+
+// UninstallLibraries marks libraries for removal on a cluster.
+func (d *DataPlane) UninstallLibraries(ctx context.Context, clusterID string, libs []driver.LibrarySpec) error {
+	_, err := d.do(ctx, "UninstallLibraries", clusterID, func() (any, error) {
+		return nil, d.driver.UninstallLibraries(ctx, clusterID, libs)
+	})
+
+	return err
+}
+
+// ClusterLibraryStatuses returns the library statuses for one cluster.
+func (d *DataPlane) ClusterLibraryStatuses(ctx context.Context, clusterID string) ([]driver.LibraryStatus, error) {
+	out, err := d.do(ctx, "ClusterLibraryStatuses", clusterID, func() (any, error) {
+		return d.driver.ClusterLibraryStatuses(ctx, clusterID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.LibraryStatus), nil
+}
+
+// AllClusterLibraryStatuses returns library statuses across all clusters.
+func (d *DataPlane) AllClusterLibraryStatuses(ctx context.Context) ([]driver.ClusterLibraryStatuses, error) {
+	out, err := d.do(ctx, "AllClusterLibraryStatuses", nil, func() (any, error) {
+		return d.driver.AllClusterLibraryStatuses(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.ClusterLibraryStatuses), nil
+}

--- a/databricks/driver/dataplane.go
+++ b/databricks/driver/dataplane.go
@@ -88,9 +88,84 @@ type ObjectPermissions struct {
 	AccessControlList []AccessControl
 }
 
+// Run life-cycle and result state values.
+const (
+	RunRunning     = "RUNNING"
+	RunTerminated  = "TERMINATED"
+	ResultSuccess  = "SUCCESS"
+	ResultCanceled = "CANCELED"
+)
+
+// Library install status values.
+const (
+	LibraryInstalled          = "INSTALLED"
+	LibraryUninstallOnRestart = "UNINSTALL_ON_RESTART"
+)
+
+// Run describes a single job run.
+type Run struct {
+	RunID          int64
+	JobID          int64
+	RunName        string
+	LifeCycleState string
+	ResultState    string
+	StateMessage   string
+	StartTime      int64
+	EndTime        int64
+}
+
+// RunOutput is the output of a completed run.
+type RunOutput struct {
+	Run            Run
+	NotebookResult string
+}
+
+// ClusterPolicyConfig describes a cluster policy to create or edit.
+type ClusterPolicyConfig struct {
+	Name               string
+	Definition         string
+	Description        string
+	MaxClustersPerUser int64
+}
+
+// ClusterPolicy describes a cluster policy.
+type ClusterPolicy struct {
+	PolicyID           string
+	Name               string
+	Definition         string
+	Description        string
+	MaxClustersPerUser int64
+	CreatorUserName    string
+	CreatedAt          int64
+}
+
+// LibrarySpec identifies a library to install on a cluster. Exactly one source
+// field is typically set.
+type LibrarySpec struct {
+	Jar              string
+	Egg              string
+	Whl              string
+	PypiPackage      string
+	MavenCoordinates string
+	Cran             string
+}
+
+// LibraryStatus is the install status of a library on a cluster.
+type LibraryStatus struct {
+	Library LibrarySpec
+	Status  string
+}
+
+// ClusterLibraryStatuses bundles a cluster's library statuses.
+type ClusterLibraryStatuses struct {
+	ClusterID string
+	Statuses  []LibraryStatus
+}
+
 // DataPlane is the interface for the Databricks workspace data plane: compute
-// (instance pools, clusters), jobs, and object permissions. It is separate
-// from the ARM-level Databricks (workspace management) interface.
+// (instance pools, clusters, cluster policies, libraries), jobs and runs, and
+// object permissions. It is separate from the ARM-level Databricks (workspace
+// management) interface.
 type DataPlane interface {
 	CreateInstancePool(ctx context.Context, cfg InstancePoolConfig) (*InstancePool, error)
 	GetInstancePool(ctx context.Context, id string) (*InstancePool, error)
@@ -114,6 +189,22 @@ type DataPlane interface {
 	ResetJob(ctx context.Context, id int64, cfg JobConfig) error
 	DeleteJob(ctx context.Context, id int64) error
 	RunJobNow(ctx context.Context, id int64) (int64, error)
+
+	GetRun(ctx context.Context, runID int64) (*Run, error)
+	ListRuns(ctx context.Context, jobID int64) ([]Run, error)
+	CancelRun(ctx context.Context, runID int64) error
+	GetRunOutput(ctx context.Context, runID int64) (*RunOutput, error)
+
+	CreateClusterPolicy(ctx context.Context, cfg ClusterPolicyConfig) (*ClusterPolicy, error)
+	GetClusterPolicy(ctx context.Context, policyID string) (*ClusterPolicy, error)
+	EditClusterPolicy(ctx context.Context, policyID string, cfg ClusterPolicyConfig) error
+	DeleteClusterPolicy(ctx context.Context, policyID string) error
+	ListClusterPolicies(ctx context.Context) ([]ClusterPolicy, error)
+
+	InstallLibraries(ctx context.Context, clusterID string, libs []LibrarySpec) error
+	UninstallLibraries(ctx context.Context, clusterID string, libs []LibrarySpec) error
+	ClusterLibraryStatuses(ctx context.Context, clusterID string) ([]LibraryStatus, error)
+	AllClusterLibraryStatuses(ctx context.Context) ([]ClusterLibraryStatuses, error)
 
 	GetPermissions(ctx context.Context, objectType, objectID string) (*ObjectPermissions, error)
 	SetPermissions(ctx context.Context, objectType, objectID string, acl []AccessControl) (*ObjectPermissions, error)

--- a/databricks/driver/dataplane.go
+++ b/databricks/driver/dataplane.go
@@ -54,6 +54,21 @@ type Cluster struct {
 	NumWorkers   int32
 	AutoscaleMin int32
 	AutoscaleMax int32
+	Pinned       bool
+}
+
+// NodeType describes an available compute node type.
+type NodeType struct {
+	NodeTypeID  string
+	Description string
+	NumCores    float64
+	MemoryMB    int32
+}
+
+// SparkVersion describes an available runtime version.
+type SparkVersion struct {
+	Key  string
+	Name string
 }
 
 // JobConfig describes a job to create or update. SettingsJSON is the raw job
@@ -181,6 +196,12 @@ type DataPlane interface {
 	PermanentDeleteCluster(ctx context.Context, id string) error
 	StartCluster(ctx context.Context, id string) error
 	RestartCluster(ctx context.Context, id string) error
+	ResizeCluster(ctx context.Context, id string, numWorkers, autoscaleMin, autoscaleMax int32) error
+	PinCluster(ctx context.Context, id string) error
+	UnpinCluster(ctx context.Context, id string) error
+	ListNodeTypes(ctx context.Context) ([]NodeType, error)
+	ListSparkVersions(ctx context.Context) ([]SparkVersion, error)
+	ListZones(ctx context.Context) (zones []string, defaultZone string, err error)
 
 	CreateJob(ctx context.Context, cfg JobConfig) (int64, error)
 	GetJob(ctx context.Context, id int64) (*Job, error)
@@ -190,9 +211,13 @@ type DataPlane interface {
 	DeleteJob(ctx context.Context, id int64) error
 	RunJobNow(ctx context.Context, id int64) (int64, error)
 
+	SubmitRun(ctx context.Context, runName string) (int64, error)
 	GetRun(ctx context.Context, runID int64) (*Run, error)
 	ListRuns(ctx context.Context, jobID int64) ([]Run, error)
 	CancelRun(ctx context.Context, runID int64) error
+	CancelAllRuns(ctx context.Context, jobID int64) error
+	DeleteRun(ctx context.Context, runID int64) error
+	RepairRun(ctx context.Context, runID int64) (int64, error)
 	GetRunOutput(ctx context.Context, runID int64) (*RunOutput, error)
 
 	CreateClusterPolicy(ctx context.Context, cfg ClusterPolicyConfig) (*ClusterPolicy, error)

--- a/providers/azure/databricks/databricks.go
+++ b/providers/azure/databricks/databricks.go
@@ -39,6 +39,9 @@ type Mock struct {
 	pools       *memstore.Store[*driver.InstancePool]
 	clusters    *memstore.Store[*driver.Cluster]
 	jobs        *memstore.Store[*driver.Job]
+	runs        *memstore.Store[*driver.Run]
+	policies    *memstore.Store[*driver.ClusterPolicy]
+	libraries   *memstore.Store[[]driver.LibraryStatus]
 	permissions *memstore.Store[*driver.ObjectPermissions]
 	opts        *config.Options
 
@@ -53,6 +56,9 @@ func New(opts *config.Options) *Mock {
 		pools:       memstore.New[*driver.InstancePool](),
 		clusters:    memstore.New[*driver.Cluster](),
 		jobs:        memstore.New[*driver.Job](),
+		runs:        memstore.New[*driver.Run](),
+		policies:    memstore.New[*driver.ClusterPolicy](),
+		libraries:   memstore.New[[]driver.LibraryStatus](),
 		permissions: memstore.New[*driver.ObjectPermissions](),
 		opts:        opts,
 	}

--- a/providers/azure/databricks/dataplane.go
+++ b/providers/azure/databricks/dataplane.go
@@ -282,13 +282,28 @@ func (m *Mock) DeleteJob(_ context.Context, id int64) error {
 	return nil
 }
 
-// RunJobNow triggers a run and returns its run ID.
+// RunJobNow triggers a run and returns its run ID. The run completes
+// synchronously (TERMINATED / SUCCESS) so Get/List/Output are deterministic.
 func (m *Mock) RunJobNow(_ context.Context, id int64) (int64, error) {
-	if !m.jobs.Has(jobKey(id)) {
+	job, ok := m.jobs.Get(jobKey(id))
+	if !ok {
 		return 0, errors.Newf(errors.NotFound, "job %d not found", id)
 	}
 
-	return m.runSeq.Add(1), nil
+	runID := m.runSeq.Add(1)
+	now := m.opts.Clock.Now().UTC().UnixMilli()
+	m.runs.Set(jobKey(runID), &driver.Run{
+		RunID:          runID,
+		JobID:          id,
+		RunName:        job.Name,
+		LifeCycleState: driver.RunTerminated,
+		ResultState:    driver.ResultSuccess,
+		StateMessage:   "Run completed",
+		StartTime:      now,
+		EndTime:        now,
+	})
+
+	return runID, nil
 }
 
 // --- permissions ---

--- a/providers/azure/databricks/dataplane_compute.go
+++ b/providers/azure/databricks/dataplane_compute.go
@@ -1,0 +1,71 @@
+package databricks
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/databricks/driver"
+	"github.com/stackshy/cloudemu/errors"
+)
+
+// ResizeCluster changes a cluster's worker count or autoscale bounds.
+func (m *Mock) ResizeCluster(_ context.Context, id string, numWorkers, autoscaleMin, autoscaleMax int32) error {
+	cluster, ok := m.clusters.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cluster %q not found", id)
+	}
+
+	updated := *cluster
+	updated.NumWorkers = numWorkers
+	updated.AutoscaleMin = autoscaleMin
+	updated.AutoscaleMax = autoscaleMax
+	m.clusters.Set(id, &updated)
+
+	return nil
+}
+
+// PinCluster pins a cluster.
+func (m *Mock) PinCluster(ctx context.Context, id string) error {
+	return m.setClusterPinned(ctx, id, true)
+}
+
+// UnpinCluster unpins a cluster.
+func (m *Mock) UnpinCluster(ctx context.Context, id string) error {
+	return m.setClusterPinned(ctx, id, false)
+}
+
+func (m *Mock) setClusterPinned(_ context.Context, id string, pinned bool) error {
+	cluster, ok := m.clusters.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cluster %q not found", id)
+	}
+
+	updated := *cluster
+	updated.Pinned = pinned
+	m.clusters.Set(id, &updated)
+
+	return nil
+}
+
+// ListNodeTypes returns the available node-type catalog.
+func (*Mock) ListNodeTypes(_ context.Context) ([]driver.NodeType, error) {
+	return []driver.NodeType{
+		{NodeTypeID: "Standard_DS3_v2", Description: "Standard_DS3_v2", NumCores: 4, MemoryMB: 14336},
+		{NodeTypeID: "Standard_DS4_v2", Description: "Standard_DS4_v2", NumCores: 8, MemoryMB: 28672},
+		{NodeTypeID: "Standard_DS5_v2", Description: "Standard_DS5_v2", NumCores: 16, MemoryMB: 57344},
+	}, nil
+}
+
+// ListSparkVersions returns the available runtime versions.
+func (*Mock) ListSparkVersions(_ context.Context) ([]driver.SparkVersion, error) {
+	return []driver.SparkVersion{
+		{Key: "13.3.x-scala2.12", Name: "13.3 LTS (includes Apache Spark 3.4.1, Scala 2.12)"},
+		{Key: "14.3.x-scala2.12", Name: "14.3 LTS (includes Apache Spark 3.5.0, Scala 2.12)"},
+	}, nil
+}
+
+// ListZones returns the availability zones and the default.
+func (*Mock) ListZones(_ context.Context) (zones []string, defaultZone string, err error) {
+	zones = []string{"eastus-1", "eastus-2", "eastus-3"}
+
+	return zones, zones[0], nil
+}

--- a/providers/azure/databricks/dataplane_compute_test.go
+++ b/providers/azure/databricks/dataplane_compute_test.go
@@ -1,0 +1,106 @@
+package databricks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/databricks/driver"
+)
+
+func TestClusterResizePinMetadata(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cl, err := m.CreateCluster(ctx, driver.ClusterConfig{Name: "c1", SparkVersion: "13.3", NodeTypeID: "nt", NumWorkers: 1})
+	requireNoError(t, err)
+
+	requireNoError(t, m.ResizeCluster(ctx, cl.ID, 4, 0, 0))
+	got, err := m.GetCluster(ctx, cl.ID)
+	requireNoError(t, err)
+	assertEqual(t, int32(4), got.NumWorkers)
+
+	requireNoError(t, m.PinCluster(ctx, cl.ID))
+	got, err = m.GetCluster(ctx, cl.ID)
+	requireNoError(t, err)
+	assertEqual(t, true, got.Pinned)
+
+	requireNoError(t, m.UnpinCluster(ctx, cl.ID))
+	got, err = m.GetCluster(ctx, cl.ID)
+	requireNoError(t, err)
+	assertEqual(t, false, got.Pinned)
+
+	// not-found paths
+	assertError(t, m.ResizeCluster(ctx, "missing", 1, 0, 0), true)
+	assertError(t, m.PinCluster(ctx, "missing"), true)
+
+	nt, err := m.ListNodeTypes(ctx)
+	requireNoError(t, err)
+	if len(nt) == 0 {
+		t.Fatal("expected seeded node types")
+	}
+
+	sv, err := m.ListSparkVersions(ctx)
+	requireNoError(t, err)
+	if len(sv) == 0 {
+		t.Fatal("expected seeded spark versions")
+	}
+
+	zones, def, err := m.ListZones(ctx)
+	requireNoError(t, err)
+	if len(zones) == 0 || def == "" {
+		t.Fatalf("expected zones + default, got %v / %q", zones, def)
+	}
+}
+
+func TestRunSubmitRepairCancelDelete(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	runID, err := m.SubmitRun(ctx, "one-time")
+	requireNoError(t, err)
+
+	run, err := m.GetRun(ctx, runID)
+	requireNoError(t, err)
+	assertEqual(t, driver.ResultSuccess, run.ResultState)
+
+	repairID, err := m.RepairRun(ctx, runID)
+	requireNoError(t, err)
+	if repairID == 0 {
+		t.Fatal("expected non-zero repair id")
+	}
+
+	_, err = m.RepairRun(ctx, 999999)
+	assertError(t, err, true)
+
+	requireNoError(t, m.DeleteRun(ctx, runID))
+	_, err = m.GetRun(ctx, runID)
+	assertError(t, err, true)
+	assertError(t, m.DeleteRun(ctx, runID), true)
+}
+
+func TestCancelAllRuns(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	id, err := m.CreateJob(ctx, driver.JobConfig{Name: "j"})
+	requireNoError(t, err)
+
+	r1, err := m.RunJobNow(ctx, id)
+	requireNoError(t, err)
+	_, err = m.RunJobNow(ctx, id)
+	requireNoError(t, err)
+
+	requireNoError(t, m.CancelAllRuns(ctx, id))
+
+	runs, err := m.ListRuns(ctx, id)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(runs))
+
+	for _, run := range runs {
+		assertEqual(t, driver.ResultCanceled, run.ResultState)
+	}
+
+	got, err := m.GetRun(ctx, r1)
+	requireNoError(t, err)
+	assertEqual(t, driver.ResultCanceled, got.ResultState)
+}

--- a/providers/azure/databricks/dataplane_more.go
+++ b/providers/azure/databricks/dataplane_more.go
@@ -1,0 +1,227 @@
+package databricks
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/databricks/driver"
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+)
+
+// --- job runs ---
+
+// GetRun returns a run by ID.
+func (m *Mock) GetRun(_ context.Context, runID int64) (*driver.Run, error) {
+	run, ok := m.runs.Get(jobKey(runID))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "run %d not found", runID)
+	}
+
+	result := *run
+
+	return &result, nil
+}
+
+// ListRuns lists runs, optionally filtered by job ID (0 = all).
+func (m *Mock) ListRuns(_ context.Context, jobID int64) ([]driver.Run, error) {
+	all := m.runs.All()
+	out := make([]driver.Run, 0, len(all))
+
+	for _, run := range all {
+		if jobID == 0 || run.JobID == jobID {
+			out = append(out, *run)
+		}
+	}
+
+	return out, nil
+}
+
+// CancelRun marks a run canceled.
+func (m *Mock) CancelRun(_ context.Context, runID int64) error {
+	run, ok := m.runs.Get(jobKey(runID))
+	if !ok {
+		return errors.Newf(errors.NotFound, "run %d not found", runID)
+	}
+
+	updated := *run
+	updated.LifeCycleState = driver.RunTerminated
+	updated.ResultState = driver.ResultCanceled
+	updated.StateMessage = "Run canceled"
+	m.runs.Set(jobKey(runID), &updated)
+
+	return nil
+}
+
+// GetRunOutput returns a completed run's output.
+func (m *Mock) GetRunOutput(_ context.Context, runID int64) (*driver.RunOutput, error) {
+	run, ok := m.runs.Get(jobKey(runID))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "run %d not found", runID)
+	}
+
+	return &driver.RunOutput{Run: *run, NotebookResult: "ok"}, nil
+}
+
+// --- cluster policies ---
+
+// CreateClusterPolicy creates a cluster policy.
+func (m *Mock) CreateClusterPolicy(_ context.Context, cfg driver.ClusterPolicyConfig) (*driver.ClusterPolicy, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "policy name is required")
+	}
+
+	id := idgen.GenerateID("policy-")
+	policy := &driver.ClusterPolicy{
+		PolicyID:           id,
+		Name:               cfg.Name,
+		Definition:         cfg.Definition,
+		Description:        cfg.Description,
+		MaxClustersPerUser: cfg.MaxClustersPerUser,
+		CreatorUserName:    "emulator@cloudemu.dev",
+		CreatedAt:          m.opts.Clock.Now().UTC().UnixMilli(),
+	}
+	m.policies.Set(id, policy)
+
+	result := *policy
+
+	return &result, nil
+}
+
+// GetClusterPolicy returns a cluster policy by ID.
+func (m *Mock) GetClusterPolicy(_ context.Context, policyID string) (*driver.ClusterPolicy, error) {
+	policy, ok := m.policies.Get(policyID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cluster policy %q not found", policyID)
+	}
+
+	result := *policy
+
+	return &result, nil
+}
+
+// EditClusterPolicy updates a cluster policy's mutable fields.
+func (m *Mock) EditClusterPolicy(_ context.Context, policyID string, cfg driver.ClusterPolicyConfig) error {
+	policy, ok := m.policies.Get(policyID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "cluster policy %q not found", policyID)
+	}
+
+	updated := *policy
+	updated.Name = cfg.Name
+	updated.Definition = cfg.Definition
+	updated.Description = cfg.Description
+	updated.MaxClustersPerUser = cfg.MaxClustersPerUser
+	m.policies.Set(policyID, &updated)
+
+	return nil
+}
+
+// DeleteClusterPolicy deletes a cluster policy by ID.
+func (m *Mock) DeleteClusterPolicy(_ context.Context, policyID string) error {
+	if !m.policies.Delete(policyID) {
+		return errors.Newf(errors.NotFound, "cluster policy %q not found", policyID)
+	}
+
+	return nil
+}
+
+// ListClusterPolicies lists all cluster policies.
+func (m *Mock) ListClusterPolicies(_ context.Context) ([]driver.ClusterPolicy, error) {
+	all := m.policies.All()
+	out := make([]driver.ClusterPolicy, 0, len(all))
+
+	for _, p := range all {
+		out = append(out, *p)
+	}
+
+	return out, nil
+}
+
+// --- libraries ---
+
+// InstallLibraries marks libraries installed on a cluster.
+func (m *Mock) InstallLibraries(_ context.Context, clusterID string, libs []driver.LibrarySpec) error {
+	if !m.clusters.Has(clusterID) {
+		return errors.Newf(errors.NotFound, "cluster %q not found", clusterID)
+	}
+
+	statuses, _ := m.libraries.Get(clusterID)
+	current := cloneStatuses(statuses)
+
+	for i := range libs {
+		current = upsertLibrary(current, &libs[i], driver.LibraryInstalled)
+	}
+
+	m.libraries.Set(clusterID, current)
+
+	return nil
+}
+
+// UninstallLibraries marks libraries for removal on the next restart.
+func (m *Mock) UninstallLibraries(_ context.Context, clusterID string, libs []driver.LibrarySpec) error {
+	if !m.clusters.Has(clusterID) {
+		return errors.Newf(errors.NotFound, "cluster %q not found", clusterID)
+	}
+
+	statuses, _ := m.libraries.Get(clusterID)
+	current := cloneStatuses(statuses)
+
+	for i := range libs {
+		current = upsertLibrary(current, &libs[i], driver.LibraryUninstallOnRestart)
+	}
+
+	m.libraries.Set(clusterID, current)
+
+	return nil
+}
+
+// ClusterLibraryStatuses returns the library statuses for one cluster.
+func (m *Mock) ClusterLibraryStatuses(_ context.Context, clusterID string) ([]driver.LibraryStatus, error) {
+	if !m.clusters.Has(clusterID) {
+		return nil, errors.Newf(errors.NotFound, "cluster %q not found", clusterID)
+	}
+
+	statuses, _ := m.libraries.Get(clusterID)
+
+	return cloneStatuses(statuses), nil
+}
+
+// AllClusterLibraryStatuses returns library statuses across all clusters.
+func (m *Mock) AllClusterLibraryStatuses(_ context.Context) ([]driver.ClusterLibraryStatuses, error) {
+	all := m.libraries.All()
+	out := make([]driver.ClusterLibraryStatuses, 0, len(all))
+
+	for clusterID, statuses := range all {
+		out = append(out, driver.ClusterLibraryStatuses{ClusterID: clusterID, Statuses: cloneStatuses(statuses)})
+	}
+
+	return out, nil
+}
+
+// libraryKey returns a stable identity for a library spec.
+func libraryKey(l *driver.LibrarySpec) string {
+	return l.Jar + "|" + l.Egg + "|" + l.Whl + "|" + l.PypiPackage + "|" + l.MavenCoordinates + "|" + l.Cran
+}
+
+func upsertLibrary(list []driver.LibraryStatus, lib *driver.LibrarySpec, status string) []driver.LibraryStatus {
+	for i := range list {
+		if libraryKey(&list[i].Library) == libraryKey(lib) {
+			list[i].Status = status
+
+			return list
+		}
+	}
+
+	return append(list, driver.LibraryStatus{Library: *lib, Status: status})
+}
+
+func cloneStatuses(in []driver.LibraryStatus) []driver.LibraryStatus {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.LibraryStatus, len(in))
+	copy(out, in)
+
+	return out
+}

--- a/providers/azure/databricks/dataplane_more.go
+++ b/providers/azure/databricks/dataplane_more.go
@@ -62,6 +62,58 @@ func (m *Mock) GetRunOutput(_ context.Context, runID int64) (*driver.RunOutput, 
 	return &driver.RunOutput{Run: *run, NotebookResult: "ok"}, nil
 }
 
+// SubmitRun creates a one-time run (not tied to a stored job) and returns its
+// run ID. The run completes synchronously.
+func (m *Mock) SubmitRun(_ context.Context, runName string) (int64, error) {
+	runID := m.runSeq.Add(1)
+	now := m.opts.Clock.Now().UTC().UnixMilli()
+	m.runs.Set(jobKey(runID), &driver.Run{
+		RunID:          runID,
+		RunName:        runName,
+		LifeCycleState: driver.RunTerminated,
+		ResultState:    driver.ResultSuccess,
+		StateMessage:   "Run completed",
+		StartTime:      now,
+		EndTime:        now,
+	})
+
+	return runID, nil
+}
+
+// CancelAllRuns cancels every run belonging to a job.
+func (m *Mock) CancelAllRuns(_ context.Context, jobID int64) error {
+	for key, run := range m.runs.All() {
+		if run.JobID != jobID {
+			continue
+		}
+
+		updated := *run
+		updated.LifeCycleState = driver.RunTerminated
+		updated.ResultState = driver.ResultCanceled
+		m.runs.Set(key, &updated)
+	}
+
+	return nil
+}
+
+// DeleteRun removes a run by ID.
+func (m *Mock) DeleteRun(_ context.Context, runID int64) error {
+	if !m.runs.Delete(jobKey(runID)) {
+		return errors.Newf(errors.NotFound, "run %d not found", runID)
+	}
+
+	return nil
+}
+
+// RepairRun triggers a repair of a run and returns the new repair ID.
+func (m *Mock) RepairRun(_ context.Context, runID int64) (int64, error) {
+	if !m.runs.Has(jobKey(runID)) {
+		return 0, errors.Newf(errors.NotFound, "run %d not found", runID)
+	}
+
+	return m.runSeq.Add(1), nil
+}
+
 // --- cluster policies ---
 
 // CreateClusterPolicy creates a cluster policy.

--- a/providers/azure/databricks/dataplane_more_test.go
+++ b/providers/azure/databricks/dataplane_more_test.go
@@ -1,0 +1,109 @@
+package databricks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/databricks/driver"
+)
+
+func TestJobRunLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	id, err := m.CreateJob(ctx, driver.JobConfig{Name: "j1"})
+	requireNoError(t, err)
+
+	runID, err := m.RunJobNow(ctx, id)
+	requireNoError(t, err)
+
+	run, err := m.GetRun(ctx, runID)
+	requireNoError(t, err)
+	assertEqual(t, driver.RunTerminated, run.LifeCycleState)
+	assertEqual(t, driver.ResultSuccess, run.ResultState)
+	assertEqual(t, id, run.JobID)
+
+	runs, err := m.ListRuns(ctx, id)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(runs))
+
+	all, err := m.ListRuns(ctx, 0)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(all))
+
+	out, err := m.GetRunOutput(ctx, runID)
+	requireNoError(t, err)
+	assertEqual(t, runID, out.Run.RunID)
+
+	requireNoError(t, m.CancelRun(ctx, runID))
+	run, err = m.GetRun(ctx, runID)
+	requireNoError(t, err)
+	assertEqual(t, driver.ResultCanceled, run.ResultState)
+
+	_, err = m.GetRun(ctx, 999999)
+	assertError(t, err, true)
+}
+
+func TestClusterPolicyLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreateClusterPolicy(ctx, driver.ClusterPolicyConfig{Name: "p1", Definition: "{}"})
+	requireNoError(t, err)
+	assertNotEmpty(t, p.PolicyID)
+
+	_, err = m.CreateClusterPolicy(ctx, driver.ClusterPolicyConfig{})
+	assertError(t, err, true)
+
+	got, err := m.GetClusterPolicy(ctx, p.PolicyID)
+	requireNoError(t, err)
+	assertEqual(t, "p1", got.Name)
+
+	requireNoError(t, m.EditClusterPolicy(ctx, p.PolicyID, driver.ClusterPolicyConfig{Name: "p1e", Definition: "{}"}))
+	got, err = m.GetClusterPolicy(ctx, p.PolicyID)
+	requireNoError(t, err)
+	assertEqual(t, "p1e", got.Name)
+
+	policies, err := m.ListClusterPolicies(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(policies))
+
+	requireNoError(t, m.DeleteClusterPolicy(ctx, p.PolicyID))
+	_, err = m.GetClusterPolicy(ctx, p.PolicyID)
+	assertError(t, err, true)
+}
+
+func TestLibraries(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cl, err := m.CreateCluster(ctx, driver.ClusterConfig{Name: "c1", SparkVersion: "13.3", NodeTypeID: "nt", NumWorkers: 1})
+	requireNoError(t, err)
+
+	lib := driver.LibrarySpec{PypiPackage: "requests"}
+
+	// Install on a missing cluster fails.
+	assertError(t, m.InstallLibraries(ctx, "missing", []driver.LibrarySpec{lib}), true)
+
+	requireNoError(t, m.InstallLibraries(ctx, cl.ID, []driver.LibrarySpec{lib}))
+
+	statuses, err := m.ClusterLibraryStatuses(ctx, cl.ID)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(statuses))
+	assertEqual(t, driver.LibraryInstalled, statuses[0].Status)
+
+	// Re-install the same library updates in place (no duplicate).
+	requireNoError(t, m.InstallLibraries(ctx, cl.ID, []driver.LibrarySpec{lib}))
+	statuses, err = m.ClusterLibraryStatuses(ctx, cl.ID)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(statuses))
+
+	requireNoError(t, m.UninstallLibraries(ctx, cl.ID, []driver.LibrarySpec{lib}))
+	statuses, err = m.ClusterLibraryStatuses(ctx, cl.ID)
+	requireNoError(t, err)
+	assertEqual(t, driver.LibraryUninstallOnRestart, statuses[0].Status)
+
+	all, err := m.AllClusterLibraryStatuses(ctx)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(all))
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -25,10 +25,15 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks"
 	"github.com/stackshy/cloudemu/server/azure/databricks/dbfs"
 	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
+	"github.com/stackshy/cloudemu/server/azure/databricks/pipelines"
 	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
+	"github.com/stackshy/cloudemu/server/azure/databricks/scim"
 	"github.com/stackshy/cloudemu/server/azure/databricks/secrets"
+	"github.com/stackshy/cloudemu/server/azure/databricks/serving"
 	"github.com/stackshy/cloudemu/server/azure/databricks/sqlwarehouses"
 	"github.com/stackshy/cloudemu/server/azure/databricks/token"
+	"github.com/stackshy/cloudemu/server/azure/databricks/ucstorage"
+	"github.com/stackshy/cloudemu/server/azure/databricks/unitycatalog"
 	"github.com/stackshy/cloudemu/server/azure/databricks/wsfs"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	"github.com/stackshy/cloudemu/server/azure/functions"
@@ -170,21 +175,7 @@ func New(d Drivers) *server.Server {
 		srv.Register(databricks.New(d.Databricks))
 	}
 
-	// Databricks data plane matches /api/2.x/{clusters,instance-pools,jobs,
-	// permissions} — disjoint from ARM paths. Registered before the blob
-	// fallback so its REST URLs aren't swallowed. The additional /api/2.0
-	// handlers (secrets, tokens, git credentials, repos, DBFS, workspace, SQL
-	// warehouses) self-contain their state and claim disjoint path prefixes.
-	if d.DatabricksDataPlane != nil {
-		srv.Register(databricks.NewDataPlane(d.DatabricksDataPlane))
-		srv.Register(secrets.New())
-		srv.Register(token.New())
-		srv.Register(gitcredentials.New())
-		srv.Register(repos.New())
-		srv.Register(dbfs.New())
-		srv.Register(wsfs.New())
-		srv.Register(sqlwarehouses.New())
-	}
+	registerDatabricksDataPlane(srv, &d)
 
 	if d.VirtualMachines != nil {
 		srv.Register(virtualmachines.New(d.VirtualMachines))
@@ -218,4 +209,29 @@ func New(d Drivers) *server.Server {
 	}
 
 	return srv
+}
+
+// registerDatabricksDataPlane registers the Databricks workspace data-plane
+// handlers when the data plane is enabled. The core handler is driver-backed;
+// the rest are self-contained handlers that own their in-memory state and
+// claim disjoint /api path prefixes (so registration order is unconstrained).
+// They sit before the blob fallback so their REST URLs aren't swallowed.
+func registerDatabricksDataPlane(srv *server.Server, d *Drivers) {
+	if d.DatabricksDataPlane == nil {
+		return
+	}
+
+	srv.Register(databricks.NewDataPlane(d.DatabricksDataPlane))
+	srv.Register(secrets.New())
+	srv.Register(token.New())
+	srv.Register(gitcredentials.New())
+	srv.Register(repos.New())
+	srv.Register(dbfs.New())
+	srv.Register(wsfs.New())
+	srv.Register(sqlwarehouses.New())
+	srv.Register(pipelines.New())
+	srv.Register(serving.New())
+	srv.Register(unitycatalog.New())
+	srv.Register(ucstorage.New())
+	srv.Register(scim.New())
 }

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -23,6 +23,13 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/blob"
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/databricks"
+	"github.com/stackshy/cloudemu/server/azure/databricks/dbfs"
+	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
+	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
+	"github.com/stackshy/cloudemu/server/azure/databricks/secrets"
+	"github.com/stackshy/cloudemu/server/azure/databricks/sqlwarehouses"
+	"github.com/stackshy/cloudemu/server/azure/databricks/token"
+	"github.com/stackshy/cloudemu/server/azure/databricks/wsfs"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	"github.com/stackshy/cloudemu/server/azure/functions"
 	"github.com/stackshy/cloudemu/server/azure/iam"
@@ -165,9 +172,18 @@ func New(d Drivers) *server.Server {
 
 	// Databricks data plane matches /api/2.x/{clusters,instance-pools,jobs,
 	// permissions} — disjoint from ARM paths. Registered before the blob
-	// fallback so its REST URLs aren't swallowed.
+	// fallback so its REST URLs aren't swallowed. The additional /api/2.0
+	// handlers (secrets, tokens, git credentials, repos, DBFS, workspace, SQL
+	// warehouses) self-contain their state and claim disjoint path prefixes.
 	if d.DatabricksDataPlane != nil {
 		srv.Register(databricks.NewDataPlane(d.DatabricksDataPlane))
+		srv.Register(secrets.New())
+		srv.Register(token.New())
+		srv.Register(gitcredentials.New())
+		srv.Register(repos.New())
+		srv.Register(dbfs.New())
+		srv.Register(wsfs.New())
+		srv.Register(sqlwarehouses.New())
 	}
 
 	if d.VirtualMachines != nil {

--- a/server/azure/databricks/dataplane.go
+++ b/server/azure/databricks/dataplane.go
@@ -58,6 +58,15 @@ const (
 	actUninstall       = "uninstall"
 	actClusterStatus   = "cluster-status"
 	actAllStatuses     = "all-cluster-statuses"
+	actResize          = "resize"
+	actPin             = "pin"
+	actUnpin           = "unpin"
+	actListNodeTypes   = "list-node-types"
+	actSparkVersions   = "spark-versions"
+	actListZones       = "list-zones"
+	actSubmit          = "submit"
+	actCancelAll       = "cancel-all"
+	actRepair          = "repair"
 )
 
 // minSubResourceSegs is the [api, ver, resource, sub, action] segment count

--- a/server/azure/databricks/dataplane.go
+++ b/server/azure/databricks/dataplane.go
@@ -29,6 +29,14 @@ const (
 	resClusters    = "clusters"
 	resJobs        = "jobs"
 	resPermissions = "permissions"
+	resPolicies    = "policies"
+	resLibraries   = "libraries"
+)
+
+// Sub-resource segments (e.g. /jobs/runs/..., /policies/clusters/...).
+const (
+	subRuns     = "runs"
+	subClusters = "clusters"
 )
 
 // Data-plane action path segments.
@@ -44,7 +52,17 @@ const (
 	actUpdate          = "update"
 	actReset           = "reset"
 	actRunNow          = "run-now"
+	actCancel          = "cancel"
+	actGetOutput       = "get-output"
+	actInstall         = "install"
+	actUninstall       = "uninstall"
+	actClusterStatus   = "cluster-status"
+	actAllStatuses     = "all-cluster-statuses"
 )
+
+// minSubResourceSegs is the [api, ver, resource, sub, action] segment count
+// for nested paths like /jobs/runs/{action} and /policies/clusters/{action}.
+const minSubResourceSegs = 5
 
 // minResourceSegs is the [api, ver, resource, action] segment count after
 // dpSplit; minPermissionsSegs additionally needs [type, id].
@@ -95,7 +113,7 @@ func (*DataPlaneHandler) Matches(r *http.Request) bool {
 	}
 
 	switch parts[2] {
-	case resPools, resClusters, resJobs, resPermissions:
+	case resPools, resClusters, resJobs, resPermissions, resPolicies, resLibraries:
 		return true
 	default:
 		return false
@@ -119,12 +137,38 @@ func (h *DataPlaneHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case resClusters:
 		h.serveClusters(w, r, action)
 	case resJobs:
-		h.serveJobs(w, r, action)
+		h.serveJobsResource(w, r, parts)
+	case resPolicies:
+		h.servePoliciesResource(w, r, parts)
+	case resLibraries:
+		h.serveLibraries(w, r, action)
 	case resPermissions:
 		h.servePermissions(w, r, parts)
 	default:
 		dpError(w, http.StatusNotFound, "ENDPOINT_NOT_FOUND", "unknown resource: "+resource)
 	}
+}
+
+// serveJobsResource routes /jobs/{action} and the nested /jobs/runs/{action}.
+func (h *DataPlaneHandler) serveJobsResource(w http.ResponseWriter, r *http.Request, parts []string) {
+	if parts[3] == subRuns && len(parts) >= minSubResourceSegs {
+		h.serveRuns(w, r, parts[4])
+
+		return
+	}
+
+	h.serveJobs(w, r, parts[3])
+}
+
+// servePoliciesResource routes the nested /policies/clusters/{action}.
+func (h *DataPlaneHandler) servePoliciesResource(w http.ResponseWriter, r *http.Request, parts []string) {
+	if parts[3] == subClusters && len(parts) >= minSubResourceSegs {
+		h.servePolicies(w, r, parts[4])
+
+		return
+	}
+
+	dpError(w, http.StatusNotFound, "ENDPOINT_NOT_FOUND", "unknown policies path")
 }
 
 // dpSplit strips the leading "/api/" and returns [ver, resource, action, ...].

--- a/server/azure/databricks/dataplane_compute_ops.go
+++ b/server/azure/databricks/dataplane_compute_ops.go
@@ -1,0 +1,207 @@
+package databricks
+
+import "net/http"
+
+// --- wire types ---
+
+type nodeTypeJSON struct {
+	NodeTypeID  string  `json:"node_type_id"`
+	Description string  `json:"description"`
+	NumCores    float64 `json:"num_cores"`
+	MemoryMB    int32   `json:"memory_mb"`
+}
+
+type listNodeTypesResponse struct {
+	NodeTypes []nodeTypeJSON `json:"node_types"`
+}
+
+type sparkVersionJSON struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+}
+
+type sparkVersionsResponse struct {
+	Versions []sparkVersionJSON `json:"versions"`
+}
+
+type listZonesResponse struct {
+	Zones       []string `json:"zones"`
+	DefaultZone string   `json:"default_zone"`
+}
+
+type submitRunRequest struct {
+	RunName string `json:"run_name"`
+}
+
+type submitRunResponse struct {
+	RunID int64 `json:"run_id"`
+}
+
+type cancelAllRequest struct {
+	JobID int64 `json:"job_id"`
+}
+
+type repairRunResponse struct {
+	RepairID int64 `json:"repair_id"`
+}
+
+// --- cluster lifecycle + metadata ops ---
+
+func (h *DataPlaneHandler) resizeCluster(w http.ResponseWriter, r *http.Request) {
+	var in clusterJSON
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	var minW, maxW int32
+	if in.Autoscale != nil {
+		minW, maxW = in.Autoscale.MinWorkers, in.Autoscale.MaxWorkers
+	}
+
+	if err := h.dp.ResizeCluster(r.Context(), in.ClusterID, in.NumWorkers, minW, maxW); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) pinCluster(w http.ResponseWriter, r *http.Request) {
+	h.clusterPinAction(w, r, true)
+}
+
+func (h *DataPlaneHandler) unpinCluster(w http.ResponseWriter, r *http.Request) {
+	h.clusterPinAction(w, r, false)
+}
+
+func (h *DataPlaneHandler) clusterPinAction(w http.ResponseWriter, r *http.Request, pin bool) {
+	var in clusterID
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	var err error
+	if pin {
+		err = h.dp.PinCluster(r.Context(), in.ClusterID)
+	} else {
+		err = h.dp.UnpinCluster(r.Context(), in.ClusterID)
+	}
+
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) listNodeTypes(w http.ResponseWriter, r *http.Request) {
+	types, err := h.dp.ListNodeTypes(r.Context())
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	out := make([]nodeTypeJSON, 0, len(types))
+	for _, t := range types {
+		out = append(out, nodeTypeJSON{
+			NodeTypeID: t.NodeTypeID, Description: t.Description, NumCores: t.NumCores, MemoryMB: t.MemoryMB,
+		})
+	}
+
+	dpJSON(w, listNodeTypesResponse{NodeTypes: out})
+}
+
+func (h *DataPlaneHandler) sparkVersions(w http.ResponseWriter, r *http.Request) {
+	versions, err := h.dp.ListSparkVersions(r.Context())
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	out := make([]sparkVersionJSON, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, sparkVersionJSON{Key: v.Key, Name: v.Name})
+	}
+
+	dpJSON(w, sparkVersionsResponse{Versions: out})
+}
+
+func (h *DataPlaneHandler) listZones(w http.ResponseWriter, r *http.Request) {
+	zones, defaultZone, err := h.dp.ListZones(r.Context())
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, listZonesResponse{Zones: zones, DefaultZone: defaultZone})
+}
+
+// --- run ops ---
+
+func (h *DataPlaneHandler) submitRun(w http.ResponseWriter, r *http.Request) {
+	var in submitRunRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	runID, err := h.dp.SubmitRun(r.Context(), in.RunName)
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, submitRunResponse{RunID: runID})
+}
+
+func (h *DataPlaneHandler) cancelAllRuns(w http.ResponseWriter, r *http.Request) {
+	var in cancelAllRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.CancelAllRuns(r.Context(), in.JobID); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) deleteRun(w http.ResponseWriter, r *http.Request) {
+	var in runIDRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.DeleteRun(r.Context(), in.RunID); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) repairRun(w http.ResponseWriter, r *http.Request) {
+	var in runIDRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	repairID, err := h.dp.RepairRun(r.Context(), in.RunID)
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, repairRunResponse{RepairID: repairID})
+}

--- a/server/azure/databricks/dataplane_extra_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_extra_roundtrip_test.go
@@ -1,0 +1,135 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+)
+
+func TestSDKClusterResizePinMetadata(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:  "c-extra",
+		SparkVersion: "13.3.x-scala2.12",
+		NodeTypeId:   "Standard_DS3_v2",
+		NumWorkers:   1,
+	})
+	if err != nil {
+		t.Fatalf("Create cluster: %v", err)
+	}
+
+	id := wait.ClusterId
+
+	if _, err = w.Clusters.Resize(ctx, compute.ResizeCluster{ClusterId: id, NumWorkers: 3}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+
+	resized, err := w.Clusters.GetByClusterId(ctx, id)
+	if err != nil {
+		t.Fatalf("Get after resize: %v", err)
+	}
+
+	if resized.NumWorkers != 3 {
+		t.Fatalf("got %d workers, want 3", resized.NumWorkers)
+	}
+
+	if err = w.Clusters.Pin(ctx, compute.PinCluster{ClusterId: id}); err != nil {
+		t.Fatalf("Pin: %v", err)
+	}
+
+	if err = w.Clusters.Unpin(ctx, compute.UnpinCluster{ClusterId: id}); err != nil {
+		t.Fatalf("Unpin: %v", err)
+	}
+
+	nodeTypes, err := w.Clusters.ListNodeTypes(ctx)
+	if err != nil {
+		t.Fatalf("ListNodeTypes: %v", err)
+	}
+
+	if len(nodeTypes.NodeTypes) == 0 {
+		t.Fatal("expected node types")
+	}
+
+	versions, err := w.Clusters.SparkVersions(ctx)
+	if err != nil {
+		t.Fatalf("SparkVersions: %v", err)
+	}
+
+	if len(versions.Versions) == 0 {
+		t.Fatal("expected spark versions")
+	}
+
+	zones, err := w.Clusters.ListZones(ctx)
+	if err != nil {
+		t.Fatalf("ListZones: %v", err)
+	}
+
+	if len(zones.Zones) == 0 || zones.DefaultZone == "" {
+		t.Fatalf("expected zones + default, got %+v", zones)
+	}
+}
+
+func TestSDKRunSubmitRepairDelete(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	submit, err := w.Jobs.Submit(ctx, jobs.SubmitRun{RunName: "one-time"})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	runID := submit.Response.RunId
+	if runID == 0 {
+		t.Fatal("expected a submitted run id")
+	}
+
+	repair, err := w.Jobs.RepairRun(ctx, jobs.RepairRun{RunId: runID})
+	if err != nil {
+		t.Fatalf("RepairRun: %v", err)
+	}
+
+	if repair.Response.RepairId == 0 {
+		t.Fatal("expected a repair id")
+	}
+
+	if err = w.Jobs.DeleteRun(ctx, jobs.DeleteRun{RunId: runID}); err != nil {
+		t.Fatalf("DeleteRun: %v", err)
+	}
+
+	if _, err = w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: runID}); err == nil {
+		t.Fatal("expected error after DeleteRun")
+	}
+}
+
+func TestSDKCancelAllRuns(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	job, err := w.Jobs.Create(ctx, jobs.CreateJob{Name: "cancel-all-job"})
+	if err != nil {
+		t.Fatalf("Create job: %v", err)
+	}
+
+	if _, err = w.Jobs.RunNow(ctx, jobs.RunNow{JobId: job.JobId}); err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+
+	if err = w.Jobs.CancelAllRuns(ctx, jobs.CancelAllRuns{JobId: job.JobId}); err != nil {
+		t.Fatalf("CancelAllRuns: %v", err)
+	}
+
+	runs, err := w.Jobs.ListRunsAll(ctx, jobs.ListRunsRequest{JobId: job.JobId})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+
+	for _, run := range runs {
+		if run.State != nil && run.State.ResultState != jobs.RunResultStateCanceled {
+			t.Fatalf("expected CANCELED run, got %q", run.State.ResultState)
+		}
+	}
+}

--- a/server/azure/databricks/dataplane_more_ops.go
+++ b/server/azure/databricks/dataplane_more_ops.go
@@ -116,6 +116,10 @@ func (h *DataPlaneHandler) serveRuns(w http.ResponseWriter, r *http.Request, act
 		actList:      {http.MethodGet, h.listRuns},
 		actCancel:    {http.MethodPost, h.cancelRun},
 		actGetOutput: {http.MethodGet, h.getRunOutput},
+		actSubmit:    {http.MethodPost, h.submitRun},
+		actCancelAll: {http.MethodPost, h.cancelAllRuns},
+		actDelete:    {http.MethodPost, h.deleteRun},
+		actRepair:    {http.MethodPost, h.repairRun},
 	})
 }
 

--- a/server/azure/databricks/dataplane_more_ops.go
+++ b/server/azure/databricks/dataplane_more_ops.go
@@ -1,0 +1,448 @@
+package databricks
+
+import (
+	"net/http"
+	"strconv"
+
+	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
+)
+
+// --- wire types: runs ---
+
+type runStateJSON struct {
+	LifeCycleState string `json:"life_cycle_state,omitempty"`
+	ResultState    string `json:"result_state,omitempty"`
+	StateMessage   string `json:"state_message,omitempty"`
+}
+
+type runJSON struct {
+	RunID     int64         `json:"run_id"`
+	JobID     int64         `json:"job_id,omitempty"`
+	RunName   string        `json:"run_name,omitempty"`
+	State     *runStateJSON `json:"state,omitempty"`
+	StartTime int64         `json:"start_time,omitempty"`
+	EndTime   int64         `json:"end_time,omitempty"`
+}
+
+type listRunsResponse struct {
+	Runs    []runJSON `json:"runs"`
+	HasMore bool      `json:"has_more"`
+}
+
+type runIDRequest struct {
+	RunID int64 `json:"run_id"`
+}
+
+type notebookOutputJSON struct {
+	Result string `json:"result,omitempty"`
+}
+
+type runOutputJSON struct {
+	Metadata       runJSON             `json:"metadata"`
+	NotebookOutput *notebookOutputJSON `json:"notebook_output,omitempty"`
+}
+
+// --- wire types: cluster policies ---
+
+type policyJSON struct {
+	PolicyID           string `json:"policy_id,omitempty"`
+	Name               string `json:"name"`
+	Definition         string `json:"definition,omitempty"`
+	Description        string `json:"description,omitempty"`
+	MaxClustersPerUser int64  `json:"max_clusters_per_user,omitempty"`
+	CreatorUserName    string `json:"creator_user_name,omitempty"`
+	CreatedAtTimestamp int64  `json:"created_at_timestamp,omitempty"`
+}
+
+type createPolicyResponse struct {
+	PolicyID string `json:"policy_id"`
+}
+
+type policyIDRequest struct {
+	PolicyID string `json:"policy_id"`
+}
+
+type listPoliciesResponse struct {
+	Policies []policyJSON `json:"policies"`
+}
+
+// --- wire types: libraries ---
+
+type pypiJSON struct {
+	Package string `json:"package"`
+}
+
+type mavenJSON struct {
+	Coordinates string `json:"coordinates"`
+}
+
+type cranJSON struct {
+	Package string `json:"package"`
+}
+
+type libraryJSON struct {
+	Jar   string     `json:"jar,omitempty"`
+	Egg   string     `json:"egg,omitempty"`
+	Whl   string     `json:"whl,omitempty"`
+	Pypi  *pypiJSON  `json:"pypi,omitempty"`
+	Maven *mavenJSON `json:"maven,omitempty"`
+	Cran  *cranJSON  `json:"cran,omitempty"`
+}
+
+type librariesRequest struct {
+	ClusterID string        `json:"cluster_id"`
+	Libraries []libraryJSON `json:"libraries"`
+}
+
+type libraryFullStatusJSON struct {
+	Library libraryJSON `json:"library"`
+	Status  string      `json:"status"`
+}
+
+type clusterLibraryStatusesJSON struct {
+	ClusterID       string                  `json:"cluster_id"`
+	LibraryStatuses []libraryFullStatusJSON `json:"library_statuses"`
+}
+
+type allStatusesResponse struct {
+	Statuses []clusterLibraryStatusesJSON `json:"statuses"`
+}
+
+// --- runs routing + ops ---
+
+func (h *DataPlaneHandler) serveRuns(w http.ResponseWriter, r *http.Request, action string) {
+	dispatch(w, r, action, map[string]dpRoute{
+		actGet:       {http.MethodGet, h.getRun},
+		actList:      {http.MethodGet, h.listRuns},
+		actCancel:    {http.MethodPost, h.cancelRun},
+		actGetOutput: {http.MethodGet, h.getRunOutput},
+	})
+}
+
+func (h *DataPlaneHandler) getRun(w http.ResponseWriter, r *http.Request) {
+	id, ok := int64Query(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	run, err := h.dp.GetRun(r.Context(), id)
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, toRunJSON(run))
+}
+
+func (h *DataPlaneHandler) listRuns(w http.ResponseWriter, r *http.Request) {
+	var jobID int64
+	if v := r.URL.Query().Get("job_id"); v != "" {
+		jobID, _ = strconv.ParseInt(v, 10, 64)
+	}
+
+	runs, err := h.dp.ListRuns(r.Context(), jobID)
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	out := make([]runJSON, 0, len(runs))
+	for i := range runs {
+		out = append(out, toRunJSON(&runs[i]))
+	}
+
+	dpJSON(w, listRunsResponse{Runs: out})
+}
+
+func (h *DataPlaneHandler) cancelRun(w http.ResponseWriter, r *http.Request) {
+	var in runIDRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.CancelRun(r.Context(), in.RunID); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) getRunOutput(w http.ResponseWriter, r *http.Request) {
+	id, ok := int64Query(w, r, "run_id")
+	if !ok {
+		return
+	}
+
+	out, err := h.dp.GetRunOutput(r.Context(), id)
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, runOutputJSON{
+		Metadata:       toRunJSON(&out.Run),
+		NotebookOutput: &notebookOutputJSON{Result: out.NotebookResult},
+	})
+}
+
+// --- cluster policies routing + ops ---
+
+func (h *DataPlaneHandler) servePolicies(w http.ResponseWriter, r *http.Request, action string) {
+	dispatch(w, r, action, map[string]dpRoute{
+		actCreate: {http.MethodPost, h.createPolicy},
+		actGet:    {http.MethodGet, h.getPolicy},
+		actEdit:   {http.MethodPost, h.editPolicy},
+		actDelete: {http.MethodPost, h.deletePolicy},
+		actList:   {http.MethodGet, h.listPolicies},
+	})
+}
+
+func (h *DataPlaneHandler) createPolicy(w http.ResponseWriter, r *http.Request) {
+	var in policyJSON
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	policy, err := h.dp.CreateClusterPolicy(r.Context(), policyConfig(&in))
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, createPolicyResponse{PolicyID: policy.PolicyID})
+}
+
+func (h *DataPlaneHandler) getPolicy(w http.ResponseWriter, r *http.Request) {
+	policy, err := h.dp.GetClusterPolicy(r.Context(), r.URL.Query().Get("policy_id"))
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, toPolicyJSON(policy))
+}
+
+func (h *DataPlaneHandler) editPolicy(w http.ResponseWriter, r *http.Request) {
+	var in policyJSON
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.EditClusterPolicy(r.Context(), in.PolicyID, policyConfig(&in)); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) deletePolicy(w http.ResponseWriter, r *http.Request) {
+	var in policyIDRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.DeleteClusterPolicy(r.Context(), in.PolicyID); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) listPolicies(w http.ResponseWriter, r *http.Request) {
+	policies, err := h.dp.ListClusterPolicies(r.Context())
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	out := make([]policyJSON, 0, len(policies))
+	for i := range policies {
+		out = append(out, toPolicyJSON(&policies[i]))
+	}
+
+	dpJSON(w, listPoliciesResponse{Policies: out})
+}
+
+// --- libraries routing + ops ---
+
+func (h *DataPlaneHandler) serveLibraries(w http.ResponseWriter, r *http.Request, action string) {
+	dispatch(w, r, action, map[string]dpRoute{
+		actInstall:       {http.MethodPost, h.installLibraries},
+		actUninstall:     {http.MethodPost, h.uninstallLibraries},
+		actClusterStatus: {http.MethodGet, h.clusterStatus},
+		actAllStatuses:   {http.MethodGet, h.allClusterStatuses},
+	})
+}
+
+func (h *DataPlaneHandler) installLibraries(w http.ResponseWriter, r *http.Request) {
+	var in librariesRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.InstallLibraries(r.Context(), in.ClusterID, toDriverLibs(in.Libraries)); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) uninstallLibraries(w http.ResponseWriter, r *http.Request) {
+	var in librariesRequest
+	if !dpDecode(w, r, &in) {
+		return
+	}
+
+	if err := h.dp.UninstallLibraries(r.Context(), in.ClusterID, toDriverLibs(in.Libraries)); err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, struct{}{})
+}
+
+func (h *DataPlaneHandler) clusterStatus(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.URL.Query().Get("cluster_id")
+
+	statuses, err := h.dp.ClusterLibraryStatuses(r.Context(), clusterID)
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	dpJSON(w, toClusterStatusesJSON(clusterID, statuses))
+}
+
+func (h *DataPlaneHandler) allClusterStatuses(w http.ResponseWriter, r *http.Request) {
+	all, err := h.dp.AllClusterLibraryStatuses(r.Context())
+	if err != nil {
+		dpWriteErr(w, err)
+
+		return
+	}
+
+	out := make([]clusterLibraryStatusesJSON, 0, len(all))
+	for i := range all {
+		out = append(out, toClusterStatusesJSON(all[i].ClusterID, all[i].Statuses))
+	}
+
+	dpJSON(w, allStatusesResponse{Statuses: out})
+}
+
+// --- converters ---
+
+func toRunJSON(run *dbxdriver.Run) runJSON {
+	return runJSON{
+		RunID:   run.RunID,
+		JobID:   run.JobID,
+		RunName: run.RunName,
+		State: &runStateJSON{
+			LifeCycleState: run.LifeCycleState,
+			ResultState:    run.ResultState,
+			StateMessage:   run.StateMessage,
+		},
+		StartTime: run.StartTime,
+		EndTime:   run.EndTime,
+	}
+}
+
+func policyConfig(in *policyJSON) dbxdriver.ClusterPolicyConfig {
+	return dbxdriver.ClusterPolicyConfig{
+		Name:               in.Name,
+		Definition:         in.Definition,
+		Description:        in.Description,
+		MaxClustersPerUser: in.MaxClustersPerUser,
+	}
+}
+
+func toPolicyJSON(p *dbxdriver.ClusterPolicy) policyJSON {
+	return policyJSON{
+		PolicyID:           p.PolicyID,
+		Name:               p.Name,
+		Definition:         p.Definition,
+		Description:        p.Description,
+		MaxClustersPerUser: p.MaxClustersPerUser,
+		CreatorUserName:    p.CreatorUserName,
+		CreatedAtTimestamp: p.CreatedAt,
+	}
+}
+
+func toClusterStatusesJSON(clusterID string, statuses []dbxdriver.LibraryStatus) clusterLibraryStatusesJSON {
+	out := clusterLibraryStatusesJSON{ClusterID: clusterID}
+	for i := range statuses {
+		out.LibraryStatuses = append(out.LibraryStatuses, libraryFullStatusJSON{
+			Library: toLibraryJSON(&statuses[i].Library),
+			Status:  statuses[i].Status,
+		})
+	}
+
+	return out
+}
+
+func toDriverLibs(in []libraryJSON) []dbxdriver.LibrarySpec {
+	out := make([]dbxdriver.LibrarySpec, 0, len(in))
+
+	for _, l := range in {
+		spec := dbxdriver.LibrarySpec{Jar: l.Jar, Egg: l.Egg, Whl: l.Whl}
+		if l.Pypi != nil {
+			spec.PypiPackage = l.Pypi.Package
+		}
+
+		if l.Maven != nil {
+			spec.MavenCoordinates = l.Maven.Coordinates
+		}
+
+		if l.Cran != nil {
+			spec.Cran = l.Cran.Package
+		}
+
+		out = append(out, spec)
+	}
+
+	return out
+}
+
+func toLibraryJSON(l *dbxdriver.LibrarySpec) libraryJSON {
+	out := libraryJSON{Jar: l.Jar, Egg: l.Egg, Whl: l.Whl}
+	if l.PypiPackage != "" {
+		out.Pypi = &pypiJSON{Package: l.PypiPackage}
+	}
+
+	if l.MavenCoordinates != "" {
+		out.Maven = &mavenJSON{Coordinates: l.MavenCoordinates}
+	}
+
+	if l.Cran != "" {
+		out.Cran = &cranJSON{Package: l.Cran}
+	}
+
+	return out
+}
+
+// int64Query parses a required int64 query parameter.
+func int64Query(w http.ResponseWriter, r *http.Request, name string) (int64, bool) {
+	v, err := strconv.ParseInt(r.URL.Query().Get(name), 10, 64)
+	if err != nil {
+		dpError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid "+name)
+
+		return 0, false
+	}
+
+	return v, true
+}

--- a/server/azure/databricks/dataplane_more_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_more_roundtrip_test.go
@@ -1,0 +1,162 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+)
+
+func TestSDKJobRuns(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Jobs.Create(ctx, jobs.CreateJob{Name: "job-runs"})
+	if err != nil {
+		t.Fatalf("Create job: %v", err)
+	}
+
+	run, err := w.Jobs.RunNow(ctx, jobs.RunNow{JobId: created.JobId})
+	if err != nil {
+		t.Fatalf("RunNow: %v", err)
+	}
+
+	runID := run.Response.RunId
+
+	got, err := w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: runID})
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+
+	if got.State == nil || got.State.ResultState != jobs.RunResultStateSuccess {
+		t.Fatalf("expected SUCCESS result, got %+v", got.State)
+	}
+
+	runs, err := w.Jobs.ListRunsAll(ctx, jobs.ListRunsRequest{JobId: created.JobId})
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+
+	if len(runs) != 1 {
+		t.Fatalf("got %d runs, want 1", len(runs))
+	}
+
+	out, err := w.Jobs.GetRunOutput(ctx, jobs.GetRunOutputRequest{RunId: runID})
+	if err != nil {
+		t.Fatalf("GetRunOutput: %v", err)
+	}
+
+	if out.NotebookOutput == nil || out.NotebookOutput.Result == "" {
+		t.Fatalf("expected notebook output, got %+v", out)
+	}
+
+	if _, err = w.Jobs.CancelRun(ctx, jobs.CancelRun{RunId: runID}); err != nil {
+		t.Fatalf("CancelRun: %v", err)
+	}
+
+	canceled, err := w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: runID})
+	if err != nil {
+		t.Fatalf("GetRun after cancel: %v", err)
+	}
+
+	if canceled.State.ResultState != jobs.RunResultStateCanceled {
+		t.Fatalf("expected CANCELED, got %q", canceled.State.ResultState)
+	}
+}
+
+func TestSDKClusterPolicies(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.ClusterPolicies.Create(ctx, compute.CreatePolicy{
+		Name:       "policy-1",
+		Definition: `{"spark_version":{"type":"fixed","value":"13.3.x-scala2.12"}}`,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.PolicyId == "" {
+		t.Fatal("expected policy id")
+	}
+
+	got, err := w.ClusterPolicies.Get(ctx, compute.GetClusterPolicyRequest{PolicyId: created.PolicyId})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name != "policy-1" {
+		t.Fatalf("got name %q, want policy-1", got.Name)
+	}
+
+	if err = w.ClusterPolicies.Edit(ctx, compute.EditPolicy{
+		PolicyId:   created.PolicyId,
+		Name:       "policy-1-edited",
+		Definition: got.Definition,
+	}); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+
+	policies, err := w.ClusterPolicies.ListAll(ctx, compute.ListClusterPoliciesRequest{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(policies) != 1 {
+		t.Fatalf("got %d policies, want 1", len(policies))
+	}
+
+	if err = w.ClusterPolicies.Delete(ctx, compute.DeletePolicy{PolicyId: created.PolicyId}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+}
+
+func TestSDKLibraries(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:  "lib-cluster",
+		SparkVersion: "13.3.x-scala2.12",
+		NodeTypeId:   "Standard_DS3_v2",
+		NumWorkers:   1,
+	})
+	if err != nil {
+		t.Fatalf("Create cluster: %v", err)
+	}
+
+	clusterID := wait.ClusterId
+
+	if err = w.Libraries.Install(ctx, compute.InstallLibraries{
+		ClusterId: clusterID,
+		Libraries: []compute.Library{{Pypi: &compute.PythonPyPiLibrary{Package: "requests"}}},
+	}); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	status, err := w.Libraries.ClusterStatusByClusterId(ctx, clusterID)
+	if err != nil {
+		t.Fatalf("ClusterStatus: %v", err)
+	}
+
+	if len(status.LibraryStatuses) != 1 || status.LibraryStatuses[0].Status != compute.LibraryInstallStatusInstalled {
+		t.Fatalf("expected one INSTALLED library, got %+v", status.LibraryStatuses)
+	}
+
+	if err = w.Libraries.Uninstall(ctx, compute.UninstallLibraries{
+		ClusterId: clusterID,
+		Libraries: []compute.Library{{Pypi: &compute.PythonPyPiLibrary{Package: "requests"}}},
+	}); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	after, err := w.Libraries.ClusterStatusByClusterId(ctx, clusterID)
+	if err != nil {
+		t.Fatalf("ClusterStatus after uninstall: %v", err)
+	}
+
+	if after.LibraryStatuses[0].Status != compute.LibraryInstallStatusUninstallOnRestart {
+		t.Fatalf("expected UNINSTALL_ON_RESTART, got %q", after.LibraryStatuses[0].Status)
+	}
+}

--- a/server/azure/databricks/dataplane_ops.go
+++ b/server/azure/databricks/dataplane_ops.go
@@ -220,6 +220,12 @@ func (h *DataPlaneHandler) serveClusters(w http.ResponseWriter, r *http.Request,
 		actPermanentDelete: {http.MethodPost, lifecycle},
 		actStart:           {http.MethodPost, lifecycle},
 		actRestart:         {http.MethodPost, lifecycle},
+		actResize:          {http.MethodPost, h.resizeCluster},
+		actPin:             {http.MethodPost, h.pinCluster},
+		actUnpin:           {http.MethodPost, h.unpinCluster},
+		actListNodeTypes:   {http.MethodGet, h.listNodeTypes},
+		actSparkVersions:   {http.MethodGet, h.sparkVersions},
+		actListZones:       {http.MethodGet, h.listZones},
 	})
 }
 

--- a/server/azure/databricks/dbfs/dbfs.go
+++ b/server/azure/databricks/dbfs/dbfs.go
@@ -1,0 +1,687 @@
+// Package dbfs implements the Databricks DBFS data-plane REST API
+// (the /api/2.0/dbfs/... surface) as a server.Handler, backed by an in-memory
+// filesystem. Point the real github.com/databricks/databricks-sdk-go
+// WorkspaceClient at a server registered with this handler and w.Dbfs.Put,
+// Read, List, Mkdirs, Delete, GetStatus, and the block-upload helpers
+// (WriteFile via create/add-block/close) work end-to-end.
+//
+// Covered endpoints:
+//
+//	POST /api/2.0/dbfs/mkdirs        {path}
+//	POST /api/2.0/dbfs/put           {path, contents(base64), overwrite}
+//	POST /api/2.0/dbfs/create        {path, overwrite} -> {handle}
+//	POST /api/2.0/dbfs/add-block     {handle, data(base64)}
+//	POST /api/2.0/dbfs/close         {handle}
+//	POST /api/2.0/dbfs/delete        {path, recursive}
+//	GET  /api/2.0/dbfs/get-status    ?path=        -> {path, is_dir, file_size}
+//	GET  /api/2.0/dbfs/list          ?path=        -> {files:[...]}
+//	GET  /api/2.0/dbfs/read          ?path=&offset=&length= -> {bytes_read, data}
+package dbfs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+// Resource segment that this handler claims (3rd path segment after split).
+const resDbfs = "dbfs"
+
+// minSegs is the [api, ver, dbfs, action] segment count required to route.
+const minSegs = 4
+
+// Action path segments.
+const (
+	actMkdirs    = "mkdirs"
+	actPut       = "put"
+	actCreate    = "create"
+	actAddBlock  = "add-block"
+	actClose     = "close"
+	actDelete    = "delete"
+	actGetStatus = "get-status"
+	actList      = "list"
+	actRead      = "read"
+)
+
+// Databricks error codes.
+const (
+	codeNotFound     = "RESOURCE_DOES_NOT_EXIST"
+	codeExists       = "RESOURCE_ALREADY_EXISTS"
+	codeInvalidParam = "INVALID_PARAMETER_VALUE"
+	codeNotFoundPath = "ENDPOINT_NOT_FOUND"
+	codeMalformed    = "MALFORMED_REQUEST"
+	codeMethod       = "INVALID_PARAMETER_VALUE"
+)
+
+// Handler serves the DBFS data-plane REST API over an in-memory filesystem.
+type Handler struct {
+	mu      sync.RWMutex
+	files   map[string][]byte // absolute path -> contents
+	dirs    map[string]bool   // absolute path -> exists (set of directories)
+	blocks  map[int64][]byte  // open write-stream handle -> accumulated bytes
+	bpaths  map[int64]string  // open write-stream handle -> target path
+	nextHnd int64
+}
+
+// New returns a DBFS handler with an empty filesystem (root "/" always exists).
+func New() *Handler {
+	return &Handler{
+		files:  make(map[string][]byte),
+		dirs:   map[string]bool{"/": true},
+		blocks: make(map[int64][]byte),
+		bpaths: make(map[int64]string),
+	}
+}
+
+// Matches claims /api/{ver}/dbfs/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+
+	return len(parts) >= minSegs && parts[0] == "api" && parts[2] == resDbfs
+}
+
+// route binds an action to its required HTTP method and handler.
+type route struct {
+	method string
+	fn     func(*Handler, http.ResponseWriter, *http.Request)
+}
+
+// routes maps each action segment to its handler. It is a method (not a global)
+// to satisfy gochecknoglobals; the map is small and rebuilt per request.
+func routes() map[string]route {
+	return map[string]route{
+		actMkdirs:    {http.MethodPost, (*Handler).mkdirs},
+		actPut:       {http.MethodPost, (*Handler).put},
+		actCreate:    {http.MethodPost, (*Handler).create},
+		actAddBlock:  {http.MethodPost, (*Handler).addBlock},
+		actClose:     {http.MethodPost, (*Handler).closeStream},
+		actDelete:    {http.MethodPost, (*Handler).delete},
+		actGetStatus: {http.MethodGet, (*Handler).getStatus},
+		actList:      {http.MethodGet, (*Handler).list},
+		actRead:      {http.MethodGet, (*Handler).read},
+	}
+}
+
+// ServeHTTP routes by the action segment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minSegs {
+		writeErr(w, http.StatusNotFound, codeNotFoundPath, "unsupported path")
+
+		return
+	}
+
+	rt, ok := routes()[parts[3]]
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFoundPath, "unknown action: "+parts[3])
+
+		return
+	}
+
+	if r.Method != rt.method {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	rt.fn(h, w, r)
+}
+
+type mkdirsRequest struct {
+	Path string `json:"path"`
+}
+
+func (h *Handler) mkdirs(w http.ResponseWriter, r *http.Request) {
+	var req mkdirsRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	p := cleanPath(req.Path)
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.files[p]; ok {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path already exists as a file: "+p)
+
+		return
+	}
+
+	h.makeDirs(p)
+
+	writeJSON(w, struct{}{})
+}
+
+type putRequest struct {
+	Path      string `json:"path"`
+	Contents  string `json:"contents"`
+	Overwrite bool   `json:"overwrite"`
+}
+
+func (h *Handler) put(w http.ResponseWriter, r *http.Request) {
+	var req putRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	p := cleanPath(req.Path)
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	data, err := base64.StdEncoding.DecodeString(req.Contents)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "contents is not valid base64")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if !h.writeFile(w, p, data, req.Overwrite) {
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+type createRequest struct {
+	Path      string `json:"path"`
+	Overwrite bool   `json:"overwrite"`
+}
+
+type createResponse struct {
+	Handle int64 `json:"handle"`
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	p := cleanPath(req.Path)
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.files[p]; ok && !req.Overwrite {
+		writeErr(w, http.StatusBadRequest, codeExists, "file already exists: "+p)
+
+		return
+	}
+
+	if h.dirs[p] {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is a directory: "+p)
+
+		return
+	}
+
+	h.nextHnd++
+	hnd := h.nextHnd
+	h.blocks[hnd] = []byte{}
+	h.bpaths[hnd] = p
+
+	writeJSON(w, createResponse{Handle: hnd})
+}
+
+type addBlockRequest struct {
+	Handle int64  `json:"handle"`
+	Data   string `json:"data"`
+}
+
+func (h *Handler) addBlock(w http.ResponseWriter, r *http.Request) {
+	var req addBlockRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	data, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "data is not valid base64")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	buf, ok := h.blocks[req.Handle]
+	if !ok {
+		writeErr(w, http.StatusBadRequest, codeNotFound, "unknown stream handle")
+
+		return
+	}
+
+	h.blocks[req.Handle] = append(buf, data...)
+
+	writeJSON(w, struct{}{})
+}
+
+type closeRequest struct {
+	Handle int64 `json:"handle"`
+}
+
+func (h *Handler) closeStream(w http.ResponseWriter, r *http.Request) {
+	var req closeRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	buf, ok := h.blocks[req.Handle]
+	if !ok {
+		writeErr(w, http.StatusBadRequest, codeNotFound, "unknown stream handle")
+
+		return
+	}
+
+	p := h.bpaths[req.Handle]
+	delete(h.blocks, req.Handle)
+	delete(h.bpaths, req.Handle)
+
+	// The create call already enforced overwrite semantics, so persist
+	// unconditionally here.
+	if !h.writeFile(w, p, buf, true) {
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+type deleteRequest struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive"`
+}
+
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request) {
+	var req deleteRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	p := cleanPath(req.Path)
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.files[p]; ok {
+		delete(h.files, p)
+		writeJSON(w, struct{}{})
+
+		return
+	}
+
+	if h.dirs[p] {
+		h.deleteDir(w, p, req.Recursive)
+
+		return
+	}
+
+	writeErr(w, http.StatusNotFound, codeNotFound, "no such file or directory: "+p)
+}
+
+// deleteDir removes directory p; requires recursive when it has children.
+func (h *Handler) deleteDir(w http.ResponseWriter, p string, recursive bool) {
+	children := h.childPaths(p)
+	if len(children) > 0 && !recursive {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "directory not empty: "+p)
+
+		return
+	}
+
+	for _, c := range children {
+		delete(h.files, c)
+		delete(h.dirs, c)
+	}
+
+	if p != "/" {
+		delete(h.dirs, p)
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+type fileInfo struct {
+	Path     string `json:"path"`
+	IsDir    bool   `json:"is_dir"`
+	FileSize int64  `json:"file_size"`
+}
+
+func (h *Handler) getStatus(w http.ResponseWriter, r *http.Request) {
+	p := cleanPath(r.URL.Query().Get("path"))
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if data, ok := h.files[p]; ok {
+		writeJSON(w, fileInfo{Path: p, IsDir: false, FileSize: int64(len(data))})
+
+		return
+	}
+
+	if h.dirs[p] {
+		writeJSON(w, fileInfo{Path: p, IsDir: true})
+
+		return
+	}
+
+	writeErr(w, http.StatusNotFound, codeNotFound, "no such file or directory: "+p)
+}
+
+type listResponse struct {
+	Files []fileInfo `json:"files"`
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	p := cleanPath(r.URL.Query().Get("path"))
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	// Listing a file returns details of just that file.
+	if data, ok := h.files[p]; ok {
+		writeJSON(w, listResponse{Files: []fileInfo{{Path: p, IsDir: false, FileSize: int64(len(data))}}})
+
+		return
+	}
+
+	if !h.dirs[p] {
+		writeErr(w, http.StatusNotFound, codeNotFound, "no such file or directory: "+p)
+
+		return
+	}
+
+	writeJSON(w, listResponse{Files: h.directChildren(p)})
+}
+
+type readResponse struct {
+	BytesRead int64  `json:"bytes_read"`
+	Data      string `json:"data"`
+}
+
+func (h *Handler) read(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	p := cleanPath(q.Get("path"))
+	if p == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is required")
+
+		return
+	}
+
+	offset, length, ok := parseReadRange(w, q.Get("offset"), q.Get("length"))
+	if !ok {
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	data, ok := h.files[p]
+	if !ok {
+		if h.dirs[p] {
+			writeErr(w, http.StatusBadRequest, codeInvalidParam, "cannot read a directory: "+p)
+
+			return
+		}
+
+		writeErr(w, http.StatusNotFound, codeNotFound, "no such file: "+p)
+
+		return
+	}
+
+	chunk := sliceRange(data, offset, length)
+	writeJSON(w, readResponse{
+		BytesRead: int64(len(chunk)),
+		Data:      base64.StdEncoding.EncodeToString(chunk),
+	})
+}
+
+// parseReadRange parses the offset/length query params (both optional).
+func parseReadRange(w http.ResponseWriter, offsetStr, lengthStr string) (offset, length int64, ok bool) {
+	var err error
+
+	if offsetStr != "" {
+		offset, err = strconv.ParseInt(offsetStr, 10, 64)
+		if err != nil || offset < 0 {
+			writeErr(w, http.StatusBadRequest, codeInvalidParam, "invalid offset")
+
+			return 0, 0, false
+		}
+	}
+
+	if lengthStr != "" {
+		length, err = strconv.ParseInt(lengthStr, 10, 64)
+		if err != nil || length < 0 {
+			writeErr(w, http.StatusBadRequest, codeInvalidParam, "invalid length")
+
+			return 0, 0, false
+		}
+	}
+
+	return offset, length, true
+}
+
+// sliceRange returns data[offset:offset+length], clamped to bounds. A length of
+// 0 means read to end of file.
+func sliceRange(data []byte, offset, length int64) []byte {
+	if offset >= int64(len(data)) {
+		return nil
+	}
+
+	end := int64(len(data))
+	if length > 0 && offset+length < end {
+		end = offset + length
+	}
+
+	return data[offset:end]
+}
+
+// writeFile persists data at p, enforcing overwrite and creating parent dirs.
+// It writes an error response and returns false on failure. Caller holds the
+// write lock.
+func (h *Handler) writeFile(w http.ResponseWriter, p string, data []byte, overwrite bool) bool {
+	if h.dirs[p] {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "path is a directory: "+p)
+
+		return false
+	}
+
+	if _, ok := h.files[p]; ok && !overwrite {
+		writeErr(w, http.StatusBadRequest, codeExists, "file already exists: "+p)
+
+		return false
+	}
+
+	h.makeDirs(parentOf(p))
+	h.files[p] = data
+
+	return true
+}
+
+// makeDirs records p and all of its ancestors as directories. Caller holds the
+// write lock.
+func (h *Handler) makeDirs(p string) {
+	for d := cleanPath(p); d != ""; d = parentOf(d) {
+		h.dirs[d] = true
+
+		if d == "/" {
+			break
+		}
+	}
+}
+
+// childPaths returns every file and directory strictly beneath dir. Caller
+// holds a lock.
+func (h *Handler) childPaths(dir string) []string {
+	prefix := dirPrefix(dir)
+
+	var out []string
+
+	for f := range h.files {
+		if strings.HasPrefix(f, prefix) {
+			out = append(out, f)
+		}
+	}
+
+	for d := range h.dirs {
+		if d != dir && strings.HasPrefix(d, prefix) {
+			out = append(out, d)
+		}
+	}
+
+	return out
+}
+
+// directChildren returns the immediate entries of dir, sorted by path. Caller
+// holds a lock.
+func (h *Handler) directChildren(dir string) []fileInfo {
+	prefix := dirPrefix(dir)
+
+	out := make([]fileInfo, 0)
+
+	for f, data := range h.files {
+		if isDirectChild(f, prefix) {
+			out = append(out, fileInfo{Path: f, IsDir: false, FileSize: int64(len(data))})
+		}
+	}
+
+	for d := range h.dirs {
+		if d != dir && isDirectChild(d, prefix) {
+			out = append(out, fileInfo{Path: d, IsDir: true})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+
+	return out
+}
+
+// isDirectChild reports whether p sits immediately under prefix (no deeper).
+func isDirectChild(p, prefix string) bool {
+	if !strings.HasPrefix(p, prefix) {
+		return false
+	}
+
+	return !strings.Contains(p[len(prefix):], "/")
+}
+
+// dirPrefix returns dir with a guaranteed trailing slash for prefix matching.
+func dirPrefix(dir string) string {
+	if dir == "/" {
+		return "/"
+	}
+
+	return dir + "/"
+}
+
+// parentOf returns the parent directory of an absolute path.
+func parentOf(p string) string {
+	parent := path.Dir(p)
+	if parent == "." {
+		return "/"
+	}
+
+	return parent
+}
+
+// cleanPath normalizes a DBFS path to an absolute, slash-cleaned form. An empty
+// or root-only input returns "/" for callers that accept it; truly empty input
+// (after trimming) returns "".
+func cleanPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+
+	cleaned := path.Clean(p)
+
+	return cleaned
+}
+
+// splitPath strips leading/trailing slashes and splits on "/".
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, codeMalformed, "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, codeMethod, "method not allowed")
+}

--- a/server/azure/databricks/dbfs/dbfs.go
+++ b/server/azure/databricks/dbfs/dbfs.go
@@ -509,8 +509,10 @@ func sliceRange(data []byte, offset, length int64) []byte {
 	}
 
 	end := int64(len(data))
-	if length > 0 && offset+length < end {
-		end = offset + length
+	// Guard against int64 overflow: a huge length (e.g. math.MaxInt64) makes
+	// offset+length wrap negative, which would slice with low > high and panic.
+	if want := offset + length; length > 0 && want >= offset && want < end {
+		end = want
 	}
 
 	return data[offset:end]

--- a/server/azure/databricks/dbfs/dbfs_roundtrip_test.go
+++ b/server/azure/databricks/dbfs/dbfs_roundtrip_test.go
@@ -1,0 +1,175 @@
+package dbfs_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/files"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/dbfs"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(dbfs.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKDbfsPutReadRoundtrip(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	want := []byte("hello dbfs roundtrip")
+	p := "/tmp/cloudemu/hello.txt"
+
+	if err := w.Dbfs.Put(ctx, files.Put{
+		Path:      p,
+		Contents:  base64.StdEncoding.EncodeToString(want),
+		Overwrite: true,
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	res, err := w.Dbfs.Read(ctx, files.ReadDbfsRequest{Path: p})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	got, err := base64.StdEncoding.DecodeString(res.Data)
+	if err != nil {
+		t.Fatalf("decode read data: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("round-tripped bytes = %q, want %q", got, want)
+	}
+
+	if res.BytesRead != int64(len(want)) {
+		t.Fatalf("bytes_read = %d, want %d", res.BytesRead, len(want))
+	}
+}
+
+func TestSDKDbfsGetStatusAndList(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	want := []byte("status-and-list")
+	p := "/data/sub/file.bin"
+
+	if err := w.Dbfs.Put(ctx, files.Put{
+		Path:      p,
+		Contents:  base64.StdEncoding.EncodeToString(want),
+		Overwrite: true,
+	}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	st, err := w.Dbfs.GetStatusByPath(ctx, p)
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+
+	if st.IsDir {
+		t.Fatal("GetStatus: expected file, got dir")
+	}
+
+	if st.FileSize != int64(len(want)) {
+		t.Fatalf("GetStatus file_size = %d, want %d", st.FileSize, len(want))
+	}
+
+	entries, err := w.Dbfs.ListAll(ctx, files.ListDbfsRequest{Path: "/data/sub"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(entries) != 1 || entries[0].Path != p {
+		t.Fatalf("List = %+v, want single entry %q", entries, p)
+	}
+}
+
+func TestSDKDbfsMkdirsListAndDelete(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	if err := w.Dbfs.Mkdirs(ctx, files.MkDirs{Path: "/proj/logs"}); err != nil {
+		t.Fatalf("Mkdirs: %v", err)
+	}
+
+	st, err := w.Dbfs.GetStatusByPath(ctx, "/proj/logs")
+	if err != nil {
+		t.Fatalf("GetStatus dir: %v", err)
+	}
+
+	if !st.IsDir {
+		t.Fatal("expected /proj/logs to be a directory")
+	}
+
+	entries, err := w.Dbfs.ListAll(ctx, files.ListDbfsRequest{Path: "/proj"})
+	if err != nil {
+		t.Fatalf("List /proj: %v", err)
+	}
+
+	if len(entries) != 1 || !entries[0].IsDir || entries[0].Path != "/proj/logs" {
+		t.Fatalf("List /proj = %+v, want single dir /proj/logs", entries)
+	}
+
+	if err := w.Dbfs.Delete(ctx, files.Delete{Path: "/proj", Recursive: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err := w.Dbfs.GetStatusByPath(ctx, "/proj"); err == nil {
+		t.Fatal("GetStatus after delete: expected error, got nil")
+	}
+}
+
+func TestSDKDbfsWriteFileBlockUpload(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	want := bytes.Repeat([]byte("block-upload-payload;"), 100)
+	p := "/streamed/data.bin"
+
+	// WriteFile drives the create / add-block / close stream API.
+	if err := w.Dbfs.WriteFile(ctx, p, want); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got, err := w.Dbfs.ReadFile(ctx, p)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Fatalf("round-tripped %d bytes, want %d bytes (mismatch)", len(got), len(want))
+	}
+}
+
+func TestSDKDbfsReadMissingFile(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	if _, err := w.Dbfs.Read(ctx, files.ReadDbfsRequest{Path: "/does/not/exist"}); err == nil {
+		t.Fatal("Read missing file: expected error, got nil")
+	}
+}

--- a/server/azure/databricks/gitcredentials/gitcredentials.go
+++ b/server/azure/databricks/gitcredentials/gitcredentials.go
@@ -1,0 +1,300 @@
+// Package gitcredentials emulates the Databricks Git Credentials data-plane
+// REST API (the /api/2.0/git-credentials surface served at the workspace URL)
+// as a server.Handler. Point the real
+// github.com/databricks/databricks-sdk-go WorkspaceClient at a server
+// registered with this handler and w.GitCredentials Create/Get/List/Update/
+// Delete work end-to-end against an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.0/git-credentials
+//	GET    /api/2.0/git-credentials
+//	GET    /api/2.0/git-credentials/{credential_id}
+//	PATCH  /api/2.0/git-credentials/{credential_id}
+//	DELETE /api/2.0/git-credentials/{credential_id}
+package gitcredentials
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 1 << 20
+
+// resourceSegment is the path segment this handler claims.
+const resourceSegment = "git-credentials"
+
+// minResourceSegs is the [api, ver, git-credentials] segment count; a
+// credential id, when present, is the 4th segment.
+const (
+	minResourceSegs = 3
+	idSegIndex      = 3
+	withIDSegs      = 4
+)
+
+const intBase = 10
+
+// credential is the in-memory record for a stored Git credential.
+type credential struct {
+	id          int64
+	gitProvider string
+	gitUsername string
+	token       string
+}
+
+// Handler serves the Databricks Git Credentials data-plane REST API.
+type Handler struct {
+	mu     sync.RWMutex
+	store  map[int64]*credential
+	nextID int64
+}
+
+// New returns a Git Credentials handler with an empty in-memory store.
+func New() *Handler {
+	return &Handler{
+		store:  make(map[int64]*credential),
+		nextID: 1,
+	}
+}
+
+// Matches claims /api/{ver}/git-credentials[/...] paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+
+	return len(parts) >= minResourceSegs && parts[0] == "api" && parts[2] == resourceSegment
+}
+
+// ServeHTTP routes by HTTP method and the presence of a {credential_id} segment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minResourceSegs {
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unsupported path")
+
+		return
+	}
+
+	if len(parts) >= withIDSegs {
+		h.serveByID(w, r, parts[idSegIndex])
+
+		return
+	}
+
+	h.serveCollection(w, r)
+}
+
+// serveCollection handles the id-less endpoints: POST (create) and GET (list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.create(w, r)
+	case http.MethodGet:
+		h.list(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveByID handles the {credential_id} endpoints: GET, PATCH, DELETE.
+func (h *Handler) serveByID(w http.ResponseWriter, r *http.Request, idSeg string) {
+	id, err := strconv.ParseInt(idSeg, intBase, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid credential_id: "+idSeg)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, id)
+	case http.MethodPatch:
+		h.update(w, r, id)
+	case http.MethodDelete:
+		h.delete(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// createRequest is the Create/Update request body shape.
+type createRequest struct {
+	GitProvider         string `json:"git_provider"`
+	GitUsername         string `json:"git_username,omitempty"`
+	PersonalAccessToken string `json:"personal_access_token,omitempty"`
+}
+
+// credentialResponse is the public view of a credential (token omitted).
+type credentialResponse struct {
+	CredentialID int64  `json:"credential_id"`
+	GitProvider  string `json:"git_provider"`
+	GitUsername  string `json:"git_username,omitempty"`
+}
+
+// listResponse is the List endpoint body shape.
+type listResponse struct {
+	Credentials []credentialResponse `json:"credentials,omitempty"`
+}
+
+func toResponse(c *credential) credentialResponse {
+	return credentialResponse{
+		CredentialID: c.id,
+		GitProvider:  c.gitProvider,
+		GitUsername:  c.gitUsername,
+	}
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if req.GitProvider == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "git_provider is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	c := &credential{
+		id:          h.nextID,
+		gitProvider: req.GitProvider,
+		gitUsername: req.GitUsername,
+		token:       req.PersonalAccessToken,
+	}
+	h.store[c.id] = c
+	h.nextID++
+	h.mu.Unlock()
+
+	writeJSON(w, toResponse(c))
+}
+
+func (h *Handler) get(w http.ResponseWriter, id int64) {
+	h.mu.RLock()
+	c, ok := h.store[id]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeNotFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, toResponse(c))
+}
+
+func (h *Handler) list(w http.ResponseWriter) {
+	h.mu.RLock()
+	out := make([]credentialResponse, 0, len(h.store))
+
+	for _, c := range h.store {
+		out = append(out, toResponse(c))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listResponse{Credentials: out})
+}
+
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, id int64) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if req.GitProvider == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "git_provider is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	c, ok := h.store[id]
+
+	if ok {
+		c.gitProvider = req.GitProvider
+		c.gitUsername = req.GitUsername
+
+		if req.PersonalAccessToken != "" {
+			c.token = req.PersonalAccessToken
+		}
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeNotFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func (h *Handler) delete(w http.ResponseWriter, id int64) {
+	h.mu.Lock()
+	_, ok := h.store[id]
+
+	if ok {
+		delete(h.store, id)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeNotFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// splitPath strips surrounding slashes and returns the path segments. Path
+// /api/2.0/git-credentials/5 → ["api","2.0","git-credentials","5"].
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func writeNotFound(w http.ResponseWriter, id int64) {
+	writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST",
+		"git credential does not exist: "+strconv.FormatInt(id, intBase))
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+}

--- a/server/azure/databricks/gitcredentials/gitcredentials_roundtrip_test.go
+++ b/server/azure/databricks/gitcredentials/gitcredentials_roundtrip_test.go
@@ -1,0 +1,108 @@
+package gitcredentials_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New(gitcredentials.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "x",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKGitCredentialLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.GitCredentials.Create(ctx, workspace.CreateCredentialsRequest{
+		GitProvider:         "gitHub",
+		GitUsername:         "octocat",
+		PersonalAccessToken: "ghp_secret",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.CredentialId == 0 {
+		t.Fatal("expected non-zero credential id")
+	}
+
+	if created.GitProvider != "gitHub" || created.GitUsername != "octocat" {
+		t.Fatalf("unexpected create response: %+v", created)
+	}
+
+	got, err := w.GitCredentials.GetByCredentialId(ctx, created.CredentialId)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.CredentialId != created.CredentialId || got.GitUsername != "octocat" {
+		t.Fatalf("unexpected get response: %+v", got)
+	}
+
+	all, err := w.GitCredentials.ListAll(ctx, workspace.ListCredentialsRequest{})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 1 || all[0].CredentialId != created.CredentialId {
+		t.Fatalf("unexpected list: %+v", all)
+	}
+
+	if err = w.GitCredentials.Update(ctx, workspace.UpdateCredentialsRequest{
+		CredentialId:        created.CredentialId,
+		GitProvider:         "gitLab",
+		GitUsername:         "newuser",
+		PersonalAccessToken: "glpat_secret",
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	updated, err := w.GitCredentials.GetByCredentialId(ctx, created.CredentialId)
+	if err != nil {
+		t.Fatalf("Get after update: %v", err)
+	}
+
+	if updated.GitProvider != "gitLab" || updated.GitUsername != "newuser" {
+		t.Fatalf("update not applied: %+v", updated)
+	}
+
+	if err = w.GitCredentials.DeleteByCredentialId(ctx, created.CredentialId); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err = w.GitCredentials.GetByCredentialId(ctx, created.CredentialId); err == nil {
+		t.Fatal("expected error getting deleted credential")
+	}
+}
+
+func TestSDKGitCredentialGetMissing(t *testing.T) {
+	w := newWorkspace(t)
+
+	if _, err := w.GitCredentials.GetByCredentialId(context.Background(), 999); err == nil {
+		t.Fatal("expected error for missing credential")
+	}
+}

--- a/server/azure/databricks/integration_roundtrip_test.go
+++ b/server/azure/databricks/integration_roundtrip_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/databricks/databricks-sdk-go/service/workspace"
 )
 
-// TestSDKFullWorkspaceDataPlane stands up a single Azure server with the whole
-// Databricks data plane registered and drives the real WorkspaceClient across
-// every resource family through that one endpoint — proving the handlers
-// coexist (disjoint routing) and behave like a real workspace.
+// TestSDKFullWorkspaceDataPlane stands up a SINGLE Azure server with the whole
+// Databricks data plane registered and drives the real WorkspaceClient through
+// a full lifecycle of every resource family against that one endpoint — the
+// way a real user would, proving the handlers coexist and behave correctly
+// together (not just in isolation).
 func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 	w := newWorkspace(t)
 	ctx := context.Background()
@@ -36,6 +37,19 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 		if err != nil || got.Value == "" {
 			t.Fatalf("GetSecret: %v (value=%q)", err, got.Value)
 		}
+
+		secs, err := w.Secrets.ListSecretsAll(ctx, workspace.ListSecretsRequest{Scope: "s1"})
+		if err != nil || len(secs) != 1 {
+			t.Fatalf("ListSecrets: %v (n=%d)", err, len(secs))
+		}
+
+		if err := w.Secrets.DeleteSecret(ctx, workspace.DeleteSecret{Scope: "s1", Key: "k"}); err != nil {
+			t.Fatalf("DeleteSecret: %v", err)
+		}
+
+		if err := w.Secrets.DeleteScope(ctx, workspace.DeleteScope{Scope: "s1"}); err != nil {
+			t.Fatalf("DeleteScope: %v", err)
+		}
 	})
 
 	t.Run("tokens", func(t *testing.T) {
@@ -43,9 +57,20 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 		if err != nil || tok.TokenValue == "" {
 			t.Fatalf("Tokens.Create: %v", err)
 		}
+
+		list, err := w.Tokens.ListAll(ctx)
+		if err != nil || len(list) != 1 {
+			t.Fatalf("Tokens.List: %v (n=%d)", err, len(list))
+		}
+
+		if err := w.Tokens.Delete(ctx, settings.RevokeTokenRequest{TokenId: tok.TokenInfo.TokenId}); err != nil {
+			t.Fatalf("Tokens.Delete: %v", err)
+		}
 	})
 
-	clusterID := t.Run("clusters", func(t *testing.T) {
+	var clusterID string
+
+	t.Run("clusters", func(t *testing.T) {
 		wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
 			ClusterName: "c1", SparkVersion: "13.3.x-scala2.12", NodeTypeId: "Standard_DS3_v2", NumWorkers: 1,
 		})
@@ -53,17 +78,75 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 			t.Fatalf("Clusters.Create: %v", err)
 		}
 
-		if _, err = w.Clusters.GetByClusterId(ctx, wait.ClusterId); err != nil {
-			t.Fatalf("Clusters.Get: %v", err)
+		clusterID = wait.ClusterId
+
+		got, err := w.Clusters.GetByClusterId(ctx, clusterID)
+		if err != nil || got.State != compute.StateRunning {
+			t.Fatalf("Clusters.Get: %v (state=%v)", err, got.State)
+		}
+
+		if _, err := w.Clusters.Resize(ctx, compute.ResizeCluster{ClusterId: clusterID, NumWorkers: 2}); err != nil {
+			t.Fatalf("Clusters.Resize: %v", err)
+		}
+
+		if err := w.Clusters.Pin(ctx, compute.PinCluster{ClusterId: clusterID}); err != nil {
+			t.Fatalf("Clusters.Pin: %v", err)
+		}
+
+		if _, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{}); err != nil {
+			t.Fatalf("Clusters.List: %v", err)
 		}
 	})
-	_ = clusterID
 
 	t.Run("instance_pools", func(t *testing.T) {
-		if _, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
+		pool, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
 			InstancePoolName: "p1", NodeTypeId: "Standard_DS3_v2",
-		}); err != nil {
+		})
+		if err != nil {
 			t.Fatalf("InstancePools.Create: %v", err)
+		}
+
+		if _, err := w.InstancePools.GetByInstancePoolId(ctx, pool.InstancePoolId); err != nil {
+			t.Fatalf("InstancePools.Get: %v", err)
+		}
+
+		if err := w.InstancePools.DeleteByInstancePoolId(ctx, pool.InstancePoolId); err != nil {
+			t.Fatalf("InstancePools.Delete: %v", err)
+		}
+	})
+
+	t.Run("cluster_policies", func(t *testing.T) {
+		pol, err := w.ClusterPolicies.Create(ctx, compute.CreatePolicy{Name: "pol", Definition: "{}"})
+		if err != nil {
+			t.Fatalf("ClusterPolicies.Create: %v", err)
+		}
+
+		if _, err := w.ClusterPolicies.Get(ctx, compute.GetClusterPolicyRequest{PolicyId: pol.PolicyId}); err != nil {
+			t.Fatalf("ClusterPolicies.Get: %v", err)
+		}
+
+		if err := w.ClusterPolicies.Delete(ctx, compute.DeletePolicy{PolicyId: pol.PolicyId}); err != nil {
+			t.Fatalf("ClusterPolicies.Delete: %v", err)
+		}
+	})
+
+	t.Run("libraries", func(t *testing.T) {
+		lib := compute.Library{Pypi: &compute.PythonPyPiLibrary{Package: "requests"}}
+		if err := w.Libraries.Install(ctx, compute.InstallLibraries{
+			ClusterId: clusterID, Libraries: []compute.Library{lib},
+		}); err != nil {
+			t.Fatalf("Libraries.Install: %v", err)
+		}
+
+		st, err := w.Libraries.ClusterStatusByClusterId(ctx, clusterID)
+		if err != nil || len(st.LibraryStatuses) != 1 {
+			t.Fatalf("Libraries.ClusterStatus: %v", err)
+		}
+
+		if err := w.Libraries.Uninstall(ctx, compute.UninstallLibraries{
+			ClusterId: clusterID, Libraries: []compute.Library{lib},
+		}); err != nil {
+			t.Fatalf("Libraries.Uninstall: %v", err)
 		}
 	})
 
@@ -78,14 +161,23 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 			t.Fatalf("Jobs.RunNow: %v", err)
 		}
 
-		if _, err = w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: run.Response.RunId}); err != nil {
+		if _, err := w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: run.Response.RunId}); err != nil {
 			t.Fatalf("Jobs.GetRun: %v", err)
+		}
+
+		if _, err := w.Jobs.ListRunsAll(ctx, jobs.ListRunsRequest{JobId: job.JobId}); err != nil {
+			t.Fatalf("Jobs.ListRuns: %v", err)
+		}
+
+		if err := w.Jobs.DeleteByJobId(ctx, job.JobId); err != nil {
+			t.Fatalf("Jobs.Delete: %v", err)
 		}
 	})
 
-	t.Run("cluster_policies", func(t *testing.T) {
-		if _, err := w.ClusterPolicies.Create(ctx, compute.CreatePolicy{Name: "pol", Definition: "{}"}); err != nil {
-			t.Fatalf("ClusterPolicies.Create: %v", err)
+	// terminate the cluster created earlier (lifecycle close-out)
+	t.Run("cluster_terminate", func(t *testing.T) {
+		if _, err := w.Clusters.Delete(ctx, compute.DeleteCluster{ClusterId: clusterID}); err != nil {
+			t.Fatalf("Clusters.Delete: %v", err)
 		}
 	})
 
@@ -94,21 +186,47 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 		if err != nil || wait.Id == "" {
 			t.Fatalf("Warehouses.Create: %v", err)
 		}
+
+		if _, err := w.Warehouses.GetById(ctx, wait.Id); err != nil {
+			t.Fatalf("Warehouses.Get: %v", err)
+		}
+
+		if _, err := w.Warehouses.Stop(ctx, sql.StopRequest{Id: wait.Id}); err != nil {
+			t.Fatalf("Warehouses.Stop: %v", err)
+		}
+
+		if err := w.Warehouses.DeleteById(ctx, wait.Id); err != nil {
+			t.Fatalf("Warehouses.Delete: %v", err)
+		}
 	})
 
 	t.Run("repos", func(t *testing.T) {
-		if _, err := w.Repos.Create(ctx, workspace.CreateRepoRequest{
-			Url: "https://github.com/x/y", Provider: "gitHub",
-		}); err != nil {
+		repo, err := w.Repos.Create(ctx, workspace.CreateRepoRequest{Url: "https://github.com/x/y", Provider: "gitHub"})
+		if err != nil {
 			t.Fatalf("Repos.Create: %v", err)
+		}
+
+		if _, err := w.Repos.GetByRepoId(ctx, repo.Id); err != nil {
+			t.Fatalf("Repos.Get: %v", err)
+		}
+
+		if err := w.Repos.DeleteByRepoId(ctx, repo.Id); err != nil {
+			t.Fatalf("Repos.Delete: %v", err)
 		}
 	})
 
 	t.Run("git_credentials", func(t *testing.T) {
-		if _, err := w.GitCredentials.Create(ctx, workspace.CreateCredentialsRequest{
-			GitProvider: "gitHub", GitUsername: "u",
-		}); err != nil {
+		cred, err := w.GitCredentials.Create(ctx, workspace.CreateCredentialsRequest{GitProvider: "gitHub", GitUsername: "u"})
+		if err != nil {
 			t.Fatalf("GitCredentials.Create: %v", err)
+		}
+
+		if _, err := w.GitCredentials.GetByCredentialId(ctx, cred.CredentialId); err != nil {
+			t.Fatalf("GitCredentials.Get: %v", err)
+		}
+
+		if err := w.GitCredentials.DeleteByCredentialId(ctx, cred.CredentialId); err != nil {
+			t.Fatalf("GitCredentials.Delete: %v", err)
 		}
 	})
 
@@ -121,6 +239,10 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 		if err != nil || !st.IsDir {
 			t.Fatalf("Dbfs.GetStatus: %v (isDir=%v)", err, st.IsDir)
 		}
+
+		if err := w.Dbfs.Delete(ctx, files.Delete{Path: "/tmp/cloudemu", Recursive: true}); err != nil {
+			t.Fatalf("Dbfs.Delete: %v", err)
+		}
 	})
 
 	t.Run("workspace", func(t *testing.T) {
@@ -130,6 +252,10 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 
 		if _, err := w.Workspace.GetStatus(ctx, workspace.GetStatusRequest{Path: "/Shared/cloudemu"}); err != nil {
 			t.Fatalf("Workspace.GetStatus: %v", err)
+		}
+
+		if err := w.Workspace.Delete(ctx, workspace.Delete{Path: "/Shared/cloudemu", Recursive: true}); err != nil {
+			t.Fatalf("Workspace.Delete: %v", err)
 		}
 	})
 
@@ -141,23 +267,62 @@ func TestSDKFullWorkspaceDataPlane(t *testing.T) {
 		if _, err := w.Schemas.Create(ctx, catalog.CreateSchema{Name: "sch", CatalogName: "cat"}); err != nil {
 			t.Fatalf("Schemas.Create: %v", err)
 		}
+
+		if _, err := w.Schemas.GetByFullName(ctx, "cat.sch"); err != nil {
+			t.Fatalf("Schemas.Get: %v", err)
+		}
+
+		if err := w.Catalogs.DeleteByName(ctx, "cat"); err != nil {
+			t.Fatalf("Catalogs.Delete: %v", err)
+		}
 	})
 
 	t.Run("uc_storage", func(t *testing.T) {
-		if _, err := w.Metastores.Create(ctx, catalog.CreateMetastore{Name: "ms"}); err != nil {
+		ms, err := w.Metastores.Create(ctx, catalog.CreateMetastore{Name: "ms"})
+		if err != nil {
 			t.Fatalf("Metastores.Create: %v", err)
+		}
+
+		if _, err := w.Metastores.GetById(ctx, ms.MetastoreId); err != nil {
+			t.Fatalf("Metastores.Get: %v", err)
+		}
+
+		if err := w.Metastores.DeleteById(ctx, ms.MetastoreId); err != nil {
+			t.Fatalf("Metastores.Delete: %v", err)
 		}
 	})
 
 	t.Run("scim", func(t *testing.T) {
-		if _, err := w.Users.Create(ctx, iam.User{UserName: "alice@example.com"}); err != nil {
+		user, err := w.Users.Create(ctx, iam.User{UserName: "alice@example.com"})
+		if err != nil {
 			t.Fatalf("Users.Create: %v", err)
+		}
+
+		if _, err := w.Users.GetById(ctx, user.Id); err != nil {
+			t.Fatalf("Users.Get: %v", err)
+		}
+
+		if err := w.Users.DeleteById(ctx, user.Id); err != nil {
+			t.Fatalf("Users.Delete: %v", err)
 		}
 	})
 
 	t.Run("pipelines", func(t *testing.T) {
+		p, err := w.Pipelines.Create(ctx, pipelines.CreatePipeline{Name: "pl1"})
+		if err != nil {
+			t.Fatalf("Pipelines.Create: %v", err)
+		}
+
+		if _, err := w.Pipelines.GetByPipelineId(ctx, p.PipelineId); err != nil {
+			t.Fatalf("Pipelines.Get: %v", err)
+		}
+
 		if _, err := w.Pipelines.ListPipelinesAll(ctx, pipelines.ListPipelinesRequest{}); err != nil {
 			t.Fatalf("Pipelines.List: %v", err)
+		}
+
+		if err := w.Pipelines.DeleteByPipelineId(ctx, p.PipelineId); err != nil {
+			t.Fatalf("Pipelines.Delete: %v", err)
 		}
 	})
 

--- a/server/azure/databricks/integration_roundtrip_test.go
+++ b/server/azure/databricks/integration_roundtrip_test.go
@@ -1,0 +1,169 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/databricks/databricks-sdk-go/service/compute"
+	"github.com/databricks/databricks-sdk-go/service/files"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/databricks/databricks-sdk-go/service/jobs"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+	"github.com/databricks/databricks-sdk-go/service/settings"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+)
+
+// TestSDKFullWorkspaceDataPlane stands up a single Azure server with the whole
+// Databricks data plane registered and drives the real WorkspaceClient across
+// every resource family through that one endpoint — proving the handlers
+// coexist (disjoint routing) and behave like a real workspace.
+func TestSDKFullWorkspaceDataPlane(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	t.Run("secrets", func(t *testing.T) {
+		if err := w.Secrets.CreateScope(ctx, workspace.CreateScope{Scope: "s1"}); err != nil {
+			t.Fatalf("CreateScope: %v", err)
+		}
+
+		if err := w.Secrets.PutSecret(ctx, workspace.PutSecret{Scope: "s1", Key: "k", StringValue: "v"}); err != nil {
+			t.Fatalf("PutSecret: %v", err)
+		}
+
+		got, err := w.Secrets.GetSecret(ctx, workspace.GetSecretRequest{Scope: "s1", Key: "k"})
+		if err != nil || got.Value == "" {
+			t.Fatalf("GetSecret: %v (value=%q)", err, got.Value)
+		}
+	})
+
+	t.Run("tokens", func(t *testing.T) {
+		tok, err := w.Tokens.Create(ctx, settings.CreateTokenRequest{Comment: "c", LifetimeSeconds: 3600})
+		if err != nil || tok.TokenValue == "" {
+			t.Fatalf("Tokens.Create: %v", err)
+		}
+	})
+
+	clusterID := t.Run("clusters", func(t *testing.T) {
+		wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+			ClusterName: "c1", SparkVersion: "13.3.x-scala2.12", NodeTypeId: "Standard_DS3_v2", NumWorkers: 1,
+		})
+		if err != nil || wait.ClusterId == "" {
+			t.Fatalf("Clusters.Create: %v", err)
+		}
+
+		if _, err = w.Clusters.GetByClusterId(ctx, wait.ClusterId); err != nil {
+			t.Fatalf("Clusters.Get: %v", err)
+		}
+	})
+	_ = clusterID
+
+	t.Run("instance_pools", func(t *testing.T) {
+		if _, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
+			InstancePoolName: "p1", NodeTypeId: "Standard_DS3_v2",
+		}); err != nil {
+			t.Fatalf("InstancePools.Create: %v", err)
+		}
+	})
+
+	t.Run("jobs_and_runs", func(t *testing.T) {
+		job, err := w.Jobs.Create(ctx, jobs.CreateJob{Name: "j1"})
+		if err != nil {
+			t.Fatalf("Jobs.Create: %v", err)
+		}
+
+		run, err := w.Jobs.RunNow(ctx, jobs.RunNow{JobId: job.JobId})
+		if err != nil || run.Response.RunId == 0 {
+			t.Fatalf("Jobs.RunNow: %v", err)
+		}
+
+		if _, err = w.Jobs.GetRun(ctx, jobs.GetRunRequest{RunId: run.Response.RunId}); err != nil {
+			t.Fatalf("Jobs.GetRun: %v", err)
+		}
+	})
+
+	t.Run("cluster_policies", func(t *testing.T) {
+		if _, err := w.ClusterPolicies.Create(ctx, compute.CreatePolicy{Name: "pol", Definition: "{}"}); err != nil {
+			t.Fatalf("ClusterPolicies.Create: %v", err)
+		}
+	})
+
+	t.Run("sql_warehouses", func(t *testing.T) {
+		wait, err := w.Warehouses.Create(ctx, sql.CreateWarehouseRequest{Name: "wh1", ClusterSize: "2X-Small"})
+		if err != nil || wait.Id == "" {
+			t.Fatalf("Warehouses.Create: %v", err)
+		}
+	})
+
+	t.Run("repos", func(t *testing.T) {
+		if _, err := w.Repos.Create(ctx, workspace.CreateRepoRequest{
+			Url: "https://github.com/x/y", Provider: "gitHub",
+		}); err != nil {
+			t.Fatalf("Repos.Create: %v", err)
+		}
+	})
+
+	t.Run("git_credentials", func(t *testing.T) {
+		if _, err := w.GitCredentials.Create(ctx, workspace.CreateCredentialsRequest{
+			GitProvider: "gitHub", GitUsername: "u",
+		}); err != nil {
+			t.Fatalf("GitCredentials.Create: %v", err)
+		}
+	})
+
+	t.Run("dbfs", func(t *testing.T) {
+		if err := w.Dbfs.Mkdirs(ctx, files.MkDirs{Path: "/tmp/cloudemu"}); err != nil {
+			t.Fatalf("Dbfs.Mkdirs: %v", err)
+		}
+
+		st, err := w.Dbfs.GetStatus(ctx, files.GetStatusRequest{Path: "/tmp/cloudemu"})
+		if err != nil || !st.IsDir {
+			t.Fatalf("Dbfs.GetStatus: %v (isDir=%v)", err, st.IsDir)
+		}
+	})
+
+	t.Run("workspace", func(t *testing.T) {
+		if err := w.Workspace.Mkdirs(ctx, workspace.Mkdirs{Path: "/Shared/cloudemu"}); err != nil {
+			t.Fatalf("Workspace.Mkdirs: %v", err)
+		}
+
+		if _, err := w.Workspace.GetStatus(ctx, workspace.GetStatusRequest{Path: "/Shared/cloudemu"}); err != nil {
+			t.Fatalf("Workspace.GetStatus: %v", err)
+		}
+	})
+
+	t.Run("unity_catalog", func(t *testing.T) {
+		if _, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{Name: "cat"}); err != nil {
+			t.Fatalf("Catalogs.Create: %v", err)
+		}
+
+		if _, err := w.Schemas.Create(ctx, catalog.CreateSchema{Name: "sch", CatalogName: "cat"}); err != nil {
+			t.Fatalf("Schemas.Create: %v", err)
+		}
+	})
+
+	t.Run("uc_storage", func(t *testing.T) {
+		if _, err := w.Metastores.Create(ctx, catalog.CreateMetastore{Name: "ms"}); err != nil {
+			t.Fatalf("Metastores.Create: %v", err)
+		}
+	})
+
+	t.Run("scim", func(t *testing.T) {
+		if _, err := w.Users.Create(ctx, iam.User{UserName: "alice@example.com"}); err != nil {
+			t.Fatalf("Users.Create: %v", err)
+		}
+	})
+
+	t.Run("pipelines", func(t *testing.T) {
+		if _, err := w.Pipelines.ListPipelinesAll(ctx, pipelines.ListPipelinesRequest{}); err != nil {
+			t.Fatalf("Pipelines.List: %v", err)
+		}
+	})
+
+	t.Run("serving", func(t *testing.T) {
+		if _, err := w.ServingEndpoints.ListAll(ctx); err != nil {
+			t.Fatalf("ServingEndpoints.List: %v", err)
+		}
+	})
+}

--- a/server/azure/databricks/pipelines/pipelines.go
+++ b/server/azure/databricks/pipelines/pipelines.go
@@ -1,0 +1,449 @@
+// Package pipelines implements the Databricks Pipelines (Delta Live Tables)
+// data-plane REST API (the /api/2.0/pipelines surface) as a server.Handler.
+// Point the real github.com/databricks/databricks-sdk-go WorkspaceClient at a
+// server registered with a Handler from New and w.Pipelines works end-to-end
+// against an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.0/pipelines
+//	GET    /api/2.0/pipelines
+//	GET    /api/2.0/pipelines/{id}
+//	PUT    /api/2.0/pipelines/{id}
+//	DELETE /api/2.0/pipelines/{id}
+//	POST   /api/2.0/pipelines/{id}/updates
+//	POST   /api/2.0/pipelines/{id}/stop
+package pipelines
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+// Pipeline lifecycle state. Pipelines settle in IDLE so the SDK Stop waiter,
+// which polls Get until IDLE, resolves immediately. The STARTING/RUNNING/
+// STOPPING intermediate states are not emitted by this in-memory backend.
+const stateIdle = "IDLE"
+
+// Path segment positions after splitting on "/" ([api, ver, pipelines, id, act]).
+const (
+	idxAPI      = 0
+	idxResource = 2
+	idxID       = 3
+	idxAction   = 4
+)
+
+// minMatchSegs is the [api, ver, pipelines] segment count Matches needs.
+const minMatchSegs = 3
+
+const actionUpdates = "updates"
+const actionStop = "stop"
+
+// pipeline is the in-memory state for a single Delta Live Tables pipeline.
+type pipeline struct {
+	ID           string
+	Name         string
+	Storage      string
+	Target       string
+	Catalog      string
+	Channel      string
+	Edition      string
+	Continuous   bool
+	Development  bool
+	State        string
+	CreatorName  string
+	LatestUpdate string
+}
+
+// Handler serves the Databricks Pipelines data-plane REST API.
+type Handler struct {
+	mu       sync.RWMutex
+	items    map[string]*pipeline
+	nextID   int
+	updateID int
+}
+
+// New returns a Pipelines handler backed by an empty in-memory store.
+func New() *Handler {
+	return &Handler{items: make(map[string]*pipeline)}
+}
+
+// Matches claims /api/{ver}/pipelines/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minMatchSegs || parts[idxAPI] != "api" {
+		return false
+	}
+
+	return parts[idxResource] == "pipelines"
+}
+
+// ServeHTTP routes by path shape: collection (create/list) vs. item (get/
+// update/delete) vs. item action (updates/stop).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minMatchSegs {
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unsupported path")
+
+		return
+	}
+
+	if len(parts) == minMatchSegs {
+		h.serveCollection(w, r)
+
+		return
+	}
+
+	h.serveItem(w, r, parts)
+}
+
+// serveCollection handles /api/2.0/pipelines (POST create, GET list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.create(w, r)
+	case http.MethodGet:
+		h.list(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItem handles /api/2.0/pipelines/{id}[/{action}].
+func (h *Handler) serveItem(w http.ResponseWriter, r *http.Request, parts []string) {
+	id := parts[idxID]
+
+	if len(parts) > idxAction {
+		h.serveItemAction(w, r, id, parts[idxAction])
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, id)
+	case http.MethodPut:
+		h.update(w, r, id)
+	case http.MethodDelete:
+		h.delete(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItemAction handles the /{id}/{updates,stop} sub-routes.
+func (h *Handler) serveItemAction(w http.ResponseWriter, r *http.Request, id, action string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	switch action {
+	case actionUpdates:
+		h.startUpdate(w, id)
+	case actionStop:
+		h.stop(w, id)
+	default:
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unknown action: "+action)
+	}
+}
+
+// createRequest is the subset of CreatePipeline fields we honor.
+type createRequest struct {
+	Name        string `json:"name"`
+	Storage     string `json:"storage"`
+	Target      string `json:"target"`
+	Catalog     string `json:"catalog"`
+	Channel     string `json:"channel"`
+	Edition     string `json:"edition"`
+	Continuous  bool   `json:"continuous"`
+	Development bool   `json:"development"`
+	CreatorName string `json:"creator_user_name"`
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "name is required")
+
+		return
+	}
+
+	p := newPipeline(&req)
+
+	h.mu.Lock()
+	h.nextID++
+	p.ID = fmt.Sprintf("pipe-%d", h.nextID)
+	h.items[p.ID] = p
+	h.mu.Unlock()
+
+	writeJSON(w, map[string]string{"pipeline_id": p.ID})
+}
+
+// newPipeline builds a pipeline from a create request. Pipelines start IDLE so
+// any state-polling waiter resolves immediately.
+func newPipeline(req *createRequest) *pipeline {
+	return &pipeline{
+		Name:        req.Name,
+		Storage:     req.Storage,
+		Target:      req.Target,
+		Catalog:     req.Catalog,
+		Channel:     req.Channel,
+		Edition:     req.Edition,
+		Continuous:  req.Continuous,
+		Development: req.Development,
+		State:       stateIdle,
+		CreatorName: req.CreatorName,
+	}
+}
+
+func (h *Handler) get(w http.ResponseWriter, id string) {
+	var snapshot pipeline
+
+	h.mu.RLock()
+	p, ok := h.items[id]
+
+	if ok {
+		snapshot = *p
+	}
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, toResponse(&snapshot))
+}
+
+func (h *Handler) list(w http.ResponseWriter) {
+	h.mu.RLock()
+	out := make([]map[string]any, 0, len(h.items))
+
+	for _, p := range h.items {
+		out = append(out, toStateInfo(p))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, map[string]any{"statuses": out})
+}
+
+// updateRequest is the subset of EditPipeline fields we honor.
+type updateRequest struct {
+	Name        string `json:"name"`
+	Storage     string `json:"storage"`
+	Target      string `json:"target"`
+	Catalog     string `json:"catalog"`
+	Channel     string `json:"channel"`
+	Edition     string `json:"edition"`
+	Continuous  bool   `json:"continuous"`
+	Development bool   `json:"development"`
+}
+
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, id string) {
+	var req updateRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	p, ok := h.items[id]
+
+	if ok {
+		applyUpdate(p, &req)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func applyUpdate(p *pipeline, req *updateRequest) {
+	if req.Name != "" {
+		p.Name = req.Name
+	}
+
+	if req.Storage != "" {
+		p.Storage = req.Storage
+	}
+
+	if req.Target != "" {
+		p.Target = req.Target
+	}
+
+	if req.Catalog != "" {
+		p.Catalog = req.Catalog
+	}
+
+	if req.Channel != "" {
+		p.Channel = req.Channel
+	}
+
+	if req.Edition != "" {
+		p.Edition = req.Edition
+	}
+
+	p.Continuous = req.Continuous
+	p.Development = req.Development
+}
+
+func (h *Handler) delete(w http.ResponseWriter, id string) {
+	h.mu.Lock()
+	_, ok := h.items[id]
+
+	if ok {
+		delete(h.items, id)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func (h *Handler) startUpdate(w http.ResponseWriter, id string) {
+	var updateID string
+
+	h.mu.Lock()
+	p, ok := h.items[id]
+
+	if ok {
+		h.updateID++
+		updateID = fmt.Sprintf("upd-%d", h.updateID)
+		p.LatestUpdate = updateID
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, map[string]string{"update_id": updateID})
+}
+
+// stop drives a pipeline back to IDLE. The SDK Stop call returns a waiter that
+// polls Get until IDLE, so leaving the pipeline IDLE lets the waiter resolve.
+func (h *Handler) stop(w http.ResponseWriter, id string) {
+	h.mu.Lock()
+	p, ok := h.items[id]
+
+	if ok {
+		p.State = stateIdle
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// toResponse renders a pipeline as the GetPipelineResponse JSON shape.
+func toResponse(p *pipeline) map[string]any {
+	return map[string]any{
+		"pipeline_id":       p.ID,
+		"name":              p.Name,
+		"state":             p.State,
+		"creator_user_name": p.CreatorName,
+		"spec":              toSpec(p),
+	}
+}
+
+// toSpec renders the pipeline settings as the PipelineSpec JSON shape.
+func toSpec(p *pipeline) map[string]any {
+	return map[string]any{
+		"id":          p.ID,
+		"name":        p.Name,
+		"storage":     p.Storage,
+		"target":      p.Target,
+		"catalog":     p.Catalog,
+		"channel":     p.Channel,
+		"edition":     p.Edition,
+		"continuous":  p.Continuous,
+		"development": p.Development,
+	}
+}
+
+// toStateInfo renders a pipeline as the PipelineStateInfo JSON shape used by
+// ListPipelines.
+func toStateInfo(p *pipeline) map[string]any {
+	return map[string]any{
+		"pipeline_id":       p.ID,
+		"name":              p.Name,
+		"state":             p.State,
+		"creator_user_name": p.CreatorName,
+	}
+}
+
+// splitPath strips the leading/trailing "/" and returns the path segments.
+func splitPath(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func notFound(w http.ResponseWriter, id string) {
+	writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "pipeline not found: "+id)
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+}

--- a/server/azure/databricks/pipelines/pipelines_roundtrip_test.go
+++ b/server/azure/databricks/pipelines/pipelines_roundtrip_test.go
@@ -1,0 +1,155 @@
+package pipelines_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/pipelines"
+
+	"github.com/stackshy/cloudemu/server"
+	pipelineshandler "github.com/stackshy/cloudemu/server/azure/databricks/pipelines"
+)
+
+func newPipelineClient(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(pipelineshandler.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:               ts.URL,
+		Token:              "test-token",
+		Credentials:        config.PatCredentials{},
+		HTTPTimeoutSeconds: 10,
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKPipelineLifecycle(t *testing.T) {
+	w := newPipelineClient(t)
+	ctx := context.Background()
+
+	created, err := w.Pipelines.Create(ctx, pipelines.CreatePipeline{
+		Name:        "pipe-1",
+		Storage:     "/mnt/pipe",
+		Target:      "db",
+		Continuous:  true,
+		Development: true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	id := created.PipelineId
+	if id == "" {
+		t.Fatal("expected pipeline id from create")
+	}
+
+	got, err := w.Pipelines.GetByPipelineId(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByPipelineId: %v", err)
+	}
+
+	if got.Name != "pipe-1" {
+		t.Fatalf("unexpected pipeline: %+v", got)
+	}
+
+	if got.State != pipelines.PipelineStateIdle {
+		t.Fatalf("got state %q, want IDLE", got.State)
+	}
+
+	all, err := w.Pipelines.ListPipelinesAll(ctx, pipelines.ListPipelinesRequest{})
+	if err != nil {
+		t.Fatalf("ListPipelinesAll: %v", err)
+	}
+
+	if len(all) != 1 {
+		t.Fatalf("got %d pipelines, want 1", len(all))
+	}
+
+	if all[0].PipelineId != id {
+		t.Fatalf("listed id %q, want %q", all[0].PipelineId, id)
+	}
+
+	if err = w.Pipelines.Update(ctx, pipelines.EditPipeline{
+		PipelineId: id,
+		Name:       "pipe-1-edited",
+		Channel:    "PREVIEW",
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	edited, err := w.Pipelines.GetByPipelineId(ctx, id)
+	if err != nil {
+		t.Fatalf("GetByPipelineId after update: %v", err)
+	}
+
+	if edited.Name != "pipe-1-edited" {
+		t.Fatalf("update not applied: %+v", edited)
+	}
+
+	upd, err := w.Pipelines.StartUpdate(ctx, pipelines.StartUpdate{
+		PipelineId:  id,
+		FullRefresh: true,
+	})
+	if err != nil {
+		t.Fatalf("StartUpdate: %v", err)
+	}
+
+	if upd.UpdateId == "" {
+		t.Fatal("expected update id from StartUpdate")
+	}
+
+	stopWait, err := w.Pipelines.Stop(ctx, pipelines.StopRequest{PipelineId: id})
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	stopped, err := stopWait.Get()
+	if err != nil {
+		t.Fatalf("Stop wait: %v", err)
+	}
+
+	if stopped.State != pipelines.PipelineStateIdle {
+		t.Fatalf("got state %q after stop, want IDLE", stopped.State)
+	}
+
+	if err = w.Pipelines.DeleteByPipelineId(ctx, id); err != nil {
+		t.Fatalf("DeleteByPipelineId: %v", err)
+	}
+
+	if _, err = w.Pipelines.GetByPipelineId(ctx, id); err == nil {
+		t.Fatal("expected error getting deleted pipeline")
+	}
+}
+
+func TestSDKPipelineGetMissing(t *testing.T) {
+	w := newPipelineClient(t)
+
+	if _, err := w.Pipelines.GetByPipelineId(context.Background(), "does-not-exist"); err == nil {
+		t.Fatal("expected RESOURCE_DOES_NOT_EXIST error")
+	}
+}
+
+func TestSDKPipelineListEmpty(t *testing.T) {
+	w := newPipelineClient(t)
+
+	all, err := w.Pipelines.ListPipelinesAll(context.Background(), pipelines.ListPipelinesRequest{})
+	if err != nil {
+		t.Fatalf("ListPipelinesAll: %v", err)
+	}
+
+	if len(all) != 0 {
+		t.Fatalf("got %d pipelines, want 0", len(all))
+	}
+}

--- a/server/azure/databricks/repos/repos.go
+++ b/server/azure/databricks/repos/repos.go
@@ -41,6 +41,7 @@ type repo struct {
 	provider string
 	path     string
 	branch   string
+	tag      string
 	headSHA  string
 }
 
@@ -126,6 +127,7 @@ type repoView struct {
 	Provider     string `json:"provider"`
 	Path         string `json:"path"`
 	Branch       string `json:"branch"`
+	Tag          string `json:"tag,omitempty"`
 	HeadCommitID string `json:"head_commit_id"`
 }
 
@@ -218,12 +220,16 @@ func (h *Handler) update(w http.ResponseWriter, r *http.Request, id int64) {
 		return
 	}
 
+	// branch and tag are mutually exclusive checkout refs: setting one detaches
+	// from the other (a tag checkout clears the branch, and vice versa).
 	if req.Branch != "" {
 		rp.branch = req.Branch
+		rp.tag = ""
 	}
 
 	if req.Tag != "" {
-		rp.branch = req.Tag
+		rp.tag = req.Tag
+		rp.branch = ""
 	}
 
 	out := view(rp)
@@ -282,6 +288,7 @@ func view(rp *repo) repoView {
 		Provider:     rp.provider,
 		Path:         rp.path,
 		Branch:       rp.branch,
+		Tag:          rp.tag,
 		HeadCommitID: rp.headSHA,
 	}
 }

--- a/server/azure/databricks/repos/repos.go
+++ b/server/azure/databricks/repos/repos.go
@@ -1,0 +1,337 @@
+// Package repos implements the Databricks Repos (Git folders) data-plane REST
+// API (the /api/2.0/repos surface served at the workspace URL) as a
+// server.Handler. Point the real github.com/databricks/databricks-sdk-go
+// WorkspaceClient at a server registered with this handler and w.Repos
+// Create/Get/List/Update/Delete work end-to-end against an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.0/repos              create
+//	GET    /api/2.0/repos             list
+//	GET    /api/2.0/repos/{repo_id}    get
+//	PATCH  /api/2.0/repos/{repo_id}    update
+//	DELETE /api/2.0/repos/{repo_id}    delete
+package repos
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	maxBodyBytes = 5 << 20
+	resRepos     = "repos"
+	// reposSegs is the [api, ver, repos] segment count; an item path adds
+	// the {repo_id} segment for itemSegs.
+	reposSegs = 3
+	itemSegs  = 4
+	// defaultBranch and stubCommit are the values reported for a freshly
+	// created Git folder.
+	defaultBranch = "main"
+	stubCommit    = "0000000000000000000000000000000000000000"
+)
+
+// repo is the in-memory state for a single Git folder (repo).
+type repo struct {
+	id       int64
+	url      string
+	provider string
+	path     string
+	branch   string
+	headSHA  string
+}
+
+// Handler serves the Databricks Repos data-plane REST API backed by an
+// in-memory map keyed by repo id.
+type Handler struct {
+	mu     sync.RWMutex
+	repos  map[int64]*repo
+	nextID int64
+}
+
+// New returns a Repos handler with an empty in-memory backend.
+func New() *Handler {
+	return &Handler{
+		repos:  make(map[int64]*repo),
+		nextID: 1,
+	}
+}
+
+// Matches claims /api/{ver}/repos and /api/{ver}/repos/{repo_id} paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := split(r.URL.Path)
+
+	return len(parts) >= reposSegs && parts[0] == "api" && parts[2] == resRepos
+}
+
+// ServeHTTP routes by method and by the presence of a {repo_id} segment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := split(r.URL.Path)
+	if len(parts) >= itemSegs {
+		h.serveItem(w, r, parts[3])
+
+		return
+	}
+
+	h.serveCollection(w, r)
+}
+
+// serveCollection handles the /api/2.0/repos collection (create and list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.create(w, r)
+	case http.MethodGet:
+		h.list(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItem handles /api/2.0/repos/{repo_id} (get, update, delete).
+func (h *Handler) serveItem(w http.ResponseWriter, r *http.Request, idSeg string) {
+	id, err := strconv.ParseInt(idSeg, 10, 64)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid repo_id: "+idSeg)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, id)
+	case http.MethodPatch:
+		h.update(w, r, id)
+	case http.MethodDelete:
+		h.delete(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// createRequest is the POST /repos body.
+type createRequest struct {
+	URL      string `json:"url"`
+	Provider string `json:"provider"`
+	Path     string `json:"path"`
+}
+
+// repoView is the JSON shape returned for a single repo.
+type repoView struct {
+	ID           int64  `json:"id"`
+	URL          string `json:"url"`
+	Provider     string `json:"provider"`
+	Path         string `json:"path"`
+	Branch       string `json:"branch"`
+	HeadCommitID string `json:"head_commit_id"`
+}
+
+// listResponse is the GET /repos body.
+type listResponse struct {
+	Repos         []repoView `json:"repos"`
+	NextPageToken string     `json:"next_page_token,omitempty"`
+}
+
+// updateRequest is the PATCH /repos/{repo_id} body.
+type updateRequest struct {
+	Branch string `json:"branch"`
+	Tag    string `json:"tag"`
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if req.URL == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "url is required")
+
+		return
+	}
+
+	if req.Provider == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "provider is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	id := h.nextID
+	h.nextID++
+	rp := &repo{
+		id:       id,
+		url:      req.URL,
+		provider: req.Provider,
+		path:     defaultPath(req.Path, req.URL, id),
+		branch:   defaultBranch,
+		headSHA:  stubCommit,
+	}
+	h.repos[id] = rp
+	h.mu.Unlock()
+
+	writeJSON(w, view(rp))
+}
+
+func (h *Handler) get(w http.ResponseWriter, id int64) {
+	h.mu.RLock()
+	rp, ok := h.repos[id]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, view(rp))
+}
+
+func (h *Handler) list(w http.ResponseWriter) {
+	h.mu.RLock()
+
+	views := make([]repoView, 0, len(h.repos))
+	for _, rp := range h.repos {
+		views = append(views, view(rp))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listResponse{Repos: views})
+}
+
+func (h *Handler) update(w http.ResponseWriter, r *http.Request, id int64) {
+	var req updateRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+
+	rp, ok := h.repos[id]
+	if !ok {
+		h.mu.Unlock()
+		notFound(w, id)
+
+		return
+	}
+
+	if req.Branch != "" {
+		rp.branch = req.Branch
+	}
+
+	if req.Tag != "" {
+		rp.branch = req.Tag
+	}
+
+	out := view(rp)
+	h.mu.Unlock()
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) delete(w http.ResponseWriter, id int64) {
+	h.mu.Lock()
+
+	_, ok := h.repos[id]
+	if ok {
+		delete(h.repos, id)
+	}
+
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// defaultPath derives a workspace path for a repo when none was supplied,
+// using the trailing path segment of the Git URL or the repo id as a fallback.
+func defaultPath(path, url string, id int64) string {
+	if path != "" {
+		return path
+	}
+
+	name := strings.TrimSuffix(lastSegment(url), ".git")
+	if name == "" {
+		name = "repo-" + strconv.FormatInt(id, 10)
+	}
+
+	return "/Repos/cloudemu/" + name
+}
+
+func lastSegment(url string) string {
+	trimmed := strings.TrimRight(url, "/")
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		return trimmed[idx+1:]
+	}
+
+	return trimmed
+}
+
+func view(rp *repo) repoView {
+	return repoView{
+		ID:           rp.id,
+		URL:          rp.url,
+		Provider:     rp.provider,
+		Path:         rp.path,
+		Branch:       rp.branch,
+		HeadCommitID: rp.headSHA,
+	}
+}
+
+// split strips the leading "/api/" prefix slashes and returns the path
+// segments, keeping "api" at index 0 for the Matches/ServeHTTP guards.
+func split(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, "MALFORMED_REQUEST", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func notFound(w http.ResponseWriter, id int64) {
+	writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST",
+		"repo "+strconv.FormatInt(id, 10)+" does not exist")
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+}

--- a/server/azure/databricks/repos/repos_roundtrip_test.go
+++ b/server/azure/databricks/repos/repos_roundtrip_test.go
@@ -1,0 +1,98 @@
+package repos_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New(repos.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: config.PatCredentials{},
+	})
+	require.NoError(t, err)
+
+	return w
+}
+
+func TestSDKReposLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Repos.Create(ctx, workspace.CreateRepoRequest{
+		Url:      "https://github.com/example/demo.git",
+		Provider: "gitHub",
+		Path:     "/Repos/team/demo",
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, created.Id)
+	assert.Equal(t, "/Repos/team/demo", created.Path)
+	assert.Equal(t, "gitHub", created.Provider)
+	assert.Equal(t, "main", created.Branch)
+	assert.NotEmpty(t, created.HeadCommitId)
+
+	got, err := w.Repos.GetByRepoId(ctx, created.Id)
+	require.NoError(t, err)
+	assert.Equal(t, created.Id, got.Id)
+	assert.Equal(t, "https://github.com/example/demo.git", got.Url)
+
+	err = w.Repos.Update(ctx, workspace.UpdateRepoRequest{
+		RepoId: created.Id,
+		Branch: "develop",
+	})
+	require.NoError(t, err)
+
+	afterUpdate, err := w.Repos.GetByRepoId(ctx, created.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "develop", afterUpdate.Branch)
+
+	all, err := w.Repos.ListAll(ctx, workspace.ListReposRequest{})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+	assert.Equal(t, created.Id, all[0].Id)
+	assert.Equal(t, "develop", all[0].Branch)
+
+	err = w.Repos.DeleteByRepoId(ctx, created.Id)
+	require.NoError(t, err)
+
+	_, err = w.Repos.GetByRepoId(ctx, created.Id)
+	require.Error(t, err)
+}
+
+func TestSDKReposDefaultPath(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Repos.Create(ctx, workspace.CreateRepoRequest{
+		Url:      "https://github.com/example/no-path.git",
+		Provider: "gitHub",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/Repos/cloudemu/no-path", created.Path)
+}
+
+func TestSDKReposGetMissing(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	_, err := w.Repos.GetByRepoId(ctx, 999)
+	require.Error(t, err)
+}

--- a/server/azure/databricks/scim/scim.go
+++ b/server/azure/databricks/scim/scim.go
@@ -1,0 +1,633 @@
+// Package scim emulates the Databricks workspace SCIM 2.0 identity APIs
+// (the /api/2.0/preview/scim/v2/... surface served at the workspace URL) as a
+// server.Handler. Point the real github.com/databricks/databricks-sdk-go
+// WorkspaceClient at a server registered with this handler and the
+// w.Users, w.Groups and w.ServicePrincipals operations work end-to-end against
+// an in-memory backend.
+//
+// Covered endpoints (Users, Groups and ServicePrincipals each):
+//
+//	POST   /api/2.0/preview/scim/v2/{Resource}        create
+//	GET    /api/2.0/preview/scim/v2/{Resource}        list (SCIM envelope)
+//	GET    /api/2.0/preview/scim/v2/{Resource}/{id}   get
+//	PUT    /api/2.0/preview/scim/v2/{Resource}/{id}   update (replace)
+//	PATCH  /api/2.0/preview/scim/v2/{Resource}/{id}   patch
+//	DELETE /api/2.0/preview/scim/v2/{Resource}/{id}   delete
+//
+// SCIM list pagination: the databricks-sdk-go pager keeps requesting pages
+// (startIndex = startIndex + len(Resources)) until a page returns zero
+// Resources. List therefore returns every matching resource on the first page
+// and an empty Resources slice for any startIndex past the last item, which
+// terminates the iterator after a single populated page.
+package scim
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+// SCIM path segment counts after splitPath. A collection path
+// (/api/2.0/preview/scim/v2/Users) has collectionSegs segments; an item path
+// (/api/2.0/preview/scim/v2/Users/{id}) has itemSegs.
+const (
+	collectionSegs = 6
+	itemSegs       = 7
+	previewIdx     = 2
+	resourceIdx    = 5
+	idIdx          = 6
+)
+
+// firstStartIndex is the 1-based index of the first SCIM result.
+const firstStartIndex = 1
+
+// SCIM resource path segments.
+const (
+	resUsers             = "Users"
+	resGroups            = "Groups"
+	resServicePrincipals = "ServicePrincipals"
+)
+
+// SCIM list response schema URN.
+const listResponseSchema = "urn:ietf:params:scim:api:messages:2.0:ListResponse"
+
+// Databricks/SCIM error codes.
+const (
+	codeNotFound      = "RESOURCE_DOES_NOT_EXIST"
+	codeAlreadyExists = "RESOURCE_ALREADY_EXISTS"
+	codeInvalidParam  = "INVALID_PARAMETER_VALUE"
+	codeMalformed     = "MALFORMED_REQUEST"
+	codeNotFoundPath  = "ENDPOINT_NOT_FOUND"
+)
+
+// complexValue mirrors the SCIM multi-valued attribute shape (emails, members,
+// roles, entitlements, groups).
+type complexValue struct {
+	Display string `json:"display,omitempty"`
+	Primary bool   `json:"primary,omitempty"`
+	Ref     string `json:"$ref,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Value   string `json:"value,omitempty"`
+}
+
+// name mirrors the SCIM name sub-object.
+type name struct {
+	FamilyName string `json:"familyName,omitempty"`
+	GivenName  string `json:"givenName,omitempty"`
+}
+
+// userJSON is the wire shape for a SCIM User.
+type userJSON struct {
+	Schemas      []string       `json:"schemas,omitempty"`
+	ID           string         `json:"id,omitempty"`
+	UserName     string         `json:"userName,omitempty"`
+	DisplayName  string         `json:"displayName,omitempty"`
+	Active       bool           `json:"active,omitempty"`
+	ExternalID   string         `json:"externalId,omitempty"`
+	Name         *name          `json:"name,omitempty"`
+	Emails       []complexValue `json:"emails,omitempty"`
+	Entitlements []complexValue `json:"entitlements,omitempty"`
+	Roles        []complexValue `json:"roles,omitempty"`
+	Groups       []complexValue `json:"groups,omitempty"`
+}
+
+// groupJSON is the wire shape for a SCIM Group.
+type groupJSON struct {
+	Schemas      []string       `json:"schemas,omitempty"`
+	ID           string         `json:"id,omitempty"`
+	DisplayName  string         `json:"displayName,omitempty"`
+	ExternalID   string         `json:"externalId,omitempty"`
+	Members      []complexValue `json:"members,omitempty"`
+	Entitlements []complexValue `json:"entitlements,omitempty"`
+	Roles        []complexValue `json:"roles,omitempty"`
+	Groups       []complexValue `json:"groups,omitempty"`
+}
+
+// servicePrincipalJSON is the wire shape for a SCIM ServicePrincipal.
+type servicePrincipalJSON struct {
+	Schemas       []string       `json:"schemas,omitempty"`
+	ID            string         `json:"id,omitempty"`
+	ApplicationID string         `json:"applicationId,omitempty"`
+	DisplayName   string         `json:"displayName,omitempty"`
+	Active        bool           `json:"active,omitempty"`
+	ExternalID    string         `json:"externalId,omitempty"`
+	Entitlements  []complexValue `json:"entitlements,omitempty"`
+	Roles         []complexValue `json:"roles,omitempty"`
+	Groups        []complexValue `json:"groups,omitempty"`
+}
+
+// Handler serves the Databricks SCIM identity APIs from in-memory state. It is
+// safe for concurrent use.
+type Handler struct {
+	mu                sync.RWMutex
+	users             map[string]*userJSON
+	groups            map[string]*groupJSON
+	servicePrincipals map[string]*servicePrincipalJSON
+	nextID            int64
+}
+
+// New returns a ready-to-use SCIM handler with empty state.
+func New() *Handler {
+	return &Handler{
+		users:             make(map[string]*userJSON),
+		groups:            make(map[string]*groupJSON),
+		servicePrincipals: make(map[string]*servicePrincipalJSON),
+		nextID:            1,
+	}
+}
+
+// Matches claims /api/{ver}/preview/scim/v2/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+
+	return len(parts) >= collectionSegs && parts[0] == "api" && parts[previewIdx] == "preview"
+}
+
+// allocID returns the next monotonically increasing id as a string. Callers
+// must hold the write lock.
+func (h *Handler) allocID() string {
+	id := h.nextID
+	h.nextID++
+
+	return strconv.FormatInt(id, 10)
+}
+
+// ServeHTTP routes by resource and by the presence of an {id} segment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < collectionSegs {
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unsupported path")
+
+		return
+	}
+
+	resource := parts[resourceIdx]
+
+	var id string
+	if len(parts) >= itemSegs {
+		id = parts[idIdx]
+	}
+
+	switch resource {
+	case resUsers:
+		h.serveUsers(w, r, id)
+	case resGroups:
+		h.serveGroups(w, r, id)
+	case resServicePrincipals:
+		h.serveServicePrincipals(w, r, id)
+	default:
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unknown resource: "+resource)
+	}
+}
+
+func (h *Handler) serveUsers(w http.ResponseWriter, r *http.Request, id string) {
+	if id == "" {
+		h.serveUserCollection(w, r)
+
+		return
+	}
+
+	h.serveUserItem(w, r, id)
+}
+
+func (h *Handler) serveUserCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createUser(w, r)
+	case http.MethodGet:
+		h.listUsers(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveUserItem(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getUser(w, id)
+	case http.MethodPut, http.MethodPatch:
+		h.updateUser(w, r, id)
+	case http.MethodDelete:
+		h.deleteUser(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveGroups(w http.ResponseWriter, r *http.Request, id string) {
+	if id == "" {
+		h.serveGroupCollection(w, r)
+
+		return
+	}
+
+	h.serveGroupItem(w, r, id)
+}
+
+func (h *Handler) serveGroupCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createGroup(w, r)
+	case http.MethodGet:
+		h.listGroups(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveGroupItem(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getGroup(w, id)
+	case http.MethodPut, http.MethodPatch:
+		h.updateGroup(w, r, id)
+	case http.MethodDelete:
+		h.deleteGroup(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveServicePrincipals(w http.ResponseWriter, r *http.Request, id string) {
+	if id == "" {
+		h.serveSPCollection(w, r)
+
+		return
+	}
+
+	h.serveSPItem(w, r, id)
+}
+
+func (h *Handler) serveSPCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createServicePrincipal(w, r)
+	case http.MethodGet:
+		h.listServicePrincipals(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveSPItem(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getServicePrincipal(w, id)
+	case http.MethodPut, http.MethodPatch:
+		h.updateServicePrincipal(w, r, id)
+	case http.MethodDelete:
+		h.deleteServicePrincipal(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
+	createKeyed(w, r, &h.mu, createParams[userJSON]{
+		store:    h.users,
+		alloc:    h.allocID,
+		kind:     "user",
+		keyField: "userName",
+		key:      func(u *userJSON) string { return u.UserName },
+		setID:    func(u *userJSON, id string) { u.ID = id },
+	})
+}
+
+func (h *Handler) getUser(w http.ResponseWriter, id string) {
+	h.mu.RLock()
+	u, ok := h.users[id]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, "user", id)
+
+		return
+	}
+
+	writeJSON(w, u)
+}
+
+func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
+	listPage(w, r, &h.mu, h.users)
+}
+
+func (h *Handler) updateUser(w http.ResponseWriter, r *http.Request, id string) {
+	var in userJSON
+	if !decode(w, r, &in) {
+		return
+	}
+
+	out, ok := replace(w, &h.mu, h.users, id, "user", &in, func(u *userJSON) { u.ID = id })
+	if !ok {
+		return
+	}
+
+	writeJSON(w, &out)
+}
+
+func (h *Handler) deleteUser(w http.ResponseWriter, id string) {
+	removeByID(w, &h.mu, h.users, id, "user")
+}
+
+func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
+	createKeyed(w, r, &h.mu, createParams[groupJSON]{
+		store:    h.groups,
+		alloc:    h.allocID,
+		kind:     "group",
+		keyField: "displayName",
+		key:      func(g *groupJSON) string { return g.DisplayName },
+		setID:    func(g *groupJSON, id string) { g.ID = id },
+	})
+}
+
+func (h *Handler) getGroup(w http.ResponseWriter, id string) {
+	h.mu.RLock()
+	g, ok := h.groups[id]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, "group", id)
+
+		return
+	}
+
+	writeJSON(w, g)
+}
+
+func (h *Handler) listGroups(w http.ResponseWriter, r *http.Request) {
+	listPage(w, r, &h.mu, h.groups)
+}
+
+func (h *Handler) updateGroup(w http.ResponseWriter, r *http.Request, id string) {
+	var in groupJSON
+	if !decode(w, r, &in) {
+		return
+	}
+
+	out, ok := replace(w, &h.mu, h.groups, id, "group", &in, func(g *groupJSON) { g.ID = id })
+	if !ok {
+		return
+	}
+
+	writeJSON(w, &out)
+}
+
+func (h *Handler) deleteGroup(w http.ResponseWriter, id string) {
+	removeByID(w, &h.mu, h.groups, id, "group")
+}
+
+func (h *Handler) createServicePrincipal(w http.ResponseWriter, r *http.Request) {
+	var in servicePrincipalJSON
+	if !decode(w, r, &in) {
+		return
+	}
+
+	h.mu.Lock()
+
+	in.ID = h.allocID()
+	if in.ApplicationID == "" {
+		in.ApplicationID = "app-" + in.ID
+	}
+
+	stored := in
+	h.servicePrincipals[stored.ID] = &stored
+	out := stored
+	h.mu.Unlock()
+
+	writeJSON(w, &out)
+}
+
+func (h *Handler) getServicePrincipal(w http.ResponseWriter, id string) {
+	h.mu.RLock()
+	sp, ok := h.servicePrincipals[id]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, "service principal", id)
+
+		return
+	}
+
+	writeJSON(w, sp)
+}
+
+func (h *Handler) listServicePrincipals(w http.ResponseWriter, r *http.Request) {
+	listPage(w, r, &h.mu, h.servicePrincipals)
+}
+
+func (h *Handler) updateServicePrincipal(w http.ResponseWriter, r *http.Request, id string) {
+	var in servicePrincipalJSON
+	if !decode(w, r, &in) {
+		return
+	}
+
+	out, ok := replace(w, &h.mu, h.servicePrincipals, id, "service principal", &in, func(sp *servicePrincipalJSON) {
+		sp.ID = id
+		if sp.ApplicationID == "" {
+			sp.ApplicationID = h.servicePrincipals[id].ApplicationID
+		}
+	})
+	if !ok {
+		return
+	}
+
+	writeJSON(w, &out)
+}
+
+func (h *Handler) deleteServicePrincipal(w http.ResponseWriter, id string) {
+	removeByID(w, &h.mu, h.servicePrincipals, id, "service principal")
+}
+
+// listResponse is the SCIM list envelope. Resources is always returned on the
+// first page in full, with totalResults and itemsPerPage equal to its length,
+// so the SDK pager stops after a single page.
+type listResponse[T any] struct {
+	Schemas      []string `json:"schemas"`
+	TotalResults int      `json:"totalResults"`
+	StartIndex   int      `json:"startIndex"`
+	ItemsPerPage int      `json:"itemsPerPage"`
+	Resources    []T      `json:"Resources"`
+}
+
+// newListResponse wraps items in a SCIM list envelope sized to the slice.
+func newListResponse[T any](items []T) listResponse[T] {
+	return listResponse[T]{
+		Schemas:      []string{listResponseSchema},
+		TotalResults: len(items),
+		StartIndex:   firstStartIndex,
+		ItemsPerPage: len(items),
+		Resources:    items,
+	}
+}
+
+// pastLastItem reports whether the request's startIndex points past the last
+// stored item, in which case an empty Resources slice must be returned to stop
+// the SDK pager. A missing or first-page startIndex is never past the end.
+func pastLastItem(r *http.Request, total int) bool {
+	raw := r.URL.Query().Get("startIndex")
+	if raw == "" {
+		return false
+	}
+
+	start, err := strconv.Atoi(raw)
+	if err != nil || start <= firstStartIndex {
+		return false
+	}
+
+	return start > total
+}
+
+// createParams configures a keyed create: the store and its kind label, the
+// required-key field name, and accessors for the uniqueness key and id.
+type createParams[T any] struct {
+	store    map[string]*T
+	alloc    func() string
+	kind     string
+	keyField string
+	key      func(*T) string
+	setID    func(*T, string)
+}
+
+// createKeyed decodes a create body, enforces a non-empty unique key, rejects
+// duplicates, and stores the value under a fresh id. It serves both Users
+// (keyed by userName) and Groups (keyed by displayName).
+func createKeyed[T any](w http.ResponseWriter, r *http.Request, mu *sync.RWMutex, p createParams[T]) {
+	var in T
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if p.key(&in) == "" {
+		writeError(w, http.StatusBadRequest, codeInvalidParam, p.keyField+" is required")
+
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, existing := range p.store {
+		if p.key(existing) == p.key(&in) {
+			writeError(w, http.StatusConflict, codeAlreadyExists, p.kind+" already exists: "+p.key(&in))
+
+			return
+		}
+	}
+
+	id := p.alloc()
+	p.setID(&in, id)
+	stored := in
+	p.store[id] = &stored
+
+	writeJSON(w, &stored)
+}
+
+// listPage writes the SCIM list envelope for store, returning every value on
+// the first page and an empty page for any startIndex past the last item.
+func listPage[T any](w http.ResponseWriter, r *http.Request, mu *sync.RWMutex, store map[string]*T) {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	items := make([]T, 0, len(store))
+
+	if !pastLastItem(r, len(store)) {
+		for _, v := range store {
+			items = append(items, *v)
+		}
+	}
+
+	writeJSON(w, newListResponse(items))
+}
+
+// replace overwrites the entry at id (preserving the id) and returns the stored
+// copy, writing a not-found error and reporting false when id is absent.
+func replace[T any](w http.ResponseWriter, mu *sync.RWMutex, store map[string]*T, id, kind string, in *T, setID func(*T)) (T, bool) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, ok := store[id]; !ok {
+		notFound(w, kind, id)
+
+		return *in, false
+	}
+
+	setID(in)
+	stored := *in
+	store[id] = &stored
+
+	return stored, true
+}
+
+// removeByID deletes id from store, writing a not-found error when absent and
+// an empty success body otherwise.
+func removeByID[T any](w http.ResponseWriter, mu *sync.RWMutex, store map[string]*T, id, kind string) {
+	mu.Lock()
+	_, ok := store[id]
+
+	if ok {
+		delete(store, id)
+	}
+
+	mu.Unlock()
+
+	if !ok {
+		notFound(w, kind, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// splitPath strips surrounding slashes and returns the path segments.
+// Path /api/2.0/preview/scim/v2/Users → [api, 2.0, preview, scim, v2, Users].
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, codeMalformed, "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func notFound(w http.ResponseWriter, kind, id string) {
+	writeError(w, http.StatusNotFound, codeNotFound, kind+" "+id+" does not exist")
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, codeInvalidParam, "method not allowed")
+}

--- a/server/azure/databricks/scim/scim_roundtrip_test.go
+++ b/server/azure/databricks/scim/scim_roundtrip_test.go
@@ -1,0 +1,161 @@
+package scim_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/iam"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/scim"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New(scim.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:               ts.URL,
+		Token:              "test-token",
+		Credentials:        config.PatCredentials{},
+		HTTPTimeoutSeconds: 10,
+	})
+	require.NoError(t, err)
+
+	return w
+}
+
+func TestSDKUsersLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Users.Create(ctx, iam.User{
+		UserName:    "alice@example.com",
+		DisplayName: "Alice",
+		Active:      true,
+		Emails: []iam.ComplexValue{
+			{Value: "alice@example.com", Primary: true, Type: "work"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.Id)
+	assert.Equal(t, "alice@example.com", created.UserName)
+
+	got, err := w.Users.GetById(ctx, created.Id)
+	require.NoError(t, err)
+	assert.Equal(t, created.Id, got.Id)
+	assert.Equal(t, "Alice", got.DisplayName)
+	require.Len(t, got.Emails, 1)
+	assert.Equal(t, "alice@example.com", got.Emails[0].Value)
+
+	all, err := w.Users.ListAll(ctx, iam.ListUsersRequest{})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, created.Id, all[0].Id)
+
+	err = w.Users.Update(ctx, iam.User{
+		Id:          created.Id,
+		UserName:    "alice@example.com",
+		DisplayName: "Alice Updated",
+		Active:      true,
+	})
+	require.NoError(t, err)
+
+	got, err = w.Users.GetById(ctx, created.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice Updated", got.DisplayName)
+
+	err = w.Users.DeleteById(ctx, created.Id)
+	require.NoError(t, err)
+
+	all, err = w.Users.ListAll(ctx, iam.ListUsersRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+func TestSDKGroupsLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Groups.Create(ctx, iam.Group{
+		DisplayName: "engineers",
+		Members: []iam.ComplexValue{
+			{Value: "123", Display: "alice"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.Id)
+	assert.Equal(t, "engineers", created.DisplayName)
+
+	got, err := w.Groups.GetById(ctx, created.Id)
+	require.NoError(t, err)
+	assert.Equal(t, created.Id, got.Id)
+	require.Len(t, got.Members, 1)
+	assert.Equal(t, "123", got.Members[0].Value)
+
+	all, err := w.Groups.ListAll(ctx, iam.ListGroupsRequest{})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, created.Id, all[0].Id)
+
+	err = w.Groups.DeleteById(ctx, created.Id)
+	require.NoError(t, err)
+
+	all, err = w.Groups.ListAll(ctx, iam.ListGroupsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+func TestSDKServicePrincipalsLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.ServicePrincipals.Create(ctx, iam.ServicePrincipal{
+		DisplayName: "ci-runner",
+		Active:      true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, created.Id)
+	require.NotEmpty(t, created.ApplicationId)
+	assert.Equal(t, "ci-runner", created.DisplayName)
+
+	got, err := w.ServicePrincipals.GetById(ctx, created.Id)
+	require.NoError(t, err)
+	assert.Equal(t, created.Id, got.Id)
+	assert.Equal(t, created.ApplicationId, got.ApplicationId)
+
+	all, err := w.ServicePrincipals.ListAll(ctx, iam.ListServicePrincipalsRequest{})
+	require.NoError(t, err)
+	require.Len(t, all, 1)
+	assert.Equal(t, created.Id, all[0].Id)
+
+	err = w.ServicePrincipals.DeleteById(ctx, created.Id)
+	require.NoError(t, err)
+
+	all, err = w.ServicePrincipals.ListAll(ctx, iam.ListServicePrincipalsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, all)
+}
+
+func TestSDKListMultipleReturns(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"u1@example.com", "u2@example.com", "u3@example.com"} {
+		_, err := w.Users.Create(ctx, iam.User{UserName: n})
+		require.NoError(t, err)
+	}
+
+	all, err := w.Users.ListAll(ctx, iam.ListUsersRequest{})
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+}

--- a/server/azure/databricks/secrets/secrets.go
+++ b/server/azure/databricks/secrets/secrets.go
@@ -1,0 +1,544 @@
+// Package secrets emulates the Databricks Secrets data-plane REST API
+// (the /api/2.0/secrets/... surface served at the workspace URL) as a
+// server.Handler. Point the real github.com/databricks/databricks-sdk-go
+// WorkspaceClient at a server registered with this handler and the
+// w.Secrets.* operations work end-to-end against an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST     /api/2.0/secrets/scopes/{create,delete}
+//	GET      /api/2.0/secrets/scopes/list
+//	POST     /api/2.0/secrets/{put,delete}
+//	GET      /api/2.0/secrets/{get,list}
+//	POST     /api/2.0/secrets/acls/{put,delete}
+//	GET      /api/2.0/secrets/acls/{get,list}
+package secrets
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxBodyBytes = 5 << 20
+
+// minSegs is the [api, ver, secrets, action] segment count; nested
+// scopes/acls paths add a fifth action segment.
+const (
+	minSegs    = 4
+	nestedSegs = 5
+)
+
+// resource / sub-resource path segments.
+const (
+	resSecrets = "secrets"
+	subScopes  = "scopes"
+	subAcls    = "acls"
+)
+
+// action path segments.
+const (
+	actCreate = "create"
+	actDelete = "delete"
+	actList   = "list"
+	actPut    = "put"
+	actGet    = "get"
+)
+
+// Databricks error codes.
+const (
+	codeNotFound      = "RESOURCE_DOES_NOT_EXIST"
+	codeAlreadyExists = "RESOURCE_ALREADY_EXISTS"
+	codeInvalidParam  = "INVALID_PARAMETER_VALUE"
+	codeMalformed     = "MALFORMED_REQUEST"
+	codeNotAllowed    = "INVALID_PARAMETER_VALUE"
+	codeNotFoundPath  = "ENDPOINT_NOT_FOUND"
+)
+
+// scopeBackendDatabricks is the default backend type for a created scope.
+const scopeBackendDatabricks = "DATABRICKS"
+
+// scope holds the secrets and ACLs for a single secret scope.
+type scope struct {
+	backendType string
+	secrets     map[string]secretEntry
+	acls        map[string]string
+}
+
+// secretEntry is a stored secret value plus its last-updated timestamp.
+type secretEntry struct {
+	value       string
+	lastUpdated int64
+}
+
+// Handler serves the Databricks Secrets data-plane REST API from in-memory
+// state. It is safe for concurrent use.
+type Handler struct {
+	mu     sync.RWMutex
+	scopes map[string]*scope
+}
+
+// New returns a ready-to-use Secrets handler with empty state.
+func New() *Handler {
+	return &Handler{scopes: make(map[string]*scope)}
+}
+
+// route binds an action to its required HTTP method and handler.
+type route struct {
+	method string
+	fn     func(http.ResponseWriter, *http.Request)
+}
+
+// Matches claims /api/{ver}/secrets/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+
+	return len(parts) >= minSegs && parts[0] == "api" && parts[2] == resSecrets
+}
+
+// ServeHTTP routes by sub-resource and action.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minSegs {
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unsupported path")
+
+		return
+	}
+
+	switch parts[3] {
+	case subScopes:
+		serveNested(w, r, parts, h.scopeRoutes())
+	case subAcls:
+		serveNested(w, r, parts, h.aclRoutes())
+	default:
+		dispatch(w, r, parts[3], h.secretRoutes())
+	}
+}
+
+func (h *Handler) scopeRoutes() map[string]route {
+	return map[string]route{
+		actCreate: {http.MethodPost, h.createScope},
+		actDelete: {http.MethodPost, h.deleteScope},
+		actList:   {http.MethodGet, h.listScopes},
+	}
+}
+
+func (h *Handler) secretRoutes() map[string]route {
+	return map[string]route{
+		actPut:    {http.MethodPost, h.putSecret},
+		actDelete: {http.MethodPost, h.deleteSecret},
+		actList:   {http.MethodGet, h.listSecrets},
+		actGet:    {http.MethodGet, h.getSecret},
+	}
+}
+
+func (h *Handler) aclRoutes() map[string]route {
+	return map[string]route{
+		actPut:    {http.MethodPost, h.putACL},
+		actDelete: {http.MethodPost, h.deleteACL},
+		actGet:    {http.MethodGet, h.getACL},
+		actList:   {http.MethodGet, h.listACLs},
+	}
+}
+
+// serveNested routes nested /secrets/{scopes,acls}/{action} paths.
+func serveNested(w http.ResponseWriter, r *http.Request, parts []string, routes map[string]route) {
+	if len(parts) < nestedSegs {
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unsupported path")
+
+		return
+	}
+
+	dispatch(w, r, parts[4], routes)
+}
+
+// dispatch looks up action, enforces the method, and invokes the handler.
+func dispatch(w http.ResponseWriter, r *http.Request, action string, routes map[string]route) {
+	rt, ok := routes[action]
+	if !ok {
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unknown action: "+action)
+
+		return
+	}
+
+	if r.Method != rt.method {
+		writeError(w, http.StatusMethodNotAllowed, codeNotAllowed, "method not allowed")
+
+		return
+	}
+
+	rt.fn(w, r)
+}
+
+// requireScope returns the named scope, writing a RESOURCE_DOES_NOT_EXIST
+// error and reporting false when it does not exist. Callers must hold the
+// appropriate lock.
+func (h *Handler) requireScope(w http.ResponseWriter, name string) (*scope, bool) {
+	sc, ok := h.scopes[name]
+	if !ok {
+		writeError(w, http.StatusNotFound, codeNotFound, "no such scope: "+name)
+
+		return nil, false
+	}
+
+	return sc, true
+}
+
+// deleteMember removes key from m within scopeName, writing a not-found error
+// (using kind in the message) when either the scope or the key is absent.
+func deleteMember[V any](w http.ResponseWriter, h *Handler, scopeName, key, kind string, pick func(*scope) map[string]V) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	sc, ok := h.requireScope(w, scopeName)
+	if !ok {
+		return
+	}
+
+	m := pick(sc)
+	if _, ok = m[key]; !ok {
+		writeError(w, http.StatusNotFound, codeNotFound, "no such "+kind+": "+key)
+
+		return
+	}
+
+	delete(m, key)
+	writeJSON(w, struct{}{})
+}
+
+// --- scope ops ---
+
+type createScopeRequest struct {
+	Scope                  string `json:"scope"`
+	InitialManagePrincipal string `json:"initial_manage_principal,omitempty"`
+	ScopeBackendType       string `json:"scope_backend_type,omitempty"`
+}
+
+func (h *Handler) createScope(w http.ResponseWriter, r *http.Request) {
+	var in createScopeRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.Scope == "" {
+		writeError(w, http.StatusBadRequest, codeInvalidParam, "scope is required")
+
+		return
+	}
+
+	backend := in.ScopeBackendType
+	if backend == "" {
+		backend = scopeBackendDatabricks
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.scopes[in.Scope]; ok {
+		writeError(w, http.StatusConflict, codeAlreadyExists, "scope already exists: "+in.Scope)
+
+		return
+	}
+
+	h.scopes[in.Scope] = &scope{
+		backendType: backend,
+		secrets:     make(map[string]secretEntry),
+		acls:        make(map[string]string),
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+type scopeRequest struct {
+	Scope string `json:"scope"`
+}
+
+func (h *Handler) deleteScope(w http.ResponseWriter, r *http.Request) {
+	var in scopeRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.scopes[in.Scope]; !ok {
+		writeError(w, http.StatusNotFound, codeNotFound, "no such scope: "+in.Scope)
+
+		return
+	}
+
+	delete(h.scopes, in.Scope)
+	writeJSON(w, struct{}{})
+}
+
+type secretScopeJSON struct {
+	Name        string `json:"name"`
+	BackendType string `json:"backend_type"`
+}
+
+type listScopesResponse struct {
+	Scopes []secretScopeJSON `json:"scopes"`
+}
+
+func (h *Handler) listScopes(w http.ResponseWriter, _ *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	out := make([]secretScopeJSON, 0, len(h.scopes))
+	for name, sc := range h.scopes {
+		out = append(out, secretScopeJSON{Name: name, BackendType: sc.backendType})
+	}
+
+	writeJSON(w, listScopesResponse{Scopes: out})
+}
+
+// --- secret ops ---
+
+type putSecretRequest struct {
+	Scope       string `json:"scope"`
+	Key         string `json:"key"`
+	StringValue string `json:"string_value"`
+}
+
+func (h *Handler) putSecret(w http.ResponseWriter, r *http.Request) {
+	var in putSecretRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.Key == "" {
+		writeError(w, http.StatusBadRequest, codeInvalidParam, "key is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	sc, ok := h.requireScope(w, in.Scope)
+	if !ok {
+		return
+	}
+
+	sc.secrets[in.Key] = secretEntry{value: in.StringValue, lastUpdated: time.Now().UnixMilli()}
+
+	writeJSON(w, struct{}{})
+}
+
+type deleteSecretRequest struct {
+	Scope string `json:"scope"`
+	Key   string `json:"key"`
+}
+
+func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request) {
+	var in deleteSecretRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	deleteMember(w, h, in.Scope, in.Key, "secret", func(sc *scope) map[string]secretEntry {
+		return sc.secrets
+	})
+}
+
+type secretMetadataJSON struct {
+	Key                  string `json:"key"`
+	LastUpdatedTimestamp int64  `json:"last_updated_timestamp"`
+}
+
+type listSecretsResponse struct {
+	Secrets []secretMetadataJSON `json:"secrets"`
+}
+
+func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
+	scopeName := r.URL.Query().Get("scope")
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	sc, ok := h.requireScope(w, scopeName)
+	if !ok {
+		return
+	}
+
+	out := make([]secretMetadataJSON, 0, len(sc.secrets))
+	for key, entry := range sc.secrets {
+		out = append(out, secretMetadataJSON{Key: key, LastUpdatedTimestamp: entry.lastUpdated})
+	}
+
+	writeJSON(w, listSecretsResponse{Secrets: out})
+}
+
+type getSecretResponse struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func (h *Handler) getSecret(w http.ResponseWriter, r *http.Request) {
+	scopeName := r.URL.Query().Get("scope")
+	key := r.URL.Query().Get("key")
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	sc, ok := h.requireScope(w, scopeName)
+	if !ok {
+		return
+	}
+
+	entry, ok := sc.secrets[key]
+	if !ok {
+		writeError(w, http.StatusNotFound, codeNotFound, "no such secret: "+key)
+
+		return
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(entry.value))
+	writeJSON(w, getSecretResponse{Key: key, Value: encoded})
+}
+
+// --- acl ops ---
+
+type putACLRequest struct {
+	Scope      string `json:"scope"`
+	Principal  string `json:"principal"`
+	Permission string `json:"permission"`
+}
+
+func (h *Handler) putACL(w http.ResponseWriter, r *http.Request) {
+	var in putACLRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.Principal == "" {
+		writeError(w, http.StatusBadRequest, codeInvalidParam, "principal is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	sc, ok := h.requireScope(w, in.Scope)
+	if !ok {
+		return
+	}
+
+	sc.acls[in.Principal] = in.Permission
+
+	writeJSON(w, struct{}{})
+}
+
+type deleteACLRequest struct {
+	Scope     string `json:"scope"`
+	Principal string `json:"principal"`
+}
+
+func (h *Handler) deleteACL(w http.ResponseWriter, r *http.Request) {
+	var in deleteACLRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	deleteMember(w, h, in.Scope, in.Principal, "acl", func(sc *scope) map[string]string {
+		return sc.acls
+	})
+}
+
+type aclItemJSON struct {
+	Principal  string `json:"principal"`
+	Permission string `json:"permission"`
+}
+
+func (h *Handler) getACL(w http.ResponseWriter, r *http.Request) {
+	scopeName := r.URL.Query().Get("scope")
+	principal := r.URL.Query().Get("principal")
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	sc, ok := h.requireScope(w, scopeName)
+	if !ok {
+		return
+	}
+
+	perm, ok := sc.acls[principal]
+	if !ok {
+		writeError(w, http.StatusNotFound, codeNotFound, "no such acl: "+principal)
+
+		return
+	}
+
+	writeJSON(w, aclItemJSON{Principal: principal, Permission: perm})
+}
+
+type listACLsResponse struct {
+	Items []aclItemJSON `json:"items"`
+}
+
+func (h *Handler) listACLs(w http.ResponseWriter, r *http.Request) {
+	scopeName := r.URL.Query().Get("scope")
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	sc, ok := h.requireScope(w, scopeName)
+	if !ok {
+		return
+	}
+
+	out := make([]aclItemJSON, 0, len(sc.acls))
+	for principal, perm := range sc.acls {
+		out = append(out, aclItemJSON{Principal: principal, Permission: perm})
+	}
+
+	writeJSON(w, listACLsResponse{Items: out})
+}
+
+// --- helpers ---
+
+// splitPath strips surrounding slashes and returns the path segments.
+// Path /api/2.0/secrets/scopes/create → [api, 2.0, secrets, scopes, create].
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, codeMalformed, "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}

--- a/server/azure/databricks/secrets/secrets_roundtrip_test.go
+++ b/server/azure/databricks/secrets/secrets_roundtrip_test.go
@@ -1,0 +1,174 @@
+package secrets_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/secrets"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New(secrets.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "x",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKSecretsRoundtrip(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	const (
+		scopeName = "my-scope"
+		secretKey = "db-password"
+		secretVal = "hunter2"
+		principal = "data-scientists"
+	)
+
+	if err := w.Secrets.CreateScope(ctx, workspace.CreateScope{Scope: scopeName}); err != nil {
+		t.Fatalf("CreateScope: %v", err)
+	}
+
+	scopes, err := w.Secrets.ListScopesAll(ctx)
+	if err != nil {
+		t.Fatalf("ListScopes: %v", err)
+	}
+
+	if len(scopes) != 1 || scopes[0].Name != scopeName {
+		t.Fatalf("unexpected scopes: %+v", scopes)
+	}
+
+	if scopes[0].BackendType != workspace.ScopeBackendTypeDatabricks {
+		t.Fatalf("got backend %q, want DATABRICKS", scopes[0].BackendType)
+	}
+
+	if err = w.Secrets.PutSecret(ctx, workspace.PutSecret{
+		Scope:       scopeName,
+		Key:         secretKey,
+		StringValue: secretVal,
+	}); err != nil {
+		t.Fatalf("PutSecret: %v", err)
+	}
+
+	got, err := w.Secrets.GetSecret(ctx, workspace.GetSecretRequest{Scope: scopeName, Key: secretKey})
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+
+	// The SDK returns the raw base64 value; "hunter2" → "aHVudGVyMg==".
+	if got.Key != secretKey || got.Value != "aHVudGVyMg==" {
+		t.Fatalf("unexpected secret: %+v", got)
+	}
+
+	metas, err := w.Secrets.ListSecretsAll(ctx, workspace.ListSecretsRequest{Scope: scopeName})
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+
+	if len(metas) != 1 || metas[0].Key != secretKey || metas[0].LastUpdatedTimestamp == 0 {
+		t.Fatalf("unexpected secret metadata: %+v", metas)
+	}
+
+	if err = w.Secrets.PutAcl(ctx, workspace.PutAcl{
+		Scope:      scopeName,
+		Principal:  principal,
+		Permission: workspace.AclPermissionManage,
+	}); err != nil {
+		t.Fatalf("PutAcl: %v", err)
+	}
+
+	acl, err := w.Secrets.GetAcl(ctx, workspace.GetAclRequest{Scope: scopeName, Principal: principal})
+	if err != nil {
+		t.Fatalf("GetAcl: %v", err)
+	}
+
+	if acl.Principal != principal || acl.Permission != workspace.AclPermissionManage {
+		t.Fatalf("unexpected acl: %+v", acl)
+	}
+
+	acls, err := w.Secrets.ListAclsAll(ctx, workspace.ListAclsRequest{Scope: scopeName})
+	if err != nil {
+		t.Fatalf("ListAcls: %v", err)
+	}
+
+	if len(acls) != 1 || acls[0].Principal != principal {
+		t.Fatalf("unexpected acls: %+v", acls)
+	}
+
+	if err = w.Secrets.DeleteSecret(ctx, workspace.DeleteSecret{Scope: scopeName, Key: secretKey}); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	if err = w.Secrets.DeleteAcl(ctx, workspace.DeleteAcl{Scope: scopeName, Principal: principal}); err != nil {
+		t.Fatalf("DeleteAcl: %v", err)
+	}
+
+	if err = w.Secrets.DeleteScope(ctx, workspace.DeleteScope{Scope: scopeName}); err != nil {
+		t.Fatalf("DeleteScope: %v", err)
+	}
+
+	remaining, err := w.Secrets.ListScopesAll(ctx)
+	if err != nil {
+		t.Fatalf("ListScopes after delete: %v", err)
+	}
+
+	if len(remaining) != 0 {
+		t.Fatalf("expected no scopes after delete, got %+v", remaining)
+	}
+}
+
+func TestPutSecretRequiresScope(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	err := w.Secrets.PutSecret(ctx, workspace.PutSecret{Scope: "missing", Key: "k", StringValue: "v"})
+	if err == nil {
+		t.Fatal("expected error putting secret into missing scope")
+	}
+}
+
+func TestPutAclRequiresScope(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	err := w.Secrets.PutAcl(ctx, workspace.PutAcl{
+		Scope:      "missing",
+		Principal:  "p",
+		Permission: workspace.AclPermissionRead,
+	})
+	if err == nil {
+		t.Fatal("expected error putting acl into missing scope")
+	}
+}
+
+func TestDuplicateScopeConflicts(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	if err := w.Secrets.CreateScope(ctx, workspace.CreateScope{Scope: "dup"}); err != nil {
+		t.Fatalf("CreateScope: %v", err)
+	}
+
+	if err := w.Secrets.CreateScope(ctx, workspace.CreateScope{Scope: "dup"}); err == nil {
+		t.Fatal("expected conflict creating duplicate scope")
+	}
+}

--- a/server/azure/databricks/serving/serving.go
+++ b/server/azure/databricks/serving/serving.go
@@ -1,0 +1,470 @@
+// Package serving implements the Databricks Serving Endpoints data-plane REST
+// API (the /api/2.0/serving-endpoints surface served at the workspace URL) as a
+// server.Handler. Point the real github.com/databricks/databricks-sdk-go
+// WorkspaceClient at a server registered with a Handler from New and
+// w.ServingEndpoints Create/Get/List/UpdateConfig/Delete work end-to-end
+// against an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.0/serving-endpoints                create
+//	GET    /api/2.0/serving-endpoints                list
+//	GET    /api/2.0/serving-endpoints/{name}         get
+//	PUT    /api/2.0/serving-endpoints/{name}/config  update config
+//	DELETE /api/2.0/serving-endpoints/{name}         delete
+//
+// Create and UpdateConfig return an LRO waiter that polls Get until the
+// endpoint's config_update state reaches NOT_UPDATING; this backend reports
+// endpoints as terminal (config_update NOT_UPDATING, ready READY) so the waiter
+// resolves on the first poll.
+package serving
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+const resServingEndpoints = "serving-endpoints"
+
+// Endpoint state values mirroring serving.EndpointStateConfigUpdate and
+// serving.EndpointStateReady. A freshly created or updated endpoint is reported
+// terminal so the SDK Create/UpdateConfig waiters resolve immediately.
+const (
+	configUpdateNotUpdating = "NOT_UPDATING"
+	stateReady              = "READY"
+)
+
+// Path segment positions after splitting on "/".
+const (
+	idxAPI      = 0
+	idxResource = 2
+	idxName     = 3
+	idxAction   = 4
+)
+
+// collectionSegs is the [api, ver, serving-endpoints] segment count; an item
+// path adds the {name} segment for itemSegs.
+const (
+	collectionSegs = 3
+	itemSegs       = 4
+)
+
+// actionConfig is the /{name}/config sub-route segment.
+const actionConfig = "config"
+
+// endpoint is the in-memory state for a single serving endpoint.
+type endpoint struct {
+	Name                 string
+	ID                   string
+	Description          string
+	CreationTimestamp    int64
+	LastUpdatedTimestamp int64
+	ConfigVersion        int64
+	ServedEntities       []json.RawMessage
+	ServedModels         []json.RawMessage
+	TrafficConfig        json.RawMessage
+	Tags                 json.RawMessage
+}
+
+// Handler serves the Databricks Serving Endpoints data-plane REST API backed by
+// an in-memory map keyed by endpoint name.
+type Handler struct {
+	mu     sync.RWMutex
+	items  map[string]*endpoint
+	nextID int64
+}
+
+// New returns a Serving Endpoints handler with an empty in-memory backend.
+func New() *Handler {
+	return &Handler{items: make(map[string]*endpoint)}
+}
+
+// Matches claims paths whose 3rd segment is "serving-endpoints".
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+
+	return len(parts) >= collectionSegs && parts[idxAPI] == "api" && parts[idxResource] == resServingEndpoints
+}
+
+// ServeHTTP routes by path shape: collection (create/list), item (get/delete),
+// or item action (/{name}/config).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < collectionSegs {
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unsupported path")
+
+		return
+	}
+
+	switch len(parts) {
+	case collectionSegs:
+		h.serveCollection(w, r)
+	case itemSegs:
+		h.serveItem(w, r, parts[idxName])
+	default:
+		h.serveItemAction(w, r, parts[idxName], parts[idxAction])
+	}
+}
+
+// serveCollection handles /api/2.0/serving-endpoints (POST create, GET list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.create(w, r)
+	case http.MethodGet:
+		h.list(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItem handles /api/2.0/serving-endpoints/{name} (GET get, DELETE delete).
+func (h *Handler) serveItem(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, name)
+	case http.MethodDelete:
+		h.delete(w, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItemAction handles /api/2.0/serving-endpoints/{name}/config.
+func (h *Handler) serveItemAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	if action != actionConfig {
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unknown action: "+action)
+
+		return
+	}
+
+	if r.Method != http.MethodPut {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	h.updateConfig(w, r, name)
+}
+
+// createRequest is the subset of CreateServingEndpoint fields we honor.
+type createRequest struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Config      *configInput    `json:"config"`
+	Tags        json.RawMessage `json:"tags"`
+}
+
+// configInput is the subset of EndpointCoreConfigInput fields we honor.
+type configInput struct {
+	ServedEntities []json.RawMessage `json:"served_entities"`
+	ServedModels   []json.RawMessage `json:"served_models"`
+	TrafficConfig  json.RawMessage   `json:"traffic_config"`
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "name is required")
+
+		return
+	}
+
+	h.mu.Lock()
+
+	if _, ok := h.items[req.Name]; ok {
+		h.mu.Unlock()
+		writeErr(w, http.StatusConflict, "RESOURCE_ALREADY_EXISTS", "serving endpoint already exists: "+req.Name)
+
+		return
+	}
+
+	h.nextID++
+	ep := newEndpoint(&req, h.nextID)
+	h.items[ep.Name] = ep
+	out := detailed(ep)
+	h.mu.Unlock()
+
+	writeJSON(w, out)
+}
+
+// newEndpoint builds an endpoint from a create request.
+func newEndpoint(req *createRequest, id int64) *endpoint {
+	ep := &endpoint{
+		Name:          req.Name,
+		ID:            idFor(id),
+		Description:   req.Description,
+		ConfigVersion: 1,
+		Tags:          req.Tags,
+	}
+
+	applyConfig(ep, req.Config)
+
+	return ep
+}
+
+// applyConfig copies the served entities/models and traffic config from a
+// config payload onto the endpoint.
+func applyConfig(ep *endpoint, cfg *configInput) {
+	if cfg == nil {
+		return
+	}
+
+	ep.ServedEntities = cfg.ServedEntities
+	ep.ServedModels = cfg.ServedModels
+	ep.TrafficConfig = cfg.TrafficConfig
+}
+
+func (h *Handler) get(w http.ResponseWriter, name string) {
+	var out map[string]any
+
+	h.mu.RLock()
+	ep, ok := h.items[name]
+
+	if ok {
+		out = detailed(ep)
+	}
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, name)
+
+		return
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) list(w http.ResponseWriter) {
+	h.mu.RLock()
+	out := make([]map[string]any, 0, len(h.items))
+
+	for _, ep := range h.items {
+		out = append(out, summary(ep))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, map[string]any{"endpoints": out})
+}
+
+// updateConfigRequest is the subset of EndpointCoreConfigInput fields honored
+// on the /{name}/config route. Name comes from the path, not the body.
+type updateConfigRequest struct {
+	ServedEntities []json.RawMessage `json:"served_entities"`
+	ServedModels   []json.RawMessage `json:"served_models"`
+	TrafficConfig  json.RawMessage   `json:"traffic_config"`
+}
+
+func (h *Handler) updateConfig(w http.ResponseWriter, r *http.Request, name string) {
+	var req updateConfigRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	var out map[string]any
+
+	h.mu.Lock()
+	ep, ok := h.items[name]
+
+	if ok {
+		ep.ConfigVersion++
+		applyConfig(ep, &configInput{
+			ServedEntities: req.ServedEntities,
+			ServedModels:   req.ServedModels,
+			TrafficConfig:  req.TrafficConfig,
+		})
+
+		out = detailed(ep)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, name)
+
+		return
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) delete(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	_, ok := h.items[name]
+
+	if ok {
+		delete(h.items, name)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, name)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// terminalState is the always-terminal EndpointState reported for every
+// endpoint, letting Create/UpdateConfig waiters resolve on the first poll.
+func terminalState() map[string]any {
+	return map[string]any{
+		"config_update": configUpdateNotUpdating,
+		"ready":         stateReady,
+	}
+}
+
+// configOutput renders an endpoint's current config as the
+// EndpointCoreConfigOutput JSON shape used by Get/Create/UpdateConfig.
+func configOutput(ep *endpoint) map[string]any {
+	out := map[string]any{"config_version": ep.ConfigVersion}
+
+	if ep.ServedEntities != nil {
+		out["served_entities"] = ep.ServedEntities
+	}
+
+	if ep.ServedModels != nil {
+		out["served_models"] = ep.ServedModels
+	}
+
+	if ep.TrafficConfig != nil {
+		out["traffic_config"] = ep.TrafficConfig
+	}
+
+	return out
+}
+
+// detailed renders an endpoint as the ServingEndpointDetailed JSON shape
+// returned by Get, Create, and UpdateConfig.
+func detailed(ep *endpoint) map[string]any {
+	out := map[string]any{
+		"name":                   ep.Name,
+		"id":                     ep.ID,
+		"creation_timestamp":     ep.CreationTimestamp,
+		"last_updated_timestamp": ep.LastUpdatedTimestamp,
+		"state":                  terminalState(),
+		"config":                 configOutput(ep),
+	}
+
+	if ep.Description != "" {
+		out["description"] = ep.Description
+	}
+
+	if ep.Tags != nil {
+		out["tags"] = ep.Tags
+	}
+
+	return out
+}
+
+// summary renders an endpoint as the ServingEndpoint JSON shape returned by
+// List, whose config is an EndpointCoreConfigSummary.
+func summary(ep *endpoint) map[string]any {
+	cfg := map[string]any{}
+
+	if ep.ServedEntities != nil {
+		cfg["served_entities"] = ep.ServedEntities
+	}
+
+	if ep.ServedModels != nil {
+		cfg["served_models"] = ep.ServedModels
+	}
+
+	out := map[string]any{
+		"name":                   ep.Name,
+		"id":                     ep.ID,
+		"creation_timestamp":     ep.CreationTimestamp,
+		"last_updated_timestamp": ep.LastUpdatedTimestamp,
+		"state":                  terminalState(),
+		"config":                 cfg,
+	}
+
+	if ep.Description != "" {
+		out["description"] = ep.Description
+	}
+
+	if ep.Tags != nil {
+		out["tags"] = ep.Tags
+	}
+
+	return out
+}
+
+// idFor builds a stable system-generated endpoint id.
+func idFor(seq int64) string {
+	return "endpoint-" + itoa(seq)
+}
+
+func itoa(v int64) string {
+	if v == 0 {
+		return "0"
+	}
+
+	var buf [20]byte
+	pos := len(buf)
+
+	for v > 0 {
+		pos--
+		buf[pos] = byte('0' + v%10)
+		v /= 10
+	}
+
+	return string(buf[pos:])
+}
+
+// splitPath strips the leading/trailing "/" and returns the path segments,
+// keeping "api" at index 0 for the Matches/ServeHTTP guards.
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func notFound(w http.ResponseWriter, name string) {
+	writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "serving endpoint not found: "+name)
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+}

--- a/server/azure/databricks/serving/serving_roundtrip_test.go
+++ b/server/azure/databricks/serving/serving_roundtrip_test.go
@@ -1,0 +1,176 @@
+package serving_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	dbserving "github.com/databricks/databricks-sdk-go/service/serving"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/serving"
+)
+
+func newServingClient(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(serving.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:               ts.URL,
+		Token:              "x",
+		Credentials:        config.PatCredentials{},
+		HTTPTimeoutSeconds: 10,
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func entityConfig(version string) *dbserving.EndpointCoreConfigInput {
+	return &dbserving.EndpointCoreConfigInput{
+		ServedEntities: []dbserving.ServedEntityInput{
+			{
+				Name:               "m",
+				EntityName:         "main.default.model",
+				EntityVersion:      version,
+				ScaleToZeroEnabled: true,
+			},
+		},
+		TrafficConfig: &dbserving.TrafficConfig{
+			Routes: []dbserving.Route{
+				{ServedModelName: "m", TrafficPercentage: 100},
+			},
+		},
+	}
+}
+
+func TestSDKServingEndpointLifecycle(t *testing.T) {
+	w := newServingClient(t)
+	ctx := context.Background()
+
+	wait, err := w.ServingEndpoints.Create(ctx, dbserving.CreateServingEndpoint{
+		Name:        "ep-1",
+		Description: "test endpoint",
+		Config:      entityConfig("1"),
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	created, err := wait.Get()
+	if err != nil {
+		t.Fatalf("Create wait: %v", err)
+	}
+
+	if created.Name != "ep-1" {
+		t.Fatalf("got name %q after create, want ep-1", created.Name)
+	}
+
+	if created.State == nil || created.State.ConfigUpdate != dbserving.EndpointStateConfigUpdateNotUpdating {
+		t.Fatalf("create state not terminal: %+v", created.State)
+	}
+
+	if created.State.Ready != dbserving.EndpointStateReadyReady {
+		t.Fatalf("got ready %q, want READY", created.State.Ready)
+	}
+
+	got, err := w.ServingEndpoints.Get(ctx, dbserving.GetServingEndpointRequest{Name: "ep-1"})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Description != "test endpoint" {
+		t.Fatalf("unexpected description: %q", got.Description)
+	}
+
+	if got.Config == nil || len(got.Config.ServedEntities) != 1 ||
+		got.Config.ServedEntities[0].EntityVersion != "1" {
+		t.Fatalf("config not round-tripped: %+v", got.Config)
+	}
+
+	all, err := w.ServingEndpoints.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 1 || all[0].Name != "ep-1" {
+		t.Fatalf("got %d endpoints, want 1 named ep-1: %+v", len(all), all)
+	}
+
+	updWait, err := w.ServingEndpoints.UpdateConfig(ctx, dbserving.EndpointCoreConfigInput{
+		Name:           "ep-1",
+		ServedEntities: entityConfig("2").ServedEntities,
+		TrafficConfig:  entityConfig("2").TrafficConfig,
+	})
+	if err != nil {
+		t.Fatalf("UpdateConfig: %v", err)
+	}
+
+	updated, err := updWait.Get()
+	if err != nil {
+		t.Fatalf("UpdateConfig wait: %v", err)
+	}
+
+	if updated.Config == nil || len(updated.Config.ServedEntities) != 1 ||
+		updated.Config.ServedEntities[0].EntityVersion != "2" {
+		t.Fatalf("update not applied: %+v", updated.Config)
+	}
+
+	if err = w.ServingEndpoints.Delete(ctx, dbserving.DeleteServingEndpointRequest{Name: "ep-1"}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err = w.ServingEndpoints.Get(ctx, dbserving.GetServingEndpointRequest{Name: "ep-1"}); err == nil {
+		t.Fatal("expected error getting deleted endpoint")
+	}
+}
+
+func TestSDKServingEndpointGetMissing(t *testing.T) {
+	w := newServingClient(t)
+
+	_, err := w.ServingEndpoints.Get(context.Background(), dbserving.GetServingEndpointRequest{Name: "nope"})
+	if err == nil {
+		t.Fatal("expected RESOURCE_DOES_NOT_EXIST error")
+	}
+}
+
+func TestSDKServingEndpointListEmpty(t *testing.T) {
+	w := newServingClient(t)
+
+	all, err := w.ServingEndpoints.ListAll(context.Background())
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 0 {
+		t.Fatalf("got %d endpoints, want 0", len(all))
+	}
+}
+
+func TestSDKServingEndpointDuplicate(t *testing.T) {
+	w := newServingClient(t)
+	ctx := context.Background()
+
+	if _, err := w.ServingEndpoints.Create(ctx, dbserving.CreateServingEndpoint{
+		Name:   "dup",
+		Config: entityConfig("1"),
+	}); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	if _, err := w.ServingEndpoints.Create(ctx, dbserving.CreateServingEndpoint{
+		Name:   "dup",
+		Config: entityConfig("1"),
+	}); err == nil {
+		t.Fatal("expected RESOURCE_ALREADY_EXISTS error")
+	}
+}

--- a/server/azure/databricks/sqlwarehouses/sqlwarehouses.go
+++ b/server/azure/databricks/sqlwarehouses/sqlwarehouses.go
@@ -1,0 +1,441 @@
+// Package sqlwarehouses implements the Databricks SQL Warehouses data-plane
+// REST API (the /api/2.0/sql/warehouses surface) as a server.Handler. Point the
+// real github.com/databricks/databricks-sdk-go WorkspaceClient at a server
+// registered with a Handler from New and w.Warehouses works end-to-end against
+// an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.0/sql/warehouses
+//	GET    /api/2.0/sql/warehouses
+//	GET    /api/2.0/sql/warehouses/{id}
+//	POST   /api/2.0/sql/warehouses/{id}/edit
+//	DELETE /api/2.0/sql/warehouses/{id}
+//	POST   /api/2.0/sql/warehouses/{id}/start
+//	POST   /api/2.0/sql/warehouses/{id}/stop
+package sqlwarehouses
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+// Warehouse lifecycle states, mirroring sql.State. Create/Start drive a
+// warehouse to RUNNING and Stop to STOPPED; the STARTING/STOPPING/DELETING/
+// DELETED intermediate states are not emitted by this in-memory backend.
+const (
+	stateRunning = "RUNNING"
+	stateStopped = "STOPPED"
+)
+
+// Defaults applied when a create request omits the field.
+const (
+	defaultAutoStopMins   = 120
+	defaultClusterSize    = "X-Small"
+	defaultMaxNumClusters = 1
+	defaultMinNumClusters = 1
+)
+
+// Path segment positions after splitting on "/".
+const (
+	idxAPI       = 0
+	idxSQL       = 2
+	idxWarehouse = 3
+	idxID        = 4
+	idxAction    = 5
+)
+
+// minMatchSegs is the [api, ver, sql, warehouses] segment count Matches needs.
+const minMatchSegs = 4
+
+// warehouse is the in-memory state for a single SQL warehouse.
+type warehouse struct {
+	ID                      string
+	Name                    string
+	ClusterSize             string
+	State                   string
+	AutoStopMins            int
+	MaxNumClusters          int
+	MinNumClusters          int
+	NumClusters             int
+	EnablePhoton            bool
+	EnableServerlessCompute bool
+	CreatorName             string
+	WarehouseType           string
+	SpotInstancePolicy      string
+}
+
+// Handler serves the Databricks SQL Warehouses data-plane REST API.
+type Handler struct {
+	mu     sync.RWMutex
+	items  map[string]*warehouse
+	nextID int
+}
+
+// New returns a SQL Warehouses handler backed by an empty in-memory store.
+func New() *Handler {
+	return &Handler{items: make(map[string]*warehouse)}
+}
+
+// Matches claims /api/{ver}/sql/warehouses/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minMatchSegs || parts[idxAPI] != "api" {
+		return false
+	}
+
+	return parts[idxSQL] == "sql" && parts[idxWarehouse] == "warehouses"
+}
+
+// ServeHTTP routes by path shape: collection (create/list) vs. item (get/edit/
+// delete/start/stop).
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minMatchSegs {
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unsupported path")
+
+		return
+	}
+
+	if len(parts) == minMatchSegs {
+		h.serveCollection(w, r)
+
+		return
+	}
+
+	h.serveItem(w, r, parts)
+}
+
+// serveCollection handles /api/2.0/sql/warehouses (POST create, GET list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.create(w, r)
+	case http.MethodGet:
+		h.list(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItem handles /api/2.0/sql/warehouses/{id}[/{action}].
+func (h *Handler) serveItem(w http.ResponseWriter, r *http.Request, parts []string) {
+	id := parts[idxID]
+
+	if len(parts) > idxAction {
+		h.serveItemAction(w, r, id, parts[idxAction])
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, id)
+	case http.MethodDelete:
+		h.delete(w, id)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+// serveItemAction handles the /{id}/{edit,start,stop} sub-routes.
+func (h *Handler) serveItemAction(w http.ResponseWriter, r *http.Request, id, action string) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	switch action {
+	case "edit":
+		h.edit(w, r, id)
+	case "start":
+		h.start(w, id)
+	case "stop":
+		h.stop(w, id)
+	default:
+		writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "unknown action: "+action)
+	}
+}
+
+// createRequest is the subset of CreateWarehouseRequest fields we honor.
+type createRequest struct {
+	Name                    string `json:"name"`
+	ClusterSize             string `json:"cluster_size"`
+	AutoStopMins            int    `json:"auto_stop_mins"`
+	MaxNumClusters          int    `json:"max_num_clusters"`
+	MinNumClusters          int    `json:"min_num_clusters"`
+	EnablePhoton            bool   `json:"enable_photon"`
+	EnableServerlessCompute bool   `json:"enable_serverless_compute"`
+	CreatorName             string `json:"creator_name"`
+	WarehouseType           string `json:"warehouse_type"`
+	SpotInstancePolicy      string `json:"spot_instance_policy"`
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	var req createRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "name is required")
+
+		return
+	}
+
+	wh := newWarehouse(&req)
+
+	h.mu.Lock()
+	h.nextID++
+	wh.ID = fmt.Sprintf("%d", h.nextID)
+	h.items[wh.ID] = wh
+	h.mu.Unlock()
+
+	writeJSON(w, map[string]string{"id": wh.ID})
+}
+
+// newWarehouse builds a warehouse from a create request, applying defaults. The
+// Create SDK call returns an LRO waiter that polls Get until RUNNING, so a fresh
+// warehouse starts RUNNING for the waiter to resolve immediately.
+func newWarehouse(req *createRequest) *warehouse {
+	wh := &warehouse{
+		Name:                    req.Name,
+		ClusterSize:             req.ClusterSize,
+		State:                   stateRunning,
+		AutoStopMins:            req.AutoStopMins,
+		MaxNumClusters:          req.MaxNumClusters,
+		MinNumClusters:          req.MinNumClusters,
+		EnablePhoton:            req.EnablePhoton,
+		EnableServerlessCompute: req.EnableServerlessCompute,
+		CreatorName:             req.CreatorName,
+		WarehouseType:           req.WarehouseType,
+		SpotInstancePolicy:      req.SpotInstancePolicy,
+	}
+
+	if wh.ClusterSize == "" {
+		wh.ClusterSize = defaultClusterSize
+	}
+
+	if wh.AutoStopMins == 0 {
+		wh.AutoStopMins = defaultAutoStopMins
+	}
+
+	if wh.MaxNumClusters == 0 {
+		wh.MaxNumClusters = defaultMaxNumClusters
+	}
+
+	if wh.MinNumClusters == 0 {
+		wh.MinNumClusters = defaultMinNumClusters
+	}
+
+	wh.NumClusters = wh.MinNumClusters
+
+	return wh
+}
+
+func (h *Handler) get(w http.ResponseWriter, id string) {
+	var snapshot warehouse
+
+	h.mu.RLock()
+	wh, ok := h.items[id]
+
+	if ok {
+		snapshot = *wh
+	}
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, toResponse(&snapshot))
+}
+
+func (h *Handler) list(w http.ResponseWriter) {
+	h.mu.RLock()
+	out := make([]map[string]any, 0, len(h.items))
+
+	for _, wh := range h.items {
+		out = append(out, toResponse(wh))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, map[string]any{"warehouses": out})
+}
+
+// editRequest is the subset of EditWarehouseRequest fields we honor.
+type editRequest struct {
+	Name           string `json:"name"`
+	ClusterSize    string `json:"cluster_size"`
+	AutoStopMins   int    `json:"auto_stop_mins"`
+	MaxNumClusters int    `json:"max_num_clusters"`
+	MinNumClusters int    `json:"min_num_clusters"`
+}
+
+func (h *Handler) edit(w http.ResponseWriter, r *http.Request, id string) {
+	var req editRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	wh, ok := h.items[id]
+
+	if ok {
+		applyEdit(wh, req)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func applyEdit(wh *warehouse, req editRequest) {
+	if req.Name != "" {
+		wh.Name = req.Name
+	}
+
+	if req.ClusterSize != "" {
+		wh.ClusterSize = req.ClusterSize
+	}
+
+	if req.AutoStopMins != 0 {
+		wh.AutoStopMins = req.AutoStopMins
+	}
+
+	if req.MaxNumClusters != 0 {
+		wh.MaxNumClusters = req.MaxNumClusters
+	}
+
+	if req.MinNumClusters != 0 {
+		wh.MinNumClusters = req.MinNumClusters
+	}
+}
+
+func (h *Handler) delete(w http.ResponseWriter, id string) {
+	h.mu.Lock()
+	_, ok := h.items[id]
+
+	if ok {
+		delete(h.items, id)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func (h *Handler) start(w http.ResponseWriter, id string) {
+	h.transition(w, id, stateRunning)
+}
+
+func (h *Handler) stop(w http.ResponseWriter, id string) {
+	h.transition(w, id, stateStopped)
+}
+
+// transition sets a warehouse to the given terminal state. The Start/Stop SDK
+// calls return LRO waiters that poll Get until RUNNING/STOPPED respectively, so
+// setting the terminal state directly lets those waiters resolve.
+func (h *Handler) transition(w http.ResponseWriter, id, state string) {
+	h.mu.Lock()
+	wh, ok := h.items[id]
+
+	if ok {
+		wh.State = state
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		notFound(w, id)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// toResponse renders a warehouse as the GetWarehouseResponse / EndpointInfo JSON
+// shape shared by Get and List.
+func toResponse(wh *warehouse) map[string]any {
+	return map[string]any{
+		"id":                        wh.ID,
+		"name":                      wh.Name,
+		"cluster_size":              wh.ClusterSize,
+		"state":                     wh.State,
+		"auto_stop_mins":            wh.AutoStopMins,
+		"max_num_clusters":          wh.MaxNumClusters,
+		"min_num_clusters":          wh.MinNumClusters,
+		"num_clusters":              wh.NumClusters,
+		"enable_photon":             wh.EnablePhoton,
+		"enable_serverless_compute": wh.EnableServerlessCompute,
+		"creator_name":              wh.CreatorName,
+		"warehouse_type":            wh.WarehouseType,
+		"spot_instance_policy":      wh.SpotInstancePolicy,
+	}
+}
+
+// splitPath strips the leading/trailing "/" and returns the path segments.
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func notFound(w http.ResponseWriter, id string) {
+	writeErr(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "warehouse not found: "+id)
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+}

--- a/server/azure/databricks/sqlwarehouses/sqlwarehouses_roundtrip_test.go
+++ b/server/azure/databricks/sqlwarehouses/sqlwarehouses_roundtrip_test.go
@@ -1,0 +1,171 @@
+package sqlwarehouses_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/sqlwarehouses"
+)
+
+func newWarehouseClient(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(sqlwarehouses.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKWarehouseLifecycle(t *testing.T) {
+	w := newWarehouseClient(t)
+	ctx := context.Background()
+
+	wait, err := w.Warehouses.Create(ctx, sql.CreateWarehouseRequest{
+		Name:           "wh-1",
+		ClusterSize:    "Small",
+		AutoStopMins:   30,
+		MaxNumClusters: 2,
+		MinNumClusters: 1,
+		EnablePhoton:   true,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	id := wait.Id
+	if id == "" {
+		t.Fatal("expected warehouse id from waiter")
+	}
+
+	created, err := wait.Get()
+	if err != nil {
+		t.Fatalf("Create wait: %v", err)
+	}
+
+	if created.State != sql.StateRunning {
+		t.Fatalf("got state %q after create, want RUNNING", created.State)
+	}
+
+	got, err := w.Warehouses.GetById(ctx, id)
+	if err != nil {
+		t.Fatalf("GetById: %v", err)
+	}
+
+	if got.Name != "wh-1" || got.ClusterSize != "Small" {
+		t.Fatalf("unexpected warehouse: %+v", got)
+	}
+
+	if got.State != sql.StateRunning {
+		t.Fatalf("got state %q, want RUNNING", got.State)
+	}
+
+	all, err := w.Warehouses.ListAll(ctx, sql.ListWarehousesRequest{})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 1 {
+		t.Fatalf("got %d warehouses, want 1", len(all))
+	}
+
+	if all[0].Id != id {
+		t.Fatalf("listed id %q, want %q", all[0].Id, id)
+	}
+
+	editWait, err := w.Warehouses.Edit(ctx, sql.EditWarehouseRequest{
+		Id:          id,
+		Name:        "wh-1-edited",
+		ClusterSize: "Medium",
+	})
+	if err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+
+	if _, err = editWait.Get(); err != nil {
+		t.Fatalf("Edit wait: %v", err)
+	}
+
+	edited, err := w.Warehouses.GetById(ctx, id)
+	if err != nil {
+		t.Fatalf("GetById after edit: %v", err)
+	}
+
+	if edited.Name != "wh-1-edited" || edited.ClusterSize != "Medium" {
+		t.Fatalf("edit not applied: %+v", edited)
+	}
+
+	stopWait, err := w.Warehouses.Stop(ctx, sql.StopRequest{Id: id})
+	if err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	stopped, err := stopWait.Get()
+	if err != nil {
+		t.Fatalf("Stop wait: %v", err)
+	}
+
+	if stopped.State != sql.StateStopped {
+		t.Fatalf("got state %q after stop, want STOPPED", stopped.State)
+	}
+
+	startWait, err := w.Warehouses.Start(ctx, sql.StartRequest{Id: id})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	running, err := startWait.Get()
+	if err != nil {
+		t.Fatalf("Start wait: %v", err)
+	}
+
+	if running.State != sql.StateRunning {
+		t.Fatalf("got state %q after start, want RUNNING", running.State)
+	}
+
+	if err = w.Warehouses.DeleteById(ctx, id); err != nil {
+		t.Fatalf("DeleteById: %v", err)
+	}
+
+	if _, err = w.Warehouses.GetById(ctx, id); err == nil {
+		t.Fatal("expected error getting deleted warehouse")
+	}
+}
+
+func TestSDKWarehouseGetMissing(t *testing.T) {
+	w := newWarehouseClient(t)
+
+	if _, err := w.Warehouses.GetById(context.Background(), "does-not-exist"); err == nil {
+		t.Fatal("expected RESOURCE_DOES_NOT_EXIST error")
+	}
+}
+
+func TestSDKWarehouseListEmpty(t *testing.T) {
+	w := newWarehouseClient(t)
+
+	all, err := w.Warehouses.ListAll(context.Background(), sql.ListWarehousesRequest{})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 0 {
+		t.Fatalf("got %d warehouses, want 0", len(all))
+	}
+}

--- a/server/azure/databricks/token/token.go
+++ b/server/azure/databricks/token/token.go
@@ -1,0 +1,273 @@
+// Package token implements the Databricks personal-access-token data-plane REST
+// API (the /api/2.0/token surface served at the workspace URL) as a
+// server.Handler. Point the real github.com/databricks/databricks-sdk-go
+// WorkspaceClient at a server registered with this handler and w.Tokens.Create,
+// w.Tokens.ListAll, and w.Tokens.Delete work end-to-end against an in-memory
+// backend.
+//
+// Covered endpoints:
+//
+//	POST /api/2.0/token/create
+//	GET  /api/2.0/token/list
+//	POST /api/2.0/token/delete
+package token
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxBodyBytes = 1 << 20
+
+// Segment indices and counts for /api/{ver}/token/{action} paths.
+const (
+	segAPI      = 0
+	segResource = 2
+	segAction   = 3
+	minSegs     = 4
+)
+
+const resToken = "token"
+
+// Action path segments.
+const (
+	actCreate = "create"
+	actList   = "list"
+	actDelete = "delete"
+)
+
+// Databricks error codes.
+const (
+	codeNotFound  = "RESOURCE_DOES_NOT_EXIST"
+	codeInvalid   = "INVALID_PARAMETER_VALUE"
+	codeEndpoint  = "ENDPOINT_NOT_FOUND"
+	codeMalformed = "MALFORMED_REQUEST"
+)
+
+const millisPerSecond = 1000
+
+// tokenInfo is the stored metadata for a single personal access token.
+type tokenInfo struct {
+	tokenID      string
+	comment      string
+	creationTime int64
+	expiryTime   int64
+}
+
+// Handler serves the Databricks token data-plane REST API backed by an
+// in-memory store.
+type Handler struct {
+	mu     sync.RWMutex
+	tokens map[string]tokenInfo
+	nextID int64
+}
+
+// New returns a token handler with an empty in-memory store.
+func New() *Handler {
+	return &Handler{tokens: make(map[string]tokenInfo)}
+}
+
+// Matches claims /api/{ver}/token/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := split(r.URL.Path)
+	if len(parts) < minSegs || parts[segAPI] != "api" {
+		return false
+	}
+
+	return parts[segResource] == resToken
+}
+
+// ServeHTTP routes by action.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := split(r.URL.Path)
+	if len(parts) < minSegs {
+		writeError(w, http.StatusNotFound, codeEndpoint, "unsupported path")
+
+		return
+	}
+
+	switch action := parts[segAction]; action {
+	case actCreate:
+		h.create(w, r)
+	case actList:
+		h.list(w, r)
+	case actDelete:
+		h.deleteToken(w, r)
+	default:
+		writeError(w, http.StatusNotFound, codeEndpoint, "unknown action: "+action)
+	}
+}
+
+// --- wire types ---
+
+type tokenInfoJSON struct {
+	TokenID      string `json:"token_id"`
+	Comment      string `json:"comment,omitempty"`
+	CreationTime int64  `json:"creation_time"`
+	ExpiryTime   int64  `json:"expiry_time"`
+}
+
+type createRequest struct {
+	Comment         string `json:"comment"`
+	LifetimeSeconds int64  `json:"lifetime_seconds"`
+}
+
+type createResponse struct {
+	TokenValue string        `json:"token_value"`
+	TokenInfo  tokenInfoJSON `json:"token_info"`
+}
+
+type listResponse struct {
+	TokenInfos []tokenInfoJSON `json:"token_infos"`
+}
+
+type deleteRequest struct {
+	TokenID string `json:"token_id"`
+}
+
+// --- ops ---
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	var in createRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	now := time.Now().UnixMilli()
+
+	var expiry int64
+	if in.LifetimeSeconds > 0 {
+		expiry = now + in.LifetimeSeconds*millisPerSecond
+	}
+
+	h.mu.Lock()
+	h.nextID++
+	id := strconv.FormatInt(h.nextID, 10)
+	info := tokenInfo{tokenID: id, comment: in.Comment, creationTime: now, expiryTime: expiry}
+	h.tokens[id] = info
+	h.mu.Unlock()
+
+	writeJSON(w, createResponse{
+		TokenValue: "dapi" + id,
+		TokenInfo:  toJSON(info),
+	})
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	h.mu.RLock()
+	out := make([]tokenInfoJSON, 0, len(h.tokens))
+
+	for _, info := range h.tokens {
+		out = append(out, toJSON(info))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listResponse{TokenInfos: out})
+}
+
+func (h *Handler) deleteToken(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	var in deleteRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.TokenID == "" {
+		writeError(w, http.StatusBadRequest, codeInvalid, "token_id is required")
+
+		return
+	}
+
+	h.mu.Lock()
+
+	_, ok := h.tokens[in.TokenID]
+	if ok {
+		delete(h.tokens, in.TokenID)
+	}
+
+	h.mu.Unlock()
+
+	if !ok {
+		writeError(w, http.StatusNotFound, codeNotFound, "token "+in.TokenID+" does not exist")
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+// --- helpers ---
+
+func toJSON(info tokenInfo) tokenInfoJSON {
+	return tokenInfoJSON{
+		TokenID:      info.tokenID,
+		Comment:      info.comment,
+		CreationTime: info.creationTime,
+		ExpiryTime:   info.expiryTime,
+	}
+}
+
+// split strips the leading/trailing slashes and returns the path segments.
+func split(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, codeMalformed, "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, codeInvalid, "method not allowed")
+}

--- a/server/azure/databricks/token/token_roundtrip_test.go
+++ b/server/azure/databricks/token/token_roundtrip_test.go
@@ -1,0 +1,118 @@
+package token_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/settings"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/token"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(token.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "x",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKTokenLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Tokens.Create(ctx, settings.CreateTokenRequest{
+		Comment:         "ci-token",
+		LifetimeSeconds: 3600,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.TokenValue == "" {
+		t.Fatal("expected token value")
+	}
+
+	if created.TokenInfo == nil || created.TokenInfo.TokenId == "" {
+		t.Fatalf("expected token info with id, got %+v", created.TokenInfo)
+	}
+
+	if created.TokenInfo.Comment != "ci-token" {
+		t.Fatalf("got comment %q, want ci-token", created.TokenInfo.Comment)
+	}
+
+	if created.TokenInfo.CreationTime == 0 {
+		t.Fatal("expected non-zero creation time")
+	}
+
+	if created.TokenInfo.ExpiryTime != created.TokenInfo.CreationTime+3600*1000 {
+		t.Fatalf("unexpected expiry time: %d", created.TokenInfo.ExpiryTime)
+	}
+
+	infos, err := w.Tokens.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(infos) != 1 {
+		t.Fatalf("got %d tokens, want 1", len(infos))
+	}
+
+	if infos[0].TokenId != created.TokenInfo.TokenId {
+		t.Fatalf("got token id %q, want %q", infos[0].TokenId, created.TokenInfo.TokenId)
+	}
+
+	if err = w.Tokens.Delete(ctx, settings.RevokeTokenRequest{TokenId: created.TokenInfo.TokenId}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	infos, err = w.Tokens.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll after delete: %v", err)
+	}
+
+	if len(infos) != 0 {
+		t.Fatalf("got %d tokens after delete, want 0", len(infos))
+	}
+}
+
+func TestSDKTokenNoExpiry(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Tokens.Create(ctx, settings.CreateTokenRequest{Comment: "no-expiry"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.TokenInfo.ExpiryTime != 0 {
+		t.Fatalf("got expiry %d, want 0 (no expiry)", created.TokenInfo.ExpiryTime)
+	}
+}
+
+func TestSDKTokenDeleteMissing(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	err := w.Tokens.Delete(ctx, settings.RevokeTokenRequest{TokenId: "does-not-exist"})
+	if err == nil {
+		t.Fatal("expected error deleting missing token")
+	}
+}

--- a/server/azure/databricks/ucstorage/externallocations.go
+++ b/server/azure/databricks/ucstorage/externallocations.go
@@ -1,0 +1,209 @@
+package ucstorage
+
+import (
+	"net/http"
+	"time"
+)
+
+// externalLocation is the in-memory state for a single external location.
+type externalLocation struct {
+	name           string
+	url            string
+	credentialName string
+	comment        string
+	readOnly       bool
+	createdAt      int64
+	updatedAt      int64
+}
+
+type externalLocationView struct {
+	Name           string `json:"name"`
+	URL            string `json:"url"`
+	CredentialName string `json:"credential_name,omitempty"`
+	Comment        string `json:"comment,omitempty"`
+	ReadOnly       bool   `json:"read_only"`
+	MetastoreID    string `json:"metastore_id"`
+	CreatedAt      int64  `json:"created_at"`
+	UpdatedAt      int64  `json:"updated_at"`
+}
+
+type createExternalLocationRequest struct {
+	Name           string `json:"name"`
+	URL            string `json:"url"`
+	CredentialName string `json:"credential_name"`
+	Comment        string `json:"comment"`
+	ReadOnly       bool   `json:"read_only"`
+}
+
+type updateExternalLocationRequest struct {
+	NewName        string `json:"new_name"`
+	URL            string `json:"url"`
+	CredentialName string `json:"credential_name"`
+	Comment        string `json:"comment"`
+	ReadOnly       *bool  `json:"read_only"`
+}
+
+type listExternalLocationsResponse struct {
+	ExternalLocations []externalLocationView `json:"external_locations"`
+}
+
+func (e *externalLocation) view() externalLocationView {
+	return externalLocationView{
+		Name:           e.name,
+		URL:            e.url,
+		CredentialName: e.credentialName,
+		Comment:        e.comment,
+		ReadOnly:       e.readOnly,
+		MetastoreID:    stubMetastoreID,
+		CreatedAt:      e.createdAt,
+		UpdatedAt:      e.updatedAt,
+	}
+}
+
+func (h *Handler) serveExternalLocations(w http.ResponseWriter, r *http.Request, item string) {
+	if item == "" {
+		h.serveExternalLocationCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getExternalLocation(w, item)
+	case http.MethodPatch:
+		updateResource(h, w, r, item, externalLocationUpdateSpec(h))
+	case http.MethodDelete:
+		h.deleteExternalLocation(w, item)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveExternalLocationCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createExternalLocation(w, r)
+	case http.MethodGet:
+		h.listExternalLocations(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createExternalLocation(w http.ResponseWriter, r *http.Request) {
+	var in createExternalLocationRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		missingField(w, "name")
+
+		return
+	}
+
+	if in.URL == "" {
+		missingField(w, "url")
+
+		return
+	}
+
+	now := time.Now().UnixMilli()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.extLocs[in.Name]; ok {
+		writeError(w, http.StatusConflict, codeAlreadyExists, "external location already exists: "+in.Name)
+
+		return
+	}
+
+	e := &externalLocation{
+		name:           in.Name,
+		url:            in.URL,
+		credentialName: in.CredentialName,
+		comment:        in.Comment,
+		readOnly:       in.ReadOnly,
+		createdAt:      now,
+		updatedAt:      now,
+	}
+	h.extLocs[in.Name] = e
+
+	writeJSON(w, e.view())
+}
+
+func (h *Handler) getExternalLocation(w http.ResponseWriter, name string) {
+	h.mu.RLock()
+	e, ok := h.extLocs[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, "external location", name)
+
+		return
+	}
+
+	writeJSON(w, e.view())
+}
+
+func (h *Handler) listExternalLocations(w http.ResponseWriter) {
+	h.mu.RLock()
+
+	out := make([]externalLocationView, 0, len(h.extLocs))
+	for _, e := range h.extLocs {
+		out = append(out, e.view())
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listExternalLocationsResponse{ExternalLocations: out})
+}
+
+func externalLocationUpdateSpec(h *Handler) updateSpec[updateExternalLocationRequest, externalLocation] {
+	return updateSpec[updateExternalLocationRequest, externalLocation]{
+		kind:  "external location",
+		store: h.extLocs,
+		apply: applyExternalLocationUpdate,
+		setAt: func(e *externalLocation, t int64) { e.updatedAt = t },
+		view:  func(e *externalLocation) any { return e.view() },
+	}
+}
+
+func applyExternalLocationUpdate(e *externalLocation, in *updateExternalLocationRequest) string {
+	if in.URL != "" {
+		e.url = in.URL
+	}
+
+	if in.CredentialName != "" {
+		e.credentialName = in.CredentialName
+	}
+
+	if in.Comment != "" {
+		e.comment = in.Comment
+	}
+
+	if in.ReadOnly != nil {
+		e.readOnly = *in.ReadOnly
+	}
+
+	if in.NewName != "" {
+		e.name = in.NewName
+	}
+
+	return e.name
+}
+
+func (h *Handler) deleteExternalLocation(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.extLocs[name]; !ok {
+		notFound(w, "external location", name)
+
+		return
+	}
+
+	delete(h.extLocs, name)
+
+	writeJSON(w, struct{}{})
+}

--- a/server/azure/databricks/ucstorage/helpers.go
+++ b/server/azure/databricks/ucstorage/helpers.go
@@ -1,0 +1,102 @@
+package ucstorage
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// splitPath strips surrounding slashes and returns the path segments.
+// Path /api/2.1/unity-catalog/metastores/abc →
+// [api, 2.1, unity-catalog, metastores, abc].
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, codeMalformed, "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, codeInvalidParam, "method not allowed")
+}
+
+func notFound(w http.ResponseWriter, kind, name string) {
+	writeError(w, http.StatusNotFound, codeNotFound, kind+" does not exist: "+name)
+}
+
+func missingField(w http.ResponseWriter, field string) {
+	writeError(w, http.StatusBadRequest, codeInvalidParam, field+" is required")
+}
+
+// updateSpec describes how to apply a PATCH to a name-keyed resource stored in
+// store. apply mutates the resource from the decoded request and reports the
+// requested rename ("" for no change); view renders the response body. The
+// shared flow handles locking, lookup, re-keying, and the updated_at stamp.
+type updateSpec[R any, V any] struct {
+	kind  string
+	store map[string]*V
+	apply func(*V, *R) string
+	setAt func(*V, int64)
+	view  func(*V) any
+}
+
+// updateResource runs the shared decode/lock/lookup/apply/rename/respond flow
+// used by the name-keyed PATCH handlers.
+func updateResource[R any, V any](h *Handler, w http.ResponseWriter, r *http.Request, key string, spec updateSpec[R, V]) {
+	var in R
+	if !decode(w, r, &in) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	item, ok := spec.store[key]
+	if !ok {
+		notFound(w, spec.kind, key)
+
+		return
+	}
+
+	if n := spec.apply(item, &in); n != "" && n != key {
+		delete(spec.store, key)
+		spec.store[n] = item
+	}
+
+	spec.setAt(item, time.Now().UnixMilli())
+
+	writeJSON(w, spec.view(item))
+}

--- a/server/azure/databricks/ucstorage/metastores.go
+++ b/server/azure/databricks/ucstorage/metastores.go
@@ -1,0 +1,206 @@
+package ucstorage
+
+import (
+	"net/http"
+	"time"
+)
+
+const metastorePrivilegeModel = "1.0"
+
+// metastore is the in-memory state for a single Unity Catalog metastore.
+type metastore struct {
+	id          string
+	name        string
+	region      string
+	storageRoot string
+	createdAt   int64
+	updatedAt   int64
+}
+
+type metastoreView struct {
+	MetastoreID           string `json:"metastore_id"`
+	Name                  string `json:"name"`
+	Region                string `json:"region,omitempty"`
+	StorageRoot           string `json:"storage_root,omitempty"`
+	PrivilegeModelVersion string `json:"privilege_model_version"`
+	CreatedAt             int64  `json:"created_at"`
+	UpdatedAt             int64  `json:"updated_at"`
+}
+
+type createMetastoreRequest struct {
+	Name        string `json:"name"`
+	Region      string `json:"region"`
+	StorageRoot string `json:"storage_root"`
+}
+
+type updateMetastoreRequest struct {
+	NewName string `json:"new_name"`
+}
+
+type listMetastoresResponse struct {
+	Metastores []metastoreView `json:"metastores"`
+}
+
+func (m *metastore) view() metastoreView {
+	return metastoreView{
+		MetastoreID:           m.id,
+		Name:                  m.name,
+		Region:                m.region,
+		StorageRoot:           m.storageRoot,
+		PrivilegeModelVersion: metastorePrivilegeModel,
+		CreatedAt:             m.createdAt,
+		UpdatedAt:             m.updatedAt,
+	}
+}
+
+func (h *Handler) serveMetastores(w http.ResponseWriter, r *http.Request, item string) {
+	if item == "" {
+		h.serveMetastoreCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getMetastore(w, item)
+	case http.MethodPatch:
+		h.updateMetastore(w, r, item)
+	case http.MethodDelete:
+		h.deleteMetastore(w, item)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveMetastoreCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createMetastore(w, r)
+	case http.MethodGet:
+		h.listMetastores(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createMetastore(w http.ResponseWriter, r *http.Request) {
+	var in createMetastoreRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		missingField(w, "name")
+
+		return
+	}
+
+	now := time.Now().UnixMilli()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.metastores[in.Name]; ok {
+		writeError(w, http.StatusConflict, codeAlreadyExists, "metastore already exists: "+in.Name)
+
+		return
+	}
+
+	m := &metastore{
+		id:          "metastore-" + in.Name,
+		name:        in.Name,
+		region:      in.Region,
+		storageRoot: in.StorageRoot,
+		createdAt:   now,
+		updatedAt:   now,
+	}
+	h.metastores[in.Name] = m
+
+	writeJSON(w, m.view())
+}
+
+// findMetastore locates a metastore by name or by metastore_id. The SDK
+// addresses metastores by id on Get/Update/Delete, while create returns both.
+func (h *Handler) findMetastore(key string) *metastore {
+	if m, ok := h.metastores[key]; ok {
+		return m
+	}
+
+	for _, m := range h.metastores {
+		if m.id == key {
+			return m
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) getMetastore(w http.ResponseWriter, key string) {
+	h.mu.RLock()
+	m := h.findMetastore(key)
+	h.mu.RUnlock()
+
+	if m == nil {
+		notFound(w, "metastore", key)
+
+		return
+	}
+
+	writeJSON(w, m.view())
+}
+
+func (h *Handler) listMetastores(w http.ResponseWriter) {
+	h.mu.RLock()
+
+	out := make([]metastoreView, 0, len(h.metastores))
+	for _, m := range h.metastores {
+		out = append(out, m.view())
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listMetastoresResponse{Metastores: out})
+}
+
+func (h *Handler) updateMetastore(w http.ResponseWriter, r *http.Request, key string) {
+	var in updateMetastoreRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	m := h.findMetastore(key)
+	if m == nil {
+		notFound(w, "metastore", key)
+
+		return
+	}
+
+	if in.NewName != "" && in.NewName != m.name {
+		delete(h.metastores, m.name)
+		m.name = in.NewName
+		m.id = "metastore-" + in.NewName
+		h.metastores[in.NewName] = m
+	}
+
+	m.updatedAt = time.Now().UnixMilli()
+
+	writeJSON(w, m.view())
+}
+
+func (h *Handler) deleteMetastore(w http.ResponseWriter, key string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	m := h.findMetastore(key)
+	if m == nil {
+		notFound(w, "metastore", key)
+
+		return
+	}
+
+	delete(h.metastores, m.name)
+
+	writeJSON(w, struct{}{})
+}

--- a/server/azure/databricks/ucstorage/storagecredentials.go
+++ b/server/azure/databricks/ucstorage/storagecredentials.go
@@ -1,0 +1,210 @@
+package ucstorage
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// storageCredential is the in-memory state for a single storage credential. The
+// azure identity blocks are preserved as raw JSON so any of the documented
+// shapes (managed identity / service principal) round-trips unchanged.
+type storageCredential struct {
+	name                  string
+	comment               string
+	readOnly              bool
+	azureManagedIdentity  json.RawMessage
+	azureServicePrincipal json.RawMessage
+	createdAt             int64
+	updatedAt             int64
+}
+
+type storageCredentialView struct {
+	Name                  string          `json:"name"`
+	FullName              string          `json:"full_name"`
+	ID                    string          `json:"id"`
+	Comment               string          `json:"comment,omitempty"`
+	ReadOnly              bool            `json:"read_only"`
+	AzureManagedIdentity  json.RawMessage `json:"azure_managed_identity,omitempty"`
+	AzureServicePrincipal json.RawMessage `json:"azure_service_principal,omitempty"`
+	MetastoreID           string          `json:"metastore_id"`
+	CreatedAt             int64           `json:"created_at"`
+	UpdatedAt             int64           `json:"updated_at"`
+}
+
+type createStorageCredentialRequest struct {
+	Name                  string          `json:"name"`
+	Comment               string          `json:"comment"`
+	ReadOnly              bool            `json:"read_only"`
+	AzureManagedIdentity  json.RawMessage `json:"azure_managed_identity"`
+	AzureServicePrincipal json.RawMessage `json:"azure_service_principal"`
+}
+
+type updateStorageCredentialRequest struct {
+	NewName               string          `json:"new_name"`
+	Comment               string          `json:"comment"`
+	ReadOnly              *bool           `json:"read_only"`
+	AzureManagedIdentity  json.RawMessage `json:"azure_managed_identity"`
+	AzureServicePrincipal json.RawMessage `json:"azure_service_principal"`
+}
+
+type listStorageCredentialsResponse struct {
+	StorageCredentials []storageCredentialView `json:"storage_credentials"`
+}
+
+func (c *storageCredential) view() storageCredentialView {
+	return storageCredentialView{
+		Name:                  c.name,
+		FullName:              c.name,
+		ID:                    "credential-" + c.name,
+		Comment:               c.comment,
+		ReadOnly:              c.readOnly,
+		AzureManagedIdentity:  c.azureManagedIdentity,
+		AzureServicePrincipal: c.azureServicePrincipal,
+		MetastoreID:           stubMetastoreID,
+		CreatedAt:             c.createdAt,
+		UpdatedAt:             c.updatedAt,
+	}
+}
+
+func (h *Handler) serveStorageCredentials(w http.ResponseWriter, r *http.Request, item string) {
+	if item == "" {
+		h.serveStorageCredentialCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getStorageCredential(w, item)
+	case http.MethodPatch:
+		updateResource(h, w, r, item, storageCredentialUpdateSpec(h))
+	case http.MethodDelete:
+		h.deleteStorageCredential(w, item)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveStorageCredentialCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createStorageCredential(w, r)
+	case http.MethodGet:
+		h.listStorageCredentials(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createStorageCredential(w http.ResponseWriter, r *http.Request) {
+	var in createStorageCredentialRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if in.Name == "" {
+		missingField(w, "name")
+
+		return
+	}
+
+	now := time.Now().UnixMilli()
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.credentials[in.Name]; ok {
+		writeError(w, http.StatusConflict, codeAlreadyExists, "storage credential already exists: "+in.Name)
+
+		return
+	}
+
+	c := &storageCredential{
+		name:                  in.Name,
+		comment:               in.Comment,
+		readOnly:              in.ReadOnly,
+		azureManagedIdentity:  in.AzureManagedIdentity,
+		azureServicePrincipal: in.AzureServicePrincipal,
+		createdAt:             now,
+		updatedAt:             now,
+	}
+	h.credentials[in.Name] = c
+
+	writeJSON(w, c.view())
+}
+
+func (h *Handler) getStorageCredential(w http.ResponseWriter, name string) {
+	h.mu.RLock()
+	c, ok := h.credentials[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, "storage credential", name)
+
+		return
+	}
+
+	writeJSON(w, c.view())
+}
+
+func (h *Handler) listStorageCredentials(w http.ResponseWriter) {
+	h.mu.RLock()
+
+	out := make([]storageCredentialView, 0, len(h.credentials))
+	for _, c := range h.credentials {
+		out = append(out, c.view())
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listStorageCredentialsResponse{StorageCredentials: out})
+}
+
+func storageCredentialUpdateSpec(h *Handler) updateSpec[updateStorageCredentialRequest, storageCredential] {
+	return updateSpec[updateStorageCredentialRequest, storageCredential]{
+		kind:  "storage credential",
+		store: h.credentials,
+		apply: applyStorageCredentialUpdate,
+		setAt: func(c *storageCredential, t int64) { c.updatedAt = t },
+		view:  func(c *storageCredential) any { return c.view() },
+	}
+}
+
+func applyStorageCredentialUpdate(c *storageCredential, in *updateStorageCredentialRequest) string {
+	if in.Comment != "" {
+		c.comment = in.Comment
+	}
+
+	if in.ReadOnly != nil {
+		c.readOnly = *in.ReadOnly
+	}
+
+	if len(in.AzureManagedIdentity) > 0 {
+		c.azureManagedIdentity = in.AzureManagedIdentity
+	}
+
+	if len(in.AzureServicePrincipal) > 0 {
+		c.azureServicePrincipal = in.AzureServicePrincipal
+	}
+
+	if in.NewName != "" {
+		c.name = in.NewName
+	}
+
+	return c.name
+}
+
+func (h *Handler) deleteStorageCredential(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.credentials[name]; !ok {
+		notFound(w, "storage credential", name)
+
+		return
+	}
+
+	delete(h.credentials, name)
+
+	writeJSON(w, struct{}{})
+}

--- a/server/azure/databricks/ucstorage/ucstorage.go
+++ b/server/azure/databricks/ucstorage/ucstorage.go
@@ -1,0 +1,144 @@
+// Package ucstorage emulates the Databricks Unity Catalog storage/governance
+// REST APIs (Metastores, External Locations, Storage Credentials, Volumes)
+// served under /api/2.1/unity-catalog/... as a server.Handler. Point the real
+// github.com/databricks/databricks-sdk-go WorkspaceClient at a server
+// registered with this handler and w.Metastores, w.ExternalLocations,
+// w.StorageCredentials, and w.Volumes work end-to-end against an in-memory
+// backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.1/unity-catalog/metastores              create
+//	GET    /api/2.1/unity-catalog/metastores              list
+//	GET    /api/2.1/unity-catalog/metastores/{id}         get
+//	PATCH  /api/2.1/unity-catalog/metastores/{id}         update
+//	DELETE /api/2.1/unity-catalog/metastores/{id}         delete
+//	POST   /api/2.1/unity-catalog/external-locations          create
+//	GET    /api/2.1/unity-catalog/external-locations          list
+//	GET    /api/2.1/unity-catalog/external-locations/{name}   get
+//	PATCH  /api/2.1/unity-catalog/external-locations/{name}   update
+//	DELETE /api/2.1/unity-catalog/external-locations/{name}   delete
+//	POST   /api/2.1/unity-catalog/storage-credentials         create
+//	GET    /api/2.1/unity-catalog/storage-credentials         list
+//	GET    /api/2.1/unity-catalog/storage-credentials/{name}  get
+//	PATCH  /api/2.1/unity-catalog/storage-credentials/{name}  update
+//	DELETE /api/2.1/unity-catalog/storage-credentials/{name}  delete
+//	POST   /api/2.1/unity-catalog/volumes                      create
+//	GET    /api/2.1/unity-catalog/volumes                      list
+//	GET    /api/2.1/unity-catalog/volumes/{full_name}          get
+//	PATCH  /api/2.1/unity-catalog/volumes/{full_name}          update
+//	DELETE /api/2.1/unity-catalog/volumes/{full_name}          delete
+package ucstorage
+
+import (
+	"net/http"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+// Unity Catalog path constants. ucRoot is the segment that precedes the
+// per-resource collection segment.
+const (
+	ucAPI  = "api"
+	ucRoot = "unity-catalog"
+)
+
+// Resource collection segments claimed by this handler.
+const (
+	resMetastores         = "metastores"
+	resExternalLocations  = "external-locations"
+	resStorageCredentials = "storage-credentials"
+	resVolumes            = "volumes"
+)
+
+// Segment counts after splitPath. collectionSegs is [api, ver, unity-catalog,
+// resource]; itemSegs adds the trailing {id|name|full_name} segment.
+const (
+	collectionSegs = 4
+	itemSegs       = 5
+)
+
+// idxRoot, idxResource, and idxItem index splitPath output.
+const (
+	idxRoot     = 2
+	idxResource = 3
+	idxItem     = 4
+)
+
+// Databricks error codes.
+const (
+	codeNotFound      = "RESOURCE_DOES_NOT_EXIST"
+	codeAlreadyExists = "RESOURCE_ALREADY_EXISTS"
+	codeInvalidParam  = "INVALID_PARAMETER_VALUE"
+	codeMalformed     = "MALFORMED_REQUEST"
+	codeNotFoundPath  = "ENDPOINT_NOT_FOUND"
+)
+
+// stubMetastoreID is the parent metastore id reported on created resources.
+const stubMetastoreID = "metastore-cloudemu"
+
+// Handler serves the Unity Catalog storage/governance REST API from in-memory
+// state. It is safe for concurrent use.
+type Handler struct {
+	mu          sync.RWMutex
+	metastores  map[string]*metastore
+	extLocs     map[string]*externalLocation
+	credentials map[string]*storageCredential
+	volumes     map[string]*volume
+}
+
+// New returns a ready-to-use handler with empty state.
+func New() *Handler {
+	return &Handler{
+		metastores:  make(map[string]*metastore),
+		extLocs:     make(map[string]*externalLocation),
+		credentials: make(map[string]*storageCredential),
+		volumes:     make(map[string]*volume),
+	}
+}
+
+// Matches claims only /api/{ver}/unity-catalog/{metastores,external-locations,
+// storage-credentials,volumes}[/...] paths. Catalog/schema/table paths owned by
+// the sibling unitycatalog handler are deliberately left unclaimed.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < collectionSegs || parts[0] != ucAPI || parts[idxRoot] != ucRoot {
+		return false
+	}
+
+	switch parts[idxResource] {
+	case resMetastores, resExternalLocations, resStorageCredentials, resVolumes:
+		return true
+	default:
+		return false
+	}
+}
+
+// ServeHTTP routes by resource and by the presence of an item segment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < collectionSegs {
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unsupported path")
+
+		return
+	}
+
+	item := ""
+	if len(parts) >= itemSegs {
+		item = parts[idxItem]
+	}
+
+	switch parts[idxResource] {
+	case resMetastores:
+		h.serveMetastores(w, r, item)
+	case resExternalLocations:
+		h.serveExternalLocations(w, r, item)
+	case resStorageCredentials:
+		h.serveStorageCredentials(w, r, item)
+	case resVolumes:
+		h.serveVolumes(w, r, item)
+	default:
+		writeError(w, http.StatusNotFound, codeNotFoundPath, "unknown resource: "+parts[idxResource])
+	}
+}

--- a/server/azure/databricks/ucstorage/ucstorage_roundtrip_test.go
+++ b/server/azure/databricks/ucstorage/ucstorage_roundtrip_test.go
@@ -1,0 +1,172 @@
+package ucstorage_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/ucstorage"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New(ucstorage.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:               ts.URL,
+		Token:              "test-token",
+		Credentials:        config.PatCredentials{},
+		HTTPTimeoutSeconds: 10,
+	})
+	require.NoError(t, err)
+
+	return w
+}
+
+func TestSDKMetastoresLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Metastores.Create(ctx, catalog.CreateMetastore{
+		Name:        "main",
+		Region:      "westus",
+		StorageRoot: "abfss://root@acct.dfs.core.windows.net/",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "main", created.Name)
+	assert.NotEmpty(t, created.MetastoreId)
+
+	got, err := w.Metastores.Get(ctx, catalog.GetMetastoreRequest{Id: created.MetastoreId})
+	require.NoError(t, err)
+	assert.Equal(t, "westus", got.Region)
+
+	updated, err := w.Metastores.Update(ctx, catalog.UpdateMetastore{
+		Id:      created.MetastoreId,
+		NewName: "renamed",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", updated.Name)
+
+	all, err := w.Metastores.ListAll(ctx, catalog.ListMetastoresRequest{})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+	assert.Equal(t, "renamed", all[0].Name)
+
+	err = w.Metastores.Delete(ctx, catalog.DeleteMetastoreRequest{Id: updated.MetastoreId})
+	require.NoError(t, err)
+
+	_, err = w.Metastores.Get(ctx, catalog.GetMetastoreRequest{Id: updated.MetastoreId})
+	require.Error(t, err)
+}
+
+func TestSDKStorageCredentialsLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.StorageCredentials.Create(ctx, catalog.CreateStorageCredential{
+		Name:    "cred1",
+		Comment: "demo",
+		AzureManagedIdentity: &catalog.AzureManagedIdentityRequest{
+			AccessConnectorId: "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Databricks/accessConnectors/ac",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "cred1", created.Name)
+	require.NotNil(t, created.AzureManagedIdentity)
+	assert.Contains(t, created.AzureManagedIdentity.AccessConnectorId, "accessConnectors/ac")
+
+	got, err := w.StorageCredentials.Get(ctx, catalog.GetStorageCredentialRequest{Name: "cred1"})
+	require.NoError(t, err)
+	assert.Equal(t, "demo", got.Comment)
+
+	all, err := w.StorageCredentials.ListAll(ctx, catalog.ListStorageCredentialsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	err = w.StorageCredentials.Delete(ctx, catalog.DeleteStorageCredentialRequest{Name: "cred1"})
+	require.NoError(t, err)
+
+	_, err = w.StorageCredentials.Get(ctx, catalog.GetStorageCredentialRequest{Name: "cred1"})
+	require.Error(t, err)
+}
+
+func TestSDKExternalLocationsLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	_, err := w.StorageCredentials.Create(ctx, catalog.CreateStorageCredential{
+		Name: "loc-cred",
+		AzureManagedIdentity: &catalog.AzureManagedIdentityRequest{
+			AccessConnectorId: "/subscriptions/x/resourceGroups/rg/providers/Microsoft.Databricks/accessConnectors/ac",
+		},
+	})
+	require.NoError(t, err)
+
+	created, err := w.ExternalLocations.Create(ctx, catalog.CreateExternalLocation{
+		Name:           "loc1",
+		Url:            "abfss://data@acct.dfs.core.windows.net/dir",
+		CredentialName: "loc-cred",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "loc1", created.Name)
+	assert.Equal(t, "loc-cred", created.CredentialName)
+
+	got, err := w.ExternalLocations.Get(ctx, catalog.GetExternalLocationRequest{Name: "loc1"})
+	require.NoError(t, err)
+	assert.Equal(t, "abfss://data@acct.dfs.core.windows.net/dir", got.Url)
+
+	all, err := w.ExternalLocations.ListAll(ctx, catalog.ListExternalLocationsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	err = w.ExternalLocations.Delete(ctx, catalog.DeleteExternalLocationRequest{Name: "loc1"})
+	require.NoError(t, err)
+
+	_, err = w.ExternalLocations.Get(ctx, catalog.GetExternalLocationRequest{Name: "loc1"})
+	require.Error(t, err)
+}
+
+func TestSDKVolumesLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Volumes.Create(ctx, catalog.CreateVolumeRequestContent{
+		CatalogName: "cat",
+		SchemaName:  "sch",
+		Name:        "vol",
+		VolumeType:  catalog.VolumeTypeManaged,
+		Comment:     "demo volume",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "cat.sch.vol", created.FullName)
+	assert.Equal(t, catalog.VolumeTypeManaged, created.VolumeType)
+
+	got, err := w.Volumes.Read(ctx, catalog.ReadVolumeRequest{Name: "cat.sch.vol"})
+	require.NoError(t, err)
+	assert.Equal(t, "demo volume", got.Comment)
+
+	all, err := w.Volumes.ListAll(ctx, catalog.ListVolumesRequest{
+		CatalogName: "cat",
+		SchemaName:  "sch",
+	})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+	assert.Equal(t, "cat.sch.vol", all[0].FullName)
+
+	err = w.Volumes.Delete(ctx, catalog.DeleteVolumeRequest{Name: "cat.sch.vol"})
+	require.NoError(t, err)
+
+	_, err = w.Volumes.Read(ctx, catalog.ReadVolumeRequest{Name: "cat.sch.vol"})
+	require.Error(t, err)
+}

--- a/server/azure/databricks/ucstorage/volumes.go
+++ b/server/azure/databricks/ucstorage/volumes.go
@@ -1,0 +1,251 @@
+package ucstorage
+
+import (
+	"net/http"
+	"time"
+)
+
+const defaultVolumeType = "MANAGED"
+
+// volume is the in-memory state for a single Unity Catalog volume. It is keyed
+// in the handler by its dotted three-level full_name catalog.schema.name.
+type volume struct {
+	catalogName     string
+	schemaName      string
+	name            string
+	volumeType      string
+	comment         string
+	storageLocation string
+	createdAt       int64
+	updatedAt       int64
+}
+
+func (v *volume) fullName() string {
+	return v.catalogName + "." + v.schemaName + "." + v.name
+}
+
+type volumeView struct {
+	CatalogName     string `json:"catalog_name"`
+	SchemaName      string `json:"schema_name"`
+	Name            string `json:"name"`
+	FullName        string `json:"full_name"`
+	VolumeID        string `json:"volume_id"`
+	VolumeType      string `json:"volume_type"`
+	Comment         string `json:"comment,omitempty"`
+	StorageLocation string `json:"storage_location,omitempty"`
+	MetastoreID     string `json:"metastore_id"`
+	CreatedAt       int64  `json:"created_at"`
+	UpdatedAt       int64  `json:"updated_at"`
+}
+
+type createVolumeRequest struct {
+	CatalogName     string `json:"catalog_name"`
+	SchemaName      string `json:"schema_name"`
+	Name            string `json:"name"`
+	VolumeType      string `json:"volume_type"`
+	Comment         string `json:"comment"`
+	StorageLocation string `json:"storage_location"`
+}
+
+type updateVolumeRequest struct {
+	NewName string `json:"new_name"`
+	Comment string `json:"comment"`
+}
+
+type listVolumesResponse struct {
+	Volumes []volumeView `json:"volumes"`
+}
+
+func (v *volume) view() volumeView {
+	return volumeView{
+		CatalogName:     v.catalogName,
+		SchemaName:      v.schemaName,
+		Name:            v.name,
+		FullName:        v.fullName(),
+		VolumeID:        "volume-" + v.fullName(),
+		VolumeType:      v.volumeType,
+		Comment:         v.comment,
+		StorageLocation: v.storageLocation,
+		MetastoreID:     stubMetastoreID,
+		CreatedAt:       v.createdAt,
+		UpdatedAt:       v.updatedAt,
+	}
+}
+
+func (h *Handler) serveVolumes(w http.ResponseWriter, r *http.Request, item string) {
+	if item == "" {
+		h.serveVolumeCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getVolume(w, item)
+	case http.MethodPatch:
+		h.updateVolume(w, r, item)
+	case http.MethodDelete:
+		h.deleteVolume(w, item)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveVolumeCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createVolume(w, r)
+	case http.MethodGet:
+		h.listVolumes(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createVolume(w http.ResponseWriter, r *http.Request) {
+	var in createVolumeRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	if !validateVolumeRequest(w, &in) {
+		return
+	}
+
+	volType := in.VolumeType
+	if volType == "" {
+		volType = defaultVolumeType
+	}
+
+	now := time.Now().UnixMilli()
+	v := &volume{
+		catalogName:     in.CatalogName,
+		schemaName:      in.SchemaName,
+		name:            in.Name,
+		volumeType:      volType,
+		comment:         in.Comment,
+		storageLocation: in.StorageLocation,
+		createdAt:       now,
+		updatedAt:       now,
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.volumes[v.fullName()]; ok {
+		writeError(w, http.StatusConflict, codeAlreadyExists, "volume already exists: "+v.fullName())
+
+		return
+	}
+
+	h.volumes[v.fullName()] = v
+
+	writeJSON(w, v.view())
+}
+
+func validateVolumeRequest(w http.ResponseWriter, in *createVolumeRequest) bool {
+	if in.CatalogName == "" {
+		missingField(w, "catalog_name")
+
+		return false
+	}
+
+	if in.SchemaName == "" {
+		missingField(w, "schema_name")
+
+		return false
+	}
+
+	if in.Name == "" {
+		missingField(w, "name")
+
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) getVolume(w http.ResponseWriter, fullName string) {
+	h.mu.RLock()
+	v, ok := h.volumes[fullName]
+	h.mu.RUnlock()
+
+	if !ok {
+		notFound(w, "volume", fullName)
+
+		return
+	}
+
+	writeJSON(w, v.view())
+}
+
+func (h *Handler) listVolumes(w http.ResponseWriter, r *http.Request) {
+	catalog := r.URL.Query().Get("catalog_name")
+	schema := r.URL.Query().Get("schema_name")
+
+	h.mu.RLock()
+
+	out := make([]volumeView, 0, len(h.volumes))
+
+	for _, v := range h.volumes {
+		if catalog != "" && v.catalogName != catalog {
+			continue
+		}
+
+		if schema != "" && v.schemaName != schema {
+			continue
+		}
+
+		out = append(out, v.view())
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listVolumesResponse{Volumes: out})
+}
+
+func (h *Handler) updateVolume(w http.ResponseWriter, r *http.Request, fullName string) {
+	var in updateVolumeRequest
+	if !decode(w, r, &in) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	v, ok := h.volumes[fullName]
+	if !ok {
+		notFound(w, "volume", fullName)
+
+		return
+	}
+
+	if in.Comment != "" {
+		v.comment = in.Comment
+	}
+
+	if in.NewName != "" && in.NewName != v.name {
+		v.name = in.NewName
+
+		delete(h.volumes, fullName)
+		h.volumes[v.fullName()] = v
+	}
+
+	v.updatedAt = time.Now().UnixMilli()
+
+	writeJSON(w, v.view())
+}
+
+func (h *Handler) deleteVolume(w http.ResponseWriter, fullName string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.volumes[fullName]; !ok {
+		notFound(w, "volume", fullName)
+
+		return
+	}
+
+	delete(h.volumes, fullName)
+
+	writeJSON(w, struct{}{})
+}

--- a/server/azure/databricks/unitycatalog/catalogs.go
+++ b/server/azure/databricks/unitycatalog/catalogs.go
@@ -1,0 +1,163 @@
+package unitycatalog
+
+import "net/http"
+
+// catalogView is the JSON shape returned for a single catalog (CatalogInfo).
+type catalogView struct {
+	Name     string `json:"name"`
+	FullName string `json:"full_name"`
+	Comment  string `json:"comment,omitempty"`
+}
+
+// createCatalogRequest is the POST /catalogs body (CreateCatalog).
+type createCatalogRequest struct {
+	Name    string `json:"name"`
+	Comment string `json:"comment"`
+}
+
+// updateCatalogRequest is the PATCH /catalogs/{name} body (UpdateCatalog).
+type updateCatalogRequest struct {
+	NewName string `json:"new_name"`
+	Comment string `json:"comment"`
+}
+
+// listCatalogsResponse is the GET /catalogs body.
+type listCatalogsResponse struct {
+	Catalogs []catalogView `json:"catalogs"`
+}
+
+// serveCatalogs routes the /catalogs collection and /catalogs/{name} item.
+func (h *Handler) serveCatalogs(w http.ResponseWriter, r *http.Request, name string) {
+	if name == "" {
+		h.serveCatalogCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCatalog(w, name)
+	case http.MethodPatch:
+		h.updateCatalog(w, r, name)
+	case http.MethodDelete:
+		h.deleteCatalog(w, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveCatalogCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createCatalog(w, r)
+	case http.MethodGet:
+		h.listCatalogs(w)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createCatalog(w http.ResponseWriter, r *http.Request) {
+	var req createCatalogRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "name is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.catalogs[req.Name]; ok {
+		writeErr(w, http.StatusConflict, codeAlreadyExists, "catalog already exists: "+req.Name)
+
+		return
+	}
+
+	c := &catalog{name: req.Name, comment: req.Comment}
+	h.catalogs[req.Name] = c
+
+	writeJSON(w, catalogToView(c))
+}
+
+func (h *Handler) getCatalog(w http.ResponseWriter, name string) {
+	h.mu.RLock()
+	c, ok := h.catalogs[name]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "catalog does not exist: "+name)
+
+		return
+	}
+
+	writeJSON(w, catalogToView(c))
+}
+
+func (h *Handler) listCatalogs(w http.ResponseWriter) {
+	h.mu.RLock()
+
+	views := make([]catalogView, 0, len(h.catalogs))
+	for _, c := range h.catalogs {
+		views = append(views, catalogToView(c))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listCatalogsResponse{Catalogs: views})
+}
+
+func (h *Handler) updateCatalog(w http.ResponseWriter, r *http.Request, name string) {
+	var req updateCatalogRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	c, ok := h.catalogs[name]
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "catalog does not exist: "+name)
+
+		return
+	}
+
+	if req.Comment != "" {
+		c.comment = req.Comment
+	}
+
+	if req.NewName != "" && req.NewName != name {
+		delete(h.catalogs, name)
+
+		c.name = req.NewName
+		h.catalogs[req.NewName] = c
+	}
+
+	writeJSON(w, catalogToView(c))
+}
+
+func (h *Handler) deleteCatalog(w http.ResponseWriter, name string) {
+	h.mu.Lock()
+
+	_, ok := h.catalogs[name]
+	if ok {
+		delete(h.catalogs, name)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "catalog does not exist: "+name)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func catalogToView(c *catalog) catalogView {
+	return catalogView{Name: c.name, FullName: c.name, Comment: c.comment}
+}

--- a/server/azure/databricks/unitycatalog/schemas.go
+++ b/server/azure/databricks/unitycatalog/schemas.go
@@ -1,0 +1,185 @@
+package unitycatalog
+
+import "net/http"
+
+// schemaView is the JSON shape returned for a single schema (SchemaInfo).
+type schemaView struct {
+	Name        string `json:"name"`
+	CatalogName string `json:"catalog_name"`
+	FullName    string `json:"full_name"`
+	Comment     string `json:"comment,omitempty"`
+}
+
+// createSchemaRequest is the POST /schemas body (CreateSchema).
+type createSchemaRequest struct {
+	Name        string `json:"name"`
+	CatalogName string `json:"catalog_name"`
+	Comment     string `json:"comment"`
+}
+
+// updateSchemaRequest is the PATCH /schemas/{full_name} body (UpdateSchema).
+type updateSchemaRequest struct {
+	NewName string `json:"new_name"`
+	Comment string `json:"comment"`
+}
+
+// listSchemasResponse is the GET /schemas body.
+type listSchemasResponse struct {
+	Schemas []schemaView `json:"schemas"`
+}
+
+// serveSchemas routes the /schemas collection and /schemas/{full_name} item.
+func (h *Handler) serveSchemas(w http.ResponseWriter, r *http.Request, fullName string) {
+	if fullName == "" {
+		h.serveSchemaCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSchema(w, fullName)
+	case http.MethodPatch:
+		h.updateSchema(w, r, fullName)
+	case http.MethodDelete:
+		h.deleteSchema(w, fullName)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveSchemaCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createSchema(w, r)
+	case http.MethodGet:
+		h.listSchemas(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createSchema(w http.ResponseWriter, r *http.Request) {
+	var req createSchemaRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" || req.CatalogName == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "name and catalog_name are required")
+
+		return
+	}
+
+	full := req.CatalogName + "." + req.Name
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.catalogs[req.CatalogName]; !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "catalog does not exist: "+req.CatalogName)
+
+		return
+	}
+
+	if _, ok := h.schemas[full]; ok {
+		writeErr(w, http.StatusConflict, codeAlreadyExists, "schema already exists: "+full)
+
+		return
+	}
+
+	s := &schema{name: req.Name, catalogName: req.CatalogName, comment: req.Comment}
+	h.schemas[full] = s
+
+	writeJSON(w, schemaToView(s))
+}
+
+func (h *Handler) getSchema(w http.ResponseWriter, fullName string) {
+	h.mu.RLock()
+	s, ok := h.schemas[fullName]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "schema does not exist: "+fullName)
+
+		return
+	}
+
+	writeJSON(w, schemaToView(s))
+}
+
+func (h *Handler) listSchemas(w http.ResponseWriter, r *http.Request) {
+	catalogName := r.URL.Query().Get("catalog_name")
+
+	h.mu.RLock()
+
+	views := make([]schemaView, 0, len(h.schemas))
+
+	for _, s := range h.schemas {
+		if catalogName != "" && s.catalogName != catalogName {
+			continue
+		}
+
+		views = append(views, schemaToView(s))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listSchemasResponse{Schemas: views})
+}
+
+func (h *Handler) updateSchema(w http.ResponseWriter, r *http.Request, fullName string) {
+	var req updateSchemaRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	s, ok := h.schemas[fullName]
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "schema does not exist: "+fullName)
+
+		return
+	}
+
+	if req.Comment != "" {
+		s.comment = req.Comment
+	}
+
+	if req.NewName != "" && req.NewName != s.name {
+		delete(h.schemas, fullName)
+
+		s.name = req.NewName
+		h.schemas[s.catalogName+"."+s.name] = s
+	}
+
+	writeJSON(w, schemaToView(s))
+}
+
+func (h *Handler) deleteSchema(w http.ResponseWriter, fullName string) {
+	h.mu.Lock()
+
+	_, ok := h.schemas[fullName]
+	if ok {
+		delete(h.schemas, fullName)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "schema does not exist: "+fullName)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func schemaToView(s *schema) schemaView {
+	return schemaView{
+		Name:        s.name,
+		CatalogName: s.catalogName,
+		FullName:    s.catalogName + "." + s.name,
+		Comment:     s.comment,
+	}
+}

--- a/server/azure/databricks/unitycatalog/tables.go
+++ b/server/azure/databricks/unitycatalog/tables.go
@@ -1,0 +1,164 @@
+package unitycatalog
+
+import "net/http"
+
+// tableView is the JSON shape returned for a single table (TableInfo).
+type tableView struct {
+	Name        string `json:"name"`
+	CatalogName string `json:"catalog_name"`
+	SchemaName  string `json:"schema_name"`
+	FullName    string `json:"full_name"`
+	Comment     string `json:"comment,omitempty"`
+}
+
+// createTableRequest is the POST /tables body (CreateTableRequest).
+type createTableRequest struct {
+	Name        string `json:"name"`
+	CatalogName string `json:"catalog_name"`
+	SchemaName  string `json:"schema_name"`
+	Comment     string `json:"comment"`
+}
+
+// listTablesResponse is the GET /tables body.
+type listTablesResponse struct {
+	Tables []tableView `json:"tables"`
+}
+
+// serveTables routes the /tables collection and /tables/{full_name} item.
+func (h *Handler) serveTables(w http.ResponseWriter, r *http.Request, fullName string) {
+	if fullName == "" {
+		h.serveTableCollection(w, r)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTable(w, fullName)
+	case http.MethodDelete:
+		h.deleteTable(w, fullName)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveTableCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createTable(w, r)
+	case http.MethodGet:
+		h.listTables(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
+	var req createTableRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" || req.CatalogName == "" || req.SchemaName == "" {
+		writeErr(w, http.StatusBadRequest, codeInvalidParam, "name, catalog_name and schema_name are required")
+
+		return
+	}
+
+	schemaFull := req.CatalogName + "." + req.SchemaName
+	full := schemaFull + "." + req.Name
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.schemas[schemaFull]; !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "schema does not exist: "+schemaFull)
+
+		return
+	}
+
+	if _, ok := h.tables[full]; ok {
+		writeErr(w, http.StatusConflict, codeAlreadyExists, "table already exists: "+full)
+
+		return
+	}
+
+	tbl := &table{name: req.Name, catalogName: req.CatalogName, schemaName: req.SchemaName, comment: req.Comment}
+	h.tables[full] = tbl
+
+	writeJSON(w, tableToView(tbl))
+}
+
+func (h *Handler) getTable(w http.ResponseWriter, fullName string) {
+	h.mu.RLock()
+	tbl, ok := h.tables[fullName]
+	h.mu.RUnlock()
+
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "table does not exist: "+fullName)
+
+		return
+	}
+
+	writeJSON(w, tableToView(tbl))
+}
+
+func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
+	catalogName := r.URL.Query().Get("catalog_name")
+	schemaName := r.URL.Query().Get("schema_name")
+
+	h.mu.RLock()
+
+	views := make([]tableView, 0, len(h.tables))
+
+	for _, tbl := range h.tables {
+		if !tableMatches(tbl, catalogName, schemaName) {
+			continue
+		}
+
+		views = append(views, tableToView(tbl))
+	}
+	h.mu.RUnlock()
+
+	writeJSON(w, listTablesResponse{Tables: views})
+}
+
+func (h *Handler) deleteTable(w http.ResponseWriter, fullName string) {
+	h.mu.Lock()
+
+	_, ok := h.tables[fullName]
+	if ok {
+		delete(h.tables, fullName)
+	}
+	h.mu.Unlock()
+
+	if !ok {
+		writeErr(w, http.StatusNotFound, codeNotFound, "table does not exist: "+fullName)
+
+		return
+	}
+
+	writeJSON(w, struct{}{})
+}
+
+func tableMatches(tbl *table, catalogName, schemaName string) bool {
+	if catalogName != "" && tbl.catalogName != catalogName {
+		return false
+	}
+
+	if schemaName != "" && tbl.schemaName != schemaName {
+		return false
+	}
+
+	return true
+}
+
+func tableToView(tbl *table) tableView {
+	return tableView{
+		Name:        tbl.name,
+		CatalogName: tbl.catalogName,
+		SchemaName:  tbl.schemaName,
+		FullName:    tbl.catalogName + "." + tbl.schemaName + "." + tbl.name,
+		Comment:     tbl.comment,
+	}
+}

--- a/server/azure/databricks/unitycatalog/unitycatalog.go
+++ b/server/azure/databricks/unitycatalog/unitycatalog.go
@@ -1,0 +1,192 @@
+// Package unitycatalog emulates the Databricks Unity Catalog core REST API
+// (the /api/2.1/unity-catalog/{catalogs,schemas,tables} surface served at the
+// workspace URL) as a server.Handler. Point the real
+// github.com/databricks/databricks-sdk-go WorkspaceClient at a server
+// registered with this handler and w.Catalogs, w.Schemas, and w.Tables work
+// end-to-end against an in-memory backend.
+//
+// Covered endpoints:
+//
+//	POST   /api/2.1/unity-catalog/catalogs              create
+//	GET    /api/2.1/unity-catalog/catalogs              list
+//	GET    /api/2.1/unity-catalog/catalogs/{name}       get
+//	PATCH  /api/2.1/unity-catalog/catalogs/{name}       update
+//	DELETE /api/2.1/unity-catalog/catalogs/{name}       delete
+//	POST   /api/2.1/unity-catalog/schemas               create
+//	GET    /api/2.1/unity-catalog/schemas               list
+//	GET    /api/2.1/unity-catalog/schemas/{full_name}   get
+//	PATCH  /api/2.1/unity-catalog/schemas/{full_name}   update
+//	DELETE /api/2.1/unity-catalog/schemas/{full_name}   delete
+//	POST   /api/2.1/unity-catalog/tables                create
+//	GET    /api/2.1/unity-catalog/tables                list
+//	GET    /api/2.1/unity-catalog/tables/{full_name}    get
+//	DELETE /api/2.1/unity-catalog/tables/{full_name}    delete
+package unitycatalog
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const maxBodyBytes = 5 << 20
+
+// resource path segments under "unity-catalog".
+const (
+	resCatalogs = "catalogs"
+	resSchemas  = "schemas"
+	resTables   = "tables"
+)
+
+// ucSegs is the [api, ver, unity-catalog, resource] segment count; an item
+// path adds the trailing {name}/{full_name} segment for ucItemSegs.
+const (
+	ucSegs     = 4
+	ucItemSegs = 5
+	segUnity   = "unity-catalog"
+)
+
+// Databricks error codes.
+const (
+	codeNotFound      = "RESOURCE_DOES_NOT_EXIST"
+	codeAlreadyExists = "RESOURCE_ALREADY_EXISTS"
+	codeInvalidParam  = "INVALID_PARAMETER_VALUE"
+	codeMalformed     = "MALFORMED_REQUEST"
+	codeNotFoundPath  = "ENDPOINT_NOT_FOUND"
+)
+
+// catalog is the in-memory state for a single catalog.
+type catalog struct {
+	name    string
+	comment string
+}
+
+// schema is the in-memory state for a single schema, keyed by "catalog.schema".
+type schema struct {
+	name        string
+	catalogName string
+	comment     string
+}
+
+// table is the in-memory state for a single table, keyed by
+// "catalog.schema.table".
+type table struct {
+	name        string
+	catalogName string
+	schemaName  string
+	comment     string
+}
+
+// Handler serves the Unity Catalog core REST API backed by in-memory maps.
+// It is safe for concurrent use.
+type Handler struct {
+	mu       sync.RWMutex
+	catalogs map[string]*catalog
+	schemas  map[string]*schema
+	tables   map[string]*table
+}
+
+// New returns a Unity Catalog handler with empty in-memory state.
+func New() *Handler {
+	return &Handler{
+		catalogs: make(map[string]*catalog),
+		schemas:  make(map[string]*schema),
+		tables:   make(map[string]*table),
+	}
+}
+
+// Matches claims /api/{ver}/unity-catalog/{catalogs,schemas,tables}/... paths.
+// It deliberately does not claim metastores, external-locations,
+// storage-credentials, or volumes.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := split(r.URL.Path)
+	if len(parts) < ucSegs || parts[0] != "api" || parts[2] != segUnity {
+		return false
+	}
+
+	switch parts[3] {
+	case resCatalogs, resSchemas, resTables:
+		return true
+	default:
+		return false
+	}
+}
+
+// ServeHTTP routes by the resource segment after "unity-catalog".
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := split(r.URL.Path)
+	if len(parts) < ucSegs {
+		writeErr(w, http.StatusNotFound, codeNotFoundPath, "unsupported path")
+
+		return
+	}
+
+	name := itemName(parts)
+
+	switch parts[3] {
+	case resCatalogs:
+		h.serveCatalogs(w, r, name)
+	case resSchemas:
+		h.serveSchemas(w, r, name)
+	case resTables:
+		h.serveTables(w, r, name)
+	default:
+		writeErr(w, http.StatusNotFound, codeNotFoundPath, "unknown resource: "+parts[3])
+	}
+}
+
+// itemName joins any path segments after the resource into a single name,
+// preserving dotted full names that were not percent-encoded into one segment.
+func itemName(parts []string) string {
+	if len(parts) < ucItemSegs {
+		return ""
+	}
+
+	return strings.Join(parts[4:], "/")
+}
+
+// split strips surrounding slashes and returns the path segments, keeping
+// "api" at index 0 for the Matches/ServeHTTP guards.
+func split(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeErr(w, http.StatusBadRequest, codeMalformed, "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}
+
+func methodNotAllowed(w http.ResponseWriter) {
+	writeErr(w, http.StatusMethodNotAllowed, codeInvalidParam, "method not allowed")
+}

--- a/server/azure/databricks/unitycatalog/unitycatalog_roundtrip_test.go
+++ b/server/azure/databricks/unitycatalog/unitycatalog_roundtrip_test.go
@@ -1,0 +1,110 @@
+package unitycatalog_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/catalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/unitycatalog"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New(unitycatalog.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:               ts.URL,
+		Token:              "test-token",
+		Credentials:        config.PatCredentials{},
+		HTTPTimeoutSeconds: 10,
+	})
+	require.NoError(t, err)
+
+	return w
+}
+
+func TestSDKCatalogLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{Name: "main", Comment: "primary"})
+	require.NoError(t, err)
+	assert.Equal(t, "main", created.Name)
+	assert.Equal(t, "main", created.FullName)
+
+	got, err := w.Catalogs.GetByName(ctx, "main")
+	require.NoError(t, err)
+	assert.Equal(t, "primary", got.Comment)
+
+	updated, err := w.Catalogs.Update(ctx, catalog.UpdateCatalog{Name: "main", Comment: "updated"})
+	require.NoError(t, err)
+	assert.Equal(t, "updated", updated.Comment)
+
+	all, err := w.Catalogs.ListAll(ctx, catalog.ListCatalogsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+	assert.Equal(t, "main", all[0].Name)
+
+	err = w.Catalogs.DeleteByName(ctx, "main")
+	require.NoError(t, err)
+
+	_, err = w.Catalogs.GetByName(ctx, "main")
+	require.Error(t, err)
+}
+
+func TestSDKSchemaLifecycle(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	_, err := w.Catalogs.Create(ctx, catalog.CreateCatalog{Name: "main"})
+	require.NoError(t, err)
+
+	created, err := w.Schemas.Create(ctx, catalog.CreateSchema{Name: "sales", CatalogName: "main"})
+	require.NoError(t, err)
+	assert.Equal(t, "main.sales", created.FullName)
+
+	got, err := w.Schemas.GetByFullName(ctx, "main.sales")
+	require.NoError(t, err)
+	assert.Equal(t, "main", got.CatalogName)
+
+	updated, err := w.Schemas.Update(ctx, catalog.UpdateSchema{FullName: "main.sales", Comment: "c"})
+	require.NoError(t, err)
+	assert.Equal(t, "c", updated.Comment)
+
+	all, err := w.Schemas.ListAll(ctx, catalog.ListSchemasRequest{CatalogName: "main"})
+	require.NoError(t, err)
+	assert.Len(t, all, 1)
+	assert.Equal(t, "main.sales", all[0].FullName)
+
+	err = w.Schemas.DeleteByFullName(ctx, "main.sales")
+	require.NoError(t, err)
+
+	_, err = w.Schemas.GetByFullName(ctx, "main.sales")
+	require.Error(t, err)
+}
+
+func TestSDKTablesListAndGet(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	all, err := w.Tables.ListAll(ctx, catalog.ListTablesRequest{
+		CatalogName: "main",
+		SchemaName:  "sales",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, all)
+
+	_, err = w.Tables.GetByFullName(ctx, "main.sales.orders")
+	require.Error(t, err)
+}

--- a/server/azure/databricks/wsfs/ops.go
+++ b/server/azure/databricks/wsfs/ops.go
@@ -1,0 +1,339 @@
+package wsfs
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+)
+
+// importRequest is the POST /import body.
+type importRequest struct {
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+	Format    string `json:"format"`
+	Language  string `json:"language"`
+	Overwrite bool   `json:"overwrite"`
+}
+
+// exportResponse is the GET /export body.
+type exportResponse struct {
+	Content  string `json:"content"`
+	FileType string `json:"file_type"`
+}
+
+// objectInfo is the wire shape returned by list and get-status.
+type objectInfo struct {
+	Path       string `json:"path"`
+	ObjectType string `json:"object_type"`
+	ObjectID   int64  `json:"object_id"`
+	Language   string `json:"language,omitempty"`
+}
+
+// listResponse is the GET /list body.
+type listResponse struct {
+	Objects []objectInfo `json:"objects"`
+}
+
+// mkdirsRequest is the POST /mkdirs body.
+type mkdirsRequest struct {
+	Path string `json:"path"`
+}
+
+// deleteRequest is the POST /delete body.
+type deleteRequest struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive"`
+}
+
+func (h *Handler) serveImport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		wsfsMethodNotAllowed(w)
+
+		return
+	}
+
+	var req importRequest
+	if !wsfsDecode(w, r, &req) {
+		return
+	}
+
+	path := normalizePath(req.Path)
+	if path == "" {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is required")
+
+		return
+	}
+
+	content, err := base64.StdEncoding.DecodeString(req.Content)
+	if err != nil {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "content is not valid base64")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if existing, ok := h.objects[path]; ok {
+		if existing.objectType == objectDirectory {
+			wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is a directory")
+
+			return
+		}
+
+		if !req.Overwrite {
+			wsfsError(w, http.StatusBadRequest, "RESOURCE_ALREADY_EXISTS", "object already exists: "+path)
+
+			return
+		}
+	}
+
+	language := req.Language
+	if language == "" {
+		language = defaultLanguage
+	}
+
+	h.nextID++
+	h.objects[path] = &object{
+		content:    content,
+		objectType: objectNotebook,
+		language:   language,
+		objectID:   h.nextID,
+	}
+
+	wsfsJSON(w, struct{}{})
+}
+
+func (h *Handler) serveExport(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		wsfsMethodNotAllowed(w)
+
+		return
+	}
+
+	path := normalizePath(r.URL.Query().Get("path"))
+	if path == "" {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is required")
+
+		return
+	}
+
+	format := r.URL.Query().Get("format")
+	if format == "" {
+		format = "SOURCE"
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	obj, ok := h.objects[path]
+	if !ok {
+		wsfsError(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "object does not exist: "+path)
+
+		return
+	}
+
+	if obj.objectType == objectDirectory {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "cannot export a directory in this format")
+
+		return
+	}
+
+	wsfsJSON(w, exportResponse{
+		Content:  base64.StdEncoding.EncodeToString(obj.content),
+		FileType: format,
+	})
+}
+
+func (h *Handler) serveList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		wsfsMethodNotAllowed(w)
+
+		return
+	}
+
+	path := normalizePath(r.URL.Query().Get("path"))
+	if path == "" {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is required")
+
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if _, ok := h.objects[path]; !ok {
+		wsfsError(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "path does not exist: "+path)
+
+		return
+	}
+
+	out := make([]objectInfo, 0)
+
+	for p, obj := range h.objects {
+		if p == path || p == "/" {
+			continue
+		}
+
+		if parentOf(p) == path {
+			out = append(out, h.toObjectInfo(p, obj))
+		}
+	}
+
+	wsfsJSON(w, listResponse{Objects: out})
+}
+
+func (h *Handler) serveMkdirs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		wsfsMethodNotAllowed(w)
+
+		return
+	}
+
+	var req mkdirsRequest
+	if !wsfsDecode(w, r, &req) {
+		return
+	}
+
+	path := normalizePath(req.Path)
+	if path == "" {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if existing, ok := h.objects[path]; ok {
+		if existing.objectType == objectDirectory {
+			wsfsJSON(w, struct{}{})
+
+			return
+		}
+
+		wsfsError(w, http.StatusBadRequest, "RESOURCE_ALREADY_EXISTS", "a non-directory object exists at: "+path)
+
+		return
+	}
+
+	h.makeDirs(path)
+	wsfsJSON(w, struct{}{})
+}
+
+func (h *Handler) serveDelete(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		wsfsMethodNotAllowed(w)
+
+		return
+	}
+
+	var req deleteRequest
+	if !wsfsDecode(w, r, &req) {
+		return
+	}
+
+	path := normalizePath(req.Path)
+	if path == "" {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is required")
+
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	obj, ok := h.objects[path]
+	if !ok {
+		wsfsError(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "object does not exist: "+path)
+
+		return
+	}
+
+	if obj.objectType == objectDirectory {
+		if children := h.childPaths(path); len(children) > 0 {
+			if !req.Recursive {
+				wsfsError(w, http.StatusBadRequest, "DIRECTORY_NOT_EMPTY", "directory is not empty: "+path)
+
+				return
+			}
+
+			for _, c := range children {
+				delete(h.objects, c)
+			}
+		}
+	}
+
+	delete(h.objects, path)
+	wsfsJSON(w, struct{}{})
+}
+
+func (h *Handler) serveGetStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		wsfsMethodNotAllowed(w)
+
+		return
+	}
+
+	path := normalizePath(r.URL.Query().Get("path"))
+	if path == "" {
+		wsfsError(w, http.StatusBadRequest, "INVALID_PARAMETER_VALUE", "path is required")
+
+		return
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	obj, ok := h.objects[path]
+	if !ok {
+		wsfsError(w, http.StatusNotFound, "RESOURCE_DOES_NOT_EXIST", "object does not exist: "+path)
+
+		return
+	}
+
+	wsfsJSON(w, h.toObjectInfo(path, obj))
+}
+
+// toObjectInfo converts a stored object to its wire shape. Caller holds the lock.
+func (*Handler) toObjectInfo(path string, obj *object) objectInfo {
+	info := objectInfo{
+		Path:       path,
+		ObjectType: obj.objectType,
+		ObjectID:   obj.objectID,
+	}
+
+	if obj.objectType == objectNotebook {
+		info.Language = obj.language
+	}
+
+	return info
+}
+
+// makeDirs creates path and any missing parent directories. Caller holds the lock.
+func (h *Handler) makeDirs(path string) {
+	for cur := path; cur != "/" && cur != ""; cur = parentOf(cur) {
+		if _, ok := h.objects[cur]; ok {
+			continue
+		}
+
+		h.nextID++
+		h.objects[cur] = &object{objectType: objectDirectory, objectID: h.nextID}
+	}
+}
+
+// childPaths returns every stored path nested under dir at any depth. Caller
+// holds the lock.
+func (h *Handler) childPaths(dir string) []string {
+	prefix := dir + "/"
+
+	var children []string
+
+	for p := range h.objects {
+		if strings.HasPrefix(p, prefix) {
+			children = append(children, p)
+		}
+	}
+
+	return children
+}

--- a/server/azure/databricks/wsfs/wsfs.go
+++ b/server/azure/databricks/wsfs/wsfs.go
@@ -1,0 +1,168 @@
+// Package wsfs implements the Databricks Workspace (notebooks/directories)
+// data-plane REST API (the /api/2.0/workspace surface) as a self-contained
+// server.Handler backed by in-memory state. Point the real
+// github.com/databricks/databricks-sdk-go WorkspaceClient at a server.Server
+// registered with a Handler from this package and w.Workspace import, export,
+// list, mkdirs, delete, and get-status work end-to-end.
+//
+// Covered endpoints:
+//
+//	POST /api/2.0/workspace/import
+//	GET  /api/2.0/workspace/export
+//	GET  /api/2.0/workspace/list
+//	POST /api/2.0/workspace/mkdirs
+//	POST /api/2.0/workspace/delete
+//	GET  /api/2.0/workspace/get-status
+package wsfs
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+const wsfsMaxBodyBytes = 11 << 20
+
+// Workspace object types mirrored from the Databricks SDK enum.
+const (
+	objectNotebook  = "NOTEBOOK"
+	objectDirectory = "DIRECTORY"
+)
+
+// Default notebook language when an import omits one.
+const defaultLanguage = "PYTHON"
+
+// minPathSegs is the [api, ver, workspace, action] segment count after split.
+const minPathSegs = 4
+
+// object is a stored workspace entry.
+type object struct {
+	content    []byte
+	objectType string
+	language   string
+	objectID   int64
+}
+
+// Handler serves the Databricks workspace filesystem data-plane API.
+type Handler struct {
+	mu      sync.RWMutex
+	objects map[string]*object
+	nextID  int64
+}
+
+// New returns a workspace handler with an empty in-memory tree containing the
+// implicit root directory.
+func New() *Handler {
+	h := &Handler{objects: make(map[string]*object)}
+	h.nextID++
+	h.objects["/"] = &object{objectType: objectDirectory, objectID: h.nextID}
+
+	return h
+}
+
+// Matches claims /api/{ver}/workspace/... paths.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := wsfsSplit(r.URL.Path)
+	if len(parts) < minPathSegs || parts[0] != "api" {
+		return false
+	}
+
+	return parts[2] == "workspace"
+}
+
+// ServeHTTP routes by the action segment.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	parts := wsfsSplit(r.URL.Path)
+	if len(parts) < minPathSegs {
+		wsfsError(w, http.StatusNotFound, "ENDPOINT_NOT_FOUND", "unsupported path")
+
+		return
+	}
+
+	switch parts[3] {
+	case "import":
+		h.serveImport(w, r)
+	case "export":
+		h.serveExport(w, r)
+	case "list":
+		h.serveList(w, r)
+	case "mkdirs":
+		h.serveMkdirs(w, r)
+	case "delete":
+		h.serveDelete(w, r)
+	case "get-status":
+		h.serveGetStatus(w, r)
+	default:
+		wsfsError(w, http.StatusNotFound, "ENDPOINT_NOT_FOUND", "unknown action: "+parts[3])
+	}
+}
+
+// wsfsSplit strips surrounding slashes and returns the path segments, keeping
+// the leading "api" at index 0 for the Matches/ServeHTTP guards.
+func wsfsSplit(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+func wsfsDecode(w http.ResponseWriter, r *http.Request, v any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, wsfsMaxBodyBytes)
+
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		wsfsError(w, http.StatusBadRequest, "MALFORMED_REQUEST", "invalid JSON: "+err.Error())
+
+		return false
+	}
+
+	return true
+}
+
+func wsfsJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// wsfsErrorBody is the Databricks error envelope shape.
+type wsfsErrorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func wsfsError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(wsfsErrorBody{ErrorCode: code, Message: msg})
+}
+
+func wsfsMethodNotAllowed(w http.ResponseWriter) {
+	wsfsError(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+}
+
+// normalizePath trims trailing slashes (except for root) so paths compare
+// consistently regardless of how the caller spells them.
+func normalizePath(p string) string {
+	if p == "" {
+		return ""
+	}
+
+	if p == "/" {
+		return "/"
+	}
+
+	return strings.TrimRight(p, "/")
+}
+
+// parentOf returns the parent directory path of p ("/" for top-level entries).
+func parentOf(p string) string {
+	idx := strings.LastIndex(p, "/")
+	if idx <= 0 {
+		return "/"
+	}
+
+	return p[:idx]
+}

--- a/server/azure/databricks/wsfs/wsfs_roundtrip_test.go
+++ b/server/azure/databricks/wsfs/wsfs_roundtrip_test.go
@@ -1,0 +1,130 @@
+package wsfs_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/workspace"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/wsfs"
+)
+
+func newWorkspace(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(wsfs.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+func TestSDKWorkspaceRoundtrip(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	const (
+		dir      = "/Users/alice"
+		nbPath   = "/Users/alice/notebook"
+		nbSource = "print('hello cloudemu')\n"
+	)
+
+	if err := w.Workspace.Mkdirs(ctx, workspace.Mkdirs{Path: dir}); err != nil {
+		t.Fatalf("Mkdirs: %v", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(nbSource))
+	if err := w.Workspace.Import(ctx, workspace.Import{
+		Path:      nbPath,
+		Content:   encoded,
+		Format:    workspace.ImportFormatSource,
+		Language:  workspace.LanguagePython,
+		Overwrite: true,
+	}); err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	exported, err := w.Workspace.Export(ctx, workspace.ExportRequest{
+		Path:   nbPath,
+		Format: workspace.ExportFormatSource,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(exported.Content)
+	if err != nil {
+		t.Fatalf("decode exported content: %v", err)
+	}
+
+	if string(decoded) != nbSource {
+		t.Fatalf("content round-trip mismatch: got %q want %q", string(decoded), nbSource)
+	}
+
+	status, err := w.Workspace.GetStatus(ctx, workspace.GetStatusRequest{Path: nbPath})
+	if err != nil {
+		t.Fatalf("GetStatus: %v", err)
+	}
+
+	if status.ObjectType != workspace.ObjectTypeNotebook {
+		t.Fatalf("got object type %q, want NOTEBOOK", status.ObjectType)
+	}
+
+	if status.Language != workspace.LanguagePython {
+		t.Fatalf("got language %q, want PYTHON", status.Language)
+	}
+
+	if status.ObjectId == 0 {
+		t.Fatal("expected non-zero object id")
+	}
+
+	objects, err := w.Workspace.ListAll(ctx, workspace.ListWorkspaceRequest{Path: dir})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf("got %d objects, want 1", len(objects))
+	}
+
+	if objects[0].Path != nbPath || objects[0].ObjectType != workspace.ObjectTypeNotebook {
+		t.Fatalf("unexpected list entry: %+v", objects[0])
+	}
+
+	dirStatus, err := w.Workspace.GetStatus(ctx, workspace.GetStatusRequest{Path: dir})
+	if err != nil {
+		t.Fatalf("GetStatus dir: %v", err)
+	}
+
+	if dirStatus.ObjectType != workspace.ObjectTypeDirectory {
+		t.Fatalf("got dir object type %q, want DIRECTORY", dirStatus.ObjectType)
+	}
+
+	if err = w.Workspace.Delete(ctx, workspace.Delete{Path: dir, Recursive: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, err = w.Workspace.GetStatus(ctx, workspace.GetStatusRequest{Path: nbPath}); err == nil {
+		t.Fatal("expected error getting status of deleted notebook")
+	}
+
+	if _, err = w.Workspace.GetStatus(ctx, workspace.GetStatusRequest{Path: dir}); err == nil {
+		t.Fatal("expected error getting status of deleted directory")
+	}
+}


### PR DESCRIPTION
## <img src="https://raw.githubusercontent.com/stackshy/cloudemu/development/.github/logo.svg" alt="cloudemu" width="28" height="28" align="absmiddle" /> Release Notes — v1.7.2

## ✨ Feature

### Azure Databricks — full in-memory workspace coverage

Run and manage **jobs and their runs** end-to-end, **resize and pin clusters** and browse available machine types / runtimes / regions, set **cluster policies**, and install **cluster libraries**. Store **secrets and access tokens**, connect **Git folders and credentials**, work with **files and notebooks**, and run **SQL warehouses and data pipelines**. Manage **model serving endpoints** and **identities** (users, groups, and service accounts), and organize data with **Unity Catalog** — catalogs, schemas, tables, and storage.

## Technical Details

<details>
<summary><b>Azure Databricks</b></summary>

- SDK: `databricks-sdk-go` — the real WorkspaceClient works against a local endpoint (`Config.Host`).
- Jobs / runs: submit, run-now, get-run, list-runs, cancel-run, cancel-all, get-output, delete-run, repair-run.
- Clusters: resize, pin, unpin, list-node-types, spark-versions, list-zones.
- Cluster policies; libraries (install / uninstall / status).
- Secrets (scopes / secrets / ACLs), tokens, git credentials, repos.
- DBFS (incl. block upload), workspace (notebooks / directories).
- SQL warehouses, pipelines, serving endpoints.
- Identity (SCIM): users, groups, service principals.
- Unity Catalog: catalogs, schemas, tables; metastores, external locations, storage credentials, volumes.
</details>