### PR TITLE
feat(artifactregistry): GCP Artifact Registry v1 REST server (SDK-compat)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/smithy-go v1.27.1
 	github.com/databricks/databricks-sdk-go v0.144.0
@@ -75,9 +78,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -1,0 +1,137 @@
+// Package artifactregistry implements the artifactregistry.googleapis.com v1
+// REST API as a server.Handler. Real google.golang.org/api/artifactregistry/v1
+// clients pointed at this server CRUD repositories and list docker images
+// end-to-end against the shared containerregistry driver.
+//
+// Coverage (v1 REST):
+//
+//	POST   /v1/projects/{p}/locations/{l}/repositories?repositoryId={id}        — Create repo (async)
+//	GET    /v1/projects/{p}/locations/{l}/repositories/{id}                     — Get repo
+//	GET    /v1/projects/{p}/locations/{l}/repositories                          — List repos
+//	DELETE /v1/projects/{p}/locations/{l}/repositories/{id}                     — Delete repo (async)
+//	GET    /v1/projects/{p}/locations/{l}/repositories/{id}/dockerImages        — List docker images
+//
+// The driver has no location dimension, so {l} is accepted and echoed but not
+// used to partition state.
+package artifactregistry
+
+import (
+	"net/http"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	pathPrefix      = "/v1/projects/"
+	locationsSeg    = "locations"
+	repositoriesSeg = "repositories"
+	dockerImagesSeg = "dockerImages"
+)
+
+// minRepoCollectionParts is the segment count of a repositories collection
+// path: [projects, {p}, locations, {l}, repositories].
+const minRepoCollectionParts = 5
+
+// Handler serves artifactregistry.googleapis.com v1 requests.
+type Handler struct {
+	registry crdriver.ContainerRegistry
+}
+
+// New returns an Artifact Registry handler backed by reg.
+func New(reg crdriver.ContainerRegistry) *Handler {
+	return &Handler{registry: reg}
+}
+
+type route struct {
+	project    string
+	location   string
+	repository string // repo id; empty for the collection
+	sub        string // "dockerImages" or ""
+}
+
+// parseRoute extracts the components of an Artifact Registry v1 path.
+func parseRoute(urlPath string) (route, bool) {
+	if !strings.HasPrefix(urlPath, pathPrefix) {
+		return route{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(urlPath, "/v1/"), "/")
+	// parts: [projects, {p}, locations, {l}, repositories, {id}?, {sub}?]
+	if len(parts) < minRepoCollectionParts ||
+		parts[0] != "projects" || parts[2] != locationsSeg || parts[4] != repositoriesSeg {
+		return route{}, false
+	}
+
+	rt := route{project: parts[1], location: parts[3]}
+
+	if len(parts) > minRepoCollectionParts {
+		rt.repository = parts[5]
+	}
+
+	const subIdx = 6
+	if len(parts) > subIdx {
+		rt.sub = parts[subIdx]
+	}
+
+	return rt, true
+}
+
+// Matches claims artifactregistry v1 repository paths. Disjoint from the IAM
+// handler (which matches serviceAccounts|roles at the same prefix).
+func (*Handler) Matches(r *http.Request) bool {
+	_, ok := parseRoute(r.URL.Path)
+	return ok
+}
+
+// ServeHTTP dispatches on method and path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed Artifact Registry v1 path")
+		return
+	}
+
+	if rt.repository == "" {
+		h.serveCollection(w, r, &rt)
+		return
+	}
+
+	h.serveResource(w, r, &rt)
+}
+
+// serveCollection handles the repositories collection (create, list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listRepositories(w, r, rt)
+	case http.MethodPost:
+		h.createRepository(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported repositories operation")
+	}
+}
+
+// serveResource handles a single repository and its dockerImages sub-collection.
+func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rt *route) {
+	if rt.sub == dockerImagesSeg {
+		if r.Method == http.MethodGet {
+			h.listDockerImages(w, r, rt)
+			return
+		}
+
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported dockerImages operation")
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getRepository(w, r, rt)
+	case http.MethodDelete:
+		h.deleteRepository(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported repository operation")
+	}
+}

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -1,0 +1,88 @@
+package artifactregistry
+
+import (
+	"net/http"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	repoID := r.URL.Query().Get("repositoryId")
+
+	var body repositoryJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
+		Name: repoID,
+		Tags: body.Labels,
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, repoID, toRepositoryJSON(rt.project, rt.location, repo)))
+}
+
+func (h *Handler) getRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	repo, err := h.registry.GetRepository(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toRepositoryJSON(rt.project, rt.location, repo))
+}
+
+func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request, rt *route) {
+	repos, err := h.registry.ListRepositories(r.Context())
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]repositoryJSON, 0, len(repos))
+	for i := range repos {
+		out = append(out, toRepositoryJSON(rt.project, rt.location, &repos[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listRepositoriesResponse{Repositories: out})
+}
+
+func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	// Artifact Registry's delete has no force flag; it removes the repository
+	// and its contents.
+	if err := h.registry.DeleteRepository(r.Context(), rt.repository, true); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.repository, nil))
+}
+
+func (h *Handler) listDockerImages(w http.ResponseWriter, r *http.Request, rt *route) {
+	images, err := h.registry.ListImages(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]dockerImageJSON, 0, len(images))
+	for i := range images {
+		out = append(out, toDockerImageJSON(rt.project, rt.location, rt.repository, &images[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listDockerImagesResponse{DockerImages: out})
+}
+
+// doneOperation builds a completed long-running operation envelope.
+func doneOperation(rt *route, id string, response any) operationJSON {
+	return operationJSON{
+		Name:     "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id,
+		Done:     true,
+		Response: response,
+	}
+}

--- a/server/gcp/artifactregistry/sdk_roundtrip_test.go
+++ b/server/gcp/artifactregistry/sdk_roundtrip_test.go
@@ -1,0 +1,162 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+const (
+	testParent = "projects/demo/locations/us"
+)
+
+func newARService(t *testing.T) (*ar.Service, crdriver.ContainerRegistry) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{ArtifactRegistry: cloud.ArtifactRegistry})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := ar.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("artifactregistry.NewService: %v", err)
+	}
+
+	return svc, cloud.ArtifactRegistry
+}
+
+func TestSDKArtifactRegistryRepositoryLifecycle(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	op, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format: "DOCKER",
+		Labels: map[string]string{"team": "platform"},
+	}).RepositoryId("myrepo").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatalf("Create operation not marked done: %+v", op)
+	}
+
+	name := testParent + "/repositories/myrepo"
+
+	repo, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if repo.Name != name || repo.Format != "DOCKER" {
+		t.Fatalf("Get returned %+v", repo)
+	}
+
+	list, err := svc.Projects.Locations.Repositories.List(testParent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(list.Repositories) != 1 {
+		t.Fatalf("got %d repositories, want 1", len(list.Repositories))
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Delete(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err = svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	assertGoogleAPICode(t, err, 404)
+}
+
+func TestSDKArtifactRegistryDockerImages(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+		RepositoryId("imgs").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Artifact Registry has no REST "push image" call — images arrive via
+	// docker push. Seed one through the driver to simulate that.
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "imgs",
+		Tag:        "v1",
+		MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+		SizeBytes:  1024,
+	}); err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	listed, err := svc.Projects.Locations.Repositories.DockerImages.
+		List(testParent + "/repositories/imgs").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("DockerImages.List: %v", err)
+	}
+
+	if len(listed.DockerImages) != 1 {
+		t.Fatalf("got %d docker images, want 1", len(listed.DockerImages))
+	}
+
+	if !contains(listed.DockerImages[0].Tags, "v1") || listed.DockerImages[0].ImageSizeBytes != 1024 {
+		t.Fatalf("DockerImages.List returned %+v", listed.DockerImages[0])
+	}
+}
+
+func TestSDKArtifactRegistryErrors(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	_, err := svc.Projects.Locations.Repositories.Get(testParent + "/repositories/ghost").Context(ctx).Do()
+	assertGoogleAPICode(t, err, 404)
+
+	mk := func() error {
+		_, e := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+			RepositoryId("dup").Context(ctx).Do()
+
+		return e
+	}
+
+	if err := mk(); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	assertGoogleAPICode(t, mk(), 409)
+}
+
+func assertGoogleAPICode(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("want *googleapi.Error with code %d, got %v", want, err)
+	}
+
+	if gerr.Code != want {
+		t.Fatalf("got HTTP %d, want %d (%v)", gerr.Code, want, err)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -53,11 +53,16 @@ func repositoryResourceName(project, location, id string) string {
 	return "projects/" + project + "/locations/" + location + "/repositories/" + id
 }
 
-// shortID returns the final path segment, so a driver repository name of either
-// "myrepo" or "projects/x/repositories/myrepo" yields "myrepo".
-func shortID(name string) string {
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		return name[idx+1:]
+// repositoriesMarker precedes the repository name in the self-link the driver
+// stores (projects/{p}/repositories/{name}).
+const repositoriesMarker = "/repositories/"
+
+// repoName recovers the bare repository name from the driver's self-link Name.
+// It splits on the resource-type marker rather than the last slash so
+// hierarchical names like "team/app" survive intact.
+func repoName(name string) string {
+	if idx := strings.Index(name, repositoriesMarker); idx >= 0 {
+		return name[idx+len(repositoriesMarker):]
 	}
 
 	return name
@@ -65,7 +70,7 @@ func shortID(name string) string {
 
 func toRepositoryJSON(project, location string, r *crdriver.Repository) repositoryJSON {
 	return repositoryJSON{
-		Name:       repositoryResourceName(project, location, shortID(r.Name)),
+		Name:       repositoryResourceName(project, location, repoName(r.Name)),
 		Format:     dockerFormat,
 		Labels:     r.Tags,
 		CreateTime: r.CreatedAt,

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -1,0 +1,93 @@
+package artifactregistry
+
+import (
+	"strconv"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+// repositoryJSON is the artifactregistry.googleapis.com v1 Repository shape.
+type repositoryJSON struct {
+	Name        string            `json:"name"`
+	Format      string            `json:"format,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	CreateTime  string            `json:"createTime,omitempty"`
+	UpdateTime  string            `json:"updateTime,omitempty"`
+}
+
+// dockerImageJSON is the v1 DockerImage shape. imageSizeBytes is an int64
+// rendered as a string, the Google APIs convention.
+type dockerImageJSON struct {
+	Name           string   `json:"name"`
+	URI            string   `json:"uri,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	ImageSizeBytes string   `json:"imageSizeBytes,omitempty"`
+	MediaType      string   `json:"mediaType,omitempty"`
+	UploadTime     string   `json:"uploadTime,omitempty"`
+	UpdateTime     string   `json:"updateTime,omitempty"`
+}
+
+type listRepositoriesResponse struct {
+	Repositories  []repositoryJSON `json:"repositories"`
+	NextPageToken string           `json:"nextPageToken,omitempty"`
+}
+
+type listDockerImagesResponse struct {
+	DockerImages  []dockerImageJSON `json:"dockerImages"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
+}
+
+// operationJSON is a google.longrunning.Operation. Artifact Registry's create
+// and delete are async; the mock returns a completed operation immediately.
+type operationJSON struct {
+	Name     string `json:"name"`
+	Done     bool   `json:"done"`
+	Response any    `json:"response,omitempty"`
+}
+
+const dockerFormat = "DOCKER"
+
+func repositoryResourceName(project, location, id string) string {
+	return "projects/" + project + "/locations/" + location + "/repositories/" + id
+}
+
+// shortID returns the final path segment, so a driver repository name of either
+// "myrepo" or "projects/x/repositories/myrepo" yields "myrepo".
+func shortID(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+
+	return name
+}
+
+func toRepositoryJSON(project, location string, r *crdriver.Repository) repositoryJSON {
+	return repositoryJSON{
+		Name:       repositoryResourceName(project, location, shortID(r.Name)),
+		Format:     dockerFormat,
+		Labels:     r.Tags,
+		CreateTime: r.CreatedAt,
+		UpdateTime: r.CreatedAt,
+	}
+}
+
+func toDockerImageJSON(project, location, repo string, d *crdriver.ImageDetail) dockerImageJSON {
+	base := repositoryResourceName(project, location, repo) + "/dockerImages/" + d.Digest
+
+	uri := d.Repository
+	if d.Digest != "" {
+		uri += "@" + d.Digest
+	}
+
+	return dockerImageJSON{
+		Name:           base,
+		URI:            uri,
+		Tags:           d.Tags,
+		ImageSizeBytes: strconv.FormatInt(d.SizeBytes, 10),
+		MediaType:      d.MediaType,
+		UploadTime:     d.PushedAt,
+		UpdateTime:     d.PushedAt,
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -8,6 +8,7 @@ package gcp
 
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
@@ -18,6 +19,7 @@ import (
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
@@ -37,17 +39,18 @@ import (
 
 // Drivers bundles the driver interfaces the GCP server can expose.
 type Drivers struct {
-	Compute        computedriver.Compute
-	Storage        storagedriver.Bucket
-	Firestore      dbdriver.Database
-	Networking     netdriver.Networking
-	Monitoring     mondriver.Monitoring
-	CloudFunctions sdrv.Serverless
-	PubSub         mqdriver.MessageQueue
-	CloudSQL       rdbdriver.RelationalDB
-	GKE            *gkeprov.Mock
-	VertexAI       vertexaidriver.VertexAI
-	IAM            iamdriver.IAM
+	Compute          computedriver.Compute
+	Storage          storagedriver.Bucket
+	Firestore        dbdriver.Database
+	Networking       netdriver.Networking
+	Monitoring       mondriver.Monitoring
+	CloudFunctions   sdrv.Serverless
+	PubSub           mqdriver.MessageQueue
+	CloudSQL         rdbdriver.RelationalDB
+	GKE              *gkeprov.Mock
+	VertexAI         vertexaidriver.VertexAI
+	IAM              iamdriver.IAM
+	ArtifactRegistry crdriver.ContainerRegistry
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -133,6 +136,13 @@ func New(d Drivers) *server.Server {
 	// consistency with the pattern above.
 	if d.IAM != nil {
 		srv.Register(iam.New(d.IAM))
+	}
+
+	// Artifact Registry matches /v1/projects/{p}/locations/{l}/repositories[/…]
+	// — disjoint from IAM (serviceAccounts|roles) and Cloud Asset. Registered
+	// among the /v1/projects/ family, before Firestore's catch-all.
+	if d.ArtifactRegistry != nil {
+		srv.Register(artifactregistry.New(d.ArtifactRegistry))
 	}
 
 	if d.Firestore != nil {


### PR DESCRIPTION
## Summary

Adds the GCP Artifact Registry wire server so the real `google.golang.org/api/artifactregistry/v1` client drives the existing container-registry driver over HTTP. This is the GCP slice of registry SDK-compat (AWS ECR shipped in #234; Azure ACR to follow).

## Operations (artifactregistry.googleapis.com v1 REST)
- **Repositories:** Create (async), Get, List, Delete (async)
- **Images:** `dockerImages.list`

## Behavior / fidelity
- Create and Delete return a **completed long-running `Operation`** inline (Artifact Registry's create/delete are async; SDKs accept a done op).
- Repository resource names are emitted in canonical `projects/{p}/locations/{l}/repositories/{id}` form; `format` is `DOCKER`; `imageSizeBytes` is rendered as an int64 string (the Google APIs convention).
- The driver has no location dimension, so the URL location is accepted/echoed but not used to partition state.
- Errors map to GCP status codes (404 notFound, 409 alreadyExists, …).

## Routing
Matches `/v1/projects/{p}/locations/{l}/repositories[/…]` — disjoint from the IAM (serviceAccounts|roles), CloudFunctions (functions), GKE (clusters), and Vertex AI handlers that share the `locations/` depth, and registered before Firestore's permissive `/v1/projects/` fallback.

## Tests
Real `artifactregistry/v1` roundtrip tests: repository lifecycle (create → get → list → delete → 404), dockerImages list (image seeded via the driver since AR's REST API has no push call — images arrive via `docker push`), and error paths (missing repo 404, duplicate create 409) asserted via `*googleapi.Error`.

`go build`, `go test ./...` (191 packages), and `golangci-lint run` all pass.