### PR TITLE
Add GCP Vertex AI Emulation (Driver, Provider, SDK-Compat REST Server)

### DIFF
--- a/chaos/wrappers_vertexai.go
+++ b/chaos/wrappers_vertexai.go
@@ -1,0 +1,127 @@
+package chaos
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// chaosVertexAI wraps a Vertex AI service. It consults the engine on the calls
+// most worth failing in tests — job and pipeline submission, model deployment,
+// the online prediction and generateContent runtimes, and Feature Store online
+// serving — and delegates every other operation through the embedded
+// driver.VertexAI unchanged.
+type chaosVertexAI struct {
+	driver.VertexAI
+	engine *Engine
+}
+
+// WrapVertexAI returns a Vertex AI service that injects chaos on submission and
+// runtime calls. service+operation pairs use the "vertexai" service name.
+func WrapVertexAI(inner driver.VertexAI, engine *Engine) driver.VertexAI {
+	return &chaosVertexAI{VertexAI: inner, engine: engine}
+}
+
+func (c *chaosVertexAI) CreateCustomJob(ctx context.Context, cfg driver.CustomJobConfig) (*driver.CustomJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateCustomJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateCustomJob(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreateHyperparameterTuningJob(
+	ctx context.Context, cfg driver.HyperparameterTuningJobConfig,
+) (*driver.HyperparameterTuningJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateHyperparameterTuningJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateHyperparameterTuningJob(ctx, cfg)
+}
+
+//nolint:gocritic // cfg matches the driver signature; delegated unchanged on success.
+func (c *chaosVertexAI) CreateBatchPredictionJob(
+	ctx context.Context, cfg driver.BatchPredictionJobConfig,
+) (*driver.BatchPredictionJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateBatchPredictionJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateBatchPredictionJob(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreateTrainingPipeline(
+	ctx context.Context, cfg driver.TrainingPipelineConfig,
+) (*driver.TrainingPipeline, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateTrainingPipeline"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateTrainingPipeline(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreatePipelineJob(ctx context.Context, cfg driver.PipelineJobConfig) (*driver.PipelineJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreatePipelineJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreatePipelineJob(ctx, cfg)
+}
+
+func (c *chaosVertexAI) CreateTuningJob(ctx context.Context, cfg driver.TuningJobConfig) (*driver.TuningJob, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "CreateTuningJob"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.CreateTuningJob(ctx, cfg)
+}
+
+//nolint:gocritic // dm matches the driver signature; delegated unchanged on success.
+func (c *chaosVertexAI) DeployModel(
+	ctx context.Context, endpoint string, dm driver.DeployedModel,
+) (*driver.Operation, *driver.Endpoint, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "DeployModel"); err != nil {
+		return nil, nil, err
+	}
+
+	return c.VertexAI.DeployModel(ctx, endpoint, dm)
+}
+
+func (c *chaosVertexAI) Predict(ctx context.Context, req driver.PredictRequest) (*driver.PredictResponse, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "Predict"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.Predict(ctx, req)
+}
+
+func (c *chaosVertexAI) GenerateContent(
+	ctx context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.GenerateContentResponse, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "GenerateContent"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.GenerateContent(ctx, model, req)
+}
+
+func (c *chaosVertexAI) WriteFeatureValues(
+	ctx context.Context, entityType, entityID string, values []driver.FeatureNameValue,
+) error {
+	if err := applyChaos(ctx, c.engine, "vertexai", "WriteFeatureValues"); err != nil {
+		return err
+	}
+
+	return c.VertexAI.WriteFeatureValues(ctx, entityType, entityID, values)
+}
+
+func (c *chaosVertexAI) FetchFeatureValues(
+	ctx context.Context, featureView, entityID string,
+) ([]driver.FeatureNameValue, error) {
+	if err := applyChaos(ctx, c.engine, "vertexai", "FetchFeatureValues"); err != nil {
+		return nil, err
+	}
+
+	return c.VertexAI.FetchFeatureValues(ctx, featureView, entityID)
+}

--- a/chaos/wrappers_vertexai_test.go
+++ b/chaos/wrappers_vertexai_test.go
@@ -1,0 +1,67 @@
+package chaos_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu"
+	"github.com/stackshy/cloudemu/chaos"
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func newChaosVertexAI(t *testing.T) (driver.VertexAI, *chaos.Engine) {
+	t.Helper()
+
+	e := chaos.New(config.RealClock{})
+	t.Cleanup(e.Stop)
+
+	return chaos.WrapVertexAI(cloudemu.NewGCP().VertexAI, e), e
+}
+
+func TestWrapVertexAICreateCustomJobChaos(t *testing.T) {
+	v, e := newChaosVertexAI(t)
+	ctx := context.Background()
+
+	if _, err := v.CreateCustomJob(ctx, driver.CustomJobConfig{Location: "us-central1", DisplayName: "j1"}); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("vertexai", time.Hour))
+
+	if _, err := v.CreateCustomJob(ctx, driver.CustomJobConfig{Location: "us-central1", DisplayName: "j2"}); err == nil {
+		t.Error("expected chaos error on CreateCustomJob")
+	}
+}
+
+func TestWrapVertexAIGenerateContentChaos(t *testing.T) {
+	v, e := newChaosVertexAI(t)
+	ctx := context.Background()
+
+	req := driver.GenerateContentRequest{
+		Contents: []driver.Content{{Role: "user", Parts: []driver.Part{{Text: "hi there"}}}},
+	}
+
+	if _, err := v.GenerateContent(ctx, "gemini-2.5-pro", req); err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+
+	e.Apply(chaos.ServiceOutage("vertexai", time.Hour))
+
+	if _, err := v.GenerateContent(ctx, "gemini-2.5-pro", req); err == nil {
+		t.Error("expected chaos error on GenerateContent")
+	}
+}
+
+func TestWrapVertexAIUnwrappedOperationPassesThrough(t *testing.T) {
+	v, e := newChaosVertexAI(t)
+	ctx := context.Background()
+
+	e.Apply(chaos.ServiceOutage("vertexai", time.Hour))
+
+	// ListModels is not a chaos-wrapped operation; it must still succeed.
+	if _, err := v.ListModels(ctx, "us-central1"); err != nil {
+		t.Errorf("unwrapped ListModels should pass through, got: %v", err)
+	}
+}

--- a/cost/cost.go
+++ b/cost/cost.go
@@ -89,6 +89,21 @@ func defaultRates() map[string]float64 {
 		"sagemaker:InvokeEndpoint":                0.0,    // bundled into hosting hours
 		"sagemaker:CreateNotebookInstance":        0.0464, // ml.t3.medium-equivalent instance-hour
 		"sagemaker:CreateModel":                   0.0,
+
+		// Vertex AI (training/pipelines per node-hour, online prediction and
+		// generateContent per request/call, registry resources free)
+		"vertexai:CreateCustomJob":               0.19, // n1-standard-4-equivalent node-hour
+		"vertexai:CreateHyperparameterTuningJob": 0.19,
+		"vertexai:CreateTrainingPipeline":        0.19,
+		"vertexai:CreatePipelineJob":             0.03, // pipeline run execution
+		"vertexai:CreateBatchPredictionJob":      0.19,
+		"vertexai:CreateTuningJob":               0.19,
+		"vertexai:DeployModel":                   0.19,     // online prediction node-hour
+		"vertexai:Predict":                       0.0,      // bundled into deployed node-hours
+		"vertexai:GenerateContent":               0.000125, // per 1K input chars-equivalent call
+		"vertexai:AssignNotebookRuntime":         0.15,     // managed notebook node-hour
+		"vertexai:CreateModel":                   0.0,
+		"vertexai:CreateEndpoint":                0.0,
 	}
 }
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1372,10 +1372,15 @@ field). Auto-metrics → Cloud Monitoring via `SetMonitoring`.
 | Vector Search | Index (+upsert/remove datapoints), IndexEndpoint (+deploy/undeploy/findNeighbors) |
 | ML Metadata | MetadataStore, Tensorboard, Schedule, NotebookRuntimeTemplate, NotebookRuntime |
 
-The full Go API/driver and in-memory provider cover every family above. SDK-compat HTTP
-(REST round-tripped) currently spans models, endpoints (+predict), datasets, custom &
-batch-prediction jobs and `generateContent`/`countTokens`; the remaining families' handlers
-follow the same wire pattern as the next increment. **Total: 128 operations** (Go API/driver).
+The full Go API/driver, in-memory provider, and SDK-compat HTTP server (REST round-tripped)
+cover every family above — models (+versions/evaluations), endpoints (+predict), datasets,
+custom/batch-prediction/hyperparameter-tuning jobs, training & pipeline jobs, tuning jobs,
+cached contents, Feature Store (featurestores/entityTypes/features + online read/write),
+Feature Registry & online stores, Vector Search (indexes + index endpoints), ML metadata,
+tensorboards, schedules, notebook runtimes, and `generateContent`/`countTokens`. A portable
+Layer-1 wrapper (`vertexai/vertexai.go`), chaos injection (`chaos.WrapVertexAI`), and cost
+rates integrate Vertex with the cross-cutting layers like every other service.
+**Total: 128 operations** (Go API/driver).
 
 ---
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -27,6 +27,7 @@ This document lists every service and operation available in CloudEmu across all
 | 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
 | 20 | Generative AI | `bedrock` (+ `bedrock-runtime`) | — | — |
 | 21 | Databricks | — | `databricks` | — |
+| 22 | Machine Learning | _(planned: SageMaker)_ | _(planned: Azure ML / AI Foundry)_ | `vertexai` |
 
 ---
 
@@ -1322,6 +1323,37 @@ Azure-only. The control plane backs the real `armdatabricks` SDK; the data plane
 
 ---
 
+## 22. Machine Learning
+
+**Driver interface:** `vertexai/driver/` | **AWS:** _planned (SageMaker)_ | **Azure:** _planned (Azure ML / AI Foundry)_ | **GCP:** GCP Vertex AI (`aiplatform.googleapis.com`)
+
+GCP-first. The REST surface is rooted at `/v1/projects/{p}/locations/{l}/...` with the
+Model Garden `generateContent` surface at `/v1/publishers/...`. Control-plane mutations
+return done `google.longrunning.Operation`s; job-family creates are synchronous (poll the
+`state` field). Auto-metrics are pushed to Cloud Monitoring via `SetMonitoring`.
+
+| Family | Resources / Operations |
+|--------|------------------------|
+| Datasets | Create/Get/List/Patch/Delete (+ImportData/ExportData) |
+| Model registry | UploadModel, Get/List/Patch/Delete, versions, evaluations |
+| Endpoints | Create/Get/List/Delete, DeployModel/UndeployModel, Predict/RawPredict |
+| Generative AI | generateContent, countTokens (publishers.models + endpoints), tuning jobs, cached contents |
+| Jobs | CustomJob, BatchPredictionJob, HyperparameterTuningJob (synchronous create + cancel) |
+| Pipelines | TrainingPipeline, PipelineJob |
+| Feature Store | FeatureGroup, Feature, FeatureOnlineStore, FeatureView (+fetchFeatureValues) |
+| Vector Search | Index (+upsert/remove datapoints), IndexEndpoint (+deploy/undeploy/findNeighbors) |
+| ML Metadata | MetadataStore, Tensorboard, Schedule, NotebookRuntimeTemplate, NotebookRuntime |
+| Operations | GetOperation / ListOperations (Go API) |
+
+The full Go API/driver and in-memory provider cover every family above. SDK-compat HTTP
+(REST round-tripped) currently spans models, endpoints (+predict), datasets, custom &
+batch-prediction jobs and `generateContent`/`countTokens`; the remaining families'
+handlers follow the same wire pattern as the next increment.
+
+**Total: 118 operations** (Go API/driver)
+
+---
+
 ## Summary
 
 | Service | Operations |
@@ -1350,4 +1382,5 @@ Azure-only. The control plane backs the real `armdatabricks` SDK; the data plane
 | Resource Discovery (engine + AWS + Azure + GCP handlers) | 26 |
 | Generative AI — AWS Bedrock | 22 |
 | Databricks — Azure (control + data plane) | 52 |
-| **Grand Total** | **572** |
+| Machine Learning — GCP Vertex AI (Go API/driver) | 118 |
+| **Grand Total** | **690** |

--- a/docs/services.md
+++ b/docs/services.md
@@ -1375,7 +1375,7 @@ field). Auto-metrics → Cloud Monitoring via `SetMonitoring`.
 The full Go API/driver and in-memory provider cover every family above. SDK-compat HTTP
 (REST round-tripped) currently spans models, endpoints (+predict), datasets, custom &
 batch-prediction jobs and `generateContent`/`countTokens`; the remaining families' handlers
-follow the same wire pattern as the next increment. **Total: 127 operations** (Go API/driver).
+follow the same wire pattern as the next increment. **Total: 128 operations** (Go API/driver).
 
 ---
 
@@ -1408,5 +1408,5 @@ follow the same wire pattern as the next increment. **Total: 127 operations** (G
 | Generative AI — AWS Bedrock | 22 |
 | Databricks — Azure (control + data plane) | 52 |
 | Machine Learning — AWS SageMaker (control plane + runtime) | 121 |
-| Machine Learning — GCP Vertex AI (Go API/driver) | 127 |
-| **Grand Total** | **820** |
+| Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
+| **Grand Total** | **821** |

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/gcp/memorystore"
 	"github.com/stackshy/cloudemu/providers/gcp/pubsub"
 	"github.com/stackshy/cloudemu/providers/gcp/secretmanager"
+	"github.com/stackshy/cloudemu/providers/gcp/vertexai"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 )
 
@@ -44,6 +45,7 @@ type Provider struct {
 	Eventarc         *eventarc.Mock
 	CloudSQL         *cloudsql.Mock
 	GKE              *gke.Mock
+	VertexAI         *vertexai.Mock
 
 	ResourceDiscovery *resourcediscovery.Engine
 }
@@ -70,6 +72,7 @@ func New(opts ...config.Option) *Provider {
 		Eventarc:         eventarc.New(o),
 		CloudSQL:         cloudsql.New(o),
 		GKE:              gke.New(o),
+		VertexAI:         vertexai.New(o),
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 	p.GCS.SetMonitoring(p.CloudMonitoring)
@@ -83,6 +86,7 @@ func New(opts ...config.Option) *Provider {
 	p.Eventarc.SetMonitoring(p.CloudMonitoring)
 	p.CloudSQL.SetMonitoring(p.CloudMonitoring)
 	p.GKE.SetMonitoring(p.CloudMonitoring)
+	p.VertexAI.SetMonitoring(p.CloudMonitoring)
 
 	p.ResourceDiscovery = resourcediscovery.New(
 		resourcediscovery.ProviderGCP, o.ProjectID, o.Region,

--- a/providers/gcp/vertexai/clone.go
+++ b/providers/gcp/vertexai/clone.go
@@ -1,0 +1,74 @@
+package vertexai
+
+import "github.com/stackshy/cloudemu/vertexai/driver"
+
+// copyLabels deep-copies a label map so stored resources never alias a caller's
+// map (and vice-versa on return).
+func copyLabels(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+
+	return out
+}
+
+func copyStrSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]string, len(in))
+	copy(out, in)
+
+	return out
+}
+
+// cloneModel returns a deep copy so callers never alias the stored slices/maps.
+func cloneModel(in *driver.Model) *driver.Model {
+	out := *in
+	out.VersionAliases = copyStrSlice(in.VersionAliases)
+	out.Labels = copyLabels(in.Labels)
+
+	return &out
+}
+
+func cloneDataset(in *driver.Dataset) *driver.Dataset {
+	out := *in
+	out.Labels = copyLabels(in.Labels)
+
+	return &out
+}
+
+func cloneEndpoint(in *driver.Endpoint) *driver.Endpoint {
+	out := *in
+	out.Labels = copyLabels(in.Labels)
+
+	if in.DeployedModels != nil {
+		out.DeployedModels = make([]driver.DeployedModel, len(in.DeployedModels))
+		copy(out.DeployedModels, in.DeployedModels)
+	}
+
+	if in.TrafficSplit != nil {
+		out.TrafficSplit = make(map[string]int, len(in.TrafficSplit))
+		for k, v := range in.TrafficSplit {
+			out.TrafficSplit[k] = v
+		}
+	}
+
+	return &out
+}
+
+func cloneIndexEndpoint(in *driver.IndexEndpoint) *driver.IndexEndpoint {
+	out := *in
+	if in.DeployedIndexes != nil {
+		out.DeployedIndexes = make([]driver.DeployedIndex, len(in.DeployedIndexes))
+		copy(out.DeployedIndexes, in.DeployedIndexes)
+	}
+
+	return &out
+}

--- a/providers/gcp/vertexai/datasets.go
+++ b/providers/gcp/vertexai/datasets.go
@@ -28,16 +28,14 @@ func (m *Mock) CreateDataset(_ context.Context, cfg driver.DatasetConfig) (*driv
 		Name:              name,
 		DisplayName:       cfg.DisplayName,
 		MetadataSchemaURI: cfg.MetadataSchemaURI,
-		Labels:            cfg.Labels,
+		Labels:            copyLabels(cfg.Labels),
 		CreateTime:        now,
 		UpdateTime:        now,
 	}
 	m.datasets.Set(name, ds)
 	m.emitMetric("dataset/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
-	out := *ds
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneDataset(ds), nil
 }
 
 func (m *Mock) GetDataset(_ context.Context, name string) (*driver.Dataset, error) {
@@ -46,9 +44,7 @@ func (m *Mock) GetDataset(_ context.Context, name string) (*driver.Dataset, erro
 		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
 	}
 
-	out := *ds
-
-	return &out, nil
+	return cloneDataset(ds), nil
 }
 
 func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Dataset, error) {
@@ -56,7 +52,7 @@ func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Datase
 
 	for _, ds := range m.datasets.All() {
 		if location == "" || locationOf(ds.Name) == location {
-			out = append(out, *ds)
+			out = append(out, *cloneDataset(ds))
 		}
 	}
 
@@ -69,14 +65,16 @@ func (m *Mock) PatchDataset(_ context.Context, name, displayName string) (*drive
 		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
 	}
 
+	// Copy-then-Set: never mutate the stored pointer in place.
+	updated := *ds
 	if displayName != "" {
-		ds.DisplayName = displayName
+		updated.DisplayName = displayName
 	}
 
-	ds.UpdateTime = m.now()
-	out := *ds
+	updated.UpdateTime = m.now()
+	m.datasets.Set(name, &updated)
 
-	return &out, nil
+	return cloneDataset(&updated), nil
 }
 
 func (m *Mock) DeleteDataset(_ context.Context, name string) (*driver.Operation, error) {

--- a/providers/gcp/vertexai/datasets.go
+++ b/providers/gcp/vertexai/datasets.go
@@ -1,0 +1,106 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// locationOf extracts the location segment from a resource name, or the
+// default when absent.
+func locationOf(name string) string {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		if p == "locations" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+
+	return defaultLocation
+}
+
+func (m *Mock) CreateDataset(_ context.Context, cfg driver.DatasetConfig) (*driver.Operation, *driver.Dataset, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "datasets", m.newID())
+	ds := &driver.Dataset{
+		Name:              name,
+		DisplayName:       cfg.DisplayName,
+		MetadataSchemaURI: cfg.MetadataSchemaURI,
+		Labels:            cfg.Labels,
+		CreateTime:        now,
+		UpdateTime:        now,
+	}
+	m.datasets.Set(name, ds)
+	m.emitMetric("dataset/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *ds
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetDataset(_ context.Context, name string) (*driver.Dataset, error) {
+	ds, ok := m.datasets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	out := *ds
+
+	return &out, nil
+}
+
+func (m *Mock) ListDatasets(_ context.Context, location string) ([]driver.Dataset, error) {
+	out := make([]driver.Dataset, 0)
+
+	for _, ds := range m.datasets.All() {
+		if location == "" || locationOf(ds.Name) == location {
+			out = append(out, *ds)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) PatchDataset(_ context.Context, name, displayName string) (*driver.Dataset, error) {
+	ds, ok := m.datasets.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	if displayName != "" {
+		ds.DisplayName = displayName
+	}
+
+	ds.UpdateTime = m.now()
+	out := *ds
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteDataset(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.datasets.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	m.datasets.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ImportData(_ context.Context, name, _ string) (*driver.Operation, error) {
+	if !m.datasets.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ExportData(_ context.Context, name, _ string) (*driver.Operation, error) {
+	if !m.datasets.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "dataset %q not found", name)
+	}
+
+	return m.doneOp(locationOf(name), name), nil
+}

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -1,0 +1,143 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointConfig) (*driver.Operation, *driver.Endpoint, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "endpoints", m.newID())
+	ep := &driver.Endpoint{
+		Name:         name,
+		DisplayName:  cfg.DisplayName,
+		Description:  cfg.Description,
+		TrafficSplit: map[string]int{},
+		Labels:       cfg.Labels,
+		CreateTime:   now,
+		UpdateTime:   now,
+	}
+	m.endpoints.Set(name, ep)
+	m.emitMetric("endpoint/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *ep
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	out := *ep
+
+	return &out, nil
+}
+
+func (m *Mock) ListEndpoints(_ context.Context, location string) ([]driver.Endpoint, error) {
+	out := make([]driver.Endpoint, 0)
+
+	for _, ep := range m.endpoints.All() {
+		if location == "" || locationOf(ep.Name) == location {
+			out = append(out, *ep)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteEndpoint(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.endpoints.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
+	}
+
+	m.endpoints.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+//nolint:gocritic // dm matches the driver signature; copied on entry.
+func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.DeployedModel) (*driver.Operation, *driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(endpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
+	}
+
+	if dm.ID == "" {
+		dm.ID = m.newID()
+	}
+
+	updated := *ep
+	updated.DeployedModels = append(append([]driver.DeployedModel{}, ep.DeployedModels...), dm)
+	updated.TrafficSplit = map[string]int{dm.ID: 100}
+	updated.UpdateTime = m.now()
+	m.endpoints.Set(endpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+}
+
+func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string) (*driver.Operation, *driver.Endpoint, error) {
+	ep, ok := m.endpoints.Get(endpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
+	}
+
+	kept := make([]driver.DeployedModel, 0, len(ep.DeployedModels))
+
+	for _, d := range ep.DeployedModels {
+		if d.ID != deployedModelID {
+			kept = append(kept, d)
+		}
+	}
+
+	updated := *ep
+	updated.DeployedModels = kept
+	delete(updated.TrafficSplit, deployedModelID)
+	updated.UpdateTime = m.now()
+	m.endpoints.Set(endpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+}
+
+// Predict echoes the request instances back as predictions, which is
+// deterministic and adequate for exercising client serialization.
+//
+
+func (m *Mock) Predict(_ context.Context, req driver.PredictRequest) (*driver.PredictResponse, error) {
+	ep, ok := m.endpoints.Get(req.Endpoint)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", req.Endpoint)
+	}
+
+	m.emitMetric("prediction/count", float64(len(req.Instances)), map[string]string{"endpoint": req.Endpoint})
+
+	resp := &driver.PredictResponse{Predictions: append([]any{}, req.Instances...)}
+	if len(ep.DeployedModels) > 0 {
+		resp.DeployedModelID = ep.DeployedModels[0].ID
+		resp.Model = ep.DeployedModels[0].Model
+		resp.ModelDisplayName = ep.DeployedModels[0].DisplayName
+	}
+
+	return resp, nil
+}
+
+func (m *Mock) RawPredict(_ context.Context, endpoint string, body []byte) ([]byte, error) {
+	if !m.endpoints.Has(endpoint) {
+		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
+	}
+
+	m.emitMetric("prediction/count", 1, map[string]string{"endpoint": endpoint})
+
+	out := make([]byte, len(body))
+	copy(out, body)
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -15,16 +15,14 @@ func (m *Mock) CreateEndpoint(_ context.Context, cfg driver.EndpointConfig) (*dr
 		DisplayName:  cfg.DisplayName,
 		Description:  cfg.Description,
 		TrafficSplit: map[string]int{},
-		Labels:       cfg.Labels,
+		Labels:       copyLabels(cfg.Labels),
 		CreateTime:   now,
 		UpdateTime:   now,
 	}
 	m.endpoints.Set(name, ep)
 	m.emitMetric("endpoint/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
-	out := *ep
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneEndpoint(ep), nil
 }
 
 func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, error) {
@@ -33,9 +31,7 @@ func (m *Mock) GetEndpoint(_ context.Context, name string) (*driver.Endpoint, er
 		return nil, errors.Newf(errors.NotFound, "endpoint %q not found", name)
 	}
 
-	out := *ep
-
-	return &out, nil
+	return cloneEndpoint(ep), nil
 }
 
 func (m *Mock) ListEndpoints(_ context.Context, location string) ([]driver.Endpoint, error) {
@@ -43,7 +39,7 @@ func (m *Mock) ListEndpoints(_ context.Context, location string) ([]driver.Endpo
 
 	for _, ep := range m.endpoints.All() {
 		if location == "" || locationOf(ep.Name) == location {
-			out = append(out, *ep)
+			out = append(out, *cloneEndpoint(ep))
 		}
 	}
 
@@ -71,15 +67,14 @@ func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.Deploye
 		dm.ID = m.newID()
 	}
 
-	updated := *ep
-	updated.DeployedModels = append(append([]driver.DeployedModel{}, ep.DeployedModels...), dm)
+	// Deep-copy working set so the stored endpoint is never mutated in place.
+	updated := cloneEndpoint(ep)
+	updated.DeployedModels = append(updated.DeployedModels, dm)
 	updated.TrafficSplit = map[string]int{dm.ID: 100}
 	updated.UpdateTime = m.now()
-	m.endpoints.Set(endpoint, &updated)
+	m.endpoints.Set(endpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+	return m.doneOp(locationOf(endpoint), endpoint), cloneEndpoint(updated), nil
 }
 
 func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string) (*driver.Operation, *driver.Endpoint, error) {
@@ -88,23 +83,22 @@ func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string
 		return nil, nil, errors.Newf(errors.NotFound, "endpoint %q not found", endpoint)
 	}
 
-	kept := make([]driver.DeployedModel, 0, len(ep.DeployedModels))
+	updated := cloneEndpoint(ep)
 
-	for _, d := range ep.DeployedModels {
+	kept := make([]driver.DeployedModel, 0, len(updated.DeployedModels))
+
+	for _, d := range updated.DeployedModels {
 		if d.ID != deployedModelID {
 			kept = append(kept, d)
 		}
 	}
 
-	updated := *ep
 	updated.DeployedModels = kept
 	delete(updated.TrafficSplit, deployedModelID)
 	updated.UpdateTime = m.now()
-	m.endpoints.Set(endpoint, &updated)
+	m.endpoints.Set(endpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(endpoint), endpoint), &out, nil
+	return m.doneOp(locationOf(endpoint), endpoint), cloneEndpoint(updated), nil
 }
 
 // Predict echoes the request instances back as predictions, which is

--- a/providers/gcp/vertexai/endpoints.go
+++ b/providers/gcp/vertexai/endpoints.go
@@ -70,11 +70,38 @@ func (m *Mock) DeployModel(_ context.Context, endpoint string, dm driver.Deploye
 	// Deep-copy working set so the stored endpoint is never mutated in place.
 	updated := cloneEndpoint(ep)
 	updated.DeployedModels = append(updated.DeployedModels, dm)
-	updated.TrafficSplit = map[string]int{dm.ID: 100}
+	// Rebalance traffic evenly across every deployed model so each keeps a
+	// split entry and the total stays at 100 (real multi-model endpoints never
+	// drop a deployed model from the split).
+	updated.TrafficSplit = evenTrafficSplit(updated.DeployedModels)
 	updated.UpdateTime = m.now()
 	m.endpoints.Set(endpoint, updated)
 
 	return m.doneOp(locationOf(endpoint), endpoint), cloneEndpoint(updated), nil
+}
+
+// evenTrafficSplit distributes 100% as evenly as possible across the deployed
+// models, assigning any rounding remainder to the first model so the split
+// always totals exactly 100. Returns an empty (non-nil) map when none remain.
+func evenTrafficSplit(models []driver.DeployedModel) map[string]int {
+	split := make(map[string]int, len(models))
+	if len(models) == 0 {
+		return split
+	}
+
+	base := 100 / len(models)
+	remainder := 100 % len(models)
+
+	for i, dm := range models {
+		share := base
+		if i < remainder {
+			share++
+		}
+
+		split[dm.ID] = share
+	}
+
+	return split
 }
 
 func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string) (*driver.Operation, *driver.Endpoint, error) {
@@ -94,7 +121,7 @@ func (m *Mock) UndeployModel(_ context.Context, endpoint, deployedModelID string
 	}
 
 	updated.DeployedModels = kept
-	delete(updated.TrafficSplit, deployedModelID)
+	updated.TrafficSplit = evenTrafficSplit(kept)
 	updated.UpdateTime = m.now()
 	m.endpoints.Set(endpoint, updated)
 

--- a/providers/gcp/vertexai/featurestore.go
+++ b/providers/gcp/vertexai/featurestore.go
@@ -1,0 +1,207 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (m *Mock) CreateFeatureGroup(_ context.Context, cfg driver.FeatureGroupConfig) (*driver.Operation, *driver.FeatureGroup, error) {
+	name := m.resName(cfg.Location, "featureGroups", orID(cfg.FeatureGroupID, m.newID()))
+	fg := &driver.FeatureGroup{Name: name, Description: cfg.Description, BigQueryURI: cfg.BigQueryURI, CreateTime: m.now()}
+	m.featureGroups.Set(name, fg)
+
+	out := *fg
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func orID(id, gen string) string {
+	if id != "" {
+		return id
+	}
+
+	return gen
+}
+
+func (m *Mock) GetFeatureGroup(_ context.Context, name string) (*driver.FeatureGroup, error) {
+	fg, ok := m.featureGroups.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature group %q not found", name)
+	}
+
+	out := *fg
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureGroups(_ context.Context, location string) ([]driver.FeatureGroup, error) {
+	out := make([]driver.FeatureGroup, 0)
+
+	for _, fg := range m.featureGroups.All() {
+		if location == "" || locationOf(fg.Name) == location {
+			out = append(out, *fg)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureGroup(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.featureGroups.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature group %q not found", name)
+	}
+
+	m.featureGroups.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) CreateFeature(_ context.Context, parent, featureID, description string) (*driver.Operation, *driver.Feature, error) {
+	if !m.featureGroups.Has(parent) {
+		return nil, nil, errors.Newf(errors.NotFound, "feature group %q not found", parent)
+	}
+
+	name := parent + "/features/" + orID(featureID, m.newID())
+	f := &driver.Feature{Name: name, Description: description, CreateTime: m.now()}
+	m.features.Set(name, f)
+
+	out := *f
+
+	return m.doneOp(locationOf(parent), name), &out, nil
+}
+
+func (m *Mock) GetFeature(_ context.Context, name string) (*driver.Feature, error) {
+	f, ok := m.features.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature %q not found", name)
+	}
+
+	out := *f
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatures(_ context.Context, parent string) ([]driver.Feature, error) {
+	out := make([]driver.Feature, 0)
+
+	for k, f := range m.features.All() {
+		if len(k) > len(parent) && k[:len(parent)] == parent {
+			out = append(out, *f)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeature(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.features.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature %q not found", name)
+	}
+
+	m.features.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) CreateFeatureOnlineStore(
+	_ context.Context, cfg driver.FeatureOnlineStoreConfig,
+) (*driver.Operation, *driver.FeatureOnlineStore, error) {
+	name := m.resName(cfg.Location, "featureOnlineStores", orID(cfg.FeatureOnlineStoreID, m.newID()))
+	s := &driver.FeatureOnlineStore{Name: name, State: "STABLE", CreateTime: m.now()}
+	m.onlineStores.Set(name, s)
+
+	out := *s
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetFeatureOnlineStore(_ context.Context, name string) (*driver.FeatureOnlineStore, error) {
+	s, ok := m.onlineStores.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature online store %q not found", name)
+	}
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureOnlineStores(_ context.Context, location string) ([]driver.FeatureOnlineStore, error) {
+	out := make([]driver.FeatureOnlineStore, 0)
+
+	for _, s := range m.onlineStores.All() {
+		if location == "" || locationOf(s.Name) == location {
+			out = append(out, *s)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureOnlineStore(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.onlineStores.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature online store %q not found", name)
+	}
+
+	m.onlineStores.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) CreateFeatureView(_ context.Context, cfg driver.FeatureViewConfig) (*driver.Operation, *driver.FeatureView, error) {
+	if !m.onlineStores.Has(cfg.Parent) {
+		return nil, nil, errors.Newf(errors.NotFound, "feature online store %q not found", cfg.Parent)
+	}
+
+	name := cfg.Parent + "/featureViews/" + orID(cfg.FeatureViewID, m.newID())
+	fv := &driver.FeatureView{Name: name, BigQueryURI: cfg.BigQueryURI, CreateTime: m.now()}
+	m.featureViews.Set(name, fv)
+
+	out := *fv
+
+	return m.doneOp(locationOf(cfg.Parent), name), &out, nil
+}
+
+func (m *Mock) GetFeatureView(_ context.Context, name string) (*driver.FeatureView, error) {
+	fv, ok := m.featureViews.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "feature view %q not found", name)
+	}
+
+	out := *fv
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeatureViews(_ context.Context, parent string) ([]driver.FeatureView, error) {
+	out := make([]driver.FeatureView, 0)
+
+	for k, fv := range m.featureViews.All() {
+		if len(k) > len(parent) && k[:len(parent)] == parent {
+			out = append(out, *fv)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeatureView(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.featureViews.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "feature view %q not found", name)
+	}
+
+	m.featureViews.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// FetchFeatureValues returns a deterministic synthetic value for the entity.
+func (m *Mock) FetchFeatureValues(_ context.Context, featureView, entityID string) ([]driver.FeatureNameValue, error) {
+	if !m.featureViews.Has(featureView) {
+		return nil, errors.Newf(errors.NotFound, "feature view %q not found", featureView)
+	}
+
+	return []driver.FeatureNameValue{{Name: "entity_id", Value: entityID}}, nil
+}

--- a/providers/gcp/vertexai/featurestore.go
+++ b/providers/gcp/vertexai/featurestore.go
@@ -2,6 +2,7 @@ package vertexai
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/vertexai/driver"
@@ -88,7 +89,7 @@ func (m *Mock) ListFeatures(_ context.Context, parent string) ([]driver.Feature,
 	out := make([]driver.Feature, 0)
 
 	for k, f := range m.features.All() {
-		if len(k) > len(parent) && k[:len(parent)] == parent {
+		if strings.HasPrefix(k, parent+"/") {
 			out = append(out, *f)
 		}
 	}
@@ -180,7 +181,7 @@ func (m *Mock) ListFeatureViews(_ context.Context, parent string) ([]driver.Feat
 	out := make([]driver.FeatureView, 0)
 
 	for k, fv := range m.featureViews.All() {
-		if len(k) > len(parent) && k[:len(parent)] == parent {
+		if strings.HasPrefix(k, parent+"/") {
 			out = append(out, *fv)
 		}
 	}
@@ -284,7 +285,7 @@ func (m *Mock) ListEntityTypes(_ context.Context, parent string) ([]driver.Entit
 	out := make([]driver.EntityType, 0)
 
 	for k, et := range m.entityTypes.All() {
-		if len(k) > len(parent) && k[:len(parent)] == parent {
+		if strings.HasPrefix(k, parent+"/") {
 			out = append(out, *et)
 		}
 	}

--- a/providers/gcp/vertexai/featurestore.go
+++ b/providers/gcp/vertexai/featurestore.go
@@ -58,6 +58,7 @@ func (m *Mock) DeleteFeatureGroup(_ context.Context, name string) (*driver.Opera
 	return m.doneOp(locationOf(name), name), nil
 }
 
+//nolint:dupl // parent/child create shape recurs; each maps a distinct resource.
 func (m *Mock) CreateFeature(_ context.Context, parent, featureID, description string) (*driver.Operation, *driver.Feature, error) {
 	if !m.featureGroups.Has(parent) {
 		return nil, nil, errors.Newf(errors.NotFound, "feature group %q not found", parent)
@@ -204,4 +205,133 @@ func (m *Mock) FetchFeatureValues(_ context.Context, featureView, entityID strin
 	}
 
 	return []driver.FeatureNameValue{{Name: "entity_id", Value: entityID}}, nil
+}
+
+// --- Classic Featurestore / EntityType (pre-FeatureGroup) ---
+
+func (m *Mock) CreateFeaturestore(_ context.Context, cfg driver.FeaturestoreConfig) (*driver.Operation, *driver.Featurestore, error) {
+	name := m.resName(cfg.Location, "featurestores", orID(cfg.FeaturestoreID, m.newID()))
+	fs := &driver.Featurestore{Name: name, State: "STABLE", OnlineNodeCount: cfg.OnlineNodeCount, CreateTime: m.now()}
+	m.featurestores.Set(name, fs)
+
+	out := *fs
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetFeaturestore(_ context.Context, name string) (*driver.Featurestore, error) {
+	fs, ok := m.featurestores.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "featurestore %q not found", name)
+	}
+
+	out := *fs
+
+	return &out, nil
+}
+
+func (m *Mock) ListFeaturestores(_ context.Context, location string) ([]driver.Featurestore, error) {
+	out := make([]driver.Featurestore, 0)
+
+	for _, fs := range m.featurestores.All() {
+		if location == "" || locationOf(fs.Name) == location {
+			out = append(out, *fs)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteFeaturestore(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.featurestores.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "featurestore %q not found", name)
+	}
+
+	m.featurestores.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+//nolint:dupl // parent/child create shape recurs; each maps a distinct resource.
+func (m *Mock) CreateEntityType(
+	_ context.Context, parent, entityTypeID, description string,
+) (*driver.Operation, *driver.EntityType, error) {
+	if !m.featurestores.Has(parent) {
+		return nil, nil, errors.Newf(errors.NotFound, "featurestore %q not found", parent)
+	}
+
+	name := parent + "/entityTypes/" + orID(entityTypeID, m.newID())
+	et := &driver.EntityType{Name: name, Description: description, CreateTime: m.now()}
+	m.entityTypes.Set(name, et)
+
+	out := *et
+
+	return m.doneOp(locationOf(parent), name), &out, nil
+}
+
+func (m *Mock) GetEntityType(_ context.Context, name string) (*driver.EntityType, error) {
+	et, ok := m.entityTypes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "entity type %q not found", name)
+	}
+
+	out := *et
+
+	return &out, nil
+}
+
+func (m *Mock) ListEntityTypes(_ context.Context, parent string) ([]driver.EntityType, error) {
+	out := make([]driver.EntityType, 0)
+
+	for k, et := range m.entityTypes.All() {
+		if len(k) > len(parent) && k[:len(parent)] == parent {
+			out = append(out, *et)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteEntityType(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.entityTypes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "entity type %q not found", name)
+	}
+
+	m.entityTypes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func entityKey(entityType, entityID string) string {
+	return entityType + "\x00" + entityID
+}
+
+// WriteFeatureValues stores online feature values for an entity.
+func (m *Mock) WriteFeatureValues(_ context.Context, entityType, entityID string, values []driver.FeatureNameValue) error {
+	if !m.entityTypes.Has(entityType) {
+		return errors.Newf(errors.NotFound, "entity type %q not found", entityType)
+	}
+
+	stored := make([]driver.FeatureNameValue, len(values))
+	copy(stored, values)
+	m.entityRecords.Set(entityKey(entityType, entityID), stored)
+
+	return nil
+}
+
+// ReadFeatureValues returns the online feature values for an entity.
+func (m *Mock) ReadFeatureValues(_ context.Context, entityType, entityID string) ([]driver.FeatureNameValue, error) {
+	if !m.entityTypes.Has(entityType) {
+		return nil, errors.Newf(errors.NotFound, "entity type %q not found", entityType)
+	}
+
+	rec, ok := m.entityRecords.Get(entityKey(entityType, entityID))
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "entity %q not found", entityID)
+	}
+
+	out := make([]driver.FeatureNameValue, len(rec))
+	copy(out, rec)
+
+	return out, nil
 }

--- a/providers/gcp/vertexai/genai.go
+++ b/providers/gcp/vertexai/genai.go
@@ -3,6 +3,7 @@ package vertexai
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/vertexai/driver"
@@ -151,19 +152,64 @@ func (m *Mock) CreateCachedContent(_ context.Context, cfg driver.CachedContentCo
 		return nil, errors.New(errors.InvalidArgument, "model is required")
 	}
 
+	ttl := cfg.TTLSeconds
+	if ttl <= 0 {
+		ttl = defaultCacheTTLSeconds
+	}
+
+	created := m.opts.Clock.Now().UTC()
+	expire := created.Add(time.Duration(ttl) * time.Second)
+
 	name := m.resName(cfg.Location, "cachedContents", m.newID())
 	cc := &driver.CachedContent{
-		Name:        name,
-		Model:       cfg.Model,
-		DisplayName: cfg.DisplayName,
-		CreateTime:  m.now(),
-		ExpireTime:  m.now(),
+		Name:              name,
+		Model:             cfg.Model,
+		DisplayName:       cfg.DisplayName,
+		Contents:          cloneContents(cfg.Contents),
+		SystemInstruction: cloneContent(cfg.SystemInstruction),
+		CreateTime:        created.Format(time.RFC3339),
+		ExpireTime:        expire.Format(time.RFC3339),
 	}
 	m.cachedContent.Set(name, cc)
 
-	out := *cc
+	return cloneCachedContent(cc), nil
+}
 
-	return &out, nil
+// defaultCacheTTLSeconds matches Vertex's default context-cache lifetime (1h)
+// when the caller omits an explicit TTL.
+const defaultCacheTTLSeconds = 3600
+
+func cloneContents(in []driver.Content) []driver.Content {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]driver.Content, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].Parts = append([]driver.Part(nil), in[i].Parts...)
+	}
+
+	return out
+}
+
+func cloneContent(in *driver.Content) *driver.Content {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	out.Parts = append([]driver.Part(nil), in.Parts...)
+
+	return &out
+}
+
+func cloneCachedContent(in *driver.CachedContent) *driver.CachedContent {
+	out := *in
+	out.Contents = cloneContents(in.Contents)
+	out.SystemInstruction = cloneContent(in.SystemInstruction)
+
+	return &out
 }
 
 func (m *Mock) GetCachedContent(_ context.Context, name string) (*driver.CachedContent, error) {
@@ -172,9 +218,7 @@ func (m *Mock) GetCachedContent(_ context.Context, name string) (*driver.CachedC
 		return nil, errors.Newf(errors.NotFound, "cached content %q not found", name)
 	}
 
-	out := *cc
-
-	return &out, nil
+	return cloneCachedContent(cc), nil
 }
 
 func (m *Mock) ListCachedContents(_ context.Context, location string) ([]driver.CachedContent, error) {
@@ -182,7 +226,7 @@ func (m *Mock) ListCachedContents(_ context.Context, location string) ([]driver.
 
 	for _, cc := range m.cachedContent.All() {
 		if location == "" || locationOf(cc.Name) == location {
-			out = append(out, *cc)
+			out = append(out, *cloneCachedContent(cc))
 		}
 	}
 

--- a/providers/gcp/vertexai/genai.go
+++ b/providers/gcp/vertexai/genai.go
@@ -1,0 +1,200 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// approxTokens is a deterministic, whitespace-based token estimate.
+func approxTokens(text string) int {
+	if strings.TrimSpace(text) == "" {
+		return 0
+	}
+
+	return len(strings.Fields(text))
+}
+
+// GenerateContent returns a deterministic emulated Gemini response: it echoes
+// the last user turn as the model reply and reports plausible token usage.
+//
+
+func (m *Mock) GenerateContent(
+	_ context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.GenerateContentResponse, error) {
+	if model == "" {
+		return nil, errors.New(errors.InvalidArgument, "model is required")
+	}
+
+	prompt := lastUserText(req.Contents)
+	reply := "Emulated response to: " + prompt
+
+	promptTokens := approxTokens(prompt)
+	outTokens := approxTokens(reply)
+
+	m.emitMetric("generate_content/count", 1, map[string]string{"model": model})
+
+	return &driver.GenerateContentResponse{
+		Candidates: []driver.Candidate{{
+			Content:      driver.Content{Role: "model", Parts: []driver.Part{{Text: reply}}},
+			FinishReason: "STOP",
+		}},
+		UsageMetadata: driver.UsageMetadata{
+			PromptTokenCount:     promptTokens,
+			CandidatesTokenCount: outTokens,
+			TotalTokenCount:      promptTokens + outTokens,
+		},
+	}, nil
+}
+
+func (*Mock) CountTokens(_ context.Context, model string, req driver.GenerateContentRequest) (*driver.CountTokensResponse, error) {
+	if model == "" {
+		return nil, errors.New(errors.InvalidArgument, "model is required")
+	}
+
+	total := 0
+
+	for _, c := range req.Contents {
+		for _, p := range c.Parts {
+			total += approxTokens(p.Text)
+		}
+	}
+
+	return &driver.CountTokensResponse{TotalTokens: total}, nil
+}
+
+func lastUserText(contents []driver.Content) string {
+	for i := len(contents) - 1; i >= 0; i-- {
+		if contents[i].Role == "user" || contents[i].Role == "" {
+			var b strings.Builder
+			for _, p := range contents[i].Parts {
+				b.WriteString(p.Text)
+			}
+
+			return b.String()
+		}
+	}
+
+	return ""
+}
+
+// --- Tuning jobs (synchronous create) ---
+
+func (m *Mock) CreateTuningJob(_ context.Context, cfg driver.TuningJobConfig) (*driver.TuningJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "tuningJobs", m.newID())
+
+	tuned := cfg.TunedModelName
+	if tuned == "" {
+		tuned = m.resName(cfg.Location, "models", m.newID())
+	}
+
+	job := &driver.TuningJob{
+		Name:           name,
+		BaseModel:      cfg.BaseModel,
+		State:          driver.JobStateSucceeded,
+		TunedModelName: tuned,
+		Endpoint:       m.resName(cfg.Location, "endpoints", m.newID()),
+		CreateTime:     now,
+		EndTime:        now,
+	}
+	m.tuningJobs.Set(name, job)
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetTuningJob(_ context.Context, name string) (*driver.TuningJob, error) {
+	j, ok := m.tuningJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "tuning job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListTuningJobs(_ context.Context, location string) ([]driver.TuningJob, error) {
+	out := make([]driver.TuningJob, 0)
+
+	for _, j := range m.tuningJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelTuningJob(_ context.Context, name string) error {
+	j, ok := m.tuningJobs.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "tuning job %q not found", name)
+	}
+
+	updated := *j
+	updated.State = driver.JobStateCancelled
+	m.tuningJobs.Set(name, &updated)
+
+	return nil
+}
+
+// --- Cached contents (synchronous CRUD) ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateCachedContent(_ context.Context, cfg driver.CachedContentConfig) (*driver.CachedContent, error) {
+	if cfg.Model == "" {
+		return nil, errors.New(errors.InvalidArgument, "model is required")
+	}
+
+	name := m.resName(cfg.Location, "cachedContents", m.newID())
+	cc := &driver.CachedContent{
+		Name:        name,
+		Model:       cfg.Model,
+		DisplayName: cfg.DisplayName,
+		CreateTime:  m.now(),
+		ExpireTime:  m.now(),
+	}
+	m.cachedContent.Set(name, cc)
+
+	out := *cc
+
+	return &out, nil
+}
+
+func (m *Mock) GetCachedContent(_ context.Context, name string) (*driver.CachedContent, error) {
+	cc, ok := m.cachedContent.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cached content %q not found", name)
+	}
+
+	out := *cc
+
+	return &out, nil
+}
+
+func (m *Mock) ListCachedContents(_ context.Context, location string) ([]driver.CachedContent, error) {
+	out := make([]driver.CachedContent, 0)
+
+	for _, cc := range m.cachedContent.All() {
+		if location == "" || locationOf(cc.Name) == location {
+			out = append(out, *cc)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteCachedContent(_ context.Context, name string) error {
+	if !m.cachedContent.Has(name) {
+		return errors.Newf(errors.NotFound, "cached content %q not found", name)
+	}
+
+	m.cachedContent.Delete(name)
+
+	return nil
+}

--- a/providers/gcp/vertexai/jobs.go
+++ b/providers/gcp/vertexai/jobs.go
@@ -1,0 +1,175 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// cancelJob copy-then-Sets a job's State to canceled, or returns NotFound.
+func cancelJob[T any](store *memstore.Store[*T], name string, setState func(*T)) error {
+	j, ok := store.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "job %q not found", name)
+	}
+
+	updated := *j
+	setState(&updated)
+	store.Set(name, &updated)
+
+	return nil
+}
+
+// --- Custom jobs ---
+
+//nolint:dupl // synchronous-create job shape recurs across job families.
+func (m *Mock) CreateCustomJob(_ context.Context, cfg driver.CustomJobConfig) (*driver.CustomJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "customJobs", m.newID())
+	job := &driver.CustomJob{Name: name, DisplayName: cfg.DisplayName, State: driver.JobStateSucceeded, CreateTime: now, EndTime: now}
+	m.customJobs.Set(name, job)
+	m.emitMetric("custom_job/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetCustomJob(_ context.Context, name string) (*driver.CustomJob, error) {
+	j, ok := m.customJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "custom job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListCustomJobs(_ context.Context, location string) ([]driver.CustomJob, error) {
+	out := make([]driver.CustomJob, 0)
+
+	for _, j := range m.customJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelCustomJob(_ context.Context, name string) error {
+	return cancelJob(m.customJobs, name, func(j *driver.CustomJob) { j.State = driver.JobStateCancelled })
+}
+
+func (m *Mock) DeleteCustomJob(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.customJobs.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "custom job %q not found", name)
+	}
+
+	m.customJobs.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Batch prediction jobs ---
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) CreateBatchPredictionJob(_ context.Context, cfg driver.BatchPredictionJobConfig) (*driver.BatchPredictionJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "batchPredictionJobs", m.newID())
+	job := &driver.BatchPredictionJob{
+		Name: name, DisplayName: cfg.DisplayName, Model: cfg.Model,
+		State: driver.JobStateSucceeded, CreateTime: now, EndTime: now,
+	}
+	m.batchJobs.Set(name, job)
+	m.emitMetric("batch_prediction_job/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetBatchPredictionJob(_ context.Context, name string) (*driver.BatchPredictionJob, error) {
+	j, ok := m.batchJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "batch prediction job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListBatchPredictionJobs(_ context.Context, location string) ([]driver.BatchPredictionJob, error) {
+	out := make([]driver.BatchPredictionJob, 0)
+
+	for _, j := range m.batchJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelBatchPredictionJob(_ context.Context, name string) error {
+	return cancelJob(m.batchJobs, name, func(j *driver.BatchPredictionJob) { j.State = driver.JobStateCancelled })
+}
+
+func (m *Mock) DeleteBatchPredictionJob(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.batchJobs.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "batch prediction job %q not found", name)
+	}
+
+	m.batchJobs.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Hyperparameter tuning jobs ---
+
+func (m *Mock) CreateHyperparameterTuningJob(
+	_ context.Context, cfg driver.HyperparameterTuningJobConfig,
+) (*driver.HyperparameterTuningJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "hyperparameterTuningJobs", m.newID())
+	job := &driver.HyperparameterTuningJob{
+		Name: name, DisplayName: cfg.DisplayName, State: driver.JobStateSucceeded,
+		MaxTrialCount: cfg.MaxTrialCount, CreateTime: now, EndTime: now,
+	}
+	m.hpoJobs.Set(name, job)
+
+	out := *job
+
+	return &out, nil
+}
+
+func (m *Mock) GetHyperparameterTuningJob(_ context.Context, name string) (*driver.HyperparameterTuningJob, error) {
+	j, ok := m.hpoJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "hyperparameter tuning job %q not found", name)
+	}
+
+	out := *j
+
+	return &out, nil
+}
+
+func (m *Mock) ListHyperparameterTuningJobs(_ context.Context, location string) ([]driver.HyperparameterTuningJob, error) {
+	out := make([]driver.HyperparameterTuningJob, 0)
+
+	for _, j := range m.hpoJobs.All() {
+		if location == "" || locationOf(j.Name) == location {
+			out = append(out, *j)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelHyperparameterTuningJob(_ context.Context, name string) error {
+	return cancelJob(m.hpoJobs, name, func(j *driver.HyperparameterTuningJob) { j.State = driver.JobStateCancelled })
+}

--- a/providers/gcp/vertexai/metadata.go
+++ b/providers/gcp/vertexai/metadata.go
@@ -133,21 +133,28 @@ func (m *Mock) ListSchedules(_ context.Context, location string) ([]driver.Sched
 }
 
 func (m *Mock) PauseSchedule(_ context.Context, name string) error {
-	return m.setScheduleState(name, "PAUSED")
+	return m.setScheduleState(name, "ACTIVE", "PAUSED")
 }
 
 func (m *Mock) ResumeSchedule(_ context.Context, name string) error {
-	return m.setScheduleState(name, "ACTIVE")
+	return m.setScheduleState(name, "PAUSED", "ACTIVE")
 }
 
-func (m *Mock) setScheduleState(name, state string) error {
+// setScheduleState copy-then-Sets a schedule to target only from the required
+// source state, rejecting illegal transitions like the real API.
+func (m *Mock) setScheduleState(name, from, target string) error {
 	s, ok := m.schedules.Get(name)
 	if !ok {
 		return errors.Newf(errors.NotFound, "schedule %q not found", name)
 	}
 
+	if s.State != from {
+		return errors.Newf(errors.FailedPrecondition,
+			"schedule %q is %s; cannot transition to %s", name, s.State, target)
+	}
+
 	updated := *s
-	updated.State = state
+	updated.State = target
 	m.schedules.Set(name, &updated)
 
 	return nil
@@ -246,21 +253,28 @@ func (m *Mock) ListNotebookRuntimes(_ context.Context, location string) ([]drive
 }
 
 func (m *Mock) StartNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
-	return m.setRuntimeState(name, "RUNNING")
+	return m.setRuntimeState(name, "STOPPED", "RUNNING")
 }
 
 func (m *Mock) StopNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
-	return m.setRuntimeState(name, "STOPPED")
+	return m.setRuntimeState(name, "RUNNING", "STOPPED")
 }
 
-func (m *Mock) setRuntimeState(name, state string) (*driver.Operation, error) {
+// setRuntimeState copy-then-Sets a notebook runtime to target only from the
+// required source state, rejecting illegal transitions like the real API.
+func (m *Mock) setRuntimeState(name, from, target string) (*driver.Operation, error) {
 	nr, ok := m.nbRuntimes.Get(name)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
 	}
 
+	if nr.RuntimeState != from {
+		return nil, errors.Newf(errors.FailedPrecondition,
+			"notebook runtime %q is %s; cannot transition to %s", name, nr.RuntimeState, target)
+	}
+
 	updated := *nr
-	updated.RuntimeState = state
+	updated.RuntimeState = target
 	m.nbRuntimes.Set(name, &updated)
 
 	return m.doneOp(locationOf(name), name), nil

--- a/providers/gcp/vertexai/metadata.go
+++ b/providers/gcp/vertexai/metadata.go
@@ -1,0 +1,277 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Metadata stores ---
+
+func (m *Mock) CreateMetadataStore(_ context.Context, location, storeID string) (*driver.Operation, *driver.MetadataStore, error) {
+	name := m.resName(location, "metadataStores", orID(storeID, m.newID()))
+	s := &driver.MetadataStore{Name: name, CreateTime: m.now()}
+	m.metadataStores.Set(name, s)
+
+	out := *s
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetMetadataStore(_ context.Context, name string) (*driver.MetadataStore, error) {
+	s, ok := m.metadataStores.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "metadata store %q not found", name)
+	}
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) ListMetadataStores(_ context.Context, location string) ([]driver.MetadataStore, error) {
+	out := make([]driver.MetadataStore, 0)
+
+	for _, s := range m.metadataStores.All() {
+		if location == "" || locationOf(s.Name) == location {
+			out = append(out, *s)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteMetadataStore(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.metadataStores.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "metadata store %q not found", name)
+	}
+
+	m.metadataStores.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Tensorboards ---
+
+func (m *Mock) CreateTensorboard(_ context.Context, location, displayName string) (*driver.Operation, *driver.Tensorboard, error) {
+	name := m.resName(location, "tensorboards", m.newID())
+	tb := &driver.Tensorboard{Name: name, DisplayName: displayName, CreateTime: m.now()}
+	m.tensorboards.Set(name, tb)
+
+	out := *tb
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetTensorboard(_ context.Context, name string) (*driver.Tensorboard, error) {
+	tb, ok := m.tensorboards.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "tensorboard %q not found", name)
+	}
+
+	out := *tb
+
+	return &out, nil
+}
+
+func (m *Mock) ListTensorboards(_ context.Context, location string) ([]driver.Tensorboard, error) {
+	out := make([]driver.Tensorboard, 0)
+
+	for _, tb := range m.tensorboards.All() {
+		if location == "" || locationOf(tb.Name) == location {
+			out = append(out, *tb)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteTensorboard(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.tensorboards.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "tensorboard %q not found", name)
+	}
+
+	m.tensorboards.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Schedules ---
+
+func (m *Mock) CreateSchedule(_ context.Context, location, displayName, cron string) (*driver.Schedule, error) {
+	name := m.resName(location, "schedules", m.newID())
+	s := &driver.Schedule{Name: name, DisplayName: displayName, Cron: cron, State: "ACTIVE", CreateTime: m.now()}
+	m.schedules.Set(name, s)
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) GetSchedule(_ context.Context, name string) (*driver.Schedule, error) {
+	s, ok := m.schedules.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "schedule %q not found", name)
+	}
+
+	out := *s
+
+	return &out, nil
+}
+
+func (m *Mock) ListSchedules(_ context.Context, location string) ([]driver.Schedule, error) {
+	out := make([]driver.Schedule, 0)
+
+	for _, s := range m.schedules.All() {
+		if location == "" || locationOf(s.Name) == location {
+			out = append(out, *s)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) PauseSchedule(_ context.Context, name string) error {
+	return m.setScheduleState(name, "PAUSED")
+}
+
+func (m *Mock) ResumeSchedule(_ context.Context, name string) error {
+	return m.setScheduleState(name, "ACTIVE")
+}
+
+func (m *Mock) setScheduleState(name, state string) error {
+	s, ok := m.schedules.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "schedule %q not found", name)
+	}
+
+	updated := *s
+	updated.State = state
+	m.schedules.Set(name, &updated)
+
+	return nil
+}
+
+func (m *Mock) DeleteSchedule(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.schedules.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "schedule %q not found", name)
+	}
+
+	m.schedules.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Notebook runtime templates ---
+
+func (m *Mock) CreateNotebookRuntimeTemplate(
+	_ context.Context, location, displayName, machineType string,
+) (*driver.Operation, *driver.NotebookRuntimeTemplate, error) {
+	name := m.resName(location, "notebookRuntimeTemplates", m.newID())
+	t := &driver.NotebookRuntimeTemplate{Name: name, DisplayName: displayName, MachineType: machineType, CreateTime: m.now()}
+	m.nbTemplates.Set(name, t)
+
+	out := *t
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetNotebookRuntimeTemplate(_ context.Context, name string) (*driver.NotebookRuntimeTemplate, error) {
+	t, ok := m.nbTemplates.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime template %q not found", name)
+	}
+
+	out := *t
+
+	return &out, nil
+}
+
+func (m *Mock) ListNotebookRuntimeTemplates(_ context.Context, location string) ([]driver.NotebookRuntimeTemplate, error) {
+	out := make([]driver.NotebookRuntimeTemplate, 0)
+
+	for _, t := range m.nbTemplates.All() {
+		if location == "" || locationOf(t.Name) == location {
+			out = append(out, *t)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteNotebookRuntimeTemplate(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.nbTemplates.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime template %q not found", name)
+	}
+
+	m.nbTemplates.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Notebook runtimes ---
+
+func (m *Mock) AssignNotebookRuntime(_ context.Context, location, displayName string) (*driver.Operation, *driver.NotebookRuntime, error) {
+	name := m.resName(location, "notebookRuntimes", m.newID())
+	nr := &driver.NotebookRuntime{Name: name, DisplayName: displayName, RuntimeState: "RUNNING", CreateTime: m.now()}
+	m.nbRuntimes.Set(name, nr)
+
+	out := *nr
+
+	return m.doneOp(location, name), &out, nil
+}
+
+func (m *Mock) GetNotebookRuntime(_ context.Context, name string) (*driver.NotebookRuntime, error) {
+	nr, ok := m.nbRuntimes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
+	}
+
+	out := *nr
+
+	return &out, nil
+}
+
+func (m *Mock) ListNotebookRuntimes(_ context.Context, location string) ([]driver.NotebookRuntime, error) {
+	out := make([]driver.NotebookRuntime, 0)
+
+	for _, nr := range m.nbRuntimes.All() {
+		if location == "" || locationOf(nr.Name) == location {
+			out = append(out, *nr)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) StartNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
+	return m.setRuntimeState(name, "RUNNING")
+}
+
+func (m *Mock) StopNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
+	return m.setRuntimeState(name, "STOPPED")
+}
+
+func (m *Mock) setRuntimeState(name, state string) (*driver.Operation, error) {
+	nr, ok := m.nbRuntimes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
+	}
+
+	updated := *nr
+	updated.RuntimeState = state
+	m.nbRuntimes.Set(name, &updated)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) DeleteNotebookRuntime(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.nbRuntimes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "notebook runtime %q not found", name)
+	}
+
+	m.nbRuntimes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}

--- a/providers/gcp/vertexai/models.go
+++ b/providers/gcp/vertexai/models.go
@@ -97,6 +97,14 @@ func (m *Mock) ListModelVersions(_ context.Context, name string) ([]driver.Model
 }
 
 func (m *Mock) DeleteModelVersion(_ context.Context, name string) (*driver.Operation, error) {
+	base, _, _ := strings.Cut(name, "@")
+
+	if !m.models.Has(base) {
+		return nil, errors.Newf(errors.NotFound, "model version %q not found", name)
+	}
+
+	m.models.Delete(base)
+
 	return m.doneOp(locationOf(name), name), nil
 }
 

--- a/providers/gcp/vertexai/models.go
+++ b/providers/gcp/vertexai/models.go
@@ -1,0 +1,144 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+//nolint:gocritic // cfg matches the driver signature; copied on entry.
+func (m *Mock) UploadModel(_ context.Context, cfg driver.ModelConfig) (*driver.Operation, *driver.Model, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "models", m.newID())
+	model := &driver.Model{
+		Name:           name,
+		DisplayName:    cfg.DisplayName,
+		Description:    cfg.Description,
+		ContainerImage: cfg.ContainerImage,
+		ArtifactURI:    cfg.ArtifactURI,
+		VersionID:      "1",
+		VersionAliases: []string{"default"},
+		Labels:         cfg.Labels,
+		CreateTime:     now,
+		UpdateTime:     now,
+	}
+	m.models.Set(name, model)
+	m.emitMetric("model/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *model
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetModel(_ context.Context, name string) (*driver.Model, error) {
+	base, _, _ := strings.Cut(name, "@")
+
+	model, ok := m.models.Get(base)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	out := *model
+
+	return &out, nil
+}
+
+func (m *Mock) ListModels(_ context.Context, location string) ([]driver.Model, error) {
+	out := make([]driver.Model, 0)
+
+	for _, model := range m.models.All() {
+		if location == "" || locationOf(model.Name) == location {
+			out = append(out, *model)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) PatchModel(_ context.Context, name, displayName, description string) (*driver.Model, error) {
+	model, ok := m.models.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	if displayName != "" {
+		model.DisplayName = displayName
+	}
+
+	if description != "" {
+		model.Description = description
+	}
+
+	model.UpdateTime = m.now()
+	out := *model
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteModel(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.models.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	m.models.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ListModelVersions(_ context.Context, name string) ([]driver.Model, error) {
+	base, _, _ := strings.Cut(name, "@")
+
+	model, ok := m.models.Get(base)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
+	}
+
+	return []driver.Model{*model}, nil
+}
+
+func (m *Mock) DeleteModelVersion(_ context.Context, name string) (*driver.Operation, error) {
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) ImportModelEvaluation(_ context.Context, modelName string, eval driver.ModelEvaluation) (*driver.ModelEvaluation, error) {
+	if !m.models.Has(modelName) {
+		return nil, errors.Newf(errors.NotFound, "model %q not found", modelName)
+	}
+
+	name := modelName + "/evaluations/" + m.newID()
+	ev := &driver.ModelEvaluation{
+		Name:        name,
+		DisplayName: eval.DisplayName,
+		MetricsType: eval.MetricsType,
+		CreateTime:  m.now(),
+	}
+	m.evaluations.Set(name, ev)
+	out := *ev
+
+	return &out, nil
+}
+
+func (m *Mock) GetModelEvaluation(_ context.Context, name string) (*driver.ModelEvaluation, error) {
+	ev, ok := m.evaluations.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "model evaluation %q not found", name)
+	}
+
+	out := *ev
+
+	return &out, nil
+}
+
+func (m *Mock) ListModelEvaluations(_ context.Context, modelName string) ([]driver.ModelEvaluation, error) {
+	out := make([]driver.ModelEvaluation, 0)
+
+	for _, ev := range m.evaluations.All() {
+		if strings.HasPrefix(ev.Name, modelName+"/evaluations/") {
+			out = append(out, *ev)
+		}
+	}
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/models.go
+++ b/providers/gcp/vertexai/models.go
@@ -20,16 +20,14 @@ func (m *Mock) UploadModel(_ context.Context, cfg driver.ModelConfig) (*driver.O
 		ArtifactURI:    cfg.ArtifactURI,
 		VersionID:      "1",
 		VersionAliases: []string{"default"},
-		Labels:         cfg.Labels,
+		Labels:         copyLabels(cfg.Labels),
 		CreateTime:     now,
 		UpdateTime:     now,
 	}
 	m.models.Set(name, model)
 	m.emitMetric("model/count", 1, map[string]string{"location": orLocation(cfg.Location)})
 
-	out := *model
-
-	return m.doneOp(cfg.Location, name), &out, nil
+	return m.doneOp(cfg.Location, name), cloneModel(model), nil
 }
 
 func (m *Mock) GetModel(_ context.Context, name string) (*driver.Model, error) {
@@ -40,9 +38,7 @@ func (m *Mock) GetModel(_ context.Context, name string) (*driver.Model, error) {
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
-	out := *model
-
-	return &out, nil
+	return cloneModel(model), nil
 }
 
 func (m *Mock) ListModels(_ context.Context, location string) ([]driver.Model, error) {
@@ -50,7 +46,7 @@ func (m *Mock) ListModels(_ context.Context, location string) ([]driver.Model, e
 
 	for _, model := range m.models.All() {
 		if location == "" || locationOf(model.Name) == location {
-			out = append(out, *model)
+			out = append(out, *cloneModel(model))
 		}
 	}
 
@@ -63,18 +59,20 @@ func (m *Mock) PatchModel(_ context.Context, name, displayName, description stri
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
+	// Copy-then-Set: never mutate the stored pointer in place.
+	updated := *model
 	if displayName != "" {
-		model.DisplayName = displayName
+		updated.DisplayName = displayName
 	}
 
 	if description != "" {
-		model.Description = description
+		updated.Description = description
 	}
 
-	model.UpdateTime = m.now()
-	out := *model
+	updated.UpdateTime = m.now()
+	m.models.Set(name, &updated)
 
-	return &out, nil
+	return cloneModel(&updated), nil
 }
 
 func (m *Mock) DeleteModel(_ context.Context, name string) (*driver.Operation, error) {
@@ -95,7 +93,7 @@ func (m *Mock) ListModelVersions(_ context.Context, name string) ([]driver.Model
 		return nil, errors.Newf(errors.NotFound, "model %q not found", name)
 	}
 
-	return []driver.Model{*model}, nil
+	return []driver.Model{*cloneModel(model)}, nil
 }
 
 func (m *Mock) DeleteModelVersion(_ context.Context, name string) (*driver.Operation, error) {

--- a/providers/gcp/vertexai/operations.go
+++ b/providers/gcp/vertexai/operations.go
@@ -1,0 +1,35 @@
+package vertexai
+
+import (
+	"context"
+	"strings"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// GetOperation returns a recorded operation by name.
+func (m *Mock) GetOperation(_ context.Context, name string) (*driver.Operation, error) {
+	op, ok := m.operations.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "operation %q not found", name)
+	}
+
+	out := *op
+
+	return &out, nil
+}
+
+// ListOperations returns all operations whose name is scoped under parent
+// (projects/{p}/locations/{l}).
+func (m *Mock) ListOperations(_ context.Context, parent string) ([]driver.Operation, error) {
+	out := make([]driver.Operation, 0)
+
+	for _, op := range m.operations.All() {
+		if parent == "" || strings.HasPrefix(op.Name, parent+"/operations/") {
+			out = append(out, *op)
+		}
+	}
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/pipelines.go
+++ b/providers/gcp/vertexai/pipelines.go
@@ -1,0 +1,131 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Training pipelines ---
+
+func (m *Mock) CreateTrainingPipeline(_ context.Context, cfg driver.TrainingPipelineConfig) (*driver.TrainingPipeline, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "trainingPipelines", m.newID())
+	tp := &driver.TrainingPipeline{
+		Name: name, DisplayName: cfg.DisplayName,
+		State: driver.PipelineStateSucceeded, CreateTime: now, EndTime: now,
+	}
+	m.trainPipes.Set(name, tp)
+
+	out := *tp
+
+	return &out, nil
+}
+
+func (m *Mock) GetTrainingPipeline(_ context.Context, name string) (*driver.TrainingPipeline, error) {
+	tp, ok := m.trainPipes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "training pipeline %q not found", name)
+	}
+
+	out := *tp
+
+	return &out, nil
+}
+
+func (m *Mock) ListTrainingPipelines(_ context.Context, location string) ([]driver.TrainingPipeline, error) {
+	out := make([]driver.TrainingPipeline, 0)
+
+	for _, tp := range m.trainPipes.All() {
+		if location == "" || locationOf(tp.Name) == location {
+			out = append(out, *tp)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelTrainingPipeline(_ context.Context, name string) error {
+	tp, ok := m.trainPipes.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "training pipeline %q not found", name)
+	}
+
+	updated := *tp
+	updated.State = driver.PipelineStateCancelled
+	m.trainPipes.Set(name, &updated)
+
+	return nil
+}
+
+func (m *Mock) DeleteTrainingPipeline(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.trainPipes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "training pipeline %q not found", name)
+	}
+
+	m.trainPipes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+// --- Pipeline jobs ---
+
+//nolint:dupl // synchronous-create job shape recurs across job families.
+func (m *Mock) CreatePipelineJob(_ context.Context, cfg driver.PipelineJobConfig) (*driver.PipelineJob, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "pipelineJobs", m.newID())
+	pj := &driver.PipelineJob{Name: name, DisplayName: cfg.DisplayName, State: driver.PipelineStateSucceeded, CreateTime: now, EndTime: now}
+	m.pipelineJobs.Set(name, pj)
+	m.emitMetric("pipeline_job/count", 1, map[string]string{"location": orLocation(cfg.Location)})
+
+	out := *pj
+
+	return &out, nil
+}
+
+func (m *Mock) GetPipelineJob(_ context.Context, name string) (*driver.PipelineJob, error) {
+	pj, ok := m.pipelineJobs.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "pipeline job %q not found", name)
+	}
+
+	out := *pj
+
+	return &out, nil
+}
+
+func (m *Mock) ListPipelineJobs(_ context.Context, location string) ([]driver.PipelineJob, error) {
+	out := make([]driver.PipelineJob, 0)
+
+	for _, pj := range m.pipelineJobs.All() {
+		if location == "" || locationOf(pj.Name) == location {
+			out = append(out, *pj)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) CancelPipelineJob(_ context.Context, name string) error {
+	pj, ok := m.pipelineJobs.Get(name)
+	if !ok {
+		return errors.Newf(errors.NotFound, "pipeline job %q not found", name)
+	}
+
+	updated := *pj
+	updated.State = driver.PipelineStateCancelled
+	m.pipelineJobs.Set(name, &updated)
+
+	return nil
+}
+
+func (m *Mock) DeletePipelineJob(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.pipelineJobs.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "pipeline job %q not found", name)
+	}
+
+	m.pipelineJobs.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}

--- a/providers/gcp/vertexai/vectorsearch.go
+++ b/providers/gcp/vertexai/vectorsearch.go
@@ -1,0 +1,193 @@
+package vertexai
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (m *Mock) CreateIndex(_ context.Context, cfg driver.IndexConfig) (*driver.Operation, *driver.Index, error) {
+	now := m.now()
+	name := m.resName(cfg.Location, "indexes", m.newID())
+	idx := &driver.Index{
+		Name: name, DisplayName: cfg.DisplayName, Description: cfg.Description,
+		Dimensions: cfg.Dimensions, CreateTime: now, UpdateTime: now,
+	}
+	m.indexes.Set(name, idx)
+
+	out := *idx
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetIndex(_ context.Context, name string) (*driver.Index, error) {
+	idx, ok := m.indexes.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "index %q not found", name)
+	}
+
+	out := *idx
+
+	return &out, nil
+}
+
+func (m *Mock) ListIndexes(_ context.Context, location string) ([]driver.Index, error) {
+	out := make([]driver.Index, 0)
+
+	for _, idx := range m.indexes.All() {
+		if location == "" || locationOf(idx.Name) == location {
+			out = append(out, *idx)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteIndex(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.indexes.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "index %q not found", name)
+	}
+
+	m.indexes.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) UpsertDatapoints(_ context.Context, index string, datapoints []driver.Datapoint) error {
+	idx, ok := m.indexes.Get(index)
+	if !ok {
+		return errors.Newf(errors.NotFound, "index %q not found", index)
+	}
+
+	updated := *idx
+	updated.DatapointCount += len(datapoints)
+	updated.UpdateTime = m.now()
+	m.indexes.Set(index, &updated)
+
+	return nil
+}
+
+func (m *Mock) RemoveDatapoints(_ context.Context, index string, datapointIDs []string) error {
+	idx, ok := m.indexes.Get(index)
+	if !ok {
+		return errors.Newf(errors.NotFound, "index %q not found", index)
+	}
+
+	updated := *idx
+	updated.DatapointCount = maxZero(updated.DatapointCount - len(datapointIDs))
+	updated.UpdateTime = m.now()
+	m.indexes.Set(index, &updated)
+
+	return nil
+}
+
+func maxZero(v int) int {
+	if v < 0 {
+		return 0
+	}
+
+	return v
+}
+
+func (m *Mock) CreateIndexEndpoint(_ context.Context, cfg driver.IndexEndpointConfig) (*driver.Operation, *driver.IndexEndpoint, error) {
+	name := m.resName(cfg.Location, "indexEndpoints", m.newID())
+	ie := &driver.IndexEndpoint{Name: name, DisplayName: cfg.DisplayName, Description: cfg.Description, CreateTime: m.now()}
+	m.indexEndpoints.Set(name, ie)
+
+	out := *ie
+
+	return m.doneOp(cfg.Location, name), &out, nil
+}
+
+func (m *Mock) GetIndexEndpoint(_ context.Context, name string) (*driver.IndexEndpoint, error) {
+	ie, ok := m.indexEndpoints.Get(name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", name)
+	}
+
+	out := *ie
+
+	return &out, nil
+}
+
+func (m *Mock) ListIndexEndpoints(_ context.Context, location string) ([]driver.IndexEndpoint, error) {
+	out := make([]driver.IndexEndpoint, 0)
+
+	for _, ie := range m.indexEndpoints.All() {
+		if location == "" || locationOf(ie.Name) == location {
+			out = append(out, *ie)
+		}
+	}
+
+	return out, nil
+}
+
+func (m *Mock) DeleteIndexEndpoint(_ context.Context, name string) (*driver.Operation, error) {
+	if !m.indexEndpoints.Has(name) {
+		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", name)
+	}
+
+	m.indexEndpoints.Delete(name)
+
+	return m.doneOp(locationOf(name), name), nil
+}
+
+func (m *Mock) DeployIndex(
+	_ context.Context, indexEndpoint string, di driver.DeployedIndex,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	ie, ok := m.indexEndpoints.Get(indexEndpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	if di.ID == "" {
+		di.ID = m.newID()
+	}
+
+	updated := *ie
+	updated.DeployedIndexes = append(append([]driver.DeployedIndex{}, ie.DeployedIndexes...), di)
+	m.indexEndpoints.Set(indexEndpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+}
+
+func (m *Mock) UndeployIndex(_ context.Context, indexEndpoint, deployedIndexID string) (*driver.Operation, *driver.IndexEndpoint, error) {
+	ie, ok := m.indexEndpoints.Get(indexEndpoint)
+	if !ok {
+		return nil, nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	kept := make([]driver.DeployedIndex, 0, len(ie.DeployedIndexes))
+
+	for _, d := range ie.DeployedIndexes {
+		if d.ID != deployedIndexID {
+			kept = append(kept, d)
+		}
+	}
+
+	updated := *ie
+	updated.DeployedIndexes = kept
+	m.indexEndpoints.Set(indexEndpoint, &updated)
+
+	out := updated
+
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+}
+
+// FindNeighbors returns deterministic synthetic neighbors for the query.
+func (m *Mock) FindNeighbors(_ context.Context, indexEndpoint, _ string, _ []float64, count int) ([]driver.Neighbor, error) {
+	if !m.indexEndpoints.Has(indexEndpoint) {
+		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	out := make([]driver.Neighbor, 0, count)
+	for i := 0; i < count; i++ {
+		out = append(out, driver.Neighbor{DatapointID: "dp-" + strconv.Itoa(i), Distance: float64(i) * 0.1})
+	}
+
+	return out, nil
+}

--- a/providers/gcp/vertexai/vectorsearch.go
+++ b/providers/gcp/vertexai/vectorsearch.go
@@ -107,9 +107,7 @@ func (m *Mock) GetIndexEndpoint(_ context.Context, name string) (*driver.IndexEn
 		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", name)
 	}
 
-	out := *ie
-
-	return &out, nil
+	return cloneIndexEndpoint(ie), nil
 }
 
 func (m *Mock) ListIndexEndpoints(_ context.Context, location string) ([]driver.IndexEndpoint, error) {
@@ -117,7 +115,7 @@ func (m *Mock) ListIndexEndpoints(_ context.Context, location string) ([]driver.
 
 	for _, ie := range m.indexEndpoints.All() {
 		if location == "" || locationOf(ie.Name) == location {
-			out = append(out, *ie)
+			out = append(out, *cloneIndexEndpoint(ie))
 		}
 	}
 
@@ -146,13 +144,11 @@ func (m *Mock) DeployIndex(
 		di.ID = m.newID()
 	}
 
-	updated := *ie
-	updated.DeployedIndexes = append(append([]driver.DeployedIndex{}, ie.DeployedIndexes...), di)
-	m.indexEndpoints.Set(indexEndpoint, &updated)
+	updated := cloneIndexEndpoint(ie)
+	updated.DeployedIndexes = append(updated.DeployedIndexes, di)
+	m.indexEndpoints.Set(indexEndpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), cloneIndexEndpoint(updated), nil
 }
 
 func (m *Mock) UndeployIndex(_ context.Context, indexEndpoint, deployedIndexID string) (*driver.Operation, *driver.IndexEndpoint, error) {
@@ -161,27 +157,38 @@ func (m *Mock) UndeployIndex(_ context.Context, indexEndpoint, deployedIndexID s
 		return nil, nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
 	}
 
-	kept := make([]driver.DeployedIndex, 0, len(ie.DeployedIndexes))
+	updated := cloneIndexEndpoint(ie)
 
-	for _, d := range ie.DeployedIndexes {
+	kept := make([]driver.DeployedIndex, 0, len(updated.DeployedIndexes))
+
+	for _, d := range updated.DeployedIndexes {
 		if d.ID != deployedIndexID {
 			kept = append(kept, d)
 		}
 	}
 
-	updated := *ie
 	updated.DeployedIndexes = kept
-	m.indexEndpoints.Set(indexEndpoint, &updated)
+	m.indexEndpoints.Set(indexEndpoint, updated)
 
-	out := updated
-
-	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), &out, nil
+	return m.doneOp(locationOf(indexEndpoint), indexEndpoint), cloneIndexEndpoint(updated), nil
 }
+
+// maxNeighbors bounds the synthesized neighbor count so an unvalidated (or
+// hostile) request can't trigger an unbounded allocation.
+const maxNeighbors = 1000
 
 // FindNeighbors returns deterministic synthetic neighbors for the query.
 func (m *Mock) FindNeighbors(_ context.Context, indexEndpoint, _ string, _ []float64, count int) ([]driver.Neighbor, error) {
 	if !m.indexEndpoints.Has(indexEndpoint) {
 		return nil, errors.Newf(errors.NotFound, "index endpoint %q not found", indexEndpoint)
+	}
+
+	if count < 0 {
+		count = 0
+	}
+
+	if count > maxNeighbors {
+		count = maxNeighbors
 	}
 
 	out := make([]driver.Neighbor, 0, count)

--- a/providers/gcp/vertexai/vertexai.go
+++ b/providers/gcp/vertexai/vertexai.go
@@ -44,6 +44,9 @@ type Mock struct {
 	tuningJobs    *memstore.Store[*driver.TuningJob]
 	cachedContent *memstore.Store[*driver.CachedContent]
 
+	featurestores *memstore.Store[*driver.Featurestore]
+	entityTypes   *memstore.Store[*driver.EntityType]
+	entityRecords *memstore.Store[[]driver.FeatureNameValue] // keyed by entityType\x00entityID
 	featureGroups *memstore.Store[*driver.FeatureGroup]
 	features      *memstore.Store[*driver.Feature]
 	onlineStores  *memstore.Store[*driver.FeatureOnlineStore]
@@ -78,6 +81,9 @@ func New(opts *config.Options) *Mock {
 		pipelineJobs:   memstore.New[*driver.PipelineJob](),
 		tuningJobs:     memstore.New[*driver.TuningJob](),
 		cachedContent:  memstore.New[*driver.CachedContent](),
+		featurestores:  memstore.New[*driver.Featurestore](),
+		entityTypes:    memstore.New[*driver.EntityType](),
+		entityRecords:  memstore.New[[]driver.FeatureNameValue](),
 		featureGroups:  memstore.New[*driver.FeatureGroup](),
 		features:       memstore.New[*driver.Feature](),
 		onlineStores:   memstore.New[*driver.FeatureOnlineStore](),

--- a/providers/gcp/vertexai/vertexai.go
+++ b/providers/gcp/vertexai/vertexai.go
@@ -1,0 +1,148 @@
+// Package vertexai provides an in-memory mock implementation of Google Cloud
+// Vertex AI (aiplatform.googleapis.com): datasets, the model registry,
+// endpoints and online prediction, custom/training/tuning/batch jobs,
+// pipelines, the Gemini generateContent runtime, Feature Store, Vector Search,
+// Tensorboard, ML metadata, schedules and notebook runtimes.
+//
+// Control-plane mutations return an already-done Operation so SDK pollers
+// terminate on the first poll. Job-family resources are created synchronously
+// and driven straight to a terminal success state, mirroring how the real API
+// returns the resource from create and exposes progress via a state field.
+package vertexai
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/internal/idgen"
+	"github.com/stackshy/cloudemu/internal/memstore"
+	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// Compile-time check that Mock implements the full Vertex AI surface.
+var _ driver.VertexAI = (*Mock)(nil)
+
+// defaultLocation is used when a resource name carries no parseable location.
+const defaultLocation = "us-central1"
+
+// Mock is an in-memory mock implementation of Vertex AI.
+type Mock struct {
+	opts *config.Options
+
+	datasets    *memstore.Store[*driver.Dataset]
+	models      *memstore.Store[*driver.Model]
+	evaluations *memstore.Store[*driver.ModelEvaluation]
+	endpoints   *memstore.Store[*driver.Endpoint]
+
+	customJobs    *memstore.Store[*driver.CustomJob]
+	batchJobs     *memstore.Store[*driver.BatchPredictionJob]
+	hpoJobs       *memstore.Store[*driver.HyperparameterTuningJob]
+	trainPipes    *memstore.Store[*driver.TrainingPipeline]
+	pipelineJobs  *memstore.Store[*driver.PipelineJob]
+	tuningJobs    *memstore.Store[*driver.TuningJob]
+	cachedContent *memstore.Store[*driver.CachedContent]
+
+	featureGroups *memstore.Store[*driver.FeatureGroup]
+	features      *memstore.Store[*driver.Feature]
+	onlineStores  *memstore.Store[*driver.FeatureOnlineStore]
+	featureViews  *memstore.Store[*driver.FeatureView]
+
+	indexes        *memstore.Store[*driver.Index]
+	indexEndpoints *memstore.Store[*driver.IndexEndpoint]
+
+	metadataStores *memstore.Store[*driver.MetadataStore]
+	tensorboards   *memstore.Store[*driver.Tensorboard]
+	schedules      *memstore.Store[*driver.Schedule]
+	nbTemplates    *memstore.Store[*driver.NotebookRuntimeTemplate]
+	nbRuntimes     *memstore.Store[*driver.NotebookRuntime]
+
+	operations *memstore.Store[*driver.Operation]
+
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new Vertex AI mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		opts:           opts,
+		datasets:       memstore.New[*driver.Dataset](),
+		models:         memstore.New[*driver.Model](),
+		evaluations:    memstore.New[*driver.ModelEvaluation](),
+		endpoints:      memstore.New[*driver.Endpoint](),
+		customJobs:     memstore.New[*driver.CustomJob](),
+		batchJobs:      memstore.New[*driver.BatchPredictionJob](),
+		hpoJobs:        memstore.New[*driver.HyperparameterTuningJob](),
+		trainPipes:     memstore.New[*driver.TrainingPipeline](),
+		pipelineJobs:   memstore.New[*driver.PipelineJob](),
+		tuningJobs:     memstore.New[*driver.TuningJob](),
+		cachedContent:  memstore.New[*driver.CachedContent](),
+		featureGroups:  memstore.New[*driver.FeatureGroup](),
+		features:       memstore.New[*driver.Feature](),
+		onlineStores:   memstore.New[*driver.FeatureOnlineStore](),
+		featureViews:   memstore.New[*driver.FeatureView](),
+		indexes:        memstore.New[*driver.Index](),
+		indexEndpoints: memstore.New[*driver.IndexEndpoint](),
+		metadataStores: memstore.New[*driver.MetadataStore](),
+		tensorboards:   memstore.New[*driver.Tensorboard](),
+		schedules:      memstore.New[*driver.Schedule](),
+		nbTemplates:    memstore.New[*driver.NotebookRuntimeTemplate](),
+		nbRuntimes:     memstore.New[*driver.NotebookRuntime](),
+		operations:     memstore.New[*driver.Operation](),
+	}
+}
+
+// SetMonitoring sets the monitoring backend for auto-metric generation.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) now() string {
+	return m.opts.Clock.Now().UTC().Format(time.RFC3339)
+}
+
+// resName builds a Vertex resource name under the given location and collection.
+func (m *Mock) resName(location, collection, id string) string {
+	return "projects/" + m.opts.ProjectID + "/locations/" + orLocation(location) + "/" + collection + "/" + id
+}
+
+func orLocation(loc string) string {
+	if loc == "" {
+		return defaultLocation
+	}
+
+	return loc
+}
+
+func (*Mock) newID() string {
+	return idgen.GenerateID("")
+}
+
+// doneOp records and returns an already-complete operation for the given
+// location, carrying the response resource name in its metadata.
+func (m *Mock) doneOp(location, resourceName string) *driver.Operation {
+	name := "projects/" + m.opts.ProjectID + "/locations/" + orLocation(location) + "/operations/" + m.newID()
+	op := &driver.Operation{
+		Name:     name,
+		Done:     true,
+		Metadata: map[string]any{"target": resourceName},
+		Response: map[string]any{"name": resourceName},
+	}
+	m.operations.Set(name, op)
+
+	return op
+}
+
+// emitMetric pushes an auto-metric to the wired monitoring backend (no-op when
+// monitoring is not set). Failures never affect the control plane.
+func (m *Mock) emitMetric(metricName string, value float64, dims map[string]string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{{
+		Namespace: "aiplatform.googleapis.com", MetricName: metricName, Value: value,
+		Unit: "Count", Dimensions: dims, Timestamp: m.opts.Clock.Now(),
+	}})
+}

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -162,3 +162,138 @@ func TestLegacyFeaturestore(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, stores, 1)
 }
+
+// TestPatchModelDoesNotMutateSnapshot guards the copy-then-Set fix: an earlier
+// GetModel snapshot must not change when PatchModel runs.
+func TestPatchModelDoesNotMutateSnapshot(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "before"})
+	require.NoError(t, err)
+
+	snap, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+
+	_, err = m.PatchModel(ctx, model.Name, "after", "desc")
+	require.NoError(t, err)
+
+	assert.Equal(t, "before", snap.DisplayName, "prior snapshot must be unaffected by PatchModel")
+
+	got, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "after", got.DisplayName)
+}
+
+// TestCreateLabelsAreCloned guards against storing the caller's map by
+// reference: mutating cfg.Labels after create must not change the stored model.
+func TestCreateLabelsAreCloned(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	labels := map[string]string{"team": "ml"}
+
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m", Labels: labels})
+	require.NoError(t, err)
+
+	labels["team"] = "mutated"
+
+	got, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "ml", got.Labels["team"], "stored labels must be a clone of the caller's map")
+}
+
+// TestDeployModelKeepsTrafficForAllModels guards the traffic-split merge fix:
+// deploying a second model must not drop the first from the split.
+func TestDeployModelKeepsTrafficForAllModels(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
+	require.NoError(t, err)
+
+	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "A", Model: "m/A"})
+	require.NoError(t, err)
+
+	_, after, err := m.DeployModel(ctx, ep.Name, driver.DeployedModel{ID: "B", Model: "m/B"})
+	require.NoError(t, err)
+
+	require.Len(t, after.DeployedModels, 2)
+	assert.Contains(t, after.TrafficSplit, "A", "A must keep a traffic-split entry after B deploys")
+	assert.Contains(t, after.TrafficSplit, "B")
+
+	total := 0
+	for _, v := range after.TrafficSplit {
+		total += v
+	}
+
+	assert.Equal(t, 100, total, "traffic split must total 100")
+
+	// Undeploy rebalances onto the survivor.
+	_, post, err := m.UndeployModel(ctx, ep.Name, "A")
+	require.NoError(t, err)
+	assert.NotContains(t, post.TrafficSplit, "A")
+	assert.Equal(t, 100, post.TrafficSplit["B"])
+}
+
+// TestCachedContentTTLAndContents guards the expiry/persist fix.
+func TestCachedContentTTLAndContents(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cc, err := m.CreateCachedContent(ctx, driver.CachedContentConfig{
+		Location: "us-central1", Model: "gemini-2.5-pro", TTLSeconds: 3600,
+		Contents: []driver.Content{{Role: "user", Parts: []driver.Part{{Text: "hi"}}}},
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, cc.CreateTime, cc.ExpireTime, "expireTime must be createTime + TTL, not equal")
+	assert.Greater(t, cc.ExpireTime, cc.CreateTime)
+	require.Len(t, cc.Contents, 1, "contents must be persisted")
+	assert.Equal(t, "hi", cc.Contents[0].Parts[0].Text)
+}
+
+// TestDeleteModelVersionActuallyDeletes guards the no-op fix.
+func TestDeleteModelVersionActuallyDeletes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.NoError(t, err)
+
+	_, err = m.DeleteModelVersion(ctx, model.Name+"@1")
+	require.NoError(t, err)
+
+	_, err = m.GetModel(ctx, model.Name)
+	require.Error(t, err, "model must be gone after version delete")
+
+	_, err = m.DeleteModelVersion(ctx, model.Name+"@1")
+	require.Error(t, err, "deleting a missing version must return NotFound")
+}
+
+// TestChildListingPrefixDelimiter guards against sibling leakage between
+// featureGroups whose IDs share a prefix (fg1 vs fg10).
+func TestChildListingPrefixDelimiter(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, fg1, err := m.CreateFeatureGroup(ctx, driver.FeatureGroupConfig{Location: "us-central1", FeatureGroupID: "fg1"})
+	require.NoError(t, err)
+	_, fg10, err := m.CreateFeatureGroup(ctx, driver.FeatureGroupConfig{Location: "us-central1", FeatureGroupID: "fg10"})
+	require.NoError(t, err)
+
+	_, _, err = m.CreateFeature(ctx, fg1.Name, "f1", "")
+	require.NoError(t, err)
+	_, _, err = m.CreateFeature(ctx, fg10.Name, "f10a", "")
+	require.NoError(t, err)
+	_, _, err = m.CreateFeature(ctx, fg10.Name, "f10b", "")
+	require.NoError(t, err)
+
+	f1, err := m.ListFeatures(ctx, fg1.Name)
+	require.NoError(t, err)
+	assert.Len(t, f1, 1, "fg1 listing must not leak fg10's features")
+
+	f10, err := m.ListFeatures(ctx, fg10.Name)
+	require.NoError(t, err)
+	assert.Len(t, f10, 2)
+}

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -128,3 +128,37 @@ func TestNotFound(t *testing.T) {
 	_, err := m.GetModel(context.Background(), "projects/proj/locations/us-central1/models/ghost")
 	require.Error(t, err)
 }
+
+func TestLegacyFeaturestore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, fs, err := m.CreateFeaturestore(ctx, driver.FeaturestoreConfig{Location: "us-central1", FeaturestoreID: "fs1"})
+	require.NoError(t, err)
+	assert.Contains(t, fs.Name, "/featurestores/fs1")
+
+	got, err := m.GetFeaturestore(ctx, fs.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "STABLE", got.State)
+
+	_, et, err := m.CreateEntityType(ctx, fs.Name, "users", "user entities")
+	require.NoError(t, err)
+	assert.Contains(t, et.Name, "/entityTypes/users")
+
+	ets, err := m.ListEntityTypes(ctx, fs.Name)
+	require.NoError(t, err)
+	assert.Len(t, ets, 1)
+
+	require.NoError(t, m.WriteFeatureValues(ctx, et.Name, "u1", []driver.FeatureNameValue{{Name: "age", Value: "30"}}))
+	vals, err := m.ReadFeatureValues(ctx, et.Name, "u1")
+	require.NoError(t, err)
+	require.Len(t, vals, 1)
+	assert.Equal(t, "age", vals[0].Name)
+
+	_, err = m.ReadFeatureValues(ctx, et.Name, "ghost")
+	require.Error(t, err)
+
+	stores, err := m.ListFeaturestores(ctx, "us-central1")
+	require.NoError(t, err)
+	assert.Len(t, stores, 1)
+}

--- a/providers/gcp/vertexai/vertexai_test.go
+++ b/providers/gcp/vertexai/vertexai_test.go
@@ -1,0 +1,130 @@
+package vertexai
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithProjectID("proj"))
+
+	return New(opts)
+}
+
+func TestModelUploadAndGet(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	op, model, err := m.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m1"})
+	require.NoError(t, err)
+	assert.True(t, op.Done)
+	assert.Contains(t, model.Name, "projects/proj/locations/us-central1/models/")
+
+	got, err := m.GetModel(ctx, model.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "m1", got.DisplayName)
+
+	// version-suffixed name resolves to the base model.
+	got2, err := m.GetModel(ctx, model.Name+"@1")
+	require.NoError(t, err)
+	assert.Equal(t, model.Name, got2.Name)
+}
+
+func TestEndpointDeployAndPredict(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, ep, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
+	require.NoError(t, err)
+
+	_, _, err = m.DeployModel(ctx, ep.Name, driver.DeployedModel{Model: "projects/proj/locations/us-central1/models/m", DisplayName: "v1"})
+	require.NoError(t, err)
+
+	got, err := m.GetEndpoint(ctx, ep.Name)
+	require.NoError(t, err)
+	require.Len(t, got.DeployedModels, 1)
+
+	resp, err := m.Predict(ctx, driver.PredictRequest{Endpoint: ep.Name, Instances: []any{map[string]any{"x": 1}}})
+	require.NoError(t, err)
+	assert.Len(t, resp.Predictions, 1)
+	assert.NotEmpty(t, resp.DeployedModelID)
+}
+
+func TestGenerateContent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	resp, err := m.GenerateContent(ctx, "publishers/google/models/gemini-2.5-pro", driver.GenerateContentRequest{
+		Contents: []driver.Content{{Role: "user", Parts: []driver.Part{{Text: "hello there world"}}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Candidates, 1)
+	assert.Equal(t, "model", resp.Candidates[0].Content.Role)
+	assert.Equal(t, 3, resp.UsageMetadata.PromptTokenCount)
+	assert.Positive(t, resp.UsageMetadata.TotalTokenCount)
+}
+
+func TestJobsSynchronousSuccess(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	cj, err := m.CreateCustomJob(ctx, driver.CustomJobConfig{Location: "us-central1", DisplayName: "train"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobStateSucceeded, cj.State)
+
+	bp, err := m.CreateBatchPredictionJob(ctx, driver.BatchPredictionJobConfig{Location: "us-central1", DisplayName: "bp"})
+	require.NoError(t, err)
+	assert.Equal(t, driver.JobStateSucceeded, bp.State)
+
+	require.NoError(t, m.CancelCustomJob(ctx, cj.Name))
+	got, _ := m.GetCustomJob(ctx, cj.Name)
+	assert.Equal(t, driver.JobStateCancelled, got.State)
+}
+
+func TestVectorSearchFindNeighbors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, idx, err := m.CreateIndex(ctx, driver.IndexConfig{Location: "us-central1", DisplayName: "idx", Dimensions: 4})
+	require.NoError(t, err)
+	require.NoError(t, m.UpsertDatapoints(ctx, idx.Name, []driver.Datapoint{{DatapointID: "a", FeatureVector: []float64{1, 2, 3, 4}}}))
+
+	got, err := m.GetIndex(ctx, idx.Name)
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.DatapointCount)
+
+	_, ie, err := m.CreateIndexEndpoint(ctx, driver.IndexEndpointConfig{Location: "us-central1", DisplayName: "ie"})
+	require.NoError(t, err)
+	_, _, err = m.DeployIndex(ctx, ie.Name, driver.DeployedIndex{ID: "d1", Index: idx.Name})
+	require.NoError(t, err)
+
+	nbrs, err := m.FindNeighbors(ctx, ie.Name, "d1", []float64{1, 2, 3, 4}, 3)
+	require.NoError(t, err)
+	assert.Len(t, nbrs, 3)
+}
+
+func TestOperationsRetrievable(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	op, _, err := m.CreateEndpoint(ctx, driver.EndpointConfig{Location: "us-central1", DisplayName: "ep"})
+	require.NoError(t, err)
+
+	got, err := m.GetOperation(ctx, op.Name)
+	require.NoError(t, err)
+	assert.True(t, got.Done)
+}
+
+func TestNotFound(t *testing.T) {
+	m := newTestMock()
+	_, err := m.GetModel(context.Background(), "projects/proj/locations/us-central1/models/ghost")
+	require.Error(t, err)
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -29,8 +29,10 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
+	vertexaisrv "github.com/stackshy/cloudemu/server/gcp/vertexai"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+	vertexaidriver "github.com/stackshy/cloudemu/vertexai/driver"
 )
 
 // Drivers bundles the driver interfaces the GCP server can expose.
@@ -44,6 +46,7 @@ type Drivers struct {
 	PubSub         mqdriver.MessageQueue
 	CloudSQL       rdbdriver.RelationalDB
 	GKE            *gkeprov.Mock
+	VertexAI       vertexaidriver.VertexAI
 	IAM            iamdriver.IAM
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
@@ -104,6 +107,14 @@ func New(d Drivers) *server.Server {
 	// same /v1/projects/ space as Firestore, so register first.
 	if d.GKE != nil {
 		srv.Register(gke.New(d.GKE))
+	}
+
+	// Vertex AI matches /v1/projects/{p}/locations/{l}/{models|endpoints|datasets|
+	// customJobs|batchPredictionJobs}/... and /v1/publishers/...:generateContent.
+	// Disjoint from GKE/functions/instances; registered before Firestore's
+	// permissive /v1/projects/ prefix.
+	if d.VertexAI != nil {
+		srv.Register(vertexaisrv.New(d.VertexAI))
 	}
 
 	// Cloud Asset Inventory matches /v1/{scope}:method and /v1/{parent}/

--- a/server/gcp/vertexai/cachedcontents.go
+++ b/server/gcp/vertexai/cachedcontents.go
@@ -1,0 +1,102 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func cachedContentJSON(c *driver.CachedContent) map[string]any {
+	return map[string]any{
+		"name": c.Name, "model": c.Model, "displayName": c.DisplayName,
+		"createTime": c.CreateTime, "expireTime": c.ExpireTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveCachedContents(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listCachedContents(w, r, p.location)
+		case http.MethodPost:
+			h.createCachedContent(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCachedContent(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteCachedContent(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createCachedContent(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		Model       string `json:"model"`
+		DisplayName string `json:"displayName"`
+		TTL         struct {
+			Seconds int `json:"seconds"`
+		} `json:"ttl"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	cc, err := h.svc.CreateCachedContent(r.Context(), driver.CachedContentConfig{
+		Location: location, Model: req.Model, DisplayName: req.DisplayName, TTLSeconds: req.TTL.Seconds,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, cachedContentJSON(cc))
+}
+
+func (h *Handler) getCachedContent(w http.ResponseWriter, r *http.Request, name string) {
+	cc, err := h.svc.GetCachedContent(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, cachedContentJSON(cc))
+}
+
+func (h *Handler) listCachedContents(w http.ResponseWriter, r *http.Request, location string) {
+	ccs, err := h.svc.ListCachedContents(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ccs))
+	for i := range ccs {
+		out = append(out, cachedContentJSON(&ccs[i]))
+	}
+
+	writeJSON(w, map[string]any{"cachedContents": out})
+}
+
+func (h *Handler) deleteCachedContent(w http.ResponseWriter, r *http.Request, name string) {
+	if err := h.svc.DeleteCachedContent(r.Context(), name); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}

--- a/server/gcp/vertexai/datasets.go
+++ b/server/gcp/vertexai/datasets.go
@@ -86,7 +86,7 @@ func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location
 		return
 	}
 
-	op, _, err := h.svc.CreateDataset(r.Context(), driver.DatasetConfig{
+	op, ds, err := h.svc.CreateDataset(r.Context(), driver.DatasetConfig{
 		Location: location, DisplayName: req.DisplayName,
 		MetadataSchemaURI: req.MetadataSchemaURI, Labels: req.Labels,
 	})
@@ -96,7 +96,7 @@ func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, datasetJSON(ds), "Dataset")
 }
 
 func (h *Handler) getDataset(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/datasets.go
+++ b/server/gcp/vertexai/datasets.go
@@ -1,0 +1,157 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func datasetJSON(d *driver.Dataset) map[string]any {
+	return map[string]any{
+		"name":              d.Name,
+		"displayName":       d.DisplayName,
+		"metadataSchemaUri": d.MetadataSchemaURI,
+		"labels":            d.Labels,
+		"createTime":        d.CreateTime,
+		"updateTime":        d.UpdateTime,
+	}
+}
+
+func (h *Handler) serveDatasets(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listDatasets(w, r, p.location)
+		case http.MethodPost:
+			h.createDataset(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.datasetAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getDataset(w, r, p.name)
+	case http.MethodPatch:
+		h.patchDataset(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteDataset(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) datasetAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var op *driver.Operation
+
+	var err error
+
+	switch p.action {
+	case "import":
+		op, err = h.svc.ImportData(r.Context(), p.name, "")
+	case "export":
+		op, err = h.svc.ExportData(r.Context(), p.name, "")
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown dataset action: "+p.action)
+
+		return
+	}
+
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createDataset(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName       string            `json:"displayName"`
+		MetadataSchemaURI string            `json:"metadataSchemaUri"`
+		Labels            map[string]string `json:"labels"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateDataset(r.Context(), driver.DatasetConfig{
+		Location: location, DisplayName: req.DisplayName,
+		MetadataSchemaURI: req.MetadataSchemaURI, Labels: req.Labels,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getDataset(w http.ResponseWriter, r *http.Request, name string) {
+	ds, err := h.svc.GetDataset(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, datasetJSON(ds))
+}
+
+func (h *Handler) listDatasets(w http.ResponseWriter, r *http.Request, location string) {
+	dss, err := h.svc.ListDatasets(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(dss))
+	for i := range dss {
+		out = append(out, datasetJSON(&dss[i]))
+	}
+
+	writeJSON(w, map[string]any{"datasets": out})
+}
+
+func (h *Handler) patchDataset(w http.ResponseWriter, r *http.Request, name string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	ds, err := h.svc.PatchDataset(r.Context(), name, req.DisplayName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, datasetJSON(ds))
+}
+
+func (h *Handler) deleteDataset(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteDataset(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -1,0 +1,245 @@
+package vertexai
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func endpointJSON(e *driver.Endpoint) map[string]any {
+	dms := make([]map[string]any, 0, len(e.DeployedModels))
+	for _, d := range e.DeployedModels {
+		dms = append(dms, map[string]any{
+			"id": d.ID, "model": d.Model, "displayName": d.DisplayName,
+		})
+	}
+
+	traffic := map[string]any{}
+	for k, v := range e.TrafficSplit {
+		traffic[k] = v
+	}
+
+	return map[string]any{
+		"name":           e.Name,
+		"displayName":    e.DisplayName,
+		"description":    e.Description,
+		"deployedModels": dms,
+		"trafficSplit":   traffic,
+		"labels":         e.Labels,
+		"createTime":     e.CreateTime,
+		"updateTime":     e.UpdateTime,
+	}
+}
+
+func (h *Handler) serveEndpoints(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listEndpoints(w, r, p.location)
+		case http.MethodPost:
+			h.createEndpoint(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.endpointAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getEndpoint(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteEndpoint(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) endpointAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	switch p.action {
+	case "predict":
+		h.predict(w, r, p.name)
+	case "rawPredict":
+		h.rawPredict(w, r, p.name)
+	case "deployModel":
+		h.deployModel(w, r, p.name)
+	case "undeployModel":
+		h.undeployModel(w, r, p.name)
+	case actionGenerateContent, actionStreamGenerateContent:
+		h.endpointGenerateContent(w, r, p.name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown endpoint action: "+p.action)
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string            `json:"displayName"`
+		Description string            `json:"description"`
+		Labels      map[string]string `json:"labels"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
+		Location: location, DisplayName: req.DisplayName, Description: req.Description, Labels: req.Labels,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	ep, err := h.svc.GetEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, endpointJSON(ep))
+}
+
+func (h *Handler) listEndpoints(w http.ResponseWriter, r *http.Request, location string) {
+	eps, err := h.svc.ListEndpoints(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(eps))
+	for i := range eps {
+		out = append(out, endpointJSON(&eps[i]))
+	}
+
+	writeJSON(w, map[string]any{"endpoints": out})
+}
+
+func (h *Handler) deleteEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint string) {
+	var req struct {
+		DeployedModel struct {
+			ID                 string `json:"id"`
+			Model              string `json:"model"`
+			DisplayName        string `json:"displayName"`
+			DedicatedResources struct {
+				MachineSpec struct {
+					MachineType string `json:"machineType"`
+				} `json:"machineSpec"`
+				MinReplicaCount int `json:"minReplicaCount"`
+				MaxReplicaCount int `json:"maxReplicaCount"`
+			} `json:"dedicatedResources"`
+		} `json:"deployedModel"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	dm := req.DeployedModel
+
+	op, _, err := h.svc.DeployModel(r.Context(), endpoint, driver.DeployedModel{
+		ID: dm.ID, Model: dm.Model, DisplayName: dm.DisplayName,
+		MachineType:     dm.DedicatedResources.MachineSpec.MachineType,
+		MinReplicaCount: dm.DedicatedResources.MinReplicaCount,
+		MaxReplicaCount: dm.DedicatedResources.MaxReplicaCount,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) undeployModel(w http.ResponseWriter, r *http.Request, endpoint string) {
+	var req struct {
+		DeployedModelID string `json:"deployedModelId"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.UndeployModel(r.Context(), endpoint, req.DeployedModelID)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) predict(w http.ResponseWriter, r *http.Request, endpoint string) {
+	var req struct {
+		Instances  []any `json:"instances"`
+		Parameters any   `json:"parameters"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	resp, err := h.svc.Predict(r.Context(), driver.PredictRequest{
+		Endpoint: endpoint, Instances: req.Instances, Parameters: req.Parameters,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{
+		"predictions":      resp.Predictions,
+		"deployedModelId":  resp.DeployedModelID,
+		"model":            resp.Model,
+		"modelDisplayName": resp.ModelDisplayName,
+	})
+}
+
+func (h *Handler) rawPredict(w http.ResponseWriter, r *http.Request, endpoint string) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "badRequest", "failed to read body")
+
+		return
+	}
+
+	out, cerr := h.svc.RawPredict(r.Context(), endpoint, body)
+	if cerr != nil {
+		writeCErr(w, cerr)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -92,7 +92,7 @@ func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, locatio
 		return
 	}
 
-	op, _, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
+	op, ep, err := h.svc.CreateEndpoint(r.Context(), driver.EndpointConfig{
 		Location: location, DisplayName: req.DisplayName, Description: req.Description, Labels: req.Labels,
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func (h *Handler) createEndpoint(w http.ResponseWriter, r *http.Request, locatio
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, endpointJSON(ep), "Endpoint")
 }
 
 func (h *Handler) getEndpoint(w http.ResponseWriter, r *http.Request, name string) {
@@ -164,7 +164,7 @@ func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint s
 
 	dm := req.DeployedModel
 
-	op, _, err := h.svc.DeployModel(r.Context(), endpoint, driver.DeployedModel{
+	op, ep, err := h.svc.DeployModel(r.Context(), endpoint, driver.DeployedModel{
 		ID: dm.ID, Model: dm.Model, DisplayName: dm.DisplayName,
 		MachineType:     dm.DedicatedResources.MachineSpec.MachineType,
 		MinReplicaCount: dm.DedicatedResources.MinReplicaCount,
@@ -176,7 +176,15 @@ func (h *Handler) deployModel(w http.ResponseWriter, r *http.Request, endpoint s
 		return
 	}
 
-	writeOp(w, op)
+	// DeployModelResponse carries the newly deployed model (the last appended).
+	var deployed map[string]any
+
+	if n := len(ep.DeployedModels); n > 0 {
+		d := ep.DeployedModels[n-1]
+		deployed = map[string]any{"id": d.ID, "model": d.Model, "displayName": d.DisplayName}
+	}
+
+	writeResourceOp(w, op, map[string]any{"deployedModel": deployed}, "DeployModelResponse")
 }
 
 func (h *Handler) undeployModel(w http.ResponseWriter, r *http.Request, endpoint string) {
@@ -195,7 +203,7 @@ func (h *Handler) undeployModel(w http.ResponseWriter, r *http.Request, endpoint
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nil, "UndeployModelResponse")
 }
 
 func (h *Handler) predict(w http.ResponseWriter, r *http.Request, endpoint string) {

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -1,6 +1,7 @@
 package vertexai
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 
@@ -248,7 +249,13 @@ func (h *Handler) rawPredict(w http.ResponseWriter, r *http.Request, endpoint st
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(out)
+	// Re-encode the echoed payload through json rather than writing the
+	// request-derived bytes verbatim: it keeps the response valid JSON and
+	// breaks the request→response taint flow (gosec G705) at the source.
+	var payload any
+	if jerr := json.Unmarshal(out, &payload); jerr != nil {
+		payload = map[string]any{"raw": string(out)}
+	}
+
+	writeJSON(w, payload)
 }

--- a/server/gcp/vertexai/endpoints.go
+++ b/server/gcp/vertexai/endpoints.go
@@ -32,6 +32,7 @@ func endpointJSON(e *driver.Endpoint) map[string]any {
 	}
 }
 
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
 func (h *Handler) serveEndpoints(w http.ResponseWriter, r *http.Request, p *vPath) {
 	if p.name == "" {
 		switch r.Method {

--- a/server/gcp/vertexai/featureregistry.go
+++ b/server/gcp/vertexai/featureregistry.go
@@ -1,0 +1,415 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Feature groups + features (Feature Registry) ---
+
+func featureGroupJSON(g *driver.FeatureGroup) map[string]any {
+	return map[string]any{
+		"name": g.Name, "description": g.Description,
+		"bigQuery":   map[string]any{"bigQuerySource": map[string]any{"inputUri": g.BigQueryURI}},
+		"createTime": g.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveFeatureGroups(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subRes == "features" {
+		h.serveFeatures(w, r, p)
+
+		return
+	}
+
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatureGroups(w, r, p.location)
+		case http.MethodPost:
+			h.createFeatureGroup(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeatureGroup(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteFeatureGroup(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		Description string `json:"description"`
+		BigQuery    struct {
+			BigQuerySource struct {
+				InputURI string `json:"inputUri"`
+			} `json:"bigQuerySource"`
+		} `json:"bigQuery"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupConfig{
+		Location: location, FeatureGroupID: r.URL.Query().Get("featureGroupId"),
+		Description: req.Description, BigQueryURI: req.BigQuery.BigQuerySource.InputURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeatureGroup(w http.ResponseWriter, r *http.Request, name string) {
+	g, err := h.svc.GetFeatureGroup(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featureGroupJSON(g))
+}
+
+func (h *Handler) listFeatureGroups(w http.ResponseWriter, r *http.Request, location string) {
+	gs, err := h.svc.ListFeatureGroups(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(gs))
+	for i := range gs {
+		out = append(out, featureGroupJSON(&gs[i]))
+	}
+
+	writeJSON(w, map[string]any{"featureGroups": out})
+}
+
+func (h *Handler) deleteFeatureGroup(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeatureGroup(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func featureJSON(f *driver.Feature) map[string]any {
+	return map[string]any{"name": f.Name, "description": f.Description, "createTime": f.CreateTime}
+}
+
+func (h *Handler) serveFeatures(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatures(w, r, p.name)
+		case http.MethodPost:
+			h.createFeature(w, r, p)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	name := p.name + "/features/" + p.subName
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeature(w, r, name)
+	case http.MethodDelete:
+		h.deleteFeature(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeature(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var req struct {
+		Description string `json:"description"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeature(r.Context(), p.name, r.URL.Query().Get("featureId"), req.Description)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeature(w http.ResponseWriter, r *http.Request, name string) {
+	f, err := h.svc.GetFeature(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featureJSON(f))
+}
+
+func (h *Handler) listFeatures(w http.ResponseWriter, r *http.Request, parent string) {
+	fs, err := h.svc.ListFeatures(r.Context(), parent)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(fs))
+	for i := range fs {
+		out = append(out, featureJSON(&fs[i]))
+	}
+
+	writeJSON(w, map[string]any{"features": out})
+}
+
+func (h *Handler) deleteFeature(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeature(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Feature online stores + feature views ---
+
+func onlineStoreJSON(s *driver.FeatureOnlineStore) map[string]any {
+	return map[string]any{"name": s.Name, "state": s.State, "createTime": s.CreateTime}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveFeatureOnlineStores(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subRes == "featureViews" {
+		h.serveFeatureViews(w, r, p)
+
+		return
+	}
+
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatureOnlineStores(w, r, p.location)
+		case http.MethodPost:
+			h.createFeatureOnlineStore(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeatureOnlineStore(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteFeatureOnlineStore(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeatureOnlineStore(w http.ResponseWriter, r *http.Request, location string) {
+	if !decode(w, r, &struct{}{}) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeatureOnlineStore(r.Context(), driver.FeatureOnlineStoreConfig{
+		Location: location, FeatureOnlineStoreID: r.URL.Query().Get("featureOnlineStoreId"),
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeatureOnlineStore(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.svc.GetFeatureOnlineStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, onlineStoreJSON(s))
+}
+
+func (h *Handler) listFeatureOnlineStores(w http.ResponseWriter, r *http.Request, location string) {
+	ss, err := h.svc.ListFeatureOnlineStores(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ss))
+	for i := range ss {
+		out = append(out, onlineStoreJSON(&ss[i]))
+	}
+
+	writeJSON(w, map[string]any{"featureOnlineStores": out})
+}
+
+func (h *Handler) deleteFeatureOnlineStore(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeatureOnlineStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func featureViewJSON(v *driver.FeatureView) map[string]any {
+	return map[string]any{
+		"name":           v.Name,
+		"bigQuerySource": map[string]any{"uri": v.BigQueryURI},
+		"createTime":     v.CreateTime,
+	}
+}
+
+func (h *Handler) serveFeatureViews(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeatureViews(w, r, p.name)
+		case http.MethodPost:
+			h.createFeatureView(w, r, p)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	name := p.name + "/featureViews/" + p.subName
+
+	if r.Method == http.MethodPost && p.action == "fetchFeatureValues" {
+		h.fetchFeatureValues(w, r, name)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeatureView(w, r, name)
+	case http.MethodDelete:
+		h.deleteFeatureView(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeatureView(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var req struct {
+		BigQuerySource struct {
+			URI string `json:"uri"`
+		} `json:"bigQuerySource"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeatureView(r.Context(), driver.FeatureViewConfig{
+		Parent: p.name, FeatureViewID: r.URL.Query().Get("featureViewId"),
+		BigQueryURI: req.BigQuerySource.URI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeatureView(w http.ResponseWriter, r *http.Request, name string) {
+	v, err := h.svc.GetFeatureView(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featureViewJSON(v))
+}
+
+func (h *Handler) listFeatureViews(w http.ResponseWriter, r *http.Request, parent string) {
+	vs, err := h.svc.ListFeatureViews(r.Context(), parent)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(vs))
+	for i := range vs {
+		out = append(out, featureViewJSON(&vs[i]))
+	}
+
+	writeJSON(w, map[string]any{"featureViews": out})
+}
+
+func (h *Handler) deleteFeatureView(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeatureView(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) fetchFeatureValues(w http.ResponseWriter, r *http.Request, featureView string) {
+	var req struct {
+		DataKey struct {
+			Key string `json:"key"`
+		} `json:"dataKey"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	vals, err := h.svc.FetchFeatureValues(r.Context(), featureView, req.DataKey.Key)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{"keyValues": map[string]any{"features": featureValuesJSON(vals)}})
+}

--- a/server/gcp/vertexai/featureregistry.go
+++ b/server/gcp/vertexai/featureregistry.go
@@ -61,7 +61,7 @@ func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	op, _, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupConfig{
+	op, fg, err := h.svc.CreateFeatureGroup(r.Context(), driver.FeatureGroupConfig{
 		Location: location, FeatureGroupID: r.URL.Query().Get("featureGroupId"),
 		Description: req.Description, BigQueryURI: req.BigQuery.BigQuerySource.InputURI,
 	})
@@ -71,7 +71,7 @@ func (h *Handler) createFeatureGroup(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featureGroupJSON(fg), "FeatureGroup")
 }
 
 func (h *Handler) getFeatureGroup(w http.ResponseWriter, r *http.Request, name string) {
@@ -151,14 +151,14 @@ func (h *Handler) createFeature(w http.ResponseWriter, r *http.Request, p *vPath
 		return
 	}
 
-	op, _, err := h.svc.CreateFeature(r.Context(), p.name, r.URL.Query().Get("featureId"), req.Description)
+	op, f, err := h.svc.CreateFeature(r.Context(), p.name, r.URL.Query().Get("featureId"), req.Description)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featureJSON(f), "Feature")
 }
 
 func (h *Handler) getFeature(w http.ResponseWriter, r *http.Request, name string) {
@@ -241,7 +241,7 @@ func (h *Handler) createFeatureOnlineStore(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	op, _, err := h.svc.CreateFeatureOnlineStore(r.Context(), driver.FeatureOnlineStoreConfig{
+	op, s, err := h.svc.CreateFeatureOnlineStore(r.Context(), driver.FeatureOnlineStoreConfig{
 		Location: location, FeatureOnlineStoreID: r.URL.Query().Get("featureOnlineStoreId"),
 	})
 	if err != nil {
@@ -250,7 +250,7 @@ func (h *Handler) createFeatureOnlineStore(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, onlineStoreJSON(s), "FeatureOnlineStore")
 }
 
 func (h *Handler) getFeatureOnlineStore(w http.ResponseWriter, r *http.Request, name string) {
@@ -342,7 +342,7 @@ func (h *Handler) createFeatureView(w http.ResponseWriter, r *http.Request, p *v
 		return
 	}
 
-	op, _, err := h.svc.CreateFeatureView(r.Context(), driver.FeatureViewConfig{
+	op, fv, err := h.svc.CreateFeatureView(r.Context(), driver.FeatureViewConfig{
 		Parent: p.name, FeatureViewID: r.URL.Query().Get("featureViewId"),
 		BigQueryURI: req.BigQuerySource.URI,
 	})
@@ -352,7 +352,7 @@ func (h *Handler) createFeatureView(w http.ResponseWriter, r *http.Request, p *v
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featureViewJSON(fv), "FeatureView")
 }
 
 func (h *Handler) getFeatureView(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/featurestore.go
+++ b/server/gcp/vertexai/featurestore.go
@@ -58,7 +58,7 @@ func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	op, _, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
+	op, fs, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
 		Location: location, FeaturestoreID: r.URL.Query().Get("featurestoreId"),
 		OnlineNodeCount: req.OnlineServingConfig.FixedNodeCount,
 	})
@@ -68,7 +68,7 @@ func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, loc
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, featurestoreJSON(fs), "Featurestore")
 }
 
 func (h *Handler) getFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
@@ -169,14 +169,14 @@ func (h *Handler) createEntityType(w http.ResponseWriter, r *http.Request, p *vP
 		return
 	}
 
-	op, _, err := h.svc.CreateEntityType(r.Context(), p.name, r.URL.Query().Get("entityTypeId"), req.EntityType.Description)
+	op, et, err := h.svc.CreateEntityType(r.Context(), p.name, r.URL.Query().Get("entityTypeId"), req.EntityType.Description)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, entityTypeJSON(et), "EntityType")
 }
 
 func (h *Handler) getEntityType(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/featurestore.go
+++ b/server/gcp/vertexai/featurestore.go
@@ -1,0 +1,274 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Featurestores ---
+
+func featurestoreJSON(f *driver.Featurestore) map[string]any {
+	return map[string]any{
+		"name": f.Name, "state": f.State,
+		"onlineServingConfig": map[string]any{"fixedNodeCount": f.OnlineNodeCount},
+		"createTime":          f.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveFeaturestores(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subRes == "entityTypes" {
+		h.serveEntityTypes(w, r, p)
+
+		return
+	}
+
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFeaturestores(w, r, p.location)
+		case http.MethodPost:
+			h.createFeaturestore(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getFeaturestore(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteFeaturestore(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createFeaturestore(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		OnlineServingConfig struct {
+			FixedNodeCount int `json:"fixedNodeCount"`
+		} `json:"onlineServingConfig"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateFeaturestore(r.Context(), driver.FeaturestoreConfig{
+		Location: location, FeaturestoreID: r.URL.Query().Get("featurestoreId"),
+		OnlineNodeCount: req.OnlineServingConfig.FixedNodeCount,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
+	fs, err := h.svc.GetFeaturestore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, featurestoreJSON(fs))
+}
+
+func (h *Handler) listFeaturestores(w http.ResponseWriter, r *http.Request, location string) {
+	fss, err := h.svc.ListFeaturestores(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(fss))
+	for i := range fss {
+		out = append(out, featurestoreJSON(&fss[i]))
+	}
+
+	writeJSON(w, map[string]any{"featurestores": out})
+}
+
+func (h *Handler) deleteFeaturestore(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteFeaturestore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Entity types + online feature values ---
+
+func entityTypeJSON(e *driver.EntityType) map[string]any {
+	return map[string]any{"name": e.Name, "description": e.Description, "createTime": e.CreateTime}
+}
+
+func (h *Handler) serveEntityTypes(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listEntityTypes(w, r, p.name)
+		case http.MethodPost:
+			h.createEntityType(w, r, p)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	name := p.name + "/entityTypes/" + p.subName
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.entityTypeAction(w, r, name, p.action)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getEntityType(w, r, name)
+	case http.MethodDelete:
+		h.deleteEntityType(w, r, name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) entityTypeAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	switch action {
+	case "readFeatureValues":
+		h.readFeatureValues(w, r, name)
+	case "writeFeatureValues":
+		h.writeFeatureValues(w, r, name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown entityType action: "+action)
+	}
+}
+
+func (h *Handler) createEntityType(w http.ResponseWriter, r *http.Request, p *vPath) {
+	var req struct {
+		EntityType struct {
+			Description string `json:"description"`
+		} `json:"entityType"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateEntityType(r.Context(), p.name, r.URL.Query().Get("entityTypeId"), req.EntityType.Description)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getEntityType(w http.ResponseWriter, r *http.Request, name string) {
+	et, err := h.svc.GetEntityType(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, entityTypeJSON(et))
+}
+
+func (h *Handler) listEntityTypes(w http.ResponseWriter, r *http.Request, parent string) {
+	ets, err := h.svc.ListEntityTypes(r.Context(), parent)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ets))
+	for i := range ets {
+		out = append(out, entityTypeJSON(&ets[i]))
+	}
+
+	writeJSON(w, map[string]any{"entityTypes": out})
+}
+
+func (h *Handler) deleteEntityType(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteEntityType(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) readFeatureValues(w http.ResponseWriter, r *http.Request, entityType string) {
+	var req struct {
+		EntityID string `json:"entityId"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	vals, err := h.svc.ReadFeatureValues(r.Context(), entityType, req.EntityID)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{"entityView": map[string]any{"entityId": req.EntityID, "data": featureValuesJSON(vals)}})
+}
+
+func (h *Handler) writeFeatureValues(w http.ResponseWriter, r *http.Request, entityType string) {
+	var req struct {
+		Payloads []struct {
+			EntityID      string            `json:"entityId"`
+			FeatureValues map[string]string `json:"featureValues"`
+		} `json:"payloads"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	for _, pl := range req.Payloads {
+		values := make([]driver.FeatureNameValue, 0, len(pl.FeatureValues))
+		for name, val := range pl.FeatureValues {
+			values = append(values, driver.FeatureNameValue{Name: name, Value: val})
+		}
+
+		if err := h.svc.WriteFeatureValues(r.Context(), entityType, pl.EntityID, values); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+func featureValuesJSON(vals []driver.FeatureNameValue) []map[string]any {
+	out := make([]map[string]any, 0, len(vals))
+	for _, v := range vals {
+		out = append(out, map[string]any{"name": v.Name, "value": v.Value})
+	}
+
+	return out
+}

--- a/server/gcp/vertexai/genai.go
+++ b/server/gcp/vertexai/genai.go
@@ -1,0 +1,143 @@
+package vertexai
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// wireContent is the JSON shape of a generateContent content turn.
+type wireContent struct {
+	Role  string `json:"role"`
+	Parts []struct {
+		Text string `json:"text"`
+	} `json:"parts"`
+}
+
+type wireGenerateRequest struct {
+	Contents          []wireContent `json:"contents"`
+	SystemInstruction *wireContent  `json:"systemInstruction"`
+	GenerationConfig  *struct {
+		Temperature     *float64 `json:"temperature"`
+		TopP            *float64 `json:"topP"`
+		TopK            *int     `json:"topK"`
+		MaxOutputTokens *int     `json:"maxOutputTokens"`
+	} `json:"generationConfig"`
+}
+
+func toContents(in []wireContent) []driver.Content {
+	out := make([]driver.Content, 0, len(in))
+
+	for _, c := range in {
+		parts := make([]driver.Part, 0, len(c.Parts))
+		for _, p := range c.Parts {
+			parts = append(parts, driver.Part{Text: p.Text})
+		}
+
+		out = append(out, driver.Content{Role: c.Role, Parts: parts})
+	}
+
+	return out
+}
+
+func toDriverRequest(req wireGenerateRequest) driver.GenerateContentRequest {
+	dr := driver.GenerateContentRequest{Contents: toContents(req.Contents)}
+
+	if req.SystemInstruction != nil {
+		si := toContents([]wireContent{*req.SystemInstruction})
+		dr.SystemInstruction = &si[0]
+	}
+
+	if req.GenerationConfig != nil {
+		dr.GenerationConfig = &driver.GenerationConfig{
+			Temperature:     req.GenerationConfig.Temperature,
+			TopP:            req.GenerationConfig.TopP,
+			TopK:            req.GenerationConfig.TopK,
+			MaxOutputTokens: req.GenerationConfig.MaxOutputTokens,
+		}
+	}
+
+	return dr
+}
+
+func generateResponseJSON(resp *driver.GenerateContentResponse) map[string]any {
+	cands := make([]map[string]any, 0, len(resp.Candidates))
+
+	for _, c := range resp.Candidates {
+		parts := make([]map[string]any, 0, len(c.Content.Parts))
+		for _, p := range c.Content.Parts {
+			parts = append(parts, map[string]any{"text": p.Text})
+		}
+
+		cands = append(cands, map[string]any{
+			"content":      map[string]any{"role": c.Content.Role, "parts": parts},
+			"finishReason": c.FinishReason,
+		})
+	}
+
+	return map[string]any{
+		"candidates": cands,
+		"usageMetadata": map[string]any{
+			"promptTokenCount":     resp.UsageMetadata.PromptTokenCount,
+			"candidatesTokenCount": resp.UsageMetadata.CandidatesTokenCount,
+			"totalTokenCount":      resp.UsageMetadata.TotalTokenCount,
+		},
+	}
+}
+
+// servePublishers handles /v1/publishers/{pub}/models/{model}:{action}.
+func (h *Handler) servePublishers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, "/v1/")
+
+	model, action := splitActionPair(rest)
+	if action == "" {
+		writeError(w, http.StatusNotFound, "notFound", "missing action on publishers path")
+
+		return
+	}
+
+	h.runGenAI(w, r, model, action)
+}
+
+func (h *Handler) endpointGenerateContent(w http.ResponseWriter, r *http.Request, endpoint string) {
+	h.runGenAI(w, r, endpoint, "generateContent")
+}
+
+// runGenAI dispatches generateContent / countTokens for either a publisher
+// model path or an endpoint resource name.
+func (h *Handler) runGenAI(w http.ResponseWriter, r *http.Request, model, action string) {
+	var req wireGenerateRequest
+	if !decode(w, r, &req) {
+		return
+	}
+
+	switch action {
+	case "generateContent", actionStreamGenerateContent:
+		resp, err := h.svc.GenerateContent(r.Context(), model, toDriverRequest(req))
+		if err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, generateResponseJSON(resp))
+	case "countTokens":
+		resp, err := h.svc.CountTokens(r.Context(), model, toDriverRequest(req))
+		if err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{"totalTokens": resp.TotalTokens})
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown generative action: "+action)
+	}
+}

--- a/server/gcp/vertexai/genai.go
+++ b/server/gcp/vertexai/genai.go
@@ -119,7 +119,7 @@ func (h *Handler) runGenAI(w http.ResponseWriter, r *http.Request, model, action
 	}
 
 	switch action {
-	case "generateContent", actionStreamGenerateContent:
+	case "generateContent":
 		resp, err := h.svc.GenerateContent(r.Context(), model, toDriverRequest(req))
 		if err != nil {
 			writeCErr(w, err)
@@ -128,6 +128,18 @@ func (h *Handler) runGenAI(w http.ResponseWriter, r *http.Request, model, action
 		}
 
 		writeJSON(w, generateResponseJSON(resp))
+	case actionStreamGenerateContent:
+		resp, err := h.svc.GenerateContent(r.Context(), model, toDriverRequest(req))
+		if err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		// streamGenerateContent returns a JSON array of response chunks; emit a
+		// single-element array so SDK stream decoders iterate it correctly
+		// (a lone object fails array-decoding / yields zero chunks).
+		writeJSON(w, []map[string]any{generateResponseJSON(resp)})
 	case "countTokens":
 		resp, err := h.svc.CountTokens(r.Context(), model, toDriverRequest(req))
 		if err != nil {

--- a/server/gcp/vertexai/handler.go
+++ b/server/gcp/vertexai/handler.go
@@ -5,14 +5,23 @@
 // {location}-aiplatform.googleapis.com.
 //
 // Control-plane mutations return google.longrunning.Operation envelopes with
-// done=true so SDK pollers terminate on the first poll. Job-family creates
-// return the resource directly (synchronous). predict / generateContent are
-// synchronous data-plane calls.
+// done=true AND the typed result populated in response (with its @type), so SDK
+// pollers terminate on the first poll and unmarshal the resource straight off
+// the operation. Job-family creates return the resource directly (synchronous).
+// predict / generateContent are synchronous data-plane calls.
 //
 // The /v1/projects/{p}/locations/{l}/ prefix is shared with Cloud Functions,
 // Cloud SQL and GKE; Matches narrows on the Vertex collection segment so this
 // handler claims only its own URLs. It also claims /v1/publishers/ for the
 // Model Garden generateContent surface.
+//
+// LRO polling note: the operations collection
+// (.../locations/{l}/operations/{id}) is intentionally NOT claimed here — the
+// GKE handler, registered ahead of Vertex on the shared prefix, already owns
+// it. This is safe because every Vertex mutation completes done-on-arrival with
+// its result inlined (above), so a client never needs to poll. If a future
+// non-done Vertex op is introduced, route operations through a shared
+// per-location operations handler before relying on polling.
 package vertexai
 
 import (

--- a/server/gcp/vertexai/handler.go
+++ b/server/gcp/vertexai/handler.go
@@ -1,0 +1,182 @@
+// Package vertexai implements the Google Cloud Vertex AI
+// (aiplatform.googleapis.com) REST API as a server.Handler. Real
+// google.golang.org/api/aiplatform/v1 clients (and any REST caller) configured
+// with a custom endpoint hit this handler the same way they hit
+// {location}-aiplatform.googleapis.com.
+//
+// Control-plane mutations return google.longrunning.Operation envelopes with
+// done=true so SDK pollers terminate on the first poll. Job-family creates
+// return the resource directly (synchronous). predict / generateContent are
+// synchronous data-plane calls.
+//
+// The /v1/projects/{p}/locations/{l}/ prefix is shared with Cloud Functions,
+// Cloud SQL and GKE; Matches narrows on the Vertex collection segment so this
+// handler claims only its own URLs. It also claims /v1/publishers/ for the
+// Model Garden generateContent surface.
+package vertexai
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+const (
+	pathPrefix       = "/v1/projects/"
+	publishersPrefix = "/v1/publishers/"
+	locationsSeg     = "locations"
+	maxBodyBytes     = 6 << 20
+
+	actionCancel                = "cancel"
+	actionGenerateContent       = "generateContent"
+	actionStreamGenerateContent = "streamGenerateContent"
+)
+
+// vertexCollections are the resource collections this handler serves. Listed
+// explicitly so it never shadows the sibling functions/instances/clusters
+// handlers on the shared locations prefix.
+//
+//nolint:gochecknoglobals // immutable routing set shared by Matches and dispatch
+var vertexCollections = map[string]bool{
+	"datasets": true, "models": true, "endpoints": true,
+	"customJobs": true, "batchPredictionJobs": true,
+}
+
+// Handler serves Vertex AI REST requests against a vertexai driver.
+type Handler struct {
+	svc driver.VertexAI
+}
+
+// New returns a Vertex AI handler backed by svc.
+func New(svc driver.VertexAI) *Handler {
+	return &Handler{svc: svc}
+}
+
+// Matches claims the Vertex collection URLs and the publishers generateContent
+// surface.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, publishersPrefix) {
+		return true
+	}
+
+	if !strings.HasPrefix(r.URL.Path, pathPrefix) {
+		return false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
+
+	const idxScope, idxResource = 1, 3
+
+	if len(parts) <= idxResource || parts[idxScope] != locationsSeg {
+		return false
+	}
+
+	return vertexCollections[stripAction(parts[idxResource])]
+}
+
+// vPath is a parsed Vertex REST path.
+type vPath struct {
+	project    string
+	location   string
+	collection string
+	name       string // full resource name when addressing a specific resource
+	subRes     string // e.g. "features" / "featureViews" / "operations"
+	subName    string
+	action     string // ":predict", ":deployModel", ":upload", ... (no leading colon)
+}
+
+// parsePath splits a Vertex projects/locations URL.
+func parsePath(urlPath string) (vPath, bool) {
+	parts := strings.Split(strings.TrimPrefix(urlPath, pathPrefix), "/")
+
+	const (
+		minParts    = 4
+		idxProject  = 0
+		idxLocation = 2
+		idxResource = 3
+		idxName     = 4
+		idxSubRes   = 5
+		idxSubName  = 6
+	)
+
+	if len(parts) < minParts {
+		return vPath{}, false
+	}
+
+	p := vPath{project: parts[idxProject], location: parts[idxLocation]}
+	p.collection, p.action = splitActionPair(parts[idxResource])
+
+	if len(parts) > idxName {
+		seg, act := splitActionPair(parts[idxName])
+		p.name = "projects/" + p.project + "/locations/" + p.location + "/" + p.collection + "/" + seg
+
+		if act != "" {
+			p.action = act
+		}
+	}
+
+	if len(parts) > idxSubRes {
+		p.subRes, _ = splitActionPair(parts[idxSubRes])
+	}
+
+	if len(parts) > idxSubName {
+		seg, act := splitActionPair(parts[idxSubName])
+		p.subName = seg
+
+		if act != "" {
+			p.action = act
+		}
+	}
+
+	return p, true
+}
+
+// stripAction returns a path segment without any ":action" suffix.
+func stripAction(seg string) string {
+	if i := strings.Index(seg, ":"); i >= 0 {
+		return seg[:i]
+	}
+
+	return seg
+}
+
+// splitActionPair splits "seg:action" into ("seg", "action").
+func splitActionPair(seg string) (name, action string) {
+	if i := strings.Index(seg, ":"); i >= 0 {
+		return seg[:i], seg[i+1:]
+	}
+
+	return seg, ""
+}
+
+// ServeHTTP dispatches Vertex requests.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, publishersPrefix) {
+		h.servePublishers(w, r)
+
+		return
+	}
+
+	p, ok := parsePath(r.URL.Path)
+	if !ok {
+		writeError(w, http.StatusNotFound, "notFound", "unsupported path: "+r.URL.Path)
+
+		return
+	}
+
+	switch p.collection {
+	case "models":
+		h.serveModels(w, r, &p)
+	case "endpoints":
+		h.serveEndpoints(w, r, &p)
+	case "datasets":
+		h.serveDatasets(w, r, &p)
+	case "customJobs":
+		h.serveCustomJobs(w, r, &p)
+	case "batchPredictionJobs":
+		h.serveBatchPredictionJobs(w, r, &p)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unsupported collection: "+p.collection)
+	}
+}

--- a/server/gcp/vertexai/handler.go
+++ b/server/gcp/vertexai/handler.go
@@ -41,16 +41,50 @@ const (
 var vertexCollections = map[string]bool{
 	"datasets": true, "models": true, "endpoints": true,
 	"customJobs": true, "batchPredictionJobs": true,
+	"hyperparameterTuningJobs": true, "trainingPipelines": true,
+	"pipelineJobs": true, "tuningJobs": true, "cachedContents": true,
+	"featurestores": true, "featureGroups": true, "featureOnlineStores": true,
+	"indexes": true, "indexEndpoints": true, "metadataStores": true,
+	"tensorboards": true, "schedules": true, "notebookRuntimes": true,
+	"notebookRuntimeTemplates": true,
 }
+
+// collectionHandler serves one Vertex collection's requests.
+type collectionHandler func(http.ResponseWriter, *http.Request, *vPath)
 
 // Handler serves Vertex AI REST requests against a vertexai driver.
 type Handler struct {
-	svc driver.VertexAI
+	svc    driver.VertexAI
+	routes map[string]collectionHandler
 }
 
 // New returns a Vertex AI handler backed by svc.
 func New(svc driver.VertexAI) *Handler {
-	return &Handler{svc: svc}
+	h := &Handler{svc: svc}
+	h.routes = map[string]collectionHandler{
+		"models":                   h.serveModels,
+		"endpoints":                h.serveEndpoints,
+		"datasets":                 h.serveDatasets,
+		"customJobs":               h.serveCustomJobs,
+		"batchPredictionJobs":      h.serveBatchPredictionJobs,
+		"hyperparameterTuningJobs": h.serveHyperparameterTuningJobs,
+		"trainingPipelines":        h.serveTrainingPipelines,
+		"pipelineJobs":             h.servePipelineJobs,
+		"tuningJobs":               h.serveTuningJobs,
+		"cachedContents":           h.serveCachedContents,
+		"featurestores":            h.serveFeaturestores,
+		"featureGroups":            h.serveFeatureGroups,
+		"featureOnlineStores":      h.serveFeatureOnlineStores,
+		"indexes":                  h.serveIndexes,
+		"indexEndpoints":           h.serveIndexEndpoints,
+		"metadataStores":           h.serveMetadataStores,
+		"tensorboards":             h.serveTensorboards,
+		"schedules":                h.serveSchedules,
+		"notebookRuntimes":         h.serveNotebookRuntimes,
+		"notebookRuntimeTemplates": h.serveNotebookRuntimeTemplates,
+	}
+
+	return h
 }
 
 // Matches claims the Vertex collection URLs and the publishers generateContent
@@ -165,18 +199,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch p.collection {
-	case "models":
-		h.serveModels(w, r, &p)
-	case "endpoints":
-		h.serveEndpoints(w, r, &p)
-	case "datasets":
-		h.serveDatasets(w, r, &p)
-	case "customJobs":
-		h.serveCustomJobs(w, r, &p)
-	case "batchPredictionJobs":
-		h.serveBatchPredictionJobs(w, r, &p)
-	default:
+	serve, ok := h.routes[p.collection]
+	if !ok {
 		writeError(w, http.StatusNotFound, "notFound", "unsupported collection: "+p.collection)
+
+		return
 	}
+
+	serve(w, r, &p)
 }

--- a/server/gcp/vertexai/jobs.go
+++ b/server/gcp/vertexai/jobs.go
@@ -1,0 +1,216 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Custom jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveCustomJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listCustomJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createCustomJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelCustomJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getCustomJob(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteCustomJob(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func customJobJSON(j *driver.CustomJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "state": j.State,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createCustomJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateCustomJob(r.Context(), driver.CustomJobConfig{Location: location, DisplayName: req.DisplayName})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, customJobJSON(job))
+}
+
+func (h *Handler) getCustomJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetCustomJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, customJobJSON(job))
+}
+
+func (h *Handler) listCustomJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListCustomJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, customJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"customJobs": out})
+}
+
+func (h *Handler) deleteCustomJob(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteCustomJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Batch prediction jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveBatchPredictionJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listBatchPredictionJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createBatchPredictionJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelBatchPredictionJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getBatchPredictionJob(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteBatchPredictionJob(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func batchJobJSON(j *driver.BatchPredictionJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "model": j.Model, "state": j.State,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createBatchPredictionJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Model       string `json:"model"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateBatchPredictionJob(r.Context(), driver.BatchPredictionJobConfig{
+		Location: location, DisplayName: req.DisplayName, Model: req.Model,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, batchJobJSON(job))
+}
+
+func (h *Handler) getBatchPredictionJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetBatchPredictionJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, batchJobJSON(job))
+}
+
+func (h *Handler) listBatchPredictionJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListBatchPredictionJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, batchJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"batchPredictionJobs": out})
+}
+
+func (h *Handler) deleteBatchPredictionJob(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteBatchPredictionJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/metadata.go
+++ b/server/gcp/vertexai/metadata.go
@@ -42,14 +42,14 @@ func (h *Handler) createMetadataStore(w http.ResponseWriter, r *http.Request, lo
 		return
 	}
 
-	op, _, err := h.svc.CreateMetadataStore(r.Context(), location, r.URL.Query().Get("metadataStoreId"))
+	op, s, err := h.svc.CreateMetadataStore(r.Context(), location, r.URL.Query().Get("metadataStoreId"))
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, metadataStoreJSON(s), "MetadataStore")
 }
 
 func (h *Handler) getMetadataStore(w http.ResponseWriter, r *http.Request, name string) {
@@ -130,14 +130,14 @@ func (h *Handler) createTensorboard(w http.ResponseWriter, r *http.Request, loca
 		return
 	}
 
-	op, _, err := h.svc.CreateTensorboard(r.Context(), location, req.DisplayName)
+	op, tb, err := h.svc.CreateTensorboard(r.Context(), location, req.DisplayName)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, tensorboardJSON(tb), "Tensorboard")
 }
 
 func (h *Handler) getTensorboard(w http.ResponseWriter, r *http.Request, name string) {
@@ -344,14 +344,14 @@ func (h *Handler) createNotebookRuntimeTemplate(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	op, _, err := h.svc.CreateNotebookRuntimeTemplate(r.Context(), location, req.DisplayName, req.MachineSpec.MachineType)
+	op, t, err := h.svc.CreateNotebookRuntimeTemplate(r.Context(), location, req.DisplayName, req.MachineSpec.MachineType)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nbTemplateJSON(t), "NotebookRuntimeTemplate")
 }
 
 func (h *Handler) getNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, name string) {
@@ -468,14 +468,14 @@ func (h *Handler) assignNotebookRuntime(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	op, _, err := h.svc.AssignNotebookRuntime(r.Context(), location, req.NotebookRuntime.DisplayName)
+	op, nr, err := h.svc.AssignNotebookRuntime(r.Context(), location, req.NotebookRuntime.DisplayName)
 	if err != nil {
 		writeCErr(w, err)
 
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nbRuntimeJSON(nr), "NotebookRuntime")
 }
 
 func (h *Handler) getNotebookRuntime(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/metadata.go
+++ b/server/gcp/vertexai/metadata.go
@@ -1,0 +1,517 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Metadata stores ---
+
+func metadataStoreJSON(s *driver.MetadataStore) map[string]any {
+	return map[string]any{"name": s.Name, "createTime": s.CreateTime}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveMetadataStores(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listMetadataStores(w, r, p.location)
+		case http.MethodPost:
+			h.createMetadataStore(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getMetadataStore(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteMetadataStore(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createMetadataStore(w http.ResponseWriter, r *http.Request, location string) {
+	if !decode(w, r, &struct{}{}) {
+		return
+	}
+
+	op, _, err := h.svc.CreateMetadataStore(r.Context(), location, r.URL.Query().Get("metadataStoreId"))
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getMetadataStore(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.svc.GetMetadataStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, metadataStoreJSON(s))
+}
+
+func (h *Handler) listMetadataStores(w http.ResponseWriter, r *http.Request, location string) {
+	ss, err := h.svc.ListMetadataStores(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ss))
+	for i := range ss {
+		out = append(out, metadataStoreJSON(&ss[i]))
+	}
+
+	writeJSON(w, map[string]any{"metadataStores": out})
+}
+
+func (h *Handler) deleteMetadataStore(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteMetadataStore(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Tensorboards ---
+
+func tensorboardJSON(t *driver.Tensorboard) map[string]any {
+	return map[string]any{"name": t.Name, "displayName": t.DisplayName, "createTime": t.CreateTime}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveTensorboards(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTensorboards(w, r, p.location)
+		case http.MethodPost:
+			h.createTensorboard(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTensorboard(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteTensorboard(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createTensorboard(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateTensorboard(r.Context(), location, req.DisplayName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getTensorboard(w http.ResponseWriter, r *http.Request, name string) {
+	t, err := h.svc.GetTensorboard(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, tensorboardJSON(t))
+}
+
+func (h *Handler) listTensorboards(w http.ResponseWriter, r *http.Request, location string) {
+	ts, err := h.svc.ListTensorboards(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ts))
+	for i := range ts {
+		out = append(out, tensorboardJSON(&ts[i]))
+	}
+
+	writeJSON(w, map[string]any{"tensorboards": out})
+}
+
+func (h *Handler) deleteTensorboard(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteTensorboard(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Schedules ---
+
+func scheduleJSON(s *driver.Schedule) map[string]any {
+	return map[string]any{
+		"name": s.Name, "displayName": s.DisplayName, "cron": s.Cron,
+		"state": s.State, "createTime": s.CreateTime,
+	}
+}
+
+func (h *Handler) serveSchedules(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listSchedules(w, r, p.location)
+		case http.MethodPost:
+			h.createSchedule(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.scheduleAction(w, r, p.name, p.action)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getSchedule(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteSchedule(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) scheduleAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	var err error
+
+	switch action {
+	case "pause":
+		err = h.svc.PauseSchedule(r.Context(), name)
+	case "resume":
+		err = h.svc.ResumeSchedule(r.Context(), name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown schedule action: "+action)
+
+		return
+	}
+
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+func (h *Handler) createSchedule(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Cron        string `json:"cron"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	s, err := h.svc.CreateSchedule(r.Context(), location, req.DisplayName, req.Cron)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, scheduleJSON(s))
+}
+
+func (h *Handler) getSchedule(w http.ResponseWriter, r *http.Request, name string) {
+	s, err := h.svc.GetSchedule(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, scheduleJSON(s))
+}
+
+func (h *Handler) listSchedules(w http.ResponseWriter, r *http.Request, location string) {
+	ss, err := h.svc.ListSchedules(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ss))
+	for i := range ss {
+		out = append(out, scheduleJSON(&ss[i]))
+	}
+
+	writeJSON(w, map[string]any{"schedules": out})
+}
+
+func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteSchedule(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Notebook runtime templates ---
+
+func nbTemplateJSON(t *driver.NotebookRuntimeTemplate) map[string]any {
+	return map[string]any{
+		"name": t.Name, "displayName": t.DisplayName,
+		"machineSpec": map[string]any{"machineType": t.MachineType}, "createTime": t.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveNotebookRuntimeTemplates(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listNotebookRuntimeTemplates(w, r, p.location)
+		case http.MethodPost:
+			h.createNotebookRuntimeTemplate(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNotebookRuntimeTemplate(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteNotebookRuntimeTemplate(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) createNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		MachineSpec struct {
+			MachineType string `json:"machineType"`
+		} `json:"machineSpec"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateNotebookRuntimeTemplate(r.Context(), location, req.DisplayName, req.MachineSpec.MachineType)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, name string) {
+	t, err := h.svc.GetNotebookRuntimeTemplate(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nbTemplateJSON(t))
+}
+
+func (h *Handler) listNotebookRuntimeTemplates(w http.ResponseWriter, r *http.Request, location string) {
+	ts, err := h.svc.ListNotebookRuntimeTemplates(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ts))
+	for i := range ts {
+		out = append(out, nbTemplateJSON(&ts[i]))
+	}
+
+	writeJSON(w, map[string]any{"notebookRuntimeTemplates": out})
+}
+
+func (h *Handler) deleteNotebookRuntimeTemplate(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteNotebookRuntimeTemplate(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Notebook runtimes ---
+
+func nbRuntimeJSON(n *driver.NotebookRuntime) map[string]any {
+	return map[string]any{
+		"name": n.Name, "displayName": n.DisplayName,
+		"runtimeState": n.RuntimeState, "createTime": n.CreateTime,
+	}
+}
+
+func (h *Handler) serveNotebookRuntimes(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch {
+		case r.Method == http.MethodGet:
+			h.listNotebookRuntimes(w, r, p.location)
+		case r.Method == http.MethodPost && p.action == "assign":
+			h.assignNotebookRuntime(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.notebookRuntimeAction(w, r, p.name, p.action)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getNotebookRuntime(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteNotebookRuntime(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) notebookRuntimeAction(w http.ResponseWriter, r *http.Request, name, action string) {
+	var (
+		op  *driver.Operation
+		err error
+	)
+
+	switch action {
+	case "start":
+		op, err = h.svc.StartNotebookRuntime(r.Context(), name)
+	case "stop":
+		op, err = h.svc.StopNotebookRuntime(r.Context(), name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown notebookRuntime action: "+action)
+
+		return
+	}
+
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) assignNotebookRuntime(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		NotebookRuntime struct {
+			DisplayName string `json:"displayName"`
+		} `json:"notebookRuntime"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.AssignNotebookRuntime(r.Context(), location, req.NotebookRuntime.DisplayName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getNotebookRuntime(w http.ResponseWriter, r *http.Request, name string) {
+	n, err := h.svc.GetNotebookRuntime(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, nbRuntimeJSON(n))
+}
+
+func (h *Handler) listNotebookRuntimes(w http.ResponseWriter, r *http.Request, location string) {
+	ns, err := h.svc.ListNotebookRuntimes(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ns))
+	for i := range ns {
+		out = append(out, nbRuntimeJSON(&ns[i]))
+	}
+
+	writeJSON(w, map[string]any{"notebookRuntimes": out})
+}
+
+func (h *Handler) deleteNotebookRuntime(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteNotebookRuntime(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/models.go
+++ b/server/gcp/vertexai/models.go
@@ -35,6 +35,18 @@ func (h *Handler) serveModels(w http.ResponseWriter, r *http.Request, p *vPath) 
 		return
 	}
 
+	if p.subRes == "evaluations" {
+		h.serveModelEvaluations(w, r, p)
+
+		return
+	}
+
+	if r.Method == http.MethodGet && p.action == "listVersions" {
+		h.listModelVersions(w, r, p.name)
+
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		h.getModel(w, r, p.name)
@@ -43,6 +55,97 @@ func (h *Handler) serveModels(w http.ResponseWriter, r *http.Request, p *vPath) 
 	default:
 		methodNotAllowed(w)
 	}
+}
+
+func evaluationJSON(e *driver.ModelEvaluation) map[string]any {
+	return map[string]any{
+		"name": e.Name, "displayName": e.DisplayName,
+		"metricsSchemaUri": e.MetricsType, "createTime": e.CreateTime,
+	}
+}
+
+func (h *Handler) serveModelEvaluations(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.subName == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listModelEvaluations(w, r, p.name)
+		case http.MethodPost:
+			h.importModelEvaluation(w, r, p.name)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w)
+
+		return
+	}
+
+	ev, err := h.svc.GetModelEvaluation(r.Context(), p.name+"/evaluations/"+p.subName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, evaluationJSON(ev))
+}
+
+func (h *Handler) importModelEvaluation(w http.ResponseWriter, r *http.Request, modelName string) {
+	var req struct {
+		DisplayName      string `json:"displayName"`
+		MetricsSchemaURI string `json:"metricsSchemaUri"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	ev, err := h.svc.ImportModelEvaluation(r.Context(), modelName, driver.ModelEvaluation{
+		DisplayName: req.DisplayName, MetricsType: req.MetricsSchemaURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, evaluationJSON(ev))
+}
+
+func (h *Handler) listModelEvaluations(w http.ResponseWriter, r *http.Request, modelName string) {
+	evs, err := h.svc.ListModelEvaluations(r.Context(), modelName)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(evs))
+	for i := range evs {
+		out = append(out, evaluationJSON(&evs[i]))
+	}
+
+	writeJSON(w, map[string]any{"modelEvaluations": out})
+}
+
+func (h *Handler) listModelVersions(w http.ResponseWriter, r *http.Request, name string) {
+	models, err := h.svc.ListModelVersions(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(models))
+	for i := range models {
+		out = append(out, modelJSON(&models[i]))
+	}
+
+	writeJSON(w, map[string]any{"models": out})
 }
 
 func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location string) {

--- a/server/gcp/vertexai/models.go
+++ b/server/gcp/vertexai/models.go
@@ -165,7 +165,7 @@ func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	op, _, err := h.svc.UploadModel(r.Context(), driver.ModelConfig{
+	op, mdl, err := h.svc.UploadModel(r.Context(), driver.ModelConfig{
 		Location:       location,
 		DisplayName:    req.Model.DisplayName,
 		Description:    req.Model.Description,
@@ -179,7 +179,7 @@ func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, modelJSON(mdl), "Model")
 }
 
 func (h *Handler) getModel(w http.ResponseWriter, r *http.Request, name string) {

--- a/server/gcp/vertexai/models.go
+++ b/server/gcp/vertexai/models.go
@@ -1,0 +1,118 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func modelJSON(m *driver.Model) map[string]any {
+	return map[string]any{
+		"name":           m.Name,
+		"displayName":    m.DisplayName,
+		"description":    m.Description,
+		"versionId":      m.VersionID,
+		"versionAliases": m.VersionAliases,
+		"artifactUri":    m.ArtifactURI,
+		"containerSpec":  map[string]any{"imageUri": m.ContainerImage},
+		"labels":         m.Labels,
+		"createTime":     m.CreateTime,
+		"updateTime":     m.UpdateTime,
+	}
+}
+
+func (h *Handler) serveModels(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch {
+		case r.Method == http.MethodGet:
+			h.listModels(w, r, p.location)
+		case r.Method == http.MethodPost && p.action == "upload":
+			h.uploadModel(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getModel(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteModel(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) uploadModel(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		Model struct {
+			DisplayName   string `json:"displayName"`
+			Description   string `json:"description"`
+			ArtifactURI   string `json:"artifactUri"`
+			ContainerSpec struct {
+				ImageURI string `json:"imageUri"`
+			} `json:"containerSpec"`
+			Labels map[string]string `json:"labels"`
+		} `json:"model"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.UploadModel(r.Context(), driver.ModelConfig{
+		Location:       location,
+		DisplayName:    req.Model.DisplayName,
+		Description:    req.Model.Description,
+		ContainerImage: req.Model.ContainerSpec.ImageURI,
+		ArtifactURI:    req.Model.ArtifactURI,
+		Labels:         req.Model.Labels,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getModel(w http.ResponseWriter, r *http.Request, name string) {
+	model, err := h.svc.GetModel(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, modelJSON(model))
+}
+
+func (h *Handler) listModels(w http.ResponseWriter, r *http.Request, location string) {
+	models, err := h.svc.ListModels(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(models))
+	for i := range models {
+		out = append(out, modelJSON(&models[i]))
+	}
+
+	writeJSON(w, map[string]any{"models": out})
+}
+
+func (h *Handler) deleteModel(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteModel(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/pipelines.go
+++ b/server/gcp/vertexai/pipelines.go
@@ -1,0 +1,219 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Training pipelines ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveTrainingPipelines(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTrainingPipelines(w, r, p.location)
+		case http.MethodPost:
+			h.createTrainingPipeline(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelTrainingPipeline(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTrainingPipeline(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteTrainingPipeline(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func trainingPipelineJSON(t *driver.TrainingPipeline) map[string]any {
+	return map[string]any{
+		"name": t.Name, "displayName": t.DisplayName, "state": t.State,
+		"createTime": t.CreateTime, "endTime": t.EndTime,
+	}
+}
+
+func (h *Handler) createTrainingPipeline(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		TaskType    string `json:"taskType"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	tp, err := h.svc.CreateTrainingPipeline(r.Context(), driver.TrainingPipelineConfig{
+		Location: location, DisplayName: req.DisplayName, TaskType: req.TaskType,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, trainingPipelineJSON(tp))
+}
+
+func (h *Handler) getTrainingPipeline(w http.ResponseWriter, r *http.Request, name string) {
+	tp, err := h.svc.GetTrainingPipeline(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, trainingPipelineJSON(tp))
+}
+
+func (h *Handler) listTrainingPipelines(w http.ResponseWriter, r *http.Request, location string) {
+	tps, err := h.svc.ListTrainingPipelines(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(tps))
+	for i := range tps {
+		out = append(out, trainingPipelineJSON(&tps[i]))
+	}
+
+	writeJSON(w, map[string]any{"trainingPipelines": out})
+}
+
+func (h *Handler) deleteTrainingPipeline(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteTrainingPipeline(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+// --- Pipeline jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) servePipelineJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listPipelineJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createPipelineJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelPipelineJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getPipelineJob(w, r, p.name)
+	case http.MethodDelete:
+		h.deletePipelineJob(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func pipelineJobJSON(j *driver.PipelineJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "state": j.State,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createPipelineJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		TemplateURI string `json:"templateUri"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	pj, err := h.svc.CreatePipelineJob(r.Context(), driver.PipelineJobConfig{
+		Location: location, DisplayName: req.DisplayName, TemplateURI: req.TemplateURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, pipelineJobJSON(pj))
+}
+
+func (h *Handler) getPipelineJob(w http.ResponseWriter, r *http.Request, name string) {
+	pj, err := h.svc.GetPipelineJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, pipelineJobJSON(pj))
+}
+
+func (h *Handler) listPipelineJobs(w http.ResponseWriter, r *http.Request, location string) {
+	pjs, err := h.svc.ListPipelineJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(pjs))
+	for i := range pjs {
+		out = append(out, pipelineJobJSON(&pjs[i]))
+	}
+
+	writeJSON(w, map[string]any{"pipelineJobs": out})
+}
+
+func (h *Handler) deletePipelineJob(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeletePipelineJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}

--- a/server/gcp/vertexai/responses.go
+++ b/server/gcp/vertexai/responses.go
@@ -1,0 +1,47 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func writeJSON(w http.ResponseWriter, v any) {
+	gcprest.WriteJSON(w, http.StatusOK, v)
+}
+
+func writeError(w http.ResponseWriter, status int, reason, msg string) {
+	gcprest.WriteError(w, status, reason, msg)
+}
+
+func writeCErr(w http.ResponseWriter, err error) {
+	gcprest.WriteCErr(w, err)
+}
+
+func decode(w http.ResponseWriter, r *http.Request, v any) bool {
+	return gcprest.DecodeJSON(w, r, v)
+}
+
+// writeOp writes a long-running Operation as the GCP JSON envelope.
+func writeOp(w http.ResponseWriter, op *driver.Operation) {
+	body := map[string]any{"name": op.Name, "done": op.Done}
+	if op.Metadata != nil {
+		body["metadata"] = op.Metadata
+	}
+
+	if op.Response != nil {
+		body["response"] = op.Response
+	}
+
+	if op.Error != nil {
+		body["error"] = map[string]any{"code": op.Error.Code, "message": op.Error.Message}
+	}
+
+	writeJSON(w, body)
+}
+
+// methodNotAllowed writes a 405 in GCP error shape.
+func methodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+}

--- a/server/gcp/vertexai/responses.go
+++ b/server/gcp/vertexai/responses.go
@@ -41,6 +41,35 @@ func writeOp(w http.ResponseWriter, op *driver.Operation) {
 	writeJSON(w, body)
 }
 
+// typeURLPrefix is the google.protobuf.Any type-URL prefix for aiplatform v1
+// messages. SDK pollers read the typed result out of a done operation's
+// response, keyed by @type, so done LROs must carry it.
+const typeURLPrefix = "type.googleapis.com/google.cloud.aiplatform.v1."
+
+// writeResourceOp writes a done LRO whose response carries the created/affected
+// resource (plus its @type) so SDK callers can unmarshal the typed result off
+// the operation. A nil resource yields a response with only the @type (e.g.
+// UndeployModelResponse). respType is the bare message name, e.g. "Model".
+func writeResourceOp(w http.ResponseWriter, op *driver.Operation, resource map[string]any, respType string) {
+	body := map[string]any{"name": op.Name, "done": op.Done}
+	if op.Metadata != nil {
+		body["metadata"] = op.Metadata
+	}
+
+	resp := map[string]any{"@type": typeURLPrefix + respType}
+	for k, v := range resource {
+		resp[k] = v
+	}
+
+	body["response"] = resp
+
+	if op.Error != nil {
+		body["error"] = map[string]any{"code": op.Error.Code, "message": op.Error.Message}
+	}
+
+	writeJSON(w, body)
+}
+
 // methodNotAllowed writes a 405 in GCP error shape.
 func methodNotAllowed(w http.ResponseWriter) {
 	writeError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -1,0 +1,158 @@
+package vertexai_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const base = "/v1/projects/mock-project/locations/us-central1"
+
+func newServer(t *testing.T) string {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{
+		VertexAI: cloud.VertexAI,
+		// Firestore included to exercise routing precedence: Vertex must claim
+		// its collections before Firestore's permissive /v1/projects/ prefix.
+		Firestore: cloud.Firestore,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts.URL
+}
+
+func do(t *testing.T, method, url string, body any) map[string]any {
+	t.Helper()
+
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		require.NoError(t, err)
+		rdr = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequest(method, url, rdr)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "method=%s url=%s body=%s", method, url, raw)
+
+	out := map[string]any{}
+	if len(bytes.TrimSpace(raw)) > 0 {
+		require.NoError(t, json.Unmarshal(raw, &out), "body=%s", raw)
+	}
+
+	return out
+}
+
+func TestModelUploadAndGet(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/models:upload", map[string]any{
+		"model": map[string]any{"displayName": "m1", "containerSpec": map[string]any{"imageUri": "img:latest"}},
+	})
+	assert.Equal(t, true, op["done"])
+	name, _ := op["response"].(map[string]any)["name"].(string)
+	require.NotEmpty(t, name)
+
+	got := do(t, http.MethodGet, url+"/v1/"+name, nil)
+	assert.Equal(t, "m1", got["displayName"])
+
+	list := do(t, http.MethodGet, url+base+"/models", nil)
+	assert.Len(t, list["models"], 1)
+}
+
+func TestEndpointDeployPredict(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/endpoints", map[string]any{"displayName": "ep"})
+	assert.Equal(t, true, op["done"])
+	epName := op["response"].(map[string]any)["name"].(string)
+	require.NotEmpty(t, epName)
+
+	do(t, http.MethodPost, url+"/v1/"+epName+":deployModel", map[string]any{
+		"deployedModel": map[string]any{"model": base + "/models/m", "displayName": "v1"},
+	})
+
+	got := do(t, http.MethodGet, url+"/v1/"+epName, nil)
+	assert.Len(t, got["deployedModels"], 1)
+
+	pred := do(t, http.MethodPost, url+"/v1/"+epName+":predict", map[string]any{
+		"instances": []any{map[string]any{"x": 1}},
+	})
+	assert.Len(t, pred["predictions"], 1)
+	assert.NotEmpty(t, pred["deployedModelId"])
+}
+
+func TestPublishersGenerateContent(t *testing.T) {
+	url := newServer(t)
+
+	resp := do(t, http.MethodPost, url+"/v1/publishers/google/models/gemini-2.5-pro:generateContent", map[string]any{
+		"contents": []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "hello there world"}}}},
+	})
+
+	cands, ok := resp["candidates"].([]any)
+	require.True(t, ok)
+	require.Len(t, cands, 1)
+	usage := resp["usageMetadata"].(map[string]any)
+	assert.EqualValues(t, 3, usage["promptTokenCount"])
+
+	ct := do(t, http.MethodPost, url+"/v1/publishers/google/models/gemini-2.5-pro:countTokens", map[string]any{
+		"contents": []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "one two"}}}},
+	})
+	assert.EqualValues(t, 2, ct["totalTokens"])
+}
+
+func TestCustomJobSynchronous(t *testing.T) {
+	url := newServer(t)
+
+	job := do(t, http.MethodPost, url+base+"/customJobs", map[string]any{"displayName": "train"})
+	assert.Equal(t, "JOB_STATE_SUCCEEDED", job["state"])
+	name := job["name"].(string)
+
+	got := do(t, http.MethodGet, url+"/v1/"+name, nil)
+	assert.Equal(t, "JOB_STATE_SUCCEEDED", got["state"])
+
+	do(t, http.MethodPost, url+"/v1/"+name+":cancel", map[string]any{})
+}
+
+func TestDatasetCreate(t *testing.T) {
+	url := newServer(t)
+
+	op := do(t, http.MethodPost, url+base+"/datasets", map[string]any{"displayName": "ds"})
+	assert.Equal(t, true, op["done"])
+
+	list := do(t, http.MethodGet, url+base+"/datasets", nil)
+	assert.Len(t, list["datasets"], 1)
+}
+
+func TestNotFoundMapsTo404(t *testing.T) {
+	url := newServer(t)
+
+	req, _ := http.NewRequest(http.MethodGet, url+base+"/models/ghost", nil)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.True(t, strings.Contains(string(body), "notFound"))
+}

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -144,6 +144,158 @@ func TestDatasetCreate(t *testing.T) {
 	assert.Len(t, list["datasets"], 1)
 }
 
+func opName(t *testing.T, op map[string]any) string {
+	t.Helper()
+
+	assert.Equal(t, true, op["done"])
+	resp, ok := op["response"].(map[string]any)
+	require.True(t, ok, "operation missing response: %v", op)
+	name, _ := resp["name"].(string)
+	require.NotEmpty(t, name)
+
+	return name
+}
+
+func TestTrainingPipelineAndPipelineJob(t *testing.T) {
+	url := newServer(t)
+
+	tp := do(t, http.MethodPost, url+base+"/trainingPipelines", map[string]any{"displayName": "tp"})
+	assert.Equal(t, "PIPELINE_STATE_SUCCEEDED", tp["state"])
+	do(t, http.MethodGet, url+"/v1/"+tp["name"].(string), nil)
+	assert.Len(t, do(t, http.MethodGet, url+base+"/trainingPipelines", nil)["trainingPipelines"], 1)
+	do(t, http.MethodPost, url+"/v1/"+tp["name"].(string)+":cancel", map[string]any{})
+
+	pj := do(t, http.MethodPost, url+base+"/pipelineJobs", map[string]any{"displayName": "pj"})
+	assert.Equal(t, "PIPELINE_STATE_SUCCEEDED", pj["state"])
+	assert.Len(t, do(t, http.MethodGet, url+base+"/pipelineJobs", nil)["pipelineJobs"], 1)
+}
+
+func TestTuningAndHyperparameterJobs(t *testing.T) {
+	url := newServer(t)
+
+	tj := do(t, http.MethodPost, url+base+"/tuningJobs", map[string]any{"baseModel": "gemini-2.5-pro"})
+	require.NotEmpty(t, tj["name"])
+	assert.Len(t, do(t, http.MethodGet, url+base+"/tuningJobs", nil)["tuningJobs"], 1)
+
+	hpo := do(t, http.MethodPost, url+base+"/hyperparameterTuningJobs", map[string]any{
+		"displayName": "hpo", "maxTrialCount": 4,
+	})
+	require.NotEmpty(t, hpo["name"])
+	assert.EqualValues(t, 4, hpo["maxTrialCount"])
+	do(t, http.MethodPost, url+"/v1/"+hpo["name"].(string)+":cancel", map[string]any{})
+}
+
+func TestCachedContents(t *testing.T) {
+	url := newServer(t)
+
+	cc := do(t, http.MethodPost, url+base+"/cachedContents", map[string]any{
+		"model": "gemini-2.5-pro", "displayName": "ctx",
+	})
+	require.NotEmpty(t, cc["name"])
+	assert.Len(t, do(t, http.MethodGet, url+base+"/cachedContents", nil)["cachedContents"], 1)
+	do(t, http.MethodDelete, url+"/v1/"+cc["name"].(string), nil)
+}
+
+func TestFeaturestoreAndEntityTypes(t *testing.T) {
+	url := newServer(t)
+
+	fsName := opName(t, do(t, http.MethodPost, url+base+"/featurestores?featurestoreId=fs1", map[string]any{}))
+	etName := opName(t, do(t, http.MethodPost, url+"/v1/"+fsName+"/entityTypes?entityTypeId=user", map[string]any{
+		"entityType": map[string]any{"description": "users"},
+	}))
+
+	do(t, http.MethodPost, url+"/v1/"+etName+":writeFeatureValues", map[string]any{
+		"payloads": []any{map[string]any{"entityId": "u1", "featureValues": map[string]any{"age": "30"}}},
+	})
+	read := do(t, http.MethodPost, url+"/v1/"+etName+":readFeatureValues", map[string]any{"entityId": "u1"})
+	require.NotNil(t, read["entityView"])
+
+	assert.Len(t, do(t, http.MethodGet, url+"/v1/"+fsName+"/entityTypes", nil)["entityTypes"], 1)
+}
+
+func TestFeatureRegistryAndOnlineStore(t *testing.T) {
+	url := newServer(t)
+
+	fgName := opName(t, do(t, http.MethodPost, url+base+"/featureGroups?featureGroupId=fg1", map[string]any{
+		"bigQuery": map[string]any{"bigQuerySource": map[string]any{"inputUri": "bq://t"}},
+	}))
+	opName(t, do(t, http.MethodPost, url+"/v1/"+fgName+"/features?featureId=f1", map[string]any{"description": "feat"}))
+	assert.Len(t, do(t, http.MethodGet, url+"/v1/"+fgName+"/features", nil)["features"], 1)
+
+	osName := opName(t, do(t, http.MethodPost, url+base+"/featureOnlineStores?featureOnlineStoreId=os1", map[string]any{}))
+	fvName := opName(t, do(t, http.MethodPost, url+"/v1/"+osName+"/featureViews?featureViewId=fv1", map[string]any{
+		"bigQuerySource": map[string]any{"uri": "bq://t"},
+	}))
+	do(t, http.MethodPost, url+"/v1/"+fvName+":fetchFeatureValues", map[string]any{
+		"dataKey": map[string]any{"key": "u1"},
+	})
+}
+
+func TestIndexesAndVectorSearch(t *testing.T) {
+	url := newServer(t)
+
+	idxName := opName(t, do(t, http.MethodPost, url+base+"/indexes", map[string]any{
+		"displayName": "idx", "metadata": map[string]any{"config": map[string]any{"dimensions": 8}},
+	}))
+	do(t, http.MethodPost, url+"/v1/"+idxName+":upsertDatapoints", map[string]any{
+		"datapoints": []any{map[string]any{"datapointId": "d1", "featureVector": []any{0.1, 0.2}}},
+	})
+	got := do(t, http.MethodGet, url+"/v1/"+idxName, nil)
+	assert.EqualValues(t, 1, got["indexStats"].(map[string]any)["vectorsCount"])
+
+	ieName := opName(t, do(t, http.MethodPost, url+base+"/indexEndpoints", map[string]any{"displayName": "ie"}))
+	do(t, http.MethodPost, url+"/v1/"+ieName+":deployIndex", map[string]any{
+		"deployedIndex": map[string]any{"id": "di1", "index": idxName},
+	})
+	nn := do(t, http.MethodPost, url+"/v1/"+ieName+":findNeighbors", map[string]any{
+		"deployedIndexId": "di1",
+		"queries":         []any{map[string]any{"datapoint": map[string]any{"featureVector": []any{0.1}}, "neighborCount": 3}},
+	})
+	require.NotNil(t, nn["nearestNeighbors"])
+}
+
+func TestMetadataTensorboardScheduleNotebook(t *testing.T) {
+	url := newServer(t)
+
+	opName(t, do(t, http.MethodPost, url+base+"/metadataStores?metadataStoreId=ms1", map[string]any{}))
+	assert.Len(t, do(t, http.MethodGet, url+base+"/metadataStores", nil)["metadataStores"], 1)
+
+	opName(t, do(t, http.MethodPost, url+base+"/tensorboards", map[string]any{"displayName": "tb"}))
+
+	sched := do(t, http.MethodPost, url+base+"/schedules", map[string]any{"displayName": "sc", "cron": "0 * * * *"})
+	assert.Equal(t, "ACTIVE", sched["state"])
+	do(t, http.MethodPost, url+"/v1/"+sched["name"].(string)+":pause", map[string]any{})
+	assert.Equal(t, "PAUSED", do(t, http.MethodGet, url+"/v1/"+sched["name"].(string), nil)["state"])
+	do(t, http.MethodPost, url+"/v1/"+sched["name"].(string)+":resume", map[string]any{})
+
+	opName(t, do(t, http.MethodPost, url+base+"/notebookRuntimeTemplates", map[string]any{
+		"displayName": "nt", "machineSpec": map[string]any{"machineType": "n1-standard-4"},
+	}))
+	nr := opName(t, do(t, http.MethodPost, url+base+"/notebookRuntimes:assign", map[string]any{
+		"notebookRuntime": map[string]any{"displayName": "nr"},
+	}))
+	do(t, http.MethodPost, url+"/v1/"+nr+":stop", map[string]any{})
+	assert.Equal(t, "STOPPED", do(t, http.MethodGet, url+"/v1/"+nr, nil)["runtimeState"])
+	do(t, http.MethodPost, url+"/v1/"+nr+":start", map[string]any{})
+}
+
+func TestModelVersionsAndEvaluations(t *testing.T) {
+	url := newServer(t)
+
+	mName := opName(t, do(t, http.MethodPost, url+base+"/models:upload", map[string]any{
+		"model": map[string]any{"displayName": "m1"},
+	}))
+
+	versions := do(t, http.MethodGet, url+"/v1/"+mName+":listVersions", nil)
+	assert.Len(t, versions["models"], 1)
+
+	ev := do(t, http.MethodPost, url+"/v1/"+mName+"/evaluations", map[string]any{
+		"displayName": "eval1", "metricsSchemaUri": "schema://x",
+	})
+	require.NotEmpty(t, ev["name"])
+	assert.Len(t, do(t, http.MethodGet, url+"/v1/"+mName+"/evaluations", nil)["modelEvaluations"], 1)
+}
+
 func TestNotFoundMapsTo404(t *testing.T) {
 	url := newServer(t)
 

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -73,6 +73,13 @@ func TestModelUploadAndGet(t *testing.T) {
 	name, _ := op["response"].(map[string]any)["name"].(string)
 	require.NotEmpty(t, name)
 
+	// The done LRO response must carry the typed Model (with @type and
+	// versionId), not just {name}, so SDK pollers can read the result.
+	resp := op["response"].(map[string]any)
+	assert.Contains(t, resp["@type"], "google.cloud.aiplatform.v1.Model")
+	assert.Equal(t, "1", resp["versionId"])
+	assert.Equal(t, "m1", resp["displayName"])
+
 	got := do(t, http.MethodGet, url+"/v1/"+name, nil)
 	assert.Equal(t, "m1", got["displayName"])
 

--- a/server/gcp/vertexai/sdk_roundtrip_test.go
+++ b/server/gcp/vertexai/sdk_roundtrip_test.go
@@ -128,6 +128,33 @@ func TestPublishersGenerateContent(t *testing.T) {
 	assert.EqualValues(t, 2, ct["totalTokens"])
 }
 
+// TestStreamGenerateContentReturnsArray verifies :streamGenerateContent emits a
+// JSON array of chunks (not a lone object), which SDK stream decoders require.
+func TestStreamGenerateContentReturnsArray(t *testing.T) {
+	url := newServer(t)
+
+	body, _ := json.Marshal(map[string]any{
+		"contents": []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "hello there world"}}}},
+	})
+
+	req, err := http.NewRequest(http.MethodPost,
+		url+"/v1/publishers/google/models/gemini-2.5-pro:streamGenerateContent", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var chunks []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &chunks), "stream response must be a JSON array, got %s", raw)
+	require.GreaterOrEqual(t, len(chunks), 1)
+	assert.Contains(t, chunks[0], "candidates")
+}
+
 func TestCustomJobSynchronous(t *testing.T) {
 	url := newServer(t)
 

--- a/server/gcp/vertexai/tuning.go
+++ b/server/gcp/vertexai/tuning.go
@@ -1,0 +1,203 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Hyperparameter tuning jobs ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveHyperparameterTuningJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listHyperparameterTuningJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createHyperparameterTuningJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelHyperparameterTuningJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		h.getHyperparameterTuningJob(w, r, p.name)
+
+		return
+	}
+
+	methodNotAllowed(w)
+}
+
+func hpoJobJSON(j *driver.HyperparameterTuningJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "displayName": j.DisplayName, "state": j.State,
+		"maxTrialCount": j.MaxTrialCount, "createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+func (h *Handler) createHyperparameterTuningJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName   string `json:"displayName"`
+		MaxTrialCount int    `json:"maxTrialCount"`
+		ParallelTrial int    `json:"parallelTrialCount"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateHyperparameterTuningJob(r.Context(), driver.HyperparameterTuningJobConfig{
+		Location: location, DisplayName: req.DisplayName,
+		MaxTrialCount: req.MaxTrialCount, ParallelTrials: req.ParallelTrial,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, hpoJobJSON(job))
+}
+
+func (h *Handler) getHyperparameterTuningJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetHyperparameterTuningJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, hpoJobJSON(job))
+}
+
+func (h *Handler) listHyperparameterTuningJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListHyperparameterTuningJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, hpoJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"hyperparameterTuningJobs": out})
+}
+
+// --- Tuning jobs (model tuning) ---
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveTuningJobs(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTuningJobs(w, r, p.location)
+		case http.MethodPost:
+			h.createTuningJob(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action == actionCancel {
+		if err := h.svc.CancelTuningJob(r.Context(), p.name); err != nil {
+			writeCErr(w, err)
+
+			return
+		}
+
+		writeJSON(w, map[string]any{})
+
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		h.getTuningJob(w, r, p.name)
+
+		return
+	}
+
+	methodNotAllowed(w)
+}
+
+func tuningJobJSON(j *driver.TuningJob) map[string]any {
+	return map[string]any{
+		"name": j.Name, "baseModel": j.BaseModel, "state": j.State,
+		"tunedModelDisplayName": j.TunedModelName, "endpoint": j.Endpoint,
+		"createTime": j.CreateTime, "endTime": j.EndTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) createTuningJob(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		BaseModel             string `json:"baseModel"`
+		TunedModelDisplayName string `json:"tunedModelDisplayName"`
+		SupervisedTuningSpec  struct {
+			TrainingDatasetURI string `json:"trainingDatasetUri"`
+		} `json:"supervisedTuningSpec"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	job, err := h.svc.CreateTuningJob(r.Context(), driver.TuningJobConfig{
+		Location: location, BaseModel: req.BaseModel, TunedModelName: req.TunedModelDisplayName,
+		TrainingDataURI: req.SupervisedTuningSpec.TrainingDatasetURI,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, tuningJobJSON(job))
+}
+
+func (h *Handler) getTuningJob(w http.ResponseWriter, r *http.Request, name string) {
+	job, err := h.svc.GetTuningJob(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, tuningJobJSON(job))
+}
+
+func (h *Handler) listTuningJobs(w http.ResponseWriter, r *http.Request, location string) {
+	jobs, err := h.svc.ListTuningJobs(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(jobs))
+	for i := range jobs {
+		out = append(out, tuningJobJSON(&jobs[i]))
+	}
+
+	writeJSON(w, map[string]any{"tuningJobs": out})
+}

--- a/server/gcp/vertexai/vectorsearch.go
+++ b/server/gcp/vertexai/vectorsearch.go
@@ -73,7 +73,7 @@ func (h *Handler) createIndex(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	op, _, err := h.svc.CreateIndex(r.Context(), driver.IndexConfig{
+	op, idx, err := h.svc.CreateIndex(r.Context(), driver.IndexConfig{
 		Location: location, DisplayName: req.DisplayName, Description: req.Description,
 		Dimensions: req.Metadata.Config.Dimensions,
 	})
@@ -83,7 +83,7 @@ func (h *Handler) createIndex(w http.ResponseWriter, r *http.Request, location s
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, indexJSON(idx), "Index")
 }
 
 func (h *Handler) getIndex(w http.ResponseWriter, r *http.Request, name string) {
@@ -236,7 +236,7 @@ func (h *Handler) createIndexEndpoint(w http.ResponseWriter, r *http.Request, lo
 		return
 	}
 
-	op, _, err := h.svc.CreateIndexEndpoint(r.Context(), driver.IndexEndpointConfig{
+	op, ie, err := h.svc.CreateIndexEndpoint(r.Context(), driver.IndexEndpointConfig{
 		Location: location, DisplayName: req.DisplayName, Description: req.Description,
 	})
 	if err != nil {
@@ -245,7 +245,7 @@ func (h *Handler) createIndexEndpoint(w http.ResponseWriter, r *http.Request, lo
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, indexEndpointJSON(ie), "IndexEndpoint")
 }
 
 func (h *Handler) getIndexEndpoint(w http.ResponseWriter, r *http.Request, name string) {
@@ -298,7 +298,7 @@ func (h *Handler) deployIndex(w http.ResponseWriter, r *http.Request, indexEndpo
 		return
 	}
 
-	op, _, err := h.svc.DeployIndex(r.Context(), indexEndpoint, driver.DeployedIndex{
+	op, ie, err := h.svc.DeployIndex(r.Context(), indexEndpoint, driver.DeployedIndex{
 		ID: req.DeployedIndex.ID, Index: req.DeployedIndex.Index,
 	})
 	if err != nil {
@@ -307,7 +307,15 @@ func (h *Handler) deployIndex(w http.ResponseWriter, r *http.Request, indexEndpo
 		return
 	}
 
-	writeOp(w, op)
+	// DeployIndexResponse carries the newly deployed index (the last appended).
+	var deployed map[string]any
+
+	if n := len(ie.DeployedIndexes); n > 0 {
+		d := ie.DeployedIndexes[n-1]
+		deployed = map[string]any{"id": d.ID, "index": d.Index}
+	}
+
+	writeResourceOp(w, op, map[string]any{"deployedIndex": deployed}, "DeployIndexResponse")
 }
 
 func (h *Handler) undeployIndex(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
@@ -326,7 +334,7 @@ func (h *Handler) undeployIndex(w http.ResponseWriter, r *http.Request, indexEnd
 		return
 	}
 
-	writeOp(w, op)
+	writeResourceOp(w, op, nil, "UndeployIndexResponse")
 }
 
 func (h *Handler) findNeighbors(w http.ResponseWriter, r *http.Request, indexEndpoint string) {

--- a/server/gcp/vertexai/vectorsearch.go
+++ b/server/gcp/vertexai/vectorsearch.go
@@ -1,0 +1,372 @@
+package vertexai
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Indexes ---
+
+func indexJSON(i *driver.Index) map[string]any {
+	return map[string]any{
+		"name": i.Name, "displayName": i.DisplayName, "description": i.Description,
+		"indexStats": map[string]any{"vectorsCount": i.DatapointCount},
+		"createTime": i.CreateTime, "updateTime": i.UpdateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveIndexes(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listIndexes(w, r, p.location)
+		case http.MethodPost:
+			h.createIndex(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.indexAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getIndex(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteIndex(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) indexAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	switch p.action {
+	case "upsertDatapoints":
+		h.upsertDatapoints(w, r, p.name)
+	case "removeDatapoints":
+		h.removeDatapoints(w, r, p.name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown index action: "+p.action)
+	}
+}
+
+func (h *Handler) createIndex(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Description string `json:"description"`
+		Metadata    struct {
+			Config struct {
+				Dimensions int `json:"dimensions"`
+			} `json:"config"`
+		} `json:"metadata"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateIndex(r.Context(), driver.IndexConfig{
+		Location: location, DisplayName: req.DisplayName, Description: req.Description,
+		Dimensions: req.Metadata.Config.Dimensions,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getIndex(w http.ResponseWriter, r *http.Request, name string) {
+	idx, err := h.svc.GetIndex(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, indexJSON(idx))
+}
+
+func (h *Handler) listIndexes(w http.ResponseWriter, r *http.Request, location string) {
+	idxs, err := h.svc.ListIndexes(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(idxs))
+	for i := range idxs {
+		out = append(out, indexJSON(&idxs[i]))
+	}
+
+	writeJSON(w, map[string]any{"indexes": out})
+}
+
+func (h *Handler) deleteIndex(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteIndex(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) upsertDatapoints(w http.ResponseWriter, r *http.Request, index string) {
+	var req struct {
+		Datapoints []struct {
+			DatapointID   string    `json:"datapointId"`
+			FeatureVector []float64 `json:"featureVector"`
+		} `json:"datapoints"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	dps := make([]driver.Datapoint, 0, len(req.Datapoints))
+	for _, d := range req.Datapoints {
+		dps = append(dps, driver.Datapoint{DatapointID: d.DatapointID, FeatureVector: d.FeatureVector})
+	}
+
+	if err := h.svc.UpsertDatapoints(r.Context(), index, dps); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+func (h *Handler) removeDatapoints(w http.ResponseWriter, r *http.Request, index string) {
+	var req struct {
+		DatapointIDs []string `json:"datapointIds"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	if err := h.svc.RemoveDatapoints(r.Context(), index, req.DatapointIDs); err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, map[string]any{})
+}
+
+// --- Index endpoints ---
+
+func indexEndpointJSON(e *driver.IndexEndpoint) map[string]any {
+	dis := make([]map[string]any, 0, len(e.DeployedIndexes))
+	for _, d := range e.DeployedIndexes {
+		dis = append(dis, map[string]any{"id": d.ID, "index": d.Index})
+	}
+
+	return map[string]any{
+		"name": e.Name, "displayName": e.DisplayName, "description": e.Description,
+		"deployedIndexes": dis, "createTime": e.CreateTime,
+	}
+}
+
+//nolint:dupl // REST shim; the decode/dispatch shape recurs across collections.
+func (h *Handler) serveIndexEndpoints(w http.ResponseWriter, r *http.Request, p *vPath) {
+	if p.name == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listIndexEndpoints(w, r, p.location)
+		case http.MethodPost:
+			h.createIndexEndpoint(w, r, p.location)
+		default:
+			methodNotAllowed(w)
+		}
+
+		return
+	}
+
+	if r.Method == http.MethodPost && p.action != "" {
+		h.indexEndpointAction(w, r, p)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getIndexEndpoint(w, r, p.name)
+	case http.MethodDelete:
+		h.deleteIndexEndpoint(w, r, p.name)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *Handler) indexEndpointAction(w http.ResponseWriter, r *http.Request, p *vPath) {
+	switch p.action {
+	case "deployIndex":
+		h.deployIndex(w, r, p.name)
+	case "undeployIndex":
+		h.undeployIndex(w, r, p.name)
+	case "findNeighbors":
+		h.findNeighbors(w, r, p.name)
+	default:
+		writeError(w, http.StatusNotFound, "notFound", "unknown indexEndpoint action: "+p.action)
+	}
+}
+
+func (h *Handler) createIndexEndpoint(w http.ResponseWriter, r *http.Request, location string) {
+	var req struct {
+		DisplayName string `json:"displayName"`
+		Description string `json:"description"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.CreateIndexEndpoint(r.Context(), driver.IndexEndpointConfig{
+		Location: location, DisplayName: req.DisplayName, Description: req.Description,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) getIndexEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	ie, err := h.svc.GetIndexEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeJSON(w, indexEndpointJSON(ie))
+}
+
+func (h *Handler) listIndexEndpoints(w http.ResponseWriter, r *http.Request, location string) {
+	ies, err := h.svc.ListIndexEndpoints(r.Context(), location)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	out := make([]map[string]any, 0, len(ies))
+	for i := range ies {
+		out = append(out, indexEndpointJSON(&ies[i]))
+	}
+
+	writeJSON(w, map[string]any{"indexEndpoints": out})
+}
+
+func (h *Handler) deleteIndexEndpoint(w http.ResponseWriter, r *http.Request, name string) {
+	op, err := h.svc.DeleteIndexEndpoint(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) deployIndex(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
+	var req struct {
+		DeployedIndex struct {
+			ID    string `json:"id"`
+			Index string `json:"index"`
+		} `json:"deployedIndex"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.DeployIndex(r.Context(), indexEndpoint, driver.DeployedIndex{
+		ID: req.DeployedIndex.ID, Index: req.DeployedIndex.Index,
+	})
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) undeployIndex(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
+	var req struct {
+		DeployedIndexID string `json:"deployedIndexId"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	op, _, err := h.svc.UndeployIndex(r.Context(), indexEndpoint, req.DeployedIndexID)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	writeOp(w, op)
+}
+
+func (h *Handler) findNeighbors(w http.ResponseWriter, r *http.Request, indexEndpoint string) {
+	var req struct {
+		DeployedIndexID string `json:"deployedIndexId"`
+		Queries         []struct {
+			Datapoint struct {
+				FeatureVector []float64 `json:"featureVector"`
+			} `json:"datapoint"`
+			NeighborCount int `json:"neighborCount"`
+		} `json:"queries"`
+	}
+
+	if !decode(w, r, &req) {
+		return
+	}
+
+	var (
+		query []float64
+		count int
+	)
+
+	if len(req.Queries) > 0 {
+		query = req.Queries[0].Datapoint.FeatureVector
+		count = req.Queries[0].NeighborCount
+	}
+
+	neighbors, err := h.svc.FindNeighbors(r.Context(), indexEndpoint, req.DeployedIndexID, query, count)
+	if err != nil {
+		writeCErr(w, err)
+
+		return
+	}
+
+	nn := make([]map[string]any, 0, len(neighbors))
+	for _, n := range neighbors {
+		nn = append(nn, map[string]any{
+			"datapoint": map[string]any{"datapointId": n.DatapointID}, "distance": n.Distance,
+		})
+	}
+
+	writeJSON(w, map[string]any{"nearestNeighbors": []map[string]any{{"id": "0", "neighbors": nn}}})
+}

--- a/vertexai/driver/datasets.go
+++ b/vertexai/driver/datasets.go
@@ -1,0 +1,33 @@
+package driver
+
+import "context"
+
+// DatasetConfig describes a dataset to create.
+type DatasetConfig struct {
+	Location          string
+	DisplayName       string
+	MetadataSchemaURI string
+	Labels            map[string]string
+}
+
+// Dataset is a Vertex AI dataset.
+type Dataset struct {
+	Name              string // projects/{p}/locations/{l}/datasets/{id}
+	DisplayName       string
+	MetadataSchemaURI string
+	Labels            map[string]string
+	CreateTime        string
+	UpdateTime        string
+}
+
+// datasetsAPI covers dataset lifecycle plus import/export (modeled as
+// already-done operations).
+type datasetsAPI interface {
+	CreateDataset(ctx context.Context, cfg DatasetConfig) (*Operation, *Dataset, error)
+	GetDataset(ctx context.Context, name string) (*Dataset, error)
+	ListDatasets(ctx context.Context, location string) ([]Dataset, error)
+	PatchDataset(ctx context.Context, name, displayName string) (*Dataset, error)
+	DeleteDataset(ctx context.Context, name string) (*Operation, error)
+	ImportData(ctx context.Context, name, gcsURI string) (*Operation, error)
+	ExportData(ctx context.Context, name, gcsOutputURI string) (*Operation, error)
+}

--- a/vertexai/driver/driver.go
+++ b/vertexai/driver/driver.go
@@ -1,0 +1,57 @@
+// Package driver defines the interface for Google Cloud Vertex AI
+// (aiplatform.googleapis.com): datasets, the model registry, endpoints and
+// online prediction, custom/training/tuning jobs, batch prediction, pipelines,
+// the Gemini generateContent runtime, Feature Store, Vector Search,
+// Tensorboard, ML metadata, schedules and notebook runtimes.
+//
+// The interface uses plain Go types only (no cloud SDK dependencies). Resource
+// names follow Vertex's REST convention
+// projects/{project}/locations/{location}/{collection}/{id}. Long-running
+// control-plane mutations are modeled as completing synchronously; the
+// job-family resources expose a state field that the mock drives straight to a
+// terminal success state.
+package driver
+
+import "context"
+
+// Job state values (JobState enum) shared by custom/batch/HPO jobs.
+const (
+	JobStateQueued    = "JOB_STATE_QUEUED"
+	JobStatePending   = "JOB_STATE_PENDING"
+	JobStateRunning   = "JOB_STATE_RUNNING"
+	JobStateSucceeded = "JOB_STATE_SUCCEEDED"
+	JobStateFailed    = "JOB_STATE_FAILED"
+	JobStateCancelled = "JOB_STATE_CANCELED"
+)
+
+// Pipeline state values (PipelineState enum) used by trainingPipelines and
+// pipelineJobs.
+const (
+	PipelineStateRunning   = "PIPELINE_STATE_RUNNING"
+	PipelineStateSucceeded = "PIPELINE_STATE_SUCCEEDED"
+	PipelineStateFailed    = "PIPELINE_STATE_FAILED"
+	PipelineStateCancelled = "PIPELINE_STATE_CANCELED"
+)
+
+// VertexAI is the interface that Vertex AI implementations must satisfy. It is
+// composed of one segment per resource family so the surface stays navigable.
+type VertexAI interface {
+	datasetsAPI
+	modelsAPI
+	endpointsAPI
+	jobsAPI
+	pipelinesAPI
+	genAIAPI
+	featureStoreAPI
+	vectorSearchAPI
+	metadataAPI
+	operationsAPI
+}
+
+// operationsAPI exposes the long-running-operation polling surface. Every
+// control-plane mutation in this emulator returns an already-done Operation,
+// but clients still GET it, so it must be retrievable.
+type operationsAPI interface {
+	GetOperation(ctx context.Context, name string) (*Operation, error)
+	ListOperations(ctx context.Context, parent string) ([]Operation, error)
+}

--- a/vertexai/driver/endpoints.go
+++ b/vertexai/driver/endpoints.go
@@ -1,0 +1,62 @@
+package driver
+
+import "context"
+
+// EndpointConfig describes an endpoint to create.
+type EndpointConfig struct {
+	Location    string
+	DisplayName string
+	Description string
+	Labels      map[string]string
+}
+
+// DeployedModel is a model deployed to an endpoint.
+type DeployedModel struct {
+	ID              string
+	Model           string // model resource name
+	DisplayName     string
+	MachineType     string
+	MinReplicaCount int
+	MaxReplicaCount int
+}
+
+// Endpoint serves online predictions for one or more deployed models.
+type Endpoint struct {
+	Name           string // projects/{p}/locations/{l}/endpoints/{id}
+	DisplayName    string
+	Description    string
+	DeployedModels []DeployedModel
+	TrafficSplit   map[string]int
+	Labels         map[string]string
+	CreateTime     string
+	UpdateTime     string
+}
+
+// PredictRequest is an online prediction request.
+type PredictRequest struct {
+	Endpoint   string
+	Instances  []any
+	Parameters any
+}
+
+// PredictResponse carries model predictions.
+type PredictResponse struct {
+	Predictions      []any
+	DeployedModelID  string
+	Model            string
+	ModelDisplayName string
+}
+
+// endpointsAPI covers endpoints, model deployment, and online prediction.
+type endpointsAPI interface {
+	CreateEndpoint(ctx context.Context, cfg EndpointConfig) (*Operation, *Endpoint, error)
+	GetEndpoint(ctx context.Context, name string) (*Endpoint, error)
+	ListEndpoints(ctx context.Context, location string) ([]Endpoint, error)
+	DeleteEndpoint(ctx context.Context, name string) (*Operation, error)
+
+	DeployModel(ctx context.Context, endpoint string, dm DeployedModel) (*Operation, *Endpoint, error)
+	UndeployModel(ctx context.Context, endpoint, deployedModelID string) (*Operation, *Endpoint, error)
+
+	Predict(ctx context.Context, req PredictRequest) (*PredictResponse, error)
+	RawPredict(ctx context.Context, endpoint string, body []byte) ([]byte, error)
+}

--- a/vertexai/driver/featurestore.go
+++ b/vertexai/driver/featurestore.go
@@ -1,0 +1,84 @@
+package driver
+
+import "context"
+
+// FeatureGroupConfig describes a (BigQuery-backed) feature group.
+type FeatureGroupConfig struct {
+	Location       string
+	FeatureGroupID string
+	Description    string
+	BigQueryURI    string
+}
+
+// FeatureGroup is a feature group.
+type FeatureGroup struct {
+	Name        string // projects/{p}/locations/{l}/featureGroups/{id}
+	Description string
+	BigQueryURI string
+	CreateTime  string
+}
+
+// Feature is a feature within a group.
+type Feature struct {
+	Name        string // .../featureGroups/{g}/features/{id}
+	Description string
+	CreateTime  string
+}
+
+// FeatureOnlineStoreConfig describes an online store.
+type FeatureOnlineStoreConfig struct {
+	Location             string
+	FeatureOnlineStoreID string
+}
+
+// FeatureOnlineStore serves online feature reads.
+type FeatureOnlineStore struct {
+	Name       string // projects/{p}/locations/{l}/featureOnlineStores/{id}
+	State      string
+	CreateTime string
+}
+
+// FeatureViewConfig describes a feature view in an online store.
+type FeatureViewConfig struct {
+	Parent        string // online store resource name
+	FeatureViewID string
+	BigQueryURI   string
+}
+
+// FeatureView maps source data into an online store.
+type FeatureView struct {
+	Name        string // .../featureOnlineStores/{s}/featureViews/{id}
+	BigQueryURI string
+	CreateTime  string
+}
+
+// FeatureNameValue is one feature name/value in an online read.
+type FeatureNameValue struct {
+	Name  string
+	Value string
+}
+
+// featureStoreAPI covers the BigQuery-backed Feature Store: groups, features,
+// online stores, views, and the fetchFeatureValues data plane.
+type featureStoreAPI interface {
+	CreateFeatureGroup(ctx context.Context, cfg FeatureGroupConfig) (*Operation, *FeatureGroup, error)
+	GetFeatureGroup(ctx context.Context, name string) (*FeatureGroup, error)
+	ListFeatureGroups(ctx context.Context, location string) ([]FeatureGroup, error)
+	DeleteFeatureGroup(ctx context.Context, name string) (*Operation, error)
+
+	CreateFeature(ctx context.Context, parent, featureID, description string) (*Operation, *Feature, error)
+	GetFeature(ctx context.Context, name string) (*Feature, error)
+	ListFeatures(ctx context.Context, parent string) ([]Feature, error)
+	DeleteFeature(ctx context.Context, name string) (*Operation, error)
+
+	CreateFeatureOnlineStore(ctx context.Context, cfg FeatureOnlineStoreConfig) (*Operation, *FeatureOnlineStore, error)
+	GetFeatureOnlineStore(ctx context.Context, name string) (*FeatureOnlineStore, error)
+	ListFeatureOnlineStores(ctx context.Context, location string) ([]FeatureOnlineStore, error)
+	DeleteFeatureOnlineStore(ctx context.Context, name string) (*Operation, error)
+
+	CreateFeatureView(ctx context.Context, cfg FeatureViewConfig) (*Operation, *FeatureView, error)
+	GetFeatureView(ctx context.Context, name string) (*FeatureView, error)
+	ListFeatureViews(ctx context.Context, parent string) ([]FeatureView, error)
+	DeleteFeatureView(ctx context.Context, name string) (*Operation, error)
+	FetchFeatureValues(ctx context.Context, featureView, entityID string) ([]FeatureNameValue, error)
+}

--- a/vertexai/driver/featurestore.go
+++ b/vertexai/driver/featurestore.go
@@ -58,9 +58,47 @@ type FeatureNameValue struct {
 	Value string
 }
 
-// featureStoreAPI covers the BigQuery-backed Feature Store: groups, features,
-// online stores, views, and the fetchFeatureValues data plane.
+// FeaturestoreConfig describes a classic (pre-Feature-Group) Featurestore.
+type FeaturestoreConfig struct {
+	Location        string
+	FeaturestoreID  string
+	OnlineNodeCount int
+}
+
+// Featurestore is the classic Vertex AI Featurestore — a container of
+// EntityTypes, distinct from the newer BigQuery-backed FeatureGroup.
+type Featurestore struct {
+	Name            string // projects/{p}/locations/{l}/featurestores/{id}
+	State           string
+	OnlineNodeCount int
+	CreateTime      string
+}
+
+// EntityType groups features within a classic Featurestore.
+type EntityType struct {
+	Name        string // .../featurestores/{f}/entityTypes/{id}
+	Description string
+	CreateTime  string
+}
+
+// featureStoreAPI covers both Feature Store generations: the classic
+// Featurestore/EntityType resources (+ online read/write) and the newer
+// BigQuery-backed FeatureGroup / FeatureOnlineStore / FeatureView stack.
 type featureStoreAPI interface {
+	CreateFeaturestore(ctx context.Context, cfg FeaturestoreConfig) (*Operation, *Featurestore, error)
+	GetFeaturestore(ctx context.Context, name string) (*Featurestore, error)
+	ListFeaturestores(ctx context.Context, location string) ([]Featurestore, error)
+	DeleteFeaturestore(ctx context.Context, name string) (*Operation, error)
+
+	CreateEntityType(ctx context.Context, parent, entityTypeID, description string) (*Operation, *EntityType, error)
+	GetEntityType(ctx context.Context, name string) (*EntityType, error)
+	ListEntityTypes(ctx context.Context, parent string) ([]EntityType, error)
+	DeleteEntityType(ctx context.Context, name string) (*Operation, error)
+
+	// Classic online serving, keyed by entityType + entity id.
+	WriteFeatureValues(ctx context.Context, entityType, entityID string, values []FeatureNameValue) error
+	ReadFeatureValues(ctx context.Context, entityType, entityID string) ([]FeatureNameValue, error)
+
 	CreateFeatureGroup(ctx context.Context, cfg FeatureGroupConfig) (*Operation, *FeatureGroup, error)
 	GetFeatureGroup(ctx context.Context, name string) (*FeatureGroup, error)
 	ListFeatureGroups(ctx context.Context, location string) ([]FeatureGroup, error)

--- a/vertexai/driver/genai.go
+++ b/vertexai/driver/genai.go
@@ -84,11 +84,13 @@ type CachedContentConfig struct {
 
 // CachedContent is a context-cache entry (synchronous CRUD).
 type CachedContent struct {
-	Name        string // projects/{p}/locations/{l}/cachedContents/{id}
-	Model       string
-	DisplayName string
-	CreateTime  string
-	ExpireTime  string
+	Name              string // projects/{p}/locations/{l}/cachedContents/{id}
+	Model             string
+	DisplayName       string
+	Contents          []Content
+	SystemInstruction *Content
+	CreateTime        string
+	ExpireTime        string
 }
 
 // genAIAPI covers the Gemini runtime plus tuning jobs and context caching.

--- a/vertexai/driver/genai.go
+++ b/vertexai/driver/genai.go
@@ -1,0 +1,108 @@
+package driver
+
+import "context"
+
+// Part is a single content part (text only is modeled).
+type Part struct {
+	Text string
+}
+
+// Content is one turn in a generateContent exchange.
+type Content struct {
+	Role  string // "user" | "model"
+	Parts []Part
+}
+
+// GenerationConfig holds optional sampling controls.
+type GenerationConfig struct {
+	Temperature     *float64
+	TopP            *float64
+	TopK            *int
+	MaxOutputTokens *int
+}
+
+// GenerateContentRequest is the Gemini generateContent request.
+type GenerateContentRequest struct {
+	Model             string
+	Contents          []Content
+	SystemInstruction *Content
+	GenerationConfig  *GenerationConfig
+}
+
+// Candidate is one generated response candidate.
+type Candidate struct {
+	Content      Content
+	FinishReason string
+}
+
+// UsageMetadata reports token accounting for a generateContent call.
+type UsageMetadata struct {
+	PromptTokenCount     int
+	CandidatesTokenCount int
+	TotalTokenCount      int
+}
+
+// GenerateContentResponse is the Gemini generateContent response.
+type GenerateContentResponse struct {
+	Candidates    []Candidate
+	UsageMetadata UsageMetadata
+}
+
+// CountTokensResponse reports the token count for an input.
+type CountTokensResponse struct {
+	TotalTokens int
+}
+
+// TuningJobConfig describes a Gemini supervised-tuning job.
+type TuningJobConfig struct {
+	Location        string
+	BaseModel       string
+	TunedModelName  string
+	TrainingDataURI string
+}
+
+// TuningJob describes a tuning job (create is synchronous; poll State).
+type TuningJob struct {
+	Name           string // projects/{p}/locations/{l}/tuningJobs/{id}
+	BaseModel      string
+	State          string
+	TunedModelName string
+	Endpoint       string
+	CreateTime     string
+	EndTime        string
+}
+
+// CachedContentConfig describes a context-cache entry to create.
+type CachedContentConfig struct {
+	Location          string
+	Model             string
+	DisplayName       string
+	Contents          []Content
+	SystemInstruction *Content
+	TTLSeconds        int
+}
+
+// CachedContent is a context-cache entry (synchronous CRUD).
+type CachedContent struct {
+	Name        string // projects/{p}/locations/{l}/cachedContents/{id}
+	Model       string
+	DisplayName string
+	CreateTime  string
+	ExpireTime  string
+}
+
+// genAIAPI covers the Gemini runtime plus tuning jobs and context caching.
+type genAIAPI interface {
+	GenerateContent(ctx context.Context, model string, req GenerateContentRequest) (*GenerateContentResponse, error)
+	CountTokens(ctx context.Context, model string, req GenerateContentRequest) (*CountTokensResponse, error)
+
+	CreateTuningJob(ctx context.Context, cfg TuningJobConfig) (*TuningJob, error)
+	GetTuningJob(ctx context.Context, name string) (*TuningJob, error)
+	ListTuningJobs(ctx context.Context, location string) ([]TuningJob, error)
+	CancelTuningJob(ctx context.Context, name string) error
+
+	CreateCachedContent(ctx context.Context, cfg CachedContentConfig) (*CachedContent, error)
+	GetCachedContent(ctx context.Context, name string) (*CachedContent, error)
+	ListCachedContents(ctx context.Context, location string) ([]CachedContent, error)
+	DeleteCachedContent(ctx context.Context, name string) error
+}

--- a/vertexai/driver/jobs.go
+++ b/vertexai/driver/jobs.go
@@ -1,0 +1,79 @@
+package driver
+
+import "context"
+
+// CustomJobConfig describes a custom training job.
+type CustomJobConfig struct {
+	Location       string
+	DisplayName    string
+	MachineType    string
+	ReplicaCount   int
+	ContainerImage string
+}
+
+// CustomJob is a custom training job (create is synchronous; poll State).
+type CustomJob struct {
+	Name        string // projects/{p}/locations/{l}/customJobs/{id}
+	DisplayName string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// BatchPredictionJobConfig describes a batch prediction job.
+type BatchPredictionJobConfig struct {
+	Location        string
+	DisplayName     string
+	Model           string
+	InputURI        string
+	OutputURIPrefix string
+}
+
+// BatchPredictionJob is an offline prediction job (create is synchronous).
+type BatchPredictionJob struct {
+	Name        string // projects/{p}/locations/{l}/batchPredictionJobs/{id}
+	DisplayName string
+	Model       string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// HyperparameterTuningJobConfig describes an HPO job.
+type HyperparameterTuningJobConfig struct {
+	Location       string
+	DisplayName    string
+	MaxTrialCount  int
+	ParallelTrials int
+}
+
+// HyperparameterTuningJob is an HPO job (create is synchronous).
+type HyperparameterTuningJob struct {
+	Name          string // projects/{p}/locations/{l}/hyperparameterTuningJobs/{id}
+	DisplayName   string
+	State         string
+	MaxTrialCount int
+	CreateTime    string
+	EndTime       string
+}
+
+// jobsAPI covers the synchronous-create job family (poll State after create;
+// cancel returns no body).
+type jobsAPI interface {
+	CreateCustomJob(ctx context.Context, cfg CustomJobConfig) (*CustomJob, error)
+	GetCustomJob(ctx context.Context, name string) (*CustomJob, error)
+	ListCustomJobs(ctx context.Context, location string) ([]CustomJob, error)
+	CancelCustomJob(ctx context.Context, name string) error
+	DeleteCustomJob(ctx context.Context, name string) (*Operation, error)
+
+	CreateBatchPredictionJob(ctx context.Context, cfg BatchPredictionJobConfig) (*BatchPredictionJob, error)
+	GetBatchPredictionJob(ctx context.Context, name string) (*BatchPredictionJob, error)
+	ListBatchPredictionJobs(ctx context.Context, location string) ([]BatchPredictionJob, error)
+	CancelBatchPredictionJob(ctx context.Context, name string) error
+	DeleteBatchPredictionJob(ctx context.Context, name string) (*Operation, error)
+
+	CreateHyperparameterTuningJob(ctx context.Context, cfg HyperparameterTuningJobConfig) (*HyperparameterTuningJob, error)
+	GetHyperparameterTuningJob(ctx context.Context, name string) (*HyperparameterTuningJob, error)
+	ListHyperparameterTuningJobs(ctx context.Context, location string) ([]HyperparameterTuningJob, error)
+	CancelHyperparameterTuningJob(ctx context.Context, name string) error
+}

--- a/vertexai/driver/metadata.go
+++ b/vertexai/driver/metadata.go
@@ -1,0 +1,74 @@
+package driver
+
+import "context"
+
+// MetadataStore is an ML-metadata store.
+type MetadataStore struct {
+	Name       string // projects/{p}/locations/{l}/metadataStores/{id}
+	CreateTime string
+}
+
+// Tensorboard is a managed Tensorboard instance.
+type Tensorboard struct {
+	Name        string // projects/{p}/locations/{l}/tensorboards/{id}
+	DisplayName string
+	CreateTime  string
+}
+
+// Schedule runs a pipeline job on a cron schedule.
+type Schedule struct {
+	Name        string // projects/{p}/locations/{l}/schedules/{id}
+	DisplayName string
+	Cron        string
+	State       string // ACTIVE | PAUSED | COMPLETED
+	CreateTime  string
+}
+
+// NotebookRuntimeTemplate is a template for notebook runtimes.
+type NotebookRuntimeTemplate struct {
+	Name        string // projects/{p}/locations/{l}/notebookRuntimeTemplates/{id}
+	DisplayName string
+	MachineType string
+	CreateTime  string
+}
+
+// NotebookRuntime is an assigned notebook runtime.
+type NotebookRuntime struct {
+	Name         string // projects/{p}/locations/{l}/notebookRuntimes/{id}
+	DisplayName  string
+	RuntimeState string // RUNNING | STOPPED
+	CreateTime   string
+}
+
+// metadataAPI covers ML metadata stores, Tensorboard, schedules, and notebook
+// runtimes/templates.
+type metadataAPI interface {
+	CreateMetadataStore(ctx context.Context, location, storeID string) (*Operation, *MetadataStore, error)
+	GetMetadataStore(ctx context.Context, name string) (*MetadataStore, error)
+	ListMetadataStores(ctx context.Context, location string) ([]MetadataStore, error)
+	DeleteMetadataStore(ctx context.Context, name string) (*Operation, error)
+
+	CreateTensorboard(ctx context.Context, location, displayName string) (*Operation, *Tensorboard, error)
+	GetTensorboard(ctx context.Context, name string) (*Tensorboard, error)
+	ListTensorboards(ctx context.Context, location string) ([]Tensorboard, error)
+	DeleteTensorboard(ctx context.Context, name string) (*Operation, error)
+
+	CreateSchedule(ctx context.Context, location, displayName, cron string) (*Schedule, error)
+	GetSchedule(ctx context.Context, name string) (*Schedule, error)
+	ListSchedules(ctx context.Context, location string) ([]Schedule, error)
+	PauseSchedule(ctx context.Context, name string) error
+	ResumeSchedule(ctx context.Context, name string) error
+	DeleteSchedule(ctx context.Context, name string) (*Operation, error)
+
+	CreateNotebookRuntimeTemplate(ctx context.Context, location, displayName, machineType string) (*Operation, *NotebookRuntimeTemplate, error)
+	GetNotebookRuntimeTemplate(ctx context.Context, name string) (*NotebookRuntimeTemplate, error)
+	ListNotebookRuntimeTemplates(ctx context.Context, location string) ([]NotebookRuntimeTemplate, error)
+	DeleteNotebookRuntimeTemplate(ctx context.Context, name string) (*Operation, error)
+
+	AssignNotebookRuntime(ctx context.Context, location, displayName string) (*Operation, *NotebookRuntime, error)
+	GetNotebookRuntime(ctx context.Context, name string) (*NotebookRuntime, error)
+	ListNotebookRuntimes(ctx context.Context, location string) ([]NotebookRuntime, error)
+	StartNotebookRuntime(ctx context.Context, name string) (*Operation, error)
+	StopNotebookRuntime(ctx context.Context, name string) (*Operation, error)
+	DeleteNotebookRuntime(ctx context.Context, name string) (*Operation, error)
+}

--- a/vertexai/driver/models.go
+++ b/vertexai/driver/models.go
@@ -1,0 +1,53 @@
+package driver
+
+import "context"
+
+// ModelConfig describes a model to upload to the registry.
+type ModelConfig struct {
+	Location       string
+	DisplayName    string
+	Description    string
+	ContainerImage string
+	ArtifactURI    string
+	Labels         map[string]string
+}
+
+// Model is a registered model. Versions are addressed via the @version suffix
+// on the resource name rather than a sub-collection.
+type Model struct {
+	Name           string // projects/{p}/locations/{l}/models/{id}
+	DisplayName    string
+	Description    string
+	ContainerImage string
+	ArtifactURI    string
+	VersionID      string
+	VersionAliases []string
+	Labels         map[string]string
+	CreateTime     string
+	UpdateTime     string
+}
+
+// ModelEvaluation is an evaluation attached to a model version.
+type ModelEvaluation struct {
+	Name        string // .../models/{id}/evaluations/{eid}
+	DisplayName string
+	MetricsType string
+	CreateTime  string
+}
+
+// modelsAPI covers the model registry (upload/get/list/patch/delete + versions
+// + evaluations).
+type modelsAPI interface {
+	UploadModel(ctx context.Context, cfg ModelConfig) (*Operation, *Model, error)
+	GetModel(ctx context.Context, name string) (*Model, error)
+	ListModels(ctx context.Context, location string) ([]Model, error)
+	PatchModel(ctx context.Context, name, displayName, description string) (*Model, error)
+	DeleteModel(ctx context.Context, name string) (*Operation, error)
+
+	ListModelVersions(ctx context.Context, name string) ([]Model, error)
+	DeleteModelVersion(ctx context.Context, name string) (*Operation, error)
+
+	ImportModelEvaluation(ctx context.Context, modelName string, eval ModelEvaluation) (*ModelEvaluation, error)
+	GetModelEvaluation(ctx context.Context, name string) (*ModelEvaluation, error)
+	ListModelEvaluations(ctx context.Context, modelName string) ([]ModelEvaluation, error)
+}

--- a/vertexai/driver/operations.go
+++ b/vertexai/driver/operations.go
@@ -1,0 +1,17 @@
+package driver
+
+// Operation is a google.longrunning.Operation. The emulator returns operations
+// that are already complete (Done=true) so SDK pollers terminate immediately.
+type Operation struct {
+	Name     string
+	Done     bool
+	Metadata map[string]any
+	Response map[string]any
+	Error    *OperationError
+}
+
+// OperationError mirrors google.rpc.Status on a failed operation.
+type OperationError struct {
+	Code    int
+	Message string
+}

--- a/vertexai/driver/pipelines.go
+++ b/vertexai/driver/pipelines.go
@@ -1,0 +1,50 @@
+package driver
+
+import "context"
+
+// TrainingPipelineConfig describes a training pipeline.
+type TrainingPipelineConfig struct {
+	Location    string
+	DisplayName string
+	TaskType    string // AutoML task definition or custom
+}
+
+// TrainingPipeline wraps AutoML/custom training (create is synchronous).
+type TrainingPipeline struct {
+	Name        string // projects/{p}/locations/{l}/trainingPipelines/{id}
+	DisplayName string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// PipelineJobConfig describes a Kubeflow/TFX pipeline run.
+type PipelineJobConfig struct {
+	Location    string
+	DisplayName string
+	TemplateURI string
+}
+
+// PipelineJob is a pipeline execution (create is synchronous).
+type PipelineJob struct {
+	Name        string // projects/{p}/locations/{l}/pipelineJobs/{id}
+	DisplayName string
+	State       string
+	CreateTime  string
+	EndTime     string
+}
+
+// pipelinesAPI covers training pipelines and pipeline jobs.
+type pipelinesAPI interface {
+	CreateTrainingPipeline(ctx context.Context, cfg TrainingPipelineConfig) (*TrainingPipeline, error)
+	GetTrainingPipeline(ctx context.Context, name string) (*TrainingPipeline, error)
+	ListTrainingPipelines(ctx context.Context, location string) ([]TrainingPipeline, error)
+	CancelTrainingPipeline(ctx context.Context, name string) error
+	DeleteTrainingPipeline(ctx context.Context, name string) (*Operation, error)
+
+	CreatePipelineJob(ctx context.Context, cfg PipelineJobConfig) (*PipelineJob, error)
+	GetPipelineJob(ctx context.Context, name string) (*PipelineJob, error)
+	ListPipelineJobs(ctx context.Context, location string) ([]PipelineJob, error)
+	CancelPipelineJob(ctx context.Context, name string) error
+	DeletePipelineJob(ctx context.Context, name string) (*Operation, error)
+}

--- a/vertexai/driver/vectorsearch.go
+++ b/vertexai/driver/vectorsearch.go
@@ -1,0 +1,75 @@
+package driver
+
+import "context"
+
+// IndexConfig describes a Vector Search index.
+type IndexConfig struct {
+	Location    string
+	DisplayName string
+	Description string
+	Dimensions  int
+}
+
+// Index is a Vector Search index.
+type Index struct {
+	Name           string // projects/{p}/locations/{l}/indexes/{id}
+	DisplayName    string
+	Description    string
+	Dimensions     int
+	DatapointCount int
+	CreateTime     string
+	UpdateTime     string
+}
+
+// Datapoint is a single vector datapoint.
+type Datapoint struct {
+	DatapointID   string
+	FeatureVector []float64
+}
+
+// IndexEndpointConfig describes a Vector Search index endpoint.
+type IndexEndpointConfig struct {
+	Location    string
+	DisplayName string
+	Description string
+}
+
+// DeployedIndex is an index deployed to an index endpoint.
+type DeployedIndex struct {
+	ID    string
+	Index string
+}
+
+// IndexEndpoint serves nearest-neighbor queries.
+type IndexEndpoint struct {
+	Name            string // projects/{p}/locations/{l}/indexEndpoints/{id}
+	DisplayName     string
+	Description     string
+	DeployedIndexes []DeployedIndex
+	CreateTime      string
+}
+
+// Neighbor is a nearest-neighbor result.
+type Neighbor struct {
+	DatapointID string
+	Distance    float64
+}
+
+// vectorSearchAPI covers indexes and index endpoints + the findNeighbors and
+// upsert/remove data-plane calls.
+type vectorSearchAPI interface {
+	CreateIndex(ctx context.Context, cfg IndexConfig) (*Operation, *Index, error)
+	GetIndex(ctx context.Context, name string) (*Index, error)
+	ListIndexes(ctx context.Context, location string) ([]Index, error)
+	DeleteIndex(ctx context.Context, name string) (*Operation, error)
+	UpsertDatapoints(ctx context.Context, index string, datapoints []Datapoint) error
+	RemoveDatapoints(ctx context.Context, index string, datapointIDs []string) error
+
+	CreateIndexEndpoint(ctx context.Context, cfg IndexEndpointConfig) (*Operation, *IndexEndpoint, error)
+	GetIndexEndpoint(ctx context.Context, name string) (*IndexEndpoint, error)
+	ListIndexEndpoints(ctx context.Context, location string) ([]IndexEndpoint, error)
+	DeleteIndexEndpoint(ctx context.Context, name string) (*Operation, error)
+	DeployIndex(ctx context.Context, indexEndpoint string, di DeployedIndex) (*Operation, *IndexEndpoint, error)
+	UndeployIndex(ctx context.Context, indexEndpoint, deployedIndexID string) (*Operation, *IndexEndpoint, error)
+	FindNeighbors(ctx context.Context, indexEndpoint, deployedIndexID string, query []float64, count int) ([]Neighbor, error)
+}

--- a/vertexai/vertexai.go
+++ b/vertexai/vertexai.go
@@ -1,0 +1,130 @@
+// Package vertexai provides a portable Google Cloud Vertex AI API with
+// cross-cutting concerns. It wraps a driver.VertexAI (the control plane plus the
+// prediction and generateContent runtimes) with recording, metrics, rate
+// limiting, error injection, and latency simulation — the same middle layer
+// every other service ships (see bedrock/bedrock.go, sagemaker/sagemaker.go) so
+// Vertex AI participates in the three-layer design.
+//
+// The wrapper implements driver.VertexAI, so it is a drop-in replacement for the
+// raw mock when constructing the SDK-compat server.
+package vertexai
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	"github.com/stackshy/cloudemu/ratelimit"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// Compile-time check that the portable type implements the full service.
+var _ driver.VertexAI = (*VertexAI)(nil)
+
+// VertexAI is the portable Vertex AI type wrapping a driver with cross-cutting
+// concerns.
+type VertexAI struct {
+	drv      driver.VertexAI
+	recorder *recorder.Recorder
+	metrics  *metrics.Collector
+	limiter  *ratelimit.Limiter
+	injector *inject.Injector
+	latency  time.Duration
+}
+
+// New creates a portable VertexAI wrapping the given driver.
+func New(d driver.VertexAI, opts ...Option) *VertexAI {
+	v := &VertexAI{drv: d}
+	for _, opt := range opts {
+		opt(v)
+	}
+
+	return v
+}
+
+// Option configures a portable VertexAI.
+type Option func(*VertexAI)
+
+// WithRecorder sets the call recorder.
+func WithRecorder(r *recorder.Recorder) Option { return func(v *VertexAI) { v.recorder = r } }
+
+// WithMetrics sets the metrics collector.
+func WithMetrics(m *metrics.Collector) Option { return func(v *VertexAI) { v.metrics = m } }
+
+// WithRateLimiter sets the rate limiter.
+func WithRateLimiter(l *ratelimit.Limiter) Option { return func(v *VertexAI) { v.limiter = l } }
+
+// WithErrorInjection sets the error injector.
+func WithErrorInjection(i *inject.Injector) Option { return func(v *VertexAI) { v.injector = i } }
+
+// WithLatency sets simulated latency applied to every call.
+func WithLatency(d time.Duration) Option { return func(v *VertexAI) { v.latency = d } }
+
+// do applies the cross-cutting concerns around a single driver call.
+func (v *VertexAI) do(_ context.Context, op string, input any, fn func() (any, error)) (any, error) {
+	start := time.Now()
+
+	if v.injector != nil {
+		if err := v.injector.Check("vertexai", op); err != nil {
+			v.rec(op, input, nil, err, time.Since(start))
+
+			return nil, err
+		}
+	}
+
+	if v.limiter != nil {
+		if err := v.limiter.Allow(); err != nil {
+			v.rec(op, input, nil, err, time.Since(start))
+
+			return nil, err
+		}
+	}
+
+	if v.latency > 0 {
+		time.Sleep(v.latency)
+	}
+
+	out, err := fn()
+	dur := time.Since(start)
+
+	if v.metrics != nil {
+		labels := map[string]string{"service": "vertexai", "operation": op}
+		v.metrics.Counter("calls_total", 1, labels)
+		v.metrics.Histogram("call_duration", dur, labels)
+
+		if err != nil {
+			v.metrics.Counter("errors_total", 1, labels)
+		}
+	}
+
+	v.rec(op, input, out, err, dur)
+
+	return out, err
+}
+
+func (v *VertexAI) rec(op string, input, output any, err error, dur time.Duration) {
+	if v.recorder != nil {
+		v.recorder.Record("vertexai", op, input, output, err, dur)
+	}
+}
+
+// cast converts the do() result to T, short-circuiting on error.
+func cast[T any](out any, err error) (T, error) {
+	if err != nil {
+		var zero T
+
+		return zero, err
+	}
+
+	return out.(T), nil //nolint:forcetypeassert // do() returns exactly the driver's typed result
+}
+
+// opPair bundles a long-running Operation with the typed resource it returns so
+// the (op, resource, error) driver methods can flow through the single-value
+// do() pipeline.
+type opPair[T any] struct {
+	op  *driver.Operation
+	res T
+}

--- a/vertexai/vertexai_test.go
+++ b/vertexai/vertexai_test.go
@@ -1,0 +1,70 @@
+package vertexai_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/inject"
+	"github.com/stackshy/cloudemu/metrics"
+	gcpvertex "github.com/stackshy/cloudemu/providers/gcp/vertexai"
+	"github.com/stackshy/cloudemu/recorder"
+	"github.com/stackshy/cloudemu/vertexai"
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func newPortable(opts ...vertexai.Option) *vertexai.VertexAI {
+	o := config.NewOptions(config.WithProjectID("test-project"))
+
+	return vertexai.New(gcpvertex.New(o), opts...)
+}
+
+func TestPortableRecordsAndCountsCalls(t *testing.T) {
+	rec := recorder.New()
+	col := metrics.NewCollector()
+	v := newPortable(vertexai.WithRecorder(rec), vertexai.WithMetrics(col))
+	ctx := context.Background()
+
+	_, _, err := v.CreateDataset(ctx, driver.DatasetConfig{Location: "us-central1", DisplayName: "ds1"})
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, rec.CallCountFor("vertexai", "CreateDataset"))
+	assert.NotEmpty(t, col.All())
+}
+
+func TestPortableErrorInjection(t *testing.T) {
+	inj := inject.NewInjector()
+	boom := errors.New("injected")
+	inj.Set("vertexai", "UploadModel", boom, inject.Always{})
+
+	v := newPortable(vertexai.WithErrorInjection(inj))
+
+	_, _, err := v.UploadModel(context.Background(), driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.ErrorIs(t, err, boom)
+}
+
+func TestPortableLatencyApplied(t *testing.T) {
+	v := newPortable(vertexai.WithLatency(20 * time.Millisecond))
+
+	start := time.Now()
+	_, err := v.ListModels(context.Background(), "us-central1")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(start), 20*time.Millisecond)
+}
+
+func TestPortableForwardsResults(t *testing.T) {
+	v := newPortable()
+	ctx := context.Background()
+
+	_, m, err := v.UploadModel(ctx, driver.ModelConfig{Location: "us-central1", DisplayName: "m"})
+	require.NoError(t, err)
+
+	got, err := v.GetModel(ctx, m.Name)
+	require.NoError(t, err)
+	assert.Equal(t, "m", got.DisplayName)
+}

--- a/vertexai/wrappers_datasets.go
+++ b/vertexai/wrappers_datasets.go
@@ -1,0 +1,43 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateDataset(ctx context.Context, cfg driver.DatasetConfig) (*driver.Operation, *driver.Dataset, error) {
+	r, err := cast[opPair[*driver.Dataset]](v.do(ctx, "CreateDataset", cfg, func() (any, error) {
+		op, ds, e := v.drv.CreateDataset(ctx, cfg)
+
+		return opPair[*driver.Dataset]{op, ds}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetDataset(ctx context.Context, name string) (*driver.Dataset, error) {
+	return cast[*driver.Dataset](v.do(ctx, "GetDataset", name, func() (any, error) { return v.drv.GetDataset(ctx, name) }))
+}
+
+func (v *VertexAI) ListDatasets(ctx context.Context, location string) ([]driver.Dataset, error) {
+	return cast[[]driver.Dataset](v.do(ctx, "ListDatasets", location, func() (any, error) { return v.drv.ListDatasets(ctx, location) }))
+}
+
+func (v *VertexAI) PatchDataset(ctx context.Context, name, displayName string) (*driver.Dataset, error) {
+	return cast[*driver.Dataset](v.do(ctx, "PatchDataset", name, func() (any, error) {
+		return v.drv.PatchDataset(ctx, name, displayName)
+	}))
+}
+
+func (v *VertexAI) DeleteDataset(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteDataset", name, func() (any, error) { return v.drv.DeleteDataset(ctx, name) }))
+}
+
+func (v *VertexAI) ImportData(ctx context.Context, name, gcsURI string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "ImportData", name, func() (any, error) { return v.drv.ImportData(ctx, name, gcsURI) }))
+}
+
+func (v *VertexAI) ExportData(ctx context.Context, name, gcsOutputURI string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "ExportData", name, func() (any, error) { return v.drv.ExportData(ctx, name, gcsOutputURI) }))
+}

--- a/vertexai/wrappers_endpoints.go
+++ b/vertexai/wrappers_endpoints.go
@@ -1,0 +1,62 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateEndpoint(ctx context.Context, cfg driver.EndpointConfig) (*driver.Operation, *driver.Endpoint, error) {
+	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "CreateEndpoint", cfg, func() (any, error) {
+		op, ep, e := v.drv.CreateEndpoint(ctx, cfg)
+
+		return opPair[*driver.Endpoint]{op, ep}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetEndpoint(ctx context.Context, name string) (*driver.Endpoint, error) {
+	return cast[*driver.Endpoint](v.do(ctx, "GetEndpoint", name, func() (any, error) { return v.drv.GetEndpoint(ctx, name) }))
+}
+
+func (v *VertexAI) ListEndpoints(ctx context.Context, location string) ([]driver.Endpoint, error) {
+	return cast[[]driver.Endpoint](v.do(ctx, "ListEndpoints", location, func() (any, error) { return v.drv.ListEndpoints(ctx, location) }))
+}
+
+func (v *VertexAI) DeleteEndpoint(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteEndpoint", name, func() (any, error) { return v.drv.DeleteEndpoint(ctx, name) }))
+}
+
+//nolint:gocritic // dm matches the driver signature; forwarded unchanged.
+func (v *VertexAI) DeployModel(
+	ctx context.Context, endpoint string, dm driver.DeployedModel,
+) (*driver.Operation, *driver.Endpoint, error) {
+	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "DeployModel", endpoint, func() (any, error) {
+		op, ep, e := v.drv.DeployModel(ctx, endpoint, dm)
+
+		return opPair[*driver.Endpoint]{op, ep}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) UndeployModel(
+	ctx context.Context, endpoint, deployedModelID string,
+) (*driver.Operation, *driver.Endpoint, error) {
+	r, err := cast[opPair[*driver.Endpoint]](v.do(ctx, "UndeployModel", endpoint, func() (any, error) {
+		op, ep, e := v.drv.UndeployModel(ctx, endpoint, deployedModelID)
+
+		return opPair[*driver.Endpoint]{op, ep}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) Predict(ctx context.Context, req driver.PredictRequest) (*driver.PredictResponse, error) {
+	return cast[*driver.PredictResponse](v.do(ctx, "Predict", req, func() (any, error) { return v.drv.Predict(ctx, req) }))
+}
+
+func (v *VertexAI) RawPredict(ctx context.Context, endpoint string, body []byte) ([]byte, error) {
+	return cast[[]byte](v.do(ctx, "RawPredict", endpoint, func() (any, error) { return v.drv.RawPredict(ctx, endpoint, body) }))
+}

--- a/vertexai/wrappers_featurestore.go
+++ b/vertexai/wrappers_featurestore.go
@@ -1,0 +1,203 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Legacy Featurestore / EntityType / Feature values ---
+
+func (v *VertexAI) CreateFeaturestore(
+	ctx context.Context, cfg driver.FeaturestoreConfig,
+) (*driver.Operation, *driver.Featurestore, error) {
+	r, err := cast[opPair[*driver.Featurestore]](v.do(ctx, "CreateFeaturestore", cfg, func() (any, error) {
+		op, fs, e := v.drv.CreateFeaturestore(ctx, cfg)
+
+		return opPair[*driver.Featurestore]{op, fs}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeaturestore(ctx context.Context, name string) (*driver.Featurestore, error) {
+	return cast[*driver.Featurestore](v.do(ctx, "GetFeaturestore", name, func() (any, error) { return v.drv.GetFeaturestore(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeaturestores(ctx context.Context, location string) ([]driver.Featurestore, error) {
+	return cast[[]driver.Featurestore](v.do(ctx, "ListFeaturestores", location, func() (any, error) {
+		return v.drv.ListFeaturestores(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteFeaturestore(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeaturestore", name, func() (any, error) {
+		return v.drv.DeleteFeaturestore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreateEntityType(
+	ctx context.Context, parent, entityTypeID, description string,
+) (*driver.Operation, *driver.EntityType, error) {
+	r, err := cast[opPair[*driver.EntityType]](v.do(ctx, "CreateEntityType", parent, func() (any, error) {
+		op, et, e := v.drv.CreateEntityType(ctx, parent, entityTypeID, description)
+
+		return opPair[*driver.EntityType]{op, et}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetEntityType(ctx context.Context, name string) (*driver.EntityType, error) {
+	return cast[*driver.EntityType](v.do(ctx, "GetEntityType", name, func() (any, error) { return v.drv.GetEntityType(ctx, name) }))
+}
+
+func (v *VertexAI) ListEntityTypes(ctx context.Context, parent string) ([]driver.EntityType, error) {
+	return cast[[]driver.EntityType](v.do(ctx, "ListEntityTypes", parent, func() (any, error) { return v.drv.ListEntityTypes(ctx, parent) }))
+}
+
+func (v *VertexAI) DeleteEntityType(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteEntityType", name, func() (any, error) {
+		return v.drv.DeleteEntityType(ctx, name)
+	}))
+}
+
+func (v *VertexAI) WriteFeatureValues(
+	ctx context.Context, entityType, entityID string, values []driver.FeatureNameValue,
+) error {
+	_, err := v.do(ctx, "WriteFeatureValues", entityType, func() (any, error) {
+		return nil, v.drv.WriteFeatureValues(ctx, entityType, entityID, values)
+	})
+
+	return err
+}
+
+func (v *VertexAI) ReadFeatureValues(
+	ctx context.Context, entityType, entityID string,
+) ([]driver.FeatureNameValue, error) {
+	return cast[[]driver.FeatureNameValue](v.do(ctx, "ReadFeatureValues", entityType, func() (any, error) {
+		return v.drv.ReadFeatureValues(ctx, entityType, entityID)
+	}))
+}
+
+func (v *VertexAI) CreateFeature(
+	ctx context.Context, parent, featureID, description string,
+) (*driver.Operation, *driver.Feature, error) {
+	r, err := cast[opPair[*driver.Feature]](v.do(ctx, "CreateFeature", parent, func() (any, error) {
+		op, f, e := v.drv.CreateFeature(ctx, parent, featureID, description)
+
+		return opPair[*driver.Feature]{op, f}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeature(ctx context.Context, name string) (*driver.Feature, error) {
+	return cast[*driver.Feature](v.do(ctx, "GetFeature", name, func() (any, error) { return v.drv.GetFeature(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeatures(ctx context.Context, parent string) ([]driver.Feature, error) {
+	return cast[[]driver.Feature](v.do(ctx, "ListFeatures", parent, func() (any, error) { return v.drv.ListFeatures(ctx, parent) }))
+}
+
+func (v *VertexAI) DeleteFeature(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeature", name, func() (any, error) { return v.drv.DeleteFeature(ctx, name) }))
+}
+
+// --- Feature Registry (featureGroups) ---
+
+func (v *VertexAI) CreateFeatureGroup(
+	ctx context.Context, cfg driver.FeatureGroupConfig,
+) (*driver.Operation, *driver.FeatureGroup, error) {
+	r, err := cast[opPair[*driver.FeatureGroup]](v.do(ctx, "CreateFeatureGroup", cfg, func() (any, error) {
+		op, fg, e := v.drv.CreateFeatureGroup(ctx, cfg)
+
+		return opPair[*driver.FeatureGroup]{op, fg}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeatureGroup(ctx context.Context, name string) (*driver.FeatureGroup, error) {
+	return cast[*driver.FeatureGroup](v.do(ctx, "GetFeatureGroup", name, func() (any, error) { return v.drv.GetFeatureGroup(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeatureGroups(ctx context.Context, location string) ([]driver.FeatureGroup, error) {
+	return cast[[]driver.FeatureGroup](v.do(ctx, "ListFeatureGroups", location, func() (any, error) {
+		return v.drv.ListFeatureGroups(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteFeatureGroup(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeatureGroup", name, func() (any, error) {
+		return v.drv.DeleteFeatureGroup(ctx, name)
+	}))
+}
+
+// --- Feature Online Stores ---
+
+func (v *VertexAI) CreateFeatureOnlineStore(
+	ctx context.Context, cfg driver.FeatureOnlineStoreConfig,
+) (*driver.Operation, *driver.FeatureOnlineStore, error) {
+	r, err := cast[opPair[*driver.FeatureOnlineStore]](v.do(ctx, "CreateFeatureOnlineStore", cfg, func() (any, error) {
+		op, fos, e := v.drv.CreateFeatureOnlineStore(ctx, cfg)
+
+		return opPair[*driver.FeatureOnlineStore]{op, fos}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeatureOnlineStore(ctx context.Context, name string) (*driver.FeatureOnlineStore, error) {
+	return cast[*driver.FeatureOnlineStore](v.do(ctx, "GetFeatureOnlineStore", name, func() (any, error) {
+		return v.drv.GetFeatureOnlineStore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListFeatureOnlineStores(ctx context.Context, location string) ([]driver.FeatureOnlineStore, error) {
+	return cast[[]driver.FeatureOnlineStore](v.do(ctx, "ListFeatureOnlineStores", location, func() (any, error) {
+		return v.drv.ListFeatureOnlineStores(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteFeatureOnlineStore(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeatureOnlineStore", name, func() (any, error) {
+		return v.drv.DeleteFeatureOnlineStore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreateFeatureView(
+	ctx context.Context, cfg driver.FeatureViewConfig,
+) (*driver.Operation, *driver.FeatureView, error) {
+	r, err := cast[opPair[*driver.FeatureView]](v.do(ctx, "CreateFeatureView", cfg, func() (any, error) {
+		op, fv, e := v.drv.CreateFeatureView(ctx, cfg)
+
+		return opPair[*driver.FeatureView]{op, fv}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetFeatureView(ctx context.Context, name string) (*driver.FeatureView, error) {
+	return cast[*driver.FeatureView](v.do(ctx, "GetFeatureView", name, func() (any, error) { return v.drv.GetFeatureView(ctx, name) }))
+}
+
+func (v *VertexAI) ListFeatureViews(ctx context.Context, parent string) ([]driver.FeatureView, error) {
+	return cast[[]driver.FeatureView](v.do(ctx, "ListFeatureViews", parent, func() (any, error) {
+		return v.drv.ListFeatureViews(ctx, parent)
+	}))
+}
+
+func (v *VertexAI) DeleteFeatureView(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteFeatureView", name, func() (any, error) {
+		return v.drv.DeleteFeatureView(ctx, name)
+	}))
+}
+
+func (v *VertexAI) FetchFeatureValues(
+	ctx context.Context, featureView, entityID string,
+) ([]driver.FeatureNameValue, error) {
+	return cast[[]driver.FeatureNameValue](v.do(ctx, "FetchFeatureValues", featureView, func() (any, error) {
+		return v.drv.FetchFeatureValues(ctx, featureView, entityID)
+	}))
+}

--- a/vertexai/wrappers_genai.go
+++ b/vertexai/wrappers_genai.go
@@ -1,0 +1,48 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) GenerateContent(
+	ctx context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.GenerateContentResponse, error) {
+	return cast[*driver.GenerateContentResponse](v.do(ctx, "GenerateContent", model, func() (any, error) {
+		return v.drv.GenerateContent(ctx, model, req)
+	}))
+}
+
+func (v *VertexAI) CountTokens(
+	ctx context.Context, model string, req driver.GenerateContentRequest,
+) (*driver.CountTokensResponse, error) {
+	return cast[*driver.CountTokensResponse](v.do(ctx, "CountTokens", model, func() (any, error) {
+		return v.drv.CountTokens(ctx, model, req)
+	}))
+}
+
+//nolint:gocritic // cfg matches the driver signature; forwarded unchanged.
+func (v *VertexAI) CreateCachedContent(ctx context.Context, cfg driver.CachedContentConfig) (*driver.CachedContent, error) {
+	return cast[*driver.CachedContent](v.do(ctx, "CreateCachedContent", cfg, func() (any, error) {
+		return v.drv.CreateCachedContent(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetCachedContent(ctx context.Context, name string) (*driver.CachedContent, error) {
+	return cast[*driver.CachedContent](v.do(ctx, "GetCachedContent", name, func() (any, error) {
+		return v.drv.GetCachedContent(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListCachedContents(ctx context.Context, location string) ([]driver.CachedContent, error) {
+	return cast[[]driver.CachedContent](v.do(ctx, "ListCachedContents", location, func() (any, error) {
+		return v.drv.ListCachedContents(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteCachedContent(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "DeleteCachedContent", name, func() (any, error) { return nil, v.drv.DeleteCachedContent(ctx, name) })
+
+	return err
+}

--- a/vertexai/wrappers_jobs.go
+++ b/vertexai/wrappers_jobs.go
@@ -1,0 +1,92 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateCustomJob(ctx context.Context, cfg driver.CustomJobConfig) (*driver.CustomJob, error) {
+	return cast[*driver.CustomJob](v.do(ctx, "CreateCustomJob", cfg, func() (any, error) { return v.drv.CreateCustomJob(ctx, cfg) }))
+}
+
+func (v *VertexAI) GetCustomJob(ctx context.Context, name string) (*driver.CustomJob, error) {
+	return cast[*driver.CustomJob](v.do(ctx, "GetCustomJob", name, func() (any, error) { return v.drv.GetCustomJob(ctx, name) }))
+}
+
+func (v *VertexAI) ListCustomJobs(ctx context.Context, location string) ([]driver.CustomJob, error) {
+	return cast[[]driver.CustomJob](v.do(ctx, "ListCustomJobs", location, func() (any, error) { return v.drv.ListCustomJobs(ctx, location) }))
+}
+
+func (v *VertexAI) CancelCustomJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelCustomJob", name, func() (any, error) { return nil, v.drv.CancelCustomJob(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) DeleteCustomJob(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteCustomJob", name, func() (any, error) { return v.drv.DeleteCustomJob(ctx, name) }))
+}
+
+func (v *VertexAI) CreateHyperparameterTuningJob(
+	ctx context.Context, cfg driver.HyperparameterTuningJobConfig,
+) (*driver.HyperparameterTuningJob, error) {
+	return cast[*driver.HyperparameterTuningJob](v.do(ctx, "CreateHyperparameterTuningJob", cfg, func() (any, error) {
+		return v.drv.CreateHyperparameterTuningJob(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetHyperparameterTuningJob(ctx context.Context, name string) (*driver.HyperparameterTuningJob, error) {
+	return cast[*driver.HyperparameterTuningJob](v.do(ctx, "GetHyperparameterTuningJob", name, func() (any, error) {
+		return v.drv.GetHyperparameterTuningJob(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListHyperparameterTuningJobs(ctx context.Context, location string) ([]driver.HyperparameterTuningJob, error) {
+	return cast[[]driver.HyperparameterTuningJob](v.do(ctx, "ListHyperparameterTuningJobs", location, func() (any, error) {
+		return v.drv.ListHyperparameterTuningJobs(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelHyperparameterTuningJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelHyperparameterTuningJob", name, func() (any, error) {
+		return nil, v.drv.CancelHyperparameterTuningJob(ctx, name)
+	})
+
+	return err
+}
+
+//nolint:gocritic // cfg matches the driver signature; forwarded unchanged.
+func (v *VertexAI) CreateBatchPredictionJob(
+	ctx context.Context, cfg driver.BatchPredictionJobConfig,
+) (*driver.BatchPredictionJob, error) {
+	return cast[*driver.BatchPredictionJob](v.do(ctx, "CreateBatchPredictionJob", cfg, func() (any, error) {
+		return v.drv.CreateBatchPredictionJob(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetBatchPredictionJob(ctx context.Context, name string) (*driver.BatchPredictionJob, error) {
+	return cast[*driver.BatchPredictionJob](v.do(ctx, "GetBatchPredictionJob", name, func() (any, error) {
+		return v.drv.GetBatchPredictionJob(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListBatchPredictionJobs(ctx context.Context, location string) ([]driver.BatchPredictionJob, error) {
+	return cast[[]driver.BatchPredictionJob](v.do(ctx, "ListBatchPredictionJobs", location, func() (any, error) {
+		return v.drv.ListBatchPredictionJobs(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelBatchPredictionJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelBatchPredictionJob", name, func() (any, error) {
+		return nil, v.drv.CancelBatchPredictionJob(ctx, name)
+	})
+
+	return err
+}
+
+func (v *VertexAI) DeleteBatchPredictionJob(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteBatchPredictionJob", name, func() (any, error) {
+		return v.drv.DeleteBatchPredictionJob(ctx, name)
+	}))
+}

--- a/vertexai/wrappers_metadata.go
+++ b/vertexai/wrappers_metadata.go
@@ -1,0 +1,187 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+// --- Metadata stores ---
+
+func (v *VertexAI) CreateMetadataStore(
+	ctx context.Context, location, storeID string,
+) (*driver.Operation, *driver.MetadataStore, error) {
+	r, err := cast[opPair[*driver.MetadataStore]](v.do(ctx, "CreateMetadataStore", location, func() (any, error) {
+		op, s, e := v.drv.CreateMetadataStore(ctx, location, storeID)
+
+		return opPair[*driver.MetadataStore]{op, s}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetMetadataStore(ctx context.Context, name string) (*driver.MetadataStore, error) {
+	return cast[*driver.MetadataStore](v.do(ctx, "GetMetadataStore", name, func() (any, error) {
+		return v.drv.GetMetadataStore(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListMetadataStores(ctx context.Context, location string) ([]driver.MetadataStore, error) {
+	return cast[[]driver.MetadataStore](v.do(ctx, "ListMetadataStores", location, func() (any, error) {
+		return v.drv.ListMetadataStores(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteMetadataStore(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteMetadataStore", name, func() (any, error) {
+		return v.drv.DeleteMetadataStore(ctx, name)
+	}))
+}
+
+// --- Tensorboards ---
+
+func (v *VertexAI) CreateTensorboard(
+	ctx context.Context, location, displayName string,
+) (*driver.Operation, *driver.Tensorboard, error) {
+	r, err := cast[opPair[*driver.Tensorboard]](v.do(ctx, "CreateTensorboard", location, func() (any, error) {
+		op, tb, e := v.drv.CreateTensorboard(ctx, location, displayName)
+
+		return opPair[*driver.Tensorboard]{op, tb}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetTensorboard(ctx context.Context, name string) (*driver.Tensorboard, error) {
+	return cast[*driver.Tensorboard](v.do(ctx, "GetTensorboard", name, func() (any, error) { return v.drv.GetTensorboard(ctx, name) }))
+}
+
+func (v *VertexAI) ListTensorboards(ctx context.Context, location string) ([]driver.Tensorboard, error) {
+	return cast[[]driver.Tensorboard](v.do(ctx, "ListTensorboards", location, func() (any, error) {
+		return v.drv.ListTensorboards(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteTensorboard(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteTensorboard", name, func() (any, error) {
+		return v.drv.DeleteTensorboard(ctx, name)
+	}))
+}
+
+// --- Schedules ---
+
+func (v *VertexAI) CreateSchedule(ctx context.Context, location, displayName, cron string) (*driver.Schedule, error) {
+	return cast[*driver.Schedule](v.do(ctx, "CreateSchedule", location, func() (any, error) {
+		return v.drv.CreateSchedule(ctx, location, displayName, cron)
+	}))
+}
+
+func (v *VertexAI) GetSchedule(ctx context.Context, name string) (*driver.Schedule, error) {
+	return cast[*driver.Schedule](v.do(ctx, "GetSchedule", name, func() (any, error) { return v.drv.GetSchedule(ctx, name) }))
+}
+
+func (v *VertexAI) ListSchedules(ctx context.Context, location string) ([]driver.Schedule, error) {
+	return cast[[]driver.Schedule](v.do(ctx, "ListSchedules", location, func() (any, error) { return v.drv.ListSchedules(ctx, location) }))
+}
+
+func (v *VertexAI) PauseSchedule(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "PauseSchedule", name, func() (any, error) { return nil, v.drv.PauseSchedule(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) ResumeSchedule(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "ResumeSchedule", name, func() (any, error) { return nil, v.drv.ResumeSchedule(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) DeleteSchedule(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteSchedule", name, func() (any, error) { return v.drv.DeleteSchedule(ctx, name) }))
+}
+
+// --- Notebook runtime templates ---
+
+func (v *VertexAI) CreateNotebookRuntimeTemplate(
+	ctx context.Context, location, displayName, machineType string,
+) (*driver.Operation, *driver.NotebookRuntimeTemplate, error) {
+	r, err := cast[opPair[*driver.NotebookRuntimeTemplate]](v.do(ctx, "CreateNotebookRuntimeTemplate", location, func() (any, error) {
+		op, t, e := v.drv.CreateNotebookRuntimeTemplate(ctx, location, displayName, machineType)
+
+		return opPair[*driver.NotebookRuntimeTemplate]{op, t}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetNotebookRuntimeTemplate(ctx context.Context, name string) (*driver.NotebookRuntimeTemplate, error) {
+	return cast[*driver.NotebookRuntimeTemplate](v.do(ctx, "GetNotebookRuntimeTemplate", name, func() (any, error) {
+		return v.drv.GetNotebookRuntimeTemplate(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListNotebookRuntimeTemplates(ctx context.Context, location string) ([]driver.NotebookRuntimeTemplate, error) {
+	return cast[[]driver.NotebookRuntimeTemplate](v.do(ctx, "ListNotebookRuntimeTemplates", location, func() (any, error) {
+		return v.drv.ListNotebookRuntimeTemplates(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteNotebookRuntimeTemplate(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteNotebookRuntimeTemplate", name, func() (any, error) {
+		return v.drv.DeleteNotebookRuntimeTemplate(ctx, name)
+	}))
+}
+
+// --- Notebook runtimes ---
+
+func (v *VertexAI) AssignNotebookRuntime(
+	ctx context.Context, location, displayName string,
+) (*driver.Operation, *driver.NotebookRuntime, error) {
+	r, err := cast[opPair[*driver.NotebookRuntime]](v.do(ctx, "AssignNotebookRuntime", location, func() (any, error) {
+		op, nr, e := v.drv.AssignNotebookRuntime(ctx, location, displayName)
+
+		return opPair[*driver.NotebookRuntime]{op, nr}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetNotebookRuntime(ctx context.Context, name string) (*driver.NotebookRuntime, error) {
+	return cast[*driver.NotebookRuntime](v.do(ctx, "GetNotebookRuntime", name, func() (any, error) {
+		return v.drv.GetNotebookRuntime(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListNotebookRuntimes(ctx context.Context, location string) ([]driver.NotebookRuntime, error) {
+	return cast[[]driver.NotebookRuntime](v.do(ctx, "ListNotebookRuntimes", location, func() (any, error) {
+		return v.drv.ListNotebookRuntimes(ctx, location)
+	}))
+}
+
+func (v *VertexAI) StartNotebookRuntime(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "StartNotebookRuntime", name, func() (any, error) {
+		return v.drv.StartNotebookRuntime(ctx, name)
+	}))
+}
+
+func (v *VertexAI) StopNotebookRuntime(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "StopNotebookRuntime", name, func() (any, error) {
+		return v.drv.StopNotebookRuntime(ctx, name)
+	}))
+}
+
+func (v *VertexAI) DeleteNotebookRuntime(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteNotebookRuntime", name, func() (any, error) {
+		return v.drv.DeleteNotebookRuntime(ctx, name)
+	}))
+}
+
+// --- Operations ---
+
+func (v *VertexAI) GetOperation(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "GetOperation", name, func() (any, error) { return v.drv.GetOperation(ctx, name) }))
+}
+
+func (v *VertexAI) ListOperations(ctx context.Context, parent string) ([]driver.Operation, error) {
+	return cast[[]driver.Operation](v.do(ctx, "ListOperations", parent, func() (any, error) { return v.drv.ListOperations(ctx, parent) }))
+}

--- a/vertexai/wrappers_models.go
+++ b/vertexai/wrappers_models.go
@@ -1,0 +1,66 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+//nolint:gocritic // cfg matches the driver signature; forwarded unchanged.
+func (v *VertexAI) UploadModel(ctx context.Context, cfg driver.ModelConfig) (*driver.Operation, *driver.Model, error) {
+	r, err := cast[opPair[*driver.Model]](v.do(ctx, "UploadModel", cfg, func() (any, error) {
+		op, m, e := v.drv.UploadModel(ctx, cfg)
+
+		return opPair[*driver.Model]{op, m}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetModel(ctx context.Context, name string) (*driver.Model, error) {
+	return cast[*driver.Model](v.do(ctx, "GetModel", name, func() (any, error) { return v.drv.GetModel(ctx, name) }))
+}
+
+func (v *VertexAI) ListModels(ctx context.Context, location string) ([]driver.Model, error) {
+	return cast[[]driver.Model](v.do(ctx, "ListModels", location, func() (any, error) { return v.drv.ListModels(ctx, location) }))
+}
+
+func (v *VertexAI) PatchModel(ctx context.Context, name, displayName, description string) (*driver.Model, error) {
+	return cast[*driver.Model](v.do(ctx, "PatchModel", name, func() (any, error) {
+		return v.drv.PatchModel(ctx, name, displayName, description)
+	}))
+}
+
+func (v *VertexAI) DeleteModel(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteModel", name, func() (any, error) { return v.drv.DeleteModel(ctx, name) }))
+}
+
+func (v *VertexAI) ListModelVersions(ctx context.Context, name string) ([]driver.Model, error) {
+	return cast[[]driver.Model](v.do(ctx, "ListModelVersions", name, func() (any, error) { return v.drv.ListModelVersions(ctx, name) }))
+}
+
+func (v *VertexAI) DeleteModelVersion(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteModelVersion", name, func() (any, error) {
+		return v.drv.DeleteModelVersion(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ImportModelEvaluation(
+	ctx context.Context, modelName string, eval driver.ModelEvaluation,
+) (*driver.ModelEvaluation, error) {
+	return cast[*driver.ModelEvaluation](v.do(ctx, "ImportModelEvaluation", modelName, func() (any, error) {
+		return v.drv.ImportModelEvaluation(ctx, modelName, eval)
+	}))
+}
+
+func (v *VertexAI) GetModelEvaluation(ctx context.Context, name string) (*driver.ModelEvaluation, error) {
+	return cast[*driver.ModelEvaluation](v.do(ctx, "GetModelEvaluation", name, func() (any, error) {
+		return v.drv.GetModelEvaluation(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListModelEvaluations(ctx context.Context, modelName string) ([]driver.ModelEvaluation, error) {
+	return cast[[]driver.ModelEvaluation](v.do(ctx, "ListModelEvaluations", modelName, func() (any, error) {
+		return v.drv.ListModelEvaluations(ctx, modelName)
+	}))
+}

--- a/vertexai/wrappers_pipelines.go
+++ b/vertexai/wrappers_pipelines.go
@@ -1,0 +1,87 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateTrainingPipeline(
+	ctx context.Context, cfg driver.TrainingPipelineConfig,
+) (*driver.TrainingPipeline, error) {
+	return cast[*driver.TrainingPipeline](v.do(ctx, "CreateTrainingPipeline", cfg, func() (any, error) {
+		return v.drv.CreateTrainingPipeline(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetTrainingPipeline(ctx context.Context, name string) (*driver.TrainingPipeline, error) {
+	return cast[*driver.TrainingPipeline](v.do(ctx, "GetTrainingPipeline", name, func() (any, error) {
+		return v.drv.GetTrainingPipeline(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListTrainingPipelines(ctx context.Context, location string) ([]driver.TrainingPipeline, error) {
+	return cast[[]driver.TrainingPipeline](v.do(ctx, "ListTrainingPipelines", location, func() (any, error) {
+		return v.drv.ListTrainingPipelines(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelTrainingPipeline(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelTrainingPipeline", name, func() (any, error) {
+		return nil, v.drv.CancelTrainingPipeline(ctx, name)
+	})
+
+	return err
+}
+
+func (v *VertexAI) DeleteTrainingPipeline(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteTrainingPipeline", name, func() (any, error) {
+		return v.drv.DeleteTrainingPipeline(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreatePipelineJob(ctx context.Context, cfg driver.PipelineJobConfig) (*driver.PipelineJob, error) {
+	return cast[*driver.PipelineJob](v.do(ctx, "CreatePipelineJob", cfg, func() (any, error) {
+		return v.drv.CreatePipelineJob(ctx, cfg)
+	}))
+}
+
+func (v *VertexAI) GetPipelineJob(ctx context.Context, name string) (*driver.PipelineJob, error) {
+	return cast[*driver.PipelineJob](v.do(ctx, "GetPipelineJob", name, func() (any, error) { return v.drv.GetPipelineJob(ctx, name) }))
+}
+
+func (v *VertexAI) ListPipelineJobs(ctx context.Context, location string) ([]driver.PipelineJob, error) {
+	return cast[[]driver.PipelineJob](v.do(ctx, "ListPipelineJobs", location, func() (any, error) {
+		return v.drv.ListPipelineJobs(ctx, location)
+	}))
+}
+
+func (v *VertexAI) CancelPipelineJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelPipelineJob", name, func() (any, error) { return nil, v.drv.CancelPipelineJob(ctx, name) })
+
+	return err
+}
+
+func (v *VertexAI) DeletePipelineJob(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeletePipelineJob", name, func() (any, error) {
+		return v.drv.DeletePipelineJob(ctx, name)
+	}))
+}
+
+func (v *VertexAI) CreateTuningJob(ctx context.Context, cfg driver.TuningJobConfig) (*driver.TuningJob, error) {
+	return cast[*driver.TuningJob](v.do(ctx, "CreateTuningJob", cfg, func() (any, error) { return v.drv.CreateTuningJob(ctx, cfg) }))
+}
+
+func (v *VertexAI) GetTuningJob(ctx context.Context, name string) (*driver.TuningJob, error) {
+	return cast[*driver.TuningJob](v.do(ctx, "GetTuningJob", name, func() (any, error) { return v.drv.GetTuningJob(ctx, name) }))
+}
+
+func (v *VertexAI) ListTuningJobs(ctx context.Context, location string) ([]driver.TuningJob, error) {
+	return cast[[]driver.TuningJob](v.do(ctx, "ListTuningJobs", location, func() (any, error) { return v.drv.ListTuningJobs(ctx, location) }))
+}
+
+func (v *VertexAI) CancelTuningJob(ctx context.Context, name string) error {
+	_, err := v.do(ctx, "CancelTuningJob", name, func() (any, error) { return nil, v.drv.CancelTuningJob(ctx, name) })
+
+	return err
+}

--- a/vertexai/wrappers_vectorsearch.go
+++ b/vertexai/wrappers_vectorsearch.go
@@ -1,0 +1,107 @@
+package vertexai
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/vertexai/driver"
+)
+
+func (v *VertexAI) CreateIndex(ctx context.Context, cfg driver.IndexConfig) (*driver.Operation, *driver.Index, error) {
+	r, err := cast[opPair[*driver.Index]](v.do(ctx, "CreateIndex", cfg, func() (any, error) {
+		op, idx, e := v.drv.CreateIndex(ctx, cfg)
+
+		return opPair[*driver.Index]{op, idx}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetIndex(ctx context.Context, name string) (*driver.Index, error) {
+	return cast[*driver.Index](v.do(ctx, "GetIndex", name, func() (any, error) { return v.drv.GetIndex(ctx, name) }))
+}
+
+func (v *VertexAI) ListIndexes(ctx context.Context, location string) ([]driver.Index, error) {
+	return cast[[]driver.Index](v.do(ctx, "ListIndexes", location, func() (any, error) { return v.drv.ListIndexes(ctx, location) }))
+}
+
+func (v *VertexAI) DeleteIndex(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteIndex", name, func() (any, error) { return v.drv.DeleteIndex(ctx, name) }))
+}
+
+func (v *VertexAI) UpsertDatapoints(ctx context.Context, index string, datapoints []driver.Datapoint) error {
+	_, err := v.do(ctx, "UpsertDatapoints", index, func() (any, error) {
+		return nil, v.drv.UpsertDatapoints(ctx, index, datapoints)
+	})
+
+	return err
+}
+
+func (v *VertexAI) RemoveDatapoints(ctx context.Context, index string, datapointIDs []string) error {
+	_, err := v.do(ctx, "RemoveDatapoints", index, func() (any, error) {
+		return nil, v.drv.RemoveDatapoints(ctx, index, datapointIDs)
+	})
+
+	return err
+}
+
+func (v *VertexAI) CreateIndexEndpoint(
+	ctx context.Context, cfg driver.IndexEndpointConfig,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	r, err := cast[opPair[*driver.IndexEndpoint]](v.do(ctx, "CreateIndexEndpoint", cfg, func() (any, error) {
+		op, ie, e := v.drv.CreateIndexEndpoint(ctx, cfg)
+
+		return opPair[*driver.IndexEndpoint]{op, ie}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) GetIndexEndpoint(ctx context.Context, name string) (*driver.IndexEndpoint, error) {
+	return cast[*driver.IndexEndpoint](v.do(ctx, "GetIndexEndpoint", name, func() (any, error) {
+		return v.drv.GetIndexEndpoint(ctx, name)
+	}))
+}
+
+func (v *VertexAI) ListIndexEndpoints(ctx context.Context, location string) ([]driver.IndexEndpoint, error) {
+	return cast[[]driver.IndexEndpoint](v.do(ctx, "ListIndexEndpoints", location, func() (any, error) {
+		return v.drv.ListIndexEndpoints(ctx, location)
+	}))
+}
+
+func (v *VertexAI) DeleteIndexEndpoint(ctx context.Context, name string) (*driver.Operation, error) {
+	return cast[*driver.Operation](v.do(ctx, "DeleteIndexEndpoint", name, func() (any, error) {
+		return v.drv.DeleteIndexEndpoint(ctx, name)
+	}))
+}
+
+func (v *VertexAI) DeployIndex(
+	ctx context.Context, indexEndpoint string, di driver.DeployedIndex,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	r, err := cast[opPair[*driver.IndexEndpoint]](v.do(ctx, "DeployIndex", indexEndpoint, func() (any, error) {
+		op, ie, e := v.drv.DeployIndex(ctx, indexEndpoint, di)
+
+		return opPair[*driver.IndexEndpoint]{op, ie}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) UndeployIndex(
+	ctx context.Context, indexEndpoint, deployedIndexID string,
+) (*driver.Operation, *driver.IndexEndpoint, error) {
+	r, err := cast[opPair[*driver.IndexEndpoint]](v.do(ctx, "UndeployIndex", indexEndpoint, func() (any, error) {
+		op, ie, e := v.drv.UndeployIndex(ctx, indexEndpoint, deployedIndexID)
+
+		return opPair[*driver.IndexEndpoint]{op, ie}, e
+	}))
+
+	return r.op, r.res, err
+}
+
+func (v *VertexAI) FindNeighbors(
+	ctx context.Context, indexEndpoint, deployedIndexID string, query []float64, count int,
+) ([]driver.Neighbor, error) {
+	return cast[[]driver.Neighbor](v.do(ctx, "FindNeighbors", indexEndpoint, func() (any, error) {
+		return v.drv.FindNeighbors(ctx, indexEndpoint, deployedIndexID, query, count)
+	}))
+}


### PR DESCRIPTION
## Summary

Adds full Google Cloud Vertex AI (`aiplatform.googleapis.com`) emulation across all three layers, with behavioral integration matching every other service.

- **Driver + in-memory provider** — the complete Vertex AI surface (~128 operations) spanning datasets, model registry (versions/evaluations), endpoints + online prediction, custom/batch/HPO/tuning jobs, training & pipeline jobs, the Gemini `generateContent` runtime + cached contents, Feature Store (legacy + Registry + online stores/views), Vector Search, ML metadata, tensorboards, schedules, and notebook runtimes.
- **Portable Layer-1 wrapper** (`vertexai/vertexai.go`) — wraps the driver with recorder, metrics, rate limiting, error injection and latency simulation through a single `do()` pipeline, exactly like `bedrock`/`sagemaker`.
- **SDK-compat REST server** — now serves **all 20 collections** (previously only 5 core ones). Real `google.golang.org/api/aiplatform/v1` clients (or any REST caller) configured with a custom endpoint hit it the same way they hit `{location}-aiplatform.googleapis.com`. Control-plane mutations return done `google.longrunning.Operation`s; job-family creates are synchronous.
- **Cross-cutting parity** — `chaos.WrapVertexAI` injects failures on submission/runtime calls; default Vertex cost rates added.

## Provider correctness (SageMaker review lessons applied proactively)

- Deep-copy slices/maps on store and return (`clone.go`); no shared backing arrays or maps.
- Copy-then-Set on every mutator — stored pointers are never mutated in place (fixes the `UndeployModel` traffic-split aliasing class of bug).
- Lifecycle guards: schedule Pause/Resume and notebook-runtime Start/Stop reject illegal transitions (`FailedPrecondition`).
- `FindNeighbors` bounds its allocation against unvalidated/hostile counts.
- `ServeHTTP` dispatches via a route table to stay within cyclomatic-complexity limits.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all green
- [x] `golangci-lint run` clean on every touched package (provider, Layer-1, server, chaos, cost)
- [x] SDK-compat roundtrip tests start a real `httptest` server and exercise every new family over HTTP (models/versions/evaluations, jobs, pipelines, tuning, cached contents, Feature Store + online read/write, Feature Registry, online stores/views + fetch, Vector Search deploy + findNeighbors, metadata/tensorboard/schedule/notebook lifecycle)
- [x] Layer-1 wrapper tests cover recording, error injection, latency, result forwarding
- [x] Chaos wrapper tests cover injected-failure and pass-through paths
