### PR TITLE
fix(databricks): preserve cluster policy_id / instance_pool_id / azure_attributes + cluster_source

### DIFF
--- a/databricks/driver/dataplane.go
+++ b/databricks/driver/dataplane.go
@@ -16,6 +16,10 @@ const (
 	ClusterTerminated = "TERMINATED"
 )
 
+// ClusterSourceAPI is the cluster_source reported for clusters created through
+// the API surface (the only path the in-memory backend offers).
+const ClusterSourceAPI = "API"
+
 // InstancePoolConfig describes an instance pool to create or edit.
 type InstancePoolConfig struct {
 	Name                               string
@@ -40,28 +44,38 @@ type InstancePool struct {
 
 // ClusterConfig describes a cluster to create or edit.
 type ClusterConfig struct {
-	Name          string
-	SparkVersion  string
-	NodeTypeID    string
-	NumWorkers    int32
-	AutoscaleMin  int32
-	AutoscaleMax  int32
-	RuntimeEngine string
-	CustomTags    map[string]string
+	Name              string
+	SparkVersion      string
+	NodeTypeID        string
+	NumWorkers        int32
+	AutoscaleMin      int32
+	AutoscaleMax      int32
+	RuntimeEngine     string
+	CustomTags        map[string]string
+	PolicyID          string
+	InstancePoolID    string
+	AzureAvailability string
 }
 
 // Cluster describes a compute cluster.
 type Cluster struct {
-	ID            string
-	Name          string
-	SparkVersion  string
-	NodeTypeID    string
-	State         string
-	NumWorkers    int32
-	AutoscaleMin  int32
-	AutoscaleMax  int32
-	RuntimeEngine string
-	CustomTags    map[string]string
+	ID                string
+	Name              string
+	SparkVersion      string
+	NodeTypeID        string
+	State             string
+	NumWorkers        int32
+	AutoscaleMin      int32
+	AutoscaleMax      int32
+	RuntimeEngine     string
+	CustomTags        map[string]string
+	PolicyID          string
+	InstancePoolID    string
+	AzureAvailability string
+	// ClusterSource is assigned by the backend, not the caller. Real Databricks
+	// reports how the cluster was created (API / UI / JOB); the in-memory
+	// backend always creates via the API surface, so it reports "API".
+	ClusterSource string
 	Pinned        bool
 }
 

--- a/providers/azure/databricks/dataplane.go
+++ b/providers/azure/databricks/dataplane.go
@@ -105,16 +105,20 @@ func (m *Mock) CreateCluster(_ context.Context, cfg driver.ClusterConfig) (*driv
 
 	id := idgen.GenerateID("cluster-")
 	cluster := &driver.Cluster{
-		ID:            id,
-		Name:          cfg.Name,
-		SparkVersion:  cfg.SparkVersion,
-		NodeTypeID:    cfg.NodeTypeID,
-		State:         driver.ClusterRunning,
-		NumWorkers:    cfg.NumWorkers,
-		AutoscaleMin:  cfg.AutoscaleMin,
-		AutoscaleMax:  cfg.AutoscaleMax,
-		RuntimeEngine: cfg.RuntimeEngine,
-		CustomTags:    cfg.CustomTags,
+		ID:                id,
+		Name:              cfg.Name,
+		SparkVersion:      cfg.SparkVersion,
+		NodeTypeID:        cfg.NodeTypeID,
+		State:             driver.ClusterRunning,
+		NumWorkers:        cfg.NumWorkers,
+		AutoscaleMin:      cfg.AutoscaleMin,
+		AutoscaleMax:      cfg.AutoscaleMax,
+		RuntimeEngine:     cfg.RuntimeEngine,
+		CustomTags:        cfg.CustomTags,
+		PolicyID:          cfg.PolicyID,
+		InstancePoolID:    cfg.InstancePoolID,
+		AzureAvailability: cfg.AzureAvailability,
+		ClusterSource:     driver.ClusterSourceAPI,
 	}
 	m.clusters.Set(id, cluster)
 
@@ -165,6 +169,9 @@ func (m *Mock) EditCluster(_ context.Context, id string, cfg driver.ClusterConfi
 	updated.AutoscaleMax = cfg.AutoscaleMax
 	updated.RuntimeEngine = cfg.RuntimeEngine
 	updated.CustomTags = cfg.CustomTags
+	updated.PolicyID = cfg.PolicyID
+	updated.InstancePoolID = cfg.InstancePoolID
+	updated.AzureAvailability = cfg.AzureAvailability
 	m.clusters.Set(id, &updated)
 
 	return nil

--- a/server/azure/databricks/dataplane_fields_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_fields_roundtrip_test.go
@@ -119,4 +119,23 @@ func TestSDKClusterPolicyPoolAzureSource(t *testing.T) {
 	if got.ClusterSource != compute.ClusterSourceApi {
 		t.Fatalf("cluster_source: got %q, want API", got.ClusterSource)
 	}
+
+	// The issue reports the drop on create->list, so pin the list path too
+	// (it shares the same response converter as Get).
+	all, err := w.Clusters.ListAll(ctx, compute.ListClustersRequest{})
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	if len(all) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(all))
+	}
+
+	listed := all[0]
+	if listed.PolicyId != "policy-123" || listed.InstancePoolId != pool.InstancePoolId ||
+		listed.ClusterSource != compute.ClusterSourceApi ||
+		listed.AzureAttributes == nil ||
+		listed.AzureAttributes.Availability != compute.AzureAvailabilityOnDemandAzure {
+		t.Fatalf("list dropped a field: %+v (azure=%+v)", listed, listed.AzureAttributes)
+	}
 }

--- a/server/azure/databricks/dataplane_fields_roundtrip_test.go
+++ b/server/azure/databricks/dataplane_fields_roundtrip_test.go
@@ -69,3 +69,54 @@ func TestSDKInstancePoolIdleAndTags(t *testing.T) {
 		t.Fatalf("custom_tags: got %v, want {team:data}", got.CustomTags)
 	}
 }
+
+// TestSDKClusterPolicyPoolAzureSource pins issue #229: policy_id,
+// instance_pool_id, azure_attributes.availability, and the backend-assigned
+// cluster_source must survive a create→get round-trip.
+func TestSDKClusterPolicyPoolAzureSource(t *testing.T) {
+	w := newWorkspace(t)
+	ctx := context.Background()
+
+	pool, err := w.InstancePools.Create(ctx, compute.CreateInstancePool{
+		InstancePoolName: "p1", NodeTypeId: "Standard_DS3_v2", MinIdleInstances: 1,
+	})
+	if err != nil {
+		t.Fatalf("Create pool: %v", err)
+	}
+
+	wait, err := w.Clusters.Create(ctx, compute.CreateCluster{
+		ClusterName:    "c1",
+		SparkVersion:   "13.3.x-scala2.12",
+		NodeTypeId:     "Standard_DS3_v2",
+		NumWorkers:     2,
+		PolicyId:       "policy-123",
+		InstancePoolId: pool.InstancePoolId,
+		AzureAttributes: &compute.AzureAttributes{
+			Availability: compute.AzureAvailabilityOnDemandAzure,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create cluster: %v", err)
+	}
+
+	got, err := w.Clusters.Get(ctx, compute.GetClusterRequest{ClusterId: wait.ClusterId})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.PolicyId != "policy-123" {
+		t.Fatalf("policy_id: got %q, want policy-123", got.PolicyId)
+	}
+
+	if got.InstancePoolId != pool.InstancePoolId {
+		t.Fatalf("instance_pool_id: got %q, want %q", got.InstancePoolId, pool.InstancePoolId)
+	}
+
+	if got.AzureAttributes == nil || got.AzureAttributes.Availability != compute.AzureAvailabilityOnDemandAzure {
+		t.Fatalf("azure_attributes.availability: got %+v, want ON_DEMAND_AZURE", got.AzureAttributes)
+	}
+
+	if got.ClusterSource != compute.ClusterSourceApi {
+		t.Fatalf("cluster_source: got %q, want API", got.ClusterSource)
+	}
+}

--- a/server/azure/databricks/dataplane_ops.go
+++ b/server/azure/databricks/dataplane_ops.go
@@ -35,16 +35,24 @@ type listPoolsResponse struct {
 	InstancePools []instancePoolJSON `json:"instance_pools"`
 }
 
+type azureAttributesJSON struct {
+	Availability string `json:"availability,omitempty"`
+}
+
 type clusterJSON struct {
-	ClusterID     string            `json:"cluster_id,omitempty"`
-	ClusterName   string            `json:"cluster_name,omitempty"`
-	SparkVersion  string            `json:"spark_version"`
-	NodeTypeID    string            `json:"node_type_id"`
-	State         string            `json:"state,omitempty"`
-	NumWorkers    int32             `json:"num_workers,omitempty"`
-	Autoscale     *autoscaleJSON    `json:"autoscale,omitempty"`
-	RuntimeEngine string            `json:"runtime_engine,omitempty"`
-	CustomTags    map[string]string `json:"custom_tags,omitempty"`
+	ClusterID       string               `json:"cluster_id,omitempty"`
+	ClusterName     string               `json:"cluster_name,omitempty"`
+	SparkVersion    string               `json:"spark_version"`
+	NodeTypeID      string               `json:"node_type_id"`
+	State           string               `json:"state,omitempty"`
+	NumWorkers      int32                `json:"num_workers,omitempty"`
+	Autoscale       *autoscaleJSON       `json:"autoscale,omitempty"`
+	RuntimeEngine   string               `json:"runtime_engine,omitempty"`
+	CustomTags      map[string]string    `json:"custom_tags,omitempty"`
+	PolicyID        string               `json:"policy_id,omitempty"`
+	InstancePoolID  string               `json:"instance_pool_id,omitempty"`
+	AzureAttributes *azureAttributesJSON `json:"azure_attributes,omitempty"`
+	ClusterSource   string               `json:"cluster_source,omitempty"`
 }
 
 type clusterID struct {
@@ -528,10 +536,15 @@ func clusterConfig(in *clusterJSON) dbxdriver.ClusterConfig {
 		Name: in.ClusterName, SparkVersion: in.SparkVersion,
 		NodeTypeID: in.NodeTypeID, NumWorkers: in.NumWorkers,
 		RuntimeEngine: in.RuntimeEngine, CustomTags: in.CustomTags,
+		PolicyID: in.PolicyID, InstancePoolID: in.InstancePoolID,
 	}
 	if in.Autoscale != nil {
 		cfg.AutoscaleMin = in.Autoscale.MinWorkers
 		cfg.AutoscaleMax = in.Autoscale.MaxWorkers
+	}
+
+	if in.AzureAttributes != nil {
+		cfg.AzureAvailability = in.AzureAttributes.Availability
 	}
 
 	return cfg
@@ -542,9 +555,14 @@ func toClusterJSON(c *dbxdriver.Cluster) clusterJSON {
 		ClusterID: c.ID, ClusterName: c.Name, SparkVersion: c.SparkVersion,
 		NodeTypeID: c.NodeTypeID, State: c.State, NumWorkers: c.NumWorkers,
 		RuntimeEngine: c.RuntimeEngine, CustomTags: c.CustomTags,
+		PolicyID: c.PolicyID, InstancePoolID: c.InstancePoolID, ClusterSource: c.ClusterSource,
 	}
 	if c.AutoscaleMax > 0 {
 		out.Autoscale = &autoscaleJSON{MinWorkers: c.AutoscaleMin, MaxWorkers: c.AutoscaleMax}
+	}
+
+	if c.AzureAvailability != "" {
+		out.AzureAttributes = &azureAttributesJSON{Availability: c.AzureAvailability}
 	}
 
 	return out


### PR DESCRIPTION
Fixes #229.

## Summary

Follow-up to #223. Four more cluster fields dropped on a create→list round-trip because they didn't exist on the driver / wire structs. Added them end-to-end (driver → provider → wire):

| Field | Behavior |
|-------|----------|
| `policy_id` | stored from request, echoed on get/list |
| `instance_pool_id` | stored from request, echoed |
| `azure_attributes.availability` | decoded from the nested `azure_attributes` object, echoed back in the same shape |
| `cluster_source` | backend-assigned — reported as `API` (the only creation path the in-memory backend offers), matching how real Databricks tags API-created clusters |

## Not a bug: SQL warehouse `auto_stop_mins=0`

The reporter also listed `auto_stop_mins=0 → 120`, but this is working as intended. The handler already honors an explicit `0` (the #223 pointer fix). `databricks-sdk-go` tags `auto_stop_mins` as `omitempty`, so a plain `AutoStopMins: 0` is **omitted from the wire** and the server applies its default — exactly as real Databricks does. To send an explicit `0` (disable auto-stop) the caller sets `ForceSendFields: []string{"AutoStopMins"}`, which round-trips correctly (covered by an existing test). No server change needed; explained on the issue.

## Tests

Real-`databricks-sdk-go` round-trip test (`TestSDKClusterPolicyPoolAzureSource`) creating a cluster with a policy, a real pool, and Azure on-demand availability, asserting all four come back (incl. `cluster_source == API`). `go build`, package tests, and `golangci-lint` clean.