### PR TITLE
fix(resourcegraph): index Databricks workspaces + support 'type in~' filter

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -103,6 +103,7 @@ func New(opts ...config.Option) *Provider {
 			Storage:    p.BlobStorage,
 			Database:   p.CosmosDB,
 			Serverless: p.Functions,
+			Databricks: p.Databricks,
 		},
 	)
 

--- a/resourcediscovery/engine.go
+++ b/resourcediscovery/engine.go
@@ -5,6 +5,7 @@ import (
 
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
@@ -20,6 +21,7 @@ type Drivers struct {
 	Storage    storagedriver.Bucket
 	Database   dbdriver.Database
 	Serverless serverlessdriver.Serverless
+	Databricks dbxdriver.Databricks
 }
 
 // Engine walks all configured service drivers and returns a normalized
@@ -75,6 +77,8 @@ func (e *Engine) ListAll(ctx context.Context) ([]Resource, error) {
 // List walks every configured driver and returns resources matching q.
 // Filtering happens after collection — walkers always return their full set
 // so tag/region resolution is consistent regardless of query shape.
+//
+//nolint:gocritic // q is the public Query filter, taken by value by API contract
 func (e *Engine) List(ctx context.Context, q Query) ([]Resource, error) {
 	var out []Resource
 
@@ -116,6 +120,10 @@ func (e *Engine) walkers() []func(context.Context) ([]Resource, error) {
 
 	if e.drivers.Serverless != nil {
 		ws = append(ws, e.walkServerless)
+	}
+
+	if e.drivers.Databricks != nil {
+		ws = append(ws, e.walkDatabricks)
 	}
 
 	return ws

--- a/resourcediscovery/types.go
+++ b/resourcediscovery/types.go
@@ -33,20 +33,30 @@ type Resource struct {
 // slice. An empty/nil slice means "no service filter". This shape supports
 // cases like AWS's "ec2" which spans both compute and networking — the
 // caller can pass Services: []string{"compute", "networking"}.
+//
+// Type is a single exact-match type filter. Types is an any-of set on the
+// resource Type, for callers that select several types at once (e.g. a KQL
+// `where type in~ ('a', 'b')`); an empty/nil slice means "no type-set filter".
+// Type and Types are independent — both must pass when both are set.
 type Query struct {
 	Services []string
 	Type     string
+	Types    []string
 	Region   string
 	Tags     map[string]string
 }
 
 // matches returns true if r satisfies every non-empty field of q.
-func (q Query) matches(r *Resource) bool {
+func (q *Query) matches(r *Resource) bool {
 	if !sliceMatch(q.Services, r.Service) {
 		return false
 	}
 
 	if !fieldMatch(q.Type, r.Type) {
+		return false
+	}
+
+	if !sliceMatch(q.Types, r.Type) {
 		return false
 	}
 

--- a/resourcediscovery/walkers.go
+++ b/resourcediscovery/walkers.go
@@ -23,6 +23,7 @@ const (
 	ServiceStorage    = "storage"
 	ServiceDatabase   = "database"
 	ServiceServerless = "serverless"
+	ServiceDatabricks = "databricks"
 )
 
 // Resource type constants emitted by the walkers.
@@ -34,6 +35,7 @@ const (
 	TypeBucket        = "Bucket"
 	TypeTable         = "Table"
 	TypeFunction      = "Function"
+	TypeWorkspace     = "Workspace"
 )
 
 func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
@@ -197,6 +199,35 @@ func (e *Engine) walkServerless(ctx context.Context) ([]Resource, error) {
 			ID:     fns[i].Name,
 			ARN:    arn,
 			Region: e.region, Tags: copyTags(fns[i].Tags),
+		})
+	}
+
+	return out, nil
+}
+
+// walkDatabricks lists Databricks workspaces from the control-plane driver.
+// Workspaces are ARM resources whose driver is wired in separately from the
+// five portable service drivers, so they need their own walker to appear in
+// the cross-service inventory (and therefore in Resource Graph results).
+func (e *Engine) walkDatabricks(ctx context.Context) ([]Resource, error) {
+	workspaces, err := e.drivers.Databricks.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkDatabricks: %w", err)
+	}
+
+	out := make([]Resource, 0, len(workspaces))
+
+	for i := range workspaces {
+		region := workspaces[i].Location
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceDatabricks, Type: TypeWorkspace,
+			ID:     workspaces[i].Name,
+			ARN:    workspaces[i].ID,
+			Region: region, Tags: copyTags(workspaces[i].Tags),
 		})
 	}
 

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -268,6 +268,8 @@ func portableToAzureType(service, typ string) string {
 		return "microsoft.documentdb/databaseaccounts"
 	case "serverless/Function":
 		return "microsoft.web/sites"
+	case "databricks/Workspace":
+		return "microsoft.databricks/workspaces"
 	default:
 		return strings.ToLower(service + "/" + typ)
 	}

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -34,16 +34,17 @@ import (
 // Canonical Azure resource type strings used by Resource Graph query syntax
 // and emitted in response rows.
 const (
-	azureTypeVM      = "microsoft.compute/virtualmachines"
-	azureTypeVNet    = "microsoft.network/virtualnetworks"
-	azureTypeSubnet  = "microsoft.network/subnets"
-	azureTypeSubnetN = "microsoft.network/virtualnetworks/subnets"
-	azureTypeNSG     = "microsoft.network/networksecuritygroups"
-	azureTypeStorage = "microsoft.storage/storageaccounts"
-	azureTypeStoCnt  = "microsoft.storage/storageaccounts/blobservices/containers"
-	azureTypeCosmos  = "microsoft.documentdb/databaseaccounts"
-	azureTypeCosmosC = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
-	azureTypeWebSite = "microsoft.web/sites"
+	azureTypeVM        = "microsoft.compute/virtualmachines"
+	azureTypeVNet      = "microsoft.network/virtualnetworks"
+	azureTypeSubnet    = "microsoft.network/subnets"
+	azureTypeSubnetN   = "microsoft.network/virtualnetworks/subnets"
+	azureTypeNSG       = "microsoft.network/networksecuritygroups"
+	azureTypeStorage   = "microsoft.storage/storageaccounts"
+	azureTypeStoCnt    = "microsoft.storage/storageaccounts/blobservices/containers"
+	azureTypeCosmos    = "microsoft.documentdb/databaseaccounts"
+	azureTypeCosmosC   = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
+	azureTypeWebSite   = "microsoft.web/sites"
+	azureTypeDatabrick = "microsoft.databricks/workspaces"
 )
 
 // Portable service identifiers as emitted by the resourcediscovery walkers.
@@ -53,6 +54,7 @@ const (
 	portableStorage    = "storage"
 	portableDatabase   = "database"
 	portableServerless = "serverless"
+	portableDatabricks = "databricks"
 )
 
 // parsedKQL is the result of KQL parsing — an engine Query plus the limit
@@ -80,6 +82,10 @@ type parsedKQL struct {
 var (
 	// type == 'X' / type =~ 'X' / type == "X".
 	reWhereType = regexp.MustCompile(`(?i)^\s*type\s*(==|=~)\s*['"]([^'"]+)['"]\s*$`)
+	// type in ('a','b') / type in~ ('a', "b") — case-insensitive in-list.
+	reWhereTypeIn = regexp.MustCompile(`(?i)^\s*type\s+in~?\s*\(([^)]*)\)\s*$`)
+	// a single quoted item inside an in-list.
+	reQuotedItem = regexp.MustCompile(`['"]([^'"]+)['"]`)
 	// resourceGroup == 'X'.
 	reWhereRG = regexp.MustCompile(`(?i)^\s*resourceGroup\s*==\s*['"]([^'"]+)['"]\s*$`)
 	// location == 'X'.
@@ -142,6 +148,19 @@ func applyWhere(out *parsedKQL, body string) {
 		return
 	}
 
+	if m := reWhereTypeIn.FindStringSubmatch(body); m != nil {
+		items := reQuotedItem.FindAllStringSubmatch(m[1], -1)
+
+		types := make([]string, 0, len(items))
+		for _, it := range items {
+			types = append(types, it[1])
+		}
+
+		applyTypeList(out, types)
+
+		return
+	}
+
 	if m := reWhereRG.FindStringSubmatch(body); m != nil {
 		// The engine does not track resource groups; every Azure resource
 		// is bucketed under a single "default" group. Filtering by RG is
@@ -190,6 +209,42 @@ func applyType(out *parsedKQL, azureType string) {
 	}
 }
 
+// applyTypeList handles `where type in~ ('a', 'b')` — an any-of set of types.
+// Each Azure type maps to a portable (service, type) pair; the services and
+// types are unioned into the engine Query as any-of filters. Like applyType,
+// a second type clause AND-ed on top is a contradiction and flips ForceEmpty.
+func applyTypeList(out *parsedKQL, azureTypes []string) {
+	if out.typeSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.typeSet = true
+
+	for _, at := range azureTypes {
+		svc, typ := mapAzureType(strings.ToLower(strings.TrimSpace(at)))
+		if svc != "" {
+			out.Query.Services = appendUnique(out.Query.Services, svc)
+		}
+
+		if typ != "" {
+			out.Query.Types = appendUnique(out.Query.Types, typ)
+		}
+	}
+}
+
+// appendUnique appends v to s only if it is not already present, preserving
+// order. Keeps the any-of filter slices free of duplicate entries.
+func appendUnique(s []string, v string) []string {
+	for _, existing := range s {
+		if existing == v {
+			return s
+		}
+	}
+
+	return append(s, v)
+}
+
 // addTag records a tag predicate. Repeating the same key with a different
 // value is a KQL contradiction (a single tag cannot hold two values at
 // once); flips ForceEmpty so the handler returns an empty result.
@@ -232,6 +287,8 @@ func mapAzureType(azureType string) (service, typ string) {
 		return portableDatabase, "Table"
 	case azureTypeWebSite:
 		return portableServerless, "Function"
+	case azureTypeDatabrick:
+		return portableDatabricks, "Workspace"
 	default:
 		return "", ""
 	}

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -200,6 +200,14 @@ func applyType(out *parsedKQL, azureType string) {
 	out.typeSet = true
 
 	svc, typ := mapAzureType(strings.ToLower(azureType))
+	if svc == "" && typ == "" {
+		// Unmapped type — match none, not all. Without this the empty Query
+		// would fall through to "no filter" and return the whole inventory.
+		out.ForceEmpty = true
+
+		return
+	}
+
 	if svc != "" {
 		out.Query.Services = []string{svc}
 	}
@@ -230,6 +238,13 @@ func applyTypeList(out *parsedKQL, azureTypes []string) {
 		if typ != "" {
 			out.Query.Types = appendUnique(out.Query.Types, typ)
 		}
+	}
+
+	// An empty list, or one containing only types cloudemu doesn't model,
+	// resolves to no filter terms. Match none rather than letting the empty
+	// Query fall through to "no filter" and return the whole inventory.
+	if len(out.Query.Services) == 0 && len(out.Query.Types) == 0 {
+		out.ForceEmpty = true
 	}
 }
 

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -225,6 +225,22 @@ func TestSDKResourceGraph_DatabricksIndexing(t *testing.T) {
 		data := out.Data.([]any)
 		assert.Len(t, data, 2)
 	})
+
+	t.Run("type in~ with an unmodeled type matches none, not all", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type in~ ('microsoft.keyvault/vaults')"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords, "an unmapped type must not widen to the whole inventory")
+	})
+
+	t.Run("type == an unmodeled type matches none, not all", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.keyvault/vaults'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
 }
 
 func rowsHaveType(data []any, want string) bool {

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stackshy/cloudemu"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	azureserver "github.com/stackshy/cloudemu/server/azure"
 )
@@ -157,6 +158,83 @@ func TestSDKResourceGraph(t *testing.T) {
 		assert.Contains(t, id, "Microsoft.Network")
 		assert.Equal(t, "123456789012", row["subscriptionId"])
 	})
+}
+
+// TestSDKResourceGraph_DatabricksIndexing pins issue #225: Databricks ARM
+// workspaces must appear in Resource Graph results (they are wired as a
+// service driver but were not fed into the discovery inventory), and the
+// `where type in~ (...)` case-insensitive in-list predicate must actually
+// filter instead of returning every row.
+func TestSDKResourceGraph_DatabricksIndexing(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.Databricks.CreateWorkspace(ctx, dbxdriver.WorkspaceConfig{
+		Name: "ws-1", ResourceGroup: "rg-1", Location: "eastus", SKUName: "premium",
+		ManagedResourceGroupID: "/subscriptions/123456789012/resourceGroups/databricks-rg-1",
+		Tags:                   map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "control-bucket"))
+
+	srv := azureserver.New(azureserver.Drivers{
+		Databricks:          cloudP.Databricks,
+		DatabricksDataPlane: cloudP.Databricks,
+		BlobStorage:         cloudP.BlobStorage,
+		ResourceDiscovery:   cloudP.ResourceDiscovery,
+		SubscriptionID:      "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	t.Run("workspace appears in bare Resources query", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2, "control bucket + databricks workspace")
+		assert.True(t, rowsHaveType(data, "microsoft.databricks/workspaces"),
+			"databricks workspace must be indexed alongside storage")
+	})
+
+	t.Run("type in~ filters to just the workspace", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type in~ ('microsoft.databricks/workspaces') | project id, name, type"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1, "in~ must narrow to the workspace, not return all rows")
+
+		row := data[0].(map[string]any)
+		assert.Equal(t, "ws-1", row["name"])
+		assert.Equal(t, "microsoft.databricks/workspaces", row["type"])
+	})
+
+	t.Run("type in~ with multiple types returns both", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type in~ ('microsoft.databricks/workspaces', 'microsoft.storage/storageaccounts')"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2)
+	})
+}
+
+func rowsHaveType(data []any, want string) bool {
+	for _, d := range data {
+		if row, ok := d.(map[string]any); ok && row["type"] == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newResourceGraphClient(t *testing.T, ts *httptest.Server) *armresourcegraph.Client {


### PR DESCRIPTION
Fixes #225.

## Summary

Two Resource Graph bugs blocked Azure Resource-Graph-driven discovery against cloudemu (the reporter was finding Databricks workspaces via `armresourcegraph`, then enriching via `armdatabricks`).

## Bug 1 — Databricks workspaces weren't indexed

The `resourcediscovery` engine only walked five driver types (compute/networking/storage/database/serverless). The Databricks ARM driver was wired as a service handler but never passed into the discovery inventory, so a bare `Resources` query returned everything **except** workspaces.

- Added a `Databricks` field to `resourcediscovery.Drivers` and a `walkDatabricks` walker (emits `Service: databricks`, `Type: Workspace`).
- Wired `Databricks: p.Databricks` into the Azure provider's `ResourceDiscovery`.
- Added the `microsoft.databricks/workspaces` ↔ `databricks/Workspace` mapping in both directions in the Resource Graph handler.

## Bug 2 — `where type in~ (...)` was ignored

The KQL parser only matched `==` / `=~`. `in` / `in~` (case-insensitive in-list) fell through, so the type filter was dropped and **all** rows were returned.

- Added `in` / `in~` parsing and a `Types` any-of filter on the engine `Query` (multi-type selection unions the mapped services and types).

## Tests

New real-`armresourcegraph`-SDK test (`TestSDKResourceGraph_DatabricksIndexing`): workspace now appears in a bare query, `in~` narrows to just the workspace, and a multi-type `in~` returns both. `go build`, full package tests, and `golangci-lint` all clean.