### PR TITLE
feat(loadbalancer): SDK-compat servers for ELBv2, Azure LB, and GCP LB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
+	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4 h1:fo6cmbxkKq/OtKUG0sK70fDsYjtK
 github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4/go.mod h1:7VJFM2lSPHz2I1rRb0a+lbphoOp7hXIgYjGhSTOLY7k=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0 h1:OJRqQ6G7RjmwJ9fkhFgcJBSinjrLJxfd5AacBUrhKXc=
+github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0/go.mod h1:qNnJkZTDHDL2sO8hyVH2yILcfSEkjP/pIns2JsF1g1o=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -14,6 +14,7 @@ import (
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -29,6 +30,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/ec2"
 	"github.com/stackshy/cloudemu/server/aws/ecr"
 	"github.com/stackshy/cloudemu/server/aws/eks"
+	"github.com/stackshy/cloudemu/server/aws/elbv2"
 	"github.com/stackshy/cloudemu/server/aws/iam"
 	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/rds"
@@ -67,6 +69,9 @@ type Drivers struct {
 	SecretsManager secretsdriver.Secrets
 	// Route53 serves the Route 53 REST/XML protocol against the dns driver.
 	Route53 dnsdriver.DNS
+	// ELB serves the Elastic Load Balancing v2 (ALB/NLB) query protocol
+	// against the loadbalancer driver.
+	ELB lbdriver.LoadBalancer
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -156,6 +161,14 @@ func New(d Drivers) *server.Server {
 	// and from EC2's (RunInstances, …), so no shadowing occurs.
 	if d.Redshift != nil {
 		srv.Register(redshift.New(d.Redshift))
+	}
+
+	// ELBv2 also speaks AWS query-protocol; its action set (CreateLoadBalancer,
+	// CreateTargetGroup, CreateListener, RegisterTargets, …) is disjoint from
+	// RDS, IAM, Redshift, and EC2. It must register before the EC2 catch-all so
+	// the EC2 handler doesn't claim ELBv2 form bodies first.
+	if d.ELB != nil {
+		srv.Register(elbv2.New(d.ELB))
 	}
 
 	if d.EC2 != nil || d.VPC != nil {

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -1,0 +1,168 @@
+// Package elbv2 implements the AWS Elastic Load Balancing v2 (ALB/NLB)
+// query-protocol as a server.Handler. Point the real aws-sdk-go-v2
+// elasticloadbalancingv2 client at a Server registered with this handler and
+// LoadBalancer / TargetGroup / Listener / Rule / target-health operations work
+// against an in-memory loadbalancer driver.
+//
+// ELBv2 shares the AWS query wire shape with EC2 and RDS (POST + form-encoded
+// body, XML response). To keep dispatch unambiguous, this handler's Matches
+// predicate parses the form body once and only claims requests whose Action is
+// one of the known ELBv2 operations. The EC2 handler is the catch-all for all
+// other query-protocol actions, so this handler MUST register before EC2. Its
+// action set is disjoint from RDS/IAM/Redshift, so ordering relative to those
+// is unconstrained.
+package elbv2
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// Namespace is the XML namespace for AWS ELBv2 responses.
+const Namespace = "http://elasticloadbalancing.amazonaws.com/doc/2015-12-01/"
+
+const (
+	formContentType  = "application/x-www-form-urlencoded"
+	maxFormBodyBytes = 1 << 20
+)
+
+// elbActions is the set of Action values this handler recognizes. Matches uses
+// it to decide whether to claim a request.
+var elbActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"CreateLoadBalancer":    {},
+	"DescribeLoadBalancers": {},
+	"DeleteLoadBalancer":    {},
+	"CreateTargetGroup":     {},
+	"DescribeTargetGroups":  {},
+	"DeleteTargetGroup":     {},
+	"CreateListener":        {},
+	"DescribeListeners":     {},
+	"DeleteListener":        {},
+	"CreateRule":            {},
+	"DescribeRules":         {},
+	"DeleteRule":            {},
+	"RegisterTargets":       {},
+	"DeregisterTargets":     {},
+	"DescribeTargetHealth":  {},
+}
+
+// Handler serves ELBv2 query-protocol requests.
+type Handler struct {
+	lb lbdriver.LoadBalancer
+}
+
+// New returns an ELBv2 handler backed by lb.
+func New(lb lbdriver.LoadBalancer) *Handler {
+	return &Handler{lb: lb}
+}
+
+// Matches returns true if the request looks like an AWS ELBv2 query-protocol
+// call (POST + form-encoded body whose Action is one of the known ELBv2
+// operations). Calling ParseForm here caches the parsed form on the request so
+// ServeHTTP can use it without re-reading the body.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.Header.Get("X-Amz-Target") != "" {
+		return false
+	}
+
+	if r.Method != http.MethodPost {
+		return false
+	}
+
+	if !strings.HasPrefix(r.Header.Get("Content-Type"), formContentType) {
+		return false
+	}
+
+	r.Body = http.MaxBytesReader(nil, r.Body, maxFormBodyBytes)
+	if err := r.ParseForm(); err != nil {
+		return false
+	}
+
+	_, ok := elbActions[r.Form.Get("Action")]
+
+	return ok
+}
+
+// ServeHTTP dispatches on Action. The form has already been parsed by Matches.
+//
+//nolint:gocyclo // 15 cases for one-shot dispatch; splitting into sub-routers would be more complex than the switch.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	action := r.Form.Get("Action")
+
+	switch action {
+	case "CreateLoadBalancer":
+		h.createLoadBalancer(w, r)
+	case "DescribeLoadBalancers":
+		h.describeLoadBalancers(w, r)
+	case "DeleteLoadBalancer":
+		h.deleteLoadBalancer(w, r)
+	case "CreateTargetGroup":
+		h.createTargetGroup(w, r)
+	case "DescribeTargetGroups":
+		h.describeTargetGroups(w, r)
+	case "DeleteTargetGroup":
+		h.deleteTargetGroup(w, r)
+	case "CreateListener":
+		h.createListener(w, r)
+	case "DescribeListeners":
+		h.describeListeners(w, r)
+	case "DeleteListener":
+		h.deleteListener(w, r)
+	case "CreateRule":
+		h.createRule(w, r)
+	case "DescribeRules":
+		h.describeRules(w, r)
+	case "DeleteRule":
+		h.deleteRule(w, r)
+	case "RegisterTargets":
+		h.registerTargets(w, r)
+	case "DeregisterTargets":
+		h.deregisterTargets(w, r)
+	case "DescribeTargetHealth":
+		h.describeTargetHealth(w, r)
+	default:
+		awsquery.WriteXMLError(w, http.StatusBadRequest,
+			"InvalidAction", "unknown ELBv2 action: "+action)
+	}
+}
+
+// writeErr maps cloudemu errors to ELBv2 XML error responses.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, notFoundCode(err), err.Error())
+	case cerrors.IsAlreadyExists(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "DuplicateLoadBalancerName", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "ValidationError", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "ResourceInUse", err.Error())
+	default:
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+	}
+}
+
+// notFoundCode picks the AWS-shaped error code from the error message. The
+// message always carries the resource keyword.
+func notFoundCode(err error) string {
+	msg := err.Error()
+
+	switch {
+	case strings.Contains(msg, "load balancer"):
+		return "LoadBalancerNotFound"
+	case strings.Contains(msg, "target group"):
+		return "TargetGroupNotFound"
+	case strings.Contains(msg, "listener"):
+		return "ListenerNotFound"
+	case strings.Contains(msg, "rule"):
+		return "RuleNotFound"
+	case strings.Contains(msg, "target"):
+		return "TargetGroupNotFound"
+	default:
+		return "ResourceNotFound"
+	}
+}

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -149,6 +149,10 @@ func writeErr(w http.ResponseWriter, err error) {
 // notFoundCode picks the AWS-shaped error code from the error message. The
 // message always carries the resource keyword.
 func notFoundCode(err error) string {
+	// Order matters: a rule's not-found message embeds the parent listener ARN
+	// (which contains "listener"), so "rule" must be checked before "listener"
+	// or a RuleNotFound would be misclassified as ListenerNotFound. Likewise
+	// "target group" before "target".
 	msg := err.Error()
 
 	switch {
@@ -156,10 +160,10 @@ func notFoundCode(err error) string {
 		return "LoadBalancerNotFound"
 	case strings.Contains(msg, "target group"):
 		return "TargetGroupNotFound"
-	case strings.Contains(msg, "listener"):
-		return "ListenerNotFound"
 	case strings.Contains(msg, "rule"):
 		return "RuleNotFound"
+	case strings.Contains(msg, "listener"):
+		return "ListenerNotFound"
 	case strings.Contains(msg, "target"):
 		return "TargetGroupNotFound"
 	default:

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strconv"
 
+	cerrors "github.com/stackshy/cloudemu/errors"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
 	"github.com/stackshy/cloudemu/server/wire/awsquery"
 )
@@ -81,6 +82,13 @@ func (h *Handler) resolveLBArns(r *http.Request) ([]string, error) {
 				arns = append(arns, all[i].ARN)
 			}
 		}
+	}
+
+	// A Names filter that resolves to nothing must not fall through to the
+	// driver's "empty means all" behavior — real ELBv2 returns
+	// LoadBalancerNotFound for a name that doesn't exist.
+	if len(arns) == 0 {
+		return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", names[0])
 	}
 
 	return arns, nil
@@ -173,6 +181,12 @@ func (h *Handler) resolveTGArns(r *http.Request) ([]string, error) {
 				arns = append(arns, all[i].ARN)
 			}
 		}
+	}
+
+	// As in resolveLBArns: a Names filter matching nothing is TargetGroupNotFound,
+	// not "return all".
+	if len(arns) == 0 {
+		return nil, cerrors.Newf(cerrors.NotFound, "target group %q not found", names[0])
 	}
 
 	return arns, nil

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -1,0 +1,618 @@
+package elbv2
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// --- load balancers ---
+
+func (h *Handler) createLoadBalancer(w http.ResponseWriter, r *http.Request) {
+	form := r.Form
+
+	cfg := lbdriver.LBConfig{
+		Name:    form.Get("Name"),
+		Type:    typeOrDefault(form.Get("Type")),
+		Scheme:  schemeOrDefault(form.Get("Scheme")),
+		Subnets: awsquery.ListStrings(form, "Subnets.member"),
+		Tags:    parseTags(form),
+	}
+
+	lb, err := h.lb.CreateLoadBalancer(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createLoadBalancerResponse{
+		Xmlns:    Namespace,
+		Result:   loadBalancersResult{LoadBalancers: loadBalancersXML{Member: []loadBalancerXML{toLoadBalancerXML(lb)}}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeLoadBalancers(w http.ResponseWriter, r *http.Request) {
+	arns, err := h.resolveLBArns(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	lbs, err := h.lb.DescribeLoadBalancers(r.Context(), arns)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := loadBalancersXML{Member: make([]loadBalancerXML, 0, len(lbs))}
+	for i := range lbs {
+		out.Member = append(out.Member, toLoadBalancerXML(&lbs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeLoadBalancersResponse{
+		Xmlns:    Namespace,
+		Result:   loadBalancersResult{LoadBalancers: out},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// resolveLBArns turns the DescribeLoadBalancers filter parameters (arns and/or
+// names) into a list of driver ARNs. An empty result means "all".
+func (h *Handler) resolveLBArns(r *http.Request) ([]string, error) {
+	arns := awsquery.ListStrings(r.Form, "LoadBalancerArns.member")
+
+	names := awsquery.ListStrings(r.Form, "Names.member")
+	if len(names) == 0 {
+		return arns, nil
+	}
+
+	all, err := h.lb.DescribeLoadBalancers(r.Context(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range names {
+		for i := range all {
+			if all[i].Name == name {
+				arns = append(arns, all[i].ARN)
+			}
+		}
+	}
+
+	return arns, nil
+}
+
+func (h *Handler) deleteLoadBalancer(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("LoadBalancerArn")
+
+	if err := h.lb.DeleteLoadBalancer(r.Context(), arn); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteLoadBalancerResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// --- target groups ---
+
+func (h *Handler) createTargetGroup(w http.ResponseWriter, r *http.Request) {
+	form := r.Form
+
+	cfg := lbdriver.TargetGroupConfig{
+		Name:       form.Get("Name"),
+		Protocol:   form.Get("Protocol"),
+		Port:       formInt(form.Get("Port")),
+		VPCID:      form.Get("VpcId"),
+		HealthPath: form.Get("HealthCheckPath"),
+		Tags:       parseTags(form),
+	}
+
+	tg, err := h.lb.CreateTargetGroup(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createTargetGroupResponse{
+		Xmlns:    Namespace,
+		Result:   targetGroupsResult{TargetGroups: targetGroupsXML{Member: []targetGroupXML{toTargetGroupXML(tg)}}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeTargetGroups(w http.ResponseWriter, r *http.Request) {
+	arns, err := h.resolveTGArns(r)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	tgs, err := h.lb.DescribeTargetGroups(r.Context(), arns)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := targetGroupsXML{Member: make([]targetGroupXML, 0, len(tgs))}
+	for i := range tgs {
+		out.Member = append(out.Member, toTargetGroupXML(&tgs[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeTargetGroupsResponse{
+		Xmlns:    Namespace,
+		Result:   targetGroupsResult{TargetGroups: out},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// resolveTGArns turns the DescribeTargetGroups filter parameters (arns and/or
+// names) into a list of driver ARNs. An empty result means "all".
+func (h *Handler) resolveTGArns(r *http.Request) ([]string, error) {
+	arns := awsquery.ListStrings(r.Form, "TargetGroupArns.member")
+
+	names := awsquery.ListStrings(r.Form, "Names.member")
+	if len(names) == 0 {
+		return arns, nil
+	}
+
+	all, err := h.lb.DescribeTargetGroups(r.Context(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, name := range names {
+		for i := range all {
+			if all[i].Name == name {
+				arns = append(arns, all[i].ARN)
+			}
+		}
+	}
+
+	return arns, nil
+}
+
+func (h *Handler) deleteTargetGroup(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("TargetGroupArn")
+
+	if err := h.lb.DeleteTargetGroup(r.Context(), arn); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteTargetGroupResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// --- listeners ---
+
+func (h *Handler) createListener(w http.ResponseWriter, r *http.Request) {
+	form := r.Form
+
+	cfg := lbdriver.ListenerConfig{
+		LBARN:          form.Get("LoadBalancerArn"),
+		Protocol:       form.Get("Protocol"),
+		Port:           formInt(form.Get("Port")),
+		TargetGroupARN: firstForwardTargetGroup(form, "DefaultActions.member"),
+	}
+
+	li, err := h.lb.CreateListener(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createListenerResponse{
+		Xmlns:    Namespace,
+		Result:   listenersResult{Listeners: listenersXML{Member: []listenerXML{toListenerXML(li)}}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeListeners(w http.ResponseWriter, r *http.Request) {
+	lbARN := r.Form.Get("LoadBalancerArn")
+
+	lis, err := h.lb.DescribeListeners(r.Context(), lbARN)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// Filter to specific listener ARNs if requested.
+	if wanted := awsquery.ListStrings(r.Form, "ListenerArns.member"); len(wanted) > 0 {
+		lis = filterListeners(lis, wanted)
+	}
+
+	out := listenersXML{Member: make([]listenerXML, 0, len(lis))}
+	for i := range lis {
+		out.Member = append(out.Member, toListenerXML(&lis[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeListenersResponse{
+		Xmlns:    Namespace,
+		Result:   listenersResult{Listeners: out},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteListener(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("ListenerArn")
+
+	if err := h.lb.DeleteListener(r.Context(), arn); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteListenerResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// --- rules ---
+
+func (h *Handler) createRule(w http.ResponseWriter, r *http.Request) {
+	form := r.Form
+
+	cfg := lbdriver.RuleConfig{
+		ListenerARN: form.Get("ListenerArn"),
+		Priority:    formInt(form.Get("Priority")),
+		Conditions:  parseConditions(form, "Conditions.member"),
+		Actions:     parseActions(form, "Actions.member"),
+	}
+
+	rule, err := h.lb.CreateRule(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createRuleResponse{
+		Xmlns:    Namespace,
+		Result:   rulesResult{Rules: rulesXML{Member: []ruleXML{toRuleXML(rule)}}},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeRules(w http.ResponseWriter, r *http.Request) {
+	listenerARN := r.Form.Get("ListenerArn")
+
+	rules, err := h.lb.DescribeRules(r.Context(), listenerARN)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := rulesXML{Member: make([]ruleXML, 0, len(rules))}
+	for i := range rules {
+		out.Member = append(out.Member, toRuleXML(&rules[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeRulesResponse{
+		Xmlns:    Namespace,
+		Result:   rulesResult{Rules: out},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteRule(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("RuleArn")
+
+	if err := h.lb.DeleteRule(r.Context(), arn); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deleteRuleResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// --- targets / health ---
+
+func (h *Handler) registerTargets(w http.ResponseWriter, r *http.Request) {
+	tgARN := r.Form.Get("TargetGroupArn")
+	targets := parseTargets(r.Form, "Targets.member")
+
+	if err := h.lb.RegisterTargets(r.Context(), tgARN, targets); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, registerTargetsResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deregisterTargets(w http.ResponseWriter, r *http.Request) {
+	tgARN := r.Form.Get("TargetGroupArn")
+	targets := parseTargets(r.Form, "Targets.member")
+
+	if err := h.lb.DeregisterTargets(r.Context(), tgARN, targets); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, deregisterTargetsResponse{
+		Xmlns:    Namespace,
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeTargetHealth(w http.ResponseWriter, r *http.Request) {
+	tgARN := r.Form.Get("TargetGroupArn")
+
+	health, err := h.lb.DescribeTargetHealth(r.Context(), tgARN)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// Optional filter: only the requested targets.
+	if wanted := parseTargets(r.Form, "Targets.member"); len(wanted) > 0 {
+		health = filterHealth(health, wanted)
+	}
+
+	out := targetHealthDescriptionsXML{Member: make([]targetHealthDescriptionXML, 0, len(health))}
+	for i := range health {
+		th := health[i]
+		out.Member = append(out.Member, targetHealthDescriptionXML{
+			Target: targetDescriptionXML{ID: th.Target.ID, Port: th.Target.Port},
+			TargetHealth: &targetHealthXML{
+				State:  th.State,
+				Reason: th.Reason,
+			},
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, describeTargetHealthResponse{
+		Xmlns:    Namespace,
+		Result:   describeTargetHealthResult{TargetHealthDescriptions: out},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// --- form parsing helpers ---
+
+// parseTags parses the ELBv2 Tags.member.N.{Key,Value} entries.
+func parseTags(form url.Values) map[string]string {
+	indices := awsquery.CollectIndices(form, "Tags.member")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(indices))
+
+	for _, n := range indices {
+		base := "Tags.member." + strconv.Itoa(n)
+		if k := form.Get(base + ".Key"); k != "" {
+			out[k] = form.Get(base + ".Value")
+		}
+	}
+
+	return out
+}
+
+// firstForwardTargetGroup returns the TargetGroupArn of the first forward
+// action in the given action-list prefix, checking both the flat form
+// (member.N.TargetGroupArn) and the ForwardConfig shape.
+func firstForwardTargetGroup(form url.Values, prefix string) string {
+	for _, a := range parseActions(form, prefix) {
+		if a.TargetGroupARN != "" {
+			return a.TargetGroupARN
+		}
+	}
+
+	return ""
+}
+
+// parseActions parses an Actions/DefaultActions member list into driver
+// RuleActions. Both the flat TargetGroupArn field and the
+// ForwardConfig.TargetGroups.member.N.TargetGroupArn nesting are accepted.
+func parseActions(form url.Values, prefix string) []lbdriver.RuleAction {
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]lbdriver.RuleAction, 0, len(indices))
+
+	for _, n := range indices {
+		base := prefix + "." + strconv.Itoa(n)
+
+		tgARN := form.Get(base + ".TargetGroupArn")
+		if tgARN == "" {
+			tgARN = form.Get(base + ".ForwardConfig.TargetGroups.member.1.TargetGroupArn")
+		}
+
+		out = append(out, lbdriver.RuleAction{
+			Type:           typeOr(form.Get(base+".Type"), "forward"),
+			TargetGroupARN: tgARN,
+		})
+	}
+
+	return out
+}
+
+// parseConditions parses a Conditions member list into driver RuleConditions.
+func parseConditions(form url.Values, prefix string) []lbdriver.RuleCondition {
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]lbdriver.RuleCondition, 0, len(indices))
+
+	for _, n := range indices {
+		base := prefix + "." + strconv.Itoa(n)
+
+		field := form.Get(base + ".Field")
+
+		values := awsquery.ListStrings(form, base+".Values.member")
+		if len(values) == 0 {
+			// Some SDKs nest values under the typed config
+			// (PathPatternConfig / HostHeaderConfig).
+			values = append(values,
+				awsquery.ListStrings(form, base+".PathPatternConfig.Values.member")...)
+			values = append(values,
+				awsquery.ListStrings(form, base+".HostHeaderConfig.Values.member")...)
+		}
+
+		out = append(out, lbdriver.RuleCondition{Field: field, Values: values})
+	}
+
+	return out
+}
+
+// parseTargets parses a Targets member list into driver Targets.
+func parseTargets(form url.Values, prefix string) []lbdriver.Target {
+	indices := awsquery.CollectIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make([]lbdriver.Target, 0, len(indices))
+
+	for _, n := range indices {
+		base := prefix + "." + strconv.Itoa(n)
+
+		id := form.Get(base + ".Id")
+		if id == "" {
+			continue
+		}
+
+		out = append(out, lbdriver.Target{ID: id, Port: formInt(form.Get(base + ".Port"))})
+	}
+
+	return out
+}
+
+// filterListeners keeps only listeners whose ARN is in wanted.
+func filterListeners(lis []lbdriver.ListenerInfo, wanted []string) []lbdriver.ListenerInfo {
+	set := make(map[string]struct{}, len(wanted))
+	for _, w := range wanted {
+		set[w] = struct{}{}
+	}
+
+	out := lis[:0]
+	for i := range lis {
+		if _, ok := set[lis[i].ARN]; ok {
+			out = append(out, lis[i])
+		}
+	}
+
+	return out
+}
+
+// filterHealth keeps only the health entries whose target ID appears in wanted.
+func filterHealth(health []lbdriver.TargetHealth, wanted []lbdriver.Target) []lbdriver.TargetHealth {
+	set := make(map[string]struct{}, len(wanted))
+	for _, t := range wanted {
+		set[t.ID] = struct{}{}
+	}
+
+	out := health[:0]
+	for i := range health {
+		if _, ok := set[health[i].Target.ID]; ok {
+			out = append(out, health[i])
+		}
+	}
+
+	return out
+}
+
+// toRuleXML converts a driver RuleInfo to its XML representation.
+func toRuleXML(rule *lbdriver.RuleInfo) ruleXML {
+	out := ruleXML{
+		RuleArn:   rule.ARN,
+		Priority:  priorityString(rule.Priority, rule.IsDefault),
+		IsDefault: rule.IsDefault,
+	}
+
+	if len(rule.Conditions) > 0 {
+		conds := &ruleConditionsXML{}
+		for _, c := range rule.Conditions {
+			conds.Member = append(conds.Member, ruleConditionXML{
+				Field:  c.Field,
+				Values: &stringListXML{Member: c.Values},
+			})
+		}
+
+		out.Conditions = conds
+	}
+
+	if len(rule.Actions) > 0 {
+		acts := &actionsXML{}
+		for _, a := range rule.Actions {
+			acts.Member = append(acts.Member, actionXML{
+				Type:           a.Type,
+				TargetGroupArn: a.TargetGroupARN,
+			})
+		}
+
+		out.Actions = acts
+	}
+
+	return out
+}
+
+// priorityString renders a rule priority for the wire. Default rules serialize
+// as "default"; others as their numeric priority.
+func priorityString(priority int, isDefault bool) string {
+	if isDefault {
+		return "default"
+	}
+
+	return strconv.Itoa(priority)
+}
+
+// typeOrDefault maps an empty load-balancer type to ELBv2's default
+// ("application").
+func typeOrDefault(t string) string {
+	if t == "" {
+		return "application"
+	}
+
+	return t
+}
+
+// schemeOrDefault maps an empty scheme to ELBv2's default ("internet-facing").
+func schemeOrDefault(s string) string {
+	if s == "" {
+		return "internet-facing"
+	}
+
+	return s
+}
+
+func typeOr(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+
+	return v
+}
+
+// formInt returns the integer value of a form field, or 0 on missing/parse error.
+func formInt(v string) int {
+	if v == "" {
+		return 0
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0
+	}
+
+	return n
+}

--- a/server/aws/elbv2/sdk_roundtrip_test.go
+++ b/server/aws/elbv2/sdk_roundtrip_test.go
@@ -1,0 +1,310 @@
+package elbv2_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	elb "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	elbtypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newSDKClient(t *testing.T) *elb.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		ELB: cloud.ELB,
+		// EC2 also wired so we exercise the dispatch precedence: a request for
+		// ELBv2 must claim the body before EC2 sees it.
+		EC2: cloud.EC2,
+		VPC: cloud.VPC,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return elb.NewFromConfig(cfg, func(o *elb.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKELBLoadBalancerLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("my-alb"),
+		Type:    elbtypes.LoadBalancerTypeEnumApplication,
+		Scheme:  elbtypes.LoadBalancerSchemeEnumInternetFacing,
+		Subnets: []string{"subnet-a", "subnet-b"},
+		Tags:    []elbtypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	if len(created.LoadBalancers) != 1 {
+		t.Fatalf("got %d load balancers, want 1", len(created.LoadBalancers))
+	}
+
+	lb := created.LoadBalancers[0]
+	if aws.ToString(lb.LoadBalancerName) != "my-alb" {
+		t.Fatalf("name = %q, want my-alb", aws.ToString(lb.LoadBalancerName))
+	}
+
+	arn := aws.ToString(lb.LoadBalancerArn)
+	if arn == "" {
+		t.Fatal("expected a load balancer ARN")
+	}
+
+	if lb.DNSName == nil || aws.ToString(lb.DNSName) == "" {
+		t.Fatal("expected a DNS name")
+	}
+
+	// Describe by ARN.
+	got, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{
+		LoadBalancerArns: []string{arn},
+	})
+	if err != nil {
+		t.Fatalf("DescribeLoadBalancers by ARN: %v", err)
+	}
+
+	if len(got.LoadBalancers) != 1 || aws.ToString(got.LoadBalancers[0].LoadBalancerArn) != arn {
+		t.Fatalf("describe by ARN = %+v, want the created LB", got.LoadBalancers)
+	}
+
+	// Describe by name.
+	byName, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{
+		Names: []string{"my-alb"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeLoadBalancers by name: %v", err)
+	}
+
+	if len(byName.LoadBalancers) != 1 {
+		t.Fatalf("describe by name got %d, want 1", len(byName.LoadBalancers))
+	}
+
+	// List all.
+	all, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{})
+	if err != nil {
+		t.Fatalf("DescribeLoadBalancers all: %v", err)
+	}
+
+	if len(all.LoadBalancers) != 1 {
+		t.Fatalf("list all got %d, want 1", len(all.LoadBalancers))
+	}
+
+	if _, err := client.DeleteLoadBalancer(ctx, &elb.DeleteLoadBalancerInput{
+		LoadBalancerArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("DeleteLoadBalancer: %v", err)
+	}
+
+	// After delete the ARN lookup returns nothing (driver drops the entry).
+	after, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{})
+	if err != nil {
+		t.Fatalf("DescribeLoadBalancers after delete: %v", err)
+	}
+
+	if len(after.LoadBalancers) != 0 {
+		t.Fatalf("after delete got %d LBs, want 0", len(after.LoadBalancers))
+	}
+}
+
+func TestSDKELBDeleteMissingLoadBalancer(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.DeleteLoadBalancer(ctx, &elb.DeleteLoadBalancerInput{
+		LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/missing"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("DeleteLoadBalancer(missing): want API error, got %v", err)
+	}
+
+	if apiErr.ErrorCode() != "LoadBalancerNotFound" {
+		t.Fatalf("error code = %q, want LoadBalancerNotFound", apiErr.ErrorCode())
+	}
+}
+
+func TestSDKELBTargetGroupAndTargets(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:            aws.String("web-tg"),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		VpcId:           aws.String("vpc-123"),
+		HealthCheckPath: aws.String("/healthz"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	if len(tgOut.TargetGroups) != 1 {
+		t.Fatalf("got %d target groups, want 1", len(tgOut.TargetGroups))
+	}
+
+	tg := tgOut.TargetGroups[0]
+	tgARN := aws.ToString(tg.TargetGroupArn)
+
+	if aws.ToString(tg.TargetGroupName) != "web-tg" {
+		t.Fatalf("tg name = %q, want web-tg", aws.ToString(tg.TargetGroupName))
+	}
+
+	if aws.ToInt32(tg.Port) != 80 {
+		t.Fatalf("tg port = %d, want 80", aws.ToInt32(tg.Port))
+	}
+
+	desc, err := client.DescribeTargetGroups(ctx, &elb.DescribeTargetGroupsInput{
+		Names: []string{"web-tg"},
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetGroups: %v", err)
+	}
+
+	if len(desc.TargetGroups) != 1 {
+		t.Fatalf("describe tg got %d, want 1", len(desc.TargetGroups))
+	}
+
+	// Register targets and query their health.
+	if _, err := client.RegisterTargets(ctx, &elb.RegisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets: []elbtypes.TargetDescription{
+			{Id: aws.String("i-111"), Port: aws.Int32(80)},
+			{Id: aws.String("i-222"), Port: aws.Int32(80)},
+		},
+	}); err != nil {
+		t.Fatalf("RegisterTargets: %v", err)
+	}
+
+	health, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth: %v", err)
+	}
+
+	if len(health.TargetHealthDescriptions) != 2 {
+		t.Fatalf("target health got %d entries, want 2", len(health.TargetHealthDescriptions))
+	}
+
+	if _, err := client.DeregisterTargets(ctx, &elb.DeregisterTargetsInput{
+		TargetGroupArn: aws.String(tgARN),
+		Targets:        []elbtypes.TargetDescription{{Id: aws.String("i-111")}},
+	}); err != nil {
+		t.Fatalf("DeregisterTargets: %v", err)
+	}
+
+	health2, err := client.DescribeTargetHealth(ctx, &elb.DescribeTargetHealthInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetHealth after deregister: %v", err)
+	}
+
+	if len(health2.TargetHealthDescriptions) != 1 {
+		t.Fatalf("target health after deregister got %d, want 1", len(health2.TargetHealthDescriptions))
+	}
+
+	if _, err := client.DeleteTargetGroup(ctx, &elb.DeleteTargetGroupInput{
+		TargetGroupArn: aws.String(tgARN),
+	}); err != nil {
+		t.Fatalf("DeleteTargetGroup: %v", err)
+	}
+}
+
+func TestSDKELBListenerLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	lbOut, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+		Name:    aws.String("listener-alb"),
+		Subnets: []string{"subnet-a"},
+	})
+	if err != nil {
+		t.Fatalf("CreateLoadBalancer: %v", err)
+	}
+
+	lbARN := aws.ToString(lbOut.LoadBalancers[0].LoadBalancerArn)
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("listener-tg"),
+		Protocol: elbtypes.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+
+	liOut, err := client.CreateListener(ctx, &elb.CreateListenerInput{
+		LoadBalancerArn: aws.String(lbARN),
+		Protocol:        elbtypes.ProtocolEnumHttp,
+		Port:            aws.Int32(80),
+		DefaultActions: []elbtypes.Action{{
+			Type:           elbtypes.ActionTypeEnumForward,
+			TargetGroupArn: aws.String(tgARN),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateListener: %v", err)
+	}
+
+	if len(liOut.Listeners) != 1 {
+		t.Fatalf("got %d listeners, want 1", len(liOut.Listeners))
+	}
+
+	li := liOut.Listeners[0]
+	liARN := aws.ToString(li.ListenerArn)
+
+	if aws.ToInt32(li.Port) != 80 {
+		t.Fatalf("listener port = %d, want 80", aws.ToInt32(li.Port))
+	}
+
+	if len(li.DefaultActions) != 1 || aws.ToString(li.DefaultActions[0].TargetGroupArn) != tgARN {
+		t.Fatalf("listener default action = %+v, want forward to %s", li.DefaultActions, tgARN)
+	}
+
+	desc, err := client.DescribeListeners(ctx, &elb.DescribeListenersInput{
+		LoadBalancerArn: aws.String(lbARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeListeners: %v", err)
+	}
+
+	if len(desc.Listeners) != 1 || aws.ToString(desc.Listeners[0].ListenerArn) != liARN {
+		t.Fatalf("describe listeners = %+v, want the created listener", desc.Listeners)
+	}
+
+	if _, err := client.DeleteListener(ctx, &elb.DeleteListenerInput{
+		ListenerArn: aws.String(liARN),
+	}); err != nil {
+		t.Fatalf("DeleteListener: %v", err)
+	}
+}

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -1,0 +1,323 @@
+package elbv2
+
+import (
+	"encoding/xml"
+
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+)
+
+// All ELBv2 query-protocol responses are wrapped in <FooResponse> with a
+// <FooResult> child and a trailing <ResponseMetadata>. Lists are wrapped in a
+// <member> element per entry. The structures below mirror the AWS-published XML
+// closely enough that aws-sdk-go-v2's elasticloadbalancingv2 unmarshalers
+// consume them (the SDK matches element names case-insensitively).
+
+type responseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+// emptyResult is the payload for operations that return no data. The SDK still
+// looks up the <XxxResult> element, so every response must carry one even when
+// it's empty.
+type emptyResult struct{}
+
+// --- load balancer ---
+
+type loadBalancerStateXML struct {
+	Code   string `xml:"Code,omitempty"`
+	Reason string `xml:"Reason,omitempty"`
+}
+
+type availabilityZoneXML struct {
+	SubnetID string `xml:"SubnetId,omitempty"`
+}
+
+type availabilityZonesXML struct {
+	Member []availabilityZoneXML `xml:"member,omitempty"`
+}
+
+type loadBalancerXML struct {
+	LoadBalancerArn   string                `xml:"LoadBalancerArn"`
+	LoadBalancerName  string                `xml:"LoadBalancerName"`
+	DNSName           string                `xml:"DNSName,omitempty"`
+	Scheme            string                `xml:"Scheme,omitempty"`
+	Type              string                `xml:"Type,omitempty"`
+	VpcID             string                `xml:"VpcId,omitempty"`
+	State             *loadBalancerStateXML `xml:"State,omitempty"`
+	AvailabilityZones *availabilityZonesXML `xml:"AvailabilityZones,omitempty"`
+}
+
+type loadBalancersXML struct {
+	Member []loadBalancerXML `xml:"member,omitempty"`
+}
+
+type loadBalancersResult struct {
+	LoadBalancers loadBalancersXML `xml:"LoadBalancers"`
+}
+
+type createLoadBalancerResponse struct {
+	XMLName  xml.Name            `xml:"CreateLoadBalancerResponse"`
+	Xmlns    string              `xml:"xmlns,attr"`
+	Result   loadBalancersResult `xml:"CreateLoadBalancerResult"`
+	Metadata responseMetadata    `xml:"ResponseMetadata"`
+}
+
+type describeLoadBalancersResponse struct {
+	XMLName  xml.Name            `xml:"DescribeLoadBalancersResponse"`
+	Xmlns    string              `xml:"xmlns,attr"`
+	Result   loadBalancersResult `xml:"DescribeLoadBalancersResult"`
+	Metadata responseMetadata    `xml:"ResponseMetadata"`
+}
+
+type deleteLoadBalancerResponse struct {
+	XMLName  xml.Name         `xml:"DeleteLoadBalancerResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   emptyResult      `xml:"DeleteLoadBalancerResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// --- target group ---
+
+type targetGroupXML struct {
+	TargetGroupArn  string `xml:"TargetGroupArn"`
+	TargetGroupName string `xml:"TargetGroupName"`
+	Protocol        string `xml:"Protocol,omitempty"`
+	Port            int    `xml:"Port,omitempty"`
+	VpcID           string `xml:"VpcId,omitempty"`
+	TargetType      string `xml:"TargetType,omitempty"`
+	HealthCheckPath string `xml:"HealthCheckPath,omitempty"`
+}
+
+type targetGroupsXML struct {
+	Member []targetGroupXML `xml:"member,omitempty"`
+}
+
+type targetGroupsResult struct {
+	TargetGroups targetGroupsXML `xml:"TargetGroups"`
+}
+
+type createTargetGroupResponse struct {
+	XMLName  xml.Name           `xml:"CreateTargetGroupResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   targetGroupsResult `xml:"CreateTargetGroupResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+type describeTargetGroupsResponse struct {
+	XMLName  xml.Name           `xml:"DescribeTargetGroupsResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   targetGroupsResult `xml:"DescribeTargetGroupsResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+type deleteTargetGroupResponse struct {
+	XMLName  xml.Name         `xml:"DeleteTargetGroupResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   emptyResult      `xml:"DeleteTargetGroupResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// --- listener / actions ---
+
+type actionXML struct {
+	Type           string `xml:"Type"`
+	TargetGroupArn string `xml:"TargetGroupArn,omitempty"`
+	Order          int    `xml:"Order,omitempty"`
+}
+
+type actionsXML struct {
+	Member []actionXML `xml:"member,omitempty"`
+}
+
+type listenerXML struct {
+	ListenerArn     string      `xml:"ListenerArn"`
+	LoadBalancerArn string      `xml:"LoadBalancerArn,omitempty"`
+	Protocol        string      `xml:"Protocol,omitempty"`
+	Port            int         `xml:"Port,omitempty"`
+	DefaultActions  *actionsXML `xml:"DefaultActions,omitempty"`
+}
+
+type listenersXML struct {
+	Member []listenerXML `xml:"member,omitempty"`
+}
+
+type listenersResult struct {
+	Listeners listenersXML `xml:"Listeners"`
+}
+
+type createListenerResponse struct {
+	XMLName  xml.Name         `xml:"CreateListenerResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   listenersResult  `xml:"CreateListenerResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type describeListenersResponse struct {
+	XMLName  xml.Name         `xml:"DescribeListenersResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   listenersResult  `xml:"DescribeListenersResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteListenerResponse struct {
+	XMLName  xml.Name         `xml:"DeleteListenerResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   emptyResult      `xml:"DeleteListenerResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// --- rules ---
+
+type ruleConditionXML struct {
+	Field  string         `xml:"Field,omitempty"`
+	Values *stringListXML `xml:"Values,omitempty"`
+}
+
+type ruleConditionsXML struct {
+	Member []ruleConditionXML `xml:"member,omitempty"`
+}
+
+type stringListXML struct {
+	Member []string `xml:"member,omitempty"`
+}
+
+type ruleXML struct {
+	RuleArn    string             `xml:"RuleArn"`
+	Priority   string             `xml:"Priority,omitempty"`
+	Conditions *ruleConditionsXML `xml:"Conditions,omitempty"`
+	Actions    *actionsXML        `xml:"Actions,omitempty"`
+	IsDefault  bool               `xml:"IsDefault"`
+}
+
+type rulesXML struct {
+	Member []ruleXML `xml:"member,omitempty"`
+}
+
+type rulesResult struct {
+	Rules rulesXML `xml:"Rules"`
+}
+
+type createRuleResponse struct {
+	XMLName  xml.Name         `xml:"CreateRuleResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   rulesResult      `xml:"CreateRuleResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type describeRulesResponse struct {
+	XMLName  xml.Name         `xml:"DescribeRulesResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   rulesResult      `xml:"DescribeRulesResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deleteRuleResponse struct {
+	XMLName  xml.Name         `xml:"DeleteRuleResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   emptyResult      `xml:"DeleteRuleResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// --- targets / health ---
+
+type targetDescriptionXML struct {
+	ID   string `xml:"Id"`
+	Port int    `xml:"Port,omitempty"`
+}
+
+type targetHealthXML struct {
+	State  string `xml:"State,omitempty"`
+	Reason string `xml:"Reason,omitempty"`
+}
+
+type targetHealthDescriptionXML struct {
+	Target       targetDescriptionXML `xml:"Target"`
+	TargetHealth *targetHealthXML     `xml:"TargetHealth,omitempty"`
+}
+
+type targetHealthDescriptionsXML struct {
+	Member []targetHealthDescriptionXML `xml:"member,omitempty"`
+}
+
+type describeTargetHealthResult struct {
+	TargetHealthDescriptions targetHealthDescriptionsXML `xml:"TargetHealthDescriptions"`
+}
+
+type registerTargetsResponse struct {
+	XMLName  xml.Name         `xml:"RegisterTargetsResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   emptyResult      `xml:"RegisterTargetsResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type deregisterTargetsResponse struct {
+	XMLName  xml.Name         `xml:"DeregisterTargetsResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   emptyResult      `xml:"DeregisterTargetsResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type describeTargetHealthResponse struct {
+	XMLName  xml.Name                   `xml:"DescribeTargetHealthResponse"`
+	Xmlns    string                     `xml:"xmlns,attr"`
+	Result   describeTargetHealthResult `xml:"DescribeTargetHealthResult"`
+	Metadata responseMetadata           `xml:"ResponseMetadata"`
+}
+
+// toLoadBalancerXML converts a driver LBInfo to its XML representation.
+func toLoadBalancerXML(lb *lbdriver.LBInfo) loadBalancerXML {
+	out := loadBalancerXML{
+		LoadBalancerArn:  lb.ARN,
+		LoadBalancerName: lb.Name,
+		DNSName:          lb.DNSName,
+		Scheme:           lb.Scheme,
+		Type:             lb.Type,
+		State:            &loadBalancerStateXML{Code: lb.State},
+	}
+
+	if len(lb.Subnets) > 0 {
+		az := &availabilityZonesXML{}
+		for _, s := range lb.Subnets {
+			az.Member = append(az.Member, availabilityZoneXML{SubnetID: s})
+		}
+
+		out.AvailabilityZones = az
+	}
+
+	return out
+}
+
+// toTargetGroupXML converts a driver TargetGroupInfo to its XML representation.
+func toTargetGroupXML(tg *lbdriver.TargetGroupInfo) targetGroupXML {
+	return targetGroupXML{
+		TargetGroupArn:  tg.ARN,
+		TargetGroupName: tg.Name,
+		Protocol:        tg.Protocol,
+		Port:            tg.Port,
+		VpcID:           tg.VPCID,
+		TargetType:      "instance",
+		HealthCheckPath: tg.HealthPath,
+	}
+}
+
+// toListenerXML converts a driver ListenerInfo to its XML representation. The
+// forward-to-target-group default action is reconstructed from the stored
+// TargetGroupARN.
+func toListenerXML(li *lbdriver.ListenerInfo) listenerXML {
+	out := listenerXML{
+		ListenerArn:     li.ARN,
+		LoadBalancerArn: li.LBARN,
+		Protocol:        li.Protocol,
+		Port:            li.Port,
+	}
+
+	if li.TargetGroupARN != "" {
+		out.DefaultActions = &actionsXML{Member: []actionXML{{
+			Type:           "forward",
+			TargetGroupArn: li.TargetGroupARN,
+			Order:          1,
+		}}}
+	}
+
+	return out
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -14,6 +14,7 @@ import (
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -47,6 +48,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/iam"
 	"github.com/stackshy/cloudemu/server/azure/images"
 	keyvaultsrv "github.com/stackshy/cloudemu/server/azure/keyvault"
+	lbsrv "github.com/stackshy/cloudemu/server/azure/loadbalancer"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
 	"github.com/stackshy/cloudemu/server/azure/network"
@@ -90,7 +92,10 @@ type Drivers struct {
 	KeyVault secretsdriver.Secrets
 	// DNS serves the Azure DNS (Microsoft.Network/dnsZones) ARM API against the
 	// dns driver.
-	DNS                 dnsdriver.DNS
+	DNS dnsdriver.DNS
+	// LB serves the Azure Load Balancer (Microsoft.Network/loadBalancers) ARM
+	// API against the loadbalancer driver.
+	LB                  lbdriver.LoadBalancer
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -154,6 +159,15 @@ func New(d Drivers) *server.Server {
 	// fallback.
 	if d.DNS != nil {
 		srv.Register(dnssrv.New(d.DNS))
+	}
+
+	// Azure Load Balancer shares the Microsoft.Network ARM provider with the
+	// network handler above and the DNS handler, but claims a disjoint resource
+	// type (loadBalancers vs virtualNetworks / networkSecurityGroups /
+	// locations / dnsZones), so registration order relative to them is
+	// unconstrained. Registered before the BlobStorage fallback.
+	if d.LB != nil {
+		srv.Register(lbsrv.New(d.LB))
 	}
 
 	if d.Monitor != nil {

--- a/server/azure/loadbalancer/handler.go
+++ b/server/azure/loadbalancer/handler.go
@@ -1,0 +1,112 @@
+// Package loadbalancer implements the Azure Load Balancer
+// (Microsoft.Network/loadBalancers) ARM REST API as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork
+// LoadBalancersClient clients configured with a custom endpoint hit this
+// handler the same way they hit management.azure.com, driving the shared
+// loadbalancer driver.
+//
+// Azure Load Balancer shares the Microsoft.Network ARM provider with the VNet
+// handler (server/azure/network) and the DNS handler (server/azure/dns), but on
+// a disjoint resource type — this handler claims loadBalancers while the network
+// handler claims virtualNetworks / networkSecurityGroups / locations and the DNS
+// handler claims dnsZones — so registration order between them is unconstrained.
+// All must register before the permissive BlobStorage fallback.
+//
+// Driver-abstraction mapping (Azure → loadbalancer driver):
+//
+//	loadBalancers/{name}                       → LoadBalancer (LBInfo.Name = {name})
+//	.../backendAddressPools/{pool}             → TargetGroup  (one per pool)
+//	.../loadBalancingRules/{rule}              → Listener     (FrontendPort→Port,
+//	                                             Protocol, BackendAddressPool→TargetGroupARN)
+//	.../frontendIPConfigurations/{fe}          → reflected back on Get/List only
+//
+// Azure addresses the load balancer by its user-assigned name in the URL, while
+// the driver keys load balancers on a generated id. The handler resolves the
+// SDK-facing name to the driver LB via a DescribeLoadBalancers scan (LBInfo.Name
+// is preserved verbatim by the driver), and scopes backend pools / rules to
+// their parent load balancer via internal tags so multiple load balancers stay
+// isolated.
+//
+// Coverage:
+//
+//	PUT    .../loadBalancers/{name}            — LoadBalancers.BeginCreateOrUpdate (LRO, sync-200)
+//	GET    .../loadBalancers/{name}            — LoadBalancers.Get
+//	DELETE .../loadBalancers/{name}            — LoadBalancers.BeginDelete (LRO, sync-200)
+//	GET    .../resourceGroups/{rg}/…/loadBalancers    — LoadBalancers.List (RG scope)
+//	GET    .../subscriptions/{s}/…/loadBalancers      — LoadBalancers.ListAll (sub scope)
+package loadbalancer
+
+import (
+	"net/http"
+	"strings"
+
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// Handler serves Microsoft.Network/loadBalancers ARM requests against a
+// loadbalancer driver.
+type Handler struct {
+	lb lbdriver.LoadBalancer
+}
+
+// New returns an Azure Load Balancer handler backed by lb.
+func New(lb lbdriver.LoadBalancer) *Handler {
+	return &Handler{lb: lb}
+}
+
+// isLBsType reports whether the ARM resource type is loadBalancers,
+// case-insensitively (the subscription-scoped list may use lowercase).
+func isLBsType(resourceType string) bool {
+	return strings.EqualFold(resourceType, typeLBs)
+}
+
+// Matches claims ARM URLs targeting Microsoft.Network/loadBalancers. Disjoint
+// from the network handler (virtualNetworks / networkSecurityGroups /
+// locations) and the dns handler (dnsZones) on the same provider, so
+// registration order between them is unconstrained. Registered before the
+// BlobStorage fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && isLBsType(rp.ResourceType)
+}
+
+// ServeHTTP routes on the parsed path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// Collection list: no load balancer name (subscription- or RG-scoped list).
+	if rp.ResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listLoadBalancers(w, r, &rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateLoadBalancer(w, r, &rp)
+	case http.MethodGet:
+		h.getLoadBalancer(w, r, &rp)
+	case http.MethodDelete:
+		h.deleteLoadBalancer(w, r, &rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/loadbalancer/operations.go
+++ b/server/azure/loadbalancer/operations.go
@@ -1,0 +1,422 @@
+package loadbalancer
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// Internal tags scope a driver target group to its Azure parent load balancer
+// and preserve the SDK-facing backend-pool name. They are stripped from the
+// tags echoed back to callers.
+const (
+	tagLBName   = "cloudemu:azureLBName"
+	tagPoolName = "cloudemu:azurePoolName"
+)
+
+// createOrUpdateLoadBalancer handles PUT .../loadBalancers/{name}. The whole
+// nested load balancer arrives in one body; we reconcile the driver's LB,
+// backend pools (target groups) and load-balancing rules (listeners) to match.
+//
+// LoadBalancers.CreateOrUpdate is an LRO in the SDK; returning 200 with the
+// fully-provisioned body (ProvisioningState=Succeeded) completes the poller on
+// the first response.
+func (h *Handler) createOrUpdateLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body loadBalancerJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	lb, err := h.upsertLB(r.Context(), rp.ResourceName, &body)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	pools, err := h.reconcilePools(r.Context(), lb, &body)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.reconcileRules(r.Context(), lb, pools, &body); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out, err := h.buildLBJSON(r.Context(), rp, lb)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// upsertLB creates the load balancer if absent, otherwise returns the existing
+// one (CreateOrUpdate is idempotent on the top-level resource).
+func (h *Handler) upsertLB(ctx context.Context, name string, body *loadBalancerJSON) (*lbdriver.LBInfo, error) {
+	if lb, err := h.findLBByName(ctx, name); err == nil {
+		return lb, nil
+	}
+
+	return h.lb.CreateLoadBalancer(ctx, lbdriver.LBConfig{
+		Name:   name,
+		Type:   "network",
+		Scheme: schemeFromBody(body),
+		Tags:   stripInternalTags(body.Tags),
+	})
+}
+
+// reconcilePools ensures every backend address pool in the body exists as a
+// driver target group tagged to this load balancer, and returns them keyed by
+// Azure pool name.
+func (h *Handler) reconcilePools(ctx context.Context, lb *lbdriver.LBInfo,
+	body *loadBalancerJSON,
+) (map[string]*lbdriver.TargetGroupInfo, error) {
+	out := make(map[string]*lbdriver.TargetGroupInfo)
+
+	if body.Properties == nil {
+		return out, nil
+	}
+
+	existing, err := h.poolsForLB(ctx, lb.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range body.Properties.BackendAddressPools {
+		pool := body.Properties.BackendAddressPools[i]
+		if pool.Name == "" {
+			continue
+		}
+
+		if tg, ok := existing[pool.Name]; ok {
+			out[pool.Name] = tg
+			continue
+		}
+
+		tg, cErr := h.lb.CreateTargetGroup(ctx, lbdriver.TargetGroupConfig{
+			Name: lb.Name + "-" + pool.Name,
+			Tags: map[string]string{tagLBName: lb.Name, tagPoolName: pool.Name},
+		})
+		if cErr != nil {
+			return nil, cErr
+		}
+
+		out[pool.Name] = tg
+	}
+
+	return out, nil
+}
+
+// reconcileRules ensures every load-balancing rule in the body exists as a
+// driver listener on this load balancer, resolving the rule's backend pool
+// reference to the matching target group ARN.
+func (h *Handler) reconcileRules(ctx context.Context, lb *lbdriver.LBInfo,
+	pools map[string]*lbdriver.TargetGroupInfo, body *loadBalancerJSON,
+) error {
+	if body.Properties == nil {
+		return nil
+	}
+
+	existing, err := h.lb.DescribeListeners(ctx, lb.ARN)
+	if err != nil {
+		return err
+	}
+
+	haveByPort := make(map[int]struct{}, len(existing))
+	for i := range existing {
+		haveByPort[existing[i].Port] = struct{}{}
+	}
+
+	for i := range body.Properties.LoadBalancingRules {
+		rule := body.Properties.LoadBalancingRules[i]
+		if rule.Properties == nil {
+			continue
+		}
+
+		port := int(rule.Properties.FrontendPort)
+		if _, ok := haveByPort[port]; ok {
+			continue
+		}
+
+		var tgARN string
+		if rule.Properties.BackendAddressPool != nil {
+			if tg, ok := pools[poolNameFromID(rule.Properties.BackendAddressPool.ID)]; ok {
+				tgARN = tg.ARN
+			}
+		}
+
+		if _, err := h.lb.CreateListener(ctx, lbdriver.ListenerConfig{
+			LBARN:          lb.ARN,
+			Protocol:       protocolOrDefault(rule.Properties.Protocol),
+			Port:           port,
+			TargetGroupARN: tgARN,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *Handler) getLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out, err := h.buildLBJSON(r.Context(), rp, lb)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// deleteLoadBalancer removes the load balancer and its backend pools. The
+// driver drops the load balancer's listeners as part of DeleteLoadBalancer.
+// LoadBalancers.Delete is an LRO; a 200 with empty body completes the poller.
+func (h *Handler) deleteLoadBalancer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	pools, err := h.poolsForLB(r.Context(), lb.Name)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	for _, tg := range pools {
+		if derr := h.lb.DeleteTargetGroup(r.Context(), tg.ARN); derr != nil && !cerrors.IsNotFound(derr) {
+			azurearm.WriteCErr(w, derr)
+			return
+		}
+	}
+
+	if derr := h.lb.DeleteLoadBalancer(r.Context(), lb.ARN); derr != nil {
+		azurearm.WriteCErr(w, derr)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listLoadBalancers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	lbs, err := h.lb.DescribeLoadBalancers(r.Context(), nil)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := lbListResult{Value: make([]loadBalancerJSON, 0, len(lbs))}
+
+	for i := range lbs {
+		scope := *rp
+		scope.ResourceName = lbs[i].Name
+
+		item, berr := h.buildLBJSON(r.Context(), &scope, &lbs[i])
+		if berr != nil {
+			azurearm.WriteCErr(w, berr)
+			return
+		}
+
+		out.Value = append(out.Value, item)
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// --- helpers ---
+
+// findLBByName resolves the SDK-facing load balancer name to its driver record.
+func (h *Handler) findLBByName(ctx context.Context, name string) (*lbdriver.LBInfo, error) {
+	lbs, err := h.lb.DescribeLoadBalancers(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range lbs {
+		if strings.EqualFold(lbs[i].Name, name) {
+			return &lbs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "load balancer %q not found", name)
+}
+
+// poolsForLB returns the target groups tagged to load balancer lbName, keyed by
+// their Azure pool name.
+func (h *Handler) poolsForLB(ctx context.Context, lbName string) (map[string]*lbdriver.TargetGroupInfo, error) {
+	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(map[string]*lbdriver.TargetGroupInfo)
+
+	for i := range tgs {
+		if tgs[i].Tags[tagLBName] != lbName {
+			continue
+		}
+
+		out[tgs[i].Tags[tagPoolName]] = &tgs[i]
+	}
+
+	return out, nil
+}
+
+// buildLBJSON reconstructs the nested ARM load balancer body from driver state.
+func (h *Handler) buildLBJSON(ctx context.Context, rp *azurearm.ResourcePath,
+	lb *lbdriver.LBInfo,
+) (loadBalancerJSON, error) {
+	pools, err := h.poolsForLB(ctx, lb.Name)
+	if err != nil {
+		return loadBalancerJSON{}, err
+	}
+
+	listeners, err := h.lb.DescribeListeners(ctx, lb.ARN)
+	if err != nil {
+		return loadBalancerJSON{}, err
+	}
+
+	lbID := azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeLBs, lb.Name)
+
+	props := &loadBalancerProps{
+		ProvisioningState: provisioningStateSucceeded,
+		FrontendIPConfigurations: []frontendIPJSON{{
+			ID:   lbID + "/frontendIPConfigurations/default",
+			Name: "default",
+			Type: feResourceType,
+			Properties: &frontendIPProps{
+				ProvisioningState: provisioningStateSucceeded,
+			},
+		}},
+	}
+
+	// Backend pools, keyed by ARN so rules can reference them.
+	poolIDByARN := make(map[string]string, len(pools))
+
+	for name, tg := range pools {
+		poolID := lbID + "/backendAddressPools/" + name
+		poolIDByARN[tg.ARN] = poolID
+		props.BackendAddressPools = append(props.BackendAddressPools, backendPoolJSON{
+			ID:         poolID,
+			Name:       name,
+			Type:       poolResourceType,
+			Properties: &backendPoolProps{ProvisioningState: provisioningStateSucceeded},
+		})
+	}
+
+	for i := range listeners {
+		li := listeners[i]
+		ruleName := "rule-" + portString(li.Port)
+		ruleProps := &loadBalancingRuleProps{
+			Protocol:          li.Protocol,
+			FrontendPort:      int32(li.Port),
+			BackendPort:       int32(li.Port),
+			ProvisioningState: provisioningStateSucceeded,
+			FrontendIPConfiguration: &subResource{
+				ID: lbID + "/frontendIPConfigurations/default",
+			},
+		}
+
+		if poolID, ok := poolIDByARN[li.TargetGroupARN]; ok {
+			ruleProps.BackendAddressPool = &subResource{ID: poolID}
+		}
+
+		props.LoadBalancingRules = append(props.LoadBalancingRules, loadBalancingRuleJSON{
+			ID:         lbID + "/loadBalancingRules/" + ruleName,
+			Name:       ruleName,
+			Type:       ruleResourceType,
+			Properties: ruleProps,
+		})
+	}
+
+	return loadBalancerJSON{
+		ID:         lbID,
+		Name:       lb.Name,
+		Type:       lbResourceType,
+		Location:   defaultLBLocation,
+		SKU:        &lbSKU{Name: "Standard", Tier: "Regional"},
+		Tags:       stripInternalTags(lb.Tags),
+		Properties: props,
+	}, nil
+}
+
+// schemeFromBody infers the driver scheme from the request body. Azure load
+// balancers are internal unless a public frontend is present; we default to
+// internal, which is the common case for the Standard SKU.
+func schemeFromBody(body *loadBalancerJSON) string {
+	if body.Properties != nil {
+		for _, fe := range body.Properties.FrontendIPConfigurations {
+			if fe.Properties != nil && fe.Properties.PrivateIPAddress == "" {
+				return "internet-facing"
+			}
+		}
+	}
+
+	return "internal"
+}
+
+// protocolOrDefault normalizes the ARM transport protocol to the driver's
+// stored value, defaulting to TCP.
+func protocolOrDefault(p string) string {
+	if p == "" {
+		return "Tcp"
+	}
+
+	return p
+}
+
+// poolNameFromID extracts the trailing backend-pool name from an ARM
+// backendAddressPools sub-resource ID.
+func poolNameFromID(id string) string {
+	const marker = "/backendAddressPools/"
+
+	idx := strings.LastIndex(id, marker)
+	if idx < 0 {
+		return id
+	}
+
+	return id[idx+len(marker):]
+}
+
+// stripInternalTags removes cloudemu-internal bookkeeping tags before echoing
+// tags back to the caller.
+func stripInternalTags(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+
+	for k, v := range in {
+		if strings.HasPrefix(k, "cloudemu:") {
+			continue
+		}
+
+		out[k] = v
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+func portString(p int) string {
+	return strconv.Itoa(p)
+}

--- a/server/azure/loadbalancer/sdk_roundtrip_test.go
+++ b/server/azure/loadbalancer/sdk_roundtrip_test.go
@@ -1,0 +1,199 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+const (
+	testRG  = "rg-1"
+	testSub = "sub-1"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newLBClient(t *testing.T) *armnetwork.LoadBalancersClient {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		LB: cloudP.LB,
+		// Wire the network handler too so we prove the loadBalancers resource
+		// type isn't shadowed by the virtualNetworks / NSG handler on the same
+		// Microsoft.Network provider.
+		Network: cloudP.VNet,
+	})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := armnetwork.NewLoadBalancersClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("armnetwork.NewLoadBalancersClient: %v", err)
+	}
+
+	return client
+}
+
+func TestSDKAzureLBLifecycle(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-1", armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		SKU:      &armnetwork.LoadBalancerSKU{Name: to.Ptr(armnetwork.LoadBalancerSKUNameStandard)},
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{
+				{Name: to.Ptr("pool-a")},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "lb-1" {
+		t.Fatalf("created name = %v, want lb-1", created.Name)
+	}
+
+	if created.Properties == nil || len(created.Properties.BackendAddressPools) != 1 {
+		t.Fatalf("backend pools = %+v, want 1", created.Properties)
+	}
+
+	if *created.Properties.BackendAddressPools[0].Name != "pool-a" {
+		t.Fatalf("pool name = %v, want pool-a", created.Properties.BackendAddressPools[0].Name)
+	}
+
+	got, err := client.Get(ctx, testRG, "lb-1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tags = %v, want env=test", got.Tags)
+	}
+
+	var names []string
+
+	pager := client.NewListPager(testRG, nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("List: %v", perr)
+		}
+
+		for _, lb := range page.Value {
+			names = append(names, *lb.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "lb-1" {
+		t.Fatalf("list = %v, want [lb-1]", names)
+	}
+
+	delPoller, err := client.BeginDelete(ctx, testRG, "lb-1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	_, err = client.Get(ctx, testRG, "lb-1", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKAzureLBWithRule(t *testing.T) {
+	client := newLBClient(t)
+	ctx := context.Background()
+
+	poolID := "/subscriptions/" + testSub + "/resourceGroups/" + testRG +
+		"/providers/Microsoft.Network/loadBalancers/lb-web/backendAddressPools/web-pool"
+
+	poller, err := client.BeginCreateOrUpdate(ctx, testRG, "lb-web", armnetwork.LoadBalancer{
+		Location: to.Ptr("eastus"),
+		Properties: &armnetwork.LoadBalancerPropertiesFormat{
+			BackendAddressPools: []*armnetwork.BackendAddressPool{
+				{Name: to.Ptr("web-pool")},
+			},
+			LoadBalancingRules: []*armnetwork.LoadBalancingRule{
+				{
+					Name: to.Ptr("http-rule"),
+					Properties: &armnetwork.LoadBalancingRulePropertiesFormat{
+						Protocol:           to.Ptr(armnetwork.TransportProtocolTCP),
+						FrontendPort:       to.Ptr(int32(80)),
+						BackendPort:        to.Ptr(int32(8080)),
+						BackendAddressPool: &armnetwork.SubResource{ID: to.Ptr(poolID)},
+					},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	if created.Properties == nil || len(created.Properties.LoadBalancingRules) != 1 {
+		t.Fatalf("rules = %+v, want 1", created.Properties)
+	}
+
+	rule := created.Properties.LoadBalancingRules[0]
+	if rule.Properties == nil || *rule.Properties.FrontendPort != 80 {
+		t.Fatalf("rule frontend port = %+v, want 80", rule.Properties)
+	}
+
+	if rule.Properties.BackendAddressPool == nil {
+		t.Fatal("rule missing backend address pool reference")
+	}
+}

--- a/server/azure/loadbalancer/types.go
+++ b/server/azure/loadbalancer/types.go
@@ -1,0 +1,100 @@
+package loadbalancer
+
+// Azure ARM JSON wire structures for Microsoft.Network/loadBalancers. Only the
+// subset of fields the driver can populate is modeled; the real armnetwork
+// LoadBalancer type carries far more, but its JSON unmarshaler ignores unknown
+// members and treats absent members as nil.
+
+const (
+	providerName = "Microsoft.Network"
+	typeLBs      = "loadBalancers"
+
+	lbResourceType   = "Microsoft.Network/loadBalancers"
+	poolResourceType = "Microsoft.Network/loadBalancers/backendAddressPools"
+	ruleResourceType = "Microsoft.Network/loadBalancers/loadBalancingRules"
+	feResourceType   = "Microsoft.Network/loadBalancers/frontendIPConfigurations"
+
+	defaultLBLocation = "eastus"
+
+	// provisioningStateSucceeded is the terminal state the SDK poller waits for.
+	provisioningStateSucceeded = "Succeeded"
+)
+
+// subResource is Azure's {"id": "..."} reference shape.
+type subResource struct {
+	ID string `json:"id,omitempty"`
+}
+
+// --- backend address pools (→ driver target groups) ---
+
+type backendPoolProps struct {
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type backendPoolJSON struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Properties *backendPoolProps `json:"properties,omitempty"`
+}
+
+// --- frontend IP configurations ---
+
+type frontendIPProps struct {
+	PrivateIPAddress  string `json:"privateIPAddress,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type frontendIPJSON struct {
+	ID         string           `json:"id,omitempty"`
+	Name       string           `json:"name,omitempty"`
+	Type       string           `json:"type,omitempty"`
+	Properties *frontendIPProps `json:"properties,omitempty"`
+}
+
+// --- load balancing rules (→ driver listeners) ---
+
+type loadBalancingRuleProps struct {
+	Protocol                string       `json:"protocol,omitempty"`
+	FrontendPort            int32        `json:"frontendPort,omitempty"`
+	BackendPort             int32        `json:"backendPort,omitempty"`
+	FrontendIPConfiguration *subResource `json:"frontendIPConfiguration,omitempty"`
+	BackendAddressPool      *subResource `json:"backendAddressPool,omitempty"`
+	ProvisioningState       string       `json:"provisioningState,omitempty"`
+}
+
+type loadBalancingRuleJSON struct {
+	ID         string                  `json:"id,omitempty"`
+	Name       string                  `json:"name,omitempty"`
+	Type       string                  `json:"type,omitempty"`
+	Properties *loadBalancingRuleProps `json:"properties,omitempty"`
+}
+
+// --- load balancer ---
+
+type loadBalancerProps struct {
+	BackendAddressPools      []backendPoolJSON       `json:"backendAddressPools,omitempty"`
+	FrontendIPConfigurations []frontendIPJSON        `json:"frontendIPConfigurations,omitempty"`
+	LoadBalancingRules       []loadBalancingRuleJSON `json:"loadBalancingRules,omitempty"`
+	ProvisioningState        string                  `json:"provisioningState,omitempty"`
+}
+
+type lbSKU struct {
+	Name string `json:"name,omitempty"`
+	Tier string `json:"tier,omitempty"`
+}
+
+type loadBalancerJSON struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name,omitempty"`
+	Type       string             `json:"type,omitempty"`
+	Location   string             `json:"location,omitempty"`
+	Etag       string             `json:"etag,omitempty"`
+	SKU        *lbSKU             `json:"sku,omitempty"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	Properties *loadBalancerProps `json:"properties,omitempty"`
+}
+
+type lbListResult struct {
+	Value []loadBalancerJSON `json:"value"`
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -13,6 +13,7 @@ import (
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -31,6 +32,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
 	"github.com/stackshy/cloudemu/server/gcp/gke"
 	"github.com/stackshy/cloudemu/server/gcp/iam"
+	lbsrv "github.com/stackshy/cloudemu/server/gcp/loadbalancer"
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
@@ -58,6 +60,9 @@ type Drivers struct {
 	// CloudDNS serves the dns.googleapis.com v1 REST API against the dns
 	// driver.
 	CloudDNS dnsdriver.DNS
+	// LB serves the Cloud Load Balancing REST API (backendServices +
+	// forwardingRules on the compute API) against the loadbalancer driver.
+	LB lbdriver.LoadBalancer
 	// SecretManager serves the secretmanager.googleapis.com v1 REST API
 	// against the secrets driver.
 	SecretManager secretsdriver.Secrets
@@ -94,6 +99,19 @@ func New(d Drivers) *server.Server {
 
 	if d.Networking != nil {
 		srv.Register(networks.New(d.Networking))
+	}
+
+	// Cloud Load Balancing shares the /compute/v1/projects/… URL space with the
+	// compute and networks handlers above but claims a disjoint set of resource
+	// types — backendServices / forwardingRules — whereas compute claims
+	// instances / operations / disks / snapshots / images and networks claims
+	// networks / subnetworks / firewalls. gcprest.ParsePath keys dispatch on the
+	// resource-type segment, so first-match-wins routing is unambiguous and
+	// registration order relative to those two is unconstrained. Mutating LB ops
+	// return operation envelopes the SDK polls via the compute handler's
+	// /global/operations route.
+	if d.LB != nil {
+		srv.Register(lbsrv.New(d.LB))
 	}
 
 	// CloudFunctions matches /v1/projects/{p}/locations/{l}/functions paths

--- a/server/gcp/loadbalancer/handler.go
+++ b/server/gcp/loadbalancer/handler.go
@@ -1,0 +1,141 @@
+// Package loadbalancer implements the GCP Cloud Load Balancing REST API
+// (backendServices + forwardingRules) against a CloudEmu loadbalancer driver.
+// Real cloud.google.com/go/compute/apiv1 BackendServices and
+// GlobalForwardingRules clients configured with a custom endpoint hit this
+// handler the same way they hit compute.googleapis.com.
+//
+// Registration / shadowing: this handler shares the /compute/v1/projects/…
+// URL space with the existing compute (server/gcp/compute) and networks
+// (server/gcp/networks) handlers, but claims a disjoint set of resource types —
+// backendServices / forwardingRules — whereas compute claims instances /
+// operations / disks / snapshots / images and networks claims networks /
+// subnetworks / firewalls. Because gcprest.ParsePath keys dispatch on the
+// resource-type segment, first-match-wins routing is unambiguous and the three
+// handlers can register in any order. Folding into the existing handlers was
+// unnecessary since there is no route overlap. NOTE: mutating operations return
+// compute#operation envelopes the SDK polls at
+// /compute/v1/projects/{p}/global/operations/{name}, which the compute handler
+// serves — so wire the Compute handler alongside this one when the SDK's
+// Insert/Delete pollers are exercised.
+//
+// Driver-abstraction mapping (GCP → loadbalancer driver):
+//
+//	global/backendServices/{name}     → TargetGroup  (Insert/Get/List/Delete)
+//	global/forwardingRules/{name}     → LoadBalancer (Insert/Get/List/Delete);
+//	                                    a forwarding rule that references a
+//	                                    backendService also creates a Listener
+//	                                    linking the load balancer to that target
+//	                                    group.
+//
+// Both GCP and the driver key resources by their user-assigned name (the driver
+// preserves Name verbatim), so the handler resolves SDK-facing names to driver
+// records via a Describe scan.
+package loadbalancer
+
+import (
+	"net/http"
+
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	resourceBackendServices = "backendServices"
+	resourceForwardingRules = "forwardingRules"
+)
+
+// Handler serves the GCP load-balancing REST surface.
+type Handler struct {
+	lb lbdriver.LoadBalancer
+}
+
+// New returns a GCP load balancer handler backed by lb.
+func New(lb lbdriver.LoadBalancer) *Handler {
+	return &Handler{lb: lb}
+}
+
+// Matches returns true for /compute/v1/.../backendServices|forwardingRules
+// URLs. Disjoint from the compute (instances/operations/disks/…) and networks
+// (networks/subnetworks/firewalls) handlers, so registration order is
+// unconstrained.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := gcprest.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	switch rp.ResourceType {
+	case resourceBackendServices, resourceForwardingRules:
+		return true
+	}
+
+	return false
+}
+
+// ServeHTTP routes the request based on resource type and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := gcprest.ParsePath(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed path")
+		return
+	}
+
+	switch rp.ResourceType {
+	case resourceBackendServices:
+		h.routeBackendServices(w, r, rp)
+	case resourceForwardingRules:
+		h.routeForwardingRules(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unknown resource type")
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeBackendServices(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertBackendService(w, r, rp)
+		case http.MethodGet:
+			h.listBackendServices(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getBackendService(w, r, rp)
+	case http.MethodDelete:
+		h.deleteBackendService(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}
+
+//nolint:gocritic,dupl // rp is a request-scoped value; CRUD route shape is duplicate-by-design across resource types
+func (h *Handler) routeForwardingRules(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	if rp.ResourceName == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.insertForwardingRule(w, r, rp)
+		case http.MethodGet:
+			h.listForwardingRules(w, r, rp)
+		default:
+			gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getForwardingRule(w, r, rp)
+	case http.MethodDelete:
+		h.deleteForwardingRule(w, r, rp)
+	default:
+		gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+	}
+}

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -1,0 +1,362 @@
+package loadbalancer
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+// --- backend services (target groups) ---
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var req backendServiceRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	if _, err := h.lb.CreateTargetGroup(r.Context(), lbdriver.TargetGroupConfig{
+		Name:     req.Name,
+		Protocol: req.Protocol,
+		Port:     req.Port,
+	}); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		resourceBackendServices, req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	tg, err := h.findTGByName(r.Context(), rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toBackendServiceResponse(tg, rp, hostOf(r)))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listBackendServices(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	tgs, err := h.lb.DescribeTargetGroups(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	out := backendServiceListResponse{
+		Kind:     "compute#backendServiceList",
+		ID:       "projects/" + rp.Project + "/global/backendServices",
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceBackendServices, ""),
+	}
+
+	for i := range tgs {
+		out.Items = append(out.Items, toBackendServiceResponse(&tgs[i], rp, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteBackendService(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	tg, err := h.findTGByName(r.Context(), rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.lb.DeleteTargetGroup(r.Context(), tg.ARN); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		resourceBackendServices, rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// --- forwarding rules (load balancers) ---
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	var req forwardingRuleRequest
+
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.Name == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "name required")
+		return
+	}
+
+	lb, err := h.lb.CreateLoadBalancer(r.Context(), lbdriver.LBConfig{
+		Name:   req.Name,
+		Type:   "network",
+		Scheme: schemeFromRule(&req),
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// A forwarding rule that references a backend service becomes a listener
+	// linking the load balancer to that target group.
+	if bsName := backendServiceName(req.BackendService); bsName != "" {
+		if tg, ferr := h.findTGByName(r.Context(), bsName); ferr == nil {
+			_, _ = h.lb.CreateListener(r.Context(), lbdriver.ListenerConfig{
+				LBARN:          lb.ARN,
+				Protocol:       req.IPProtocol,
+				Port:           firstPort(req.PortRange),
+				TargetGroupARN: tg.ARN,
+			})
+		}
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		resourceForwardingRules, req.Name, "insert")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) getForwardingRule(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, h.toForwardingRuleResponse(r.Context(), lb, rp, hostOf(r)))
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listForwardingRules(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	lbs, err := h.lb.DescribeLoadBalancers(r.Context(), nil)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	host := hostOf(r)
+	out := forwardingRuleListResponse{
+		Kind:     "compute#forwardingRuleList",
+		ID:       "projects/" + rp.Project + "/global/forwardingRules",
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceForwardingRules, ""),
+	}
+
+	for i := range lbs {
+		out.Items = append(out.Items, h.toForwardingRuleResponse(r.Context(), &lbs[i], rp, host))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, out)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) deleteForwardingRule(w http.ResponseWriter, r *http.Request, rp gcprest.ResourcePath) {
+	lb, err := h.findLBByName(r.Context(), rp.ResourceName)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if err := h.lb.DeleteLoadBalancer(r.Context(), lb.ARN); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := gcprest.NewDoneOperation(hostOf(r), rp.Project, gcprest.ScopeGlobal, "",
+		resourceForwardingRules, rp.ResourceName, "delete")
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// --- lookups + response shaping ---
+
+func (h *Handler) findTGByName(ctx context.Context, name string) (*lbdriver.TargetGroupInfo, error) {
+	tgs, err := h.lb.DescribeTargetGroups(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range tgs {
+		if tgs[i].Name == name {
+			return &tgs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "backend service %q not found", name)
+}
+
+func (h *Handler) findLBByName(ctx context.Context, name string) (*lbdriver.LBInfo, error) {
+	lbs, err := h.lb.DescribeLoadBalancers(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range lbs {
+		if lbs[i].Name == name {
+			return &lbs[i], nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "forwarding rule %q not found", name)
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func toBackendServiceResponse(tg *lbdriver.TargetGroupInfo, rp gcprest.ResourcePath, host string) backendServiceResponse {
+	return backendServiceResponse{
+		Kind:     "compute#backendService",
+		ID:       numericID(tg.ID),
+		Name:     tg.Name,
+		Protocol: tg.Protocol,
+		Port:     tg.Port,
+		SelfLink: gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceBackendServices, tg.Name),
+	}
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) toForwardingRuleResponse(ctx context.Context, lb *lbdriver.LBInfo,
+	rp gcprest.ResourcePath, host string,
+) forwardingRuleResponse {
+	out := forwardingRuleResponse{
+		Kind:                "compute#forwardingRule",
+		ID:                  numericID(lb.ID),
+		Name:                lb.Name,
+		IPAddress:           lb.DNSName,
+		IPProtocol:          "TCP",
+		LoadBalancingScheme: schemeToGCP(lb.Scheme),
+		SelfLink:            gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "", resourceForwardingRules, lb.Name),
+	}
+
+	// Reflect the backing backend service, if a listener links one.
+	if listeners, err := h.lb.DescribeListeners(ctx, lb.ARN); err == nil && len(listeners) > 0 {
+		out.IPProtocol = protocolOrDefault(listeners[0].Protocol)
+		out.PortRange = strconv.Itoa(listeners[0].Port)
+
+		if tgName := h.tgNameByARN(ctx, listeners[0].TargetGroupARN); tgName != "" {
+			out.BackendService = gcprest.SelfLink(host, rp.Project, gcprest.ScopeGlobal, "",
+				resourceBackendServices, tgName)
+		}
+	}
+
+	return out
+}
+
+// tgNameByARN resolves a target-group ARN back to its name for response links.
+func (h *Handler) tgNameByARN(ctx context.Context, arn string) string {
+	if arn == "" {
+		return ""
+	}
+
+	tgs, err := h.lb.DescribeTargetGroups(ctx, []string{arn})
+	if err != nil || len(tgs) == 0 {
+		return ""
+	}
+
+	return tgs[0].Name
+}
+
+// backendServiceName extracts the trailing backend-service name from a compute
+// self-link or relative reference.
+func backendServiceName(ref string) string {
+	if ref == "" {
+		return ""
+	}
+
+	const marker = "/backendServices/"
+
+	if idx := strings.LastIndex(ref, marker); idx >= 0 {
+		return ref[idx+len(marker):]
+	}
+
+	return ref
+}
+
+// firstPort parses the low end of a GCP portRange (e.g. "80" or "80-80").
+func firstPort(portRange string) int {
+	if portRange == "" {
+		return 0
+	}
+
+	if idx := strings.Index(portRange, "-"); idx >= 0 {
+		portRange = portRange[:idx]
+	}
+
+	n, err := strconv.Atoi(strings.TrimSpace(portRange))
+	if err != nil {
+		return 0
+	}
+
+	return n
+}
+
+// schemeFromRule maps a GCP loadBalancingScheme to the driver scheme.
+func schemeFromRule(req *forwardingRuleRequest) string {
+	if strings.EqualFold(req.LoadBalancingScheme, "INTERNAL") {
+		return "internal"
+	}
+
+	return "internet-facing"
+}
+
+// schemeToGCP maps the driver scheme back to a GCP loadBalancingScheme.
+func schemeToGCP(scheme string) string {
+	if scheme == "internal" {
+		return "INTERNAL"
+	}
+
+	return "EXTERNAL"
+}
+
+// protocolOrDefault normalizes a stored listener protocol, defaulting to TCP.
+func protocolOrDefault(p string) string {
+	if p == "" {
+		return "TCP"
+	}
+
+	return p
+}
+
+// numericID returns a stable uint64-shaped string derived from a driver ID.
+// GCP wire IDs are uint64 and proto JSON unmarshalling rejects anything else.
+func numericID(driverID string) string {
+	const fnvOffset uint64 = 14695981039346656037
+
+	const fnvPrime uint64 = 1099511628211
+
+	h := fnvOffset
+	for i := 0; i < len(driverID); i++ {
+		h ^= uint64(driverID[i])
+		h *= fnvPrime
+	}
+
+	return strconv.FormatUint(h, 10)
+}
+
+func hostOf(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host
+}

--- a/server/gcp/loadbalancer/operations.go
+++ b/server/gcp/loadbalancer/operations.go
@@ -119,15 +119,23 @@ func (h *Handler) insertForwardingRule(w http.ResponseWriter, r *http.Request, r
 	}
 
 	// A forwarding rule that references a backend service becomes a listener
-	// linking the load balancer to that target group.
+	// linking the load balancer to that target group. A dangling reference to a
+	// non-existent backend service is an error (as in real GCP), and a failed
+	// link must not be swallowed into a phantom success.
 	if bsName := backendServiceName(req.BackendService); bsName != "" {
-		if tg, ferr := h.findTGByName(r.Context(), bsName); ferr == nil {
-			_, _ = h.lb.CreateListener(r.Context(), lbdriver.ListenerConfig{
-				LBARN:          lb.ARN,
-				Protocol:       req.IPProtocol,
-				Port:           firstPort(req.PortRange),
-				TargetGroupARN: tg.ARN,
-			})
+		tg, ferr := h.findTGByName(r.Context(), bsName)
+		if ferr != nil {
+			gcprest.WriteCErr(w, ferr)
+			return
+		}
+		if _, lerr := h.lb.CreateListener(r.Context(), lbdriver.ListenerConfig{
+			LBARN:          lb.ARN,
+			Protocol:       req.IPProtocol,
+			Port:           firstPort(req.PortRange),
+			TargetGroupARN: tg.ARN,
+		}); lerr != nil {
+			gcprest.WriteCErr(w, lerr)
+			return
 		}
 	}
 

--- a/server/gcp/loadbalancer/sdk_roundtrip_test.go
+++ b/server/gcp/loadbalancer/sdk_roundtrip_test.go
@@ -1,0 +1,225 @@
+package loadbalancer_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	gcpcompute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const testProject = "proj-1"
+
+func ptrStr(s string) *string { return &s }
+
+func newGCPLBServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	cloudP := cloudemu.NewGCP()
+	// Register Compute too so the shared /global/operations polling endpoint is
+	// wired up — LB mutating ops return Operation envelopes the SDK polls there.
+	// This also proves the backendServices / forwardingRules resource types
+	// aren't shadowed by the compute (instances/operations/…) handler.
+	srv := gcpserver.New(gcpserver.Drivers{LB: cloudP.LB, Compute: cloudP.GCE})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func TestSDKGCPBackendServiceRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	client, err := gcpcompute.NewBackendServicesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewBackendServicesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	insertOp, err := client.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:     ptrStr("web-backend"),
+			Protocol: ptrStr("HTTP"),
+			Port:     func() *int32 { p := int32(80); return &p }(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	if err := insertOp.Wait(ctx); err != nil {
+		t.Fatalf("Insert wait: %v", err)
+	}
+
+	got, err := client.Get(ctx, &computepb.GetBackendServiceRequest{
+		Project:        testProject,
+		BackendService: "web-backend",
+	})
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.GetName() != "web-backend" {
+		t.Fatalf("name = %q, want web-backend", got.GetName())
+	}
+
+	if got.GetProtocol() != "HTTP" {
+		t.Fatalf("protocol = %q, want HTTP", got.GetProtocol())
+	}
+
+	// List.
+	var names []string
+
+	it := client.List(ctx, &computepb.ListBackendServicesRequest{Project: testProject})
+
+	for {
+		bs, iErr := it.Next()
+		if iErr == iterator.Done {
+			break
+		}
+
+		if iErr != nil {
+			t.Fatalf("List: %v", iErr)
+		}
+
+		names = append(names, bs.GetName())
+	}
+
+	if len(names) != 1 || names[0] != "web-backend" {
+		t.Fatalf("list = %v, want [web-backend]", names)
+	}
+
+	delOp, err := client.Delete(ctx, &computepb.DeleteBackendServiceRequest{
+		Project:        testProject,
+		BackendService: "web-backend",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("Delete wait: %v", err)
+	}
+
+	_, err = client.Get(ctx, &computepb.GetBackendServiceRequest{
+		Project:        testProject,
+		BackendService: "web-backend",
+	})
+	if err == nil {
+		t.Fatal("Get after delete: want error, got nil")
+	}
+}
+
+func TestSDKGCPForwardingRuleRoundTrip(t *testing.T) {
+	ts := newGCPLBServer(t)
+	ctx := context.Background()
+
+	bsClient, err := gcpcompute.NewBackendServicesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewBackendServicesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = bsClient.Close() })
+
+	frClient, err := gcpcompute.NewGlobalForwardingRulesRESTClient(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("NewGlobalForwardingRulesRESTClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = frClient.Close() })
+
+	// Backing backend service the forwarding rule references.
+	bsOp, err := bsClient.Insert(ctx, &computepb.InsertBackendServiceRequest{
+		Project: testProject,
+		BackendServiceResource: &computepb.BackendService{
+			Name:     ptrStr("fr-backend"),
+			Protocol: ptrStr("TCP"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("BackendService Insert: %v", err)
+	}
+
+	if err := bsOp.Wait(ctx); err != nil {
+		t.Fatalf("BackendService Insert wait: %v", err)
+	}
+
+	frOp, err := frClient.Insert(ctx, &computepb.InsertGlobalForwardingRuleRequest{
+		Project: testProject,
+		ForwardingRuleResource: &computepb.ForwardingRule{
+			Name:           ptrStr("my-lb"),
+			IPProtocol:     ptrStr("TCP"),
+			PortRange:      ptrStr("80"),
+			BackendService: ptrStr("projects/" + testProject + "/global/backendServices/fr-backend"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("ForwardingRule Insert: %v", err)
+	}
+
+	if err := frOp.Wait(ctx); err != nil {
+		t.Fatalf("ForwardingRule Insert wait: %v", err)
+	}
+
+	got, err := frClient.Get(ctx, &computepb.GetGlobalForwardingRuleRequest{
+		Project:        testProject,
+		ForwardingRule: "my-lb",
+	})
+	if err != nil {
+		t.Fatalf("ForwardingRule Get: %v", err)
+	}
+
+	if got.GetName() != "my-lb" {
+		t.Fatalf("name = %q, want my-lb", got.GetName())
+	}
+
+	if got.GetPortRange() != "80" {
+		t.Fatalf("portRange = %q, want 80", got.GetPortRange())
+	}
+
+	if got.GetBackendService() == "" {
+		t.Fatal("expected forwarding rule to reflect its backend service")
+	}
+
+	delOp, err := frClient.Delete(ctx, &computepb.DeleteGlobalForwardingRuleRequest{
+		Project:        testProject,
+		ForwardingRule: "my-lb",
+	})
+	if err != nil {
+		t.Fatalf("ForwardingRule Delete: %v", err)
+	}
+
+	if err := delOp.Wait(ctx); err != nil {
+		t.Fatalf("ForwardingRule Delete wait: %v", err)
+	}
+
+	_, err = frClient.Get(ctx, &computepb.GetGlobalForwardingRuleRequest{
+		Project:        testProject,
+		ForwardingRule: "my-lb",
+	})
+	if err == nil {
+		t.Fatal("Get after delete: want error, got nil")
+	}
+}

--- a/server/gcp/loadbalancer/types.go
+++ b/server/gcp/loadbalancer/types.go
@@ -1,0 +1,66 @@
+package loadbalancer
+
+// GCP Compute Load Balancing REST shapes. Only the subset of fields the
+// loadbalancer driver can populate is modeled; the compute SDK ignores unknown
+// members on the wire.
+
+// --- backend services (→ driver target groups) ---
+
+type backendServiceRequest struct {
+	Name         string   `json:"name"`
+	Description  string   `json:"description,omitempty"`
+	Protocol     string   `json:"protocol,omitempty"`
+	Port         int      `json:"port,omitempty"`
+	PortName     string   `json:"portName,omitempty"`
+	HealthChecks []string `json:"healthChecks,omitempty"`
+}
+
+type backendServiceResponse struct {
+	Kind        string `json:"kind"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	Port        int    `json:"port,omitempty"`
+	SelfLink    string `json:"selfLink"`
+}
+
+type backendServiceListResponse struct {
+	Kind     string                   `json:"kind"`
+	ID       string                   `json:"id"`
+	Items    []backendServiceResponse `json:"items"`
+	SelfLink string                   `json:"selfLink"`
+}
+
+// --- forwarding rules (→ driver load balancers) ---
+
+type forwardingRuleRequest struct {
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	IPProtocol          string `json:"IPProtocol,omitempty"`
+	PortRange           string `json:"portRange,omitempty"`
+	Target              string `json:"target,omitempty"`
+	BackendService      string `json:"backendService,omitempty"`
+	LoadBalancingScheme string `json:"loadBalancingScheme,omitempty"`
+}
+
+type forwardingRuleResponse struct {
+	Kind                string `json:"kind"`
+	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	Description         string `json:"description,omitempty"`
+	IPAddress           string `json:"IPAddress,omitempty"`
+	IPProtocol          string `json:"IPProtocol,omitempty"`
+	PortRange           string `json:"portRange,omitempty"`
+	Target              string `json:"target,omitempty"`
+	BackendService      string `json:"backendService,omitempty"`
+	LoadBalancingScheme string `json:"loadBalancingScheme,omitempty"`
+	SelfLink            string `json:"selfLink"`
+}
+
+type forwardingRuleListResponse struct {
+	Kind     string                   `json:"kind"`
+	ID       string                   `json:"id"`
+	Items    []forwardingRuleResponse `json:"items"`
+	SelfLink string                   `json:"selfLink"`
+}


### PR DESCRIPTION
## Summary
Wires the existing `loadbalancer` driver through the SDK-compat HTTP layer across all three providers — the Load Balancer slice of #143. Real cloud SDK clients drive the in-memory driver with only an endpoint change. Follows the merged Secrets (#238) and DNS (#252) slices.

## Providers
- **AWS ELBv2** (`server/aws/elbv2`) — AWS query protocol. Load balancers, target groups, listeners, rules, RegisterTargets/DeregisterTargets/DescribeTargetHealth. Matches the ELBv2 action set, registered before EC2 (disjoint actions).
- **Azure LB** (`server/azure/loadbalancer`) — ARM `Microsoft.Network/loadBalancers`. Backend pools → target groups, load-balancing rules → listeners (pool scoping via internal `cloudemu:*` tags, stripped on output). Matches only `loadBalancers` (disjoint from the network/dns handlers).
- **GCP LB** (`server/gcp/loadbalancer`) — compute REST `backendServices` + global `forwardingRules`; a forwarding rule referencing a backend service also creates a listener. Matches only those resource types, disjoint from the existing compute/networks handlers (mutating ops return `compute#operation` envelopes the compute handler already polls).

## Tests
Real-SDK roundtrip per provider (`elasticloadbalancingv2`, `armnetwork.LoadBalancersClient`, `compute/apiv1`) against `httptest.NewServer` (TLS for Azure). `go build ./...` ✓, `go vet` clean, full `go test ./server/...` green fresh.

## Known gaps (documented, follow-up)
- `ModifyListener`, Get/PutLBAttributes, SetTargetHealth are on the driver but not exposed on the wire (outside core lifecycle); registered targets report the driver's default `initial` health.
- Azure: scheme inferred (defaults internal/Standard SKU), frontend IP configs synthesized.
- GCP: global forwarding rules only; healthChecks/targetPools/urlMaps not wired.