### PR TITLE
feat(secrets): Secrets SDK-compat servers across AWS, Azure, and GCP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
-	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1
@@ -44,8 +45,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
 	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7
 	github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.5
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
-	github.com/aws/smithy-go v1.27.1
+	github.com/aws/smithy-go v1.27.3
 	github.com/databricks/databricks-sdk-go v0.144.0
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/stretchr/testify v1.11.1
@@ -66,13 +68,14 @@ require (
 	cloud.google.com/go/monitoring v1.27.0 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,10 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0 h1:S087d
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0/go.mod h1:B4cEyXrWBmbfMDAPnpJ1di7MAt5DKP57jPEObAvZChg=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0 h1:aMFOzch6ZJo4Ct9hI4A9Y2fPen5YNRTPmkSBhe5m0ZQ=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0/go.mod h1:Oct8bx+g+DXKngU7i/LzFzYt44rmLdMu4uoofIpooVo=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 h1:4iB+IesclUXdP0ICgAabvq2FYLXrJWKx1fJQ+GxSo3Y=
@@ -82,8 +86,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0/go.mod h1:vB2GH9GAYYJTO3mEn8oYwzEdhlayZIdQz6zdzgUIRvA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
-github.com/aws/aws-sdk-go-v2 v1.42.0 h1:XvXMJTkFQtpBKIWZnmr9ZEOc2InWM2yldjXEJ/bymhA=
-github.com/aws/aws-sdk-go-v2 v1.42.0/go.mod h1:27+ACypSLljLAEKsCYOmrjKh83vuTRkuAe9Uv/3A4bg=
+github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
+github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 h1:p1BBrg/Hhp6uK7zpejeI8QFXHJeC/mynzi04Sl03k9g=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13/go.mod h1:8cIfkE9MDhkRZGpQ22aV6/lkYeYSozpz16Smrs5x4Ls=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
@@ -92,10 +96,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29/go.mod h1:MzoLFUArKGpGD+ukmPiTPG1X5x4o6M2kq4v2dr1FiEc=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJagbOyotl/cxoLY4xviKuE7p2GY=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30/go.mod h1:1hTMsAgbdS/AtUi4bw8+gUuh1pceo+eXRLfpSuSQj3M=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -150,6 +154,8 @@ github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7 h1:P4Y
 github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7/go.mod h1:5wimXnFCB0SDWjXfkvWjjPsS3LAIZCiEayM6AE8EniQ=
 github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0 h1:YRiKEeNe+Kgi03T1ODgPFJ/EkIA4MtKcitJjtoEd8kA=
 github.com/aws/aws-sdk-go-v2/service/sagemakerruntime v1.41.0/go.mod h1:y1haDXp66bFbEY007eY3iipsa1Mwi27QQNapOv0MQ7g=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.5 h1:CWn32XhRKVJQlCpU5T1PpspYbgUisB+Ke1w7NR4AHZw=
+github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.5/go.mod h1:oUyL28WfxY0RqPhFpkrWZx26Cu4JlyrWMMcWq8qqhi0=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1KxLgHBKKY/CLqwP8lg=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27 h1:QgaWXVmNDxv/U/3UIHfGb7ohvtFgerf/bYcYylj4i8E=
@@ -160,8 +166,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6f
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19/go.mod h1:YO8TrYtFdl5w/4vmjL8zaBSsiNp3w0L1FfKVKenZT7w=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
-github.com/aws/smithy-go v1.27.1 h1:4T340VFndXtADGF52gYa1POyL7s9E4Z1OeZ1hCscIw8=
-github.com/aws/smithy-go v1.27.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
+github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -20,6 +20,7 @@ import (
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
 	sagemakerdriver "github.com/stackshy/cloudemu/sagemaker/driver"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/aws/bedrock"
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
@@ -35,6 +36,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/resourcegroupstaggingapi"
 	"github.com/stackshy/cloudemu/server/aws/s3"
 	sagemakersrv "github.com/stackshy/cloudemu/server/aws/sagemaker"
+	secretsmanagersrv "github.com/stackshy/cloudemu/server/aws/secretsmanager"
 	"github.com/stackshy/cloudemu/server/aws/sqs"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
@@ -58,6 +60,9 @@ type Drivers struct {
 	ECR        crdriver.ContainerRegistry
 	Bedrock    bedrockdriver.Bedrock
 	SageMaker  sagemakerdriver.Service
+	// SecretsManager serves the Secrets Manager JSON 1.1 protocol against
+	// the secrets driver.
+	SecretsManager secretsdriver.Secrets
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -133,6 +138,12 @@ func New(d Drivers) *server.Server {
 
 	if d.ECR != nil {
 		srv.Register(ecr.New(d.ECR))
+	}
+
+	// Secrets Manager matches the X-Amz-Target prefix "secretsmanager." —
+	// disjoint from DynamoDB, SQS, ECR, SageMaker, and the tagging API.
+	if d.SecretsManager != nil {
+		srv.Register(secretsmanagersrv.New(d.SecretsManager))
 	}
 
 	// Redshift sits with the other query-protocol handlers before the EC2

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -1,0 +1,79 @@
+// Package secretsmanager implements the AWS Secrets Manager JSON-RPC protocol
+// as a server.Handler. Point the real aws-sdk-go-v2 Secrets Manager client at
+// a Server registered with this handler and secret/version operations work
+// against an in-memory secrets driver.
+//
+// Secrets Manager uses the AWS JSON 1.1 wire shape (POST + JSON body,
+// dispatched on the X-Amz-Target header), the same family as DynamoDB and ECR.
+package secretsmanager
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "secretsmanager."
+
+// Handler serves Secrets Manager JSON-RPC requests against a Secrets driver.
+type Handler struct {
+	secrets secretsdriver.Secrets
+}
+
+// New returns a Secrets Manager handler backed by s.
+func New(s secretsdriver.Secrets) *Handler {
+	return &Handler{secrets: s}
+}
+
+// Matches returns true for Secrets Manager-shaped requests, identified by an
+// X-Amz-Target header of "secretsmanager.<Operation>".
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches Secrets Manager operations based on X-Amz-Target.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix) {
+	case "CreateSecret":
+		h.createSecret(w, r)
+	case "DeleteSecret":
+		h.deleteSecret(w, r)
+	case "DescribeSecret":
+		h.describeSecret(w, r)
+	case "ListSecrets":
+		h.listSecrets(w, r)
+	case "GetSecretValue":
+		h.getSecretValue(w, r)
+	case "PutSecretValue":
+		h.putSecretValue(w, r)
+	case "ListSecretVersionIds":
+		h.listSecretVersionIDs(w, r)
+	default:
+		op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown Secrets Manager operation: "+op)
+	}
+}
+
+// writeErr maps canonical cloudemu errors to Secrets Manager JSON error
+// responses. Secrets Manager returns errors as HTTP 400 with a "__type" body
+// the SDK maps to a typed exception.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceExistsException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidRequestException", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServiceError", err.Error())
+	}
+}

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -1,0 +1,178 @@
+package secretsmanager
+
+import (
+	"net/http"
+
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request) {
+	var req createSecretRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.secrets.CreateSecret(r.Context(), secretsdriver.SecretConfig{
+		Name:        req.Name,
+		Description: req.Description,
+		Tags:        tagsToMap(req.Tags),
+	}, secretValue(req.SecretString, req.SecretBinary))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// The driver seeds the initial version internally; fetch it so the
+	// response carries the VersionId real Secrets Manager returns.
+	out := createSecretResponse{ARN: info.ResourceID, Name: info.Name}
+	if ver, verr := h.secrets.GetSecretValue(r.Context(), info.Name, ""); verr == nil {
+		out.VersionID = ver.VersionID
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request) {
+	var req secretIDRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := resolveSecretID(req.SecretID)
+
+	// Secrets Manager echoes the deleted secret's ARN and name, so capture
+	// them before removal.
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.secrets.DeleteSecret(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, deleteSecretResponse{ARN: info.ResourceID, Name: info.Name})
+}
+
+func (h *Handler) describeSecret(w http.ResponseWriter, r *http.Request) {
+	var req secretIDRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.secrets.GetSecret(r.Context(), resolveSecretID(req.SecretID))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, toSecretListEntry(info))
+}
+
+func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
+	infos, err := h.secrets.ListSecrets(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	entries := make([]secretListEntryJSON, 0, len(infos))
+	for i := range infos {
+		entries = append(entries, toSecretListEntry(&infos[i]))
+	}
+
+	wire.WriteJSON(w, listSecretsResponse{SecretList: entries})
+}
+
+func (h *Handler) getSecretValue(w http.ResponseWriter, r *http.Request) {
+	var req getSecretValueRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := resolveSecretID(req.SecretID)
+
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	ver, err := h.secrets.GetSecretValue(r.Context(), name, req.VersionID)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, getSecretValueResponse{
+		ARN:           info.ResourceID,
+		Name:          info.Name,
+		VersionID:     ver.VersionID,
+		SecretString:  string(ver.Value),
+		VersionStages: stagesFor(ver.Current),
+		CreatedDate:   epochSeconds(ver.CreatedAt),
+	})
+}
+
+func (h *Handler) putSecretValue(w http.ResponseWriter, r *http.Request) {
+	var req putSecretValueRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := resolveSecretID(req.SecretID)
+
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	ver, err := h.secrets.PutSecretValue(r.Context(), name, secretValue(req.SecretString, req.SecretBinary))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, putSecretValueResponse{
+		ARN:           info.ResourceID,
+		Name:          info.Name,
+		VersionID:     ver.VersionID,
+		VersionStages: stagesFor(ver.Current),
+	})
+}
+
+func (h *Handler) listSecretVersionIDs(w http.ResponseWriter, r *http.Request) {
+	var req secretIDRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := resolveSecretID(req.SecretID)
+
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	versions, err := h.secrets.ListSecretVersions(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]versionJSON, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, versionJSON{
+			VersionID:     v.VersionID,
+			VersionStages: stagesFor(v.Current),
+			CreatedDate:   epochSeconds(v.CreatedAt),
+		})
+	}
+
+	wire.WriteJSON(w, listSecretVersionIDsResponse{ARN: info.ResourceID, Name: info.Name, Versions: out})
+}

--- a/server/aws/secretsmanager/sdk_roundtrip_test.go
+++ b/server/aws/secretsmanager/sdk_roundtrip_test.go
@@ -1,0 +1,221 @@
+package secretsmanager_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newSecretsClient(t *testing.T) *awssm.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{SecretsManager: cloud.SecretsManager})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awssm.NewFromConfig(cfg, func(o *awssm.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKSecretLifecycle(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("db-password"),
+		Description:  aws.String("primary database password"),
+		SecretString: aws.String("hunter2"),
+		Tags:         []smtypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	if aws.ToString(created.Name) != "db-password" {
+		t.Fatalf("got secret name %q, want db-password", aws.ToString(created.Name))
+	}
+
+	if aws.ToString(created.ARN) == "" || aws.ToString(created.VersionId) == "" {
+		t.Fatalf("CreateSecret returned empty ARN or VersionId: %+v", created)
+	}
+
+	desc, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("db-password")})
+	if err != nil {
+		t.Fatalf("DescribeSecret: %v", err)
+	}
+
+	if aws.ToString(desc.Description) != "primary database password" {
+		t.Fatalf("got description %q", aws.ToString(desc.Description))
+	}
+
+	if len(desc.Tags) != 1 || aws.ToString(desc.Tags[0].Key) != "env" {
+		t.Fatalf("DescribeSecret tags = %+v, want env tag", desc.Tags)
+	}
+
+	list, err := client.ListSecrets(ctx, &awssm.ListSecretsInput{})
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+
+	if len(list.SecretList) != 1 || aws.ToString(list.SecretList[0].Name) != "db-password" {
+		t.Fatalf("ListSecrets = %+v, want one entry db-password", list.SecretList)
+	}
+
+	deleted, err := client.DeleteSecret(ctx, &awssm.DeleteSecretInput{SecretId: aws.String("db-password")})
+	if err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	if aws.ToString(deleted.Name) != "db-password" {
+		t.Fatalf("DeleteSecret echoed name %q", aws.ToString(deleted.Name))
+	}
+
+	if _, err := client.DescribeSecret(ctx, &awssm.DescribeSecretInput{SecretId: aws.String("db-password")}); err == nil {
+		t.Fatal("DescribeSecret after delete: want error, got nil")
+	}
+}
+
+func TestSDKSecretValueVersioning(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("api-key"),
+		SecretString: aws.String("v1-value"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	got, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("api-key")})
+	if err != nil {
+		t.Fatalf("GetSecretValue: %v", err)
+	}
+
+	if aws.ToString(got.SecretString) != "v1-value" {
+		t.Fatalf("got value %q, want v1-value", aws.ToString(got.SecretString))
+	}
+
+	if len(got.VersionStages) != 1 || got.VersionStages[0] != "AWSCURRENT" {
+		t.Fatalf("got stages %v, want [AWSCURRENT]", got.VersionStages)
+	}
+
+	put, err := client.PutSecretValue(ctx, &awssm.PutSecretValueInput{
+		SecretId:     aws.String("api-key"),
+		SecretString: aws.String("v2-value"),
+	})
+	if err != nil {
+		t.Fatalf("PutSecretValue: %v", err)
+	}
+
+	if aws.ToString(put.VersionId) == aws.ToString(created.VersionId) {
+		t.Fatal("PutSecretValue reused the initial VersionId")
+	}
+
+	current, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("api-key")})
+	if err != nil {
+		t.Fatalf("GetSecretValue(current): %v", err)
+	}
+
+	if aws.ToString(current.SecretString) != "v2-value" {
+		t.Fatalf("current value = %q, want v2-value", aws.ToString(current.SecretString))
+	}
+
+	old, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{
+		SecretId:  aws.String("api-key"),
+		VersionId: created.VersionId,
+	})
+	if err != nil {
+		t.Fatalf("GetSecretValue(v1): %v", err)
+	}
+
+	if aws.ToString(old.SecretString) != "v1-value" {
+		t.Fatalf("v1 value = %q, want v1-value", aws.ToString(old.SecretString))
+	}
+
+	versions, err := client.ListSecretVersionIds(ctx, &awssm.ListSecretVersionIdsInput{SecretId: aws.String("api-key")})
+	if err != nil {
+		t.Fatalf("ListSecretVersionIds: %v", err)
+	}
+
+	if len(versions.Versions) != 2 {
+		t.Fatalf("got %d versions, want 2", len(versions.Versions))
+	}
+}
+
+func TestSDKSecretByARN(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("arn-lookup"),
+		SecretString: aws.String("value"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	got, err := client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: created.ARN})
+	if err != nil {
+		t.Fatalf("GetSecretValue(by ARN): %v", err)
+	}
+
+	if aws.ToString(got.Name) != "arn-lookup" {
+		t.Fatalf("got name %q, want arn-lookup", aws.ToString(got.Name))
+	}
+}
+
+func TestSDKSecretErrors(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("dup"),
+		SecretString: aws.String("x"),
+	}); err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	_, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("dup"),
+		SecretString: aws.String("y"),
+	})
+
+	var exists *smtypes.ResourceExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("duplicate CreateSecret: got %v, want ResourceExistsException", err)
+	}
+
+	_, err = client.GetSecretValue(ctx, &awssm.GetSecretValueInput{SecretId: aws.String("missing")})
+
+	var notFound *smtypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetSecretValue(missing): got %v, want ResourceNotFoundException", err)
+	}
+
+	_, err = client.DeleteSecret(ctx, &awssm.DeleteSecretInput{SecretId: aws.String("missing")})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("DeleteSecret(missing): got %v, want ResourceNotFoundException", err)
+	}
+}

--- a/server/aws/secretsmanager/types.go
+++ b/server/aws/secretsmanager/types.go
@@ -1,0 +1,183 @@
+package secretsmanager
+
+import (
+	"strings"
+	"time"
+
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// Version stage labels, matching real Secrets Manager staging semantics: the
+// current version carries AWSCURRENT, superseded versions AWSPREVIOUS.
+const (
+	stageCurrent  = "AWSCURRENT"
+	stagePrevious = "AWSPREVIOUS"
+)
+
+type tagJSON struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type secretListEntryJSON struct {
+	ARN             string    `json:"ARN"`
+	Name            string    `json:"Name"`
+	Description     string    `json:"Description,omitempty"`
+	Tags            []tagJSON `json:"Tags,omitempty"`
+	CreatedDate     float64   `json:"CreatedDate,omitempty"`
+	LastChangedDate float64   `json:"LastChangedDate,omitempty"`
+}
+
+type versionJSON struct {
+	VersionID     string   `json:"VersionId"`
+	VersionStages []string `json:"VersionStages,omitempty"`
+	CreatedDate   float64  `json:"CreatedDate,omitempty"`
+}
+
+// --- request envelopes ---
+
+type createSecretRequest struct {
+	Name         string    `json:"Name"`
+	Description  string    `json:"Description"`
+	SecretString string    `json:"SecretString"`
+	SecretBinary []byte    `json:"SecretBinary"`
+	Tags         []tagJSON `json:"Tags"`
+}
+
+type secretIDRequest struct {
+	SecretID string `json:"SecretId"`
+}
+
+type getSecretValueRequest struct {
+	SecretID  string `json:"SecretId"`
+	VersionID string `json:"VersionId"`
+}
+
+type putSecretValueRequest struct {
+	SecretID     string `json:"SecretId"`
+	SecretString string `json:"SecretString"`
+	SecretBinary []byte `json:"SecretBinary"`
+}
+
+// --- response envelopes ---
+
+type createSecretResponse struct {
+	ARN       string `json:"ARN"`
+	Name      string `json:"Name"`
+	VersionID string `json:"VersionId,omitempty"`
+}
+
+type deleteSecretResponse struct {
+	ARN  string `json:"ARN"`
+	Name string `json:"Name"`
+}
+
+type listSecretsResponse struct {
+	SecretList []secretListEntryJSON `json:"SecretList"`
+}
+
+type getSecretValueResponse struct {
+	ARN           string   `json:"ARN"`
+	Name          string   `json:"Name"`
+	VersionID     string   `json:"VersionId"`
+	SecretString  string   `json:"SecretString,omitempty"`
+	VersionStages []string `json:"VersionStages,omitempty"`
+	CreatedDate   float64  `json:"CreatedDate,omitempty"`
+}
+
+type putSecretValueResponse struct {
+	ARN           string   `json:"ARN"`
+	Name          string   `json:"Name"`
+	VersionID     string   `json:"VersionId"`
+	VersionStages []string `json:"VersionStages,omitempty"`
+}
+
+type listSecretVersionIDsResponse struct {
+	ARN      string        `json:"ARN"`
+	Name     string        `json:"Name"`
+	Versions []versionJSON `json:"Versions"`
+}
+
+// epochSeconds converts an RFC3339 timestamp to Unix epoch seconds, the form
+// the AWS JSON protocol uses for timestamp fields. Returns 0 on parse failure.
+func epochSeconds(iso string) float64 {
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return float64(t.Unix())
+}
+
+// resolveSecretID accepts either a plain secret name or a full ARN
+// ("arn:aws:secretsmanager:<region>:<account>:secret:<name>") — real Secrets
+// Manager accepts both forms for SecretId — and returns the bare name the
+// driver keys on.
+func resolveSecretID(id string) string {
+	const marker = ":secret:"
+
+	if !strings.HasPrefix(id, "arn:") {
+		return id
+	}
+
+	if i := strings.LastIndex(id, marker); i >= 0 {
+		return id[i+len(marker):]
+	}
+
+	return id
+}
+
+// secretValue picks the string payload if present, else the binary one — the
+// driver stores raw bytes either way.
+func secretValue(secretString string, secretBinary []byte) []byte {
+	if secretString != "" {
+		return []byte(secretString)
+	}
+
+	return secretBinary
+}
+
+func stagesFor(current bool) []string {
+	if current {
+		return []string{stageCurrent}
+	}
+
+	return []string{stagePrevious}
+}
+
+func mapToTags(m map[string]string) []tagJSON {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make([]tagJSON, 0, len(m))
+	for k, v := range m {
+		out = append(out, tagJSON{Key: k, Value: v})
+	}
+
+	return out
+}
+
+func tagsToMap(tags []tagJSON) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}
+
+func toSecretListEntry(info *secretsdriver.SecretInfo) secretListEntryJSON {
+	return secretListEntryJSON{
+		ARN:             info.ResourceID,
+		Name:            info.Name,
+		Description:     info.Description,
+		Tags:            mapToTags(info.Tags),
+		CreatedDate:     epochSeconds(info.CreatedAt),
+		LastChangedDate: epochSeconds(info.UpdatedAt),
+	}
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -18,6 +18,7 @@ import (
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/azure/acr"
 	aksserver "github.com/stackshy/cloudemu/server/azure/aks"
@@ -43,6 +44,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/functions"
 	"github.com/stackshy/cloudemu/server/azure/iam"
 	"github.com/stackshy/cloudemu/server/azure/images"
+	keyvaultsrv "github.com/stackshy/cloudemu/server/azure/keyvault"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
 	"github.com/stackshy/cloudemu/server/azure/network"
@@ -64,23 +66,26 @@ import (
 // compute driver — the driver's Volume*/Snapshot*/Image* methods back the
 // corresponding resources.
 type Drivers struct {
-	VirtualMachines     computedriver.Compute
-	Disks               computedriver.Compute
-	Snapshots           computedriver.Compute
-	Images              computedriver.Compute
-	SSHPublicKeys       computedriver.Compute
-	BlobStorage         storagedriver.Bucket
-	CosmosDB            dbdriver.Database
-	Network             netdriver.Networking
-	Monitor             mondriver.Monitoring
-	Functions           sdrv.Serverless
-	ServiceBus          mqdriver.MessageQueue
-	SQL                 rdbdriver.RelationalDB
-	PostgresFlex        rdbdriver.RelationalDB
-	MySQLFlex           rdbdriver.RelationalDB
-	AKS                 aksserver.Backend
-	IAM                 iamdriver.IAM
-	ACR                 crdriver.ContainerRegistry
+	VirtualMachines computedriver.Compute
+	Disks           computedriver.Compute
+	Snapshots       computedriver.Compute
+	Images          computedriver.Compute
+	SSHPublicKeys   computedriver.Compute
+	BlobStorage     storagedriver.Bucket
+	CosmosDB        dbdriver.Database
+	Network         netdriver.Networking
+	Monitor         mondriver.Monitoring
+	Functions       sdrv.Serverless
+	ServiceBus      mqdriver.MessageQueue
+	SQL             rdbdriver.RelationalDB
+	PostgresFlex    rdbdriver.RelationalDB
+	MySQLFlex       rdbdriver.RelationalDB
+	AKS             aksserver.Backend
+	IAM             iamdriver.IAM
+	ACR             crdriver.ContainerRegistry
+	// KeyVault serves the Key Vault secrets data-plane API (/secrets/…)
+	// against the secrets driver.
+	KeyVault            secretsdriver.Secrets
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -210,6 +215,13 @@ func New(d Drivers) *server.Server {
 	// must register before the permissive BlobStorage fallback below.
 	if d.ACR != nil {
 		srv.Register(acr.New(d.ACR))
+	}
+
+	// Key Vault secrets data-plane API matches /secrets/… — disjoint from ARM
+	// and from the Databricks secrets API (/api/{ver}/secrets), and must
+	// register before the permissive BlobStorage fallback below.
+	if d.KeyVault != nil {
+		srv.Register(keyvaultsrv.New(d.KeyVault))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/keyvault/handler.go
+++ b/server/azure/keyvault/handler.go
@@ -1,0 +1,135 @@
+// Package keyvault implements the Azure Key Vault secrets data-plane API
+// (/secrets/…) as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets clients
+// pointed at this server set, read, list, and delete secrets against the
+// shared secrets driver.
+//
+// Key Vault uses challenge-based auth: the SDK's first request carries no
+// Authorization header and expects a 401 with a WWW-Authenticate challenge
+// before retrying with a bearer token. The handler serves that challenge and
+// accepts any token. Point clients at the server with
+// DisableChallengeResourceVerification since the emulated vault's host is not
+// under vault.azure.net.
+//
+// Coverage (Key Vault 7.x REST shapes):
+//
+//	PUT    /secrets/{name}            — set secret (create or new version)
+//	GET    /secrets/{name}            — get current secret value
+//	GET    /secrets/{name}/{version}  — get specific version
+//	GET    /secrets/{name}/versions   — list versions
+//	GET    /secrets                   — list secrets
+//	DELETE /secrets/{name}            — delete secret
+package keyvault
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+)
+
+const pathPrefix = "/secrets"
+
+const versionsSeg = "versions"
+
+// Handler serves the Key Vault secrets data-plane API against a Secrets
+// driver.
+type Handler struct {
+	secrets secretsdriver.Secrets
+}
+
+// New returns a Key Vault handler backed by s.
+func New(s secretsdriver.Secrets) *Handler {
+	return &Handler{secrets: s}
+}
+
+// Matches claims /secrets data-plane requests. Disjoint from ARM
+// (/subscriptions/…) and from the Databricks secrets API (/api/{ver}/secrets)
+// and registered before the blob storage REST fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	return r.URL.Path == pathPrefix || strings.HasPrefix(r.URL.Path, pathPrefix+"/")
+}
+
+// ServeHTTP answers the bearer challenge for unauthenticated requests, then
+// routes on the path tail and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("Authorization") == "" {
+		w.Header().Set("WWW-Authenticate",
+			`Bearer authorization="https://login.microsoftonline.com/common", resource="https://vault.azure.net"`)
+		writeErr(w, http.StatusUnauthorized, "Unauthorized", "bearer token required")
+
+		return
+	}
+
+	tail := strings.Trim(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
+	if tail == "" {
+		if r.Method == http.MethodGet {
+			h.listSecrets(w, r)
+			return
+		}
+
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+
+		return
+	}
+
+	h.routeSecret(w, r, tail)
+}
+
+// routeSecret dispatches /secrets/{name}[/{version}|/versions] requests.
+func (h *Handler) routeSecret(w http.ResponseWriter, r *http.Request, tail string) {
+	name, sub, hasSub := strings.Cut(tail, "/")
+	if !hasSub {
+		h.routeBareSecret(w, r, name)
+		return
+	}
+
+	switch {
+	case sub == versionsSeg && r.Method == http.MethodGet:
+		h.listSecretVersions(w, r, name)
+	case !strings.Contains(sub, "/") && r.Method == http.MethodGet:
+		h.getSecret(w, r, name, sub)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+	}
+}
+
+// routeBareSecret dispatches /secrets/{name} requests by method.
+func (h *Handler) routeBareSecret(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPut:
+		h.setSecret(w, r, name)
+	case http.MethodGet:
+		h.getSecret(w, r, name, "")
+	case http.MethodDelete:
+		h.deleteSecret(w, r, name)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "BadRequest", "unsupported Key Vault operation")
+	}
+}
+
+// writeErr emits a Key Vault-style error body with the given HTTP status.
+func writeErr(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{"code": code, "message": msg},
+	})
+}
+
+// writeCErr maps a canonical cloudemu error to a Key Vault error response.
+func writeCErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeErr(w, http.StatusNotFound, "SecretNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeErr(w, http.StatusConflict, "Conflict", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeErr(w, http.StatusBadRequest, "BadParameter", err.Error())
+	default:
+		writeErr(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+	}
+}

--- a/server/azure/keyvault/operations.go
+++ b/server/azure/keyvault/operations.go
@@ -1,0 +1,131 @@
+package keyvault
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// setSecret creates the secret on first PUT and adds a new version on
+// subsequent PUTs, mirroring Key Vault's create-or-update SetSecret call.
+func (h *Handler) setSecret(w http.ResponseWriter, r *http.Request, name string) {
+	var req setSecretRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if _, err := h.secrets.GetSecret(r.Context(), name); err != nil {
+		if !cerrors.IsNotFound(err) {
+			writeCErr(w, err)
+			return
+		}
+
+		h.createSecret(w, r, name, &req)
+
+		return
+	}
+
+	ver, err := h.secrets.PutSecretValue(r.Context(), name, []byte(req.Value))
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	h.writeBundle(w, r, name, ver)
+}
+
+func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request, name string, req *setSecretRequest) {
+	info, err := h.secrets.CreateSecret(r.Context(), secretsdriver.SecretConfig{
+		Name: name,
+		Tags: req.Tags,
+	}, []byte(req.Value))
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	ver, err := h.secrets.GetSecretValue(r.Context(), info.Name, "")
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, toBundle(r, info, ver))
+}
+
+// writeBundle emits the full secret bundle for the given version.
+func (h *Handler) writeBundle(w http.ResponseWriter, r *http.Request, name string, ver *secretsdriver.SecretVersion) {
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, toBundle(r, info, ver))
+}
+
+func (h *Handler) getSecret(w http.ResponseWriter, r *http.Request, name, version string) {
+	ver, err := h.secrets.GetSecretValue(r.Context(), name, version)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	h.writeBundle(w, r, name, ver)
+}
+
+func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request, name string) {
+	info, err := h.secrets.GetSecret(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	ver, err := h.secrets.GetSecretValue(r.Context(), name, "")
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	if err := h.secrets.DeleteSecret(r.Context(), name); err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, deletedSecretBundleJSON{
+		secretBundleJSON: toBundle(r, info, ver),
+		RecoveryID:       vaultBaseURL(r) + "/deletedsecrets/" + info.Name,
+	})
+}
+
+func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
+	infos, err := h.secrets.ListSecrets(r.Context())
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	items := make([]secretItemJSON, 0, len(infos))
+	for i := range infos {
+		items = append(items, toItem(r, &infos[i]))
+	}
+
+	wire.WriteJSON(w, listResponseJSON{Value: items})
+}
+
+func (h *Handler) listSecretVersions(w http.ResponseWriter, r *http.Request, name string) {
+	versions, err := h.secrets.ListSecretVersions(r.Context(), name)
+	if err != nil {
+		writeCErr(w, err)
+		return
+	}
+
+	items := make([]secretItemJSON, 0, len(versions))
+	for i := range versions {
+		items = append(items, toVersionItem(r, name, &versions[i]))
+	}
+
+	wire.WriteJSON(w, listResponseJSON{Value: items})
+}

--- a/server/azure/keyvault/sdk_roundtrip_test.go
+++ b/server/azure/keyvault/sdk_roundtrip_test.go
@@ -1,0 +1,184 @@
+package keyvault_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newSecretsClient(t *testing.T) *azsecrets.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{KeyVault: cloud.KeyVault})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := azsecrets.NewClient(ts.URL, fakeCred{}, &azsecrets.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+		// The emulated vault's host is 127.0.0.1, not *.vault.azure.net.
+		DisableChallengeResourceVerification: true,
+	})
+	if err != nil {
+		t.Fatalf("azsecrets.NewClient: %v", err)
+	}
+
+	return client
+}
+
+func TestSDKKeyVaultSecretLifecycle(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	set, err := client.SetSecret(ctx, "db-password", azsecrets.SetSecretParameters{
+		Value: to.Ptr("hunter2"),
+		Tags:  map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("SetSecret: %v", err)
+	}
+
+	if set.ID == nil || set.ID.Name() != "db-password" {
+		t.Fatalf("SetSecret id = %v, want name db-password", set.ID)
+	}
+
+	got, err := client.GetSecret(ctx, "db-password", "", nil)
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+
+	if got.Value == nil || *got.Value != "hunter2" {
+		t.Fatalf("got value %v, want hunter2", got.Value)
+	}
+
+	if got.Attributes == nil || got.Attributes.Enabled == nil || !*got.Attributes.Enabled {
+		t.Fatalf("got attributes %+v, want enabled", got.Attributes)
+	}
+
+	var names []string
+
+	pager := client.NewListSecretPropertiesPager(nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListSecretProperties: %v", err)
+		}
+
+		for _, item := range page.Value {
+			names = append(names, item.ID.Name())
+		}
+	}
+
+	if len(names) != 1 || names[0] != "db-password" {
+		t.Fatalf("list = %v, want [db-password]", names)
+	}
+
+	deleted, err := client.DeleteSecret(ctx, "db-password", nil)
+	if err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+
+	if deleted.ID == nil || deleted.ID.Name() != "db-password" {
+		t.Fatalf("DeleteSecret id = %v", deleted.ID)
+	}
+
+	if _, err := client.GetSecret(ctx, "db-password", "", nil); err == nil {
+		t.Fatal("GetSecret after delete: want error, got nil")
+	}
+}
+
+func TestSDKKeyVaultSecretVersioning(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	first, err := client.SetSecret(ctx, "api-key", azsecrets.SetSecretParameters{Value: to.Ptr("v1-value")}, nil)
+	if err != nil {
+		t.Fatalf("SetSecret(v1): %v", err)
+	}
+
+	second, err := client.SetSecret(ctx, "api-key", azsecrets.SetSecretParameters{Value: to.Ptr("v2-value")}, nil)
+	if err != nil {
+		t.Fatalf("SetSecret(v2): %v", err)
+	}
+
+	if first.ID.Version() == second.ID.Version() {
+		t.Fatal("second SetSecret reused the first version id")
+	}
+
+	current, err := client.GetSecret(ctx, "api-key", "", nil)
+	if err != nil {
+		t.Fatalf("GetSecret(current): %v", err)
+	}
+
+	if *current.Value != "v2-value" {
+		t.Fatalf("current value = %q, want v2-value", *current.Value)
+	}
+
+	old, err := client.GetSecret(ctx, "api-key", first.ID.Version(), nil)
+	if err != nil {
+		t.Fatalf("GetSecret(v1): %v", err)
+	}
+
+	if *old.Value != "v1-value" {
+		t.Fatalf("v1 value = %q, want v1-value", *old.Value)
+	}
+
+	var versions []string
+
+	pager := client.NewListSecretPropertiesVersionsPager("api-key", nil)
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("ListSecretPropertiesVersions: %v", err)
+		}
+
+		for _, item := range page.Value {
+			versions = append(versions, item.ID.Version())
+		}
+	}
+
+	if len(versions) != 2 {
+		t.Fatalf("got %d versions %v, want 2", len(versions), versions)
+	}
+}
+
+func TestSDKKeyVaultErrors(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	_, err := client.GetSecret(ctx, "missing", "", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("GetSecret(missing): got %v, want 404 ResponseError", err)
+	}
+
+	if respErr.ErrorCode != "SecretNotFound" {
+		t.Fatalf("got error code %q, want SecretNotFound", respErr.ErrorCode)
+	}
+
+	_, err = client.DeleteSecret(ctx, "missing", nil)
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("DeleteSecret(missing): got %v, want 404 ResponseError", err)
+	}
+}

--- a/server/azure/keyvault/types.go
+++ b/server/azure/keyvault/types.go
@@ -1,0 +1,118 @@
+package keyvault
+
+import (
+	"net/http"
+	"time"
+
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+)
+
+type attributesJSON struct {
+	Enabled bool  `json:"enabled"`
+	Created int64 `json:"created,omitempty"`
+	Updated int64 `json:"updated,omitempty"`
+}
+
+// secretBundleJSON is the Key Vault secret bundle: the value plus its
+// versioned identifier and attributes.
+type secretBundleJSON struct {
+	Value      string            `json:"value"`
+	ID         string            `json:"id"`
+	Attributes attributesJSON    `json:"attributes"`
+	Tags       map[string]string `json:"tags,omitempty"`
+}
+
+// secretItemJSON is a Key Vault list entry: identifier and attributes, no
+// value.
+type secretItemJSON struct {
+	ID         string            `json:"id"`
+	Attributes attributesJSON    `json:"attributes"`
+	Tags       map[string]string `json:"tags,omitempty"`
+}
+
+type listResponseJSON struct {
+	Value    []secretItemJSON `json:"value"`
+	NextLink *string          `json:"nextLink"`
+}
+
+// deletedSecretBundleJSON extends the bundle with the recovery identifier the
+// SDK's DeleteSecret response carries.
+type deletedSecretBundleJSON struct {
+	secretBundleJSON
+
+	RecoveryID string `json:"recoveryId"`
+}
+
+type setSecretRequest struct {
+	Value string            `json:"value"`
+	Tags  map[string]string `json:"tags"`
+}
+
+// epochSeconds converts an RFC3339 timestamp to Unix epoch seconds, the form
+// Key Vault uses for attribute timestamps. Returns 0 on parse failure.
+func epochSeconds(iso string) int64 {
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return t.Unix()
+}
+
+// vaultBaseURL reconstructs the vault base URL from the request so secret
+// identifiers point back at this server.
+func vaultBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host
+}
+
+// secretID builds the canonical Key Vault secret identifier
+// "{vault}/secrets/{name}[/{version}]".
+func secretID(r *http.Request, name, version string) string {
+	id := vaultBaseURL(r) + pathPrefix + "/" + name
+	if version != "" {
+		id += "/" + version
+	}
+
+	return id
+}
+
+func toBundle(r *http.Request, info *secretsdriver.SecretInfo, ver *secretsdriver.SecretVersion) secretBundleJSON {
+	return secretBundleJSON{
+		Value: string(ver.Value),
+		ID:    secretID(r, info.Name, ver.VersionID),
+		Attributes: attributesJSON{
+			Enabled: true,
+			Created: epochSeconds(ver.CreatedAt),
+			Updated: epochSeconds(ver.CreatedAt),
+		},
+		Tags: info.Tags,
+	}
+}
+
+func toItem(r *http.Request, info *secretsdriver.SecretInfo) secretItemJSON {
+	return secretItemJSON{
+		ID: secretID(r, info.Name, ""),
+		Attributes: attributesJSON{
+			Enabled: true,
+			Created: epochSeconds(info.CreatedAt),
+			Updated: epochSeconds(info.UpdatedAt),
+		},
+		Tags: info.Tags,
+	}
+}
+
+func toVersionItem(r *http.Request, name string, ver *secretsdriver.SecretVersion) secretItemJSON {
+	return secretItemJSON{
+		ID: secretID(r, name, ver.VersionID),
+		Attributes: attributesJSON{
+			Enabled: true,
+			Created: epochSeconds(ver.CreatedAt),
+			Updated: epochSeconds(ver.CreatedAt),
+		},
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -18,6 +18,7 @@ import (
 	gkeprov "github.com/stackshy/cloudemu/providers/gcp/gke"
 	rdbdriver "github.com/stackshy/cloudemu/relationaldb/driver"
 	"github.com/stackshy/cloudemu/resourcediscovery"
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
@@ -31,6 +32,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
+	secretmanagersrv "github.com/stackshy/cloudemu/server/gcp/secretmanager"
 	vertexaisrv "github.com/stackshy/cloudemu/server/gcp/vertexai"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
@@ -51,6 +53,9 @@ type Drivers struct {
 	VertexAI         vertexaidriver.VertexAI
 	IAM              iamdriver.IAM
 	ArtifactRegistry crdriver.ContainerRegistry
+	// SecretManager serves the secretmanager.googleapis.com v1 REST API
+	// against the secrets driver.
+	SecretManager secretsdriver.Secrets
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -143,6 +148,13 @@ func New(d Drivers) *server.Server {
 	// among the /v1/projects/ family, before Firestore's catch-all.
 	if d.ArtifactRegistry != nil {
 		srv.Register(artifactregistry.New(d.ArtifactRegistry))
+	}
+
+	// Secret Manager matches /v1/projects/{p}/secrets[/…] — disjoint from IAM
+	// (serviceAccounts|roles), Artifact Registry (locations/…), and the rest
+	// of the /v1/projects/ family. Registered before Firestore's catch-all.
+	if d.SecretManager != nil {
+		srv.Register(secretmanagersrv.New(d.SecretManager))
 	}
 
 	if d.Firestore != nil {

--- a/server/gcp/secretmanager/handler.go
+++ b/server/gcp/secretmanager/handler.go
@@ -1,0 +1,176 @@
+// Package secretmanager implements the secretmanager.googleapis.com v1 REST
+// API as a server.Handler. Real google.golang.org/api/secretmanager/v1
+// clients pointed at this server CRUD secrets, add versions, and access
+// payloads end-to-end against the shared secrets driver.
+//
+// Coverage (v1 REST):
+//
+//	POST   /v1/projects/{p}/secrets?secretId={id}              — Create secret
+//	GET    /v1/projects/{p}/secrets/{id}                       — Get secret
+//	GET    /v1/projects/{p}/secrets                            — List secrets
+//	DELETE /v1/projects/{p}/secrets/{id}                       — Delete secret
+//	POST   /v1/projects/{p}/secrets/{id}:addVersion            — Add version
+//	GET    /v1/projects/{p}/secrets/{id}/versions              — List versions
+//	GET    /v1/projects/{p}/secrets/{id}/versions/{v}          — Get version
+//	GET    /v1/projects/{p}/secrets/{id}/versions/{v}:access   — Access payload
+//
+// "latest" is accepted as a version alias, matching real Secret Manager. The
+// driver seeds an initial (empty) version on create, so a freshly created
+// secret carries one more version than the addVersion calls made against it.
+package secretmanager
+
+import (
+	"net/http"
+	"strings"
+
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	pathPrefix  = "/v1/projects/"
+	secretsSeg  = "secrets"
+	versionsSeg = "versions"
+
+	verbAddVersion = "addVersion"
+	verbAccess     = "access"
+
+	latestAlias = "latest"
+)
+
+// Path-tail segment counts after the [projects, {p}, secrets] head: a bare
+// secret, its versions collection, and a specific version.
+const (
+	minSecretCollectionParts = 3 // [projects, {p}, secrets]
+	restVersionsCollection   = 2 // [{id}, versions]
+	restVersionResource      = 3 // [{id}, versions, {v}]
+)
+
+// Handler serves secretmanager.googleapis.com v1 requests.
+type Handler struct {
+	secrets secretsdriver.Secrets
+}
+
+// New returns a Secret Manager handler backed by s.
+func New(s secretsdriver.Secrets) *Handler {
+	return &Handler{secrets: s}
+}
+
+type route struct {
+	project string
+	secret  string // secret id; empty for the collection
+	version string // version id; empty unless a versions/{v} path
+	listVer bool   // true for the versions collection
+	verb    string // "addVersion" or "access" colon-verb, if any
+}
+
+// parseRoute extracts the components of a Secret Manager v1 path. The
+// trailing segment may carry a ":verb" suffix (addVersion, access).
+func parseRoute(urlPath string) (route, bool) {
+	if !strings.HasPrefix(urlPath, pathPrefix) {
+		return route{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(urlPath, "/v1/"), "/")
+	if len(parts) < minSecretCollectionParts || parts[0] != "projects" || parts[2] != secretsSeg {
+		return route{}, false
+	}
+
+	rt := route{project: parts[1]}
+	rest := parts[minSecretCollectionParts:]
+
+	if len(rest) == 0 {
+		return rt, true
+	}
+
+	rt.secret, rt.verb, _ = strings.Cut(rest[0], ":")
+	if len(rest) == 1 {
+		return rt, true
+	}
+
+	if rest[1] != versionsSeg || len(rest) > restVersionResource {
+		return route{}, false
+	}
+
+	if len(rest) == restVersionsCollection {
+		rt.listVer = true
+		return rt, true
+	}
+
+	rt.version, rt.verb, _ = strings.Cut(rest[2], ":")
+
+	return rt, true
+}
+
+// Matches claims /v1/projects/{p}/secrets[...] paths — disjoint from IAM
+// (serviceAccounts|roles), Artifact Registry (locations/...), and Cloud Asset
+// among the /v1/projects/ family. Registered before Firestore's permissive
+// fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	rt, ok := parseRoute(r.URL.Path)
+	return ok && rt.project != ""
+}
+
+// ServeHTTP routes on the parsed path and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unrecognized Secret Manager path")
+		return
+	}
+
+	switch {
+	case rt.secret == "":
+		h.serveCollection(w, r, rt)
+	case rt.listVer || rt.version != "":
+		h.serveVersions(w, r, rt)
+	default:
+		h.serveSecret(w, r, rt)
+	}
+}
+
+// serveCollection dispatches /secrets collection requests.
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rt route) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createSecret(w, r, rt)
+	case http.MethodGet:
+		h.listSecrets(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveSecret dispatches /secrets/{id} resource requests, including the
+// :addVersion custom method.
+func (h *Handler) serveSecret(w http.ResponseWriter, r *http.Request, rt route) {
+	switch {
+	case rt.verb == verbAddVersion && r.Method == http.MethodPost:
+		h.addVersion(w, r, rt)
+	case rt.verb == "" && r.Method == http.MethodGet:
+		h.getSecret(w, r, rt)
+	case rt.verb == "" && r.Method == http.MethodDelete:
+		h.deleteSecret(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveVersions dispatches /secrets/{id}/versions[...] requests, including
+// the :access custom method.
+func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, rt route) {
+	switch {
+	case rt.listVer && r.Method == http.MethodGet:
+		h.listVersions(w, r, rt)
+	case rt.verb == verbAccess && r.Method == http.MethodGet:
+		h.accessVersion(w, r, rt)
+	case rt.verb == "" && r.Method == http.MethodGet:
+		h.getVersion(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+func writeUnsupported(w http.ResponseWriter) {
+	gcprest.WriteError(w, http.StatusBadRequest, "badRequest", "unsupported Secret Manager operation")
+}

--- a/server/gcp/secretmanager/operations.go
+++ b/server/gcp/secretmanager/operations.go
@@ -1,0 +1,116 @@
+package secretmanager
+
+import (
+	"net/http"
+
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+func (h *Handler) createSecret(w http.ResponseWriter, r *http.Request, rt route) {
+	var req createSecretRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	id := r.URL.Query().Get("secretId")
+
+	info, err := h.secrets.CreateSecret(r.Context(), secretsdriver.SecretConfig{
+		Name: id,
+		Tags: req.Labels,
+	}, nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toSecretJSON(rt.project, info))
+}
+
+func (h *Handler) getSecret(w http.ResponseWriter, r *http.Request, rt route) {
+	info, err := h.secrets.GetSecret(r.Context(), rt.secret)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toSecretJSON(rt.project, info))
+}
+
+func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request, rt route) {
+	infos, err := h.secrets.ListSecrets(r.Context())
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]secretJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toSecretJSON(rt.project, &infos[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listSecretsResponse{Secrets: out, TotalSize: len(out)})
+}
+
+func (h *Handler) deleteSecret(w http.ResponseWriter, r *http.Request, rt route) {
+	if err := h.secrets.DeleteSecret(r.Context(), rt.secret); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// google.protobuf.Empty.
+	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
+}
+
+func (h *Handler) addVersion(w http.ResponseWriter, r *http.Request, rt route) {
+	var req addVersionRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	ver, err := h.secrets.PutSecretValue(r.Context(), rt.secret, req.Payload.Data)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver))
+}
+
+func (h *Handler) listVersions(w http.ResponseWriter, r *http.Request, rt route) {
+	versions, err := h.secrets.ListSecretVersions(r.Context(), rt.secret)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]versionResourceJSON, 0, len(versions))
+	for i := range versions {
+		out = append(out, toVersionJSON(rt.project, rt.secret, &versions[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listVersionsResponse{Versions: out, TotalSize: len(out)})
+}
+
+func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request, rt route) {
+	ver, err := h.secrets.GetSecretValue(r.Context(), rt.secret, driverVersion(rt.version))
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toVersionJSON(rt.project, rt.secret, ver))
+}
+
+func (h *Handler) accessVersion(w http.ResponseWriter, r *http.Request, rt route) {
+	ver, err := h.secrets.GetSecretValue(r.Context(), rt.secret, driverVersion(rt.version))
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, accessResponse{
+		Name:    versionName(rt.project, rt.secret, ver.VersionID),
+		Payload: payloadJSON{Data: ver.Value},
+	})
+}

--- a/server/gcp/secretmanager/sdk_roundtrip_test.go
+++ b/server/gcp/secretmanager/sdk_roundtrip_test.go
@@ -1,0 +1,191 @@
+package secretmanager_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	sm "google.golang.org/api/secretmanager/v1"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const testParent = "projects/demo"
+
+func newSMService(t *testing.T) *sm.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{SecretManager: cloud.SecretManager})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := sm.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("secretmanager.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func encode(s string) string {
+	return base64.StdEncoding.EncodeToString([]byte(s))
+}
+
+func TestSDKSecretManagerLifecycle(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	created, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+		Labels:      map[string]string{"env": "test"},
+	}).SecretId("db-password").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if created.Name != testParent+"/secrets/db-password" {
+		t.Fatalf("got name %q", created.Name)
+	}
+
+	got, err := svc.Projects.Secrets.Get(testParent + "/secrets/db-password").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Labels["env"] != "test" {
+		t.Fatalf("labels = %v, want env=test", got.Labels)
+	}
+
+	if got.Replication == nil || got.Replication.Automatic == nil {
+		t.Fatalf("replication = %+v, want automatic", got.Replication)
+	}
+
+	list, err := svc.Projects.Secrets.List(testParent).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	if len(list.Secrets) != 1 || list.Secrets[0].Name != created.Name {
+		t.Fatalf("List = %+v, want one secret %s", list.Secrets, created.Name)
+	}
+
+	if _, err := svc.Projects.Secrets.Delete(created.Name).Context(ctx).Do(); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err = svc.Projects.Secrets.Get(created.Name).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKSecretManagerVersionsAndAccess(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	name := testParent + "/secrets/api-key"
+
+	if _, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+	}).SecretId("api-key").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	v1, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("v1-value")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion(v1): %v", err)
+	}
+
+	v2, err := svc.Projects.Secrets.AddVersion(name, &sm.AddSecretVersionRequest{
+		Payload: &sm.SecretPayload{Data: encode("v2-value")},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("AddVersion(v2): %v", err)
+	}
+
+	if v1.Name == v2.Name {
+		t.Fatal("AddVersion reused a version name")
+	}
+
+	latest, err := svc.Projects.Secrets.Versions.Access(name + "/versions/latest").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Access(latest): %v", err)
+	}
+
+	if latest.Payload.Data != encode("v2-value") {
+		t.Fatalf("latest = %q, want %q", latest.Payload.Data, encode("v2-value"))
+	}
+
+	old, err := svc.Projects.Secrets.Versions.Access(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Access(v1): %v", err)
+	}
+
+	if old.Payload.Data != encode("v1-value") {
+		t.Fatalf("v1 = %q, want %q", old.Payload.Data, encode("v1-value"))
+	}
+
+	meta, err := svc.Projects.Secrets.Versions.Get(v1.Name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Versions.Get: %v", err)
+	}
+
+	if meta.State != "ENABLED" {
+		t.Fatalf("state = %q, want ENABLED", meta.State)
+	}
+
+	versions, err := svc.Projects.Secrets.Versions.List(name).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Versions.List: %v", err)
+	}
+
+	// The driver seeds an initial version on create, so two AddVersion calls
+	// yield three versions.
+	if len(versions.Versions) != 3 {
+		t.Fatalf("got %d versions, want 3", len(versions.Versions))
+	}
+}
+
+func TestSDKSecretManagerErrors(t *testing.T) {
+	svc := newSMService(t)
+	ctx := context.Background()
+
+	_, err := svc.Projects.Secrets.Get(testParent + "/secrets/missing").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+
+	if _, err := svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+	}).SecretId("dup").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	_, err = svc.Projects.Secrets.Create(testParent, &sm.Secret{
+		Replication: &sm.Replication{Automatic: &sm.Automatic{}},
+	}).SecretId("dup").Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 409 {
+		t.Fatalf("duplicate Create: got %v, want 409", err)
+	}
+
+	_, err = svc.Projects.Secrets.Versions.Access(testParent + "/secrets/missing/versions/latest").Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Access(missing): got %v, want 404", err)
+	}
+}

--- a/server/gcp/secretmanager/types.go
+++ b/server/gcp/secretmanager/types.go
@@ -1,0 +1,94 @@
+package secretmanager
+
+import (
+	secretsdriver "github.com/stackshy/cloudemu/secrets/driver"
+)
+
+// stateEnabled is the lifecycle state reported for every version — the mock
+// models neither disabled nor destroyed versions.
+const stateEnabled = "ENABLED"
+
+type automaticJSON struct{}
+
+type replicationJSON struct {
+	Automatic *automaticJSON `json:"automatic,omitempty"`
+}
+
+type secretJSON struct {
+	Name        string            `json:"name"`
+	Replication replicationJSON   `json:"replication"`
+	CreateTime  string            `json:"createTime,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+type versionResourceJSON struct {
+	Name       string `json:"name"`
+	CreateTime string `json:"createTime,omitempty"`
+	State      string `json:"state"`
+}
+
+// payloadJSON carries the secret bytes; encoding/json renders []byte as the
+// std-base64 string the wire expects.
+type payloadJSON struct {
+	Data []byte `json:"data"`
+}
+
+type createSecretRequest struct {
+	Labels map[string]string `json:"labels"`
+}
+
+type addVersionRequest struct {
+	Payload payloadJSON `json:"payload"`
+}
+
+type accessResponse struct {
+	Name    string      `json:"name"`
+	Payload payloadJSON `json:"payload"`
+}
+
+type listSecretsResponse struct {
+	Secrets   []secretJSON `json:"secrets"`
+	TotalSize int          `json:"totalSize"`
+}
+
+type listVersionsResponse struct {
+	Versions  []versionResourceJSON `json:"versions"`
+	TotalSize int                   `json:"totalSize"`
+}
+
+// secretName builds the canonical "projects/{p}/secrets/{id}" resource name,
+// echoing the project from the request URL.
+func secretName(project, id string) string {
+	return "projects/" + project + "/" + secretsSeg + "/" + id
+}
+
+func versionName(project, id, version string) string {
+	return secretName(project, id) + "/" + versionsSeg + "/" + version
+}
+
+// driverVersion maps the URL version segment to the driver's version key —
+// "latest" resolves to the current version (empty key).
+func driverVersion(v string) string {
+	if v == latestAlias {
+		return ""
+	}
+
+	return v
+}
+
+func toSecretJSON(project string, info *secretsdriver.SecretInfo) secretJSON {
+	return secretJSON{
+		Name:        secretName(project, info.Name),
+		Replication: replicationJSON{Automatic: &automaticJSON{}},
+		CreateTime:  info.CreatedAt,
+		Labels:      info.Tags,
+	}
+}
+
+func toVersionJSON(project, id string, ver *secretsdriver.SecretVersion) versionResourceJSON {
+	return versionResourceJSON{
+		Name:       versionName(project, id, ver.VersionID),
+		CreateTime: ver.CreatedAt,
+		State:      stateEnabled,
+	}
+}


### PR DESCRIPTION
## Summary

Adds SDK-compat wire servers for the secrets service across all three providers, so the real cloud SDK clients drive the existing secrets driver over HTTP. This is the secrets slice of #143 (remaining after: DNS, load balancer, cache, logging, notifications, event bus).

One commit per provider.

## AWS Secrets Manager (`server/aws/secretsmanager`)

AWS JSON 1.1 protocol (POST + JSON body, dispatched on `X-Amz-Target: secretsmanager.*`), same family as DynamoDB and ECR.

- **Operations:** CreateSecret, DescribeSecret, ListSecrets, DeleteSecret, GetSecretValue, PutSecretValue, ListSecretVersionIds
- `SecretId` accepts both the bare name and the full ARN, as in real Secrets Manager.
- Version staging is faithful: the current version carries `AWSCURRENT`, superseded versions `AWSPREVIOUS`; timestamps are Unix epoch seconds.
- Error codes map to typed exceptions: `ResourceNotFoundException`, `ResourceExistsException`, `InvalidParameterException`, `InvalidRequestException`, `LimitExceededException`.
- `SecretBinary` is accepted on input; values surface as `SecretString` (the driver stores raw bytes without recording the medium).

## Azure Key Vault (`server/azure/keyvault`)

Key Vault secrets data-plane REST (`/secrets/…`), driven by the real `azsecrets` client.

- **Operations:** SetSecret (create-or-new-version), GetSecret (current or by version), ListSecretProperties, ListSecretPropertiesVersions, DeleteSecret
- **Challenge-based auth is modeled:** an unauthenticated request gets the 401 + `WWW-Authenticate` bearer challenge the SDK expects, then any token is accepted. Clients set `DisableChallengeResourceVerification` since the emulated vault isn't under `vault.azure.net`.
- Secret identifiers are canonical `{vault}/secrets/{name}/{version}` URLs pointing back at the server, so `ID.Name()` / `ID.Version()` parse correctly.
- Routing matches `/secrets/…` — disjoint from ARM (`/subscriptions/…`) and the Databricks secrets API (`/api/{ver}/secrets`), registered before the permissive BlobStorage fallback.
- Errors map to Key Vault codes (404 `SecretNotFound`, …) surfaced via `*azcore.ResponseError`.

## GCP Secret Manager (`server/gcp/secretmanager`)

`secretmanager.googleapis.com` v1 REST, driven by the real `google.golang.org/api/secretmanager/v1` client.

- **Operations:** secrets create / get / list / delete, `:addVersion`, versions list / get, `:access`
- `latest` is accepted as a version alias; payloads are std-base64 on the wire; version state reports `ENABLED`.
- Resource names are canonical `projects/{p}/secrets/{id}[/versions/{v}]`, echoing the URL project.
- Routing matches `/v1/projects/{p}/secrets[/…]` — disjoint from IAM (serviceAccounts|roles) and Artifact Registry (locations/…), registered before Firestore's permissive `/v1/projects/` fallback.
- Errors map to GCP status codes (404 notFound, 409 alreadyExists) asserted via `*googleapi.Error`.
- Quirk: the driver seeds an initial version on create (its CreateSecret takes a value), so a fresh secret carries one more version than the `:addVersion` calls made against it; `latest` always resolves correctly.

## Tests

Real-SDK roundtrip tests per provider: secret lifecycle (create → get/describe → list → delete → 404), value versioning (put/add → access current + pinned old version → list versions), ARN lookup (AWS), and error paths asserted via each SDK's typed errors.

`go build`, `go test ./...` (163 packages), and `golangci-lint run` all pass.
