### PR TITLE
feat(iam): managed policy versions across AWS/Azure/GCP

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -942,6 +942,64 @@ func TestFIFODeduplication(t *testing.T) {
 	}
 }
 
+func TestIAMPolicyVersions(t *testing.T) {
+	ctx := context.Background()
+
+	providers := []struct {
+		name string
+		iam  iamdriver.IAM
+	}{
+		{"aws", NewAWS().IAM},
+		{"azure", NewAzure().IAM},
+		{"gcp", NewGCP().IAM},
+	}
+
+	for _, tc := range providers {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := tc.iam.CreatePolicy(ctx, iamdriver.PolicyConfig{Name: "vpol", PolicyDocument: `{"v":1}`})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// CreatePolicy auto-seeds a default v1.
+			versions, err := tc.iam.ListPolicyVersions(ctx, p.ARN)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(versions) != 1 || versions[0].VersionID != "v1" || !versions[0].IsDefaultVersion {
+				t.Fatalf("expected seeded default v1, got %+v", versions)
+			}
+
+			// A new default version updates the policy's effective document.
+			v2, err := tc.iam.CreatePolicyVersion(ctx, iamdriver.PolicyVersionConfig{
+				PolicyARN: p.ARN, PolicyDocument: `{"v":2}`, SetAsDefault: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v2.IsDefaultVersion {
+				t.Error("expected v2 to be the default version")
+			}
+
+			got, err := tc.iam.GetPolicy(ctx, p.ARN)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.PolicyDocument != `{"v":2}` {
+				t.Errorf("expected effective document to follow default, got %q", got.PolicyDocument)
+			}
+
+			// The default version cannot be deleted; a non-default one can.
+			if err := tc.iam.DeletePolicyVersion(ctx, p.ARN, "v2"); err == nil {
+				t.Error("expected error deleting the default version")
+			}
+			if err := tc.iam.DeletePolicyVersion(ctx, p.ARN, "v1"); err != nil {
+				t.Fatalf("unexpected error deleting non-default version: %v", err)
+			}
+		})
+	}
+}
+
 func TestIAMCheckPermission(t *testing.T) {
 	ctx := context.Background()
 	p := NewAWS()

--- a/iam/driver/driver.go
+++ b/iam/driver/driver.go
@@ -56,6 +56,21 @@ type PolicyInfo struct {
 	Description    string
 }
 
+// PolicyVersionConfig describes a new version of a managed policy to create.
+type PolicyVersionConfig struct {
+	PolicyARN      string
+	PolicyDocument string
+	SetAsDefault   bool
+}
+
+// PolicyVersionInfo describes a single version of a managed policy.
+type PolicyVersionInfo struct {
+	VersionID        string
+	PolicyDocument   string
+	IsDefaultVersion bool
+	CreatedAt        string
+}
+
 // GroupConfig describes a group to create.
 type GroupConfig struct {
 	Name string
@@ -117,6 +132,12 @@ type IAM interface {
 	DeletePolicy(ctx context.Context, arn string) error
 	GetPolicy(ctx context.Context, arn string) (*PolicyInfo, error)
 	ListPolicies(ctx context.Context) ([]PolicyInfo, error)
+
+	CreatePolicyVersion(ctx context.Context, config PolicyVersionConfig) (*PolicyVersionInfo, error)
+	GetPolicyVersion(ctx context.Context, policyARN, versionID string) (*PolicyVersionInfo, error)
+	ListPolicyVersions(ctx context.Context, policyARN string) ([]PolicyVersionInfo, error)
+	DeletePolicyVersion(ctx context.Context, policyARN, versionID string) error
+	SetDefaultPolicyVersion(ctx context.Context, policyARN, versionID string) error
 
 	AttachUserPolicy(ctx context.Context, userName, policyARN string) error
 	DetachUserPolicy(ctx context.Context, userName, policyARN string) error

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -180,6 +180,57 @@ func (i *IAM) ListPolicies(ctx context.Context) ([]driver.PolicyInfo, error) {
 	return out.([]driver.PolicyInfo), nil
 }
 
+func (i *IAM) CreatePolicyVersion(
+	ctx context.Context, config driver.PolicyVersionConfig,
+) (*driver.PolicyVersionInfo, error) {
+	out, err := i.do(ctx, "CreatePolicyVersion", config, func() (any, error) {
+		return i.driver.CreatePolicyVersion(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PolicyVersionInfo), nil
+}
+
+func (i *IAM) GetPolicyVersion(ctx context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	out, err := i.do(ctx, "GetPolicyVersion", policyARN, func() (any, error) {
+		return i.driver.GetPolicyVersion(ctx, policyARN, versionID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PolicyVersionInfo), nil
+}
+
+func (i *IAM) ListPolicyVersions(ctx context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	out, err := i.do(ctx, "ListPolicyVersions", policyARN, func() (any, error) {
+		return i.driver.ListPolicyVersions(ctx, policyARN)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.PolicyVersionInfo), nil
+}
+
+func (i *IAM) DeletePolicyVersion(ctx context.Context, policyARN, versionID string) error {
+	_, err := i.do(ctx, "DeletePolicyVersion", policyARN, func() (any, error) {
+		return nil, i.driver.DeletePolicyVersion(ctx, policyARN, versionID)
+	})
+
+	return err
+}
+
+func (i *IAM) SetDefaultPolicyVersion(ctx context.Context, policyARN, versionID string) error {
+	_, err := i.do(ctx, "SetDefaultPolicyVersion", policyARN, func() (any, error) {
+		return nil, i.driver.SetDefaultPolicyVersion(ctx, policyARN, versionID)
+	})
+
+	return err
+}
+
 func (i *IAM) AttachUserPolicy(ctx context.Context, userName, policyARN string) error {
 	_, err := i.do(ctx, "AttachUserPolicy", userName, func() (any, error) {
 		return nil, i.driver.AttachUserPolicy(ctx, userName, policyARN)

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -25,6 +25,8 @@ type mockDriver struct {
 	userPolicies     map[string][]string // userName -> []policyARN
 	rolePolicies     map[string][]string // roleName -> []policyARN
 	groupUsers       map[string]map[string]bool
+	policyVersions   map[string][]*driver.PolicyVersionInfo
+	versionSeq       map[string]int
 	seq              int
 }
 
@@ -39,6 +41,8 @@ func newMockDriver() *mockDriver {
 		userPolicies:     make(map[string][]string),
 		rolePolicies:     make(map[string][]string),
 		groupUsers:       make(map[string]map[string]bool),
+		policyVersions:   make(map[string][]*driver.PolicyVersionInfo),
+		versionSeq:       make(map[string]int),
 	}
 }
 
@@ -197,6 +201,69 @@ func (m *mockDriver) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error
 	}
 
 	return result, nil
+}
+
+func (m *mockDriver) CreatePolicyVersion(
+	_ context.Context, cfg driver.PolicyVersionConfig,
+) (*driver.PolicyVersionInfo, error) {
+	if _, ok := m.policies[cfg.PolicyARN]; !ok {
+		return nil, fmt.Errorf("policy not found")
+	}
+
+	m.versionSeq[cfg.PolicyARN]++
+	v := &driver.PolicyVersionInfo{
+		VersionID:        fmt.Sprintf("v%d", m.versionSeq[cfg.PolicyARN]),
+		PolicyDocument:   cfg.PolicyDocument,
+		IsDefaultVersion: cfg.SetAsDefault,
+	}
+	m.policyVersions[cfg.PolicyARN] = append(m.policyVersions[cfg.PolicyARN], v)
+
+	return v, nil
+}
+
+func (m *mockDriver) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	for _, v := range m.policyVersions[policyARN] {
+		if v.VersionID == versionID {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("version not found")
+}
+
+func (m *mockDriver) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	if _, ok := m.policies[policyARN]; !ok {
+		return nil, fmt.Errorf("policy not found")
+	}
+
+	result := make([]driver.PolicyVersionInfo, 0, len(m.policyVersions[policyARN]))
+	for _, v := range m.policyVersions[policyARN] {
+		result = append(result, *v)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	versions := m.policyVersions[policyARN]
+	for idx, v := range versions {
+		if v.VersionID == versionID {
+			m.policyVersions[policyARN] = append(versions[:idx], versions[idx+1:]...)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("version not found")
+}
+
+func (m *mockDriver) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	for _, v := range m.policyVersions[policyARN] {
+		if v.VersionID == versionID {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("version not found")
 }
 
 func (m *mockDriver) AttachUserPolicy(_ context.Context, userName, policyARN string) error {
@@ -668,6 +735,49 @@ func TestCreatePolicy(t *testing.T) {
 		_, err := i.CreatePolicy(ctx, driver.PolicyConfig{})
 		require.Error(t, err)
 	})
+}
+
+func TestPolicyVersions(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	p, err := i.CreatePolicy(ctx, driver.PolicyConfig{Name: "my-policy", PolicyDocument: "{}"})
+	require.NoError(t, err)
+
+	v, err := i.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{
+		PolicyARN: p.ARN, PolicyDocument: `{"doc":2}`, SetAsDefault: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "v1", v.VersionID)
+	assert.True(t, v.IsDefaultVersion)
+
+	got, err := i.GetPolicyVersion(ctx, p.ARN, v.VersionID)
+	require.NoError(t, err)
+	assert.Equal(t, `{"doc":2}`, got.PolicyDocument)
+
+	versions, err := i.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Len(t, versions, 1)
+
+	require.NoError(t, i.SetDefaultPolicyVersion(ctx, p.ARN, v.VersionID))
+	require.NoError(t, i.DeletePolicyVersion(ctx, p.ARN, v.VersionID))
+
+	_, err = i.GetPolicyVersion(ctx, p.ARN, v.VersionID)
+	require.Error(t, err)
+}
+
+func TestPolicyVersionErrorsPropagate(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing"})
+	require.Error(t, err)
+	_, err = i.GetPolicyVersion(ctx, "missing", "v1")
+	require.Error(t, err)
+	_, err = i.ListPolicyVersions(ctx, "missing")
+	require.Error(t, err)
+	require.Error(t, i.DeletePolicyVersion(ctx, "missing", "v1"))
+	require.Error(t, i.SetDefaultPolicyVersion(ctx, "missing", "v1"))
 }
 
 func TestDeletePolicy(t *testing.T) {

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -296,6 +296,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 		return nil, errors.Newf(errors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toPolicyInfo(p)
 
 	return &info, nil
@@ -305,6 +308,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	all := m.policies.All()
 	result := make([]driver.PolicyInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, p := range all {
 		result = append(result, toPolicyInfo(p))
@@ -718,6 +724,9 @@ func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
 // to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	policyARNs := m.collectPolicyARNs(principal)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	hasAllow := false
 

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -273,9 +273,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		Description:    cfg.Description,
 	}
 	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
-	m.policies.Set(arn, p)
 
+	// Snapshot before publishing p to the store: once Set runs, p is shared and
+	// its document may be mutated concurrently by the version operations.
 	info := toPolicyInfo(p)
+	m.policies.Set(arn, p)
 
 	return &info, nil
 }

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -62,6 +62,15 @@ type policyData struct {
 	Path           string
 	PolicyDocument string
 	Description    string
+	versions       []*policyVersionData
+	versionCounter int
+}
+
+type policyVersionData struct {
+	VersionID      string
+	PolicyDocument string
+	IsDefault      bool
+	CreatedAt      string
 }
 
 type groupData struct {
@@ -263,6 +272,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		PolicyDocument: cfg.PolicyDocument,
 		Description:    cfg.Description,
 	}
+	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
 	m.policies.Set(arn, p)
 
 	info := toPolicyInfo(p)
@@ -301,6 +311,171 @@ func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	}
 
 	return result, nil
+}
+
+const maxPolicyVersions = 5
+
+// seedInitialVersion records the default v1 version when a policy is created.
+func seedInitialVersion(p *policyData, document, createdAt string) {
+	p.versionCounter = 1
+	p.versions = []*policyVersionData{{
+		VersionID:      "v1",
+		PolicyDocument: document,
+		IsDefault:      true,
+		CreatedAt:      createdAt,
+	}}
+}
+
+// CreatePolicyVersion adds a new version to a managed policy, optionally as the default.
+func (m *Mock) CreatePolicyVersion(_ context.Context, cfg driver.PolicyVersionConfig) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(cfg.PolicyARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "policy %q not found", cfg.PolicyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(p.versions) >= maxPolicyVersions {
+		return nil, errors.Newf(errors.ResourceExhausted,
+			"policy %q already has the maximum of %d versions", cfg.PolicyARN, maxPolicyVersions)
+	}
+
+	p.versionCounter++
+	v := &policyVersionData{
+		VersionID:      fmt.Sprintf("v%d", p.versionCounter),
+		PolicyDocument: cfg.PolicyDocument,
+		IsDefault:      cfg.SetAsDefault,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	if cfg.SetAsDefault {
+		clearDefaults(p.versions)
+		p.PolicyDocument = cfg.PolicyDocument
+	}
+
+	p.versions = append(p.versions, v)
+	m.policies.Set(cfg.PolicyARN, p)
+
+	info := toPolicyVersionInfo(v)
+
+	return &info, nil
+}
+
+// GetPolicyVersion returns a single version of a managed policy.
+func (m *Mock) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, v := range p.versions {
+		if v.VersionID == versionID {
+			info := toPolicyVersionInfo(v)
+			return &info, nil
+		}
+	}
+
+	return nil, errors.Newf(errors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// ListPolicyVersions returns all versions of a managed policy.
+func (m *Mock) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]driver.PolicyVersionInfo, 0, len(p.versions))
+	for _, v := range p.versions {
+		result = append(result, toPolicyVersionInfo(v))
+	}
+
+	return result, nil
+}
+
+// DeletePolicyVersion removes a non-default version of a managed policy.
+func (m *Mock) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for idx, v := range p.versions {
+		if v.VersionID != versionID {
+			continue
+		}
+
+		if v.IsDefault {
+			return errors.Newf(errors.FailedPrecondition,
+				"cannot delete the default version %q of policy %q", versionID, policyARN)
+		}
+
+		p.versions = append(p.versions[:idx], p.versions[idx+1:]...)
+		m.policies.Set(policyARN, p)
+
+		return nil
+	}
+
+	return errors.Newf(errors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// SetDefaultPolicyVersion marks an existing version as the default for a managed policy.
+func (m *Mock) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target := findVersion(p.versions, versionID)
+	if target == nil {
+		return errors.Newf(errors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+	}
+
+	clearDefaults(p.versions)
+
+	target.IsDefault = true
+	p.PolicyDocument = target.PolicyDocument
+	m.policies.Set(policyARN, p)
+
+	return nil
+}
+
+func clearDefaults(versions []*policyVersionData) {
+	for _, v := range versions {
+		v.IsDefault = false
+	}
+}
+
+func findVersion(versions []*policyVersionData, versionID string) *policyVersionData {
+	for _, v := range versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func toPolicyVersionInfo(v *policyVersionData) driver.PolicyVersionInfo {
+	return driver.PolicyVersionInfo{
+		VersionID:        v.VersionID,
+		PolicyDocument:   v.PolicyDocument,
+		IsDefaultVersion: v.IsDefault,
+		CreatedAt:        v.CreatedAt,
+	}
 }
 
 func (m *Mock) attachPolicy(

--- a/providers/aws/awsiam/iam_test.go
+++ b/providers/aws/awsiam/iam_test.go
@@ -3,6 +3,7 @@ package awsiam
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -773,6 +774,43 @@ func TestPolicyVersionsErrors(t *testing.T) {
 
 	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
 	assertEqual(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestPolicyVersionsConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "concurrent", PolicyDocument: `{"v":1}`})
+	requireNoError(t, err)
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: `{"v":2}`})
+	requireNoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "u", p.ARN))
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for i := range iterations {
+		wg.Add(4)
+
+		go func() { defer wg.Done(); _, _ = m.GetPolicy(ctx, p.ARN) }()
+		go func() { defer wg.Done(); _, _ = m.ListPolicies(ctx) }()
+		go func() { defer wg.Done(); _, _ = m.CheckPermission(ctx, "u", "s3:GetObject", "*") }()
+		go func(n int) {
+			defer wg.Done()
+
+			ver := "v1"
+			if n%2 == 0 {
+				ver = "v2"
+			}
+
+			_ = m.SetDefaultPolicyVersion(ctx, p.ARN, ver)
+		}(i)
+	}
+
+	wg.Wait()
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/aws/awsiam/iam_test.go
+++ b/providers/aws/awsiam/iam_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/iam/driver"
 )
 
@@ -685,6 +686,93 @@ func TestCheckPermissionViaRole(t *testing.T) {
 	allowed, err := m.CheckPermission(ctx, "reader", "s3:GetObject", "arn:aws:s3:::bucket/key")
 	requireNoError(t, err)
 	assertEqual(t, true, allowed)
+}
+
+func TestPolicyVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	doc1 := makePolicyDoc([]map[string]any{{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}})
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc1})
+	requireNoError(t, err)
+
+	// CreatePolicy seeds a default v1.
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(versions))
+	assertEqual(t, "v1", versions[0].VersionID)
+	assertEqual(t, true, versions[0].IsDefaultVersion)
+
+	// A non-default version does not change the policy's effective document.
+	doc2 := makePolicyDoc([]map[string]any{{"Effect": "Deny", "Action": "s3:*", "Resource": "*"}})
+	v2, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc2})
+	requireNoError(t, err)
+	assertEqual(t, "v2", v2.VersionID)
+	assertEqual(t, false, v2.IsDefaultVersion)
+
+	got, err := m.GetPolicy(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, doc1, got.PolicyDocument)
+
+	// Creating a version as default updates the effective document.
+	doc3 := makePolicyDoc([]map[string]any{{"Effect": "Allow", "Action": "ec2:*", "Resource": "*"}})
+	v3, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc3, SetAsDefault: true})
+	requireNoError(t, err)
+	assertEqual(t, true, v3.IsDefaultVersion)
+
+	got, err = m.GetPolicy(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, doc3, got.PolicyDocument)
+
+	gv, err := m.GetPolicyVersion(ctx, p.ARN, "v2")
+	requireNoError(t, err)
+	assertEqual(t, doc2, gv.PolicyDocument)
+
+	// SetDefaultPolicyVersion switches the default back to v1.
+	requireNoError(t, m.SetDefaultPolicyVersion(ctx, p.ARN, "v1"))
+	got, err = m.GetPolicy(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, doc1, got.PolicyDocument)
+
+	// The default version cannot be deleted.
+	err = m.DeletePolicyVersion(ctx, p.ARN, "v1")
+	assertError(t, err, true)
+	assertEqual(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+
+	// A non-default version can be deleted.
+	requireNoError(t, m.DeletePolicyVersion(ctx, p.ARN, "v2"))
+	versions, err = m.ListPolicyVersions(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(versions))
+}
+
+func TestPolicyVersionsErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing", PolicyDocument: "{}"})
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.GetPolicyVersion(ctx, "missing", "v1")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.ListPolicyVersions(ctx, "missing")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(m.DeletePolicyVersion(ctx, "missing", "v1")))
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(m.SetDefaultPolicyVersion(ctx, "missing", "v1")))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	requireNoError(t, err)
+
+	_, err = m.GetPolicyVersion(ctx, p.ARN, "v9")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+
+	// v1 is seeded; four more reach the maximum of five, the next is rejected.
+	for range 4 {
+		_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+		requireNoError(t, err)
+	}
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+	assertEqual(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -62,6 +62,15 @@ type policyData struct {
 	Path           string
 	PolicyDocument string
 	Description    string
+	versions       []*policyVersionData
+	versionCounter int
+}
+
+type policyVersionData struct {
+	VersionID      string
+	PolicyDocument string
+	IsDefault      bool
+	CreatedAt      string
 }
 
 type groupData struct {
@@ -263,6 +272,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		PolicyDocument: cfg.PolicyDocument,
 		Description:    cfg.Description,
 	}
+	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
 	m.policies.Set(arn, p)
 
 	info := toPolicyInfo(p)
@@ -301,6 +311,171 @@ func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	}
 
 	return result, nil
+}
+
+const maxPolicyVersions = 5
+
+// seedInitialVersion records the default v1 version when a policy is created.
+func seedInitialVersion(p *policyData, document, createdAt string) {
+	p.versionCounter = 1
+	p.versions = []*policyVersionData{{
+		VersionID:      "v1",
+		PolicyDocument: document,
+		IsDefault:      true,
+		CreatedAt:      createdAt,
+	}}
+}
+
+// CreatePolicyVersion adds a new version to a managed policy, optionally as the default.
+func (m *Mock) CreatePolicyVersion(_ context.Context, cfg driver.PolicyVersionConfig) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(cfg.PolicyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", cfg.PolicyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(p.versions) >= maxPolicyVersions {
+		return nil, cerrors.Newf(cerrors.ResourceExhausted,
+			"policy %q already has the maximum of %d versions", cfg.PolicyARN, maxPolicyVersions)
+	}
+
+	p.versionCounter++
+	v := &policyVersionData{
+		VersionID:      fmt.Sprintf("v%d", p.versionCounter),
+		PolicyDocument: cfg.PolicyDocument,
+		IsDefault:      cfg.SetAsDefault,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	if cfg.SetAsDefault {
+		clearDefaults(p.versions)
+		p.PolicyDocument = cfg.PolicyDocument
+	}
+
+	p.versions = append(p.versions, v)
+	m.policies.Set(cfg.PolicyARN, p)
+
+	info := toPolicyVersionInfo(v)
+
+	return &info, nil
+}
+
+// GetPolicyVersion returns a single version of a managed policy.
+func (m *Mock) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, v := range p.versions {
+		if v.VersionID == versionID {
+			info := toPolicyVersionInfo(v)
+			return &info, nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// ListPolicyVersions returns all versions of a managed policy.
+func (m *Mock) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]driver.PolicyVersionInfo, 0, len(p.versions))
+	for _, v := range p.versions {
+		result = append(result, toPolicyVersionInfo(v))
+	}
+
+	return result, nil
+}
+
+// DeletePolicyVersion removes a non-default version of a managed policy.
+func (m *Mock) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for idx, v := range p.versions {
+		if v.VersionID != versionID {
+			continue
+		}
+
+		if v.IsDefault {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"cannot delete the default version %q of policy %q", versionID, policyARN)
+		}
+
+		p.versions = append(p.versions[:idx], p.versions[idx+1:]...)
+		m.policies.Set(policyARN, p)
+
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// SetDefaultPolicyVersion marks an existing version as the default for a managed policy.
+func (m *Mock) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target := findVersion(p.versions, versionID)
+	if target == nil {
+		return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+	}
+
+	clearDefaults(p.versions)
+
+	target.IsDefault = true
+	p.PolicyDocument = target.PolicyDocument
+	m.policies.Set(policyARN, p)
+
+	return nil
+}
+
+func clearDefaults(versions []*policyVersionData) {
+	for _, v := range versions {
+		v.IsDefault = false
+	}
+}
+
+func findVersion(versions []*policyVersionData, versionID string) *policyVersionData {
+	for _, v := range versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func toPolicyVersionInfo(v *policyVersionData) driver.PolicyVersionInfo {
+	return driver.PolicyVersionInfo{
+		VersionID:        v.VersionID,
+		PolicyDocument:   v.PolicyDocument,
+		IsDefaultVersion: v.IsDefault,
+		CreatedAt:        v.CreatedAt,
+	}
 }
 
 func (m *Mock) attachPolicy(

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -273,9 +273,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		Description:    cfg.Description,
 	}
 	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
-	m.policies.Set(arn, p)
 
+	// Snapshot before publishing p to the store: once Set runs, p is shared and
+	// its document may be mutated concurrently by the version operations.
 	info := toPolicyInfo(p)
+	m.policies.Set(arn, p)
 
 	return &info, nil
 }

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -296,6 +296,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toPolicyInfo(p)
 
 	return &info, nil
@@ -305,6 +308,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	all := m.policies.All()
 	result := make([]driver.PolicyInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, p := range all {
 		result = append(result, toPolicyInfo(p))
@@ -718,6 +724,9 @@ func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
 // to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	policyARNs := m.collectPolicyARNs(principal)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	hasAllow := false
 

--- a/providers/azure/azureiam/iam_test.go
+++ b/providers/azure/azureiam/iam_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -903,4 +904,84 @@ func TestGetPolicy(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
+}
+
+func TestPolicyVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	doc1 := `{"doc":1}`
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc1})
+	require.NoError(t, err)
+
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "v1", versions[0].VersionID)
+	assert.True(t, versions[0].IsDefaultVersion)
+
+	doc2 := `{"doc":2}`
+	v2, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc2})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", v2.VersionID)
+	assert.False(t, v2.IsDefaultVersion)
+
+	got, err := m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	doc3 := `{"doc":3}`
+	v3, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc3, SetAsDefault: true})
+	require.NoError(t, err)
+	assert.True(t, v3.IsDefaultVersion)
+
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc3, got.PolicyDocument)
+
+	gv, err := m.GetPolicyVersion(ctx, p.ARN, "v2")
+	require.NoError(t, err)
+	assert.Equal(t, doc2, gv.PolicyDocument)
+
+	require.NoError(t, m.SetDefaultPolicyVersion(ctx, p.ARN, "v1"))
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	err = m.DeletePolicyVersion(ctx, p.ARN, "v1")
+	require.Error(t, err)
+	assert.Equal(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+
+	require.NoError(t, m.DeletePolicyVersion(ctx, p.ARN, "v2"))
+	versions, err = m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Len(t, versions, 2)
+}
+
+func TestPolicyVersionsErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing", PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.GetPolicyVersion(ctx, "missing", "v1")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.ListPolicyVersions(ctx, "missing")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.DeletePolicyVersion(ctx, "missing", "v1")))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.SetDefaultPolicyVersion(ctx, "missing", "v1")))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	require.NoError(t, err)
+
+	_, err = m.GetPolicyVersion(ctx, p.ARN, "v9")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+
+	for range 4 {
+		_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+		require.NoError(t, err)
+	}
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
 }

--- a/providers/azure/azureiam/iam_test.go
+++ b/providers/azure/azureiam/iam_test.go
@@ -2,6 +2,7 @@ package azureiam
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -984,4 +985,41 @@ func TestPolicyVersionsErrors(t *testing.T) {
 
 	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
 	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestPolicyVersionsConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "concurrent", PolicyDocument: `{"v":1}`})
+	require.NoError(t, err)
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: `{"v":2}`})
+	require.NoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	require.NoError(t, err)
+	require.NoError(t, m.AttachUserPolicy(ctx, "u", p.ARN))
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for i := range iterations {
+		wg.Add(4)
+
+		go func() { defer wg.Done(); _, _ = m.GetPolicy(ctx, p.ARN) }()
+		go func() { defer wg.Done(); _, _ = m.ListPolicies(ctx) }()
+		go func() { defer wg.Done(); _, _ = m.CheckPermission(ctx, "u", "s3:GetObject", "*") }()
+		go func(n int) {
+			defer wg.Done()
+
+			ver := "v1"
+			if n%2 == 0 {
+				ver = "v2"
+			}
+
+			_ = m.SetDefaultPolicyVersion(ctx, p.ARN, ver)
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -276,9 +276,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		Description:    cfg.Description,
 	}
 	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
-	m.policies.Set(arn, p)
 
+	// Snapshot before publishing p to the store: once Set runs, p is shared and
+	// its document may be mutated concurrently by the version operations.
 	info := toPolicyInfo(p)
+	m.policies.Set(arn, p)
 
 	return &info, nil
 }

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -62,6 +62,15 @@ type policyData struct {
 	Path           string
 	PolicyDocument string
 	Description    string
+	versions       []*policyVersionData
+	versionCounter int
+}
+
+type policyVersionData struct {
+	VersionID      string
+	PolicyDocument string
+	IsDefault      bool
+	CreatedAt      string
 }
 
 type groupData struct {
@@ -266,6 +275,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		PolicyDocument: cfg.PolicyDocument,
 		Description:    cfg.Description,
 	}
+	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
 	m.policies.Set(arn, p)
 
 	info := toPolicyInfo(p)
@@ -304,6 +314,171 @@ func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	}
 
 	return result, nil
+}
+
+const maxPolicyVersions = 5
+
+// seedInitialVersion records the default v1 version when a policy is created.
+func seedInitialVersion(p *policyData, document, createdAt string) {
+	p.versionCounter = 1
+	p.versions = []*policyVersionData{{
+		VersionID:      "v1",
+		PolicyDocument: document,
+		IsDefault:      true,
+		CreatedAt:      createdAt,
+	}}
+}
+
+// CreatePolicyVersion adds a new version to a managed policy, optionally as the default.
+func (m *Mock) CreatePolicyVersion(_ context.Context, cfg driver.PolicyVersionConfig) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(cfg.PolicyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", cfg.PolicyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(p.versions) >= maxPolicyVersions {
+		return nil, cerrors.Newf(cerrors.ResourceExhausted,
+			"policy %q already has the maximum of %d versions", cfg.PolicyARN, maxPolicyVersions)
+	}
+
+	p.versionCounter++
+	v := &policyVersionData{
+		VersionID:      fmt.Sprintf("v%d", p.versionCounter),
+		PolicyDocument: cfg.PolicyDocument,
+		IsDefault:      cfg.SetAsDefault,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	if cfg.SetAsDefault {
+		clearDefaults(p.versions)
+		p.PolicyDocument = cfg.PolicyDocument
+	}
+
+	p.versions = append(p.versions, v)
+	m.policies.Set(cfg.PolicyARN, p)
+
+	info := toPolicyVersionInfo(v)
+
+	return &info, nil
+}
+
+// GetPolicyVersion returns a single version of a managed policy.
+func (m *Mock) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, v := range p.versions {
+		if v.VersionID == versionID {
+			info := toPolicyVersionInfo(v)
+			return &info, nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// ListPolicyVersions returns all versions of a managed policy.
+func (m *Mock) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]driver.PolicyVersionInfo, 0, len(p.versions))
+	for _, v := range p.versions {
+		result = append(result, toPolicyVersionInfo(v))
+	}
+
+	return result, nil
+}
+
+// DeletePolicyVersion removes a non-default version of a managed policy.
+func (m *Mock) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for idx, v := range p.versions {
+		if v.VersionID != versionID {
+			continue
+		}
+
+		if v.IsDefault {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"cannot delete the default version %q of policy %q", versionID, policyARN)
+		}
+
+		p.versions = append(p.versions[:idx], p.versions[idx+1:]...)
+		m.policies.Set(policyARN, p)
+
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// SetDefaultPolicyVersion marks an existing version as the default for a managed policy.
+func (m *Mock) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target := findVersion(p.versions, versionID)
+	if target == nil {
+		return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+	}
+
+	clearDefaults(p.versions)
+
+	target.IsDefault = true
+	p.PolicyDocument = target.PolicyDocument
+	m.policies.Set(policyARN, p)
+
+	return nil
+}
+
+func clearDefaults(versions []*policyVersionData) {
+	for _, v := range versions {
+		v.IsDefault = false
+	}
+}
+
+func findVersion(versions []*policyVersionData, versionID string) *policyVersionData {
+	for _, v := range versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func toPolicyVersionInfo(v *policyVersionData) driver.PolicyVersionInfo {
+	return driver.PolicyVersionInfo{
+		VersionID:        v.VersionID,
+		PolicyDocument:   v.PolicyDocument,
+		IsDefaultVersion: v.IsDefault,
+		CreatedAt:        v.CreatedAt,
+	}
 }
 
 func (m *Mock) attachPolicy(

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -299,6 +299,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toPolicyInfo(p)
 
 	return &info, nil
@@ -308,6 +311,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	all := m.policies.All()
 	result := make([]driver.PolicyInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, p := range all {
 		result = append(result, toPolicyInfo(p))
@@ -721,6 +727,9 @@ func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
 // to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	policyARNs := m.collectPolicyARNs(principal)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	hasAllow := false
 

--- a/providers/gcp/gcpiam/iam_test.go
+++ b/providers/gcp/gcpiam/iam_test.go
@@ -3,6 +3,7 @@ package gcpiam
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -895,4 +896,41 @@ func TestPolicyVersionsErrors(t *testing.T) {
 
 	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
 	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestPolicyVersionsConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "concurrent", PolicyDocument: `{"v":1}`})
+	require.NoError(t, err)
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: `{"v":2}`})
+	require.NoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	require.NoError(t, err)
+	require.NoError(t, m.AttachUserPolicy(ctx, "u", p.ARN))
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for i := range iterations {
+		wg.Add(4)
+
+		go func() { defer wg.Done(); _, _ = m.GetPolicy(ctx, p.ARN) }()
+		go func() { defer wg.Done(); _, _ = m.ListPolicies(ctx) }()
+		go func() { defer wg.Done(); _, _ = m.CheckPermission(ctx, "u", "s3:GetObject", "*") }()
+		go func(n int) {
+			defer wg.Done()
+
+			ver := "v1"
+			if n%2 == 0 {
+				ver = "v2"
+			}
+
+			_ = m.SetDefaultPolicyVersion(ctx, p.ARN, ver)
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/providers/gcp/gcpiam/iam_test.go
+++ b/providers/gcp/gcpiam/iam_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -814,4 +815,84 @@ func TestDetachRolePolicy(t *testing.T) {
 	policies, err := m.ListAttachedRolePolicies(ctx, "svc-role")
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(policies))
+}
+
+func TestPolicyVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	doc1 := `{"doc":1}`
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc1})
+	require.NoError(t, err)
+
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "v1", versions[0].VersionID)
+	assert.True(t, versions[0].IsDefaultVersion)
+
+	doc2 := `{"doc":2}`
+	v2, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc2})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", v2.VersionID)
+	assert.False(t, v2.IsDefaultVersion)
+
+	got, err := m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	doc3 := `{"doc":3}`
+	v3, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc3, SetAsDefault: true})
+	require.NoError(t, err)
+	assert.True(t, v3.IsDefaultVersion)
+
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc3, got.PolicyDocument)
+
+	gv, err := m.GetPolicyVersion(ctx, p.ARN, "v2")
+	require.NoError(t, err)
+	assert.Equal(t, doc2, gv.PolicyDocument)
+
+	require.NoError(t, m.SetDefaultPolicyVersion(ctx, p.ARN, "v1"))
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	err = m.DeletePolicyVersion(ctx, p.ARN, "v1")
+	require.Error(t, err)
+	assert.Equal(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+
+	require.NoError(t, m.DeletePolicyVersion(ctx, p.ARN, "v2"))
+	versions, err = m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Len(t, versions, 2)
+}
+
+func TestPolicyVersionsErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing", PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.GetPolicyVersion(ctx, "missing", "v1")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.ListPolicyVersions(ctx, "missing")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.DeletePolicyVersion(ctx, "missing", "v1")))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.SetDefaultPolicyVersion(ctx, "missing", "v1")))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	require.NoError(t, err)
+
+	_, err = m.GetPolicyVersion(ctx, p.ARN, "v9")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+
+	for range 4 {
+		_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+		require.NoError(t, err)
+	}
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
 }

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -44,6 +44,11 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DeletePolicy":                  {},
 	"GetPolicy":                     {},
 	"ListPolicies":                  {},
+	"CreatePolicyVersion":           {},
+	"GetPolicyVersion":              {},
+	"ListPolicyVersions":            {},
+	"DeletePolicyVersion":           {},
+	"SetDefaultPolicyVersion":       {},
 	"AttachUserPolicy":              {},
 	"DetachUserPolicy":              {},
 	"AttachRolePolicy":              {},
@@ -134,6 +139,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getPolicy(w, r)
 	case "ListPolicies":
 		h.listPolicies(w, r)
+	case "CreatePolicyVersion":
+		h.createPolicyVersion(w, r)
+	case "GetPolicyVersion":
+		h.getPolicyVersion(w, r)
+	case "ListPolicyVersions":
+		h.listPolicyVersions(w, r)
+	case "DeletePolicyVersion":
+		h.deletePolicyVersion(w, r)
+	case "SetDefaultPolicyVersion":
+		h.setDefaultPolicyVersion(w, r)
 	case "AttachUserPolicy":
 		h.attachUserPolicy(w, r)
 	case "DetachUserPolicy":
@@ -195,6 +210,8 @@ func writeErr(w http.ResponseWriter, err error) {
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInput", err.Error())
 	case cerrors.IsFailedPrecondition(err):
 		awsquery.WriteXMLError(w, http.StatusConflict, "DeleteConflict", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		awsquery.WriteXMLError(w, http.StatusConflict, "LimitExceeded", err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -8,6 +9,9 @@ import (
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/server/wire/awsquery"
 )
+
+// defaultPolicyVersionID is the version a freshly created policy starts with.
+const defaultPolicyVersionID = "v1"
 
 // parseIAMTags parses Tags.member.N.{Key,Value} pairs (the shape the
 // aws-sdk-go-v2/service/iam client emits for tagged-create requests).
@@ -184,7 +188,7 @@ func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, createPolicyResponse{
 		Xmlns:    Namespace,
-		Result:   createPolicyResult{Policy: toPolicyXML(p)},
+		Result:   createPolicyResult{Policy: toPolicyXML(p, defaultPolicyVersionID)},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -210,12 +214,11 @@ func (h *Handler) getPolicy(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, getPolicyResponse{
 		Xmlns:    Namespace,
-		Result:   getPolicyResult{Policy: toPolicyXML(p)},
+		Result:   getPolicyResult{Policy: toPolicyXML(p, h.defaultVersionID(r.Context(), p.ARN))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
 
-//nolint:dupl // list handlers share shape but operate on different driver types and response envelopes.
 func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 	policies, err := h.iam.ListPolicies(r.Context())
 	if err != nil {
@@ -225,12 +228,106 @@ func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 
 	out := policiesListXML{Member: make([]policyXML, 0, len(policies))}
 	for i := range policies {
-		out.Member = append(out.Member, toPolicyXML(&policies[i]))
+		out.Member = append(out.Member, toPolicyXML(&policies[i], h.defaultVersionID(r.Context(), policies[i].ARN)))
 	}
 
 	awsquery.WriteXMLResponse(w, listPoliciesResponse{
 		Xmlns:    Namespace,
 		Result:   listPoliciesResult{Policies: out, IsTruncated: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// defaultVersionID returns the version ID currently marked default for the
+// policy, falling back to "v1" if the versions cannot be read.
+func (h *Handler) defaultVersionID(ctx context.Context, policyARN string) string {
+	versions, err := h.iam.ListPolicyVersions(ctx, policyARN)
+	if err != nil {
+		return defaultPolicyVersionID
+	}
+
+	for i := range versions {
+		if versions[i].IsDefaultVersion {
+			return versions[i].VersionID
+		}
+	}
+
+	return defaultPolicyVersionID
+}
+
+func (h *Handler) createPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	cfg := iamdriver.PolicyVersionConfig{
+		PolicyARN:      r.Form.Get("PolicyArn"),
+		PolicyDocument: r.Form.Get("PolicyDocument"),
+		SetAsDefault:   r.Form.Get("SetAsDefault") == "true",
+	}
+
+	v, err := h.iam.CreatePolicyVersion(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createPolicyVersionResponse{
+		Xmlns:    Namespace,
+		Result:   createPolicyVersionResult{PolicyVersion: toPolicyVersionXML(v, true)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	v, err := h.iam.GetPolicyVersion(r.Context(), r.Form.Get("PolicyArn"), r.Form.Get("VersionId"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getPolicyVersionResponse{
+		Xmlns:    Namespace,
+		Result:   getPolicyVersionResult{PolicyVersion: toPolicyVersionXML(v, true)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listPolicyVersions(w http.ResponseWriter, r *http.Request) {
+	versions, err := h.iam.ListPolicyVersions(r.Context(), r.Form.Get("PolicyArn"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := policyVersionsListXML{Member: make([]policyVersionXML, 0, len(versions))}
+	for i := range versions {
+		out.Member = append(out.Member, toPolicyVersionXML(&versions[i], false))
+	}
+
+	awsquery.WriteXMLResponse(w, listPolicyVersionsResponse{
+		Xmlns:    Namespace,
+		Result:   listPolicyVersionsResult{Versions: out, IsTruncated: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deletePolicyVersion(w http.ResponseWriter, r *http.Request) {
+	if err := h.iam.DeletePolicyVersion(r.Context(), r.Form.Get("PolicyArn"), r.Form.Get("VersionId")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deletePolicyVersionResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) setDefaultPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	if err := h.iam.SetDefaultPolicyVersion(r.Context(), r.Form.Get("PolicyArn"), r.Form.Get("VersionId")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, setDefaultPolicyVersionResponse{
+		Xmlns:    Namespace,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/iam/sdk_roundtrip_test.go
+++ b/server/aws/iam/sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package iam_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -311,5 +312,158 @@ func TestSDKIAMInstanceProfiles(t *testing.T) {
 		InstanceProfileName: aws.String("ec2-profile"),
 	}); err != nil {
 		t.Fatalf("DeleteInstanceProfile: %v", err)
+	}
+}
+
+func createPolicyForVersions(t *testing.T, client *awsiam.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreatePolicy(context.Background(), &awsiam.CreatePolicyInput{
+		PolicyName:     aws.String(name),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	return aws.ToString(out.Policy.Arn)
+}
+
+func TestSDKIAMPolicyVersionLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	arn := createPolicyForVersions(t, client, "versioned")
+
+	// CreatePolicy auto-seeds a default v1.
+	listed, err := client.ListPolicyVersions(ctx, &awsiam.ListPolicyVersionsInput{PolicyArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListPolicyVersions: %v", err)
+	}
+
+	if len(listed.Versions) != 1 ||
+		aws.ToString(listed.Versions[0].VersionId) != "v1" || !listed.Versions[0].IsDefaultVersion {
+		t.Fatalf("expected seeded default v1, got %+v", listed.Versions)
+	}
+
+	const docV2 = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`
+
+	created, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn:      aws.String(arn),
+		PolicyDocument: aws.String(docV2),
+		SetAsDefault:   true,
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicyVersion: %v", err)
+	}
+
+	if aws.ToString(created.PolicyVersion.VersionId) != "v2" || !created.PolicyVersion.IsDefaultVersion {
+		t.Fatalf("expected new default v2, got %+v", created.PolicyVersion)
+	}
+
+	// GetPolicyVersion round-trips the stored document.
+	gotVer, err := client.GetPolicyVersion(ctx, &awsiam.GetPolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v2"),
+	})
+	if err != nil {
+		t.Fatalf("GetPolicyVersion: %v", err)
+	}
+
+	if aws.ToString(gotVer.PolicyVersion.Document) != docV2 {
+		t.Fatalf("GetPolicyVersion document mismatch: %q", aws.ToString(gotVer.PolicyVersion.Document))
+	}
+
+	// GetPolicy reflects the new default, then tracks SetDefaultPolicyVersion.
+	assertDefaultVersion(t, client, arn, "v2")
+
+	if _, err := client.SetDefaultPolicyVersion(ctx, &awsiam.SetDefaultPolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("SetDefaultPolicyVersion: %v", err)
+	}
+
+	assertDefaultVersion(t, client, arn, "v1")
+}
+
+func assertDefaultVersion(t *testing.T, client *awsiam.Client, arn, want string) {
+	t.Helper()
+
+	pol, err := client.GetPolicy(context.Background(), &awsiam.GetPolicyInput{PolicyArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	if got := aws.ToString(pol.Policy.DefaultVersionId); got != want {
+		t.Fatalf("got default version %q, want %q", got, want)
+	}
+}
+
+func TestSDKIAMPolicyVersionEdgeCases(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	arn := createPolicyForVersions(t, client, "edge")
+
+	// The default version cannot be deleted (AWS DeleteConflict).
+	_, err := client.DeletePolicyVersion(ctx, &awsiam.DeletePolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v1"),
+	})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("deleting default version: want DeleteConflictException, got %v", err)
+	}
+
+	// A non-default version can be deleted.
+	if _, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn: aws.String(arn), PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("CreatePolicyVersion: %v", err)
+	}
+
+	if _, err := client.DeletePolicyVersion(ctx, &awsiam.DeletePolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v2"),
+	}); err != nil {
+		t.Fatalf("DeletePolicyVersion(v2): %v", err)
+	}
+
+	// Unknown version and unknown policy both map to NoSuchEntity.
+	var notFound *iamtypes.NoSuchEntityException
+
+	_, err = client.GetPolicyVersion(ctx, &awsiam.GetPolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v99"),
+	})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("get unknown version: want NoSuchEntityException, got %v", err)
+	}
+
+	_, err = client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn:      aws.String("arn:aws:iam::123456789012:policy/missing"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("create version on missing policy: want NoSuchEntityException, got %v", err)
+	}
+}
+
+func TestSDKIAMPolicyVersionLimit(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	arn := createPolicyForVersions(t, client, "maxed")
+
+	// v1 is seeded; four more reach the maximum of five.
+	for range 4 {
+		if _, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+			PolicyArn: aws.String(arn), PolicyDocument: aws.String(samplePolicy),
+		}); err != nil {
+			t.Fatalf("CreatePolicyVersion: %v", err)
+		}
+	}
+
+	_, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn: aws.String(arn), PolicyDocument: aws.String(samplePolicy),
+	})
+
+	var limit *iamtypes.LimitExceededException
+	if !errors.As(err, &limit) {
+		t.Fatalf("exceeding version limit: want LimitExceededException, got %v", err)
 	}
 }

--- a/server/aws/iam/xml.go
+++ b/server/aws/iam/xml.go
@@ -98,17 +98,45 @@ type policyXML struct {
 //   - IsAttachable is always true. Real AWS distinguishes
 //     customer-managed (attachable) from AWS-managed policies; we only
 //     emit customer-managed, so true is correct.
-func toPolicyXML(p *iamdriver.PolicyInfo) policyXML {
+func toPolicyXML(p *iamdriver.PolicyInfo, defaultVersionID string) policyXML {
 	return policyXML{
 		PolicyName:       p.Name,
 		PolicyID:         p.ID,
 		Arn:              p.ARN,
 		Path:             p.Path,
-		DefaultVersionID: "v1",
+		DefaultVersionID: defaultVersionID,
 		AttachmentCount:  0,
 		IsAttachable:     true,
 		Description:      p.Description,
 	}
+}
+
+type policyVersionXML struct {
+	Document         string `xml:"Document,omitempty"`
+	VersionID        string `xml:"VersionId"`
+	IsDefaultVersion bool   `xml:"IsDefaultVersion"`
+	CreateDate       string `xml:"CreateDate,omitempty"`
+}
+
+type policyVersionsListXML struct {
+	Member []policyVersionXML `xml:"member,omitempty"`
+}
+
+// toPolicyVersionXML maps a driver version to its wire shape. The real IAM API
+// omits the document body from ListPolicyVersions, so includeDocument is false
+// there and true for Create/GetPolicyVersion.
+func toPolicyVersionXML(v *iamdriver.PolicyVersionInfo, includeDocument bool) policyVersionXML {
+	out := policyVersionXML{
+		VersionID:        v.VersionID,
+		IsDefaultVersion: v.IsDefaultVersion,
+		CreateDate:       v.CreatedAt,
+	}
+
+	if includeDocument {
+		out.Document = v.PolicyDocument
+	}
+
+	return out
 }
 
 type groupXML struct {
@@ -351,6 +379,52 @@ type listPoliciesResponse struct {
 type listPoliciesResult struct {
 	Policies    policiesListXML `xml:"Policies"`
 	IsTruncated bool            `xml:"IsTruncated"`
+}
+
+type createPolicyVersionResponse struct {
+	XMLName  xml.Name                  `xml:"CreatePolicyVersionResponse"`
+	Xmlns    string                    `xml:"xmlns,attr"`
+	Result   createPolicyVersionResult `xml:"CreatePolicyVersionResult"`
+	Metadata responseMetadata          `xml:"ResponseMetadata"`
+}
+
+type createPolicyVersionResult struct {
+	PolicyVersion policyVersionXML `xml:"PolicyVersion"`
+}
+
+type getPolicyVersionResponse struct {
+	XMLName  xml.Name               `xml:"GetPolicyVersionResponse"`
+	Xmlns    string                 `xml:"xmlns,attr"`
+	Result   getPolicyVersionResult `xml:"GetPolicyVersionResult"`
+	Metadata responseMetadata       `xml:"ResponseMetadata"`
+}
+
+type getPolicyVersionResult struct {
+	PolicyVersion policyVersionXML `xml:"PolicyVersion"`
+}
+
+type listPolicyVersionsResponse struct {
+	XMLName  xml.Name                 `xml:"ListPolicyVersionsResponse"`
+	Xmlns    string                   `xml:"xmlns,attr"`
+	Result   listPolicyVersionsResult `xml:"ListPolicyVersionsResult"`
+	Metadata responseMetadata         `xml:"ResponseMetadata"`
+}
+
+type listPolicyVersionsResult struct {
+	Versions    policyVersionsListXML `xml:"Versions"`
+	IsTruncated bool                  `xml:"IsTruncated"`
+}
+
+type deletePolicyVersionResponse struct {
+	XMLName  xml.Name         `xml:"DeletePolicyVersionResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type setDefaultPolicyVersionResponse struct {
+	XMLName  xml.Name         `xml:"SetDefaultPolicyVersionResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
 type attachUserPolicyResponse struct {


### PR DESCRIPTION
## Summary

Adds IAM **managed policy versions** — a previously unmodeled resource — with full CRUD + List across all three providers, plus the AWS SDK wire surface.

New operations on the IAM driver, portable API, and AWS/Azure/GCP mocks:
- `CreatePolicyVersion`, `GetPolicyVersion`, `ListPolicyVersions`, `DeletePolicyVersion`, `SetDefaultPolicyVersion`

## Behavior (mirrors AWS managed-policy semantics)
- `CreatePolicy` auto-seeds a default `v1`.
- Version IDs are `v1`, `v2`, … and are never reused.
- A policy may have at most **5 versions**; exceeding it fails.
- A version created with `SetAsDefault` becomes the default and its document becomes the policy's effective document (reflected by `GetPolicy`).
- The default version cannot be deleted.
- Unknown policy/version returns not-found.

## AWS SDK wire layer
The five operations are wired through the AWS query/XML server so the real `aws-sdk-go-v2` IAM client drives them. `GetPolicy` now reports the actual default version. Error codes are faithful to AWS:
- deleting the default version → `DeleteConflict`
- exceeding the version cap → `LimitExceeded`
- unknown policy/version → `NoSuchEntity`

Azure and GCP have no equivalent policy-version API in their own SDKs, so those providers are covered at the portable/driver level (the library's in-process API) rather than via a wire surface.

## Tests
- Provider-level tests for AWS, Azure, GCP (lifecycle + error paths).
- Portable wrapper tests.
- Cross-provider integration test in `cloudemu_test.go`.
- Real `aws-sdk-go-v2` round-trip tests covering the happy path and every edge case (DeleteConflict, LimitExceeded, NoSuchEntity).

`go build`, `go test ./...` (182 packages), and `golangci-lint run` all pass.