### PR TITLE
docs: document Bedrock and Databricks (parity with shipped code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ SDK-compat coverage across AWS, Azure, and GCP:
 | Networking | VPC (under EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
 | Monitoring | CloudWatch | Azure Monitor | Cloud Monitoring |
 | Resource Discovery | Resource Explorer + Resource Groups Tagging API | Resource Graph | Cloud Asset Inventory |
+| Generative AI | Bedrock (control plane + bedrock-runtime InvokeModel/Converse) | — | — |
+| Databricks | — | Databricks (ARM workspace + workspace data plane) | — |
 
 The Kubernetes story is two layers, both shipped:
 

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -142,6 +142,7 @@ Region, credentials, and tokens can be any dummy values — the server doesn't v
 | **IAM** *(query protocol)* | Users (Create/Get/List/Delete), Roles (Create/Get/List/Delete), Policies (Create/Get/List/Delete), Attach/Detach/ListAttached for both Users and Roles, Groups (Create/Get/List/Delete + AddUserToGroup/RemoveUserFromGroup/ListGroupsForUser), AccessKeys (Create/List/Delete), InstanceProfiles (Create/Get/List/Delete + AddRoleToInstanceProfile/RemoveRoleFromInstanceProfile). Errors surface as typed `*types.NoSuchEntityException` / `*types.EntityAlreadyExistsException`. |
 | **Resource Explorer 2** *(JSON)* | Search — free-text plus filter expression over the cross-service inventory; results include ARN, resource type, region, owning account, and tags |
 | **Resource Groups Tagging API** *(JSON-RPC)* | GetResources (filter by `ResourceTypeFilters` + `TagFilters`, paginated), TagResources, UntagResources, GetTagKeys, GetTagValues |
+| **Bedrock** *(REST + JSON, `bedrock` + `bedrock-runtime`)* | Control plane: ListFoundationModels, GetFoundationModel, model-customization jobs (Create/Get/List), custom models (List/Get/Delete), Guardrails (Create/Get/List/Update/Delete), Provisioned Throughput (Create/Get/List/Delete), invocation-logging config (Put/Get/Delete). Runtime: InvokeModel (family-aware response envelopes) and Converse. |
 
 ### Azure (`server/azure/`)
 
@@ -163,6 +164,8 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **AKS** | `Microsoft.ContainerService/managedClusters` — ManagedClusters (CreateOrUpdate, Get, UpdateTags, Delete, List/ListByResourceGroup), AgentPools (CreateOrUpdate, Get, Delete, List), MaintenanceConfigurations (CreateOrUpdate, Get, Delete, List), ListClusterAdmin/User/MonitoringUser Credentials, RotateClusterCertificates. Stub kubeconfig only — data plane deferred to Wave 2. |
 | **IAM (armauthorization)** | `Microsoft.Authorization` — RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete) at any scope (subscription, resource group, resource, management group). Real `armauthorization` SDK clients round-trip end-to-end. Microsoft Graph (users/groups) is out of scope — deferred to a future handler. |
 | **Resource Graph** | `Microsoft.ResourceGraph` — `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` with a KQL-shaped query over the cross-service inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
+| **Databricks (ARM control plane)** | `Microsoft.Databricks/workspaces` — CreateOrUpdate, Get, Delete, UpdateTags, List / ListByResourceGroup. Real `armdatabricks` SDK clients round-trip end-to-end. |
+| **Databricks (workspace data plane)** *(`databricks-sdk-go`, `/api/2.x`)* | Point the real `WorkspaceClient` at `Config.Host`. Clusters (create/edit/start/restart/resize/pin/unpin/delete + list-node-types / spark-versions / zones), instance pools, jobs + runs (submit / run-now / get / list / cancel / cancel-all / repair / output / delete), cluster policies, libraries (install / uninstall / status), and object permissions. Self-contained families: secrets (scopes / secrets / ACLs), tokens, git credentials, repos, DBFS (incl. block upload), workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity (users / groups / service principals), and Unity Catalog (catalogs / schemas / tables + metastores / external locations / storage credentials / volumes). |
 
 ### GCP (`server/gcp/`)
 
@@ -200,13 +203,18 @@ server/
 │   ├── aws.go                      # awsserver.New(Drivers{...})
 │   ├── s3/  ec2/  dynamodb/  lambda/  sqs/  cloudwatch/
 │   ├── rds/  redshift/             # query-protocol relational DB handlers
-│   └── eks/                        # REST EKS control-plane handler
+│   ├── eks/                        # REST EKS control-plane handler
+│   └── bedrock/                    # REST Bedrock control plane + bedrock-runtime
 ├── azure/
 │   ├── azure.go                    # azureserver.New(Drivers{...})
 │   ├── virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
 │   ├── blob/  cosmos/  network/  monitor/  functions/  servicebus/
 │   ├── azuresql/  postgresflex/  mysqlflex/   # ARM relational DB handlers
-│   └── aks/                        # ARM AKS control-plane handler
+│   ├── aks/                        # ARM AKS control-plane handler
+│   └── databricks/                 # ARM workspace + workspace data-plane families
+│       ├── secrets/  token/  gitcredentials/  repos/  dbfs/  wsfs/
+│       ├── sqlwarehouses/  pipelines/  serving/  scim/
+│       └── unitycatalog/  ucstorage/
 └── gcp/
     ├── gcp.go                      # gcpserver.New(Drivers{...})
     ├── compute/  networks/  gcs/  firestore/  monitoring/
@@ -240,12 +248,15 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | AWS Redshift | Form-encoded POST whose `Action=` is a known Redshift operation (registered before EC2) |
 | AWS EC2 | `Action=…` in URL query or `Content-Type: application/x-www-form-urlencoded` POST |
 | AWS CloudWatch | `Smithy-Protocol: rpc-v2-cbor` header |
+| AWS Bedrock | URL prefix `/foundation-models`, `/model-customization-jobs`, `/custom-models`, `/guardrails`, `/provisioned-model-throughput`, `/logging/modelinvocations`, or bedrock-runtime `/model/{id}/invoke` and `/model/{id}/converse` |
 | AWS S3 | Fallback (everything else REST-shaped) |
 | Azure (all ARM) | URL begins with `/subscriptions/{sub}` and matches `Microsoft.<Provider>/<Type>` |
 | Azure SQL | ARM provider `Microsoft.Sql` |
 | Azure PostgreSQL Flexible | ARM provider `Microsoft.DBforPostgreSQL/flexibleServers` |
 | Azure MySQL Flexible | ARM provider `Microsoft.DBforMySQL/flexibleServers` |
 | Azure AKS | ARM provider `Microsoft.ContainerService/managedClusters` |
+| Azure Databricks (ARM) | ARM provider `Microsoft.Databricks/workspaces` |
+| Azure Databricks (data plane) | Non-ARM URL prefix `/api/2.0/` or `/api/2.1/` (workspace data plane) |
 | Azure Cosmos | URL begins with `/dbs/` (data plane, non-ARM) |
 | Azure Functions invoke | URL begins with `/api/` (non-ARM data plane) |
 | Azure Service Bus data plane | Non-ARM URL ending in `/messages` or `/messages/head` |
@@ -274,7 +285,9 @@ Kubernetes ships as **two cooperating handlers**: per-provider control planes (E
 
 The data plane intentionally has no controllers — Deployments don't spawn ReplicaSets, Pods stay Pending, Endpoints are empty stubs. RBAC, subresources, PV/PVC, StatefulSet/DaemonSet/Job/CronJob, and Ingress are out of scope.
 
-The remaining service domains (IAM, DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
+Two provider-specific services also ship as full SDK-compat handlers. **AWS Bedrock** covers the `bedrock` control plane (foundation models, customization jobs, custom models, guardrails, provisioned throughput, invocation logging) and the `bedrock-runtime` data plane (InvokeModel with family-aware response envelopes, and Converse). **Azure Databricks** covers the `armdatabricks` ARM workspace resource plus the `databricks-sdk-go` workspace data plane — clusters, instance pools, jobs and runs, cluster policies, libraries, permissions, secrets, tokens, git credentials, repos, DBFS, workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity, and Unity Catalog.
+
+The remaining service domains (DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
 
 ## Writing your own handler
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -25,6 +25,8 @@ This document lists every service and operation available in CloudEmu across all
 | 17 | Relational Database | `rds` (+ Aurora/Neptune/DocumentDB engines), `redshift` | `azuresql`, `postgresflex`, `mysqlflex` | `cloudsql` |
 | 18 | Kubernetes | `eks` + shared `kubernetes/` | `aks` + shared `kubernetes/` | `gke` + shared `kubernetes/` |
 | 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
+| 20 | Generative AI | `bedrock` (+ `bedrock-runtime`) | — | — |
+| 21 | Databricks | — | `databricks` | — |
 
 ---
 
@@ -1149,6 +1151,177 @@ Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups T
 
 ---
 
+## 20. Generative AI
+
+**Driver interface:** `bedrock/driver/driver.go`
+**AWS:** `bedrock` (+ `bedrock-runtime`) | **Azure:** — | **GCP:** —
+
+AWS-only. Backs the real `aws-sdk-go-v2/service/bedrock` and `.../bedrockruntime` clients against the in-memory backend.
+
+### Foundation Model Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `ListFoundationModels` | `(ctx) ([]FoundationModel, error)` |
+| `GetFoundationModel` | `(ctx, modelID) (*FoundationModel, error)` |
+
+### Model Customization Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateModelCustomizationJob` | `(ctx, CustomizationJobConfig) (*CustomizationJob, error)` |
+| `GetModelCustomizationJob` | `(ctx, jobIdentifier) (*CustomizationJob, error)` |
+| `ListModelCustomizationJobs` | `(ctx) ([]CustomizationJob, error)` |
+
+### Custom Model Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `ListCustomModels` | `(ctx) ([]CustomModel, error)` |
+| `GetCustomModel` | `(ctx, modelIdentifier) (*CustomModel, error)` |
+| `DeleteCustomModel` | `(ctx, modelIdentifier) error` |
+
+### Runtime Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `InvokeModel` | `(ctx, InvokeModelInput) (*InvokeModelResult, error)` |
+| `Converse` | `(ctx, ConverseInput) (*ConverseOutput, error)` |
+
+### Guardrail Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateGuardrail` | `(ctx, GuardrailConfig) (*Guardrail, error)` |
+| `GetGuardrail` | `(ctx, identifier, version) (*Guardrail, error)` |
+| `ListGuardrails` | `(ctx) ([]Guardrail, error)` |
+| `UpdateGuardrail` | `(ctx, identifier, GuardrailConfig) (*Guardrail, error)` |
+| `DeleteGuardrail` | `(ctx, identifier) error` |
+
+### Provisioned Throughput Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateProvisionedModelThroughput` | `(ctx, ProvisionedThroughputConfig) (*ProvisionedThroughput, error)` |
+| `GetProvisionedModelThroughput` | `(ctx, identifier) (*ProvisionedThroughput, error)` |
+| `ListProvisionedModelThroughputs` | `(ctx) ([]ProvisionedThroughput, error)` |
+| `DeleteProvisionedModelThroughput` | `(ctx, identifier) error` |
+
+### Invocation Logging Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutModelInvocationLoggingConfiguration` | `(ctx, LoggingConfig) error` |
+| `GetModelInvocationLoggingConfiguration` | `(ctx) (*LoggingConfig, error)` |
+| `DeleteModelInvocationLoggingConfiguration` | `(ctx) error` |
+
+**Total: 22 operations**
+
+---
+
+## 21. Databricks
+
+**Driver interfaces:** `databricks/driver/driver.go` (control plane), `databricks/driver/dataplane.go` (data plane)
+**AWS:** — | **Azure:** `databricks` | **GCP:** —
+
+Azure-only. The control plane backs the real `armdatabricks` SDK; the data plane backs the real `databricks-sdk-go` WorkspaceClient. The SDK-compat-only workspace families (secrets, tokens, git credentials, repos, DBFS, workspace files, SQL warehouses, pipelines, serving endpoints, SCIM identity, Unity Catalog) have no portable Go API — see [sdk-server.md](sdk-server.md).
+
+### Workspace Operations (control plane)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateWorkspace` | `(ctx, WorkspaceConfig) (*Workspace, error)` |
+| `GetWorkspace` | `(ctx, resourceGroup, name) (*Workspace, error)` |
+| `DeleteWorkspace` | `(ctx, resourceGroup, name) error` |
+| `UpdateWorkspaceTags` | `(ctx, resourceGroup, name, tags) (*Workspace, error)` |
+| `ListWorkspacesByResourceGroup` | `(ctx, resourceGroup) ([]Workspace, error)` |
+| `ListWorkspaces` | `(ctx) ([]Workspace, error)` |
+
+### Instance Pool Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateInstancePool` | `(ctx, InstancePoolConfig) (*InstancePool, error)` |
+| `GetInstancePool` | `(ctx, id) (*InstancePool, error)` |
+| `ListInstancePools` | `(ctx) ([]InstancePool, error)` |
+| `EditInstancePool` | `(ctx, id, InstancePoolConfig) error` |
+| `DeleteInstancePool` | `(ctx, id) error` |
+
+### Cluster Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateCluster` | `(ctx, ClusterConfig) (*Cluster, error)` |
+| `GetCluster` | `(ctx, id) (*Cluster, error)` |
+| `ListClusters` | `(ctx) ([]Cluster, error)` |
+| `EditCluster` | `(ctx, id, ClusterConfig) error` |
+| `DeleteCluster` | `(ctx, id) error` |
+| `PermanentDeleteCluster` | `(ctx, id) error` |
+| `StartCluster` | `(ctx, id) error` |
+| `RestartCluster` | `(ctx, id) error` |
+| `ResizeCluster` | `(ctx, id, numWorkers, autoscaleMin, autoscaleMax) error` |
+| `PinCluster` | `(ctx, id) error` |
+| `UnpinCluster` | `(ctx, id) error` |
+| `ListNodeTypes` | `(ctx) ([]NodeType, error)` |
+| `ListSparkVersions` | `(ctx) ([]SparkVersion, error)` |
+| `ListZones` | `(ctx) (zones, defaultZone, error)` |
+
+### Job Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateJob` | `(ctx, JobConfig) (int64, error)` |
+| `GetJob` | `(ctx, id) (*Job, error)` |
+| `ListJobs` | `(ctx) ([]Job, error)` |
+| `UpdateJob` | `(ctx, id, JobConfig) error` |
+| `ResetJob` | `(ctx, id, JobConfig) error` |
+| `DeleteJob` | `(ctx, id) error` |
+| `RunJobNow` | `(ctx, id) (int64, error)` |
+
+### Run Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `SubmitRun` | `(ctx, runName) (int64, error)` |
+| `GetRun` | `(ctx, runID) (*Run, error)` |
+| `ListRuns` | `(ctx, jobID) ([]Run, error)` |
+| `CancelRun` | `(ctx, runID) error` |
+| `CancelAllRuns` | `(ctx, jobID) error` |
+| `DeleteRun` | `(ctx, runID) error` |
+| `RepairRun` | `(ctx, runID) (int64, error)` |
+| `GetRunOutput` | `(ctx, runID) (*RunOutput, error)` |
+
+### Cluster Policy Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateClusterPolicy` | `(ctx, ClusterPolicyConfig) (*ClusterPolicy, error)` |
+| `GetClusterPolicy` | `(ctx, policyID) (*ClusterPolicy, error)` |
+| `EditClusterPolicy` | `(ctx, policyID, ClusterPolicyConfig) error` |
+| `DeleteClusterPolicy` | `(ctx, policyID) error` |
+| `ListClusterPolicies` | `(ctx) ([]ClusterPolicy, error)` |
+
+### Library Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `InstallLibraries` | `(ctx, clusterID, []LibrarySpec) error` |
+| `UninstallLibraries` | `(ctx, clusterID, []LibrarySpec) error` |
+| `ClusterLibraryStatuses` | `(ctx, clusterID) ([]LibraryStatus, error)` |
+| `AllClusterLibraryStatuses` | `(ctx) ([]ClusterLibraryStatuses, error)` |
+
+### Permission Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetPermissions` | `(ctx, objectType, objectID) (*ObjectPermissions, error)` |
+| `SetPermissions` | `(ctx, objectType, objectID, acl) (*ObjectPermissions, error)` |
+| `UpdatePermissions` | `(ctx, objectType, objectID, acl) (*ObjectPermissions, error)` |
+
+**Total: 52 operations**
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -1175,4 +1348,6 @@ Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups T
 | Kubernetes — GCP GKE (control plane) | 26 |
 | Kubernetes — data plane (8 resources × 7 verbs incl. Watch) | 56 |
 | Resource Discovery (engine + AWS + Azure + GCP handlers) | 26 |
-| **Grand Total** | **498** |
+| Generative AI — AWS Bedrock | 22 |
+| Databricks — Azure (control + data plane) | 52 |
+| **Grand Total** | **572** |


### PR DESCRIPTION
## Summary

Brings the docs back in parity with the code. **AWS Bedrock** and **Azure Databricks** (control plane + full workspace data plane) have shipped but were absent from every doc. This PR documents them.

## What changed

- **docs/sdk-server.md** — Bedrock added to the AWS handler table; Databricks (ARM control plane + `databricks-sdk-go` data plane) added to the Azure table. Plus protocol-detection rows, the internal file tree, and a coverage-status note. Also drops the now-shipped IAM from the "remaining domains" line.
- **docs/services.md** — two new portable-API sections: **20. Generative AI** (`bedrock`, 22 ops) and **21. Databricks** (`databricks`, 52 ops), with master-table rows and an updated grand total (498 → 572).
- **README.md** — Bedrock and Databricks rows added to the "What's supported" table.

Docs-only; no code changes.