### PR TITLE
v1.8.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,6 +157,12 @@ linters:
           - goconst
           - mnd
         path: _test\.go
+      # The SageMaker SDK-compat handlers are ~100 near-identical decode/encode
+      # shims (one per operation); dupl flags the shared shape, which is
+      # intentional boilerplate, not extractable logic.
+      - linters:
+          - dupl
+        path: server/aws/sagemaker/
       - linters:
           - revive
         text: "exported (.+) should have comment" # TODO fix errors reported by this and remove this line

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -157,12 +157,6 @@ linters:
           - goconst
           - mnd
         path: _test\.go
-      # The SageMaker SDK-compat handlers are ~100 near-identical decode/encode
-      # shims (one per operation); dupl flags the shared shape, which is
-      # intentional boilerplate, not extractable logic.
-      - linters:
-          - dupl
-        path: server/aws/sagemaker/
       - linters:
           - revive
         text: "exported (.+) should have comment" # TODO fix errors reported by this and remove this line

--- a/chaos/wrappers_sagemaker.go
+++ b/chaos/wrappers_sagemaker.go
@@ -1,0 +1,92 @@
+package chaos
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// chaosSageMaker wraps a SageMaker service. It consults the engine on the
+// calls most worth failing in tests — job submission, endpoint creation, the
+// inference runtime, and the Feature Store online store — and delegates every
+// other operation through the embedded driver.Service unchanged.
+type chaosSageMaker struct {
+	driver.Service
+	engine *Engine
+}
+
+// WrapSageMaker returns a SageMaker service that injects chaos on submission
+// and runtime calls. service+operation pairs use the "sagemaker" service name.
+func WrapSageMaker(inner driver.Service, engine *Engine) driver.Service {
+	return &chaosSageMaker{Service: inner, engine: engine}
+}
+
+//nolint:gocritic // cfg matches the driver signature; delegated unchanged on success.
+func (c *chaosSageMaker) CreateTrainingJob(ctx context.Context, cfg driver.TrainingJobConfig) (*driver.TrainingJob, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "CreateTrainingJob"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.CreateTrainingJob(ctx, cfg)
+}
+
+//nolint:gocritic // cfg matches the driver signature; delegated unchanged on success.
+func (c *chaosSageMaker) CreateProcessingJob(ctx context.Context, cfg driver.ProcessingJobConfig) (*driver.ProcessingJob, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "CreateProcessingJob"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.CreateProcessingJob(ctx, cfg)
+}
+
+//nolint:gocritic // cfg matches the driver signature; delegated unchanged on success.
+func (c *chaosSageMaker) CreateTransformJob(ctx context.Context, cfg driver.TransformJobConfig) (*driver.TransformJob, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "CreateTransformJob"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.CreateTransformJob(ctx, cfg)
+}
+
+func (c *chaosSageMaker) CreateEndpoint(ctx context.Context, cfg driver.EndpointSpec) (*driver.Endpoint, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "CreateEndpoint"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.CreateEndpoint(ctx, cfg)
+}
+
+//nolint:gocritic // in matches the driver signature; delegated unchanged on success.
+func (c *chaosSageMaker) InvokeEndpoint(ctx context.Context, in driver.InvokeEndpointInput) (*driver.InvokeEndpointOutput, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "InvokeEndpoint"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.InvokeEndpoint(ctx, in)
+}
+
+func (c *chaosSageMaker) InvokeEndpointAsync(
+	ctx context.Context, in driver.InvokeEndpointAsyncInput,
+) (*driver.InvokeEndpointAsyncOutput, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "InvokeEndpointAsync"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.InvokeEndpointAsync(ctx, in)
+}
+
+func (c *chaosSageMaker) PutRecord(ctx context.Context, groupName string, record []driver.FeatureValue) error {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "PutRecord"); err != nil {
+		return err
+	}
+
+	return c.Service.PutRecord(ctx, groupName, record)
+}
+
+func (c *chaosSageMaker) GetRecord(ctx context.Context, groupName, recordID string) ([]driver.FeatureValue, error) {
+	if err := applyChaos(ctx, c.engine, "sagemaker", "GetRecord"); err != nil {
+		return nil, err
+	}
+
+	return c.Service.GetRecord(ctx, groupName, recordID)
+}

--- a/chaos/wrappers_sagemaker_test.go
+++ b/chaos/wrappers_sagemaker_test.go
@@ -1,0 +1,73 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+func newChaosSageMaker(t *testing.T) (driver.Service, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapSageMaker(cloudemu.NewAWS().SageMaker, e), e
+}
+
+func TestWrapSageMakerCreateTrainingJobChaos(t *testing.T) {
+	sm, e := newChaosSageMaker(t)
+	ctx := context.Background()
+
+	if _, err := sm.CreateTrainingJob(ctx, driver.TrainingJobConfig{JobName: "j1"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("sagemaker", time.Hour))
+
+	if _, err := sm.CreateTrainingJob(ctx, driver.TrainingJobConfig{JobName: "j2"}); err == nil {
+		t.Error("expected chaos error on CreateTrainingJob")
+	}
+}
+
+func TestWrapSageMakerInvokeEndpointChaos(t *testing.T) {
+	sm, e := newChaosSageMaker(t)
+	ctx := context.Background()
+
+	_, _ = sm.CreateModel(ctx, driver.ModelConfig{ModelName: "m"})
+	_, _ = sm.CreateEndpointConfig(ctx, driver.EndpointConfigSpec{
+		ConfigName:         "cfg",
+		ProductionVariants: []driver.ProductionVariant{{VariantName: "v1", ModelName: "m"}},
+	})
+	if _, err := sm.CreateEndpoint(ctx, driver.EndpointSpec{EndpointName: "ep", ConfigName: "cfg"}); err != nil {
+		t.Fatalf("create endpoint: %v", err)
+	}
+
+	if _, err := sm.InvokeEndpoint(ctx, driver.InvokeEndpointInput{EndpointName: "ep", Body: []byte("x")}); err != nil {
+		t.Fatalf("baseline invoke: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("sagemaker", time.Hour))
+
+	if _, err := sm.InvokeEndpoint(ctx, driver.InvokeEndpointInput{EndpointName: "ep", Body: []byte("x")}); err == nil {
+		t.Error("expected chaos error on InvokeEndpoint")
+	}
+}
+
+func TestWrapSageMakerNonChaosOpsDelegate(t *testing.T) {
+	sm, e := newChaosSageMaker(t)
+	ctx := context.Background()
+
+	// A control-plane outage targets "sagemaker"; an unrelated outage must not
+	// affect delegated reads.
+	e.Apply(chaos.ServiceOutage("storage", time.Hour))
+
+	if _, err := sm.CreateModel(ctx, driver.ModelConfig{ModelName: "ok"}); err != nil {
+		t.Fatalf("delegated CreateModel should not be affected: %v", err)
+	}
+}

--- a/chaos/wrappers_vertexai.go
+++ b/chaos/wrappers_vertexai.go
@@ -1,0 +1,127 @@
+package chaos
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// chaosVertexAI wraps a Vertex AI service. It consults the engine on the calls
+// most worth failing in tests — job and pipeline submission, model deployment,
+// the online prediction and generateContent runtimes, and Feature Store online
+// serving — and delegates every other operation through the embedded
+// driver.VertexAI unchanged.
+type chaosVertexAI struct {
+	driver.VertexAI
+	engine *Engine
+}
+
+// WrapVertexAI returns a Vertex AI service that injects chaos on submission and
+// runtime calls. service+operation pairs use the "vertexai" service name.
+func WrapVertexAI(inner driver.VertexAI, engine *Engine) driver.VertexAI {
+	return &chaosVertexAI{VertexAI: inner, engine: engine}
+}
+
+func (c *chaosVertexAI) CreateCustomJob(ctx context.Context, cfg driver.CustomJobConfig) (*driver.CustomJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateCustomJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateCustomJob(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreateHyperparameterTuningJob(
+	ctx context.Context, cfg driver.HyperparameterTuningJobConfig,
+) (*driver.HyperparameterTuningJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateHyperparameterTuningJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateHyperparameterTuningJob(ctx, cfg)
+}
+
+//nolint:gocritic // cfg matches the driver signature; delegated unchanged on success.
+func (c *chaosVertexAI) CreateBatchPredictionJob(
+	ctx context.Context, cfg driver.BatchPredictionJobConfig,
+) (*driver.BatchPredictionJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateBatchPredictionJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateBatchPredictionJob(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreateTrainingPipeline(
+	ctx context.Context, cfg driver.TrainingPipelineConfig,
+) (*driver.TrainingPipeline, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateTrainingPipeline"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateTrainingPipeline(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreatePipelineJob(ctx context.Context, cfg driver.PipelineJobConfig) (*driver.PipelineJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreatePipelineJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreatePipelineJob(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreateTuningJob(ctx context.Context, cfg driver.TuningJobConfig) (*driver.TuningJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateTuningJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateTuningJob(ctx, cfg)
+}
+
+//nolint:gocritic // dm matches the driver signature; delegated unchanged on success.
+func (c *chaosVertexAI) DeployModel(
+	ctx context.Context, endpoint string, dm driver.DeployedModel,
+) (*driver.Operation, *driver.Endpoint, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "DeployModel"); err != nil {
+		return nil, nil, err
+	}
+
+	return c.VertexAI.DeployModel(ctx, endpoint, dm)
+}
+
+func (c *chaosVertexAI) Predict(ctx context.Context, req driver.PredictRequest) (*driver.PredictResponse, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "Predict"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.Predict(ctx, req)
+}
+
+func (c *chaosVertexAI) GenerateContent(
+	ctx context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.GenerateContentResponse, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "GenerateContent"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.GenerateContent(ctx, model, req)
+}
+
+func (c *chaosVertexAI) WriteFeatureValues(
+	ctx context.Context, entityType, entityID string, values []driver.FeatureNameValue,
+) error {
+	if err := applyChaos(ctx, c.engine, "vertexai", "WriteFeatureValues"); err != nil {
+		return err
+	}
+
+	return c.VertexAI.WriteFeatureValues(ctx, entityType, entityID, values)
+}
+
+func (c *chaosVertexAI) FetchFeatureValues(
+	ctx context.Context, featureView, entityID string,
+) ([]driver.FeatureNameValue, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "FetchFeatureValues"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.FetchFeatureValues(ctx, featureView, entityID)
+}

--- a/chaos/wrappers_vertexai_test.go
+++ b/chaos/wrappers_vertexai_test.go
@@ -1,0 +1,67 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func newChaosVertexAI(t *testing.T) (driver.VertexAI, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapVertexAI(cloudemu.NewGCP().VertexAI, e), e
+}
+
+func TestWrapVertexAICreateCustomJobChaos(t *testing.T) {
+	v, e := newChaosVertexAI(t)
+	ctx := context.Background()
+
+	if _, err := v.CreateCustomJob(ctx, driver.CustomJobConfig{Location: "us-central1", DisplayName: "j1"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("vertexai", time.Hour))
+
+	if _, err := v.CreateCustomJob(ctx, driver.CustomJobConfig{Location: "us-central1", DisplayName: "j2"}); err == nil {
+		t.Error("expected chaos error on CreateCustomJob")
+	}
+}
+
+func TestWrapVertexAIGenerateContentChaos(t *testing.T) {
+	v, e := newChaosVertexAI(t)
+	ctx := context.Background()
+
+	req := driver.GenerateContentRequest{
+		Contents: []driver.Content{{Role: "user", Parts: []driver.Part{{Text: "hi there"}}}},
+	}
+
+	if _, err := v.GenerateContent(ctx, "gemini-2.5-pro", req); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("vertexai", time.Hour))
+
+	if _, err := v.GenerateContent(ctx, "gemini-2.5-pro", req); err == nil {
+		t.Error("expected chaos error on GenerateContent")
+	}
+}
+
+func TestWrapVertexAIUnwrappedOperationPassesThrough(t *testing.T) {
+	v, e := newChaosVertexAI(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("vertexai", time.Hour))
+
+	// ListModels is not a chaos-wrapped operation; it must still succeed.
+	if _, err := v.ListModels(ctx, "us-central1"); err != nil {
+		t.Errorf("unwrapped ListModels should pass through, got: %v", err)
+	}
+}

--- a/cost/cost.go
+++ b/cost/cost.go
@@ -89,6 +89,21 @@ func defaultRates() map[string]float64 {
 		"sagemaker:InvokeEndpoint":                0.0,    // bundled into hosting hours
 		"sagemaker:CreateNotebookInstance":        0.0464, // ml.t3.medium-equivalent instance-hour
 		"sagemaker:CreateModel":                   0.0,
+
+		// Vertex AI (training/pipelines per node-hour, online prediction and
+		// generateContent per request/call, registry resources free)
+		"vertexai:CreateCustomJob":               0.19, // n1-standard-4-equivalent node-hour
+		"vertexai:CreateHyperparameterTuningJob": 0.19,
+		"vertexai:CreateTrainingPipeline":        0.19,
+		"vertexai:CreatePipelineJob":             0.03, // pipeline run execution
+		"vertexai:CreateBatchPredictionJob":      0.19,
+		"vertexai:CreateTuningJob":               0.19,
+		"vertexai:DeployModel":                   0.19,     // online prediction node-hour
+		"vertexai:Predict":                       0.0,      // bundled into deployed node-hours
+		"vertexai:GenerateContent":               0.000125, // per 1K input chars-equivalent call
+		"vertexai:AssignNotebookRuntime":         0.15,     // managed notebook node-hour
+		"vertexai:CreateModel":                   0.0,
+		"vertexai:CreateEndpoint":                0.0,
 	}
 }
 

--- a/cost/cost.go
+++ b/cost/cost.go
@@ -78,6 +78,17 @@ func defaultRates() map[string]float64 {
 		// IAM (free)
 		"iam:CreateUser":      0.0,
 		"iam:CheckPermission": 0.0,
+
+		// SageMaker (training/processing per instance-hour, hosting per
+		// instance-hour, inference per request)
+		"sagemaker:CreateTrainingJob":             0.115, // ml.m5.large-equivalent instance-hour
+		"sagemaker:CreateProcessingJob":           0.115,
+		"sagemaker:CreateTransformJob":            0.115,
+		"sagemaker:CreateHyperParameterTuningJob": 0.115,
+		"sagemaker:CreateEndpoint":                0.115,  // real-time hosting instance-hour
+		"sagemaker:InvokeEndpoint":                0.0,    // bundled into hosting hours
+		"sagemaker:CreateNotebookInstance":        0.0464, // ml.t3.medium-equivalent instance-hour
+		"sagemaker:CreateModel":                   0.0,
 	}
 }
 

--- a/databricks/dataplane.go
+++ b/databricks/dataplane.go
@@ -151,6 +151,8 @@ func (d *DataPlane) DeleteInstancePool(ctx context.Context, id string) error {
 }
 
 // CreateCluster creates a cluster.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (d *DataPlane) CreateCluster(ctx context.Context, cfg driver.ClusterConfig) (*driver.Cluster, error) {
 	out, err := d.do(ctx, "CreateCluster", cfg, func() (any, error) { return d.driver.CreateCluster(ctx, cfg) })
 	if err != nil {
@@ -181,6 +183,8 @@ func (d *DataPlane) ListClusters(ctx context.Context) ([]driver.Cluster, error) 
 }
 
 // EditCluster updates a cluster.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (d *DataPlane) EditCluster(ctx context.Context, id string, cfg driver.ClusterConfig) error {
 	_, err := d.do(ctx, "EditCluster", id, func() (any, error) { return nil, d.driver.EditCluster(ctx, id, cfg) })
 

--- a/databricks/driver/dataplane.go
+++ b/databricks/driver/dataplane.go
@@ -16,6 +16,10 @@ const (
 	ClusterTerminated = "TERMINATED"
 )
 
+// ClusterSourceAPI is the cluster_source reported for clusters created through
+// the API surface (the only path the in-memory backend offers).
+const ClusterSourceAPI = "API"
+
 // InstancePoolConfig describes an instance pool to create or edit.
 type InstancePoolConfig struct {
 	Name                               string
@@ -40,28 +44,38 @@ type InstancePool struct {
 
 // ClusterConfig describes a cluster to create or edit.
 type ClusterConfig struct {
-	Name          string
-	SparkVersion  string
-	NodeTypeID    string
-	NumWorkers    int32
-	AutoscaleMin  int32
-	AutoscaleMax  int32
-	RuntimeEngine string
-	CustomTags    map[string]string
+	Name              string
+	SparkVersion      string
+	NodeTypeID        string
+	NumWorkers        int32
+	AutoscaleMin      int32
+	AutoscaleMax      int32
+	RuntimeEngine     string
+	CustomTags        map[string]string
+	PolicyID          string
+	InstancePoolID    string
+	AzureAvailability string
 }
 
 // Cluster describes a compute cluster.
 type Cluster struct {
-	ID            string
-	Name          string
-	SparkVersion  string
-	NodeTypeID    string
-	State         string
-	NumWorkers    int32
-	AutoscaleMin  int32
-	AutoscaleMax  int32
-	RuntimeEngine string
-	CustomTags    map[string]string
+	ID                string
+	Name              string
+	SparkVersion      string
+	NodeTypeID        string
+	State             string
+	NumWorkers        int32
+	AutoscaleMin      int32
+	AutoscaleMax      int32
+	RuntimeEngine     string
+	CustomTags        map[string]string
+	PolicyID          string
+	InstancePoolID    string
+	AzureAvailability string
+	// ClusterSource is assigned by the backend, not the caller. Real Databricks
+	// reports how the cluster was created (API / UI / JOB); the in-memory
+	// backend always creates via the API surface, so it reports "API".
+	ClusterSource string
 	Pinned        bool
 }
 

--- a/databricks/driver/dataplane.go
+++ b/databricks/driver/dataplane.go
@@ -18,43 +18,51 @@ const (
 
 // InstancePoolConfig describes an instance pool to create or edit.
 type InstancePoolConfig struct {
-	Name             string
-	NodeTypeID       string
-	MinIdleInstances int32
-	MaxCapacity      int32
+	Name                               string
+	NodeTypeID                         string
+	MinIdleInstances                   int32
+	MaxCapacity                        int32
+	IdleInstanceAutoterminationMinutes int32
+	CustomTags                         map[string]string
 }
 
 // InstancePool describes an instance pool.
 type InstancePool struct {
-	ID               string
-	Name             string
-	NodeTypeID       string
-	State            string
-	MinIdleInstances int32
-	MaxCapacity      int32
+	ID                                 string
+	Name                               string
+	NodeTypeID                         string
+	State                              string
+	MinIdleInstances                   int32
+	MaxCapacity                        int32
+	IdleInstanceAutoterminationMinutes int32
+	CustomTags                         map[string]string
 }
 
 // ClusterConfig describes a cluster to create or edit.
 type ClusterConfig struct {
-	Name         string
-	SparkVersion string
-	NodeTypeID   string
-	NumWorkers   int32
-	AutoscaleMin int32
-	AutoscaleMax int32
+	Name          string
+	SparkVersion  string
+	NodeTypeID    string
+	NumWorkers    int32
+	AutoscaleMin  int32
+	AutoscaleMax  int32
+	RuntimeEngine string
+	CustomTags    map[string]string
 }
 
 // Cluster describes a compute cluster.
 type Cluster struct {
-	ID           string
-	Name         string
-	SparkVersion string
-	NodeTypeID   string
-	State        string
-	NumWorkers   int32
-	AutoscaleMin int32
-	AutoscaleMax int32
-	Pinned       bool
+	ID            string
+	Name          string
+	SparkVersion  string
+	NodeTypeID    string
+	State         string
+	NumWorkers    int32
+	AutoscaleMin  int32
+	AutoscaleMax  int32
+	RuntimeEngine string
+	CustomTags    map[string]string
+	Pinned        bool
 }
 
 // NodeType describes an available compute node type.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1372,10 +1372,15 @@ field). Auto-metrics → Cloud Monitoring via `SetMonitoring`.
 | Vector Search | Index (+upsert/remove datapoints), IndexEndpoint (+deploy/undeploy/findNeighbors) |
 | ML Metadata | MetadataStore, Tensorboard, Schedule, NotebookRuntimeTemplate, NotebookRuntime |
 
-The full Go API/driver and in-memory provider cover every family above. SDK-compat HTTP
-(REST round-tripped) currently spans models, endpoints (+predict), datasets, custom &
-batch-prediction jobs and `generateContent`/`countTokens`; the remaining families' handlers
-follow the same wire pattern as the next increment. **Total: 128 operations** (Go API/driver).
+The full Go API/driver, in-memory provider, and SDK-compat HTTP server (REST round-tripped)
+cover every family above — models (+versions/evaluations), endpoints (+predict), datasets,
+custom/batch-prediction/hyperparameter-tuning jobs, training & pipeline jobs, tuning jobs,
+cached contents, Feature Store (featurestores/entityTypes/features + online read/write),
+Feature Registry & online stores, Vector Search (indexes + index endpoints), ML metadata,
+tensorboards, schedules, notebook runtimes, and `generateContent`/`countTokens`. A portable
+Layer-1 wrapper (`vertexai/vertexai.go`), chaos injection (`chaos.WrapVertexAI`), and cost
+rates integrate Vertex with the cross-cutting layers like every other service.
+**Total: 128 operations** (Go API/driver).
 
 ---
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -27,6 +27,7 @@ This document lists every service and operation available in CloudEmu across all
 | 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
 | 20 | Generative AI | `bedrock` (+ `bedrock-runtime`) | — | — |
 | 21 | Databricks | — | `databricks` | — |
+| 22 | Machine Learning | _(planned: SageMaker)_ | _(planned: Azure ML / AI Foundry)_ | `vertexai` |
 
 ---
 
@@ -1322,6 +1323,37 @@ Azure-only. The control plane backs the real `armdatabricks` SDK; the data plane
 
 ---
 
+## 22. Machine Learning
+
+**Driver interface:** `vertexai/driver/` | **AWS:** _planned (SageMaker)_ | **Azure:** _planned (Azure ML / AI Foundry)_ | **GCP:** GCP Vertex AI (`aiplatform.googleapis.com`)
+
+GCP-first. The REST surface is rooted at `/v1/projects/{p}/locations/{l}/...` with the
+Model Garden `generateContent` surface at `/v1/publishers/...`. Control-plane mutations
+return done `google.longrunning.Operation`s; job-family creates are synchronous (poll the
+`state` field). Auto-metrics are pushed to Cloud Monitoring via `SetMonitoring`.
+
+| Family | Resources / Operations |
+|--------|------------------------|
+| Datasets | Create/Get/List/Patch/Delete (+ImportData/ExportData) |
+| Model registry | UploadModel, Get/List/Patch/Delete, versions, evaluations |
+| Endpoints | Create/Get/List/Delete, DeployModel/UndeployModel, Predict/RawPredict |
+| Generative AI | generateContent, countTokens (publishers.models + endpoints), tuning jobs, cached contents |
+| Jobs | CustomJob, BatchPredictionJob, HyperparameterTuningJob (synchronous create + cancel) |
+| Pipelines | TrainingPipeline, PipelineJob |
+| Feature Store | FeatureGroup, Feature, FeatureOnlineStore, FeatureView (+fetchFeatureValues) |
+| Vector Search | Index (+upsert/remove datapoints), IndexEndpoint (+deploy/undeploy/findNeighbors) |
+| ML Metadata | MetadataStore, Tensorboard, Schedule, NotebookRuntimeTemplate, NotebookRuntime |
+| Operations | GetOperation / ListOperations (Go API) |
+
+The full Go API/driver and in-memory provider cover every family above. SDK-compat HTTP
+(REST round-tripped) currently spans models, endpoints (+predict), datasets, custom &
+batch-prediction jobs and `generateContent`/`countTokens`; the remaining families'
+handlers follow the same wire pattern as the next increment.
+
+**Total: 118 operations** (Go API/driver)
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -1350,4 +1382,5 @@ Azure-only. The control plane backs the real `armdatabricks` SDK; the data plane
 | Resource Discovery (engine + AWS + Azure + GCP handlers) | 26 |
 | Generative AI — AWS Bedrock | 22 |
 | Databricks — Azure (control + data plane) | 52 |
-| **Grand Total** | **572** |
+| Machine Learning — GCP Vertex AI (Go API/driver) | 118 |
+| **Grand Total** | **690** |

--- a/docs/services.md
+++ b/docs/services.md
@@ -25,6 +25,7 @@ This document lists every service and operation available in CloudEmu across all
 | 17 | Relational Database | `rds` (+ Aurora/Neptune/DocumentDB engines), `redshift` | `azuresql`, `postgresflex`, `mysqlflex` | `cloudsql` |
 | 18 | Kubernetes | `eks` + shared `kubernetes/` | `aks` + shared `kubernetes/` | `gke` + shared `kubernetes/` |
 | 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
+| 20 | Machine Learning | `sagemaker` (+ `sagemaker-runtime`) | _(planned: Azure ML / AI Foundry)_ | _(planned: Vertex AI)_ |
 
 ---
 
@@ -1149,6 +1150,38 @@ Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups T
 
 ---
 
+## 20. Machine Learning
+
+**Driver interface:** `sagemaker/driver/driver.go` (control plane + `Runtime`)
+**AWS:** SageMaker AI (+ sagemaker-runtime) | **Azure:** _planned_ | **GCP:** _planned_
+
+AWS-only today. The control plane speaks awsJson1_1 (`X-Amz-Target: SageMaker.*`); the
+runtime speaks restJson1 (`POST /endpoints/{name}/invocations`). Asynchronous jobs
+complete synchronously to a terminal state so Describe/List are deterministic. Auto-metrics
+are pushed to CloudWatch via `SetMonitoring`.
+
+| Family | Resources / Operations |
+|--------|------------------------|
+| Jobs | Training, Processing, Transform, HyperParameterTuning, AutoML (V2), Labeling, Compilation — each Create/Describe/List/Stop |
+| Inference | Model, EndpointConfig, Endpoint (+ UpdateEndpoint, UpdateEndpointWeightsAndCapacities), InferenceComponent |
+| Runtime | InvokeEndpoint, InvokeEndpointAsync (sagemaker-runtime) |
+| Model Registry | ModelPackageGroup, ModelPackage (versioned, approval status) |
+| Studio | Domain, UserProfile, Space, App |
+| Notebooks | NotebookInstance (+ Start/Stop), NotebookInstanceLifecycleConfig, CodeRepository |
+| Clusters | HyperPod Cluster (+ ListClusterNodes / DescribeClusterNode) |
+| Feature Store | FeatureGroup + online-store runtime (PutRecord / GetRecord / DeleteRecord) |
+| Pipelines | Pipeline (+ executions), Experiment, Trial |
+| Tagging | AddTags / ListTags / DeleteTags |
+
+SDK-compat HTTP coverage (real `aws-sdk-go-v2/service/sagemaker` + `sagemakerruntime`
+round-tripped): Model, EndpointConfig, Endpoint, TrainingJob, InvokeEndpoint, tagging. The
+remaining families are served by the Go API/driver; their SDK-compat handlers follow the
+same wire pattern and are the next increment.
+
+**Total: 121 operations** (Go API/driver)
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -1175,4 +1208,5 @@ Operations: **Engine 8** + **AWS Resource Explorer 1** + **AWS Resource Groups T
 | Kubernetes — GCP GKE (control plane) | 26 |
 | Kubernetes — data plane (8 resources × 7 verbs incl. Watch) | 56 |
 | Resource Discovery (engine + AWS + Azure + GCP handlers) | 26 |
-| **Grand Total** | **498** |
+| Machine Learning — AWS SageMaker (control plane + runtime) | 121 |
+| **Grand Total** | **619** |

--- a/docs/services.md
+++ b/docs/services.md
@@ -1375,7 +1375,7 @@ field). Auto-metrics → Cloud Monitoring via `SetMonitoring`.
 The full Go API/driver and in-memory provider cover every family above. SDK-compat HTTP
 (REST round-tripped) currently spans models, endpoints (+predict), datasets, custom &
 batch-prediction jobs and `generateContent`/`countTokens`; the remaining families' handlers
-follow the same wire pattern as the next increment. **Total: 127 operations** (Go API/driver).
+follow the same wire pattern as the next increment. **Total: 128 operations** (Go API/driver).
 
 ---
 
@@ -1408,5 +1408,5 @@ follow the same wire pattern as the next increment. **Total: 127 operations** (G
 | Generative AI — AWS Bedrock | 22 |
 | Databricks — Azure (control + data plane) | 52 |
 | Machine Learning — AWS SageMaker (control plane + runtime) | 121 |
-| Machine Learning — GCP Vertex AI (Go API/driver) | 127 |
-| **Grand Total** | **820** |
+| Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
+| **Grand Total** | **821** |

--- a/docs/services.md
+++ b/docs/services.md
@@ -1173,12 +1173,14 @@ are pushed to CloudWatch via `SetMonitoring`.
 | Pipelines | Pipeline (+ executions), Experiment, Trial |
 | Tagging | AddTags / ListTags / DeleteTags |
 
-SDK-compat HTTP coverage (real `aws-sdk-go-v2/service/sagemaker` + `sagemakerruntime`
-round-tripped): Model, EndpointConfig, Endpoint, TrainingJob, InvokeEndpoint, tagging. The
-remaining families are served by the Go API/driver; their SDK-compat handlers follow the
-same wire pattern and are the next increment.
+SDK-compat HTTP coverage spans every family above and is round-tripped against the real
+`aws-sdk-go-v2/service/sagemaker`, `sagemakerruntime`, and `sagemakerfeaturestoreruntime`
+clients: all job kinds, the model/endpoint/inference-component stack + InvokeEndpoint, model
+registry, Studio, notebook instances, HyperPod clusters (+ nodes), Feature Store control
+plane + online-store runtime (PutRecord/GetRecord/DeleteRecord), pipelines/experiments/
+trials, and tagging.
 
-**Total: 121 operations** (Go API/driver)
+**Total: 121 operations** (Go API/driver), all exposed over the SDK-compat HTTP server.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,10 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12 h1:kOX5fC
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 h1:0vYBf7g+R421AjrPAKh+zoNDhWxqg4KixviLFTQ+6vI=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0/go.mod h1:AyCRrgn6Qm1nKR2grD+o8iFlKx5c7jF2h72YkkjEaoQ=
+github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 h1:YRiKEeNe+Kgi03T1ODgPFJ/EkIA4MtKcitJjtoEd8kA=
+github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0/go.mod h1:y1haDXp66bFbEY007eY3iipsa1Mwi27QQNapOv0MQ7g=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 h1:QgaWXVmNDxv/U/3UIHfGb7ohvtFgerf/bYcYylj4i8E=

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 h1:0vYBf7g+R421AjrPAKh+zoNDhWxqg4KixviLFTQ+6vI=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0/go.mod h1:AyCRrgn6Qm1nKR2grD+o8iFlKx5c7jF2h72YkkjEaoQ=
+github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 h1:P4YEn9pJpohKdSDgys1nhlT15ZoQh+wnzU8+bn6hO4A=
+github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7/go.mod h1:5wimXnFCB0SDWjXfkvWjjPsS3LAIZCiEayM6AE8EniQ=
 github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 h1:YRiKEeNe+Kgi03T1ODgPFJ/EkIA4MtKcitJjtoEd8kA=
 github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0/go.mod h1:y1haDXp66bFbEY007eY3iipsa1Mwi27QQNapOv0MQ7g=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/aws/redshift"
 	"github.com/stackshy/cloudemu/providers/aws/route53"
 	"github.com/stackshy/cloudemu/providers/aws/s3"
+	"github.com/stackshy/cloudemu/providers/aws/sagemaker"
 	"github.com/stackshy/cloudemu/providers/aws/secretsmanager"
 	"github.com/stackshy/cloudemu/providers/aws/sns"
 	"github.com/stackshy/cloudemu/providers/aws/sqs"
@@ -48,6 +49,7 @@ type Provider struct {
 	Redshift          *redshift.Mock
 	EKS               *eks.Mock
 	Bedrock           *bedrock.Mock
+	SageMaker         *sagemaker.Mock
 	ResourceDiscovery *resourcediscovery.Engine
 }
 
@@ -75,6 +77,7 @@ func New(opts ...config.Option) *Provider {
 		Redshift:       redshift.New(o),
 		EKS:            eks.New(o),
 		Bedrock:        bedrock.New(o),
+		SageMaker:      sagemaker.New(o),
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
 	p.S3.SetMonitoring(p.CloudWatch)
@@ -89,6 +92,7 @@ func New(opts ...config.Option) *Provider {
 	p.RDS.SetMonitoring(p.CloudWatch)
 	p.Redshift.SetMonitoring(p.CloudWatch)
 	p.EKS.SetMonitoring(p.CloudWatch)
+	p.SageMaker.SetMonitoring(p.CloudWatch)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderAWS, o.AccountID, o.Region,

--- a/providers/aws/sagemaker/cluster.go
+++ b/providers/aws/sagemaker/cluster.go
@@ -8,9 +8,18 @@ import (
 	"github.com/stackshy/cloudemu/sagemaker/driver"
 )
 
+// maxClusterInstancesPerGroup bounds the per-group instance count so an
+// oversized (copy-paste or hostile) create can't make a later ListClusterNodes
+// allocate unbounded node structs. The real HyperPod ceiling is in this range.
+const maxClusterInstancesPerGroup = 6758
+
 func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterSpec) (*driver.Cluster, error) {
 	if cfg.ClusterName == "" {
 		return nil, errors.New(errors.InvalidArgument, "clusterName is required")
+	}
+
+	if err := validateInstanceGroups(cfg.InstanceGroups); err != nil {
+		return nil, err
 	}
 
 	if m.clusters.Has(cfg.ClusterName) {
@@ -30,9 +39,25 @@ func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterSpec) (*driver
 	m.setTags(arn, cfg.Tags)
 	m.emitResourceCreated("Cluster")
 
-	out := *c
+	return cloneCluster(c), nil
+}
 
-	return &out, nil
+// validateInstanceGroups rejects negative or over-cap instance counts before
+// they are stored.
+func validateInstanceGroups(groups []driver.ClusterInstanceGroupSpec) error {
+	for _, g := range groups {
+		if g.InstanceCount < 0 {
+			return errors.Newf(errors.InvalidArgument, "instance group %q has negative InstanceCount", g.GroupName)
+		}
+
+		if g.InstanceCount > maxClusterInstancesPerGroup {
+			return errors.Newf(errors.InvalidArgument,
+				"instance group %q InstanceCount %d exceeds the maximum of %d",
+				g.GroupName, g.InstanceCount, maxClusterInstancesPerGroup)
+		}
+	}
+
+	return nil
 }
 
 func toInstanceGroups(in []driver.ClusterInstanceGroupSpec) []driver.ClusterInstanceGroup {
@@ -44,15 +69,26 @@ func toInstanceGroups(in []driver.ClusterInstanceGroupSpec) []driver.ClusterInst
 	return out
 }
 
+// cloneCluster deep-copies the instance-group and tag slices.
+func cloneCluster(in *driver.Cluster) *driver.Cluster {
+	out := *in
+	if in.InstanceGroups != nil {
+		out.InstanceGroups = make([]driver.ClusterInstanceGroup, len(in.InstanceGroups))
+		copy(out.InstanceGroups, in.InstanceGroups)
+	}
+
+	out.Tags = copyTags(in.Tags)
+
+	return &out
+}
+
 func (m *Mock) DescribeCluster(_ context.Context, name string) (*driver.Cluster, error) {
 	c, ok := m.clusters.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "cluster %q not found", name)
 	}
 
-	out := *c
-
-	return &out, nil
+	return cloneCluster(c), nil
 }
 
 func (m *Mock) ListClusters(_ context.Context) ([]driver.Cluster, error) {
@@ -60,7 +96,7 @@ func (m *Mock) ListClusters(_ context.Context) ([]driver.Cluster, error) {
 	out := make([]driver.Cluster, 0, len(all))
 
 	for _, v := range all {
-		out = append(out, *v)
+		out = append(out, *cloneCluster(v))
 	}
 
 	return out, nil
@@ -72,12 +108,16 @@ func (m *Mock) UpdateCluster(_ context.Context, name string, groups []driver.Clu
 		return nil, errors.Newf(errors.NotFound, "cluster %q not found", name)
 	}
 
-	c.InstanceGroups = toInstanceGroups(groups)
-	c.Status = driver.ClusterInService
+	if err := validateInstanceGroups(groups); err != nil {
+		return nil, err
+	}
 
-	out := *c
+	updated := *c
+	updated.InstanceGroups = toInstanceGroups(groups)
+	updated.Status = driver.ClusterInService
+	m.clusters.Set(name, &updated)
 
-	return &out, nil
+	return cloneCluster(&updated), nil
 }
 
 func (m *Mock) DeleteCluster(_ context.Context, name string) error {

--- a/providers/aws/sagemaker/cluster.go
+++ b/providers/aws/sagemaker/cluster.go
@@ -1,0 +1,132 @@
+package sagemaker
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterSpec) (*driver.Cluster, error) {
+	if cfg.ClusterName == "" {
+		return nil, errors.New(errors.InvalidArgument, "clusterName is required")
+	}
+
+	if m.clusters.Has(cfg.ClusterName) {
+		return nil, errors.Newf(errors.AlreadyExists, "cluster %q already exists", cfg.ClusterName)
+	}
+
+	arn := m.arn("cluster/" + cfg.ClusterName)
+	c := &driver.Cluster{
+		ClusterName:    cfg.ClusterName,
+		ClusterARN:     arn,
+		Status:         driver.ClusterInService, // synchronous Creating -> InService
+		InstanceGroups: toInstanceGroups(cfg.InstanceGroups),
+		CreationTime:   m.now(),
+		Tags:           copyTags(cfg.Tags),
+	}
+	m.clusters.Set(cfg.ClusterName, c)
+	m.setTags(arn, cfg.Tags)
+
+	out := *c
+
+	return &out, nil
+}
+
+func toInstanceGroups(in []driver.ClusterInstanceGroupSpec) []driver.ClusterInstanceGroup {
+	out := make([]driver.ClusterInstanceGroup, 0, len(in))
+	for _, g := range in {
+		out = append(out, driver.ClusterInstanceGroup(g))
+	}
+
+	return out
+}
+
+func (m *Mock) DescribeCluster(_ context.Context, name string) (*driver.Cluster, error) {
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cluster %q not found", name)
+	}
+
+	out := *c
+
+	return &out, nil
+}
+
+func (m *Mock) ListClusters(_ context.Context) ([]driver.Cluster, error) {
+	all := m.clusters.All()
+	out := make([]driver.Cluster, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) UpdateCluster(_ context.Context, name string, groups []driver.ClusterInstanceGroupSpec) (*driver.Cluster, error) {
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cluster %q not found", name)
+	}
+
+	c.InstanceGroups = toInstanceGroups(groups)
+	c.Status = driver.ClusterInService
+
+	out := *c
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteCluster(_ context.Context, name string) error {
+	if !m.clusters.Has(name) {
+		return errors.Newf(errors.NotFound, "cluster %q not found", name)
+	}
+
+	m.clusters.Delete(name)
+
+	return nil
+}
+
+// ListClusterNodes synthesizes one node per instance, deterministically, from
+// the cluster's instance-group configuration.
+func (m *Mock) ListClusterNodes(_ context.Context, clusterName string) ([]driver.ClusterNode, error) {
+	c, ok := m.clusters.Get(clusterName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cluster %q not found", clusterName)
+	}
+
+	out := make([]driver.ClusterNode, 0)
+
+	for _, g := range c.InstanceGroups {
+		for i := 0; i < g.InstanceCount; i++ {
+			out = append(out, driver.ClusterNode{
+				NodeID:       g.GroupName + "-" + strconv.Itoa(i),
+				GroupName:    g.GroupName,
+				InstanceType: g.InstanceType,
+				Status:       "Running",
+				LaunchTime:   c.CreationTime,
+			})
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DescribeClusterNode(ctx context.Context, clusterName, nodeID string) (*driver.ClusterNode, error) {
+	nodes, err := m.ListClusterNodes(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range nodes {
+		if nodes[i].NodeID == nodeID {
+			out := nodes[i]
+
+			return &out, nil
+		}
+	}
+
+	return nil, errors.Newf(errors.NotFound, "cluster node %q not found", nodeID)
+}

--- a/providers/aws/sagemaker/cluster.go
+++ b/providers/aws/sagemaker/cluster.go
@@ -28,6 +28,7 @@ func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterSpec) (*driver
 	}
 	m.clusters.Set(cfg.ClusterName, c)
 	m.setTags(arn, cfg.Tags)
+	m.emitResourceCreated("Cluster")
 
 	out := *c
 

--- a/providers/aws/sagemaker/featurestore.go
+++ b/providers/aws/sagemaker/featurestore.go
@@ -1,0 +1,138 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// recordKey joins a feature group name and a record identifier.
+func recordKey(group, recordID string) string {
+	return group + "\x00" + recordID
+}
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateFeatureGroup(_ context.Context, cfg driver.FeatureGroupSpec) (*driver.FeatureGroup, error) {
+	if cfg.GroupName == "" {
+		return nil, errors.New(errors.InvalidArgument, "featureGroupName is required")
+	}
+
+	if cfg.RecordIdentifierName == "" {
+		return nil, errors.New(errors.InvalidArgument, "recordIdentifierFeatureName is required")
+	}
+
+	if m.featureGroups.Has(cfg.GroupName) {
+		return nil, errors.Newf(errors.AlreadyExists, "feature group %q already exists", cfg.GroupName)
+	}
+
+	arn := m.arn("feature-group/" + cfg.GroupName)
+	fg := &driver.FeatureGroup{
+		GroupName:            cfg.GroupName,
+		GroupARN:             arn,
+		RecordIdentifierName: cfg.RecordIdentifierName,
+		EventTimeFeatureName: cfg.EventTimeFeatureName,
+		Features:             cfg.Features,
+		OnlineStoreEnabled:   cfg.OnlineStoreEnabled,
+		OfflineStoreS3URI:    cfg.OfflineStoreS3URI,
+		RoleARN:              cfg.RoleARN,
+		Status:               driver.FeatureGroupCreated, // synchronous Creating -> Created
+		CreationTime:         m.now(),
+		Tags:                 copyTags(cfg.Tags),
+	}
+	m.featureGroups.Set(cfg.GroupName, fg)
+	m.setTags(arn, cfg.Tags)
+
+	out := *fg
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeFeatureGroup(_ context.Context, name string) (*driver.FeatureGroup, error) {
+	fg, ok := m.featureGroups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature group %q not found", name)
+	}
+
+	out := *fg
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureGroups(_ context.Context) ([]driver.FeatureGroup, error) {
+	all := m.featureGroups.All()
+	out := make([]driver.FeatureGroup, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureGroup(_ context.Context, name string) error {
+	if !m.featureGroups.Has(name) {
+		return errors.Newf(errors.NotFound, "feature group %q not found", name)
+	}
+
+	m.featureGroups.Delete(name)
+
+	return nil
+}
+
+// --- Online store runtime ---
+
+// PutRecord writes a record to the online store, keyed by the record
+// identifier feature's value.
+func (m *Mock) PutRecord(_ context.Context, groupName string, record []driver.FeatureValue) error {
+	fg, ok := m.featureGroups.Get(groupName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "feature group %q not found", groupName)
+	}
+
+	recordID := ""
+
+	for _, fv := range record {
+		if fv.Name == fg.RecordIdentifierName {
+			recordID = fv.Value
+
+			break
+		}
+	}
+
+	if recordID == "" {
+		return errors.Newf(errors.InvalidArgument, "record is missing identifier feature %q", fg.RecordIdentifierName)
+	}
+
+	stored := make([]driver.FeatureValue, len(record))
+	copy(stored, record)
+	m.featureRecords.Set(recordKey(groupName, recordID), stored)
+
+	return nil
+}
+
+func (m *Mock) GetRecord(_ context.Context, groupName, recordID string) ([]driver.FeatureValue, error) {
+	if !m.featureGroups.Has(groupName) {
+		return nil, errors.Newf(errors.NotFound, "feature group %q not found", groupName)
+	}
+
+	rec, ok := m.featureRecords.Get(recordKey(groupName, recordID))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "record %q not found", recordID)
+	}
+
+	out := make([]driver.FeatureValue, len(rec))
+	copy(out, rec)
+
+	return out, nil
+}
+
+func (m *Mock) DeleteRecord(_ context.Context, groupName, recordID string) error {
+	if !m.featureGroups.Has(groupName) {
+		return errors.Newf(errors.NotFound, "feature group %q not found", groupName)
+	}
+
+	m.featureRecords.Delete(recordKey(groupName, recordID))
+
+	return nil
+}

--- a/providers/aws/sagemaker/featurestore.go
+++ b/providers/aws/sagemaker/featurestore.go
@@ -42,6 +42,7 @@ func (m *Mock) CreateFeatureGroup(_ context.Context, cfg driver.FeatureGroupSpec
 	}
 	m.featureGroups.Set(cfg.GroupName, fg)
 	m.setTags(arn, cfg.Tags)
+	m.emitResourceCreated("FeatureGroup")
 
 	out := *fg
 

--- a/providers/aws/sagemaker/featurestore.go
+++ b/providers/aws/sagemaker/featurestore.go
@@ -92,16 +92,20 @@ func (m *Mock) PutRecord(_ context.Context, groupName string, record []driver.Fe
 	}
 
 	recordID := ""
+	found := false
 
 	for _, fv := range record {
 		if fv.Name == fg.RecordIdentifierName {
 			recordID = fv.Value
+			found = true
 
 			break
 		}
 	}
 
-	if recordID == "" {
+	// Check for presence of the identifier feature, not a non-empty value: an
+	// identifier whose value is legitimately the empty string is valid.
+	if !found {
 		return errors.Newf(errors.InvalidArgument, "record is missing identifier feature %q", fg.RecordIdentifierName)
 	}
 

--- a/providers/aws/sagemaker/inference.go
+++ b/providers/aws/sagemaker/inference.go
@@ -24,7 +24,8 @@ func (m *Mock) CreateModel(_ context.Context, cfg driver.ModelConfig) (*driver.M
 		ModelName:    cfg.ModelName,
 		ModelARN:     arn,
 		RoleARN:      cfg.RoleARN,
-		Containers:   cfg.Containers,
+		Containers:   copyContainers(cfg.Containers),
+		Pipeline:     cfg.Pipeline,
 		CreationTime: m.now(),
 		Tags:         copyTags(cfg.Tags),
 	}
@@ -32,9 +33,16 @@ func (m *Mock) CreateModel(_ context.Context, cfg driver.ModelConfig) (*driver.M
 	m.setTags(arn, cfg.Tags)
 	m.emitResourceCreated("Model")
 
-	out := *model
+	return cloneModel(model), nil
+}
 
-	return &out, nil
+// cloneModel returns a deep copy so callers never alias the stored slices.
+func cloneModel(in *driver.Model) *driver.Model {
+	out := *in
+	out.Containers = copyContainers(in.Containers)
+	out.Tags = copyTags(in.Tags)
+
+	return &out
 }
 
 func (m *Mock) DescribeModel(_ context.Context, name string) (*driver.Model, error) {
@@ -43,9 +51,7 @@ func (m *Mock) DescribeModel(_ context.Context, name string) (*driver.Model, err
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
-	out := *model
-
-	return &out, nil
+	return cloneModel(model), nil
 }
 
 func (m *Mock) ListModels(_ context.Context) ([]driver.Model, error) {
@@ -53,7 +59,7 @@ func (m *Mock) ListModels(_ context.Context) ([]driver.Model, error) {
 	out := make([]driver.Model, 0, len(all))
 
 	for _, v := range all {
-		out = append(out, *v)
+		out = append(out, *cloneModel(v))
 	}
 
 	return out, nil
@@ -85,7 +91,7 @@ func (m *Mock) CreateEndpointConfig(_ context.Context, cfg driver.EndpointConfig
 	ec := &driver.EndpointConfig{
 		ConfigName:         cfg.ConfigName,
 		ConfigARN:          arn,
-		ProductionVariants: cfg.ProductionVariants,
+		ProductionVariants: copyVariants(cfg.ProductionVariants),
 		Serverless:         cfg.Serverless,
 		AsyncOutputS3URI:   cfg.AsyncOutputS3URI,
 		CreationTime:       m.now(),
@@ -94,9 +100,17 @@ func (m *Mock) CreateEndpointConfig(_ context.Context, cfg driver.EndpointConfig
 	m.endpointConfigs.Set(cfg.ConfigName, ec)
 	m.setTags(arn, cfg.Tags)
 
-	out := *ec
+	return cloneEndpointConfig(ec), nil
+}
 
-	return &out, nil
+// cloneEndpointConfig deep-copies the variant slice so callers never alias the
+// stored config.
+func cloneEndpointConfig(in *driver.EndpointConfig) *driver.EndpointConfig {
+	out := *in
+	out.ProductionVariants = copyVariants(in.ProductionVariants)
+	out.Tags = copyTags(in.Tags)
+
+	return &out
 }
 
 func (m *Mock) DescribeEndpointConfig(_ context.Context, name string) (*driver.EndpointConfig, error) {
@@ -105,9 +119,7 @@ func (m *Mock) DescribeEndpointConfig(_ context.Context, name string) (*driver.E
 		return nil, errors.Newf(errors.NotFound, "endpoint config %q not found", name)
 	}
 
-	out := *ec
-
-	return &out, nil
+	return cloneEndpointConfig(ec), nil
 }
 
 func (m *Mock) ListEndpointConfigs(_ context.Context) ([]driver.EndpointConfig, error) {
@@ -115,7 +127,7 @@ func (m *Mock) ListEndpointConfigs(_ context.Context) ([]driver.EndpointConfig, 
 	out := make([]driver.EndpointConfig, 0, len(all))
 
 	for _, v := range all {
-		out = append(out, *v)
+		out = append(out, *cloneEndpointConfig(v))
 	}
 
 	return out, nil
@@ -158,7 +170,7 @@ func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointSpec) (*driv
 		EndpointARN:      arn,
 		ConfigName:       cfg.ConfigName,
 		Status:           driver.EndpointInService, // synchronous Creating -> InService
-		Variants:         ec.ProductionVariants,
+		Variants:         copyVariants(ec.ProductionVariants),
 		CreationTime:     now,
 		LastModifiedTime: now,
 		Tags:             copyTags(cfg.Tags),
@@ -167,9 +179,17 @@ func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointSpec) (*driv
 	m.setTags(arn, cfg.Tags)
 	m.emitResourceCreated("Endpoint")
 
-	out := *ep
+	return cloneEndpoint(ep), nil
+}
 
-	return &out, nil
+// cloneEndpoint deep-copies the variant slice so callers never alias stored
+// state.
+func cloneEndpoint(in *driver.Endpoint) *driver.Endpoint {
+	out := *in
+	out.Variants = copyVariants(in.Variants)
+	out.Tags = copyTags(in.Tags)
+
+	return &out
 }
 
 func (m *Mock) DescribeEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {
@@ -178,9 +198,7 @@ func (m *Mock) DescribeEndpoint(_ context.Context, name string) (*driver.Endpoin
 		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
 	}
 
-	out := *ep
-
-	return &out, nil
+	return cloneEndpoint(ep), nil
 }
 
 func (m *Mock) ListEndpoints(_ context.Context) ([]driver.Endpoint, error) {
@@ -188,7 +206,7 @@ func (m *Mock) ListEndpoints(_ context.Context) ([]driver.Endpoint, error) {
 	out := make([]driver.Endpoint, 0, len(all))
 
 	for _, v := range all {
-		out = append(out, *v)
+		out = append(out, *cloneEndpoint(v))
 	}
 
 	return out, nil
@@ -205,14 +223,16 @@ func (m *Mock) UpdateEndpoint(_ context.Context, name, configName string) (*driv
 		return nil, errors.Newf(errors.InvalidArgument, "endpoint config %q not found", configName)
 	}
 
-	ep.ConfigName = configName
-	ep.Variants = ec.ProductionVariants
-	ep.Status = driver.EndpointInService
-	ep.LastModifiedTime = m.now()
+	// Copy-then-Set: never mutate the stored pointer in place, so concurrent
+	// readers see either the old or the new endpoint atomically.
+	updated := *ep
+	updated.ConfigName = configName
+	updated.Variants = copyVariants(ec.ProductionVariants)
+	updated.Status = driver.EndpointInService
+	updated.LastModifiedTime = m.now()
+	m.endpoints.Set(name, &updated)
 
-	out := *ep
-
-	return &out, nil
+	return cloneEndpoint(&updated), nil
 }
 
 func (m *Mock) UpdateEndpointWeightsAndCapacities(
@@ -228,21 +248,25 @@ func (m *Mock) UpdateEndpointWeightsAndCapacities(
 		byName[w.VariantName] = w
 	}
 
-	for i := range ep.Variants {
-		if w, ok := byName[ep.Variants[i].VariantName]; ok {
-			ep.Variants[i].InitialVariantWeight = w.DesiredWeight
+	// Copy-then-Set: build a fresh variant slice so neither the stored endpoint
+	// nor the source EndpointConfig is mutated in place.
+	updated := *ep
+	updated.Variants = copyVariants(ep.Variants)
+
+	for i := range updated.Variants {
+		if w, ok := byName[updated.Variants[i].VariantName]; ok {
+			updated.Variants[i].InitialVariantWeight = w.DesiredWeight
 			if w.DesiredInstanceCount > 0 {
-				ep.Variants[i].InitialInstanceCount = w.DesiredInstanceCount
+				updated.Variants[i].InitialInstanceCount = w.DesiredInstanceCount
 			}
 		}
 	}
 
-	ep.Status = driver.EndpointInService
-	ep.LastModifiedTime = m.now()
+	updated.Status = driver.EndpointInService
+	updated.LastModifiedTime = m.now()
+	m.endpoints.Set(name, &updated)
 
-	out := *ep
-
-	return &out, nil
+	return cloneEndpoint(&updated), nil
 }
 
 func (m *Mock) DeleteEndpoint(_ context.Context, name string) error {

--- a/providers/aws/sagemaker/inference.go
+++ b/providers/aws/sagemaker/inference.go
@@ -9,7 +9,7 @@ import (
 
 // --- Model ---
 
-//nolint:gocritic,dupl // cfg matches the driver signature; the create-record shape recurs across resources.
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
 func (m *Mock) CreateModel(_ context.Context, cfg driver.ModelConfig) (*driver.Model, error) {
 	if cfg.ModelName == "" {
 		return nil, errors.New(errors.InvalidArgument, "modelName is required")
@@ -30,6 +30,7 @@ func (m *Mock) CreateModel(_ context.Context, cfg driver.ModelConfig) (*driver.M
 	}
 	m.models.Set(cfg.ModelName, model)
 	m.setTags(arn, cfg.Tags)
+	m.emitResourceCreated("Model")
 
 	out := *model
 
@@ -164,6 +165,7 @@ func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointSpec) (*driv
 	}
 	m.endpoints.Set(cfg.EndpointName, ep)
 	m.setTags(arn, cfg.Tags)
+	m.emitResourceCreated("Endpoint")
 
 	out := *ep
 

--- a/providers/aws/sagemaker/inference.go
+++ b/providers/aws/sagemaker/inference.go
@@ -1,0 +1,324 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// --- Model ---
+
+//nolint:gocritic,dupl // cfg matches the driver signature; the create-record shape recurs across resources.
+func (m *Mock) CreateModel(_ context.Context, cfg driver.ModelConfig) (*driver.Model, error) {
+	if cfg.ModelName == "" {
+		return nil, errors.New(errors.InvalidArgument, "modelName is required")
+	}
+
+	if m.models.Has(cfg.ModelName) {
+		return nil, errors.Newf(errors.AlreadyExists, "model %q already exists", cfg.ModelName)
+	}
+
+	arn := m.arn("model/" + cfg.ModelName)
+	model := &driver.Model{
+		ModelName:    cfg.ModelName,
+		ModelARN:     arn,
+		RoleARN:      cfg.RoleARN,
+		Containers:   cfg.Containers,
+		CreationTime: m.now(),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.models.Set(cfg.ModelName, model)
+	m.setTags(arn, cfg.Tags)
+
+	out := *model
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeModel(_ context.Context, name string) (*driver.Model, error) {
+	model, ok := m.models.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	out := *model
+
+	return &out, nil
+}
+
+func (m *Mock) ListModels(_ context.Context) ([]driver.Model, error) {
+	all := m.models.All()
+	out := make([]driver.Model, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteModel(_ context.Context, name string) error {
+	if !m.models.Has(name) {
+		return errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	m.models.Delete(name)
+
+	return nil
+}
+
+// --- Endpoint config ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateEndpointConfig(_ context.Context, cfg driver.EndpointConfigSpec) (*driver.EndpointConfig, error) {
+	if cfg.ConfigName == "" {
+		return nil, errors.New(errors.InvalidArgument, "endpointConfigName is required")
+	}
+
+	if m.endpointConfigs.Has(cfg.ConfigName) {
+		return nil, errors.Newf(errors.AlreadyExists, "endpoint config %q already exists", cfg.ConfigName)
+	}
+
+	arn := m.arn("endpoint-config/" + cfg.ConfigName)
+	ec := &driver.EndpointConfig{
+		ConfigName:         cfg.ConfigName,
+		ConfigARN:          arn,
+		ProductionVariants: cfg.ProductionVariants,
+		Serverless:         cfg.Serverless,
+		AsyncOutputS3URI:   cfg.AsyncOutputS3URI,
+		CreationTime:       m.now(),
+		Tags:               copyTags(cfg.Tags),
+	}
+	m.endpointConfigs.Set(cfg.ConfigName, ec)
+	m.setTags(arn, cfg.Tags)
+
+	out := *ec
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeEndpointConfig(_ context.Context, name string) (*driver.EndpointConfig, error) {
+	ec, ok := m.endpointConfigs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint config %q not found", name)
+	}
+
+	out := *ec
+
+	return &out, nil
+}
+
+func (m *Mock) ListEndpointConfigs(_ context.Context) ([]driver.EndpointConfig, error) {
+	all := m.endpointConfigs.All()
+	out := make([]driver.EndpointConfig, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteEndpointConfig(_ context.Context, name string) error {
+	if !m.endpointConfigs.Has(name) {
+		return errors.Newf(errors.NotFound, "endpoint config %q not found", name)
+	}
+
+	m.endpointConfigs.Delete(name)
+
+	return nil
+}
+
+// --- Endpoint ---
+
+func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointSpec) (*driver.Endpoint, error) {
+	if cfg.EndpointName == "" {
+		return nil, errors.New(errors.InvalidArgument, "endpointName is required")
+	}
+
+	if cfg.ConfigName == "" {
+		return nil, errors.New(errors.InvalidArgument, "endpointConfigName is required")
+	}
+
+	if m.endpoints.Has(cfg.EndpointName) {
+		return nil, errors.Newf(errors.AlreadyExists, "endpoint %q already exists", cfg.EndpointName)
+	}
+
+	ec, ok := m.endpointConfigs.Get(cfg.ConfigName)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "endpoint config %q not found", cfg.ConfigName)
+	}
+
+	now := m.now()
+	arn := m.arn("endpoint/" + cfg.EndpointName)
+	ep := &driver.Endpoint{
+		EndpointName:     cfg.EndpointName,
+		EndpointARN:      arn,
+		ConfigName:       cfg.ConfigName,
+		Status:           driver.EndpointInService, // synchronous Creating -> InService
+		Variants:         ec.ProductionVariants,
+		CreationTime:     now,
+		LastModifiedTime: now,
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.endpoints.Set(cfg.EndpointName, ep)
+	m.setTags(arn, cfg.Tags)
+
+	out := *ep
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	out := *ep
+
+	return &out, nil
+}
+
+func (m *Mock) ListEndpoints(_ context.Context) ([]driver.Endpoint, error) {
+	all := m.endpoints.All()
+	out := make([]driver.Endpoint, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) UpdateEndpoint(_ context.Context, name, configName string) (*driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	ec, ok := m.endpointConfigs.Get(configName)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "endpoint config %q not found", configName)
+	}
+
+	ep.ConfigName = configName
+	ep.Variants = ec.ProductionVariants
+	ep.Status = driver.EndpointInService
+	ep.LastModifiedTime = m.now()
+
+	out := *ep
+
+	return &out, nil
+}
+
+func (m *Mock) UpdateEndpointWeightsAndCapacities(
+	_ context.Context, name string, weights []driver.VariantWeight,
+) (*driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	byName := make(map[string]driver.VariantWeight, len(weights))
+	for _, w := range weights {
+		byName[w.VariantName] = w
+	}
+
+	for i := range ep.Variants {
+		if w, ok := byName[ep.Variants[i].VariantName]; ok {
+			ep.Variants[i].InitialVariantWeight = w.DesiredWeight
+			if w.DesiredInstanceCount > 0 {
+				ep.Variants[i].InitialInstanceCount = w.DesiredInstanceCount
+			}
+		}
+	}
+
+	ep.Status = driver.EndpointInService
+	ep.LastModifiedTime = m.now()
+
+	out := *ep
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteEndpoint(_ context.Context, name string) error {
+	if !m.endpoints.Has(name) {
+		return errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	m.endpoints.Delete(name)
+
+	return nil
+}
+
+// --- Inference component ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateInferenceComponent(_ context.Context, cfg driver.InferenceComponentSpec) (*driver.InferenceComponent, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "inferenceComponentName is required")
+	}
+
+	if m.inferenceComponents.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "inference component %q already exists", cfg.Name)
+	}
+
+	if !m.endpoints.Has(cfg.EndpointName) {
+		return nil, errors.Newf(errors.InvalidArgument, "endpoint %q not found", cfg.EndpointName)
+	}
+
+	now := m.now()
+	arn := m.arn("inference-component/" + cfg.Name)
+	ic := &driver.InferenceComponent{
+		Name:             cfg.Name,
+		ARN:              arn,
+		EndpointName:     cfg.EndpointName,
+		ModelName:        cfg.ModelName,
+		VariantName:      cfg.VariantName,
+		CopyCount:        cfg.CopyCount,
+		Status:           driver.IInService,
+		CreationTime:     now,
+		LastModifiedTime: now,
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.inferenceComponents.Set(cfg.Name, ic)
+	m.setTags(arn, cfg.Tags)
+
+	out := *ic
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeInferenceComponent(_ context.Context, name string) (*driver.InferenceComponent, error) {
+	ic, ok := m.inferenceComponents.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "inference component %q not found", name)
+	}
+
+	out := *ic
+
+	return &out, nil
+}
+
+func (m *Mock) ListInferenceComponents(_ context.Context) ([]driver.InferenceComponent, error) {
+	all := m.inferenceComponents.All()
+	out := make([]driver.InferenceComponent, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteInferenceComponent(_ context.Context, name string) error {
+	if !m.inferenceComponents.Has(name) {
+		return errors.Newf(errors.NotFound, "inference component %q not found", name)
+	}
+
+	m.inferenceComponents.Delete(name)
+
+	return nil
+}

--- a/providers/aws/sagemaker/jobs.go
+++ b/providers/aws/sagemaker/jobs.go
@@ -500,14 +500,18 @@ func (m *Mock) StopCompilationJob(_ context.Context, name string) error {
 
 // --- shared helpers ---
 
-// stopJob applies mutate to a stored job, or returns NotFound.
+// stopJob applies mutate to a COPY of a stored job and re-stores it, or returns
+// NotFound. Copy-then-Set keeps concurrent Describe*/List* readers race-free:
+// they observe either the old or the new pointer, never an in-place write.
 func stopJob[T any](store *memstore.Store[*T], name, kind string, mutate func(*T)) error {
 	job, ok := store.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "%s %q not found", kind, name)
 	}
 
-	mutate(job)
+	updated := *job
+	mutate(&updated)
+	store.Set(name, &updated)
 
 	return nil
 }

--- a/providers/aws/sagemaker/jobs.go
+++ b/providers/aws/sagemaker/jobs.go
@@ -1,0 +1,529 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// --- Training jobs ---
+
+// CreateTrainingJob creates a training job that completes synchronously.
+//
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateTrainingJob(_ context.Context, cfg driver.TrainingJobConfig) (*driver.TrainingJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "trainingJobName is required")
+	}
+
+	if m.trainingJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "training job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("training-job/" + cfg.JobName)
+	job := &driver.TrainingJob{
+		JobName:              cfg.JobName,
+		JobARN:               arn,
+		RoleARN:              cfg.RoleARN,
+		AlgorithmImage:       cfg.AlgorithmImage,
+		HyperParameters:      copyStrMap(cfg.HyperParameters),
+		InputChannels:        cfg.InputChannels,
+		OutputS3URI:          cfg.OutputS3URI,
+		Resources:            cfg.Resources,
+		Status:               driver.JobCompleted,
+		SecondaryStatus:      driver.SecondaryCompleted,
+		SecondaryTransitions: trainingTransitions(now),
+		ModelArtifactS3URI:   cfg.OutputS3URI + "/output/model.tar.gz",
+		CreationTime:         now,
+		TrainingStartTime:    now,
+		TrainingEndTime:      now,
+		LastModifiedTime:     now,
+		Tags:                 copyTags(cfg.Tags),
+	}
+	m.trainingJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("TrainingJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func trainingTransitions(now string) []driver.SecondaryStatusTransition {
+	stages := []string{
+		driver.SecondaryStarting, driver.SecondaryDownloading,
+		driver.SecondaryTraining, driver.SecondaryUploading, driver.SecondaryCompleted,
+	}
+	out := make([]driver.SecondaryStatusTransition, 0, len(stages))
+
+	for _, s := range stages {
+		out = append(out, driver.SecondaryStatusTransition{Status: s, StartTime: now, EndTime: now})
+	}
+
+	return out
+}
+
+// DescribeTrainingJob returns a training job by name.
+func (m *Mock) DescribeTrainingJob(_ context.Context, name string) (*driver.TrainingJob, error) {
+	job, ok := m.trainingJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "training job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+// ListTrainingJobs lists all training jobs.
+func (m *Mock) ListTrainingJobs(_ context.Context) ([]driver.TrainingJob, error) {
+	all := m.trainingJobs.All()
+	out := make([]driver.TrainingJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+// StopTrainingJob marks a training job stopped.
+func (m *Mock) StopTrainingJob(_ context.Context, name string) error {
+	return stopJob(m.trainingJobs, name, "training job", func(j *driver.TrainingJob) {
+		j.Status, j.SecondaryStatus = driver.JobStopped, driver.JobStopped
+	})
+}
+
+// --- Processing jobs ---
+
+//nolint:gocritic,dupl // cfg matches the driver signature; the create-job shape recurs across job kinds.
+func (m *Mock) CreateProcessingJob(_ context.Context, cfg driver.ProcessingJobConfig) (*driver.ProcessingJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "processingJobName is required")
+	}
+
+	if m.processingJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "processing job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("processing-job/" + cfg.JobName)
+	job := &driver.ProcessingJob{
+		JobName:           cfg.JobName,
+		JobARN:            arn,
+		RoleARN:           cfg.RoleARN,
+		AppImage:          cfg.AppImage,
+		Inputs:            cfg.Inputs,
+		OutputS3URI:       cfg.OutputS3URI,
+		Resources:         cfg.Resources,
+		Status:            driver.JobCompleted,
+		CreationTime:      now,
+		ProcessingEndTime: now,
+		LastModifiedTime:  now,
+		Tags:              copyTags(cfg.Tags),
+	}
+	m.processingJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("ProcessingJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeProcessingJob(_ context.Context, name string) (*driver.ProcessingJob, error) {
+	job, ok := m.processingJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "processing job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) ListProcessingJobs(_ context.Context) ([]driver.ProcessingJob, error) {
+	all := m.processingJobs.All()
+	out := make([]driver.ProcessingJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopProcessingJob(_ context.Context, name string) error {
+	return stopJob(m.processingJobs, name, "processing job", func(j *driver.ProcessingJob) {
+		j.Status = driver.JobStopped
+	})
+}
+
+// --- Transform jobs ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateTransformJob(_ context.Context, cfg driver.TransformJobConfig) (*driver.TransformJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "transformJobName is required")
+	}
+
+	if cfg.ModelName == "" {
+		return nil, errors.New(errors.InvalidArgument, "modelName is required")
+	}
+
+	if m.transformJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "transform job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("transform-job/" + cfg.JobName)
+	job := &driver.TransformJob{
+		JobName:          cfg.JobName,
+		JobARN:           arn,
+		ModelName:        cfg.ModelName,
+		InputS3URI:       cfg.InputS3URI,
+		OutputS3URI:      cfg.OutputS3URI,
+		InstanceType:     cfg.InstanceType,
+		InstanceCount:    cfg.InstanceCount,
+		Status:           driver.JobCompleted,
+		CreationTime:     now,
+		TransformEndTime: now,
+		LastModifiedTime: now,
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.transformJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("TransformJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeTransformJob(_ context.Context, name string) (*driver.TransformJob, error) {
+	job, ok := m.transformJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "transform job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) ListTransformJobs(_ context.Context) ([]driver.TransformJob, error) {
+	all := m.transformJobs.All()
+	out := make([]driver.TransformJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopTransformJob(_ context.Context, name string) error {
+	return stopJob(m.transformJobs, name, "transform job", func(j *driver.TransformJob) {
+		j.Status = driver.JobStopped
+	})
+}
+
+// --- Hyperparameter tuning jobs ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateHyperParameterTuningJob(
+	_ context.Context, cfg driver.HyperParameterTuningJobConfig,
+) (*driver.HyperParameterTuningJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "hyperParameterTuningJobName is required")
+	}
+
+	if m.tuningJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "tuning job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("hyper-parameter-tuning-job/" + cfg.JobName)
+	best := cfg.JobName + "-001"
+	job := &driver.HyperParameterTuningJob{
+		JobName:           cfg.JobName,
+		JobARN:            arn,
+		Strategy:          orDefault(cfg.Strategy, "Bayesian"),
+		MaxJobs:           cfg.MaxJobs,
+		MaxParallelJobs:   cfg.MaxParallelJobs,
+		ObjectiveMetric:   cfg.ObjectiveMetric,
+		ObjectiveType:     orDefault(cfg.ObjectiveType, "Maximize"),
+		Status:            driver.JobCompleted,
+		BestTrainingJob:   best,
+		TrainingJobCounts: map[string]int{"Completed": maxInt(cfg.MaxJobs, 1)},
+		CreationTime:      now,
+		HPOJobEndTime:     now,
+		LastModifiedTime:  now,
+		Tags:              copyTags(cfg.Tags),
+	}
+	m.tuningJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("HyperParameterTuningJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeHyperParameterTuningJob(_ context.Context, name string) (*driver.HyperParameterTuningJob, error) {
+	job, ok := m.tuningJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "tuning job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) ListHyperParameterTuningJobs(_ context.Context) ([]driver.HyperParameterTuningJob, error) {
+	all := m.tuningJobs.All()
+	out := make([]driver.HyperParameterTuningJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopHyperParameterTuningJob(_ context.Context, name string) error {
+	return stopJob(m.tuningJobs, name, "tuning job", func(j *driver.HyperParameterTuningJob) {
+		j.Status = driver.JobStopped
+	})
+}
+
+// --- AutoML jobs ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateAutoMLJobV2(_ context.Context, cfg driver.AutoMLJobConfig) (*driver.AutoMLJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "autoMLJobName is required")
+	}
+
+	if m.autoMLJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "AutoML job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("automl-job/" + cfg.JobName)
+	job := &driver.AutoMLJob{
+		JobName:           cfg.JobName,
+		JobARN:            arn,
+		RoleARN:           cfg.RoleARN,
+		InputS3URI:        cfg.InputS3URI,
+		OutputS3URI:       cfg.OutputS3URI,
+		ProblemType:       cfg.ProblemType,
+		TargetColumn:      cfg.TargetColumn,
+		Status:            driver.JobCompleted,
+		SecondaryStatus:   "Completed",
+		BestCandidateName: cfg.JobName + "-best",
+		CreationTime:      now,
+		AutoMLJobEndTime:  now,
+		LastModifiedTime:  now,
+		Tags:              copyTags(cfg.Tags),
+	}
+	m.autoMLJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("AutoMLJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeAutoMLJobV2(_ context.Context, name string) (*driver.AutoMLJob, error) {
+	job, ok := m.autoMLJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "AutoML job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) ListAutoMLJobs(_ context.Context) ([]driver.AutoMLJob, error) {
+	all := m.autoMLJobs.All()
+	out := make([]driver.AutoMLJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopAutoMLJob(_ context.Context, name string) error {
+	return stopJob(m.autoMLJobs, name, "AutoML job", func(j *driver.AutoMLJob) {
+		j.Status, j.SecondaryStatus = driver.JobStopped, driver.JobStopped
+	})
+}
+
+// --- Labeling jobs ---
+
+//nolint:gocritic,dupl // cfg matches the driver signature; the create-job shape recurs across job kinds.
+func (m *Mock) CreateLabelingJob(_ context.Context, cfg driver.LabelingJobConfig) (*driver.LabelingJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "labelingJobName is required")
+	}
+
+	if m.labelingJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "labeling job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("labeling-job/" + cfg.JobName)
+	job := &driver.LabelingJob{
+		JobName:          cfg.JobName,
+		JobARN:           arn,
+		RoleARN:          cfg.RoleARN,
+		InputS3URI:       cfg.InputS3URI,
+		OutputS3URI:      cfg.OutputS3URI,
+		LabelAttribute:   cfg.LabelAttribute,
+		WorkteamARN:      cfg.WorkteamARN,
+		Status:           driver.JobCompleted,
+		CreationTime:     now,
+		LabelingEndTime:  now,
+		LastModifiedTime: now,
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.labelingJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("LabelingJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeLabelingJob(_ context.Context, name string) (*driver.LabelingJob, error) {
+	job, ok := m.labelingJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "labeling job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) ListLabelingJobs(_ context.Context) ([]driver.LabelingJob, error) {
+	all := m.labelingJobs.All()
+	out := make([]driver.LabelingJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopLabelingJob(_ context.Context, name string) error {
+	return stopJob(m.labelingJobs, name, "labeling job", func(j *driver.LabelingJob) {
+		j.Status = driver.JobStopped
+	})
+}
+
+// --- Compilation jobs ---
+
+//nolint:gocritic,dupl // cfg matches the driver signature; the create-job shape recurs across job kinds.
+func (m *Mock) CreateCompilationJob(_ context.Context, cfg driver.CompilationJobConfig) (*driver.CompilationJob, error) {
+	if cfg.JobName == "" {
+		return nil, errors.New(errors.InvalidArgument, "compilationJobName is required")
+	}
+
+	if m.compilationJobs.Has(cfg.JobName) {
+		return nil, errors.Newf(errors.AlreadyExists, "compilation job %q already exists", cfg.JobName)
+	}
+
+	now := m.now()
+	arn := m.arn("compilation-job/" + cfg.JobName)
+	job := &driver.CompilationJob{
+		JobName:            cfg.JobName,
+		JobARN:             arn,
+		RoleARN:            cfg.RoleARN,
+		InputS3URI:         cfg.InputS3URI,
+		OutputS3URI:        cfg.OutputS3URI,
+		TargetDevice:       cfg.TargetDevice,
+		Framework:          cfg.Framework,
+		Status:             driver.JobCompleted,
+		CreationTime:       now,
+		CompilationEndTime: now,
+		LastModifiedTime:   now,
+		Tags:               copyTags(cfg.Tags),
+	}
+	m.compilationJobs.Set(cfg.JobName, job)
+	m.setTags(arn, cfg.Tags)
+	m.emitJobMetric("CompilationJob")
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeCompilationJob(_ context.Context, name string) (*driver.CompilationJob, error) {
+	job, ok := m.compilationJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "compilation job %q not found", name)
+	}
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) ListCompilationJobs(_ context.Context) ([]driver.CompilationJob, error) {
+	all := m.compilationJobs.All()
+	out := make([]driver.CompilationJob, 0, len(all))
+
+	for _, j := range all {
+		out = append(out, *j)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopCompilationJob(_ context.Context, name string) error {
+	return stopJob(m.compilationJobs, name, "compilation job", func(j *driver.CompilationJob) {
+		j.Status = driver.JobStopped
+	})
+}
+
+// --- shared helpers ---
+
+// stopJob applies mutate to a stored job, or returns NotFound.
+func stopJob[T any](store *memstore.Store[*T], name, kind string, mutate func(*T)) error {
+	job, ok := store.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "%s %q not found", kind, name)
+	}
+
+	mutate(job)
+
+	return nil
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}

--- a/providers/aws/sagemaker/jobs.go
+++ b/providers/aws/sagemaker/jobs.go
@@ -455,7 +455,7 @@ func (m *Mock) CreateCompilationJob(_ context.Context, cfg driver.CompilationJob
 		OutputS3URI:        cfg.OutputS3URI,
 		TargetDevice:       cfg.TargetDevice,
 		Framework:          cfg.Framework,
-		Status:             driver.JobCompleted,
+		Status:             driver.CompilationCompleted,
 		CreationTime:       now,
 		CompilationEndTime: now,
 		LastModifiedTime:   now,
@@ -494,7 +494,7 @@ func (m *Mock) ListCompilationJobs(_ context.Context) ([]driver.CompilationJob, 
 
 func (m *Mock) StopCompilationJob(_ context.Context, name string) error {
 	return stopJob(m.compilationJobs, name, "compilation job", func(j *driver.CompilationJob) {
-		j.Status = driver.JobStopped
+		j.Status = driver.CompilationStopped
 	})
 }
 

--- a/providers/aws/sagemaker/metrics.go
+++ b/providers/aws/sagemaker/metrics.go
@@ -1,0 +1,30 @@
+package sagemaker
+
+import (
+	"context"
+
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+)
+
+// emitMetric pushes a single metric to the wired monitoring backend (no-op
+// when monitoring is not set), mirroring the S3/EC2 auto-metric pattern.
+func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "AWS/SageMaker", MetricName: metricName, Value: value, Unit: unit,
+		Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
+}
+
+// emitJobMetric records the creation of a job of the given type.
+func (m *Mock) emitJobMetric(jobType string) {
+	m.emitMetric("JobsCreated", 1, "Count", map[string]string{"JobType": jobType})
+}
+
+// emitInvocation records an endpoint invocation.
+func (m *Mock) emitInvocation(endpointName string) {
+	m.emitMetric("Invocations", 1, "Count", map[string]string{"EndpointName": endpointName})
+}

--- a/providers/aws/sagemaker/metrics.go
+++ b/providers/aws/sagemaker/metrics.go
@@ -6,6 +6,10 @@ import (
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 )
 
+// nominalLatencyMs is the synthetic per-invocation ModelLatency the emulator
+// reports (real endpoints publish a measured value).
+const nominalLatencyMs = 42.0
+
 // emitMetric pushes a single metric to the wired monitoring backend (no-op
 // when monitoring is not set), mirroring the S3/EC2 auto-metric pattern.
 func (m *Mock) emitMetric(metricName string, value float64, unit string, dims map[string]string) {
@@ -24,7 +28,16 @@ func (m *Mock) emitJobMetric(jobType string) {
 	m.emitMetric("JobsCreated", 1, "Count", map[string]string{"JobType": jobType})
 }
 
-// emitInvocation records an endpoint invocation.
+// emitInvocation records an endpoint invocation plus a nominal ModelLatency,
+// mirroring the two metrics real SageMaker endpoints publish most.
 func (m *Mock) emitInvocation(endpointName string) {
-	m.emitMetric("Invocations", 1, "Count", map[string]string{"EndpointName": endpointName})
+	dims := map[string]string{"EndpointName": endpointName}
+	m.emitMetric("Invocations", 1, "Count", dims)
+	m.emitMetric("ModelLatency", nominalLatencyMs, "Milliseconds", dims)
+}
+
+// emitResourceCreated records the creation of a control-plane resource of the
+// given type (endpoints, notebook instances, clusters, …).
+func (m *Mock) emitResourceCreated(resourceType string) {
+	m.emitMetric("ResourcesCreated", 1, "Count", map[string]string{"ResourceType": resourceType})
 }

--- a/providers/aws/sagemaker/notebook.go
+++ b/providers/aws/sagemaker/notebook.go
@@ -66,11 +66,11 @@ func (m *Mock) ListNotebookInstances(_ context.Context) ([]driver.NotebookInstan
 	return out, nil
 }
 
-// StartNotebookInstance moves a Stopped/Failed instance to InService. Starting
-// an instance that is not stopped is rejected, matching real SageMaker.
+// StartNotebookInstance moves a Stopped instance to InService. Starting an
+// instance that is not stopped is rejected, matching real SageMaker.
 func (m *Mock) StartNotebookInstance(_ context.Context, name string) error {
 	return m.transitionNotebook(name, driver.NotebookInService,
-		map[string]bool{driver.NotebookStopped: true, driver.NotebookFailed: true})
+		map[string]bool{driver.NotebookStopped: true})
 }
 
 // StopNotebookInstance moves an InService instance to Stopped. Stopping an

--- a/providers/aws/sagemaker/notebook.go
+++ b/providers/aws/sagemaker/notebook.go
@@ -37,6 +37,7 @@ func (m *Mock) CreateNotebookInstance(_ context.Context, cfg driver.NotebookInst
 	}
 	m.notebooks.Set(cfg.Name, nb)
 	m.setTags(arn, cfg.Tags)
+	m.emitResourceCreated("NotebookInstance")
 
 	out := *nb
 

--- a/providers/aws/sagemaker/notebook.go
+++ b/providers/aws/sagemaker/notebook.go
@@ -1,0 +1,213 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// --- Notebook instance ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateNotebookInstance(_ context.Context, cfg driver.NotebookInstanceSpec) (*driver.NotebookInstance, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "notebookInstanceName is required")
+	}
+
+	if m.notebooks.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "notebook instance %q already exists", cfg.Name)
+	}
+
+	now := m.now()
+	arn := m.arn("notebook-instance/" + cfg.Name)
+	nb := &driver.NotebookInstance{
+		Name:             cfg.Name,
+		ARN:              arn,
+		InstanceType:     cfg.InstanceType,
+		RoleARN:          cfg.RoleARN,
+		VolumeSizeInGB:   cfg.VolumeSizeInGB,
+		LifecycleConfig:  cfg.LifecycleConfig,
+		DefaultCodeRepo:  cfg.DefaultCodeRepo,
+		Status:           driver.NotebookInService, // synchronous Pending -> InService
+		URL:              cfg.Name + ".notebook." + m.opts.Region + ".sagemaker.aws",
+		CreationTime:     now,
+		LastModifiedTime: now,
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.notebooks.Set(cfg.Name, nb)
+	m.setTags(arn, cfg.Tags)
+
+	out := *nb
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeNotebookInstance(_ context.Context, name string) (*driver.NotebookInstance, error) {
+	nb, ok := m.notebooks.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook instance %q not found", name)
+	}
+
+	out := *nb
+
+	return &out, nil
+}
+
+func (m *Mock) ListNotebookInstances(_ context.Context) ([]driver.NotebookInstance, error) {
+	all := m.notebooks.All()
+	out := make([]driver.NotebookInstance, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StartNotebookInstance(_ context.Context, name string) error {
+	return m.setNotebookStatus(name, driver.NotebookInService)
+}
+
+func (m *Mock) StopNotebookInstance(_ context.Context, name string) error {
+	return m.setNotebookStatus(name, driver.NotebookStopped)
+}
+
+func (m *Mock) setNotebookStatus(name, status string) error {
+	nb, ok := m.notebooks.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "notebook instance %q not found", name)
+	}
+
+	nb.Status = status
+	nb.LastModifiedTime = m.now()
+
+	return nil
+}
+
+func (m *Mock) DeleteNotebookInstance(_ context.Context, name string) error {
+	if !m.notebooks.Has(name) {
+		return errors.Newf(errors.NotFound, "notebook instance %q not found", name)
+	}
+
+	m.notebooks.Delete(name)
+
+	return nil
+}
+
+// --- Notebook lifecycle config ---
+
+func (m *Mock) CreateNotebookInstanceLifecycleConfig(
+	_ context.Context, cfg driver.NotebookLifecycleConfigSpec,
+) (*driver.NotebookLifecycleConfig, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "notebookInstanceLifecycleConfigName is required")
+	}
+
+	if m.notebookLCs.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "lifecycle config %q already exists", cfg.Name)
+	}
+
+	lc := &driver.NotebookLifecycleConfig{
+		Name:         cfg.Name,
+		ARN:          m.arn("notebook-instance-lifecycle-config/" + cfg.Name),
+		OnCreate:     cfg.OnCreate,
+		OnStart:      cfg.OnStart,
+		CreationTime: m.now(),
+	}
+	m.notebookLCs.Set(cfg.Name, lc)
+
+	out := *lc
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeNotebookInstanceLifecycleConfig(_ context.Context, name string) (*driver.NotebookLifecycleConfig, error) {
+	lc, ok := m.notebookLCs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "lifecycle config %q not found", name)
+	}
+
+	out := *lc
+
+	return &out, nil
+}
+
+func (m *Mock) ListNotebookInstanceLifecycleConfigs(_ context.Context) ([]driver.NotebookLifecycleConfig, error) {
+	all := m.notebookLCs.All()
+	out := make([]driver.NotebookLifecycleConfig, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteNotebookInstanceLifecycleConfig(_ context.Context, name string) error {
+	if !m.notebookLCs.Has(name) {
+		return errors.Newf(errors.NotFound, "lifecycle config %q not found", name)
+	}
+
+	m.notebookLCs.Delete(name)
+
+	return nil
+}
+
+// --- Code repository ---
+
+func (m *Mock) CreateCodeRepository(_ context.Context, cfg driver.CodeRepositorySpec) (*driver.CodeRepository, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "codeRepositoryName is required")
+	}
+
+	if m.codeRepos.Has(cfg.Name) {
+		return nil, errors.Newf(errors.AlreadyExists, "code repository %q already exists", cfg.Name)
+	}
+
+	repo := &driver.CodeRepository{
+		Name:         cfg.Name,
+		ARN:          m.arn("code-repository/" + cfg.Name),
+		GitURL:       cfg.GitURL,
+		Branch:       cfg.Branch,
+		SecretARN:    cfg.SecretARN,
+		CreationTime: m.now(),
+	}
+	m.codeRepos.Set(cfg.Name, repo)
+
+	out := *repo
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeCodeRepository(_ context.Context, name string) (*driver.CodeRepository, error) {
+	repo, ok := m.codeRepos.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "code repository %q not found", name)
+	}
+
+	out := *repo
+
+	return &out, nil
+}
+
+func (m *Mock) ListCodeRepositories(_ context.Context) ([]driver.CodeRepository, error) {
+	all := m.codeRepos.All()
+	out := make([]driver.CodeRepository, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteCodeRepository(_ context.Context, name string) error {
+	if !m.codeRepos.Has(name) {
+		return errors.Newf(errors.NotFound, "code repository %q not found", name)
+	}
+
+	m.codeRepos.Delete(name)
+
+	return nil
+}

--- a/providers/aws/sagemaker/notebook.go
+++ b/providers/aws/sagemaker/notebook.go
@@ -66,22 +66,37 @@ func (m *Mock) ListNotebookInstances(_ context.Context) ([]driver.NotebookInstan
 	return out, nil
 }
 
+// StartNotebookInstance moves a Stopped/Failed instance to InService. Starting
+// an instance that is not stopped is rejected, matching real SageMaker.
 func (m *Mock) StartNotebookInstance(_ context.Context, name string) error {
-	return m.setNotebookStatus(name, driver.NotebookInService)
+	return m.transitionNotebook(name, driver.NotebookInService,
+		map[string]bool{driver.NotebookStopped: true, driver.NotebookFailed: true})
 }
 
+// StopNotebookInstance moves an InService instance to Stopped. Stopping an
+// instance that is not in service is rejected, matching real SageMaker.
 func (m *Mock) StopNotebookInstance(_ context.Context, name string) error {
-	return m.setNotebookStatus(name, driver.NotebookStopped)
+	return m.transitionNotebook(name, driver.NotebookStopped,
+		map[string]bool{driver.NotebookInService: true})
 }
 
-func (m *Mock) setNotebookStatus(name, status string) error {
+// transitionNotebook copy-then-Sets the notebook to target only when its
+// current status is in allowedFrom; otherwise it returns FailedPrecondition.
+func (m *Mock) transitionNotebook(name, target string, allowedFrom map[string]bool) error {
 	nb, ok := m.notebooks.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "notebook instance %q not found", name)
 	}
 
-	nb.Status = status
-	nb.LastModifiedTime = m.now()
+	if !allowedFrom[nb.Status] {
+		return errors.Newf(errors.FailedPrecondition,
+			"notebook instance %q is %s; cannot transition to %s", name, nb.Status, target)
+	}
+
+	updated := *nb
+	updated.Status = target
+	updated.LastModifiedTime = m.now()
+	m.notebooks.Set(name, &updated)
 
 	return nil
 }

--- a/providers/aws/sagemaker/pipeline.go
+++ b/providers/aws/sagemaker/pipeline.go
@@ -33,6 +33,7 @@ func (m *Mock) CreatePipeline(_ context.Context, cfg driver.PipelineSpec) (*driv
 	}
 	m.pipelines.Set(cfg.PipelineName, p)
 	m.setTags(arn, cfg.Tags)
+	m.emitResourceCreated("Pipeline")
 
 	out := *p
 

--- a/providers/aws/sagemaker/pipeline.go
+++ b/providers/aws/sagemaker/pipeline.go
@@ -68,13 +68,15 @@ func (m *Mock) UpdatePipeline(_ context.Context, name, definition string) (*driv
 		return nil, errors.Newf(errors.NotFound, "pipeline %q not found", name)
 	}
 
+	updated := *p
 	if definition != "" {
-		p.Definition = definition
+		updated.Definition = definition
 	}
 
-	p.LastModifiedTime = m.now()
+	updated.LastModifiedTime = m.now()
+	m.pipelines.Set(name, &updated)
 
-	out := *p
+	out := updated
 
 	return &out, nil
 }
@@ -141,8 +143,10 @@ func (m *Mock) StopPipelineExecution(_ context.Context, executionARN string) err
 		return errors.Newf(errors.NotFound, "pipeline execution %q not found", executionARN)
 	}
 
-	ex.Status = driver.ExecutionStopped
-	ex.EndTime = m.now()
+	updated := *ex
+	updated.Status = driver.ExecutionStopped
+	updated.EndTime = m.now()
+	m.executions.Set(executionARN, &updated)
 
 	return nil
 }

--- a/providers/aws/sagemaker/pipeline.go
+++ b/providers/aws/sagemaker/pipeline.go
@@ -1,0 +1,270 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// --- Pipeline ---
+
+func (m *Mock) CreatePipeline(_ context.Context, cfg driver.PipelineSpec) (*driver.Pipeline, error) {
+	if cfg.PipelineName == "" {
+		return nil, errors.New(errors.InvalidArgument, "pipelineName is required")
+	}
+
+	if m.pipelines.Has(cfg.PipelineName) {
+		return nil, errors.Newf(errors.AlreadyExists, "pipeline %q already exists", cfg.PipelineName)
+	}
+
+	now := m.now()
+	arn := m.arn("pipeline/" + cfg.PipelineName)
+	p := &driver.Pipeline{
+		PipelineName:     cfg.PipelineName,
+		PipelineARN:      arn,
+		RoleARN:          cfg.RoleARN,
+		Definition:       cfg.Definition,
+		Status:           driver.PipelineActive,
+		CreationTime:     now,
+		LastModifiedTime: now,
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.pipelines.Set(cfg.PipelineName, p)
+	m.setTags(arn, cfg.Tags)
+
+	out := *p
+
+	return &out, nil
+}
+
+func (m *Mock) DescribePipeline(_ context.Context, name string) (*driver.Pipeline, error) {
+	p, ok := m.pipelines.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "pipeline %q not found", name)
+	}
+
+	out := *p
+
+	return &out, nil
+}
+
+func (m *Mock) ListPipelines(_ context.Context) ([]driver.Pipeline, error) {
+	all := m.pipelines.All()
+	out := make([]driver.Pipeline, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) UpdatePipeline(_ context.Context, name, definition string) (*driver.Pipeline, error) {
+	p, ok := m.pipelines.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "pipeline %q not found", name)
+	}
+
+	if definition != "" {
+		p.Definition = definition
+	}
+
+	p.LastModifiedTime = m.now()
+
+	out := *p
+
+	return &out, nil
+}
+
+func (m *Mock) DeletePipeline(_ context.Context, name string) error {
+	if !m.pipelines.Has(name) {
+		return errors.Newf(errors.NotFound, "pipeline %q not found", name)
+	}
+
+	m.pipelines.Delete(name)
+
+	return nil
+}
+
+// --- Pipeline execution ---
+
+func (m *Mock) StartPipelineExecution(_ context.Context, pipelineName string) (*driver.PipelineExecution, error) {
+	if !m.pipelines.Has(pipelineName) {
+		return nil, errors.Newf(errors.NotFound, "pipeline %q not found", pipelineName)
+	}
+
+	now := m.now()
+	arn := m.arn("pipeline/" + pipelineName + "/execution/" + idgen.GenerateID(""))
+	ex := &driver.PipelineExecution{
+		ExecutionARN: arn,
+		PipelineName: pipelineName,
+		Status:       driver.ExecutionSucceeded, // synchronous Executing -> Succeeded
+		StartTime:    now,
+		EndTime:      now,
+	}
+	m.executions.Set(arn, ex)
+
+	out := *ex
+
+	return &out, nil
+}
+
+func (m *Mock) DescribePipelineExecution(_ context.Context, executionARN string) (*driver.PipelineExecution, error) {
+	ex, ok := m.executions.Get(executionARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "pipeline execution %q not found", executionARN)
+	}
+
+	out := *ex
+
+	return &out, nil
+}
+
+func (m *Mock) ListPipelineExecutions(_ context.Context, pipelineName string) ([]driver.PipelineExecution, error) {
+	out := make([]driver.PipelineExecution, 0)
+
+	for _, ex := range m.executions.All() {
+		if pipelineName == "" || ex.PipelineName == pipelineName {
+			out = append(out, *ex)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StopPipelineExecution(_ context.Context, executionARN string) error {
+	ex, ok := m.executions.Get(executionARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "pipeline execution %q not found", executionARN)
+	}
+
+	ex.Status = driver.ExecutionStopped
+	ex.EndTime = m.now()
+
+	return nil
+}
+
+// --- Experiment ---
+
+func (m *Mock) CreateExperiment(_ context.Context, cfg driver.ExperimentSpec) (*driver.Experiment, error) {
+	if cfg.ExperimentName == "" {
+		return nil, errors.New(errors.InvalidArgument, "experimentName is required")
+	}
+
+	if m.experiments.Has(cfg.ExperimentName) {
+		return nil, errors.Newf(errors.AlreadyExists, "experiment %q already exists", cfg.ExperimentName)
+	}
+
+	arn := m.arn("experiment/" + cfg.ExperimentName)
+	e := &driver.Experiment{
+		ExperimentName: cfg.ExperimentName,
+		ExperimentARN:  arn,
+		Description:    cfg.Description,
+		CreationTime:   m.now(),
+		Tags:           copyTags(cfg.Tags),
+	}
+	m.experiments.Set(cfg.ExperimentName, e)
+	m.setTags(arn, cfg.Tags)
+
+	out := *e
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeExperiment(_ context.Context, name string) (*driver.Experiment, error) {
+	e, ok := m.experiments.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "experiment %q not found", name)
+	}
+
+	out := *e
+
+	return &out, nil
+}
+
+func (m *Mock) ListExperiments(_ context.Context) ([]driver.Experiment, error) {
+	all := m.experiments.All()
+	out := make([]driver.Experiment, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteExperiment(_ context.Context, name string) error {
+	if !m.experiments.Has(name) {
+		return errors.Newf(errors.NotFound, "experiment %q not found", name)
+	}
+
+	m.experiments.Delete(name)
+
+	return nil
+}
+
+// --- Trial ---
+
+func (m *Mock) CreateTrial(_ context.Context, cfg driver.TrialSpec) (*driver.Trial, error) {
+	if cfg.TrialName == "" {
+		return nil, errors.New(errors.InvalidArgument, "trialName is required")
+	}
+
+	if cfg.ExperimentName != "" && !m.experiments.Has(cfg.ExperimentName) {
+		return nil, errors.Newf(errors.InvalidArgument, "experiment %q not found", cfg.ExperimentName)
+	}
+
+	if m.trials.Has(cfg.TrialName) {
+		return nil, errors.Newf(errors.AlreadyExists, "trial %q already exists", cfg.TrialName)
+	}
+
+	arn := m.arn("experiment-trial/" + cfg.TrialName)
+	t := &driver.Trial{
+		TrialName:      cfg.TrialName,
+		TrialARN:       arn,
+		ExperimentName: cfg.ExperimentName,
+		CreationTime:   m.now(),
+		Tags:           copyTags(cfg.Tags),
+	}
+	m.trials.Set(cfg.TrialName, t)
+	m.setTags(arn, cfg.Tags)
+
+	out := *t
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeTrial(_ context.Context, name string) (*driver.Trial, error) {
+	t, ok := m.trials.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "trial %q not found", name)
+	}
+
+	out := *t
+
+	return &out, nil
+}
+
+func (m *Mock) ListTrials(_ context.Context, experimentName string) ([]driver.Trial, error) {
+	out := make([]driver.Trial, 0)
+
+	for _, t := range m.trials.All() {
+		if experimentName == "" || t.ExperimentName == experimentName {
+			out = append(out, *t)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteTrial(_ context.Context, name string) error {
+	if !m.trials.Has(name) {
+		return errors.Newf(errors.NotFound, "trial %q not found", name)
+	}
+
+	m.trials.Delete(name)
+
+	return nil
+}

--- a/providers/aws/sagemaker/registry.go
+++ b/providers/aws/sagemaker/registry.go
@@ -10,7 +10,6 @@ import (
 
 // --- Model package group ---
 
-//nolint:dupl // the create-record shape recurs across resources; sharing it would obscure each resource.
 func (m *Mock) CreateModelPackageGroup(_ context.Context, cfg driver.ModelPackageGroupSpec) (*driver.ModelPackageGroup, error) {
 	if cfg.GroupName == "" {
 		return nil, errors.New(errors.InvalidArgument, "modelPackageGroupName is required")

--- a/providers/aws/sagemaker/registry.go
+++ b/providers/aws/sagemaker/registry.go
@@ -80,6 +80,12 @@ func (m *Mock) CreateModelPackage(_ context.Context, cfg driver.ModelPackageSpec
 		return nil, errors.Newf(errors.InvalidArgument, "model package group %q not found", cfg.GroupName)
 	}
 
+	// Serialize version assignment: without the lock two concurrent creates for
+	// the same group could compute the same N+1 and mint a colliding ARN, and
+	// the second Set would silently overwrite the first.
+	m.pkgMu.Lock()
+	defer m.pkgMu.Unlock()
+
 	version := m.nextPackageVersion(cfg.GroupName)
 	arn := m.arn("model-package/" + cfg.GroupName + "/" + strconv.Itoa(version))
 	p := &driver.ModelPackage{
@@ -142,11 +148,14 @@ func (m *Mock) UpdateModelPackage(_ context.Context, arn, approvalStatus string)
 		return nil, errors.Newf(errors.NotFound, "model package %q not found", arn)
 	}
 
+	updated := *p
 	if approvalStatus != "" {
-		p.ApprovalStatus = approvalStatus
+		updated.ApprovalStatus = approvalStatus
 	}
 
-	out := *p
+	m.packages.Set(arn, &updated)
+
+	out := updated
 
 	return &out, nil
 }

--- a/providers/aws/sagemaker/registry.go
+++ b/providers/aws/sagemaker/registry.go
@@ -1,0 +1,163 @@
+package sagemaker
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// --- Model package group ---
+
+//nolint:dupl // the create-record shape recurs across resources; sharing it would obscure each resource.
+func (m *Mock) CreateModelPackageGroup(_ context.Context, cfg driver.ModelPackageGroupSpec) (*driver.ModelPackageGroup, error) {
+	if cfg.GroupName == "" {
+		return nil, errors.New(errors.InvalidArgument, "modelPackageGroupName is required")
+	}
+
+	if m.packageGroups.Has(cfg.GroupName) {
+		return nil, errors.Newf(errors.AlreadyExists, "model package group %q already exists", cfg.GroupName)
+	}
+
+	arn := m.arn("model-package-group/" + cfg.GroupName)
+	g := &driver.ModelPackageGroup{
+		GroupName:    cfg.GroupName,
+		GroupARN:     arn,
+		Description:  cfg.Description,
+		Status:       driver.PackageCompleted,
+		CreationTime: m.now(),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.packageGroups.Set(cfg.GroupName, g)
+	m.setTags(arn, cfg.Tags)
+
+	out := *g
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeModelPackageGroup(_ context.Context, name string) (*driver.ModelPackageGroup, error) {
+	g, ok := m.packageGroups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model package group %q not found", name)
+	}
+
+	out := *g
+
+	return &out, nil
+}
+
+func (m *Mock) ListModelPackageGroups(_ context.Context) ([]driver.ModelPackageGroup, error) {
+	all := m.packageGroups.All()
+	out := make([]driver.ModelPackageGroup, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteModelPackageGroup(_ context.Context, name string) error {
+	if !m.packageGroups.Has(name) {
+		return errors.Newf(errors.NotFound, "model package group %q not found", name)
+	}
+
+	m.packageGroups.Delete(name)
+
+	return nil
+}
+
+// --- Model package (versioned) ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateModelPackage(_ context.Context, cfg driver.ModelPackageSpec) (*driver.ModelPackage, error) {
+	if cfg.GroupName == "" {
+		return nil, errors.New(errors.InvalidArgument, "modelPackageGroupName is required")
+	}
+
+	if !m.packageGroups.Has(cfg.GroupName) {
+		return nil, errors.Newf(errors.InvalidArgument, "model package group %q not found", cfg.GroupName)
+	}
+
+	version := m.nextPackageVersion(cfg.GroupName)
+	arn := m.arn("model-package/" + cfg.GroupName + "/" + strconv.Itoa(version))
+	p := &driver.ModelPackage{
+		PackageARN:     arn,
+		GroupName:      cfg.GroupName,
+		Version:        version,
+		Description:    cfg.Description,
+		InferenceImage: cfg.InferenceImage,
+		ModelDataURL:   cfg.ModelDataURL,
+		Status:         driver.PackageCompleted,
+		ApprovalStatus: orDefault(cfg.ApprovalStatus, driver.ApprovalPendingManual),
+		CreationTime:   m.now(),
+		Tags:           copyTags(cfg.Tags),
+	}
+	m.packages.Set(arn, p)
+	m.setTags(arn, cfg.Tags)
+
+	out := *p
+
+	return &out, nil
+}
+
+func (m *Mock) nextPackageVersion(group string) int {
+	highest := 0
+	for _, p := range m.packages.All() {
+		if p.GroupName == group && p.Version > highest {
+			highest = p.Version
+		}
+	}
+
+	return highest + 1
+}
+
+func (m *Mock) DescribeModelPackage(_ context.Context, arn string) (*driver.ModelPackage, error) {
+	p, ok := m.packages.Get(arn)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model package %q not found", arn)
+	}
+
+	out := *p
+
+	return &out, nil
+}
+
+func (m *Mock) ListModelPackages(_ context.Context, groupName string) ([]driver.ModelPackage, error) {
+	out := make([]driver.ModelPackage, 0)
+
+	for _, p := range m.packages.All() {
+		if groupName == "" || p.GroupName == groupName {
+			out = append(out, *p)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) UpdateModelPackage(_ context.Context, arn, approvalStatus string) (*driver.ModelPackage, error) {
+	p, ok := m.packages.Get(arn)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model package %q not found", arn)
+	}
+
+	if approvalStatus != "" {
+		p.ApprovalStatus = approvalStatus
+	}
+
+	out := *p
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteModelPackage(_ context.Context, arn string) error {
+	if !m.packages.Has(arn) {
+		return errors.Newf(errors.NotFound, "model package %q not found", arn)
+	}
+
+	m.packages.Delete(arn)
+
+	return nil
+}

--- a/providers/aws/sagemaker/runtime.go
+++ b/providers/aws/sagemaker/runtime.go
@@ -1,0 +1,71 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// InvokeEndpoint performs an emulated synchronous inference call. The endpoint
+// must exist and be InService. The response echoes the request body, which is
+// deterministic and adequate for exercising client serialization paths.
+//
+//nolint:gocritic // in matches the driver signature; copied on entry.
+func (m *Mock) InvokeEndpoint(_ context.Context, in driver.InvokeEndpointInput) (*driver.InvokeEndpointOutput, error) {
+	ep, ok := m.endpoints.Get(in.EndpointName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", in.EndpointName)
+	}
+
+	if ep.Status != driver.EndpointInService {
+		return nil, errors.Newf(errors.FailedPrecondition, "endpoint %q is not InService (status %s)", in.EndpointName, ep.Status)
+	}
+
+	if in.InferenceComponentName != "" && !m.inferenceComponents.Has(in.InferenceComponentName) {
+		return nil, errors.Newf(errors.NotFound, "inference component %q not found", in.InferenceComponentName)
+	}
+
+	m.emitInvocation(in.EndpointName)
+
+	variant := ""
+	if len(ep.Variants) > 0 {
+		variant = ep.Variants[0].VariantName
+	}
+
+	body := in.Body
+	if body == nil {
+		body = []byte{}
+	}
+
+	return &driver.InvokeEndpointOutput{
+		ContentType:    orDefault(in.Accept, orDefault(in.ContentType, "application/octet-stream")),
+		Body:           body,
+		InvokedVariant: variant,
+	}, nil
+}
+
+// InvokeEndpointAsync records an asynchronous invocation and returns the S3
+// location where the (echoed) result is considered to have been written.
+//
+
+func (m *Mock) InvokeEndpointAsync(_ context.Context, in driver.InvokeEndpointAsyncInput) (*driver.InvokeEndpointAsyncOutput, error) {
+	ep, ok := m.endpoints.Get(in.EndpointName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", in.EndpointName)
+	}
+
+	if ep.Status != driver.EndpointInService {
+		return nil, errors.Newf(errors.FailedPrecondition, "endpoint %q is not InService (status %s)", in.EndpointName, ep.Status)
+	}
+
+	m.emitInvocation(in.EndpointName)
+
+	id := idgen.GenerateID("")
+
+	return &driver.InvokeEndpointAsyncOutput{
+		OutputS3URI: "s3://sagemaker-async-results/" + in.EndpointName + "/" + id + ".out",
+		InferenceID: id,
+	}, nil
+}

--- a/providers/aws/sagemaker/sagemaker.go
+++ b/providers/aws/sagemaker/sagemaker.go
@@ -1,0 +1,141 @@
+// Package sagemaker provides an in-memory mock implementation of Amazon
+// SageMaker AI: training/processing/transform/tuning/AutoML/labeling/
+// compilation jobs, the model-and-endpoint inference stack, the model
+// registry, Studio, notebook instances, HyperPod clusters, Feature Store and
+// pipelines. Asynchronous jobs complete synchronously (straight to a terminal
+// state) so Describe/List calls are deterministic, mirroring the Bedrock mock.
+package sagemaker
+
+import (
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// Compile-time checks that Mock implements the driver interfaces.
+var (
+	_ driver.SageMaker = (*Mock)(nil)
+	_ driver.Runtime   = (*Mock)(nil)
+)
+
+// Mock is an in-memory mock implementation of Amazon SageMaker AI.
+type Mock struct {
+	opts *config.Options
+
+	trainingJobs    *memstore.Store[*driver.TrainingJob]
+	processingJobs  *memstore.Store[*driver.ProcessingJob]
+	transformJobs   *memstore.Store[*driver.TransformJob]
+	tuningJobs      *memstore.Store[*driver.HyperParameterTuningJob]
+	autoMLJobs      *memstore.Store[*driver.AutoMLJob]
+	labelingJobs    *memstore.Store[*driver.LabelingJob]
+	compilationJobs *memstore.Store[*driver.CompilationJob]
+
+	models              *memstore.Store[*driver.Model]
+	endpointConfigs     *memstore.Store[*driver.EndpointConfig]
+	endpoints           *memstore.Store[*driver.Endpoint]
+	inferenceComponents *memstore.Store[*driver.InferenceComponent]
+
+	packageGroups *memstore.Store[*driver.ModelPackageGroup]
+	packages      *memstore.Store[*driver.ModelPackage] // keyed by package ARN
+
+	domains      *memstore.Store[*driver.Domain]
+	userProfiles *memstore.Store[*driver.UserProfile] // keyed by domainID\x00name
+	spaces       *memstore.Store[*driver.Space]       // keyed by domainID\x00name
+	apps         *memstore.Store[*driver.App]         // keyed by app composite key
+
+	notebooks   *memstore.Store[*driver.NotebookInstance]
+	notebookLCs *memstore.Store[*driver.NotebookLifecycleConfig]
+	codeRepos   *memstore.Store[*driver.CodeRepository]
+
+	clusters *memstore.Store[*driver.Cluster]
+
+	featureGroups  *memstore.Store[*driver.FeatureGroup]
+	featureRecords *memstore.Store[[]driver.FeatureValue] // keyed by group\x00recordID
+
+	pipelines   *memstore.Store[*driver.Pipeline]
+	executions  *memstore.Store[*driver.PipelineExecution] // keyed by execution ARN
+	experiments *memstore.Store[*driver.Experiment]
+	trials      *memstore.Store[*driver.Trial]
+
+	tags *memstore.Store[[]driver.Tag] // keyed by resource ARN
+
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new SageMaker mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		opts:                opts,
+		trainingJobs:        memstore.New[*driver.TrainingJob](),
+		processingJobs:      memstore.New[*driver.ProcessingJob](),
+		transformJobs:       memstore.New[*driver.TransformJob](),
+		tuningJobs:          memstore.New[*driver.HyperParameterTuningJob](),
+		autoMLJobs:          memstore.New[*driver.AutoMLJob](),
+		labelingJobs:        memstore.New[*driver.LabelingJob](),
+		compilationJobs:     memstore.New[*driver.CompilationJob](),
+		models:              memstore.New[*driver.Model](),
+		endpointConfigs:     memstore.New[*driver.EndpointConfig](),
+		endpoints:           memstore.New[*driver.Endpoint](),
+		inferenceComponents: memstore.New[*driver.InferenceComponent](),
+		packageGroups:       memstore.New[*driver.ModelPackageGroup](),
+		packages:            memstore.New[*driver.ModelPackage](),
+		domains:             memstore.New[*driver.Domain](),
+		userProfiles:        memstore.New[*driver.UserProfile](),
+		spaces:              memstore.New[*driver.Space](),
+		apps:                memstore.New[*driver.App](),
+		notebooks:           memstore.New[*driver.NotebookInstance](),
+		notebookLCs:         memstore.New[*driver.NotebookLifecycleConfig](),
+		codeRepos:           memstore.New[*driver.CodeRepository](),
+		clusters:            memstore.New[*driver.Cluster](),
+		featureGroups:       memstore.New[*driver.FeatureGroup](),
+		featureRecords:      memstore.New[[]driver.FeatureValue](),
+		pipelines:           memstore.New[*driver.Pipeline](),
+		executions:          memstore.New[*driver.PipelineExecution](),
+		experiments:         memstore.New[*driver.Experiment](),
+		trials:              memstore.New[*driver.Trial](),
+		tags:                memstore.New[[]driver.Tag](),
+	}
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) now() string {
+	return m.opts.Clock.Now().UTC().Format(time.RFC3339)
+}
+
+// arn builds a SageMaker ARN for the given resource segment (e.g.
+// "training-job/my-job").
+func (m *Mock) arn(resource string) string {
+	return idgen.AWSARN("sagemaker", m.opts.Region, m.opts.AccountID, resource)
+}
+
+func copyTags(in []driver.Tag) []driver.Tag {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.Tag, len(in))
+	copy(out, in)
+
+	return out
+}
+
+func copyStrMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}

--- a/providers/aws/sagemaker/sagemaker.go
+++ b/providers/aws/sagemaker/sagemaker.go
@@ -3,10 +3,15 @@
 // compilation jobs, the model-and-endpoint inference stack, the model
 // registry, Studio, notebook instances, HyperPod clusters, Feature Store and
 // pipelines. Asynchronous jobs complete synchronously (straight to a terminal
-// state) so Describe/List calls are deterministic, mirroring the Bedrock mock.
+// state) so Describe/List calls are deterministic.
+//
+// This is the Layer-3 driver implementation. The portable Layer-1 wrapper that
+// adds recording/metrics/rate-limiting/error-injection/latency lives in the
+// module-root sagemaker package (sagemaker/sagemaker.go).
 package sagemaker
 
 import (
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
@@ -62,6 +67,10 @@ type Mock struct {
 	trials      *memstore.Store[*driver.Trial]
 
 	tags *memstore.Store[[]driver.Tag] // keyed by resource ARN
+
+	// pkgMu serializes the read-compute-write of model-package version numbers
+	// so two concurrent CreateModelPackage calls can't mint the same ARN.
+	pkgMu sync.Mutex
 
 	monitoring mondriver.Monitoring
 }
@@ -136,6 +145,32 @@ func copyStrMap(in map[string]string) map[string]string {
 	for k, v := range in {
 		out[k] = v
 	}
+
+	return out
+}
+
+// copyVariants returns a deep copy of a production-variant slice so stored
+// endpoints/configs never share a backing array (mutating one would otherwise
+// corrupt the source EndpointConfig and sibling endpoints).
+func copyVariants(in []driver.ProductionVariant) []driver.ProductionVariant {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.ProductionVariant, len(in))
+	copy(out, in)
+
+	return out
+}
+
+// copyContainers returns a deep copy of a container-definition slice.
+func copyContainers(in []driver.ContainerDefinition) []driver.ContainerDefinition {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.ContainerDefinition, len(in))
+	copy(out, in)
 
 	return out
 }

--- a/providers/aws/sagemaker/sagemaker.go
+++ b/providers/aws/sagemaker/sagemaker.go
@@ -163,14 +163,21 @@ func copyVariants(in []driver.ProductionVariant) []driver.ProductionVariant {
 	return out
 }
 
-// copyContainers returns a deep copy of a container-definition slice.
+// copyContainers returns a deep copy of a container-definition slice,
+// including each container's Environment map — a plain slice copy would leave
+// the maps aliased, so mutating a returned container's Environment would still
+// corrupt the stored model.
 func copyContainers(in []driver.ContainerDefinition) []driver.ContainerDefinition {
 	if in == nil {
 		return nil
 	}
 
 	out := make([]driver.ContainerDefinition, len(in))
-	copy(out, in)
+
+	for i, c := range in {
+		c.Environment = copyStrMap(c.Environment)
+		out[i] = c
+	}
 
 	return out
 }

--- a/providers/aws/sagemaker/sagemaker_test.go
+++ b/providers/aws/sagemaker/sagemaker_test.go
@@ -1,0 +1,344 @@
+package sagemaker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/config"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/providers/aws/cloudwatch"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(
+		config.WithClock(fc),
+		config.WithRegion("us-east-1"),
+		config.WithAccountID("123456789012"),
+	)
+
+	return New(opts)
+}
+
+func TestTrainingJobLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	job, err := m.CreateTrainingJob(ctx, driver.TrainingJobConfig{
+		JobName:        "train-1",
+		RoleARN:        "arn:aws:iam::123456789012:role/svc",
+		AlgorithmImage: "xgboost:latest",
+		OutputS3URI:    "s3://bucket/out",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobCompleted, job.Status)
+	assert.Equal(t, driver.SecondaryCompleted, job.SecondaryStatus)
+	assert.NotEmpty(t, job.SecondaryTransitions)
+	assert.Equal(t, "arn:aws:sagemaker:us-east-1:123456789012:training-job/train-1", job.JobARN)
+	assert.Equal(t, "s3://bucket/out/output/model.tar.gz", job.ModelArtifactS3URI)
+
+	got, err := m.DescribeTrainingJob(ctx, "train-1")
+	require.NoError(t, err)
+	assert.Equal(t, "train-1", got.JobName)
+
+	list, err := m.ListTrainingJobs(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	require.NoError(t, m.StopTrainingJob(ctx, "train-1"))
+	got, _ = m.DescribeTrainingJob(ctx, "train-1")
+	assert.Equal(t, driver.JobStopped, got.Status)
+}
+
+func TestTrainingJobDuplicateAndMissing(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateTrainingJob(ctx, driver.TrainingJobConfig{JobName: "dup"})
+	require.NoError(t, err)
+	_, err = m.CreateTrainingJob(ctx, driver.TrainingJobConfig{JobName: "dup"})
+	require.Error(t, err)
+
+	_, err = m.CreateTrainingJob(ctx, driver.TrainingJobConfig{})
+	require.Error(t, err)
+
+	_, err = m.DescribeTrainingJob(ctx, "nope")
+	require.Error(t, err)
+}
+
+func TestAllJobKindsComplete(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	pj, err := m.CreateProcessingJob(ctx, driver.ProcessingJobConfig{JobName: "p1"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobCompleted, pj.Status)
+
+	_, err = m.CreateModel(ctx, driver.ModelConfig{ModelName: "m1"})
+	require.NoError(t, err)
+	tj, err := m.CreateTransformJob(ctx, driver.TransformJobConfig{JobName: "t1", ModelName: "m1"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobCompleted, tj.Status)
+
+	hj, err := m.CreateHyperParameterTuningJob(ctx, driver.HyperParameterTuningJobConfig{JobName: "h1", MaxJobs: 4})
+	require.NoError(t, err)
+	assert.Equal(t, "h1-001", hj.BestTrainingJob)
+
+	aj, err := m.CreateAutoMLJobV2(ctx, driver.AutoMLJobConfig{JobName: "a1"})
+	require.NoError(t, err)
+	assert.Equal(t, "a1-best", aj.BestCandidateName)
+
+	lj, err := m.CreateLabelingJob(ctx, driver.LabelingJobConfig{JobName: "l1"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobCompleted, lj.Status)
+
+	cj, err := m.CreateCompilationJob(ctx, driver.CompilationJobConfig{JobName: "c1"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobCompleted, cj.Status)
+}
+
+func TestInferenceFlowAndInvoke(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateModel(ctx, driver.ModelConfig{ModelName: "model-a", RoleARN: "role"})
+	require.NoError(t, err)
+
+	_, err = m.CreateEndpointConfig(ctx, driver.EndpointConfigSpec{
+		ConfigName: "cfg-a",
+		ProductionVariants: []driver.ProductionVariant{
+			{VariantName: "v1", ModelName: "model-a", InstanceType: "ml.m5.large", InitialInstanceCount: 1, InitialVariantWeight: 1},
+		},
+	})
+	require.NoError(t, err)
+
+	ep, err := m.CreateEndpoint(ctx, driver.EndpointSpec{EndpointName: "ep-a", ConfigName: "cfg-a"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.EndpointInService, ep.Status)
+	assert.Len(t, ep.Variants, 1)
+
+	out, err := m.InvokeEndpoint(ctx, driver.InvokeEndpointInput{
+		EndpointName: "ep-a", ContentType: "application/json", Body: []byte(`{"x":1}`),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []byte(`{"x":1}`), out.Body)
+	assert.Equal(t, "v1", out.InvokedVariant)
+
+	_, err = m.UpdateEndpointWeightsAndCapacities(ctx, "ep-a", []driver.VariantWeight{
+		{VariantName: "v1", DesiredWeight: 0.5, DesiredInstanceCount: 3},
+	})
+	require.NoError(t, err)
+	got, _ := m.DescribeEndpoint(ctx, "ep-a")
+	assert.InDelta(t, 0.5, got.Variants[0].InitialVariantWeight, 0.001)
+	assert.Equal(t, 3, got.Variants[0].InitialInstanceCount)
+}
+
+func TestInvokeEndpointErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.InvokeEndpoint(ctx, driver.InvokeEndpointInput{EndpointName: "missing"})
+	require.Error(t, err)
+}
+
+func TestEndpointRequiresExistingConfig(t *testing.T) {
+	m := newTestMock()
+	_, err := m.CreateEndpoint(context.Background(), driver.EndpointSpec{EndpointName: "e", ConfigName: "nope"})
+	require.Error(t, err)
+}
+
+func TestModelRegistryVersioning(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateModelPackageGroup(ctx, driver.ModelPackageGroupSpec{GroupName: "grp"})
+	require.NoError(t, err)
+
+	p1, err := m.CreateModelPackage(ctx, driver.ModelPackageSpec{GroupName: "grp"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, p1.Version)
+	assert.Equal(t, driver.ApprovalPendingManual, p1.ApprovalStatus)
+
+	p2, err := m.CreateModelPackage(ctx, driver.ModelPackageSpec{GroupName: "grp"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, p2.Version)
+
+	upd, err := m.UpdateModelPackage(ctx, p2.PackageARN, driver.ApprovalApproved)
+	require.NoError(t, err)
+	assert.Equal(t, driver.ApprovalApproved, upd.ApprovalStatus)
+
+	pkgs, err := m.ListModelPackages(ctx, "grp")
+	require.NoError(t, err)
+	assert.Len(t, pkgs, 2)
+}
+
+func TestStudioDomainAndChildren(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	d, err := m.CreateDomain(ctx, driver.DomainSpec{DomainName: "team", AuthMode: "IAM"})
+	require.NoError(t, err)
+	assert.Contains(t, d.DomainID, "d-")
+	assert.Equal(t, driver.StudioInService, d.Status)
+
+	_, err = m.CreateUserProfile(ctx, driver.UserProfileSpec{DomainID: d.DomainID, UserProfileName: "alice"})
+	require.NoError(t, err)
+	_, err = m.CreateUserProfile(ctx, driver.UserProfileSpec{DomainID: "d-missing", UserProfileName: "bob"})
+	require.Error(t, err)
+
+	app, err := m.CreateApp(ctx, driver.AppSpec{
+		DomainID: d.DomainID, UserProfileName: "alice", AppType: "JupyterServer", AppName: "default",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, driver.AppInService, app.Status)
+
+	apps, err := m.ListApps(ctx, d.DomainID)
+	require.NoError(t, err)
+	assert.Len(t, apps, 1)
+}
+
+func TestNotebookInstanceStartStop(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	nb, err := m.CreateNotebookInstance(ctx, driver.NotebookInstanceSpec{Name: "nb", InstanceType: "ml.t3.medium"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.NotebookInService, nb.Status)
+
+	require.NoError(t, m.StopNotebookInstance(ctx, "nb"))
+	got, _ := m.DescribeNotebookInstance(ctx, "nb")
+	assert.Equal(t, driver.NotebookStopped, got.Status)
+
+	require.NoError(t, m.StartNotebookInstance(ctx, "nb"))
+	got, _ = m.DescribeNotebookInstance(ctx, "nb")
+	assert.Equal(t, driver.NotebookInService, got.Status)
+}
+
+func TestHyperPodClusterNodes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	c, err := m.CreateCluster(ctx, driver.ClusterSpec{
+		ClusterName: "cl",
+		InstanceGroups: []driver.ClusterInstanceGroupSpec{
+			{GroupName: "workers", InstanceType: "ml.p4d.24xlarge", InstanceCount: 3},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, driver.ClusterInService, c.Status)
+
+	nodes, err := m.ListClusterNodes(ctx, "cl")
+	require.NoError(t, err)
+	assert.Len(t, nodes, 3)
+
+	node, err := m.DescribeClusterNode(ctx, "cl", "workers-0")
+	require.NoError(t, err)
+	assert.Equal(t, "Running", node.Status)
+}
+
+func TestFeatureStoreRuntime(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreateFeatureGroup(ctx, driver.FeatureGroupSpec{
+		GroupName:            "fg",
+		RecordIdentifierName: "id",
+		EventTimeFeatureName: "ts",
+		OnlineStoreEnabled:   true,
+		Features:             []driver.FeatureDefinition{{Name: "id", Type: "String"}, {Name: "score", Type: "Fractional"}},
+	})
+	require.NoError(t, err)
+
+	rec := []driver.FeatureValue{{Name: "id", Value: "u1"}, {Name: "score", Value: "0.9"}}
+	require.NoError(t, m.PutRecord(ctx, "fg", rec))
+
+	got, err := m.GetRecord(ctx, "fg", "u1")
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+
+	require.NoError(t, m.DeleteRecord(ctx, "fg", "u1"))
+	_, err = m.GetRecord(ctx, "fg", "u1")
+	require.Error(t, err)
+
+	// Missing identifier feature is rejected.
+	require.Error(t, m.PutRecord(ctx, "fg", []driver.FeatureValue{{Name: "score", Value: "1"}}))
+}
+
+func TestPipelineExecutionAndExperiments(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePipeline(ctx, driver.PipelineSpec{PipelineName: "pl", Definition: "{}"})
+	require.NoError(t, err)
+
+	ex, err := m.StartPipelineExecution(ctx, "pl")
+	require.NoError(t, err)
+	assert.Equal(t, driver.ExecutionSucceeded, ex.Status)
+
+	require.NoError(t, m.StopPipelineExecution(ctx, ex.ExecutionARN))
+	got, _ := m.DescribePipelineExecution(ctx, ex.ExecutionARN)
+	assert.Equal(t, driver.ExecutionStopped, got.Status)
+
+	_, err = m.CreateExperiment(ctx, driver.ExperimentSpec{ExperimentName: "exp"})
+	require.NoError(t, err)
+	_, err = m.CreateTrial(ctx, driver.TrialSpec{TrialName: "tr", ExperimentName: "exp"})
+	require.NoError(t, err)
+	trials, err := m.ListTrials(ctx, "exp")
+	require.NoError(t, err)
+	assert.Len(t, trials, 1)
+}
+
+func TestTagsLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	job, err := m.CreateTrainingJob(ctx, driver.TrainingJobConfig{
+		JobName: "tagged",
+		Tags:    []driver.Tag{{Key: "team", Value: "ml"}},
+	})
+	require.NoError(t, err)
+
+	tags, err := m.ListTags(ctx, job.JobARN)
+	require.NoError(t, err)
+	assert.Len(t, tags, 1)
+
+	_, err = m.AddTags(ctx, job.JobARN, []driver.Tag{{Key: "env", Value: "test"}, {Key: "team", Value: "ai"}})
+	require.NoError(t, err)
+	tags, _ = m.ListTags(ctx, job.JobARN)
+	assert.Len(t, tags, 2)
+
+	require.NoError(t, m.DeleteTags(ctx, job.JobARN, []string{"env"}))
+	tags, _ = m.ListTags(ctx, job.JobARN)
+	assert.Len(t, tags, 1)
+	assert.Equal(t, "ai", tags[0].Value)
+}
+
+func TestAutoMetricsEmission(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"))
+	m := New(opts)
+	ctx := context.Background()
+
+	cw := cloudwatch.New(opts)
+	m.SetMonitoring(cw)
+
+	_, err := m.CreateTrainingJob(ctx, driver.TrainingJobConfig{JobName: "metric-job"})
+	require.NoError(t, err)
+
+	result, err := cw.GetMetricData(ctx, mondriver.GetMetricInput{
+		Namespace:  "AWS/SageMaker",
+		MetricName: "JobsCreated",
+		Dimensions: map[string]string{"JobType": "TrainingJob"},
+		StartTime:  fc.Now().Add(-time.Hour),
+		EndTime:    fc.Now().Add(time.Hour),
+		Period:     60,
+		Stat:       "Sum",
+	})
+	require.NoError(t, err)
+	assert.True(t, len(result.Values) > 0)
+}

--- a/providers/aws/sagemaker/sagemaker_test.go
+++ b/providers/aws/sagemaker/sagemaker_test.go
@@ -99,7 +99,7 @@ func TestAllJobKindsComplete(t *testing.T) {
 
 	cj, err := m.CreateCompilationJob(ctx, driver.CompilationJobConfig{JobName: "c1"})
 	require.NoError(t, err)
-	assert.Equal(t, driver.JobCompleted, cj.Status)
+	assert.Equal(t, driver.CompilationCompleted, cj.Status)
 }
 
 func TestInferenceFlowAndInvoke(t *testing.T) {

--- a/providers/aws/sagemaker/studio.go
+++ b/providers/aws/sagemaker/studio.go
@@ -1,0 +1,292 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// scopedKey joins a domain ID and a child name into a single store key.
+func scopedKey(domainID, name string) string {
+	return domainID + "\x00" + name
+}
+
+// appKey builds the composite key identifying a Studio app.
+func appKey(in *driver.AppSpec) string {
+	return in.DomainID + "\x00" + in.UserProfileName + "\x00" + in.SpaceName + "\x00" + in.AppType + "\x00" + in.AppName
+}
+
+// --- Domain ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateDomain(_ context.Context, cfg driver.DomainSpec) (*driver.Domain, error) {
+	if cfg.DomainName == "" {
+		return nil, errors.New(errors.InvalidArgument, "domainName is required")
+	}
+
+	id := "d-" + idgen.GenerateID("")
+	arn := m.arn("domain/" + id)
+	d := &driver.Domain{
+		DomainID:         id,
+		DomainName:       cfg.DomainName,
+		DomainARN:        arn,
+		AuthMode:         orDefault(cfg.AuthMode, "IAM"),
+		VPCID:            cfg.VPCID,
+		SubnetIDs:        cfg.SubnetIDs,
+		ExecutionRoleARN: cfg.ExecutionRoleARN,
+		URL:              "https://" + id + ".studio." + m.opts.Region + ".sagemaker.aws",
+		Status:           driver.StudioInService,
+		CreationTime:     m.now(),
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.domains.Set(id, d)
+	m.setTags(arn, cfg.Tags)
+
+	out := *d
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeDomain(_ context.Context, domainID string) (*driver.Domain, error) {
+	d, ok := m.domains.Get(domainID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "domain %q not found", domainID)
+	}
+
+	out := *d
+
+	return &out, nil
+}
+
+func (m *Mock) ListDomains(_ context.Context) ([]driver.Domain, error) {
+	all := m.domains.All()
+	out := make([]driver.Domain, 0, len(all))
+
+	for _, v := range all {
+		out = append(out, *v)
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteDomain(_ context.Context, domainID string) error {
+	if !m.domains.Has(domainID) {
+		return errors.Newf(errors.NotFound, "domain %q not found", domainID)
+	}
+
+	m.domains.Delete(domainID)
+
+	return nil
+}
+
+// --- User profile ---
+
+func (m *Mock) CreateUserProfile(_ context.Context, cfg driver.UserProfileSpec) (*driver.UserProfile, error) {
+	if cfg.DomainID == "" || cfg.UserProfileName == "" {
+		return nil, errors.New(errors.InvalidArgument, "domainId and userProfileName are required")
+	}
+
+	if !m.domains.Has(cfg.DomainID) {
+		return nil, errors.Newf(errors.InvalidArgument, "domain %q not found", cfg.DomainID)
+	}
+
+	key := scopedKey(cfg.DomainID, cfg.UserProfileName)
+	if m.userProfiles.Has(key) {
+		return nil, errors.Newf(errors.AlreadyExists, "user profile %q already exists", cfg.UserProfileName)
+	}
+
+	arn := m.arn("user-profile/" + cfg.DomainID + "/" + cfg.UserProfileName)
+	up := &driver.UserProfile{
+		DomainID:         cfg.DomainID,
+		UserProfileName:  cfg.UserProfileName,
+		UserProfileARN:   arn,
+		ExecutionRoleARN: cfg.ExecutionRoleARN,
+		Status:           driver.StudioInService,
+		CreationTime:     m.now(),
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.userProfiles.Set(key, up)
+	m.setTags(arn, cfg.Tags)
+
+	out := *up
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeUserProfile(_ context.Context, domainID, name string) (*driver.UserProfile, error) {
+	up, ok := m.userProfiles.Get(scopedKey(domainID, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "user profile %q not found", name)
+	}
+
+	out := *up
+
+	return &out, nil
+}
+
+func (m *Mock) ListUserProfiles(_ context.Context, domainID string) ([]driver.UserProfile, error) {
+	out := make([]driver.UserProfile, 0)
+
+	for _, up := range m.userProfiles.All() {
+		if domainID == "" || up.DomainID == domainID {
+			out = append(out, *up)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteUserProfile(_ context.Context, domainID, name string) error {
+	key := scopedKey(domainID, name)
+	if !m.userProfiles.Has(key) {
+		return errors.Newf(errors.NotFound, "user profile %q not found", name)
+	}
+
+	m.userProfiles.Delete(key)
+
+	return nil
+}
+
+// --- Space ---
+
+func (m *Mock) CreateSpace(_ context.Context, cfg driver.SpaceSpec) (*driver.Space, error) {
+	if cfg.DomainID == "" || cfg.SpaceName == "" {
+		return nil, errors.New(errors.InvalidArgument, "domainId and spaceName are required")
+	}
+
+	if !m.domains.Has(cfg.DomainID) {
+		return nil, errors.Newf(errors.InvalidArgument, "domain %q not found", cfg.DomainID)
+	}
+
+	key := scopedKey(cfg.DomainID, cfg.SpaceName)
+	if m.spaces.Has(key) {
+		return nil, errors.Newf(errors.AlreadyExists, "space %q already exists", cfg.SpaceName)
+	}
+
+	arn := m.arn("space/" + cfg.DomainID + "/" + cfg.SpaceName)
+	sp := &driver.Space{
+		DomainID:     cfg.DomainID,
+		SpaceName:    cfg.SpaceName,
+		SpaceARN:     arn,
+		Status:       driver.StudioInService,
+		CreationTime: m.now(),
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.spaces.Set(key, sp)
+	m.setTags(arn, cfg.Tags)
+
+	out := *sp
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeSpace(_ context.Context, domainID, name string) (*driver.Space, error) {
+	sp, ok := m.spaces.Get(scopedKey(domainID, name))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "space %q not found", name)
+	}
+
+	out := *sp
+
+	return &out, nil
+}
+
+func (m *Mock) ListSpaces(_ context.Context, domainID string) ([]driver.Space, error) {
+	out := make([]driver.Space, 0)
+
+	for _, sp := range m.spaces.All() {
+		if domainID == "" || sp.DomainID == domainID {
+			out = append(out, *sp)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteSpace(_ context.Context, domainID, name string) error {
+	key := scopedKey(domainID, name)
+	if !m.spaces.Has(key) {
+		return errors.Newf(errors.NotFound, "space %q not found", name)
+	}
+
+	m.spaces.Delete(key)
+
+	return nil
+}
+
+// --- App ---
+
+//nolint:gocritic // in matches the driver signature; copied on entry.
+func (m *Mock) CreateApp(_ context.Context, in driver.AppSpec) (*driver.App, error) {
+	if in.DomainID == "" || in.AppName == "" || in.AppType == "" {
+		return nil, errors.New(errors.InvalidArgument, "domainId, appType and appName are required")
+	}
+
+	if !m.domains.Has(in.DomainID) {
+		return nil, errors.Newf(errors.InvalidArgument, "domain %q not found", in.DomainID)
+	}
+
+	key := appKey(&in)
+	if m.apps.Has(key) {
+		return nil, errors.Newf(errors.AlreadyExists, "app %q already exists", in.AppName)
+	}
+
+	arn := m.arn("app/" + in.DomainID + "/" + in.AppType + "/" + in.AppName)
+	app := &driver.App{
+		DomainID:        in.DomainID,
+		UserProfileName: in.UserProfileName,
+		SpaceName:       in.SpaceName,
+		AppType:         in.AppType,
+		AppName:         in.AppName,
+		AppARN:          arn,
+		Status:          driver.AppInService,
+		CreationTime:    m.now(),
+	}
+	m.apps.Set(key, app)
+
+	out := *app
+
+	return &out, nil
+}
+
+//nolint:gocritic // in matches the driver signature; copied on entry.
+func (m *Mock) DescribeApp(_ context.Context, in driver.AppSpec) (*driver.App, error) {
+	app, ok := m.apps.Get(appKey(&in))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "app %q not found", in.AppName)
+	}
+
+	out := *app
+
+	return &out, nil
+}
+
+func (m *Mock) ListApps(_ context.Context, domainID string) ([]driver.App, error) {
+	out := make([]driver.App, 0)
+
+	for _, app := range m.apps.All() {
+		if domainID == "" || app.DomainID == domainID {
+			out = append(out, *app)
+		}
+	}
+
+	return out, nil
+}
+
+//nolint:gocritic // in matches the driver signature; copied on entry.
+func (m *Mock) DeleteApp(_ context.Context, in driver.AppSpec) error {
+	key := appKey(&in)
+
+	app, ok := m.apps.Get(key)
+	if !ok {
+		return errors.Newf(errors.NotFound, "app %q not found", in.AppName)
+	}
+
+	app.Status = driver.AppDeleted
+
+	m.apps.Delete(key)
+
+	return nil
+}

--- a/providers/aws/sagemaker/tags.go
+++ b/providers/aws/sagemaker/tags.go
@@ -1,0 +1,75 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// setTags records the initial tags for a resource ARN (no-op for empty input).
+func (m *Mock) setTags(arn string, tags []driver.Tag) {
+	if len(tags) == 0 {
+		return
+	}
+
+	m.tags.Set(arn, copyTags(tags))
+}
+
+// AddTags merges tags onto a resource, overwriting values for existing keys.
+func (m *Mock) AddTags(_ context.Context, resourceARN string, tags []driver.Tag) ([]driver.Tag, error) {
+	existing, _ := m.tags.Get(resourceARN)
+
+	merged := make([]driver.Tag, 0, len(existing)+len(tags))
+	index := map[string]int{}
+
+	for _, t := range existing {
+		index[t.Key] = len(merged)
+		merged = append(merged, t)
+	}
+
+	for _, t := range tags {
+		if i, ok := index[t.Key]; ok {
+			merged[i].Value = t.Value
+			continue
+		}
+
+		index[t.Key] = len(merged)
+		merged = append(merged, t)
+	}
+
+	m.tags.Set(resourceARN, merged)
+
+	return copyTags(merged), nil
+}
+
+// ListTags returns the tags for a resource ARN.
+func (m *Mock) ListTags(_ context.Context, resourceARN string) ([]driver.Tag, error) {
+	tags, _ := m.tags.Get(resourceARN)
+
+	return copyTags(tags), nil
+}
+
+// DeleteTags removes the given tag keys from a resource ARN.
+func (m *Mock) DeleteTags(_ context.Context, resourceARN string, keys []string) error {
+	existing, ok := m.tags.Get(resourceARN)
+	if !ok {
+		return nil
+	}
+
+	remove := make(map[string]bool, len(keys))
+	for _, k := range keys {
+		remove[k] = true
+	}
+
+	kept := make([]driver.Tag, 0, len(existing))
+
+	for _, t := range existing {
+		if !remove[t.Key] {
+			kept = append(kept, t)
+		}
+	}
+
+	m.tags.Set(resourceARN, kept)
+
+	return nil
+}

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -103,6 +103,7 @@ func New(opts ...config.Option) *Provider {
 			Storage:    p.BlobStorage,
 			Database:   p.CosmosDB,
 			Serverless: p.Functions,
+			Databricks: p.Databricks,
 		},
 	)
 

--- a/providers/azure/databricks/dataplane.go
+++ b/providers/azure/databricks/dataplane.go
@@ -105,16 +105,20 @@ func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterConfig) (*driv
 
 	id := idgen.GenerateID("cluster-")
 	cluster := &driver.Cluster{
-		ID:            id,
-		Name:          cfg.Name,
-		SparkVersion:  cfg.SparkVersion,
-		NodeTypeID:    cfg.NodeTypeID,
-		State:         driver.ClusterRunning,
-		NumWorkers:    cfg.NumWorkers,
-		AutoscaleMin:  cfg.AutoscaleMin,
-		AutoscaleMax:  cfg.AutoscaleMax,
-		RuntimeEngine: cfg.RuntimeEngine,
-		CustomTags:    cfg.CustomTags,
+		ID:                id,
+		Name:              cfg.Name,
+		SparkVersion:      cfg.SparkVersion,
+		NodeTypeID:        cfg.NodeTypeID,
+		State:             driver.ClusterRunning,
+		NumWorkers:        cfg.NumWorkers,
+		AutoscaleMin:      cfg.AutoscaleMin,
+		AutoscaleMax:      cfg.AutoscaleMax,
+		RuntimeEngine:     cfg.RuntimeEngine,
+		CustomTags:        cfg.CustomTags,
+		PolicyID:          cfg.PolicyID,
+		InstancePoolID:    cfg.InstancePoolID,
+		AzureAvailability: cfg.AzureAvailability,
+		ClusterSource:     driver.ClusterSourceAPI,
 	}
 	m.clusters.Set(id, cluster)
 
@@ -165,6 +169,9 @@ func (m *Mock) EditCluster(_ context.Context, id string, cfg driver.ClusterConfi
 	updated.AutoscaleMax = cfg.AutoscaleMax
 	updated.RuntimeEngine = cfg.RuntimeEngine
 	updated.CustomTags = cfg.CustomTags
+	updated.PolicyID = cfg.PolicyID
+	updated.InstancePoolID = cfg.InstancePoolID
+	updated.AzureAvailability = cfg.AzureAvailability
 	m.clusters.Set(id, &updated)
 
 	return nil

--- a/providers/azure/databricks/dataplane.go
+++ b/providers/azure/databricks/dataplane.go
@@ -22,12 +22,14 @@ func (m *Mock) CreateInstancePool(_ context.Context, cfg driver.InstancePoolConf
 
 	id := idgen.GenerateID("pool-")
 	pool := &driver.InstancePool{
-		ID:               id,
-		Name:             cfg.Name,
-		NodeTypeID:       cfg.NodeTypeID,
-		State:            driver.PoolActive,
-		MinIdleInstances: cfg.MinIdleInstances,
-		MaxCapacity:      cfg.MaxCapacity,
+		ID:                                 id,
+		Name:                               cfg.Name,
+		NodeTypeID:                         cfg.NodeTypeID,
+		State:                              driver.PoolActive,
+		MinIdleInstances:                   cfg.MinIdleInstances,
+		MaxCapacity:                        cfg.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: cfg.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         cfg.CustomTags,
 	}
 	m.pools.Set(id, pool)
 
@@ -72,6 +74,8 @@ func (m *Mock) EditInstancePool(_ context.Context, id string, cfg driver.Instanc
 	updated.NodeTypeID = cfg.NodeTypeID
 	updated.MinIdleInstances = cfg.MinIdleInstances
 	updated.MaxCapacity = cfg.MaxCapacity
+	updated.IdleInstanceAutoterminationMinutes = cfg.IdleInstanceAutoterminationMinutes
+	updated.CustomTags = cfg.CustomTags
 	m.pools.Set(id, &updated)
 
 	return nil
@@ -89,6 +93,8 @@ func (m *Mock) DeleteInstancePool(_ context.Context, id string) error {
 // --- clusters ---
 
 // CreateCluster creates a cluster in the RUNNING state.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterConfig) (*driver.Cluster, error) {
 	switch {
 	case cfg.SparkVersion == "":
@@ -99,14 +105,16 @@ func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterConfig) (*driv
 
 	id := idgen.GenerateID("cluster-")
 	cluster := &driver.Cluster{
-		ID:           id,
-		Name:         cfg.Name,
-		SparkVersion: cfg.SparkVersion,
-		NodeTypeID:   cfg.NodeTypeID,
-		State:        driver.ClusterRunning,
-		NumWorkers:   cfg.NumWorkers,
-		AutoscaleMin: cfg.AutoscaleMin,
-		AutoscaleMax: cfg.AutoscaleMax,
+		ID:            id,
+		Name:          cfg.Name,
+		SparkVersion:  cfg.SparkVersion,
+		NodeTypeID:    cfg.NodeTypeID,
+		State:         driver.ClusterRunning,
+		NumWorkers:    cfg.NumWorkers,
+		AutoscaleMin:  cfg.AutoscaleMin,
+		AutoscaleMax:  cfg.AutoscaleMax,
+		RuntimeEngine: cfg.RuntimeEngine,
+		CustomTags:    cfg.CustomTags,
 	}
 	m.clusters.Set(id, cluster)
 
@@ -140,6 +148,8 @@ func (m *Mock) ListClusters(_ context.Context) ([]driver.Cluster, error) {
 }
 
 // EditCluster updates a cluster's mutable fields.
+//
+//nolint:gocritic // cfg matches the driver.DataPlane interface signature (by value)
 func (m *Mock) EditCluster(_ context.Context, id string, cfg driver.ClusterConfig) error {
 	cluster, ok := m.clusters.Get(id)
 	if !ok {
@@ -153,6 +163,8 @@ func (m *Mock) EditCluster(_ context.Context, id string, cfg driver.ClusterConfi
 	updated.NumWorkers = cfg.NumWorkers
 	updated.AutoscaleMin = cfg.AutoscaleMin
 	updated.AutoscaleMax = cfg.AutoscaleMax
+	updated.RuntimeEngine = cfg.RuntimeEngine
+	updated.CustomTags = cfg.CustomTags
 	m.clusters.Set(id, &updated)
 
 	return nil

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/gcp/memorystore"
 	"github.com/stackshy/cloudemu/providers/gcp/pubsub"
 	"github.com/stackshy/cloudemu/providers/gcp/secretmanager"
+	"github.com/stackshy/cloudemu/providers/gcp/vertexai"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
@@ -44,6 +45,7 @@ type Provider struct {
 	Eventarc         *eventarc.Mock
 	CloudSQL         *cloudsql.Mock
 	GKE              *gke.Mock
+	VertexAI         *vertexai.Mock
 
 	ResourceDiscovery *resourcediscovery.Engine
 }
@@ -70,6 +72,7 @@ func New(opts ...config.Option) *Provider {
 		Eventarc:         eventarc.New(o),
 		CloudSQL:         cloudsql.New(o),
 		GKE:              gke.New(o),
+		VertexAI:         vertexai.New(o),
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 	p.GCS.SetMonitoring(p.CloudMonitoring)
@@ -83,6 +86,7 @@ func New(opts ...config.Option) *Provider {
 	p.Eventarc.SetMonitoring(p.CloudMonitoring)
 	p.CloudSQL.SetMonitoring(p.CloudMonitoring)
 	p.GKE.SetMonitoring(p.CloudMonitoring)
+	p.VertexAI.SetMonitoring(p.CloudMonitoring)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderGCP, o.ProjectID, o.Region,

--- a/providers/gcp/vertexai/clone.go
+++ b/providers/gcp/vertexai/clone.go
@@ -1,0 +1,74 @@
+package vertexai
+
+import "github.com/stackshy/cloudemu/vertexai/driver"
+
+// copyLabels deep-copies a label map so stored resources never alias a caller's
+// map (and vice-versa on return).
+func copyLabels(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+func copyStrSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]string, len(in))
+	copy(out, in)
+
+	return out
+}
+
+// cloneModel returns a deep copy so callers never alias the stored slices/maps.
+func cloneModel(in *driver.Model) *driver.Model {
+	out := *in
+	out.VersionAliases = copyStrSlice(in.VersionAliases)
+	out.Labels = copyLabels(in.Labels)
+
+	return &out
+}
+
+func cloneDataset(in *driver.Dataset) *driver.Dataset {
+	out := *in
+	out.Labels = copyLabels(in.Labels)
+
+	return &out
+}
+
+func cloneEndpoint(in *driver.Endpoint) *driver.Endpoint {
+	out := *in
+	out.Labels = copyLabels(in.Labels)
+
+	if in.DeployedModels != nil {
+		out.DeployedModels = make([]driver.DeployedModel, len(in.DeployedModels))
+		copy(out.DeployedModels, in.DeployedModels)
+	}
+
+	if in.TrafficSplit != nil {
+		out.TrafficSplit = make(map[string]int, len(in.TrafficSplit))
+		for k, v := range in.TrafficSplit {
+			out.TrafficSplit[k] = v
+		}
+	}
+
+	return &out
+}
+
+func cloneIndexEndpoint(in *driver.IndexEndpoint) *driver.IndexEndpoint {
+	out := *in
+	if in.DeployedIndexes != nil {
+		out.DeployedIndexes = make([]driver.DeployedIndex, len(in.DeployedIndexes))
+		copy(out.DeployedIndexes, in.DeployedIndexes)
+	}
+
+	return &out
+}

--- a/providers/gcp/vertexai/datasets.go
+++ b/providers/gcp/vertexai/datasets.go
@@ -28,16 +28,14 @@ func (m *Mock) CreateDataset(_ context.Context, cfg driver.DatasetConfig) (*driv
 		Name:              name,
 		DisplayName:       cfg.DisplayName,
 		MetadataSchemaURI: cfg.MetadataSchemaURI,
-		Labels:            cfg.Labels,
+		Labels:            copyLabels(cfg.Labels),
 		CreateTime:        now,
 		UpdateTime:        now,
 	}
 	m.datasets.Set(name, ds)
 	m.emitMetric("dataset/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
-	out := *ds
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneDataset(ds), nil
 }
 
 func (m *Mock) GetDataset(_ context.Context, name string) (*driver.Dataset, error) {
@@ -46,9 +44,7 @@ func (m *Mock) GetDataset(_ context.Context, name string) (*driver.Dataset, erro
 		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
 	}
 
-	out := *ds
-
-	return &out, nil
+	return cloneDataset(ds), nil
 }
 
 func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Dataset, error) {
@@ -56,7 +52,7 @@ func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Datase
 
 	for _, ds := range m.datasets.All() {
 		if location == "" || locationOf(ds.Name) == location {
-			out = append(out, *ds)
+			out = append(out, *cloneDataset(ds))
 		}
 	}
 
@@ -69,14 +65,16 @@ func (m *Mock) PatchDataset(_ context.Context, name, displayName string) (*drive
 		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
 	}
 
+	// Copy-then-Set: never mutate the stored pointer in place.
+	updated := *ds
 	if displayName != "" {
-		ds.DisplayName = displayName
+		updated.DisplayName = displayName
 	}
 
-	ds.UpdateTime = m.now()
-	out := *ds
+	updated.UpdateTime = m.now()
+	m.datasets.Set(name, &updated)
 
-	return &out, nil
+	return cloneDataset(&updated), nil
 }
 
 func (m *Mock) DeleteDataset(_ context.Context, name string) (*driver.Operation, error) {

--- a/providers/gcp/vertexai/datasets.go
+++ b/providers/gcp/vertexai/datasets.go
@@ -1,0 +1,106 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// locationOf extracts the location segment from a resource name, or the
+// default when absent.
+func locationOf(name string) string {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		if p == "locations" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+
+	return defaultLocation
+}
+
+func (m *Mock) CreateDataset(_ context.Context, cfg driver.DatasetConfig) (*driver.Operation, *driver.Dataset, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "datasets", m.newID())
+	ds := &driver.Dataset{
+		Name:              name,
+		DisplayName:       cfg.DisplayName,
+		MetadataSchemaURI: cfg.MetadataSchemaURI,
+		Labels:            cfg.Labels,
+		CreateTime:        now,
+		UpdateTime:        now,
+	}
+	m.datasets.Set(name, ds)
+	m.emitMetric("dataset/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *ds
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetDataset(_ context.Context, name string) (*driver.Dataset, error) {
+	ds, ok := m.datasets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	out := *ds
+
+	return &out, nil
+}
+
+func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Dataset, error) {
+	out := make([]driver.Dataset, 0)
+
+	for _, ds := range m.datasets.All() {
+		if location == "" || locationOf(ds.Name) == location {
+			out = append(out, *ds)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) PatchDataset(_ context.Context, name, displayName string) (*driver.Dataset, error) {
+	ds, ok := m.datasets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	if displayName != "" {
+		ds.DisplayName = displayName
+	}
+
+	ds.UpdateTime = m.now()
+	out := *ds
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteDataset(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.datasets.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	m.datasets.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ImportData(_ context.Context, name, _ string) (*driver.Operation, error) {
+	if !m.datasets.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ExportData(_ context.Context, name, _ string) (*driver.Operation, error) {
+	if !m.datasets.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	return m.doneOp(locationOf(name), name), nil
+}

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -1,0 +1,143 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointConfig) (*driver.Operation, *driver.Endpoint, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "endpoints", m.newID())
+	ep := &driver.Endpoint{
+		Name:         name,
+		DisplayName:  cfg.DisplayName,
+		Description:  cfg.Description,
+		TrafficSplit: map[string]int{},
+		Labels:       cfg.Labels,
+		CreateTime:   now,
+		UpdateTime:   now,
+	}
+	m.endpoints.Set(name, ep)
+	m.emitMetric("endpoint/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *ep
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	out := *ep
+
+	return &out, nil
+}
+
+func (m *Mock) ListEndpoints(_ context.Context, location string) ([]driver.Endpoint, error) {
+	out := make([]driver.Endpoint, 0)
+
+	for _, ep := range m.endpoints.All() {
+		if location == "" || locationOf(ep.Name) == location {
+			out = append(out, *ep)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteEndpoint(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.endpoints.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	m.endpoints.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+//nolint:gocritic // dm matches the driver signature; copied on entry.
+func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.DeployedModel) (*driver.Operation, *driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(endpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
+	}
+
+	if dm.ID == "" {
+		dm.ID = m.newID()
+	}
+
+	updated := *ep
+	updated.DeployedModels = append(append([]driver.DeployedModel{}, ep.DeployedModels...), dm)
+	updated.TrafficSplit = map[string]int{dm.ID: 100}
+	updated.UpdateTime = m.now()
+	m.endpoints.Set(endpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+}
+
+func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string) (*driver.Operation, *driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(endpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
+	}
+
+	kept := make([]driver.DeployedModel, 0, len(ep.DeployedModels))
+
+	for _, d := range ep.DeployedModels {
+		if d.ID != deployedModelID {
+			kept = append(kept, d)
+		}
+	}
+
+	updated := *ep
+	updated.DeployedModels = kept
+	delete(updated.TrafficSplit, deployedModelID)
+	updated.UpdateTime = m.now()
+	m.endpoints.Set(endpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+}
+
+// Predict echoes the request instances back as predictions, which is
+// deterministic and adequate for exercising client serialization.
+//
+
+func (m *Mock) Predict(_ context.Context, req driver.PredictRequest) (*driver.PredictResponse, error) {
+	ep, ok := m.endpoints.Get(req.Endpoint)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", req.Endpoint)
+	}
+
+	m.emitMetric("prediction/count", float64(len(req.Instances)), map[string]string{"endpoint": req.Endpoint})
+
+	resp := &driver.PredictResponse{Predictions: append([]any{}, req.Instances...)}
+	if len(ep.DeployedModels) > 0 {
+		resp.DeployedModelID = ep.DeployedModels[0].ID
+		resp.Model = ep.DeployedModels[0].Model
+		resp.ModelDisplayName = ep.DeployedModels[0].DisplayName
+	}
+
+	return resp, nil
+}
+
+func (m *Mock) RawPredict(_ context.Context, endpoint string, body []byte) ([]byte, error) {
+	if !m.endpoints.Has(endpoint) {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
+	}
+
+	m.emitMetric("prediction/count", 1, map[string]string{"endpoint": endpoint})
+
+	out := make([]byte, len(body))
+	copy(out, body)
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -15,16 +15,14 @@ func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointConfig) (*dr
 		DisplayName:  cfg.DisplayName,
 		Description:  cfg.Description,
 		TrafficSplit: map[string]int{},
-		Labels:       cfg.Labels,
+		Labels:       copyLabels(cfg.Labels),
 		CreateTime:   now,
 		UpdateTime:   now,
 	}
 	m.endpoints.Set(name, ep)
 	m.emitMetric("endpoint/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
-	out := *ep
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneEndpoint(ep), nil
 }
 
 func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {
@@ -33,9 +31,7 @@ func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, er
 		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
 	}
 
-	out := *ep
-
-	return &out, nil
+	return cloneEndpoint(ep), nil
 }
 
 func (m *Mock) ListEndpoints(_ context.Context, location string) ([]driver.Endpoint, error) {
@@ -43,7 +39,7 @@ func (m *Mock) ListEndpoints(_ context.Context, location string) ([]driver.Endpo
 
 	for _, ep := range m.endpoints.All() {
 		if location == "" || locationOf(ep.Name) == location {
-			out = append(out, *ep)
+			out = append(out, *cloneEndpoint(ep))
 		}
 	}
 
@@ -71,15 +67,14 @@ func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.Deploye
 		dm.ID = m.newID()
 	}
 
-	updated := *ep
-	updated.DeployedModels = append(append([]driver.DeployedModel{}, ep.DeployedModels...), dm)
+	// Deep-copy working set so the stored endpoint is never mutated in place.
+	updated := cloneEndpoint(ep)
+	updated.DeployedModels = append(updated.DeployedModels, dm)
 	updated.TrafficSplit = map[string]int{dm.ID: 100}
 	updated.UpdateTime = m.now()
-	m.endpoints.Set(endpoint, &updated)
+	m.endpoints.Set(endpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+	return m.doneOp(locationOf(endpoint), endpoint), cloneEndpoint(updated), nil
 }
 
 func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string) (*driver.Operation, *driver.Endpoint, error) {
@@ -88,23 +83,22 @@ func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string
 		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
 	}
 
-	kept := make([]driver.DeployedModel, 0, len(ep.DeployedModels))
+	updated := cloneEndpoint(ep)
 
-	for _, d := range ep.DeployedModels {
+	kept := make([]driver.DeployedModel, 0, len(updated.DeployedModels))
+
+	for _, d := range updated.DeployedModels {
 		if d.ID != deployedModelID {
 			kept = append(kept, d)
 		}
 	}
 
-	updated := *ep
 	updated.DeployedModels = kept
 	delete(updated.TrafficSplit, deployedModelID)
 	updated.UpdateTime = m.now()
-	m.endpoints.Set(endpoint, &updated)
+	m.endpoints.Set(endpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+	return m.doneOp(locationOf(endpoint), endpoint), cloneEndpoint(updated), nil
 }
 
 // Predict echoes the request instances back as predictions, which is

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -70,11 +70,38 @@ func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.Deploye
 	// Deep-copy working set so the stored endpoint is never mutated in place.
 	updated := cloneEndpoint(ep)
 	updated.DeployedModels = append(updated.DeployedModels, dm)
-	updated.TrafficSplit = map[string]int{dm.ID: 100}
+	// Rebalance traffic evenly across every deployed model so each keeps a
+	// split entry and the total stays at 100 (real multi-model endpoints never
+	// drop a deployed model from the split).
+	updated.TrafficSplit = evenTrafficSplit(updated.DeployedModels)
 	updated.UpdateTime = m.now()
 	m.endpoints.Set(endpoint, updated)
 
 	return m.doneOp(locationOf(endpoint), endpoint), cloneEndpoint(updated), nil
+}
+
+// evenTrafficSplit distributes 100% as evenly as possible across the deployed
+// models, assigning any rounding remainder to the first model so the split
+// always totals exactly 100. Returns an empty (non-nil) map when none remain.
+func evenTrafficSplit(models []driver.DeployedModel) map[string]int {
+	split := make(map[string]int, len(models))
+	if len(models) == 0 {
+		return split
+	}
+
+	base := 100 / len(models)
+	remainder := 100 % len(models)
+
+	for i, dm := range models {
+		share := base
+		if i < remainder {
+			share++
+		}
+
+		split[dm.ID] = share
+	}
+
+	return split
 }
 
 func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string) (*driver.Operation, *driver.Endpoint, error) {
@@ -94,7 +121,7 @@ func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string
 	}
 
 	updated.DeployedModels = kept
-	delete(updated.TrafficSplit, deployedModelID)
+	updated.TrafficSplit = evenTrafficSplit(kept)
 	updated.UpdateTime = m.now()
 	m.endpoints.Set(endpoint, updated)
 

--- a/providers/gcp/vertexai/featurestore.go
+++ b/providers/gcp/vertexai/featurestore.go
@@ -1,0 +1,207 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (m *Mock) CreateFeatureGroup(_ context.Context, cfg driver.FeatureGroupConfig) (*driver.Operation, *driver.FeatureGroup, error) {
+	name := m.resName(cfg.Location, "featureGroups", orID(cfg.FeatureGroupID, m.newID()))
+	fg := &driver.FeatureGroup{Name: name, Description: cfg.Description, BigQueryURI: cfg.BigQueryURI, CreateTime: m.now()}
+	m.featureGroups.Set(name, fg)
+
+	out := *fg
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func orID(id, gen string) string {
+	if id != "" {
+		return id
+	}
+
+	return gen
+}
+
+func (m *Mock) GetFeatureGroup(_ context.Context, name string) (*driver.FeatureGroup, error) {
+	fg, ok := m.featureGroups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature group %q not found", name)
+	}
+
+	out := *fg
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureGroups(_ context.Context, location string) ([]driver.FeatureGroup, error) {
+	out := make([]driver.FeatureGroup, 0)
+
+	for _, fg := range m.featureGroups.All() {
+		if location == "" || locationOf(fg.Name) == location {
+			out = append(out, *fg)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureGroup(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.featureGroups.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature group %q not found", name)
+	}
+
+	m.featureGroups.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) CreateFeature(_ context.Context, parent, featureID, description string) (*driver.Operation, *driver.Feature, error) {
+	if !m.featureGroups.Has(parent) {
+		return nil, nil, errors.Newf(errors.NotFound, "feature group %q not found", parent)
+	}
+
+	name := parent + "/features/" + orID(featureID, m.newID())
+	f := &driver.Feature{Name: name, Description: description, CreateTime: m.now()}
+	m.features.Set(name, f)
+
+	out := *f
+
+	return m.doneOp(locationOf(parent), name), &out, nil
+}
+
+func (m *Mock) GetFeature(_ context.Context, name string) (*driver.Feature, error) {
+	f, ok := m.features.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature %q not found", name)
+	}
+
+	out := *f
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatures(_ context.Context, parent string) ([]driver.Feature, error) {
+	out := make([]driver.Feature, 0)
+
+	for k, f := range m.features.All() {
+		if len(k) > len(parent) && k[:len(parent)] == parent {
+			out = append(out, *f)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeature(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.features.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature %q not found", name)
+	}
+
+	m.features.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) CreateFeatureOnlineStore(
+	_ context.Context, cfg driver.FeatureOnlineStoreConfig,
+) (*driver.Operation, *driver.FeatureOnlineStore, error) {
+	name := m.resName(cfg.Location, "featureOnlineStores", orID(cfg.FeatureOnlineStoreID, m.newID()))
+	s := &driver.FeatureOnlineStore{Name: name, State: "STABLE", CreateTime: m.now()}
+	m.onlineStores.Set(name, s)
+
+	out := *s
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetFeatureOnlineStore(_ context.Context, name string) (*driver.FeatureOnlineStore, error) {
+	s, ok := m.onlineStores.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature online store %q not found", name)
+	}
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureOnlineStores(_ context.Context, location string) ([]driver.FeatureOnlineStore, error) {
+	out := make([]driver.FeatureOnlineStore, 0)
+
+	for _, s := range m.onlineStores.All() {
+		if location == "" || locationOf(s.Name) == location {
+			out = append(out, *s)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureOnlineStore(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.onlineStores.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature online store %q not found", name)
+	}
+
+	m.onlineStores.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) CreateFeatureView(_ context.Context, cfg driver.FeatureViewConfig) (*driver.Operation, *driver.FeatureView, error) {
+	if !m.onlineStores.Has(cfg.Parent) {
+		return nil, nil, errors.Newf(errors.NotFound, "feature online store %q not found", cfg.Parent)
+	}
+
+	name := cfg.Parent + "/featureViews/" + orID(cfg.FeatureViewID, m.newID())
+	fv := &driver.FeatureView{Name: name, BigQueryURI: cfg.BigQueryURI, CreateTime: m.now()}
+	m.featureViews.Set(name, fv)
+
+	out := *fv
+
+	return m.doneOp(locationOf(cfg.Parent), name), &out, nil
+}
+
+func (m *Mock) GetFeatureView(_ context.Context, name string) (*driver.FeatureView, error) {
+	fv, ok := m.featureViews.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature view %q not found", name)
+	}
+
+	out := *fv
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureViews(_ context.Context, parent string) ([]driver.FeatureView, error) {
+	out := make([]driver.FeatureView, 0)
+
+	for k, fv := range m.featureViews.All() {
+		if len(k) > len(parent) && k[:len(parent)] == parent {
+			out = append(out, *fv)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureView(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.featureViews.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature view %q not found", name)
+	}
+
+	m.featureViews.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// FetchFeatureValues returns a deterministic synthetic value for the entity.
+func (m *Mock) FetchFeatureValues(_ context.Context, featureView, entityID string) ([]driver.FeatureNameValue, error) {
+	if !m.featureViews.Has(featureView) {
+		return nil, errors.Newf(errors.NotFound, "feature view %q not found", featureView)
+	}
+
+	return []driver.FeatureNameValue{{Name: "entity_id", Value: entityID}}, nil
+}

--- a/providers/gcp/vertexai/featurestore.go
+++ b/providers/gcp/vertexai/featurestore.go
@@ -2,6 +2,7 @@ package vertexai
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/vertexai/driver"
@@ -88,7 +89,7 @@ func (m *Mock) ListFeatures(_ context.Context, parent string) ([]driver.Feature,
 	out := make([]driver.Feature, 0)
 
 	for k, f := range m.features.All() {
-		if len(k) > len(parent) && k[:len(parent)] == parent {
+		if strings.HasPrefix(k, parent+"/") {
 			out = append(out, *f)
 		}
 	}
@@ -180,7 +181,7 @@ func (m *Mock) ListFeatureViews(_ context.Context, parent string) ([]driver.Feat
 	out := make([]driver.FeatureView, 0)
 
 	for k, fv := range m.featureViews.All() {
-		if len(k) > len(parent) && k[:len(parent)] == parent {
+		if strings.HasPrefix(k, parent+"/") {
 			out = append(out, *fv)
 		}
 	}
@@ -284,7 +285,7 @@ func (m *Mock) ListEntityTypes(_ context.Context, parent string) ([]driver.Entit
 	out := make([]driver.EntityType, 0)
 
 	for k, et := range m.entityTypes.All() {
-		if len(k) > len(parent) && k[:len(parent)] == parent {
+		if strings.HasPrefix(k, parent+"/") {
 			out = append(out, *et)
 		}
 	}

--- a/providers/gcp/vertexai/featurestore.go
+++ b/providers/gcp/vertexai/featurestore.go
@@ -58,6 +58,7 @@ func (m *Mock) DeleteFeatureGroup(_ context.Context, name string) (*driver.Opera
 	return m.doneOp(locationOf(name), name), nil
 }
 
+//nolint:dupl // parent/child create shape recurs; each maps a distinct resource.
 func (m *Mock) CreateFeature(_ context.Context, parent, featureID, description string) (*driver.Operation, *driver.Feature, error) {
 	if !m.featureGroups.Has(parent) {
 		return nil, nil, errors.Newf(errors.NotFound, "feature group %q not found", parent)
@@ -204,4 +205,133 @@ func (m *Mock) FetchFeatureValues(_ context.Context, featureView, entityID strin
 	}
 
 	return []driver.FeatureNameValue{{Name: "entity_id", Value: entityID}}, nil
+}
+
+// --- Classic Featurestore / EntityType (pre-FeatureGroup) ---
+
+func (m *Mock) CreateFeaturestore(_ context.Context, cfg driver.FeaturestoreConfig) (*driver.Operation, *driver.Featurestore, error) {
+	name := m.resName(cfg.Location, "featurestores", orID(cfg.FeaturestoreID, m.newID()))
+	fs := &driver.Featurestore{Name: name, State: "STABLE", OnlineNodeCount: cfg.OnlineNodeCount, CreateTime: m.now()}
+	m.featurestores.Set(name, fs)
+
+	out := *fs
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetFeaturestore(_ context.Context, name string) (*driver.Featurestore, error) {
+	fs, ok := m.featurestores.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "featurestore %q not found", name)
+	}
+
+	out := *fs
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeaturestores(_ context.Context, location string) ([]driver.Featurestore, error) {
+	out := make([]driver.Featurestore, 0)
+
+	for _, fs := range m.featurestores.All() {
+		if location == "" || locationOf(fs.Name) == location {
+			out = append(out, *fs)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeaturestore(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.featurestores.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "featurestore %q not found", name)
+	}
+
+	m.featurestores.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+//nolint:dupl // parent/child create shape recurs; each maps a distinct resource.
+func (m *Mock) CreateEntityType(
+	_ context.Context, parent, entityTypeID, description string,
+) (*driver.Operation, *driver.EntityType, error) {
+	if !m.featurestores.Has(parent) {
+		return nil, nil, errors.Newf(errors.NotFound, "featurestore %q not found", parent)
+	}
+
+	name := parent + "/entityTypes/" + orID(entityTypeID, m.newID())
+	et := &driver.EntityType{Name: name, Description: description, CreateTime: m.now()}
+	m.entityTypes.Set(name, et)
+
+	out := *et
+
+	return m.doneOp(locationOf(parent), name), &out, nil
+}
+
+func (m *Mock) GetEntityType(_ context.Context, name string) (*driver.EntityType, error) {
+	et, ok := m.entityTypes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "entity type %q not found", name)
+	}
+
+	out := *et
+
+	return &out, nil
+}
+
+func (m *Mock) ListEntityTypes(_ context.Context, parent string) ([]driver.EntityType, error) {
+	out := make([]driver.EntityType, 0)
+
+	for k, et := range m.entityTypes.All() {
+		if len(k) > len(parent) && k[:len(parent)] == parent {
+			out = append(out, *et)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteEntityType(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.entityTypes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "entity type %q not found", name)
+	}
+
+	m.entityTypes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func entityKey(entityType, entityID string) string {
+	return entityType + "\x00" + entityID
+}
+
+// WriteFeatureValues stores online feature values for an entity.
+func (m *Mock) WriteFeatureValues(_ context.Context, entityType, entityID string, values []driver.FeatureNameValue) error {
+	if !m.entityTypes.Has(entityType) {
+		return errors.Newf(errors.NotFound, "entity type %q not found", entityType)
+	}
+
+	stored := make([]driver.FeatureNameValue, len(values))
+	copy(stored, values)
+	m.entityRecords.Set(entityKey(entityType, entityID), stored)
+
+	return nil
+}
+
+// ReadFeatureValues returns the online feature values for an entity.
+func (m *Mock) ReadFeatureValues(_ context.Context, entityType, entityID string) ([]driver.FeatureNameValue, error) {
+	if !m.entityTypes.Has(entityType) {
+		return nil, errors.Newf(errors.NotFound, "entity type %q not found", entityType)
+	}
+
+	rec, ok := m.entityRecords.Get(entityKey(entityType, entityID))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "entity %q not found", entityID)
+	}
+
+	out := make([]driver.FeatureNameValue, len(rec))
+	copy(out, rec)
+
+	return out, nil
 }

--- a/providers/gcp/vertexai/genai.go
+++ b/providers/gcp/vertexai/genai.go
@@ -3,6 +3,7 @@ package vertexai
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/vertexai/driver"
@@ -151,19 +152,64 @@ func (m *Mock) CreateCachedContent(_ context.Context, cfg driver.CachedContentCo
 		return nil, errors.New(errors.InvalidArgument, "model is required")
 	}
 
+	ttl := cfg.TTLSeconds
+	if ttl <= 0 {
+		ttl = defaultCacheTTLSeconds
+	}
+
+	created := m.opts.Clock.Now().UTC()
+	expire := created.Add(time.Duration(ttl) * time.Second)
+
 	name := m.resName(cfg.Location, "cachedContents", m.newID())
 	cc := &driver.CachedContent{
-		Name:        name,
-		Model:       cfg.Model,
-		DisplayName: cfg.DisplayName,
-		CreateTime:  m.now(),
-		ExpireTime:  m.now(),
+		Name:              name,
+		Model:             cfg.Model,
+		DisplayName:       cfg.DisplayName,
+		Contents:          cloneContents(cfg.Contents),
+		SystemInstruction: cloneContent(cfg.SystemInstruction),
+		CreateTime:        created.Format(time.RFC3339),
+		ExpireTime:        expire.Format(time.RFC3339),
 	}
 	m.cachedContent.Set(name, cc)
 
-	out := *cc
+	return cloneCachedContent(cc), nil
+}
 
-	return &out, nil
+// defaultCacheTTLSeconds matches Vertex's default context-cache lifetime (1h)
+// when the caller omits an explicit TTL.
+const defaultCacheTTLSeconds = 3600
+
+func cloneContents(in []driver.Content) []driver.Content {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.Content, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].Parts = append([]driver.Part(nil), in[i].Parts...)
+	}
+
+	return out
+}
+
+func cloneContent(in *driver.Content) *driver.Content {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	out.Parts = append([]driver.Part(nil), in.Parts...)
+
+	return &out
+}
+
+func cloneCachedContent(in *driver.CachedContent) *driver.CachedContent {
+	out := *in
+	out.Contents = cloneContents(in.Contents)
+	out.SystemInstruction = cloneContent(in.SystemInstruction)
+
+	return &out
 }
 
 func (m *Mock) GetCachedContent(_ context.Context, name string) (*driver.CachedContent, error) {
@@ -172,9 +218,7 @@ func (m *Mock) GetCachedContent(_ context.Context, name string) (*driver.CachedC
 		return nil, errors.Newf(errors.NotFound, "cached content %q not found", name)
 	}
 
-	out := *cc
-
-	return &out, nil
+	return cloneCachedContent(cc), nil
 }
 
 func (m *Mock) ListCachedContents(_ context.Context, location string) ([]driver.CachedContent, error) {
@@ -182,7 +226,7 @@ func (m *Mock) ListCachedContents(_ context.Context, location string) ([]driver.
 
 	for _, cc := range m.cachedContent.All() {
 		if location == "" || locationOf(cc.Name) == location {
-			out = append(out, *cc)
+			out = append(out, *cloneCachedContent(cc))
 		}
 	}
 

--- a/providers/gcp/vertexai/genai.go
+++ b/providers/gcp/vertexai/genai.go
@@ -1,0 +1,200 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// approxTokens is a deterministic, whitespace-based token estimate.
+func approxTokens(text string) int {
+	if strings.TrimSpace(text) == "" {
+		return 0
+	}
+
+	return len(strings.Fields(text))
+}
+
+// GenerateContent returns a deterministic emulated Gemini response: it echoes
+// the last user turn as the model reply and reports plausible token usage.
+//
+
+func (m *Mock) GenerateContent(
+	_ context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.GenerateContentResponse, error) {
+	if model == "" {
+		return nil, errors.New(errors.InvalidArgument, "model is required")
+	}
+
+	prompt := lastUserText(req.Contents)
+	reply := "Emulated response to: " + prompt
+
+	promptTokens := approxTokens(prompt)
+	outTokens := approxTokens(reply)
+
+	m.emitMetric("generate_content/count", 1, map[string]string{"model": model})
+
+	return &driver.GenerateContentResponse{
+		Candidates: []driver.Candidate{{
+			Content:      driver.Content{Role: "model", Parts: []driver.Part{{Text: reply}}},
+			FinishReason: "STOP",
+		}},
+		UsageMetadata: driver.UsageMetadata{
+			PromptTokenCount:     promptTokens,
+			CandidatesTokenCount: outTokens,
+			TotalTokenCount:      promptTokens + outTokens,
+		},
+	}, nil
+}
+
+func (*Mock) CountTokens(_ context.Context, model string, req driver.GenerateContentRequest) (*driver.CountTokensResponse, error) {
+	if model == "" {
+		return nil, errors.New(errors.InvalidArgument, "model is required")
+	}
+
+	total := 0
+
+	for _, c := range req.Contents {
+		for _, p := range c.Parts {
+			total += approxTokens(p.Text)
+		}
+	}
+
+	return &driver.CountTokensResponse{TotalTokens: total}, nil
+}
+
+func lastUserText(contents []driver.Content) string {
+	for i := len(contents) - 1; i >= 0; i-- {
+		if contents[i].Role == "user" || contents[i].Role == "" {
+			var b strings.Builder
+			for _, p := range contents[i].Parts {
+				b.WriteString(p.Text)
+			}
+
+			return b.String()
+		}
+	}
+
+	return ""
+}
+
+// --- Tuning jobs (synchronous create) ---
+
+func (m *Mock) CreateTuningJob(_ context.Context, cfg driver.TuningJobConfig) (*driver.TuningJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "tuningJobs", m.newID())
+
+	tuned := cfg.TunedModelName
+	if tuned == "" {
+		tuned = m.resName(cfg.Location, "models", m.newID())
+	}
+
+	job := &driver.TuningJob{
+		Name:           name,
+		BaseModel:      cfg.BaseModel,
+		State:          driver.JobStateSucceeded,
+		TunedModelName: tuned,
+		Endpoint:       m.resName(cfg.Location, "endpoints", m.newID()),
+		CreateTime:     now,
+		EndTime:        now,
+	}
+	m.tuningJobs.Set(name, job)
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetTuningJob(_ context.Context, name string) (*driver.TuningJob, error) {
+	j, ok := m.tuningJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "tuning job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListTuningJobs(_ context.Context, location string) ([]driver.TuningJob, error) {
+	out := make([]driver.TuningJob, 0)
+
+	for _, j := range m.tuningJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelTuningJob(_ context.Context, name string) error {
+	j, ok := m.tuningJobs.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "tuning job %q not found", name)
+	}
+
+	updated := *j
+	updated.State = driver.JobStateCancelled
+	m.tuningJobs.Set(name, &updated)
+
+	return nil
+}
+
+// --- Cached contents (synchronous CRUD) ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateCachedContent(_ context.Context, cfg driver.CachedContentConfig) (*driver.CachedContent, error) {
+	if cfg.Model == "" {
+		return nil, errors.New(errors.InvalidArgument, "model is required")
+	}
+
+	name := m.resName(cfg.Location, "cachedContents", m.newID())
+	cc := &driver.CachedContent{
+		Name:        name,
+		Model:       cfg.Model,
+		DisplayName: cfg.DisplayName,
+		CreateTime:  m.now(),
+		ExpireTime:  m.now(),
+	}
+	m.cachedContent.Set(name, cc)
+
+	out := *cc
+
+	return &out, nil
+}
+
+func (m *Mock) GetCachedContent(_ context.Context, name string) (*driver.CachedContent, error) {
+	cc, ok := m.cachedContent.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cached content %q not found", name)
+	}
+
+	out := *cc
+
+	return &out, nil
+}
+
+func (m *Mock) ListCachedContents(_ context.Context, location string) ([]driver.CachedContent, error) {
+	out := make([]driver.CachedContent, 0)
+
+	for _, cc := range m.cachedContent.All() {
+		if location == "" || locationOf(cc.Name) == location {
+			out = append(out, *cc)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteCachedContent(_ context.Context, name string) error {
+	if !m.cachedContent.Has(name) {
+		return errors.Newf(errors.NotFound, "cached content %q not found", name)
+	}
+
+	m.cachedContent.Delete(name)
+
+	return nil
+}

--- a/providers/gcp/vertexai/jobs.go
+++ b/providers/gcp/vertexai/jobs.go
@@ -1,0 +1,175 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// cancelJob copy-then-Sets a job's State to canceled, or returns NotFound.
+func cancelJob[T any](store *memstore.Store[*T], name string, setState func(*T)) error {
+	j, ok := store.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "job %q not found", name)
+	}
+
+	updated := *j
+	setState(&updated)
+	store.Set(name, &updated)
+
+	return nil
+}
+
+// --- Custom jobs ---
+
+//nolint:dupl // synchronous-create job shape recurs across job families.
+func (m *Mock) CreateCustomJob(_ context.Context, cfg driver.CustomJobConfig) (*driver.CustomJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "customJobs", m.newID())
+	job := &driver.CustomJob{Name: name, DisplayName: cfg.DisplayName, State: driver.JobStateSucceeded, CreateTime: now, EndTime: now}
+	m.customJobs.Set(name, job)
+	m.emitMetric("custom_job/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetCustomJob(_ context.Context, name string) (*driver.CustomJob, error) {
+	j, ok := m.customJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "custom job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListCustomJobs(_ context.Context, location string) ([]driver.CustomJob, error) {
+	out := make([]driver.CustomJob, 0)
+
+	for _, j := range m.customJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelCustomJob(_ context.Context, name string) error {
+	return cancelJob(m.customJobs, name, func(j *driver.CustomJob) { j.State = driver.JobStateCancelled })
+}
+
+func (m *Mock) DeleteCustomJob(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.customJobs.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "custom job %q not found", name)
+	}
+
+	m.customJobs.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Batch prediction jobs ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateBatchPredictionJob(_ context.Context, cfg driver.BatchPredictionJobConfig) (*driver.BatchPredictionJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "batchPredictionJobs", m.newID())
+	job := &driver.BatchPredictionJob{
+		Name: name, DisplayName: cfg.DisplayName, Model: cfg.Model,
+		State: driver.JobStateSucceeded, CreateTime: now, EndTime: now,
+	}
+	m.batchJobs.Set(name, job)
+	m.emitMetric("batch_prediction_job/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetBatchPredictionJob(_ context.Context, name string) (*driver.BatchPredictionJob, error) {
+	j, ok := m.batchJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "batch prediction job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListBatchPredictionJobs(_ context.Context, location string) ([]driver.BatchPredictionJob, error) {
+	out := make([]driver.BatchPredictionJob, 0)
+
+	for _, j := range m.batchJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelBatchPredictionJob(_ context.Context, name string) error {
+	return cancelJob(m.batchJobs, name, func(j *driver.BatchPredictionJob) { j.State = driver.JobStateCancelled })
+}
+
+func (m *Mock) DeleteBatchPredictionJob(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.batchJobs.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "batch prediction job %q not found", name)
+	}
+
+	m.batchJobs.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Hyperparameter tuning jobs ---
+
+func (m *Mock) CreateHyperparameterTuningJob(
+	_ context.Context, cfg driver.HyperparameterTuningJobConfig,
+) (*driver.HyperparameterTuningJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "hyperparameterTuningJobs", m.newID())
+	job := &driver.HyperparameterTuningJob{
+		Name: name, DisplayName: cfg.DisplayName, State: driver.JobStateSucceeded,
+		MaxTrialCount: cfg.MaxTrialCount, CreateTime: now, EndTime: now,
+	}
+	m.hpoJobs.Set(name, job)
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetHyperparameterTuningJob(_ context.Context, name string) (*driver.HyperparameterTuningJob, error) {
+	j, ok := m.hpoJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "hyperparameter tuning job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListHyperparameterTuningJobs(_ context.Context, location string) ([]driver.HyperparameterTuningJob, error) {
+	out := make([]driver.HyperparameterTuningJob, 0)
+
+	for _, j := range m.hpoJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelHyperparameterTuningJob(_ context.Context, name string) error {
+	return cancelJob(m.hpoJobs, name, func(j *driver.HyperparameterTuningJob) { j.State = driver.JobStateCancelled })
+}

--- a/providers/gcp/vertexai/metadata.go
+++ b/providers/gcp/vertexai/metadata.go
@@ -133,21 +133,28 @@ func (m *Mock) ListSchedules(_ context.Context, location string) ([]driver.Sched
 }
 
 func (m *Mock) PauseSchedule(_ context.Context, name string) error {
-	return m.setScheduleState(name, "PAUSED")
+	return m.setScheduleState(name, "ACTIVE", "PAUSED")
 }
 
 func (m *Mock) ResumeSchedule(_ context.Context, name string) error {
-	return m.setScheduleState(name, "ACTIVE")
+	return m.setScheduleState(name, "PAUSED", "ACTIVE")
 }
 
-func (m *Mock) setScheduleState(name, state string) error {
+// setScheduleState copy-then-Sets a schedule to target only from the required
+// source state, rejecting illegal transitions like the real API.
+func (m *Mock) setScheduleState(name, from, target string) error {
 	s, ok := m.schedules.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "schedule %q not found", name)
 	}
 
+	if s.State != from {
+		return errors.Newf(errors.FailedPrecondition,
+			"schedule %q is %s; cannot transition to %s", name, s.State, target)
+	}
+
 	updated := *s
-	updated.State = state
+	updated.State = target
 	m.schedules.Set(name, &updated)
 
 	return nil
@@ -246,21 +253,28 @@ func (m *Mock) ListNotebookRuntimes(_ context.Context, location string) ([]drive
 }
 
 func (m *Mock) StartNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
-	return m.setRuntimeState(name, "RUNNING")
+	return m.setRuntimeState(name, "STOPPED", "RUNNING")
 }
 
 func (m *Mock) StopNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
-	return m.setRuntimeState(name, "STOPPED")
+	return m.setRuntimeState(name, "RUNNING", "STOPPED")
 }
 
-func (m *Mock) setRuntimeState(name, state string) (*driver.Operation, error) {
+// setRuntimeState copy-then-Sets a notebook runtime to target only from the
+// required source state, rejecting illegal transitions like the real API.
+func (m *Mock) setRuntimeState(name, from, target string) (*driver.Operation, error) {
 	nr, ok := m.nbRuntimes.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
 	}
 
+	if nr.RuntimeState != from {
+		return nil, errors.Newf(errors.FailedPrecondition,
+			"notebook runtime %q is %s; cannot transition to %s", name, nr.RuntimeState, target)
+	}
+
 	updated := *nr
-	updated.RuntimeState = state
+	updated.RuntimeState = target
 	m.nbRuntimes.Set(name, &updated)
 
 	return m.doneOp(locationOf(name), name), nil

--- a/providers/gcp/vertexai/metadata.go
+++ b/providers/gcp/vertexai/metadata.go
@@ -1,0 +1,277 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Metadata stores ---
+
+func (m *Mock) CreateMetadataStore(_ context.Context, location, storeID string) (*driver.Operation, *driver.MetadataStore, error) {
+	name := m.resName(location, "metadataStores", orID(storeID, m.newID()))
+	s := &driver.MetadataStore{Name: name, CreateTime: m.now()}
+	m.metadataStores.Set(name, s)
+
+	out := *s
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetMetadataStore(_ context.Context, name string) (*driver.MetadataStore, error) {
+	s, ok := m.metadataStores.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "metadata store %q not found", name)
+	}
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) ListMetadataStores(_ context.Context, location string) ([]driver.MetadataStore, error) {
+	out := make([]driver.MetadataStore, 0)
+
+	for _, s := range m.metadataStores.All() {
+		if location == "" || locationOf(s.Name) == location {
+			out = append(out, *s)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteMetadataStore(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.metadataStores.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "metadata store %q not found", name)
+	}
+
+	m.metadataStores.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Tensorboards ---
+
+func (m *Mock) CreateTensorboard(_ context.Context, location, displayName string) (*driver.Operation, *driver.Tensorboard, error) {
+	name := m.resName(location, "tensorboards", m.newID())
+	tb := &driver.Tensorboard{Name: name, DisplayName: displayName, CreateTime: m.now()}
+	m.tensorboards.Set(name, tb)
+
+	out := *tb
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetTensorboard(_ context.Context, name string) (*driver.Tensorboard, error) {
+	tb, ok := m.tensorboards.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "tensorboard %q not found", name)
+	}
+
+	out := *tb
+
+	return &out, nil
+}
+
+func (m *Mock) ListTensorboards(_ context.Context, location string) ([]driver.Tensorboard, error) {
+	out := make([]driver.Tensorboard, 0)
+
+	for _, tb := range m.tensorboards.All() {
+		if location == "" || locationOf(tb.Name) == location {
+			out = append(out, *tb)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteTensorboard(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.tensorboards.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "tensorboard %q not found", name)
+	}
+
+	m.tensorboards.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Schedules ---
+
+func (m *Mock) CreateSchedule(_ context.Context, location, displayName, cron string) (*driver.Schedule, error) {
+	name := m.resName(location, "schedules", m.newID())
+	s := &driver.Schedule{Name: name, DisplayName: displayName, Cron: cron, State: "ACTIVE", CreateTime: m.now()}
+	m.schedules.Set(name, s)
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) GetSchedule(_ context.Context, name string) (*driver.Schedule, error) {
+	s, ok := m.schedules.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "schedule %q not found", name)
+	}
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) ListSchedules(_ context.Context, location string) ([]driver.Schedule, error) {
+	out := make([]driver.Schedule, 0)
+
+	for _, s := range m.schedules.All() {
+		if location == "" || locationOf(s.Name) == location {
+			out = append(out, *s)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) PauseSchedule(_ context.Context, name string) error {
+	return m.setScheduleState(name, "PAUSED")
+}
+
+func (m *Mock) ResumeSchedule(_ context.Context, name string) error {
+	return m.setScheduleState(name, "ACTIVE")
+}
+
+func (m *Mock) setScheduleState(name, state string) error {
+	s, ok := m.schedules.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "schedule %q not found", name)
+	}
+
+	updated := *s
+	updated.State = state
+	m.schedules.Set(name, &updated)
+
+	return nil
+}
+
+func (m *Mock) DeleteSchedule(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.schedules.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "schedule %q not found", name)
+	}
+
+	m.schedules.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Notebook runtime templates ---
+
+func (m *Mock) CreateNotebookRuntimeTemplate(
+	_ context.Context, location, displayName, machineType string,
+) (*driver.Operation, *driver.NotebookRuntimeTemplate, error) {
+	name := m.resName(location, "notebookRuntimeTemplates", m.newID())
+	t := &driver.NotebookRuntimeTemplate{Name: name, DisplayName: displayName, MachineType: machineType, CreateTime: m.now()}
+	m.nbTemplates.Set(name, t)
+
+	out := *t
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetNotebookRuntimeTemplate(_ context.Context, name string) (*driver.NotebookRuntimeTemplate, error) {
+	t, ok := m.nbTemplates.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime template %q not found", name)
+	}
+
+	out := *t
+
+	return &out, nil
+}
+
+func (m *Mock) ListNotebookRuntimeTemplates(_ context.Context, location string) ([]driver.NotebookRuntimeTemplate, error) {
+	out := make([]driver.NotebookRuntimeTemplate, 0)
+
+	for _, t := range m.nbTemplates.All() {
+		if location == "" || locationOf(t.Name) == location {
+			out = append(out, *t)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteNotebookRuntimeTemplate(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.nbTemplates.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime template %q not found", name)
+	}
+
+	m.nbTemplates.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Notebook runtimes ---
+
+func (m *Mock) AssignNotebookRuntime(_ context.Context, location, displayName string) (*driver.Operation, *driver.NotebookRuntime, error) {
+	name := m.resName(location, "notebookRuntimes", m.newID())
+	nr := &driver.NotebookRuntime{Name: name, DisplayName: displayName, RuntimeState: "RUNNING", CreateTime: m.now()}
+	m.nbRuntimes.Set(name, nr)
+
+	out := *nr
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetNotebookRuntime(_ context.Context, name string) (*driver.NotebookRuntime, error) {
+	nr, ok := m.nbRuntimes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
+	}
+
+	out := *nr
+
+	return &out, nil
+}
+
+func (m *Mock) ListNotebookRuntimes(_ context.Context, location string) ([]driver.NotebookRuntime, error) {
+	out := make([]driver.NotebookRuntime, 0)
+
+	for _, nr := range m.nbRuntimes.All() {
+		if location == "" || locationOf(nr.Name) == location {
+			out = append(out, *nr)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StartNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
+	return m.setRuntimeState(name, "RUNNING")
+}
+
+func (m *Mock) StopNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
+	return m.setRuntimeState(name, "STOPPED")
+}
+
+func (m *Mock) setRuntimeState(name, state string) (*driver.Operation, error) {
+	nr, ok := m.nbRuntimes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
+	}
+
+	updated := *nr
+	updated.RuntimeState = state
+	m.nbRuntimes.Set(name, &updated)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) DeleteNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.nbRuntimes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
+	}
+
+	m.nbRuntimes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}

--- a/providers/gcp/vertexai/models.go
+++ b/providers/gcp/vertexai/models.go
@@ -97,6 +97,14 @@ func (m *Mock) ListModelVersions(_ context.Context, name string) ([]driver.Model
 }
 
 func (m *Mock) DeleteModelVersion(_ context.Context, name string) (*driver.Operation, error) {
+	base, _, _ := strings.Cut(name, "@")
+
+	if !m.models.Has(base) {
+		return nil, errors.Newf(errors.NotFound, "model version %q not found", name)
+	}
+
+	m.models.Delete(base)
+
 	return m.doneOp(locationOf(name), name), nil
 }
 

--- a/providers/gcp/vertexai/models.go
+++ b/providers/gcp/vertexai/models.go
@@ -1,0 +1,144 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) UploadModel(_ context.Context, cfg driver.ModelConfig) (*driver.Operation, *driver.Model, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "models", m.newID())
+	model := &driver.Model{
+		Name:           name,
+		DisplayName:    cfg.DisplayName,
+		Description:    cfg.Description,
+		ContainerImage: cfg.ContainerImage,
+		ArtifactURI:    cfg.ArtifactURI,
+		VersionID:      "1",
+		VersionAliases: []string{"default"},
+		Labels:         cfg.Labels,
+		CreateTime:     now,
+		UpdateTime:     now,
+	}
+	m.models.Set(name, model)
+	m.emitMetric("model/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *model
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetModel(_ context.Context, name string) (*driver.Model, error) {
+	base, _, _ := strings.Cut(name, "@")
+
+	model, ok := m.models.Get(base)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	out := *model
+
+	return &out, nil
+}
+
+func (m *Mock) ListModels(_ context.Context, location string) ([]driver.Model, error) {
+	out := make([]driver.Model, 0)
+
+	for _, model := range m.models.All() {
+		if location == "" || locationOf(model.Name) == location {
+			out = append(out, *model)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) PatchModel(_ context.Context, name, displayName, description string) (*driver.Model, error) {
+	model, ok := m.models.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	if displayName != "" {
+		model.DisplayName = displayName
+	}
+
+	if description != "" {
+		model.Description = description
+	}
+
+	model.UpdateTime = m.now()
+	out := *model
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteModel(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.models.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	m.models.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ListModelVersions(_ context.Context, name string) ([]driver.Model, error) {
+	base, _, _ := strings.Cut(name, "@")
+
+	model, ok := m.models.Get(base)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	return []driver.Model{*model}, nil
+}
+
+func (m *Mock) DeleteModelVersion(_ context.Context, name string) (*driver.Operation, error) {
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ImportModelEvaluation(_ context.Context, modelName string, eval driver.ModelEvaluation) (*driver.ModelEvaluation, error) {
+	if !m.models.Has(modelName) {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", modelName)
+	}
+
+	name := modelName + "/evaluations/" + m.newID()
+	ev := &driver.ModelEvaluation{
+		Name:        name,
+		DisplayName: eval.DisplayName,
+		MetricsType: eval.MetricsType,
+		CreateTime:  m.now(),
+	}
+	m.evaluations.Set(name, ev)
+	out := *ev
+
+	return &out, nil
+}
+
+func (m *Mock) GetModelEvaluation(_ context.Context, name string) (*driver.ModelEvaluation, error) {
+	ev, ok := m.evaluations.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model evaluation %q not found", name)
+	}
+
+	out := *ev
+
+	return &out, nil
+}
+
+func (m *Mock) ListModelEvaluations(_ context.Context, modelName string) ([]driver.ModelEvaluation, error) {
+	out := make([]driver.ModelEvaluation, 0)
+
+	for _, ev := range m.evaluations.All() {
+		if strings.HasPrefix(ev.Name, modelName+"/evaluations/") {
+			out = append(out, *ev)
+		}
+	}
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/models.go
+++ b/providers/gcp/vertexai/models.go
@@ -20,16 +20,14 @@ func (m *Mock) UploadModel(_ context.Context, cfg driver.ModelConfig) (*driver.O
 		ArtifactURI:    cfg.ArtifactURI,
 		VersionID:      "1",
 		VersionAliases: []string{"default"},
-		Labels:         cfg.Labels,
+		Labels:         copyLabels(cfg.Labels),
 		CreateTime:     now,
 		UpdateTime:     now,
 	}
 	m.models.Set(name, model)
 	m.emitMetric("model/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
-	out := *model
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneModel(model), nil
 }
 
 func (m *Mock) GetModel(_ context.Context, name string) (*driver.Model, error) {
@@ -40,9 +38,7 @@ func (m *Mock) GetModel(_ context.Context, name string) (*driver.Model, error) {
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
-	out := *model
-
-	return &out, nil
+	return cloneModel(model), nil
 }
 
 func (m *Mock) ListModels(_ context.Context, location string) ([]driver.Model, error) {
@@ -50,7 +46,7 @@ func (m *Mock) ListModels(_ context.Context, location string) ([]driver.Model, e
 
 	for _, model := range m.models.All() {
 		if location == "" || locationOf(model.Name) == location {
-			out = append(out, *model)
+			out = append(out, *cloneModel(model))
 		}
 	}
 
@@ -63,18 +59,20 @@ func (m *Mock) PatchModel(_ context.Context, name, displayName, description stri
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
+	// Copy-then-Set: never mutate the stored pointer in place.
+	updated := *model
 	if displayName != "" {
-		model.DisplayName = displayName
+		updated.DisplayName = displayName
 	}
 
 	if description != "" {
-		model.Description = description
+		updated.Description = description
 	}
 
-	model.UpdateTime = m.now()
-	out := *model
+	updated.UpdateTime = m.now()
+	m.models.Set(name, &updated)
 
-	return &out, nil
+	return cloneModel(&updated), nil
 }
 
 func (m *Mock) DeleteModel(_ context.Context, name string) (*driver.Operation, error) {
@@ -95,7 +93,7 @@ func (m *Mock) ListModelVersions(_ context.Context, name string) ([]driver.Model
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
-	return []driver.Model{*model}, nil
+	return []driver.Model{*cloneModel(model)}, nil
 }
 
 func (m *Mock) DeleteModelVersion(_ context.Context, name string) (*driver.Operation, error) {

--- a/providers/gcp/vertexai/operations.go
+++ b/providers/gcp/vertexai/operations.go
@@ -1,0 +1,35 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// GetOperation returns a recorded operation by name.
+func (m *Mock) GetOperation(_ context.Context, name string) (*driver.Operation, error) {
+	op, ok := m.operations.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "operation %q not found", name)
+	}
+
+	out := *op
+
+	return &out, nil
+}
+
+// ListOperations returns all operations whose name is scoped under parent
+// (projects/{p}/locations/{l}).
+func (m *Mock) ListOperations(_ context.Context, parent string) ([]driver.Operation, error) {
+	out := make([]driver.Operation, 0)
+
+	for _, op := range m.operations.All() {
+		if parent == "" || strings.HasPrefix(op.Name, parent+"/operations/") {
+			out = append(out, *op)
+		}
+	}
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/pipelines.go
+++ b/providers/gcp/vertexai/pipelines.go
@@ -1,0 +1,131 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Training pipelines ---
+
+func (m *Mock) CreateTrainingPipeline(_ context.Context, cfg driver.TrainingPipelineConfig) (*driver.TrainingPipeline, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "trainingPipelines", m.newID())
+	tp := &driver.TrainingPipeline{
+		Name: name, DisplayName: cfg.DisplayName,
+		State: driver.PipelineStateSucceeded, CreateTime: now, EndTime: now,
+	}
+	m.trainPipes.Set(name, tp)
+
+	out := *tp
+
+	return &out, nil
+}
+
+func (m *Mock) GetTrainingPipeline(_ context.Context, name string) (*driver.TrainingPipeline, error) {
+	tp, ok := m.trainPipes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "training pipeline %q not found", name)
+	}
+
+	out := *tp
+
+	return &out, nil
+}
+
+func (m *Mock) ListTrainingPipelines(_ context.Context, location string) ([]driver.TrainingPipeline, error) {
+	out := make([]driver.TrainingPipeline, 0)
+
+	for _, tp := range m.trainPipes.All() {
+		if location == "" || locationOf(tp.Name) == location {
+			out = append(out, *tp)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelTrainingPipeline(_ context.Context, name string) error {
+	tp, ok := m.trainPipes.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "training pipeline %q not found", name)
+	}
+
+	updated := *tp
+	updated.State = driver.PipelineStateCancelled
+	m.trainPipes.Set(name, &updated)
+
+	return nil
+}
+
+func (m *Mock) DeleteTrainingPipeline(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.trainPipes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "training pipeline %q not found", name)
+	}
+
+	m.trainPipes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Pipeline jobs ---
+
+//nolint:dupl // synchronous-create job shape recurs across job families.
+func (m *Mock) CreatePipelineJob(_ context.Context, cfg driver.PipelineJobConfig) (*driver.PipelineJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "pipelineJobs", m.newID())
+	pj := &driver.PipelineJob{Name: name, DisplayName: cfg.DisplayName, State: driver.PipelineStateSucceeded, CreateTime: now, EndTime: now}
+	m.pipelineJobs.Set(name, pj)
+	m.emitMetric("pipeline_job/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *pj
+
+	return &out, nil
+}
+
+func (m *Mock) GetPipelineJob(_ context.Context, name string) (*driver.PipelineJob, error) {
+	pj, ok := m.pipelineJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "pipeline job %q not found", name)
+	}
+
+	out := *pj
+
+	return &out, nil
+}
+
+func (m *Mock) ListPipelineJobs(_ context.Context, location string) ([]driver.PipelineJob, error) {
+	out := make([]driver.PipelineJob, 0)
+
+	for _, pj := range m.pipelineJobs.All() {
+		if location == "" || locationOf(pj.Name) == location {
+			out = append(out, *pj)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelPipelineJob(_ context.Context, name string) error {
+	pj, ok := m.pipelineJobs.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "pipeline job %q not found", name)
+	}
+
+	updated := *pj
+	updated.State = driver.PipelineStateCancelled
+	m.pipelineJobs.Set(name, &updated)
+
+	return nil
+}
+
+func (m *Mock) DeletePipelineJob(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.pipelineJobs.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "pipeline job %q not found", name)
+	}
+
+	m.pipelineJobs.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}

--- a/providers/gcp/vertexai/vectorsearch.go
+++ b/providers/gcp/vertexai/vectorsearch.go
@@ -1,0 +1,193 @@
+package vertexai
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (m *Mock) CreateIndex(_ context.Context, cfg driver.IndexConfig) (*driver.Operation, *driver.Index, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "indexes", m.newID())
+	idx := &driver.Index{
+		Name: name, DisplayName: cfg.DisplayName, Description: cfg.Description,
+		Dimensions: cfg.Dimensions, CreateTime: now, UpdateTime: now,
+	}
+	m.indexes.Set(name, idx)
+
+	out := *idx
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetIndex(_ context.Context, name string) (*driver.Index, error) {
+	idx, ok := m.indexes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "index %q not found", name)
+	}
+
+	out := *idx
+
+	return &out, nil
+}
+
+func (m *Mock) ListIndexes(_ context.Context, location string) ([]driver.Index, error) {
+	out := make([]driver.Index, 0)
+
+	for _, idx := range m.indexes.All() {
+		if location == "" || locationOf(idx.Name) == location {
+			out = append(out, *idx)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteIndex(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.indexes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "index %q not found", name)
+	}
+
+	m.indexes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) UpsertDatapoints(_ context.Context, index string, datapoints []driver.Datapoint) error {
+	idx, ok := m.indexes.Get(index)
+	if !ok {
+		return errors.Newf(errors.NotFound, "index %q not found", index)
+	}
+
+	updated := *idx
+	updated.DatapointCount += len(datapoints)
+	updated.UpdateTime = m.now()
+	m.indexes.Set(index, &updated)
+
+	return nil
+}
+
+func (m *Mock) RemoveDatapoints(_ context.Context, index string, datapointIDs []string) error {
+	idx, ok := m.indexes.Get(index)
+	if !ok {
+		return errors.Newf(errors.NotFound, "index %q not found", index)
+	}
+
+	updated := *idx
+	updated.DatapointCount = maxZero(updated.DatapointCount - len(datapointIDs))
+	updated.UpdateTime = m.now()
+	m.indexes.Set(index, &updated)
+
+	return nil
+}
+
+func maxZero(v int) int {
+	if v < 0 {
+		return 0
+	}
+
+	return v
+}
+
+func (m *Mock) CreateIndexEndpoint(_ context.Context, cfg driver.IndexEndpointConfig) (*driver.Operation, *driver.IndexEndpoint, error) {
+	name := m.resName(cfg.Location, "indexEndpoints", m.newID())
+	ie := &driver.IndexEndpoint{Name: name, DisplayName: cfg.DisplayName, Description: cfg.Description, CreateTime: m.now()}
+	m.indexEndpoints.Set(name, ie)
+
+	out := *ie
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetIndexEndpoint(_ context.Context, name string) (*driver.IndexEndpoint, error) {
+	ie, ok := m.indexEndpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", name)
+	}
+
+	out := *ie
+
+	return &out, nil
+}
+
+func (m *Mock) ListIndexEndpoints(_ context.Context, location string) ([]driver.IndexEndpoint, error) {
+	out := make([]driver.IndexEndpoint, 0)
+
+	for _, ie := range m.indexEndpoints.All() {
+		if location == "" || locationOf(ie.Name) == location {
+			out = append(out, *ie)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteIndexEndpoint(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.indexEndpoints.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", name)
+	}
+
+	m.indexEndpoints.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) DeployIndex(
+	_ context.Context, indexEndpoint string, di driver.DeployedIndex,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	ie, ok := m.indexEndpoints.Get(indexEndpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	if di.ID == "" {
+		di.ID = m.newID()
+	}
+
+	updated := *ie
+	updated.DeployedIndexes = append(append([]driver.DeployedIndex{}, ie.DeployedIndexes...), di)
+	m.indexEndpoints.Set(indexEndpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+}
+
+func (m *Mock) UndeployIndex(_ context.Context, indexEndpoint, deployedIndexID string) (*driver.Operation, *driver.IndexEndpoint, error) {
+	ie, ok := m.indexEndpoints.Get(indexEndpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	kept := make([]driver.DeployedIndex, 0, len(ie.DeployedIndexes))
+
+	for _, d := range ie.DeployedIndexes {
+		if d.ID != deployedIndexID {
+			kept = append(kept, d)
+		}
+	}
+
+	updated := *ie
+	updated.DeployedIndexes = kept
+	m.indexEndpoints.Set(indexEndpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+}
+
+// FindNeighbors returns deterministic synthetic neighbors for the query.
+func (m *Mock) FindNeighbors(_ context.Context, indexEndpoint, _ string, _ []float64, count int) ([]driver.Neighbor, error) {
+	if !m.indexEndpoints.Has(indexEndpoint) {
+		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	out := make([]driver.Neighbor, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, driver.Neighbor{DatapointID: "dp-" + strconv.Itoa(i), Distance: float64(i) * 0.1})
+	}
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/vectorsearch.go
+++ b/providers/gcp/vertexai/vectorsearch.go
@@ -107,9 +107,7 @@ func (m *Mock) GetIndexEndpoint(_ context.Context, name string) (*driver.IndexEn
 		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", name)
 	}
 
-	out := *ie
-
-	return &out, nil
+	return cloneIndexEndpoint(ie), nil
 }
 
 func (m *Mock) ListIndexEndpoints(_ context.Context, location string) ([]driver.IndexEndpoint, error) {
@@ -117,7 +115,7 @@ func (m *Mock) ListIndexEndpoints(_ context.Context, location string) ([]driver.
 
 	for _, ie := range m.indexEndpoints.All() {
 		if location == "" || locationOf(ie.Name) == location {
-			out = append(out, *ie)
+			out = append(out, *cloneIndexEndpoint(ie))
 		}
 	}
 
@@ -146,13 +144,11 @@ func (m *Mock) DeployIndex(
 		di.ID = m.newID()
 	}
 
-	updated := *ie
-	updated.DeployedIndexes = append(append([]driver.DeployedIndex{}, ie.DeployedIndexes...), di)
-	m.indexEndpoints.Set(indexEndpoint, &updated)
+	updated := cloneIndexEndpoint(ie)
+	updated.DeployedIndexes = append(updated.DeployedIndexes, di)
+	m.indexEndpoints.Set(indexEndpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), cloneIndexEndpoint(updated), nil
 }
 
 func (m *Mock) UndeployIndex(_ context.Context, indexEndpoint, deployedIndexID string) (*driver.Operation, *driver.IndexEndpoint, error) {
@@ -161,27 +157,38 @@ func (m *Mock) UndeployIndex(_ context.Context, indexEndpoint, deployedIndexID s
 		return nil, nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
 	}
 
-	kept := make([]driver.DeployedIndex, 0, len(ie.DeployedIndexes))
+	updated := cloneIndexEndpoint(ie)
 
-	for _, d := range ie.DeployedIndexes {
+	kept := make([]driver.DeployedIndex, 0, len(updated.DeployedIndexes))
+
+	for _, d := range updated.DeployedIndexes {
 		if d.ID != deployedIndexID {
 			kept = append(kept, d)
 		}
 	}
 
-	updated := *ie
 	updated.DeployedIndexes = kept
-	m.indexEndpoints.Set(indexEndpoint, &updated)
+	m.indexEndpoints.Set(indexEndpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), cloneIndexEndpoint(updated), nil
 }
+
+// maxNeighbors bounds the synthesized neighbor count so an unvalidated (or
+// hostile) request can't trigger an unbounded allocation.
+const maxNeighbors = 1000
 
 // FindNeighbors returns deterministic synthetic neighbors for the query.
 func (m *Mock) FindNeighbors(_ context.Context, indexEndpoint, _ string, _ []float64, count int) ([]driver.Neighbor, error) {
 	if !m.indexEndpoints.Has(indexEndpoint) {
 		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	if count < 0 {
+		count = 0
+	}
+
+	if count > maxNeighbors {
+		count = maxNeighbors
 	}
 
 	out := make([]driver.Neighbor, 0, count)

--- a/providers/gcp/vertexai/vertexai.go
+++ b/providers/gcp/vertexai/vertexai.go
@@ -44,6 +44,9 @@ type Mock struct {
 	tuningJobs    *memstore.Store[*driver.TuningJob]
 	cachedContent *memstore.Store[*driver.CachedContent]
 
+	featurestores *memstore.Store[*driver.Featurestore]
+	entityTypes   *memstore.Store[*driver.EntityType]
+	entityRecords *memstore.Store[[]driver.FeatureNameValue] // keyed by entityType\x00entityID
 	featureGroups *memstore.Store[*driver.FeatureGroup]
 	features      *memstore.Store[*driver.Feature]
 	onlineStores  *memstore.Store[*driver.FeatureOnlineStore]
@@ -78,6 +81,9 @@ func New(opts *config.Options) *Mock {
 		pipelineJobs:   memstore.New[*driver.PipelineJob](),
 		tuningJobs:     memstore.New[*driver.TuningJob](),
 		cachedContent:  memstore.New[*driver.CachedContent](),
+		featurestores:  memstore.New[*driver.Featurestore](),
+		entityTypes:    memstore.New[*driver.EntityType](),
+		entityRecords:  memstore.New[[]driver.FeatureNameValue](),
 		featureGroups:  memstore.New[*driver.FeatureGroup](),
 		features:       memstore.New[*driver.Feature](),
 		onlineStores:   memstore.New[*driver.FeatureOnlineStore](),

--- a/providers/gcp/vertexai/vertexai.go
+++ b/providers/gcp/vertexai/vertexai.go
@@ -1,0 +1,148 @@
+// Package vertexai provides an in-memory mock implementation of Google Cloud
+// Vertex AI (aiplatform.googleapis.com): datasets, the model registry,
+// endpoints and online prediction, custom/training/tuning/batch jobs,
+// pipelines, the Gemini generateContent runtime, Feature Store, Vector Search,
+// Tensorboard, ML metadata, schedules and notebook runtimes.
+//
+// Control-plane mutations return an already-done Operation so SDK pollers
+// terminate on the first poll. Job-family resources are created synchronously
+// and driven straight to a terminal success state, mirroring how the real API
+// returns the resource from create and exposes progress via a state field.
+package vertexai
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// Compile-time check that Mock implements the full Vertex AI surface.
+var _ driver.VertexAI = (*Mock)(nil)
+
+// defaultLocation is used when a resource name carries no parseable location.
+const defaultLocation = "us-central1"
+
+// Mock is an in-memory mock implementation of Vertex AI.
+type Mock struct {
+	opts *config.Options
+
+	datasets    *memstore.Store[*driver.Dataset]
+	models      *memstore.Store[*driver.Model]
+	evaluations *memstore.Store[*driver.ModelEvaluation]
+	endpoints   *memstore.Store[*driver.Endpoint]
+
+	customJobs    *memstore.Store[*driver.CustomJob]
+	batchJobs     *memstore.Store[*driver.BatchPredictionJob]
+	hpoJobs       *memstore.Store[*driver.HyperparameterTuningJob]
+	trainPipes    *memstore.Store[*driver.TrainingPipeline]
+	pipelineJobs  *memstore.Store[*driver.PipelineJob]
+	tuningJobs    *memstore.Store[*driver.TuningJob]
+	cachedContent *memstore.Store[*driver.CachedContent]
+
+	featureGroups *memstore.Store[*driver.FeatureGroup]
+	features      *memstore.Store[*driver.Feature]
+	onlineStores  *memstore.Store[*driver.FeatureOnlineStore]
+	featureViews  *memstore.Store[*driver.FeatureView]
+
+	indexes        *memstore.Store[*driver.Index]
+	indexEndpoints *memstore.Store[*driver.IndexEndpoint]
+
+	metadataStores *memstore.Store[*driver.MetadataStore]
+	tensorboards   *memstore.Store[*driver.Tensorboard]
+	schedules      *memstore.Store[*driver.Schedule]
+	nbTemplates    *memstore.Store[*driver.NotebookRuntimeTemplate]
+	nbRuntimes     *memstore.Store[*driver.NotebookRuntime]
+
+	operations *memstore.Store[*driver.Operation]
+
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new Vertex AI mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		opts:           opts,
+		datasets:       memstore.New[*driver.Dataset](),
+		models:         memstore.New[*driver.Model](),
+		evaluations:    memstore.New[*driver.ModelEvaluation](),
+		endpoints:      memstore.New[*driver.Endpoint](),
+		customJobs:     memstore.New[*driver.CustomJob](),
+		batchJobs:      memstore.New[*driver.BatchPredictionJob](),
+		hpoJobs:        memstore.New[*driver.HyperparameterTuningJob](),
+		trainPipes:     memstore.New[*driver.TrainingPipeline](),
+		pipelineJobs:   memstore.New[*driver.PipelineJob](),
+		tuningJobs:     memstore.New[*driver.TuningJob](),
+		cachedContent:  memstore.New[*driver.CachedContent](),
+		featureGroups:  memstore.New[*driver.FeatureGroup](),
+		features:       memstore.New[*driver.Feature](),
+		onlineStores:   memstore.New[*driver.FeatureOnlineStore](),
+		featureViews:   memstore.New[*driver.FeatureView](),
+		indexes:        memstore.New[*driver.Index](),
+		indexEndpoints: memstore.New[*driver.IndexEndpoint](),
+		metadataStores: memstore.New[*driver.MetadataStore](),
+		tensorboards:   memstore.New[*driver.Tensorboard](),
+		schedules:      memstore.New[*driver.Schedule](),
+		nbTemplates:    memstore.New[*driver.NotebookRuntimeTemplate](),
+		nbRuntimes:     memstore.New[*driver.NotebookRuntime](),
+		operations:     memstore.New[*driver.Operation](),
+	}
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) now() string {
+	return m.opts.Clock.Now().UTC().Format(time.RFC3339)
+}
+
+// resName builds a Vertex resource name under the given location and collection.
+func (m *Mock) resName(location, collection, id string) string {
+	return "projects/" + m.opts.ProjectID + "/locations/" + orLocation(location) + "/" + collection + "/" + id
+}
+
+func orLocation(loc string) string {
+	if loc == "" {
+		return defaultLocation
+	}
+
+	return loc
+}
+
+func (*Mock) newID() string {
+	return idgen.GenerateID("")
+}
+
+// doneOp records and returns an already-complete operation for the given
+// location, carrying the response resource name in its metadata.
+func (m *Mock) doneOp(location, resourceName string) *driver.Operation {
+	name := "projects/" + m.opts.ProjectID + "/locations/" + orLocation(location) + "/operations/" + m.newID()
+	op := &driver.Operation{
+		Name:     name,
+		Done:     true,
+		Metadata: map[string]any{"target": resourceName},
+		Response: map[string]any{"name": resourceName},
+	}
+	m.operations.Set(name, op)
+
+	return op
+}
+
+// emitMetric pushes an auto-metric to the wired monitoring backend (no-op when
+// monitoring is not set). Failures never affect the control plane.
+func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "aiplatform.googleapis.com", MetricName: metricName, Value: value,
+		Unit: "Count", Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
+}

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -162,3 +162,138 @@ func TestLegacyFeaturestore(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, stores, 1)
 }
+
+// TestPatchModelDoesNotMutateSnapshot guards the copy-then-Set fix: an earlier
+// GetModel snapshot must not change when PatchModel runs.
+func TestPatchModelDoesNotMutateSnapshot(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "before"})
+	require.NoError(t, err)
+
+	snap, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+
+	_, err = m.PatchModel(ctx, model.Name, "after", "desc")
+	require.NoError(t, err)
+
+	assert.Equal(t, "before", snap.DisplayName, "prior snapshot must be unaffected by PatchModel")
+
+	got, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "after", got.DisplayName)
+}
+
+// TestCreateLabelsAreCloned guards against storing the caller's map by
+// reference: mutating cfg.Labels after create must not change the stored model.
+func TestCreateLabelsAreCloned(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	labels := map[string]string{"team": "ml"}
+
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m", Labels: labels})
+	require.NoError(t, err)
+
+	labels["team"] = "mutated"
+
+	got, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "ml", got.Labels["team"], "stored labels must be a clone of the caller's map")
+}
+
+// TestDeployModelKeepsTrafficForAllModels guards the traffic-split merge fix:
+// deploying a second model must not drop the first from the split.
+func TestDeployModelKeepsTrafficForAllModels(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
+	require.NoError(t, err)
+
+	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "A", Model: "m/A"})
+	require.NoError(t, err)
+
+	_, after, err := m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "B", Model: "m/B"})
+	require.NoError(t, err)
+
+	require.Len(t, after.DeployedModels, 2)
+	assert.Contains(t, after.TrafficSplit, "A", "A must keep a traffic-split entry after B deploys")
+	assert.Contains(t, after.TrafficSplit, "B")
+
+	total := 0
+	for _, v := range after.TrafficSplit {
+		total += v
+	}
+
+	assert.Equal(t, 100, total, "traffic split must total 100")
+
+	// Undeploy rebalances onto the survivor.
+	_, post, err := m.UndeployModel(ctx, ep.Name, "A")
+	require.NoError(t, err)
+	assert.NotContains(t, post.TrafficSplit, "A")
+	assert.Equal(t, 100, post.TrafficSplit["B"])
+}
+
+// TestCachedContentTTLAndContents guards the expiry/persist fix.
+func TestCachedContentTTLAndContents(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cc, err := m.CreateCachedContent(ctx, driver.CachedContentConfig{
+		Location: "us-central1", Model: "gemini-2.5-pro", TTLSeconds: 3600,
+		Contents: []driver.Content{{Role: "user", Parts: []driver.Part{{Text: "hi"}}}},
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, cc.CreateTime, cc.ExpireTime, "expireTime must be createTime + TTL, not equal")
+	assert.Greater(t, cc.ExpireTime, cc.CreateTime)
+	require.Len(t, cc.Contents, 1, "contents must be persisted")
+	assert.Equal(t, "hi", cc.Contents[0].Parts[0].Text)
+}
+
+// TestDeleteModelVersionActuallyDeletes guards the no-op fix.
+func TestDeleteModelVersionActuallyDeletes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.NoError(t, err)
+
+	_, err = m.DeleteModelVersion(ctx, model.Name+"@1")
+	require.NoError(t, err)
+
+	_, err = m.GetModel(ctx, model.Name)
+	require.Error(t, err, "model must be gone after version delete")
+
+	_, err = m.DeleteModelVersion(ctx, model.Name+"@1")
+	require.Error(t, err, "deleting a missing version must return NotFound")
+}
+
+// TestChildListingPrefixDelimiter guards against sibling leakage between
+// featureGroups whose IDs share a prefix (fg1 vs fg10).
+func TestChildListingPrefixDelimiter(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, fg1, err := m.CreateFeatureGroup(ctx, driver.FeatureGroupConfig{Location: "us-central1", FeatureGroupID: "fg1"})
+	require.NoError(t, err)
+	_, fg10, err := m.CreateFeatureGroup(ctx, driver.FeatureGroupConfig{Location: "us-central1", FeatureGroupID: "fg10"})
+	require.NoError(t, err)
+
+	_, _, err = m.CreateFeature(ctx, fg1.Name, "f1", "")
+	require.NoError(t, err)
+	_, _, err = m.CreateFeature(ctx, fg10.Name, "f10a", "")
+	require.NoError(t, err)
+	_, _, err = m.CreateFeature(ctx, fg10.Name, "f10b", "")
+	require.NoError(t, err)
+
+	f1, err := m.ListFeatures(ctx, fg1.Name)
+	require.NoError(t, err)
+	assert.Len(t, f1, 1, "fg1 listing must not leak fg10's features")
+
+	f10, err := m.ListFeatures(ctx, fg10.Name)
+	require.NoError(t, err)
+	assert.Len(t, f10, 2)
+}

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -128,3 +128,37 @@ func TestNotFound(t *testing.T) {
 	_, err := m.GetModel(context.Background(), "projects/proj/locations/us-central1/models/ghost")
 	require.Error(t, err)
 }
+
+func TestLegacyFeaturestore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, fs, err := m.CreateFeaturestore(ctx, driver.FeaturestoreConfig{Location: "us-central1", FeaturestoreID: "fs1"})
+	require.NoError(t, err)
+	assert.Contains(t, fs.Name, "/featurestores/fs1")
+
+	got, err := m.GetFeaturestore(ctx, fs.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "STABLE", got.State)
+
+	_, et, err := m.CreateEntityType(ctx, fs.Name, "users", "user entities")
+	require.NoError(t, err)
+	assert.Contains(t, et.Name, "/entityTypes/users")
+
+	ets, err := m.ListEntityTypes(ctx, fs.Name)
+	require.NoError(t, err)
+	assert.Len(t, ets, 1)
+
+	require.NoError(t, m.WriteFeatureValues(ctx, et.Name, "u1", []driver.FeatureNameValue{{Name: "age", Value: "30"}}))
+	vals, err := m.ReadFeatureValues(ctx, et.Name, "u1")
+	require.NoError(t, err)
+	require.Len(t, vals, 1)
+	assert.Equal(t, "age", vals[0].Name)
+
+	_, err = m.ReadFeatureValues(ctx, et.Name, "ghost")
+	require.Error(t, err)
+
+	stores, err := m.ListFeaturestores(ctx, "us-central1")
+	require.NoError(t, err)
+	assert.Len(t, stores, 1)
+}

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -1,0 +1,130 @@
+package vertexai
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithProjectID("proj"))
+
+	return New(opts)
+}
+
+func TestModelUploadAndGet(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	op, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m1"})
+	require.NoError(t, err)
+	assert.True(t, op.Done)
+	assert.Contains(t, model.Name, "projects/proj/locations/us-central1/models/")
+
+	got, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", got.DisplayName)
+
+	// version-suffixed name resolves to the base model.
+	got2, err := m.GetModel(ctx, model.Name+"@1")
+	require.NoError(t, err)
+	assert.Equal(t, model.Name, got2.Name)
+}
+
+func TestEndpointDeployAndPredict(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
+	require.NoError(t, err)
+
+	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{Model: "projects/proj/locations/us-central1/models/m", DisplayName: "v1"})
+	require.NoError(t, err)
+
+	got, err := m.GetEndpoint(ctx, ep.Name)
+	require.NoError(t, err)
+	require.Len(t, got.DeployedModels, 1)
+
+	resp, err := m.Predict(ctx, driver.PredictRequest{Endpoint: ep.Name, Instances: []any{map[string]any{"x": 1}}})
+	require.NoError(t, err)
+	assert.Len(t, resp.Predictions, 1)
+	assert.NotEmpty(t, resp.DeployedModelID)
+}
+
+func TestGenerateContent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	resp, err := m.GenerateContent(ctx, "publishers/google/models/gemini-2.5-pro", driver.GenerateContentRequest{
+		Contents: []driver.Content{{Role: "user", Parts: []driver.Part{{Text: "hello there world"}}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Candidates, 1)
+	assert.Equal(t, "model", resp.Candidates[0].Content.Role)
+	assert.Equal(t, 3, resp.UsageMetadata.PromptTokenCount)
+	assert.Positive(t, resp.UsageMetadata.TotalTokenCount)
+}
+
+func TestJobsSynchronousSuccess(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cj, err := m.CreateCustomJob(ctx, driver.CustomJobConfig{Location: "us-central1", DisplayName: "train"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobStateSucceeded, cj.State)
+
+	bp, err := m.CreateBatchPredictionJob(ctx, driver.BatchPredictionJobConfig{Location: "us-central1", DisplayName: "bp"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobStateSucceeded, bp.State)
+
+	require.NoError(t, m.CancelCustomJob(ctx, cj.Name))
+	got, _ := m.GetCustomJob(ctx, cj.Name)
+	assert.Equal(t, driver.JobStateCancelled, got.State)
+}
+
+func TestVectorSearchFindNeighbors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, idx, err := m.CreateIndex(ctx, driver.IndexConfig{Location: "us-central1", DisplayName: "idx", Dimensions: 4})
+	require.NoError(t, err)
+	require.NoError(t, m.UpsertDatapoints(ctx, idx.Name, []driver.Datapoint{{DatapointID: "a", FeatureVector: []float64{1, 2, 3, 4}}}))
+
+	got, err := m.GetIndex(ctx, idx.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.DatapointCount)
+
+	_, ie, err := m.CreateIndexEndpoint(ctx, driver.IndexEndpointConfig{Location: "us-central1", DisplayName: "ie"})
+	require.NoError(t, err)
+	_, _, err = m.DeployIndex(ctx, ie.Name, driver.DeployedIndex{ID: "d1", Index: idx.Name})
+	require.NoError(t, err)
+
+	nbrs, err := m.FindNeighbors(ctx, ie.Name, "d1", []float64{1, 2, 3, 4}, 3)
+	require.NoError(t, err)
+	assert.Len(t, nbrs, 3)
+}
+
+func TestOperationsRetrievable(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	op, _, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
+	require.NoError(t, err)
+
+	got, err := m.GetOperation(ctx, op.Name)
+	require.NoError(t, err)
+	assert.True(t, got.Done)
+}
+
+func TestNotFound(t *testing.T) {
+	m := newTestMock()
+	_, err := m.GetModel(context.Background(), "projects/proj/locations/us-central1/models/ghost")
+	require.Error(t, err)
+}

--- a/resourcediscovery/engine.go
+++ b/resourcediscovery/engine.go
@@ -5,6 +5,7 @@ import (
 
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	serverlessdriver "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
@@ -20,6 +21,7 @@ type Drivers struct {
 	Storage    storagedriver.Bucket
 	Database   dbdriver.Database
 	Serverless serverlessdriver.Serverless
+	Databricks dbxdriver.Databricks
 }
 
 // Engine walks all configured service drivers and returns a normalized
@@ -75,6 +77,8 @@ func (e *Engine) ListAll(ctx context.Context) ([]Resource, error) {
 // List walks every configured driver and returns resources matching q.
 // Filtering happens after collection — walkers always return their full set
 // so tag/region resolution is consistent regardless of query shape.
+//
+//nolint:gocritic // q is the public Query filter, taken by value by API contract
 func (e *Engine) List(ctx context.Context, q Query) ([]Resource, error) {
 	var out []Resource
 
@@ -116,6 +120,10 @@ func (e *Engine) walkers() []func(context.Context) ([]Resource, error) {
 
 	if e.drivers.Serverless != nil {
 		ws = append(ws, e.walkServerless)
+	}
+
+	if e.drivers.Databricks != nil {
+		ws = append(ws, e.walkDatabricks)
 	}
 
 	return ws

--- a/resourcediscovery/types.go
+++ b/resourcediscovery/types.go
@@ -33,20 +33,30 @@ type Resource struct {
 // slice. An empty/nil slice means "no service filter". This shape supports
 // cases like AWS's "ec2" which spans both compute and networking — the
 // caller can pass Services: []string{"compute", "networking"}.
+//
+// Type is a single exact-match type filter. Types is an any-of set on the
+// resource Type, for callers that select several types at once (e.g. a KQL
+// `where type in~ ('a', 'b')`); an empty/nil slice means "no type-set filter".
+// Type and Types are independent — both must pass when both are set.
 type Query struct {
 	Services []string
 	Type     string
+	Types    []string
 	Region   string
 	Tags     map[string]string
 }
 
 // matches returns true if r satisfies every non-empty field of q.
-func (q Query) matches(r *Resource) bool {
+func (q *Query) matches(r *Resource) bool {
 	if !sliceMatch(q.Services, r.Service) {
 		return false
 	}
 
 	if !fieldMatch(q.Type, r.Type) {
+		return false
+	}
+
+	if !sliceMatch(q.Types, r.Type) {
 		return false
 	}
 

--- a/resourcediscovery/walkers.go
+++ b/resourcediscovery/walkers.go
@@ -23,6 +23,7 @@ const (
 	ServiceStorage    = "storage"
 	ServiceDatabase   = "database"
 	ServiceServerless = "serverless"
+	ServiceDatabricks = "databricks"
 )
 
 // Resource type constants emitted by the walkers.
@@ -34,6 +35,7 @@ const (
 	TypeBucket        = "Bucket"
 	TypeTable         = "Table"
 	TypeFunction      = "Function"
+	TypeWorkspace     = "Workspace"
 )
 
 func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
@@ -197,6 +199,35 @@ func (e *Engine) walkServerless(ctx context.Context) ([]Resource, error) {
 			ID:     fns[i].Name,
 			ARN:    arn,
 			Region: e.region, Tags: copyTags(fns[i].Tags),
+		})
+	}
+
+	return out, nil
+}
+
+// walkDatabricks lists Databricks workspaces from the control-plane driver.
+// Workspaces are ARM resources whose driver is wired in separately from the
+// five portable service drivers, so they need their own walker to appear in
+// the cross-service inventory (and therefore in Resource Graph results).
+func (e *Engine) walkDatabricks(ctx context.Context) ([]Resource, error) {
+	workspaces, err := e.drivers.Databricks.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkDatabricks: %w", err)
+	}
+
+	out := make([]Resource, 0, len(workspaces))
+
+	for i := range workspaces {
+		region := workspaces[i].Location
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceDatabricks, Type: TypeWorkspace,
+			ID:     workspaces[i].Name,
+			ARN:    workspaces[i].ID,
+			Region: region, Tags: copyTags(workspaces[i].Tags),
 		})
 	}
 

--- a/sagemaker/driver/cluster.go
+++ b/sagemaker/driver/cluster.go
@@ -1,0 +1,68 @@
+package driver
+
+import "context"
+
+// HyperPod cluster status values.
+const (
+	ClusterCreating       = "Creating"
+	ClusterInService      = "InService"
+	ClusterUpdating       = "Updating"
+	ClusterDeleting       = "Deleting"
+	ClusterFailed         = "Failed"
+	ClusterRollingBack    = "RollingBack"
+	ClusterSystemUpdating = "SystemUpdating"
+)
+
+// ClusterInstanceGroupSpec describes one instance group in a cluster.
+type ClusterInstanceGroupSpec struct {
+	GroupName     string
+	InstanceType  string
+	InstanceCount int
+	ExecutionRole string
+}
+
+// ClusterSpec describes a HyperPod cluster to create.
+type ClusterSpec struct {
+	ClusterName    string
+	InstanceGroups []ClusterInstanceGroupSpec
+	Tags           []Tag
+}
+
+// ClusterInstanceGroup is a materialized instance group.
+type ClusterInstanceGroup struct {
+	GroupName     string
+	InstanceType  string
+	InstanceCount int
+	ExecutionRole string
+}
+
+// Cluster is a HyperPod cluster.
+type Cluster struct {
+	ClusterName    string
+	ClusterARN     string
+	Status         string
+	InstanceGroups []ClusterInstanceGroup
+	FailureMessage string
+	CreationTime   string
+	Tags           []Tag
+}
+
+// ClusterNode is a single node within a cluster instance group.
+type ClusterNode struct {
+	NodeID       string
+	GroupName    string
+	InstanceType string
+	Status       string // Running, Pending, Failed, ShuttingDown
+	LaunchTime   string
+}
+
+// clusterAPI covers HyperPod clusters and their nodes.
+type clusterAPI interface {
+	CreateCluster(ctx context.Context, cfg ClusterSpec) (*Cluster, error)
+	DescribeCluster(ctx context.Context, name string) (*Cluster, error)
+	ListClusters(ctx context.Context) ([]Cluster, error)
+	UpdateCluster(ctx context.Context, name string, groups []ClusterInstanceGroupSpec) (*Cluster, error)
+	DeleteCluster(ctx context.Context, name string) error
+	ListClusterNodes(ctx context.Context, clusterName string) ([]ClusterNode, error)
+	DescribeClusterNode(ctx context.Context, clusterName, nodeID string) (*ClusterNode, error)
+}

--- a/sagemaker/driver/driver.go
+++ b/sagemaker/driver/driver.go
@@ -1,0 +1,55 @@
+// Package driver defines the interface for Amazon SageMaker AI: training,
+// processing, transform, tuning, AutoML, labeling and compilation jobs; the
+// model/endpoint inference stack; the model registry; Studio; notebook
+// instances; HyperPod clusters; Feature Store; and pipelines.
+//
+// The interface uses plain Go types only (no AWS SDK dependencies). It spans
+// the control plane and the inference runtime (InvokeEndpoint), and the
+// Feature Store online runtime (PutRecord/GetRecord).
+package driver
+
+import "context"
+
+// Tag is a single resource tag.
+type Tag struct {
+	Key   string
+	Value string
+}
+
+// SageMaker is the interface that SageMaker AI control-plane implementations
+// must satisfy. It is composed of one segment per resource family so the
+// surface stays navigable as it grows.
+type SageMaker interface {
+	jobsAPI
+	inferenceAPI
+	registryAPI
+	studioAPI
+	notebookAPI
+	clusterAPI
+	featureStoreAPI
+	pipelineAPI
+	tagsAPI
+}
+
+// tagsAPI covers AddTags/ListTags/DeleteTags, which apply to most resources by
+// ARN.
+type tagsAPI interface {
+	AddTags(ctx context.Context, resourceARN string, tags []Tag) ([]Tag, error)
+	ListTags(ctx context.Context, resourceARN string) ([]Tag, error)
+	DeleteTags(ctx context.Context, resourceARN string, keys []string) error
+}
+
+// Runtime is the SageMaker inference runtime (the sagemaker-runtime service):
+// synchronous and asynchronous endpoint invocation.
+type Runtime interface {
+	InvokeEndpoint(ctx context.Context, in InvokeEndpointInput) (*InvokeEndpointOutput, error)
+	InvokeEndpointAsync(ctx context.Context, in InvokeEndpointAsyncInput) (*InvokeEndpointAsyncOutput, error)
+}
+
+// Service is the union of the SageMaker control plane and the inference
+// runtime. The in-memory mock satisfies it, letting a single SDK-compat HTTP
+// handler serve both the sagemaker and sagemaker-runtime SDK clients.
+type Service interface {
+	SageMaker
+	Runtime
+}

--- a/sagemaker/driver/featurestore.go
+++ b/sagemaker/driver/featurestore.go
@@ -1,0 +1,66 @@
+package driver
+
+import "context"
+
+// Feature group status values.
+const (
+	FeatureGroupCreating     = "Creating"
+	FeatureGroupCreated      = "Created"
+	FeatureGroupCreateFailed = "CreateFailed"
+	FeatureGroupDeleting     = "Deleting"
+	FeatureGroupDeleteFailed = "DeleteFailed"
+)
+
+// FeatureDefinition describes one feature in a group.
+type FeatureDefinition struct {
+	Name string
+	Type string // Integral, Fractional, String
+}
+
+// FeatureGroupSpec describes a feature group to create.
+type FeatureGroupSpec struct {
+	GroupName            string
+	RecordIdentifierName string
+	EventTimeFeatureName string
+	Features             []FeatureDefinition
+	OnlineStoreEnabled   bool
+	OfflineStoreS3URI    string
+	RoleARN              string
+	Tags                 []Tag
+}
+
+// FeatureGroup is a Feature Store feature group.
+type FeatureGroup struct {
+	GroupName            string
+	GroupARN             string
+	RecordIdentifierName string
+	EventTimeFeatureName string
+	Features             []FeatureDefinition
+	OnlineStoreEnabled   bool
+	OfflineStoreS3URI    string
+	RoleARN              string
+	Status               string
+	FailureReason        string
+	CreationTime         string
+	Tags                 []Tag
+}
+
+// FeatureValue is one feature name/value pair in an online-store record.
+type FeatureValue struct {
+	Name  string
+	Value string
+}
+
+// featureStoreAPI covers Feature Store control plane plus the online-store
+// runtime (PutRecord/GetRecord/DeleteRecord), which the real service exposes
+// via the sagemaker-featurestore-runtime endpoint.
+type featureStoreAPI interface {
+	CreateFeatureGroup(ctx context.Context, cfg FeatureGroupSpec) (*FeatureGroup, error)
+	DescribeFeatureGroup(ctx context.Context, name string) (*FeatureGroup, error)
+	ListFeatureGroups(ctx context.Context) ([]FeatureGroup, error)
+	DeleteFeatureGroup(ctx context.Context, name string) error
+
+	PutRecord(ctx context.Context, groupName string, record []FeatureValue) error
+	GetRecord(ctx context.Context, groupName, recordID string) ([]FeatureValue, error)
+	DeleteRecord(ctx context.Context, groupName, recordID string) error
+}

--- a/sagemaker/driver/inference.go
+++ b/sagemaker/driver/inference.go
@@ -31,11 +31,15 @@ type ContainerDefinition struct {
 	Mode         string // SingleModel, MultiModel
 }
 
-// ModelConfig describes a model to create.
+// ModelConfig describes a model to create. Pipeline distinguishes an
+// inference-pipeline model (created via Containers) from a single-container
+// model (created via PrimaryContainer); the two echo back differently on
+// Describe.
 type ModelConfig struct {
 	ModelName  string
 	RoleARN    string
 	Containers []ContainerDefinition
+	Pipeline   bool
 	Tags       []Tag
 }
 
@@ -45,6 +49,7 @@ type Model struct {
 	ModelARN     string
 	RoleARN      string
 	Containers   []ContainerDefinition
+	Pipeline     bool
 	CreationTime string
 	Tags         []Tag
 }

--- a/sagemaker/driver/inference.go
+++ b/sagemaker/driver/inference.go
@@ -1,0 +1,191 @@
+package driver
+
+import "context"
+
+// Endpoint lifecycle status values.
+const (
+	EndpointOutOfService   = "OutOfService"
+	EndpointCreating       = "Creating"
+	EndpointUpdating       = "Updating"
+	EndpointSystemUpdating = "SystemUpdating"
+	EndpointRollingBack    = "RollingBack"
+	EndpointInService      = "InService"
+	EndpointDeleting       = "Deleting"
+	EndpointFailed         = "Failed"
+)
+
+// InferenceComponent status values.
+const (
+	ICreating  = "Creating"
+	IInService = "InService"
+	IUpdating  = "Updating"
+	IFailed    = "Failed"
+	IDeleting  = "Deleting"
+)
+
+// ContainerDefinition is one container in a model.
+type ContainerDefinition struct {
+	Image        string
+	ModelDataURL string
+	Environment  map[string]string
+	Mode         string // SingleModel, MultiModel
+}
+
+// ModelConfig describes a model to create.
+type ModelConfig struct {
+	ModelName  string
+	RoleARN    string
+	Containers []ContainerDefinition
+	Tags       []Tag
+}
+
+// Model describes a created model (a static metadata record, no status).
+type Model struct {
+	ModelName    string
+	ModelARN     string
+	RoleARN      string
+	Containers   []ContainerDefinition
+	CreationTime string
+	Tags         []Tag
+}
+
+// ProductionVariant is one instance-backed serving variant.
+type ProductionVariant struct {
+	VariantName          string
+	ModelName            string
+	InstanceType         string
+	InitialInstanceCount int
+	InitialVariantWeight float64
+}
+
+// ServerlessConfig configures serverless inference for a variant.
+type ServerlessConfig struct {
+	MemorySizeInMB int
+	MaxConcurrency int
+}
+
+// EndpointConfigSpec describes an endpoint configuration to create.
+type EndpointConfigSpec struct {
+	ConfigName         string
+	ProductionVariants []ProductionVariant
+	Serverless         *ServerlessConfig
+	AsyncOutputS3URI   string
+	Tags               []Tag
+}
+
+// EndpointConfig is a static endpoint configuration record.
+type EndpointConfig struct {
+	ConfigName         string
+	ConfigARN          string
+	ProductionVariants []ProductionVariant
+	Serverless         *ServerlessConfig
+	AsyncOutputS3URI   string
+	CreationTime       string
+	Tags               []Tag
+}
+
+// EndpointSpec describes an endpoint to create.
+type EndpointSpec struct {
+	EndpointName string
+	ConfigName   string
+	Tags         []Tag
+}
+
+// VariantWeight is a per-variant weight/capacity update.
+type VariantWeight struct {
+	VariantName          string
+	DesiredWeight        float64
+	DesiredInstanceCount int
+}
+
+// Endpoint is a deployed endpoint with a lifecycle status.
+type Endpoint struct {
+	EndpointName     string
+	EndpointARN      string
+	ConfigName       string
+	Status           string
+	Variants         []ProductionVariant
+	FailureReason    string
+	CreationTime     string
+	LastModifiedTime string
+	Tags             []Tag
+}
+
+// InferenceComponentSpec describes an inference component to create.
+type InferenceComponentSpec struct {
+	Name         string
+	EndpointName string
+	ModelName    string
+	VariantName  string
+	CopyCount    int
+	Tags         []Tag
+}
+
+// InferenceComponent packs a model onto a shared endpoint.
+type InferenceComponent struct {
+	Name             string
+	ARN              string
+	EndpointName     string
+	ModelName        string
+	VariantName      string
+	CopyCount        int
+	Status           string
+	CreationTime     string
+	LastModifiedTime string
+	Tags             []Tag
+}
+
+// inferenceAPI covers the model/endpoint serving stack.
+type inferenceAPI interface {
+	CreateModel(ctx context.Context, cfg ModelConfig) (*Model, error)
+	DescribeModel(ctx context.Context, name string) (*Model, error)
+	ListModels(ctx context.Context) ([]Model, error)
+	DeleteModel(ctx context.Context, name string) error
+
+	CreateEndpointConfig(ctx context.Context, cfg EndpointConfigSpec) (*EndpointConfig, error)
+	DescribeEndpointConfig(ctx context.Context, name string) (*EndpointConfig, error)
+	ListEndpointConfigs(ctx context.Context) ([]EndpointConfig, error)
+	DeleteEndpointConfig(ctx context.Context, name string) error
+
+	CreateEndpoint(ctx context.Context, cfg EndpointSpec) (*Endpoint, error)
+	DescribeEndpoint(ctx context.Context, name string) (*Endpoint, error)
+	ListEndpoints(ctx context.Context) ([]Endpoint, error)
+	UpdateEndpoint(ctx context.Context, name, configName string) (*Endpoint, error)
+	UpdateEndpointWeightsAndCapacities(ctx context.Context, name string, weights []VariantWeight) (*Endpoint, error)
+	DeleteEndpoint(ctx context.Context, name string) error
+
+	CreateInferenceComponent(ctx context.Context, cfg InferenceComponentSpec) (*InferenceComponent, error)
+	DescribeInferenceComponent(ctx context.Context, name string) (*InferenceComponent, error)
+	ListInferenceComponents(ctx context.Context) ([]InferenceComponent, error)
+	DeleteInferenceComponent(ctx context.Context, name string) error
+}
+
+// InvokeEndpointInput is a synchronous invocation request.
+type InvokeEndpointInput struct {
+	EndpointName           string
+	ContentType            string
+	Accept                 string
+	Body                   []byte
+	InferenceComponentName string
+	TargetModel            string
+}
+
+// InvokeEndpointOutput is a synchronous invocation response.
+type InvokeEndpointOutput struct {
+	ContentType    string
+	Body           []byte
+	InvokedVariant string
+}
+
+// InvokeEndpointAsyncInput is an asynchronous invocation request.
+type InvokeEndpointAsyncInput struct {
+	EndpointName string
+	InputS3URI   string
+	ContentType  string
+}
+
+// InvokeEndpointAsyncOutput carries the S3 location of the async result.
+type InvokeEndpointAsyncOutput struct {
+	OutputS3URI string
+	InferenceID string
+}

--- a/sagemaker/driver/jobs.go
+++ b/sagemaker/driver/jobs.go
@@ -26,6 +26,17 @@ const (
 	LabelingInitializing = "Initializing"
 )
 
+// Compilation (Neo) jobs use upper-case status values, distinct from the
+// mixed-case set the other jobs share.
+const (
+	CompilationInProgress = "INPROGRESS"
+	CompilationCompleted  = "COMPLETED"
+	CompilationFailed     = "FAILED"
+	CompilationStarting   = "STARTING"
+	CompilationStopping   = "STOPPING"
+	CompilationStopped    = "STOPPED"
+)
+
 // Channel is an input data channel for a training/processing job.
 type Channel struct {
 	Name        string

--- a/sagemaker/driver/jobs.go
+++ b/sagemaker/driver/jobs.go
@@ -1,0 +1,298 @@
+package driver
+
+import "context"
+
+// Job status values shared across the asynchronous job resources.
+const (
+	JobInProgress = "InProgress"
+	JobCompleted  = "Completed"
+	JobFailed     = "Failed"
+	JobStopping   = "Stopping"
+	JobStopped    = "Stopped"
+)
+
+// Training secondary-status values (a subset of the documented set) used to
+// synthesize a plausible SecondaryStatusTransitions history.
+const (
+	SecondaryStarting    = "Starting"
+	SecondaryDownloading = "Downloading"
+	SecondaryTraining    = "Training"
+	SecondaryUploading   = "Uploading"
+	SecondaryCompleted   = "Completed"
+)
+
+// HPO and labeling carry their own initial states.
+const (
+	LabelingInitializing = "Initializing"
+)
+
+// Channel is an input data channel for a training/processing job.
+type Channel struct {
+	Name        string
+	S3URI       string
+	ContentType string
+}
+
+// ResourceConfig describes the compute for a job.
+type ResourceConfig struct {
+	InstanceType   string
+	InstanceCount  int
+	VolumeSizeInGB int
+}
+
+// TrainingJobConfig describes a training job to create.
+type TrainingJobConfig struct {
+	JobName           string
+	RoleARN           string
+	AlgorithmImage    string
+	HyperParameters   map[string]string
+	InputChannels     []Channel
+	OutputS3URI       string
+	Resources         ResourceConfig
+	MaxRuntimeSeconds int
+	Tags              []Tag
+}
+
+// SecondaryStatusTransition is one entry in a training job's status history.
+type SecondaryStatusTransition struct {
+	Status        string
+	StartTime     string
+	EndTime       string
+	StatusMessage string
+}
+
+// TrainingJob describes a training job.
+type TrainingJob struct {
+	JobName              string
+	JobARN               string
+	RoleARN              string
+	AlgorithmImage       string
+	HyperParameters      map[string]string
+	InputChannels        []Channel
+	OutputS3URI          string
+	Resources            ResourceConfig
+	Status               string
+	SecondaryStatus      string
+	SecondaryTransitions []SecondaryStatusTransition
+	ModelArtifactS3URI   string
+	FailureReason        string
+	CreationTime         string
+	TrainingStartTime    string
+	TrainingEndTime      string
+	LastModifiedTime     string
+	Tags                 []Tag
+}
+
+// ProcessingJobConfig describes a processing job to create.
+type ProcessingJobConfig struct {
+	JobName     string
+	RoleARN     string
+	AppImage    string
+	Inputs      []Channel
+	OutputS3URI string
+	Resources   ResourceConfig
+	Tags        []Tag
+}
+
+// ProcessingJob describes a processing job.
+type ProcessingJob struct {
+	JobName           string
+	JobARN            string
+	RoleARN           string
+	AppImage          string
+	Inputs            []Channel
+	OutputS3URI       string
+	Resources         ResourceConfig
+	Status            string
+	FailureReason     string
+	CreationTime      string
+	ProcessingEndTime string
+	LastModifiedTime  string
+	Tags              []Tag
+}
+
+// TransformJobConfig describes a batch transform job to create.
+type TransformJobConfig struct {
+	JobName       string
+	ModelName     string
+	InputS3URI    string
+	OutputS3URI   string
+	InstanceType  string
+	InstanceCount int
+	Tags          []Tag
+}
+
+// TransformJob describes a batch transform job.
+type TransformJob struct {
+	JobName          string
+	JobARN           string
+	ModelName        string
+	InputS3URI       string
+	OutputS3URI      string
+	InstanceType     string
+	InstanceCount    int
+	Status           string
+	FailureReason    string
+	CreationTime     string
+	TransformEndTime string
+	LastModifiedTime string
+	Tags             []Tag
+}
+
+// HyperParameterTuningJobConfig describes a tuning job to create.
+type HyperParameterTuningJobConfig struct {
+	JobName            string
+	Strategy           string // Bayesian, Random, Grid
+	MaxJobs            int
+	MaxParallelJobs    int
+	ObjectiveMetric    string
+	ObjectiveType      string // Maximize, Minimize
+	TrainingDefinition TrainingJobConfig
+	Tags               []Tag
+}
+
+// HyperParameterTuningJob describes a tuning job.
+type HyperParameterTuningJob struct {
+	JobName           string
+	JobARN            string
+	Strategy          string
+	MaxJobs           int
+	MaxParallelJobs   int
+	ObjectiveMetric   string
+	ObjectiveType     string
+	Status            string
+	BestTrainingJob   string
+	TrainingJobCounts map[string]int
+	FailureReason     string
+	CreationTime      string
+	HPOJobEndTime     string
+	LastModifiedTime  string
+	Tags              []Tag
+}
+
+// AutoMLJobConfig describes an Autopilot (AutoML V2) job to create.
+type AutoMLJobConfig struct {
+	JobName      string
+	RoleARN      string
+	InputS3URI   string
+	OutputS3URI  string
+	ProblemType  string // BinaryClassification, MulticlassClassification, Regression
+	TargetColumn string
+	Tags         []Tag
+}
+
+// AutoMLJob describes an AutoML job.
+type AutoMLJob struct {
+	JobName           string
+	JobARN            string
+	RoleARN           string
+	InputS3URI        string
+	OutputS3URI       string
+	ProblemType       string
+	TargetColumn      string
+	Status            string
+	SecondaryStatus   string
+	BestCandidateName string
+	FailureReason     string
+	CreationTime      string
+	AutoMLJobEndTime  string
+	LastModifiedTime  string
+	Tags              []Tag
+}
+
+// LabelingJobConfig describes a Ground Truth labeling job to create.
+type LabelingJobConfig struct {
+	JobName        string
+	RoleARN        string
+	InputS3URI     string
+	OutputS3URI    string
+	LabelAttribute string
+	WorkteamARN    string
+	Tags           []Tag
+}
+
+// LabelingJob describes a Ground Truth labeling job.
+type LabelingJob struct {
+	JobName          string
+	JobARN           string
+	RoleARN          string
+	InputS3URI       string
+	OutputS3URI      string
+	LabelAttribute   string
+	WorkteamARN      string
+	Status           string
+	LabeledObjects   int
+	FailureReason    string
+	CreationTime     string
+	LabelingEndTime  string
+	LastModifiedTime string
+	Tags             []Tag
+}
+
+// CompilationJobConfig describes a Neo compilation job to create.
+type CompilationJobConfig struct {
+	JobName      string
+	RoleARN      string
+	InputS3URI   string
+	OutputS3URI  string
+	TargetDevice string
+	Framework    string
+	Tags         []Tag
+}
+
+// CompilationJob describes a Neo compilation job.
+type CompilationJob struct {
+	JobName            string
+	JobARN             string
+	RoleARN            string
+	InputS3URI         string
+	OutputS3URI        string
+	TargetDevice       string
+	Framework          string
+	Status             string
+	FailureReason      string
+	CreationTime       string
+	CompilationEndTime string
+	LastModifiedTime   string
+	Tags               []Tag
+}
+
+// jobsAPI covers every asynchronous SageMaker job resource. Create transitions
+// the job synchronously to a terminal state (Completed) so Describe/List are
+// deterministic, mirroring the existing Bedrock customization-job mock.
+type jobsAPI interface {
+	CreateTrainingJob(ctx context.Context, cfg TrainingJobConfig) (*TrainingJob, error)
+	DescribeTrainingJob(ctx context.Context, name string) (*TrainingJob, error)
+	ListTrainingJobs(ctx context.Context) ([]TrainingJob, error)
+	StopTrainingJob(ctx context.Context, name string) error
+
+	CreateProcessingJob(ctx context.Context, cfg ProcessingJobConfig) (*ProcessingJob, error)
+	DescribeProcessingJob(ctx context.Context, name string) (*ProcessingJob, error)
+	ListProcessingJobs(ctx context.Context) ([]ProcessingJob, error)
+	StopProcessingJob(ctx context.Context, name string) error
+
+	CreateTransformJob(ctx context.Context, cfg TransformJobConfig) (*TransformJob, error)
+	DescribeTransformJob(ctx context.Context, name string) (*TransformJob, error)
+	ListTransformJobs(ctx context.Context) ([]TransformJob, error)
+	StopTransformJob(ctx context.Context, name string) error
+
+	CreateHyperParameterTuningJob(ctx context.Context, cfg HyperParameterTuningJobConfig) (*HyperParameterTuningJob, error)
+	DescribeHyperParameterTuningJob(ctx context.Context, name string) (*HyperParameterTuningJob, error)
+	ListHyperParameterTuningJobs(ctx context.Context) ([]HyperParameterTuningJob, error)
+	StopHyperParameterTuningJob(ctx context.Context, name string) error
+
+	CreateAutoMLJobV2(ctx context.Context, cfg AutoMLJobConfig) (*AutoMLJob, error)
+	DescribeAutoMLJobV2(ctx context.Context, name string) (*AutoMLJob, error)
+	ListAutoMLJobs(ctx context.Context) ([]AutoMLJob, error)
+	StopAutoMLJob(ctx context.Context, name string) error
+
+	CreateLabelingJob(ctx context.Context, cfg LabelingJobConfig) (*LabelingJob, error)
+	DescribeLabelingJob(ctx context.Context, name string) (*LabelingJob, error)
+	ListLabelingJobs(ctx context.Context) ([]LabelingJob, error)
+	StopLabelingJob(ctx context.Context, name string) error
+
+	CreateCompilationJob(ctx context.Context, cfg CompilationJobConfig) (*CompilationJob, error)
+	DescribeCompilationJob(ctx context.Context, name string) (*CompilationJob, error)
+	ListCompilationJobs(ctx context.Context) ([]CompilationJob, error)
+	StopCompilationJob(ctx context.Context, name string) error
+}

--- a/sagemaker/driver/notebook.go
+++ b/sagemaker/driver/notebook.go
@@ -1,0 +1,96 @@
+package driver
+
+import "context"
+
+// Notebook instance status values.
+const (
+	NotebookPending   = "Pending"
+	NotebookInService = "InService"
+	NotebookStopping  = "Stopping"
+	NotebookStopped   = "Stopped"
+	NotebookDeleting  = "Deleting"
+	NotebookUpdating  = "Updating"
+	NotebookFailed    = "Failed"
+)
+
+// NotebookInstanceSpec describes a notebook instance to create.
+type NotebookInstanceSpec struct {
+	Name            string
+	InstanceType    string
+	RoleARN         string
+	VolumeSizeInGB  int
+	LifecycleConfig string
+	DefaultCodeRepo string
+	Tags            []Tag
+}
+
+// NotebookInstance is a managed notebook instance.
+type NotebookInstance struct {
+	Name             string
+	ARN              string
+	InstanceType     string
+	RoleARN          string
+	VolumeSizeInGB   int
+	LifecycleConfig  string
+	DefaultCodeRepo  string
+	Status           string
+	URL              string
+	FailureReason    string
+	CreationTime     string
+	LastModifiedTime string
+	Tags             []Tag
+}
+
+// NotebookLifecycleConfigSpec describes a lifecycle config to create.
+type NotebookLifecycleConfigSpec struct {
+	Name     string
+	OnCreate string
+	OnStart  string
+}
+
+// NotebookLifecycleConfig is a notebook lifecycle configuration.
+type NotebookLifecycleConfig struct {
+	Name         string
+	ARN          string
+	OnCreate     string
+	OnStart      string
+	CreationTime string
+}
+
+// CodeRepositorySpec describes a Git code repository to create.
+type CodeRepositorySpec struct {
+	Name      string
+	GitURL    string
+	Branch    string
+	SecretARN string
+}
+
+// CodeRepository is a registered Git repository.
+type CodeRepository struct {
+	Name         string
+	ARN          string
+	GitURL       string
+	Branch       string
+	SecretARN    string
+	CreationTime string
+}
+
+// notebookAPI covers notebook instances and supporting resources.
+type notebookAPI interface {
+	CreateNotebookInstance(ctx context.Context, cfg NotebookInstanceSpec) (*NotebookInstance, error)
+	DescribeNotebookInstance(ctx context.Context, name string) (*NotebookInstance, error)
+	ListNotebookInstances(ctx context.Context) ([]NotebookInstance, error)
+	StartNotebookInstance(ctx context.Context, name string) error
+	StopNotebookInstance(ctx context.Context, name string) error
+	DeleteNotebookInstance(ctx context.Context, name string) error
+
+	CreateNotebookInstanceLifecycleConfig(ctx context.Context, cfg NotebookLifecycleConfigSpec) (*NotebookLifecycleConfig, error)
+	DescribeNotebookInstanceLifecycleConfig(ctx context.Context, name string) (*NotebookLifecycleConfig, error)
+	ListNotebookInstanceLifecycleConfigs(ctx context.Context) ([]NotebookLifecycleConfig, error)
+	DeleteNotebookInstanceLifecycleConfig(ctx context.Context, name string) error
+
+	CreateCodeRepository(ctx context.Context, cfg CodeRepositorySpec) (*CodeRepository, error)
+	DescribeCodeRepository(ctx context.Context, name string) (*CodeRepository, error)
+	ListCodeRepositories(ctx context.Context) ([]CodeRepository, error)
+	DeleteCodeRepository(ctx context.Context, name string) error
+}

--- a/sagemaker/driver/pipeline.go
+++ b/sagemaker/driver/pipeline.go
@@ -1,0 +1,110 @@
+package driver
+
+import "context"
+
+// Pipeline status values.
+const (
+	PipelineActive   = "Active"
+	PipelineDeleting = "Deleting"
+)
+
+// Pipeline execution status values.
+const (
+	ExecutionExecuting = "Executing"
+	ExecutionStopping  = "Stopping"
+	ExecutionStopped   = "Stopped"
+	ExecutionFailed    = "Failed"
+	ExecutionSucceeded = "Succeeded"
+)
+
+// Experiment / trial component primary status values.
+const (
+	ComponentInProgress = "InProgress"
+	ComponentCompleted  = "Completed"
+	ComponentFailed     = "Failed"
+)
+
+// PipelineSpec describes a pipeline to create.
+type PipelineSpec struct {
+	PipelineName string
+	RoleARN      string
+	Definition   string // JSON pipeline definition
+	Tags         []Tag
+}
+
+// Pipeline is a SageMaker pipeline.
+type Pipeline struct {
+	PipelineName     string
+	PipelineARN      string
+	RoleARN          string
+	Definition       string
+	Status           string
+	CreationTime     string
+	LastModifiedTime string
+	Tags             []Tag
+}
+
+// PipelineExecution is one run of a pipeline.
+type PipelineExecution struct {
+	ExecutionARN string
+	PipelineName string
+	Status       string
+	StartTime    string
+	EndTime      string
+}
+
+// ExperimentSpec describes an experiment to create.
+type ExperimentSpec struct {
+	ExperimentName string
+	Description    string
+	Tags           []Tag
+}
+
+// Experiment groups related trials.
+type Experiment struct {
+	ExperimentName string
+	ExperimentARN  string
+	Description    string
+	CreationTime   string
+	Tags           []Tag
+}
+
+// TrialSpec describes a trial to create.
+type TrialSpec struct {
+	TrialName      string
+	ExperimentName string
+	Tags           []Tag
+}
+
+// Trial is a single trial within an experiment.
+type Trial struct {
+	TrialName      string
+	TrialARN       string
+	ExperimentName string
+	CreationTime   string
+	Tags           []Tag
+}
+
+// pipelineAPI covers pipelines (+ executions) and experiments/trials.
+type pipelineAPI interface {
+	CreatePipeline(ctx context.Context, cfg PipelineSpec) (*Pipeline, error)
+	DescribePipeline(ctx context.Context, name string) (*Pipeline, error)
+	ListPipelines(ctx context.Context) ([]Pipeline, error)
+	UpdatePipeline(ctx context.Context, name, definition string) (*Pipeline, error)
+	DeletePipeline(ctx context.Context, name string) error
+
+	StartPipelineExecution(ctx context.Context, pipelineName string) (*PipelineExecution, error)
+	DescribePipelineExecution(ctx context.Context, executionARN string) (*PipelineExecution, error)
+	ListPipelineExecutions(ctx context.Context, pipelineName string) ([]PipelineExecution, error)
+	StopPipelineExecution(ctx context.Context, executionARN string) error
+
+	CreateExperiment(ctx context.Context, cfg ExperimentSpec) (*Experiment, error)
+	DescribeExperiment(ctx context.Context, name string) (*Experiment, error)
+	ListExperiments(ctx context.Context) ([]Experiment, error)
+	DeleteExperiment(ctx context.Context, name string) error
+
+	CreateTrial(ctx context.Context, cfg TrialSpec) (*Trial, error)
+	DescribeTrial(ctx context.Context, name string) (*Trial, error)
+	ListTrials(ctx context.Context, experimentName string) ([]Trial, error)
+	DeleteTrial(ctx context.Context, name string) error
+}

--- a/sagemaker/driver/registry.go
+++ b/sagemaker/driver/registry.go
@@ -1,0 +1,73 @@
+package driver
+
+import "context"
+
+// Model package status values.
+const (
+	PackagePending    = "Pending"
+	PackageInProgress = "InProgress"
+	PackageCompleted  = "Completed"
+	PackageFailed     = "Failed"
+)
+
+// Model approval status values.
+const (
+	ApprovalApproved      = "Approved"
+	ApprovalRejected      = "Rejected"
+	ApprovalPendingManual = "PendingManualApproval"
+)
+
+// ModelPackageGroupSpec describes a model package group to create.
+type ModelPackageGroupSpec struct {
+	GroupName   string
+	Description string
+	Tags        []Tag
+}
+
+// ModelPackageGroup is a container for versioned model packages.
+type ModelPackageGroup struct {
+	GroupName    string
+	GroupARN     string
+	Description  string
+	Status       string
+	CreationTime string
+	Tags         []Tag
+}
+
+// ModelPackageSpec describes a model package (registry entry) to create.
+type ModelPackageSpec struct {
+	GroupName      string
+	Description    string
+	InferenceImage string
+	ModelDataURL   string
+	ApprovalStatus string
+	Tags           []Tag
+}
+
+// ModelPackage is a versioned model registry entry.
+type ModelPackage struct {
+	PackageARN     string
+	GroupName      string
+	Version        int
+	Description    string
+	InferenceImage string
+	ModelDataURL   string
+	Status         string
+	ApprovalStatus string
+	CreationTime   string
+	Tags           []Tag
+}
+
+// registryAPI covers the model registry (groups + versioned packages).
+type registryAPI interface {
+	CreateModelPackageGroup(ctx context.Context, cfg ModelPackageGroupSpec) (*ModelPackageGroup, error)
+	DescribeModelPackageGroup(ctx context.Context, name string) (*ModelPackageGroup, error)
+	ListModelPackageGroups(ctx context.Context) ([]ModelPackageGroup, error)
+	DeleteModelPackageGroup(ctx context.Context, name string) error
+
+	CreateModelPackage(ctx context.Context, cfg ModelPackageSpec) (*ModelPackage, error)
+	DescribeModelPackage(ctx context.Context, arn string) (*ModelPackage, error)
+	ListModelPackages(ctx context.Context, groupName string) ([]ModelPackage, error)
+	UpdateModelPackage(ctx context.Context, arn, approvalStatus string) (*ModelPackage, error)
+	DeleteModelPackage(ctx context.Context, arn string) error
+}

--- a/sagemaker/driver/studio.go
+++ b/sagemaker/driver/studio.go
@@ -1,0 +1,129 @@
+package driver
+
+import "context"
+
+// Studio resource lifecycle status values (shared by Domain, UserProfile,
+// Space). Apps use the App* subset.
+const (
+	StudioPending      = "Pending"
+	StudioInService    = "InService"
+	StudioUpdating     = "Updating"
+	StudioDeleting     = "Deleting"
+	StudioFailed       = "Failed"
+	StudioUpdateFailed = "Update_Failed"
+	StudioDeleteFailed = "Delete_Failed"
+)
+
+// App status values.
+const (
+	AppPending   = "Pending"
+	AppInService = "InService"
+	AppDeleting  = "Deleting"
+	AppDeleted   = "Deleted"
+	AppFailed    = "Failed"
+)
+
+// DomainSpec describes a Studio domain to create.
+type DomainSpec struct {
+	DomainName       string
+	AuthMode         string // SSO, IAM
+	VPCID            string
+	SubnetIDs        []string
+	ExecutionRoleARN string
+	Tags             []Tag
+}
+
+// Domain is a Studio domain.
+type Domain struct {
+	DomainID         string
+	DomainName       string
+	DomainARN        string
+	AuthMode         string
+	VPCID            string
+	SubnetIDs        []string
+	ExecutionRoleARN string
+	URL              string
+	Status           string
+	CreationTime     string
+	Tags             []Tag
+}
+
+// UserProfileSpec describes a Studio user profile to create.
+type UserProfileSpec struct {
+	DomainID         string
+	UserProfileName  string
+	ExecutionRoleARN string
+	Tags             []Tag
+}
+
+// UserProfile is a Studio user profile, scoped to a domain.
+type UserProfile struct {
+	DomainID         string
+	UserProfileName  string
+	UserProfileARN   string
+	ExecutionRoleARN string
+	Status           string
+	CreationTime     string
+	Tags             []Tag
+}
+
+// SpaceSpec describes a Studio space to create.
+type SpaceSpec struct {
+	DomainID  string
+	SpaceName string
+	Tags      []Tag
+}
+
+// Space is a Studio space, scoped to a domain.
+type Space struct {
+	DomainID     string
+	SpaceName    string
+	SpaceARN     string
+	Status       string
+	CreationTime string
+	Tags         []Tag
+}
+
+// AppSpec describes a Studio app to create.
+type AppSpec struct {
+	DomainID        string
+	UserProfileName string
+	SpaceName       string
+	AppType         string // JupyterServer, KernelGateway, JupyterLab, CodeEditor, ...
+	AppName         string
+}
+
+// App is a Studio app.
+type App struct {
+	DomainID        string
+	UserProfileName string
+	SpaceName       string
+	AppType         string
+	AppName         string
+	AppARN          string
+	Status          string
+	CreationTime    string
+}
+
+// studioAPI covers SageMaker Studio control-plane resources.
+type studioAPI interface {
+	CreateDomain(ctx context.Context, cfg DomainSpec) (*Domain, error)
+	DescribeDomain(ctx context.Context, domainID string) (*Domain, error)
+	ListDomains(ctx context.Context) ([]Domain, error)
+	DeleteDomain(ctx context.Context, domainID string) error
+
+	CreateUserProfile(ctx context.Context, cfg UserProfileSpec) (*UserProfile, error)
+	DescribeUserProfile(ctx context.Context, domainID, name string) (*UserProfile, error)
+	ListUserProfiles(ctx context.Context, domainID string) ([]UserProfile, error)
+	DeleteUserProfile(ctx context.Context, domainID, name string) error
+
+	CreateSpace(ctx context.Context, cfg SpaceSpec) (*Space, error)
+	DescribeSpace(ctx context.Context, domainID, name string) (*Space, error)
+	ListSpaces(ctx context.Context, domainID string) ([]Space, error)
+	DeleteSpace(ctx context.Context, domainID, name string) error
+
+	CreateApp(ctx context.Context, cfg AppSpec) (*App, error)
+	DescribeApp(ctx context.Context, in AppSpec) (*App, error)
+	ListApps(ctx context.Context, domainID string) ([]App, error)
+	DeleteApp(ctx context.Context, in AppSpec) error
+}

--- a/sagemaker/sagemaker.go
+++ b/sagemaker/sagemaker.go
@@ -1,0 +1,121 @@
+// Package sagemaker provides a portable Amazon SageMaker AI API with
+// cross-cutting concerns. It wraps a driver.Service (the control plane plus the
+// inference runtime) with recording, metrics, rate limiting, error injection,
+// and latency simulation — the same middle layer every other service ships
+// (see bedrock/bedrock.go) so SageMaker participates in the three-layer design.
+//
+// The wrapper implements driver.Service, so it is a drop-in replacement for the
+// raw mock when constructing the SDK-compat server.
+package sagemaker
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// Compile-time check that the portable type implements the full service.
+var _ driver.Service = (*SageMaker)(nil)
+
+// SageMaker is the portable SageMaker type wrapping a driver with cross-cutting
+// concerns.
+type SageMaker struct {
+	drv      driver.Service
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// New creates a portable SageMaker wrapping the given driver.
+func New(d driver.Service, opts ...Option) *SageMaker {
+	s := &SageMaker{drv: d}
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+// Option configures a portable SageMaker.
+type Option func(*SageMaker)
+
+// WithRecorder sets the call recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(s *SageMaker) { s.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(s *SageMaker) { s.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(s *SageMaker) { s.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(s *SageMaker) { s.injector = i } }
+
+// WithLatency sets simulated latency applied to every call.
+func WithLatency(d time.Duration) Option { return func(s *SageMaker) { s.latency = d } }
+
+// do applies the cross-cutting concerns around a single driver call.
+func (s *SageMaker) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if s.injector != nil {
+		if err := s.injector.Check("sagemaker", op); err != nil {
+			s.rec(op, input, nil, err, time.Since(start))
+
+			return nil, err
+		}
+	}
+
+	if s.limiter != nil {
+		if err := s.limiter.Allow(); err != nil {
+			s.rec(op, input, nil, err, time.Since(start))
+
+			return nil, err
+		}
+	}
+
+	if s.latency > 0 {
+		time.Sleep(s.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if s.metrics != nil {
+		labels := map[string]string{"service": "sagemaker", "operation": op}
+		s.metrics.Counter("calls_total", 1, labels)
+		s.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			s.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	s.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (s *SageMaker) rec(op string, input, output any, err error, dur time.Duration) {
+	if s.recorder != nil {
+		s.recorder.Record("sagemaker", op, input, output, err, dur)
+	}
+}
+
+// cast converts the do() result to T, short-circuiting on error.
+func cast[T any](out any, err error) (T, error) {
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	return out.(T), nil //nolint:forcetypeassert // do() returns exactly the driver's typed result
+}

--- a/sagemaker/sagemaker_test.go
+++ b/sagemaker/sagemaker_test.go
@@ -1,0 +1,70 @@
+package sagemaker_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	awssm "github.com/stackshy/cloudemu/providers/aws/sagemaker"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/sagemaker"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+func newPortable(opts ...sagemaker.Option) *sagemaker.SageMaker {
+	o := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+
+	return sagemaker.New(awssm.New(o), opts...)
+}
+
+func TestPortableRecordsAndCountsCalls(t *testing.T) {
+	rec := recorder.New()
+	col := metrics.NewCollector()
+	s := newPortable(sagemaker.WithRecorder(rec), sagemaker.WithMetrics(col))
+	ctx := context.Background()
+
+	_, err := s.CreateTrainingJob(ctx, driver.TrainingJobConfig{JobName: "j1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, rec.CallCountFor("sagemaker", "CreateTrainingJob"))
+	assert.NotEmpty(t, col.All())
+}
+
+func TestPortableErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	boom := errors.New("injected")
+	inj.Set("sagemaker", "CreateModel", boom, inject.Always{})
+
+	s := newPortable(sagemaker.WithErrorInjection(inj))
+
+	_, err := s.CreateModel(context.Background(), driver.ModelConfig{ModelName: "m"})
+	require.ErrorIs(t, err, boom)
+}
+
+func TestPortableLatencyApplied(t *testing.T) {
+	s := newPortable(sagemaker.WithLatency(20 * time.Millisecond))
+
+	start := time.Now()
+	_, err := s.ListModels(context.Background())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), 20*time.Millisecond)
+}
+
+func TestPortableForwardsResults(t *testing.T) {
+	s := newPortable()
+	ctx := context.Background()
+
+	_, err := s.CreateModel(ctx, driver.ModelConfig{ModelName: "m"})
+	require.NoError(t, err)
+
+	got, err := s.DescribeModel(ctx, "m")
+	require.NoError(t, err)
+	assert.Equal(t, "m", got.ModelName)
+}

--- a/sagemaker/wrappers_inference.go
+++ b/sagemaker/wrappers_inference.go
@@ -1,0 +1,159 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateModel(ctx context.Context, cfg driver.ModelConfig) (*driver.Model, error) {
+	return cast[*driver.Model](s.do(ctx, "CreateModel", cfg, func() (any, error) { return s.drv.CreateModel(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeModel(ctx context.Context, name string) (*driver.Model, error) {
+	return cast[*driver.Model](s.do(ctx, "DescribeModel", name, func() (any, error) { return s.drv.DescribeModel(ctx, name) }))
+}
+
+func (s *SageMaker) ListModels(ctx context.Context) ([]driver.Model, error) {
+	return cast[[]driver.Model](s.do(ctx, "ListModels", nil, func() (any, error) { return s.drv.ListModels(ctx) }))
+}
+
+func (s *SageMaker) DeleteModel(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteModel", name, func() (any, error) { return nil, s.drv.DeleteModel(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateEndpointConfig(ctx context.Context, cfg driver.EndpointConfigSpec) (*driver.EndpointConfig, error) {
+	return cast[*driver.EndpointConfig](s.do(ctx, "CreateEndpointConfig", cfg, func() (any, error) {
+		return s.drv.CreateEndpointConfig(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeEndpointConfig(ctx context.Context, name string) (*driver.EndpointConfig, error) {
+	return cast[*driver.EndpointConfig](s.do(ctx, "DescribeEndpointConfig", name, func() (any, error) {
+		return s.drv.DescribeEndpointConfig(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListEndpointConfigs(ctx context.Context) ([]driver.EndpointConfig, error) {
+	return cast[[]driver.EndpointConfig](s.do(ctx, "ListEndpointConfigs", nil, func() (any, error) { return s.drv.ListEndpointConfigs(ctx) }))
+}
+
+func (s *SageMaker) DeleteEndpointConfig(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteEndpointConfig", name, func() (any, error) { return nil, s.drv.DeleteEndpointConfig(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) CreateEndpoint(ctx context.Context, cfg driver.EndpointSpec) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](s.do(ctx, "CreateEndpoint", cfg, func() (any, error) { return s.drv.CreateEndpoint(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeEndpoint(ctx context.Context, name string) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](s.do(ctx, "DescribeEndpoint", name, func() (any, error) { return s.drv.DescribeEndpoint(ctx, name) }))
+}
+
+func (s *SageMaker) ListEndpoints(ctx context.Context) ([]driver.Endpoint, error) {
+	return cast[[]driver.Endpoint](s.do(ctx, "ListEndpoints", nil, func() (any, error) { return s.drv.ListEndpoints(ctx) }))
+}
+
+func (s *SageMaker) UpdateEndpoint(ctx context.Context, name, configName string) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](s.do(ctx, "UpdateEndpoint", name, func() (any, error) {
+		return s.drv.UpdateEndpoint(ctx, name, configName)
+	}))
+}
+
+func (s *SageMaker) UpdateEndpointWeightsAndCapacities(
+	ctx context.Context, name string, weights []driver.VariantWeight,
+) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](s.do(ctx, "UpdateEndpointWeightsAndCapacities", name, func() (any, error) {
+		return s.drv.UpdateEndpointWeightsAndCapacities(ctx, name, weights)
+	}))
+}
+
+func (s *SageMaker) DeleteEndpoint(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteEndpoint", name, func() (any, error) { return nil, s.drv.DeleteEndpoint(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateInferenceComponent(ctx context.Context, cfg driver.InferenceComponentSpec) (*driver.InferenceComponent, error) {
+	return cast[*driver.InferenceComponent](s.do(ctx, "CreateInferenceComponent", cfg, func() (any, error) {
+		return s.drv.CreateInferenceComponent(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeInferenceComponent(ctx context.Context, name string) (*driver.InferenceComponent, error) {
+	return cast[*driver.InferenceComponent](s.do(ctx, "DescribeInferenceComponent", name, func() (any, error) {
+		return s.drv.DescribeInferenceComponent(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListInferenceComponents(ctx context.Context) ([]driver.InferenceComponent, error) {
+	return cast[[]driver.InferenceComponent](s.do(ctx, "ListInferenceComponents", nil, func() (any, error) {
+		return s.drv.ListInferenceComponents(ctx)
+	}))
+}
+
+func (s *SageMaker) DeleteInferenceComponent(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteInferenceComponent", name, func() (any, error) { return nil, s.drv.DeleteInferenceComponent(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) CreateModelPackageGroup(ctx context.Context, cfg driver.ModelPackageGroupSpec) (*driver.ModelPackageGroup, error) {
+	return cast[*driver.ModelPackageGroup](s.do(ctx, "CreateModelPackageGroup", cfg, func() (any, error) {
+		return s.drv.CreateModelPackageGroup(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeModelPackageGroup(ctx context.Context, name string) (*driver.ModelPackageGroup, error) {
+	return cast[*driver.ModelPackageGroup](s.do(ctx, "DescribeModelPackageGroup", name, func() (any, error) {
+		return s.drv.DescribeModelPackageGroup(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListModelPackageGroups(ctx context.Context) ([]driver.ModelPackageGroup, error) {
+	return cast[[]driver.ModelPackageGroup](s.do(ctx, "ListModelPackageGroups", nil, func() (any, error) {
+		return s.drv.ListModelPackageGroups(ctx)
+	}))
+}
+
+func (s *SageMaker) DeleteModelPackageGroup(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteModelPackageGroup", name, func() (any, error) { return nil, s.drv.DeleteModelPackageGroup(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateModelPackage(ctx context.Context, cfg driver.ModelPackageSpec) (*driver.ModelPackage, error) {
+	return cast[*driver.ModelPackage](s.do(ctx, "CreateModelPackage", cfg, func() (any, error) { return s.drv.CreateModelPackage(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeModelPackage(ctx context.Context, arn string) (*driver.ModelPackage, error) {
+	return cast[*driver.ModelPackage](s.do(ctx, "DescribeModelPackage", arn, func() (any, error) {
+		return s.drv.DescribeModelPackage(ctx, arn)
+	}))
+}
+
+func (s *SageMaker) ListModelPackages(ctx context.Context, groupName string) ([]driver.ModelPackage, error) {
+	return cast[[]driver.ModelPackage](s.do(ctx, "ListModelPackages", groupName, func() (any, error) {
+		return s.drv.ListModelPackages(ctx, groupName)
+	}))
+}
+
+func (s *SageMaker) UpdateModelPackage(ctx context.Context, arn, approvalStatus string) (*driver.ModelPackage, error) {
+	return cast[*driver.ModelPackage](s.do(ctx, "UpdateModelPackage", arn, func() (any, error) {
+		return s.drv.UpdateModelPackage(ctx, arn, approvalStatus)
+	}))
+}
+
+func (s *SageMaker) DeleteModelPackage(ctx context.Context, arn string) error {
+	_, err := s.do(ctx, "DeleteModelPackage", arn, func() (any, error) { return nil, s.drv.DeleteModelPackage(ctx, arn) })
+
+	return err
+}

--- a/sagemaker/wrappers_jobs.go
+++ b/sagemaker/wrappers_jobs.go
@@ -1,0 +1,162 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateTrainingJob(ctx context.Context, cfg driver.TrainingJobConfig) (*driver.TrainingJob, error) {
+	return cast[*driver.TrainingJob](s.do(ctx, "CreateTrainingJob", cfg, func() (any, error) { return s.drv.CreateTrainingJob(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeTrainingJob(ctx context.Context, name string) (*driver.TrainingJob, error) {
+	return cast[*driver.TrainingJob](s.do(ctx, "DescribeTrainingJob", name, func() (any, error) {
+		return s.drv.DescribeTrainingJob(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListTrainingJobs(ctx context.Context) ([]driver.TrainingJob, error) {
+	return cast[[]driver.TrainingJob](s.do(ctx, "ListTrainingJobs", nil, func() (any, error) { return s.drv.ListTrainingJobs(ctx) }))
+}
+
+func (s *SageMaker) StopTrainingJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopTrainingJob", name, func() (any, error) { return nil, s.drv.StopTrainingJob(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateProcessingJob(ctx context.Context, cfg driver.ProcessingJobConfig) (*driver.ProcessingJob, error) {
+	return cast[*driver.ProcessingJob](s.do(ctx, "CreateProcessingJob", cfg, func() (any, error) {
+		return s.drv.CreateProcessingJob(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeProcessingJob(ctx context.Context, name string) (*driver.ProcessingJob, error) {
+	return cast[*driver.ProcessingJob](s.do(ctx, "DescribeProcessingJob", name, func() (any, error) {
+		return s.drv.DescribeProcessingJob(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListProcessingJobs(ctx context.Context) ([]driver.ProcessingJob, error) {
+	return cast[[]driver.ProcessingJob](s.do(ctx, "ListProcessingJobs", nil, func() (any, error) { return s.drv.ListProcessingJobs(ctx) }))
+}
+
+func (s *SageMaker) StopProcessingJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopProcessingJob", name, func() (any, error) { return nil, s.drv.StopProcessingJob(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateTransformJob(ctx context.Context, cfg driver.TransformJobConfig) (*driver.TransformJob, error) {
+	return cast[*driver.TransformJob](s.do(ctx, "CreateTransformJob", cfg, func() (any, error) { return s.drv.CreateTransformJob(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeTransformJob(ctx context.Context, name string) (*driver.TransformJob, error) {
+	return cast[*driver.TransformJob](s.do(ctx, "DescribeTransformJob", name, func() (any, error) {
+		return s.drv.DescribeTransformJob(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListTransformJobs(ctx context.Context) ([]driver.TransformJob, error) {
+	return cast[[]driver.TransformJob](s.do(ctx, "ListTransformJobs", nil, func() (any, error) { return s.drv.ListTransformJobs(ctx) }))
+}
+
+func (s *SageMaker) StopTransformJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopTransformJob", name, func() (any, error) { return nil, s.drv.StopTransformJob(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) CreateHyperParameterTuningJob(
+	//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+	ctx context.Context, cfg driver.HyperParameterTuningJobConfig,
+) (*driver.HyperParameterTuningJob, error) {
+	return cast[*driver.HyperParameterTuningJob](s.do(ctx, "CreateHyperParameterTuningJob", cfg, func() (any, error) {
+		return s.drv.CreateHyperParameterTuningJob(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeHyperParameterTuningJob(ctx context.Context, name string) (*driver.HyperParameterTuningJob, error) {
+	return cast[*driver.HyperParameterTuningJob](s.do(ctx, "DescribeHyperParameterTuningJob", name, func() (any, error) {
+		return s.drv.DescribeHyperParameterTuningJob(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListHyperParameterTuningJobs(ctx context.Context) ([]driver.HyperParameterTuningJob, error) {
+	return cast[[]driver.HyperParameterTuningJob](s.do(ctx, "ListHyperParameterTuningJobs", nil, func() (any, error) {
+		return s.drv.ListHyperParameterTuningJobs(ctx)
+	}))
+}
+
+func (s *SageMaker) StopHyperParameterTuningJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopHyperParameterTuningJob", name, func() (any, error) { return nil, s.drv.StopHyperParameterTuningJob(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateAutoMLJobV2(ctx context.Context, cfg driver.AutoMLJobConfig) (*driver.AutoMLJob, error) {
+	return cast[*driver.AutoMLJob](s.do(ctx, "CreateAutoMLJobV2", cfg, func() (any, error) { return s.drv.CreateAutoMLJobV2(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeAutoMLJobV2(ctx context.Context, name string) (*driver.AutoMLJob, error) {
+	return cast[*driver.AutoMLJob](s.do(ctx, "DescribeAutoMLJobV2", name, func() (any, error) { return s.drv.DescribeAutoMLJobV2(ctx, name) }))
+}
+
+func (s *SageMaker) ListAutoMLJobs(ctx context.Context) ([]driver.AutoMLJob, error) {
+	return cast[[]driver.AutoMLJob](s.do(ctx, "ListAutoMLJobs", nil, func() (any, error) { return s.drv.ListAutoMLJobs(ctx) }))
+}
+
+func (s *SageMaker) StopAutoMLJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopAutoMLJob", name, func() (any, error) { return nil, s.drv.StopAutoMLJob(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateLabelingJob(ctx context.Context, cfg driver.LabelingJobConfig) (*driver.LabelingJob, error) {
+	return cast[*driver.LabelingJob](s.do(ctx, "CreateLabelingJob", cfg, func() (any, error) { return s.drv.CreateLabelingJob(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeLabelingJob(ctx context.Context, name string) (*driver.LabelingJob, error) {
+	return cast[*driver.LabelingJob](s.do(ctx, "DescribeLabelingJob", name, func() (any, error) {
+		return s.drv.DescribeLabelingJob(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListLabelingJobs(ctx context.Context) ([]driver.LabelingJob, error) {
+	return cast[[]driver.LabelingJob](s.do(ctx, "ListLabelingJobs", nil, func() (any, error) { return s.drv.ListLabelingJobs(ctx) }))
+}
+
+func (s *SageMaker) StopLabelingJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopLabelingJob", name, func() (any, error) { return nil, s.drv.StopLabelingJob(ctx, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateCompilationJob(ctx context.Context, cfg driver.CompilationJobConfig) (*driver.CompilationJob, error) {
+	return cast[*driver.CompilationJob](s.do(ctx, "CreateCompilationJob", cfg, func() (any, error) {
+		return s.drv.CreateCompilationJob(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeCompilationJob(ctx context.Context, name string) (*driver.CompilationJob, error) {
+	return cast[*driver.CompilationJob](s.do(ctx, "DescribeCompilationJob", name, func() (any, error) {
+		return s.drv.DescribeCompilationJob(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListCompilationJobs(ctx context.Context) ([]driver.CompilationJob, error) {
+	return cast[[]driver.CompilationJob](s.do(ctx, "ListCompilationJobs", nil, func() (any, error) { return s.drv.ListCompilationJobs(ctx) }))
+}
+
+func (s *SageMaker) StopCompilationJob(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopCompilationJob", name, func() (any, error) { return nil, s.drv.StopCompilationJob(ctx, name) })
+
+	return err
+}

--- a/sagemaker/wrappers_rest.go
+++ b/sagemaker/wrappers_rest.go
@@ -1,0 +1,205 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+// --- Cluster ---
+
+func (s *SageMaker) CreateCluster(ctx context.Context, cfg driver.ClusterSpec) (*driver.Cluster, error) {
+	return cast[*driver.Cluster](s.do(ctx, "CreateCluster", cfg, func() (any, error) { return s.drv.CreateCluster(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeCluster(ctx context.Context, name string) (*driver.Cluster, error) {
+	return cast[*driver.Cluster](s.do(ctx, "DescribeCluster", name, func() (any, error) { return s.drv.DescribeCluster(ctx, name) }))
+}
+
+func (s *SageMaker) ListClusters(ctx context.Context) ([]driver.Cluster, error) {
+	return cast[[]driver.Cluster](s.do(ctx, "ListClusters", nil, func() (any, error) { return s.drv.ListClusters(ctx) }))
+}
+
+func (s *SageMaker) UpdateCluster(ctx context.Context, name string, groups []driver.ClusterInstanceGroupSpec) (*driver.Cluster, error) {
+	return cast[*driver.Cluster](s.do(ctx, "UpdateCluster", name, func() (any, error) { return s.drv.UpdateCluster(ctx, name, groups) }))
+}
+
+func (s *SageMaker) DeleteCluster(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteCluster", name, func() (any, error) { return nil, s.drv.DeleteCluster(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) ListClusterNodes(ctx context.Context, clusterName string) ([]driver.ClusterNode, error) {
+	return cast[[]driver.ClusterNode](s.do(ctx, "ListClusterNodes", clusterName, func() (any, error) {
+		return s.drv.ListClusterNodes(ctx, clusterName)
+	}))
+}
+
+func (s *SageMaker) DescribeClusterNode(ctx context.Context, clusterName, nodeID string) (*driver.ClusterNode, error) {
+	return cast[*driver.ClusterNode](s.do(ctx, "DescribeClusterNode", nodeID, func() (any, error) {
+		return s.drv.DescribeClusterNode(ctx, clusterName, nodeID)
+	}))
+}
+
+// --- Feature Store ---
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateFeatureGroup(ctx context.Context, cfg driver.FeatureGroupSpec) (*driver.FeatureGroup, error) {
+	return cast[*driver.FeatureGroup](s.do(ctx, "CreateFeatureGroup", cfg, func() (any, error) { return s.drv.CreateFeatureGroup(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeFeatureGroup(ctx context.Context, name string) (*driver.FeatureGroup, error) {
+	return cast[*driver.FeatureGroup](s.do(ctx, "DescribeFeatureGroup", name, func() (any, error) {
+		return s.drv.DescribeFeatureGroup(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListFeatureGroups(ctx context.Context) ([]driver.FeatureGroup, error) {
+	return cast[[]driver.FeatureGroup](s.do(ctx, "ListFeatureGroups", nil, func() (any, error) { return s.drv.ListFeatureGroups(ctx) }))
+}
+
+func (s *SageMaker) DeleteFeatureGroup(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteFeatureGroup", name, func() (any, error) { return nil, s.drv.DeleteFeatureGroup(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) PutRecord(ctx context.Context, groupName string, record []driver.FeatureValue) error {
+	_, err := s.do(ctx, "PutRecord", groupName, func() (any, error) { return nil, s.drv.PutRecord(ctx, groupName, record) })
+
+	return err
+}
+
+func (s *SageMaker) GetRecord(ctx context.Context, groupName, recordID string) ([]driver.FeatureValue, error) {
+	return cast[[]driver.FeatureValue](s.do(ctx, "GetRecord", recordID, func() (any, error) {
+		return s.drv.GetRecord(ctx, groupName, recordID)
+	}))
+}
+
+func (s *SageMaker) DeleteRecord(ctx context.Context, groupName, recordID string) error {
+	_, err := s.do(ctx, "DeleteRecord", recordID, func() (any, error) { return nil, s.drv.DeleteRecord(ctx, groupName, recordID) })
+
+	return err
+}
+
+// --- Pipelines / experiments / trials ---
+
+func (s *SageMaker) CreatePipeline(ctx context.Context, cfg driver.PipelineSpec) (*driver.Pipeline, error) {
+	return cast[*driver.Pipeline](s.do(ctx, "CreatePipeline", cfg, func() (any, error) { return s.drv.CreatePipeline(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribePipeline(ctx context.Context, name string) (*driver.Pipeline, error) {
+	return cast[*driver.Pipeline](s.do(ctx, "DescribePipeline", name, func() (any, error) { return s.drv.DescribePipeline(ctx, name) }))
+}
+
+func (s *SageMaker) ListPipelines(ctx context.Context) ([]driver.Pipeline, error) {
+	return cast[[]driver.Pipeline](s.do(ctx, "ListPipelines", nil, func() (any, error) { return s.drv.ListPipelines(ctx) }))
+}
+
+func (s *SageMaker) UpdatePipeline(ctx context.Context, name, definition string) (*driver.Pipeline, error) {
+	return cast[*driver.Pipeline](s.do(ctx, "UpdatePipeline", name, func() (any, error) {
+		return s.drv.UpdatePipeline(ctx, name, definition)
+	}))
+}
+
+func (s *SageMaker) DeletePipeline(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeletePipeline", name, func() (any, error) { return nil, s.drv.DeletePipeline(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) StartPipelineExecution(ctx context.Context, pipelineName string) (*driver.PipelineExecution, error) {
+	return cast[*driver.PipelineExecution](s.do(ctx, "StartPipelineExecution", pipelineName, func() (any, error) {
+		return s.drv.StartPipelineExecution(ctx, pipelineName)
+	}))
+}
+
+func (s *SageMaker) DescribePipelineExecution(ctx context.Context, executionARN string) (*driver.PipelineExecution, error) {
+	return cast[*driver.PipelineExecution](s.do(ctx, "DescribePipelineExecution", executionARN, func() (any, error) {
+		return s.drv.DescribePipelineExecution(ctx, executionARN)
+	}))
+}
+
+func (s *SageMaker) ListPipelineExecutions(ctx context.Context, pipelineName string) ([]driver.PipelineExecution, error) {
+	return cast[[]driver.PipelineExecution](s.do(ctx, "ListPipelineExecutions", pipelineName, func() (any, error) {
+		return s.drv.ListPipelineExecutions(ctx, pipelineName)
+	}))
+}
+
+func (s *SageMaker) StopPipelineExecution(ctx context.Context, executionARN string) error {
+	_, err := s.do(ctx, "StopPipelineExecution", executionARN, func() (any, error) {
+		return nil, s.drv.StopPipelineExecution(ctx, executionARN)
+	})
+
+	return err
+}
+
+func (s *SageMaker) CreateExperiment(ctx context.Context, cfg driver.ExperimentSpec) (*driver.Experiment, error) {
+	return cast[*driver.Experiment](s.do(ctx, "CreateExperiment", cfg, func() (any, error) { return s.drv.CreateExperiment(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeExperiment(ctx context.Context, name string) (*driver.Experiment, error) {
+	return cast[*driver.Experiment](s.do(ctx, "DescribeExperiment", name, func() (any, error) { return s.drv.DescribeExperiment(ctx, name) }))
+}
+
+func (s *SageMaker) ListExperiments(ctx context.Context) ([]driver.Experiment, error) {
+	return cast[[]driver.Experiment](s.do(ctx, "ListExperiments", nil, func() (any, error) { return s.drv.ListExperiments(ctx) }))
+}
+
+func (s *SageMaker) DeleteExperiment(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteExperiment", name, func() (any, error) { return nil, s.drv.DeleteExperiment(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) CreateTrial(ctx context.Context, cfg driver.TrialSpec) (*driver.Trial, error) {
+	return cast[*driver.Trial](s.do(ctx, "CreateTrial", cfg, func() (any, error) { return s.drv.CreateTrial(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeTrial(ctx context.Context, name string) (*driver.Trial, error) {
+	return cast[*driver.Trial](s.do(ctx, "DescribeTrial", name, func() (any, error) { return s.drv.DescribeTrial(ctx, name) }))
+}
+
+func (s *SageMaker) ListTrials(ctx context.Context, experimentName string) ([]driver.Trial, error) {
+	return cast[[]driver.Trial](s.do(ctx, "ListTrials", experimentName, func() (any, error) { return s.drv.ListTrials(ctx, experimentName) }))
+}
+
+func (s *SageMaker) DeleteTrial(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteTrial", name, func() (any, error) { return nil, s.drv.DeleteTrial(ctx, name) })
+
+	return err
+}
+
+// --- Tags ---
+
+func (s *SageMaker) AddTags(ctx context.Context, resourceARN string, tags []driver.Tag) ([]driver.Tag, error) {
+	return cast[[]driver.Tag](s.do(ctx, "AddTags", resourceARN, func() (any, error) { return s.drv.AddTags(ctx, resourceARN, tags) }))
+}
+
+func (s *SageMaker) ListTags(ctx context.Context, resourceARN string) ([]driver.Tag, error) {
+	return cast[[]driver.Tag](s.do(ctx, "ListTags", resourceARN, func() (any, error) { return s.drv.ListTags(ctx, resourceARN) }))
+}
+
+func (s *SageMaker) DeleteTags(ctx context.Context, resourceARN string, keys []string) error {
+	_, err := s.do(ctx, "DeleteTags", resourceARN, func() (any, error) { return nil, s.drv.DeleteTags(ctx, resourceARN, keys) })
+
+	return err
+}
+
+// --- Runtime ---
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) InvokeEndpoint(ctx context.Context, in driver.InvokeEndpointInput) (*driver.InvokeEndpointOutput, error) {
+	return cast[*driver.InvokeEndpointOutput](s.do(ctx, "InvokeEndpoint", in.EndpointName, func() (any, error) {
+		return s.drv.InvokeEndpoint(ctx, in)
+	}))
+}
+
+func (s *SageMaker) InvokeEndpointAsync(
+	ctx context.Context, in driver.InvokeEndpointAsyncInput,
+) (*driver.InvokeEndpointAsyncOutput, error) {
+	return cast[*driver.InvokeEndpointAsyncOutput](s.do(ctx, "InvokeEndpointAsync", in.EndpointName, func() (any, error) {
+		return s.drv.InvokeEndpointAsync(ctx, in)
+	}))
+}

--- a/sagemaker/wrappers_studio_notebook.go
+++ b/sagemaker/wrappers_studio_notebook.go
@@ -1,0 +1,176 @@
+package sagemaker
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+)
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateDomain(ctx context.Context, cfg driver.DomainSpec) (*driver.Domain, error) {
+	return cast[*driver.Domain](s.do(ctx, "CreateDomain", cfg, func() (any, error) { return s.drv.CreateDomain(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeDomain(ctx context.Context, domainID string) (*driver.Domain, error) {
+	return cast[*driver.Domain](s.do(ctx, "DescribeDomain", domainID, func() (any, error) { return s.drv.DescribeDomain(ctx, domainID) }))
+}
+
+func (s *SageMaker) ListDomains(ctx context.Context) ([]driver.Domain, error) {
+	return cast[[]driver.Domain](s.do(ctx, "ListDomains", nil, func() (any, error) { return s.drv.ListDomains(ctx) }))
+}
+
+func (s *SageMaker) DeleteDomain(ctx context.Context, domainID string) error {
+	_, err := s.do(ctx, "DeleteDomain", domainID, func() (any, error) { return nil, s.drv.DeleteDomain(ctx, domainID) })
+
+	return err
+}
+
+func (s *SageMaker) CreateUserProfile(ctx context.Context, cfg driver.UserProfileSpec) (*driver.UserProfile, error) {
+	return cast[*driver.UserProfile](s.do(ctx, "CreateUserProfile", cfg, func() (any, error) { return s.drv.CreateUserProfile(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeUserProfile(ctx context.Context, domainID, name string) (*driver.UserProfile, error) {
+	return cast[*driver.UserProfile](s.do(ctx, "DescribeUserProfile", name, func() (any, error) {
+		return s.drv.DescribeUserProfile(ctx, domainID, name)
+	}))
+}
+
+func (s *SageMaker) ListUserProfiles(ctx context.Context, domainID string) ([]driver.UserProfile, error) {
+	return cast[[]driver.UserProfile](s.do(ctx, "ListUserProfiles", domainID, func() (any, error) {
+		return s.drv.ListUserProfiles(ctx, domainID)
+	}))
+}
+
+func (s *SageMaker) DeleteUserProfile(ctx context.Context, domainID, name string) error {
+	_, err := s.do(ctx, "DeleteUserProfile", name, func() (any, error) { return nil, s.drv.DeleteUserProfile(ctx, domainID, name) })
+
+	return err
+}
+
+func (s *SageMaker) CreateSpace(ctx context.Context, cfg driver.SpaceSpec) (*driver.Space, error) {
+	return cast[*driver.Space](s.do(ctx, "CreateSpace", cfg, func() (any, error) { return s.drv.CreateSpace(ctx, cfg) }))
+}
+
+func (s *SageMaker) DescribeSpace(ctx context.Context, domainID, name string) (*driver.Space, error) {
+	return cast[*driver.Space](s.do(ctx, "DescribeSpace", name, func() (any, error) { return s.drv.DescribeSpace(ctx, domainID, name) }))
+}
+
+func (s *SageMaker) ListSpaces(ctx context.Context, domainID string) ([]driver.Space, error) {
+	return cast[[]driver.Space](s.do(ctx, "ListSpaces", domainID, func() (any, error) { return s.drv.ListSpaces(ctx, domainID) }))
+}
+
+func (s *SageMaker) DeleteSpace(ctx context.Context, domainID, name string) error {
+	_, err := s.do(ctx, "DeleteSpace", name, func() (any, error) { return nil, s.drv.DeleteSpace(ctx, domainID, name) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateApp(ctx context.Context, in driver.AppSpec) (*driver.App, error) {
+	return cast[*driver.App](s.do(ctx, "CreateApp", in, func() (any, error) { return s.drv.CreateApp(ctx, in) }))
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) DescribeApp(ctx context.Context, in driver.AppSpec) (*driver.App, error) {
+	return cast[*driver.App](s.do(ctx, "DescribeApp", in, func() (any, error) { return s.drv.DescribeApp(ctx, in) }))
+}
+
+func (s *SageMaker) ListApps(ctx context.Context, domainID string) ([]driver.App, error) {
+	return cast[[]driver.App](s.do(ctx, "ListApps", domainID, func() (any, error) { return s.drv.ListApps(ctx, domainID) }))
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) DeleteApp(ctx context.Context, in driver.AppSpec) error {
+	_, err := s.do(ctx, "DeleteApp", in, func() (any, error) { return nil, s.drv.DeleteApp(ctx, in) })
+
+	return err
+}
+
+//nolint:gocritic // cfg/in matches the driver signature; forwarded unchanged.
+func (s *SageMaker) CreateNotebookInstance(ctx context.Context, cfg driver.NotebookInstanceSpec) (*driver.NotebookInstance, error) {
+	return cast[*driver.NotebookInstance](s.do(ctx, "CreateNotebookInstance", cfg, func() (any, error) {
+		return s.drv.CreateNotebookInstance(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeNotebookInstance(ctx context.Context, name string) (*driver.NotebookInstance, error) {
+	return cast[*driver.NotebookInstance](s.do(ctx, "DescribeNotebookInstance", name, func() (any, error) {
+		return s.drv.DescribeNotebookInstance(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListNotebookInstances(ctx context.Context) ([]driver.NotebookInstance, error) {
+	return cast[[]driver.NotebookInstance](s.do(ctx, "ListNotebookInstances", nil, func() (any, error) {
+		return s.drv.ListNotebookInstances(ctx)
+	}))
+}
+
+func (s *SageMaker) StartNotebookInstance(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StartNotebookInstance", name, func() (any, error) { return nil, s.drv.StartNotebookInstance(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) StopNotebookInstance(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "StopNotebookInstance", name, func() (any, error) { return nil, s.drv.StopNotebookInstance(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) DeleteNotebookInstance(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteNotebookInstance", name, func() (any, error) { return nil, s.drv.DeleteNotebookInstance(ctx, name) })
+
+	return err
+}
+
+func (s *SageMaker) CreateNotebookInstanceLifecycleConfig(
+	ctx context.Context, cfg driver.NotebookLifecycleConfigSpec,
+) (*driver.NotebookLifecycleConfig, error) {
+	return cast[*driver.NotebookLifecycleConfig](s.do(ctx, "CreateNotebookInstanceLifecycleConfig", cfg, func() (any, error) {
+		return s.drv.CreateNotebookInstanceLifecycleConfig(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeNotebookInstanceLifecycleConfig(ctx context.Context, name string) (*driver.NotebookLifecycleConfig, error) {
+	return cast[*driver.NotebookLifecycleConfig](s.do(ctx, "DescribeNotebookInstanceLifecycleConfig", name, func() (any, error) {
+		return s.drv.DescribeNotebookInstanceLifecycleConfig(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListNotebookInstanceLifecycleConfigs(ctx context.Context) ([]driver.NotebookLifecycleConfig, error) {
+	return cast[[]driver.NotebookLifecycleConfig](s.do(ctx, "ListNotebookInstanceLifecycleConfigs", nil, func() (any, error) {
+		return s.drv.ListNotebookInstanceLifecycleConfigs(ctx)
+	}))
+}
+
+func (s *SageMaker) DeleteNotebookInstanceLifecycleConfig(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteNotebookInstanceLifecycleConfig", name, func() (any, error) {
+		return nil, s.drv.DeleteNotebookInstanceLifecycleConfig(ctx, name)
+	})
+
+	return err
+}
+
+func (s *SageMaker) CreateCodeRepository(ctx context.Context, cfg driver.CodeRepositorySpec) (*driver.CodeRepository, error) {
+	return cast[*driver.CodeRepository](s.do(ctx, "CreateCodeRepository", cfg, func() (any, error) {
+		return s.drv.CreateCodeRepository(ctx, cfg)
+	}))
+}
+
+func (s *SageMaker) DescribeCodeRepository(ctx context.Context, name string) (*driver.CodeRepository, error) {
+	return cast[*driver.CodeRepository](s.do(ctx, "DescribeCodeRepository", name, func() (any, error) {
+		return s.drv.DescribeCodeRepository(ctx, name)
+	}))
+}
+
+func (s *SageMaker) ListCodeRepositories(ctx context.Context) ([]driver.CodeRepository, error) {
+	return cast[[]driver.CodeRepository](s.do(ctx, "ListCodeRepositories", nil, func() (any, error) {
+		return s.drv.ListCodeRepositories(ctx)
+	}))
+}
+
+func (s *SageMaker) DeleteCodeRepository(ctx context.Context, name string) error {
+	_, err := s.do(ctx, "DeleteCodeRepository", name, func() (any, error) { return nil, s.drv.DeleteCodeRepository(ctx, name) })
+
+	return err
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -18,6 +18,7 @@ import (
 	eksdriver "github.com/stackshy/cloudemu/providers/aws/eks/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
+	sagemakerdriver "github.com/stackshy/cloudemu/sagemaker/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/aws/bedrock"
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
@@ -31,6 +32,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/resourceexplorer2"
 	"github.com/stackshy/cloudemu/server/aws/resourcegroupstaggingapi"
 	"github.com/stackshy/cloudemu/server/aws/s3"
+	sagemakersrv "github.com/stackshy/cloudemu/server/aws/sagemaker"
 	"github.com/stackshy/cloudemu/server/aws/sqs"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
@@ -52,6 +54,7 @@ type Drivers struct {
 	EKS        eksdriver.EKS
 	IAM        iamdriver.IAM
 	Bedrock    bedrockdriver.Bedrock
+	SageMaker  sagemakerdriver.Service
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -155,6 +158,14 @@ func New(d Drivers) *server.Server {
 	// REST fallback that would otherwise claim those paths.
 	if d.Bedrock != nil {
 		srv.Register(bedrock.New(d.Bedrock))
+	}
+
+	// SageMaker control plane matches the X-Amz-Target prefix "SageMaker."
+	// (disjoint from DynamoDB/SQS/Resource-Groups-Tagging), and the runtime
+	// matches /endpoints/{name}/invocations. The runtime path must register
+	// before S3's permissive REST fallback.
+	if d.SageMaker != nil {
+		srv.Register(sagemakersrv.New(d.SageMaker))
 	}
 
 	// Kubernetes data-plane API. Matches /k8s/{uid}/... — disjoint from

--- a/server/aws/sagemaker/cluster.go
+++ b/server/aws/sagemaker/cluster.go
@@ -1,0 +1,225 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// wireInstanceGroup is the JSON shape of a HyperPod instance group.
+type wireInstanceGroup struct {
+	InstanceGroupName string `json:"InstanceGroupName"`
+	InstanceType      string `json:"InstanceType"`
+	InstanceCount     int    `json:"InstanceCount"`
+	ExecutionRole     string `json:"ExecutionRole"`
+}
+
+func toGroupSpecs(in []wireInstanceGroup) []driver.ClusterInstanceGroupSpec {
+	out := make([]driver.ClusterInstanceGroupSpec, 0, len(in))
+	for _, g := range in {
+		out = append(out, driver.ClusterInstanceGroupSpec{
+			GroupName:     g.InstanceGroupName,
+			InstanceType:  g.InstanceType,
+			InstanceCount: g.InstanceCount,
+			ExecutionRole: g.ExecutionRole,
+		})
+	}
+
+	return out
+}
+
+func (h *Handler) routeCluster(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateCluster":
+		h.createCluster(w, r)
+	case "DescribeCluster":
+		h.describeCluster(w, r)
+	case "ListClusters":
+		h.listClusters(w, r)
+	case "UpdateCluster":
+		h.updateCluster(w, r)
+	case "DeleteCluster":
+		h.deleteCluster(w, r)
+	case "ListClusterNodes":
+		h.listClusterNodes(w, r)
+	case "DescribeClusterNode":
+		h.describeClusterNode(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClusterName    string              `json:"ClusterName"`
+		InstanceGroups []wireInstanceGroup `json:"InstanceGroups"`
+		Tags           []wireTag           `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	c, err := h.svc.CreateCluster(r.Context(), driver.ClusterSpec{
+		ClusterName:    req.ClusterName,
+		InstanceGroups: toGroupSpecs(req.InstanceGroups),
+		Tags:           toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ClusterArn": c.ClusterARN})
+}
+
+func clusterToWire(c *driver.Cluster) map[string]any {
+	groups := make([]wireInstanceGroup, 0, len(c.InstanceGroups))
+	for _, g := range c.InstanceGroups {
+		groups = append(groups, wireInstanceGroup{
+			InstanceGroupName: g.GroupName,
+			InstanceType:      g.InstanceType,
+			InstanceCount:     g.InstanceCount,
+			ExecutionRole:     g.ExecutionRole,
+		})
+	}
+
+	return map[string]any{
+		"ClusterName":    c.ClusterName,
+		"ClusterArn":     c.ClusterARN,
+		"ClusterStatus":  c.Status,
+		"InstanceGroups": groups,
+		"CreationTime":   epoch(c.CreationTime),
+	}
+}
+
+func (h *Handler) describeCluster(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ClusterName")
+	if !ok {
+		return
+	}
+
+	c, err := h.svc.DescribeCluster(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, clusterToWire(c))
+}
+
+func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request) {
+	clusters, err := h.svc.ListClusters(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(clusters))
+	for i := range clusters {
+		out = append(out, map[string]any{
+			"ClusterName":   clusters[i].ClusterName,
+			"ClusterArn":    clusters[i].ClusterARN,
+			"ClusterStatus": clusters[i].Status,
+			"CreationTime":  epoch(clusters[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"ClusterSummaries": out})
+}
+
+func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClusterName    string              `json:"ClusterName"`
+		InstanceGroups []wireInstanceGroup `json:"InstanceGroups"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	c, err := h.svc.UpdateCluster(r.Context(), req.ClusterName, toGroupSpecs(req.InstanceGroups))
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ClusterArn": c.ClusterARN})
+}
+
+func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ClusterName")
+	if !ok {
+		return
+	}
+
+	if err := h.svc.DeleteCluster(r.Context(), name); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ClusterArn": ""})
+}
+
+func (h *Handler) listClusterNodes(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ClusterName")
+	if !ok {
+		return
+	}
+
+	nodes, err := h.svc.ListClusterNodes(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(nodes))
+	for i := range nodes {
+		out = append(out, map[string]any{
+			"InstanceGroupName": nodes[i].GroupName,
+			"InstanceId":        nodes[i].NodeID,
+			"InstanceType":      nodes[i].InstanceType,
+			"InstanceStatus":    map[string]any{"Status": nodes[i].Status},
+			"LaunchTime":        epoch(nodes[i].LaunchTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"ClusterNodeSummaries": out})
+}
+
+func (h *Handler) describeClusterNode(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClusterName string `json:"ClusterName"`
+		NodeID      string `json:"NodeId"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	node, err := h.svc.DescribeClusterNode(r.Context(), req.ClusterName, req.NodeID)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"NodeDetails": map[string]any{
+			"InstanceGroupName": node.GroupName,
+			"InstanceId":        node.NodeID,
+			"InstanceType":      node.InstanceType,
+			"InstanceStatus":    map[string]any{"Status": node.Status},
+			"LaunchTime":        epoch(node.LaunchTime),
+		},
+	})
+}

--- a/server/aws/sagemaker/cluster.go
+++ b/server/aws/sagemaker/cluster.go
@@ -52,6 +52,7 @@ func (h *Handler) routeCluster(w http.ResponseWriter, r *http.Request, op string
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ClusterName    string              `json:"ClusterName"`
@@ -121,17 +122,14 @@ func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(clusters))
-	for i := range clusters {
-		out = append(out, map[string]any{
-			"ClusterName":   clusters[i].ClusterName,
-			"ClusterArn":    clusters[i].ClusterARN,
-			"ClusterStatus": clusters[i].Status,
-			"CreationTime":  epoch(clusters[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"ClusterSummaries": out})
+	writeSummaries(w, "ClusterSummaries", clusters, func(c *driver.Cluster) map[string]any {
+		return map[string]any{
+			"ClusterName":   c.ClusterName,
+			"ClusterArn":    c.ClusterARN,
+			"ClusterStatus": c.Status,
+			"CreationTime":  epoch(c.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request) {
@@ -182,18 +180,15 @@ func (h *Handler) listClusterNodes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(nodes))
-	for i := range nodes {
-		out = append(out, map[string]any{
-			"InstanceGroupName": nodes[i].GroupName,
-			"InstanceId":        nodes[i].NodeID,
-			"InstanceType":      nodes[i].InstanceType,
-			"InstanceStatus":    map[string]any{"Status": nodes[i].Status},
-			"LaunchTime":        epoch(nodes[i].LaunchTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"ClusterNodeSummaries": out})
+	writeSummaries(w, "ClusterNodeSummaries", nodes, func(n *driver.ClusterNode) map[string]any {
+		return map[string]any{
+			"InstanceGroupName": n.GroupName,
+			"InstanceId":        n.NodeID,
+			"InstanceType":      n.InstanceType,
+			"InstanceStatus":    map[string]any{"Status": n.Status},
+			"LaunchTime":        epoch(n.LaunchTime),
+		}
+	})
 }
 
 func (h *Handler) describeClusterNode(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/errors.go
+++ b/server/aws/sagemaker/errors.go
@@ -1,0 +1,26 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// writeDriverError maps a driver error to the closest SageMaker exception and
+// HTTP status. SageMaker uses awsJson1_1, so the SDK keys off X-Amzn-ErrorType
+// (written by wire.WriteJSONError) to pick the typed error.
+func writeDriverError(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUse", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+	}
+}

--- a/server/aws/sagemaker/featurestore.go
+++ b/server/aws/sagemaker/featurestore.go
@@ -119,17 +119,14 @@ func (h *Handler) listFeatureGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(groups))
-	for i := range groups {
-		out = append(out, map[string]any{
-			"FeatureGroupName":   groups[i].GroupName,
-			"FeatureGroupArn":    groups[i].GroupARN,
-			"FeatureGroupStatus": groups[i].Status,
-			"CreationTime":       epoch(groups[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"FeatureGroupSummaries": out})
+	writeSummaries(w, "FeatureGroupSummaries", groups, func(g *driver.FeatureGroup) map[string]any {
+		return map[string]any{
+			"FeatureGroupName":   g.GroupName,
+			"FeatureGroupArn":    g.GroupARN,
+			"FeatureGroupStatus": g.Status,
+			"CreationTime":       epoch(g.CreationTime),
+		}
+	})
 }
 
 // serveFeatureStoreRuntime handles the sagemaker-featurestore-runtime REST API.

--- a/server/aws/sagemaker/featurestore.go
+++ b/server/aws/sagemaker/featurestore.go
@@ -1,0 +1,211 @@
+package sagemaker
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// wireFeatureDef is the JSON shape of a feature definition.
+type wireFeatureDef struct {
+	FeatureName string `json:"FeatureName"`
+	FeatureType string `json:"FeatureType"`
+}
+
+// wireFeatureValue is the JSON shape of an online-store record entry.
+type wireFeatureValue struct {
+	FeatureName   string `json:"FeatureName"`
+	ValueAsString string `json:"ValueAsString"`
+}
+
+func (h *Handler) routeFeatureStore(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateFeatureGroup":
+		h.createFeatureGroup(w, r)
+	case "DescribeFeatureGroup":
+		h.describeFeatureGroup(w, r)
+	case "ListFeatureGroups":
+		h.listFeatureGroups(w, r)
+	case "DeleteFeatureGroup":
+		stopByName(w, r, "FeatureGroupName", h.svc.DeleteFeatureGroup)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		FeatureGroupName            string           `json:"FeatureGroupName"`
+		RecordIdentifierFeatureName string           `json:"RecordIdentifierFeatureName"`
+		EventTimeFeatureName        string           `json:"EventTimeFeatureName"`
+		FeatureDefinitions          []wireFeatureDef `json:"FeatureDefinitions"`
+		RoleArn                     string           `json:"RoleArn"`
+		OnlineStoreConfig           *struct{}        `json:"OnlineStoreConfig"`
+		OfflineStoreConfig          struct {
+			S3StorageConfig struct {
+				S3URI string `json:"S3Uri"`
+			} `json:"S3StorageConfig"`
+		} `json:"OfflineStoreConfig"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	defs := make([]driver.FeatureDefinition, 0, len(req.FeatureDefinitions))
+	for _, d := range req.FeatureDefinitions {
+		defs = append(defs, driver.FeatureDefinition{Name: d.FeatureName, Type: d.FeatureType})
+	}
+
+	fg, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupSpec{
+		GroupName:            req.FeatureGroupName,
+		RecordIdentifierName: req.RecordIdentifierFeatureName,
+		EventTimeFeatureName: req.EventTimeFeatureName,
+		Features:             defs,
+		OnlineStoreEnabled:   req.OnlineStoreConfig != nil,
+		OfflineStoreS3URI:    req.OfflineStoreConfig.S3StorageConfig.S3URI,
+		RoleARN:              req.RoleArn,
+		Tags:                 toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"FeatureGroupArn": fg.GroupARN})
+}
+
+func (h *Handler) describeFeatureGroup(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "FeatureGroupName")
+	if !ok {
+		return
+	}
+
+	fg, err := h.svc.DescribeFeatureGroup(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	defs := make([]wireFeatureDef, 0, len(fg.Features))
+	for _, d := range fg.Features {
+		defs = append(defs, wireFeatureDef{FeatureName: d.Name, FeatureType: d.Type})
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FeatureGroupName":            fg.GroupName,
+		"FeatureGroupArn":             fg.GroupARN,
+		"RecordIdentifierFeatureName": fg.RecordIdentifierName,
+		"EventTimeFeatureName":        fg.EventTimeFeatureName,
+		"FeatureDefinitions":          defs,
+		"FeatureGroupStatus":          fg.Status,
+		"CreationTime":                epoch(fg.CreationTime),
+	})
+}
+
+func (h *Handler) listFeatureGroups(w http.ResponseWriter, r *http.Request) {
+	groups, err := h.svc.ListFeatureGroups(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(groups))
+	for i := range groups {
+		out = append(out, map[string]any{
+			"FeatureGroupName":   groups[i].GroupName,
+			"FeatureGroupArn":    groups[i].GroupARN,
+			"FeatureGroupStatus": groups[i].Status,
+			"CreationTime":       epoch(groups[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"FeatureGroupSummaries": out})
+}
+
+// serveFeatureStoreRuntime handles the sagemaker-featurestore-runtime REST API.
+// The smithy binding is POST/GET/DELETE /FeatureGroup/{FeatureGroupName} for
+// PutRecord/GetRecord/DeleteRecord respectively.
+func (h *Handler) serveFeatureStoreRuntime(w http.ResponseWriter, r *http.Request) {
+	group := decodeName(strings.TrimPrefix(r.URL.Path, "/FeatureGroup/"))
+
+	switch r.Method {
+	case http.MethodPut:
+		h.putRecord(w, r, group)
+	case http.MethodGet:
+		h.getRecord(w, r, group)
+	case http.MethodDelete:
+		h.deleteRecord(w, r, group)
+	default:
+		wire.WriteJSONError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) putRecord(w http.ResponseWriter, r *http.Request, group string) {
+	var req struct {
+		Record []wireFeatureValue `json:"Record"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rec := make([]driver.FeatureValue, 0, len(req.Record))
+	for _, fv := range req.Record {
+		rec = append(rec, driver.FeatureValue{Name: fv.FeatureName, Value: fv.ValueAsString})
+	}
+
+	if err := h.svc.PutRecord(r.Context(), group, rec); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+func (h *Handler) getRecord(w http.ResponseWriter, r *http.Request, group string) {
+	recordID := r.URL.Query().Get("RecordIdentifierValueAsString")
+
+	rec, err := h.svc.GetRecord(r.Context(), group, recordID)
+	if err != nil {
+		// FeatureStore GetRecord returns 200 with no Record when absent.
+		if cerrors.IsNotFound(err) {
+			wire.WriteJSON(w, map[string]any{})
+
+			return
+		}
+
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]wireFeatureValue, 0, len(rec))
+	for _, fv := range rec {
+		out = append(out, wireFeatureValue{FeatureName: fv.Name, ValueAsString: fv.Value})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Record": out})
+}
+
+func (h *Handler) deleteRecord(w http.ResponseWriter, r *http.Request, group string) {
+	recordID := r.URL.Query().Get("RecordIdentifierValueAsString")
+
+	if err := h.svc.DeleteRecord(r.Context(), group, recordID); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}

--- a/server/aws/sagemaker/handler.go
+++ b/server/aws/sagemaker/handler.go
@@ -188,6 +188,18 @@ func stopByName(w http.ResponseWriter, r *http.Request, field string, fn func(co
 	wire.WriteJSON(w, map[string]any{})
 }
 
+// writeSummaries projects items into the awsJson1_1 list shape
+// {"<key>": [ {...}, ... ]} via per-item project. It collapses the otherwise
+// identical make/loop/WriteJSON boilerplate shared by every List* handler.
+func writeSummaries[T any](w http.ResponseWriter, key string, items []T, project func(*T) map[string]any) {
+	out := make([]map[string]any, 0, len(items))
+	for i := range items {
+		out = append(out, project(&items[i]))
+	}
+
+	wire.WriteJSON(w, map[string]any{key: out})
+}
+
 // epoch converts a stored RFC3339 timestamp to Unix seconds for awsJson1_1
 // timestamp serialization (the SDK's default format is unixTimestamp).
 func epoch(iso string) float64 {

--- a/server/aws/sagemaker/handler.go
+++ b/server/aws/sagemaker/handler.go
@@ -13,6 +13,7 @@
 package sagemaker
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -33,14 +34,14 @@ func New(svc driver.Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// Matches claims awsJson1_1 control-plane requests (by X-Amz-Target) and the
-// runtime invocation REST paths.
+// Matches claims awsJson1_1 control-plane requests (by X-Amz-Target), the
+// runtime invocation REST paths, and the feature-store online-runtime paths.
 func (*Handler) Matches(r *http.Request) bool {
 	if strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix) {
 		return true
 	}
 
-	return isRuntimePath(r.URL.Path)
+	return isRuntimePath(r.URL.Path) || isFeatureStorePath(r.URL.Path)
 }
 
 func isRuntimePath(p string) bool {
@@ -48,8 +49,12 @@ func isRuntimePath(p string) bool {
 		(strings.HasSuffix(p, "/invocations") || strings.HasSuffix(p, "/async-invocations"))
 }
 
+func isFeatureStorePath(p string) bool {
+	return strings.HasPrefix(p, "/FeatureGroup/")
+}
+
 // ServeHTTP dispatches by X-Amz-Target for the control plane, falling back to
-// the runtime REST path.
+// the runtime and feature-store REST paths.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if isRuntimePath(r.URL.Path) {
 		h.serveRuntime(w, r)
@@ -57,11 +62,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if isFeatureStorePath(r.URL.Path) {
+		h.serveFeatureStoreRuntime(w, r)
+
+		return
+	}
+
 	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
 
-	if h.routeModels(w, r, op) || h.routeEndpoints(w, r, op) ||
-		h.routeJobs(w, r, op) || h.routeTags(w, r, op) {
-		return
+	routers := []func(http.ResponseWriter, *http.Request, string) bool{
+		h.routeModels, h.routeEndpoints, h.routeInferenceComponents,
+		h.routeJobs, h.routeMoreJobs,
+		h.routeRegistry, h.routeStudio, h.routeNotebook,
+		h.routeCluster, h.routeFeatureStore, h.routePipelines, h.routeTags,
+	}
+	for _, route := range routers {
+		if route(w, r, op) {
+			return
+		}
 	}
 
 	wire.WriteJSONError(w, http.StatusBadRequest, "UnknownOperationException", "unknown operation: "+op)
@@ -137,6 +155,37 @@ func (h *Handler) routeTags(w http.ResponseWriter, r *http.Request, op string) b
 	}
 
 	return true
+}
+
+// decodeName1 decodes a request body and returns the string value of the
+// single named field (e.g. "TrainingJobName"). Used by the many Describe/Stop
+// operations whose request is just one identifier.
+func decodeName1(w http.ResponseWriter, r *http.Request, field string) (string, bool) {
+	var m map[string]any
+	if !wire.DecodeJSON(w, r, &m) {
+		return "", false
+	}
+
+	name, _ := m[field].(string)
+
+	return name, true
+}
+
+// stopByName decodes the named identifier and invokes a Stop/Delete-style
+// driver call that returns only an error, writing an empty success body.
+func stopByName(w http.ResponseWriter, r *http.Request, field string, fn func(context.Context, string) error) {
+	name, ok := decodeName1(w, r, field)
+	if !ok {
+		return
+	}
+
+	if err := fn(r.Context(), name); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
 }
 
 // epoch converts a stored RFC3339 timestamp to Unix seconds for awsJson1_1

--- a/server/aws/sagemaker/handler.go
+++ b/server/aws/sagemaker/handler.go
@@ -1,0 +1,175 @@
+// Package sagemaker implements the Amazon SageMaker awsJson1_1 control-plane
+// API and the sagemaker-runtime restJson1 InvokeEndpoint data-plane API as a
+// server.Handler. Point the real aws-sdk-go-v2/service/sagemaker and
+// .../sagemakerruntime clients at a Server registered with this handler and
+// the jobs, model/endpoint inference stack and tagging surface work end-to-end
+// against an in-memory SageMaker driver.
+//
+// The control plane is dispatched by the X-Amz-Target header
+// ("SageMaker.<Operation>"); the runtime is dispatched by the REST path
+// /endpoints/{name}/invocations. Matches is scoped to those so it does not
+// shadow the catch-all S3 handler registered alongside — register this handler
+// before S3.
+package sagemaker
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "SageMaker."
+
+// Handler serves SageMaker control-plane and runtime requests.
+type Handler struct {
+	svc driver.Service
+}
+
+// New returns a SageMaker handler backed by svc.
+func New(svc driver.Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// Matches claims awsJson1_1 control-plane requests (by X-Amz-Target) and the
+// runtime invocation REST paths.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix) {
+		return true
+	}
+
+	return isRuntimePath(r.URL.Path)
+}
+
+func isRuntimePath(p string) bool {
+	return strings.HasPrefix(p, "/endpoints/") &&
+		(strings.HasSuffix(p, "/invocations") || strings.HasSuffix(p, "/async-invocations"))
+}
+
+// ServeHTTP dispatches by X-Amz-Target for the control plane, falling back to
+// the runtime REST path.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isRuntimePath(r.URL.Path) {
+		h.serveRuntime(w, r)
+
+		return
+	}
+
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	if h.routeModels(w, r, op) || h.routeEndpoints(w, r, op) ||
+		h.routeJobs(w, r, op) || h.routeTags(w, r, op) {
+		return
+	}
+
+	wire.WriteJSONError(w, http.StatusBadRequest, "UnknownOperationException", "unknown operation: "+op)
+}
+
+func (h *Handler) routeModels(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateModel":
+		h.createModel(w, r)
+	case "DescribeModel":
+		h.describeModel(w, r)
+	case "ListModels":
+		h.listModels(w, r)
+	case "DeleteModel":
+		h.deleteModel(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeEndpoints(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateEndpointConfig":
+		h.createEndpointConfig(w, r)
+	case "DescribeEndpointConfig":
+		h.describeEndpointConfig(w, r)
+	case "DeleteEndpointConfig":
+		h.deleteEndpointConfig(w, r)
+	case "CreateEndpoint":
+		h.createEndpoint(w, r)
+	case "DescribeEndpoint":
+		h.describeEndpoint(w, r)
+	case "ListEndpoints":
+		h.listEndpoints(w, r)
+	case "DeleteEndpoint":
+		h.deleteEndpoint(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeJobs(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateTrainingJob":
+		h.createTrainingJob(w, r)
+	case "DescribeTrainingJob":
+		h.describeTrainingJob(w, r)
+	case "ListTrainingJobs":
+		h.listTrainingJobs(w, r)
+	case "StopTrainingJob":
+		h.stopTrainingJob(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeTags(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "AddTags":
+		h.addTags(w, r)
+	case "ListTags":
+		h.listTags(w, r)
+	case "DeleteTags":
+		h.deleteTags(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// epoch converts a stored RFC3339 timestamp to Unix seconds for awsJson1_1
+// timestamp serialization (the SDK's default format is unixTimestamp).
+func epoch(iso string) float64 {
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return float64(t.Unix())
+}
+
+func toTags(in []wireTag) []driver.Tag {
+	out := make([]driver.Tag, 0, len(in))
+	for _, t := range in {
+		out = append(out, driver.Tag{Key: t.Key, Value: t.Value})
+	}
+
+	return out
+}
+
+func fromTags(in []driver.Tag) []wireTag {
+	out := make([]wireTag, 0, len(in))
+	for _, t := range in {
+		out = append(out, wireTag{Key: t.Key, Value: t.Value})
+	}
+
+	return out
+}
+
+// wireTag is the JSON shape of a SageMaker tag.
+type wireTag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}

--- a/server/aws/sagemaker/inference.go
+++ b/server/aws/sagemaker/inference.go
@@ -1,0 +1,342 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// wireContainer is the JSON shape of a model container definition.
+type wireContainer struct {
+	Image        string            `json:"Image"`
+	ModelDataURL string            `json:"ModelDataUrl,omitempty"`
+	Environment  map[string]string `json:"Environment,omitempty"`
+	Mode         string            `json:"Mode,omitempty"`
+}
+
+func toContainer(c wireContainer) driver.ContainerDefinition {
+	return driver.ContainerDefinition{
+		Image: c.Image, ModelDataURL: c.ModelDataURL, Environment: c.Environment, Mode: c.Mode,
+	}
+}
+
+func fromContainer(c driver.ContainerDefinition) wireContainer {
+	return wireContainer{
+		Image: c.Image, ModelDataURL: c.ModelDataURL, Environment: c.Environment, Mode: c.Mode,
+	}
+}
+
+func (h *Handler) createModel(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ModelName        string          `json:"ModelName"`
+		ExecutionRoleArn string          `json:"ExecutionRoleArn"`
+		PrimaryContainer *wireContainer  `json:"PrimaryContainer"`
+		Containers       []wireContainer `json:"Containers"`
+		Tags             []wireTag       `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	containers := make([]driver.ContainerDefinition, 0)
+	if req.PrimaryContainer != nil {
+		containers = append(containers, toContainer(*req.PrimaryContainer))
+	}
+
+	for _, c := range req.Containers {
+		containers = append(containers, toContainer(c))
+	}
+
+	model, err := h.svc.CreateModel(r.Context(), driver.ModelConfig{
+		ModelName:  req.ModelName,
+		RoleARN:    req.ExecutionRoleArn,
+		Containers: containers,
+		Tags:       toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ModelArn": model.ModelARN})
+}
+
+func (h *Handler) describeModel(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ModelName string `json:"ModelName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	model, err := h.svc.DescribeModel(r.Context(), req.ModelName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	resp := map[string]any{
+		"ModelName":        model.ModelName,
+		"ModelArn":         model.ModelARN,
+		"ExecutionRoleArn": model.RoleARN,
+		"CreationTime":     epoch(model.CreationTime),
+	}
+	if len(model.Containers) > 0 {
+		resp["PrimaryContainer"] = fromContainer(model.Containers[0])
+
+		conts := make([]wireContainer, 0, len(model.Containers))
+		for _, c := range model.Containers {
+			conts = append(conts, fromContainer(c))
+		}
+
+		resp["Containers"] = conts
+	}
+
+	wire.WriteJSON(w, resp)
+}
+
+func (h *Handler) listModels(w http.ResponseWriter, r *http.Request) {
+	models, err := h.svc.ListModels(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(models))
+	for i := range models {
+		out = append(out, map[string]any{
+			"ModelName":    models[i].ModelName,
+			"ModelArn":     models[i].ModelARN,
+			"CreationTime": epoch(models[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Models": out})
+}
+
+func (h *Handler) deleteModel(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ModelName string `json:"ModelName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteModel(r.Context(), req.ModelName); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+// wireVariant is the JSON shape of a production variant.
+type wireVariant struct {
+	VariantName          string          `json:"VariantName"`
+	ModelName            string          `json:"ModelName,omitempty"`
+	InstanceType         string          `json:"InstanceType,omitempty"`
+	InitialInstanceCount int             `json:"InitialInstanceCount,omitempty"`
+	InitialVariantWeight float64         `json:"InitialVariantWeight,omitempty"`
+	ServerlessConfig     *wireServerless `json:"ServerlessConfig,omitempty"`
+}
+
+type wireServerless struct {
+	MemorySizeInMB int `json:"MemorySizeInMB"`
+	MaxConcurrency int `json:"MaxConcurrency"`
+}
+
+func (h *Handler) createEndpointConfig(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EndpointConfigName string        `json:"EndpointConfigName"`
+		ProductionVariants []wireVariant `json:"ProductionVariants"`
+		Tags               []wireTag     `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	spec := driver.EndpointConfigSpec{ConfigName: req.EndpointConfigName, Tags: toTags(req.Tags)}
+	for _, v := range req.ProductionVariants {
+		spec.ProductionVariants = append(spec.ProductionVariants, driver.ProductionVariant{
+			VariantName:          v.VariantName,
+			ModelName:            v.ModelName,
+			InstanceType:         v.InstanceType,
+			InitialInstanceCount: v.InitialInstanceCount,
+			InitialVariantWeight: v.InitialVariantWeight,
+		})
+		if v.ServerlessConfig != nil {
+			spec.Serverless = &driver.ServerlessConfig{
+				MemorySizeInMB: v.ServerlessConfig.MemorySizeInMB,
+				MaxConcurrency: v.ServerlessConfig.MaxConcurrency,
+			}
+		}
+	}
+
+	ec, err := h.svc.CreateEndpointConfig(r.Context(), spec)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"EndpointConfigArn": ec.ConfigARN})
+}
+
+func (h *Handler) describeEndpointConfig(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EndpointConfigName string `json:"EndpointConfigName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ec, err := h.svc.DescribeEndpointConfig(r.Context(), req.EndpointConfigName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"EndpointConfigName": ec.ConfigName,
+		"EndpointConfigArn":  ec.ConfigARN,
+		"ProductionVariants": variantsToWire(ec.ProductionVariants),
+		"CreationTime":       epoch(ec.CreationTime),
+	})
+}
+
+func (h *Handler) deleteEndpointConfig(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EndpointConfigName string `json:"EndpointConfigName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteEndpointConfig(r.Context(), req.EndpointConfigName); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+func variantsToWire(in []driver.ProductionVariant) []wireVariant {
+	out := make([]wireVariant, 0, len(in))
+	for _, v := range in {
+		out = append(out, wireVariant{
+			VariantName:          v.VariantName,
+			ModelName:            v.ModelName,
+			InstanceType:         v.InstanceType,
+			InitialInstanceCount: v.InitialInstanceCount,
+			InitialVariantWeight: v.InitialVariantWeight,
+		})
+	}
+
+	return out
+}
+
+func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EndpointName       string    `json:"EndpointName"`
+		EndpointConfigName string    `json:"EndpointConfigName"`
+		Tags               []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ep, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointSpec{
+		EndpointName: req.EndpointName,
+		ConfigName:   req.EndpointConfigName,
+		Tags:         toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"EndpointArn": ep.EndpointARN})
+}
+
+func (h *Handler) describeEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EndpointName string `json:"EndpointName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ep, err := h.svc.DescribeEndpoint(r.Context(), req.EndpointName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"EndpointName":       ep.EndpointName,
+		"EndpointArn":        ep.EndpointARN,
+		"EndpointConfigName": ep.ConfigName,
+		"EndpointStatus":     ep.Status,
+		"ProductionVariants": variantsToWire(ep.Variants),
+		"CreationTime":       epoch(ep.CreationTime),
+		"LastModifiedTime":   epoch(ep.LastModifiedTime),
+	})
+}
+
+//nolint:dupl // the list-summaries shape recurs across resources; sharing it would obscure each surface.
+func (h *Handler) listEndpoints(w http.ResponseWriter, r *http.Request) {
+	eps, err := h.svc.ListEndpoints(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(eps))
+	for i := range eps {
+		out = append(out, map[string]any{
+			"EndpointName":     eps[i].EndpointName,
+			"EndpointArn":      eps[i].EndpointARN,
+			"EndpointStatus":   eps[i].Status,
+			"CreationTime":     epoch(eps[i].CreationTime),
+			"LastModifiedTime": epoch(eps[i].LastModifiedTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Endpoints": out})
+}
+
+func (h *Handler) deleteEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		EndpointName string `json:"EndpointName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteEndpoint(r.Context(), req.EndpointName); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}

--- a/server/aws/sagemaker/inference.go
+++ b/server/aws/sagemaker/inference.go
@@ -49,10 +49,15 @@ func (h *Handler) createModel(w http.ResponseWriter, r *http.Request) {
 		containers = append(containers, toContainer(c))
 	}
 
+	// An inference-pipeline model is created via Containers; a single-container
+	// model via PrimaryContainer. Track which so Describe echoes only that field.
+	pipeline := req.PrimaryContainer == nil && len(req.Containers) > 0
+
 	model, err := h.svc.CreateModel(r.Context(), driver.ModelConfig{
 		ModelName:  req.ModelName,
 		RoleARN:    req.ExecutionRoleArn,
 		Containers: containers,
+		Pipeline:   pipeline,
 		Tags:       toTags(req.Tags),
 	})
 	if err != nil {
@@ -86,15 +91,18 @@ func (h *Handler) describeModel(w http.ResponseWriter, r *http.Request) {
 		"ExecutionRoleArn": model.RoleARN,
 		"CreationTime":     epoch(model.CreationTime),
 	}
-	if len(model.Containers) > 0 {
-		resp["PrimaryContainer"] = fromContainer(model.Containers[0])
-
+	// Echo only the field the model was created with: a pipeline model reports
+	// Containers; a single-container model reports PrimaryContainer.
+	switch {
+	case model.Pipeline:
 		conts := make([]wireContainer, 0, len(model.Containers))
 		for _, c := range model.Containers {
 			conts = append(conts, fromContainer(c))
 		}
 
 		resp["Containers"] = conts
+	case len(model.Containers) > 0:
+		resp["PrimaryContainer"] = fromContainer(model.Containers[0])
 	}
 
 	wire.WriteJSON(w, resp)
@@ -108,16 +116,13 @@ func (h *Handler) listModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(models))
-	for i := range models {
-		out = append(out, map[string]any{
-			"ModelName":    models[i].ModelName,
-			"ModelArn":     models[i].ModelARN,
-			"CreationTime": epoch(models[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"Models": out})
+	writeSummaries(w, "Models", models, func(m *driver.Model) map[string]any {
+		return map[string]any{
+			"ModelName":    m.ModelName,
+			"ModelArn":     m.ModelARN,
+			"CreationTime": epoch(m.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteModel(w http.ResponseWriter, r *http.Request) {
@@ -248,6 +253,7 @@ func variantsToWire(in []driver.ProductionVariant) []wireVariant {
 	return out
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		EndpointName       string    `json:"EndpointName"`
@@ -300,6 +306,7 @@ func (h *Handler) describeEndpoint(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) listEndpoints(w http.ResponseWriter, r *http.Request) {
 	eps, err := h.svc.ListEndpoints(r.Context())
 	if err != nil {
@@ -308,18 +315,15 @@ func (h *Handler) listEndpoints(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(eps))
-	for i := range eps {
-		out = append(out, map[string]any{
-			"EndpointName":     eps[i].EndpointName,
-			"EndpointArn":      eps[i].EndpointARN,
-			"EndpointStatus":   eps[i].Status,
-			"CreationTime":     epoch(eps[i].CreationTime),
-			"LastModifiedTime": epoch(eps[i].LastModifiedTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"Endpoints": out})
+	writeSummaries(w, "Endpoints", eps, func(e *driver.Endpoint) map[string]any {
+		return map[string]any{
+			"EndpointName":     e.EndpointName,
+			"EndpointArn":      e.EndpointARN,
+			"EndpointStatus":   e.Status,
+			"CreationTime":     epoch(e.CreationTime),
+			"LastModifiedTime": epoch(e.LastModifiedTime),
+		}
+	})
 }
 
 func (h *Handler) deleteEndpoint(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/inference.go
+++ b/server/aws/sagemaker/inference.go
@@ -300,7 +300,6 @@ func (h *Handler) describeEndpoint(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // the list-summaries shape recurs across resources; sharing it would obscure each surface.
 func (h *Handler) listEndpoints(w http.ResponseWriter, r *http.Request) {
 	eps, err := h.svc.ListEndpoints(r.Context())
 	if err != nil {

--- a/server/aws/sagemaker/inference_components.go
+++ b/server/aws/sagemaker/inference_components.go
@@ -59,6 +59,7 @@ func (h *Handler) createInferenceComponent(w http.ResponseWriter, r *http.Reques
 	wire.WriteJSON(w, map[string]any{"InferenceComponentArn": ic.ARN})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) describeInferenceComponent(w http.ResponseWriter, r *http.Request) {
 	name, ok := decodeName1(w, r, "InferenceComponentName")
 	if !ok {
@@ -90,18 +91,15 @@ func (h *Handler) listInferenceComponents(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	out := make([]map[string]any, 0, len(ics))
-	for i := range ics {
-		out = append(out, map[string]any{
-			"InferenceComponentName":   ics[i].Name,
-			"InferenceComponentArn":    ics[i].ARN,
-			"EndpointName":             ics[i].EndpointName,
-			"InferenceComponentStatus": ics[i].Status,
-			"CreationTime":             epoch(ics[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"InferenceComponents": out})
+	writeSummaries(w, "InferenceComponents", ics, func(ic *driver.InferenceComponent) map[string]any {
+		return map[string]any{
+			"InferenceComponentName":   ic.Name,
+			"InferenceComponentArn":    ic.ARN,
+			"EndpointName":             ic.EndpointName,
+			"InferenceComponentStatus": ic.Status,
+			"CreationTime":             epoch(ic.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteInferenceComponent(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/inference_components.go
+++ b/server/aws/sagemaker/inference_components.go
@@ -1,0 +1,109 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) routeInferenceComponents(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateInferenceComponent":
+		h.createInferenceComponent(w, r)
+	case "DescribeInferenceComponent":
+		h.describeInferenceComponent(w, r)
+	case "ListInferenceComponents":
+		h.listInferenceComponents(w, r)
+	case "DeleteInferenceComponent":
+		h.deleteInferenceComponent(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createInferenceComponent(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		InferenceComponentName string `json:"InferenceComponentName"`
+		EndpointName           string `json:"EndpointName"`
+		VariantName            string `json:"VariantName"`
+		Specification          struct {
+			ModelName string `json:"ModelName"`
+		} `json:"Specification"`
+		RuntimeConfig struct {
+			CopyCount int `json:"CopyCount"`
+		} `json:"RuntimeConfig"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ic, err := h.svc.CreateInferenceComponent(r.Context(), driver.InferenceComponentSpec{
+		Name:         req.InferenceComponentName,
+		EndpointName: req.EndpointName,
+		ModelName:    req.Specification.ModelName,
+		VariantName:  req.VariantName,
+		CopyCount:    req.RuntimeConfig.CopyCount,
+		Tags:         toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"InferenceComponentArn": ic.ARN})
+}
+
+func (h *Handler) describeInferenceComponent(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "InferenceComponentName")
+	if !ok {
+		return
+	}
+
+	ic, err := h.svc.DescribeInferenceComponent(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"InferenceComponentName":   ic.Name,
+		"InferenceComponentArn":    ic.ARN,
+		"EndpointName":             ic.EndpointName,
+		"VariantName":              ic.VariantName,
+		"InferenceComponentStatus": ic.Status,
+		"CreationTime":             epoch(ic.CreationTime),
+	})
+}
+
+func (h *Handler) listInferenceComponents(w http.ResponseWriter, r *http.Request) {
+	ics, err := h.svc.ListInferenceComponents(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ics))
+	for i := range ics {
+		out = append(out, map[string]any{
+			"InferenceComponentName":   ics[i].Name,
+			"InferenceComponentArn":    ics[i].ARN,
+			"EndpointName":             ics[i].EndpointName,
+			"InferenceComponentStatus": ics[i].Status,
+			"CreationTime":             epoch(ics[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"InferenceComponents": out})
+}
+
+func (h *Handler) deleteInferenceComponent(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "InferenceComponentName", h.svc.DeleteInferenceComponent)
+}

--- a/server/aws/sagemaker/jobs.go
+++ b/server/aws/sagemaker/jobs.go
@@ -1,0 +1,147 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// wireAlgorithm is the JSON shape of AlgorithmSpecification.
+type wireAlgorithm struct {
+	TrainingImage     string `json:"TrainingImage"`
+	TrainingInputMode string `json:"TrainingInputMode,omitempty"`
+}
+
+type wireOutputConfig struct {
+	S3OutputPath string `json:"S3OutputPath"`
+}
+
+type wireResourceConfig struct {
+	InstanceType   string `json:"InstanceType"`
+	InstanceCount  int    `json:"InstanceCount"`
+	VolumeSizeInGB int    `json:"VolumeSizeInGB"`
+}
+
+type wireStopping struct {
+	MaxRuntimeInSeconds int `json:"MaxRuntimeInSeconds,omitempty"`
+}
+
+func (h *Handler) createTrainingJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TrainingJobName        string             `json:"TrainingJobName"`
+		RoleArn                string             `json:"RoleArn"`
+		AlgorithmSpecification wireAlgorithm      `json:"AlgorithmSpecification"`
+		OutputDataConfig       wireOutputConfig   `json:"OutputDataConfig"`
+		ResourceConfig         wireResourceConfig `json:"ResourceConfig"`
+		StoppingCondition      wireStopping       `json:"StoppingCondition"`
+		HyperParameters        map[string]string  `json:"HyperParameters"`
+		Tags                   []wireTag          `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateTrainingJob(r.Context(), driver.TrainingJobConfig{
+		JobName:         req.TrainingJobName,
+		RoleARN:         req.RoleArn,
+		AlgorithmImage:  req.AlgorithmSpecification.TrainingImage,
+		HyperParameters: req.HyperParameters,
+		OutputS3URI:     req.OutputDataConfig.S3OutputPath,
+		Resources: driver.ResourceConfig{
+			InstanceType:   req.ResourceConfig.InstanceType,
+			InstanceCount:  req.ResourceConfig.InstanceCount,
+			VolumeSizeInGB: req.ResourceConfig.VolumeSizeInGB,
+		},
+		MaxRuntimeSeconds: req.StoppingCondition.MaxRuntimeInSeconds,
+		Tags:              toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TrainingJobArn": job.JobARN})
+}
+
+func (h *Handler) describeTrainingJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TrainingJobName string `json:"TrainingJobName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.DescribeTrainingJob(r.Context(), req.TrainingJobName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TrainingJobName":   job.JobName,
+		"TrainingJobArn":    job.JobARN,
+		"TrainingJobStatus": job.Status,
+		"SecondaryStatus":   job.SecondaryStatus,
+		"RoleArn":           job.RoleARN,
+		"AlgorithmSpecification": wireAlgorithm{
+			TrainingImage:     job.AlgorithmImage,
+			TrainingInputMode: "File",
+		},
+		"OutputDataConfig": wireOutputConfig{S3OutputPath: job.OutputS3URI},
+		"ResourceConfig": wireResourceConfig{
+			InstanceType:   job.Resources.InstanceType,
+			InstanceCount:  job.Resources.InstanceCount,
+			VolumeSizeInGB: job.Resources.VolumeSizeInGB,
+		},
+		"ModelArtifacts":   map[string]any{"S3ModelArtifacts": job.ModelArtifactS3URI},
+		"HyperParameters":  job.HyperParameters,
+		"CreationTime":     epoch(job.CreationTime),
+		"LastModifiedTime": epoch(job.LastModifiedTime),
+	})
+}
+
+//nolint:dupl // the list-summaries shape recurs across resources; sharing it would obscure each surface.
+func (h *Handler) listTrainingJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListTrainingJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"TrainingJobName":   jobs[i].JobName,
+			"TrainingJobArn":    jobs[i].JobARN,
+			"TrainingJobStatus": jobs[i].Status,
+			"CreationTime":      epoch(jobs[i].CreationTime),
+			"LastModifiedTime":  epoch(jobs[i].LastModifiedTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"TrainingJobSummaries": out})
+}
+
+func (h *Handler) stopTrainingJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TrainingJobName string `json:"TrainingJobName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.StopTrainingJob(r.Context(), req.TrainingJobName); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}

--- a/server/aws/sagemaker/jobs.go
+++ b/server/aws/sagemaker/jobs.go
@@ -105,6 +105,7 @@ func (h *Handler) describeTrainingJob(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) listTrainingJobs(w http.ResponseWriter, r *http.Request) {
 	jobs, err := h.svc.ListTrainingJobs(r.Context())
 	if err != nil {
@@ -113,18 +114,15 @@ func (h *Handler) listTrainingJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"TrainingJobName":   jobs[i].JobName,
-			"TrainingJobArn":    jobs[i].JobARN,
-			"TrainingJobStatus": jobs[i].Status,
-			"CreationTime":      epoch(jobs[i].CreationTime),
-			"LastModifiedTime":  epoch(jobs[i].LastModifiedTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"TrainingJobSummaries": out})
+	writeSummaries(w, "TrainingJobSummaries", jobs, func(j *driver.TrainingJob) map[string]any {
+		return map[string]any{
+			"TrainingJobName":   j.JobName,
+			"TrainingJobArn":    j.JobARN,
+			"TrainingJobStatus": j.Status,
+			"CreationTime":      epoch(j.CreationTime),
+			"LastModifiedTime":  epoch(j.LastModifiedTime),
+		}
+	})
 }
 
 func (h *Handler) stopTrainingJob(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/jobs.go
+++ b/server/aws/sagemaker/jobs.go
@@ -105,7 +105,6 @@ func (h *Handler) describeTrainingJob(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // the list-summaries shape recurs across resources; sharing it would obscure each surface.
 func (h *Handler) listTrainingJobs(w http.ResponseWriter, r *http.Request) {
 	jobs, err := h.svc.ListTrainingJobs(r.Context())
 	if err != nil {

--- a/server/aws/sagemaker/jobs_more.go
+++ b/server/aws/sagemaker/jobs_more.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stackshy/cloudemu/server/wire"
 )
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) routeMoreJobs(w http.ResponseWriter, r *http.Request, op string) bool {
 	switch op {
 	case "CreateProcessingJob":
@@ -32,6 +33,7 @@ func (h *Handler) routeMoreJobs(w http.ResponseWriter, r *http.Request, op strin
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) routeTuningJobs(w http.ResponseWriter, r *http.Request, op string) bool {
 	switch op {
 	case "CreateHyperParameterTuningJob":
@@ -57,6 +59,7 @@ func (h *Handler) routeTuningJobs(w http.ResponseWriter, r *http.Request, op str
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) routeMoreJobs2(w http.ResponseWriter, r *http.Request, op string) bool {
 	switch op {
 	case "CreateLabelingJob":
@@ -84,6 +87,7 @@ func (h *Handler) routeMoreJobs2(w http.ResponseWriter, r *http.Request, op stri
 
 // --- Processing ---
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createProcessingJob(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ProcessingJobName string `json:"ProcessingJobName"`
@@ -143,17 +147,14 @@ func (h *Handler) listProcessingJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"ProcessingJobName":   jobs[i].JobName,
-			"ProcessingJobArn":    jobs[i].JobARN,
-			"ProcessingJobStatus": jobs[i].Status,
-			"CreationTime":        epoch(jobs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"ProcessingJobSummaries": out})
+	writeSummaries(w, "ProcessingJobSummaries", jobs, func(j *driver.ProcessingJob) map[string]any {
+		return map[string]any{
+			"ProcessingJobName":   j.JobName,
+			"ProcessingJobArn":    j.JobARN,
+			"ProcessingJobStatus": j.Status,
+			"CreationTime":        epoch(j.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) stopProcessingJob(w http.ResponseWriter, r *http.Request) {
@@ -162,6 +163,7 @@ func (h *Handler) stopProcessingJob(w http.ResponseWriter, r *http.Request) {
 
 // --- Transform ---
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createTransformJob(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TransformJobName string    `json:"TransformJobName"`
@@ -217,17 +219,14 @@ func (h *Handler) listTransformJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"TransformJobName":   jobs[i].JobName,
-			"TransformJobArn":    jobs[i].JobARN,
-			"TransformJobStatus": jobs[i].Status,
-			"CreationTime":       epoch(jobs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"TransformJobSummaries": out})
+	writeSummaries(w, "TransformJobSummaries", jobs, func(j *driver.TransformJob) map[string]any {
+		return map[string]any{
+			"TransformJobName":   j.JobName,
+			"TransformJobArn":    j.JobARN,
+			"TransformJobStatus": j.Status,
+			"CreationTime":       epoch(j.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) stopTransformJob(w http.ResponseWriter, r *http.Request) {
@@ -306,17 +305,14 @@ func (h *Handler) listTuningJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"HyperParameterTuningJobName":   jobs[i].JobName,
-			"HyperParameterTuningJobArn":    jobs[i].JobARN,
-			"HyperParameterTuningJobStatus": jobs[i].Status,
-			"CreationTime":                  epoch(jobs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"HyperParameterTuningJobSummaries": out})
+	writeSummaries(w, "HyperParameterTuningJobSummaries", jobs, func(j *driver.HyperParameterTuningJob) map[string]any {
+		return map[string]any{
+			"HyperParameterTuningJobName":   j.JobName,
+			"HyperParameterTuningJobArn":    j.JobARN,
+			"HyperParameterTuningJobStatus": j.Status,
+			"CreationTime":                  epoch(j.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) stopTuningJob(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +321,7 @@ func (h *Handler) stopTuningJob(w http.ResponseWriter, r *http.Request) {
 
 // --- AutoML V2 ---
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createAutoMLJob(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		AutoMLJobName    string `json:"AutoMLJobName"`
@@ -384,17 +381,14 @@ func (h *Handler) listAutoMLJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"AutoMLJobName":   jobs[i].JobName,
-			"AutoMLJobArn":    jobs[i].JobARN,
-			"AutoMLJobStatus": jobs[i].Status,
-			"CreationTime":    epoch(jobs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"AutoMLJobSummaries": out})
+	writeSummaries(w, "AutoMLJobSummaries", jobs, func(j *driver.AutoMLJob) map[string]any {
+		return map[string]any{
+			"AutoMLJobName":   j.JobName,
+			"AutoMLJobArn":    j.JobARN,
+			"AutoMLJobStatus": j.Status,
+			"CreationTime":    epoch(j.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) stopAutoMLJob(w http.ResponseWriter, r *http.Request) {
@@ -403,6 +397,7 @@ func (h *Handler) stopAutoMLJob(w http.ResponseWriter, r *http.Request) {
 
 // --- Labeling ---
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createLabelingJob(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		LabelingJobName    string    `json:"LabelingJobName"`
@@ -459,17 +454,14 @@ func (h *Handler) listLabelingJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"LabelingJobName":   jobs[i].JobName,
-			"LabelingJobArn":    jobs[i].JobARN,
-			"LabelingJobStatus": jobs[i].Status,
-			"CreationTime":      epoch(jobs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"LabelingJobSummaryList": out})
+	writeSummaries(w, "LabelingJobSummaryList", jobs, func(j *driver.LabelingJob) map[string]any {
+		return map[string]any{
+			"LabelingJobName":   j.JobName,
+			"LabelingJobArn":    j.JobARN,
+			"LabelingJobStatus": j.Status,
+			"CreationTime":      epoch(j.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) stopLabelingJob(w http.ResponseWriter, r *http.Request) {
@@ -478,6 +470,7 @@ func (h *Handler) stopLabelingJob(w http.ResponseWriter, r *http.Request) {
 
 // --- Compilation ---
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createCompilationJob(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		CompilationJobName string    `json:"CompilationJobName"`
@@ -532,17 +525,14 @@ func (h *Handler) listCompilationJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(jobs))
-	for i := range jobs {
-		out = append(out, map[string]any{
-			"CompilationJobName":   jobs[i].JobName,
-			"CompilationJobArn":    jobs[i].JobARN,
-			"CompilationJobStatus": jobs[i].Status,
-			"CreationTime":         epoch(jobs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"CompilationJobSummaries": out})
+	writeSummaries(w, "CompilationJobSummaries", jobs, func(j *driver.CompilationJob) map[string]any {
+		return map[string]any{
+			"CompilationJobName":   j.JobName,
+			"CompilationJobArn":    j.JobARN,
+			"CompilationJobStatus": j.Status,
+			"CreationTime":         epoch(j.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) stopCompilationJob(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/jobs_more.go
+++ b/server/aws/sagemaker/jobs_more.go
@@ -1,0 +1,550 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) routeMoreJobs(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateProcessingJob":
+		h.createProcessingJob(w, r)
+	case "DescribeProcessingJob":
+		h.describeProcessingJob(w, r)
+	case "ListProcessingJobs":
+		h.listProcessingJobs(w, r)
+	case "StopProcessingJob":
+		h.stopProcessingJob(w, r)
+	case "CreateTransformJob":
+		h.createTransformJob(w, r)
+	case "DescribeTransformJob":
+		h.describeTransformJob(w, r)
+	case "ListTransformJobs":
+		h.listTransformJobs(w, r)
+	case "StopTransformJob":
+		h.stopTransformJob(w, r)
+	default:
+		return h.routeTuningJobs(w, r, op)
+	}
+
+	return true
+}
+
+func (h *Handler) routeTuningJobs(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateHyperParameterTuningJob":
+		h.createTuningJob(w, r)
+	case "DescribeHyperParameterTuningJob":
+		h.describeTuningJob(w, r)
+	case "ListHyperParameterTuningJobs":
+		h.listTuningJobs(w, r)
+	case "StopHyperParameterTuningJob":
+		h.stopTuningJob(w, r)
+	case "CreateAutoMLJobV2":
+		h.createAutoMLJob(w, r)
+	case "DescribeAutoMLJobV2":
+		h.describeAutoMLJob(w, r)
+	case "ListAutoMLJobs":
+		h.listAutoMLJobs(w, r)
+	case "StopAutoMLJob":
+		h.stopAutoMLJob(w, r)
+	default:
+		return h.routeMoreJobs2(w, r, op)
+	}
+
+	return true
+}
+
+func (h *Handler) routeMoreJobs2(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateLabelingJob":
+		h.createLabelingJob(w, r)
+	case "DescribeLabelingJob":
+		h.describeLabelingJob(w, r)
+	case "ListLabelingJobs":
+		h.listLabelingJobs(w, r)
+	case "StopLabelingJob":
+		h.stopLabelingJob(w, r)
+	case "CreateCompilationJob":
+		h.createCompilationJob(w, r)
+	case "DescribeCompilationJob":
+		h.describeCompilationJob(w, r)
+	case "ListCompilationJobs":
+		h.listCompilationJobs(w, r)
+	case "StopCompilationJob":
+		h.stopCompilationJob(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+// --- Processing ---
+
+func (h *Handler) createProcessingJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ProcessingJobName string `json:"ProcessingJobName"`
+		RoleArn           string `json:"RoleArn"`
+		AppSpecification  struct {
+			ImageURI string `json:"ImageUri"`
+		} `json:"AppSpecification"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateProcessingJob(r.Context(), driver.ProcessingJobConfig{
+		JobName:  req.ProcessingJobName,
+		RoleARN:  req.RoleArn,
+		AppImage: req.AppSpecification.ImageURI,
+		Tags:     toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ProcessingJobArn": job.JobARN})
+}
+
+func (h *Handler) describeProcessingJob(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ProcessingJobName")
+	if !ok {
+		return
+	}
+
+	job, err := h.svc.DescribeProcessingJob(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ProcessingJobName":   job.JobName,
+		"ProcessingJobArn":    job.JobARN,
+		"ProcessingJobStatus": job.Status,
+		"RoleArn":             job.RoleARN,
+		"CreationTime":        epoch(job.CreationTime),
+	})
+}
+
+func (h *Handler) listProcessingJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListProcessingJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"ProcessingJobName":   jobs[i].JobName,
+			"ProcessingJobArn":    jobs[i].JobARN,
+			"ProcessingJobStatus": jobs[i].Status,
+			"CreationTime":        epoch(jobs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"ProcessingJobSummaries": out})
+}
+
+func (h *Handler) stopProcessingJob(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "ProcessingJobName", h.svc.StopProcessingJob)
+}
+
+// --- Transform ---
+
+func (h *Handler) createTransformJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TransformJobName string    `json:"TransformJobName"`
+		ModelName        string    `json:"ModelName"`
+		Tags             []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateTransformJob(r.Context(), driver.TransformJobConfig{
+		JobName:   req.TransformJobName,
+		ModelName: req.ModelName,
+		Tags:      toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TransformJobArn": job.JobARN})
+}
+
+func (h *Handler) describeTransformJob(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "TransformJobName")
+	if !ok {
+		return
+	}
+
+	job, err := h.svc.DescribeTransformJob(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TransformJobName":   job.JobName,
+		"TransformJobArn":    job.JobARN,
+		"TransformJobStatus": job.Status,
+		"ModelName":          job.ModelName,
+		"CreationTime":       epoch(job.CreationTime),
+	})
+}
+
+func (h *Handler) listTransformJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListTransformJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"TransformJobName":   jobs[i].JobName,
+			"TransformJobArn":    jobs[i].JobARN,
+			"TransformJobStatus": jobs[i].Status,
+			"CreationTime":       epoch(jobs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"TransformJobSummaries": out})
+}
+
+func (h *Handler) stopTransformJob(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "TransformJobName", h.svc.StopTransformJob)
+}
+
+// --- Hyperparameter tuning ---
+
+func (h *Handler) createTuningJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		HyperParameterTuningJobName   string `json:"HyperParameterTuningJobName"`
+		HyperParameterTuningJobConfig struct {
+			Strategy       string `json:"Strategy"`
+			ResourceLimits struct {
+				MaxNumberOfTrainingJobs int `json:"MaxNumberOfTrainingJobs"`
+				MaxParallelTrainingJobs int `json:"MaxParallelTrainingJobs"`
+			} `json:"ResourceLimits"`
+			HyperParameterTuningJobObjective struct {
+				Type       string `json:"Type"`
+				MetricName string `json:"MetricName"`
+			} `json:"HyperParameterTuningJobObjective"`
+		} `json:"HyperParameterTuningJobConfig"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	cfg := req.HyperParameterTuningJobConfig
+
+	job, err := h.svc.CreateHyperParameterTuningJob(r.Context(), driver.HyperParameterTuningJobConfig{
+		JobName:         req.HyperParameterTuningJobName,
+		Strategy:        cfg.Strategy,
+		MaxJobs:         cfg.ResourceLimits.MaxNumberOfTrainingJobs,
+		MaxParallelJobs: cfg.ResourceLimits.MaxParallelTrainingJobs,
+		ObjectiveMetric: cfg.HyperParameterTuningJobObjective.MetricName,
+		ObjectiveType:   cfg.HyperParameterTuningJobObjective.Type,
+		Tags:            toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"HyperParameterTuningJobArn": job.JobARN})
+}
+
+func (h *Handler) describeTuningJob(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "HyperParameterTuningJobName")
+	if !ok {
+		return
+	}
+
+	job, err := h.svc.DescribeHyperParameterTuningJob(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"HyperParameterTuningJobName":   job.JobName,
+		"HyperParameterTuningJobArn":    job.JobARN,
+		"HyperParameterTuningJobStatus": job.Status,
+		"CreationTime":                  epoch(job.CreationTime),
+	})
+}
+
+func (h *Handler) listTuningJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListHyperParameterTuningJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"HyperParameterTuningJobName":   jobs[i].JobName,
+			"HyperParameterTuningJobArn":    jobs[i].JobARN,
+			"HyperParameterTuningJobStatus": jobs[i].Status,
+			"CreationTime":                  epoch(jobs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"HyperParameterTuningJobSummaries": out})
+}
+
+func (h *Handler) stopTuningJob(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "HyperParameterTuningJobName", h.svc.StopHyperParameterTuningJob)
+}
+
+// --- AutoML V2 ---
+
+func (h *Handler) createAutoMLJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		AutoMLJobName    string `json:"AutoMLJobName"`
+		RoleArn          string `json:"RoleArn"`
+		OutputDataConfig struct {
+			S3OutputPath string `json:"S3OutputPath"`
+		} `json:"OutputDataConfig"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateAutoMLJobV2(r.Context(), driver.AutoMLJobConfig{
+		JobName:     req.AutoMLJobName,
+		RoleARN:     req.RoleArn,
+		OutputS3URI: req.OutputDataConfig.S3OutputPath,
+		Tags:        toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"AutoMLJobArn": job.JobARN})
+}
+
+func (h *Handler) describeAutoMLJob(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "AutoMLJobName")
+	if !ok {
+		return
+	}
+
+	job, err := h.svc.DescribeAutoMLJobV2(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"AutoMLJobName":            job.JobName,
+		"AutoMLJobArn":             job.JobARN,
+		"AutoMLJobStatus":          job.Status,
+		"AutoMLJobSecondaryStatus": job.SecondaryStatus,
+		"CreationTime":             epoch(job.CreationTime),
+	})
+}
+
+func (h *Handler) listAutoMLJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListAutoMLJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"AutoMLJobName":   jobs[i].JobName,
+			"AutoMLJobArn":    jobs[i].JobARN,
+			"AutoMLJobStatus": jobs[i].Status,
+			"CreationTime":    epoch(jobs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"AutoMLJobSummaries": out})
+}
+
+func (h *Handler) stopAutoMLJob(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "AutoMLJobName", h.svc.StopAutoMLJob)
+}
+
+// --- Labeling ---
+
+func (h *Handler) createLabelingJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		LabelingJobName    string    `json:"LabelingJobName"`
+		RoleArn            string    `json:"RoleArn"`
+		LabelAttributeName string    `json:"LabelAttributeName"`
+		Tags               []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateLabelingJob(r.Context(), driver.LabelingJobConfig{
+		JobName:        req.LabelingJobName,
+		RoleARN:        req.RoleArn,
+		LabelAttribute: req.LabelAttributeName,
+		Tags:           toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"LabelingJobArn": job.JobARN})
+}
+
+func (h *Handler) describeLabelingJob(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "LabelingJobName")
+	if !ok {
+		return
+	}
+
+	job, err := h.svc.DescribeLabelingJob(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"LabelingJobName":   job.JobName,
+		"LabelingJobArn":    job.JobARN,
+		"LabelingJobStatus": job.Status,
+		"CreationTime":      epoch(job.CreationTime),
+	})
+}
+
+func (h *Handler) listLabelingJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListLabelingJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"LabelingJobName":   jobs[i].JobName,
+			"LabelingJobArn":    jobs[i].JobARN,
+			"LabelingJobStatus": jobs[i].Status,
+			"CreationTime":      epoch(jobs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"LabelingJobSummaryList": out})
+}
+
+func (h *Handler) stopLabelingJob(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "LabelingJobName", h.svc.StopLabelingJob)
+}
+
+// --- Compilation ---
+
+func (h *Handler) createCompilationJob(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		CompilationJobName string    `json:"CompilationJobName"`
+		RoleArn            string    `json:"RoleArn"`
+		Tags               []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateCompilationJob(r.Context(), driver.CompilationJobConfig{
+		JobName: req.CompilationJobName,
+		RoleARN: req.RoleArn,
+		Tags:    toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"CompilationJobArn": job.JobARN})
+}
+
+func (h *Handler) describeCompilationJob(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "CompilationJobName")
+	if !ok {
+		return
+	}
+
+	job, err := h.svc.DescribeCompilationJob(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"CompilationJobName":   job.JobName,
+		"CompilationJobArn":    job.JobARN,
+		"CompilationJobStatus": job.Status,
+		"CreationTime":         epoch(job.CreationTime),
+	})
+}
+
+func (h *Handler) listCompilationJobs(w http.ResponseWriter, r *http.Request) {
+	jobs, err := h.svc.ListCompilationJobs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, map[string]any{
+			"CompilationJobName":   jobs[i].JobName,
+			"CompilationJobArn":    jobs[i].JobARN,
+			"CompilationJobStatus": jobs[i].Status,
+			"CreationTime":         epoch(jobs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"CompilationJobSummaries": out})
+}
+
+func (h *Handler) stopCompilationJob(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "CompilationJobName", h.svc.StopCompilationJob)
+}

--- a/server/aws/sagemaker/notebook.go
+++ b/server/aws/sagemaker/notebook.go
@@ -86,6 +86,7 @@ func (h *Handler) createNotebookInstance(w http.ResponseWriter, r *http.Request)
 	wire.WriteJSON(w, map[string]any{"NotebookInstanceArn": nb.ARN})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) describeNotebookInstance(w http.ResponseWriter, r *http.Request) {
 	name, ok := decodeName1(w, r, "NotebookInstanceName")
 	if !ok {
@@ -118,18 +119,15 @@ func (h *Handler) listNotebookInstances(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	out := make([]map[string]any, 0, len(nbs))
-	for i := range nbs {
-		out = append(out, map[string]any{
-			"NotebookInstanceName":   nbs[i].Name,
-			"NotebookInstanceArn":    nbs[i].ARN,
-			"NotebookInstanceStatus": nbs[i].Status,
-			"InstanceType":           nbs[i].InstanceType,
-			"CreationTime":           epoch(nbs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"NotebookInstances": out})
+	writeSummaries(w, "NotebookInstances", nbs, func(nb *driver.NotebookInstance) map[string]any {
+		return map[string]any{
+			"NotebookInstanceName":   nb.Name,
+			"NotebookInstanceArn":    nb.ARN,
+			"NotebookInstanceStatus": nb.Status,
+			"InstanceType":           nb.InstanceType,
+			"CreationTime":           epoch(nb.CreationTime),
+		}
+	})
 }
 
 // wireLCStep is one OnCreate/OnStart shell step.
@@ -145,6 +143,7 @@ func firstStepContent(steps []wireLCStep) string {
 	return ""
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createNotebookLC(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		NotebookInstanceLifecycleConfigName string       `json:"NotebookInstanceLifecycleConfigName"`
@@ -200,16 +199,13 @@ func (h *Handler) listNotebookLCs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(lcs))
-	for i := range lcs {
-		out = append(out, map[string]any{
-			"NotebookInstanceLifecycleConfigName": lcs[i].Name,
-			"NotebookInstanceLifecycleConfigArn":  lcs[i].ARN,
-			"CreationTime":                        epoch(lcs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"NotebookInstanceLifecycleConfigs": out})
+	writeSummaries(w, "NotebookInstanceLifecycleConfigs", lcs, func(lc *driver.NotebookLifecycleConfig) map[string]any {
+		return map[string]any{
+			"NotebookInstanceLifecycleConfigName": lc.Name,
+			"NotebookInstanceLifecycleConfigArn":  lc.ARN,
+			"CreationTime":                        epoch(lc.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) createCodeRepository(w http.ResponseWriter, r *http.Request) {
@@ -274,14 +270,11 @@ func (h *Handler) listCodeRepositories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(repos))
-	for i := range repos {
-		out = append(out, map[string]any{
-			"CodeRepositoryName": repos[i].Name,
-			"CodeRepositoryArn":  repos[i].ARN,
-			"CreationTime":       epoch(repos[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"CodeRepositorySummaryList": out})
+	writeSummaries(w, "CodeRepositorySummaryList", repos, func(repo *driver.CodeRepository) map[string]any {
+		return map[string]any{
+			"CodeRepositoryName": repo.Name,
+			"CodeRepositoryArn":  repo.ARN,
+			"CreationTime":       epoch(repo.CreationTime),
+		}
+	})
 }

--- a/server/aws/sagemaker/notebook.go
+++ b/server/aws/sagemaker/notebook.go
@@ -1,0 +1,287 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) routeNotebook(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateNotebookInstance":
+		h.createNotebookInstance(w, r)
+	case "DescribeNotebookInstance":
+		h.describeNotebookInstance(w, r)
+	case "ListNotebookInstances":
+		h.listNotebookInstances(w, r)
+	case "StartNotebookInstance":
+		stopByName(w, r, "NotebookInstanceName", h.svc.StartNotebookInstance)
+	case "StopNotebookInstance":
+		stopByName(w, r, "NotebookInstanceName", h.svc.StopNotebookInstance)
+	case "DeleteNotebookInstance":
+		stopByName(w, r, "NotebookInstanceName", h.svc.DeleteNotebookInstance)
+	default:
+		return h.routeNotebookSupport(w, r, op)
+	}
+
+	return true
+}
+
+func (h *Handler) routeNotebookSupport(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateNotebookInstanceLifecycleConfig":
+		h.createNotebookLC(w, r)
+	case "DescribeNotebookInstanceLifecycleConfig":
+		h.describeNotebookLC(w, r)
+	case "ListNotebookInstanceLifecycleConfigs":
+		h.listNotebookLCs(w, r)
+	case "DeleteNotebookInstanceLifecycleConfig":
+		stopByName(w, r, "NotebookInstanceLifecycleConfigName", h.svc.DeleteNotebookInstanceLifecycleConfig)
+	case "CreateCodeRepository":
+		h.createCodeRepository(w, r)
+	case "DescribeCodeRepository":
+		h.describeCodeRepository(w, r)
+	case "ListCodeRepositories":
+		h.listCodeRepositories(w, r)
+	case "DeleteCodeRepository":
+		stopByName(w, r, "CodeRepositoryName", h.svc.DeleteCodeRepository)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createNotebookInstance(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		NotebookInstanceName  string    `json:"NotebookInstanceName"`
+		InstanceType          string    `json:"InstanceType"`
+		RoleArn               string    `json:"RoleArn"`
+		VolumeSizeInGB        int       `json:"VolumeSizeInGB"`
+		LifecycleConfigName   string    `json:"LifecycleConfigName"`
+		DefaultCodeRepository string    `json:"DefaultCodeRepository"`
+		Tags                  []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	nb, err := h.svc.CreateNotebookInstance(r.Context(), driver.NotebookInstanceSpec{
+		Name:            req.NotebookInstanceName,
+		InstanceType:    req.InstanceType,
+		RoleARN:         req.RoleArn,
+		VolumeSizeInGB:  req.VolumeSizeInGB,
+		LifecycleConfig: req.LifecycleConfigName,
+		DefaultCodeRepo: req.DefaultCodeRepository,
+		Tags:            toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"NotebookInstanceArn": nb.ARN})
+}
+
+func (h *Handler) describeNotebookInstance(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "NotebookInstanceName")
+	if !ok {
+		return
+	}
+
+	nb, err := h.svc.DescribeNotebookInstance(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"NotebookInstanceName":   nb.Name,
+		"NotebookInstanceArn":    nb.ARN,
+		"NotebookInstanceStatus": nb.Status,
+		"InstanceType":           nb.InstanceType,
+		"RoleArn":                nb.RoleARN,
+		"Url":                    nb.URL,
+		"CreationTime":           epoch(nb.CreationTime),
+	})
+}
+
+func (h *Handler) listNotebookInstances(w http.ResponseWriter, r *http.Request) {
+	nbs, err := h.svc.ListNotebookInstances(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(nbs))
+	for i := range nbs {
+		out = append(out, map[string]any{
+			"NotebookInstanceName":   nbs[i].Name,
+			"NotebookInstanceArn":    nbs[i].ARN,
+			"NotebookInstanceStatus": nbs[i].Status,
+			"InstanceType":           nbs[i].InstanceType,
+			"CreationTime":           epoch(nbs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"NotebookInstances": out})
+}
+
+// wireLCStep is one OnCreate/OnStart shell step.
+type wireLCStep struct {
+	Content string `json:"Content"`
+}
+
+func firstStepContent(steps []wireLCStep) string {
+	if len(steps) > 0 {
+		return steps[0].Content
+	}
+
+	return ""
+}
+
+func (h *Handler) createNotebookLC(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		NotebookInstanceLifecycleConfigName string       `json:"NotebookInstanceLifecycleConfigName"`
+		OnCreate                            []wireLCStep `json:"OnCreate"`
+		OnStart                             []wireLCStep `json:"OnStart"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	lc, err := h.svc.CreateNotebookInstanceLifecycleConfig(r.Context(), driver.NotebookLifecycleConfigSpec{
+		Name:     req.NotebookInstanceLifecycleConfigName,
+		OnCreate: firstStepContent(req.OnCreate),
+		OnStart:  firstStepContent(req.OnStart),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"NotebookInstanceLifecycleConfigArn": lc.ARN})
+}
+
+func (h *Handler) describeNotebookLC(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "NotebookInstanceLifecycleConfigName")
+	if !ok {
+		return
+	}
+
+	lc, err := h.svc.DescribeNotebookInstanceLifecycleConfig(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"NotebookInstanceLifecycleConfigName": lc.Name,
+		"NotebookInstanceLifecycleConfigArn":  lc.ARN,
+		"OnCreate":                            []wireLCStep{{Content: lc.OnCreate}},
+		"OnStart":                             []wireLCStep{{Content: lc.OnStart}},
+		"CreationTime":                        epoch(lc.CreationTime),
+	})
+}
+
+func (h *Handler) listNotebookLCs(w http.ResponseWriter, r *http.Request) {
+	lcs, err := h.svc.ListNotebookInstanceLifecycleConfigs(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(lcs))
+	for i := range lcs {
+		out = append(out, map[string]any{
+			"NotebookInstanceLifecycleConfigName": lcs[i].Name,
+			"NotebookInstanceLifecycleConfigArn":  lcs[i].ARN,
+			"CreationTime":                        epoch(lcs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"NotebookInstanceLifecycleConfigs": out})
+}
+
+func (h *Handler) createCodeRepository(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		CodeRepositoryName string `json:"CodeRepositoryName"`
+		GitConfig          struct {
+			RepositoryURL string `json:"RepositoryUrl"`
+			Branch        string `json:"Branch"`
+			SecretArn     string `json:"SecretArn"`
+		} `json:"GitConfig"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	repo, err := h.svc.CreateCodeRepository(r.Context(), driver.CodeRepositorySpec{
+		Name:      req.CodeRepositoryName,
+		GitURL:    req.GitConfig.RepositoryURL,
+		Branch:    req.GitConfig.Branch,
+		SecretARN: req.GitConfig.SecretArn,
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"CodeRepositoryArn": repo.ARN})
+}
+
+func (h *Handler) describeCodeRepository(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "CodeRepositoryName")
+	if !ok {
+		return
+	}
+
+	repo, err := h.svc.DescribeCodeRepository(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"CodeRepositoryName": repo.Name,
+		"CodeRepositoryArn":  repo.ARN,
+		"GitConfig": map[string]any{
+			"RepositoryUrl": repo.GitURL,
+			"Branch":        repo.Branch,
+			"SecretArn":     repo.SecretARN,
+		},
+		"CreationTime": epoch(repo.CreationTime),
+	})
+}
+
+func (h *Handler) listCodeRepositories(w http.ResponseWriter, r *http.Request) {
+	repos, err := h.svc.ListCodeRepositories(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(repos))
+	for i := range repos {
+		out = append(out, map[string]any{
+			"CodeRepositoryName": repos[i].Name,
+			"CodeRepositoryArn":  repos[i].ARN,
+			"CreationTime":       epoch(repos[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"CodeRepositorySummaryList": out})
+}

--- a/server/aws/sagemaker/pipeline.go
+++ b/server/aws/sagemaker/pipeline.go
@@ -1,0 +1,408 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) routePipelines(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreatePipeline":
+		h.createPipeline(w, r)
+	case "DescribePipeline":
+		h.describePipeline(w, r)
+	case "ListPipelines":
+		h.listPipelines(w, r)
+	case "UpdatePipeline":
+		h.updatePipeline(w, r)
+	case "DeletePipeline":
+		h.deletePipeline(w, r)
+	case "StartPipelineExecution":
+		h.startPipelineExecution(w, r)
+	case "DescribePipelineExecution":
+		h.describePipelineExecution(w, r)
+	case "ListPipelineExecutions":
+		h.listPipelineExecutions(w, r)
+	case "StopPipelineExecution":
+		h.stopPipelineExecution(w, r)
+	default:
+		return h.routePipelinesMeta(w, r, op)
+	}
+
+	return true
+}
+
+func (h *Handler) routePipelinesMeta(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateExperiment":
+		h.createExperiment(w, r)
+	case "DescribeExperiment":
+		h.describeExperiment(w, r)
+	case "ListExperiments":
+		h.listExperiments(w, r)
+	case "DeleteExperiment":
+		h.deleteExperiment(w, r)
+	case "CreateTrial":
+		h.createTrial(w, r)
+	case "DescribeTrial":
+		h.describeTrial(w, r)
+	case "ListTrials":
+		h.listTrials(w, r)
+	case "DeleteTrial":
+		h.deleteTrial(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createPipeline(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		PipelineName       string    `json:"PipelineName"`
+		RoleArn            string    `json:"RoleArn"`
+		PipelineDefinition string    `json:"PipelineDefinition"`
+		Tags               []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	p, err := h.svc.CreatePipeline(r.Context(), driver.PipelineSpec{
+		PipelineName: req.PipelineName,
+		RoleARN:      req.RoleArn,
+		Definition:   req.PipelineDefinition,
+		Tags:         toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineArn": p.PipelineARN})
+}
+
+func (h *Handler) describePipeline(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "PipelineName")
+	if !ok {
+		return
+	}
+
+	p, err := h.svc.DescribePipeline(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"PipelineName":     p.PipelineName,
+		"PipelineArn":      p.PipelineARN,
+		"PipelineStatus":   p.Status,
+		"RoleArn":          p.RoleARN,
+		"CreationTime":     epoch(p.CreationTime),
+		"LastModifiedTime": epoch(p.LastModifiedTime),
+	})
+}
+
+func (h *Handler) listPipelines(w http.ResponseWriter, r *http.Request) {
+	pipelines, err := h.svc.ListPipelines(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(pipelines))
+	for i := range pipelines {
+		out = append(out, map[string]any{
+			"PipelineName": pipelines[i].PipelineName,
+			"PipelineArn":  pipelines[i].PipelineARN,
+			"CreationTime": epoch(pipelines[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineSummaries": out})
+}
+
+func (h *Handler) updatePipeline(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		PipelineName       string `json:"PipelineName"`
+		PipelineDefinition string `json:"PipelineDefinition"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	p, err := h.svc.UpdatePipeline(r.Context(), req.PipelineName, req.PipelineDefinition)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineArn": p.PipelineARN})
+}
+
+func (h *Handler) deletePipeline(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "PipelineName")
+	if !ok {
+		return
+	}
+
+	if err := h.svc.DeletePipeline(r.Context(), name); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineArn": ""})
+}
+
+func (h *Handler) startPipelineExecution(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "PipelineName")
+	if !ok {
+		return
+	}
+
+	ex, err := h.svc.StartPipelineExecution(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineExecutionArn": ex.ExecutionARN})
+}
+
+func (h *Handler) describePipelineExecution(w http.ResponseWriter, r *http.Request) {
+	arn, ok := decodeName1(w, r, "PipelineExecutionArn")
+	if !ok {
+		return
+	}
+
+	ex, err := h.svc.DescribePipelineExecution(r.Context(), arn)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"PipelineExecutionArn":    ex.ExecutionARN,
+		"PipelineExecutionStatus": ex.Status,
+		"CreationTime":            epoch(ex.StartTime),
+	})
+}
+
+func (h *Handler) listPipelineExecutions(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "PipelineName")
+	if !ok {
+		return
+	}
+
+	exs, err := h.svc.ListPipelineExecutions(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(exs))
+	for i := range exs {
+		out = append(out, map[string]any{
+			"PipelineExecutionArn":    exs[i].ExecutionARN,
+			"PipelineExecutionStatus": exs[i].Status,
+			"StartTime":               epoch(exs[i].StartTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineExecutionSummaries": out})
+}
+
+func (h *Handler) stopPipelineExecution(w http.ResponseWriter, r *http.Request) {
+	arn, ok := decodeName1(w, r, "PipelineExecutionArn")
+	if !ok {
+		return
+	}
+
+	if err := h.svc.StopPipelineExecution(r.Context(), arn); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"PipelineExecutionArn": arn})
+}
+
+func (h *Handler) createExperiment(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ExperimentName string    `json:"ExperimentName"`
+		Description    string    `json:"Description"`
+		Tags           []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	e, err := h.svc.CreateExperiment(r.Context(), driver.ExperimentSpec{
+		ExperimentName: req.ExperimentName,
+		Description:    req.Description,
+		Tags:           toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ExperimentArn": e.ExperimentARN})
+}
+
+func (h *Handler) describeExperiment(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ExperimentName")
+	if !ok {
+		return
+	}
+
+	e, err := h.svc.DescribeExperiment(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ExperimentName": e.ExperimentName,
+		"ExperimentArn":  e.ExperimentARN,
+		"Description":    e.Description,
+		"CreationTime":   epoch(e.CreationTime),
+	})
+}
+
+func (h *Handler) listExperiments(w http.ResponseWriter, r *http.Request) {
+	exps, err := h.svc.ListExperiments(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(exps))
+	for i := range exps {
+		out = append(out, map[string]any{
+			"ExperimentName": exps[i].ExperimentName,
+			"ExperimentArn":  exps[i].ExperimentARN,
+			"CreationTime":   epoch(exps[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"ExperimentSummaries": out})
+}
+
+func (h *Handler) deleteExperiment(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ExperimentName")
+	if !ok {
+		return
+	}
+
+	if err := h.svc.DeleteExperiment(r.Context(), name); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ExperimentArn": ""})
+}
+
+func (h *Handler) createTrial(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TrialName      string    `json:"TrialName"`
+		ExperimentName string    `json:"ExperimentName"`
+		Tags           []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	t, err := h.svc.CreateTrial(r.Context(), driver.TrialSpec{
+		TrialName:      req.TrialName,
+		ExperimentName: req.ExperimentName,
+		Tags:           toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TrialArn": t.TrialARN})
+}
+
+func (h *Handler) describeTrial(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "TrialName")
+	if !ok {
+		return
+	}
+
+	t, err := h.svc.DescribeTrial(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"TrialName":      t.TrialName,
+		"TrialArn":       t.TrialARN,
+		"ExperimentName": t.ExperimentName,
+		"CreationTime":   epoch(t.CreationTime),
+	})
+}
+
+func (h *Handler) listTrials(w http.ResponseWriter, r *http.Request) {
+	expName, ok := decodeName1(w, r, "ExperimentName")
+	if !ok {
+		return
+	}
+
+	trials, err := h.svc.ListTrials(r.Context(), expName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(trials))
+	for i := range trials {
+		out = append(out, map[string]any{
+			"TrialName":    trials[i].TrialName,
+			"TrialArn":     trials[i].TrialARN,
+			"CreationTime": epoch(trials[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"TrialSummaries": out})
+}
+
+func (h *Handler) deleteTrial(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "TrialName")
+	if !ok {
+		return
+	}
+
+	if err := h.svc.DeleteTrial(r.Context(), name); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TrialArn": ""})
+}

--- a/server/aws/sagemaker/pipeline.go
+++ b/server/aws/sagemaker/pipeline.go
@@ -34,6 +34,7 @@ func (h *Handler) routePipelines(w http.ResponseWriter, r *http.Request, op stri
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) routePipelinesMeta(w http.ResponseWriter, r *http.Request, op string) bool {
 	switch op {
 	case "CreateExperiment":
@@ -59,6 +60,7 @@ func (h *Handler) routePipelinesMeta(w http.ResponseWriter, r *http.Request, op 
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createPipeline(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		PipelineName       string    `json:"PipelineName"`
@@ -117,16 +119,13 @@ func (h *Handler) listPipelines(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(pipelines))
-	for i := range pipelines {
-		out = append(out, map[string]any{
-			"PipelineName": pipelines[i].PipelineName,
-			"PipelineArn":  pipelines[i].PipelineARN,
-			"CreationTime": epoch(pipelines[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"PipelineSummaries": out})
+	writeSummaries(w, "PipelineSummaries", pipelines, func(p *driver.Pipeline) map[string]any {
+		return map[string]any{
+			"PipelineName": p.PipelineName,
+			"PipelineArn":  p.PipelineARN,
+			"CreationTime": epoch(p.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) updatePipeline(w http.ResponseWriter, r *http.Request) {
@@ -200,6 +199,7 @@ func (h *Handler) describePipelineExecution(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) listPipelineExecutions(w http.ResponseWriter, r *http.Request) {
 	name, ok := decodeName1(w, r, "PipelineName")
 	if !ok {
@@ -213,16 +213,13 @@ func (h *Handler) listPipelineExecutions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	out := make([]map[string]any, 0, len(exs))
-	for i := range exs {
-		out = append(out, map[string]any{
-			"PipelineExecutionArn":    exs[i].ExecutionARN,
-			"PipelineExecutionStatus": exs[i].Status,
-			"StartTime":               epoch(exs[i].StartTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"PipelineExecutionSummaries": out})
+	writeSummaries(w, "PipelineExecutionSummaries", exs, func(e *driver.PipelineExecution) map[string]any {
+		return map[string]any{
+			"PipelineExecutionArn":    e.ExecutionARN,
+			"PipelineExecutionStatus": e.Status,
+			"StartTime":               epoch(e.StartTime),
+		}
+	})
 }
 
 func (h *Handler) stopPipelineExecution(w http.ResponseWriter, r *http.Request) {
@@ -240,6 +237,7 @@ func (h *Handler) stopPipelineExecution(w http.ResponseWriter, r *http.Request) 
 	wire.WriteJSON(w, map[string]any{"PipelineExecutionArn": arn})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createExperiment(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ExperimentName string    `json:"ExperimentName"`
@@ -294,16 +292,13 @@ func (h *Handler) listExperiments(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(exps))
-	for i := range exps {
-		out = append(out, map[string]any{
-			"ExperimentName": exps[i].ExperimentName,
-			"ExperimentArn":  exps[i].ExperimentARN,
-			"CreationTime":   epoch(exps[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"ExperimentSummaries": out})
+	writeSummaries(w, "ExperimentSummaries", exps, func(e *driver.Experiment) map[string]any {
+		return map[string]any{
+			"ExperimentName": e.ExperimentName,
+			"ExperimentArn":  e.ExperimentARN,
+			"CreationTime":   epoch(e.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteExperiment(w http.ResponseWriter, r *http.Request) {
@@ -321,6 +316,7 @@ func (h *Handler) deleteExperiment(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"ExperimentArn": ""})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createTrial(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TrialName      string    `json:"TrialName"`
@@ -367,6 +363,7 @@ func (h *Handler) describeTrial(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) listTrials(w http.ResponseWriter, r *http.Request) {
 	expName, ok := decodeName1(w, r, "ExperimentName")
 	if !ok {
@@ -380,16 +377,13 @@ func (h *Handler) listTrials(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(trials))
-	for i := range trials {
-		out = append(out, map[string]any{
-			"TrialName":    trials[i].TrialName,
-			"TrialArn":     trials[i].TrialARN,
-			"CreationTime": epoch(trials[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"TrialSummaries": out})
+	writeSummaries(w, "TrialSummaries", trials, func(t *driver.Trial) map[string]any {
+		return map[string]any{
+			"TrialName":    t.TrialName,
+			"TrialArn":     t.TrialARN,
+			"CreationTime": epoch(t.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteTrial(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/registry.go
+++ b/server/aws/sagemaker/registry.go
@@ -1,0 +1,217 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) routeRegistry(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateModelPackageGroup":
+		h.createModelPackageGroup(w, r)
+	case "DescribeModelPackageGroup":
+		h.describeModelPackageGroup(w, r)
+	case "ListModelPackageGroups":
+		h.listModelPackageGroups(w, r)
+	case "DeleteModelPackageGroup":
+		h.deleteModelPackageGroup(w, r)
+	case "CreateModelPackage":
+		h.createModelPackage(w, r)
+	case "DescribeModelPackage":
+		h.describeModelPackage(w, r)
+	case "ListModelPackages":
+		h.listModelPackages(w, r)
+	case "UpdateModelPackage":
+		h.updateModelPackage(w, r)
+	case "DeleteModelPackage":
+		h.deleteModelPackage(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createModelPackageGroup(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ModelPackageGroupName        string    `json:"ModelPackageGroupName"`
+		ModelPackageGroupDescription string    `json:"ModelPackageGroupDescription"`
+		Tags                         []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	g, err := h.svc.CreateModelPackageGroup(r.Context(), driver.ModelPackageGroupSpec{
+		GroupName:   req.ModelPackageGroupName,
+		Description: req.ModelPackageGroupDescription,
+		Tags:        toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ModelPackageGroupArn": g.GroupARN})
+}
+
+func (h *Handler) describeModelPackageGroup(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ModelPackageGroupName")
+	if !ok {
+		return
+	}
+
+	g, err := h.svc.DescribeModelPackageGroup(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ModelPackageGroupName":   g.GroupName,
+		"ModelPackageGroupArn":    g.GroupARN,
+		"ModelPackageGroupStatus": g.Status,
+		"CreationTime":            epoch(g.CreationTime),
+	})
+}
+
+func (h *Handler) listModelPackageGroups(w http.ResponseWriter, r *http.Request) {
+	groups, err := h.svc.ListModelPackageGroups(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(groups))
+	for i := range groups {
+		out = append(out, map[string]any{
+			"ModelPackageGroupName":   groups[i].GroupName,
+			"ModelPackageGroupArn":    groups[i].GroupARN,
+			"ModelPackageGroupStatus": groups[i].Status,
+			"CreationTime":            epoch(groups[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"ModelPackageGroupSummaryList": out})
+}
+
+func (h *Handler) deleteModelPackageGroup(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "ModelPackageGroupName", h.svc.DeleteModelPackageGroup)
+}
+
+func (h *Handler) createModelPackage(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ModelPackageGroupName   string `json:"ModelPackageGroupName"`
+		ModelPackageDescription string `json:"ModelPackageDescription"`
+		ModelApprovalStatus     string `json:"ModelApprovalStatus"`
+		InferenceSpecification  struct {
+			Containers []wireContainer `json:"Containers"`
+		} `json:"InferenceSpecification"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	spec := driver.ModelPackageSpec{
+		GroupName:      req.ModelPackageGroupName,
+		Description:    req.ModelPackageDescription,
+		ApprovalStatus: req.ModelApprovalStatus,
+		Tags:           toTags(req.Tags),
+	}
+	if len(req.InferenceSpecification.Containers) > 0 {
+		spec.InferenceImage = req.InferenceSpecification.Containers[0].Image
+		spec.ModelDataURL = req.InferenceSpecification.Containers[0].ModelDataURL
+	}
+
+	p, err := h.svc.CreateModelPackage(r.Context(), spec)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ModelPackageArn": p.PackageARN})
+}
+
+func (h *Handler) describeModelPackage(w http.ResponseWriter, r *http.Request) {
+	name, ok := decodeName1(w, r, "ModelPackageName")
+	if !ok {
+		return
+	}
+
+	p, err := h.svc.DescribeModelPackage(r.Context(), name)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ModelPackageArn":       p.PackageARN,
+		"ModelPackageGroupName": p.GroupName,
+		"ModelPackageVersion":   p.Version,
+		"ModelPackageStatus":    p.Status,
+		"ModelApprovalStatus":   p.ApprovalStatus,
+		"CreationTime":          epoch(p.CreationTime),
+	})
+}
+
+func (h *Handler) listModelPackages(w http.ResponseWriter, r *http.Request) {
+	groupName, ok := decodeName1(w, r, "ModelPackageGroupName")
+	if !ok {
+		return
+	}
+
+	pkgs, err := h.svc.ListModelPackages(r.Context(), groupName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(pkgs))
+	for i := range pkgs {
+		out = append(out, map[string]any{
+			"ModelPackageArn":       pkgs[i].PackageARN,
+			"ModelPackageGroupName": pkgs[i].GroupName,
+			"ModelPackageVersion":   pkgs[i].Version,
+			"ModelPackageStatus":    pkgs[i].Status,
+			"ModelApprovalStatus":   pkgs[i].ApprovalStatus,
+			"CreationTime":          epoch(pkgs[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"ModelPackageSummaryList": out})
+}
+
+func (h *Handler) updateModelPackage(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ModelPackageArn     string `json:"ModelPackageArn"`
+		ModelApprovalStatus string `json:"ModelApprovalStatus"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	p, err := h.svc.UpdateModelPackage(r.Context(), req.ModelPackageArn, req.ModelApprovalStatus)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ModelPackageArn": p.PackageARN})
+}
+
+func (h *Handler) deleteModelPackage(w http.ResponseWriter, r *http.Request) {
+	stopByName(w, r, "ModelPackageName", h.svc.DeleteModelPackage)
+}

--- a/server/aws/sagemaker/registry.go
+++ b/server/aws/sagemaker/registry.go
@@ -34,6 +34,7 @@ func (h *Handler) routeRegistry(w http.ResponseWriter, r *http.Request, op strin
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createModelPackageGroup(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ModelPackageGroupName        string    `json:"ModelPackageGroupName"`
@@ -88,17 +89,14 @@ func (h *Handler) listModelPackageGroups(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	out := make([]map[string]any, 0, len(groups))
-	for i := range groups {
-		out = append(out, map[string]any{
-			"ModelPackageGroupName":   groups[i].GroupName,
-			"ModelPackageGroupArn":    groups[i].GroupARN,
-			"ModelPackageGroupStatus": groups[i].Status,
-			"CreationTime":            epoch(groups[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"ModelPackageGroupSummaryList": out})
+	writeSummaries(w, "ModelPackageGroupSummaryList", groups, func(g *driver.ModelPackageGroup) map[string]any {
+		return map[string]any{
+			"ModelPackageGroupName":   g.GroupName,
+			"ModelPackageGroupArn":    g.GroupARN,
+			"ModelPackageGroupStatus": g.Status,
+			"CreationTime":            epoch(g.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteModelPackageGroup(w http.ResponseWriter, r *http.Request) {
@@ -141,6 +139,7 @@ func (h *Handler) createModelPackage(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"ModelPackageArn": p.PackageARN})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) describeModelPackage(w http.ResponseWriter, r *http.Request) {
 	name, ok := decodeName1(w, r, "ModelPackageName")
 	if !ok {
@@ -177,19 +176,16 @@ func (h *Handler) listModelPackages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(pkgs))
-	for i := range pkgs {
-		out = append(out, map[string]any{
-			"ModelPackageArn":       pkgs[i].PackageARN,
-			"ModelPackageGroupName": pkgs[i].GroupName,
-			"ModelPackageVersion":   pkgs[i].Version,
-			"ModelPackageStatus":    pkgs[i].Status,
-			"ModelApprovalStatus":   pkgs[i].ApprovalStatus,
-			"CreationTime":          epoch(pkgs[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"ModelPackageSummaryList": out})
+	writeSummaries(w, "ModelPackageSummaryList", pkgs, func(p *driver.ModelPackage) map[string]any {
+		return map[string]any{
+			"ModelPackageArn":       p.PackageARN,
+			"ModelPackageGroupName": p.GroupName,
+			"ModelPackageVersion":   p.Version,
+			"ModelPackageStatus":    p.Status,
+			"ModelApprovalStatus":   p.ApprovalStatus,
+			"CreationTime":          epoch(p.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) updateModelPackage(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/runtime.go
+++ b/server/aws/sagemaker/runtime.go
@@ -1,0 +1,106 @@
+package sagemaker
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const maxInvokeBytes = 6 << 20 // 6 MiB, SageMaker's real-time payload limit
+
+// serveRuntime handles POST /endpoints/{name}/invocations and
+// /endpoints/{name}/async-invocations (sagemaker-runtime restJson1).
+func (h *Handler) serveRuntime(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		wire.WriteJSONError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+
+		return
+	}
+
+	trimmed := strings.TrimPrefix(r.URL.Path, "/endpoints/")
+
+	switch {
+	case strings.HasSuffix(trimmed, "/async-invocations"):
+		h.invokeAsync(w, r, decodeName(strings.TrimSuffix(trimmed, "/async-invocations")))
+	case strings.HasSuffix(trimmed, "/invocations"):
+		h.invoke(w, r, decodeName(strings.TrimSuffix(trimmed, "/invocations")))
+	default:
+		wire.WriteJSONError(w, http.StatusNotFound, "ResourceNotFound", "unsupported runtime path")
+	}
+}
+
+func decodeName(raw string) string {
+	if decoded, err := url.PathUnescape(raw); err == nil {
+		return decoded
+	}
+
+	return raw
+}
+
+func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, endpointName string) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxInvokeBytes))
+	if err != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationError", "failed to read request body")
+
+		return
+	}
+
+	out, err := h.svc.InvokeEndpoint(r.Context(), driver.InvokeEndpointInput{
+		EndpointName:           endpointName,
+		ContentType:            r.Header.Get("Content-Type"),
+		Accept:                 r.Header.Get("Accept"),
+		Body:                   body,
+		InferenceComponentName: r.Header.Get("X-Amzn-Sagemaker-Inference-Component"),
+		TargetModel:            r.Header.Get("X-Amzn-Sagemaker-Target-Model"),
+	})
+	if err != nil {
+		writeRuntimeError(w, err)
+
+		return
+	}
+
+	if out.ContentType != "" {
+		w.Header().Set("Content-Type", out.ContentType)
+	}
+
+	if out.InvokedVariant != "" {
+		w.Header().Set("X-Amzn-Invoked-Production-Variant", out.InvokedVariant)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out.Body)
+}
+
+func (h *Handler) invokeAsync(w http.ResponseWriter, r *http.Request, endpointName string) {
+	out, err := h.svc.InvokeEndpointAsync(r.Context(), driver.InvokeEndpointAsyncInput{
+		EndpointName: endpointName,
+		InputS3URI:   r.Header.Get("X-Amzn-Sagemaker-Inputlocation"),
+		ContentType:  r.Header.Get("Content-Type"),
+	})
+	if err != nil {
+		writeRuntimeError(w, err)
+
+		return
+	}
+
+	w.Header().Set("X-Amzn-Sagemaker-Outputlocation", out.OutputS3URI)
+	w.Header().Set("X-Amzn-Sagemaker-Inferenceid", out.InferenceID)
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// writeRuntimeError maps driver errors for the restJson1 runtime surface.
+func writeRuntimeError(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusNotFound, "ValidationError", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationError", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+	}
+}

--- a/server/aws/sagemaker/sdk_roundtrip_all_test.go
+++ b/server/aws/sagemaker/sdk_roundtrip_all_test.go
@@ -1,0 +1,373 @@
+package sagemaker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssm "github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	fsrt "github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime"
+	fsrttypes "github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func smClient(t *testing.T) *awssm.Client {
+	t.Helper()
+	url := newServer(t)
+
+	return awssm.NewFromConfig(newCfg(t), func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+}
+
+func TestSDKProcessingJob(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateProcessingJob(ctx, &awssm.CreateProcessingJobInput{
+		ProcessingJobName: aws.String("pj-1"),
+		RoleArn:           aws.String("arn:aws:iam::123456789012:role/svc"),
+		AppSpecification:  &smtypes.AppSpecification{ImageUri: aws.String("proc:latest")},
+		ProcessingResources: &smtypes.ProcessingResources{
+			ClusterConfig: &smtypes.ProcessingClusterConfig{
+				InstanceCount:  aws.Int32(1),
+				InstanceType:   smtypes.ProcessingInstanceTypeMlM5Large,
+				VolumeSizeInGB: aws.Int32(10),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeProcessingJob(ctx, &awssm.DescribeProcessingJobInput{ProcessingJobName: aws.String("pj-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.ProcessingJobStatusCompleted, d.ProcessingJobStatus)
+
+	l, err := c.ListProcessingJobs(ctx, &awssm.ListProcessingJobsInput{})
+	require.NoError(t, err)
+	assert.Len(t, l.ProcessingJobSummaries, 1)
+}
+
+func TestSDKTransformJob(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateModel(ctx, &awssm.CreateModelInput{
+		ModelName:        aws.String("m-x"),
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/svc"),
+		PrimaryContainer: &smtypes.ContainerDefinition{Image: aws.String("img:latest")},
+	})
+	require.NoError(t, err)
+
+	_, err = c.CreateTransformJob(ctx, &awssm.CreateTransformJobInput{
+		TransformJobName: aws.String("tj-1"),
+		ModelName:        aws.String("m-x"),
+		TransformInput: &smtypes.TransformInput{
+			DataSource: &smtypes.TransformDataSource{
+				S3DataSource: &smtypes.TransformS3DataSource{
+					S3DataType: smtypes.S3DataTypeS3Prefix,
+					S3Uri:      aws.String("s3://in/"),
+				},
+			},
+		},
+		TransformOutput:    &smtypes.TransformOutput{S3OutputPath: aws.String("s3://out/")},
+		TransformResources: &smtypes.TransformResources{InstanceType: smtypes.TransformInstanceTypeMlM5Large, InstanceCount: aws.Int32(1)},
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeTransformJob(ctx, &awssm.DescribeTransformJobInput{TransformJobName: aws.String("tj-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.TransformJobStatusCompleted, d.TransformJobStatus)
+}
+
+func TestSDKTuningJob(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateHyperParameterTuningJob(ctx, &awssm.CreateHyperParameterTuningJobInput{
+		HyperParameterTuningJobName: aws.String("hpo-1"),
+		HyperParameterTuningJobConfig: &smtypes.HyperParameterTuningJobConfig{
+			Strategy: smtypes.HyperParameterTuningJobStrategyTypeBayesian,
+			ResourceLimits: &smtypes.ResourceLimits{
+				MaxNumberOfTrainingJobs: aws.Int32(5),
+				MaxParallelTrainingJobs: aws.Int32(2),
+			},
+			HyperParameterTuningJobObjective: &smtypes.HyperParameterTuningJobObjective{
+				Type:       smtypes.HyperParameterTuningJobObjectiveTypeMaximize,
+				MetricName: aws.String("accuracy"),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeHyperParameterTuningJob(ctx, &awssm.DescribeHyperParameterTuningJobInput{
+		HyperParameterTuningJobName: aws.String("hpo-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.HyperParameterTuningJobStatusCompleted, d.HyperParameterTuningJobStatus)
+}
+
+func TestSDKLabelingAndCompilationJobs(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateLabelingJob(ctx, &awssm.CreateLabelingJobInput{
+		LabelingJobName:    aws.String("lj-1"),
+		LabelAttributeName: aws.String("label"),
+		RoleArn:            aws.String("arn:aws:iam::123456789012:role/svc"),
+		InputConfig:        &smtypes.LabelingJobInputConfig{DataSource: &smtypes.LabelingJobDataSource{}},
+		OutputConfig:       &smtypes.LabelingJobOutputConfig{S3OutputPath: aws.String("s3://out/")},
+		HumanTaskConfig: &smtypes.HumanTaskConfig{
+			WorkteamArn:                       aws.String("arn:aws:sagemaker:us-east-1:123456789012:workteam/x"),
+			UiConfig:                          &smtypes.UiConfig{UiTemplateS3Uri: aws.String("s3://tmpl/ui.html")},
+			TaskTitle:                         aws.String("Label images"),
+			TaskDescription:                   aws.String("Draw boxes"),
+			NumberOfHumanWorkersPerDataObject: aws.Int32(1),
+			TaskTimeLimitInSeconds:            aws.Int32(600),
+		},
+	})
+	require.NoError(t, err)
+
+	dl, err := c.DescribeLabelingJob(ctx, &awssm.DescribeLabelingJobInput{LabelingJobName: aws.String("lj-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.LabelingJobStatusCompleted, dl.LabelingJobStatus)
+
+	_, err = c.CreateCompilationJob(ctx, &awssm.CreateCompilationJobInput{
+		CompilationJobName: aws.String("cj-1"),
+		RoleArn:            aws.String("arn:aws:iam::123456789012:role/svc"),
+		InputConfig:        &smtypes.InputConfig{S3Uri: aws.String("s3://in/model.tar.gz"), Framework: smtypes.FrameworkPytorch, DataInputConfig: aws.String(`{"input":[1,3,224,224]}`)},
+		OutputConfig:       &smtypes.OutputConfig{S3OutputLocation: aws.String("s3://out/")},
+		StoppingCondition:  &smtypes.StoppingCondition{MaxRuntimeInSeconds: aws.Int32(900)},
+	})
+	require.NoError(t, err)
+
+	dc, err := c.DescribeCompilationJob(ctx, &awssm.DescribeCompilationJobInput{CompilationJobName: aws.String("cj-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.CompilationJobStatusCompleted, dc.CompilationJobStatus)
+}
+
+func TestSDKModelRegistry(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateModelPackageGroup(ctx, &awssm.CreateModelPackageGroupInput{
+		ModelPackageGroupName: aws.String("grp"),
+	})
+	require.NoError(t, err)
+
+	p, err := c.CreateModelPackage(ctx, &awssm.CreateModelPackageInput{
+		ModelPackageGroupName: aws.String("grp"),
+		InferenceSpecification: &smtypes.InferenceSpecification{
+			Containers:                 []smtypes.ModelPackageContainerDefinition{{Image: aws.String("img:latest")}},
+			SupportedContentTypes:      []string{"application/json"},
+			SupportedResponseMIMETypes: []string{"application/json"},
+		},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, aws.ToString(p.ModelPackageArn))
+
+	list, err := c.ListModelPackages(ctx, &awssm.ListModelPackagesInput{ModelPackageGroupName: aws.String("grp")})
+	require.NoError(t, err)
+	assert.Len(t, list.ModelPackageSummaryList, 1)
+}
+
+func TestSDKStudio(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	dom, err := c.CreateDomain(ctx, &awssm.CreateDomainInput{
+		DomainName:          aws.String("team"),
+		AuthMode:            smtypes.AuthModeIam,
+		VpcId:               aws.String("vpc-1"),
+		SubnetIds:           []string{"subnet-1"},
+		DefaultUserSettings: &smtypes.UserSettings{ExecutionRole: aws.String("arn:aws:iam::123456789012:role/studio")},
+	})
+	require.NoError(t, err)
+	domainID := aws.ToString(dom.DomainId)
+	assert.Contains(t, domainID, "d-")
+
+	_, err = c.CreateUserProfile(ctx, &awssm.CreateUserProfileInput{
+		DomainId:        aws.String(domainID),
+		UserProfileName: aws.String("alice"),
+	})
+	require.NoError(t, err)
+
+	_, err = c.CreateApp(ctx, &awssm.CreateAppInput{
+		DomainId:        aws.String(domainID),
+		UserProfileName: aws.String("alice"),
+		AppType:         smtypes.AppTypeJupyterServer,
+		AppName:         aws.String("default"),
+	})
+	require.NoError(t, err)
+
+	da, err := c.DescribeApp(ctx, &awssm.DescribeAppInput{
+		DomainId:        aws.String(domainID),
+		UserProfileName: aws.String("alice"),
+		AppType:         smtypes.AppTypeJupyterServer,
+		AppName:         aws.String("default"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.AppStatusInService, da.Status)
+}
+
+func TestSDKNotebookInstance(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateNotebookInstance(ctx, &awssm.CreateNotebookInstanceInput{
+		NotebookInstanceName: aws.String("nb-1"),
+		InstanceType:         smtypes.InstanceTypeMlT3Medium,
+		RoleArn:              aws.String("arn:aws:iam::123456789012:role/nb"),
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeNotebookInstance(ctx, &awssm.DescribeNotebookInstanceInput{NotebookInstanceName: aws.String("nb-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.NotebookInstanceStatusInService, d.NotebookInstanceStatus)
+
+	_, err = c.StopNotebookInstance(ctx, &awssm.StopNotebookInstanceInput{NotebookInstanceName: aws.String("nb-1")})
+	require.NoError(t, err)
+}
+
+func TestSDKHyperPodCluster(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateCluster(ctx, &awssm.CreateClusterInput{
+		ClusterName: aws.String("cl-1"),
+		InstanceGroups: []smtypes.ClusterInstanceGroupSpecification{{
+			InstanceGroupName: aws.String("workers"),
+			InstanceType:      smtypes.ClusterInstanceTypeMlP4d24xlarge,
+			InstanceCount:     aws.Int32(2),
+			LifeCycleConfig:   &smtypes.ClusterLifeCycleConfig{SourceS3Uri: aws.String("s3://b/"), OnCreate: aws.String("on_create.sh")},
+			ExecutionRole:     aws.String("arn:aws:iam::123456789012:role/hp"),
+		}},
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeCluster(ctx, &awssm.DescribeClusterInput{ClusterName: aws.String("cl-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.ClusterStatusInservice, d.ClusterStatus)
+
+	nodes, err := c.ListClusterNodes(ctx, &awssm.ListClusterNodesInput{ClusterName: aws.String("cl-1")})
+	require.NoError(t, err)
+	assert.Len(t, nodes.ClusterNodeSummaries, 2)
+}
+
+func TestSDKFeatureStore(t *testing.T) {
+	url := newServer(t)
+	cfg := newCfg(t)
+	c := awssm.NewFromConfig(cfg, func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+	rt := fsrt.NewFromConfig(cfg, func(o *fsrt.Options) { o.BaseEndpoint = aws.String(url) })
+	ctx := context.Background()
+
+	_, err := c.CreateFeatureGroup(ctx, &awssm.CreateFeatureGroupInput{
+		FeatureGroupName:            aws.String("fg-1"),
+		RecordIdentifierFeatureName: aws.String("id"),
+		EventTimeFeatureName:        aws.String("ts"),
+		FeatureDefinitions: []smtypes.FeatureDefinition{
+			{FeatureName: aws.String("id"), FeatureType: smtypes.FeatureTypeString},
+			{FeatureName: aws.String("ts"), FeatureType: smtypes.FeatureTypeString},
+			{FeatureName: aws.String("score"), FeatureType: smtypes.FeatureTypeFractional},
+		},
+		OnlineStoreConfig: &smtypes.OnlineStoreConfig{EnableOnlineStore: aws.Bool(true)},
+		RoleArn:           aws.String("arn:aws:iam::123456789012:role/fs"),
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeFeatureGroup(ctx, &awssm.DescribeFeatureGroupInput{FeatureGroupName: aws.String("fg-1")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.FeatureGroupStatusCreated, d.FeatureGroupStatus)
+
+	_, err = rt.PutRecord(ctx, &fsrt.PutRecordInput{
+		FeatureGroupName: aws.String("fg-1"),
+		Record: []fsrttypes.FeatureValue{
+			{FeatureName: aws.String("id"), ValueAsString: aws.String("u1")},
+			{FeatureName: aws.String("ts"), ValueAsString: aws.String("2025-01-01T00:00:00Z")},
+			{FeatureName: aws.String("score"), ValueAsString: aws.String("0.9")},
+		},
+	})
+	require.NoError(t, err)
+
+	got, err := rt.GetRecord(ctx, &fsrt.GetRecordInput{
+		FeatureGroupName:              aws.String("fg-1"),
+		RecordIdentifierValueAsString: aws.String("u1"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, got.Record, 3)
+}
+
+func TestSDKPipelinesAndExperiments(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreatePipeline(ctx, &awssm.CreatePipelineInput{
+		PipelineName:       aws.String("pl-1"),
+		RoleArn:            aws.String("arn:aws:iam::123456789012:role/pipe"),
+		PipelineDefinition: aws.String(`{"Version":"2020-12-01","Steps":[]}`),
+	})
+	require.NoError(t, err)
+
+	exec, err := c.StartPipelineExecution(ctx, &awssm.StartPipelineExecutionInput{PipelineName: aws.String("pl-1")})
+	require.NoError(t, err)
+	assert.NotEmpty(t, aws.ToString(exec.PipelineExecutionArn))
+
+	de, err := c.DescribePipelineExecution(ctx, &awssm.DescribePipelineExecutionInput{
+		PipelineExecutionArn: exec.PipelineExecutionArn,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.PipelineExecutionStatusSucceeded, de.PipelineExecutionStatus)
+
+	_, err = c.CreateExperiment(ctx, &awssm.CreateExperimentInput{ExperimentName: aws.String("exp-1")})
+	require.NoError(t, err)
+	_, err = c.CreateTrial(ctx, &awssm.CreateTrialInput{TrialName: aws.String("tr-1"), ExperimentName: aws.String("exp-1")})
+	require.NoError(t, err)
+
+	trials, err := c.ListTrials(ctx, &awssm.ListTrialsInput{ExperimentName: aws.String("exp-1")})
+	require.NoError(t, err)
+	assert.Len(t, trials.TrialSummaries, 1)
+}
+
+func TestSDKInferenceComponent(t *testing.T) {
+	c := smClient(t)
+	ctx := context.Background()
+
+	_, err := c.CreateModel(ctx, &awssm.CreateModelInput{
+		ModelName:        aws.String("ic-model"),
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/svc"),
+		PrimaryContainer: &smtypes.ContainerDefinition{Image: aws.String("img:latest")},
+	})
+	require.NoError(t, err)
+	_, err = c.CreateEndpointConfig(ctx, &awssm.CreateEndpointConfigInput{
+		EndpointConfigName: aws.String("ic-cfg"),
+		ProductionVariants: []smtypes.ProductionVariant{{
+			VariantName:          aws.String("v1"),
+			InstanceType:         smtypes.ProductionVariantInstanceTypeMlM5Large,
+			InitialInstanceCount: aws.Int32(1),
+		}},
+	})
+	require.NoError(t, err)
+	_, err = c.CreateEndpoint(ctx, &awssm.CreateEndpointInput{
+		EndpointName: aws.String("ic-ep"), EndpointConfigName: aws.String("ic-cfg"),
+	})
+	require.NoError(t, err)
+
+	_, err = c.CreateInferenceComponent(ctx, &awssm.CreateInferenceComponentInput{
+		InferenceComponentName: aws.String("ic-1"),
+		EndpointName:           aws.String("ic-ep"),
+		VariantName:            aws.String("v1"),
+		Specification: &smtypes.InferenceComponentSpecification{
+			ModelName: aws.String("ic-model"),
+			ComputeResourceRequirements: &smtypes.InferenceComponentComputeResourceRequirements{
+				MinMemoryRequiredInMb: aws.Int32(1024),
+			},
+		},
+		RuntimeConfig: &smtypes.InferenceComponentRuntimeConfig{CopyCount: aws.Int32(1)},
+	})
+	require.NoError(t, err)
+
+	d, err := c.DescribeInferenceComponent(ctx, &awssm.DescribeInferenceComponentInput{
+		InferenceComponentName: aws.String("ic-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.InferenceComponentStatusInService, d.InferenceComponentStatus)
+}

--- a/server/aws/sagemaker/sdk_roundtrip_test.go
+++ b/server/aws/sagemaker/sdk_roundtrip_test.go
@@ -1,0 +1,178 @@
+package sagemaker_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssm "github.com/aws/aws-sdk-go-v2/service/sagemaker"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	smrt "github.com/aws/aws-sdk-go-v2/service/sagemakerruntime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newServer(t *testing.T) string {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		SageMaker: cloud.SageMaker,
+		// S3 included to exercise routing precedence: the runtime path
+		// /endpoints/{name}/invocations must be claimed before S3's catch-all.
+		S3: cloud.S3,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts.URL
+}
+
+func newCfg(t *testing.T) aws.Config {
+	t.Helper()
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	require.NoError(t, err)
+
+	return cfg
+}
+
+func TestSDKTrainingJobLifecycle(t *testing.T) {
+	url := newServer(t)
+	client := awssm.NewFromConfig(newCfg(t), func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+	ctx := context.Background()
+
+	_, err := client.CreateTrainingJob(ctx, &awssm.CreateTrainingJobInput{
+		TrainingJobName: aws.String("job-1"),
+		RoleArn:         aws.String("arn:aws:iam::123456789012:role/svc"),
+		AlgorithmSpecification: &smtypes.AlgorithmSpecification{
+			TrainingImage:     aws.String("xgboost:latest"),
+			TrainingInputMode: smtypes.TrainingInputModeFile,
+		},
+		OutputDataConfig: &smtypes.OutputDataConfig{S3OutputPath: aws.String("s3://bucket/out")},
+		ResourceConfig: &smtypes.ResourceConfig{
+			InstanceType:   smtypes.TrainingInstanceTypeMlM5Large,
+			InstanceCount:  aws.Int32(1),
+			VolumeSizeInGB: aws.Int32(10),
+		},
+		StoppingCondition: &smtypes.StoppingCondition{MaxRuntimeInSeconds: aws.Int32(3600)},
+		Tags:              []smtypes.Tag{{Key: aws.String("team"), Value: aws.String("ml")}},
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeTrainingJob(ctx, &awssm.DescribeTrainingJobInput{
+		TrainingJobName: aws.String("job-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.TrainingJobStatusCompleted, desc.TrainingJobStatus)
+	assert.Equal(t, "xgboost:latest", aws.ToString(desc.AlgorithmSpecification.TrainingImage))
+	assert.Equal(t, "s3://bucket/out/output/model.tar.gz", aws.ToString(desc.ModelArtifacts.S3ModelArtifacts))
+
+	list, err := client.ListTrainingJobs(ctx, &awssm.ListTrainingJobsInput{})
+	require.NoError(t, err)
+	assert.Len(t, list.TrainingJobSummaries, 1)
+
+	_, err = client.StopTrainingJob(ctx, &awssm.StopTrainingJobInput{TrainingJobName: aws.String("job-1")})
+	require.NoError(t, err)
+}
+
+func TestSDKInferenceFlowAndInvoke(t *testing.T) {
+	url := newServer(t)
+	cfg := newCfg(t)
+	client := awssm.NewFromConfig(cfg, func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+	rt := smrt.NewFromConfig(cfg, func(o *smrt.Options) { o.BaseEndpoint = aws.String(url) })
+	ctx := context.Background()
+
+	_, err := client.CreateModel(ctx, &awssm.CreateModelInput{
+		ModelName:        aws.String("model-a"),
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/svc"),
+		PrimaryContainer: &smtypes.ContainerDefinition{
+			Image:        aws.String("inference:latest"),
+			ModelDataUrl: aws.String("s3://bucket/model.tar.gz"),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.CreateEndpointConfig(ctx, &awssm.CreateEndpointConfigInput{
+		EndpointConfigName: aws.String("cfg-a"),
+		ProductionVariants: []smtypes.ProductionVariant{{
+			VariantName:          aws.String("v1"),
+			ModelName:            aws.String("model-a"),
+			InstanceType:         smtypes.ProductionVariantInstanceTypeMlM5Large,
+			InitialInstanceCount: aws.Int32(1),
+			InitialVariantWeight: aws.Float32(1),
+		}},
+	})
+	require.NoError(t, err)
+
+	_, err = client.CreateEndpoint(ctx, &awssm.CreateEndpointInput{
+		EndpointName:       aws.String("ep-a"),
+		EndpointConfigName: aws.String("cfg-a"),
+	})
+	require.NoError(t, err)
+
+	desc, err := client.DescribeEndpoint(ctx, &awssm.DescribeEndpointInput{EndpointName: aws.String("ep-a")})
+	require.NoError(t, err)
+	assert.Equal(t, smtypes.EndpointStatusInService, desc.EndpointStatus)
+	require.Len(t, desc.ProductionVariants, 1)
+	assert.Equal(t, "v1", aws.ToString(desc.ProductionVariants[0].VariantName))
+
+	inv, err := rt.InvokeEndpoint(ctx, &smrt.InvokeEndpointInput{
+		EndpointName: aws.String("ep-a"),
+		ContentType:  aws.String("application/json"),
+		Accept:       aws.String("application/json"),
+		Body:         []byte(`{"instances":[[1,2,3]]}`),
+	})
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal([]byte(`{"instances":[[1,2,3]]}`), inv.Body))
+	assert.Equal(t, "v1", aws.ToString(inv.InvokedProductionVariant))
+}
+
+func TestSDKTagsRoundTrip(t *testing.T) {
+	url := newServer(t)
+	client := awssm.NewFromConfig(newCfg(t), func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+	ctx := context.Background()
+
+	out, err := client.CreateModel(ctx, &awssm.CreateModelInput{
+		ModelName:        aws.String("tagged-model"),
+		ExecutionRoleArn: aws.String("arn:aws:iam::123456789012:role/svc"),
+		PrimaryContainer: &smtypes.ContainerDefinition{Image: aws.String("img:latest")},
+	})
+	require.NoError(t, err)
+
+	_, err = client.AddTags(ctx, &awssm.AddTagsInput{
+		ResourceArn: out.ModelArn,
+		Tags:        []smtypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	})
+	require.NoError(t, err)
+
+	tags, err := client.ListTags(ctx, &awssm.ListTagsInput{ResourceArn: out.ModelArn})
+	require.NoError(t, err)
+	require.Len(t, tags.Tags, 1)
+	assert.Equal(t, "env", aws.ToString(tags.Tags[0].Key))
+}
+
+func TestSDKDescribeMissingTrainingJob(t *testing.T) {
+	url := newServer(t)
+	client := awssm.NewFromConfig(newCfg(t), func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+
+	_, err := client.DescribeTrainingJob(context.Background(), &awssm.DescribeTrainingJobInput{
+		TrainingJobName: aws.String("ghost"),
+	})
+	require.Error(t, err)
+
+	var rnf *smtypes.ResourceNotFound
+	assert.True(t, errors.As(err, &rnf), "expected ResourceNotFound, got %T", err)
+}

--- a/server/aws/sagemaker/sdk_roundtrip_test.go
+++ b/server/aws/sagemaker/sdk_roundtrip_test.go
@@ -173,6 +173,11 @@ func TestSDKDescribeMissingTrainingJob(t *testing.T) {
 	})
 	require.Error(t, err)
 
+	// DescribeTrainingJob models ResourceNotFound, so the NotFound→ResourceNotFound
+	// mapping deserializes as a typed SDK error. (Typed-error matching is
+	// per-operation: the SDK only surfaces an exception an operation models;
+	// everything else — e.g. a generic ValidationException — arrives as
+	// *smithy.GenericAPIError, exactly as it does against real SageMaker.)
 	var rnf *smtypes.ResourceNotFound
 	assert.True(t, errors.As(err, &rnf), "expected ResourceNotFound, got %T", err)
 }

--- a/server/aws/sagemaker/sdk_roundtrip_test.go
+++ b/server/aws/sagemaker/sdk_roundtrip_test.go
@@ -181,3 +181,26 @@ func TestSDKDescribeMissingTrainingJob(t *testing.T) {
 	var rnf *smtypes.ResourceNotFound
 	assert.True(t, errors.As(err, &rnf), "expected ResourceNotFound, got %T", err)
 }
+
+// TestSDKValidationErrorIsGeneric locks in that an InvalidArgument →
+// ValidationException surfaces as a (non-modeled) error: CreateEndpoint against
+// a missing config returns an error that is NOT one of SageMaker's modeled
+// typed exceptions, matching real SageMaker where ValidationException is a
+// cross-service generic error.
+func TestSDKValidationErrorIsGeneric(t *testing.T) {
+	url := newServer(t)
+	client := awssm.NewFromConfig(newCfg(t), func(o *awssm.Options) { o.BaseEndpoint = aws.String(url) })
+
+	_, err := client.CreateEndpoint(context.Background(), &awssm.CreateEndpointInput{
+		EndpointName:       aws.String("ep"),
+		EndpointConfigName: aws.String("does-not-exist"),
+	})
+	require.Error(t, err)
+
+	var (
+		rnf   *smtypes.ResourceNotFound
+		inUse *smtypes.ResourceInUse
+	)
+	assert.False(t, errors.As(err, &rnf), "ValidationException must not match a modeled typed error")
+	assert.False(t, errors.As(err, &inUse), "ValidationException must not match a modeled typed error")
+}

--- a/server/aws/sagemaker/studio.go
+++ b/server/aws/sagemaker/studio.go
@@ -1,0 +1,448 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/sagemaker/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) routeStudio(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateDomain":
+		h.createDomain(w, r)
+	case "DescribeDomain":
+		h.describeDomain(w, r)
+	case "ListDomains":
+		h.listDomains(w, r)
+	case "DeleteDomain":
+		stopByName(w, r, "DomainId", h.svc.DeleteDomain)
+	case "CreateUserProfile":
+		h.createUserProfile(w, r)
+	case "DescribeUserProfile":
+		h.describeUserProfile(w, r)
+	case "ListUserProfiles":
+		h.listUserProfiles(w, r)
+	case "DeleteUserProfile":
+		h.deleteUserProfile(w, r)
+	default:
+		return h.routeStudioSpacesApps(w, r, op)
+	}
+
+	return true
+}
+
+func (h *Handler) routeStudioSpacesApps(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case "CreateSpace":
+		h.createSpace(w, r)
+	case "DescribeSpace":
+		h.describeSpace(w, r)
+	case "ListSpaces":
+		h.listSpaces(w, r)
+	case "DeleteSpace":
+		h.deleteSpace(w, r)
+	case "CreateApp":
+		h.createApp(w, r)
+	case "DescribeApp":
+		h.describeApp(w, r)
+	case "ListApps":
+		h.listApps(w, r)
+	case "DeleteApp":
+		h.deleteApp(w, r)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createSpace(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID  string    `json:"DomainId"`
+		SpaceName string    `json:"SpaceName"`
+		Tags      []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	sp, err := h.svc.CreateSpace(r.Context(), driver.SpaceSpec{
+		DomainID:  req.DomainID,
+		SpaceName: req.SpaceName,
+		Tags:      toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"SpaceArn": sp.SpaceARN})
+}
+
+func (h *Handler) describeSpace(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID  string `json:"DomainId"`
+		SpaceName string `json:"SpaceName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	sp, err := h.svc.DescribeSpace(r.Context(), req.DomainID, req.SpaceName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"DomainId":     sp.DomainID,
+		"SpaceName":    sp.SpaceName,
+		"SpaceArn":     sp.SpaceARN,
+		"Status":       sp.Status,
+		"CreationTime": epoch(sp.CreationTime),
+	})
+}
+
+func (h *Handler) listSpaces(w http.ResponseWriter, r *http.Request) {
+	domainID, ok := decodeName1(w, r, "DomainIdEquals")
+	if !ok {
+		return
+	}
+
+	spaces, err := h.svc.ListSpaces(r.Context(), domainID)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(spaces))
+	for i := range spaces {
+		out = append(out, map[string]any{
+			"DomainId":     spaces[i].DomainID,
+			"SpaceName":    spaces[i].SpaceName,
+			"Status":       spaces[i].Status,
+			"CreationTime": epoch(spaces[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Spaces": out})
+}
+
+func (h *Handler) deleteSpace(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID  string `json:"DomainId"`
+		SpaceName string `json:"SpaceName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteSpace(r.Context(), req.DomainID, req.SpaceName); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+func (h *Handler) createDomain(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainName          string   `json:"DomainName"`
+		AuthMode            string   `json:"AuthMode"`
+		VpcID               string   `json:"VpcId"`
+		SubnetIDs           []string `json:"SubnetIds"`
+		DefaultUserSettings struct {
+			ExecutionRole string `json:"ExecutionRole"`
+		} `json:"DefaultUserSettings"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	d, err := h.svc.CreateDomain(r.Context(), driver.DomainSpec{
+		DomainName:       req.DomainName,
+		AuthMode:         req.AuthMode,
+		VPCID:            req.VpcID,
+		SubnetIDs:        req.SubnetIDs,
+		ExecutionRoleARN: req.DefaultUserSettings.ExecutionRole,
+		Tags:             toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"DomainArn": d.DomainARN, "DomainId": d.DomainID, "Url": d.URL})
+}
+
+func (h *Handler) describeDomain(w http.ResponseWriter, r *http.Request) {
+	id, ok := decodeName1(w, r, "DomainId")
+	if !ok {
+		return
+	}
+
+	d, err := h.svc.DescribeDomain(r.Context(), id)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"DomainId":     d.DomainID,
+		"DomainArn":    d.DomainARN,
+		"DomainName":   d.DomainName,
+		"Status":       d.Status,
+		"AuthMode":     d.AuthMode,
+		"Url":          d.URL,
+		"CreationTime": epoch(d.CreationTime),
+	})
+}
+
+func (h *Handler) listDomains(w http.ResponseWriter, r *http.Request) {
+	domains, err := h.svc.ListDomains(r.Context())
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(domains))
+	for i := range domains {
+		out = append(out, map[string]any{
+			"DomainId":     domains[i].DomainID,
+			"DomainArn":    domains[i].DomainARN,
+			"DomainName":   domains[i].DomainName,
+			"Status":       domains[i].Status,
+			"CreationTime": epoch(domains[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Domains": out})
+}
+
+func (h *Handler) createUserProfile(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID        string `json:"DomainId"`
+		UserProfileName string `json:"UserProfileName"`
+		UserSettings    struct {
+			ExecutionRole string `json:"ExecutionRole"`
+		} `json:"UserSettings"`
+		Tags []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	up, err := h.svc.CreateUserProfile(r.Context(), driver.UserProfileSpec{
+		DomainID:         req.DomainID,
+		UserProfileName:  req.UserProfileName,
+		ExecutionRoleARN: req.UserSettings.ExecutionRole,
+		Tags:             toTags(req.Tags),
+	})
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"UserProfileArn": up.UserProfileARN})
+}
+
+func (h *Handler) describeUserProfile(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID        string `json:"DomainId"`
+		UserProfileName string `json:"UserProfileName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	up, err := h.svc.DescribeUserProfile(r.Context(), req.DomainID, req.UserProfileName)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"DomainId":        up.DomainID,
+		"UserProfileName": up.UserProfileName,
+		"UserProfileArn":  up.UserProfileARN,
+		"Status":          up.Status,
+		"CreationTime":    epoch(up.CreationTime),
+	})
+}
+
+func (h *Handler) listUserProfiles(w http.ResponseWriter, r *http.Request) {
+	domainID, ok := decodeName1(w, r, "DomainIdEquals")
+	if !ok {
+		return
+	}
+
+	ups, err := h.svc.ListUserProfiles(r.Context(), domainID)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ups))
+	for i := range ups {
+		out = append(out, map[string]any{
+			"DomainId":        ups[i].DomainID,
+			"UserProfileName": ups[i].UserProfileName,
+			"Status":          ups[i].Status,
+			"CreationTime":    epoch(ups[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"UserProfiles": out})
+}
+
+func (h *Handler) deleteUserProfile(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID        string `json:"DomainId"`
+		UserProfileName string `json:"UserProfileName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteUserProfile(r.Context(), req.DomainID, req.UserProfileName); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+func appSpecFromReq(domainID, userProfile, space, appType, appName string) driver.AppSpec {
+	return driver.AppSpec{
+		DomainID:        domainID,
+		UserProfileName: userProfile,
+		SpaceName:       space,
+		AppType:         appType,
+		AppName:         appName,
+	}
+}
+
+func (h *Handler) createApp(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID        string `json:"DomainId"`
+		UserProfileName string `json:"UserProfileName"`
+		SpaceName       string `json:"SpaceName"`
+		AppType         string `json:"AppType"`
+		AppName         string `json:"AppName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	app, err := h.svc.CreateApp(r.Context(),
+		appSpecFromReq(req.DomainID, req.UserProfileName, req.SpaceName, req.AppType, req.AppName))
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"AppArn": app.AppARN})
+}
+
+func (h *Handler) describeApp(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID        string `json:"DomainId"`
+		UserProfileName string `json:"UserProfileName"`
+		SpaceName       string `json:"SpaceName"`
+		AppType         string `json:"AppType"`
+		AppName         string `json:"AppName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	app, err := h.svc.DescribeApp(r.Context(),
+		appSpecFromReq(req.DomainID, req.UserProfileName, req.SpaceName, req.AppType, req.AppName))
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"AppArn":       app.AppARN,
+		"AppName":      app.AppName,
+		"AppType":      app.AppType,
+		"DomainId":     app.DomainID,
+		"Status":       app.Status,
+		"CreationTime": epoch(app.CreationTime),
+	})
+}
+
+func (h *Handler) listApps(w http.ResponseWriter, r *http.Request) {
+	domainID, ok := decodeName1(w, r, "DomainIdEquals")
+	if !ok {
+		return
+	}
+
+	apps, err := h.svc.ListApps(r.Context(), domainID)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(apps))
+	for i := range apps {
+		out = append(out, map[string]any{
+			"AppName":      apps[i].AppName,
+			"AppType":      apps[i].AppType,
+			"DomainId":     apps[i].DomainID,
+			"Status":       apps[i].Status,
+			"CreationTime": epoch(apps[i].CreationTime),
+		})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Apps": out})
+}
+
+func (h *Handler) deleteApp(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DomainID        string `json:"DomainId"`
+		UserProfileName string `json:"UserProfileName"`
+		SpaceName       string `json:"SpaceName"`
+		AppType         string `json:"AppType"`
+		AppName         string `json:"AppName"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteApp(r.Context(),
+		appSpecFromReq(req.DomainID, req.UserProfileName, req.SpaceName, req.AppType, req.AppName)); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}

--- a/server/aws/sagemaker/studio.go
+++ b/server/aws/sagemaker/studio.go
@@ -32,6 +32,7 @@ func (h *Handler) routeStudio(w http.ResponseWriter, r *http.Request, op string)
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) routeStudioSpacesApps(w http.ResponseWriter, r *http.Request, op string) bool {
 	switch op {
 	case "CreateSpace":
@@ -57,6 +58,7 @@ func (h *Handler) routeStudioSpacesApps(w http.ResponseWriter, r *http.Request, 
 	return true
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createSpace(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		DomainID  string    `json:"DomainId"`
@@ -82,6 +84,7 @@ func (h *Handler) createSpace(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"SpaceArn": sp.SpaceARN})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) describeSpace(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		DomainID  string `json:"DomainId"`
@@ -121,17 +124,14 @@ func (h *Handler) listSpaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(spaces))
-	for i := range spaces {
-		out = append(out, map[string]any{
-			"DomainId":     spaces[i].DomainID,
-			"SpaceName":    spaces[i].SpaceName,
-			"Status":       spaces[i].Status,
-			"CreationTime": epoch(spaces[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"Spaces": out})
+	writeSummaries(w, "Spaces", spaces, func(s *driver.Space) map[string]any {
+		return map[string]any{
+			"DomainId":     s.DomainID,
+			"SpaceName":    s.SpaceName,
+			"Status":       s.Status,
+			"CreationTime": epoch(s.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteSpace(w http.ResponseWriter, r *http.Request) {
@@ -186,6 +186,7 @@ func (h *Handler) createDomain(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"DomainArn": d.DomainARN, "DomainId": d.DomainID, "Url": d.URL})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) describeDomain(w http.ResponseWriter, r *http.Request) {
 	id, ok := decodeName1(w, r, "DomainId")
 	if !ok {
@@ -218,20 +219,18 @@ func (h *Handler) listDomains(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(domains))
-	for i := range domains {
-		out = append(out, map[string]any{
-			"DomainId":     domains[i].DomainID,
-			"DomainArn":    domains[i].DomainARN,
-			"DomainName":   domains[i].DomainName,
-			"Status":       domains[i].Status,
-			"CreationTime": epoch(domains[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"Domains": out})
+	writeSummaries(w, "Domains", domains, func(d *driver.Domain) map[string]any {
+		return map[string]any{
+			"DomainId":     d.DomainID,
+			"DomainArn":    d.DomainARN,
+			"DomainName":   d.DomainName,
+			"Status":       d.Status,
+			"CreationTime": epoch(d.CreationTime),
+		}
+	})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) createUserProfile(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		DomainID        string `json:"DomainId"`
@@ -261,6 +260,7 @@ func (h *Handler) createUserProfile(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"UserProfileArn": up.UserProfileARN})
 }
 
+//nolint:dupl // SDK-compat decode/encode shim; the skeleton recurs but each op maps a distinct type.
 func (h *Handler) describeUserProfile(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		DomainID        string `json:"DomainId"`
@@ -300,17 +300,14 @@ func (h *Handler) listUserProfiles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(ups))
-	for i := range ups {
-		out = append(out, map[string]any{
-			"DomainId":        ups[i].DomainID,
-			"UserProfileName": ups[i].UserProfileName,
-			"Status":          ups[i].Status,
-			"CreationTime":    epoch(ups[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"UserProfiles": out})
+	writeSummaries(w, "UserProfiles", ups, func(u *driver.UserProfile) map[string]any {
+		return map[string]any{
+			"DomainId":        u.DomainID,
+			"UserProfileName": u.UserProfileName,
+			"Status":          u.Status,
+			"CreationTime":    epoch(u.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteUserProfile(w http.ResponseWriter, r *http.Request) {
@@ -410,18 +407,15 @@ func (h *Handler) listApps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := make([]map[string]any, 0, len(apps))
-	for i := range apps {
-		out = append(out, map[string]any{
-			"AppName":      apps[i].AppName,
-			"AppType":      apps[i].AppType,
-			"DomainId":     apps[i].DomainID,
-			"Status":       apps[i].Status,
-			"CreationTime": epoch(apps[i].CreationTime),
-		})
-	}
-
-	wire.WriteJSON(w, map[string]any{"Apps": out})
+	writeSummaries(w, "Apps", apps, func(a *driver.App) map[string]any {
+		return map[string]any{
+			"AppName":      a.AppName,
+			"AppType":      a.AppType,
+			"DomainId":     a.DomainID,
+			"Status":       a.Status,
+			"CreationTime": epoch(a.CreationTime),
+		}
+	})
 }
 
 func (h *Handler) deleteApp(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sagemaker/tags.go
+++ b/server/aws/sagemaker/tags.go
@@ -1,0 +1,65 @@
+package sagemaker
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) addTags(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceArn string    `json:"ResourceArn"`
+		Tags        []wireTag `json:"Tags"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	tags, err := h.svc.AddTags(r.Context(), req.ResourceArn, toTags(req.Tags))
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"Tags": fromTags(tags)})
+}
+
+func (h *Handler) listTags(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceArn string `json:"ResourceArn"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	tags, err := h.svc.ListTags(r.Context(), req.ResourceArn)
+	if err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"Tags": fromTags(tags)})
+}
+
+func (h *Handler) deleteTags(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ResourceArn string   `json:"ResourceArn"`
+		TagKeys     []string `json:"TagKeys"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.DeleteTags(r.Context(), req.ResourceArn, req.TagKeys); err != nil {
+		writeDriverError(w, err)
+
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks/gitcredentials"
 	"github.com/stackshy/cloudemu/server/azure/databricks/hostmeta"
 	"github.com/stackshy/cloudemu/server/azure/databricks/pipelines"
+	"github.com/stackshy/cloudemu/server/azure/databricks/queryhistory"
 	"github.com/stackshy/cloudemu/server/azure/databricks/repos"
 	"github.com/stackshy/cloudemu/server/azure/databricks/scim"
 	"github.com/stackshy/cloudemu/server/azure/databricks/secrets"
@@ -231,6 +232,7 @@ func registerDatabricksDataPlane(srv *server.Server, d *Drivers) {
 	srv.Register(dbfs.New())
 	srv.Register(wsfs.New())
 	srv.Register(sqlwarehouses.New())
+	srv.Register(queryhistory.New())
 	srv.Register(pipelines.New())
 	srv.Register(serving.New())
 	srv.Register(unitycatalog.New())

--- a/server/azure/databricks/dataplane_fields_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_fields_roundtrip_test.go
@@ -1,0 +1,71 @@
+package databricks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/databricks/databricks-sdk-go/service/compute"
+)
+
+// TestSDKClusterCustomTagsAndRuntimeEngine pins issue #223: custom_tags and
+// runtime_engine set on Create must survive a Get round-trip.
+func TestSDKClusterCustomTagsAndRuntimeEngine(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:   "c1",
+		SparkVersion:  "13.3.x-scala2.12",
+		NodeTypeId:    "Standard_DS3_v2",
+		Autoscale:     &compute.AutoScale{MinWorkers: 2, MaxWorkers: 8},
+		RuntimeEngine: compute.RuntimeEnginePhoton,
+		CustomTags:    map[string]string{"team": "data"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := w.Clusters.Get(ctx, compute.GetClusterRequest{ClusterId: wait.ClusterId})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.RuntimeEngine != compute.RuntimeEnginePhoton {
+		t.Fatalf("runtime_engine: got %q, want PHOTON", got.RuntimeEngine)
+	}
+
+	if got.CustomTags["team"] != "data" {
+		t.Fatalf("custom_tags: got %v, want {team:data}", got.CustomTags)
+	}
+}
+
+// TestSDKInstancePoolIdleAndTags pins issue #223: idle-autotermination minutes
+// and custom_tags on an instance pool must survive a Get round-trip.
+func TestSDKInstancePoolIdleAndTags(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	created, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
+		InstancePoolName:                   "pool-1",
+		NodeTypeId:                         "Standard_DS3_v2",
+		IdleInstanceAutoterminationMinutes: 60,
+		CustomTags:                         map[string]string{"team": "data"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := w.InstancePools.GetByInstancePoolId(ctx, created.InstancePoolId)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.IdleInstanceAutoterminationMinutes != 60 {
+		t.Fatalf("idle_instance_autotermination_minutes: got %d, want 60",
+			got.IdleInstanceAutoterminationMinutes)
+	}
+
+	if got.CustomTags["team"] != "data" {
+		t.Fatalf("custom_tags: got %v, want {team:data}", got.CustomTags)
+	}
+}

--- a/server/azure/databricks/dataplane_fields_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_fields_roundtrip_test.go
@@ -119,4 +119,23 @@ func TestSDKClusterPolicyPoolAzureSource(t *testing.T) {
 	if got.ClusterSource != compute.ClusterSourceApi {
 		t.Fatalf("cluster_source: got %q, want API", got.ClusterSource)
 	}
+
+	// The issue reports the drop on create->list, so pin the list path too
+	// (it shares the same response converter as Get).
+	all, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(all))
+	}
+
+	listed := all[0]
+	if listed.PolicyId != "policy-123" || listed.InstancePoolId != pool.InstancePoolId ||
+		listed.ClusterSource != compute.ClusterSourceApi ||
+		listed.AzureAttributes == nil ||
+		listed.AzureAttributes.Availability != compute.AzureAvailabilityOnDemandAzure {
+		t.Fatalf("list dropped a field: %+v (azure=%+v)", listed, listed.AzureAttributes)
+	}
 }

--- a/server/azure/databricks/dataplane_fields_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_fields_roundtrip_test.go
@@ -69,3 +69,54 @@ func TestSDKInstancePoolIdleAndTags(t *testing.T) {
 		t.Fatalf("custom_tags: got %v, want {team:data}", got.CustomTags)
 	}
 }
+
+// TestSDKClusterPolicyPoolAzureSource pins issue #229: policy_id,
+// instance_pool_id, azure_attributes.availability, and the backend-assigned
+// cluster_source must survive a create→get round-trip.
+func TestSDKClusterPolicyPoolAzureSource(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	pool, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
+		InstancePoolName: "p1", NodeTypeId: "Standard_DS3_v2", MinIdleInstances: 1,
+	})
+	if err != nil {
+		t.Fatalf("Create pool: %v", err)
+	}
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:    "c1",
+		SparkVersion:   "13.3.x-scala2.12",
+		NodeTypeId:     "Standard_DS3_v2",
+		NumWorkers:     2,
+		PolicyId:       "policy-123",
+		InstancePoolId: pool.InstancePoolId,
+		AzureAttributes: &compute.AzureAttributes{
+			Availability: compute.AzureAvailabilityOnDemandAzure,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create cluster: %v", err)
+	}
+
+	got, err := w.Clusters.Get(ctx, compute.GetClusterRequest{ClusterId: wait.ClusterId})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.PolicyId != "policy-123" {
+		t.Fatalf("policy_id: got %q, want policy-123", got.PolicyId)
+	}
+
+	if got.InstancePoolId != pool.InstancePoolId {
+		t.Fatalf("instance_pool_id: got %q, want %q", got.InstancePoolId, pool.InstancePoolId)
+	}
+
+	if got.AzureAttributes == nil || got.AzureAttributes.Availability != compute.AzureAvailabilityOnDemandAzure {
+		t.Fatalf("azure_attributes.availability: got %+v, want ON_DEMAND_AZURE", got.AzureAttributes)
+	}
+
+	if got.ClusterSource != compute.ClusterSourceApi {
+		t.Fatalf("cluster_source: got %q, want API", got.ClusterSource)
+	}
+}

--- a/server/azure/databricks/dataplane_ops.go
+++ b/server/azure/databricks/dataplane_ops.go
@@ -35,16 +35,24 @@ type listPoolsResponse struct {
 	InstancePools []instancePoolJSON `json:"instance_pools"`
 }
 
+type azureAttributesJSON struct {
+	Availability string `json:"availability,omitempty"`
+}
+
 type clusterJSON struct {
-	ClusterID     string            `json:"cluster_id,omitempty"`
-	ClusterName   string            `json:"cluster_name,omitempty"`
-	SparkVersion  string            `json:"spark_version"`
-	NodeTypeID    string            `json:"node_type_id"`
-	State         string            `json:"state,omitempty"`
-	NumWorkers    int32             `json:"num_workers,omitempty"`
-	Autoscale     *autoscaleJSON    `json:"autoscale,omitempty"`
-	RuntimeEngine string            `json:"runtime_engine,omitempty"`
-	CustomTags    map[string]string `json:"custom_tags,omitempty"`
+	ClusterID       string               `json:"cluster_id,omitempty"`
+	ClusterName     string               `json:"cluster_name,omitempty"`
+	SparkVersion    string               `json:"spark_version"`
+	NodeTypeID      string               `json:"node_type_id"`
+	State           string               `json:"state,omitempty"`
+	NumWorkers      int32                `json:"num_workers,omitempty"`
+	Autoscale       *autoscaleJSON       `json:"autoscale,omitempty"`
+	RuntimeEngine   string               `json:"runtime_engine,omitempty"`
+	CustomTags      map[string]string    `json:"custom_tags,omitempty"`
+	PolicyID        string               `json:"policy_id,omitempty"`
+	InstancePoolID  string               `json:"instance_pool_id,omitempty"`
+	AzureAttributes *azureAttributesJSON `json:"azure_attributes,omitempty"`
+	ClusterSource   string               `json:"cluster_source,omitempty"`
 }
 
 type clusterID struct {
@@ -528,10 +536,15 @@ func clusterConfig(in *clusterJSON) dbxdriver.ClusterConfig {
 		Name: in.ClusterName, SparkVersion: in.SparkVersion,
 		NodeTypeID: in.NodeTypeID, NumWorkers: in.NumWorkers,
 		RuntimeEngine: in.RuntimeEngine, CustomTags: in.CustomTags,
+		PolicyID: in.PolicyID, InstancePoolID: in.InstancePoolID,
 	}
 	if in.Autoscale != nil {
 		cfg.AutoscaleMin = in.Autoscale.MinWorkers
 		cfg.AutoscaleMax = in.Autoscale.MaxWorkers
+	}
+
+	if in.AzureAttributes != nil {
+		cfg.AzureAvailability = in.AzureAttributes.Availability
 	}
 
 	return cfg
@@ -542,9 +555,14 @@ func toClusterJSON(c *dbxdriver.Cluster) clusterJSON {
 		ClusterID: c.ID, ClusterName: c.Name, SparkVersion: c.SparkVersion,
 		NodeTypeID: c.NodeTypeID, State: c.State, NumWorkers: c.NumWorkers,
 		RuntimeEngine: c.RuntimeEngine, CustomTags: c.CustomTags,
+		PolicyID: c.PolicyID, InstancePoolID: c.InstancePoolID, ClusterSource: c.ClusterSource,
 	}
 	if c.AutoscaleMax > 0 {
 		out.Autoscale = &autoscaleJSON{MinWorkers: c.AutoscaleMin, MaxWorkers: c.AutoscaleMax}
+	}
+
+	if c.AzureAvailability != "" {
+		out.AzureAttributes = &azureAttributesJSON{Availability: c.AzureAvailability}
 	}
 
 	return out

--- a/server/azure/databricks/dataplane_ops.go
+++ b/server/azure/databricks/dataplane_ops.go
@@ -17,12 +17,14 @@ type autoscaleJSON struct {
 }
 
 type instancePoolJSON struct {
-	InstancePoolID   string `json:"instance_pool_id,omitempty"`
-	InstancePoolName string `json:"instance_pool_name"`
-	NodeTypeID       string `json:"node_type_id"`
-	State            string `json:"state,omitempty"`
-	MinIdleInstances int32  `json:"min_idle_instances,omitempty"`
-	MaxCapacity      int32  `json:"max_capacity,omitempty"`
+	InstancePoolID                     string            `json:"instance_pool_id,omitempty"`
+	InstancePoolName                   string            `json:"instance_pool_name"`
+	NodeTypeID                         string            `json:"node_type_id"`
+	State                              string            `json:"state,omitempty"`
+	MinIdleInstances                   int32             `json:"min_idle_instances,omitempty"`
+	MaxCapacity                        int32             `json:"max_capacity,omitempty"`
+	IdleInstanceAutoterminationMinutes int32             `json:"idle_instance_autotermination_minutes,omitempty"`
+	CustomTags                         map[string]string `json:"custom_tags,omitempty"`
 }
 
 type instancePoolID struct {
@@ -34,13 +36,15 @@ type listPoolsResponse struct {
 }
 
 type clusterJSON struct {
-	ClusterID    string         `json:"cluster_id,omitempty"`
-	ClusterName  string         `json:"cluster_name,omitempty"`
-	SparkVersion string         `json:"spark_version"`
-	NodeTypeID   string         `json:"node_type_id"`
-	State        string         `json:"state,omitempty"`
-	NumWorkers   int32          `json:"num_workers,omitempty"`
-	Autoscale    *autoscaleJSON `json:"autoscale,omitempty"`
+	ClusterID     string            `json:"cluster_id,omitempty"`
+	ClusterName   string            `json:"cluster_name,omitempty"`
+	SparkVersion  string            `json:"spark_version"`
+	NodeTypeID    string            `json:"node_type_id"`
+	State         string            `json:"state,omitempty"`
+	NumWorkers    int32             `json:"num_workers,omitempty"`
+	Autoscale     *autoscaleJSON    `json:"autoscale,omitempty"`
+	RuntimeEngine string            `json:"runtime_engine,omitempty"`
+	CustomTags    map[string]string `json:"custom_tags,omitempty"`
 }
 
 type clusterID struct {
@@ -135,6 +139,8 @@ func (h *DataPlaneHandler) createPool(w http.ResponseWriter, r *http.Request) {
 	pool, err := h.dp.CreateInstancePool(r.Context(), dbxdriver.InstancePoolConfig{
 		Name: in.InstancePoolName, NodeTypeID: in.NodeTypeID,
 		MinIdleInstances: in.MinIdleInstances, MaxCapacity: in.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: in.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         in.CustomTags,
 	})
 	if err != nil {
 		dpWriteErr(w, err)
@@ -181,6 +187,8 @@ func (h *DataPlaneHandler) editPool(w http.ResponseWriter, r *http.Request) {
 	err := h.dp.EditInstancePool(r.Context(), in.InstancePoolID, dbxdriver.InstancePoolConfig{
 		Name: in.InstancePoolName, NodeTypeID: in.NodeTypeID,
 		MinIdleInstances: in.MinIdleInstances, MaxCapacity: in.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: in.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         in.CustomTags,
 	})
 	if err != nil {
 		dpWriteErr(w, err)
@@ -510,6 +518,8 @@ func toPoolJSON(p *dbxdriver.InstancePool) instancePoolJSON {
 	return instancePoolJSON{
 		InstancePoolID: p.ID, InstancePoolName: p.Name, NodeTypeID: p.NodeTypeID,
 		State: p.State, MinIdleInstances: p.MinIdleInstances, MaxCapacity: p.MaxCapacity,
+		IdleInstanceAutoterminationMinutes: p.IdleInstanceAutoterminationMinutes,
+		CustomTags:                         p.CustomTags,
 	}
 }
 
@@ -517,6 +527,7 @@ func clusterConfig(in *clusterJSON) dbxdriver.ClusterConfig {
 	cfg := dbxdriver.ClusterConfig{
 		Name: in.ClusterName, SparkVersion: in.SparkVersion,
 		NodeTypeID: in.NodeTypeID, NumWorkers: in.NumWorkers,
+		RuntimeEngine: in.RuntimeEngine, CustomTags: in.CustomTags,
 	}
 	if in.Autoscale != nil {
 		cfg.AutoscaleMin = in.Autoscale.MinWorkers
@@ -530,6 +541,7 @@ func toClusterJSON(c *dbxdriver.Cluster) clusterJSON {
 	out := clusterJSON{
 		ClusterID: c.ID, ClusterName: c.Name, SparkVersion: c.SparkVersion,
 		NodeTypeID: c.NodeTypeID, State: c.State, NumWorkers: c.NumWorkers,
+		RuntimeEngine: c.RuntimeEngine, CustomTags: c.CustomTags,
 	}
 	if c.AutoscaleMax > 0 {
 		out.Autoscale = &autoscaleJSON{MinWorkers: c.AutoscaleMin, MaxWorkers: c.AutoscaleMax}

--- a/server/azure/databricks/queryhistory/queryhistory.go
+++ b/server/azure/databricks/queryhistory/queryhistory.go
@@ -34,10 +34,12 @@ type Handler struct{}
 // New returns a query-history handler.
 func New() *Handler { return &Handler{} }
 
-// Matches claims /api/{ver}/sql/history/queries.
+// Matches claims exactly /api/{ver}/sql/history/queries. Requiring the exact
+// segment count keeps any future sub-resource (e.g. .../queries/{id}) from
+// being swallowed and served an empty list instead of a 501.
 func (*Handler) Matches(r *http.Request) bool {
 	parts := splitPath(r.URL.Path)
-	if len(parts) < minSegs || parts[idxAPI] != "api" {
+	if len(parts) != minSegs || parts[idxAPI] != "api" {
 		return false
 	}
 

--- a/server/azure/databricks/queryhistory/queryhistory.go
+++ b/server/azure/databricks/queryhistory/queryhistory.go
@@ -1,0 +1,87 @@
+// Package queryhistory implements the Databricks SQL query-history data-plane
+// REST API (the /api/2.0/sql/history/queries surface) as a server.Handler.
+//
+// The in-memory backend does not execute SQL, so there is no query activity to
+// record — the endpoint returns an empty result set. That is enough for the
+// real github.com/databricks/databricks-sdk-go WorkspaceClient's
+// w.QueryHistory.List to succeed (it previously failed with "no handler
+// registered for this request"), which unblocks tools that probe query history
+// for idle/orphaned-warehouse detection.
+//
+// Covered endpoint:
+//
+//	GET /api/2.0/sql/history/queries
+package queryhistory
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// Path segment positions after splitting on "/": [api, ver, sql, history, queries].
+const (
+	idxAPI     = 0
+	idxSQL     = 2
+	idxHistory = 3
+	idxQueries = 4
+	minSegs    = 5
+)
+
+// Handler serves the Databricks SQL query-history endpoint.
+type Handler struct{}
+
+// New returns a query-history handler.
+func New() *Handler { return &Handler{} }
+
+// Matches claims /api/{ver}/sql/history/queries.
+func (*Handler) Matches(r *http.Request) bool {
+	parts := splitPath(r.URL.Path)
+	if len(parts) < minSegs || parts[idxAPI] != "api" {
+		return false
+	}
+
+	return parts[idxSQL] == "sql" && parts[idxHistory] == "history" && parts[idxQueries] == "queries"
+}
+
+// listResponse mirrors sql.ListQueriesResponse.
+type listResponse struct {
+	Res           []any  `json:"res"`
+	HasNextPage   bool   `json:"has_next_page"`
+	NextPageToken string `json:"next_page_token,omitempty"`
+}
+
+// ServeHTTP returns an empty query-history page. Real Databricks records
+// executed queries; the in-memory backend runs none, so the list is empty.
+func (*Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "INVALID_PARAMETER_VALUE", "method not allowed")
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(listResponse{Res: []any{}, HasNextPage: false})
+}
+
+func splitPath(p string) []string {
+	trimmed := strings.Trim(p, "/")
+	if trimmed == "" {
+		return nil
+	}
+
+	return strings.Split(trimmed, "/")
+}
+
+// errorBody is the Databricks error envelope shape.
+type errorBody struct {
+	ErrorCode string `json:"error_code"`
+	Message   string `json:"message"`
+}
+
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorBody{ErrorCode: code, Message: msg})
+}

--- a/server/azure/databricks/queryhistory/queryhistory_roundtrip_test.go
+++ b/server/azure/databricks/queryhistory/queryhistory_roundtrip_test.go
@@ -1,0 +1,51 @@
+package queryhistory_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	databricks "github.com/databricks/databricks-sdk-go"
+	"github.com/databricks/databricks-sdk-go/config"
+	"github.com/databricks/databricks-sdk-go/service/sql"
+
+	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/databricks/queryhistory"
+)
+
+func newClient(t *testing.T) *databricks.WorkspaceClient {
+	t.Helper()
+
+	srv := server.New()
+	srv.Register(queryhistory.New())
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	w, err := databricks.NewWorkspaceClient(&databricks.Config{
+		Host:        ts.URL,
+		Token:       "test-token",
+		Credentials: config.PatCredentials{},
+	})
+	if err != nil {
+		t.Fatalf("new workspace client: %v", err)
+	}
+
+	return w
+}
+
+// TestSDKQueryHistoryList pins issue #223: w.QueryHistory.List previously
+// returned "no handler registered". It must now succeed (with an empty result,
+// since the in-memory backend runs no queries).
+func TestSDKQueryHistoryList(t *testing.T) {
+	w := newClient(t)
+
+	res, err := w.QueryHistory.List(context.Background(), sql.ListQueryHistoryRequest{})
+	if err != nil {
+		t.Fatalf("QueryHistory.List: %v", err)
+	}
+
+	if len(res.Res) != 0 {
+		t.Fatalf("got %d query-history entries, want 0", len(res.Res))
+	}
+}

--- a/server/azure/databricks/sqlwarehouses/sqlwarehouses.go
+++ b/server/azure/databricks/sqlwarehouses/sqlwarehouses.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -68,6 +69,53 @@ type warehouse struct {
 	CreatorName             string
 	WarehouseType           string
 	SpotInstancePolicy      string
+	Tags                    map[string]string
+}
+
+// endpointTagPair / endpointTags mirror sql.EndpointTagPair / sql.EndpointTags
+// — the wire shape of a warehouse's "tags" object.
+type endpointTagPair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type endpointTags struct {
+	CustomTags []endpointTagPair `json:"custom_tags"`
+}
+
+func (t *endpointTags) toMap() map[string]string {
+	if t == nil || len(t.CustomTags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(t.CustomTags))
+	for _, p := range t.CustomTags {
+		out[p.Key] = p.Value
+	}
+
+	return out
+}
+
+// tagsToWire renders a tag map back into the {custom_tags: [{key,value}]} wire
+// shape, with keys sorted so the output is deterministic.
+func tagsToWire(tags map[string]string) *endpointTags {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	pairs := make([]endpointTagPair, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, endpointTagPair{Key: k, Value: tags[k]})
+	}
+
+	return &endpointTags{CustomTags: pairs}
 }
 
 // Handler serves the Databricks SQL Warehouses data-plane REST API.
@@ -164,17 +212,20 @@ func (h *Handler) serveItemAction(w http.ResponseWriter, r *http.Request, id, ac
 }
 
 // createRequest is the subset of CreateWarehouseRequest fields we honor.
+// AutoStopMins is a pointer so an explicit 0 (disable auto-stop) is
+// distinguishable from an omitted field (which gets the default).
 type createRequest struct {
-	Name                    string `json:"name"`
-	ClusterSize             string `json:"cluster_size"`
-	AutoStopMins            int    `json:"auto_stop_mins"`
-	MaxNumClusters          int    `json:"max_num_clusters"`
-	MinNumClusters          int    `json:"min_num_clusters"`
-	EnablePhoton            bool   `json:"enable_photon"`
-	EnableServerlessCompute bool   `json:"enable_serverless_compute"`
-	CreatorName             string `json:"creator_name"`
-	WarehouseType           string `json:"warehouse_type"`
-	SpotInstancePolicy      string `json:"spot_instance_policy"`
+	Name                    string        `json:"name"`
+	ClusterSize             string        `json:"cluster_size"`
+	AutoStopMins            *int          `json:"auto_stop_mins"`
+	MaxNumClusters          int           `json:"max_num_clusters"`
+	MinNumClusters          int           `json:"min_num_clusters"`
+	EnablePhoton            bool          `json:"enable_photon"`
+	EnableServerlessCompute bool          `json:"enable_serverless_compute"`
+	CreatorName             string        `json:"creator_name"`
+	WarehouseType           string        `json:"warehouse_type"`
+	SpotInstancePolicy      string        `json:"spot_instance_policy"`
+	Tags                    *endpointTags `json:"tags"`
 }
 
 func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
@@ -208,7 +259,6 @@ func newWarehouse(req *createRequest) *warehouse {
 		Name:                    req.Name,
 		ClusterSize:             req.ClusterSize,
 		State:                   stateRunning,
-		AutoStopMins:            req.AutoStopMins,
 		MaxNumClusters:          req.MaxNumClusters,
 		MinNumClusters:          req.MinNumClusters,
 		EnablePhoton:            req.EnablePhoton,
@@ -216,14 +266,19 @@ func newWarehouse(req *createRequest) *warehouse {
 		CreatorName:             req.CreatorName,
 		WarehouseType:           req.WarehouseType,
 		SpotInstancePolicy:      req.SpotInstancePolicy,
+		Tags:                    req.Tags.toMap(),
 	}
 
 	if wh.ClusterSize == "" {
 		wh.ClusterSize = defaultClusterSize
 	}
 
-	if wh.AutoStopMins == 0 {
+	// A nil AutoStopMins means the field was omitted — apply the default. An
+	// explicit value (including 0, which disables auto-stop) is honored as-is.
+	if req.AutoStopMins == nil {
 		wh.AutoStopMins = defaultAutoStopMins
+	} else {
+		wh.AutoStopMins = *req.AutoStopMins
 	}
 
 	if wh.MaxNumClusters == 0 {
@@ -272,12 +327,14 @@ func (h *Handler) list(w http.ResponseWriter) {
 }
 
 // editRequest is the subset of EditWarehouseRequest fields we honor.
+// AutoStopMins is a pointer for the same explicit-0 reason as createRequest.
 type editRequest struct {
-	Name           string `json:"name"`
-	ClusterSize    string `json:"cluster_size"`
-	AutoStopMins   int    `json:"auto_stop_mins"`
-	MaxNumClusters int    `json:"max_num_clusters"`
-	MinNumClusters int    `json:"min_num_clusters"`
+	Name           string        `json:"name"`
+	ClusterSize    string        `json:"cluster_size"`
+	AutoStopMins   *int          `json:"auto_stop_mins"`
+	MaxNumClusters int           `json:"max_num_clusters"`
+	MinNumClusters int           `json:"min_num_clusters"`
+	Tags           *endpointTags `json:"tags"`
 }
 
 func (h *Handler) edit(w http.ResponseWriter, r *http.Request, id string) {
@@ -312,8 +369,8 @@ func applyEdit(wh *warehouse, req editRequest) {
 		wh.ClusterSize = req.ClusterSize
 	}
 
-	if req.AutoStopMins != 0 {
-		wh.AutoStopMins = req.AutoStopMins
+	if req.AutoStopMins != nil {
+		wh.AutoStopMins = *req.AutoStopMins
 	}
 
 	if req.MaxNumClusters != 0 {
@@ -322,6 +379,10 @@ func applyEdit(wh *warehouse, req editRequest) {
 
 	if req.MinNumClusters != 0 {
 		wh.MinNumClusters = req.MinNumClusters
+	}
+
+	if tags := req.Tags.toMap(); tags != nil {
+		wh.Tags = tags
 	}
 }
 
@@ -375,7 +436,7 @@ func (h *Handler) transition(w http.ResponseWriter, id, state string) {
 // toResponse renders a warehouse as the GetWarehouseResponse / EndpointInfo JSON
 // shape shared by Get and List.
 func toResponse(wh *warehouse) map[string]any {
-	return map[string]any{
+	out := map[string]any{
 		"id":                        wh.ID,
 		"name":                      wh.Name,
 		"cluster_size":              wh.ClusterSize,
@@ -390,6 +451,12 @@ func toResponse(wh *warehouse) map[string]any {
 		"warehouse_type":            wh.WarehouseType,
 		"spot_instance_policy":      wh.SpotInstancePolicy,
 	}
+
+	if tags := tagsToWire(wh.Tags); tags != nil {
+		out["tags"] = tags
+	}
+
+	return out
 }
 
 // splitPath strips the leading/trailing "/" and returns the path segments.

--- a/server/azure/databricks/sqlwarehouses/sqlwarehouses_roundtrip_test.go
+++ b/server/azure/databricks/sqlwarehouses/sqlwarehouses_roundtrip_test.go
@@ -169,3 +169,40 @@ func TestSDKWarehouseListEmpty(t *testing.T) {
 		t.Fatalf("got %d warehouses, want 0", len(all))
 	}
 }
+
+// TestSDKWarehouseAutoStopZeroAndTags pins issue #223: an explicit
+// auto_stop_mins of 0 (disable auto-stop) must be honored instead of being
+// replaced by the default, and warehouse tags must round-trip.
+func TestSDKWarehouseAutoStopZeroAndTags(t *testing.T) {
+	w := newWarehouseClient(t)
+	ctx := context.Background()
+
+	wait, err := w.Warehouses.Create(ctx, sql.CreateWarehouseRequest{
+		Name:         "wh-zero",
+		ClusterSize:  "Small",
+		AutoStopMins: 0,
+		// ForceSendFields makes the SDK serialize the zero value instead of
+		// omitting it — that's how a caller disables auto-stop on the wire.
+		ForceSendFields: []string{"AutoStopMins"},
+		Tags: &sql.EndpointTags{
+			CustomTags: []sql.EndpointTagPair{{Key: "team", Value: "data"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := w.Warehouses.GetById(ctx, wait.Id)
+	if err != nil {
+		t.Fatalf("GetById: %v", err)
+	}
+
+	if got.AutoStopMins != 0 {
+		t.Fatalf("auto_stop_mins: got %d, want 0 (explicit disable must be honored)", got.AutoStopMins)
+	}
+
+	if got.Tags == nil || len(got.Tags.CustomTags) != 1 ||
+		got.Tags.CustomTags[0].Key != "team" || got.Tags.CustomTags[0].Value != "data" {
+		t.Fatalf("tags: got %+v, want custom_tags [{team data}]", got.Tags)
+	}
+}

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -268,6 +268,8 @@ func portableToAzureType(service, typ string) string {
 		return "microsoft.documentdb/databaseaccounts"
 	case "serverless/Function":
 		return "microsoft.web/sites"
+	case "databricks/Workspace":
+		return "microsoft.databricks/workspaces"
 	default:
 		return strings.ToLower(service + "/" + typ)
 	}

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -34,16 +34,17 @@ import (
 // Canonical Azure resource type strings used by Resource Graph query syntax
 // and emitted in response rows.
 const (
-	azureTypeVM      = "microsoft.compute/virtualmachines"
-	azureTypeVNet    = "microsoft.network/virtualnetworks"
-	azureTypeSubnet  = "microsoft.network/subnets"
-	azureTypeSubnetN = "microsoft.network/virtualnetworks/subnets"
-	azureTypeNSG     = "microsoft.network/networksecuritygroups"
-	azureTypeStorage = "microsoft.storage/storageaccounts"
-	azureTypeStoCnt  = "microsoft.storage/storageaccounts/blobservices/containers"
-	azureTypeCosmos  = "microsoft.documentdb/databaseaccounts"
-	azureTypeCosmosC = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
-	azureTypeWebSite = "microsoft.web/sites"
+	azureTypeVM        = "microsoft.compute/virtualmachines"
+	azureTypeVNet      = "microsoft.network/virtualnetworks"
+	azureTypeSubnet    = "microsoft.network/subnets"
+	azureTypeSubnetN   = "microsoft.network/virtualnetworks/subnets"
+	azureTypeNSG       = "microsoft.network/networksecuritygroups"
+	azureTypeStorage   = "microsoft.storage/storageaccounts"
+	azureTypeStoCnt    = "microsoft.storage/storageaccounts/blobservices/containers"
+	azureTypeCosmos    = "microsoft.documentdb/databaseaccounts"
+	azureTypeCosmosC   = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
+	azureTypeWebSite   = "microsoft.web/sites"
+	azureTypeDatabrick = "microsoft.databricks/workspaces"
 )
 
 // Portable service identifiers as emitted by the resourcediscovery walkers.
@@ -53,6 +54,7 @@ const (
 	portableStorage    = "storage"
 	portableDatabase   = "database"
 	portableServerless = "serverless"
+	portableDatabricks = "databricks"
 )
 
 // parsedKQL is the result of KQL parsing — an engine Query plus the limit
@@ -80,6 +82,10 @@ type parsedKQL struct {
 var (
 	// type == 'X' / type =~ 'X' / type == "X".
 	reWhereType = regexp.MustCompile(`(?i)^\s*type\s*(==|=~)\s*['"]([^'"]+)['"]\s*$`)
+	// type in ('a','b') / type in~ ('a', "b") — case-insensitive in-list.
+	reWhereTypeIn = regexp.MustCompile(`(?i)^\s*type\s+in~?\s*\(([^)]*)\)\s*$`)
+	// a single quoted item inside an in-list.
+	reQuotedItem = regexp.MustCompile(`['"]([^'"]+)['"]`)
 	// resourceGroup == 'X'.
 	reWhereRG = regexp.MustCompile(`(?i)^\s*resourceGroup\s*==\s*['"]([^'"]+)['"]\s*$`)
 	// location == 'X'.
@@ -142,6 +148,19 @@ func applyWhere(out *parsedKQL, body string) {
 		return
 	}
 
+	if m := reWhereTypeIn.FindStringSubmatch(body); m != nil {
+		items := reQuotedItem.FindAllStringSubmatch(m[1], -1)
+
+		types := make([]string, 0, len(items))
+		for _, it := range items {
+			types = append(types, it[1])
+		}
+
+		applyTypeList(out, types)
+
+		return
+	}
+
 	if m := reWhereRG.FindStringSubmatch(body); m != nil {
 		// The engine does not track resource groups; every Azure resource
 		// is bucketed under a single "default" group. Filtering by RG is
@@ -190,6 +209,42 @@ func applyType(out *parsedKQL, azureType string) {
 	}
 }
 
+// applyTypeList handles `where type in~ ('a', 'b')` — an any-of set of types.
+// Each Azure type maps to a portable (service, type) pair; the services and
+// types are unioned into the engine Query as any-of filters. Like applyType,
+// a second type clause AND-ed on top is a contradiction and flips ForceEmpty.
+func applyTypeList(out *parsedKQL, azureTypes []string) {
+	if out.typeSet {
+		out.ForceEmpty = true
+		return
+	}
+
+	out.typeSet = true
+
+	for _, at := range azureTypes {
+		svc, typ := mapAzureType(strings.ToLower(strings.TrimSpace(at)))
+		if svc != "" {
+			out.Query.Services = appendUnique(out.Query.Services, svc)
+		}
+
+		if typ != "" {
+			out.Query.Types = appendUnique(out.Query.Types, typ)
+		}
+	}
+}
+
+// appendUnique appends v to s only if it is not already present, preserving
+// order. Keeps the any-of filter slices free of duplicate entries.
+func appendUnique(s []string, v string) []string {
+	for _, existing := range s {
+		if existing == v {
+			return s
+		}
+	}
+
+	return append(s, v)
+}
+
 // addTag records a tag predicate. Repeating the same key with a different
 // value is a KQL contradiction (a single tag cannot hold two values at
 // once); flips ForceEmpty so the handler returns an empty result.
@@ -232,6 +287,8 @@ func mapAzureType(azureType string) (service, typ string) {
 		return portableDatabase, "Table"
 	case azureTypeWebSite:
 		return portableServerless, "Function"
+	case azureTypeDatabrick:
+		return portableDatabricks, "Workspace"
 	default:
 		return "", ""
 	}

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -200,6 +200,14 @@ func applyType(out *parsedKQL, azureType string) {
 	out.typeSet = true
 
 	svc, typ := mapAzureType(strings.ToLower(azureType))
+	if svc == "" && typ == "" {
+		// Unmapped type — match none, not all. Without this the empty Query
+		// would fall through to "no filter" and return the whole inventory.
+		out.ForceEmpty = true
+
+		return
+	}
+
 	if svc != "" {
 		out.Query.Services = []string{svc}
 	}
@@ -230,6 +238,13 @@ func applyTypeList(out *parsedKQL, azureTypes []string) {
 		if typ != "" {
 			out.Query.Types = appendUnique(out.Query.Types, typ)
 		}
+	}
+
+	// An empty list, or one containing only types cloudemu doesn't model,
+	// resolves to no filter terms. Match none rather than letting the empty
+	// Query fall through to "no filter" and return the whole inventory.
+	if len(out.Query.Services) == 0 && len(out.Query.Types) == 0 {
+		out.ForceEmpty = true
 	}
 }
 

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -225,6 +225,22 @@ func TestSDKResourceGraph_DatabricksIndexing(t *testing.T) {
 		data := out.Data.([]any)
 		assert.Len(t, data, 2)
 	})
+
+	t.Run("type in~ with an unmodeled type matches none, not all", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type in~ ('microsoft.keyvault/vaults')"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords, "an unmapped type must not widen to the whole inventory")
+	})
+
+	t.Run("type == an unmodeled type matches none, not all", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.keyvault/vaults'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
 }
 
 func rowsHaveType(data []any, want string) bool {

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stackshy/cloudemu"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	azureserver "github.com/stackshy/cloudemu/server/azure"
 )
@@ -157,6 +158,83 @@ func TestSDKResourceGraph(t *testing.T) {
 		assert.Contains(t, id, "Microsoft.Network")
 		assert.Equal(t, "123456789012", row["subscriptionId"])
 	})
+}
+
+// TestSDKResourceGraph_DatabricksIndexing pins issue #225: Databricks ARM
+// workspaces must appear in Resource Graph results (they are wired as a
+// service driver but were not fed into the discovery inventory), and the
+// `where type in~ (...)` case-insensitive in-list predicate must actually
+// filter instead of returning every row.
+func TestSDKResourceGraph_DatabricksIndexing(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.Databricks.CreateWorkspace(ctx, dbxdriver.WorkspaceConfig{
+		Name: "ws-1", ResourceGroup: "rg-1", Location: "eastus", SKUName: "premium",
+		ManagedResourceGroupID: "/subscriptions/123456789012/resourceGroups/databricks-rg-1",
+		Tags:                   map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "control-bucket"))
+
+	srv := azureserver.New(azureserver.Drivers{
+		Databricks:          cloudP.Databricks,
+		DatabricksDataPlane: cloudP.Databricks,
+		BlobStorage:         cloudP.BlobStorage,
+		ResourceDiscovery:   cloudP.ResourceDiscovery,
+		SubscriptionID:      "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	t.Run("workspace appears in bare Resources query", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2, "control bucket + databricks workspace")
+		assert.True(t, rowsHaveType(data, "microsoft.databricks/workspaces"),
+			"databricks workspace must be indexed alongside storage")
+	})
+
+	t.Run("type in~ filters to just the workspace", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type in~ ('microsoft.databricks/workspaces') | project id, name, type"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1, "in~ must narrow to the workspace, not return all rows")
+
+		row := data[0].(map[string]any)
+		assert.Equal(t, "ws-1", row["name"])
+		assert.Equal(t, "microsoft.databricks/workspaces", row["type"])
+	})
+
+	t.Run("type in~ with multiple types returns both", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type in~ ('microsoft.databricks/workspaces', 'microsoft.storage/storageaccounts')"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 2)
+	})
+}
+
+func rowsHaveType(data []any, want string) bool {
+	for _, d := range data {
+		if row, ok := d.(map[string]any); ok && row["type"] == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newResourceGraphClient(t *testing.T, ts *httptest.Server) *armresourcegraph.Client {

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -29,8 +29,10 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
+	vertexaisrv "github.com/stackshy/cloudemu/server/gcp/vertexai"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+	vertexaidriver "github.com/stackshy/cloudemu/vertexai/driver"
 )
 
 // Drivers bundles the driver interfaces the GCP server can expose.
@@ -44,6 +46,7 @@ type Drivers struct {
 	PubSub         mqdriver.MessageQueue
 	CloudSQL       rdbdriver.RelationalDB
 	GKE            *gkeprov.Mock
+	VertexAI       vertexaidriver.VertexAI
 	IAM            iamdriver.IAM
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
@@ -104,6 +107,14 @@ func New(d Drivers) *server.Server {
 	// same /v1/projects/ space as Firestore, so register first.
 	if d.GKE != nil {
 		srv.Register(gke.New(d.GKE))
+	}
+
+	// Vertex AI matches /v1/projects/{p}/locations/{l}/{models|endpoints|datasets|
+	// customJobs|batchPredictionJobs}/... and /v1/publishers/...:generateContent.
+	// Disjoint from GKE/functions/instances; registered before Firestore's
+	// permissive /v1/projects/ prefix.
+	if d.VertexAI != nil {
+		srv.Register(vertexaisrv.New(d.VertexAI))
 	}
 
 	// Cloud Asset Inventory matches /v1/{scope}:method and /v1/{parent}/

--- a/server/gcp/vertexai/cachedcontents.go
+++ b/server/gcp/vertexai/cachedcontents.go
@@ -1,0 +1,102 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func cachedContentJSON(c *driver.CachedContent) map[string]any {
+	return map[string]any{
+		"name": c.Name, "model": c.Model, "displayName": c.DisplayName,
+		"createTime": c.CreateTime, "expireTime": c.ExpireTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveCachedContents(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listCachedContents(w, r, p.location)
+		case http.MethodPost:
+			h.createCachedContent(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCachedContent(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteCachedContent(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createCachedContent(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		Model       string `json:"model"`
+		DisplayName string `json:"displayName"`
+		TTL         struct {
+			Seconds int `json:"seconds"`
+		} `json:"ttl"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	cc, err := h.svc.CreateCachedContent(r.Context(), driver.CachedContentConfig{
+		Location: location, Model: req.Model, DisplayName: req.DisplayName, TTLSeconds: req.TTL.Seconds,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, cachedContentJSON(cc))
+}
+
+func (h *Handler) getCachedContent(w http.ResponseWriter, r *http.Request, name string) {
+	cc, err := h.svc.GetCachedContent(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, cachedContentJSON(cc))
+}
+
+func (h *Handler) listCachedContents(w http.ResponseWriter, r *http.Request, location string) {
+	ccs, err := h.svc.ListCachedContents(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ccs))
+	for i := range ccs {
+		out = append(out, cachedContentJSON(&ccs[i]))
+	}
+
+	writeJSON(w, map[string]any{"cachedContents": out})
+}
+
+func (h *Handler) deleteCachedContent(w http.ResponseWriter, r *http.Request, name string) {
+	if err := h.svc.DeleteCachedContent(r.Context(), name); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}

--- a/server/gcp/vertexai/datasets.go
+++ b/server/gcp/vertexai/datasets.go
@@ -86,7 +86,7 @@ func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location
 		return
 	}
 
-	op, _, err := h.svc.CreateDataset(r.Context(), driver.DatasetConfig{
+	op, ds, err := h.svc.CreateDataset(r.Context(), driver.DatasetConfig{
 		Location: location, DisplayName: req.DisplayName,
 		MetadataSchemaURI: req.MetadataSchemaURI, Labels: req.Labels,
 	})
@@ -96,7 +96,7 @@ func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, datasetJSON(ds), "Dataset")
 }
 
 func (h *Handler) getDataset(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/datasets.go
+++ b/server/gcp/vertexai/datasets.go
@@ -1,0 +1,157 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func datasetJSON(d *driver.Dataset) map[string]any {
+	return map[string]any{
+		"name":              d.Name,
+		"displayName":       d.DisplayName,
+		"metadataSchemaUri": d.MetadataSchemaURI,
+		"labels":            d.Labels,
+		"createTime":        d.CreateTime,
+		"updateTime":        d.UpdateTime,
+	}
+}
+
+func (h *Handler) serveDatasets(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listDatasets(w, r, p.location)
+		case http.MethodPost:
+			h.createDataset(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.datasetAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getDataset(w, r, p.name)
+	case http.MethodPatch:
+		h.patchDataset(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteDataset(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) datasetAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var op *driver.Operation
+
+	var err error
+
+	switch p.action {
+	case "import":
+		op, err = h.svc.ImportData(r.Context(), p.name, "")
+	case "export":
+		op, err = h.svc.ExportData(r.Context(), p.name, "")
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown dataset action: "+p.action)
+
+		return
+	}
+
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName       string            `json:"displayName"`
+		MetadataSchemaURI string            `json:"metadataSchemaUri"`
+		Labels            map[string]string `json:"labels"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateDataset(r.Context(), driver.DatasetConfig{
+		Location: location, DisplayName: req.DisplayName,
+		MetadataSchemaURI: req.MetadataSchemaURI, Labels: req.Labels,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getDataset(w http.ResponseWriter, r *http.Request, name string) {
+	ds, err := h.svc.GetDataset(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, datasetJSON(ds))
+}
+
+func (h *Handler) listDatasets(w http.ResponseWriter, r *http.Request, location string) {
+	dss, err := h.svc.ListDatasets(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(dss))
+	for i := range dss {
+		out = append(out, datasetJSON(&dss[i]))
+	}
+
+	writeJSON(w, map[string]any{"datasets": out})
+}
+
+func (h *Handler) patchDataset(w http.ResponseWriter, r *http.Request, name string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	ds, err := h.svc.PatchDataset(r.Context(), name, req.DisplayName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, datasetJSON(ds))
+}
+
+func (h *Handler) deleteDataset(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteDataset(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -1,0 +1,245 @@
+package vertexai
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func endpointJSON(e *driver.Endpoint) map[string]any {
+	dms := make([]map[string]any, 0, len(e.DeployedModels))
+	for _, d := range e.DeployedModels {
+		dms = append(dms, map[string]any{
+			"id": d.ID, "model": d.Model, "displayName": d.DisplayName,
+		})
+	}
+
+	traffic := map[string]any{}
+	for k, v := range e.TrafficSplit {
+		traffic[k] = v
+	}
+
+	return map[string]any{
+		"name":           e.Name,
+		"displayName":    e.DisplayName,
+		"description":    e.Description,
+		"deployedModels": dms,
+		"trafficSplit":   traffic,
+		"labels":         e.Labels,
+		"createTime":     e.CreateTime,
+		"updateTime":     e.UpdateTime,
+	}
+}
+
+func (h *Handler) serveEndpoints(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listEndpoints(w, r, p.location)
+		case http.MethodPost:
+			h.createEndpoint(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.endpointAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getEndpoint(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteEndpoint(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) endpointAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	switch p.action {
+	case "predict":
+		h.predict(w, r, p.name)
+	case "rawPredict":
+		h.rawPredict(w, r, p.name)
+	case "deployModel":
+		h.deployModel(w, r, p.name)
+	case "undeployModel":
+		h.undeployModel(w, r, p.name)
+	case actionGenerateContent, actionStreamGenerateContent:
+		h.endpointGenerateContent(w, r, p.name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown endpoint action: "+p.action)
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string            `json:"displayName"`
+		Description string            `json:"description"`
+		Labels      map[string]string `json:"labels"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
+		Location: location, DisplayName: req.DisplayName, Description: req.Description, Labels: req.Labels,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	ep, err := h.svc.GetEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, endpointJSON(ep))
+}
+
+func (h *Handler) listEndpoints(w http.ResponseWriter, r *http.Request, location string) {
+	eps, err := h.svc.ListEndpoints(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(eps))
+	for i := range eps {
+		out = append(out, endpointJSON(&eps[i]))
+	}
+
+	writeJSON(w, map[string]any{"endpoints": out})
+}
+
+func (h *Handler) deleteEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint string) {
+	var req struct {
+		DeployedModel struct {
+			ID                 string `json:"id"`
+			Model              string `json:"model"`
+			DisplayName        string `json:"displayName"`
+			DedicatedResources struct {
+				MachineSpec struct {
+					MachineType string `json:"machineType"`
+				} `json:"machineSpec"`
+				MinReplicaCount int `json:"minReplicaCount"`
+				MaxReplicaCount int `json:"maxReplicaCount"`
+			} `json:"dedicatedResources"`
+		} `json:"deployedModel"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	dm := req.DeployedModel
+
+	op, _, err := h.svc.DeployModel(r.Context(), endpoint, driver.DeployedModel{
+		ID: dm.ID, Model: dm.Model, DisplayName: dm.DisplayName,
+		MachineType:     dm.DedicatedResources.MachineSpec.MachineType,
+		MinReplicaCount: dm.DedicatedResources.MinReplicaCount,
+		MaxReplicaCount: dm.DedicatedResources.MaxReplicaCount,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) undeployModel(w http.ResponseWriter, r *http.Request, endpoint string) {
+	var req struct {
+		DeployedModelID string `json:"deployedModelId"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.UndeployModel(r.Context(), endpoint, req.DeployedModelID)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) predict(w http.ResponseWriter, r *http.Request, endpoint string) {
+	var req struct {
+		Instances  []any `json:"instances"`
+		Parameters any   `json:"parameters"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	resp, err := h.svc.Predict(r.Context(), driver.PredictRequest{
+		Endpoint: endpoint, Instances: req.Instances, Parameters: req.Parameters,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"predictions":      resp.Predictions,
+		"deployedModelId":  resp.DeployedModelID,
+		"model":            resp.Model,
+		"modelDisplayName": resp.ModelDisplayName,
+	})
+}
+
+func (h *Handler) rawPredict(w http.ResponseWriter, r *http.Request, endpoint string) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "badRequest", "failed to read body")
+
+		return
+	}
+
+	out, cerr := h.svc.RawPredict(r.Context(), endpoint, body)
+	if cerr != nil {
+		writeCErr(w, cerr)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -92,7 +92,7 @@ func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, locatio
 		return
 	}
 
-	op, _, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
+	op, ep, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
 		Location: location, DisplayName: req.DisplayName, Description: req.Description, Labels: req.Labels,
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, locatio
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, endpointJSON(ep), "Endpoint")
 }
 
 func (h *Handler) getEndpoint(w http.ResponseWriter, r *http.Request, name string) {
@@ -164,7 +164,7 @@ func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint s
 
 	dm := req.DeployedModel
 
-	op, _, err := h.svc.DeployModel(r.Context(), endpoint, driver.DeployedModel{
+	op, ep, err := h.svc.DeployModel(r.Context(), endpoint, driver.DeployedModel{
 		ID: dm.ID, Model: dm.Model, DisplayName: dm.DisplayName,
 		MachineType:     dm.DedicatedResources.MachineSpec.MachineType,
 		MinReplicaCount: dm.DedicatedResources.MinReplicaCount,
@@ -176,7 +176,15 @@ func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint s
 		return
 	}
 
-	writeOp(w, op)
+	// DeployModelResponse carries the newly deployed model (the last appended).
+	var deployed map[string]any
+
+	if n := len(ep.DeployedModels); n > 0 {
+		d := ep.DeployedModels[n-1]
+		deployed = map[string]any{"id": d.ID, "model": d.Model, "displayName": d.DisplayName}
+	}
+
+	writeResourceOp(w, op, map[string]any{"deployedModel": deployed}, "DeployModelResponse")
 }
 
 func (h *Handler) undeployModel(w http.ResponseWriter, r *http.Request, endpoint string) {
@@ -195,7 +203,7 @@ func (h *Handler) undeployModel(w http.ResponseWriter, r *http.Request, endpoint
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nil, "UndeployModelResponse")
 }
 
 func (h *Handler) predict(w http.ResponseWriter, r *http.Request, endpoint string) {

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -1,6 +1,7 @@
 package vertexai
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -248,7 +249,13 @@ func (h *Handler) rawPredict(w http.ResponseWriter, r *http.Request, endpoint st
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(out)
+	// Re-encode the echoed payload through json rather than writing the
+	// request-derived bytes verbatim: it keeps the response valid JSON and
+	// breaks the request→response taint flow (gosec G705) at the source.
+	var payload any
+	if jerr := json.Unmarshal(out, &payload); jerr != nil {
+		payload = map[string]any{"raw": string(out)}
+	}
+
+	writeJSON(w, payload)
 }

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -32,6 +32,7 @@ func endpointJSON(e *driver.Endpoint) map[string]any {
 	}
 }
 
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
 func (h *Handler) serveEndpoints(w http.ResponseWriter, r *http.Request, p *vPath) {
 	if p.name == "" {
 		switch r.Method {

--- a/server/gcp/vertexai/featureregistry.go
+++ b/server/gcp/vertexai/featureregistry.go
@@ -1,0 +1,415 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Feature groups + features (Feature Registry) ---
+
+func featureGroupJSON(g *driver.FeatureGroup) map[string]any {
+	return map[string]any{
+		"name": g.Name, "description": g.Description,
+		"bigQuery":   map[string]any{"bigQuerySource": map[string]any{"inputUri": g.BigQueryURI}},
+		"createTime": g.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveFeatureGroups(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subRes == "features" {
+		h.serveFeatures(w, r, p)
+
+		return
+	}
+
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatureGroups(w, r, p.location)
+		case http.MethodPost:
+			h.createFeatureGroup(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeatureGroup(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteFeatureGroup(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		Description string `json:"description"`
+		BigQuery    struct {
+			BigQuerySource struct {
+				InputURI string `json:"inputUri"`
+			} `json:"bigQuerySource"`
+		} `json:"bigQuery"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupConfig{
+		Location: location, FeatureGroupID: r.URL.Query().Get("featureGroupId"),
+		Description: req.Description, BigQueryURI: req.BigQuery.BigQuerySource.InputURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeatureGroup(w http.ResponseWriter, r *http.Request, name string) {
+	g, err := h.svc.GetFeatureGroup(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featureGroupJSON(g))
+}
+
+func (h *Handler) listFeatureGroups(w http.ResponseWriter, r *http.Request, location string) {
+	gs, err := h.svc.ListFeatureGroups(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(gs))
+	for i := range gs {
+		out = append(out, featureGroupJSON(&gs[i]))
+	}
+
+	writeJSON(w, map[string]any{"featureGroups": out})
+}
+
+func (h *Handler) deleteFeatureGroup(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeatureGroup(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func featureJSON(f *driver.Feature) map[string]any {
+	return map[string]any{"name": f.Name, "description": f.Description, "createTime": f.CreateTime}
+}
+
+func (h *Handler) serveFeatures(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatures(w, r, p.name)
+		case http.MethodPost:
+			h.createFeature(w, r, p)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	name := p.name + "/features/" + p.subName
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeature(w, r, name)
+	case http.MethodDelete:
+		h.deleteFeature(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeature(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var req struct {
+		Description string `json:"description"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeature(r.Context(), p.name, r.URL.Query().Get("featureId"), req.Description)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeature(w http.ResponseWriter, r *http.Request, name string) {
+	f, err := h.svc.GetFeature(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featureJSON(f))
+}
+
+func (h *Handler) listFeatures(w http.ResponseWriter, r *http.Request, parent string) {
+	fs, err := h.svc.ListFeatures(r.Context(), parent)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(fs))
+	for i := range fs {
+		out = append(out, featureJSON(&fs[i]))
+	}
+
+	writeJSON(w, map[string]any{"features": out})
+}
+
+func (h *Handler) deleteFeature(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeature(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Feature online stores + feature views ---
+
+func onlineStoreJSON(s *driver.FeatureOnlineStore) map[string]any {
+	return map[string]any{"name": s.Name, "state": s.State, "createTime": s.CreateTime}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveFeatureOnlineStores(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subRes == "featureViews" {
+		h.serveFeatureViews(w, r, p)
+
+		return
+	}
+
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatureOnlineStores(w, r, p.location)
+		case http.MethodPost:
+			h.createFeatureOnlineStore(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeatureOnlineStore(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteFeatureOnlineStore(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeatureOnlineStore(w http.ResponseWriter, r *http.Request, location string) {
+	if !decode(w, r, &struct{}{}) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeatureOnlineStore(r.Context(), driver.FeatureOnlineStoreConfig{
+		Location: location, FeatureOnlineStoreID: r.URL.Query().Get("featureOnlineStoreId"),
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeatureOnlineStore(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.svc.GetFeatureOnlineStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, onlineStoreJSON(s))
+}
+
+func (h *Handler) listFeatureOnlineStores(w http.ResponseWriter, r *http.Request, location string) {
+	ss, err := h.svc.ListFeatureOnlineStores(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ss))
+	for i := range ss {
+		out = append(out, onlineStoreJSON(&ss[i]))
+	}
+
+	writeJSON(w, map[string]any{"featureOnlineStores": out})
+}
+
+func (h *Handler) deleteFeatureOnlineStore(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeatureOnlineStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func featureViewJSON(v *driver.FeatureView) map[string]any {
+	return map[string]any{
+		"name":           v.Name,
+		"bigQuerySource": map[string]any{"uri": v.BigQueryURI},
+		"createTime":     v.CreateTime,
+	}
+}
+
+func (h *Handler) serveFeatureViews(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatureViews(w, r, p.name)
+		case http.MethodPost:
+			h.createFeatureView(w, r, p)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	name := p.name + "/featureViews/" + p.subName
+
+	if r.Method == http.MethodPost && p.action == "fetchFeatureValues" {
+		h.fetchFeatureValues(w, r, name)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeatureView(w, r, name)
+	case http.MethodDelete:
+		h.deleteFeatureView(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeatureView(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var req struct {
+		BigQuerySource struct {
+			URI string `json:"uri"`
+		} `json:"bigQuerySource"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeatureView(r.Context(), driver.FeatureViewConfig{
+		Parent: p.name, FeatureViewID: r.URL.Query().Get("featureViewId"),
+		BigQueryURI: req.BigQuerySource.URI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeatureView(w http.ResponseWriter, r *http.Request, name string) {
+	v, err := h.svc.GetFeatureView(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featureViewJSON(v))
+}
+
+func (h *Handler) listFeatureViews(w http.ResponseWriter, r *http.Request, parent string) {
+	vs, err := h.svc.ListFeatureViews(r.Context(), parent)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(vs))
+	for i := range vs {
+		out = append(out, featureViewJSON(&vs[i]))
+	}
+
+	writeJSON(w, map[string]any{"featureViews": out})
+}
+
+func (h *Handler) deleteFeatureView(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeatureView(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) fetchFeatureValues(w http.ResponseWriter, r *http.Request, featureView string) {
+	var req struct {
+		DataKey struct {
+			Key string `json:"key"`
+		} `json:"dataKey"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	vals, err := h.svc.FetchFeatureValues(r.Context(), featureView, req.DataKey.Key)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{"keyValues": map[string]any{"features": featureValuesJSON(vals)}})
+}

--- a/server/gcp/vertexai/featureregistry.go
+++ b/server/gcp/vertexai/featureregistry.go
@@ -61,7 +61,7 @@ func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	op, _, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupConfig{
+	op, fg, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupConfig{
 		Location: location, FeatureGroupID: r.URL.Query().Get("featureGroupId"),
 		Description: req.Description, BigQueryURI: req.BigQuery.BigQuerySource.InputURI,
 	})
@@ -71,7 +71,7 @@ func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featureGroupJSON(fg), "FeatureGroup")
 }
 
 func (h *Handler) getFeatureGroup(w http.ResponseWriter, r *http.Request, name string) {
@@ -151,14 +151,14 @@ func (h *Handler) createFeature(w http.ResponseWriter, r *http.Request, p *vPath
 		return
 	}
 
-	op, _, err := h.svc.CreateFeature(r.Context(), p.name, r.URL.Query().Get("featureId"), req.Description)
+	op, f, err := h.svc.CreateFeature(r.Context(), p.name, r.URL.Query().Get("featureId"), req.Description)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featureJSON(f), "Feature")
 }
 
 func (h *Handler) getFeature(w http.ResponseWriter, r *http.Request, name string) {
@@ -241,7 +241,7 @@ func (h *Handler) createFeatureOnlineStore(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	op, _, err := h.svc.CreateFeatureOnlineStore(r.Context(), driver.FeatureOnlineStoreConfig{
+	op, s, err := h.svc.CreateFeatureOnlineStore(r.Context(), driver.FeatureOnlineStoreConfig{
 		Location: location, FeatureOnlineStoreID: r.URL.Query().Get("featureOnlineStoreId"),
 	})
 	if err != nil {
@@ -250,7 +250,7 @@ func (h *Handler) createFeatureOnlineStore(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, onlineStoreJSON(s), "FeatureOnlineStore")
 }
 
 func (h *Handler) getFeatureOnlineStore(w http.ResponseWriter, r *http.Request, name string) {
@@ -342,7 +342,7 @@ func (h *Handler) createFeatureView(w http.ResponseWriter, r *http.Request, p *v
 		return
 	}
 
-	op, _, err := h.svc.CreateFeatureView(r.Context(), driver.FeatureViewConfig{
+	op, fv, err := h.svc.CreateFeatureView(r.Context(), driver.FeatureViewConfig{
 		Parent: p.name, FeatureViewID: r.URL.Query().Get("featureViewId"),
 		BigQueryURI: req.BigQuerySource.URI,
 	})
@@ -352,7 +352,7 @@ func (h *Handler) createFeatureView(w http.ResponseWriter, r *http.Request, p *v
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featureViewJSON(fv), "FeatureView")
 }
 
 func (h *Handler) getFeatureView(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/featurestore.go
+++ b/server/gcp/vertexai/featurestore.go
@@ -58,7 +58,7 @@ func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	op, _, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
+	op, fs, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
 		Location: location, FeaturestoreID: r.URL.Query().Get("featurestoreId"),
 		OnlineNodeCount: req.OnlineServingConfig.FixedNodeCount,
 	})
@@ -68,7 +68,7 @@ func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featurestoreJSON(fs), "Featurestore")
 }
 
 func (h *Handler) getFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
@@ -169,14 +169,14 @@ func (h *Handler) createEntityType(w http.ResponseWriter, r *http.Request, p *vP
 		return
 	}
 
-	op, _, err := h.svc.CreateEntityType(r.Context(), p.name, r.URL.Query().Get("entityTypeId"), req.EntityType.Description)
+	op, et, err := h.svc.CreateEntityType(r.Context(), p.name, r.URL.Query().Get("entityTypeId"), req.EntityType.Description)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, entityTypeJSON(et), "EntityType")
 }
 
 func (h *Handler) getEntityType(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/featurestore.go
+++ b/server/gcp/vertexai/featurestore.go
@@ -1,0 +1,274 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Featurestores ---
+
+func featurestoreJSON(f *driver.Featurestore) map[string]any {
+	return map[string]any{
+		"name": f.Name, "state": f.State,
+		"onlineServingConfig": map[string]any{"fixedNodeCount": f.OnlineNodeCount},
+		"createTime":          f.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveFeaturestores(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subRes == "entityTypes" {
+		h.serveEntityTypes(w, r, p)
+
+		return
+	}
+
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeaturestores(w, r, p.location)
+		case http.MethodPost:
+			h.createFeaturestore(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeaturestore(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteFeaturestore(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		OnlineServingConfig struct {
+			FixedNodeCount int `json:"fixedNodeCount"`
+		} `json:"onlineServingConfig"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
+		Location: location, FeaturestoreID: r.URL.Query().Get("featurestoreId"),
+		OnlineNodeCount: req.OnlineServingConfig.FixedNodeCount,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
+	fs, err := h.svc.GetFeaturestore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featurestoreJSON(fs))
+}
+
+func (h *Handler) listFeaturestores(w http.ResponseWriter, r *http.Request, location string) {
+	fss, err := h.svc.ListFeaturestores(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(fss))
+	for i := range fss {
+		out = append(out, featurestoreJSON(&fss[i]))
+	}
+
+	writeJSON(w, map[string]any{"featurestores": out})
+}
+
+func (h *Handler) deleteFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeaturestore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Entity types + online feature values ---
+
+func entityTypeJSON(e *driver.EntityType) map[string]any {
+	return map[string]any{"name": e.Name, "description": e.Description, "createTime": e.CreateTime}
+}
+
+func (h *Handler) serveEntityTypes(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listEntityTypes(w, r, p.name)
+		case http.MethodPost:
+			h.createEntityType(w, r, p)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	name := p.name + "/entityTypes/" + p.subName
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.entityTypeAction(w, r, name, p.action)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getEntityType(w, r, name)
+	case http.MethodDelete:
+		h.deleteEntityType(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) entityTypeAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	switch action {
+	case "readFeatureValues":
+		h.readFeatureValues(w, r, name)
+	case "writeFeatureValues":
+		h.writeFeatureValues(w, r, name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown entityType action: "+action)
+	}
+}
+
+func (h *Handler) createEntityType(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var req struct {
+		EntityType struct {
+			Description string `json:"description"`
+		} `json:"entityType"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateEntityType(r.Context(), p.name, r.URL.Query().Get("entityTypeId"), req.EntityType.Description)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getEntityType(w http.ResponseWriter, r *http.Request, name string) {
+	et, err := h.svc.GetEntityType(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, entityTypeJSON(et))
+}
+
+func (h *Handler) listEntityTypes(w http.ResponseWriter, r *http.Request, parent string) {
+	ets, err := h.svc.ListEntityTypes(r.Context(), parent)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ets))
+	for i := range ets {
+		out = append(out, entityTypeJSON(&ets[i]))
+	}
+
+	writeJSON(w, map[string]any{"entityTypes": out})
+}
+
+func (h *Handler) deleteEntityType(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteEntityType(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) readFeatureValues(w http.ResponseWriter, r *http.Request, entityType string) {
+	var req struct {
+		EntityID string `json:"entityId"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	vals, err := h.svc.ReadFeatureValues(r.Context(), entityType, req.EntityID)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{"entityView": map[string]any{"entityId": req.EntityID, "data": featureValuesJSON(vals)}})
+}
+
+func (h *Handler) writeFeatureValues(w http.ResponseWriter, r *http.Request, entityType string) {
+	var req struct {
+		Payloads []struct {
+			EntityID      string            `json:"entityId"`
+			FeatureValues map[string]string `json:"featureValues"`
+		} `json:"payloads"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	for _, pl := range req.Payloads {
+		values := make([]driver.FeatureNameValue, 0, len(pl.FeatureValues))
+		for name, val := range pl.FeatureValues {
+			values = append(values, driver.FeatureNameValue{Name: name, Value: val})
+		}
+
+		if err := h.svc.WriteFeatureValues(r.Context(), entityType, pl.EntityID, values); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+func featureValuesJSON(vals []driver.FeatureNameValue) []map[string]any {
+	out := make([]map[string]any, 0, len(vals))
+	for _, v := range vals {
+		out = append(out, map[string]any{"name": v.Name, "value": v.Value})
+	}
+
+	return out
+}

--- a/server/gcp/vertexai/genai.go
+++ b/server/gcp/vertexai/genai.go
@@ -1,0 +1,143 @@
+package vertexai
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// wireContent is the JSON shape of a generateContent content turn.
+type wireContent struct {
+	Role  string `json:"role"`
+	Parts []struct {
+		Text string `json:"text"`
+	} `json:"parts"`
+}
+
+type wireGenerateRequest struct {
+	Contents          []wireContent `json:"contents"`
+	SystemInstruction *wireContent  `json:"systemInstruction"`
+	GenerationConfig  *struct {
+		Temperature     *float64 `json:"temperature"`
+		TopP            *float64 `json:"topP"`
+		TopK            *int     `json:"topK"`
+		MaxOutputTokens *int     `json:"maxOutputTokens"`
+	} `json:"generationConfig"`
+}
+
+func toContents(in []wireContent) []driver.Content {
+	out := make([]driver.Content, 0, len(in))
+
+	for _, c := range in {
+		parts := make([]driver.Part, 0, len(c.Parts))
+		for _, p := range c.Parts {
+			parts = append(parts, driver.Part{Text: p.Text})
+		}
+
+		out = append(out, driver.Content{Role: c.Role, Parts: parts})
+	}
+
+	return out
+}
+
+func toDriverRequest(req wireGenerateRequest) driver.GenerateContentRequest {
+	dr := driver.GenerateContentRequest{Contents: toContents(req.Contents)}
+
+	if req.SystemInstruction != nil {
+		si := toContents([]wireContent{*req.SystemInstruction})
+		dr.SystemInstruction = &si[0]
+	}
+
+	if req.GenerationConfig != nil {
+		dr.GenerationConfig = &driver.GenerationConfig{
+			Temperature:     req.GenerationConfig.Temperature,
+			TopP:            req.GenerationConfig.TopP,
+			TopK:            req.GenerationConfig.TopK,
+			MaxOutputTokens: req.GenerationConfig.MaxOutputTokens,
+		}
+	}
+
+	return dr
+}
+
+func generateResponseJSON(resp *driver.GenerateContentResponse) map[string]any {
+	cands := make([]map[string]any, 0, len(resp.Candidates))
+
+	for _, c := range resp.Candidates {
+		parts := make([]map[string]any, 0, len(c.Content.Parts))
+		for _, p := range c.Content.Parts {
+			parts = append(parts, map[string]any{"text": p.Text})
+		}
+
+		cands = append(cands, map[string]any{
+			"content":      map[string]any{"role": c.Content.Role, "parts": parts},
+			"finishReason": c.FinishReason,
+		})
+	}
+
+	return map[string]any{
+		"candidates": cands,
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     resp.UsageMetadata.PromptTokenCount,
+			"candidatesTokenCount": resp.UsageMetadata.CandidatesTokenCount,
+			"totalTokenCount":      resp.UsageMetadata.TotalTokenCount,
+		},
+	}
+}
+
+// servePublishers handles /v1/publishers/{pub}/models/{model}:{action}.
+func (h *Handler) servePublishers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/")
+
+	model, action := splitActionPair(rest)
+	if action == "" {
+		writeError(w, http.StatusNotFound, "notFound", "missing action on publishers path")
+
+		return
+	}
+
+	h.runGenAI(w, r, model, action)
+}
+
+func (h *Handler) endpointGenerateContent(w http.ResponseWriter, r *http.Request, endpoint string) {
+	h.runGenAI(w, r, endpoint, "generateContent")
+}
+
+// runGenAI dispatches generateContent / countTokens for either a publisher
+// model path or an endpoint resource name.
+func (h *Handler) runGenAI(w http.ResponseWriter, r *http.Request, model, action string) {
+	var req wireGenerateRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	switch action {
+	case "generateContent", actionStreamGenerateContent:
+		resp, err := h.svc.GenerateContent(r.Context(), model, toDriverRequest(req))
+		if err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, generateResponseJSON(resp))
+	case "countTokens":
+		resp, err := h.svc.CountTokens(r.Context(), model, toDriverRequest(req))
+		if err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{"totalTokens": resp.TotalTokens})
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown generative action: "+action)
+	}
+}

--- a/server/gcp/vertexai/genai.go
+++ b/server/gcp/vertexai/genai.go
@@ -119,7 +119,7 @@ func (h *Handler) runGenAI(w http.ResponseWriter, r *http.Request, model, action
 	}
 
 	switch action {
-	case "generateContent", actionStreamGenerateContent:
+	case "generateContent":
 		resp, err := h.svc.GenerateContent(r.Context(), model, toDriverRequest(req))
 		if err != nil {
 			writeCErr(w, err)
@@ -128,6 +128,18 @@ func (h *Handler) runGenAI(w http.ResponseWriter, r *http.Request, model, action
 		}
 
 		writeJSON(w, generateResponseJSON(resp))
+	case actionStreamGenerateContent:
+		resp, err := h.svc.GenerateContent(r.Context(), model, toDriverRequest(req))
+		if err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		// streamGenerateContent returns a JSON array of response chunks; emit a
+		// single-element array so SDK stream decoders iterate it correctly
+		// (a lone object fails array-decoding / yields zero chunks).
+		writeJSON(w, []map[string]any{generateResponseJSON(resp)})
 	case "countTokens":
 		resp, err := h.svc.CountTokens(r.Context(), model, toDriverRequest(req))
 		if err != nil {

--- a/server/gcp/vertexai/handler.go
+++ b/server/gcp/vertexai/handler.go
@@ -5,14 +5,23 @@
 // {location}-aiplatform.googleapis.com.
 //
 // Control-plane mutations return google.longrunning.Operation envelopes with
-// done=true so SDK pollers terminate on the first poll. Job-family creates
-// return the resource directly (synchronous). predict / generateContent are
-// synchronous data-plane calls.
+// done=true AND the typed result populated in response (with its @type), so SDK
+// pollers terminate on the first poll and unmarshal the resource straight off
+// the operation. Job-family creates return the resource directly (synchronous).
+// predict / generateContent are synchronous data-plane calls.
 //
 // The /v1/projects/{p}/locations/{l}/ prefix is shared with Cloud Functions,
 // Cloud SQL and GKE; Matches narrows on the Vertex collection segment so this
 // handler claims only its own URLs. It also claims /v1/publishers/ for the
 // Model Garden generateContent surface.
+//
+// LRO polling note: the operations collection
+// (.../locations/{l}/operations/{id}) is intentionally NOT claimed here — the
+// GKE handler, registered ahead of Vertex on the shared prefix, already owns
+// it. This is safe because every Vertex mutation completes done-on-arrival with
+// its result inlined (above), so a client never needs to poll. If a future
+// non-done Vertex op is introduced, route operations through a shared
+// per-location operations handler before relying on polling.
 package vertexai
 
 import (

--- a/server/gcp/vertexai/handler.go
+++ b/server/gcp/vertexai/handler.go
@@ -1,0 +1,182 @@
+// Package vertexai implements the Google Cloud Vertex AI
+// (aiplatform.googleapis.com) REST API as a server.Handler. Real
+// google.golang.org/api/aiplatform/v1 clients (and any REST caller) configured
+// with a custom endpoint hit this handler the same way they hit
+// {location}-aiplatform.googleapis.com.
+//
+// Control-plane mutations return google.longrunning.Operation envelopes with
+// done=true so SDK pollers terminate on the first poll. Job-family creates
+// return the resource directly (synchronous). predict / generateContent are
+// synchronous data-plane calls.
+//
+// The /v1/projects/{p}/locations/{l}/ prefix is shared with Cloud Functions,
+// Cloud SQL and GKE; Matches narrows on the Vertex collection segment so this
+// handler claims only its own URLs. It also claims /v1/publishers/ for the
+// Model Garden generateContent surface.
+package vertexai
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+const (
+	pathPrefix       = "/v1/projects/"
+	publishersPrefix = "/v1/publishers/"
+	locationsSeg     = "locations"
+	maxBodyBytes     = 6 << 20
+
+	actionCancel                = "cancel"
+	actionGenerateContent       = "generateContent"
+	actionStreamGenerateContent = "streamGenerateContent"
+)
+
+// vertexCollections are the resource collections this handler serves. Listed
+// explicitly so it never shadows the sibling functions/instances/clusters
+// handlers on the shared locations prefix.
+//
+//nolint:gochecknoglobals // immutable routing set shared by Matches and dispatch
+var vertexCollections = map[string]bool{
+	"datasets": true, "models": true, "endpoints": true,
+	"customJobs": true, "batchPredictionJobs": true,
+}
+
+// Handler serves Vertex AI REST requests against a vertexai driver.
+type Handler struct {
+	svc driver.VertexAI
+}
+
+// New returns a Vertex AI handler backed by svc.
+func New(svc driver.VertexAI) *Handler {
+	return &Handler{svc: svc}
+}
+
+// Matches claims the Vertex collection URLs and the publishers generateContent
+// surface.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, publishersPrefix) {
+		return true
+	}
+
+	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+		return false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
+
+	const idxScope, idxResource = 1, 3
+
+	if len(parts) <= idxResource || parts[idxScope] != locationsSeg {
+		return false
+	}
+
+	return vertexCollections[stripAction(parts[idxResource])]
+}
+
+// vPath is a parsed Vertex REST path.
+type vPath struct {
+	project    string
+	location   string
+	collection string
+	name       string // full resource name when addressing a specific resource
+	subRes     string // e.g. "features" / "featureViews" / "operations"
+	subName    string
+	action     string // ":predict", ":deployModel", ":upload", ... (no leading colon)
+}
+
+// parsePath splits a Vertex projects/locations URL.
+func parsePath(urlPath string) (vPath, bool) {
+	parts := strings.Split(strings.TrimPrefix(urlPath, pathPrefix), "/")
+
+	const (
+		minParts    = 4
+		idxProject  = 0
+		idxLocation = 2
+		idxResource = 3
+		idxName     = 4
+		idxSubRes   = 5
+		idxSubName  = 6
+	)
+
+	if len(parts) < minParts {
+		return vPath{}, false
+	}
+
+	p := vPath{project: parts[idxProject], location: parts[idxLocation]}
+	p.collection, p.action = splitActionPair(parts[idxResource])
+
+	if len(parts) > idxName {
+		seg, act := splitActionPair(parts[idxName])
+		p.name = "projects/" + p.project + "/locations/" + p.location + "/" + p.collection + "/" + seg
+
+		if act != "" {
+			p.action = act
+		}
+	}
+
+	if len(parts) > idxSubRes {
+		p.subRes, _ = splitActionPair(parts[idxSubRes])
+	}
+
+	if len(parts) > idxSubName {
+		seg, act := splitActionPair(parts[idxSubName])
+		p.subName = seg
+
+		if act != "" {
+			p.action = act
+		}
+	}
+
+	return p, true
+}
+
+// stripAction returns a path segment without any ":action" suffix.
+func stripAction(seg string) string {
+	if i := strings.Index(seg, ":"); i >= 0 {
+		return seg[:i]
+	}
+
+	return seg
+}
+
+// splitActionPair splits "seg:action" into ("seg", "action").
+func splitActionPair(seg string) (name, action string) {
+	if i := strings.Index(seg, ":"); i >= 0 {
+		return seg[:i], seg[i+1:]
+	}
+
+	return seg, ""
+}
+
+// ServeHTTP dispatches Vertex requests.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, publishersPrefix) {
+		h.servePublishers(w, r)
+
+		return
+	}
+
+	p, ok := parsePath(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "notFound", "unsupported path: "+r.URL.Path)
+
+		return
+	}
+
+	switch p.collection {
+	case "models":
+		h.serveModels(w, r, &p)
+	case "endpoints":
+		h.serveEndpoints(w, r, &p)
+	case "datasets":
+		h.serveDatasets(w, r, &p)
+	case "customJobs":
+		h.serveCustomJobs(w, r, &p)
+	case "batchPredictionJobs":
+		h.serveBatchPredictionJobs(w, r, &p)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unsupported collection: "+p.collection)
+	}
+}

--- a/server/gcp/vertexai/handler.go
+++ b/server/gcp/vertexai/handler.go
@@ -41,16 +41,50 @@ const (
 var vertexCollections = map[string]bool{
 	"datasets": true, "models": true, "endpoints": true,
 	"customJobs": true, "batchPredictionJobs": true,
+	"hyperparameterTuningJobs": true, "trainingPipelines": true,
+	"pipelineJobs": true, "tuningJobs": true, "cachedContents": true,
+	"featurestores": true, "featureGroups": true, "featureOnlineStores": true,
+	"indexes": true, "indexEndpoints": true, "metadataStores": true,
+	"tensorboards": true, "schedules": true, "notebookRuntimes": true,
+	"notebookRuntimeTemplates": true,
 }
+
+// collectionHandler serves one Vertex collection's requests.
+type collectionHandler func(http.ResponseWriter, *http.Request, *vPath)
 
 // Handler serves Vertex AI REST requests against a vertexai driver.
 type Handler struct {
-	svc driver.VertexAI
+	svc    driver.VertexAI
+	routes map[string]collectionHandler
 }
 
 // New returns a Vertex AI handler backed by svc.
 func New(svc driver.VertexAI) *Handler {
-	return &Handler{svc: svc}
+	h := &Handler{svc: svc}
+	h.routes = map[string]collectionHandler{
+		"models":                   h.serveModels,
+		"endpoints":                h.serveEndpoints,
+		"datasets":                 h.serveDatasets,
+		"customJobs":               h.serveCustomJobs,
+		"batchPredictionJobs":      h.serveBatchPredictionJobs,
+		"hyperparameterTuningJobs": h.serveHyperparameterTuningJobs,
+		"trainingPipelines":        h.serveTrainingPipelines,
+		"pipelineJobs":             h.servePipelineJobs,
+		"tuningJobs":               h.serveTuningJobs,
+		"cachedContents":           h.serveCachedContents,
+		"featurestores":            h.serveFeaturestores,
+		"featureGroups":            h.serveFeatureGroups,
+		"featureOnlineStores":      h.serveFeatureOnlineStores,
+		"indexes":                  h.serveIndexes,
+		"indexEndpoints":           h.serveIndexEndpoints,
+		"metadataStores":           h.serveMetadataStores,
+		"tensorboards":             h.serveTensorboards,
+		"schedules":                h.serveSchedules,
+		"notebookRuntimes":         h.serveNotebookRuntimes,
+		"notebookRuntimeTemplates": h.serveNotebookRuntimeTemplates,
+	}
+
+	return h
 }
 
 // Matches claims the Vertex collection URLs and the publishers generateContent
@@ -165,18 +199,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch p.collection {
-	case "models":
-		h.serveModels(w, r, &p)
-	case "endpoints":
-		h.serveEndpoints(w, r, &p)
-	case "datasets":
-		h.serveDatasets(w, r, &p)
-	case "customJobs":
-		h.serveCustomJobs(w, r, &p)
-	case "batchPredictionJobs":
-		h.serveBatchPredictionJobs(w, r, &p)
-	default:
+	serve, ok := h.routes[p.collection]
+	if !ok {
 		writeError(w, http.StatusNotFound, "notFound", "unsupported collection: "+p.collection)
+
+		return
 	}
+
+	serve(w, r, &p)
 }

--- a/server/gcp/vertexai/jobs.go
+++ b/server/gcp/vertexai/jobs.go
@@ -1,0 +1,216 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Custom jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveCustomJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listCustomJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createCustomJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelCustomJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCustomJob(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteCustomJob(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func customJobJSON(j *driver.CustomJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "state": j.State,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createCustomJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateCustomJob(r.Context(), driver.CustomJobConfig{Location: location, DisplayName: req.DisplayName})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, customJobJSON(job))
+}
+
+func (h *Handler) getCustomJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetCustomJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, customJobJSON(job))
+}
+
+func (h *Handler) listCustomJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListCustomJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, customJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"customJobs": out})
+}
+
+func (h *Handler) deleteCustomJob(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteCustomJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Batch prediction jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveBatchPredictionJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listBatchPredictionJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createBatchPredictionJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelBatchPredictionJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getBatchPredictionJob(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteBatchPredictionJob(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func batchJobJSON(j *driver.BatchPredictionJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "model": j.Model, "state": j.State,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createBatchPredictionJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Model       string `json:"model"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateBatchPredictionJob(r.Context(), driver.BatchPredictionJobConfig{
+		Location: location, DisplayName: req.DisplayName, Model: req.Model,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, batchJobJSON(job))
+}
+
+func (h *Handler) getBatchPredictionJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetBatchPredictionJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, batchJobJSON(job))
+}
+
+func (h *Handler) listBatchPredictionJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListBatchPredictionJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, batchJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"batchPredictionJobs": out})
+}
+
+func (h *Handler) deleteBatchPredictionJob(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteBatchPredictionJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/metadata.go
+++ b/server/gcp/vertexai/metadata.go
@@ -42,14 +42,14 @@ func (h *Handler) createMetadataStore(w http.ResponseWriter, r *http.Request, lo
 		return
 	}
 
-	op, _, err := h.svc.CreateMetadataStore(r.Context(), location, r.URL.Query().Get("metadataStoreId"))
+	op, s, err := h.svc.CreateMetadataStore(r.Context(), location, r.URL.Query().Get("metadataStoreId"))
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, metadataStoreJSON(s), "MetadataStore")
 }
 
 func (h *Handler) getMetadataStore(w http.ResponseWriter, r *http.Request, name string) {
@@ -130,14 +130,14 @@ func (h *Handler) createTensorboard(w http.ResponseWriter, r *http.Request, loca
 		return
 	}
 
-	op, _, err := h.svc.CreateTensorboard(r.Context(), location, req.DisplayName)
+	op, tb, err := h.svc.CreateTensorboard(r.Context(), location, req.DisplayName)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, tensorboardJSON(tb), "Tensorboard")
 }
 
 func (h *Handler) getTensorboard(w http.ResponseWriter, r *http.Request, name string) {
@@ -344,14 +344,14 @@ func (h *Handler) createNotebookRuntimeTemplate(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	op, _, err := h.svc.CreateNotebookRuntimeTemplate(r.Context(), location, req.DisplayName, req.MachineSpec.MachineType)
+	op, t, err := h.svc.CreateNotebookRuntimeTemplate(r.Context(), location, req.DisplayName, req.MachineSpec.MachineType)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nbTemplateJSON(t), "NotebookRuntimeTemplate")
 }
 
 func (h *Handler) getNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, name string) {
@@ -468,14 +468,14 @@ func (h *Handler) assignNotebookRuntime(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	op, _, err := h.svc.AssignNotebookRuntime(r.Context(), location, req.NotebookRuntime.DisplayName)
+	op, nr, err := h.svc.AssignNotebookRuntime(r.Context(), location, req.NotebookRuntime.DisplayName)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nbRuntimeJSON(nr), "NotebookRuntime")
 }
 
 func (h *Handler) getNotebookRuntime(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/metadata.go
+++ b/server/gcp/vertexai/metadata.go
@@ -1,0 +1,517 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Metadata stores ---
+
+func metadataStoreJSON(s *driver.MetadataStore) map[string]any {
+	return map[string]any{"name": s.Name, "createTime": s.CreateTime}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveMetadataStores(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listMetadataStores(w, r, p.location)
+		case http.MethodPost:
+			h.createMetadataStore(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getMetadataStore(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteMetadataStore(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createMetadataStore(w http.ResponseWriter, r *http.Request, location string) {
+	if !decode(w, r, &struct{}{}) {
+		return
+	}
+
+	op, _, err := h.svc.CreateMetadataStore(r.Context(), location, r.URL.Query().Get("metadataStoreId"))
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getMetadataStore(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.svc.GetMetadataStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, metadataStoreJSON(s))
+}
+
+func (h *Handler) listMetadataStores(w http.ResponseWriter, r *http.Request, location string) {
+	ss, err := h.svc.ListMetadataStores(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ss))
+	for i := range ss {
+		out = append(out, metadataStoreJSON(&ss[i]))
+	}
+
+	writeJSON(w, map[string]any{"metadataStores": out})
+}
+
+func (h *Handler) deleteMetadataStore(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteMetadataStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Tensorboards ---
+
+func tensorboardJSON(t *driver.Tensorboard) map[string]any {
+	return map[string]any{"name": t.Name, "displayName": t.DisplayName, "createTime": t.CreateTime}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveTensorboards(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTensorboards(w, r, p.location)
+		case http.MethodPost:
+			h.createTensorboard(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTensorboard(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteTensorboard(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createTensorboard(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateTensorboard(r.Context(), location, req.DisplayName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getTensorboard(w http.ResponseWriter, r *http.Request, name string) {
+	t, err := h.svc.GetTensorboard(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, tensorboardJSON(t))
+}
+
+func (h *Handler) listTensorboards(w http.ResponseWriter, r *http.Request, location string) {
+	ts, err := h.svc.ListTensorboards(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ts))
+	for i := range ts {
+		out = append(out, tensorboardJSON(&ts[i]))
+	}
+
+	writeJSON(w, map[string]any{"tensorboards": out})
+}
+
+func (h *Handler) deleteTensorboard(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteTensorboard(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Schedules ---
+
+func scheduleJSON(s *driver.Schedule) map[string]any {
+	return map[string]any{
+		"name": s.Name, "displayName": s.DisplayName, "cron": s.Cron,
+		"state": s.State, "createTime": s.CreateTime,
+	}
+}
+
+func (h *Handler) serveSchedules(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listSchedules(w, r, p.location)
+		case http.MethodPost:
+			h.createSchedule(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.scheduleAction(w, r, p.name, p.action)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSchedule(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteSchedule(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) scheduleAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	var err error
+
+	switch action {
+	case "pause":
+		err = h.svc.PauseSchedule(r.Context(), name)
+	case "resume":
+		err = h.svc.ResumeSchedule(r.Context(), name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown schedule action: "+action)
+
+		return
+	}
+
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+func (h *Handler) createSchedule(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Cron        string `json:"cron"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	s, err := h.svc.CreateSchedule(r.Context(), location, req.DisplayName, req.Cron)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, scheduleJSON(s))
+}
+
+func (h *Handler) getSchedule(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.svc.GetSchedule(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, scheduleJSON(s))
+}
+
+func (h *Handler) listSchedules(w http.ResponseWriter, r *http.Request, location string) {
+	ss, err := h.svc.ListSchedules(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ss))
+	for i := range ss {
+		out = append(out, scheduleJSON(&ss[i]))
+	}
+
+	writeJSON(w, map[string]any{"schedules": out})
+}
+
+func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteSchedule(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Notebook runtime templates ---
+
+func nbTemplateJSON(t *driver.NotebookRuntimeTemplate) map[string]any {
+	return map[string]any{
+		"name": t.Name, "displayName": t.DisplayName,
+		"machineSpec": map[string]any{"machineType": t.MachineType}, "createTime": t.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveNotebookRuntimeTemplates(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listNotebookRuntimeTemplates(w, r, p.location)
+		case http.MethodPost:
+			h.createNotebookRuntimeTemplate(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNotebookRuntimeTemplate(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteNotebookRuntimeTemplate(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		MachineSpec struct {
+			MachineType string `json:"machineType"`
+		} `json:"machineSpec"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateNotebookRuntimeTemplate(r.Context(), location, req.DisplayName, req.MachineSpec.MachineType)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, name string) {
+	t, err := h.svc.GetNotebookRuntimeTemplate(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nbTemplateJSON(t))
+}
+
+func (h *Handler) listNotebookRuntimeTemplates(w http.ResponseWriter, r *http.Request, location string) {
+	ts, err := h.svc.ListNotebookRuntimeTemplates(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ts))
+	for i := range ts {
+		out = append(out, nbTemplateJSON(&ts[i]))
+	}
+
+	writeJSON(w, map[string]any{"notebookRuntimeTemplates": out})
+}
+
+func (h *Handler) deleteNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteNotebookRuntimeTemplate(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Notebook runtimes ---
+
+func nbRuntimeJSON(n *driver.NotebookRuntime) map[string]any {
+	return map[string]any{
+		"name": n.Name, "displayName": n.DisplayName,
+		"runtimeState": n.RuntimeState, "createTime": n.CreateTime,
+	}
+}
+
+func (h *Handler) serveNotebookRuntimes(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch {
+		case r.Method == http.MethodGet:
+			h.listNotebookRuntimes(w, r, p.location)
+		case r.Method == http.MethodPost && p.action == "assign":
+			h.assignNotebookRuntime(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.notebookRuntimeAction(w, r, p.name, p.action)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNotebookRuntime(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteNotebookRuntime(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) notebookRuntimeAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	var (
+		op  *driver.Operation
+		err error
+	)
+
+	switch action {
+	case "start":
+		op, err = h.svc.StartNotebookRuntime(r.Context(), name)
+	case "stop":
+		op, err = h.svc.StopNotebookRuntime(r.Context(), name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown notebookRuntime action: "+action)
+
+		return
+	}
+
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) assignNotebookRuntime(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		NotebookRuntime struct {
+			DisplayName string `json:"displayName"`
+		} `json:"notebookRuntime"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.AssignNotebookRuntime(r.Context(), location, req.NotebookRuntime.DisplayName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getNotebookRuntime(w http.ResponseWriter, r *http.Request, name string) {
+	n, err := h.svc.GetNotebookRuntime(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nbRuntimeJSON(n))
+}
+
+func (h *Handler) listNotebookRuntimes(w http.ResponseWriter, r *http.Request, location string) {
+	ns, err := h.svc.ListNotebookRuntimes(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ns))
+	for i := range ns {
+		out = append(out, nbRuntimeJSON(&ns[i]))
+	}
+
+	writeJSON(w, map[string]any{"notebookRuntimes": out})
+}
+
+func (h *Handler) deleteNotebookRuntime(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteNotebookRuntime(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/models.go
+++ b/server/gcp/vertexai/models.go
@@ -35,6 +35,18 @@ func (h *Handler) serveModels(w http.ResponseWriter, r *http.Request, p *vPath) 
 		return
 	}
 
+	if p.subRes == "evaluations" {
+		h.serveModelEvaluations(w, r, p)
+
+		return
+	}
+
+	if r.Method == http.MethodGet && p.action == "listVersions" {
+		h.listModelVersions(w, r, p.name)
+
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		h.getModel(w, r, p.name)
@@ -43,6 +55,97 @@ func (h *Handler) serveModels(w http.ResponseWriter, r *http.Request, p *vPath) 
 	default:
 		methodNotAllowed(w)
 	}
+}
+
+func evaluationJSON(e *driver.ModelEvaluation) map[string]any {
+	return map[string]any{
+		"name": e.Name, "displayName": e.DisplayName,
+		"metricsSchemaUri": e.MetricsType, "createTime": e.CreateTime,
+	}
+}
+
+func (h *Handler) serveModelEvaluations(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listModelEvaluations(w, r, p.name)
+		case http.MethodPost:
+			h.importModelEvaluation(w, r, p.name)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	ev, err := h.svc.GetModelEvaluation(r.Context(), p.name+"/evaluations/"+p.subName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, evaluationJSON(ev))
+}
+
+func (h *Handler) importModelEvaluation(w http.ResponseWriter, r *http.Request, modelName string) {
+	var req struct {
+		DisplayName      string `json:"displayName"`
+		MetricsSchemaURI string `json:"metricsSchemaUri"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	ev, err := h.svc.ImportModelEvaluation(r.Context(), modelName, driver.ModelEvaluation{
+		DisplayName: req.DisplayName, MetricsType: req.MetricsSchemaURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, evaluationJSON(ev))
+}
+
+func (h *Handler) listModelEvaluations(w http.ResponseWriter, r *http.Request, modelName string) {
+	evs, err := h.svc.ListModelEvaluations(r.Context(), modelName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(evs))
+	for i := range evs {
+		out = append(out, evaluationJSON(&evs[i]))
+	}
+
+	writeJSON(w, map[string]any{"modelEvaluations": out})
+}
+
+func (h *Handler) listModelVersions(w http.ResponseWriter, r *http.Request, name string) {
+	models, err := h.svc.ListModelVersions(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(models))
+	for i := range models {
+		out = append(out, modelJSON(&models[i]))
+	}
+
+	writeJSON(w, map[string]any{"models": out})
 }
 
 func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location string) {

--- a/server/gcp/vertexai/models.go
+++ b/server/gcp/vertexai/models.go
@@ -165,7 +165,7 @@ func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	op, _, err := h.svc.UploadModel(r.Context(), driver.ModelConfig{
+	op, mdl, err := h.svc.UploadModel(r.Context(), driver.ModelConfig{
 		Location:       location,
 		DisplayName:    req.Model.DisplayName,
 		Description:    req.Model.Description,
@@ -179,7 +179,7 @@ func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, modelJSON(mdl), "Model")
 }
 
 func (h *Handler) getModel(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/models.go
+++ b/server/gcp/vertexai/models.go
@@ -1,0 +1,118 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func modelJSON(m *driver.Model) map[string]any {
+	return map[string]any{
+		"name":           m.Name,
+		"displayName":    m.DisplayName,
+		"description":    m.Description,
+		"versionId":      m.VersionID,
+		"versionAliases": m.VersionAliases,
+		"artifactUri":    m.ArtifactURI,
+		"containerSpec":  map[string]any{"imageUri": m.ContainerImage},
+		"labels":         m.Labels,
+		"createTime":     m.CreateTime,
+		"updateTime":     m.UpdateTime,
+	}
+}
+
+func (h *Handler) serveModels(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch {
+		case r.Method == http.MethodGet:
+			h.listModels(w, r, p.location)
+		case r.Method == http.MethodPost && p.action == "upload":
+			h.uploadModel(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getModel(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteModel(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		Model struct {
+			DisplayName   string `json:"displayName"`
+			Description   string `json:"description"`
+			ArtifactURI   string `json:"artifactUri"`
+			ContainerSpec struct {
+				ImageURI string `json:"imageUri"`
+			} `json:"containerSpec"`
+			Labels map[string]string `json:"labels"`
+		} `json:"model"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.UploadModel(r.Context(), driver.ModelConfig{
+		Location:       location,
+		DisplayName:    req.Model.DisplayName,
+		Description:    req.Model.Description,
+		ContainerImage: req.Model.ContainerSpec.ImageURI,
+		ArtifactURI:    req.Model.ArtifactURI,
+		Labels:         req.Model.Labels,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getModel(w http.ResponseWriter, r *http.Request, name string) {
+	model, err := h.svc.GetModel(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, modelJSON(model))
+}
+
+func (h *Handler) listModels(w http.ResponseWriter, r *http.Request, location string) {
+	models, err := h.svc.ListModels(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(models))
+	for i := range models {
+		out = append(out, modelJSON(&models[i]))
+	}
+
+	writeJSON(w, map[string]any{"models": out})
+}
+
+func (h *Handler) deleteModel(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteModel(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/pipelines.go
+++ b/server/gcp/vertexai/pipelines.go
@@ -1,0 +1,219 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Training pipelines ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveTrainingPipelines(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTrainingPipelines(w, r, p.location)
+		case http.MethodPost:
+			h.createTrainingPipeline(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelTrainingPipeline(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTrainingPipeline(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteTrainingPipeline(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func trainingPipelineJSON(t *driver.TrainingPipeline) map[string]any {
+	return map[string]any{
+		"name": t.Name, "displayName": t.DisplayName, "state": t.State,
+		"createTime": t.CreateTime, "endTime": t.EndTime,
+	}
+}
+
+func (h *Handler) createTrainingPipeline(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		TaskType    string `json:"taskType"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	tp, err := h.svc.CreateTrainingPipeline(r.Context(), driver.TrainingPipelineConfig{
+		Location: location, DisplayName: req.DisplayName, TaskType: req.TaskType,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, trainingPipelineJSON(tp))
+}
+
+func (h *Handler) getTrainingPipeline(w http.ResponseWriter, r *http.Request, name string) {
+	tp, err := h.svc.GetTrainingPipeline(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, trainingPipelineJSON(tp))
+}
+
+func (h *Handler) listTrainingPipelines(w http.ResponseWriter, r *http.Request, location string) {
+	tps, err := h.svc.ListTrainingPipelines(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(tps))
+	for i := range tps {
+		out = append(out, trainingPipelineJSON(&tps[i]))
+	}
+
+	writeJSON(w, map[string]any{"trainingPipelines": out})
+}
+
+func (h *Handler) deleteTrainingPipeline(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteTrainingPipeline(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Pipeline jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) servePipelineJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listPipelineJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createPipelineJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelPipelineJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getPipelineJob(w, r, p.name)
+	case http.MethodDelete:
+		h.deletePipelineJob(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func pipelineJobJSON(j *driver.PipelineJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "state": j.State,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createPipelineJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		TemplateURI string `json:"templateUri"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	pj, err := h.svc.CreatePipelineJob(r.Context(), driver.PipelineJobConfig{
+		Location: location, DisplayName: req.DisplayName, TemplateURI: req.TemplateURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, pipelineJobJSON(pj))
+}
+
+func (h *Handler) getPipelineJob(w http.ResponseWriter, r *http.Request, name string) {
+	pj, err := h.svc.GetPipelineJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, pipelineJobJSON(pj))
+}
+
+func (h *Handler) listPipelineJobs(w http.ResponseWriter, r *http.Request, location string) {
+	pjs, err := h.svc.ListPipelineJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(pjs))
+	for i := range pjs {
+		out = append(out, pipelineJobJSON(&pjs[i]))
+	}
+
+	writeJSON(w, map[string]any{"pipelineJobs": out})
+}
+
+func (h *Handler) deletePipelineJob(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeletePipelineJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/responses.go
+++ b/server/gcp/vertexai/responses.go
@@ -1,0 +1,47 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func writeJSON(w http.ResponseWriter, v any) {
+	gcprest.WriteJSON(w, http.StatusOK, v)
+}
+
+func writeError(w http.ResponseWriter, status int, reason, msg string) {
+	gcprest.WriteError(w, status, reason, msg)
+}
+
+func writeCErr(w http.ResponseWriter, err error) {
+	gcprest.WriteCErr(w, err)
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	return gcprest.DecodeJSON(w, r, v)
+}
+
+// writeOp writes a long-running Operation as the GCP JSON envelope.
+func writeOp(w http.ResponseWriter, op *driver.Operation) {
+	body := map[string]any{"name": op.Name, "done": op.Done}
+	if op.Metadata != nil {
+		body["metadata"] = op.Metadata
+	}
+
+	if op.Response != nil {
+		body["response"] = op.Response
+	}
+
+	if op.Error != nil {
+		body["error"] = map[string]any{"code": op.Error.Code, "message": op.Error.Message}
+	}
+
+	writeJSON(w, body)
+}
+
+// methodNotAllowed writes a 405 in GCP error shape.
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+}

--- a/server/gcp/vertexai/responses.go
+++ b/server/gcp/vertexai/responses.go
@@ -41,6 +41,35 @@ func writeOp(w http.ResponseWriter, op *driver.Operation) {
 	writeJSON(w, body)
 }
 
+// typeURLPrefix is the google.protobuf.Any type-URL prefix for aiplatform v1
+// messages. SDK pollers read the typed result out of a done operation's
+// response, keyed by @type, so done LROs must carry it.
+const typeURLPrefix = "type.googleapis.com/google.cloud.aiplatform.v1."
+
+// writeResourceOp writes a done LRO whose response carries the created/affected
+// resource (plus its @type) so SDK callers can unmarshal the typed result off
+// the operation. A nil resource yields a response with only the @type (e.g.
+// UndeployModelResponse). respType is the bare message name, e.g. "Model".
+func writeResourceOp(w http.ResponseWriter, op *driver.Operation, resource map[string]any, respType string) {
+	body := map[string]any{"name": op.Name, "done": op.Done}
+	if op.Metadata != nil {
+		body["metadata"] = op.Metadata
+	}
+
+	resp := map[string]any{"@type": typeURLPrefix + respType}
+	for k, v := range resource {
+		resp[k] = v
+	}
+
+	body["response"] = resp
+
+	if op.Error != nil {
+		body["error"] = map[string]any{"code": op.Error.Code, "message": op.Error.Message}
+	}
+
+	writeJSON(w, body)
+}
+
 // methodNotAllowed writes a 405 in GCP error shape.
 func methodNotAllowed(w http.ResponseWriter) {
 	writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -1,0 +1,158 @@
+package vertexai_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const base = "/v1/projects/mock-project/locations/us-central1"
+
+func newServer(t *testing.T) string {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{
+		VertexAI: cloud.VertexAI,
+		// Firestore included to exercise routing precedence: Vertex must claim
+		// its collections before Firestore's permissive /v1/projects/ prefix.
+		Firestore: cloud.Firestore,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts.URL
+}
+
+func do(t *testing.T, method, url string, body any) map[string]any {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		rdr = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, url, rdr)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "method=%s url=%s body=%s", method, url, raw)
+
+	out := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		require.NoError(t, json.Unmarshal(raw, &out), "body=%s", raw)
+	}
+
+	return out
+}
+
+func TestModelUploadAndGet(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/models:upload", map[string]any{
+		"model": map[string]any{"displayName": "m1", "containerSpec": map[string]any{"imageUri": "img:latest"}},
+	})
+	assert.Equal(t, true, op["done"])
+	name, _ := op["response"].(map[string]any)["name"].(string)
+	require.NotEmpty(t, name)
+
+	got := do(t, http.MethodGet, url+"/v1/"+name, nil)
+	assert.Equal(t, "m1", got["displayName"])
+
+	list := do(t, http.MethodGet, url+base+"/models", nil)
+	assert.Len(t, list["models"], 1)
+}
+
+func TestEndpointDeployPredict(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/endpoints", map[string]any{"displayName": "ep"})
+	assert.Equal(t, true, op["done"])
+	epName := op["response"].(map[string]any)["name"].(string)
+	require.NotEmpty(t, epName)
+
+	do(t, http.MethodPost, url+"/v1/"+epName+":deployModel", map[string]any{
+		"deployedModel": map[string]any{"model": base + "/models/m", "displayName": "v1"},
+	})
+
+	got := do(t, http.MethodGet, url+"/v1/"+epName, nil)
+	assert.Len(t, got["deployedModels"], 1)
+
+	pred := do(t, http.MethodPost, url+"/v1/"+epName+":predict", map[string]any{
+		"instances": []any{map[string]any{"x": 1}},
+	})
+	assert.Len(t, pred["predictions"], 1)
+	assert.NotEmpty(t, pred["deployedModelId"])
+}
+
+func TestPublishersGenerateContent(t *testing.T) {
+	url := newServer(t)
+
+	resp := do(t, http.MethodPost, url+"/v1/publishers/google/models/gemini-2.5-pro:generateContent", map[string]any{
+		"contents": []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "hello there world"}}}},
+	})
+
+	cands, ok := resp["candidates"].([]any)
+	require.True(t, ok)
+	require.Len(t, cands, 1)
+	usage := resp["usageMetadata"].(map[string]any)
+	assert.EqualValues(t, 3, usage["promptTokenCount"])
+
+	ct := do(t, http.MethodPost, url+"/v1/publishers/google/models/gemini-2.5-pro:countTokens", map[string]any{
+		"contents": []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "one two"}}}},
+	})
+	assert.EqualValues(t, 2, ct["totalTokens"])
+}
+
+func TestCustomJobSynchronous(t *testing.T) {
+	url := newServer(t)
+
+	job := do(t, http.MethodPost, url+base+"/customJobs", map[string]any{"displayName": "train"})
+	assert.Equal(t, "JOB_STATE_SUCCEEDED", job["state"])
+	name := job["name"].(string)
+
+	got := do(t, http.MethodGet, url+"/v1/"+name, nil)
+	assert.Equal(t, "JOB_STATE_SUCCEEDED", got["state"])
+
+	do(t, http.MethodPost, url+"/v1/"+name+":cancel", map[string]any{})
+}
+
+func TestDatasetCreate(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/datasets", map[string]any{"displayName": "ds"})
+	assert.Equal(t, true, op["done"])
+
+	list := do(t, http.MethodGet, url+base+"/datasets", nil)
+	assert.Len(t, list["datasets"], 1)
+}
+
+func TestNotFoundMapsTo404(t *testing.T) {
+	url := newServer(t)
+
+	req, _ := http.NewRequest(http.MethodGet, url+base+"/models/ghost", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.True(t, strings.Contains(string(body), "notFound"))
+}

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -144,6 +144,158 @@ func TestDatasetCreate(t *testing.T) {
 	assert.Len(t, list["datasets"], 1)
 }
 
+func opName(t *testing.T, op map[string]any) string {
+	t.Helper()
+
+	assert.Equal(t, true, op["done"])
+	resp, ok := op["response"].(map[string]any)
+	require.True(t, ok, "operation missing response: %v", op)
+	name, _ := resp["name"].(string)
+	require.NotEmpty(t, name)
+
+	return name
+}
+
+func TestTrainingPipelineAndPipelineJob(t *testing.T) {
+	url := newServer(t)
+
+	tp := do(t, http.MethodPost, url+base+"/trainingPipelines", map[string]any{"displayName": "tp"})
+	assert.Equal(t, "PIPELINE_STATE_SUCCEEDED", tp["state"])
+	do(t, http.MethodGet, url+"/v1/"+tp["name"].(string), nil)
+	assert.Len(t, do(t, http.MethodGet, url+base+"/trainingPipelines", nil)["trainingPipelines"], 1)
+	do(t, http.MethodPost, url+"/v1/"+tp["name"].(string)+":cancel", map[string]any{})
+
+	pj := do(t, http.MethodPost, url+base+"/pipelineJobs", map[string]any{"displayName": "pj"})
+	assert.Equal(t, "PIPELINE_STATE_SUCCEEDED", pj["state"])
+	assert.Len(t, do(t, http.MethodGet, url+base+"/pipelineJobs", nil)["pipelineJobs"], 1)
+}
+
+func TestTuningAndHyperparameterJobs(t *testing.T) {
+	url := newServer(t)
+
+	tj := do(t, http.MethodPost, url+base+"/tuningJobs", map[string]any{"baseModel": "gemini-2.5-pro"})
+	require.NotEmpty(t, tj["name"])
+	assert.Len(t, do(t, http.MethodGet, url+base+"/tuningJobs", nil)["tuningJobs"], 1)
+
+	hpo := do(t, http.MethodPost, url+base+"/hyperparameterTuningJobs", map[string]any{
+		"displayName": "hpo", "maxTrialCount": 4,
+	})
+	require.NotEmpty(t, hpo["name"])
+	assert.EqualValues(t, 4, hpo["maxTrialCount"])
+	do(t, http.MethodPost, url+"/v1/"+hpo["name"].(string)+":cancel", map[string]any{})
+}
+
+func TestCachedContents(t *testing.T) {
+	url := newServer(t)
+
+	cc := do(t, http.MethodPost, url+base+"/cachedContents", map[string]any{
+		"model": "gemini-2.5-pro", "displayName": "ctx",
+	})
+	require.NotEmpty(t, cc["name"])
+	assert.Len(t, do(t, http.MethodGet, url+base+"/cachedContents", nil)["cachedContents"], 1)
+	do(t, http.MethodDelete, url+"/v1/"+cc["name"].(string), nil)
+}
+
+func TestFeaturestoreAndEntityTypes(t *testing.T) {
+	url := newServer(t)
+
+	fsName := opName(t, do(t, http.MethodPost, url+base+"/featurestores?featurestoreId=fs1", map[string]any{}))
+	etName := opName(t, do(t, http.MethodPost, url+"/v1/"+fsName+"/entityTypes?entityTypeId=user", map[string]any{
+		"entityType": map[string]any{"description": "users"},
+	}))
+
+	do(t, http.MethodPost, url+"/v1/"+etName+":writeFeatureValues", map[string]any{
+		"payloads": []any{map[string]any{"entityId": "u1", "featureValues": map[string]any{"age": "30"}}},
+	})
+	read := do(t, http.MethodPost, url+"/v1/"+etName+":readFeatureValues", map[string]any{"entityId": "u1"})
+	require.NotNil(t, read["entityView"])
+
+	assert.Len(t, do(t, http.MethodGet, url+"/v1/"+fsName+"/entityTypes", nil)["entityTypes"], 1)
+}
+
+func TestFeatureRegistryAndOnlineStore(t *testing.T) {
+	url := newServer(t)
+
+	fgName := opName(t, do(t, http.MethodPost, url+base+"/featureGroups?featureGroupId=fg1", map[string]any{
+		"bigQuery": map[string]any{"bigQuerySource": map[string]any{"inputUri": "bq://t"}},
+	}))
+	opName(t, do(t, http.MethodPost, url+"/v1/"+fgName+"/features?featureId=f1", map[string]any{"description": "feat"}))
+	assert.Len(t, do(t, http.MethodGet, url+"/v1/"+fgName+"/features", nil)["features"], 1)
+
+	osName := opName(t, do(t, http.MethodPost, url+base+"/featureOnlineStores?featureOnlineStoreId=os1", map[string]any{}))
+	fvName := opName(t, do(t, http.MethodPost, url+"/v1/"+osName+"/featureViews?featureViewId=fv1", map[string]any{
+		"bigQuerySource": map[string]any{"uri": "bq://t"},
+	}))
+	do(t, http.MethodPost, url+"/v1/"+fvName+":fetchFeatureValues", map[string]any{
+		"dataKey": map[string]any{"key": "u1"},
+	})
+}
+
+func TestIndexesAndVectorSearch(t *testing.T) {
+	url := newServer(t)
+
+	idxName := opName(t, do(t, http.MethodPost, url+base+"/indexes", map[string]any{
+		"displayName": "idx", "metadata": map[string]any{"config": map[string]any{"dimensions": 8}},
+	}))
+	do(t, http.MethodPost, url+"/v1/"+idxName+":upsertDatapoints", map[string]any{
+		"datapoints": []any{map[string]any{"datapointId": "d1", "featureVector": []any{0.1, 0.2}}},
+	})
+	got := do(t, http.MethodGet, url+"/v1/"+idxName, nil)
+	assert.EqualValues(t, 1, got["indexStats"].(map[string]any)["vectorsCount"])
+
+	ieName := opName(t, do(t, http.MethodPost, url+base+"/indexEndpoints", map[string]any{"displayName": "ie"}))
+	do(t, http.MethodPost, url+"/v1/"+ieName+":deployIndex", map[string]any{
+		"deployedIndex": map[string]any{"id": "di1", "index": idxName},
+	})
+	nn := do(t, http.MethodPost, url+"/v1/"+ieName+":findNeighbors", map[string]any{
+		"deployedIndexId": "di1",
+		"queries":         []any{map[string]any{"datapoint": map[string]any{"featureVector": []any{0.1}}, "neighborCount": 3}},
+	})
+	require.NotNil(t, nn["nearestNeighbors"])
+}
+
+func TestMetadataTensorboardScheduleNotebook(t *testing.T) {
+	url := newServer(t)
+
+	opName(t, do(t, http.MethodPost, url+base+"/metadataStores?metadataStoreId=ms1", map[string]any{}))
+	assert.Len(t, do(t, http.MethodGet, url+base+"/metadataStores", nil)["metadataStores"], 1)
+
+	opName(t, do(t, http.MethodPost, url+base+"/tensorboards", map[string]any{"displayName": "tb"}))
+
+	sched := do(t, http.MethodPost, url+base+"/schedules", map[string]any{"displayName": "sc", "cron": "0 * * * *"})
+	assert.Equal(t, "ACTIVE", sched["state"])
+	do(t, http.MethodPost, url+"/v1/"+sched["name"].(string)+":pause", map[string]any{})
+	assert.Equal(t, "PAUSED", do(t, http.MethodGet, url+"/v1/"+sched["name"].(string), nil)["state"])
+	do(t, http.MethodPost, url+"/v1/"+sched["name"].(string)+":resume", map[string]any{})
+
+	opName(t, do(t, http.MethodPost, url+base+"/notebookRuntimeTemplates", map[string]any{
+		"displayName": "nt", "machineSpec": map[string]any{"machineType": "n1-standard-4"},
+	}))
+	nr := opName(t, do(t, http.MethodPost, url+base+"/notebookRuntimes:assign", map[string]any{
+		"notebookRuntime": map[string]any{"displayName": "nr"},
+	}))
+	do(t, http.MethodPost, url+"/v1/"+nr+":stop", map[string]any{})
+	assert.Equal(t, "STOPPED", do(t, http.MethodGet, url+"/v1/"+nr, nil)["runtimeState"])
+	do(t, http.MethodPost, url+"/v1/"+nr+":start", map[string]any{})
+}
+
+func TestModelVersionsAndEvaluations(t *testing.T) {
+	url := newServer(t)
+
+	mName := opName(t, do(t, http.MethodPost, url+base+"/models:upload", map[string]any{
+		"model": map[string]any{"displayName": "m1"},
+	}))
+
+	versions := do(t, http.MethodGet, url+"/v1/"+mName+":listVersions", nil)
+	assert.Len(t, versions["models"], 1)
+
+	ev := do(t, http.MethodPost, url+"/v1/"+mName+"/evaluations", map[string]any{
+		"displayName": "eval1", "metricsSchemaUri": "schema://x",
+	})
+	require.NotEmpty(t, ev["name"])
+	assert.Len(t, do(t, http.MethodGet, url+"/v1/"+mName+"/evaluations", nil)["modelEvaluations"], 1)
+}
+
 func TestNotFoundMapsTo404(t *testing.T) {
 	url := newServer(t)
 

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -73,6 +73,13 @@ func TestModelUploadAndGet(t *testing.T) {
 	name, _ := op["response"].(map[string]any)["name"].(string)
 	require.NotEmpty(t, name)
 
+	// The done LRO response must carry the typed Model (with @type and
+	// versionId), not just {name}, so SDK pollers can read the result.
+	resp := op["response"].(map[string]any)
+	assert.Contains(t, resp["@type"], "google.cloud.aiplatform.v1.Model")
+	assert.Equal(t, "1", resp["versionId"])
+	assert.Equal(t, "m1", resp["displayName"])
+
 	got := do(t, http.MethodGet, url+"/v1/"+name, nil)
 	assert.Equal(t, "m1", got["displayName"])
 

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -128,6 +128,33 @@ func TestPublishersGenerateContent(t *testing.T) {
 	assert.EqualValues(t, 2, ct["totalTokens"])
 }
 
+// TestStreamGenerateContentReturnsArray verifies :streamGenerateContent emits a
+// JSON array of chunks (not a lone object), which SDK stream decoders require.
+func TestStreamGenerateContentReturnsArray(t *testing.T) {
+	url := newServer(t)
+
+	body, _ := json.Marshal(map[string]any{
+		"contents": []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "hello there world"}}}},
+	})
+
+	req, err := http.NewRequest(http.MethodPost,
+		url+"/v1/publishers/google/models/gemini-2.5-pro:streamGenerateContent", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var chunks []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &chunks), "stream response must be a JSON array, got %s", raw)
+	require.GreaterOrEqual(t, len(chunks), 1)
+	assert.Contains(t, chunks[0], "candidates")
+}
+
 func TestCustomJobSynchronous(t *testing.T) {
 	url := newServer(t)
 

--- a/server/gcp/vertexai/tuning.go
+++ b/server/gcp/vertexai/tuning.go
@@ -1,0 +1,203 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Hyperparameter tuning jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveHyperparameterTuningJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listHyperparameterTuningJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createHyperparameterTuningJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelHyperparameterTuningJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		h.getHyperparameterTuningJob(w, r, p.name)
+
+		return
+	}
+
+	methodNotAllowed(w)
+}
+
+func hpoJobJSON(j *driver.HyperparameterTuningJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "state": j.State,
+		"maxTrialCount": j.MaxTrialCount, "createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createHyperparameterTuningJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName   string `json:"displayName"`
+		MaxTrialCount int    `json:"maxTrialCount"`
+		ParallelTrial int    `json:"parallelTrialCount"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateHyperparameterTuningJob(r.Context(), driver.HyperparameterTuningJobConfig{
+		Location: location, DisplayName: req.DisplayName,
+		MaxTrialCount: req.MaxTrialCount, ParallelTrials: req.ParallelTrial,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, hpoJobJSON(job))
+}
+
+func (h *Handler) getHyperparameterTuningJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetHyperparameterTuningJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, hpoJobJSON(job))
+}
+
+func (h *Handler) listHyperparameterTuningJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListHyperparameterTuningJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, hpoJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"hyperparameterTuningJobs": out})
+}
+
+// --- Tuning jobs (model tuning) ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveTuningJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTuningJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createTuningJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelTuningJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		h.getTuningJob(w, r, p.name)
+
+		return
+	}
+
+	methodNotAllowed(w)
+}
+
+func tuningJobJSON(j *driver.TuningJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "baseModel": j.BaseModel, "state": j.State,
+		"tunedModelDisplayName": j.TunedModelName, "endpoint": j.Endpoint,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createTuningJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		BaseModel             string `json:"baseModel"`
+		TunedModelDisplayName string `json:"tunedModelDisplayName"`
+		SupervisedTuningSpec  struct {
+			TrainingDatasetURI string `json:"trainingDatasetUri"`
+		} `json:"supervisedTuningSpec"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateTuningJob(r.Context(), driver.TuningJobConfig{
+		Location: location, BaseModel: req.BaseModel, TunedModelName: req.TunedModelDisplayName,
+		TrainingDataURI: req.SupervisedTuningSpec.TrainingDatasetURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, tuningJobJSON(job))
+}
+
+func (h *Handler) getTuningJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetTuningJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, tuningJobJSON(job))
+}
+
+func (h *Handler) listTuningJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListTuningJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, tuningJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"tuningJobs": out})
+}

--- a/server/gcp/vertexai/vectorsearch.go
+++ b/server/gcp/vertexai/vectorsearch.go
@@ -73,7 +73,7 @@ func (h *Handler) createIndex(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	op, _, err := h.svc.CreateIndex(r.Context(), driver.IndexConfig{
+	op, idx, err := h.svc.CreateIndex(r.Context(), driver.IndexConfig{
 		Location: location, DisplayName: req.DisplayName, Description: req.Description,
 		Dimensions: req.Metadata.Config.Dimensions,
 	})
@@ -83,7 +83,7 @@ func (h *Handler) createIndex(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, indexJSON(idx), "Index")
 }
 
 func (h *Handler) getIndex(w http.ResponseWriter, r *http.Request, name string) {
@@ -236,7 +236,7 @@ func (h *Handler) createIndexEndpoint(w http.ResponseWriter, r *http.Request, lo
 		return
 	}
 
-	op, _, err := h.svc.CreateIndexEndpoint(r.Context(), driver.IndexEndpointConfig{
+	op, ie, err := h.svc.CreateIndexEndpoint(r.Context(), driver.IndexEndpointConfig{
 		Location: location, DisplayName: req.DisplayName, Description: req.Description,
 	})
 	if err != nil {
@@ -245,7 +245,7 @@ func (h *Handler) createIndexEndpoint(w http.ResponseWriter, r *http.Request, lo
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, indexEndpointJSON(ie), "IndexEndpoint")
 }
 
 func (h *Handler) getIndexEndpoint(w http.ResponseWriter, r *http.Request, name string) {
@@ -298,7 +298,7 @@ func (h *Handler) deployIndex(w http.ResponseWriter, r *http.Request, indexEndpo
 		return
 	}
 
-	op, _, err := h.svc.DeployIndex(r.Context(), indexEndpoint, driver.DeployedIndex{
+	op, ie, err := h.svc.DeployIndex(r.Context(), indexEndpoint, driver.DeployedIndex{
 		ID: req.DeployedIndex.ID, Index: req.DeployedIndex.Index,
 	})
 	if err != nil {
@@ -307,7 +307,15 @@ func (h *Handler) deployIndex(w http.ResponseWriter, r *http.Request, indexEndpo
 		return
 	}
 
-	writeOp(w, op)
+	// DeployIndexResponse carries the newly deployed index (the last appended).
+	var deployed map[string]any
+
+	if n := len(ie.DeployedIndexes); n > 0 {
+		d := ie.DeployedIndexes[n-1]
+		deployed = map[string]any{"id": d.ID, "index": d.Index}
+	}
+
+	writeResourceOp(w, op, map[string]any{"deployedIndex": deployed}, "DeployIndexResponse")
 }
 
 func (h *Handler) undeployIndex(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
@@ -326,7 +334,7 @@ func (h *Handler) undeployIndex(w http.ResponseWriter, r *http.Request, indexEnd
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nil, "UndeployIndexResponse")
 }
 
 func (h *Handler) findNeighbors(w http.ResponseWriter, r *http.Request, indexEndpoint string) {

--- a/server/gcp/vertexai/vectorsearch.go
+++ b/server/gcp/vertexai/vectorsearch.go
@@ -1,0 +1,372 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Indexes ---
+
+func indexJSON(i *driver.Index) map[string]any {
+	return map[string]any{
+		"name": i.Name, "displayName": i.DisplayName, "description": i.Description,
+		"indexStats": map[string]any{"vectorsCount": i.DatapointCount},
+		"createTime": i.CreateTime, "updateTime": i.UpdateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveIndexes(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listIndexes(w, r, p.location)
+		case http.MethodPost:
+			h.createIndex(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.indexAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getIndex(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteIndex(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) indexAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	switch p.action {
+	case "upsertDatapoints":
+		h.upsertDatapoints(w, r, p.name)
+	case "removeDatapoints":
+		h.removeDatapoints(w, r, p.name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown index action: "+p.action)
+	}
+}
+
+func (h *Handler) createIndex(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Description string `json:"description"`
+		Metadata    struct {
+			Config struct {
+				Dimensions int `json:"dimensions"`
+			} `json:"config"`
+		} `json:"metadata"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateIndex(r.Context(), driver.IndexConfig{
+		Location: location, DisplayName: req.DisplayName, Description: req.Description,
+		Dimensions: req.Metadata.Config.Dimensions,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getIndex(w http.ResponseWriter, r *http.Request, name string) {
+	idx, err := h.svc.GetIndex(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, indexJSON(idx))
+}
+
+func (h *Handler) listIndexes(w http.ResponseWriter, r *http.Request, location string) {
+	idxs, err := h.svc.ListIndexes(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(idxs))
+	for i := range idxs {
+		out = append(out, indexJSON(&idxs[i]))
+	}
+
+	writeJSON(w, map[string]any{"indexes": out})
+}
+
+func (h *Handler) deleteIndex(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteIndex(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) upsertDatapoints(w http.ResponseWriter, r *http.Request, index string) {
+	var req struct {
+		Datapoints []struct {
+			DatapointID   string    `json:"datapointId"`
+			FeatureVector []float64 `json:"featureVector"`
+		} `json:"datapoints"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	dps := make([]driver.Datapoint, 0, len(req.Datapoints))
+	for _, d := range req.Datapoints {
+		dps = append(dps, driver.Datapoint{DatapointID: d.DatapointID, FeatureVector: d.FeatureVector})
+	}
+
+	if err := h.svc.UpsertDatapoints(r.Context(), index, dps); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+func (h *Handler) removeDatapoints(w http.ResponseWriter, r *http.Request, index string) {
+	var req struct {
+		DatapointIDs []string `json:"datapointIds"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.RemoveDatapoints(r.Context(), index, req.DatapointIDs); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+// --- Index endpoints ---
+
+func indexEndpointJSON(e *driver.IndexEndpoint) map[string]any {
+	dis := make([]map[string]any, 0, len(e.DeployedIndexes))
+	for _, d := range e.DeployedIndexes {
+		dis = append(dis, map[string]any{"id": d.ID, "index": d.Index})
+	}
+
+	return map[string]any{
+		"name": e.Name, "displayName": e.DisplayName, "description": e.Description,
+		"deployedIndexes": dis, "createTime": e.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveIndexEndpoints(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listIndexEndpoints(w, r, p.location)
+		case http.MethodPost:
+			h.createIndexEndpoint(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.indexEndpointAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getIndexEndpoint(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteIndexEndpoint(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) indexEndpointAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	switch p.action {
+	case "deployIndex":
+		h.deployIndex(w, r, p.name)
+	case "undeployIndex":
+		h.undeployIndex(w, r, p.name)
+	case "findNeighbors":
+		h.findNeighbors(w, r, p.name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown indexEndpoint action: "+p.action)
+	}
+}
+
+func (h *Handler) createIndexEndpoint(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Description string `json:"description"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateIndexEndpoint(r.Context(), driver.IndexEndpointConfig{
+		Location: location, DisplayName: req.DisplayName, Description: req.Description,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getIndexEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	ie, err := h.svc.GetIndexEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, indexEndpointJSON(ie))
+}
+
+func (h *Handler) listIndexEndpoints(w http.ResponseWriter, r *http.Request, location string) {
+	ies, err := h.svc.ListIndexEndpoints(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ies))
+	for i := range ies {
+		out = append(out, indexEndpointJSON(&ies[i]))
+	}
+
+	writeJSON(w, map[string]any{"indexEndpoints": out})
+}
+
+func (h *Handler) deleteIndexEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteIndexEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) deployIndex(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
+	var req struct {
+		DeployedIndex struct {
+			ID    string `json:"id"`
+			Index string `json:"index"`
+		} `json:"deployedIndex"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.DeployIndex(r.Context(), indexEndpoint, driver.DeployedIndex{
+		ID: req.DeployedIndex.ID, Index: req.DeployedIndex.Index,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) undeployIndex(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
+	var req struct {
+		DeployedIndexID string `json:"deployedIndexId"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.UndeployIndex(r.Context(), indexEndpoint, req.DeployedIndexID)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) findNeighbors(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
+	var req struct {
+		DeployedIndexID string `json:"deployedIndexId"`
+		Queries         []struct {
+			Datapoint struct {
+				FeatureVector []float64 `json:"featureVector"`
+			} `json:"datapoint"`
+			NeighborCount int `json:"neighborCount"`
+		} `json:"queries"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	var (
+		query []float64
+		count int
+	)
+
+	if len(req.Queries) > 0 {
+		query = req.Queries[0].Datapoint.FeatureVector
+		count = req.Queries[0].NeighborCount
+	}
+
+	neighbors, err := h.svc.FindNeighbors(r.Context(), indexEndpoint, req.DeployedIndexID, query, count)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	nn := make([]map[string]any, 0, len(neighbors))
+	for _, n := range neighbors {
+		nn = append(nn, map[string]any{
+			"datapoint": map[string]any{"datapointId": n.DatapointID}, "distance": n.Distance,
+		})
+	}
+
+	writeJSON(w, map[string]any{"nearestNeighbors": []map[string]any{{"id": "0", "neighbors": nn}}})
+}

--- a/vertexai/driver/datasets.go
+++ b/vertexai/driver/datasets.go
@@ -1,0 +1,33 @@
+package driver
+
+import "context"
+
+// DatasetConfig describes a dataset to create.
+type DatasetConfig struct {
+	Location          string
+	DisplayName       string
+	MetadataSchemaURI string
+	Labels            map[string]string
+}
+
+// Dataset is a Vertex AI dataset.
+type Dataset struct {
+	Name              string // projects/{p}/locations/{l}/datasets/{id}
+	DisplayName       string
+	MetadataSchemaURI string
+	Labels            map[string]string
+	CreateTime        string
+	UpdateTime        string
+}
+
+// datasetsAPI covers dataset lifecycle plus import/export (modeled as
+// already-done operations).
+type datasetsAPI interface {
+	CreateDataset(ctx context.Context, cfg DatasetConfig) (*Operation, *Dataset, error)
+	GetDataset(ctx context.Context, name string) (*Dataset, error)
+	ListDatasets(ctx context.Context, location string) ([]Dataset, error)
+	PatchDataset(ctx context.Context, name, displayName string) (*Dataset, error)
+	DeleteDataset(ctx context.Context, name string) (*Operation, error)
+	ImportData(ctx context.Context, name, gcsURI string) (*Operation, error)
+	ExportData(ctx context.Context, name, gcsOutputURI string) (*Operation, error)
+}

--- a/vertexai/driver/driver.go
+++ b/vertexai/driver/driver.go
@@ -1,0 +1,57 @@
+// Package driver defines the interface for Google Cloud Vertex AI
+// (aiplatform.googleapis.com): datasets, the model registry, endpoints and
+// online prediction, custom/training/tuning jobs, batch prediction, pipelines,
+// the Gemini generateContent runtime, Feature Store, Vector Search,
+// Tensorboard, ML metadata, schedules and notebook runtimes.
+//
+// The interface uses plain Go types only (no cloud SDK dependencies). Resource
+// names follow Vertex's REST convention
+// projects/{project}/locations/{location}/{collection}/{id}. Long-running
+// control-plane mutations are modeled as completing synchronously; the
+// job-family resources expose a state field that the mock drives straight to a
+// terminal success state.
+package driver
+
+import "context"
+
+// Job state values (JobState enum) shared by custom/batch/HPO jobs.
+const (
+	JobStateQueued    = "JOB_STATE_QUEUED"
+	JobStatePending   = "JOB_STATE_PENDING"
+	JobStateRunning   = "JOB_STATE_RUNNING"
+	JobStateSucceeded = "JOB_STATE_SUCCEEDED"
+	JobStateFailed    = "JOB_STATE_FAILED"
+	JobStateCancelled = "JOB_STATE_CANCELED"
+)
+
+// Pipeline state values (PipelineState enum) used by trainingPipelines and
+// pipelineJobs.
+const (
+	PipelineStateRunning   = "PIPELINE_STATE_RUNNING"
+	PipelineStateSucceeded = "PIPELINE_STATE_SUCCEEDED"
+	PipelineStateFailed    = "PIPELINE_STATE_FAILED"
+	PipelineStateCancelled = "PIPELINE_STATE_CANCELED"
+)
+
+// VertexAI is the interface that Vertex AI implementations must satisfy. It is
+// composed of one segment per resource family so the surface stays navigable.
+type VertexAI interface {
+	datasetsAPI
+	modelsAPI
+	endpointsAPI
+	jobsAPI
+	pipelinesAPI
+	genAIAPI
+	featureStoreAPI
+	vectorSearchAPI
+	metadataAPI
+	operationsAPI
+}
+
+// operationsAPI exposes the long-running-operation polling surface. Every
+// control-plane mutation in this emulator returns an already-done Operation,
+// but clients still GET it, so it must be retrievable.
+type operationsAPI interface {
+	GetOperation(ctx context.Context, name string) (*Operation, error)
+	ListOperations(ctx context.Context, parent string) ([]Operation, error)
+}

--- a/vertexai/driver/endpoints.go
+++ b/vertexai/driver/endpoints.go
@@ -1,0 +1,62 @@
+package driver
+
+import "context"
+
+// EndpointConfig describes an endpoint to create.
+type EndpointConfig struct {
+	Location    string
+	DisplayName string
+	Description string
+	Labels      map[string]string
+}
+
+// DeployedModel is a model deployed to an endpoint.
+type DeployedModel struct {
+	ID              string
+	Model           string // model resource name
+	DisplayName     string
+	MachineType     string
+	MinReplicaCount int
+	MaxReplicaCount int
+}
+
+// Endpoint serves online predictions for one or more deployed models.
+type Endpoint struct {
+	Name           string // projects/{p}/locations/{l}/endpoints/{id}
+	DisplayName    string
+	Description    string
+	DeployedModels []DeployedModel
+	TrafficSplit   map[string]int
+	Labels         map[string]string
+	CreateTime     string
+	UpdateTime     string
+}
+
+// PredictRequest is an online prediction request.
+type PredictRequest struct {
+	Endpoint   string
+	Instances  []any
+	Parameters any
+}
+
+// PredictResponse carries model predictions.
+type PredictResponse struct {
+	Predictions      []any
+	DeployedModelID  string
+	Model            string
+	ModelDisplayName string
+}
+
+// endpointsAPI covers endpoints, model deployment, and online prediction.
+type endpointsAPI interface {
+	CreateEndpoint(ctx context.Context, cfg EndpointConfig) (*Operation, *Endpoint, error)
+	GetEndpoint(ctx context.Context, name string) (*Endpoint, error)
+	ListEndpoints(ctx context.Context, location string) ([]Endpoint, error)
+	DeleteEndpoint(ctx context.Context, name string) (*Operation, error)
+
+	DeployModel(ctx context.Context, endpoint string, dm DeployedModel) (*Operation, *Endpoint, error)
+	UndeployModel(ctx context.Context, endpoint, deployedModelID string) (*Operation, *Endpoint, error)
+
+	Predict(ctx context.Context, req PredictRequest) (*PredictResponse, error)
+	RawPredict(ctx context.Context, endpoint string, body []byte) ([]byte, error)
+}

--- a/vertexai/driver/featurestore.go
+++ b/vertexai/driver/featurestore.go
@@ -1,0 +1,84 @@
+package driver
+
+import "context"
+
+// FeatureGroupConfig describes a (BigQuery-backed) feature group.
+type FeatureGroupConfig struct {
+	Location       string
+	FeatureGroupID string
+	Description    string
+	BigQueryURI    string
+}
+
+// FeatureGroup is a feature group.
+type FeatureGroup struct {
+	Name        string // projects/{p}/locations/{l}/featureGroups/{id}
+	Description string
+	BigQueryURI string
+	CreateTime  string
+}
+
+// Feature is a feature within a group.
+type Feature struct {
+	Name        string // .../featureGroups/{g}/features/{id}
+	Description string
+	CreateTime  string
+}
+
+// FeatureOnlineStoreConfig describes an online store.
+type FeatureOnlineStoreConfig struct {
+	Location             string
+	FeatureOnlineStoreID string
+}
+
+// FeatureOnlineStore serves online feature reads.
+type FeatureOnlineStore struct {
+	Name       string // projects/{p}/locations/{l}/featureOnlineStores/{id}
+	State      string
+	CreateTime string
+}
+
+// FeatureViewConfig describes a feature view in an online store.
+type FeatureViewConfig struct {
+	Parent        string // online store resource name
+	FeatureViewID string
+	BigQueryURI   string
+}
+
+// FeatureView maps source data into an online store.
+type FeatureView struct {
+	Name        string // .../featureOnlineStores/{s}/featureViews/{id}
+	BigQueryURI string
+	CreateTime  string
+}
+
+// FeatureNameValue is one feature name/value in an online read.
+type FeatureNameValue struct {
+	Name  string
+	Value string
+}
+
+// featureStoreAPI covers the BigQuery-backed Feature Store: groups, features,
+// online stores, views, and the fetchFeatureValues data plane.
+type featureStoreAPI interface {
+	CreateFeatureGroup(ctx context.Context, cfg FeatureGroupConfig) (*Operation, *FeatureGroup, error)
+	GetFeatureGroup(ctx context.Context, name string) (*FeatureGroup, error)
+	ListFeatureGroups(ctx context.Context, location string) ([]FeatureGroup, error)
+	DeleteFeatureGroup(ctx context.Context, name string) (*Operation, error)
+
+	CreateFeature(ctx context.Context, parent, featureID, description string) (*Operation, *Feature, error)
+	GetFeature(ctx context.Context, name string) (*Feature, error)
+	ListFeatures(ctx context.Context, parent string) ([]Feature, error)
+	DeleteFeature(ctx context.Context, name string) (*Operation, error)
+
+	CreateFeatureOnlineStore(ctx context.Context, cfg FeatureOnlineStoreConfig) (*Operation, *FeatureOnlineStore, error)
+	GetFeatureOnlineStore(ctx context.Context, name string) (*FeatureOnlineStore, error)
+	ListFeatureOnlineStores(ctx context.Context, location string) ([]FeatureOnlineStore, error)
+	DeleteFeatureOnlineStore(ctx context.Context, name string) (*Operation, error)
+
+	CreateFeatureView(ctx context.Context, cfg FeatureViewConfig) (*Operation, *FeatureView, error)
+	GetFeatureView(ctx context.Context, name string) (*FeatureView, error)
+	ListFeatureViews(ctx context.Context, parent string) ([]FeatureView, error)
+	DeleteFeatureView(ctx context.Context, name string) (*Operation, error)
+	FetchFeatureValues(ctx context.Context, featureView, entityID string) ([]FeatureNameValue, error)
+}

--- a/vertexai/driver/featurestore.go
+++ b/vertexai/driver/featurestore.go
@@ -58,9 +58,47 @@ type FeatureNameValue struct {
 	Value string
 }
 
-// featureStoreAPI covers the BigQuery-backed Feature Store: groups, features,
-// online stores, views, and the fetchFeatureValues data plane.
+// FeaturestoreConfig describes a classic (pre-Feature-Group) Featurestore.
+type FeaturestoreConfig struct {
+	Location        string
+	FeaturestoreID  string
+	OnlineNodeCount int
+}
+
+// Featurestore is the classic Vertex AI Featurestore — a container of
+// EntityTypes, distinct from the newer BigQuery-backed FeatureGroup.
+type Featurestore struct {
+	Name            string // projects/{p}/locations/{l}/featurestores/{id}
+	State           string
+	OnlineNodeCount int
+	CreateTime      string
+}
+
+// EntityType groups features within a classic Featurestore.
+type EntityType struct {
+	Name        string // .../featurestores/{f}/entityTypes/{id}
+	Description string
+	CreateTime  string
+}
+
+// featureStoreAPI covers both Feature Store generations: the classic
+// Featurestore/EntityType resources (+ online read/write) and the newer
+// BigQuery-backed FeatureGroup / FeatureOnlineStore / FeatureView stack.
 type featureStoreAPI interface {
+	CreateFeaturestore(ctx context.Context, cfg FeaturestoreConfig) (*Operation, *Featurestore, error)
+	GetFeaturestore(ctx context.Context, name string) (*Featurestore, error)
+	ListFeaturestores(ctx context.Context, location string) ([]Featurestore, error)
+	DeleteFeaturestore(ctx context.Context, name string) (*Operation, error)
+
+	CreateEntityType(ctx context.Context, parent, entityTypeID, description string) (*Operation, *EntityType, error)
+	GetEntityType(ctx context.Context, name string) (*EntityType, error)
+	ListEntityTypes(ctx context.Context, parent string) ([]EntityType, error)
+	DeleteEntityType(ctx context.Context, name string) (*Operation, error)
+
+	// Classic online serving, keyed by entityType + entity id.
+	WriteFeatureValues(ctx context.Context, entityType, entityID string, values []FeatureNameValue) error
+	ReadFeatureValues(ctx context.Context, entityType, entityID string) ([]FeatureNameValue, error)
+
 	CreateFeatureGroup(ctx context.Context, cfg FeatureGroupConfig) (*Operation, *FeatureGroup, error)
 	GetFeatureGroup(ctx context.Context, name string) (*FeatureGroup, error)
 	ListFeatureGroups(ctx context.Context, location string) ([]FeatureGroup, error)

--- a/vertexai/driver/genai.go
+++ b/vertexai/driver/genai.go
@@ -84,11 +84,13 @@ type CachedContentConfig struct {
 
 // CachedContent is a context-cache entry (synchronous CRUD).
 type CachedContent struct {
-	Name        string // projects/{p}/locations/{l}/cachedContents/{id}
-	Model       string
-	DisplayName string
-	CreateTime  string
-	ExpireTime  string
+	Name              string // projects/{p}/locations/{l}/cachedContents/{id}
+	Model             string
+	DisplayName       string
+	Contents          []Content
+	SystemInstruction *Content
+	CreateTime        string
+	ExpireTime        string
 }
 
 // genAIAPI covers the Gemini runtime plus tuning jobs and context caching.

--- a/vertexai/driver/genai.go
+++ b/vertexai/driver/genai.go
@@ -1,0 +1,108 @@
+package driver
+
+import "context"
+
+// Part is a single content part (text only is modeled).
+type Part struct {
+	Text string
+}
+
+// Content is one turn in a generateContent exchange.
+type Content struct {
+	Role  string // "user" | "model"
+	Parts []Part
+}
+
+// GenerationConfig holds optional sampling controls.
+type GenerationConfig struct {
+	Temperature     *float64
+	TopP            *float64
+	TopK            *int
+	MaxOutputTokens *int
+}
+
+// GenerateContentRequest is the Gemini generateContent request.
+type GenerateContentRequest struct {
+	Model             string
+	Contents          []Content
+	SystemInstruction *Content
+	GenerationConfig  *GenerationConfig
+}
+
+// Candidate is one generated response candidate.
+type Candidate struct {
+	Content      Content
+	FinishReason string
+}
+
+// UsageMetadata reports token accounting for a generateContent call.
+type UsageMetadata struct {
+	PromptTokenCount     int
+	CandidatesTokenCount int
+	TotalTokenCount      int
+}
+
+// GenerateContentResponse is the Gemini generateContent response.
+type GenerateContentResponse struct {
+	Candidates    []Candidate
+	UsageMetadata UsageMetadata
+}
+
+// CountTokensResponse reports the token count for an input.
+type CountTokensResponse struct {
+	TotalTokens int
+}
+
+// TuningJobConfig describes a Gemini supervised-tuning job.
+type TuningJobConfig struct {
+	Location        string
+	BaseModel       string
+	TunedModelName  string
+	TrainingDataURI string
+}
+
+// TuningJob describes a tuning job (create is synchronous; poll State).
+type TuningJob struct {
+	Name           string // projects/{p}/locations/{l}/tuningJobs/{id}
+	BaseModel      string
+	State          string
+	TunedModelName string
+	Endpoint       string
+	CreateTime     string
+	EndTime        string
+}
+
+// CachedContentConfig describes a context-cache entry to create.
+type CachedContentConfig struct {
+	Location          string
+	Model             string
+	DisplayName       string
+	Contents          []Content
+	SystemInstruction *Content
+	TTLSeconds        int
+}
+
+// CachedContent is a context-cache entry (synchronous CRUD).
+type CachedContent struct {
+	Name        string // projects/{p}/locations/{l}/cachedContents/{id}
+	Model       string
+	DisplayName string
+	CreateTime  string
+	ExpireTime  string
+}
+
+// genAIAPI covers the Gemini runtime plus tuning jobs and context caching.
+type genAIAPI interface {
+	GenerateContent(ctx context.Context, model string, req GenerateContentRequest) (*GenerateContentResponse, error)
+	CountTokens(ctx context.Context, model string, req GenerateContentRequest) (*CountTokensResponse, error)
+
+	CreateTuningJob(ctx context.Context, cfg TuningJobConfig) (*TuningJob, error)
+	GetTuningJob(ctx context.Context, name string) (*TuningJob, error)
+	ListTuningJobs(ctx context.Context, location string) ([]TuningJob, error)
+	CancelTuningJob(ctx context.Context, name string) error
+
+	CreateCachedContent(ctx context.Context, cfg CachedContentConfig) (*CachedContent, error)
+	GetCachedContent(ctx context.Context, name string) (*CachedContent, error)
+	ListCachedContents(ctx context.Context, location string) ([]CachedContent, error)
+	DeleteCachedContent(ctx context.Context, name string) error
+}

--- a/vertexai/driver/jobs.go
+++ b/vertexai/driver/jobs.go
@@ -1,0 +1,79 @@
+package driver
+
+import "context"
+
+// CustomJobConfig describes a custom training job.
+type CustomJobConfig struct {
+	Location       string
+	DisplayName    string
+	MachineType    string
+	ReplicaCount   int
+	ContainerImage string
+}
+
+// CustomJob is a custom training job (create is synchronous; poll State).
+type CustomJob struct {
+	Name        string // projects/{p}/locations/{l}/customJobs/{id}
+	DisplayName string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// BatchPredictionJobConfig describes a batch prediction job.
+type BatchPredictionJobConfig struct {
+	Location        string
+	DisplayName     string
+	Model           string
+	InputURI        string
+	OutputURIPrefix string
+}
+
+// BatchPredictionJob is an offline prediction job (create is synchronous).
+type BatchPredictionJob struct {
+	Name        string // projects/{p}/locations/{l}/batchPredictionJobs/{id}
+	DisplayName string
+	Model       string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// HyperparameterTuningJobConfig describes an HPO job.
+type HyperparameterTuningJobConfig struct {
+	Location       string
+	DisplayName    string
+	MaxTrialCount  int
+	ParallelTrials int
+}
+
+// HyperparameterTuningJob is an HPO job (create is synchronous).
+type HyperparameterTuningJob struct {
+	Name          string // projects/{p}/locations/{l}/hyperparameterTuningJobs/{id}
+	DisplayName   string
+	State         string
+	MaxTrialCount int
+	CreateTime    string
+	EndTime       string
+}
+
+// jobsAPI covers the synchronous-create job family (poll State after create;
+// cancel returns no body).
+type jobsAPI interface {
+	CreateCustomJob(ctx context.Context, cfg CustomJobConfig) (*CustomJob, error)
+	GetCustomJob(ctx context.Context, name string) (*CustomJob, error)
+	ListCustomJobs(ctx context.Context, location string) ([]CustomJob, error)
+	CancelCustomJob(ctx context.Context, name string) error
+	DeleteCustomJob(ctx context.Context, name string) (*Operation, error)
+
+	CreateBatchPredictionJob(ctx context.Context, cfg BatchPredictionJobConfig) (*BatchPredictionJob, error)
+	GetBatchPredictionJob(ctx context.Context, name string) (*BatchPredictionJob, error)
+	ListBatchPredictionJobs(ctx context.Context, location string) ([]BatchPredictionJob, error)
+	CancelBatchPredictionJob(ctx context.Context, name string) error
+	DeleteBatchPredictionJob(ctx context.Context, name string) (*Operation, error)
+
+	CreateHyperparameterTuningJob(ctx context.Context, cfg HyperparameterTuningJobConfig) (*HyperparameterTuningJob, error)
+	GetHyperparameterTuningJob(ctx context.Context, name string) (*HyperparameterTuningJob, error)
+	ListHyperparameterTuningJobs(ctx context.Context, location string) ([]HyperparameterTuningJob, error)
+	CancelHyperparameterTuningJob(ctx context.Context, name string) error
+}

--- a/vertexai/driver/metadata.go
+++ b/vertexai/driver/metadata.go
@@ -1,0 +1,74 @@
+package driver
+
+import "context"
+
+// MetadataStore is an ML-metadata store.
+type MetadataStore struct {
+	Name       string // projects/{p}/locations/{l}/metadataStores/{id}
+	CreateTime string
+}
+
+// Tensorboard is a managed Tensorboard instance.
+type Tensorboard struct {
+	Name        string // projects/{p}/locations/{l}/tensorboards/{id}
+	DisplayName string
+	CreateTime  string
+}
+
+// Schedule runs a pipeline job on a cron schedule.
+type Schedule struct {
+	Name        string // projects/{p}/locations/{l}/schedules/{id}
+	DisplayName string
+	Cron        string
+	State       string // ACTIVE | PAUSED | COMPLETED
+	CreateTime  string
+}
+
+// NotebookRuntimeTemplate is a template for notebook runtimes.
+type NotebookRuntimeTemplate struct {
+	Name        string // projects/{p}/locations/{l}/notebookRuntimeTemplates/{id}
+	DisplayName string
+	MachineType string
+	CreateTime  string
+}
+
+// NotebookRuntime is an assigned notebook runtime.
+type NotebookRuntime struct {
+	Name         string // projects/{p}/locations/{l}/notebookRuntimes/{id}
+	DisplayName  string
+	RuntimeState string // RUNNING | STOPPED
+	CreateTime   string
+}
+
+// metadataAPI covers ML metadata stores, Tensorboard, schedules, and notebook
+// runtimes/templates.
+type metadataAPI interface {
+	CreateMetadataStore(ctx context.Context, location, storeID string) (*Operation, *MetadataStore, error)
+	GetMetadataStore(ctx context.Context, name string) (*MetadataStore, error)
+	ListMetadataStores(ctx context.Context, location string) ([]MetadataStore, error)
+	DeleteMetadataStore(ctx context.Context, name string) (*Operation, error)
+
+	CreateTensorboard(ctx context.Context, location, displayName string) (*Operation, *Tensorboard, error)
+	GetTensorboard(ctx context.Context, name string) (*Tensorboard, error)
+	ListTensorboards(ctx context.Context, location string) ([]Tensorboard, error)
+	DeleteTensorboard(ctx context.Context, name string) (*Operation, error)
+
+	CreateSchedule(ctx context.Context, location, displayName, cron string) (*Schedule, error)
+	GetSchedule(ctx context.Context, name string) (*Schedule, error)
+	ListSchedules(ctx context.Context, location string) ([]Schedule, error)
+	PauseSchedule(ctx context.Context, name string) error
+	ResumeSchedule(ctx context.Context, name string) error
+	DeleteSchedule(ctx context.Context, name string) (*Operation, error)
+
+	CreateNotebookRuntimeTemplate(ctx context.Context, location, displayName, machineType string) (*Operation, *NotebookRuntimeTemplate, error)
+	GetNotebookRuntimeTemplate(ctx context.Context, name string) (*NotebookRuntimeTemplate, error)
+	ListNotebookRuntimeTemplates(ctx context.Context, location string) ([]NotebookRuntimeTemplate, error)
+	DeleteNotebookRuntimeTemplate(ctx context.Context, name string) (*Operation, error)
+
+	AssignNotebookRuntime(ctx context.Context, location, displayName string) (*Operation, *NotebookRuntime, error)
+	GetNotebookRuntime(ctx context.Context, name string) (*NotebookRuntime, error)
+	ListNotebookRuntimes(ctx context.Context, location string) ([]NotebookRuntime, error)
+	StartNotebookRuntime(ctx context.Context, name string) (*Operation, error)
+	StopNotebookRuntime(ctx context.Context, name string) (*Operation, error)
+	DeleteNotebookRuntime(ctx context.Context, name string) (*Operation, error)
+}

--- a/vertexai/driver/models.go
+++ b/vertexai/driver/models.go
@@ -1,0 +1,53 @@
+package driver
+
+import "context"
+
+// ModelConfig describes a model to upload to the registry.
+type ModelConfig struct {
+	Location       string
+	DisplayName    string
+	Description    string
+	ContainerImage string
+	ArtifactURI    string
+	Labels         map[string]string
+}
+
+// Model is a registered model. Versions are addressed via the @version suffix
+// on the resource name rather than a sub-collection.
+type Model struct {
+	Name           string // projects/{p}/locations/{l}/models/{id}
+	DisplayName    string
+	Description    string
+	ContainerImage string
+	ArtifactURI    string
+	VersionID      string
+	VersionAliases []string
+	Labels         map[string]string
+	CreateTime     string
+	UpdateTime     string
+}
+
+// ModelEvaluation is an evaluation attached to a model version.
+type ModelEvaluation struct {
+	Name        string // .../models/{id}/evaluations/{eid}
+	DisplayName string
+	MetricsType string
+	CreateTime  string
+}
+
+// modelsAPI covers the model registry (upload/get/list/patch/delete + versions
+// + evaluations).
+type modelsAPI interface {
+	UploadModel(ctx context.Context, cfg ModelConfig) (*Operation, *Model, error)
+	GetModel(ctx context.Context, name string) (*Model, error)
+	ListModels(ctx context.Context, location string) ([]Model, error)
+	PatchModel(ctx context.Context, name, displayName, description string) (*Model, error)
+	DeleteModel(ctx context.Context, name string) (*Operation, error)
+
+	ListModelVersions(ctx context.Context, name string) ([]Model, error)
+	DeleteModelVersion(ctx context.Context, name string) (*Operation, error)
+
+	ImportModelEvaluation(ctx context.Context, modelName string, eval ModelEvaluation) (*ModelEvaluation, error)
+	GetModelEvaluation(ctx context.Context, name string) (*ModelEvaluation, error)
+	ListModelEvaluations(ctx context.Context, modelName string) ([]ModelEvaluation, error)
+}

--- a/vertexai/driver/operations.go
+++ b/vertexai/driver/operations.go
@@ -1,0 +1,17 @@
+package driver
+
+// Operation is a google.longrunning.Operation. The emulator returns operations
+// that are already complete (Done=true) so SDK pollers terminate immediately.
+type Operation struct {
+	Name     string
+	Done     bool
+	Metadata map[string]any
+	Response map[string]any
+	Error    *OperationError
+}
+
+// OperationError mirrors google.rpc.Status on a failed operation.
+type OperationError struct {
+	Code    int
+	Message string
+}

--- a/vertexai/driver/pipelines.go
+++ b/vertexai/driver/pipelines.go
@@ -1,0 +1,50 @@
+package driver
+
+import "context"
+
+// TrainingPipelineConfig describes a training pipeline.
+type TrainingPipelineConfig struct {
+	Location    string
+	DisplayName string
+	TaskType    string // AutoML task definition or custom
+}
+
+// TrainingPipeline wraps AutoML/custom training (create is synchronous).
+type TrainingPipeline struct {
+	Name        string // projects/{p}/locations/{l}/trainingPipelines/{id}
+	DisplayName string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// PipelineJobConfig describes a Kubeflow/TFX pipeline run.
+type PipelineJobConfig struct {
+	Location    string
+	DisplayName string
+	TemplateURI string
+}
+
+// PipelineJob is a pipeline execution (create is synchronous).
+type PipelineJob struct {
+	Name        string // projects/{p}/locations/{l}/pipelineJobs/{id}
+	DisplayName string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// pipelinesAPI covers training pipelines and pipeline jobs.
+type pipelinesAPI interface {
+	CreateTrainingPipeline(ctx context.Context, cfg TrainingPipelineConfig) (*TrainingPipeline, error)
+	GetTrainingPipeline(ctx context.Context, name string) (*TrainingPipeline, error)
+	ListTrainingPipelines(ctx context.Context, location string) ([]TrainingPipeline, error)
+	CancelTrainingPipeline(ctx context.Context, name string) error
+	DeleteTrainingPipeline(ctx context.Context, name string) (*Operation, error)
+
+	CreatePipelineJob(ctx context.Context, cfg PipelineJobConfig) (*PipelineJob, error)
+	GetPipelineJob(ctx context.Context, name string) (*PipelineJob, error)
+	ListPipelineJobs(ctx context.Context, location string) ([]PipelineJob, error)
+	CancelPipelineJob(ctx context.Context, name string) error
+	DeletePipelineJob(ctx context.Context, name string) (*Operation, error)
+}

--- a/vertexai/driver/vectorsearch.go
+++ b/vertexai/driver/vectorsearch.go
@@ -1,0 +1,75 @@
+package driver
+
+import "context"
+
+// IndexConfig describes a Vector Search index.
+type IndexConfig struct {
+	Location    string
+	DisplayName string
+	Description string
+	Dimensions  int
+}
+
+// Index is a Vector Search index.
+type Index struct {
+	Name           string // projects/{p}/locations/{l}/indexes/{id}
+	DisplayName    string
+	Description    string
+	Dimensions     int
+	DatapointCount int
+	CreateTime     string
+	UpdateTime     string
+}
+
+// Datapoint is a single vector datapoint.
+type Datapoint struct {
+	DatapointID   string
+	FeatureVector []float64
+}
+
+// IndexEndpointConfig describes a Vector Search index endpoint.
+type IndexEndpointConfig struct {
+	Location    string
+	DisplayName string
+	Description string
+}
+
+// DeployedIndex is an index deployed to an index endpoint.
+type DeployedIndex struct {
+	ID    string
+	Index string
+}
+
+// IndexEndpoint serves nearest-neighbor queries.
+type IndexEndpoint struct {
+	Name            string // projects/{p}/locations/{l}/indexEndpoints/{id}
+	DisplayName     string
+	Description     string
+	DeployedIndexes []DeployedIndex
+	CreateTime      string
+}
+
+// Neighbor is a nearest-neighbor result.
+type Neighbor struct {
+	DatapointID string
+	Distance    float64
+}
+
+// vectorSearchAPI covers indexes and index endpoints + the findNeighbors and
+// upsert/remove data-plane calls.
+type vectorSearchAPI interface {
+	CreateIndex(ctx context.Context, cfg IndexConfig) (*Operation, *Index, error)
+	GetIndex(ctx context.Context, name string) (*Index, error)
+	ListIndexes(ctx context.Context, location string) ([]Index, error)
+	DeleteIndex(ctx context.Context, name string) (*Operation, error)
+	UpsertDatapoints(ctx context.Context, index string, datapoints []Datapoint) error
+	RemoveDatapoints(ctx context.Context, index string, datapointIDs []string) error
+
+	CreateIndexEndpoint(ctx context.Context, cfg IndexEndpointConfig) (*Operation, *IndexEndpoint, error)
+	GetIndexEndpoint(ctx context.Context, name string) (*IndexEndpoint, error)
+	ListIndexEndpoints(ctx context.Context, location string) ([]IndexEndpoint, error)
+	DeleteIndexEndpoint(ctx context.Context, name string) (*Operation, error)
+	DeployIndex(ctx context.Context, indexEndpoint string, di DeployedIndex) (*Operation, *IndexEndpoint, error)
+	UndeployIndex(ctx context.Context, indexEndpoint, deployedIndexID string) (*Operation, *IndexEndpoint, error)
+	FindNeighbors(ctx context.Context, indexEndpoint, deployedIndexID string, query []float64, count int) ([]Neighbor, error)
+}

--- a/vertexai/vertexai.go
+++ b/vertexai/vertexai.go
@@ -1,0 +1,130 @@
+// Package vertexai provides a portable Google Cloud Vertex AI API with
+// cross-cutting concerns. It wraps a driver.VertexAI (the control plane plus the
+// prediction and generateContent runtimes) with recording, metrics, rate
+// limiting, error injection, and latency simulation — the same middle layer
+// every other service ships (see bedrock/bedrock.go, sagemaker/sagemaker.go) so
+// Vertex AI participates in the three-layer design.
+//
+// The wrapper implements driver.VertexAI, so it is a drop-in replacement for the
+// raw mock when constructing the SDK-compat server.
+package vertexai
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// Compile-time check that the portable type implements the full service.
+var _ driver.VertexAI = (*VertexAI)(nil)
+
+// VertexAI is the portable Vertex AI type wrapping a driver with cross-cutting
+// concerns.
+type VertexAI struct {
+	drv      driver.VertexAI
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// New creates a portable VertexAI wrapping the given driver.
+func New(d driver.VertexAI, opts ...Option) *VertexAI {
+	v := &VertexAI{drv: d}
+	for _, opt := range opts {
+		opt(v)
+	}
+
+	return v
+}
+
+// Option configures a portable VertexAI.
+type Option func(*VertexAI)
+
+// WithRecorder sets the call recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(v *VertexAI) { v.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(v *VertexAI) { v.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(v *VertexAI) { v.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(v *VertexAI) { v.injector = i } }
+
+// WithLatency sets simulated latency applied to every call.
+func WithLatency(d time.Duration) Option { return func(v *VertexAI) { v.latency = d } }
+
+// do applies the cross-cutting concerns around a single driver call.
+func (v *VertexAI) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if v.injector != nil {
+		if err := v.injector.Check("vertexai", op); err != nil {
+			v.rec(op, input, nil, err, time.Since(start))
+
+			return nil, err
+		}
+	}
+
+	if v.limiter != nil {
+		if err := v.limiter.Allow(); err != nil {
+			v.rec(op, input, nil, err, time.Since(start))
+
+			return nil, err
+		}
+	}
+
+	if v.latency > 0 {
+		time.Sleep(v.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if v.metrics != nil {
+		labels := map[string]string{"service": "vertexai", "operation": op}
+		v.metrics.Counter("calls_total", 1, labels)
+		v.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			v.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	v.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (v *VertexAI) rec(op string, input, output any, err error, dur time.Duration) {
+	if v.recorder != nil {
+		v.recorder.Record("vertexai", op, input, output, err, dur)
+	}
+}
+
+// cast converts the do() result to T, short-circuiting on error.
+func cast[T any](out any, err error) (T, error) {
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	return out.(T), nil //nolint:forcetypeassert // do() returns exactly the driver's typed result
+}
+
+// opPair bundles a long-running Operation with the typed resource it returns so
+// the (op, resource, error) driver methods can flow through the single-value
+// do() pipeline.
+type opPair[T any] struct {
+	op  *driver.Operation
+	res T
+}

--- a/vertexai/vertexai_test.go
+++ b/vertexai/vertexai_test.go
@@ -1,0 +1,70 @@
+package vertexai_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	gcpvertex "github.com/stackshy/cloudemu/providers/gcp/vertexai"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/vertexai"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func newPortable(opts ...vertexai.Option) *vertexai.VertexAI {
+	o := config.NewOptions(config.WithProjectID("test-project"))
+
+	return vertexai.New(gcpvertex.New(o), opts...)
+}
+
+func TestPortableRecordsAndCountsCalls(t *testing.T) {
+	rec := recorder.New()
+	col := metrics.NewCollector()
+	v := newPortable(vertexai.WithRecorder(rec), vertexai.WithMetrics(col))
+	ctx := context.Background()
+
+	_, _, err := v.CreateDataset(ctx, driver.DatasetConfig{Location: "us-central1", DisplayName: "ds1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, rec.CallCountFor("vertexai", "CreateDataset"))
+	assert.NotEmpty(t, col.All())
+}
+
+func TestPortableErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	boom := errors.New("injected")
+	inj.Set("vertexai", "UploadModel", boom, inject.Always{})
+
+	v := newPortable(vertexai.WithErrorInjection(inj))
+
+	_, _, err := v.UploadModel(context.Background(), driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.ErrorIs(t, err, boom)
+}
+
+func TestPortableLatencyApplied(t *testing.T) {
+	v := newPortable(vertexai.WithLatency(20 * time.Millisecond))
+
+	start := time.Now()
+	_, err := v.ListModels(context.Background(), "us-central1")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), 20*time.Millisecond)
+}
+
+func TestPortableForwardsResults(t *testing.T) {
+	v := newPortable()
+	ctx := context.Background()
+
+	_, m, err := v.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.NoError(t, err)
+
+	got, err := v.GetModel(ctx, m.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "m", got.DisplayName)
+}

--- a/vertexai/wrappers_datasets.go
+++ b/vertexai/wrappers_datasets.go
@@ -1,0 +1,43 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateDataset(ctx context.Context, cfg driver.DatasetConfig) (*driver.Operation, *driver.Dataset, error) {
+	r, err := cast[opPair[*driver.Dataset]](v.do(ctx, "CreateDataset", cfg, func() (any, error) {
+		op, ds, e := v.drv.CreateDataset(ctx, cfg)
+
+		return opPair[*driver.Dataset]{op, ds}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetDataset(ctx context.Context, name string) (*driver.Dataset, error) {
+	return cast[*driver.Dataset](v.do(ctx, "GetDataset", name, func() (any, error) { return v.drv.GetDataset(ctx, name) }))
+}
+
+func (v *VertexAI) ListDatasets(ctx context.Context, location string) ([]driver.Dataset, error) {
+	return cast[[]driver.Dataset](v.do(ctx, "ListDatasets", location, func() (any, error) { return v.drv.ListDatasets(ctx, location) }))
+}
+
+func (v *VertexAI) PatchDataset(ctx context.Context, name, displayName string) (*driver.Dataset, error) {
+	return cast[*driver.Dataset](v.do(ctx, "PatchDataset", name, func() (any, error) {
+		return v.drv.PatchDataset(ctx, name, displayName)
+	}))
+}
+
+func (v *VertexAI) DeleteDataset(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteDataset", name, func() (any, error) { return v.drv.DeleteDataset(ctx, name) }))
+}
+
+func (v *VertexAI) ImportData(ctx context.Context, name, gcsURI string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "ImportData", name, func() (any, error) { return v.drv.ImportData(ctx, name, gcsURI) }))
+}
+
+func (v *VertexAI) ExportData(ctx context.Context, name, gcsOutputURI string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "ExportData", name, func() (any, error) { return v.drv.ExportData(ctx, name, gcsOutputURI) }))
+}

--- a/vertexai/wrappers_endpoints.go
+++ b/vertexai/wrappers_endpoints.go
@@ -1,0 +1,62 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateEndpoint(ctx context.Context, cfg driver.EndpointConfig) (*driver.Operation, *driver.Endpoint, error) {
+	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "CreateEndpoint", cfg, func() (any, error) {
+		op, ep, e := v.drv.CreateEndpoint(ctx, cfg)
+
+		return opPair[*driver.Endpoint]{op, ep}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetEndpoint(ctx context.Context, name string) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](v.do(ctx, "GetEndpoint", name, func() (any, error) { return v.drv.GetEndpoint(ctx, name) }))
+}
+
+func (v *VertexAI) ListEndpoints(ctx context.Context, location string) ([]driver.Endpoint, error) {
+	return cast[[]driver.Endpoint](v.do(ctx, "ListEndpoints", location, func() (any, error) { return v.drv.ListEndpoints(ctx, location) }))
+}
+
+func (v *VertexAI) DeleteEndpoint(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteEndpoint", name, func() (any, error) { return v.drv.DeleteEndpoint(ctx, name) }))
+}
+
+//nolint:gocritic // dm matches the driver signature; forwarded unchanged.
+func (v *VertexAI) DeployModel(
+	ctx context.Context, endpoint string, dm driver.DeployedModel,
+) (*driver.Operation, *driver.Endpoint, error) {
+	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "DeployModel", endpoint, func() (any, error) {
+		op, ep, e := v.drv.DeployModel(ctx, endpoint, dm)
+
+		return opPair[*driver.Endpoint]{op, ep}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) UndeployModel(
+	ctx context.Context, endpoint, deployedModelID string,
+) (*driver.Operation, *driver.Endpoint, error) {
+	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "UndeployModel", endpoint, func() (any, error) {
+		op, ep, e := v.drv.UndeployModel(ctx, endpoint, deployedModelID)
+
+		return opPair[*driver.Endpoint]{op, ep}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) Predict(ctx context.Context, req driver.PredictRequest) (*driver.PredictResponse, error) {
+	return cast[*driver.PredictResponse](v.do(ctx, "Predict", req, func() (any, error) { return v.drv.Predict(ctx, req) }))
+}
+
+func (v *VertexAI) RawPredict(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
+	return cast[[]byte](v.do(ctx, "RawPredict", endpoint, func() (any, error) { return v.drv.RawPredict(ctx, endpoint, body) }))
+}

--- a/vertexai/wrappers_featurestore.go
+++ b/vertexai/wrappers_featurestore.go
@@ -1,0 +1,203 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Legacy Featurestore / EntityType / Feature values ---
+
+func (v *VertexAI) CreateFeaturestore(
+	ctx context.Context, cfg driver.FeaturestoreConfig,
+) (*driver.Operation, *driver.Featurestore, error) {
+	r, err := cast[opPair[*driver.Featurestore]](v.do(ctx, "CreateFeaturestore", cfg, func() (any, error) {
+		op, fs, e := v.drv.CreateFeaturestore(ctx, cfg)
+
+		return opPair[*driver.Featurestore]{op, fs}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeaturestore(ctx context.Context, name string) (*driver.Featurestore, error) {
+	return cast[*driver.Featurestore](v.do(ctx, "GetFeaturestore", name, func() (any, error) { return v.drv.GetFeaturestore(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeaturestores(ctx context.Context, location string) ([]driver.Featurestore, error) {
+	return cast[[]driver.Featurestore](v.do(ctx, "ListFeaturestores", location, func() (any, error) {
+		return v.drv.ListFeaturestores(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteFeaturestore(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeaturestore", name, func() (any, error) {
+		return v.drv.DeleteFeaturestore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreateEntityType(
+	ctx context.Context, parent, entityTypeID, description string,
+) (*driver.Operation, *driver.EntityType, error) {
+	r, err := cast[opPair[*driver.EntityType]](v.do(ctx, "CreateEntityType", parent, func() (any, error) {
+		op, et, e := v.drv.CreateEntityType(ctx, parent, entityTypeID, description)
+
+		return opPair[*driver.EntityType]{op, et}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetEntityType(ctx context.Context, name string) (*driver.EntityType, error) {
+	return cast[*driver.EntityType](v.do(ctx, "GetEntityType", name, func() (any, error) { return v.drv.GetEntityType(ctx, name) }))
+}
+
+func (v *VertexAI) ListEntityTypes(ctx context.Context, parent string) ([]driver.EntityType, error) {
+	return cast[[]driver.EntityType](v.do(ctx, "ListEntityTypes", parent, func() (any, error) { return v.drv.ListEntityTypes(ctx, parent) }))
+}
+
+func (v *VertexAI) DeleteEntityType(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteEntityType", name, func() (any, error) {
+		return v.drv.DeleteEntityType(ctx, name)
+	}))
+}
+
+func (v *VertexAI) WriteFeatureValues(
+	ctx context.Context, entityType, entityID string, values []driver.FeatureNameValue,
+) error {
+	_, err := v.do(ctx, "WriteFeatureValues", entityType, func() (any, error) {
+		return nil, v.drv.WriteFeatureValues(ctx, entityType, entityID, values)
+	})
+
+	return err
+}
+
+func (v *VertexAI) ReadFeatureValues(
+	ctx context.Context, entityType, entityID string,
+) ([]driver.FeatureNameValue, error) {
+	return cast[[]driver.FeatureNameValue](v.do(ctx, "ReadFeatureValues", entityType, func() (any, error) {
+		return v.drv.ReadFeatureValues(ctx, entityType, entityID)
+	}))
+}
+
+func (v *VertexAI) CreateFeature(
+	ctx context.Context, parent, featureID, description string,
+) (*driver.Operation, *driver.Feature, error) {
+	r, err := cast[opPair[*driver.Feature]](v.do(ctx, "CreateFeature", parent, func() (any, error) {
+		op, f, e := v.drv.CreateFeature(ctx, parent, featureID, description)
+
+		return opPair[*driver.Feature]{op, f}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeature(ctx context.Context, name string) (*driver.Feature, error) {
+	return cast[*driver.Feature](v.do(ctx, "GetFeature", name, func() (any, error) { return v.drv.GetFeature(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeatures(ctx context.Context, parent string) ([]driver.Feature, error) {
+	return cast[[]driver.Feature](v.do(ctx, "ListFeatures", parent, func() (any, error) { return v.drv.ListFeatures(ctx, parent) }))
+}
+
+func (v *VertexAI) DeleteFeature(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeature", name, func() (any, error) { return v.drv.DeleteFeature(ctx, name) }))
+}
+
+// --- Feature Registry (featureGroups) ---
+
+func (v *VertexAI) CreateFeatureGroup(
+	ctx context.Context, cfg driver.FeatureGroupConfig,
+) (*driver.Operation, *driver.FeatureGroup, error) {
+	r, err := cast[opPair[*driver.FeatureGroup]](v.do(ctx, "CreateFeatureGroup", cfg, func() (any, error) {
+		op, fg, e := v.drv.CreateFeatureGroup(ctx, cfg)
+
+		return opPair[*driver.FeatureGroup]{op, fg}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeatureGroup(ctx context.Context, name string) (*driver.FeatureGroup, error) {
+	return cast[*driver.FeatureGroup](v.do(ctx, "GetFeatureGroup", name, func() (any, error) { return v.drv.GetFeatureGroup(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeatureGroups(ctx context.Context, location string) ([]driver.FeatureGroup, error) {
+	return cast[[]driver.FeatureGroup](v.do(ctx, "ListFeatureGroups", location, func() (any, error) {
+		return v.drv.ListFeatureGroups(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteFeatureGroup(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeatureGroup", name, func() (any, error) {
+		return v.drv.DeleteFeatureGroup(ctx, name)
+	}))
+}
+
+// --- Feature Online Stores ---
+
+func (v *VertexAI) CreateFeatureOnlineStore(
+	ctx context.Context, cfg driver.FeatureOnlineStoreConfig,
+) (*driver.Operation, *driver.FeatureOnlineStore, error) {
+	r, err := cast[opPair[*driver.FeatureOnlineStore]](v.do(ctx, "CreateFeatureOnlineStore", cfg, func() (any, error) {
+		op, fos, e := v.drv.CreateFeatureOnlineStore(ctx, cfg)
+
+		return opPair[*driver.FeatureOnlineStore]{op, fos}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeatureOnlineStore(ctx context.Context, name string) (*driver.FeatureOnlineStore, error) {
+	return cast[*driver.FeatureOnlineStore](v.do(ctx, "GetFeatureOnlineStore", name, func() (any, error) {
+		return v.drv.GetFeatureOnlineStore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListFeatureOnlineStores(ctx context.Context, location string) ([]driver.FeatureOnlineStore, error) {
+	return cast[[]driver.FeatureOnlineStore](v.do(ctx, "ListFeatureOnlineStores", location, func() (any, error) {
+		return v.drv.ListFeatureOnlineStores(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteFeatureOnlineStore(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeatureOnlineStore", name, func() (any, error) {
+		return v.drv.DeleteFeatureOnlineStore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreateFeatureView(
+	ctx context.Context, cfg driver.FeatureViewConfig,
+) (*driver.Operation, *driver.FeatureView, error) {
+	r, err := cast[opPair[*driver.FeatureView]](v.do(ctx, "CreateFeatureView", cfg, func() (any, error) {
+		op, fv, e := v.drv.CreateFeatureView(ctx, cfg)
+
+		return opPair[*driver.FeatureView]{op, fv}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeatureView(ctx context.Context, name string) (*driver.FeatureView, error) {
+	return cast[*driver.FeatureView](v.do(ctx, "GetFeatureView", name, func() (any, error) { return v.drv.GetFeatureView(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeatureViews(ctx context.Context, parent string) ([]driver.FeatureView, error) {
+	return cast[[]driver.FeatureView](v.do(ctx, "ListFeatureViews", parent, func() (any, error) {
+		return v.drv.ListFeatureViews(ctx, parent)
+	}))
+}
+
+func (v *VertexAI) DeleteFeatureView(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeatureView", name, func() (any, error) {
+		return v.drv.DeleteFeatureView(ctx, name)
+	}))
+}
+
+func (v *VertexAI) FetchFeatureValues(
+	ctx context.Context, featureView, entityID string,
+) ([]driver.FeatureNameValue, error) {
+	return cast[[]driver.FeatureNameValue](v.do(ctx, "FetchFeatureValues", featureView, func() (any, error) {
+		return v.drv.FetchFeatureValues(ctx, featureView, entityID)
+	}))
+}

--- a/vertexai/wrappers_genai.go
+++ b/vertexai/wrappers_genai.go
@@ -1,0 +1,48 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) GenerateContent(
+	ctx context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.GenerateContentResponse, error) {
+	return cast[*driver.GenerateContentResponse](v.do(ctx, "GenerateContent", model, func() (any, error) {
+		return v.drv.GenerateContent(ctx, model, req)
+	}))
+}
+
+func (v *VertexAI) CountTokens(
+	ctx context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.CountTokensResponse, error) {
+	return cast[*driver.CountTokensResponse](v.do(ctx, "CountTokens", model, func() (any, error) {
+		return v.drv.CountTokens(ctx, model, req)
+	}))
+}
+
+//nolint:gocritic // cfg matches the driver signature; forwarded unchanged.
+func (v *VertexAI) CreateCachedContent(ctx context.Context, cfg driver.CachedContentConfig) (*driver.CachedContent, error) {
+	return cast[*driver.CachedContent](v.do(ctx, "CreateCachedContent", cfg, func() (any, error) {
+		return v.drv.CreateCachedContent(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetCachedContent(ctx context.Context, name string) (*driver.CachedContent, error) {
+	return cast[*driver.CachedContent](v.do(ctx, "GetCachedContent", name, func() (any, error) {
+		return v.drv.GetCachedContent(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListCachedContents(ctx context.Context, location string) ([]driver.CachedContent, error) {
+	return cast[[]driver.CachedContent](v.do(ctx, "ListCachedContents", location, func() (any, error) {
+		return v.drv.ListCachedContents(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteCachedContent(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "DeleteCachedContent", name, func() (any, error) { return nil, v.drv.DeleteCachedContent(ctx, name) })
+
+	return err
+}

--- a/vertexai/wrappers_jobs.go
+++ b/vertexai/wrappers_jobs.go
@@ -1,0 +1,92 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateCustomJob(ctx context.Context, cfg driver.CustomJobConfig) (*driver.CustomJob, error) {
+	return cast[*driver.CustomJob](v.do(ctx, "CreateCustomJob", cfg, func() (any, error) { return v.drv.CreateCustomJob(ctx, cfg) }))
+}
+
+func (v *VertexAI) GetCustomJob(ctx context.Context, name string) (*driver.CustomJob, error) {
+	return cast[*driver.CustomJob](v.do(ctx, "GetCustomJob", name, func() (any, error) { return v.drv.GetCustomJob(ctx, name) }))
+}
+
+func (v *VertexAI) ListCustomJobs(ctx context.Context, location string) ([]driver.CustomJob, error) {
+	return cast[[]driver.CustomJob](v.do(ctx, "ListCustomJobs", location, func() (any, error) { return v.drv.ListCustomJobs(ctx, location) }))
+}
+
+func (v *VertexAI) CancelCustomJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelCustomJob", name, func() (any, error) { return nil, v.drv.CancelCustomJob(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) DeleteCustomJob(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteCustomJob", name, func() (any, error) { return v.drv.DeleteCustomJob(ctx, name) }))
+}
+
+func (v *VertexAI) CreateHyperparameterTuningJob(
+	ctx context.Context, cfg driver.HyperparameterTuningJobConfig,
+) (*driver.HyperparameterTuningJob, error) {
+	return cast[*driver.HyperparameterTuningJob](v.do(ctx, "CreateHyperparameterTuningJob", cfg, func() (any, error) {
+		return v.drv.CreateHyperparameterTuningJob(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetHyperparameterTuningJob(ctx context.Context, name string) (*driver.HyperparameterTuningJob, error) {
+	return cast[*driver.HyperparameterTuningJob](v.do(ctx, "GetHyperparameterTuningJob", name, func() (any, error) {
+		return v.drv.GetHyperparameterTuningJob(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListHyperparameterTuningJobs(ctx context.Context, location string) ([]driver.HyperparameterTuningJob, error) {
+	return cast[[]driver.HyperparameterTuningJob](v.do(ctx, "ListHyperparameterTuningJobs", location, func() (any, error) {
+		return v.drv.ListHyperparameterTuningJobs(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelHyperparameterTuningJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelHyperparameterTuningJob", name, func() (any, error) {
+		return nil, v.drv.CancelHyperparameterTuningJob(ctx, name)
+	})
+
+	return err
+}
+
+//nolint:gocritic // cfg matches the driver signature; forwarded unchanged.
+func (v *VertexAI) CreateBatchPredictionJob(
+	ctx context.Context, cfg driver.BatchPredictionJobConfig,
+) (*driver.BatchPredictionJob, error) {
+	return cast[*driver.BatchPredictionJob](v.do(ctx, "CreateBatchPredictionJob", cfg, func() (any, error) {
+		return v.drv.CreateBatchPredictionJob(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetBatchPredictionJob(ctx context.Context, name string) (*driver.BatchPredictionJob, error) {
+	return cast[*driver.BatchPredictionJob](v.do(ctx, "GetBatchPredictionJob", name, func() (any, error) {
+		return v.drv.GetBatchPredictionJob(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListBatchPredictionJobs(ctx context.Context, location string) ([]driver.BatchPredictionJob, error) {
+	return cast[[]driver.BatchPredictionJob](v.do(ctx, "ListBatchPredictionJobs", location, func() (any, error) {
+		return v.drv.ListBatchPredictionJobs(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelBatchPredictionJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelBatchPredictionJob", name, func() (any, error) {
+		return nil, v.drv.CancelBatchPredictionJob(ctx, name)
+	})
+
+	return err
+}
+
+func (v *VertexAI) DeleteBatchPredictionJob(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteBatchPredictionJob", name, func() (any, error) {
+		return v.drv.DeleteBatchPredictionJob(ctx, name)
+	}))
+}

--- a/vertexai/wrappers_metadata.go
+++ b/vertexai/wrappers_metadata.go
@@ -1,0 +1,187 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Metadata stores ---
+
+func (v *VertexAI) CreateMetadataStore(
+	ctx context.Context, location, storeID string,
+) (*driver.Operation, *driver.MetadataStore, error) {
+	r, err := cast[opPair[*driver.MetadataStore]](v.do(ctx, "CreateMetadataStore", location, func() (any, error) {
+		op, s, e := v.drv.CreateMetadataStore(ctx, location, storeID)
+
+		return opPair[*driver.MetadataStore]{op, s}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetMetadataStore(ctx context.Context, name string) (*driver.MetadataStore, error) {
+	return cast[*driver.MetadataStore](v.do(ctx, "GetMetadataStore", name, func() (any, error) {
+		return v.drv.GetMetadataStore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListMetadataStores(ctx context.Context, location string) ([]driver.MetadataStore, error) {
+	return cast[[]driver.MetadataStore](v.do(ctx, "ListMetadataStores", location, func() (any, error) {
+		return v.drv.ListMetadataStores(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteMetadataStore(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteMetadataStore", name, func() (any, error) {
+		return v.drv.DeleteMetadataStore(ctx, name)
+	}))
+}
+
+// --- Tensorboards ---
+
+func (v *VertexAI) CreateTensorboard(
+	ctx context.Context, location, displayName string,
+) (*driver.Operation, *driver.Tensorboard, error) {
+	r, err := cast[opPair[*driver.Tensorboard]](v.do(ctx, "CreateTensorboard", location, func() (any, error) {
+		op, tb, e := v.drv.CreateTensorboard(ctx, location, displayName)
+
+		return opPair[*driver.Tensorboard]{op, tb}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetTensorboard(ctx context.Context, name string) (*driver.Tensorboard, error) {
+	return cast[*driver.Tensorboard](v.do(ctx, "GetTensorboard", name, func() (any, error) { return v.drv.GetTensorboard(ctx, name) }))
+}
+
+func (v *VertexAI) ListTensorboards(ctx context.Context, location string) ([]driver.Tensorboard, error) {
+	return cast[[]driver.Tensorboard](v.do(ctx, "ListTensorboards", location, func() (any, error) {
+		return v.drv.ListTensorboards(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteTensorboard(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteTensorboard", name, func() (any, error) {
+		return v.drv.DeleteTensorboard(ctx, name)
+	}))
+}
+
+// --- Schedules ---
+
+func (v *VertexAI) CreateSchedule(ctx context.Context, location, displayName, cron string) (*driver.Schedule, error) {
+	return cast[*driver.Schedule](v.do(ctx, "CreateSchedule", location, func() (any, error) {
+		return v.drv.CreateSchedule(ctx, location, displayName, cron)
+	}))
+}
+
+func (v *VertexAI) GetSchedule(ctx context.Context, name string) (*driver.Schedule, error) {
+	return cast[*driver.Schedule](v.do(ctx, "GetSchedule", name, func() (any, error) { return v.drv.GetSchedule(ctx, name) }))
+}
+
+func (v *VertexAI) ListSchedules(ctx context.Context, location string) ([]driver.Schedule, error) {
+	return cast[[]driver.Schedule](v.do(ctx, "ListSchedules", location, func() (any, error) { return v.drv.ListSchedules(ctx, location) }))
+}
+
+func (v *VertexAI) PauseSchedule(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "PauseSchedule", name, func() (any, error) { return nil, v.drv.PauseSchedule(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) ResumeSchedule(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "ResumeSchedule", name, func() (any, error) { return nil, v.drv.ResumeSchedule(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) DeleteSchedule(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteSchedule", name, func() (any, error) { return v.drv.DeleteSchedule(ctx, name) }))
+}
+
+// --- Notebook runtime templates ---
+
+func (v *VertexAI) CreateNotebookRuntimeTemplate(
+	ctx context.Context, location, displayName, machineType string,
+) (*driver.Operation, *driver.NotebookRuntimeTemplate, error) {
+	r, err := cast[opPair[*driver.NotebookRuntimeTemplate]](v.do(ctx, "CreateNotebookRuntimeTemplate", location, func() (any, error) {
+		op, t, e := v.drv.CreateNotebookRuntimeTemplate(ctx, location, displayName, machineType)
+
+		return opPair[*driver.NotebookRuntimeTemplate]{op, t}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetNotebookRuntimeTemplate(ctx context.Context, name string) (*driver.NotebookRuntimeTemplate, error) {
+	return cast[*driver.NotebookRuntimeTemplate](v.do(ctx, "GetNotebookRuntimeTemplate", name, func() (any, error) {
+		return v.drv.GetNotebookRuntimeTemplate(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListNotebookRuntimeTemplates(ctx context.Context, location string) ([]driver.NotebookRuntimeTemplate, error) {
+	return cast[[]driver.NotebookRuntimeTemplate](v.do(ctx, "ListNotebookRuntimeTemplates", location, func() (any, error) {
+		return v.drv.ListNotebookRuntimeTemplates(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteNotebookRuntimeTemplate(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteNotebookRuntimeTemplate", name, func() (any, error) {
+		return v.drv.DeleteNotebookRuntimeTemplate(ctx, name)
+	}))
+}
+
+// --- Notebook runtimes ---
+
+func (v *VertexAI) AssignNotebookRuntime(
+	ctx context.Context, location, displayName string,
+) (*driver.Operation, *driver.NotebookRuntime, error) {
+	r, err := cast[opPair[*driver.NotebookRuntime]](v.do(ctx, "AssignNotebookRuntime", location, func() (any, error) {
+		op, nr, e := v.drv.AssignNotebookRuntime(ctx, location, displayName)
+
+		return opPair[*driver.NotebookRuntime]{op, nr}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetNotebookRuntime(ctx context.Context, name string) (*driver.NotebookRuntime, error) {
+	return cast[*driver.NotebookRuntime](v.do(ctx, "GetNotebookRuntime", name, func() (any, error) {
+		return v.drv.GetNotebookRuntime(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListNotebookRuntimes(ctx context.Context, location string) ([]driver.NotebookRuntime, error) {
+	return cast[[]driver.NotebookRuntime](v.do(ctx, "ListNotebookRuntimes", location, func() (any, error) {
+		return v.drv.ListNotebookRuntimes(ctx, location)
+	}))
+}
+
+func (v *VertexAI) StartNotebookRuntime(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "StartNotebookRuntime", name, func() (any, error) {
+		return v.drv.StartNotebookRuntime(ctx, name)
+	}))
+}
+
+func (v *VertexAI) StopNotebookRuntime(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "StopNotebookRuntime", name, func() (any, error) {
+		return v.drv.StopNotebookRuntime(ctx, name)
+	}))
+}
+
+func (v *VertexAI) DeleteNotebookRuntime(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteNotebookRuntime", name, func() (any, error) {
+		return v.drv.DeleteNotebookRuntime(ctx, name)
+	}))
+}
+
+// --- Operations ---
+
+func (v *VertexAI) GetOperation(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "GetOperation", name, func() (any, error) { return v.drv.GetOperation(ctx, name) }))
+}
+
+func (v *VertexAI) ListOperations(ctx context.Context, parent string) ([]driver.Operation, error) {
+	return cast[[]driver.Operation](v.do(ctx, "ListOperations", parent, func() (any, error) { return v.drv.ListOperations(ctx, parent) }))
+}

--- a/vertexai/wrappers_models.go
+++ b/vertexai/wrappers_models.go
@@ -1,0 +1,66 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+//nolint:gocritic // cfg matches the driver signature; forwarded unchanged.
+func (v *VertexAI) UploadModel(ctx context.Context, cfg driver.ModelConfig) (*driver.Operation, *driver.Model, error) {
+	r, err := cast[opPair[*driver.Model]](v.do(ctx, "UploadModel", cfg, func() (any, error) {
+		op, m, e := v.drv.UploadModel(ctx, cfg)
+
+		return opPair[*driver.Model]{op, m}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetModel(ctx context.Context, name string) (*driver.Model, error) {
+	return cast[*driver.Model](v.do(ctx, "GetModel", name, func() (any, error) { return v.drv.GetModel(ctx, name) }))
+}
+
+func (v *VertexAI) ListModels(ctx context.Context, location string) ([]driver.Model, error) {
+	return cast[[]driver.Model](v.do(ctx, "ListModels", location, func() (any, error) { return v.drv.ListModels(ctx, location) }))
+}
+
+func (v *VertexAI) PatchModel(ctx context.Context, name, displayName, description string) (*driver.Model, error) {
+	return cast[*driver.Model](v.do(ctx, "PatchModel", name, func() (any, error) {
+		return v.drv.PatchModel(ctx, name, displayName, description)
+	}))
+}
+
+func (v *VertexAI) DeleteModel(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteModel", name, func() (any, error) { return v.drv.DeleteModel(ctx, name) }))
+}
+
+func (v *VertexAI) ListModelVersions(ctx context.Context, name string) ([]driver.Model, error) {
+	return cast[[]driver.Model](v.do(ctx, "ListModelVersions", name, func() (any, error) { return v.drv.ListModelVersions(ctx, name) }))
+}
+
+func (v *VertexAI) DeleteModelVersion(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteModelVersion", name, func() (any, error) {
+		return v.drv.DeleteModelVersion(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ImportModelEvaluation(
+	ctx context.Context, modelName string, eval driver.ModelEvaluation,
+) (*driver.ModelEvaluation, error) {
+	return cast[*driver.ModelEvaluation](v.do(ctx, "ImportModelEvaluation", modelName, func() (any, error) {
+		return v.drv.ImportModelEvaluation(ctx, modelName, eval)
+	}))
+}
+
+func (v *VertexAI) GetModelEvaluation(ctx context.Context, name string) (*driver.ModelEvaluation, error) {
+	return cast[*driver.ModelEvaluation](v.do(ctx, "GetModelEvaluation", name, func() (any, error) {
+		return v.drv.GetModelEvaluation(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListModelEvaluations(ctx context.Context, modelName string) ([]driver.ModelEvaluation, error) {
+	return cast[[]driver.ModelEvaluation](v.do(ctx, "ListModelEvaluations", modelName, func() (any, error) {
+		return v.drv.ListModelEvaluations(ctx, modelName)
+	}))
+}

--- a/vertexai/wrappers_pipelines.go
+++ b/vertexai/wrappers_pipelines.go
@@ -1,0 +1,87 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateTrainingPipeline(
+	ctx context.Context, cfg driver.TrainingPipelineConfig,
+) (*driver.TrainingPipeline, error) {
+	return cast[*driver.TrainingPipeline](v.do(ctx, "CreateTrainingPipeline", cfg, func() (any, error) {
+		return v.drv.CreateTrainingPipeline(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetTrainingPipeline(ctx context.Context, name string) (*driver.TrainingPipeline, error) {
+	return cast[*driver.TrainingPipeline](v.do(ctx, "GetTrainingPipeline", name, func() (any, error) {
+		return v.drv.GetTrainingPipeline(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListTrainingPipelines(ctx context.Context, location string) ([]driver.TrainingPipeline, error) {
+	return cast[[]driver.TrainingPipeline](v.do(ctx, "ListTrainingPipelines", location, func() (any, error) {
+		return v.drv.ListTrainingPipelines(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelTrainingPipeline(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelTrainingPipeline", name, func() (any, error) {
+		return nil, v.drv.CancelTrainingPipeline(ctx, name)
+	})
+
+	return err
+}
+
+func (v *VertexAI) DeleteTrainingPipeline(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteTrainingPipeline", name, func() (any, error) {
+		return v.drv.DeleteTrainingPipeline(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreatePipelineJob(ctx context.Context, cfg driver.PipelineJobConfig) (*driver.PipelineJob, error) {
+	return cast[*driver.PipelineJob](v.do(ctx, "CreatePipelineJob", cfg, func() (any, error) {
+		return v.drv.CreatePipelineJob(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetPipelineJob(ctx context.Context, name string) (*driver.PipelineJob, error) {
+	return cast[*driver.PipelineJob](v.do(ctx, "GetPipelineJob", name, func() (any, error) { return v.drv.GetPipelineJob(ctx, name) }))
+}
+
+func (v *VertexAI) ListPipelineJobs(ctx context.Context, location string) ([]driver.PipelineJob, error) {
+	return cast[[]driver.PipelineJob](v.do(ctx, "ListPipelineJobs", location, func() (any, error) {
+		return v.drv.ListPipelineJobs(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelPipelineJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelPipelineJob", name, func() (any, error) { return nil, v.drv.CancelPipelineJob(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) DeletePipelineJob(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeletePipelineJob", name, func() (any, error) {
+		return v.drv.DeletePipelineJob(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreateTuningJob(ctx context.Context, cfg driver.TuningJobConfig) (*driver.TuningJob, error) {
+	return cast[*driver.TuningJob](v.do(ctx, "CreateTuningJob", cfg, func() (any, error) { return v.drv.CreateTuningJob(ctx, cfg) }))
+}
+
+func (v *VertexAI) GetTuningJob(ctx context.Context, name string) (*driver.TuningJob, error) {
+	return cast[*driver.TuningJob](v.do(ctx, "GetTuningJob", name, func() (any, error) { return v.drv.GetTuningJob(ctx, name) }))
+}
+
+func (v *VertexAI) ListTuningJobs(ctx context.Context, location string) ([]driver.TuningJob, error) {
+	return cast[[]driver.TuningJob](v.do(ctx, "ListTuningJobs", location, func() (any, error) { return v.drv.ListTuningJobs(ctx, location) }))
+}
+
+func (v *VertexAI) CancelTuningJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelTuningJob", name, func() (any, error) { return nil, v.drv.CancelTuningJob(ctx, name) })
+
+	return err
+}

--- a/vertexai/wrappers_vectorsearch.go
+++ b/vertexai/wrappers_vectorsearch.go
@@ -1,0 +1,107 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateIndex(ctx context.Context, cfg driver.IndexConfig) (*driver.Operation, *driver.Index, error) {
+	r, err := cast[opPair[*driver.Index]](v.do(ctx, "CreateIndex", cfg, func() (any, error) {
+		op, idx, e := v.drv.CreateIndex(ctx, cfg)
+
+		return opPair[*driver.Index]{op, idx}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetIndex(ctx context.Context, name string) (*driver.Index, error) {
+	return cast[*driver.Index](v.do(ctx, "GetIndex", name, func() (any, error) { return v.drv.GetIndex(ctx, name) }))
+}
+
+func (v *VertexAI) ListIndexes(ctx context.Context, location string) ([]driver.Index, error) {
+	return cast[[]driver.Index](v.do(ctx, "ListIndexes", location, func() (any, error) { return v.drv.ListIndexes(ctx, location) }))
+}
+
+func (v *VertexAI) DeleteIndex(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteIndex", name, func() (any, error) { return v.drv.DeleteIndex(ctx, name) }))
+}
+
+func (v *VertexAI) UpsertDatapoints(ctx context.Context, index string, datapoints []driver.Datapoint) error {
+	_, err := v.do(ctx, "UpsertDatapoints", index, func() (any, error) {
+		return nil, v.drv.UpsertDatapoints(ctx, index, datapoints)
+	})
+
+	return err
+}
+
+func (v *VertexAI) RemoveDatapoints(ctx context.Context, index string, datapointIDs []string) error {
+	_, err := v.do(ctx, "RemoveDatapoints", index, func() (any, error) {
+		return nil, v.drv.RemoveDatapoints(ctx, index, datapointIDs)
+	})
+
+	return err
+}
+
+func (v *VertexAI) CreateIndexEndpoint(
+	ctx context.Context, cfg driver.IndexEndpointConfig,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	r, err := cast[opPair[*driver.IndexEndpoint]](v.do(ctx, "CreateIndexEndpoint", cfg, func() (any, error) {
+		op, ie, e := v.drv.CreateIndexEndpoint(ctx, cfg)
+
+		return opPair[*driver.IndexEndpoint]{op, ie}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetIndexEndpoint(ctx context.Context, name string) (*driver.IndexEndpoint, error) {
+	return cast[*driver.IndexEndpoint](v.do(ctx, "GetIndexEndpoint", name, func() (any, error) {
+		return v.drv.GetIndexEndpoint(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListIndexEndpoints(ctx context.Context, location string) ([]driver.IndexEndpoint, error) {
+	return cast[[]driver.IndexEndpoint](v.do(ctx, "ListIndexEndpoints", location, func() (any, error) {
+		return v.drv.ListIndexEndpoints(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteIndexEndpoint(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteIndexEndpoint", name, func() (any, error) {
+		return v.drv.DeleteIndexEndpoint(ctx, name)
+	}))
+}
+
+func (v *VertexAI) DeployIndex(
+	ctx context.Context, indexEndpoint string, di driver.DeployedIndex,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	r, err := cast[opPair[*driver.IndexEndpoint]](v.do(ctx, "DeployIndex", indexEndpoint, func() (any, error) {
+		op, ie, e := v.drv.DeployIndex(ctx, indexEndpoint, di)
+
+		return opPair[*driver.IndexEndpoint]{op, ie}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) UndeployIndex(
+	ctx context.Context, indexEndpoint, deployedIndexID string,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	r, err := cast[opPair[*driver.IndexEndpoint]](v.do(ctx, "UndeployIndex", indexEndpoint, func() (any, error) {
+		op, ie, e := v.drv.UndeployIndex(ctx, indexEndpoint, deployedIndexID)
+
+		return opPair[*driver.IndexEndpoint]{op, ie}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) FindNeighbors(
+	ctx context.Context, indexEndpoint, deployedIndexID string, query []float64, count int,
+) ([]driver.Neighbor, error) {
+	return cast[[]driver.Neighbor](v.do(ctx, "FindNeighbors", indexEndpoint, func() (any, error) {
+		return v.drv.FindNeighbors(ctx, indexEndpoint, deployedIndexID, query, count)
+	}))
+}


### PR DESCRIPTION
## <img src="https://raw.githubusercontent.com/stackshy/cloudemu/development/.github/logo.svg" alt="cloudemu" width="28" height="28" align="absmiddle" /> Release Notes — v1.8.0

## ✨ Features

### AWS SageMaker — in-memory emulation + SDK-compat server

Point the real `aws-sdk-go-v2` SageMaker client at an in-memory backend: models and endpoints (deploy / predict), training, processing, tuning, and batch-transform jobs, notebooks and Studio, pipelines, the model registry, feature store, and HyperPod-style clusters — with auto-metrics to CloudWatch and a portable Go API carrying the usual recording / metrics / rate-limit / error-injection / latency wrappers.

### GCP Vertex AI — in-memory emulation + SDK-compat REST server

Datasets, the model registry and endpoints (deploy / predict), Gemini `generateContent` / `streamGenerateContent` / `countTokens`, tuning, custom / batch / hyperparameter-tuning jobs, pipelines, feature store, vector search, and ML metadata — with long-running-operation machinery, served over a REST surface the Vertex client can target.

## 🔧 Enhancements

### Azure Databricks — faithful data-plane round-trips

Cluster, instance-pool, and SQL-warehouse settings that previously dropped between create and read now round-trip — custom tags, Photon runtime engine, pool idle-autotermination, and cluster policy / instance pool / Azure availability / source — and an explicit "never auto-stop" warehouse is honored. Query history is now served end-to-end.

### Azure Resource Graph — Databricks discovery & type filtering

Databricks workspaces now appear in Resource Graph results, and `where type in~ (...)` type filters narrow correctly — including returning nothing (not everything) for a type the emulator doesn't model.

## Technical Details

<details>
<summary><b>AWS SageMaker</b></summary>

- Portable Go API + driver + provider + SDK-compat handler (`server/aws/sagemaker`), AWS JSON 1.1 wire protocol.
- Families: models, endpoints (+ deploy / weights / predict / rawPredict), training / processing / tuning / batch-transform jobs, notebooks, Studio, pipelines, model registry (+ versions / packages), feature store, clusters.
- Auto-metrics to CloudWatch via `SetMonitoring`; chaos + cost wiring.
</details>

<details>
<summary><b>GCP Vertex AI</b></summary>

- Portable Go API + driver + provider + SDK-compat REST handler (`server/gcp/vertexai`), `aiplatform.googleapis.com` shape.
- Families: datasets, models (+ versions / evaluations), endpoints (+ deploy / predict), Model Garden `generateContent` / `streamGenerateContent` / `countTokens`, tuning + cached contents, custom / batch / HPO jobs, pipelines, feature store, vector search, metadata, schedules, notebook runtimes.
- `google.longrunning.Operation` responses with typed results; auto-metrics to Cloud Monitoring; chaos + cost wiring.
</details>

<details>
<summary><b>Azure Databricks</b></summary>

- Cluster: `custom_tags`, `runtime_engine`, `policy_id`, `instance_pool_id`, `azure_attributes.availability`, server-assigned `cluster_source`.
- Instance pool: `idle_instance_autotermination_minutes`, `custom_tags`.
- SQL warehouse: `tags`, and explicit `auto_stop_mins = 0` honored (pointer-based, no default coercion).
- New `GET /api/2.0/sql/history/queries` (QueryHistory) handler.
</details>

<details>
<summary><b>Azure Resource Graph</b></summary>

- Databricks ARM workspaces fed into the cross-service discovery inventory via a dedicated walker.
- KQL `where type in (...)` / `in~ (...)` parsing with an any-of type filter; `microsoft.databricks/workspaces` mapped both ways.
- An all-unmapped / empty type filter now matches none instead of the whole inventory.
</details>