### PR TITLE
feat(dns): Secrets-style SDK-compat servers for Route 53, Azure DNS, and Cloud DNS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
@@ -41,6 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0
 	github.com/aws/aws-sdk-go-v2/service/sagemakerfeaturestoreruntime v1.35.7

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontai
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0/go.mod h1:OWKfCmX4X3Vp2w7GSx1LZn8566tOHJBA6K0IAUVNYx0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0 h1:rQyNHB/4ntzvm5F9WAiaAl7jWII+jaI4rL6sSWxTNeM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0/go.mod h1:4jtknLqzaPtwIz8Y9NBp2rXxeA7BbSICWBD0FDzG2VM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0/go.mod h1:fSvRkb8d26z9dbL40Uf/OO6Vo9iExtZK3D0ulRV+8M0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
@@ -146,6 +148,8 @@ github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6 h1:v4Gii9Pxx4bvvN
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6/go.mod h1:W/WhNWo1nbW+wVQTw8681WzAj6yTOvGLl8GLWNEWC2I=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12 h1:kOX5fCUb0BSMNHbRm7icw/dEyTjiYCLczIYglbYFJnI=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12/go.mod h1:n8ixkV2383DfuJhsCMVdfeSfYWqJhO2uadau9wrta9U=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.64.0 h1:AYtTCOexiOMbe6Ier86t7Jfc8191htzChnNyg027PMo=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.64.0/go.mod h1:0hIRXFez1bZsDFMGkLZvNJbByTSVZ4sFZWpxZ39NPuM=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0 h1:hlSuz394kV0vhv9drL5lhuEFbEOEP1VyQpy15qWh1Pk=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.99.0/go.mod h1:uoA43SdFwacedBfSgfFSjjCvYe8aYBS7EnU5GZ/YKMM=
 github.com/aws/aws-sdk-go-v2/service/sagemaker v1.254.0 h1:0vYBf7g+R421AjrPAKh+zoNDhWxqg4KixviLFTQ+6vI=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -11,6 +11,7 @@ import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
@@ -34,6 +35,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/redshift"
 	"github.com/stackshy/cloudemu/server/aws/resourceexplorer2"
 	"github.com/stackshy/cloudemu/server/aws/resourcegroupstaggingapi"
+	"github.com/stackshy/cloudemu/server/aws/route53"
 	"github.com/stackshy/cloudemu/server/aws/s3"
 	sagemakersrv "github.com/stackshy/cloudemu/server/aws/sagemaker"
 	secretsmanagersrv "github.com/stackshy/cloudemu/server/aws/secretsmanager"
@@ -63,6 +65,8 @@ type Drivers struct {
 	// SecretsManager serves the Secrets Manager JSON 1.1 protocol against
 	// the secrets driver.
 	SecretsManager secretsdriver.Secrets
+	// Route53 serves the Route 53 REST/XML protocol against the dns driver.
+	Route53 dnsdriver.DNS
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -196,6 +200,14 @@ func New(d Drivers) *server.Server {
 	// (/CreateView, /Search, etc.). Must register before S3's catch-all.
 	if d.ResourceDiscovery != nil {
 		srv.Register(resourceexplorer2.New(d.ResourceDiscovery, d.AccountID, d.Region))
+	}
+
+	// Route 53 is a REST/XML service rooted at /2013-04-01/hostedzone — its own
+	// path space, disjoint from every other AWS handler. It must register
+	// before S3 because S3 is the permissive REST fallback that would otherwise
+	// claim those paths.
+	if d.Route53 != nil {
+		srv.Register(route53.New(d.Route53))
 	}
 
 	if d.S3 != nil {

--- a/server/aws/route53/handler.go
+++ b/server/aws/route53/handler.go
@@ -1,0 +1,112 @@
+// Package route53 implements the AWS Route 53 REST+XML protocol as a
+// server.Handler. Point the real aws-sdk-go-v2 Route 53 client at a Server
+// registered with this handler and hosted-zone and record operations work
+// against the shared dns driver.
+//
+// Route 53 is a REST/XML service rooted at /2013-04-01/hostedzone (unlike the
+// JSON-RPC and query-protocol AWS services). Its own path space is disjoint
+// from every other AWS handler, but it must register before the permissive S3
+// REST fallback so its URLs aren't swallowed.
+//
+// Coverage (2013-04-01 REST):
+//
+//	POST   /2013-04-01/hostedzone                    — CreateHostedZone
+//	GET    /2013-04-01/hostedzone/{id}               — GetHostedZone
+//	GET    /2013-04-01/hostedzone                    — ListHostedZones
+//	DELETE /2013-04-01/hostedzone/{id}               — DeleteHostedZone
+//	POST   /2013-04-01/hostedzone/{id}/rrset         — ChangeResourceRecordSets (CREATE/UPSERT/DELETE)
+//	GET    /2013-04-01/hostedzone/{id}/rrset         — ListResourceRecordSets
+package route53
+
+import (
+	"net/http"
+	"strings"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+)
+
+// pathPrefix roots every Route 53 REST URL. The version segment is fixed.
+const pathPrefix = "/2013-04-01/hostedzone"
+
+const rrsetSeg = "rrset"
+
+// Handler serves Route 53 REST requests against a dns driver.
+type Handler struct {
+	dns dnsdriver.DNS
+}
+
+// New returns a Route 53 handler backed by d.
+func New(d dnsdriver.DNS) *Handler {
+	return &Handler{dns: d}
+}
+
+// Matches claims /2013-04-01/hostedzone[...] requests — Route 53's own REST
+// path space, disjoint from every other AWS handler. Registered before the S3
+// REST fallback so those paths aren't swallowed by the catch-all.
+func (*Handler) Matches(r *http.Request) bool {
+	return r.URL.Path == pathPrefix || strings.HasPrefix(r.URL.Path, pathPrefix+"/")
+}
+
+// ServeHTTP routes on the path tail and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	tail := strings.Trim(strings.TrimPrefix(r.URL.Path, pathPrefix), "/")
+	if tail == "" {
+		h.serveZoneCollection(w, r)
+		return
+	}
+
+	// tail is "{id}" or "{id}/rrset".
+	id, sub, _ := strings.Cut(tail, "/")
+
+	if sub == rrsetSeg {
+		h.serveRRSet(w, r, id)
+		return
+	}
+
+	if sub != "" {
+		writeError(w, http.StatusNotFound, "NoSuchHostedZone", "unrecognized Route 53 path")
+		return
+	}
+
+	h.serveZone(w, r, id)
+}
+
+// serveZoneCollection dispatches /hostedzone collection requests.
+func (h *Handler) serveZoneCollection(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createHostedZone(w, r)
+	case http.MethodGet:
+		h.listHostedZones(w, r)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveZone dispatches /hostedzone/{id} resource requests.
+func (h *Handler) serveZone(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getHostedZone(w, r, id)
+	case http.MethodDelete:
+		h.deleteHostedZone(w, r, id)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveRRSet dispatches /hostedzone/{id}/rrset requests.
+func (h *Handler) serveRRSet(w http.ResponseWriter, r *http.Request, id string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.changeResourceRecordSets(w, r, id)
+	case http.MethodGet:
+		h.listResourceRecordSets(w, r, id)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	writeError(w, http.StatusMethodNotAllowed, "InvalidInput", "method not allowed")
+}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -31,9 +31,16 @@ func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Echo the caller's CallerReference back faithfully (the driver doesn't
+	// persist it, so this is only recoverable on the create response).
+	hz := toHostedZoneXML(info)
+	if req.CallerReference != "" {
+		hz.CallerReference = req.CallerReference
+	}
+
 	wire.WriteXML(w, http.StatusCreated, createHostedZoneResponse{
 		Xmlns:      xmlns,
-		HostedZone: toHostedZoneXML(info),
+		HostedZone: hz,
 		ChangeInfo: newChangeInfo(),
 	})
 }
@@ -97,7 +104,7 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 
 	for i := range req.ChangeBatch.Changes {
 		if err := h.applyChange(r, zoneID, &req.ChangeBatch.Changes[i]); err != nil {
-			writeErr(w, err)
+			writeChangeErr(w, err)
 			return
 		}
 	}
@@ -127,16 +134,21 @@ func (h *Handler) applyChange(r *http.Request, zoneID string, ch *changeItem) er
 }
 
 // upsertRecord updates the record if it already exists, otherwise creates it —
-// Route 53's UPSERT semantics.
+// Route 53's UPSERT semantics. Only a genuine not-found routes to create; any
+// other GetRecord error (e.g. an injected/transient failure) is propagated so
+// an existing record isn't misrouted into a create → spurious conflict.
 func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) error {
-	if _, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type); err == nil {
+	_, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type)
+	switch {
+	case err == nil:
 		_, uerr := h.dns.UpdateRecord(r.Context(), cfg)
 		return uerr
+	case cerrors.IsNotFound(err):
+		_, cerr := h.dns.CreateRecord(r.Context(), cfg)
+		return cerr
+	default:
+		return err
 	}
-
-	_, err := h.dns.CreateRecord(r.Context(), cfg)
-
-	return err
 }
 
 func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request, id string) {
@@ -215,6 +227,8 @@ func writeError(w http.ResponseWriter, status int, code, msg string) {
 }
 
 // writeErr maps a canonical cloudemu error to a Route 53 XML error response.
+// It is for zone-level operations (Get/Delete/CreateHostedZone), where a
+// missing or duplicate resource is the zone itself.
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
@@ -225,6 +239,21 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
 	case cerrors.IsFailedPrecondition(err):
 		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
+}
+
+// writeChangeErr maps a driver error from a ChangeResourceRecordSets batch. The
+// zone is known to exist here, so a missing/duplicate *record* is a bad change
+// batch — real Route 53 returns InvalidChangeBatch (400), not the zone-level
+// NoSuchHostedZone/HostedZoneAlreadyExists codes.
+func writeChangeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err), cerrors.IsAlreadyExists(err), cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
 	}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -1,0 +1,231 @@
+package route53
+
+import (
+	"encoding/xml"
+	"net/http"
+	"time"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// listMaxItems is the fixed page size echoed back to the SDK; the mock never
+// paginates, so IsTruncated is always false.
+const listMaxItems = 100
+
+func (h *Handler) createHostedZone(w http.ResponseWriter, r *http.Request) {
+	var req createHostedZoneRequest
+	if !decodeXML(w, r, &req) {
+		return
+	}
+
+	cfg := dnsdriver.ZoneConfig{Name: req.Name}
+	if req.HostedZoneConfig != nil {
+		cfg.Private = req.HostedZoneConfig.PrivateZone
+	}
+
+	info, err := h.dns.CreateZone(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteXML(w, http.StatusCreated, createHostedZoneResponse{
+		Xmlns:      xmlns,
+		HostedZone: toHostedZoneXML(info),
+		ChangeInfo: newChangeInfo(),
+	})
+}
+
+func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id string) {
+	info, err := h.dns.GetZone(r.Context(), trimZonePrefix(id))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteXML(w, http.StatusOK, getHostedZoneResponse{
+		Xmlns:      xmlns,
+		HostedZone: toHostedZoneXML(info),
+	})
+}
+
+func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
+	infos, err := h.dns.ListZones(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	zones := make([]hostedZoneXML, 0, len(infos))
+	for i := range infos {
+		zones = append(zones, toHostedZoneXML(&infos[i]))
+	}
+
+	wire.WriteXML(w, http.StatusOK, listHostedZonesResponse{
+		Xmlns:       xmlns,
+		HostedZones: zones,
+		IsTruncated: false,
+		MaxItems:    listMaxItems,
+	})
+}
+
+func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id string) {
+	if err := h.dns.DeleteZone(r.Context(), trimZonePrefix(id)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteXML(w, http.StatusOK, changeResourceRecordSetsResponse{
+		Xmlns:      xmlns,
+		ChangeInfo: newChangeInfo(),
+	})
+}
+
+// changeResourceRecordSets applies a CREATE/UPSERT/DELETE batch against the
+// zone. Changes are applied in order; the whole batch shares one INSYNC
+// ChangeInfo, matching Route 53's atomic-batch semantics closely enough for
+// the SDK's change poller.
+func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Request, id string) {
+	var req changeResourceRecordSetsRequest
+	if !decodeXML(w, r, &req) {
+		return
+	}
+
+	zoneID := trimZonePrefix(id)
+
+	for i := range req.ChangeBatch.Changes {
+		if err := h.applyChange(r, zoneID, &req.ChangeBatch.Changes[i]); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	wire.WriteXML(w, http.StatusOK, changeResourceRecordSetsResponse{
+		Xmlns:      xmlns,
+		ChangeInfo: newChangeInfo(),
+	})
+}
+
+// applyChange executes a single record change against the driver.
+func (h *Handler) applyChange(r *http.Request, zoneID string, ch *changeItem) error {
+	rr := &ch.ResourceRecordSet
+	cfg := recordConfig(zoneID, rr)
+
+	switch ch.Action {
+	case actionDelete:
+		return h.dns.DeleteRecord(r.Context(), zoneID, rr.Name, rr.Type)
+	case actionCreate:
+		_, err := h.dns.CreateRecord(r.Context(), cfg)
+		return err
+	case actionUpsert:
+		return h.upsertRecord(r, cfg)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported change action %q", ch.Action)
+	}
+}
+
+// upsertRecord updates the record if it already exists, otherwise creates it —
+// Route 53's UPSERT semantics.
+func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) error {
+	if _, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type); err == nil {
+		_, uerr := h.dns.UpdateRecord(r.Context(), cfg)
+		return uerr
+	}
+
+	_, err := h.dns.CreateRecord(r.Context(), cfg)
+
+	return err
+}
+
+func (h *Handler) listResourceRecordSets(w http.ResponseWriter, r *http.Request, id string) {
+	records, err := h.dns.ListRecords(r.Context(), trimZonePrefix(id))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	sets := make([]resourceRecordSetXML, 0, len(records))
+	for i := range records {
+		sets = append(sets, toRecordSetXML(&records[i]))
+	}
+
+	wire.WriteXML(w, http.StatusOK, listResourceRecordSetsResponse{
+		Xmlns:              xmlns,
+		ResourceRecordSets: sets,
+		IsTruncated:        false,
+		MaxItems:           listMaxItems,
+	})
+}
+
+// recordConfig builds a driver RecordConfig from a parsed record set element.
+func recordConfig(zoneID string, rr *resourceRecordSetXML) dnsdriver.RecordConfig {
+	values := make([]string, 0, len(rr.ResourceRecords))
+	for _, v := range rr.ResourceRecords {
+		values = append(values, v.Value)
+	}
+
+	cfg := dnsdriver.RecordConfig{
+		ZoneID: zoneID,
+		Name:   rr.Name,
+		Type:   rr.Type,
+		Values: values,
+		SetID:  rr.SetIdentifier,
+	}
+
+	if rr.TTL != nil {
+		cfg.TTL = int(*rr.TTL)
+	}
+
+	if rr.Weight != nil {
+		w := int(*rr.Weight)
+		cfg.Weight = &w
+	}
+
+	return cfg
+}
+
+// newChangeInfo returns a synthetic INSYNC ChangeInfo for a mutating op.
+func newChangeInfo() changeInfoXML {
+	return changeInfoXML{
+		Id:          changeID,
+		Status:      changeStatusInsync,
+		SubmittedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// decodeXML reads an XML request body into v, writing an InvalidInput error and
+// returning false on a decode failure.
+func decodeXML(w http.ResponseWriter, r *http.Request, v any) bool {
+	if err := xml.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "invalid XML: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+// writeError writes a Route 53 XML error response with the given status.
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	wire.WriteXML(w, status, errorResponse{
+		Xmlns: xmlns,
+		Error: errorXML{Code: code, Message: msg},
+	})
+}
+
+// writeErr maps a canonical cloudemu error to a Route 53 XML error response.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "NoSuchHostedZone", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "HostedZoneAlreadyExists", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusBadRequest, "InvalidChangeBatch", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
+}

--- a/server/aws/route53/sdk_roundtrip_test.go
+++ b/server/aws/route53/sdk_roundtrip_test.go
@@ -1,0 +1,237 @@
+package route53_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+	r53types "github.com/aws/aws-sdk-go-v2/service/route53/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newRoute53Client(t *testing.T) *awsr53.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{Route53: cloud.Route53})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awsr53.NewFromConfig(cfg, func(o *awsr53.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKRoute53ZoneLifecycle(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("example.com."),
+		CallerReference: aws.String("ref-1"),
+		HostedZoneConfig: &r53types.HostedZoneConfig{
+			Comment:     aws.String("test zone"),
+			PrivateZone: false,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	if created.HostedZone == nil || aws.ToString(created.HostedZone.Name) != "example.com." {
+		t.Fatalf("CreateHostedZone = %+v, want name example.com.", created.HostedZone)
+	}
+
+	zoneID := aws.ToString(created.HostedZone.Id)
+	if zoneID == "" {
+		t.Fatal("CreateHostedZone returned empty zone id")
+	}
+
+	got, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(zoneID)})
+	if err != nil {
+		t.Fatalf("GetHostedZone: %v", err)
+	}
+
+	if aws.ToString(got.HostedZone.Name) != "example.com." {
+		t.Fatalf("GetHostedZone name = %q, want example.com.", aws.ToString(got.HostedZone.Name))
+	}
+
+	list, err := client.ListHostedZones(ctx, &awsr53.ListHostedZonesInput{})
+	if err != nil {
+		t.Fatalf("ListHostedZones: %v", err)
+	}
+
+	if len(list.HostedZones) != 1 || aws.ToString(list.HostedZones[0].Name) != "example.com." {
+		t.Fatalf("ListHostedZones = %+v, want one zone example.com.", list.HostedZones)
+	}
+
+	if _, err := client.DeleteHostedZone(ctx, &awsr53.DeleteHostedZoneInput{Id: aws.String(zoneID)}); err != nil {
+		t.Fatalf("DeleteHostedZone: %v", err)
+	}
+
+	_, err = client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String(zoneID)})
+
+	var notFound *r53types.NoSuchHostedZone
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetHostedZone after delete: got %v, want NoSuchHostedZone", err)
+	}
+}
+
+func TestSDKRoute53RecordSets(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("records.com."),
+		CallerReference: aws.String("ref-2"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{
+				Action: r53types.ChangeActionCreate,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String("www.records.com."),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(300),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChangeResourceRecordSets(CREATE): %v", err)
+	}
+
+	sets, err := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets: %v", err)
+	}
+
+	if len(sets.ResourceRecordSets) != 1 {
+		t.Fatalf("got %d record sets, want 1: %+v", len(sets.ResourceRecordSets), sets.ResourceRecordSets)
+	}
+
+	rr := sets.ResourceRecordSets[0]
+	if aws.ToString(rr.Name) != "www.records.com." || rr.Type != r53types.RRTypeA || aws.ToInt64(rr.TTL) != 300 {
+		t.Fatalf("record set = %+v, want www.records.com. A 300", rr)
+	}
+
+	if len(rr.ResourceRecords) != 1 || aws.ToString(rr.ResourceRecords[0].Value) != "192.0.2.1" {
+		t.Fatalf("record values = %+v, want [192.0.2.1]", rr.ResourceRecords)
+	}
+
+	// UPSERT changes the value in place.
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{
+				Action: r53types.ChangeActionUpsert,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String("www.records.com."),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(600),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.2")}},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChangeResourceRecordSets(UPSERT): %v", err)
+	}
+
+	sets, err = client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets after upsert: %v", err)
+	}
+
+	if len(sets.ResourceRecordSets) != 1 || aws.ToInt64(sets.ResourceRecordSets[0].TTL) != 600 {
+		t.Fatalf("after upsert = %+v, want single record TTL 600", sets.ResourceRecordSets)
+	}
+
+	// DELETE removes the record.
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{
+				Action: r53types.ChangeActionDelete,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String("www.records.com."),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(600),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.2")}},
+				},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChangeResourceRecordSets(DELETE): %v", err)
+	}
+
+	sets, err = client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if err != nil {
+		t.Fatalf("ListResourceRecordSets after delete: %v", err)
+	}
+
+	if len(sets.ResourceRecordSets) != 0 {
+		t.Fatalf("got %d record sets after delete, want 0: %+v", len(sets.ResourceRecordSets), sets.ResourceRecordSets)
+	}
+}
+
+func TestSDKRoute53Errors(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	_, err := client.GetHostedZone(ctx, &awsr53.GetHostedZoneInput{Id: aws.String("zone-missing")})
+
+	var notFound *r53types.NoSuchHostedZone
+	if !errors.As(err, &notFound) {
+		t.Fatalf("GetHostedZone(missing): got %v, want NoSuchHostedZone", err)
+	}
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String("zone-missing"),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{{
+				Action: r53types.ChangeActionCreate,
+				ResourceRecordSet: &r53types.ResourceRecordSet{
+					Name:            aws.String("a.missing."),
+					Type:            r53types.RRTypeA,
+					TTL:             aws.Int64(60),
+					ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("1.1.1.1")}},
+				},
+			}},
+		},
+	})
+	if err == nil {
+		t.Fatal("ChangeResourceRecordSets(missing zone): want error, got nil")
+	}
+}

--- a/server/aws/route53/sdk_roundtrip_test.go
+++ b/server/aws/route53/sdk_roundtrip_test.go
@@ -58,6 +58,12 @@ func TestSDKRoute53ZoneLifecycle(t *testing.T) {
 		t.Fatalf("CreateHostedZone = %+v, want name example.com.", created.HostedZone)
 	}
 
+	// The caller's CallerReference must round-trip, not be replaced with an
+	// internal id.
+	if got := aws.ToString(created.HostedZone.CallerReference); got != "ref-1" {
+		t.Fatalf("CallerReference = %q, want ref-1", got)
+	}
+
 	zoneID := aws.ToString(created.HostedZone.Id)
 	if zoneID == "" {
 		t.Fatal("CreateHostedZone returned empty zone id")
@@ -233,5 +239,62 @@ func TestSDKRoute53Errors(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("ChangeResourceRecordSets(missing zone): want error, got nil")
+	}
+
+	// A record-level conflict on an existing zone must surface as
+	// InvalidChangeBatch, not the zone-level HostedZoneAlreadyExists.
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("dup.com."),
+		CallerReference: aws.String("dup-ref"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+
+	zoneID := aws.ToString(created.HostedZone.Id)
+	rec := r53types.Change{
+		Action: r53types.ChangeActionCreate,
+		ResourceRecordSet: &r53types.ResourceRecordSet{
+			Name:            aws.String("a.dup.com."),
+			Type:            r53types.RRTypeA,
+			TTL:             aws.Int64(60),
+			ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("1.2.3.4")}},
+		},
+	}
+
+	change := &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch:  &r53types.ChangeBatch{Changes: []r53types.Change{rec}},
+	}
+	if _, err = client.ChangeResourceRecordSets(ctx, change); err != nil {
+		t.Fatalf("ChangeResourceRecordSets(create): %v", err)
+	}
+
+	// Duplicate CREATE of the same record.
+	_, err = client.ChangeResourceRecordSets(ctx, change)
+
+	var badBatch *r53types.InvalidChangeBatch
+	if !errors.As(err, &badBatch) {
+		t.Fatalf("duplicate record CREATE: got %v, want InvalidChangeBatch", err)
+	}
+
+	// DELETE of a record that doesn't exist, on an existing zone → also
+	// InvalidChangeBatch (not NoSuchHostedZone).
+	missDelete := &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{Changes: []r53types.Change{{
+			Action: r53types.ChangeActionDelete,
+			ResourceRecordSet: &r53types.ResourceRecordSet{
+				Name:            aws.String("ghost.dup.com."),
+				Type:            r53types.RRTypeA,
+				TTL:             aws.Int64(60),
+				ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("9.9.9.9")}},
+			},
+		}}},
+	}
+
+	_, err = client.ChangeResourceRecordSets(ctx, missDelete)
+	if !errors.As(err, &badBatch) {
+		t.Fatalf("delete missing record: got %v, want InvalidChangeBatch", err)
 	}
 }

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -154,11 +154,16 @@ func trimZonePrefix(id string) string {
 // is returned bare (not "/hostedzone/{id}"): the SDK binds the id straight into
 // the request URL path with no prefix stripping, so echoing the bare driver id
 // keeps Get/Delete round-trips addressing the same resource.
+//
+// The dns driver does not persist the caller-supplied CallerReference, so on
+// Get/List we surface the zone name (a stable, meaningful value) rather than
+// leaking the internal zone id. CreateHostedZone overrides this with the actual
+// reference the caller sent so a create round-trip is faithful.
 func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
 	return hostedZoneXML{
 		Id:              info.ID,
 		Name:            info.Name,
-		CallerReference: info.ID,
+		CallerReference: info.Name,
 		Config: &hostedZoneConfigXML{
 			PrivateZone: info.Private,
 		},

--- a/server/aws/route53/types.go
+++ b/server/aws/route53/types.go
@@ -1,0 +1,192 @@
+package route53
+
+import (
+	"encoding/xml"
+	"strings"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+)
+
+// xmlns is the Route 53 XML namespace stamped on every response root element.
+const xmlns = "https://route53.amazonaws.com/doc/2013-04-01/"
+
+// Change actions accepted in a ChangeResourceRecordSets batch.
+const (
+	actionCreate = "CREATE"
+	actionUpsert = "UPSERT"
+	actionDelete = "DELETE"
+)
+
+// changeStatusInsync is the terminal ChangeInfo status; our mock applies
+// changes synchronously so every change is immediately INSYNC.
+const changeStatusInsync = "INSYNC"
+
+// changeID is the synthetic ChangeInfo id returned for mutating operations;
+// the SDK's change-tracking poller treats an INSYNC change as done.
+const changeID = "/change/C0000000000000000000"
+
+// --- shared record element ---
+
+// resourceRecordXML is a single record value (<ResourceRecord><Value>…).
+type resourceRecordXML struct {
+	Value string `xml:"Value"`
+}
+
+// resourceRecordSetXML is the Route 53 ResourceRecordSet element.
+type resourceRecordSetXML struct {
+	Name            string              `xml:"Name"`
+	Type            string              `xml:"Type"`
+	SetIdentifier   string              `xml:"SetIdentifier,omitempty"`
+	Weight          *int64              `xml:"Weight,omitempty"`
+	TTL             *int64              `xml:"TTL,omitempty"`
+	ResourceRecords []resourceRecordXML `xml:"ResourceRecords>ResourceRecord,omitempty"`
+}
+
+// --- hosted zone elements ---
+
+type hostedZoneConfigXML struct {
+	Comment     string `xml:"Comment,omitempty"`
+	PrivateZone bool   `xml:"PrivateZone"`
+}
+
+// hostedZoneXML is the Route 53 HostedZone element. Id is returned in the
+// "/hostedzone/{id}" form real Route 53 uses; the SDK accepts either form back
+// as input.
+type hostedZoneXML struct {
+	Id                     string               `xml:"Id"`
+	Name                   string               `xml:"Name"`
+	CallerReference        string               `xml:"CallerReference"`
+	Config                 *hostedZoneConfigXML `xml:"Config,omitempty"`
+	ResourceRecordSetCount int64                `xml:"ResourceRecordSetCount"`
+}
+
+type changeInfoXML struct {
+	Id          string `xml:"Id"`
+	Status      string `xml:"Status"`
+	SubmittedAt string `xml:"SubmittedAt"`
+}
+
+// --- request envelopes ---
+
+type createHostedZoneRequest struct {
+	XMLName          xml.Name             `xml:"CreateHostedZoneRequest"`
+	Name             string               `xml:"Name"`
+	CallerReference  string               `xml:"CallerReference"`
+	HostedZoneConfig *hostedZoneConfigXML `xml:"HostedZoneConfig"`
+}
+
+type changeResourceRecordSetsRequest struct {
+	XMLName     xml.Name    `xml:"ChangeResourceRecordSetsRequest"`
+	ChangeBatch changeBatch `xml:"ChangeBatch"`
+}
+
+type changeBatch struct {
+	Comment string       `xml:"Comment,omitempty"`
+	Changes []changeItem `xml:"Changes>Change"`
+}
+
+type changeItem struct {
+	Action            string               `xml:"Action"`
+	ResourceRecordSet resourceRecordSetXML `xml:"ResourceRecordSet"`
+}
+
+// --- response envelopes ---
+
+type createHostedZoneResponse struct {
+	XMLName    xml.Name      `xml:"CreateHostedZoneResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	HostedZone hostedZoneXML `xml:"HostedZone"`
+	ChangeInfo changeInfoXML `xml:"ChangeInfo"`
+}
+
+type getHostedZoneResponse struct {
+	XMLName    xml.Name      `xml:"GetHostedZoneResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	HostedZone hostedZoneXML `xml:"HostedZone"`
+}
+
+type listHostedZonesResponse struct {
+	XMLName     xml.Name        `xml:"ListHostedZonesResponse"`
+	Xmlns       string          `xml:"xmlns,attr"`
+	HostedZones []hostedZoneXML `xml:"HostedZones>HostedZone"`
+	IsTruncated bool            `xml:"IsTruncated"`
+	MaxItems    int32           `xml:"MaxItems"`
+}
+
+type changeResourceRecordSetsResponse struct {
+	XMLName    xml.Name      `xml:"ChangeResourceRecordSetsResponse"`
+	Xmlns      string        `xml:"xmlns,attr"`
+	ChangeInfo changeInfoXML `xml:"ChangeInfo"`
+}
+
+type listResourceRecordSetsResponse struct {
+	XMLName            xml.Name               `xml:"ListResourceRecordSetsResponse"`
+	Xmlns              string                 `xml:"xmlns,attr"`
+	ResourceRecordSets []resourceRecordSetXML `xml:"ResourceRecordSets>ResourceRecordSet"`
+	IsTruncated        bool                   `xml:"IsTruncated"`
+	MaxItems           int32                  `xml:"MaxItems"`
+}
+
+// errorResponse is the Route 53 XML error body the SDK maps to a typed
+// exception via its <Error><Code> element.
+type errorResponse struct {
+	XMLName xml.Name `xml:"ErrorResponse"`
+	Xmlns   string   `xml:"xmlns,attr"`
+	Error   errorXML `xml:"Error"`
+}
+
+type errorXML struct {
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+// trimZonePrefix strips the "/hostedzone/" prefix real Route 53 wraps zone ids
+// in, so the driver id can be recovered whichever form the SDK echoes back on
+// a subsequent request path.
+func trimZonePrefix(id string) string {
+	id = strings.TrimPrefix(id, "/")
+	id = strings.TrimPrefix(id, "hostedzone/")
+
+	return id
+}
+
+// toHostedZoneXML converts a driver zone into its Route 53 element. The zone id
+// is returned bare (not "/hostedzone/{id}"): the SDK binds the id straight into
+// the request URL path with no prefix stripping, so echoing the bare driver id
+// keeps Get/Delete round-trips addressing the same resource.
+func toHostedZoneXML(info *dnsdriver.ZoneInfo) hostedZoneXML {
+	return hostedZoneXML{
+		Id:              info.ID,
+		Name:            info.Name,
+		CallerReference: info.ID,
+		Config: &hostedZoneConfigXML{
+			PrivateZone: info.Private,
+		},
+		ResourceRecordSetCount: int64(info.RecordCount),
+	}
+}
+
+// toRecordSetXML converts a driver record into its Route 53 element.
+func toRecordSetXML(rec *dnsdriver.RecordInfo) resourceRecordSetXML {
+	ttl := int64(rec.TTL)
+
+	rrs := make([]resourceRecordXML, 0, len(rec.Values))
+	for _, v := range rec.Values {
+		rrs = append(rrs, resourceRecordXML{Value: v})
+	}
+
+	out := resourceRecordSetXML{
+		Name:            rec.Name,
+		Type:            rec.Type,
+		SetIdentifier:   rec.SetID,
+		TTL:             &ttl,
+		ResourceRecords: rrs,
+	}
+
+	if rec.Weight != nil {
+		w := int64(*rec.Weight)
+		out.Weight = &w
+	}
+
+	return out
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -11,6 +11,7 @@ import (
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
@@ -41,6 +42,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks/unitycatalog"
 	"github.com/stackshy/cloudemu/server/azure/databricks/wsfs"
 	"github.com/stackshy/cloudemu/server/azure/disks"
+	dnssrv "github.com/stackshy/cloudemu/server/azure/dns"
 	"github.com/stackshy/cloudemu/server/azure/functions"
 	"github.com/stackshy/cloudemu/server/azure/iam"
 	"github.com/stackshy/cloudemu/server/azure/images"
@@ -85,7 +87,10 @@ type Drivers struct {
 	ACR             crdriver.ContainerRegistry
 	// KeyVault serves the Key Vault secrets data-plane API (/secrets/…)
 	// against the secrets driver.
-	KeyVault            secretsdriver.Secrets
+	KeyVault secretsdriver.Secrets
+	// DNS serves the Azure DNS (Microsoft.Network/dnsZones) ARM API against the
+	// dns driver.
+	DNS                 dnsdriver.DNS
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -140,6 +145,15 @@ func New(d Drivers) *server.Server {
 
 	if d.Network != nil {
 		srv.Register(network.New(d.Network))
+	}
+
+	// Azure DNS shares the Microsoft.Network ARM provider with the network
+	// handler above, but claims a disjoint resource type (dnsZones vs
+	// virtualNetworks / networkSecurityGroups / locations), so registration
+	// order relative to it is unconstrained. Registered before the BlobStorage
+	// fallback.
+	if d.DNS != nil {
+		srv.Register(dnssrv.New(d.DNS))
 	}
 
 	if d.Monitor != nil {

--- a/server/azure/dns/handler.go
+++ b/server/azure/dns/handler.go
@@ -1,0 +1,152 @@
+// Package dns implements the Azure DNS (Microsoft.Network/dnsZones) ARM REST
+// API as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns clients
+// configured with a custom endpoint hit this handler the same way they hit
+// management.azure.com, driving the shared dns driver.
+//
+// Azure DNS shares the Microsoft.Network ARM provider with the VNet handler
+// (server/azure/network), but on a disjoint resource type — this handler
+// claims dnsZones while the network handler claims virtualNetworks /
+// networkSecurityGroups / locations — so registration order between the two is
+// unconstrained. Both must register before the permissive BlobStorage
+// fallback.
+//
+// Azure addresses zones by their user-assigned name in the URL
+// (…/dnsZones/{zoneName}), while the dns driver keys zones on a generated
+// zone-<uuid> id. The handler resolves the SDK-facing name to the driver id via
+// a ListZones scan (resolveZoneID) so callers never see the internal id.
+//
+// Coverage:
+//
+//	PUT    .../dnsZones/{z}                              — Zones.CreateOrUpdate
+//	GET    .../dnsZones/{z}                              — Zones.Get
+//	DELETE .../dnsZones/{z}                              — Zones.Delete (LRO, completes inline)
+//	GET    .../providers/Microsoft.Network/dnsZones      — Zones.List (subscription scope)
+//	GET    .../resourceGroups/{rg}/…/dnsZones            — Zones.ListByResourceGroup
+//	PUT    .../dnsZones/{z}/{type}/{name}                — RecordSets.CreateOrUpdate
+//	GET    .../dnsZones/{z}/{type}/{name}                — RecordSets.Get
+//	DELETE .../dnsZones/{z}/{type}/{name}                — RecordSets.Delete
+//	GET    .../dnsZones/{z}/recordsets|all               — RecordSets.ListByDnsZone / ListAllByDnsZone
+package dns
+
+import (
+	"net/http"
+	"strings"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName = "Microsoft.Network"
+	// typeZones is the RG-scoped resource type. Azure serializes the
+	// subscription-scoped list path in lowercase ("dnszones"), so matching is
+	// case-insensitive.
+	typeZones = "dnsZones"
+
+	// subRecordSets and subAll are the record-set list sub-paths.
+	subRecordSets = "recordsets"
+	subAll        = "all"
+)
+
+// Handler serves Microsoft.Network/dnsZones ARM requests against a dns driver.
+type Handler struct {
+	dns dnsdriver.DNS
+}
+
+// New returns an Azure DNS handler backed by d.
+func New(d dnsdriver.DNS) *Handler {
+	return &Handler{dns: d}
+}
+
+// isZonesType reports whether the ARM resource type is dnsZones, case-
+// insensitively (the subscription-scoped list uses lowercase "dnszones").
+func isZonesType(resourceType string) bool {
+	return strings.EqualFold(resourceType, typeZones)
+}
+
+// Matches claims ARM URLs targeting Microsoft.Network/dnsZones. Disjoint from
+// the network handler (virtualNetworks / networkSecurityGroups / locations) on
+// the same provider, so registration order between them is unconstrained.
+// Registered before the BlobStorage fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && isZonesType(rp.ResourceType)
+}
+
+// ServeHTTP routes on the parsed path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// Collection list: no zone name (subscription- or RG-scoped list).
+	if rp.ResourceName == "" {
+		h.serveZoneCollection(w, r, &rp)
+		return
+	}
+
+	switch rp.SubResource {
+	case "":
+		h.serveZone(w, r, &rp)
+	case subRecordSets, subAll:
+		h.serveRecordSetCollection(w, r, &rp)
+	default:
+		// .../dnsZones/{zone}/{recordType}/{name}
+		h.serveRecordSet(w, r, &rp)
+	}
+}
+
+func (h *Handler) serveZoneCollection(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.listZones(w, r, rp)
+}
+
+func (h *Handler) serveZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateZone(w, r, rp)
+	case http.MethodGet:
+		h.getZone(w, r, rp)
+	case http.MethodDelete:
+		h.deleteZone(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveRecordSetCollection(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.listRecordSets(w, r, rp)
+}
+
+func (h *Handler) serveRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateRecordSet(w, r, rp)
+	case http.MethodGet:
+		h.getRecordSet(w, r, rp)
+	case http.MethodDelete:
+		h.deleteRecordSet(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -1,0 +1,200 @@
+package dns
+
+import (
+	"net/http"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// --- zones ---
+
+func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body zoneJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	private := false
+	if body.Properties != nil {
+		private = privateFromZoneType(body.Properties.ZoneType)
+	}
+
+	// CreateOrUpdate is idempotent: if the zone already exists, echo it back.
+	if id, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
+		info, gerr := h.dns.GetZone(r.Context(), id)
+		if gerr != nil {
+			azurearm.WriteCErr(w, gerr)
+			return
+		}
+
+		azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
+
+		return
+	}
+
+	info, err := h.dns.CreateZone(r.Context(), dnsdriver.ZoneConfig{
+		Name:    rp.ResourceName,
+		Private: private,
+		Tags:    body.Tags,
+	})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusCreated, toZoneJSON(rp, info))
+}
+
+func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	id, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	info, err := h.dns.GetZone(r.Context(), id)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
+}
+
+// deleteZone removes the zone. Zones.Delete is an LRO in the SDK; returning
+// 200 with an empty body completes the poller on the first response.
+func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	id, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if derr := h.dns.DeleteZone(r.Context(), id); derr != nil {
+		azurearm.WriteCErr(w, derr)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	infos, err := h.dns.ListZones(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]zoneJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toZoneJSON(rp, &infos[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, zoneListResult{Value: out})
+}
+
+// --- record sets ---
+
+func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body recordSetJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	recordType := recordTypeSegment(rp.SubResource)
+	name := rp.SubResourceName
+
+	cfg := dnsdriver.RecordConfig{
+		ZoneID: zoneID,
+		Name:   name,
+		Type:   recordType,
+		TTL:    ttlOrDefault(body.Properties),
+		Values: recordValues(recordType, body.Properties),
+	}
+
+	info, err := h.upsertRecord(r, cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusCreated, toRecordSetJSON(rp, rp.ResourceName, info))
+}
+
+// upsertRecord updates the record if it already exists, otherwise creates it —
+// Azure's RecordSets.CreateOrUpdate is upsert semantics.
+func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) (*dnsdriver.RecordInfo, error) {
+	if _, err := h.dns.GetRecord(r.Context(), cfg.ZoneID, cfg.Name, cfg.Type); err == nil {
+		return h.dns.UpdateRecord(r.Context(), cfg)
+	}
+
+	return h.dns.CreateRecord(r.Context(), cfg)
+}
+
+func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	info, err := h.dns.GetRecord(r.Context(), zoneID, rp.SubResourceName, recordTypeSegment(rp.SubResource))
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toRecordSetJSON(rp, rp.ResourceName, info))
+}
+
+func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	derr := h.dns.DeleteRecord(r.Context(), zoneID, rp.SubResourceName, recordTypeSegment(rp.SubResource))
+	if derr != nil && !cerrors.IsNotFound(derr) {
+		azurearm.WriteCErr(w, derr)
+		return
+	}
+
+	// Azure returns 200 for a delete and 204 when the record set was already
+	// absent; either terminates the SDK call cleanly.
+	if cerrors.IsNotFound(derr) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listRecordSets(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	records, err := h.dns.ListRecords(r.Context(), zoneID)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]recordSetJSON, 0, len(records))
+	for i := range records {
+		out = append(out, toRecordSetJSON(rp, rp.ResourceName, &records[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, recordSetListResult{Value: out})
+}

--- a/server/azure/dns/sdk_roundtrip_test.go
+++ b/server/azure/dns/sdk_roundtrip_test.go
@@ -1,0 +1,204 @@
+package dns_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+const (
+	testRG  = "rg-1"
+	testSub = "sub-1"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newDNSClients(t *testing.T) (*armdns.ZonesClient, *armdns.RecordSetsClient) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{DNS: cloudP.DNS})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armdns.NewClientFactory(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("armdns.NewClientFactory: %v", err)
+	}
+
+	return cf.NewZonesClient(), cf.NewRecordSetsClient()
+}
+
+func TestSDKAzureDNSZoneLifecycle(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	created, err := zones.CreateOrUpdate(ctx, testRG, "example.com", armdns.Zone{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "example.com" {
+		t.Fatalf("CreateOrUpdate name = %v, want example.com", created.Name)
+	}
+
+	got, err := zones.Get(ctx, testRG, "example.com", nil)
+	if err != nil {
+		t.Fatalf("Zones.Get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tags = %v, want env=test", got.Tags)
+	}
+
+	var names []string
+
+	pager := zones.NewListByResourceGroupPager(testRG, nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByResourceGroup: %v", perr)
+		}
+
+		for _, z := range page.Value {
+			names = append(names, *z.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "example.com" {
+		t.Fatalf("list = %v, want [example.com]", names)
+	}
+
+	poller, err := zones.BeginDelete(ctx, testRG, "example.com", nil)
+	if err != nil {
+		t.Fatalf("Zones.BeginDelete: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	_, err = zones.Get(ctx, testRG, "example.com", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKAzureDNSRecordSets(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "records.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	set, err := records.CreateOrUpdate(ctx, testRG, "records.com", "www", armdns.RecordTypeA, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:      to.Ptr(int64(300)),
+			ARecords: []*armdns.ARecord{{IPv4Address: to.Ptr("192.0.2.1")}},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate: %v", err)
+	}
+
+	if set.Name == nil || *set.Name != "www" {
+		t.Fatalf("record set name = %v, want www", set.Name)
+	}
+
+	got, err := records.Get(ctx, testRG, "records.com", "www", armdns.RecordTypeA, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get: %v", err)
+	}
+
+	if got.Properties == nil || got.Properties.TTL == nil || *got.Properties.TTL != 300 {
+		t.Fatalf("TTL = %+v, want 300", got.Properties)
+	}
+
+	if len(got.Properties.ARecords) != 1 || *got.Properties.ARecords[0].IPv4Address != "192.0.2.1" {
+		t.Fatalf("ARecords = %+v, want [192.0.2.1]", got.Properties.ARecords)
+	}
+
+	var listed []string
+
+	pager := records.NewListByDNSZonePager(testRG, "records.com", nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByDNSZone: %v", perr)
+		}
+
+		for _, rs := range page.Value {
+			listed = append(listed, *rs.Name)
+		}
+	}
+
+	if len(listed) != 1 || listed[0] != "www" {
+		t.Fatalf("record list = %v, want [www]", listed)
+	}
+
+	if _, err := records.Delete(ctx, testRG, "records.com", "www", armdns.RecordTypeA, nil); err != nil {
+		t.Fatalf("RecordSets.Delete: %v", err)
+	}
+
+	_, err = records.Get(ctx, testRG, "records.com", "www", armdns.RecordTypeA, nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKAzureDNSErrors(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	_, err := zones.Get(ctx, testRG, "missing", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+}

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -1,0 +1,249 @@
+package dns
+
+import (
+	"context"
+	"strings"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// ARM resource type strings stamped on responses.
+const (
+	zoneResourceType    = "Microsoft.Network/dnsZones"
+	recordSetTypePrefix = "Microsoft.Network/dnsZones/"
+	defaultZoneLocation = "global"
+	defaultRecordTTL    = 3600
+)
+
+// --- zone JSON ---
+
+type zoneProperties struct {
+	ZoneType           string   `json:"zoneType,omitempty"`
+	NumberOfRecordSets int64    `json:"numberOfRecordSets,omitempty"`
+	NameServers        []string `json:"nameServers,omitempty"`
+}
+
+type zoneJSON struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name"`
+	Type       string            `json:"type"`
+	Location   string            `json:"location"`
+	Etag       string            `json:"etag,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties *zoneProperties   `json:"properties,omitempty"`
+}
+
+type zoneListResult struct {
+	Value []zoneJSON `json:"value"`
+}
+
+// --- record-set JSON ---
+//
+// Azure models record data as per-type nested arrays. We carry every element
+// type the driver's string values can populate and convert both directions in
+// recordConfig / toRecordSetJSON.
+
+type aRecordJSON struct {
+	IPv4Address string `json:"ipv4Address,omitempty"`
+}
+
+type aaaaRecordJSON struct {
+	IPv6Address string `json:"ipv6Address,omitempty"`
+}
+
+type cnameRecordJSON struct {
+	Cname string `json:"cname,omitempty"`
+}
+
+type txtRecordJSON struct {
+	Value []string `json:"value,omitempty"`
+}
+
+type nsRecordJSON struct {
+	Nsdname string `json:"nsdname,omitempty"`
+}
+
+type ptrRecordJSON struct {
+	Ptrdname string `json:"ptrdname,omitempty"`
+}
+
+type recordSetProperties struct {
+	TTL         *int64           `json:"TTL,omitempty"`
+	Fqdn        string           `json:"fqdn,omitempty"`
+	ARecords    []aRecordJSON    `json:"ARecords,omitempty"`
+	AaaaRecords []aaaaRecordJSON `json:"AAAARecords,omitempty"`
+	CnameRecord *cnameRecordJSON `json:"CNAMERecord,omitempty"`
+	TxtRecords  []txtRecordJSON  `json:"TXTRecords,omitempty"`
+	NsRecords   []nsRecordJSON   `json:"NSRecords,omitempty"`
+	PtrRecords  []ptrRecordJSON  `json:"PTRRecords,omitempty"`
+}
+
+type recordSetJSON struct {
+	ID         string               `json:"id,omitempty"`
+	Name       string               `json:"name"`
+	Type       string               `json:"type"`
+	Etag       string               `json:"etag,omitempty"`
+	Properties *recordSetProperties `json:"properties,omitempty"`
+}
+
+type recordSetListResult struct {
+	Value []recordSetJSON `json:"value"`
+}
+
+// zoneType maps the driver's private flag to Azure's ZoneType enum.
+func zoneType(private bool) string {
+	if private {
+		return "Private"
+	}
+
+	return "Public"
+}
+
+func privateFromZoneType(zt string) bool {
+	return strings.EqualFold(zt, "Private")
+}
+
+// toZoneJSON converts a driver zone into its ARM element for the given path
+// scope. Azure DNS zones are always "global" location.
+func toZoneJSON(rp *azurearm.ResourcePath, info *dnsdriver.ZoneInfo) zoneJSON {
+	return zoneJSON{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeZones, info.Name),
+		Name:     info.Name,
+		Type:     zoneResourceType,
+		Location: defaultZoneLocation,
+		Tags:     info.Tags,
+		Properties: &zoneProperties{
+			ZoneType:           zoneType(info.Private),
+			NumberOfRecordSets: int64(info.RecordCount),
+		},
+	}
+}
+
+// recordValues extracts the driver's flat string values from a typed Azure
+// record-set body, keyed on the record type in the URL.
+func recordValues(recordType string, props *recordSetProperties) []string {
+	if props == nil {
+		return nil
+	}
+
+	switch strings.ToUpper(recordType) {
+	case "A":
+		return mapStrings(props.ARecords, func(a aRecordJSON) string { return a.IPv4Address })
+	case "AAAA":
+		return mapStrings(props.AaaaRecords, func(a aaaaRecordJSON) string { return a.IPv6Address })
+	case "CNAME":
+		if props.CnameRecord != nil {
+			return []string{props.CnameRecord.Cname}
+		}
+	case "TXT":
+		var out []string
+		for _, t := range props.TxtRecords {
+			out = append(out, strings.Join(t.Value, ""))
+		}
+
+		return out
+	case "NS":
+		return mapStrings(props.NsRecords, func(n nsRecordJSON) string { return n.Nsdname })
+	case "PTR":
+		return mapStrings(props.PtrRecords, func(p ptrRecordJSON) string { return p.Ptrdname })
+	}
+
+	return nil
+}
+
+// toRecordSetProperties builds the typed Azure record-set body from a driver
+// record's flat string values, keyed on the record type.
+func toRecordSetProperties(rec *dnsdriver.RecordInfo) *recordSetProperties {
+	ttl := int64(rec.TTL)
+	props := &recordSetProperties{TTL: &ttl}
+
+	switch strings.ToUpper(rec.Type) {
+	case "A":
+		for _, v := range rec.Values {
+			props.ARecords = append(props.ARecords, aRecordJSON{IPv4Address: v})
+		}
+	case "AAAA":
+		for _, v := range rec.Values {
+			props.AaaaRecords = append(props.AaaaRecords, aaaaRecordJSON{IPv6Address: v})
+		}
+	case "CNAME":
+		if len(rec.Values) > 0 {
+			props.CnameRecord = &cnameRecordJSON{Cname: rec.Values[0]}
+		}
+	case "TXT":
+		for _, v := range rec.Values {
+			props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: []string{v}})
+		}
+	case "NS":
+		for _, v := range rec.Values {
+			props.NsRecords = append(props.NsRecords, nsRecordJSON{Nsdname: v})
+		}
+	case "PTR":
+		for _, v := range rec.Values {
+			props.PtrRecords = append(props.PtrRecords, ptrRecordJSON{Ptrdname: v})
+		}
+	}
+
+	return props
+}
+
+// toRecordSetJSON converts a driver record into its ARM element.
+func toRecordSetJSON(rp *azurearm.ResourcePath, zone string, rec *dnsdriver.RecordInfo) recordSetJSON {
+	id := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeZones, zone) +
+		"/" + rec.Type + "/" + rec.Name
+
+	return recordSetJSON{
+		ID:         id,
+		Name:       rec.Name,
+		Type:       recordSetTypePrefix + rec.Type,
+		Properties: toRecordSetProperties(rec),
+	}
+}
+
+// mapStrings projects a typed slice to its string values, dropping empties.
+func mapStrings[T any](in []T, f func(T) string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if s := f(v); s != "" {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+// ttlOrDefault reads the TTL from a record-set body, falling back to the DNS
+// default when absent.
+func ttlOrDefault(props *recordSetProperties) int {
+	if props != nil && props.TTL != nil {
+		return int(*props.TTL)
+	}
+
+	return defaultRecordTTL
+}
+
+// recordTypeSegment normalizes the {recordType} URL segment to the canonical
+// upper-case type the driver stores.
+func recordTypeSegment(s string) string {
+	return strings.ToUpper(s)
+}
+
+// resolveZoneID maps the SDK-facing zone name to the driver's internal zone id
+// by scanning the zone list. Returns a NotFound error if no zone with that name
+// exists.
+func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
+	zones, err := h.dns.ListZones(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range zones {
+		if zones[i].Name == name {
+			return zones[i].ID, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "dns zone %q not found", name)
+}

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -134,7 +134,7 @@ func recordValues(recordType string, props *recordSetProperties) []string {
 	case "AAAA":
 		return mapStrings(props.AaaaRecords, func(a aaaaRecordJSON) string { return a.IPv6Address })
 	case "CNAME":
-		if props.CnameRecord != nil {
+		if props.CnameRecord != nil && props.CnameRecord.Cname != "" {
 			return []string{props.CnameRecord.Cname}
 		}
 	case "TXT":
@@ -239,8 +239,10 @@ func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error
 		return "", err
 	}
 
+	// Azure treats DNS zone names case-insensitively (and lowercases them on
+	// some URL paths), so match without regard to case.
 	for i := range zones {
-		if zones[i].Name == name {
+		if strings.EqualFold(zones[i].Name, name) {
 			return zones[i].ID, nil
 		}
 	}

--- a/server/gcp/clouddns/handler.go
+++ b/server/gcp/clouddns/handler.go
@@ -1,0 +1,166 @@
+// Package clouddns implements the Cloud DNS (dns.googleapis.com) v1 REST API
+// as a server.Handler. Real google.golang.org/api/dns/v1 clients pointed at
+// this server CRUD managed zones, apply record changes, and list record sets
+// end-to-end against the shared dns driver.
+//
+// Cloud DNS addresses managed zones by their user-assigned name in the URL
+// (…/managedZones/{name}), while the dns driver keys zones on a generated
+// zone-<uuid> id. The handler resolves the SDK-facing name to the driver id
+// via a ListZones scan (resolveZoneID) so callers never see the internal id.
+//
+// Coverage (v1 REST):
+//
+//	POST   /dns/v1/projects/{p}/managedZones                        — Create zone
+//	GET    /dns/v1/projects/{p}/managedZones/{z}                    — Get zone
+//	GET    /dns/v1/projects/{p}/managedZones                        — List zones
+//	DELETE /dns/v1/projects/{p}/managedZones/{z}                    — Delete zone
+//	POST   /dns/v1/projects/{p}/managedZones/{z}/changes           — Apply record additions/deletions
+//	GET    /dns/v1/projects/{p}/managedZones/{z}/rrsets            — List record sets
+package clouddns
+
+import (
+	"net/http"
+	"strings"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	pathPrefix      = "/dns/v1/projects/"
+	managedZonesSeg = "managedZones"
+	changesSeg      = "changes"
+	rrsetsSeg       = "rrsets"
+)
+
+// Path-tail segment counts after the [projects, {p}, managedZones] head.
+const (
+	minZonesCollectionParts = 3 // [projects, {p}, managedZones]
+	restZoneResource        = 1 // [{zone}]
+	restZoneSubCollection   = 2 // [{zone}, changes|rrsets]
+)
+
+// Handler serves dns.googleapis.com v1 requests against a dns driver.
+type Handler struct {
+	dns dnsdriver.DNS
+}
+
+// New returns a Cloud DNS handler backed by d.
+func New(d dnsdriver.DNS) *Handler {
+	return &Handler{dns: d}
+}
+
+type route struct {
+	project string
+	zone    string // managed zone name; empty for the collection
+	sub     string // "changes" or "rrsets"; empty for a bare zone
+}
+
+// parseRoute extracts the components of a Cloud DNS v1 path.
+func parseRoute(urlPath string) (route, bool) {
+	if !strings.HasPrefix(urlPath, pathPrefix) {
+		return route{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(urlPath, "/dns/v1/"), "/")
+	if len(parts) < minZonesCollectionParts || parts[0] != "projects" || parts[2] != managedZonesSeg {
+		return route{}, false
+	}
+
+	rt := route{project: parts[1]}
+	rest := parts[minZonesCollectionParts:]
+
+	switch len(rest) {
+	case 0:
+		return rt, true
+	case restZoneResource:
+		rt.zone = rest[0]
+		return rt, true
+	case restZoneSubCollection:
+		rt.zone = rest[0]
+		rt.sub = rest[1]
+
+		return rt, true
+	default:
+		return route{}, false
+	}
+}
+
+// Matches claims /dns/v1/projects/{p}/managedZones[...] paths — a distinct URL
+// space from the /v1/projects/ family (Firestore, IAM, Secret Manager, …), so
+// registration order relative to them is unconstrained. Registered before the
+// GCS fallback for consistency with the other GCP handlers.
+func (*Handler) Matches(r *http.Request) bool {
+	rt, ok := parseRoute(r.URL.Path)
+	return ok && rt.project != ""
+}
+
+// ServeHTTP routes on the parsed path and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unrecognized Cloud DNS path")
+		return
+	}
+
+	switch {
+	case rt.zone == "":
+		h.serveZoneCollection(w, r, rt)
+	case rt.sub == changesSeg:
+		h.serveChanges(w, r, rt)
+	case rt.sub == rrsetsSeg:
+		h.serveRRSets(w, r, rt)
+	case rt.sub == "":
+		h.serveZone(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveZoneCollection dispatches /managedZones collection requests.
+func (h *Handler) serveZoneCollection(w http.ResponseWriter, r *http.Request, rt route) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createZone(w, r, rt)
+	case http.MethodGet:
+		h.listZones(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveZone dispatches /managedZones/{z} resource requests.
+func (h *Handler) serveZone(w http.ResponseWriter, r *http.Request, rt route) {
+	switch r.Method {
+	case http.MethodGet:
+		h.getZone(w, r, rt)
+	case http.MethodDelete:
+		h.deleteZone(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveChanges dispatches /managedZones/{z}/changes requests.
+func (h *Handler) serveChanges(w http.ResponseWriter, r *http.Request, rt route) {
+	if r.Method != http.MethodPost {
+		writeUnsupported(w)
+		return
+	}
+
+	h.createChange(w, r, rt)
+}
+
+// serveRRSets dispatches /managedZones/{z}/rrsets requests.
+func (h *Handler) serveRRSets(w http.ResponseWriter, r *http.Request, rt route) {
+	if r.Method != http.MethodGet {
+		writeUnsupported(w)
+		return
+	}
+
+	h.listRRSets(w, r, rt)
+}
+
+func writeUnsupported(w http.ResponseWriter) {
+	gcprest.WriteError(w, http.StatusBadRequest, "badRequest", "unsupported Cloud DNS operation")
+}

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -1,0 +1,149 @@
+package clouddns
+
+import (
+	"net/http"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
+	var req managedZoneJSON
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.dns.CreateZone(r.Context(), dnsdriver.ZoneConfig{
+		Name:    req.Name,
+		Private: privateFor(req.Visibility),
+		Tags:    req.Labels,
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toManagedZoneJSON(info))
+}
+
+func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rt route) {
+	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	info, err := h.dns.GetZone(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toManagedZoneJSON(info))
+}
+
+func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, _ route) {
+	infos, err := h.dns.ListZones(r.Context())
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]managedZoneJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toManagedZoneJSON(&infos[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, managedZonesListResponse{
+		Kind:         kindManagedZonesList,
+		ManagedZones: out,
+	})
+}
+
+func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
+	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if derr := h.dns.DeleteZone(r.Context(), id); derr != nil {
+		gcprest.WriteCErr(w, derr)
+		return
+	}
+
+	// Cloud DNS Delete returns an empty 200 body.
+	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
+}
+
+// createChange applies a batch of record additions and deletions atomically,
+// mirroring Cloud DNS's Changes.create. Deletions are applied first so a
+// replace (delete old + add new) resolves cleanly.
+func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route) {
+	var req changeJSON
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	for i := range req.Deletions {
+		d := &req.Deletions[i]
+		if derr := h.dns.DeleteRecord(r.Context(), id, d.Name, d.Type); derr != nil {
+			gcprest.WriteCErr(w, derr)
+			return
+		}
+	}
+
+	for i := range req.Additions {
+		a := &req.Additions[i]
+
+		_, aerr := h.dns.CreateRecord(r.Context(), dnsdriver.RecordConfig{
+			ZoneID: id,
+			Name:   a.Name,
+			Type:   a.Type,
+			TTL:    int(a.TTL),
+			Values: a.Rrdatas,
+		})
+		if aerr != nil {
+			gcprest.WriteCErr(w, aerr)
+			return
+		}
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, changeJSON{
+		Kind:      kindChange,
+		ID:        "1",
+		Additions: req.Additions,
+		Deletions: req.Deletions,
+		Status:    changeStatusDone,
+	})
+}
+
+func (h *Handler) listRRSets(w http.ResponseWriter, r *http.Request, rt route) {
+	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	records, err := h.dns.ListRecords(r.Context(), id)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]resourceRecordSetJSON, 0, len(records))
+	for i := range records {
+		out = append(out, toRecordSetJSON(&records[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, resourceRecordSetsListResponse{
+		Kind:   kindResourceRecordSetsList,
+		Rrsets: out,
+	})
+}

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
 	"github.com/stackshy/cloudemu/server/wire/gcprest"
 )
 
@@ -89,6 +90,29 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
+	}
+
+	// Cloud DNS applies a change atomically. The dns driver has no batch/
+	// transaction primitive, so validate the whole batch up front — every
+	// deletion must resolve and no addition may already exist — before any
+	// mutation. This makes a bad batch fail cleanly without half-applying it.
+	// (A concurrent writer between validation and apply could still race; a
+	// true fix needs a driver-level transaction — tracked as a follow-up.)
+	for i := range req.Deletions {
+		d := &req.Deletions[i]
+		if _, gerr := h.dns.GetRecord(r.Context(), id, d.Name, d.Type); gerr != nil {
+			gcprest.WriteCErr(w, gerr)
+			return
+		}
+	}
+
+	for i := range req.Additions {
+		a := &req.Additions[i]
+		if _, gerr := h.dns.GetRecord(r.Context(), id, a.Name, a.Type); gerr == nil {
+			gcprest.WriteCErr(w, cerrors.Newf(cerrors.AlreadyExists,
+				"record set %q %s already exists", a.Name, a.Type))
+			return
+		}
 	}
 
 	for i := range req.Deletions {

--- a/server/gcp/clouddns/sdk_roundtrip_test.go
+++ b/server/gcp/clouddns/sdk_roundtrip_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	dns "google.golang.org/api/dns/v1"
@@ -57,6 +58,15 @@ func TestSDKCloudDNSZoneLifecycle(t *testing.T) {
 
 	if created.Id == 0 {
 		t.Fatalf("Create returned zero zone id: %+v", created)
+	}
+
+	// Cloud DNS lets a zone be addressed by its numeric id as well as its name.
+	byID, err := svc.ManagedZones.Get(testProject, strconv.FormatUint(created.Id, 10)).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Get(by numeric id): %v", err)
+	}
+	if byID.Name != "example-zone" {
+		t.Fatalf("Get(by id) = %q, want example-zone", byID.Name)
 	}
 
 	got, err := svc.ManagedZones.Get(testProject, "example-zone").Context(ctx).Do()

--- a/server/gcp/clouddns/sdk_roundtrip_test.go
+++ b/server/gcp/clouddns/sdk_roundtrip_test.go
@@ -1,0 +1,185 @@
+package clouddns_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const testProject = "demo"
+
+func newDNSService(t *testing.T) *dns.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudDNS: cloud.CloudDNS})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := dns.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("dns.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestSDKCloudDNSZoneLifecycle(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	created, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:        "example-zone",
+		DnsName:     "example.com.",
+		Description: "test zone",
+		Visibility:  "public",
+		Labels:      map[string]string{"env": "test"},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	if created.Name != "example-zone" {
+		t.Fatalf("got zone name %q, want example-zone", created.Name)
+	}
+
+	if created.Id == 0 {
+		t.Fatalf("Create returned zero zone id: %+v", created)
+	}
+
+	got, err := svc.ManagedZones.Get(testProject, "example-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.Get: %v", err)
+	}
+
+	if got.Labels["env"] != "test" {
+		t.Fatalf("labels = %v, want env=test", got.Labels)
+	}
+
+	if got.Visibility != "public" {
+		t.Fatalf("visibility = %q, want public", got.Visibility)
+	}
+
+	list, err := svc.ManagedZones.List(testProject).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ManagedZones.List: %v", err)
+	}
+
+	if len(list.ManagedZones) != 1 || list.ManagedZones[0].Name != "example-zone" {
+		t.Fatalf("List = %+v, want one zone example-zone", list.ManagedZones)
+	}
+
+	if err := svc.ManagedZones.Delete(testProject, "example-zone").Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Delete: %v", err)
+	}
+
+	_, err = svc.ManagedZones.Get(testProject, "example-zone").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKCloudDNSRecordChanges(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "records-zone",
+		DnsName: "records.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("ManagedZones.Create: %v", err)
+	}
+
+	rrset := &dns.ResourceRecordSet{
+		Name:    "www.records.com.",
+		Type:    "A",
+		Ttl:     300,
+		Rrdatas: []string{"192.0.2.1"},
+	}
+
+	change, err := svc.Changes.Create(testProject, "records-zone", &dns.Change{
+		Additions: []*dns.ResourceRecordSet{rrset},
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Changes.Create(add): %v", err)
+	}
+
+	if change.Status != "done" {
+		t.Fatalf("change status = %q, want done", change.Status)
+	}
+
+	rrsets, err := svc.ResourceRecordSets.List(testProject, "records-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ResourceRecordSets.List: %v", err)
+	}
+
+	if len(rrsets.Rrsets) != 1 {
+		t.Fatalf("got %d rrsets, want 1: %+v", len(rrsets.Rrsets), rrsets.Rrsets)
+	}
+
+	got := rrsets.Rrsets[0]
+	if got.Name != "www.records.com." || got.Type != "A" || got.Ttl != 300 {
+		t.Fatalf("rrset = %+v, want www.records.com. A 300", got)
+	}
+
+	if len(got.Rrdatas) != 1 || got.Rrdatas[0] != "192.0.2.1" {
+		t.Fatalf("rrdatas = %v, want [192.0.2.1]", got.Rrdatas)
+	}
+
+	// Delete the record via a change with a deletion.
+	if _, err := svc.Changes.Create(testProject, "records-zone", &dns.Change{
+		Deletions: []*dns.ResourceRecordSet{rrset},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Changes.Create(delete): %v", err)
+	}
+
+	after, err := svc.ResourceRecordSets.List(testProject, "records-zone").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("ResourceRecordSets.List after delete: %v", err)
+	}
+
+	if len(after.Rrsets) != 0 {
+		t.Fatalf("got %d rrsets after delete, want 0: %+v", len(after.Rrsets), after.Rrsets)
+	}
+}
+
+func TestSDKCloudDNSErrors(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	_, err := svc.ManagedZones.Get(testProject, "missing").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+
+	if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+		Name:    "dup",
+		DnsName: "dup.com.",
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Applying a change against a missing zone is a 404.
+	_, err = svc.Changes.Create(testProject, "missing", &dns.Change{
+		Additions: []*dns.ResourceRecordSet{{Name: "a.missing.", Type: "A", Ttl: 60, Rrdatas: []string{"1.1.1.1"}}},
+	}).Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Changes.Create(missing zone): got %v, want 404", err)
+	}
+}

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -1,0 +1,130 @@
+package clouddns
+
+import (
+	"context"
+	"hash/fnv"
+	"strconv"
+
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+)
+
+// Kind values Cloud DNS stamps on its resources; the SDK tolerates them being
+// absent but real responses carry them, so we mirror the wire faithfully.
+const (
+	kindManagedZone            = "dns#managedZone"
+	kindManagedZonesList       = "dns#managedZonesListResponse"
+	kindResourceRecordSet      = "dns#resourceRecordSet"
+	kindResourceRecordSetsList = "dns#resourceRecordSetsListResponse"
+	kindChange                 = "dns#change"
+)
+
+// changeStatusDone is the terminal state Cloud DNS reports once a change has
+// propagated; our mock applies changes synchronously so every change is done.
+const changeStatusDone = "done"
+
+// managedZoneJSON is the Cloud DNS ManagedZone resource. The SDK unmarshals
+// `id` as a uint64 (via a `,string` tag), so it must serialize as a numeric
+// string — see numericID for how the driver's zone-<uuid> id is folded down.
+type managedZoneJSON struct {
+	Kind         string            `json:"kind"`
+	Name         string            `json:"name"`
+	DNSName      string            `json:"dnsName,omitempty"`
+	Description  string            `json:"description,omitempty"`
+	ID           string            `json:"id,omitempty"`
+	Visibility   string            `json:"visibility,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	CreationTime string            `json:"creationTime,omitempty"`
+}
+
+type managedZonesListResponse struct {
+	Kind         string            `json:"kind"`
+	ManagedZones []managedZoneJSON `json:"managedZones"`
+}
+
+// resourceRecordSetJSON is the Cloud DNS ResourceRecordSet resource.
+type resourceRecordSetJSON struct {
+	Kind    string   `json:"kind"`
+	Name    string   `json:"name"`
+	Type    string   `json:"type"`
+	TTL     int64    `json:"ttl"`
+	Rrdatas []string `json:"rrdatas,omitempty"`
+}
+
+type resourceRecordSetsListResponse struct {
+	Kind   string                  `json:"kind"`
+	Rrsets []resourceRecordSetJSON `json:"rrsets"`
+}
+
+// changeJSON is the Cloud DNS Change resource: a batch of record additions and
+// deletions applied atomically.
+type changeJSON struct {
+	Kind      string                  `json:"kind"`
+	ID        string                  `json:"id,omitempty"`
+	Additions []resourceRecordSetJSON `json:"additions,omitempty"`
+	Deletions []resourceRecordSetJSON `json:"deletions,omitempty"`
+	Status    string                  `json:"status,omitempty"`
+	StartTime string                  `json:"startTime,omitempty"`
+}
+
+// visibilityFor maps the driver's private flag to Cloud DNS visibility.
+func visibilityFor(private bool) string {
+	if private {
+		return "private"
+	}
+
+	return "public"
+}
+
+// privateFor is the inverse of visibilityFor.
+func privateFor(visibility string) bool {
+	return visibility == "private"
+}
+
+// numericID folds the driver's zone-<uuid> id into a stable numeric string,
+// which is what the SDK's uint64 `id` field requires on the wire.
+func numericID(id string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(id))
+
+	return strconv.FormatUint(h.Sum64(), 10)
+}
+
+func toManagedZoneJSON(info *dnsdriver.ZoneInfo) managedZoneJSON {
+	return managedZoneJSON{
+		Kind:       kindManagedZone,
+		Name:       info.Name,
+		ID:         numericID(info.ID),
+		Visibility: visibilityFor(info.Private),
+		Labels:     info.Tags,
+		DNSName:    info.Name,
+	}
+}
+
+func toRecordSetJSON(rec *dnsdriver.RecordInfo) resourceRecordSetJSON {
+	return resourceRecordSetJSON{
+		Kind:    kindResourceRecordSet,
+		Name:    rec.Name,
+		Type:    rec.Type,
+		TTL:     int64(rec.TTL),
+		Rrdatas: rec.Values,
+	}
+}
+
+// resolveZoneID maps the SDK-facing managed-zone name to the driver's internal
+// zone id by scanning the zone list. Returns a NotFound error if no zone with
+// that name exists.
+func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
+	zones, err := h.dns.ListZones(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range zones {
+		if zones[i].Name == name {
+			return zones[i].ID, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "managed zone %q not found", name)
+}

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -111,20 +111,22 @@ func toRecordSetJSON(rec *dnsdriver.RecordInfo) resourceRecordSetJSON {
 	}
 }
 
-// resolveZoneID maps the SDK-facing managed-zone name to the driver's internal
-// zone id by scanning the zone list. Returns a NotFound error if no zone with
-// that name exists.
-func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
+// resolveZoneID maps the SDK-facing {managedZone} URL segment to the driver's
+// internal zone id by scanning the zone list. Cloud DNS accepts either the zone
+// name or its numeric id there, so both are matched (the numeric id is the
+// FNV-folded value this handler hands back as ManagedZone.Id). Returns NotFound
+// if no zone matches.
+func (h *Handler) resolveZoneID(ctx context.Context, nameOrID string) (string, error) {
 	zones, err := h.dns.ListZones(ctx)
 	if err != nil {
 		return "", err
 	}
 
 	for i := range zones {
-		if zones[i].Name == name {
+		if zones[i].Name == nameOrID || numericID(zones[i].ID) == nameOrID {
 			return zones[i].ID, nil
 		}
 	}
 
-	return "", cerrors.Newf(cerrors.NotFound, "managed zone %q not found", name)
+	return "", cerrors.Newf(cerrors.NotFound, "managed zone %q not found", nameOrID)
 }

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -10,6 +10,7 @@ import (
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
+	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
@@ -22,6 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
+	"github.com/stackshy/cloudemu/server/gcp/clouddns"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
@@ -53,6 +55,9 @@ type Drivers struct {
 	VertexAI         vertexaidriver.VertexAI
 	IAM              iamdriver.IAM
 	ArtifactRegistry crdriver.ContainerRegistry
+	// CloudDNS serves the dns.googleapis.com v1 REST API against the dns
+	// driver.
+	CloudDNS dnsdriver.DNS
 	// SecretManager serves the secretmanager.googleapis.com v1 REST API
 	// against the secrets driver.
 	SecretManager secretsdriver.Secrets
@@ -155,6 +160,14 @@ func New(d Drivers) *server.Server {
 	// of the /v1/projects/ family. Registered before Firestore's catch-all.
 	if d.SecretManager != nil {
 		srv.Register(secretmanagersrv.New(d.SecretManager))
+	}
+
+	// Cloud DNS matches /dns/v1/projects/{p}/managedZones[...] — a distinct
+	// URL space from the /v1/projects/ family, so registration order is
+	// unconstrained relative to Firestore and the rest. Registered before the
+	// GCS fallback for consistency with the other handlers.
+	if d.CloudDNS != nil {
+		srv.Register(clouddns.New(d.CloudDNS))
 	}
 
 	if d.Firestore != nil {


### PR DESCRIPTION
## Summary

Wires the existing `dns` driver through the SDK-compat HTTP layer across all three providers — the **DNS slice of #143**. Real cloud SDK clients drive the in-memory DNS driver over HTTP with only an endpoint change. Follows the structure and quality bar of the just-merged Secrets slice (#238).

## AWS Route 53 (`server/aws/route53`)
REST/XML. **Operations:** CreateHostedZone, GetHostedZone, ListHostedZones, DeleteHostedZone, ChangeResourceRecordSets (CREATE/UPSERT/DELETE), ListResourceRecordSets.
- `Matches` = path prefix `/2013-04-01/hostedzone` — disjoint from the JSON-RPC (`X-Amz-Target`), query-protocol (`Action=`), and other REST-root handlers. Registered **before S3** (the permissive REST fallback).
- Returns bare driver zone IDs (the aws-sdk binds the ID straight into the request path); `ChangeResourceRecordSets` returns an immediate `INSYNC` ChangeInfo.

## Azure DNS (`server/azure/dns`)
ARM `Microsoft.Network/dnsZones`. **Operations:** zones CreateOrUpdate/Get/Delete/List/ListByResourceGroup; record sets CreateOrUpdate/Get/Delete/ListByDnsZone, converting the driver's flat `Values []string` to/from Azure's typed per-type arrays for A/AAAA/CNAME/TXT/NS/PTR.
- `Matches` = ARM provider `Microsoft.Network` **and** resource type `dnsZones` — disjoint from the existing `network` handler (which claims `virtualNetworks`/`networkSecurityGroups`). Registered **before BlobStorage**.
- Zones addressed by name in the URL → resolved to driver IDs via a `resolveZoneID` scan.

## GCP Cloud DNS (`server/gcp/clouddns`)
`dns/v1` REST/JSON. **Operations:** managedZones create/get/list/delete, changes.create (additions/deletions applied atomically, deletions first), resourceRecordSets.list.
- `Matches` = `/dns/v1/projects/{p}/managedZones[...]` — a distinct URL space from the `/v1/projects/` family (Firestore/IAM/SecretManager). Registered **before Firestore/GCS**.
- `ManagedZone.Id` is a uint64 in the SDK, so the `zone-<uuid>` driver ID is folded to a stable numeric string via FNV-64a (the one place a driver ID isn't echoed verbatim).

## Scope note
Health-check driver methods are intentionally **not** exposed — outside this slice's zones+records scope, and none of the three SDKs' zone/record clients exercise them.

## Tests
Real-SDK roundtrip test per provider (`route53`, `armdns`, `dns/v1`): zone lifecycle (create → get → list → delete → not-found) and record create → list/get → delete, asserted via each SDK's typed responses/errors.

Locally validated (no CI configured yet — see #246): `go build ./...` ✓, `go vet` clean on the new packages, and the **full `go test ./server/...` tree passes fresh** (`-count=1`), so no existing handler regressed. New deps: `service/route53`, `resourcemanager/dns/armdns` (GCP reuses the vendored `google.golang.org/api`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)