### PR TITLE
feat(acr): Azure Container Registry data-plane server (SDK-compat)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/firestore v1.22.0
 	cloud.google.com/go/storage v1.62.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3
@@ -39,6 +40,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/smithy-go v1.27.1
 	github.com/databricks/databricks-sdk-go v0.144.0
@@ -75,9 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzU
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
+github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:ldKsKtEIblsgsr6mPwrd9yRntoX6uLz/K89wsldwx/k=
+github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av4mvyWEbZ7whg72AoOCEzlXFKc=
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -1,0 +1,92 @@
+// Package acr implements the Azure Container Registry data-plane catalog API
+// (/acr/v1/…) as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry clients
+// pointed at this server list repositories and tags, read repository
+// properties, and delete repositories against the shared containerregistry
+// driver.
+//
+// ACR has no "create repository" data-plane call — repositories appear when an
+// image is pushed — so this handler is list/get/delete oriented. ACR uses
+// challenge-based auth; the mock serves anonymously, so the SDK never needs to
+// exchange a token.
+//
+// Coverage:
+//
+//	GET    /acr/v1/_catalog              — list repositories
+//	GET    /acr/v1/{name}                — repository properties
+//	DELETE /acr/v1/{name}                — delete repository
+//	GET    /acr/v1/{name}/_tags          — list tags
+package acr
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+const pathPrefix = "/acr/v1/"
+
+const (
+	catalogSeg = "_catalog"
+	tagsSuffix = "/_tags"
+)
+
+// Handler serves the ACR data-plane catalog API against a ContainerRegistry
+// driver.
+type Handler struct {
+	registry crdriver.ContainerRegistry
+}
+
+// New returns an ACR handler backed by reg.
+func New(reg crdriver.ContainerRegistry) *Handler {
+	return &Handler{registry: reg}
+}
+
+// Matches claims /acr/v1/ data-plane requests. Disjoint from ARM
+// (/subscriptions/…) and registered before the blob storage REST fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, pathPrefix)
+}
+
+// ServeHTTP routes on the path tail and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	tail := strings.TrimPrefix(r.URL.Path, pathPrefix)
+
+	switch {
+	case tail == catalogSeg && r.Method == http.MethodGet:
+		h.listRepositories(w, r)
+	case strings.HasSuffix(tail, tagsSuffix) && r.Method == http.MethodGet:
+		h.listTags(w, r, strings.TrimSuffix(tail, tagsSuffix))
+	case r.Method == http.MethodGet:
+		h.getRepositoryProperties(w, r, tail)
+	case r.Method == http.MethodDelete:
+		h.deleteRepository(w, r, tail)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+	}
+}
+
+// writeErr emits an ACR-style error body with the given HTTP status.
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"errors": []map[string]string{{"code": code, "message": msg}},
+	})
+}
+
+// writeCErr maps a canonical cloudemu error to an ACR error response.
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	default:
+		writeErr(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -30,8 +30,9 @@ import (
 const pathPrefix = "/acr/v1/"
 
 const (
-	catalogSeg = "_catalog"
-	tagsSuffix = "/_tags"
+	catalogSeg   = "_catalog"
+	tagsSuffix   = "/_tags"
+	manifestsSeg = "/_manifests"
 )
 
 // Handler serves the ACR data-plane catalog API against a ContainerRegistry
@@ -58,6 +59,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case tail == catalogSeg && r.Method == http.MethodGet:
 		h.listRepositories(w, r)
+	case strings.Contains(tail, manifestsSeg):
+		// Manifest operations are out of scope; answer explicitly rather than
+		// letting the path masquerade as a (missing) repository.
+		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "manifest operations are not supported")
 	case strings.HasSuffix(tail, tagsSuffix) && r.Method == http.MethodGet:
 		h.listTags(w, r, strings.TrimSuffix(tail, tagsSuffix))
 	case r.Method == http.MethodGet:
@@ -86,6 +91,8 @@ func writeCErr(w http.ResponseWriter, err error) {
 		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeErr(w, http.StatusConflict, "DENIED", err.Error())
 	default:
 		writeErr(w, http.StatusInternalServerError, "INTERNAL", err.Error())
 	}

--- a/server/azure/acr/operations.go
+++ b/server/azure/acr/operations.go
@@ -14,7 +14,7 @@ func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request) {
 
 	names := make([]string, 0, len(repos))
 	for i := range repos {
-		names = append(names, shortID(repos[i].Name))
+		names = append(names, repoName(repos[i].Name))
 	}
 
 	writeJSON(w, http.StatusOK, catalogResponse{Repositories: names})
@@ -35,7 +35,7 @@ func (h *Handler) getRepositoryProperties(w http.ResponseWriter, r *http.Request
 
 	writeJSON(w, http.StatusOK, repositoryProperties{
 		Registry:             registryLoginServer,
-		ImageName:            shortID(rp.Name),
+		ImageName:            repoName(rp.Name),
 		CreatedTime:          rp.CreatedAt,
 		LastUpdateTime:       rp.CreatedAt,
 		ManifestCount:        len(images),

--- a/server/azure/acr/operations.go
+++ b/server/azure/acr/operations.go
@@ -1,0 +1,78 @@
+package acr
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request) {
+	repos, err := h.registry.ListRepositories(r.Context())
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	names := make([]string, 0, len(repos))
+	for i := range repos {
+		names = append(names, shortID(repos[i].Name))
+	}
+
+	writeJSON(w, http.StatusOK, catalogResponse{Repositories: names})
+}
+
+func (h *Handler) getRepositoryProperties(w http.ResponseWriter, r *http.Request, repo string) {
+	rp, err := h.registry.GetRepository(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	images, err := h.registry.ListImages(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, repositoryProperties{
+		Registry:             registryLoginServer,
+		ImageName:            shortID(rp.Name),
+		CreatedTime:          rp.CreatedAt,
+		LastUpdateTime:       rp.CreatedAt,
+		ManifestCount:        len(images),
+		TagCount:             countTags(images),
+		ChangeableAttributes: allEnabled(),
+	})
+}
+
+func (h *Handler) listTags(w http.ResponseWriter, r *http.Request, repo string) {
+	images, err := h.registry.ListImages(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, tagListResponse{
+		Registry:  registryLoginServer,
+		ImageName: repo,
+		Tags:      toTagAttributes(images),
+	})
+}
+
+func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, repo string) {
+	if err := h.registry.DeleteRepository(r.Context(), repo, true); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// ACR's delete is asynchronous; the SDK accepts 202 Accepted.
+	writeJSON(w, http.StatusAccepted, deleteRepositoryResponse{
+		ManifestsDeleted: []string{},
+		TagsDeleted:      []string{},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/server/azure/acr/sdk_roundtrip_test.go
+++ b/server/azure/acr/sdk_roundtrip_test.go
@@ -146,6 +146,45 @@ func TestSDKACRDeleteRepository(t *testing.T) {
 	assertResponseCode(t, err, 404)
 }
 
+func TestSDKACRHierarchicalRepositoryName(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	// Registry names are commonly hierarchical (e.g. "team/app"); the bare
+	// name must survive the resource-ID round-trip, not be truncated to the
+	// last path segment.
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "team/app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	var names []string
+
+	pager := client.NewListRepositoriesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListRepositories: %v", err)
+		}
+
+		for _, n := range page.Repositories.Names {
+			names = append(names, *n)
+		}
+	}
+
+	if !contains(names, "team/app") {
+		t.Fatalf("catalog %v missing hierarchical name \"team/app\"", names)
+	}
+
+	props, err := client.GetRepositoryProperties(ctx, "team/app", nil)
+	if err != nil {
+		t.Fatalf("GetRepositoryProperties(team/app): %v", err)
+	}
+
+	if props.Name == nil || *props.Name != "team/app" {
+		t.Fatalf("got repository name %v, want team/app", props.Name)
+	}
+}
+
 func TestSDKACRErrors(t *testing.T) {
 	client, _ := newACRClient(t)
 

--- a/server/azure/acr/sdk_roundtrip_test.go
+++ b/server/azure/acr/sdk_roundtrip_test.go
@@ -1,0 +1,177 @@
+package acr_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azacr "github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
+
+	"github.com/stackshy/cloudemu"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newACRClient(t *testing.T) (*azacr.Client, crdriver.ContainerRegistry) {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ACR: cloud.ACR})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := azacr.NewClient(ts.URL, fakeCred{}, &azacr.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("azacr.NewClient: %v", err)
+	}
+
+	return client, cloud.ACR
+}
+
+func seedImage(t *testing.T, reg crdriver.ContainerRegistry, repo, tag string) {
+	t.Helper()
+
+	if _, err := reg.PutImage(context.Background(), &crdriver.ImageManifest{
+		Repository: repo,
+		Tag:        tag,
+		MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+		SizeBytes:  512,
+	}); err != nil {
+		t.Fatalf("seed PutImage(%s:%s): %v", repo, tag, err)
+	}
+}
+
+func TestSDKACRCatalogAndProperties(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	// ACR has no data-plane create; repositories appear on push.
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+
+	var names []string
+
+	pager := client.NewListRepositoriesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListRepositories: %v", err)
+		}
+
+		for _, n := range page.Repositories.Names {
+			names = append(names, *n)
+		}
+	}
+
+	if !contains(names, "app") {
+		t.Fatalf("catalog %v missing \"app\"", names)
+	}
+
+	props, err := client.GetRepositoryProperties(ctx, "app", nil)
+	if err != nil {
+		t.Fatalf("GetRepositoryProperties: %v", err)
+	}
+
+	if props.Name == nil || *props.Name != "app" {
+		t.Fatalf("got repository name %v, want app", props.Name)
+	}
+
+	if props.TagCount == nil || *props.TagCount != 1 {
+		t.Fatalf("got tag count %v, want 1", props.TagCount)
+	}
+}
+
+func TestSDKACRListTags(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "imgs"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "imgs", "v1")
+	seedImage(t, reg, "imgs", "v2")
+
+	var tags []string
+
+	pager := client.NewListTagsPager("imgs", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListTags: %v", err)
+		}
+
+		for _, tag := range page.Tags {
+			tags = append(tags, *tag.Name)
+		}
+	}
+
+	if !contains(tags, "v1") || !contains(tags, "v2") {
+		t.Fatalf("tags %v missing v1/v2", tags)
+	}
+}
+
+func TestSDKACRDeleteRepository(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "old"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	if _, err := client.DeleteRepository(ctx, "old", nil); err != nil {
+		t.Fatalf("DeleteRepository: %v", err)
+	}
+
+	_, err := client.GetRepositoryProperties(ctx, "old", nil)
+	assertResponseCode(t, err, 404)
+}
+
+func TestSDKACRErrors(t *testing.T) {
+	client, _ := newACRClient(t)
+
+	_, err := client.GetRepositoryProperties(context.Background(), "ghost", nil)
+	assertResponseCode(t, err, 404)
+}
+
+func assertResponseCode(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("want *azcore.ResponseError with code %d, got %v", want, err)
+	}
+
+	if respErr.StatusCode != want {
+		t.Fatalf("got HTTP %d, want %d (%v)", respErr.StatusCode, want, err)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -61,11 +61,16 @@ type deleteRepositoryResponse struct {
 	TagsDeleted      []string `json:"tagsDeleted"`
 }
 
-// shortID returns the final path segment, so an Azure resource-ID repository
-// name resolves back to the bare repository name used on the wire.
-func shortID(name string) string {
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		return name[idx+1:]
+// registriesMarker precedes the repository name in the Azure resource ID the
+// driver stores (…/Microsoft.ContainerRegistry/registries/{name}).
+const registriesMarker = "/registries/"
+
+// repoName recovers the bare repository name from the driver's resource-ID
+// Name. It splits on the resource-type marker rather than the last slash so
+// hierarchical names like "team/app" survive intact.
+func repoName(name string) string {
+	if idx := strings.Index(name, registriesMarker); idx >= 0 {
+		return name[idx+len(registriesMarker):]
 	}
 
 	return name

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -1,0 +1,110 @@
+package acr
+
+import (
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+// registryLoginServer is the synthetic login server reported for this mock
+// registry. Real ACR uses {registry-name}.azurecr.io.
+const registryLoginServer = "cloudemu.azurecr.io"
+
+// changeableAttributes mirrors ACR's RepositoryWriteableProperties /
+// TagWriteableProperties. The mock reports everything enabled.
+type changeableAttributes struct {
+	DeleteEnabled bool `json:"deleteEnabled"`
+	WriteEnabled  bool `json:"writeEnabled"`
+	ListEnabled   bool `json:"listEnabled"`
+	ReadEnabled   bool `json:"readEnabled"`
+}
+
+func allEnabled() changeableAttributes {
+	return changeableAttributes{DeleteEnabled: true, WriteEnabled: true, ListEnabled: true, ReadEnabled: true}
+}
+
+// catalogResponse is the GET /acr/v1/_catalog body.
+type catalogResponse struct {
+	Repositories []string `json:"repositories"`
+}
+
+// repositoryProperties is the GET /acr/v1/{name} body.
+type repositoryProperties struct {
+	Registry             string               `json:"registry"`
+	ImageName            string               `json:"imageName"`
+	CreatedTime          string               `json:"createdTime,omitempty"`
+	LastUpdateTime       string               `json:"lastUpdateTime,omitempty"`
+	ManifestCount        int                  `json:"manifestCount"`
+	TagCount             int                  `json:"tagCount"`
+	ChangeableAttributes changeableAttributes `json:"changeableAttributes"`
+}
+
+// tagAttributes is one entry in the _tags list.
+type tagAttributes struct {
+	Name                 string               `json:"name"`
+	Digest               string               `json:"digest"`
+	CreatedTime          string               `json:"createdTime,omitempty"`
+	LastUpdateTime       string               `json:"lastUpdateTime,omitempty"`
+	ChangeableAttributes changeableAttributes `json:"changeableAttributes"`
+}
+
+// tagListResponse is the GET /acr/v1/{name}/_tags body.
+type tagListResponse struct {
+	Registry  string          `json:"registry"`
+	ImageName string          `json:"imageName"`
+	Tags      []tagAttributes `json:"tags"`
+}
+
+// deleteRepositoryResponse is the DELETE /acr/v1/{name} body.
+type deleteRepositoryResponse struct {
+	ManifestsDeleted []string `json:"manifestsDeleted"`
+	TagsDeleted      []string `json:"tagsDeleted"`
+}
+
+// shortID returns the final path segment, so an Azure resource-ID repository
+// name resolves back to the bare repository name used on the wire.
+func shortID(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+
+	return name
+}
+
+func countTags(images []crdriver.ImageDetail) int {
+	n := 0
+
+	for i := range images {
+		for _, tag := range images[i].Tags {
+			if tag != "" {
+				n++
+			}
+		}
+	}
+
+	return n
+}
+
+func toTagAttributes(images []crdriver.ImageDetail) []tagAttributes {
+	out := make([]tagAttributes, 0, len(images))
+
+	for i := range images {
+		img := images[i]
+
+		for _, tag := range img.Tags {
+			if tag == "" {
+				continue
+			}
+
+			out = append(out, tagAttributes{
+				Name:                 tag,
+				Digest:               img.Digest,
+				CreatedTime:          img.PushedAt,
+				LastUpdateTime:       img.PushedAt,
+				ChangeableAttributes: allEnabled(),
+			})
+		}
+	}
+
+	return out
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -8,6 +8,7 @@ package azure
 
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
@@ -18,6 +19,7 @@ import (
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/acr"
 	aksserver "github.com/stackshy/cloudemu/server/azure/aks"
 	"github.com/stackshy/cloudemu/server/azure/azuresql"
 	"github.com/stackshy/cloudemu/server/azure/blob"
@@ -78,6 +80,7 @@ type Drivers struct {
 	MySQLFlex           rdbdriver.RelationalDB
 	AKS                 aksserver.Backend
 	IAM                 iamdriver.IAM
+	ACR                 crdriver.ContainerRegistry
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -201,6 +204,12 @@ func New(d Drivers) *server.Server {
 	// registration order is unconstrained.
 	if d.IAM != nil {
 		srv.Register(iam.New(d.IAM))
+	}
+
+	// ACR data-plane catalog API matches /acr/v1/… — disjoint from ARM and
+	// must register before the permissive BlobStorage fallback below.
+	if d.ACR != nil {
+		srv.Register(acr.New(d.ACR))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It


### PR DESCRIPTION
## Summary

Adds the Azure Container Registry wire server so the real `azcontainerregistry` client drives the existing container-registry driver over HTTP. **This completes container-registry SDK-compat across all three providers** (AWS ECR #234, GCP Artifact Registry #235, Azure ACR here).

ACR's data-plane catalog API lives at `/acr/v1/…`. Unlike ECR/Artifact Registry, **ACR has no data-plane "create repository" call** — repositories appear when an image is pushed — so this surface is list/get/delete oriented, which is how the real cloud works.

## Operations (ACR data-plane)
- `GET /acr/v1/_catalog` — list repositories
- `GET /acr/v1/{name}` — repository properties (manifest/tag counts, timestamps)
- `GET /acr/v1/{name}/_tags` — list tags
- `DELETE /acr/v1/{name}` — delete repository

## Behavior / fidelity
- ACR uses **challenge-based auth**; the mock serves anonymously, so the SDK never needs to exchange a token (no OAuth2 endpoints required).
- Delete returns **202 Accepted** (the status the SDK expects); a missing repo returns 404, which the SDK treats as an idempotent-delete success.
- Repository names are resolved to their bare form for the catalog/properties; `changeableAttributes` reported all-enabled.
- Errors map to ACR status codes (404 NAME_UNKNOWN, …).

## Routing
Matches `/acr/v1/…` — disjoint from ARM (`/subscriptions/…`) and registered **before** the permissive BlobStorage REST fallback.

## Tests
Real `azcontainerregistry` roundtrip tests (images seeded via the driver, since ACR has no REST push call): catalog + repository properties, list tags, delete + 404-after-delete, and missing-repo error via `*azcore.ResponseError`.

`go build`, `go test ./...` (191 packages), and `golangci-lint run` all pass.