### PR TITLE
v1.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cloudemu emulates AWS, Azure, and GCP cloud services entirely in memory, so you 
 
 It ships two surfaces you can mix and match:
 
-- **SDK-compat HTTP server** — point the real `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go` clients at a local endpoint and they just work. No code changes in your app.
+- **SDK-compat HTTP server** — point the real `aws-sdk-go-v2`, `azure-sdk-for-go`, `cloud.google.com/go`, or `databricks-sdk-go` clients at a local endpoint and they just work. No code changes in your app.
 - **Go API** — typed in-memory mocks (`aws.S3`, `azure.VirtualMachines`, `gcp.GCE`, …) for tests written against cloudemu directly.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ SDK-compat coverage across AWS, Azure, and GCP:
 | Networking | VPC (under EC2) | Virtual Network | VPC + Subnets + Firewalls + Routes |
 | Monitoring | CloudWatch | Azure Monitor | Cloud Monitoring |
 | Resource Discovery | Resource Explorer + Resource Groups Tagging API | Resource Graph | Cloud Asset Inventory |
+| Generative AI | Bedrock (control plane + bedrock-runtime InvokeModel/Converse) | — | — |
+| Databricks | — | Databricks (ARM workspace + workspace data plane) | — |
 
 The Kubernetes story is two layers, both shipped:
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory bac
 
 Equivalent setups for Azure (`azureserver.New`) and GCP (`gcpserver.New`) are in [docs/sdk-server.md](docs/sdk-server.md).
 
+The snippet above is a quick taste. To adopt cloudemu in a real app, don't write a demo — wire it into your existing client and tests so your real code runs against it. See [docs/integration.md](docs/integration.md).
+
 ## Or use the Go API directly
 
 ```go

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 - [Services](services.md) -- Complete provider resource reference with all operations across every supported service
 - [Features](features.md) -- Cross-cutting features: auto-metrics, alarm evaluation, IAM policy checking, FIFO dedup, cost tracking, and more
 - [SDK Server](sdk-server.md) -- SDK-compatible HTTP server (use the real aws-sdk-go-v2 against CloudEmu)
+- [Integration](integration.md) -- Wire CloudEmu into your real app and tests (not a throwaway demo)
 - [Topology](topology.md) -- Network topology simulation engine
 - [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration
 
@@ -18,6 +19,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 | Creating an AWS provider | [Getting Started](getting-started.md#creating-providers) |
 | All service operations | [Services Reference](services.md#master-table) |
 | Using real AWS SDK clients | [SDK Server](sdk-server.md) |
+| Integrating into your app | [Integration](integration.md) |
 | Auto-metric generation | [Features](features.md#1-auto-metric-generation) |
 | Error injection and rate limiting | [Features](features.md#8-portable-api-cross-cutting-concerns) |
 | Cost tracking | [Features](features.md#7-cost-tracking) |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,45 @@
+# Integrating CloudEmu into Your App
+
+The mistake to avoid: **don't write a new `main.go` that just calls CloudEmu and prints "it works."** That tests the library, not your app.
+
+Do this instead — point your app's *existing* cloud client at CloudEmu in your *existing* tests. Your real code runs against an in-memory cloud, no mocks.
+
+## The trick
+
+Read the endpoint from an env var. Tests set it to a CloudEmu server; production leaves it unset and talks to the real cloud. Your code doesn't change.
+
+```go
+// Where your app builds its client:
+return s3.NewFromConfig(cfg, func(o *s3.Options) {
+	if ep := os.Getenv("CLOUDEMU_ENDPOINT"); ep != "" {
+		o.BaseEndpoint = aws.String(ep) // tests → CloudEmu; unset → real AWS
+		o.UsePathStyle = true
+	}
+})
+```
+
+```go
+// In a _test.go file:
+func startCloudEmu(t *testing.T) {
+	srv := awsserver.New(awsserver.Drivers{S3: cloudemu.NewAWS().S3})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	t.Setenv("CLOUDEMU_ENDPOINT", ts.URL)
+}
+```
+
+Now your real tests hit the in-memory backend. The endpoint knob per SDK: AWS `o.BaseEndpoint`, GCP `option.WithEndpoint`, Azure `arm.ClientOptions` cloud endpoint, Databricks `Config.Host`.
+
+Keep CloudEmu in `_test.go` only — never import it from production code.
+
+## Tell your AI agent (paste into your repo's `AGENTS.md`)
+
+```markdown
+CloudEmu (github.com/stackshy/cloudemu) is an in-memory cloud emulator. To integrate it:
+do NOT create a demo main.go. Wire it into the real code — make the SDK endpoint read from
+CLOUDEMU_ENDPOINT (AWS o.BaseEndpoint, GCP option.WithEndpoint, Azure arm.ClientOptions,
+Databricks Config.Host), then add a _test.go helper that starts it with httptest.NewServer
+and sets CLOUDEMU_ENDPOINT via t.Setenv so existing tests run against it. Prod leaves the
+var unset → real cloud. Never import CloudEmu from production code.
+See https://github.com/stackshy/cloudemu/blob/development/docs/integration.md
+```

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -6,7 +6,7 @@ Do this instead — point your app's *existing* cloud client at CloudEmu in your
 
 ## The trick
 
-Read the endpoint from an env var. Tests set it to a CloudEmu server; production leaves it unset and talks to the real cloud. Your code doesn't change.
+Make the endpoint injectable, then point it at CloudEmu in tests. An env var is the easy default (shown below) — but it's your call: a config field or setting it directly in the test works just as well. Production uses the real cloud; your code doesn't change.
 
 ```go
 // Where your app builds its client:
@@ -36,10 +36,12 @@ Keep CloudEmu in `_test.go` only — never import it from production code.
 
 ```markdown
 CloudEmu (github.com/stackshy/cloudemu) is an in-memory cloud emulator. To integrate it:
-do NOT create a demo main.go. Wire it into the real code — make the SDK endpoint read from
-CLOUDEMU_ENDPOINT (AWS o.BaseEndpoint, GCP option.WithEndpoint, Azure arm.ClientOptions,
-Databricks Config.Host), then add a _test.go helper that starts it with httptest.NewServer
-and sets CLOUDEMU_ENDPOINT via t.Setenv so existing tests run against it. Prod leaves the
-var unset → real cloud. Never import CloudEmu from production code.
+do NOT create a demo main.go — wire it into the real code so existing tests exercise it.
+Make the SDK endpoint injectable however this codebase prefers (an env var, a config field,
+or set directly in the test — your choice) and point it at CloudEmu: AWS o.BaseEndpoint,
+GCP option.WithEndpoint, Azure arm.ClientOptions, Databricks Config.Host. Add a _test.go
+helper that starts CloudEmu with httptest.NewServer and points the client at its URL so
+existing tests run against it. Production uses the real cloud, code unchanged. Never import
+CloudEmu from production code.
 See https://github.com/stackshy/cloudemu/blob/development/docs/integration.md
 ```

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -142,6 +142,7 @@ Region, credentials, and tokens can be any dummy values — the server doesn't v
 | **IAM** *(query protocol)* | Users (Create/Get/List/Delete), Roles (Create/Get/List/Delete), Policies (Create/Get/List/Delete), Attach/Detach/ListAttached for both Users and Roles, Groups (Create/Get/List/Delete + AddUserToGroup/RemoveUserFromGroup/ListGroupsForUser), AccessKeys (Create/List/Delete), InstanceProfiles (Create/Get/List/Delete + AddRoleToInstanceProfile/RemoveRoleFromInstanceProfile). Errors surface as typed `*types.NoSuchEntityException` / `*types.EntityAlreadyExistsException`. |
 | **Resource Explorer 2** *(JSON)* | Search — free-text plus filter expression over the cross-service inventory; results include ARN, resource type, region, owning account, and tags |
 | **Resource Groups Tagging API** *(JSON-RPC)* | GetResources (filter by `ResourceTypeFilters` + `TagFilters`, paginated), TagResources, UntagResources, GetTagKeys, GetTagValues |
+| **Bedrock** *(REST + JSON, `bedrock` + `bedrock-runtime`)* | Control plane: ListFoundationModels, GetFoundationModel, model-customization jobs (Create/Get/List), custom models (List/Get/Delete), Guardrails (Create/Get/List/Update/Delete), Provisioned Throughput (Create/Get/List/Delete), invocation-logging config (Put/Get/Delete). Runtime: InvokeModel (family-aware response envelopes) and Converse. |
 
 ### Azure (`server/azure/`)
 
@@ -163,6 +164,8 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **AKS** | `Microsoft.ContainerService/managedClusters` — ManagedClusters (CreateOrUpdate, Get, UpdateTags, Delete, List/ListByResourceGroup), AgentPools (CreateOrUpdate, Get, Delete, List), MaintenanceConfigurations (CreateOrUpdate, Get, Delete, List), ListClusterAdmin/User/MonitoringUser Credentials, RotateClusterCertificates. Stub kubeconfig only — data plane deferred to Wave 2. |
 | **IAM (armauthorization)** | `Microsoft.Authorization` — RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete) at any scope (subscription, resource group, resource, management group). Real `armauthorization` SDK clients round-trip end-to-end. Microsoft Graph (users/groups) is out of scope — deferred to a future handler. |
 | **Resource Graph** | `Microsoft.ResourceGraph` — `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` with a KQL-shaped query over the cross-service inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
+| **Databricks (ARM control plane)** | `Microsoft.Databricks/workspaces` — CreateOrUpdate, Get, Delete, UpdateTags, List / ListByResourceGroup. Real `armdatabricks` SDK clients round-trip end-to-end. |
+| **Databricks (workspace data plane)** *(`databricks-sdk-go`, `/api/2.x`)* | Point the real `WorkspaceClient` at `Config.Host`. Clusters (create/edit/start/restart/resize/pin/unpin/delete + list-node-types / spark-versions / zones), instance pools, jobs + runs (submit / run-now / get / list / cancel / cancel-all / repair / output / delete), cluster policies, libraries (install / uninstall / status), and object permissions. Self-contained families: secrets (scopes / secrets / ACLs), tokens, git credentials, repos, DBFS (incl. block upload), workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity (users / groups / service principals), and Unity Catalog (catalogs / schemas / tables + metastores / external locations / storage credentials / volumes). |
 
 ### GCP (`server/gcp/`)
 
@@ -200,13 +203,18 @@ server/
 │   ├── aws.go                      # awsserver.New(Drivers{...})
 │   ├── s3/  ec2/  dynamodb/  lambda/  sqs/  cloudwatch/
 │   ├── rds/  redshift/             # query-protocol relational DB handlers
-│   └── eks/                        # REST EKS control-plane handler
+│   ├── eks/                        # REST EKS control-plane handler
+│   └── bedrock/                    # REST Bedrock control plane + bedrock-runtime
 ├── azure/
 │   ├── azure.go                    # azureserver.New(Drivers{...})
 │   ├── virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
 │   ├── blob/  cosmos/  network/  monitor/  functions/  servicebus/
 │   ├── azuresql/  postgresflex/  mysqlflex/   # ARM relational DB handlers
-│   └── aks/                        # ARM AKS control-plane handler
+│   ├── aks/                        # ARM AKS control-plane handler
+│   └── databricks/                 # ARM workspace + workspace data-plane families
+│       ├── secrets/  token/  gitcredentials/  repos/  dbfs/  wsfs/
+│       ├── sqlwarehouses/  pipelines/  serving/  scim/
+│       └── unitycatalog/  ucstorage/
 └── gcp/
     ├── gcp.go                      # gcpserver.New(Drivers{...})
     ├── compute/  networks/  gcs/  firestore/  monitoring/
@@ -240,12 +248,15 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | AWS Redshift | Form-encoded POST whose `Action=` is a known Redshift operation (registered before EC2) |
 | AWS EC2 | `Action=…` in URL query or `Content-Type: application/x-www-form-urlencoded` POST |
 | AWS CloudWatch | `Smithy-Protocol: rpc-v2-cbor` header |
+| AWS Bedrock | URL prefix `/foundation-models`, `/model-customization-jobs`, `/custom-models`, `/guardrails`, `/provisioned-model-throughput`, `/logging/modelinvocations`, or bedrock-runtime `/model/{id}/invoke` and `/model/{id}/converse` |
 | AWS S3 | Fallback (everything else REST-shaped) |
 | Azure (all ARM) | URL begins with `/subscriptions/{sub}` and matches `Microsoft.<Provider>/<Type>` |
 | Azure SQL | ARM provider `Microsoft.Sql` |
 | Azure PostgreSQL Flexible | ARM provider `Microsoft.DBforPostgreSQL/flexibleServers` |
 | Azure MySQL Flexible | ARM provider `Microsoft.DBforMySQL/flexibleServers` |
 | Azure AKS | ARM provider `Microsoft.ContainerService/managedClusters` |
+| Azure Databricks (ARM) | ARM provider `Microsoft.Databricks/workspaces` |
+| Azure Databricks (data plane) | Non-ARM URL prefix `/api/2.0/` or `/api/2.1/` (workspace data plane) |
 | Azure Cosmos | URL begins with `/dbs/` (data plane, non-ARM) |
 | Azure Functions invoke | URL begins with `/api/` (non-ARM data plane) |
 | Azure Service Bus data plane | Non-ARM URL ending in `/messages` or `/messages/head` |
@@ -274,7 +285,9 @@ Kubernetes ships as **two cooperating handlers**: per-provider control planes (E
 
 The data plane intentionally has no controllers — Deployments don't spawn ReplicaSets, Pods stay Pending, Endpoints are empty stubs. RBAC, subresources, PV/PVC, StatefulSet/DaemonSet/Job/CronJob, and Ingress are out of scope.
 
-The remaining service domains (IAM, DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
+Two provider-specific services also ship as full SDK-compat handlers. **AWS Bedrock** covers the `bedrock` control plane (foundation models, customization jobs, custom models, guardrails, provisioned throughput, invocation logging) and the `bedrock-runtime` data plane (InvokeModel with family-aware response envelopes, and Converse). **Azure Databricks** covers the `armdatabricks` ARM workspace resource plus the `databricks-sdk-go` workspace data plane — clusters, instance pools, jobs and runs, cluster policies, libraries, permissions, secrets, tokens, git credentials, repos, DBFS, workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity, and Unity Catalog.
+
+The remaining service domains (DNS, Load Balancer, Cache, Secrets, Logging, Notifications, Container Registry, Event Bus) have full driver implementations in `providers/{aws,azure,gcp}/`; SDK-compat handlers are added in lockstep across all 3 providers as each domain ships.
 
 ## Writing your own handler
 

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -118,6 +118,39 @@ opts := []option.ClientOption{
 client, _ := gcpcompute.NewInstancesRESTClient(ctx, opts...)
 ```
 
+## Quick start (Databricks)
+
+The Azure server also speaks the `databricks-sdk-go` `WorkspaceClient` wire protocol. Wire the same `*databricks.Mock` into both `Databricks` (ARM workspace control plane) and `DatabricksDataPlane` (the `/api/2.x` workspace data plane).
+
+```go
+import (
+    "net/http/httptest"
+
+    databricks "github.com/databricks/databricks-sdk-go"
+    "github.com/databricks/databricks-sdk-go/config"
+    "github.com/databricks/databricks-sdk-go/service/compute"
+    "github.com/stackshy/cloudemu"
+    azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+cp := cloudemu.NewAzure()
+srv := azureserver.New(azureserver.Drivers{
+    Databricks:          cp.Databricks, // Microsoft.Databricks/workspaces (ARM)
+    DatabricksDataPlane: cp.Databricks, // /api/2.x workspace data plane
+})
+ts := httptest.NewServer(srv)
+defer ts.Close()
+
+w, _ := databricks.NewWorkspaceClient(&databricks.Config{
+    Host:        ts.URL,
+    Token:       "test-token",
+    Credentials: config.PatCredentials{},
+})
+
+// Real WorkspaceClient calls round-trip against the in-memory backend.
+w.InstancePools.Create(ctx, compute.CreateInstancePool{InstancePoolName: "pool-1"})
+```
+
 Region, credentials, and tokens can be any dummy values — the server doesn't validate signatures or AAD tokens.
 
 ## Currently supported
@@ -165,7 +198,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **IAM (armauthorization)** | `Microsoft.Authorization` — RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete) at any scope (subscription, resource group, resource, management group). Real `armauthorization` SDK clients round-trip end-to-end. Microsoft Graph (users/groups) is out of scope — deferred to a future handler. |
 | **Resource Graph** | `Microsoft.ResourceGraph` — `POST /providers/Microsoft.ResourceGraph/resources?api-version=2022-10-01` with a KQL-shaped query over the cross-service inventory; supports `subscriptions[]` scoping and `$top`/`$skipToken` pagination |
 | **Databricks (ARM control plane)** | `Microsoft.Databricks/workspaces` — CreateOrUpdate, Get, Delete, UpdateTags, List / ListByResourceGroup. Real `armdatabricks` SDK clients round-trip end-to-end. |
-| **Databricks (workspace data plane)** *(`databricks-sdk-go`, `/api/2.x`)* | Point the real `WorkspaceClient` at `Config.Host`. Clusters (create/edit/start/restart/resize/pin/unpin/delete + list-node-types / spark-versions / zones), instance pools, jobs + runs (submit / run-now / get / list / cancel / cancel-all / repair / output / delete), cluster policies, libraries (install / uninstall / status), and object permissions. Self-contained families: secrets (scopes / secrets / ACLs), tokens, git credentials, repos, DBFS (incl. block upload), workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity (users / groups / service principals), and Unity Catalog (catalogs / schemas / tables + metastores / external locations / storage credentials / volumes). |
+| **Databricks (workspace data plane)** *(`databricks-sdk-go`, `/api/2.x`)* | Point the real `WorkspaceClient` at `Config.Host`. Clusters (create/edit/start/restart/resize/pin/unpin/delete + list-node-types / spark-versions / zones), instance pools, jobs + runs (submit / run-now / get / list / cancel / cancel-all / repair / output / delete), cluster policies, libraries (install / uninstall / status), and object permissions. Self-contained families: secrets (scopes / secrets / ACLs), tokens, git credentials, repos, DBFS (incl. block upload), workspace notebooks/directories, SQL warehouses, pipelines, serving endpoints, SCIM identity (users / groups / service principals), and Unity Catalog (catalogs / schemas / tables + metastores / external locations / storage credentials / volumes). Also serves `GET /.well-known/databricks-config` so the SDK's host-metadata resolution succeeds (workspace-host stub) instead of logging a warning. |
 
 ### GCP (`server/gcp/`)
 
@@ -257,6 +290,7 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | Azure AKS | ARM provider `Microsoft.ContainerService/managedClusters` |
 | Azure Databricks (ARM) | ARM provider `Microsoft.Databricks/workspaces` |
 | Azure Databricks (data plane) | Non-ARM URL prefix `/api/2.0/` or `/api/2.1/` (workspace data plane) |
+| Azure Databricks (host metadata) | `GET /.well-known/databricks-config` |
 | Azure Cosmos | URL begins with `/dbs/` (data plane, non-ARM) |
 | Azure Functions invoke | URL begins with `/api/` (non-ARM data plane) |
 | Azure Service Bus data plane | Non-ARM URL ending in `/messages` or `/messages/head` |

--- a/docs/services.md
+++ b/docs/services.md
@@ -25,6 +25,8 @@ This document lists every service and operation available in CloudEmu across all
 | 17 | Relational Database | `rds` (+ Aurora/Neptune/DocumentDB engines), `redshift` | `azuresql`, `postgresflex`, `mysqlflex` | `cloudsql` |
 | 18 | Kubernetes | `eks` + shared `kubernetes/` | `aks` + shared `kubernetes/` | `gke` + shared `kubernetes/` |
 | 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
+| 20 | Generative AI | `bedrock` (+ `bedrock-runtime`) | — | — |
+| 21 | Databricks | — | `databricks` | — |
 
 ---
 
@@ -1149,6 +1151,177 @@ Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups T
 
 ---
 
+## 20. Generative AI
+
+**Driver interface:** `bedrock/driver/driver.go`
+**AWS:** `bedrock` (+ `bedrock-runtime`) | **Azure:** — | **GCP:** —
+
+AWS-only. Backs the real `aws-sdk-go-v2/service/bedrock` and `.../bedrockruntime` clients against the in-memory backend.
+
+### Foundation Model Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `ListFoundationModels` | `(ctx) ([]FoundationModel, error)` |
+| `GetFoundationModel` | `(ctx, modelID) (*FoundationModel, error)` |
+
+### Model Customization Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateModelCustomizationJob` | `(ctx, CustomizationJobConfig) (*CustomizationJob, error)` |
+| `GetModelCustomizationJob` | `(ctx, jobIdentifier) (*CustomizationJob, error)` |
+| `ListModelCustomizationJobs` | `(ctx) ([]CustomizationJob, error)` |
+
+### Custom Model Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `ListCustomModels` | `(ctx) ([]CustomModel, error)` |
+| `GetCustomModel` | `(ctx, modelIdentifier) (*CustomModel, error)` |
+| `DeleteCustomModel` | `(ctx, modelIdentifier) error` |
+
+### Runtime Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `InvokeModel` | `(ctx, InvokeModelInput) (*InvokeModelResult, error)` |
+| `Converse` | `(ctx, ConverseInput) (*ConverseOutput, error)` |
+
+### Guardrail Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateGuardrail` | `(ctx, GuardrailConfig) (*Guardrail, error)` |
+| `GetGuardrail` | `(ctx, identifier, version) (*Guardrail, error)` |
+| `ListGuardrails` | `(ctx) ([]Guardrail, error)` |
+| `UpdateGuardrail` | `(ctx, identifier, GuardrailConfig) (*Guardrail, error)` |
+| `DeleteGuardrail` | `(ctx, identifier) error` |
+
+### Provisioned Throughput Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateProvisionedModelThroughput` | `(ctx, ProvisionedThroughputConfig) (*ProvisionedThroughput, error)` |
+| `GetProvisionedModelThroughput` | `(ctx, identifier) (*ProvisionedThroughput, error)` |
+| `ListProvisionedModelThroughputs` | `(ctx) ([]ProvisionedThroughput, error)` |
+| `DeleteProvisionedModelThroughput` | `(ctx, identifier) error` |
+
+### Invocation Logging Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `PutModelInvocationLoggingConfiguration` | `(ctx, LoggingConfig) error` |
+| `GetModelInvocationLoggingConfiguration` | `(ctx) (*LoggingConfig, error)` |
+| `DeleteModelInvocationLoggingConfiguration` | `(ctx) error` |
+
+**Total: 22 operations**
+
+---
+
+## 21. Databricks
+
+**Driver interfaces:** `databricks/driver/driver.go` (control plane), `databricks/driver/dataplane.go` (data plane)
+**AWS:** — | **Azure:** `databricks` | **GCP:** —
+
+Azure-only. The control plane backs the real `armdatabricks` SDK; the data plane backs the real `databricks-sdk-go` WorkspaceClient. The SDK-compat-only workspace families (secrets, tokens, git credentials, repos, DBFS, workspace files, SQL warehouses, pipelines, serving endpoints, SCIM identity, Unity Catalog) have no portable Go API — see [sdk-server.md](sdk-server.md).
+
+### Workspace Operations (control plane)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateWorkspace` | `(ctx, WorkspaceConfig) (*Workspace, error)` |
+| `GetWorkspace` | `(ctx, resourceGroup, name) (*Workspace, error)` |
+| `DeleteWorkspace` | `(ctx, resourceGroup, name) error` |
+| `UpdateWorkspaceTags` | `(ctx, resourceGroup, name, tags) (*Workspace, error)` |
+| `ListWorkspacesByResourceGroup` | `(ctx, resourceGroup) ([]Workspace, error)` |
+| `ListWorkspaces` | `(ctx) ([]Workspace, error)` |
+
+### Instance Pool Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateInstancePool` | `(ctx, InstancePoolConfig) (*InstancePool, error)` |
+| `GetInstancePool` | `(ctx, id) (*InstancePool, error)` |
+| `ListInstancePools` | `(ctx) ([]InstancePool, error)` |
+| `EditInstancePool` | `(ctx, id, InstancePoolConfig) error` |
+| `DeleteInstancePool` | `(ctx, id) error` |
+
+### Cluster Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateCluster` | `(ctx, ClusterConfig) (*Cluster, error)` |
+| `GetCluster` | `(ctx, id) (*Cluster, error)` |
+| `ListClusters` | `(ctx) ([]Cluster, error)` |
+| `EditCluster` | `(ctx, id, ClusterConfig) error` |
+| `DeleteCluster` | `(ctx, id) error` |
+| `PermanentDeleteCluster` | `(ctx, id) error` |
+| `StartCluster` | `(ctx, id) error` |
+| `RestartCluster` | `(ctx, id) error` |
+| `ResizeCluster` | `(ctx, id, numWorkers, autoscaleMin, autoscaleMax) error` |
+| `PinCluster` | `(ctx, id) error` |
+| `UnpinCluster` | `(ctx, id) error` |
+| `ListNodeTypes` | `(ctx) ([]NodeType, error)` |
+| `ListSparkVersions` | `(ctx) ([]SparkVersion, error)` |
+| `ListZones` | `(ctx) (zones, defaultZone, error)` |
+
+### Job Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateJob` | `(ctx, JobConfig) (int64, error)` |
+| `GetJob` | `(ctx, id) (*Job, error)` |
+| `ListJobs` | `(ctx) ([]Job, error)` |
+| `UpdateJob` | `(ctx, id, JobConfig) error` |
+| `ResetJob` | `(ctx, id, JobConfig) error` |
+| `DeleteJob` | `(ctx, id) error` |
+| `RunJobNow` | `(ctx, id) (int64, error)` |
+
+### Run Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `SubmitRun` | `(ctx, runName) (int64, error)` |
+| `GetRun` | `(ctx, runID) (*Run, error)` |
+| `ListRuns` | `(ctx, jobID) ([]Run, error)` |
+| `CancelRun` | `(ctx, runID) error` |
+| `CancelAllRuns` | `(ctx, jobID) error` |
+| `DeleteRun` | `(ctx, runID) error` |
+| `RepairRun` | `(ctx, runID) (int64, error)` |
+| `GetRunOutput` | `(ctx, runID) (*RunOutput, error)` |
+
+### Cluster Policy Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateClusterPolicy` | `(ctx, ClusterPolicyConfig) (*ClusterPolicy, error)` |
+| `GetClusterPolicy` | `(ctx, policyID) (*ClusterPolicy, error)` |
+| `EditClusterPolicy` | `(ctx, policyID, ClusterPolicyConfig) error` |
+| `DeleteClusterPolicy` | `(ctx, policyID) error` |
+| `ListClusterPolicies` | `(ctx) ([]ClusterPolicy, error)` |
+
+### Library Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `InstallLibraries` | `(ctx, clusterID, []LibrarySpec) error` |
+| `UninstallLibraries` | `(ctx, clusterID, []LibrarySpec) error` |
+| `ClusterLibraryStatuses` | `(ctx, clusterID) ([]LibraryStatus, error)` |
+| `AllClusterLibraryStatuses` | `(ctx) ([]ClusterLibraryStatuses, error)` |
+
+### Permission Operations
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetPermissions` | `(ctx, objectType, objectID) (*ObjectPermissions, error)` |
+| `SetPermissions` | `(ctx, objectType, objectID, acl) (*ObjectPermissions, error)` |
+| `UpdatePermissions` | `(ctx, objectType, objectID, acl) (*ObjectPermissions, error)` |
+
+**Total: 52 operations**
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -1175,4 +1348,6 @@ Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups T
 | Kubernetes — GCP GKE (control plane) | 26 |
 | Kubernetes — data plane (8 resources × 7 verbs incl. Watch) | 56 |
 | Resource Discovery (engine + AWS + Azure + GCP handlers) | 26 |
-| **Grand Total** | **498** |
+| Generative AI — AWS Bedrock | 22 |
+| Databricks — Azure (control + data plane) | 52 |
+| **Grand Total** | **572** |

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks"
 	"github.com/stackshy/cloudemu/server/azure/databricks/dbfs"
 	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
+	"github.com/stackshy/cloudemu/server/azure/databricks/hostmeta"
 	"github.com/stackshy/cloudemu/server/azure/databricks/pipelines"
 	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
 	"github.com/stackshy/cloudemu/server/azure/databricks/scim"
@@ -222,6 +223,7 @@ func registerDatabricksDataPlane(srv *server.Server, d *Drivers) {
 	}
 
 	srv.Register(databricks.NewDataPlane(d.DatabricksDataPlane))
+	srv.Register(hostmeta.New())
 	srv.Register(secrets.New())
 	srv.Register(token.New())
 	srv.Register(gitcredentials.New())

--- a/server/azure/databricks/hostmeta/hostmeta.go
+++ b/server/azure/databricks/hostmeta/hostmeta.go
@@ -1,0 +1,69 @@
+// Package hostmeta serves the Databricks host-metadata discovery endpoint
+// (GET /.well-known/databricks-config) as a server.Handler.
+//
+// The real github.com/databricks/databricks-sdk-go config resolver fetches
+// this endpoint on first use to detect the host type (workspace vs. account)
+// and back-fill the cloud, workspace id, and OIDC discovery URL. Without it the
+// SDK logs a "Failed to resolve host metadata" WARN and falls back to user
+// config. Serving a workspace-host stub silences the warning and exercises the
+// SDK's real host-metadata resolution path against the in-memory backend.
+package hostmeta
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// metadataPath is the discovery endpoint the SDK fetches at {host}/...
+const metadataPath = "/.well-known/databricks-config"
+
+// stubWorkspaceID is the workspace id reported by the in-memory backend. Real
+// workspaces use a numeric id; a fixed value is enough for the SDK's
+// workspace-vs-account detection.
+const stubWorkspaceID = "0"
+
+// hostTypeWorkspace is the wire value for a workspace host. The SDK normalizes
+// it (lower-cased) to config.WorkspaceHost — it does not accept the
+// "WORKSPACE_HOST" enum spelling on the wire.
+const hostTypeWorkspace = "workspace"
+
+// Handler serves the Databricks host-metadata discovery endpoint.
+type Handler struct{}
+
+// New returns a host-metadata handler.
+func New() *Handler { return &Handler{} }
+
+// Matches claims GET /.well-known/databricks-config.
+func (*Handler) Matches(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == metadataPath
+}
+
+// metadata mirrors the fields databricks-sdk-go reads from the discovery
+// endpoint (config.HostMetadata).
+type metadata struct {
+	HostType                            string   `json:"host_type"`
+	Cloud                               string   `json:"cloud"`
+	WorkspaceID                         string   `json:"workspace_id"`
+	OIDCEndpoint                        string   `json:"oidc_endpoint"`
+	TokenFederationDefaultOIDCAudiences []string `json:"token_federation_default_oidc_audiences"`
+}
+
+// ServeHTTP returns a workspace-host metadata document for the requesting host.
+func (*Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	tokenURL := scheme + "://" + r.Host + "/oidc/v1/token"
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(metadata{
+		HostType:                            hostTypeWorkspace,
+		Cloud:                               "Azure",
+		WorkspaceID:                         stubWorkspaceID,
+		OIDCEndpoint:                        tokenURL,
+		TokenFederationDefaultOIDCAudiences: []string{tokenURL},
+	})
+}

--- a/server/azure/databricks/hostmeta/hostmeta_roundtrip_test.go
+++ b/server/azure/databricks/hostmeta/hostmeta_roundtrip_test.go
@@ -1,0 +1,89 @@
+package hostmeta_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/common/environment"
+	"github.com/databricks/databricks-sdk-go/config"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/hostmeta"
+)
+
+func newServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(hostmeta.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+// TestEndpointShape verifies the raw discovery document decodes into the exact
+// struct databricks-sdk-go reads (config.HostMetadata).
+func TestEndpointShape(t *testing.T) {
+	ts := newServer(t)
+
+	resp, err := http.Get(ts.URL + "/.well-known/databricks-config")
+	if err != nil {
+		t.Fatalf("GET discovery endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got status %d, want 200", resp.StatusCode)
+	}
+
+	var meta config.HostMetadata
+	if err = json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		t.Fatalf("decode into config.HostMetadata: %v", err)
+	}
+
+	if meta.HostType != config.WorkspaceHost {
+		t.Fatalf("got host_type %q, want %q", meta.HostType, config.WorkspaceHost)
+	}
+
+	if meta.Cloud != environment.CloudAzure {
+		t.Fatalf("got cloud %q, want %q", meta.Cloud, environment.CloudAzure)
+	}
+
+	if meta.OIDCEndpoint == "" {
+		t.Fatal("expected non-empty oidc_endpoint")
+	}
+}
+
+// TestSDKResolvesMetadata drives the real SDK config resolver: with the
+// endpoint served, EnsureResolved back-fills the cloud from host metadata
+// instead of logging the resolution-failure warning.
+func TestSDKResolvesMetadata(t *testing.T) {
+	ts := newServer(t)
+
+	cfg := &config.Config{
+		Host:        ts.URL,
+		Token:       "x",
+		Credentials: config.PatCredentials{},
+	}
+
+	if err := cfg.EnsureResolved(); err != nil {
+		t.Fatalf("EnsureResolved: %v", err)
+	}
+
+	if cfg.Cloud != environment.CloudAzure {
+		t.Fatalf("got resolved cloud %q, want %q", cfg.Cloud, environment.CloudAzure)
+	}
+}
+
+func TestNonGetDoesNotMatch(t *testing.T) {
+	h := hostmeta.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/.well-known/databricks-config", nil)
+	if h.Matches(req) {
+		t.Fatal("POST should not match the discovery endpoint")
+	}
+}


### PR DESCRIPTION
## <img src="https://raw.githubusercontent.com/stackshy/cloudemu/development/.github/logo.svg" alt="cloudemu" width="28" height="28" align="absmiddle" /> Release Notes — v1.7.3

## 🔧 Enhancement

### Azure Databricks — host metadata

The Databricks workspace server now answers the SDK's **host-metadata discovery** request, so the real `databricks-sdk-go` client **resolves cleanly on first use** — no fallback warning — and runs through the same **workspace-detection path** it uses against real Databricks.

### Documentation — integrate cloudemu into your app

A new **integration guide** shows how to point your real SDK client at cloudemu in your existing tests instead of writing a throwaway demo, plus **`databricks-sdk-go` SDK-server wiring** and a full **operation reference** for Bedrock and Databricks.

## Technical Details

<details>
<summary><b>Databricks host metadata</b></summary>

- Serves `GET /.well-known/databricks-config` (workspace-host stub) on the Azure server when the Databricks data plane is enabled.
- Wire value `host_type: "workspace"` (the SDK normalizes it to `WORKSPACE_HOST`); reports `cloud: Azure` and a request-derived OIDC token endpoint.
- Round-trip tested by decoding into the SDK's own `config.HostMetadata` and driving `config.EnsureResolved`.
</details>

<details>
<summary><b>Documentation</b></summary>

- `docs/integration.md` — endpoint-injection pattern (env var / config / direct), a `_test.go` harness, and a copy-paste `AGENTS.md` block for coding agents.
- `docs/sdk-server.md` — `databricks-sdk-go` quick-start and host-metadata notes.
- `docs/services.md` — Bedrock (Generative AI) and Databricks operation reference.
</details>