### PR TITLE
fix(databricks): preserve dropped data-plane fields + add QueryHistory

### DIFF
--- a/databricks/dataplane.go
+++ b/databricks/dataplane.go
@@ -151,6 +151,8 @@ func (d *DataPlane) DeleteInstancePool(ctx context.Context, id string) error {
 }
 
 // CreateCluster creates a cluster.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (d *DataPlane) CreateCluster(ctx context.Context, cfg driver.ClusterConfig) (*driver.Cluster, error) {
 	out, err := d.do(ctx, "CreateCluster", cfg, func() (any, error) { return d.driver.CreateCluster(ctx, cfg) })
 	if err != nil {
@@ -181,6 +183,8 @@ func (d *DataPlane) ListClusters(ctx context.Context) ([]driver.Cluster, error) 
 }
 
 // EditCluster updates a cluster.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (d *DataPlane) EditCluster(ctx context.Context, id string, cfg driver.ClusterConfig) error {
 	_, err := d.do(ctx, "EditCluster", id, func() (any, error) { return nil, d.driver.EditCluster(ctx, id, cfg) })
 

--- a/databricks/driver/dataplane.go
+++ b/databricks/driver/dataplane.go
@@ -18,43 +18,51 @@ const (
 
 // InstancePoolConfig describes an instance pool to create or edit.
 type InstancePoolConfig struct {
-	Name             string
-	NodeTypeID       string
-	MinIdleInstances int32
-	MaxCapacity      int32
+	Name                               string
+	NodeTypeID                         string
+	MinIdleInstances                   int32
+	MaxCapacity                        int32
+	IdleInstanceAutoterminationMinutes int32
+	CustomTags                         map[string]string
 }
 
 // InstancePool describes an instance pool.
 type InstancePool struct {
-	ID               string
-	Name             string
-	NodeTypeID       string
-	State            string
-	MinIdleInstances int32
-	MaxCapacity      int32
+	ID                                 string
+	Name                               string
+	NodeTypeID                         string
+	State                              string
+	MinIdleInstances                   int32
+	MaxCapacity                        int32
+	IdleInstanceAutoterminationMinutes int32
+	CustomTags                         map[string]string
 }
 
 // ClusterConfig describes a cluster to create or edit.
 type ClusterConfig struct {
-	Name         string
-	SparkVersion string
-	NodeTypeID   string
-	NumWorkers   int32
-	AutoscaleMin int32
-	AutoscaleMax int32
+	Name          string
+	SparkVersion  string
+	NodeTypeID    string
+	NumWorkers    int32
+	AutoscaleMin  int32
+	AutoscaleMax  int32
+	RuntimeEngine string
+	CustomTags    map[string]string
 }
 
 // Cluster describes a compute cluster.
 type Cluster struct {
-	ID           string
-	Name         string
-	SparkVersion string
-	NodeTypeID   string
-	State        string
-	NumWorkers   int32
-	AutoscaleMin int32
-	AutoscaleMax int32
-	Pinned       bool
+	ID            string
+	Name          string
+	SparkVersion  string
+	NodeTypeID    string
+	State         string
+	NumWorkers    int32
+	AutoscaleMin  int32
+	AutoscaleMax  int32
+	RuntimeEngine string
+	CustomTags    map[string]string
+	Pinned        bool
 }
 
 // NodeType describes an available compute node type.

--- a/providers/azure/databricks/dataplane.go
+++ b/providers/azure/databricks/dataplane.go
@@ -22,12 +22,14 @@ func (m *Mock) CreateInstancePool(_ context.Context, cfg driver.InstancePoolConf
 
 	id := idgen.GenerateID("pool-")
 	pool := &driver.InstancePool{
-		ID:               id,
-		Name:             cfg.Name,
-		NodeTypeID:       cfg.NodeTypeID,
-		State:            driver.PoolActive,
-		MinIdleInstances: cfg.MinIdleInstances,
-		MaxCapacity:      cfg.MaxCapacity,
+		ID:                                 id,
+		Name:                               cfg.Name,
+		NodeTypeID:                         cfg.NodeTypeID,
+		State:                              driver.PoolActive,
+		MinIdleInstances:                   cfg.MinIdleInstances,
+		MaxCapacity:                        cfg.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: cfg.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         cfg.CustomTags,
 	}
 	m.pools.Set(id, pool)
 
@@ -72,6 +74,8 @@ func (m *Mock) EditInstancePool(_ context.Context, id string, cfg driver.Instanc
 	updated.NodeTypeID = cfg.NodeTypeID
 	updated.MinIdleInstances = cfg.MinIdleInstances
 	updated.MaxCapacity = cfg.MaxCapacity
+	updated.IdleInstanceAutoterminationMinutes = cfg.IdleInstanceAutoterminationMinutes
+	updated.CustomTags = cfg.CustomTags
 	m.pools.Set(id, &updated)
 
 	return nil
@@ -89,6 +93,8 @@ func (m *Mock) DeleteInstancePool(_ context.Context, id string) error {
 // --- clusters ---
 
 // CreateCluster creates a cluster in the RUNNING state.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterConfig) (*driver.Cluster, error) {
 	switch {
 	case cfg.SparkVersion == "":
@@ -99,14 +105,16 @@ func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterConfig) (*driv
 
 	id := idgen.GenerateID("cluster-")
 	cluster := &driver.Cluster{
-		ID:           id,
-		Name:         cfg.Name,
-		SparkVersion: cfg.SparkVersion,
-		NodeTypeID:   cfg.NodeTypeID,
-		State:        driver.ClusterRunning,
-		NumWorkers:   cfg.NumWorkers,
-		AutoscaleMin: cfg.AutoscaleMin,
-		AutoscaleMax: cfg.AutoscaleMax,
+		ID:            id,
+		Name:          cfg.Name,
+		SparkVersion:  cfg.SparkVersion,
+		NodeTypeID:    cfg.NodeTypeID,
+		State:         driver.ClusterRunning,
+		NumWorkers:    cfg.NumWorkers,
+		AutoscaleMin:  cfg.AutoscaleMin,
+		AutoscaleMax:  cfg.AutoscaleMax,
+		RuntimeEngine: cfg.RuntimeEngine,
+		CustomTags:    cfg.CustomTags,
 	}
 	m.clusters.Set(id, cluster)
 
@@ -140,6 +148,8 @@ func (m *Mock) ListClusters(_ context.Context) ([]driver.Cluster, error) {
 }
 
 // EditCluster updates a cluster's mutable fields.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (m *Mock) EditCluster(_ context.Context, id string, cfg driver.ClusterConfig) error {
 	cluster, ok := m.clusters.Get(id)
 	if !ok {
@@ -153,6 +163,8 @@ func (m *Mock) EditCluster(_ context.Context, id string, cfg driver.ClusterConfi
 	updated.NumWorkers = cfg.NumWorkers
 	updated.AutoscaleMin = cfg.AutoscaleMin
 	updated.AutoscaleMax = cfg.AutoscaleMax
+	updated.RuntimeEngine = cfg.RuntimeEngine
+	updated.CustomTags = cfg.CustomTags
 	m.clusters.Set(id, &updated)
 
 	return nil

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
 	"github.com/stackshy/cloudemu/server/azure/databricks/hostmeta"
 	"github.com/stackshy/cloudemu/server/azure/databricks/pipelines"
+	"github.com/stackshy/cloudemu/server/azure/databricks/queryhistory"
 	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
 	"github.com/stackshy/cloudemu/server/azure/databricks/scim"
 	"github.com/stackshy/cloudemu/server/azure/databricks/secrets"
@@ -231,6 +232,7 @@ func registerDatabricksDataPlane(srv *server.Server, d *Drivers) {
 	srv.Register(dbfs.New())
 	srv.Register(wsfs.New())
 	srv.Register(sqlwarehouses.New())
+	srv.Register(queryhistory.New())
 	srv.Register(pipelines.New())
 	srv.Register(serving.New())
 	srv.Register(unitycatalog.New())

--- a/server/azure/databricks/dataplane_fields_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_fields_roundtrip_test.go
@@ -1,0 +1,71 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+)
+
+// TestSDKClusterCustomTagsAndRuntimeEngine pins issue #223: custom_tags and
+// runtime_engine set on Create must survive a Get round-trip.
+func TestSDKClusterCustomTagsAndRuntimeEngine(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:   "c1",
+		SparkVersion:  "13.3.x-scala2.12",
+		NodeTypeId:    "Standard_DS3_v2",
+		Autoscale:     &compute.AutoScale{MinWorkers: 2, MaxWorkers: 8},
+		RuntimeEngine: compute.RuntimeEnginePhoton,
+		CustomTags:    map[string]string{"team": "data"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := w.Clusters.Get(ctx, compute.GetClusterRequest{ClusterId: wait.ClusterId})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.RuntimeEngine != compute.RuntimeEnginePhoton {
+		t.Fatalf("runtime_engine: got %q, want PHOTON", got.RuntimeEngine)
+	}
+
+	if got.CustomTags["team"] != "data" {
+		t.Fatalf("custom_tags: got %v, want {team:data}", got.CustomTags)
+	}
+}
+
+// TestSDKInstancePoolIdleAndTags pins issue #223: idle-autotermination minutes
+// and custom_tags on an instance pool must survive a Get round-trip.
+func TestSDKInstancePoolIdleAndTags(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
+		InstancePoolName:                   "pool-1",
+		NodeTypeId:                         "Standard_DS3_v2",
+		IdleInstanceAutoterminationMinutes: 60,
+		CustomTags:                         map[string]string{"team": "data"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := w.InstancePools.GetByInstancePoolId(ctx, created.InstancePoolId)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.IdleInstanceAutoterminationMinutes != 60 {
+		t.Fatalf("idle_instance_autotermination_minutes: got %d, want 60",
+			got.IdleInstanceAutoterminationMinutes)
+	}
+
+	if got.CustomTags["team"] != "data" {
+		t.Fatalf("custom_tags: got %v, want {team:data}", got.CustomTags)
+	}
+}

--- a/server/azure/databricks/dataplane_ops.go
+++ b/server/azure/databricks/dataplane_ops.go
@@ -17,12 +17,14 @@ type autoscaleJSON struct {
 }
 
 type instancePoolJSON struct {
-	InstancePoolID   string `json:"instance_pool_id,omitempty"`
-	InstancePoolName string `json:"instance_pool_name"`
-	NodeTypeID       string `json:"node_type_id"`
-	State            string `json:"state,omitempty"`
-	MinIdleInstances int32  `json:"min_idle_instances,omitempty"`
-	MaxCapacity      int32  `json:"max_capacity,omitempty"`
+	InstancePoolID                     string            `json:"instance_pool_id,omitempty"`
+	InstancePoolName                   string            `json:"instance_pool_name"`
+	NodeTypeID                         string            `json:"node_type_id"`
+	State                              string            `json:"state,omitempty"`
+	MinIdleInstances                   int32             `json:"min_idle_instances,omitempty"`
+	MaxCapacity                        int32             `json:"max_capacity,omitempty"`
+	IdleInstanceAutoterminationMinutes int32             `json:"idle_instance_autotermination_minutes,omitempty"`
+	CustomTags                         map[string]string `json:"custom_tags,omitempty"`
 }
 
 type instancePoolID struct {
@@ -34,13 +36,15 @@ type listPoolsResponse struct {
 }
 
 type clusterJSON struct {
-	ClusterID    string         `json:"cluster_id,omitempty"`
-	ClusterName  string         `json:"cluster_name,omitempty"`
-	SparkVersion string         `json:"spark_version"`
-	NodeTypeID   string         `json:"node_type_id"`
-	State        string         `json:"state,omitempty"`
-	NumWorkers   int32          `json:"num_workers,omitempty"`
-	Autoscale    *autoscaleJSON `json:"autoscale,omitempty"`
+	ClusterID     string            `json:"cluster_id,omitempty"`
+	ClusterName   string            `json:"cluster_name,omitempty"`
+	SparkVersion  string            `json:"spark_version"`
+	NodeTypeID    string            `json:"node_type_id"`
+	State         string            `json:"state,omitempty"`
+	NumWorkers    int32             `json:"num_workers,omitempty"`
+	Autoscale     *autoscaleJSON    `json:"autoscale,omitempty"`
+	RuntimeEngine string            `json:"runtime_engine,omitempty"`
+	CustomTags    map[string]string `json:"custom_tags,omitempty"`
 }
 
 type clusterID struct {
@@ -135,6 +139,8 @@ func (h *DataPlaneHandler) createPool(w http.ResponseWriter, r *http.Request) {
 	pool, err := h.dp.CreateInstancePool(r.Context(), dbxdriver.InstancePoolConfig{
 		Name: in.InstancePoolName, NodeTypeID: in.NodeTypeID,
 		MinIdleInstances: in.MinIdleInstances, MaxCapacity: in.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: in.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         in.CustomTags,
 	})
 	if err != nil {
 		dpWriteErr(w, err)
@@ -181,6 +187,8 @@ func (h *DataPlaneHandler) editPool(w http.ResponseWriter, r *http.Request) {
 	err := h.dp.EditInstancePool(r.Context(), in.InstancePoolID, dbxdriver.InstancePoolConfig{
 		Name: in.InstancePoolName, NodeTypeID: in.NodeTypeID,
 		MinIdleInstances: in.MinIdleInstances, MaxCapacity: in.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: in.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         in.CustomTags,
 	})
 	if err != nil {
 		dpWriteErr(w, err)
@@ -510,6 +518,8 @@ func toPoolJSON(p *dbxdriver.InstancePool) instancePoolJSON {
 	return instancePoolJSON{
 		InstancePoolID: p.ID, InstancePoolName: p.Name, NodeTypeID: p.NodeTypeID,
 		State: p.State, MinIdleInstances: p.MinIdleInstances, MaxCapacity: p.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: p.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         p.CustomTags,
 	}
 }
 
@@ -517,6 +527,7 @@ func clusterConfig(in *clusterJSON) dbxdriver.ClusterConfig {
 	cfg := dbxdriver.ClusterConfig{
 		Name: in.ClusterName, SparkVersion: in.SparkVersion,
 		NodeTypeID: in.NodeTypeID, NumWorkers: in.NumWorkers,
+		RuntimeEngine: in.RuntimeEngine, CustomTags: in.CustomTags,
 	}
 	if in.Autoscale != nil {
 		cfg.AutoscaleMin = in.Autoscale.MinWorkers
@@ -530,6 +541,7 @@ func toClusterJSON(c *dbxdriver.Cluster) clusterJSON {
 	out := clusterJSON{
 		ClusterID: c.ID, ClusterName: c.Name, SparkVersion: c.SparkVersion,
 		NodeTypeID: c.NodeTypeID, State: c.State, NumWorkers: c.NumWorkers,
+		RuntimeEngine: c.RuntimeEngine, CustomTags: c.CustomTags,
 	}
 	if c.AutoscaleMax > 0 {
 		out.Autoscale = &autoscaleJSON{MinWorkers: c.AutoscaleMin, MaxWorkers: c.AutoscaleMax}

--- a/server/azure/databricks/queryhistory/queryhistory.go
+++ b/server/azure/databricks/queryhistory/queryhistory.go
@@ -34,10 +34,12 @@ type Handler struct{}
 // New returns a query-history handler.
 func New() *Handler { return &Handler{} }
 
-// Matches claims /api/{ver}/sql/history/queries.
+// Matches claims exactly /api/{ver}/sql/history/queries. Requiring the exact
+// segment count keeps any future sub-resource (e.g. .../queries/{id}) from
+// being swallowed and served an empty list instead of a 501.
 func (*Handler) Matches(r *http.Request) bool {
 	parts := splitPath(r.URL.Path)
-	if len(parts) < minSegs || parts[idxAPI] != "api" {
+	if len(parts) != minSegs || parts[idxAPI] != "api" {
 		return false
 	}
 

--- a/server/azure/databricks/queryhistory/queryhistory.go
+++ b/server/azure/databricks/queryhistory/queryhistory.go
@@ -1,0 +1,87 @@
+// Package queryhistory implements the Databricks SQL query-history data-plane
+// REST API (the /api/2.0/sql/history/queries surface) as a server.Handler.
+//
+// The in-memory backend does not execute SQL, so there is no query activity to
+// record — the endpoint returns an empty result set. That is enough for the
+// real github.com/databricks/databricks-sdk-go WorkspaceClient's
+// w.QueryHistory.List to succeed (it previously failed with "no handler
+// registered for this request"), which unblocks tools that probe query history
+// for idle/orphaned-warehouse detection.
+//
+// Covered endpoint:
+//
+//	GET /api/2.0/sql/history/queries
+package queryhistory
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// Path segment positions after splitting on "/": [api, ver, sql, history, queries].
+const (
+	idxAPI     = 0
+	idxSQL     = 2
+	idxHistory = 3
+	idxQueries = 4
+	minSegs    = 5
+)
+
+// Handler serves the Databricks SQL query-history endpoint.
+type Handler struct{}
+
+// New returns a query-history handler.
+func New() *Handler { return &Handler{} }
+
+// Matches claims /api/{ver}/sql/history/queries.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minSegs || parts[idxAPI] != "api" {
+		return false
+	}
+
+	return parts[idxSQL] == "sql" && parts[idxHistory] == "history" && parts[idxQueries] == "queries"
+}
+
+// listResponse mirrors sql.ListQueriesResponse.
+type listResponse struct {
+	Res           []any  `json:"res"`
+	HasNextPage   bool   `json:"has_next_page"`
+	NextPageToken string `json:"next_page_token,omitempty"`
+}
+
+// ServeHTTP returns an empty query-history page. Real Databricks records
+// executed queries; the in-memory backend runs none, so the list is empty.
+func (*Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(listResponse{Res: []any{}, HasNextPage: false})
+}
+
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}

--- a/server/azure/databricks/queryhistory/queryhistory_roundtrip_test.go
+++ b/server/azure/databricks/queryhistory/queryhistory_roundtrip_test.go
@@ -1,0 +1,51 @@
+package queryhistory_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/queryhistory"
+)
+
+func newClient(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(queryhistory.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+// TestSDKQueryHistoryList pins issue #223: w.QueryHistory.List previously
+// returned "no handler registered". It must now succeed (with an empty result,
+// since the in-memory backend runs no queries).
+func TestSDKQueryHistoryList(t *testing.T) {
+	w := newClient(t)
+
+	res, err := w.QueryHistory.List(context.Background(), sql.ListQueryHistoryRequest{})
+	if err != nil {
+		t.Fatalf("QueryHistory.List: %v", err)
+	}
+
+	if len(res.Res) != 0 {
+		t.Fatalf("got %d query-history entries, want 0", len(res.Res))
+	}
+}

--- a/server/azure/databricks/sqlwarehouses/sqlwarehouses.go
+++ b/server/azure/databricks/sqlwarehouses/sqlwarehouses.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -68,6 +69,53 @@ type warehouse struct {
 	CreatorName             string
 	WarehouseType           string
 	SpotInstancePolicy      string
+	Tags                    map[string]string
+}
+
+// endpointTagPair / endpointTags mirror sql.EndpointTagPair / sql.EndpointTags
+// — the wire shape of a warehouse's "tags" object.
+type endpointTagPair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type endpointTags struct {
+	CustomTags []endpointTagPair `json:"custom_tags"`
+}
+
+func (t *endpointTags) toMap() map[string]string {
+	if t == nil || len(t.CustomTags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(t.CustomTags))
+	for _, p := range t.CustomTags {
+		out[p.Key] = p.Value
+	}
+
+	return out
+}
+
+// tagsToWire renders a tag map back into the {custom_tags: [{key,value}]} wire
+// shape, with keys sorted so the output is deterministic.
+func tagsToWire(tags map[string]string) *endpointTags {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	pairs := make([]endpointTagPair, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, endpointTagPair{Key: k, Value: tags[k]})
+	}
+
+	return &endpointTags{CustomTags: pairs}
 }
 
 // Handler serves the Databricks SQL Warehouses data-plane REST API.
@@ -164,17 +212,20 @@ func (h *Handler) serveItemAction(w http.ResponseWriter, r *http.Request, id, ac
 }
 
 // createRequest is the subset of CreateWarehouseRequest fields we honor.
+// AutoStopMins is a pointer so an explicit 0 (disable auto-stop) is
+// distinguishable from an omitted field (which gets the default).
 type createRequest struct {
-	Name                    string `json:"name"`
-	ClusterSize             string `json:"cluster_size"`
-	AutoStopMins            int    `json:"auto_stop_mins"`
-	MaxNumClusters          int    `json:"max_num_clusters"`
-	MinNumClusters          int    `json:"min_num_clusters"`
-	EnablePhoton            bool   `json:"enable_photon"`
-	EnableServerlessCompute bool   `json:"enable_serverless_compute"`
-	CreatorName             string `json:"creator_name"`
-	WarehouseType           string `json:"warehouse_type"`
-	SpotInstancePolicy      string `json:"spot_instance_policy"`
+	Name                    string        `json:"name"`
+	ClusterSize             string        `json:"cluster_size"`
+	AutoStopMins            *int          `json:"auto_stop_mins"`
+	MaxNumClusters          int           `json:"max_num_clusters"`
+	MinNumClusters          int           `json:"min_num_clusters"`
+	EnablePhoton            bool          `json:"enable_photon"`
+	EnableServerlessCompute bool          `json:"enable_serverless_compute"`
+	CreatorName             string        `json:"creator_name"`
+	WarehouseType           string        `json:"warehouse_type"`
+	SpotInstancePolicy      string        `json:"spot_instance_policy"`
+	Tags                    *endpointTags `json:"tags"`
 }
 
 func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
@@ -208,7 +259,6 @@ func newWarehouse(req *createRequest) *warehouse {
 		Name:                    req.Name,
 		ClusterSize:             req.ClusterSize,
 		State:                   stateRunning,
-		AutoStopMins:            req.AutoStopMins,
 		MaxNumClusters:          req.MaxNumClusters,
 		MinNumClusters:          req.MinNumClusters,
 		EnablePhoton:            req.EnablePhoton,
@@ -216,14 +266,19 @@ func newWarehouse(req *createRequest) *warehouse {
 		CreatorName:             req.CreatorName,
 		WarehouseType:           req.WarehouseType,
 		SpotInstancePolicy:      req.SpotInstancePolicy,
+		Tags:                    req.Tags.toMap(),
 	}
 
 	if wh.ClusterSize == "" {
 		wh.ClusterSize = defaultClusterSize
 	}
 
-	if wh.AutoStopMins == 0 {
+	// A nil AutoStopMins means the field was omitted — apply the default. An
+	// explicit value (including 0, which disables auto-stop) is honored as-is.
+	if req.AutoStopMins == nil {
 		wh.AutoStopMins = defaultAutoStopMins
+	} else {
+		wh.AutoStopMins = *req.AutoStopMins
 	}
 
 	if wh.MaxNumClusters == 0 {
@@ -272,12 +327,14 @@ func (h *Handler) list(w http.ResponseWriter) {
 }
 
 // editRequest is the subset of EditWarehouseRequest fields we honor.
+// AutoStopMins is a pointer for the same explicit-0 reason as createRequest.
 type editRequest struct {
-	Name           string `json:"name"`
-	ClusterSize    string `json:"cluster_size"`
-	AutoStopMins   int    `json:"auto_stop_mins"`
-	MaxNumClusters int    `json:"max_num_clusters"`
-	MinNumClusters int    `json:"min_num_clusters"`
+	Name           string        `json:"name"`
+	ClusterSize    string        `json:"cluster_size"`
+	AutoStopMins   *int          `json:"auto_stop_mins"`
+	MaxNumClusters int           `json:"max_num_clusters"`
+	MinNumClusters int           `json:"min_num_clusters"`
+	Tags           *endpointTags `json:"tags"`
 }
 
 func (h *Handler) edit(w http.ResponseWriter, r *http.Request, id string) {
@@ -312,8 +369,8 @@ func applyEdit(wh *warehouse, req editRequest) {
 		wh.ClusterSize = req.ClusterSize
 	}
 
-	if req.AutoStopMins != 0 {
-		wh.AutoStopMins = req.AutoStopMins
+	if req.AutoStopMins != nil {
+		wh.AutoStopMins = *req.AutoStopMins
 	}
 
 	if req.MaxNumClusters != 0 {
@@ -322,6 +379,10 @@ func applyEdit(wh *warehouse, req editRequest) {
 
 	if req.MinNumClusters != 0 {
 		wh.MinNumClusters = req.MinNumClusters
+	}
+
+	if tags := req.Tags.toMap(); tags != nil {
+		wh.Tags = tags
 	}
 }
 
@@ -375,7 +436,7 @@ func (h *Handler) transition(w http.ResponseWriter, id, state string) {
 // toResponse renders a warehouse as the GetWarehouseResponse / EndpointInfo JSON
 // shape shared by Get and List.
 func toResponse(wh *warehouse) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"id":                        wh.ID,
 		"name":                      wh.Name,
 		"cluster_size":              wh.ClusterSize,
@@ -390,6 +451,12 @@ func toResponse(wh *warehouse) map[string]any {
 		"warehouse_type":            wh.WarehouseType,
 		"spot_instance_policy":      wh.SpotInstancePolicy,
 	}
+
+	if tags := tagsToWire(wh.Tags); tags != nil {
+		out["tags"] = tags
+	}
+
+	return out
 }
 
 // splitPath strips the leading/trailing "/" and returns the path segments.

--- a/server/azure/databricks/sqlwarehouses/sqlwarehouses_roundtrip_test.go
+++ b/server/azure/databricks/sqlwarehouses/sqlwarehouses_roundtrip_test.go
@@ -169,3 +169,40 @@ func TestSDKWarehouseListEmpty(t *testing.T) {
 		t.Fatalf("got %d warehouses, want 0", len(all))
 	}
 }
+
+// TestSDKWarehouseAutoStopZeroAndTags pins issue #223: an explicit
+// auto_stop_mins of 0 (disable auto-stop) must be honored instead of being
+// replaced by the default, and warehouse tags must round-trip.
+func TestSDKWarehouseAutoStopZeroAndTags(t *testing.T) {
+	w := newWarehouseClient(t)
+	ctx := context.Background()
+
+	wait, err := w.Warehouses.Create(ctx, sql.CreateWarehouseRequest{
+		Name:         "wh-zero",
+		ClusterSize:  "Small",
+		AutoStopMins: 0,
+		// ForceSendFields makes the SDK serialize the zero value instead of
+		// omitting it — that's how a caller disables auto-stop on the wire.
+		ForceSendFields: []string{"AutoStopMins"},
+		Tags: &sql.EndpointTags{
+			CustomTags: []sql.EndpointTagPair{{Key: "team", Value: "data"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := w.Warehouses.GetById(ctx, wait.Id)
+	if err != nil {
+		t.Fatalf("GetById: %v", err)
+	}
+
+	if got.AutoStopMins != 0 {
+		t.Fatalf("auto_stop_mins: got %d, want 0 (explicit disable must be honored)", got.AutoStopMins)
+	}
+
+	if got.Tags == nil || len(got.Tags.CustomTags) != 1 ||
+		got.Tags.CustomTags[0].Key != "team" || got.Tags.CustomTags[0].Value != "data" {
+		t.Fatalf("tags: got %+v, want custom_tags [{team data}]", got.Tags)
+	}
+}


### PR DESCRIPTION
Fixes #223.

## Summary

Several Databricks data-plane fields were silently dropped on a create→list round-trip, and `QueryHistory.List` had no handler. Cost/governance tooling keys decisions off exactly these fields, so the gaps blocked those code paths against the emulator.

## Fixes

**Fields not preserved** — the values were dropped because the fields didn't exist on the driver / wire structs. Added them end-to-end (driver → provider → wire):

| Resource | Field |
|----------|-------|
| cluster | `custom_tags`, `runtime_engine` |
| instance pool | `idle_instance_autotermination_minutes`, `custom_tags` |
| SQL warehouse | `tags` (`custom_tags`) |

**SQL warehouse `auto_stop_mins`** — an explicit `0` (disable auto-stop) was being overwritten by the default `120`, because the handler couldn't tell "unset" from "explicit 0". `auto_stop_mins` is now a pointer in the create/edit requests, so `0` is honored and an omitted field still gets the default.

**QueryHistory** — `w.QueryHistory.List` returned "no handler registered". Added a handler for `GET /api/2.0/sql/history/queries` that returns an empty result set (the in-memory backend executes no SQL, so there's no history to record) — enough for the SDK call to succeed.

## Tests

Real-`databricks-sdk-go` round-trip tests for each: cluster tags + runtime engine, pool idle-autotermination + tags, warehouse explicit `auto_stop_mins=0` + tags (using `ForceSendFields` so the SDK serializes the zero), and `QueryHistory.List`. `go build`, all data-plane package tests, and `golangci-lint` clean.