### PR TITLE
feat(ecr): AWS ECR JSON-protocol server (SDK-compat)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
@@ -39,6 +40,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/smithy-go v1.27.1
 	github.com/databricks/databricks-sdk-go v0.144.0
@@ -75,9 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1/go.mod h1:wHrWCwhXZrl2PuCP5t36UTacy9fCHDJ+vw1r3qxTL5M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 h1:9nfacm+uWgbdPaOplvJjxN50qgthexb7GOR/97ygc5o=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4 h1:fo6cmbxkKq/OtKUG0sK70fDsYjtKuSkjIQZUJwt24YM=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4/go.mod h1:7VJFM2lSPHz2I1rRb0a+lbphoOp7hXIgYjGhSTOLY7k=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -9,6 +9,7 @@ package aws
 import (
 	bedrockdriver "github.com/stackshy/cloudemu/bedrock/driver"
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
@@ -24,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
 	"github.com/stackshy/cloudemu/server/aws/ec2"
+	"github.com/stackshy/cloudemu/server/aws/ecr"
 	"github.com/stackshy/cloudemu/server/aws/eks"
 	"github.com/stackshy/cloudemu/server/aws/iam"
 	"github.com/stackshy/cloudemu/server/aws/lambda"
@@ -53,6 +55,7 @@ type Drivers struct {
 	Redshift   rdbdriver.RelationalDB
 	EKS        eksdriver.EKS
 	IAM        iamdriver.IAM
+	ECR        crdriver.ContainerRegistry
 	Bedrock    bedrockdriver.Bedrock
 	SageMaker  sagemakerdriver.Service
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -126,6 +129,10 @@ func New(d Drivers) *server.Server {
 	// RDS, Redshift, and EC2. Registered before EC2 for the same reason.
 	if d.IAM != nil {
 		srv.Register(iam.New(d.IAM))
+	}
+
+	if d.ECR != nil {
+		srv.Register(ecr.New(d.ECR))
 	}
 
 	// Redshift sits with the other query-protocol handlers before the EC2

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -1,0 +1,79 @@
+// Package ecr implements the AWS ECR JSON-RPC protocol as a server.Handler.
+// Point the real aws-sdk-go-v2 ECR client at a Server registered with this
+// handler and repository/image operations work against an in-memory
+// containerregistry driver.
+//
+// ECR uses the AWS JSON 1.1 wire shape (POST + JSON body, dispatched on the
+// X-Amz-Target header), the same family as DynamoDB.
+package ecr
+
+import (
+	"net/http"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "AmazonEC2ContainerRegistry_V20150921."
+
+// Handler serves ECR JSON-RPC requests against a ContainerRegistry driver.
+type Handler struct {
+	registry crdriver.ContainerRegistry
+}
+
+// New returns an ECR handler backed by reg.
+func New(reg crdriver.ContainerRegistry) *Handler {
+	return &Handler{registry: reg}
+}
+
+// Matches returns true for ECR-shaped requests, identified by an X-Amz-Target
+// header of "AmazonEC2ContainerRegistry_V20150921.<Operation>".
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches ECR operations based on X-Amz-Target.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix) {
+	case "CreateRepository":
+		h.createRepository(w, r)
+	case "DescribeRepositories":
+		h.describeRepositories(w, r)
+	case "DeleteRepository":
+		h.deleteRepository(w, r)
+	case "PutImage":
+		h.putImage(w, r)
+	case "ListImages":
+		h.listImages(w, r)
+	case "DescribeImages":
+		h.describeImages(w, r)
+	case "BatchDeleteImage":
+		h.batchDeleteImage(w, r)
+	default:
+		op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown ECR operation: "+op)
+	}
+}
+
+// writeErr maps canonical cloudemu errors to ECR JSON error responses. ECR
+// returns errors as HTTP 400 with a "__type" body the SDK maps to a typed
+// exception.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryAlreadyExistsException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotEmptyException", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "ServerException", err.Error())
+	}
+}

--- a/server/aws/ecr/operations.go
+++ b/server/aws/ecr/operations.go
@@ -1,0 +1,255 @@
+package ecr
+
+import (
+	"net/http"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request) {
+	var req createRepositoryRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
+		Name:               req.RepositoryName,
+		Tags:               tagsToMap(req.Tags),
+		ImageScanOnPush:    req.ImageScanningConfiguration.ScanOnPush,
+		ImageTagMutability: req.ImageTagMutability,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := toRepositoryJSON(repo)
+	out.ImageTagMutability = req.ImageTagMutability
+
+	wire.WriteJSON(w, createRepositoryResponse{Repository: out})
+}
+
+func (h *Handler) describeRepositories(w http.ResponseWriter, r *http.Request) {
+	var req describeRepositoriesRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	repos, err := h.collectRepositories(r, req.RepositoryNames)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]repositoryJSON, 0, len(repos))
+	for i := range repos {
+		out = append(out, toRepositoryJSON(&repos[i]))
+	}
+
+	wire.WriteJSON(w, describeRepositoriesResponse{Repositories: out})
+}
+
+// collectRepositories returns the named repositories, or all of them when no
+// names are given.
+func (h *Handler) collectRepositories(r *http.Request, names []string) ([]crdriver.Repository, error) {
+	if len(names) == 0 {
+		return h.registry.ListRepositories(r.Context())
+	}
+
+	repos := make([]crdriver.Repository, 0, len(names))
+
+	for _, name := range names {
+		rp, err := h.registry.GetRepository(r.Context(), name)
+		if err != nil {
+			return nil, err
+		}
+
+		repos = append(repos, *rp)
+	}
+
+	return repos, nil
+}
+
+func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request) {
+	var req deleteRepositoryRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// ECR echoes the deleted repository, so capture it before removal.
+	repo, err := h.registry.GetRepository(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.registry.DeleteRepository(r.Context(), req.RepositoryName, req.Force); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, deleteRepositoryResponse{Repository: toRepositoryJSON(repo)})
+}
+
+func (h *Handler) putImage(w http.ResponseWriter, r *http.Request) {
+	var req putImageRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	detail, err := h.registry.PutImage(r.Context(), &crdriver.ImageManifest{
+		Repository: req.RepositoryName,
+		Tag:        req.ImageTag,
+		Digest:     req.ImageDigest,
+		MediaType:  req.ImageManifestMediaType,
+		SizeBytes:  int64(len(req.ImageManifest)),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, putImageResponse{Image: imageJSON{
+		RegistryID:             detail.RegistryID,
+		RepositoryName:         detail.Repository,
+		ImageID:                imageIDJSON{ImageDigest: detail.Digest, ImageTag: req.ImageTag},
+		ImageManifest:          req.ImageManifest,
+		ImageManifestMediaType: req.ImageManifestMediaType,
+	}})
+}
+
+func (h *Handler) listImages(w http.ResponseWriter, r *http.Request) {
+	var req repositoryNameRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	images, err := h.registry.ListImages(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	ids := make([]imageIDJSON, 0, len(images))
+	for i := range images {
+		ids = append(ids, imageIDsForDetail(&images[i])...)
+	}
+
+	wire.WriteJSON(w, listImagesResponse{ImageIDs: ids})
+}
+
+// imageIDsForDetail expands an image into one id per tag (real ECR lists each
+// tag separately), or a digest-only id when untagged.
+func imageIDsForDetail(d *crdriver.ImageDetail) []imageIDJSON {
+	ids := make([]imageIDJSON, 0, len(d.Tags))
+
+	for _, tag := range d.Tags {
+		if tag == "" {
+			continue
+		}
+
+		ids = append(ids, imageIDJSON{ImageDigest: d.Digest, ImageTag: tag})
+	}
+
+	if len(ids) == 0 {
+		return []imageIDJSON{{ImageDigest: d.Digest}}
+	}
+
+	return ids
+}
+
+func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
+	var req imageIDsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	images, err := h.registry.ListImages(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	details := make([]imageDetailJSON, 0, len(images))
+
+	for i := range images {
+		if len(req.ImageIDs) > 0 && !matchesAnyID(&images[i], req.ImageIDs) {
+			continue
+		}
+
+		details = append(details, toImageDetailJSON(&images[i]))
+	}
+
+	wire.WriteJSON(w, describeImagesResponse{ImageDetails: details})
+}
+
+func (h *Handler) batchDeleteImage(w http.ResponseWriter, r *http.Request) {
+	var req imageIDsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// A missing repository is a thrown error; missing images become per-image
+	// failures, matching real ECR.
+	if _, err := h.registry.GetRepository(r.Context(), req.RepositoryName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	deleted := make([]imageIDJSON, 0, len(req.ImageIDs))
+	failures := make([]imageFailureJSON, 0)
+
+	for _, id := range req.ImageIDs {
+		if err := h.registry.DeleteImage(r.Context(), req.RepositoryName, imageReference(id)); err != nil {
+			failures = append(failures, imageFailureJSON{
+				ImageID:       id,
+				FailureCode:   "ImageNotFound",
+				FailureReason: "Requested image not found",
+			})
+
+			continue
+		}
+
+		deleted = append(deleted, id)
+	}
+
+	wire.WriteJSON(w, batchDeleteImageResponse{ImageIDs: deleted, Failures: failures})
+}
+
+func tagsToMap(tags []tagJSON) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}
+
+func matchesAnyID(d *crdriver.ImageDetail, ids []imageIDJSON) bool {
+	for _, id := range ids {
+		if id.ImageDigest != "" && id.ImageDigest == d.Digest {
+			return true
+		}
+
+		if id.ImageTag != "" && containsTag(d.Tags, id.ImageTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/ecr/sdk_roundtrip_test.go
+++ b/server/aws/ecr/sdk_roundtrip_test.go
@@ -1,0 +1,211 @@
+package ecr_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+const sampleManifest = `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}`
+
+func newECRClient(t *testing.T) *awsecr.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{ECR: cloud.ECR})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awsecr.NewFromConfig(cfg, func(o *awsecr.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKECRRepositoryLifecycle(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName:             aws.String("app"),
+		ImageTagMutability:         ecrtypes.ImageTagMutabilityImmutable,
+		ImageScanningConfiguration: &ecrtypes.ImageScanningConfiguration{ScanOnPush: true},
+		Tags:                       []ecrtypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if aws.ToString(created.Repository.RepositoryName) != "app" {
+		t.Fatalf("got repo name %q, want app", aws.ToString(created.Repository.RepositoryName))
+	}
+
+	all, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{})
+	if err != nil {
+		t.Fatalf("DescribeRepositories(all): %v", err)
+	}
+
+	if len(all.Repositories) != 1 {
+		t.Fatalf("got %d repositories, want 1", len(all.Repositories))
+	}
+
+	byName, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{"app"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRepositories(app): %v", err)
+	}
+
+	if len(byName.Repositories) != 1 || aws.ToString(byName.Repositories[0].RepositoryName) != "app" {
+		t.Fatalf("DescribeRepositories(app) returned %+v", byName.Repositories)
+	}
+
+	if _, err := client.DeleteRepository(ctx, &awsecr.DeleteRepositoryInput{
+		RepositoryName: aws.String("app"), Force: true,
+	}); err != nil {
+		t.Fatalf("DeleteRepository: %v", err)
+	}
+
+	_, err = client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{RepositoryNames: []string{"app"}})
+
+	var notFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("describe after delete: want RepositoryNotFoundException, got %v", err)
+	}
+}
+
+func TestSDKECRImageLifecycle(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("imgs"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	put, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("imgs"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("PutImage: %v", err)
+	}
+
+	if aws.ToString(put.Image.ImageId.ImageTag) != "v1" || aws.ToString(put.Image.ImageId.ImageDigest) == "" {
+		t.Fatalf("PutImage returned %+v", put.Image.ImageId)
+	}
+
+	listed, err := client.ListImages(ctx, &awsecr.ListImagesInput{RepositoryName: aws.String("imgs")})
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+
+	if len(listed.ImageIds) != 1 || aws.ToString(listed.ImageIds[0].ImageTag) != "v1" {
+		t.Fatalf("ListImages returned %+v", listed.ImageIds)
+	}
+
+	described, err := client.DescribeImages(ctx, &awsecr.DescribeImagesInput{RepositoryName: aws.String("imgs")})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	if len(described.ImageDetails) != 1 || !contains(described.ImageDetails[0].ImageTags, "v1") {
+		t.Fatalf("DescribeImages returned %+v", described.ImageDetails)
+	}
+
+	deleted, err := client.BatchDeleteImage(ctx, &awsecr.BatchDeleteImageInput{
+		RepositoryName: aws.String("imgs"),
+		ImageIds:       []ecrtypes.ImageIdentifier{{ImageTag: aws.String("v1")}},
+	})
+	if err != nil {
+		t.Fatalf("BatchDeleteImage: %v", err)
+	}
+
+	if len(deleted.ImageIds) != 1 || len(deleted.Failures) != 0 {
+		t.Fatalf("BatchDeleteImage returned ids=%+v failures=%+v", deleted.ImageIds, deleted.Failures)
+	}
+}
+
+func TestSDKECRBatchDeleteMissingImage(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("partial"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	// Deleting an image that was never pushed yields a per-image failure, not a
+	// thrown error.
+	out, err := client.BatchDeleteImage(ctx, &awsecr.BatchDeleteImageInput{
+		RepositoryName: aws.String("partial"),
+		ImageIds:       []ecrtypes.ImageIdentifier{{ImageTag: aws.String("ghost")}},
+	})
+	if err != nil {
+		t.Fatalf("BatchDeleteImage: %v", err)
+	}
+
+	if len(out.Failures) != 1 || out.Failures[0].FailureCode != ecrtypes.ImageFailureCodeImageNotFound {
+		t.Fatalf("want one ImageNotFound failure, got %+v", out.Failures)
+	}
+}
+
+func TestSDKECRErrors(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("dup"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{RepositoryName: aws.String("dup")})
+
+	var exists *ecrtypes.RepositoryAlreadyExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("duplicate create: want RepositoryAlreadyExistsException, got %v", err)
+	}
+
+	_, err = client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("ghost"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	})
+
+	var notFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("put image on missing repo: want RepositoryNotFoundException, got %v", err)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/ecr/types.go
+++ b/server/aws/ecr/types.go
@@ -1,0 +1,158 @@
+package ecr
+
+import (
+	"time"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+type tagJSON struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type imageScanningConfigJSON struct {
+	ScanOnPush bool `json:"scanOnPush"`
+}
+
+type repositoryJSON struct {
+	RepositoryName     string  `json:"repositoryName"`
+	RepositoryURI      string  `json:"repositoryUri"`
+	RegistryID         string  `json:"registryId,omitempty"`
+	CreatedAt          float64 `json:"createdAt,omitempty"`
+	ImageTagMutability string  `json:"imageTagMutability,omitempty"`
+}
+
+type imageIDJSON struct {
+	ImageDigest string `json:"imageDigest,omitempty"`
+	ImageTag    string `json:"imageTag,omitempty"`
+}
+
+type imageJSON struct {
+	RegistryID             string      `json:"registryId,omitempty"`
+	RepositoryName         string      `json:"repositoryName"`
+	ImageID                imageIDJSON `json:"imageId"`
+	ImageManifest          string      `json:"imageManifest,omitempty"`
+	ImageManifestMediaType string      `json:"imageManifestMediaType,omitempty"`
+}
+
+type imageDetailJSON struct {
+	RegistryID       string   `json:"registryId,omitempty"`
+	RepositoryName   string   `json:"repositoryName"`
+	ImageDigest      string   `json:"imageDigest"`
+	ImageTags        []string `json:"imageTags,omitempty"`
+	ImageSizeInBytes int64    `json:"imageSizeInBytes,omitempty"`
+	ImagePushedAt    float64  `json:"imagePushedAt,omitempty"`
+}
+
+type imageFailureJSON struct {
+	ImageID       imageIDJSON `json:"imageId"`
+	FailureCode   string      `json:"failureCode"`
+	FailureReason string      `json:"failureReason"`
+}
+
+// --- request envelopes ---
+
+type createRepositoryRequest struct {
+	RepositoryName             string                  `json:"repositoryName"`
+	Tags                       []tagJSON               `json:"tags"`
+	ImageScanningConfiguration imageScanningConfigJSON `json:"imageScanningConfiguration"`
+	ImageTagMutability         string                  `json:"imageTagMutability"`
+}
+
+type describeRepositoriesRequest struct {
+	RepositoryNames []string `json:"repositoryNames"`
+}
+
+type deleteRepositoryRequest struct {
+	RepositoryName string `json:"repositoryName"`
+	Force          bool   `json:"force"`
+}
+
+type putImageRequest struct {
+	RepositoryName         string `json:"repositoryName"`
+	ImageManifest          string `json:"imageManifest"`
+	ImageManifestMediaType string `json:"imageManifestMediaType"`
+	ImageTag               string `json:"imageTag"`
+	ImageDigest            string `json:"imageDigest"`
+}
+
+type repositoryNameRequest struct {
+	RepositoryName string `json:"repositoryName"`
+}
+
+type imageIDsRequest struct {
+	RepositoryName string        `json:"repositoryName"`
+	ImageIDs       []imageIDJSON `json:"imageIds"`
+}
+
+// --- response envelopes ---
+
+type createRepositoryResponse struct {
+	Repository repositoryJSON `json:"repository"`
+}
+
+type describeRepositoriesResponse struct {
+	Repositories []repositoryJSON `json:"repositories"`
+}
+
+type deleteRepositoryResponse struct {
+	Repository repositoryJSON `json:"repository"`
+}
+
+type putImageResponse struct {
+	Image imageJSON `json:"image"`
+}
+
+type listImagesResponse struct {
+	ImageIDs []imageIDJSON `json:"imageIds"`
+}
+
+type describeImagesResponse struct {
+	ImageDetails []imageDetailJSON `json:"imageDetails"`
+}
+
+type batchDeleteImageResponse struct {
+	ImageIDs []imageIDJSON      `json:"imageIds"`
+	Failures []imageFailureJSON `json:"failures"`
+}
+
+// epochSeconds converts an RFC3339 timestamp to Unix epoch seconds, the form
+// the AWS JSON protocol uses for timestamp fields. Returns 0 on parse failure.
+func epochSeconds(iso string) float64 {
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return float64(t.Unix())
+}
+
+func toRepositoryJSON(r *crdriver.Repository) repositoryJSON {
+	return repositoryJSON{
+		RepositoryName: r.Name,
+		RepositoryURI:  r.URI,
+		CreatedAt:      epochSeconds(r.CreatedAt),
+	}
+}
+
+func toImageDetailJSON(d *crdriver.ImageDetail) imageDetailJSON {
+	return imageDetailJSON{
+		RegistryID:       d.RegistryID,
+		RepositoryName:   d.Repository,
+		ImageDigest:      d.Digest,
+		ImageTags:        d.Tags,
+		ImageSizeInBytes: d.SizeBytes,
+		ImagePushedAt:    epochSeconds(d.PushedAt),
+	}
+}
+
+// imageReference picks the digest if present, otherwise the tag — the form the
+// driver's findImage resolves.
+func imageReference(id imageIDJSON) string {
+	if id.ImageDigest != "" {
+		return id.ImageDigest
+	}
+
+	return id.ImageTag
+}


### PR DESCRIPTION
## Summary

Adds an AWS ECR wire server so the real `aws-sdk-go-v2` ECR client drives the existing in-memory container-registry driver. This is the AWS slice of registry SDK-compat (ACR and Artifact Registry to follow as separate PRs, per their distinct protocols).

ECR uses the AWS JSON 1.1 protocol (POST + JSON body, dispatched on `X-Amz-Target`), the same family as DynamoDB.

## Operations
- **Repositories:** CreateRepository, DescribeRepositories (covers get-by-name and list-all), DeleteRepository
- **Images:** PutImage, ListImages, DescribeImages, BatchDeleteImage

## Behavior / fidelity
- `BatchDeleteImage` returns per-image `failures` for images that don't exist, while a missing **repository** is a thrown `RepositoryNotFoundException` — matching real ECR.
- Timestamps are emitted as Unix epoch seconds (the AWS JSON timestamp form).
- Error codes map to ECR's typed exceptions: `RepositoryNotFoundException`, `RepositoryAlreadyExistsException`, `RepositoryNotEmptyException`, `InvalidParameterException`, `LimitExceededException`.

## Deferred (follow-up)
`BatchGetImage` (its `imageManifest` retrieval is lossy against the structured driver model), plus lifecycle policies and image scanning. Noted so coverage isn't silently assumed.

## Tests
Real `aws-sdk-go-v2/service/ecr` roundtrip tests: repository lifecycle, image lifecycle, batch-delete partial failure, and error paths (duplicate create, missing repo) asserted via the SDK's typed exceptions.

`go build`, `go test ./...` (191 packages), and `golangci-lint run` all pass.