### PR TITLE
v1.8.1

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -942,6 +942,64 @@ func TestFIFODeduplication(t *testing.T) {
 	}
 }
 
+func TestIAMPolicyVersions(t *testing.T) {
+	ctx := context.Background()
+
+	providers := []struct {
+		name string
+		iam  iamdriver.IAM
+	}{
+		{"aws", NewAWS().IAM},
+		{"azure", NewAzure().IAM},
+		{"gcp", NewGCP().IAM},
+	}
+
+	for _, tc := range providers {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := tc.iam.CreatePolicy(ctx, iamdriver.PolicyConfig{Name: "vpol", PolicyDocument: `{"v":1}`})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// CreatePolicy auto-seeds a default v1.
+			versions, err := tc.iam.ListPolicyVersions(ctx, p.ARN)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(versions) != 1 || versions[0].VersionID != "v1" || !versions[0].IsDefaultVersion {
+				t.Fatalf("expected seeded default v1, got %+v", versions)
+			}
+
+			// A new default version updates the policy's effective document.
+			v2, err := tc.iam.CreatePolicyVersion(ctx, iamdriver.PolicyVersionConfig{
+				PolicyARN: p.ARN, PolicyDocument: `{"v":2}`, SetAsDefault: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v2.IsDefaultVersion {
+				t.Error("expected v2 to be the default version")
+			}
+
+			got, err := tc.iam.GetPolicy(ctx, p.ARN)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.PolicyDocument != `{"v":2}` {
+				t.Errorf("expected effective document to follow default, got %q", got.PolicyDocument)
+			}
+
+			// The default version cannot be deleted; a non-default one can.
+			if err := tc.iam.DeletePolicyVersion(ctx, p.ARN, "v2"); err == nil {
+				t.Error("expected error deleting the default version")
+			}
+			if err := tc.iam.DeletePolicyVersion(ctx, p.ARN, "v1"); err != nil {
+				t.Fatalf("unexpected error deleting non-default version: %v", err)
+			}
+		})
+	}
+}
+
 func TestIAMCheckPermission(t *testing.T) {
 	ctx := context.Background()
 	p := NewAWS()

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/firestore v1.22.0
 	cloud.google.com/go/storage v1.62.1
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
+	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3
@@ -39,6 +40,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/smithy-go v1.27.1
 	github.com/databricks/databricks-sdk-go v0.144.0
@@ -75,9 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/smithy-go v1.27.1
 	github.com/databricks/databricks-sdk-go v0.144.0
@@ -75,9 +78,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
@@ -39,6 +40,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
+	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
+	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/smithy-go v1.27.1
 	github.com/databricks/databricks-sdk-go v0.144.0
@@ -75,9 +79,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1/go.mod h1:wHrWCwhXZrl2PuCP5t36UTacy9fCHDJ+vw1r3qxTL5M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 h1:9nfacm+uWgbdPaOplvJjxN50qgthexb7GOR/97ygc5o=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4 h1:fo6cmbxkKq/OtKUG0sK70fDsYjtKuSkjIQZUJwt24YM=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4/go.mod h1:7VJFM2lSPHz2I1rRb0a+lbphoOp7hXIgYjGhSTOLY7k=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1 h1:jHb/wfvRikGdxMXYV3QG/SzU
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1/go.mod h1:pzBXCYn05zvYIrwLgtK8Ap8QcjRg+0i76tMQdWN6wOk=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 h1:Hk5QBxZQC1jb2Fwj6mpzme37xbCDdNTxU7O9eb5+LB4=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1/go.mod h1:IYus9qsFobWIc2YVwe/WPjcnyCkPKtnHAqUYeebc8z0=
+github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:ldKsKtEIblsgsr6mPwrd9yRntoX6uLz/K89wsldwx/k=
+github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av4mvyWEbZ7whg72AoOCEzlXFKc=
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=

--- a/iam/driver/driver.go
+++ b/iam/driver/driver.go
@@ -56,6 +56,21 @@ type PolicyInfo struct {
 	Description    string
 }
 
+// PolicyVersionConfig describes a new version of a managed policy to create.
+type PolicyVersionConfig struct {
+	PolicyARN      string
+	PolicyDocument string
+	SetAsDefault   bool
+}
+
+// PolicyVersionInfo describes a single version of a managed policy.
+type PolicyVersionInfo struct {
+	VersionID        string
+	PolicyDocument   string
+	IsDefaultVersion bool
+	CreatedAt        string
+}
+
 // GroupConfig describes a group to create.
 type GroupConfig struct {
 	Name string
@@ -117,6 +132,12 @@ type IAM interface {
 	DeletePolicy(ctx context.Context, arn string) error
 	GetPolicy(ctx context.Context, arn string) (*PolicyInfo, error)
 	ListPolicies(ctx context.Context) ([]PolicyInfo, error)
+
+	CreatePolicyVersion(ctx context.Context, config PolicyVersionConfig) (*PolicyVersionInfo, error)
+	GetPolicyVersion(ctx context.Context, policyARN, versionID string) (*PolicyVersionInfo, error)
+	ListPolicyVersions(ctx context.Context, policyARN string) ([]PolicyVersionInfo, error)
+	DeletePolicyVersion(ctx context.Context, policyARN, versionID string) error
+	SetDefaultPolicyVersion(ctx context.Context, policyARN, versionID string) error
 
 	AttachUserPolicy(ctx context.Context, userName, policyARN string) error
 	DetachUserPolicy(ctx context.Context, userName, policyARN string) error

--- a/iam/iam.go
+++ b/iam/iam.go
@@ -180,6 +180,57 @@ func (i *IAM) ListPolicies(ctx context.Context) ([]driver.PolicyInfo, error) {
 	return out.([]driver.PolicyInfo), nil
 }
 
+func (i *IAM) CreatePolicyVersion(
+	ctx context.Context, config driver.PolicyVersionConfig,
+) (*driver.PolicyVersionInfo, error) {
+	out, err := i.do(ctx, "CreatePolicyVersion", config, func() (any, error) {
+		return i.driver.CreatePolicyVersion(ctx, config)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PolicyVersionInfo), nil
+}
+
+func (i *IAM) GetPolicyVersion(ctx context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	out, err := i.do(ctx, "GetPolicyVersion", policyARN, func() (any, error) {
+		return i.driver.GetPolicyVersion(ctx, policyARN, versionID)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.(*driver.PolicyVersionInfo), nil
+}
+
+func (i *IAM) ListPolicyVersions(ctx context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	out, err := i.do(ctx, "ListPolicyVersions", policyARN, func() (any, error) {
+		return i.driver.ListPolicyVersions(ctx, policyARN)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return out.([]driver.PolicyVersionInfo), nil
+}
+
+func (i *IAM) DeletePolicyVersion(ctx context.Context, policyARN, versionID string) error {
+	_, err := i.do(ctx, "DeletePolicyVersion", policyARN, func() (any, error) {
+		return nil, i.driver.DeletePolicyVersion(ctx, policyARN, versionID)
+	})
+
+	return err
+}
+
+func (i *IAM) SetDefaultPolicyVersion(ctx context.Context, policyARN, versionID string) error {
+	_, err := i.do(ctx, "SetDefaultPolicyVersion", policyARN, func() (any, error) {
+		return nil, i.driver.SetDefaultPolicyVersion(ctx, policyARN, versionID)
+	})
+
+	return err
+}
+
 func (i *IAM) AttachUserPolicy(ctx context.Context, userName, policyARN string) error {
 	_, err := i.do(ctx, "AttachUserPolicy", userName, func() (any, error) {
 		return nil, i.driver.AttachUserPolicy(ctx, userName, policyARN)

--- a/iam/iam_test.go
+++ b/iam/iam_test.go
@@ -25,6 +25,8 @@ type mockDriver struct {
 	userPolicies     map[string][]string // userName -> []policyARN
 	rolePolicies     map[string][]string // roleName -> []policyARN
 	groupUsers       map[string]map[string]bool
+	policyVersions   map[string][]*driver.PolicyVersionInfo
+	versionSeq       map[string]int
 	seq              int
 }
 
@@ -39,6 +41,8 @@ func newMockDriver() *mockDriver {
 		userPolicies:     make(map[string][]string),
 		rolePolicies:     make(map[string][]string),
 		groupUsers:       make(map[string]map[string]bool),
+		policyVersions:   make(map[string][]*driver.PolicyVersionInfo),
+		versionSeq:       make(map[string]int),
 	}
 }
 
@@ -197,6 +201,69 @@ func (m *mockDriver) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error
 	}
 
 	return result, nil
+}
+
+func (m *mockDriver) CreatePolicyVersion(
+	_ context.Context, cfg driver.PolicyVersionConfig,
+) (*driver.PolicyVersionInfo, error) {
+	if _, ok := m.policies[cfg.PolicyARN]; !ok {
+		return nil, fmt.Errorf("policy not found")
+	}
+
+	m.versionSeq[cfg.PolicyARN]++
+	v := &driver.PolicyVersionInfo{
+		VersionID:        fmt.Sprintf("v%d", m.versionSeq[cfg.PolicyARN]),
+		PolicyDocument:   cfg.PolicyDocument,
+		IsDefaultVersion: cfg.SetAsDefault,
+	}
+	m.policyVersions[cfg.PolicyARN] = append(m.policyVersions[cfg.PolicyARN], v)
+
+	return v, nil
+}
+
+func (m *mockDriver) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	for _, v := range m.policyVersions[policyARN] {
+		if v.VersionID == versionID {
+			return v, nil
+		}
+	}
+
+	return nil, fmt.Errorf("version not found")
+}
+
+func (m *mockDriver) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	if _, ok := m.policies[policyARN]; !ok {
+		return nil, fmt.Errorf("policy not found")
+	}
+
+	result := make([]driver.PolicyVersionInfo, 0, len(m.policyVersions[policyARN]))
+	for _, v := range m.policyVersions[policyARN] {
+		result = append(result, *v)
+	}
+
+	return result, nil
+}
+
+func (m *mockDriver) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	versions := m.policyVersions[policyARN]
+	for idx, v := range versions {
+		if v.VersionID == versionID {
+			m.policyVersions[policyARN] = append(versions[:idx], versions[idx+1:]...)
+			return nil
+		}
+	}
+
+	return fmt.Errorf("version not found")
+}
+
+func (m *mockDriver) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	for _, v := range m.policyVersions[policyARN] {
+		if v.VersionID == versionID {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("version not found")
 }
 
 func (m *mockDriver) AttachUserPolicy(_ context.Context, userName, policyARN string) error {
@@ -668,6 +735,49 @@ func TestCreatePolicy(t *testing.T) {
 		_, err := i.CreatePolicy(ctx, driver.PolicyConfig{})
 		require.Error(t, err)
 	})
+}
+
+func TestPolicyVersions(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	p, err := i.CreatePolicy(ctx, driver.PolicyConfig{Name: "my-policy", PolicyDocument: "{}"})
+	require.NoError(t, err)
+
+	v, err := i.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{
+		PolicyARN: p.ARN, PolicyDocument: `{"doc":2}`, SetAsDefault: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "v1", v.VersionID)
+	assert.True(t, v.IsDefaultVersion)
+
+	got, err := i.GetPolicyVersion(ctx, p.ARN, v.VersionID)
+	require.NoError(t, err)
+	assert.Equal(t, `{"doc":2}`, got.PolicyDocument)
+
+	versions, err := i.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Len(t, versions, 1)
+
+	require.NoError(t, i.SetDefaultPolicyVersion(ctx, p.ARN, v.VersionID))
+	require.NoError(t, i.DeletePolicyVersion(ctx, p.ARN, v.VersionID))
+
+	_, err = i.GetPolicyVersion(ctx, p.ARN, v.VersionID)
+	require.Error(t, err)
+}
+
+func TestPolicyVersionErrorsPropagate(t *testing.T) {
+	i := newTestIAM()
+	ctx := context.Background()
+
+	_, err := i.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing"})
+	require.Error(t, err)
+	_, err = i.GetPolicyVersion(ctx, "missing", "v1")
+	require.Error(t, err)
+	_, err = i.ListPolicyVersions(ctx, "missing")
+	require.Error(t, err)
+	require.Error(t, i.DeletePolicyVersion(ctx, "missing", "v1"))
+	require.Error(t, i.SetDefaultPolicyVersion(ctx, "missing", "v1"))
 }
 
 func TestDeletePolicy(t *testing.T) {

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -296,6 +296,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 		return nil, errors.Newf(errors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toPolicyInfo(p)
 
 	return &info, nil
@@ -305,6 +308,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	all := m.policies.All()
 	result := make([]driver.PolicyInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, p := range all {
 		result = append(result, toPolicyInfo(p))
@@ -718,6 +724,9 @@ func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
 // to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	policyARNs := m.collectPolicyARNs(principal)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	hasAllow := false
 

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -273,9 +273,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		Description:    cfg.Description,
 	}
 	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
-	m.policies.Set(arn, p)
 
+	// Snapshot before publishing p to the store: once Set runs, p is shared and
+	// its document may be mutated concurrently by the version operations.
 	info := toPolicyInfo(p)
+	m.policies.Set(arn, p)
 
 	return &info, nil
 }

--- a/providers/aws/awsiam/iam.go
+++ b/providers/aws/awsiam/iam.go
@@ -62,6 +62,15 @@ type policyData struct {
 	Path           string
 	PolicyDocument string
 	Description    string
+	versions       []*policyVersionData
+	versionCounter int
+}
+
+type policyVersionData struct {
+	VersionID      string
+	PolicyDocument string
+	IsDefault      bool
+	CreatedAt      string
 }
 
 type groupData struct {
@@ -263,6 +272,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		PolicyDocument: cfg.PolicyDocument,
 		Description:    cfg.Description,
 	}
+	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
 	m.policies.Set(arn, p)
 
 	info := toPolicyInfo(p)
@@ -301,6 +311,171 @@ func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	}
 
 	return result, nil
+}
+
+const maxPolicyVersions = 5
+
+// seedInitialVersion records the default v1 version when a policy is created.
+func seedInitialVersion(p *policyData, document, createdAt string) {
+	p.versionCounter = 1
+	p.versions = []*policyVersionData{{
+		VersionID:      "v1",
+		PolicyDocument: document,
+		IsDefault:      true,
+		CreatedAt:      createdAt,
+	}}
+}
+
+// CreatePolicyVersion adds a new version to a managed policy, optionally as the default.
+func (m *Mock) CreatePolicyVersion(_ context.Context, cfg driver.PolicyVersionConfig) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(cfg.PolicyARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "policy %q not found", cfg.PolicyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(p.versions) >= maxPolicyVersions {
+		return nil, errors.Newf(errors.ResourceExhausted,
+			"policy %q already has the maximum of %d versions", cfg.PolicyARN, maxPolicyVersions)
+	}
+
+	p.versionCounter++
+	v := &policyVersionData{
+		VersionID:      fmt.Sprintf("v%d", p.versionCounter),
+		PolicyDocument: cfg.PolicyDocument,
+		IsDefault:      cfg.SetAsDefault,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	if cfg.SetAsDefault {
+		clearDefaults(p.versions)
+		p.PolicyDocument = cfg.PolicyDocument
+	}
+
+	p.versions = append(p.versions, v)
+	m.policies.Set(cfg.PolicyARN, p)
+
+	info := toPolicyVersionInfo(v)
+
+	return &info, nil
+}
+
+// GetPolicyVersion returns a single version of a managed policy.
+func (m *Mock) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, v := range p.versions {
+		if v.VersionID == versionID {
+			info := toPolicyVersionInfo(v)
+			return &info, nil
+		}
+	}
+
+	return nil, errors.Newf(errors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// ListPolicyVersions returns all versions of a managed policy.
+func (m *Mock) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]driver.PolicyVersionInfo, 0, len(p.versions))
+	for _, v := range p.versions {
+		result = append(result, toPolicyVersionInfo(v))
+	}
+
+	return result, nil
+}
+
+// DeletePolicyVersion removes a non-default version of a managed policy.
+func (m *Mock) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for idx, v := range p.versions {
+		if v.VersionID != versionID {
+			continue
+		}
+
+		if v.IsDefault {
+			return errors.Newf(errors.FailedPrecondition,
+				"cannot delete the default version %q of policy %q", versionID, policyARN)
+		}
+
+		p.versions = append(p.versions[:idx], p.versions[idx+1:]...)
+		m.policies.Set(policyARN, p)
+
+		return nil
+	}
+
+	return errors.Newf(errors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// SetDefaultPolicyVersion marks an existing version as the default for a managed policy.
+func (m *Mock) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target := findVersion(p.versions, versionID)
+	if target == nil {
+		return errors.Newf(errors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+	}
+
+	clearDefaults(p.versions)
+
+	target.IsDefault = true
+	p.PolicyDocument = target.PolicyDocument
+	m.policies.Set(policyARN, p)
+
+	return nil
+}
+
+func clearDefaults(versions []*policyVersionData) {
+	for _, v := range versions {
+		v.IsDefault = false
+	}
+}
+
+func findVersion(versions []*policyVersionData, versionID string) *policyVersionData {
+	for _, v := range versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func toPolicyVersionInfo(v *policyVersionData) driver.PolicyVersionInfo {
+	return driver.PolicyVersionInfo{
+		VersionID:        v.VersionID,
+		PolicyDocument:   v.PolicyDocument,
+		IsDefaultVersion: v.IsDefault,
+		CreatedAt:        v.CreatedAt,
+	}
 }
 
 func (m *Mock) attachPolicy(

--- a/providers/aws/awsiam/iam_test.go
+++ b/providers/aws/awsiam/iam_test.go
@@ -3,6 +3,7 @@ package awsiam
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -773,6 +774,43 @@ func TestPolicyVersionsErrors(t *testing.T) {
 
 	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
 	assertEqual(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestPolicyVersionsConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "concurrent", PolicyDocument: `{"v":1}`})
+	requireNoError(t, err)
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: `{"v":2}`})
+	requireNoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	requireNoError(t, err)
+	requireNoError(t, m.AttachUserPolicy(ctx, "u", p.ARN))
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for i := range iterations {
+		wg.Add(4)
+
+		go func() { defer wg.Done(); _, _ = m.GetPolicy(ctx, p.ARN) }()
+		go func() { defer wg.Done(); _, _ = m.ListPolicies(ctx) }()
+		go func() { defer wg.Done(); _, _ = m.CheckPermission(ctx, "u", "s3:GetObject", "*") }()
+		go func(n int) {
+			defer wg.Done()
+
+			ver := "v1"
+			if n%2 == 0 {
+				ver = "v2"
+			}
+
+			_ = m.SetDefaultPolicyVersion(ctx, p.ARN, ver)
+		}(i)
+	}
+
+	wg.Wait()
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/aws/awsiam/iam_test.go
+++ b/providers/aws/awsiam/iam_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/iam/driver"
 )
 
@@ -685,6 +686,93 @@ func TestCheckPermissionViaRole(t *testing.T) {
 	allowed, err := m.CheckPermission(ctx, "reader", "s3:GetObject", "arn:aws:s3:::bucket/key")
 	requireNoError(t, err)
 	assertEqual(t, true, allowed)
+}
+
+func TestPolicyVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	doc1 := makePolicyDoc([]map[string]any{{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}})
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc1})
+	requireNoError(t, err)
+
+	// CreatePolicy seeds a default v1.
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 1, len(versions))
+	assertEqual(t, "v1", versions[0].VersionID)
+	assertEqual(t, true, versions[0].IsDefaultVersion)
+
+	// A non-default version does not change the policy's effective document.
+	doc2 := makePolicyDoc([]map[string]any{{"Effect": "Deny", "Action": "s3:*", "Resource": "*"}})
+	v2, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc2})
+	requireNoError(t, err)
+	assertEqual(t, "v2", v2.VersionID)
+	assertEqual(t, false, v2.IsDefaultVersion)
+
+	got, err := m.GetPolicy(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, doc1, got.PolicyDocument)
+
+	// Creating a version as default updates the effective document.
+	doc3 := makePolicyDoc([]map[string]any{{"Effect": "Allow", "Action": "ec2:*", "Resource": "*"}})
+	v3, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc3, SetAsDefault: true})
+	requireNoError(t, err)
+	assertEqual(t, true, v3.IsDefaultVersion)
+
+	got, err = m.GetPolicy(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, doc3, got.PolicyDocument)
+
+	gv, err := m.GetPolicyVersion(ctx, p.ARN, "v2")
+	requireNoError(t, err)
+	assertEqual(t, doc2, gv.PolicyDocument)
+
+	// SetDefaultPolicyVersion switches the default back to v1.
+	requireNoError(t, m.SetDefaultPolicyVersion(ctx, p.ARN, "v1"))
+	got, err = m.GetPolicy(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, doc1, got.PolicyDocument)
+
+	// The default version cannot be deleted.
+	err = m.DeletePolicyVersion(ctx, p.ARN, "v1")
+	assertError(t, err, true)
+	assertEqual(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+
+	// A non-default version can be deleted.
+	requireNoError(t, m.DeletePolicyVersion(ctx, p.ARN, "v2"))
+	versions, err = m.ListPolicyVersions(ctx, p.ARN)
+	requireNoError(t, err)
+	assertEqual(t, 2, len(versions))
+}
+
+func TestPolicyVersionsErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing", PolicyDocument: "{}"})
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.GetPolicyVersion(ctx, "missing", "v1")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.ListPolicyVersions(ctx, "missing")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(m.DeletePolicyVersion(ctx, "missing", "v1")))
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(m.SetDefaultPolicyVersion(ctx, "missing", "v1")))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	requireNoError(t, err)
+
+	_, err = m.GetPolicyVersion(ctx, p.ARN, "v9")
+	assertEqual(t, cerrors.NotFound, cerrors.GetCode(err))
+
+	// v1 is seeded; four more reach the maximum of five, the next is rejected.
+	for range 4 {
+		_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+		requireNoError(t, err)
+	}
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+	assertEqual(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
 }
 
 func requireNoError(t *testing.T, err error) {

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -62,6 +62,15 @@ type policyData struct {
 	Path           string
 	PolicyDocument string
 	Description    string
+	versions       []*policyVersionData
+	versionCounter int
+}
+
+type policyVersionData struct {
+	VersionID      string
+	PolicyDocument string
+	IsDefault      bool
+	CreatedAt      string
 }
 
 type groupData struct {
@@ -263,6 +272,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		PolicyDocument: cfg.PolicyDocument,
 		Description:    cfg.Description,
 	}
+	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
 	m.policies.Set(arn, p)
 
 	info := toPolicyInfo(p)
@@ -301,6 +311,171 @@ func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	}
 
 	return result, nil
+}
+
+const maxPolicyVersions = 5
+
+// seedInitialVersion records the default v1 version when a policy is created.
+func seedInitialVersion(p *policyData, document, createdAt string) {
+	p.versionCounter = 1
+	p.versions = []*policyVersionData{{
+		VersionID:      "v1",
+		PolicyDocument: document,
+		IsDefault:      true,
+		CreatedAt:      createdAt,
+	}}
+}
+
+// CreatePolicyVersion adds a new version to a managed policy, optionally as the default.
+func (m *Mock) CreatePolicyVersion(_ context.Context, cfg driver.PolicyVersionConfig) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(cfg.PolicyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", cfg.PolicyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(p.versions) >= maxPolicyVersions {
+		return nil, cerrors.Newf(cerrors.ResourceExhausted,
+			"policy %q already has the maximum of %d versions", cfg.PolicyARN, maxPolicyVersions)
+	}
+
+	p.versionCounter++
+	v := &policyVersionData{
+		VersionID:      fmt.Sprintf("v%d", p.versionCounter),
+		PolicyDocument: cfg.PolicyDocument,
+		IsDefault:      cfg.SetAsDefault,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	if cfg.SetAsDefault {
+		clearDefaults(p.versions)
+		p.PolicyDocument = cfg.PolicyDocument
+	}
+
+	p.versions = append(p.versions, v)
+	m.policies.Set(cfg.PolicyARN, p)
+
+	info := toPolicyVersionInfo(v)
+
+	return &info, nil
+}
+
+// GetPolicyVersion returns a single version of a managed policy.
+func (m *Mock) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, v := range p.versions {
+		if v.VersionID == versionID {
+			info := toPolicyVersionInfo(v)
+			return &info, nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// ListPolicyVersions returns all versions of a managed policy.
+func (m *Mock) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]driver.PolicyVersionInfo, 0, len(p.versions))
+	for _, v := range p.versions {
+		result = append(result, toPolicyVersionInfo(v))
+	}
+
+	return result, nil
+}
+
+// DeletePolicyVersion removes a non-default version of a managed policy.
+func (m *Mock) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for idx, v := range p.versions {
+		if v.VersionID != versionID {
+			continue
+		}
+
+		if v.IsDefault {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"cannot delete the default version %q of policy %q", versionID, policyARN)
+		}
+
+		p.versions = append(p.versions[:idx], p.versions[idx+1:]...)
+		m.policies.Set(policyARN, p)
+
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// SetDefaultPolicyVersion marks an existing version as the default for a managed policy.
+func (m *Mock) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target := findVersion(p.versions, versionID)
+	if target == nil {
+		return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+	}
+
+	clearDefaults(p.versions)
+
+	target.IsDefault = true
+	p.PolicyDocument = target.PolicyDocument
+	m.policies.Set(policyARN, p)
+
+	return nil
+}
+
+func clearDefaults(versions []*policyVersionData) {
+	for _, v := range versions {
+		v.IsDefault = false
+	}
+}
+
+func findVersion(versions []*policyVersionData, versionID string) *policyVersionData {
+	for _, v := range versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func toPolicyVersionInfo(v *policyVersionData) driver.PolicyVersionInfo {
+	return driver.PolicyVersionInfo{
+		VersionID:        v.VersionID,
+		PolicyDocument:   v.PolicyDocument,
+		IsDefaultVersion: v.IsDefault,
+		CreatedAt:        v.CreatedAt,
+	}
 }
 
 func (m *Mock) attachPolicy(

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -273,9 +273,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		Description:    cfg.Description,
 	}
 	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
-	m.policies.Set(arn, p)
 
+	// Snapshot before publishing p to the store: once Set runs, p is shared and
+	// its document may be mutated concurrently by the version operations.
 	info := toPolicyInfo(p)
+	m.policies.Set(arn, p)
 
 	return &info, nil
 }

--- a/providers/azure/azureiam/iam.go
+++ b/providers/azure/azureiam/iam.go
@@ -296,6 +296,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toPolicyInfo(p)
 
 	return &info, nil
@@ -305,6 +308,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	all := m.policies.All()
 	result := make([]driver.PolicyInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, p := range all {
 		result = append(result, toPolicyInfo(p))
@@ -718,6 +724,9 @@ func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
 // to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	policyARNs := m.collectPolicyARNs(principal)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	hasAllow := false
 

--- a/providers/azure/azureiam/iam_test.go
+++ b/providers/azure/azureiam/iam_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -903,4 +904,84 @@ func TestGetPolicy(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
+}
+
+func TestPolicyVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	doc1 := `{"doc":1}`
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc1})
+	require.NoError(t, err)
+
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "v1", versions[0].VersionID)
+	assert.True(t, versions[0].IsDefaultVersion)
+
+	doc2 := `{"doc":2}`
+	v2, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc2})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", v2.VersionID)
+	assert.False(t, v2.IsDefaultVersion)
+
+	got, err := m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	doc3 := `{"doc":3}`
+	v3, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc3, SetAsDefault: true})
+	require.NoError(t, err)
+	assert.True(t, v3.IsDefaultVersion)
+
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc3, got.PolicyDocument)
+
+	gv, err := m.GetPolicyVersion(ctx, p.ARN, "v2")
+	require.NoError(t, err)
+	assert.Equal(t, doc2, gv.PolicyDocument)
+
+	require.NoError(t, m.SetDefaultPolicyVersion(ctx, p.ARN, "v1"))
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	err = m.DeletePolicyVersion(ctx, p.ARN, "v1")
+	require.Error(t, err)
+	assert.Equal(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+
+	require.NoError(t, m.DeletePolicyVersion(ctx, p.ARN, "v2"))
+	versions, err = m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Len(t, versions, 2)
+}
+
+func TestPolicyVersionsErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing", PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.GetPolicyVersion(ctx, "missing", "v1")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.ListPolicyVersions(ctx, "missing")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.DeletePolicyVersion(ctx, "missing", "v1")))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.SetDefaultPolicyVersion(ctx, "missing", "v1")))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	require.NoError(t, err)
+
+	_, err = m.GetPolicyVersion(ctx, p.ARN, "v9")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+
+	for range 4 {
+		_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+		require.NoError(t, err)
+	}
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
 }

--- a/providers/azure/azureiam/iam_test.go
+++ b/providers/azure/azureiam/iam_test.go
@@ -2,6 +2,7 @@ package azureiam
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -984,4 +985,41 @@ func TestPolicyVersionsErrors(t *testing.T) {
 
 	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
 	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestPolicyVersionsConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "concurrent", PolicyDocument: `{"v":1}`})
+	require.NoError(t, err)
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: `{"v":2}`})
+	require.NoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	require.NoError(t, err)
+	require.NoError(t, m.AttachUserPolicy(ctx, "u", p.ARN))
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for i := range iterations {
+		wg.Add(4)
+
+		go func() { defer wg.Done(); _, _ = m.GetPolicy(ctx, p.ARN) }()
+		go func() { defer wg.Done(); _, _ = m.ListPolicies(ctx) }()
+		go func() { defer wg.Done(); _, _ = m.CheckPermission(ctx, "u", "s3:GetObject", "*") }()
+		go func(n int) {
+			defer wg.Done()
+
+			ver := "v1"
+			if n%2 == 0 {
+				ver = "v2"
+			}
+
+			_ = m.SetDefaultPolicyVersion(ctx, p.ARN, ver)
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -276,9 +276,11 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		Description:    cfg.Description,
 	}
 	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
-	m.policies.Set(arn, p)
 
+	// Snapshot before publishing p to the store: once Set runs, p is shared and
+	// its document may be mutated concurrently by the version operations.
 	info := toPolicyInfo(p)
+	m.policies.Set(arn, p)
 
 	return &info, nil
 }

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -62,6 +62,15 @@ type policyData struct {
 	Path           string
 	PolicyDocument string
 	Description    string
+	versions       []*policyVersionData
+	versionCounter int
+}
+
+type policyVersionData struct {
+	VersionID      string
+	PolicyDocument string
+	IsDefault      bool
+	CreatedAt      string
 }
 
 type groupData struct {
@@ -266,6 +275,7 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 		PolicyDocument: cfg.PolicyDocument,
 		Description:    cfg.Description,
 	}
+	seedInitialVersion(p, cfg.PolicyDocument, m.opts.Clock.Now().UTC().Format(timeFormat))
 	m.policies.Set(arn, p)
 
 	info := toPolicyInfo(p)
@@ -304,6 +314,171 @@ func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	}
 
 	return result, nil
+}
+
+const maxPolicyVersions = 5
+
+// seedInitialVersion records the default v1 version when a policy is created.
+func seedInitialVersion(p *policyData, document, createdAt string) {
+	p.versionCounter = 1
+	p.versions = []*policyVersionData{{
+		VersionID:      "v1",
+		PolicyDocument: document,
+		IsDefault:      true,
+		CreatedAt:      createdAt,
+	}}
+}
+
+// CreatePolicyVersion adds a new version to a managed policy, optionally as the default.
+func (m *Mock) CreatePolicyVersion(_ context.Context, cfg driver.PolicyVersionConfig) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(cfg.PolicyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", cfg.PolicyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(p.versions) >= maxPolicyVersions {
+		return nil, cerrors.Newf(cerrors.ResourceExhausted,
+			"policy %q already has the maximum of %d versions", cfg.PolicyARN, maxPolicyVersions)
+	}
+
+	p.versionCounter++
+	v := &policyVersionData{
+		VersionID:      fmt.Sprintf("v%d", p.versionCounter),
+		PolicyDocument: cfg.PolicyDocument,
+		IsDefault:      cfg.SetAsDefault,
+		CreatedAt:      m.opts.Clock.Now().UTC().Format(timeFormat),
+	}
+
+	if cfg.SetAsDefault {
+		clearDefaults(p.versions)
+		p.PolicyDocument = cfg.PolicyDocument
+	}
+
+	p.versions = append(p.versions, v)
+	m.policies.Set(cfg.PolicyARN, p)
+
+	info := toPolicyVersionInfo(v)
+
+	return &info, nil
+}
+
+// GetPolicyVersion returns a single version of a managed policy.
+func (m *Mock) GetPolicyVersion(_ context.Context, policyARN, versionID string) (*driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, v := range p.versions {
+		if v.VersionID == versionID {
+			info := toPolicyVersionInfo(v)
+			return &info, nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// ListPolicyVersions returns all versions of a managed policy.
+func (m *Mock) ListPolicyVersions(_ context.Context, policyARN string) ([]driver.PolicyVersionInfo, error) {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]driver.PolicyVersionInfo, 0, len(p.versions))
+	for _, v := range p.versions {
+		result = append(result, toPolicyVersionInfo(v))
+	}
+
+	return result, nil
+}
+
+// DeletePolicyVersion removes a non-default version of a managed policy.
+func (m *Mock) DeletePolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for idx, v := range p.versions {
+		if v.VersionID != versionID {
+			continue
+		}
+
+		if v.IsDefault {
+			return cerrors.Newf(cerrors.FailedPrecondition,
+				"cannot delete the default version %q of policy %q", versionID, policyARN)
+		}
+
+		p.versions = append(p.versions[:idx], p.versions[idx+1:]...)
+		m.policies.Set(policyARN, p)
+
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+}
+
+// SetDefaultPolicyVersion marks an existing version as the default for a managed policy.
+func (m *Mock) SetDefaultPolicyVersion(_ context.Context, policyARN, versionID string) error {
+	p, ok := m.policies.Get(policyARN)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "policy %q not found", policyARN)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	target := findVersion(p.versions, versionID)
+	if target == nil {
+		return cerrors.Newf(cerrors.NotFound, "version %q not found for policy %q", versionID, policyARN)
+	}
+
+	clearDefaults(p.versions)
+
+	target.IsDefault = true
+	p.PolicyDocument = target.PolicyDocument
+	m.policies.Set(policyARN, p)
+
+	return nil
+}
+
+func clearDefaults(versions []*policyVersionData) {
+	for _, v := range versions {
+		v.IsDefault = false
+	}
+}
+
+func findVersion(versions []*policyVersionData, versionID string) *policyVersionData {
+	for _, v := range versions {
+		if v.VersionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func toPolicyVersionInfo(v *policyVersionData) driver.PolicyVersionInfo {
+	return driver.PolicyVersionInfo{
+		VersionID:        v.VersionID,
+		PolicyDocument:   v.PolicyDocument,
+		IsDefaultVersion: v.IsDefault,
+		CreatedAt:        v.CreatedAt,
+	}
 }
 
 func (m *Mock) attachPolicy(

--- a/providers/gcp/gcpiam/iam.go
+++ b/providers/gcp/gcpiam/iam.go
@@ -299,6 +299,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 		return nil, cerrors.Newf(cerrors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	info := toPolicyInfo(p)
 
 	return &info, nil
@@ -308,6 +311,9 @@ func (m *Mock) GetPolicy(_ context.Context, arn string) (*driver.PolicyInfo, err
 func (m *Mock) ListPolicies(_ context.Context) ([]driver.PolicyInfo, error) {
 	all := m.policies.All()
 	result := make([]driver.PolicyInfo, 0, len(all))
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	for _, p := range all {
 		result = append(result, toPolicyInfo(p))
@@ -721,6 +727,9 @@ func (m *Mock) collectPolicyARNs(principal string) map[string]bool {
 // to perform the given action on the given resource. Explicit Deny wins over Allow.
 func (m *Mock) CheckPermission(_ context.Context, principal, action, resource string) (bool, error) {
 	policyARNs := m.collectPolicyARNs(principal)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	hasAllow := false
 

--- a/providers/gcp/gcpiam/iam_test.go
+++ b/providers/gcp/gcpiam/iam_test.go
@@ -3,6 +3,7 @@ package gcpiam
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -895,4 +896,41 @@ func TestPolicyVersionsErrors(t *testing.T) {
 
 	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
 	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
+}
+
+func TestPolicyVersionsConcurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "concurrent", PolicyDocument: `{"v":1}`})
+	require.NoError(t, err)
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: `{"v":2}`})
+	require.NoError(t, err)
+	_, err = m.CreateUser(ctx, driver.UserConfig{Name: "u"})
+	require.NoError(t, err)
+	require.NoError(t, m.AttachUserPolicy(ctx, "u", p.ARN))
+
+	const iterations = 50
+
+	var wg sync.WaitGroup
+
+	for i := range iterations {
+		wg.Add(4)
+
+		go func() { defer wg.Done(); _, _ = m.GetPolicy(ctx, p.ARN) }()
+		go func() { defer wg.Done(); _, _ = m.ListPolicies(ctx) }()
+		go func() { defer wg.Done(); _, _ = m.CheckPermission(ctx, "u", "s3:GetObject", "*") }()
+		go func(n int) {
+			defer wg.Done()
+
+			ver := "v1"
+			if n%2 == 0 {
+				ver = "v2"
+			}
+
+			_ = m.SetDefaultPolicyVersion(ctx, p.ARN, ver)
+		}(i)
+	}
+
+	wg.Wait()
 }

--- a/providers/gcp/gcpiam/iam_test.go
+++ b/providers/gcp/gcpiam/iam_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/config"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -814,4 +815,84 @@ func TestDetachRolePolicy(t *testing.T) {
 	policies, err := m.ListAttachedRolePolicies(ctx, "svc-role")
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(policies))
+}
+
+func TestPolicyVersions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	doc1 := `{"doc":1}`
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p1", PolicyDocument: doc1})
+	require.NoError(t, err)
+
+	versions, err := m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	require.Len(t, versions, 1)
+	assert.Equal(t, "v1", versions[0].VersionID)
+	assert.True(t, versions[0].IsDefaultVersion)
+
+	doc2 := `{"doc":2}`
+	v2, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc2})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", v2.VersionID)
+	assert.False(t, v2.IsDefaultVersion)
+
+	got, err := m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	doc3 := `{"doc":3}`
+	v3, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: doc3, SetAsDefault: true})
+	require.NoError(t, err)
+	assert.True(t, v3.IsDefaultVersion)
+
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc3, got.PolicyDocument)
+
+	gv, err := m.GetPolicyVersion(ctx, p.ARN, "v2")
+	require.NoError(t, err)
+	assert.Equal(t, doc2, gv.PolicyDocument)
+
+	require.NoError(t, m.SetDefaultPolicyVersion(ctx, p.ARN, "v1"))
+	got, err = m.GetPolicy(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Equal(t, doc1, got.PolicyDocument)
+
+	err = m.DeletePolicyVersion(ctx, p.ARN, "v1")
+	require.Error(t, err)
+	assert.Equal(t, cerrors.FailedPrecondition, cerrors.GetCode(err))
+
+	require.NoError(t, m.DeletePolicyVersion(ctx, p.ARN, "v2"))
+	versions, err = m.ListPolicyVersions(ctx, p.ARN)
+	require.NoError(t, err)
+	assert.Len(t, versions, 2)
+}
+
+func TestPolicyVersionsErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, err := m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: "missing", PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.GetPolicyVersion(ctx, "missing", "v1")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	_, err = m.ListPolicyVersions(ctx, "missing")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.DeletePolicyVersion(ctx, "missing", "v1")))
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(m.SetDefaultPolicyVersion(ctx, "missing", "v1")))
+
+	p, err := m.CreatePolicy(ctx, driver.PolicyConfig{Name: "p", PolicyDocument: "{}"})
+	require.NoError(t, err)
+
+	_, err = m.GetPolicyVersion(ctx, p.ARN, "v9")
+	assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err))
+
+	for range 4 {
+		_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+		require.NoError(t, err)
+	}
+
+	_, err = m.CreatePolicyVersion(ctx, driver.PolicyVersionConfig{PolicyARN: p.ARN, PolicyDocument: "{}"})
+	assert.Equal(t, cerrors.ResourceExhausted, cerrors.GetCode(err))
 }

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -9,6 +9,7 @@ package aws
 import (
 	bedrockdriver "github.com/stackshy/cloudemu/bedrock/driver"
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
@@ -24,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
 	"github.com/stackshy/cloudemu/server/aws/ec2"
+	"github.com/stackshy/cloudemu/server/aws/ecr"
 	"github.com/stackshy/cloudemu/server/aws/eks"
 	"github.com/stackshy/cloudemu/server/aws/iam"
 	"github.com/stackshy/cloudemu/server/aws/lambda"
@@ -53,6 +55,7 @@ type Drivers struct {
 	Redshift   rdbdriver.RelationalDB
 	EKS        eksdriver.EKS
 	IAM        iamdriver.IAM
+	ECR        crdriver.ContainerRegistry
 	Bedrock    bedrockdriver.Bedrock
 	SageMaker  sagemakerdriver.Service
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -126,6 +129,10 @@ func New(d Drivers) *server.Server {
 	// RDS, Redshift, and EC2. Registered before EC2 for the same reason.
 	if d.IAM != nil {
 		srv.Register(iam.New(d.IAM))
+	}
+
+	if d.ECR != nil {
+		srv.Register(ecr.New(d.ECR))
 	}
 
 	// Redshift sits with the other query-protocol handlers before the EC2

--- a/server/aws/ecr/handler.go
+++ b/server/aws/ecr/handler.go
@@ -1,0 +1,79 @@
+// Package ecr implements the AWS ECR JSON-RPC protocol as a server.Handler.
+// Point the real aws-sdk-go-v2 ECR client at a Server registered with this
+// handler and repository/image operations work against an in-memory
+// containerregistry driver.
+//
+// ECR uses the AWS JSON 1.1 wire shape (POST + JSON body, dispatched on the
+// X-Amz-Target header), the same family as DynamoDB.
+package ecr
+
+import (
+	"net/http"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "AmazonEC2ContainerRegistry_V20150921."
+
+// Handler serves ECR JSON-RPC requests against a ContainerRegistry driver.
+type Handler struct {
+	registry crdriver.ContainerRegistry
+}
+
+// New returns an ECR handler backed by reg.
+func New(reg crdriver.ContainerRegistry) *Handler {
+	return &Handler{registry: reg}
+}
+
+// Matches returns true for ECR-shaped requests, identified by an X-Amz-Target
+// header of "AmazonEC2ContainerRegistry_V20150921.<Operation>".
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches ECR operations based on X-Amz-Target.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix) {
+	case "CreateRepository":
+		h.createRepository(w, r)
+	case "DescribeRepositories":
+		h.describeRepositories(w, r)
+	case "DeleteRepository":
+		h.deleteRepository(w, r)
+	case "PutImage":
+		h.putImage(w, r)
+	case "ListImages":
+		h.listImages(w, r)
+	case "DescribeImages":
+		h.describeImages(w, r)
+	case "BatchDeleteImage":
+		h.batchDeleteImage(w, r)
+	default:
+		op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown ECR operation: "+op)
+	}
+}
+
+// writeErr maps canonical cloudemu errors to ECR JSON error responses. ECR
+// returns errors as HTTP 400 with a "__type" body the SDK maps to a typed
+// exception.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryAlreadyExistsException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "RepositoryNotEmptyException", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "ServerException", err.Error())
+	}
+}

--- a/server/aws/ecr/operations.go
+++ b/server/aws/ecr/operations.go
@@ -1,0 +1,255 @@
+package ecr
+
+import (
+	"net/http"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request) {
+	var req createRepositoryRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
+		Name:               req.RepositoryName,
+		Tags:               tagsToMap(req.Tags),
+		ImageScanOnPush:    req.ImageScanningConfiguration.ScanOnPush,
+		ImageTagMutability: req.ImageTagMutability,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := toRepositoryJSON(repo)
+	out.ImageTagMutability = req.ImageTagMutability
+
+	wire.WriteJSON(w, createRepositoryResponse{Repository: out})
+}
+
+func (h *Handler) describeRepositories(w http.ResponseWriter, r *http.Request) {
+	var req describeRepositoriesRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	repos, err := h.collectRepositories(r, req.RepositoryNames)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]repositoryJSON, 0, len(repos))
+	for i := range repos {
+		out = append(out, toRepositoryJSON(&repos[i]))
+	}
+
+	wire.WriteJSON(w, describeRepositoriesResponse{Repositories: out})
+}
+
+// collectRepositories returns the named repositories, or all of them when no
+// names are given.
+func (h *Handler) collectRepositories(r *http.Request, names []string) ([]crdriver.Repository, error) {
+	if len(names) == 0 {
+		return h.registry.ListRepositories(r.Context())
+	}
+
+	repos := make([]crdriver.Repository, 0, len(names))
+
+	for _, name := range names {
+		rp, err := h.registry.GetRepository(r.Context(), name)
+		if err != nil {
+			return nil, err
+		}
+
+		repos = append(repos, *rp)
+	}
+
+	return repos, nil
+}
+
+func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request) {
+	var req deleteRepositoryRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// ECR echoes the deleted repository, so capture it before removal.
+	repo, err := h.registry.GetRepository(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.registry.DeleteRepository(r.Context(), req.RepositoryName, req.Force); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, deleteRepositoryResponse{Repository: toRepositoryJSON(repo)})
+}
+
+func (h *Handler) putImage(w http.ResponseWriter, r *http.Request) {
+	var req putImageRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	detail, err := h.registry.PutImage(r.Context(), &crdriver.ImageManifest{
+		Repository: req.RepositoryName,
+		Tag:        req.ImageTag,
+		Digest:     req.ImageDigest,
+		MediaType:  req.ImageManifestMediaType,
+		SizeBytes:  int64(len(req.ImageManifest)),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, putImageResponse{Image: imageJSON{
+		RegistryID:             detail.RegistryID,
+		RepositoryName:         detail.Repository,
+		ImageID:                imageIDJSON{ImageDigest: detail.Digest, ImageTag: req.ImageTag},
+		ImageManifest:          req.ImageManifest,
+		ImageManifestMediaType: req.ImageManifestMediaType,
+	}})
+}
+
+func (h *Handler) listImages(w http.ResponseWriter, r *http.Request) {
+	var req repositoryNameRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	images, err := h.registry.ListImages(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	ids := make([]imageIDJSON, 0, len(images))
+	for i := range images {
+		ids = append(ids, imageIDsForDetail(&images[i])...)
+	}
+
+	wire.WriteJSON(w, listImagesResponse{ImageIDs: ids})
+}
+
+// imageIDsForDetail expands an image into one id per tag (real ECR lists each
+// tag separately), or a digest-only id when untagged.
+func imageIDsForDetail(d *crdriver.ImageDetail) []imageIDJSON {
+	ids := make([]imageIDJSON, 0, len(d.Tags))
+
+	for _, tag := range d.Tags {
+		if tag == "" {
+			continue
+		}
+
+		ids = append(ids, imageIDJSON{ImageDigest: d.Digest, ImageTag: tag})
+	}
+
+	if len(ids) == 0 {
+		return []imageIDJSON{{ImageDigest: d.Digest}}
+	}
+
+	return ids
+}
+
+func (h *Handler) describeImages(w http.ResponseWriter, r *http.Request) {
+	var req imageIDsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	images, err := h.registry.ListImages(r.Context(), req.RepositoryName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	details := make([]imageDetailJSON, 0, len(images))
+
+	for i := range images {
+		if len(req.ImageIDs) > 0 && !matchesAnyID(&images[i], req.ImageIDs) {
+			continue
+		}
+
+		details = append(details, toImageDetailJSON(&images[i]))
+	}
+
+	wire.WriteJSON(w, describeImagesResponse{ImageDetails: details})
+}
+
+func (h *Handler) batchDeleteImage(w http.ResponseWriter, r *http.Request) {
+	var req imageIDsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// A missing repository is a thrown error; missing images become per-image
+	// failures, matching real ECR.
+	if _, err := h.registry.GetRepository(r.Context(), req.RepositoryName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	deleted := make([]imageIDJSON, 0, len(req.ImageIDs))
+	failures := make([]imageFailureJSON, 0)
+
+	for _, id := range req.ImageIDs {
+		if err := h.registry.DeleteImage(r.Context(), req.RepositoryName, imageReference(id)); err != nil {
+			failures = append(failures, imageFailureJSON{
+				ImageID:       id,
+				FailureCode:   "ImageNotFound",
+				FailureReason: "Requested image not found",
+			})
+
+			continue
+		}
+
+		deleted = append(deleted, id)
+	}
+
+	wire.WriteJSON(w, batchDeleteImageResponse{ImageIDs: deleted, Failures: failures})
+}
+
+func tagsToMap(tags []tagJSON) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}
+
+func matchesAnyID(d *crdriver.ImageDetail, ids []imageIDJSON) bool {
+	for _, id := range ids {
+		if id.ImageDigest != "" && id.ImageDigest == d.Digest {
+			return true
+		}
+
+		if id.ImageTag != "" && containsTag(d.Tags, id.ImageTag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsTag(tags []string, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/ecr/sdk_roundtrip_test.go
+++ b/server/aws/ecr/sdk_roundtrip_test.go
@@ -1,0 +1,211 @@
+package ecr_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsecr "github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+const sampleManifest = `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}`
+
+func newECRClient(t *testing.T) *awsecr.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{ECR: cloud.ECR})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awsecr.NewFromConfig(cfg, func(o *awsecr.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKECRRepositoryLifecycle(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName:             aws.String("app"),
+		ImageTagMutability:         ecrtypes.ImageTagMutabilityImmutable,
+		ImageScanningConfiguration: &ecrtypes.ImageScanningConfiguration{ScanOnPush: true},
+		Tags:                       []ecrtypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	if aws.ToString(created.Repository.RepositoryName) != "app" {
+		t.Fatalf("got repo name %q, want app", aws.ToString(created.Repository.RepositoryName))
+	}
+
+	all, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{})
+	if err != nil {
+		t.Fatalf("DescribeRepositories(all): %v", err)
+	}
+
+	if len(all.Repositories) != 1 {
+		t.Fatalf("got %d repositories, want 1", len(all.Repositories))
+	}
+
+	byName, err := client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{
+		RepositoryNames: []string{"app"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeRepositories(app): %v", err)
+	}
+
+	if len(byName.Repositories) != 1 || aws.ToString(byName.Repositories[0].RepositoryName) != "app" {
+		t.Fatalf("DescribeRepositories(app) returned %+v", byName.Repositories)
+	}
+
+	if _, err := client.DeleteRepository(ctx, &awsecr.DeleteRepositoryInput{
+		RepositoryName: aws.String("app"), Force: true,
+	}); err != nil {
+		t.Fatalf("DeleteRepository: %v", err)
+	}
+
+	_, err = client.DescribeRepositories(ctx, &awsecr.DescribeRepositoriesInput{RepositoryNames: []string{"app"}})
+
+	var notFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("describe after delete: want RepositoryNotFoundException, got %v", err)
+	}
+}
+
+func TestSDKECRImageLifecycle(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("imgs"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	put, err := client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("imgs"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("PutImage: %v", err)
+	}
+
+	if aws.ToString(put.Image.ImageId.ImageTag) != "v1" || aws.ToString(put.Image.ImageId.ImageDigest) == "" {
+		t.Fatalf("PutImage returned %+v", put.Image.ImageId)
+	}
+
+	listed, err := client.ListImages(ctx, &awsecr.ListImagesInput{RepositoryName: aws.String("imgs")})
+	if err != nil {
+		t.Fatalf("ListImages: %v", err)
+	}
+
+	if len(listed.ImageIds) != 1 || aws.ToString(listed.ImageIds[0].ImageTag) != "v1" {
+		t.Fatalf("ListImages returned %+v", listed.ImageIds)
+	}
+
+	described, err := client.DescribeImages(ctx, &awsecr.DescribeImagesInput{RepositoryName: aws.String("imgs")})
+	if err != nil {
+		t.Fatalf("DescribeImages: %v", err)
+	}
+
+	if len(described.ImageDetails) != 1 || !contains(described.ImageDetails[0].ImageTags, "v1") {
+		t.Fatalf("DescribeImages returned %+v", described.ImageDetails)
+	}
+
+	deleted, err := client.BatchDeleteImage(ctx, &awsecr.BatchDeleteImageInput{
+		RepositoryName: aws.String("imgs"),
+		ImageIds:       []ecrtypes.ImageIdentifier{{ImageTag: aws.String("v1")}},
+	})
+	if err != nil {
+		t.Fatalf("BatchDeleteImage: %v", err)
+	}
+
+	if len(deleted.ImageIds) != 1 || len(deleted.Failures) != 0 {
+		t.Fatalf("BatchDeleteImage returned ids=%+v failures=%+v", deleted.ImageIds, deleted.Failures)
+	}
+}
+
+func TestSDKECRBatchDeleteMissingImage(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("partial"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	// Deleting an image that was never pushed yields a per-image failure, not a
+	// thrown error.
+	out, err := client.BatchDeleteImage(ctx, &awsecr.BatchDeleteImageInput{
+		RepositoryName: aws.String("partial"),
+		ImageIds:       []ecrtypes.ImageIdentifier{{ImageTag: aws.String("ghost")}},
+	})
+	if err != nil {
+		t.Fatalf("BatchDeleteImage: %v", err)
+	}
+
+	if len(out.Failures) != 1 || out.Failures[0].FailureCode != ecrtypes.ImageFailureCodeImageNotFound {
+		t.Fatalf("want one ImageNotFound failure, got %+v", out.Failures)
+	}
+}
+
+func TestSDKECRErrors(t *testing.T) {
+	client := newECRClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{
+		RepositoryName: aws.String("dup"),
+	}); err != nil {
+		t.Fatalf("CreateRepository: %v", err)
+	}
+
+	_, err := client.CreateRepository(ctx, &awsecr.CreateRepositoryInput{RepositoryName: aws.String("dup")})
+
+	var exists *ecrtypes.RepositoryAlreadyExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("duplicate create: want RepositoryAlreadyExistsException, got %v", err)
+	}
+
+	_, err = client.PutImage(ctx, &awsecr.PutImageInput{
+		RepositoryName: aws.String("ghost"),
+		ImageManifest:  aws.String(sampleManifest),
+		ImageTag:       aws.String("v1"),
+	})
+
+	var notFound *ecrtypes.RepositoryNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("put image on missing repo: want RepositoryNotFoundException, got %v", err)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/ecr/types.go
+++ b/server/aws/ecr/types.go
@@ -1,0 +1,158 @@
+package ecr
+
+import (
+	"time"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+type tagJSON struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type imageScanningConfigJSON struct {
+	ScanOnPush bool `json:"scanOnPush"`
+}
+
+type repositoryJSON struct {
+	RepositoryName     string  `json:"repositoryName"`
+	RepositoryURI      string  `json:"repositoryUri"`
+	RegistryID         string  `json:"registryId,omitempty"`
+	CreatedAt          float64 `json:"createdAt,omitempty"`
+	ImageTagMutability string  `json:"imageTagMutability,omitempty"`
+}
+
+type imageIDJSON struct {
+	ImageDigest string `json:"imageDigest,omitempty"`
+	ImageTag    string `json:"imageTag,omitempty"`
+}
+
+type imageJSON struct {
+	RegistryID             string      `json:"registryId,omitempty"`
+	RepositoryName         string      `json:"repositoryName"`
+	ImageID                imageIDJSON `json:"imageId"`
+	ImageManifest          string      `json:"imageManifest,omitempty"`
+	ImageManifestMediaType string      `json:"imageManifestMediaType,omitempty"`
+}
+
+type imageDetailJSON struct {
+	RegistryID       string   `json:"registryId,omitempty"`
+	RepositoryName   string   `json:"repositoryName"`
+	ImageDigest      string   `json:"imageDigest"`
+	ImageTags        []string `json:"imageTags,omitempty"`
+	ImageSizeInBytes int64    `json:"imageSizeInBytes,omitempty"`
+	ImagePushedAt    float64  `json:"imagePushedAt,omitempty"`
+}
+
+type imageFailureJSON struct {
+	ImageID       imageIDJSON `json:"imageId"`
+	FailureCode   string      `json:"failureCode"`
+	FailureReason string      `json:"failureReason"`
+}
+
+// --- request envelopes ---
+
+type createRepositoryRequest struct {
+	RepositoryName             string                  `json:"repositoryName"`
+	Tags                       []tagJSON               `json:"tags"`
+	ImageScanningConfiguration imageScanningConfigJSON `json:"imageScanningConfiguration"`
+	ImageTagMutability         string                  `json:"imageTagMutability"`
+}
+
+type describeRepositoriesRequest struct {
+	RepositoryNames []string `json:"repositoryNames"`
+}
+
+type deleteRepositoryRequest struct {
+	RepositoryName string `json:"repositoryName"`
+	Force          bool   `json:"force"`
+}
+
+type putImageRequest struct {
+	RepositoryName         string `json:"repositoryName"`
+	ImageManifest          string `json:"imageManifest"`
+	ImageManifestMediaType string `json:"imageManifestMediaType"`
+	ImageTag               string `json:"imageTag"`
+	ImageDigest            string `json:"imageDigest"`
+}
+
+type repositoryNameRequest struct {
+	RepositoryName string `json:"repositoryName"`
+}
+
+type imageIDsRequest struct {
+	RepositoryName string        `json:"repositoryName"`
+	ImageIDs       []imageIDJSON `json:"imageIds"`
+}
+
+// --- response envelopes ---
+
+type createRepositoryResponse struct {
+	Repository repositoryJSON `json:"repository"`
+}
+
+type describeRepositoriesResponse struct {
+	Repositories []repositoryJSON `json:"repositories"`
+}
+
+type deleteRepositoryResponse struct {
+	Repository repositoryJSON `json:"repository"`
+}
+
+type putImageResponse struct {
+	Image imageJSON `json:"image"`
+}
+
+type listImagesResponse struct {
+	ImageIDs []imageIDJSON `json:"imageIds"`
+}
+
+type describeImagesResponse struct {
+	ImageDetails []imageDetailJSON `json:"imageDetails"`
+}
+
+type batchDeleteImageResponse struct {
+	ImageIDs []imageIDJSON      `json:"imageIds"`
+	Failures []imageFailureJSON `json:"failures"`
+}
+
+// epochSeconds converts an RFC3339 timestamp to Unix epoch seconds, the form
+// the AWS JSON protocol uses for timestamp fields. Returns 0 on parse failure.
+func epochSeconds(iso string) float64 {
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return float64(t.Unix())
+}
+
+func toRepositoryJSON(r *crdriver.Repository) repositoryJSON {
+	return repositoryJSON{
+		RepositoryName: r.Name,
+		RepositoryURI:  r.URI,
+		CreatedAt:      epochSeconds(r.CreatedAt),
+	}
+}
+
+func toImageDetailJSON(d *crdriver.ImageDetail) imageDetailJSON {
+	return imageDetailJSON{
+		RegistryID:       d.RegistryID,
+		RepositoryName:   d.Repository,
+		ImageDigest:      d.Digest,
+		ImageTags:        d.Tags,
+		ImageSizeInBytes: d.SizeBytes,
+		ImagePushedAt:    epochSeconds(d.PushedAt),
+	}
+}
+
+// imageReference picks the digest if present, otherwise the tag — the form the
+// driver's findImage resolves.
+func imageReference(id imageIDJSON) string {
+	if id.ImageDigest != "" {
+		return id.ImageDigest
+	}
+
+	return id.ImageTag
+}

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -44,6 +44,11 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DeletePolicy":                  {},
 	"GetPolicy":                     {},
 	"ListPolicies":                  {},
+	"CreatePolicyVersion":           {},
+	"GetPolicyVersion":              {},
+	"ListPolicyVersions":            {},
+	"DeletePolicyVersion":           {},
+	"SetDefaultPolicyVersion":       {},
 	"AttachUserPolicy":              {},
 	"DetachUserPolicy":              {},
 	"AttachRolePolicy":              {},
@@ -134,6 +139,16 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getPolicy(w, r)
 	case "ListPolicies":
 		h.listPolicies(w, r)
+	case "CreatePolicyVersion":
+		h.createPolicyVersion(w, r)
+	case "GetPolicyVersion":
+		h.getPolicyVersion(w, r)
+	case "ListPolicyVersions":
+		h.listPolicyVersions(w, r)
+	case "DeletePolicyVersion":
+		h.deletePolicyVersion(w, r)
+	case "SetDefaultPolicyVersion":
+		h.setDefaultPolicyVersion(w, r)
 	case "AttachUserPolicy":
 		h.attachUserPolicy(w, r)
 	case "DetachUserPolicy":
@@ -195,6 +210,8 @@ func writeErr(w http.ResponseWriter, err error) {
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidInput", err.Error())
 	case cerrors.IsFailedPrecondition(err):
 		awsquery.WriteXMLError(w, http.StatusConflict, "DeleteConflict", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		awsquery.WriteXMLError(w, http.StatusConflict, "LimitExceeded", err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -8,6 +9,9 @@ import (
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/server/wire/awsquery"
 )
+
+// defaultPolicyVersionID is the version a freshly created policy starts with.
+const defaultPolicyVersionID = "v1"
 
 // parseIAMTags parses Tags.member.N.{Key,Value} pairs (the shape the
 // aws-sdk-go-v2/service/iam client emits for tagged-create requests).
@@ -184,7 +188,7 @@ func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, createPolicyResponse{
 		Xmlns:    Namespace,
-		Result:   createPolicyResult{Policy: toPolicyXML(p)},
+		Result:   createPolicyResult{Policy: toPolicyXML(p, defaultPolicyVersionID)},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -210,12 +214,11 @@ func (h *Handler) getPolicy(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, getPolicyResponse{
 		Xmlns:    Namespace,
-		Result:   getPolicyResult{Policy: toPolicyXML(p)},
+		Result:   getPolicyResult{Policy: toPolicyXML(p, h.defaultVersionID(r.Context(), p.ARN))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
 
-//nolint:dupl // list handlers share shape but operate on different driver types and response envelopes.
 func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 	policies, err := h.iam.ListPolicies(r.Context())
 	if err != nil {
@@ -225,12 +228,106 @@ func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 
 	out := policiesListXML{Member: make([]policyXML, 0, len(policies))}
 	for i := range policies {
-		out.Member = append(out.Member, toPolicyXML(&policies[i]))
+		out.Member = append(out.Member, toPolicyXML(&policies[i], h.defaultVersionID(r.Context(), policies[i].ARN)))
 	}
 
 	awsquery.WriteXMLResponse(w, listPoliciesResponse{
 		Xmlns:    Namespace,
 		Result:   listPoliciesResult{Policies: out, IsTruncated: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// defaultVersionID returns the version ID currently marked default for the
+// policy, falling back to "v1" if the versions cannot be read.
+func (h *Handler) defaultVersionID(ctx context.Context, policyARN string) string {
+	versions, err := h.iam.ListPolicyVersions(ctx, policyARN)
+	if err != nil {
+		return defaultPolicyVersionID
+	}
+
+	for i := range versions {
+		if versions[i].IsDefaultVersion {
+			return versions[i].VersionID
+		}
+	}
+
+	return defaultPolicyVersionID
+}
+
+func (h *Handler) createPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	cfg := iamdriver.PolicyVersionConfig{
+		PolicyARN:      r.Form.Get("PolicyArn"),
+		PolicyDocument: r.Form.Get("PolicyDocument"),
+		SetAsDefault:   r.Form.Get("SetAsDefault") == "true",
+	}
+
+	v, err := h.iam.CreatePolicyVersion(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createPolicyVersionResponse{
+		Xmlns:    Namespace,
+		Result:   createPolicyVersionResult{PolicyVersion: toPolicyVersionXML(v, true)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	v, err := h.iam.GetPolicyVersion(r.Context(), r.Form.Get("PolicyArn"), r.Form.Get("VersionId"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getPolicyVersionResponse{
+		Xmlns:    Namespace,
+		Result:   getPolicyVersionResult{PolicyVersion: toPolicyVersionXML(v, true)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listPolicyVersions(w http.ResponseWriter, r *http.Request) {
+	versions, err := h.iam.ListPolicyVersions(r.Context(), r.Form.Get("PolicyArn"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := policyVersionsListXML{Member: make([]policyVersionXML, 0, len(versions))}
+	for i := range versions {
+		out.Member = append(out.Member, toPolicyVersionXML(&versions[i], false))
+	}
+
+	awsquery.WriteXMLResponse(w, listPolicyVersionsResponse{
+		Xmlns:    Namespace,
+		Result:   listPolicyVersionsResult{Versions: out, IsTruncated: false},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deletePolicyVersion(w http.ResponseWriter, r *http.Request) {
+	if err := h.iam.DeletePolicyVersion(r.Context(), r.Form.Get("PolicyArn"), r.Form.Get("VersionId")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deletePolicyVersionResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) setDefaultPolicyVersion(w http.ResponseWriter, r *http.Request) {
+	if err := h.iam.SetDefaultPolicyVersion(r.Context(), r.Form.Get("PolicyArn"), r.Form.Get("VersionId")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, setDefaultPolicyVersionResponse{
+		Xmlns:    Namespace,
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/iam/sdk_roundtrip_test.go
+++ b/server/aws/iam/sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package iam_test
 
 import (
 	"context"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -311,5 +312,158 @@ func TestSDKIAMInstanceProfiles(t *testing.T) {
 		InstanceProfileName: aws.String("ec2-profile"),
 	}); err != nil {
 		t.Fatalf("DeleteInstanceProfile: %v", err)
+	}
+}
+
+func createPolicyForVersions(t *testing.T, client *awsiam.Client, name string) string {
+	t.Helper()
+
+	out, err := client.CreatePolicy(context.Background(), &awsiam.CreatePolicyInput{
+		PolicyName:     aws.String(name),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	return aws.ToString(out.Policy.Arn)
+}
+
+func TestSDKIAMPolicyVersionLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	arn := createPolicyForVersions(t, client, "versioned")
+
+	// CreatePolicy auto-seeds a default v1.
+	listed, err := client.ListPolicyVersions(ctx, &awsiam.ListPolicyVersionsInput{PolicyArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListPolicyVersions: %v", err)
+	}
+
+	if len(listed.Versions) != 1 ||
+		aws.ToString(listed.Versions[0].VersionId) != "v1" || !listed.Versions[0].IsDefaultVersion {
+		t.Fatalf("expected seeded default v1, got %+v", listed.Versions)
+	}
+
+	const docV2 = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"*"}]}`
+
+	created, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn:      aws.String(arn),
+		PolicyDocument: aws.String(docV2),
+		SetAsDefault:   true,
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicyVersion: %v", err)
+	}
+
+	if aws.ToString(created.PolicyVersion.VersionId) != "v2" || !created.PolicyVersion.IsDefaultVersion {
+		t.Fatalf("expected new default v2, got %+v", created.PolicyVersion)
+	}
+
+	// GetPolicyVersion round-trips the stored document.
+	gotVer, err := client.GetPolicyVersion(ctx, &awsiam.GetPolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v2"),
+	})
+	if err != nil {
+		t.Fatalf("GetPolicyVersion: %v", err)
+	}
+
+	if aws.ToString(gotVer.PolicyVersion.Document) != docV2 {
+		t.Fatalf("GetPolicyVersion document mismatch: %q", aws.ToString(gotVer.PolicyVersion.Document))
+	}
+
+	// GetPolicy reflects the new default, then tracks SetDefaultPolicyVersion.
+	assertDefaultVersion(t, client, arn, "v2")
+
+	if _, err := client.SetDefaultPolicyVersion(ctx, &awsiam.SetDefaultPolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v1"),
+	}); err != nil {
+		t.Fatalf("SetDefaultPolicyVersion: %v", err)
+	}
+
+	assertDefaultVersion(t, client, arn, "v1")
+}
+
+func assertDefaultVersion(t *testing.T, client *awsiam.Client, arn, want string) {
+	t.Helper()
+
+	pol, err := client.GetPolicy(context.Background(), &awsiam.GetPolicyInput{PolicyArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	if got := aws.ToString(pol.Policy.DefaultVersionId); got != want {
+		t.Fatalf("got default version %q, want %q", got, want)
+	}
+}
+
+func TestSDKIAMPolicyVersionEdgeCases(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	arn := createPolicyForVersions(t, client, "edge")
+
+	// The default version cannot be deleted (AWS DeleteConflict).
+	_, err := client.DeletePolicyVersion(ctx, &awsiam.DeletePolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v1"),
+	})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("deleting default version: want DeleteConflictException, got %v", err)
+	}
+
+	// A non-default version can be deleted.
+	if _, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn: aws.String(arn), PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("CreatePolicyVersion: %v", err)
+	}
+
+	if _, err := client.DeletePolicyVersion(ctx, &awsiam.DeletePolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v2"),
+	}); err != nil {
+		t.Fatalf("DeletePolicyVersion(v2): %v", err)
+	}
+
+	// Unknown version and unknown policy both map to NoSuchEntity.
+	var notFound *iamtypes.NoSuchEntityException
+
+	_, err = client.GetPolicyVersion(ctx, &awsiam.GetPolicyVersionInput{
+		PolicyArn: aws.String(arn), VersionId: aws.String("v99"),
+	})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("get unknown version: want NoSuchEntityException, got %v", err)
+	}
+
+	_, err = client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn:      aws.String("arn:aws:iam::123456789012:policy/missing"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("create version on missing policy: want NoSuchEntityException, got %v", err)
+	}
+}
+
+func TestSDKIAMPolicyVersionLimit(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	arn := createPolicyForVersions(t, client, "maxed")
+
+	// v1 is seeded; four more reach the maximum of five.
+	for range 4 {
+		if _, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+			PolicyArn: aws.String(arn), PolicyDocument: aws.String(samplePolicy),
+		}); err != nil {
+			t.Fatalf("CreatePolicyVersion: %v", err)
+		}
+	}
+
+	_, err := client.CreatePolicyVersion(ctx, &awsiam.CreatePolicyVersionInput{
+		PolicyArn: aws.String(arn), PolicyDocument: aws.String(samplePolicy),
+	})
+
+	var limit *iamtypes.LimitExceededException
+	if !errors.As(err, &limit) {
+		t.Fatalf("exceeding version limit: want LimitExceededException, got %v", err)
 	}
 }

--- a/server/aws/iam/xml.go
+++ b/server/aws/iam/xml.go
@@ -98,17 +98,45 @@ type policyXML struct {
 //   - IsAttachable is always true. Real AWS distinguishes
 //     customer-managed (attachable) from AWS-managed policies; we only
 //     emit customer-managed, so true is correct.
-func toPolicyXML(p *iamdriver.PolicyInfo) policyXML {
+func toPolicyXML(p *iamdriver.PolicyInfo, defaultVersionID string) policyXML {
 	return policyXML{
 		PolicyName:       p.Name,
 		PolicyID:         p.ID,
 		Arn:              p.ARN,
 		Path:             p.Path,
-		DefaultVersionID: "v1",
+		DefaultVersionID: defaultVersionID,
 		AttachmentCount:  0,
 		IsAttachable:     true,
 		Description:      p.Description,
 	}
+}
+
+type policyVersionXML struct {
+	Document         string `xml:"Document,omitempty"`
+	VersionID        string `xml:"VersionId"`
+	IsDefaultVersion bool   `xml:"IsDefaultVersion"`
+	CreateDate       string `xml:"CreateDate,omitempty"`
+}
+
+type policyVersionsListXML struct {
+	Member []policyVersionXML `xml:"member,omitempty"`
+}
+
+// toPolicyVersionXML maps a driver version to its wire shape. The real IAM API
+// omits the document body from ListPolicyVersions, so includeDocument is false
+// there and true for Create/GetPolicyVersion.
+func toPolicyVersionXML(v *iamdriver.PolicyVersionInfo, includeDocument bool) policyVersionXML {
+	out := policyVersionXML{
+		VersionID:        v.VersionID,
+		IsDefaultVersion: v.IsDefaultVersion,
+		CreateDate:       v.CreatedAt,
+	}
+
+	if includeDocument {
+		out.Document = v.PolicyDocument
+	}
+
+	return out
 }
 
 type groupXML struct {
@@ -351,6 +379,52 @@ type listPoliciesResponse struct {
 type listPoliciesResult struct {
 	Policies    policiesListXML `xml:"Policies"`
 	IsTruncated bool            `xml:"IsTruncated"`
+}
+
+type createPolicyVersionResponse struct {
+	XMLName  xml.Name                  `xml:"CreatePolicyVersionResponse"`
+	Xmlns    string                    `xml:"xmlns,attr"`
+	Result   createPolicyVersionResult `xml:"CreatePolicyVersionResult"`
+	Metadata responseMetadata          `xml:"ResponseMetadata"`
+}
+
+type createPolicyVersionResult struct {
+	PolicyVersion policyVersionXML `xml:"PolicyVersion"`
+}
+
+type getPolicyVersionResponse struct {
+	XMLName  xml.Name               `xml:"GetPolicyVersionResponse"`
+	Xmlns    string                 `xml:"xmlns,attr"`
+	Result   getPolicyVersionResult `xml:"GetPolicyVersionResult"`
+	Metadata responseMetadata       `xml:"ResponseMetadata"`
+}
+
+type getPolicyVersionResult struct {
+	PolicyVersion policyVersionXML `xml:"PolicyVersion"`
+}
+
+type listPolicyVersionsResponse struct {
+	XMLName  xml.Name                 `xml:"ListPolicyVersionsResponse"`
+	Xmlns    string                   `xml:"xmlns,attr"`
+	Result   listPolicyVersionsResult `xml:"ListPolicyVersionsResult"`
+	Metadata responseMetadata         `xml:"ResponseMetadata"`
+}
+
+type listPolicyVersionsResult struct {
+	Versions    policyVersionsListXML `xml:"Versions"`
+	IsTruncated bool                  `xml:"IsTruncated"`
+}
+
+type deletePolicyVersionResponse struct {
+	XMLName  xml.Name         `xml:"DeletePolicyVersionResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type setDefaultPolicyVersionResponse struct {
+	XMLName  xml.Name         `xml:"SetDefaultPolicyVersionResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
 type attachUserPolicyResponse struct {

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -1,0 +1,92 @@
+// Package acr implements the Azure Container Registry data-plane catalog API
+// (/acr/v1/…) as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry clients
+// pointed at this server list repositories and tags, read repository
+// properties, and delete repositories against the shared containerregistry
+// driver.
+//
+// ACR has no "create repository" data-plane call — repositories appear when an
+// image is pushed — so this handler is list/get/delete oriented. ACR uses
+// challenge-based auth; the mock serves anonymously, so the SDK never needs to
+// exchange a token.
+//
+// Coverage:
+//
+//	GET    /acr/v1/_catalog              — list repositories
+//	GET    /acr/v1/{name}                — repository properties
+//	DELETE /acr/v1/{name}                — delete repository
+//	GET    /acr/v1/{name}/_tags          — list tags
+package acr
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+const pathPrefix = "/acr/v1/"
+
+const (
+	catalogSeg = "_catalog"
+	tagsSuffix = "/_tags"
+)
+
+// Handler serves the ACR data-plane catalog API against a ContainerRegistry
+// driver.
+type Handler struct {
+	registry crdriver.ContainerRegistry
+}
+
+// New returns an ACR handler backed by reg.
+func New(reg crdriver.ContainerRegistry) *Handler {
+	return &Handler{registry: reg}
+}
+
+// Matches claims /acr/v1/ data-plane requests. Disjoint from ARM
+// (/subscriptions/…) and registered before the blob storage REST fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.URL.Path, pathPrefix)
+}
+
+// ServeHTTP routes on the path tail and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	tail := strings.TrimPrefix(r.URL.Path, pathPrefix)
+
+	switch {
+	case tail == catalogSeg && r.Method == http.MethodGet:
+		h.listRepositories(w, r)
+	case strings.HasSuffix(tail, tagsSuffix) && r.Method == http.MethodGet:
+		h.listTags(w, r, strings.TrimSuffix(tail, tagsSuffix))
+	case r.Method == http.MethodGet:
+		h.getRepositoryProperties(w, r, tail)
+	case r.Method == http.MethodDelete:
+		h.deleteRepository(w, r, tail)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "UNSUPPORTED", "unsupported ACR operation")
+	}
+}
+
+// writeErr emits an ACR-style error body with the given HTTP status.
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"errors": []map[string]string{{"code": code, "message": msg}},
+	})
+}
+
+// writeCErr maps a canonical cloudemu error to an ACR error response.
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	default:
+		writeErr(w, http.StatusInternalServerError, "INTERNAL", err.Error())
+	}
+}

--- a/server/azure/acr/handler.go
+++ b/server/azure/acr/handler.go
@@ -30,8 +30,9 @@ import (
 const pathPrefix = "/acr/v1/"
 
 const (
-	catalogSeg = "_catalog"
-	tagsSuffix = "/_tags"
+	catalogSeg   = "_catalog"
+	tagsSuffix   = "/_tags"
+	manifestsSeg = "/_manifests"
 )
 
 // Handler serves the ACR data-plane catalog API against a ContainerRegistry
@@ -58,6 +59,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case tail == catalogSeg && r.Method == http.MethodGet:
 		h.listRepositories(w, r)
+	case strings.Contains(tail, manifestsSeg):
+		// Manifest operations are out of scope; answer explicitly rather than
+		// letting the path masquerade as a (missing) repository.
+		writeErr(w, http.StatusNotImplemented, "UNSUPPORTED", "manifest operations are not supported")
 	case strings.HasSuffix(tail, tagsSuffix) && r.Method == http.MethodGet:
 		h.listTags(w, r, strings.TrimSuffix(tail, tagsSuffix))
 	case r.Method == http.MethodGet:
@@ -86,6 +91,8 @@ func writeCErr(w http.ResponseWriter, err error) {
 		writeErr(w, http.StatusNotFound, "NAME_UNKNOWN", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeErr(w, http.StatusBadRequest, "INVALID_REQUEST", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeErr(w, http.StatusConflict, "DENIED", err.Error())
 	default:
 		writeErr(w, http.StatusInternalServerError, "INTERNAL", err.Error())
 	}

--- a/server/azure/acr/operations.go
+++ b/server/azure/acr/operations.go
@@ -14,7 +14,7 @@ func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request) {
 
 	names := make([]string, 0, len(repos))
 	for i := range repos {
-		names = append(names, shortID(repos[i].Name))
+		names = append(names, repoName(repos[i].Name))
 	}
 
 	writeJSON(w, http.StatusOK, catalogResponse{Repositories: names})
@@ -35,7 +35,7 @@ func (h *Handler) getRepositoryProperties(w http.ResponseWriter, r *http.Request
 
 	writeJSON(w, http.StatusOK, repositoryProperties{
 		Registry:             registryLoginServer,
-		ImageName:            shortID(rp.Name),
+		ImageName:            repoName(rp.Name),
 		CreatedTime:          rp.CreatedAt,
 		LastUpdateTime:       rp.CreatedAt,
 		ManifestCount:        len(images),

--- a/server/azure/acr/operations.go
+++ b/server/azure/acr/operations.go
@@ -1,0 +1,78 @@
+package acr
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request) {
+	repos, err := h.registry.ListRepositories(r.Context())
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	names := make([]string, 0, len(repos))
+	for i := range repos {
+		names = append(names, shortID(repos[i].Name))
+	}
+
+	writeJSON(w, http.StatusOK, catalogResponse{Repositories: names})
+}
+
+func (h *Handler) getRepositoryProperties(w http.ResponseWriter, r *http.Request, repo string) {
+	rp, err := h.registry.GetRepository(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	images, err := h.registry.ListImages(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, repositoryProperties{
+		Registry:             registryLoginServer,
+		ImageName:            shortID(rp.Name),
+		CreatedTime:          rp.CreatedAt,
+		LastUpdateTime:       rp.CreatedAt,
+		ManifestCount:        len(images),
+		TagCount:             countTags(images),
+		ChangeableAttributes: allEnabled(),
+	})
+}
+
+func (h *Handler) listTags(w http.ResponseWriter, r *http.Request, repo string) {
+	images, err := h.registry.ListImages(r.Context(), repo)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, tagListResponse{
+		Registry:  registryLoginServer,
+		ImageName: repo,
+		Tags:      toTagAttributes(images),
+	})
+}
+
+func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, repo string) {
+	if err := h.registry.DeleteRepository(r.Context(), repo, true); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	// ACR's delete is asynchronous; the SDK accepts 202 Accepted.
+	writeJSON(w, http.StatusAccepted, deleteRepositoryResponse{
+		ManifestsDeleted: []string{},
+		TagsDeleted:      []string{},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/server/azure/acr/sdk_roundtrip_test.go
+++ b/server/azure/acr/sdk_roundtrip_test.go
@@ -146,6 +146,45 @@ func TestSDKACRDeleteRepository(t *testing.T) {
 	assertResponseCode(t, err, 404)
 }
 
+func TestSDKACRHierarchicalRepositoryName(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	// Registry names are commonly hierarchical (e.g. "team/app"); the bare
+	// name must survive the resource-ID round-trip, not be truncated to the
+	// last path segment.
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "team/app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	var names []string
+
+	pager := client.NewListRepositoriesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListRepositories: %v", err)
+		}
+
+		for _, n := range page.Repositories.Names {
+			names = append(names, *n)
+		}
+	}
+
+	if !contains(names, "team/app") {
+		t.Fatalf("catalog %v missing hierarchical name \"team/app\"", names)
+	}
+
+	props, err := client.GetRepositoryProperties(ctx, "team/app", nil)
+	if err != nil {
+		t.Fatalf("GetRepositoryProperties(team/app): %v", err)
+	}
+
+	if props.Name == nil || *props.Name != "team/app" {
+		t.Fatalf("got repository name %v, want team/app", props.Name)
+	}
+}
+
 func TestSDKACRErrors(t *testing.T) {
 	client, _ := newACRClient(t)
 

--- a/server/azure/acr/sdk_roundtrip_test.go
+++ b/server/azure/acr/sdk_roundtrip_test.go
@@ -1,0 +1,177 @@
+package acr_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	azacr "github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry"
+
+	"github.com/stackshy/cloudemu"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newACRClient(t *testing.T) (*azacr.Client, crdriver.ContainerRegistry) {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ACR: cloud.ACR})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := azacr.NewClient(ts.URL, fakeCred{}, &azacr.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("azacr.NewClient: %v", err)
+	}
+
+	return client, cloud.ACR
+}
+
+func seedImage(t *testing.T, reg crdriver.ContainerRegistry, repo, tag string) {
+	t.Helper()
+
+	if _, err := reg.PutImage(context.Background(), &crdriver.ImageManifest{
+		Repository: repo,
+		Tag:        tag,
+		MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+		SizeBytes:  512,
+	}); err != nil {
+		t.Fatalf("seed PutImage(%s:%s): %v", repo, tag, err)
+	}
+}
+
+func TestSDKACRCatalogAndProperties(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	// ACR has no data-plane create; repositories appear on push.
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "app"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "app", "v1")
+
+	var names []string
+
+	pager := client.NewListRepositoriesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListRepositories: %v", err)
+		}
+
+		for _, n := range page.Repositories.Names {
+			names = append(names, *n)
+		}
+	}
+
+	if !contains(names, "app") {
+		t.Fatalf("catalog %v missing \"app\"", names)
+	}
+
+	props, err := client.GetRepositoryProperties(ctx, "app", nil)
+	if err != nil {
+		t.Fatalf("GetRepositoryProperties: %v", err)
+	}
+
+	if props.Name == nil || *props.Name != "app" {
+		t.Fatalf("got repository name %v, want app", props.Name)
+	}
+
+	if props.TagCount == nil || *props.TagCount != 1 {
+		t.Fatalf("got tag count %v, want 1", props.TagCount)
+	}
+}
+
+func TestSDKACRListTags(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "imgs"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	seedImage(t, reg, "imgs", "v1")
+	seedImage(t, reg, "imgs", "v2")
+
+	var tags []string
+
+	pager := client.NewListTagsPager("imgs", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListTags: %v", err)
+		}
+
+		for _, tag := range page.Tags {
+			tags = append(tags, *tag.Name)
+		}
+	}
+
+	if !contains(tags, "v1") || !contains(tags, "v2") {
+		t.Fatalf("tags %v missing v1/v2", tags)
+	}
+}
+
+func TestSDKACRDeleteRepository(t *testing.T) {
+	client, reg := newACRClient(t)
+	ctx := context.Background()
+
+	if _, err := reg.CreateRepository(ctx, crdriver.RepositoryConfig{Name: "old"}); err != nil {
+		t.Fatalf("seed CreateRepository: %v", err)
+	}
+
+	if _, err := client.DeleteRepository(ctx, "old", nil); err != nil {
+		t.Fatalf("DeleteRepository: %v", err)
+	}
+
+	_, err := client.GetRepositoryProperties(ctx, "old", nil)
+	assertResponseCode(t, err, 404)
+}
+
+func TestSDKACRErrors(t *testing.T) {
+	client, _ := newACRClient(t)
+
+	_, err := client.GetRepositoryProperties(context.Background(), "ghost", nil)
+	assertResponseCode(t, err, 404)
+}
+
+func assertResponseCode(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		t.Fatalf("want *azcore.ResponseError with code %d, got %v", want, err)
+	}
+
+	if respErr.StatusCode != want {
+		t.Fatalf("got HTTP %d, want %d (%v)", respErr.StatusCode, want, err)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -61,11 +61,16 @@ type deleteRepositoryResponse struct {
 	TagsDeleted      []string `json:"tagsDeleted"`
 }
 
-// shortID returns the final path segment, so an Azure resource-ID repository
-// name resolves back to the bare repository name used on the wire.
-func shortID(name string) string {
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		return name[idx+1:]
+// registriesMarker precedes the repository name in the Azure resource ID the
+// driver stores (…/Microsoft.ContainerRegistry/registries/{name}).
+const registriesMarker = "/registries/"
+
+// repoName recovers the bare repository name from the driver's resource-ID
+// Name. It splits on the resource-type marker rather than the last slash so
+// hierarchical names like "team/app" survive intact.
+func repoName(name string) string {
+	if idx := strings.Index(name, registriesMarker); idx >= 0 {
+		return name[idx+len(registriesMarker):]
 	}
 
 	return name

--- a/server/azure/acr/types.go
+++ b/server/azure/acr/types.go
@@ -1,0 +1,110 @@
+package acr
+
+import (
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+// registryLoginServer is the synthetic login server reported for this mock
+// registry. Real ACR uses {registry-name}.azurecr.io.
+const registryLoginServer = "cloudemu.azurecr.io"
+
+// changeableAttributes mirrors ACR's RepositoryWriteableProperties /
+// TagWriteableProperties. The mock reports everything enabled.
+type changeableAttributes struct {
+	DeleteEnabled bool `json:"deleteEnabled"`
+	WriteEnabled  bool `json:"writeEnabled"`
+	ListEnabled   bool `json:"listEnabled"`
+	ReadEnabled   bool `json:"readEnabled"`
+}
+
+func allEnabled() changeableAttributes {
+	return changeableAttributes{DeleteEnabled: true, WriteEnabled: true, ListEnabled: true, ReadEnabled: true}
+}
+
+// catalogResponse is the GET /acr/v1/_catalog body.
+type catalogResponse struct {
+	Repositories []string `json:"repositories"`
+}
+
+// repositoryProperties is the GET /acr/v1/{name} body.
+type repositoryProperties struct {
+	Registry             string               `json:"registry"`
+	ImageName            string               `json:"imageName"`
+	CreatedTime          string               `json:"createdTime,omitempty"`
+	LastUpdateTime       string               `json:"lastUpdateTime,omitempty"`
+	ManifestCount        int                  `json:"manifestCount"`
+	TagCount             int                  `json:"tagCount"`
+	ChangeableAttributes changeableAttributes `json:"changeableAttributes"`
+}
+
+// tagAttributes is one entry in the _tags list.
+type tagAttributes struct {
+	Name                 string               `json:"name"`
+	Digest               string               `json:"digest"`
+	CreatedTime          string               `json:"createdTime,omitempty"`
+	LastUpdateTime       string               `json:"lastUpdateTime,omitempty"`
+	ChangeableAttributes changeableAttributes `json:"changeableAttributes"`
+}
+
+// tagListResponse is the GET /acr/v1/{name}/_tags body.
+type tagListResponse struct {
+	Registry  string          `json:"registry"`
+	ImageName string          `json:"imageName"`
+	Tags      []tagAttributes `json:"tags"`
+}
+
+// deleteRepositoryResponse is the DELETE /acr/v1/{name} body.
+type deleteRepositoryResponse struct {
+	ManifestsDeleted []string `json:"manifestsDeleted"`
+	TagsDeleted      []string `json:"tagsDeleted"`
+}
+
+// shortID returns the final path segment, so an Azure resource-ID repository
+// name resolves back to the bare repository name used on the wire.
+func shortID(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+
+	return name
+}
+
+func countTags(images []crdriver.ImageDetail) int {
+	n := 0
+
+	for i := range images {
+		for _, tag := range images[i].Tags {
+			if tag != "" {
+				n++
+			}
+		}
+	}
+
+	return n
+}
+
+func toTagAttributes(images []crdriver.ImageDetail) []tagAttributes {
+	out := make([]tagAttributes, 0, len(images))
+
+	for i := range images {
+		img := images[i]
+
+		for _, tag := range img.Tags {
+			if tag == "" {
+				continue
+			}
+
+			out = append(out, tagAttributes{
+				Name:                 tag,
+				Digest:               img.Digest,
+				CreatedTime:          img.PushedAt,
+				LastUpdateTime:       img.PushedAt,
+				ChangeableAttributes: allEnabled(),
+			})
+		}
+	}
+
+	return out
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -8,6 +8,7 @@ package azure
 
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
@@ -18,6 +19,7 @@ import (
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/azure/acr"
 	aksserver "github.com/stackshy/cloudemu/server/azure/aks"
 	"github.com/stackshy/cloudemu/server/azure/azuresql"
 	"github.com/stackshy/cloudemu/server/azure/blob"
@@ -78,6 +80,7 @@ type Drivers struct {
 	MySQLFlex           rdbdriver.RelationalDB
 	AKS                 aksserver.Backend
 	IAM                 iamdriver.IAM
+	ACR                 crdriver.ContainerRegistry
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -201,6 +204,12 @@ func New(d Drivers) *server.Server {
 	// registration order is unconstrained.
 	if d.IAM != nil {
 		srv.Register(iam.New(d.IAM))
+	}
+
+	// ACR data-plane catalog API matches /acr/v1/… — disjoint from ARM and
+	// must register before the permissive BlobStorage fallback below.
+	if d.ACR != nil {
+		srv.Register(acr.New(d.ACR))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/gcp/artifactregistry/handler.go
+++ b/server/gcp/artifactregistry/handler.go
@@ -1,0 +1,137 @@
+// Package artifactregistry implements the artifactregistry.googleapis.com v1
+// REST API as a server.Handler. Real google.golang.org/api/artifactregistry/v1
+// clients pointed at this server CRUD repositories and list docker images
+// end-to-end against the shared containerregistry driver.
+//
+// Coverage (v1 REST):
+//
+//	POST   /v1/projects/{p}/locations/{l}/repositories?repositoryId={id}        — Create repo (async)
+//	GET    /v1/projects/{p}/locations/{l}/repositories/{id}                     — Get repo
+//	GET    /v1/projects/{p}/locations/{l}/repositories                          — List repos
+//	DELETE /v1/projects/{p}/locations/{l}/repositories/{id}                     — Delete repo (async)
+//	GET    /v1/projects/{p}/locations/{l}/repositories/{id}/dockerImages        — List docker images
+//
+// The driver has no location dimension, so {l} is accepted and echoed but not
+// used to partition state.
+package artifactregistry
+
+import (
+	"net/http"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	pathPrefix      = "/v1/projects/"
+	locationsSeg    = "locations"
+	repositoriesSeg = "repositories"
+	dockerImagesSeg = "dockerImages"
+)
+
+// minRepoCollectionParts is the segment count of a repositories collection
+// path: [projects, {p}, locations, {l}, repositories].
+const minRepoCollectionParts = 5
+
+// Handler serves artifactregistry.googleapis.com v1 requests.
+type Handler struct {
+	registry crdriver.ContainerRegistry
+}
+
+// New returns an Artifact Registry handler backed by reg.
+func New(reg crdriver.ContainerRegistry) *Handler {
+	return &Handler{registry: reg}
+}
+
+type route struct {
+	project    string
+	location   string
+	repository string // repo id; empty for the collection
+	sub        string // "dockerImages" or ""
+}
+
+// parseRoute extracts the components of an Artifact Registry v1 path.
+func parseRoute(urlPath string) (route, bool) {
+	if !strings.HasPrefix(urlPath, pathPrefix) {
+		return route{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(urlPath, "/v1/"), "/")
+	// parts: [projects, {p}, locations, {l}, repositories, {id}?, {sub}?]
+	if len(parts) < minRepoCollectionParts ||
+		parts[0] != "projects" || parts[2] != locationsSeg || parts[4] != repositoriesSeg {
+		return route{}, false
+	}
+
+	rt := route{project: parts[1], location: parts[3]}
+
+	if len(parts) > minRepoCollectionParts {
+		rt.repository = parts[5]
+	}
+
+	const subIdx = 6
+	if len(parts) > subIdx {
+		rt.sub = parts[subIdx]
+	}
+
+	return rt, true
+}
+
+// Matches claims artifactregistry v1 repository paths. Disjoint from the IAM
+// handler (which matches serviceAccounts|roles at the same prefix).
+func (*Handler) Matches(r *http.Request) bool {
+	_, ok := parseRoute(r.URL.Path)
+	return ok
+}
+
+// ServeHTTP dispatches on method and path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed Artifact Registry v1 path")
+		return
+	}
+
+	if rt.repository == "" {
+		h.serveCollection(w, r, &rt)
+		return
+	}
+
+	h.serveResource(w, r, &rt)
+}
+
+// serveCollection handles the repositories collection (create, list).
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rt *route) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listRepositories(w, r, rt)
+	case http.MethodPost:
+		h.createRepository(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported repositories operation")
+	}
+}
+
+// serveResource handles a single repository and its dockerImages sub-collection.
+func (h *Handler) serveResource(w http.ResponseWriter, r *http.Request, rt *route) {
+	if rt.sub == dockerImagesSeg {
+		if r.Method == http.MethodGet {
+			h.listDockerImages(w, r, rt)
+			return
+		}
+
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported dockerImages operation")
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getRepository(w, r, rt)
+	case http.MethodDelete:
+		h.deleteRepository(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported repository operation")
+	}
+}

--- a/server/gcp/artifactregistry/operations.go
+++ b/server/gcp/artifactregistry/operations.go
@@ -1,0 +1,88 @@
+package artifactregistry
+
+import (
+	"net/http"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+func (h *Handler) createRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	repoID := r.URL.Query().Get("repositoryId")
+
+	var body repositoryJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	repo, err := h.registry.CreateRepository(r.Context(), crdriver.RepositoryConfig{
+		Name: repoID,
+		Tags: body.Labels,
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, repoID, toRepositoryJSON(rt.project, rt.location, repo)))
+}
+
+func (h *Handler) getRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	repo, err := h.registry.GetRepository(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toRepositoryJSON(rt.project, rt.location, repo))
+}
+
+func (h *Handler) listRepositories(w http.ResponseWriter, r *http.Request, rt *route) {
+	repos, err := h.registry.ListRepositories(r.Context())
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]repositoryJSON, 0, len(repos))
+	for i := range repos {
+		out = append(out, toRepositoryJSON(rt.project, rt.location, &repos[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listRepositoriesResponse{Repositories: out})
+}
+
+func (h *Handler) deleteRepository(w http.ResponseWriter, r *http.Request, rt *route) {
+	// Artifact Registry's delete has no force flag; it removes the repository
+	// and its contents.
+	if err := h.registry.DeleteRepository(r.Context(), rt.repository, true); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.repository, nil))
+}
+
+func (h *Handler) listDockerImages(w http.ResponseWriter, r *http.Request, rt *route) {
+	images, err := h.registry.ListImages(r.Context(), rt.repository)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]dockerImageJSON, 0, len(images))
+	for i := range images {
+		out = append(out, toDockerImageJSON(rt.project, rt.location, rt.repository, &images[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listDockerImagesResponse{DockerImages: out})
+}
+
+// doneOperation builds a completed long-running operation envelope.
+func doneOperation(rt *route, id string, response any) operationJSON {
+	return operationJSON{
+		Name:     "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id,
+		Done:     true,
+		Response: response,
+	}
+}

--- a/server/gcp/artifactregistry/sdk_roundtrip_test.go
+++ b/server/gcp/artifactregistry/sdk_roundtrip_test.go
@@ -1,0 +1,162 @@
+package artifactregistry_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+	ar "google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+const (
+	testParent = "projects/demo/locations/us"
+)
+
+func newARService(t *testing.T) (*ar.Service, crdriver.ContainerRegistry) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{ArtifactRegistry: cloud.ArtifactRegistry})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := ar.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("artifactregistry.NewService: %v", err)
+	}
+
+	return svc, cloud.ArtifactRegistry
+}
+
+func TestSDKArtifactRegistryRepositoryLifecycle(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	op, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{
+		Format: "DOCKER",
+		Labels: map[string]string{"team": "platform"},
+	}).RepositoryId("myrepo").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatalf("Create operation not marked done: %+v", op)
+	}
+
+	name := testParent + "/repositories/myrepo"
+
+	repo, err := svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if repo.Name != name || repo.Format != "DOCKER" {
+		t.Fatalf("Get returned %+v", repo)
+	}
+
+	list, err := svc.Projects.Locations.Repositories.List(testParent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(list.Repositories) != 1 {
+		t.Fatalf("got %d repositories, want 1", len(list.Repositories))
+	}
+
+	if _, err := svc.Projects.Locations.Repositories.Delete(name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err = svc.Projects.Locations.Repositories.Get(name).Context(ctx).Do()
+	assertGoogleAPICode(t, err, 404)
+}
+
+func TestSDKArtifactRegistryDockerImages(t *testing.T) {
+	svc, reg := newARService(t)
+	ctx := context.Background()
+
+	if _, err := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+		RepositoryId("imgs").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Artifact Registry has no REST "push image" call — images arrive via
+	// docker push. Seed one through the driver to simulate that.
+	if _, err := reg.PutImage(ctx, &crdriver.ImageManifest{
+		Repository: "imgs",
+		Tag:        "v1",
+		MediaType:  "application/vnd.docker.distribution.manifest.v2+json",
+		SizeBytes:  1024,
+	}); err != nil {
+		t.Fatalf("seed PutImage: %v", err)
+	}
+
+	listed, err := svc.Projects.Locations.Repositories.DockerImages.
+		List(testParent + "/repositories/imgs").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("DockerImages.List: %v", err)
+	}
+
+	if len(listed.DockerImages) != 1 {
+		t.Fatalf("got %d docker images, want 1", len(listed.DockerImages))
+	}
+
+	if !contains(listed.DockerImages[0].Tags, "v1") || listed.DockerImages[0].ImageSizeBytes != 1024 {
+		t.Fatalf("DockerImages.List returned %+v", listed.DockerImages[0])
+	}
+}
+
+func TestSDKArtifactRegistryErrors(t *testing.T) {
+	svc, _ := newARService(t)
+	ctx := context.Background()
+
+	_, err := svc.Projects.Locations.Repositories.Get(testParent + "/repositories/ghost").Context(ctx).Do()
+	assertGoogleAPICode(t, err, 404)
+
+	mk := func() error {
+		_, e := svc.Projects.Locations.Repositories.Create(testParent, &ar.Repository{Format: "DOCKER"}).
+			RepositoryId("dup").Context(ctx).Do()
+
+		return e
+	}
+
+	if err := mk(); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	assertGoogleAPICode(t, mk(), 409)
+}
+
+func assertGoogleAPICode(t *testing.T, err error, want int) {
+	t.Helper()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		t.Fatalf("want *googleapi.Error with code %d, got %v", want, err)
+	}
+
+	if gerr.Code != want {
+		t.Fatalf("got HTTP %d, want %d (%v)", gerr.Code, want, err)
+	}
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -53,11 +53,16 @@ func repositoryResourceName(project, location, id string) string {
 	return "projects/" + project + "/locations/" + location + "/repositories/" + id
 }
 
-// shortID returns the final path segment, so a driver repository name of either
-// "myrepo" or "projects/x/repositories/myrepo" yields "myrepo".
-func shortID(name string) string {
-	if idx := strings.LastIndex(name, "/"); idx >= 0 {
-		return name[idx+1:]
+// repositoriesMarker precedes the repository name in the self-link the driver
+// stores (projects/{p}/repositories/{name}).
+const repositoriesMarker = "/repositories/"
+
+// repoName recovers the bare repository name from the driver's self-link Name.
+// It splits on the resource-type marker rather than the last slash so
+// hierarchical names like "team/app" survive intact.
+func repoName(name string) string {
+	if idx := strings.Index(name, repositoriesMarker); idx >= 0 {
+		return name[idx+len(repositoriesMarker):]
 	}
 
 	return name
@@ -65,7 +70,7 @@ func shortID(name string) string {
 
 func toRepositoryJSON(project, location string, r *crdriver.Repository) repositoryJSON {
 	return repositoryJSON{
-		Name:       repositoryResourceName(project, location, shortID(r.Name)),
+		Name:       repositoryResourceName(project, location, repoName(r.Name)),
 		Format:     dockerFormat,
 		Labels:     r.Tags,
 		CreateTime: r.CreatedAt,

--- a/server/gcp/artifactregistry/types.go
+++ b/server/gcp/artifactregistry/types.go
@@ -1,0 +1,93 @@
+package artifactregistry
+
+import (
+	"strconv"
+	"strings"
+
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
+)
+
+// repositoryJSON is the artifactregistry.googleapis.com v1 Repository shape.
+type repositoryJSON struct {
+	Name        string            `json:"name"`
+	Format      string            `json:"format,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	CreateTime  string            `json:"createTime,omitempty"`
+	UpdateTime  string            `json:"updateTime,omitempty"`
+}
+
+// dockerImageJSON is the v1 DockerImage shape. imageSizeBytes is an int64
+// rendered as a string, the Google APIs convention.
+type dockerImageJSON struct {
+	Name           string   `json:"name"`
+	URI            string   `json:"uri,omitempty"`
+	Tags           []string `json:"tags,omitempty"`
+	ImageSizeBytes string   `json:"imageSizeBytes,omitempty"`
+	MediaType      string   `json:"mediaType,omitempty"`
+	UploadTime     string   `json:"uploadTime,omitempty"`
+	UpdateTime     string   `json:"updateTime,omitempty"`
+}
+
+type listRepositoriesResponse struct {
+	Repositories  []repositoryJSON `json:"repositories"`
+	NextPageToken string           `json:"nextPageToken,omitempty"`
+}
+
+type listDockerImagesResponse struct {
+	DockerImages  []dockerImageJSON `json:"dockerImages"`
+	NextPageToken string            `json:"nextPageToken,omitempty"`
+}
+
+// operationJSON is a google.longrunning.Operation. Artifact Registry's create
+// and delete are async; the mock returns a completed operation immediately.
+type operationJSON struct {
+	Name     string `json:"name"`
+	Done     bool   `json:"done"`
+	Response any    `json:"response,omitempty"`
+}
+
+const dockerFormat = "DOCKER"
+
+func repositoryResourceName(project, location, id string) string {
+	return "projects/" + project + "/locations/" + location + "/repositories/" + id
+}
+
+// shortID returns the final path segment, so a driver repository name of either
+// "myrepo" or "projects/x/repositories/myrepo" yields "myrepo".
+func shortID(name string) string {
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		return name[idx+1:]
+	}
+
+	return name
+}
+
+func toRepositoryJSON(project, location string, r *crdriver.Repository) repositoryJSON {
+	return repositoryJSON{
+		Name:       repositoryResourceName(project, location, shortID(r.Name)),
+		Format:     dockerFormat,
+		Labels:     r.Tags,
+		CreateTime: r.CreatedAt,
+		UpdateTime: r.CreatedAt,
+	}
+}
+
+func toDockerImageJSON(project, location, repo string, d *crdriver.ImageDetail) dockerImageJSON {
+	base := repositoryResourceName(project, location, repo) + "/dockerImages/" + d.Digest
+
+	uri := d.Repository
+	if d.Digest != "" {
+		uri += "@" + d.Digest
+	}
+
+	return dockerImageJSON{
+		Name:           base,
+		URI:            uri,
+		Tags:           d.Tags,
+		ImageSizeBytes: strconv.FormatInt(d.SizeBytes, 10),
+		MediaType:      d.MediaType,
+		UploadTime:     d.PushedAt,
+		UpdateTime:     d.PushedAt,
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -8,6 +8,7 @@ package gcp
 
 import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
@@ -18,6 +19,7 @@ import (
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 	"github.com/stackshy/cloudemu/server"
+	"github.com/stackshy/cloudemu/server/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
@@ -37,17 +39,18 @@ import (
 
 // Drivers bundles the driver interfaces the GCP server can expose.
 type Drivers struct {
-	Compute        computedriver.Compute
-	Storage        storagedriver.Bucket
-	Firestore      dbdriver.Database
-	Networking     netdriver.Networking
-	Monitoring     mondriver.Monitoring
-	CloudFunctions sdrv.Serverless
-	PubSub         mqdriver.MessageQueue
-	CloudSQL       rdbdriver.RelationalDB
-	GKE            *gkeprov.Mock
-	VertexAI       vertexaidriver.VertexAI
-	IAM            iamdriver.IAM
+	Compute          computedriver.Compute
+	Storage          storagedriver.Bucket
+	Firestore        dbdriver.Database
+	Networking       netdriver.Networking
+	Monitoring       mondriver.Monitoring
+	CloudFunctions   sdrv.Serverless
+	PubSub           mqdriver.MessageQueue
+	CloudSQL         rdbdriver.RelationalDB
+	GKE              *gkeprov.Mock
+	VertexAI         vertexaidriver.VertexAI
+	IAM              iamdriver.IAM
+	ArtifactRegistry crdriver.ContainerRegistry
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -133,6 +136,13 @@ func New(d Drivers) *server.Server {
 	// consistency with the pattern above.
 	if d.IAM != nil {
 		srv.Register(iam.New(d.IAM))
+	}
+
+	// Artifact Registry matches /v1/projects/{p}/locations/{l}/repositories[/…]
+	// — disjoint from IAM (serviceAccounts|roles) and Cloud Asset. Registered
+	// among the /v1/projects/ family, before Firestore's catch-all.
+	if d.ArtifactRegistry != nil {
+		srv.Register(artifactregistry.New(d.ArtifactRegistry))
 	}
 
 	if d.Firestore != nil {


### PR DESCRIPTION
## <img src="https://raw.githubusercontent.com/stackshy/cloudemu/development/.github/logo.svg" alt="cloudemu" width="28" height="28" align="absmiddle" /> Release Notes — v1.8.1

## ✨ Features

### Container Registry — SDK-compat servers across AWS, Azure, and GCP

Point the real registry clients at in-memory backends: AWS ECR (`aws-sdk-go-v2`), GCP Artifact Registry (`artifactregistry/v1`), and Azure Container Registry (`azcontainerregistry`) now drive the existing container-registry driver over each cloud's native wire protocol — repository and image/tag operations, matching each provider's real create / list / delete semantics and typed error codes.

## 🔧 Enhancements

### IAM — managed policy versions across AWS, Azure, and GCP

Managed policies now carry versions: create, get, list, set-default, and delete, mirroring AWS semantics — an auto-seeded `v1`, monotonic never-reused version IDs, a five-version cap, and a protected default version whose document becomes the policy's effective document. Wired through the AWS IAM SDK surface with faithful error codes; Azure and GCP are covered at the portable API level.

## Technical Details

<details>
<summary><b>AWS ECR</b></summary>

- SDK-compat server (AWS JSON 1.1, dispatched on `X-Amz-Target`) driving the existing container-registry driver.
- Repositories: CreateRepository, DescribeRepositories (get-by-name + list-all), DeleteRepository. Images: PutImage, ListImages, DescribeImages, BatchDeleteImage.
- `BatchDeleteImage` returns per-image failures; a missing repository throws `RepositoryNotFoundException`. Timestamps as Unix epoch seconds. Typed errors: `RepositoryNotFoundException`, `RepositoryAlreadyExistsException`, `RepositoryNotEmptyException`, `InvalidParameterException`, `LimitExceededException`.
</details>

<details>
<summary><b>GCP Artifact Registry</b></summary>

- SDK-compat REST server (`artifactregistry.googleapis.com` v1) driving the container-registry driver.
- Repositories: Create (async), Get, List, Delete (async); Images: `dockerImages.list`.
- Create / Delete return a completed long-running `Operation` inline; canonical `projects/{p}/locations/{l}/repositories/{id}` names; `format` DOCKER; `imageSizeBytes` rendered as an int64 string. Errors map to GCP status codes (404 notFound, 409 alreadyExists, …).
</details>

<details>
<summary><b>Azure Container Registry</b></summary>

- SDK-compat data-plane server (`/acr/v1/…`) driving the container-registry driver via `azcontainerregistry`.
- `_catalog` (list), repository properties, `_tags` (list), delete. No create call — repositories appear on image push, as in real ACR.
- Served anonymously (no challenge-token exchange); delete returns 202 Accepted, missing repo returns 404 (idempotent delete). Errors map to ACR codes (`NAME_UNKNOWN`, …).
</details>

<details>
<summary><b>IAM managed policy versions</b></summary>

- New driver + portable API + AWS/Azure/GCP mock operations: CreatePolicyVersion, GetPolicyVersion, ListPolicyVersions, DeletePolicyVersion, SetDefaultPolicyVersion.
- `CreatePolicy` auto-seeds `v1`; version IDs never reused; at most five versions; the default version cannot be deleted; the default's document is the policy's effective document (reflected by `GetPolicy`).
- AWS wire surface (query / XML) with faithful errors: `DeleteConflict` (delete default), `LimitExceeded` (version cap), `NoSuchEntity` (unknown policy / version). Azure and GCP covered at the portable / driver level, as their SDKs have no equivalent API.
</details>
