### PR TITLE
feat(azure/databricks): host-metadata endpoint + SDK-server docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cloudemu emulates AWS, Azure, and GCP cloud services entirely in memory, so you 
 
 It ships two surfaces you can mix and match:
 
-- **SDK-compat HTTP server** — point the real `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go` clients at a local endpoint and they just work. No code changes in your app.
+- **SDK-compat HTTP server** — point the real `aws-sdk-go-v2`, `azure-sdk-for-go`, `cloud.google.com/go`, or `databricks-sdk-go` clients at a local endpoint and they just work. No code changes in your app.
 - **Go API** — typed in-memory mocks (`aws.S3`, `azure.VirtualMachines`, `gcp.GCE`, …) for tests written against cloudemu directly.
 
 ## Install

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -118,6 +118,39 @@ opts := []option.ClientOption{
 client, _ := gcpcompute.NewInstancesRESTClient(ctx, opts...)
 ```
 
+## Quick start (Databricks)
+
+The Azure server also speaks the `databricks-sdk-go` `WorkspaceClient` wire protocol. Wire the same `*databricks.Mock` into both `Databricks` (ARM workspace control plane) and `DatabricksDataPlane` (the `/api/2.x` workspace data plane).
+
+```go
+import (
+    "net/http/httptest"
+
+    databricks "github.com/databricks/databricks-sdk-go"
+    "github.com/databricks/databricks-sdk-go/config"
+    "github.com/databricks/databricks-sdk-go/service/compute"
+    "github.com/stackshy/cloudemu"
+    azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+cp := cloudemu.NewAzure()
+srv := azureserver.New(azureserver.Drivers{
+    Databricks:          cp.Databricks, // Microsoft.Databricks/workspaces (ARM)
+    DatabricksDataPlane: cp.Databricks, // /api/2.x workspace data plane
+})
+ts := httptest.NewServer(srv)
+defer ts.Close()
+
+w, _ := databricks.NewWorkspaceClient(&databricks.Config{
+    Host:        ts.URL,
+    Token:       "test-token",
+    Credentials: config.PatCredentials{},
+})
+
+// Real WorkspaceClient calls round-trip against the in-memory backend.
+w.InstancePools.Create(ctx, compute.CreateInstancePool{InstancePoolName: "pool-1"})
+```
+
 Region, credentials, and tokens can be any dummy values — the server doesn't validate signatures or AAD tokens.
 
 ## Currently supported
@@ -165,7 +198,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **IAM (armauthorization)** | `Microsoft.Authorization` — RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete) at any scope (subscription, resource group, resource, management group). Real `armauthorization` SDK clients round-trip end-to-end. Microsoft Graph (users/groups) is out of scope — deferred to a future handler. |
 | **Resource Graph** | `Microsoft.ResourceGraph` — `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` with a KQL-shaped query over the cross-service inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
 | **Databricks (ARM control plane)** | `Microsoft.Databricks/workspaces` — CreateOrUpdate, Get, Delete, UpdateTags, List / ListByResourceGroup. Real `armdatabricks` SDK clients round-trip end-to-end. |
-| **Databricks (workspace data plane)** *(`databricks-sdk-go`, `/api/2.x`)* | Point the real `WorkspaceClient` at `Config.Host`. Clusters (create/edit/start/restart/resize/pin/unpin/delete + list-node-types / spark-versions / zones), instance pools, jobs + runs (submit / run-now / get / list / cancel / cancel-all / repair / output / delete), cluster policies, libraries (install / uninstall / status), and object permissions. Self-contained families: secrets (scopes / secrets / ACLs), tokens, git credentials, repos, DBFS (incl. block upload), workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity (users / groups / service principals), and Unity Catalog (catalogs / schemas / tables + metastores / external locations / storage credentials / volumes). |
+| **Databricks (workspace data plane)** *(`databricks-sdk-go`, `/api/2.x`)* | Point the real `WorkspaceClient` at `Config.Host`. Clusters (create/edit/start/restart/resize/pin/unpin/delete + list-node-types / spark-versions / zones), instance pools, jobs + runs (submit / run-now / get / list / cancel / cancel-all / repair / output / delete), cluster policies, libraries (install / uninstall / status), and object permissions. Self-contained families: secrets (scopes / secrets / ACLs), tokens, git credentials, repos, DBFS (incl. block upload), workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity (users / groups / service principals), and Unity Catalog (catalogs / schemas / tables + metastores / external locations / storage credentials / volumes). Also serves `GET /.well-known/databricks-config` so the SDK's host-metadata resolution succeeds (workspace-host stub) instead of logging a warning. |
 
 ### GCP (`server/gcp/`)
 
@@ -257,6 +290,7 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | Azure AKS | ARM provider `Microsoft.ContainerService/managedClusters` |
 | Azure Databricks (ARM) | ARM provider `Microsoft.Databricks/workspaces` |
 | Azure Databricks (data plane) | Non-ARM URL prefix `/api/2.0/` or `/api/2.1/` (workspace data plane) |
+| Azure Databricks (host metadata) | `GET /.well-known/databricks-config` |
 | Azure Cosmos | URL begins with `/dbs/` (data plane, non-ARM) |
 | Azure Functions invoke | URL begins with `/api/` (non-ARM data plane) |
 | Azure Service Bus data plane | Non-ARM URL ending in `/messages` or `/messages/head` |

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks"
 	"github.com/stackshy/cloudemu/server/azure/databricks/dbfs"
 	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
+	"github.com/stackshy/cloudemu/server/azure/databricks/hostmeta"
 	"github.com/stackshy/cloudemu/server/azure/databricks/pipelines"
 	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
 	"github.com/stackshy/cloudemu/server/azure/databricks/scim"
@@ -222,6 +223,7 @@ func registerDatabricksDataPlane(srv *server.Server, d *Drivers) {
 	}
 
 	srv.Register(databricks.NewDataPlane(d.DatabricksDataPlane))
+	srv.Register(hostmeta.New())
 	srv.Register(secrets.New())
 	srv.Register(token.New())
 	srv.Register(gitcredentials.New())

--- a/server/azure/databricks/hostmeta/hostmeta.go
+++ b/server/azure/databricks/hostmeta/hostmeta.go
@@ -1,0 +1,69 @@
+// Package hostmeta serves the Databricks host-metadata discovery endpoint
+// (GET /.well-known/databricks-config) as a server.Handler.
+//
+// The real github.com/databricks/databricks-sdk-go config resolver fetches
+// this endpoint on first use to detect the host type (workspace vs. account)
+// and back-fill the cloud, workspace id, and OIDC discovery URL. Without it the
+// SDK logs a "Failed to resolve host metadata" WARN and falls back to user
+// config. Serving a workspace-host stub silences the warning and exercises the
+// SDK's real host-metadata resolution path against the in-memory backend.
+package hostmeta
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// metadataPath is the discovery endpoint the SDK fetches at {host}/...
+const metadataPath = "/.well-known/databricks-config"
+
+// stubWorkspaceID is the workspace id reported by the in-memory backend. Real
+// workspaces use a numeric id; a fixed value is enough for the SDK's
+// workspace-vs-account detection.
+const stubWorkspaceID = "0"
+
+// hostTypeWorkspace is the wire value for a workspace host. The SDK normalizes
+// it (lower-cased) to config.WorkspaceHost — it does not accept the
+// "WORKSPACE_HOST" enum spelling on the wire.
+const hostTypeWorkspace = "workspace"
+
+// Handler serves the Databricks host-metadata discovery endpoint.
+type Handler struct{}
+
+// New returns a host-metadata handler.
+func New() *Handler { return &Handler{} }
+
+// Matches claims GET /.well-known/databricks-config.
+func (*Handler) Matches(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == metadataPath
+}
+
+// metadata mirrors the fields databricks-sdk-go reads from the discovery
+// endpoint (config.HostMetadata).
+type metadata struct {
+	HostType                            string   `json:"host_type"`
+	Cloud                               string   `json:"cloud"`
+	WorkspaceID                         string   `json:"workspace_id"`
+	OIDCEndpoint                        string   `json:"oidc_endpoint"`
+	TokenFederationDefaultOIDCAudiences []string `json:"token_federation_default_oidc_audiences"`
+}
+
+// ServeHTTP returns a workspace-host metadata document for the requesting host.
+func (*Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	tokenURL := scheme + "://" + r.Host + "/oidc/v1/token"
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(metadata{
+		HostType:                            hostTypeWorkspace,
+		Cloud:                               "Azure",
+		WorkspaceID:                         stubWorkspaceID,
+		OIDCEndpoint:                        tokenURL,
+		TokenFederationDefaultOIDCAudiences: []string{tokenURL},
+	})
+}

--- a/server/azure/databricks/hostmeta/hostmeta_roundtrip_test.go
+++ b/server/azure/databricks/hostmeta/hostmeta_roundtrip_test.go
@@ -1,0 +1,89 @@
+package hostmeta_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/common/environment"
+	"github.com/databricks/databricks-sdk-go/config"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/hostmeta"
+)
+
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(hostmeta.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// TestEndpointShape verifies the raw discovery document decodes into the exact
+// struct databricks-sdk-go reads (config.HostMetadata).
+func TestEndpointShape(t *testing.T) {
+	ts := newServer(t)
+
+	resp, err := http.Get(ts.URL + "/.well-known/databricks-config")
+	if err != nil {
+		t.Fatalf("GET discovery endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+
+	var meta config.HostMetadata
+	if err = json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		t.Fatalf("decode into config.HostMetadata: %v", err)
+	}
+
+	if meta.HostType != config.WorkspaceHost {
+		t.Fatalf("got host_type %q, want %q", meta.HostType, config.WorkspaceHost)
+	}
+
+	if meta.Cloud != environment.CloudAzure {
+		t.Fatalf("got cloud %q, want %q", meta.Cloud, environment.CloudAzure)
+	}
+
+	if meta.OIDCEndpoint == "" {
+		t.Fatal("expected non-empty oidc_endpoint")
+	}
+}
+
+// TestSDKResolvesMetadata drives the real SDK config resolver: with the
+// endpoint served, EnsureResolved back-fills the cloud from host metadata
+// instead of logging the resolution-failure warning.
+func TestSDKResolvesMetadata(t *testing.T) {
+	ts := newServer(t)
+
+	cfg := &config.Config{
+		Host:        ts.URL,
+		Token:       "x",
+		Credentials: config.PatCredentials{},
+	}
+
+	if err := cfg.EnsureResolved(); err != nil {
+		t.Fatalf("EnsureResolved: %v", err)
+	}
+
+	if cfg.Cloud != environment.CloudAzure {
+		t.Fatalf("got resolved cloud %q, want %q", cfg.Cloud, environment.CloudAzure)
+	}
+}
+
+func TestNonGetDoesNotMatch(t *testing.T) {
+	h := hostmeta.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/.well-known/databricks-config", nil)
+	if h.Matches(req) {
+		t.Fatal("POST should not match the discovery endpoint")
+	}
+}


### PR DESCRIPTION
Closes #218.

## Summary

Addresses both items from the feedback on the Databricks SDK-compat server.

## 1. `/.well-known/databricks-config` host-metadata handler

On the first call, `databricks-sdk-go` fetches `GET {host}/.well-known/databricks-config` to detect the host type and back-fill cloud / workspace id. Nothing served that path, so the SDK logged `Failed to resolve host metadata ... no handler registered` and fell back to user config.

A small `hostmeta` handler now serves a workspace-host stub, registered in `registerDatabricksDataPlane` (so it ships whenever `DatabricksDataPlane` is wired). This silences the warning **and** exercises the SDK's real host-metadata / workspace-vs-account resolution path against the in-memory backend.

Fidelity detail: the wire value for `host_type` is `"workspace"` (the SDK lower-cases and normalizes it to `WORKSPACE_HOST`) — sending the enum spelling would resolve to unknown. Covered by a roundtrip test that decodes the response into the SDK's own `config.HostMetadata` and drives `config.EnsureResolved`.

## 2. Docs

- **README** — added `databricks-sdk-go` to the SDK-compat bullet (it listed only the AWS/Azure/GCP SDKs).
- **docs/sdk-server.md** — added a Databricks `WorkspaceClient` quick-start, plus host-metadata notes on the data-plane row and protocol-detection table.

## Verification

- `go build ./...`, `go test ./server/...` green (incl. the combined data-plane integration test).
- `golangci-lint run` — 0 issues.