### PR TITLE
docs: integration guide — wire cloudemu into your app, not a demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory bac
 
 Equivalent setups for Azure (`azureserver.New`) and GCP (`gcpserver.New`) are in [docs/sdk-server.md](docs/sdk-server.md).
 
+The snippet above is a quick taste. To adopt cloudemu in a real app, don't write a demo — wire it into your existing client and tests so your real code runs against it. See [docs/integration.md](docs/integration.md).
+
 ## Or use the Go API directly
 
 ```go

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 - [Services](services.md) -- Complete provider resource reference with all operations across every supported service
 - [Features](features.md) -- Cross-cutting features: auto-metrics, alarm evaluation, IAM policy checking, FIFO dedup, cost tracking, and more
 - [SDK Server](sdk-server.md) -- SDK-compatible HTTP server (use the real aws-sdk-go-v2 against CloudEmu)
+- [Integration](integration.md) -- Wire CloudEmu into your real app and tests (not a throwaway demo)
 - [Topology](topology.md) -- Network topology simulation engine
 - [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration
 
@@ -18,6 +19,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 | Creating an AWS provider | [Getting Started](getting-started.md#creating-providers) |
 | All service operations | [Services Reference](services.md#master-table) |
 | Using real AWS SDK clients | [SDK Server](sdk-server.md) |
+| Integrating into your app | [Integration](integration.md) |
 | Auto-metric generation | [Features](features.md#1-auto-metric-generation) |
 | Error injection and rate limiting | [Features](features.md#8-portable-api-cross-cutting-concerns) |
 | Cost tracking | [Features](features.md#7-cost-tracking) |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,45 @@
+# Integrating CloudEmu into Your App
+
+The mistake to avoid: **don't write a new `main.go` that just calls CloudEmu and prints "it works."** That tests the library, not your app.
+
+Do this instead — point your app's *existing* cloud client at CloudEmu in your *existing* tests. Your real code runs against an in-memory cloud, no mocks.
+
+## The trick
+
+Read the endpoint from an env var. Tests set it to a CloudEmu server; production leaves it unset and talks to the real cloud. Your code doesn't change.
+
+```go
+// Where your app builds its client:
+return s3.NewFromConfig(cfg, func(o *s3.Options) {
+	if ep := os.Getenv("CLOUDEMU_ENDPOINT"); ep != "" {
+		o.BaseEndpoint = aws.String(ep) // tests → CloudEmu; unset → real AWS
+		o.UsePathStyle = true
+	}
+})
+```
+
+```go
+// In a _test.go file:
+func startCloudEmu(t *testing.T) {
+	srv := awsserver.New(awsserver.Drivers{S3: cloudemu.NewAWS().S3})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	t.Setenv("CLOUDEMU_ENDPOINT", ts.URL)
+}
+```
+
+Now your real tests hit the in-memory backend. The endpoint knob per SDK: AWS `o.BaseEndpoint`, GCP `option.WithEndpoint`, Azure `arm.ClientOptions` cloud endpoint, Databricks `Config.Host`.
+
+Keep CloudEmu in `_test.go` only — never import it from production code.
+
+## Tell your AI agent (paste into your repo's `AGENTS.md`)
+
+```markdown
+CloudEmu (github.com/stackshy/cloudemu) is an in-memory cloud emulator. To integrate it:
+do NOT create a demo main.go. Wire it into the real code — make the SDK endpoint read from
+CLOUDEMU_ENDPOINT (AWS o.BaseEndpoint, GCP option.WithEndpoint, Azure arm.ClientOptions,
+Databricks Config.Host), then add a _test.go helper that starts it with httptest.NewServer
+and sets CLOUDEMU_ENDPOINT via t.Setenv so existing tests run against it. Prod leaves the
+var unset → real cloud. Never import CloudEmu from production code.
+See https://github.com/stackshy/cloudemu/blob/development/docs/integration.md
+```

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -6,7 +6,7 @@ Do this instead — point your app's *existing* cloud client at CloudEmu in your
 
 ## The trick
 
-Read the endpoint from an env var. Tests set it to a CloudEmu server; production leaves it unset and talks to the real cloud. Your code doesn't change.
+Make the endpoint injectable, then point it at CloudEmu in tests. An env var is the easy default (shown below) — but it's your call: a config field or setting it directly in the test works just as well. Production uses the real cloud; your code doesn't change.
 
 ```go
 // Where your app builds its client:
@@ -36,10 +36,12 @@ Keep CloudEmu in `_test.go` only — never import it from production code.
 
 ```markdown
 CloudEmu (github.com/stackshy/cloudemu) is an in-memory cloud emulator. To integrate it:
-do NOT create a demo main.go. Wire it into the real code — make the SDK endpoint read from
-CLOUDEMU_ENDPOINT (AWS o.BaseEndpoint, GCP option.WithEndpoint, Azure arm.ClientOptions,
-Databricks Config.Host), then add a _test.go helper that starts it with httptest.NewServer
-and sets CLOUDEMU_ENDPOINT via t.Setenv so existing tests run against it. Prod leaves the
-var unset → real cloud. Never import CloudEmu from production code.
+do NOT create a demo main.go — wire it into the real code so existing tests exercise it.
+Make the SDK endpoint injectable however this codebase prefers (an env var, a config field,
+or set directly in the test — your choice) and point it at CloudEmu: AWS o.BaseEndpoint,
+GCP option.WithEndpoint, Azure arm.ClientOptions, Databricks Config.Host. Add a _test.go
+helper that starts CloudEmu with httptest.NewServer and points the client at its URL so
+existing tests run against it. Production uses the real cloud, code unchanged. Never import
+CloudEmu from production code.
 See https://github.com/stackshy/cloudemu/blob/development/docs/integration.md
 ```


### PR DESCRIPTION
## Summary

Adds an integration guide that fixes a real adoption problem: when people (or AI agents) are asked to "set up cloudemu," they tend to write a throwaway `main.go` that proves the library works — instead of wiring it into the real code path so existing tests actually exercise it.

## What changed

- **docs/integration.md** (new) — short, plain-English guide: the wrong-vs-right framing, the env-var endpoint-injection trick (`CLOUDEMU_ENDPOINT`), a tiny factory + `_test.go` example, the per-SDK endpoint knob, and a copy-paste `AGENTS.md` block so coding agents integrate it correctly.
- **README.md** — links the guide from the SDK-compat section and notes the README snippet is a quick taste, not the adoption pattern.
- **docs/README.md** — adds the guide to the index + quick links.

Docs only.