### PR TITLE
feat(eventbus): SDK-compat servers for EventBridge, Event Grid, and Eventarc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
@@ -36,6 +37,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0
+	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
@@ -80,7 +82,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0/go.mod h1:4jtknLqzaPtwIz8Y9NBp2rXxeA7BbSICWBD0FDzG2VM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0/go.mod h1:fSvRkb8d26z9dbL40Uf/OO6Vo9iExtZK3D0ulRV+8M0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0 h1:8JkRfARpQbzTzD+HGQAf67VIqQg3qXLIcAqtPYr/V0Q=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0/go.mod h1:NOM/LtCJfoU69VkmxPxV6PMxDm/MsOvmsao/5V5Rhgs=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=
@@ -104,8 +106,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJ
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30/go.mod h1:1hTMsAgbdS/AtUi4bw8+gUuh1pceo+eXRLfpSuSQj3M=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
-github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
-github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22/go.mod h1:zd/JsJ4P7oGfUhXn1VyLqaRZwPmZwg44Jf2dS84Dm3Y=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1O1b3Erl5CePYIAeQ=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1 h1:kGlbhb5GMfkP/bcqcbt3oDi50kwDTpRmNzYUY9LqbLk=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.66.1/go.mod h1:z45kurrOonQepd3SN5LIgropAn1NGHwBn1yOMF+QVFU=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0 h1:jZOg03lM41zl89h17avGr6AFqAb9g3s/rZytTQslz14=
@@ -126,6 +128,8 @@ github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmX
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0 h1:OJRqQ6G7RjmwJ9fkhFgcJBSinjrLJxfd5AacBUrhKXc=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0/go.mod h1:qNnJkZTDHDL2sO8hyVH2yILcfSEkjP/pIns2JsF1g1o=
+github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0 h1:LuPLDBMCmldgg779sq8swfEdRNMeKlaT852uxKYCOkk=
+github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0/go.mod h1:3g/foYPw/4CT8yV7/A1QsbvnhDZW/2x2uzl4vkqX49o=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -12,6 +12,7 @@ import (
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
@@ -31,6 +32,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/ecr"
 	"github.com/stackshy/cloudemu/server/aws/eks"
 	"github.com/stackshy/cloudemu/server/aws/elbv2"
+	"github.com/stackshy/cloudemu/server/aws/eventbridge"
 	"github.com/stackshy/cloudemu/server/aws/iam"
 	"github.com/stackshy/cloudemu/server/aws/lambda"
 	"github.com/stackshy/cloudemu/server/aws/rds"
@@ -72,6 +74,9 @@ type Drivers struct {
 	// ELB serves the Elastic Load Balancing v2 (ALB/NLB) query protocol
 	// against the loadbalancer driver.
 	ELB lbdriver.LoadBalancer
+	// EventBridge serves the EventBridge JSON 1.1 protocol against the eventbus
+	// driver.
+	EventBridge ebdriver.EventBus
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -153,6 +158,12 @@ func New(d Drivers) *server.Server {
 	// disjoint from DynamoDB, SQS, ECR, SageMaker, and the tagging API.
 	if d.SecretsManager != nil {
 		srv.Register(secretsmanagersrv.New(d.SecretsManager))
+	}
+
+	// EventBridge matches the X-Amz-Target prefix "AWSEvents." — disjoint from
+	// DynamoDB, SQS, ECR, SageMaker, Secrets Manager, and the tagging API.
+	if d.EventBridge != nil {
+		srv.Register(eventbridge.New(d.EventBridge))
 	}
 
 	// Redshift sits with the other query-protocol handlers before the EC2

--- a/server/aws/eventbridge/handler.go
+++ b/server/aws/eventbridge/handler.go
@@ -1,0 +1,96 @@
+// Package eventbridge implements the AWS EventBridge JSON-RPC protocol as a
+// server.Handler. Point the real aws-sdk-go-v2 EventBridge client at a Server
+// registered with this handler and event-bus, rule, target, and event
+// operations work against an in-memory eventbus driver.
+//
+// EventBridge uses the AWS JSON 1.1 wire shape (POST + JSON body, dispatched on
+// the X-Amz-Target header), the same family as DynamoDB, SQS, and Secrets
+// Manager. Its target prefix ("AWSEvents.") is disjoint from every other JSON
+// handler, so registration order among them is unconstrained.
+package eventbridge
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+const targetPrefix = "AWSEvents."
+
+// Handler serves EventBridge JSON-RPC requests against an EventBus driver.
+type Handler struct {
+	bus ebdriver.EventBus
+}
+
+// New returns an EventBridge handler backed by b.
+func New(b ebdriver.EventBus) *Handler {
+	return &Handler{bus: b}
+}
+
+// Matches returns true for EventBridge-shaped requests, identified by an
+// X-Amz-Target header of "AWSEvents.<Operation>".
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches EventBridge operations based on X-Amz-Target.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "CreateEventBus":
+		h.createEventBus(w, r)
+	case "DescribeEventBus":
+		h.describeEventBus(w, r)
+	case "ListEventBuses":
+		h.listEventBuses(w, r)
+	case "DeleteEventBus":
+		h.deleteEventBus(w, r)
+	case "PutRule":
+		h.putRule(w, r)
+	case "DescribeRule":
+		h.describeRule(w, r)
+	case "ListRules":
+		h.listRules(w, r)
+	case "DeleteRule":
+		h.deleteRule(w, r)
+	case "EnableRule":
+		h.enableRule(w, r)
+	case "DisableRule":
+		h.disableRule(w, r)
+	case "PutTargets":
+		h.putTargets(w, r)
+	case "RemoveTargets":
+		h.removeTargets(w, r)
+	case "ListTargetsByRule":
+		h.listTargetsByRule(w, r)
+	case "PutEvents":
+		h.putEvents(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown EventBridge operation: "+op)
+	}
+}
+
+// writeErr maps canonical cloudemu errors to EventBridge JSON error responses.
+// EventBridge returns errors as HTTP 400 with a "__type" body the SDK maps to a
+// typed exception.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidStateException", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalException", err.Error())
+	}
+}

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -1,0 +1,291 @@
+package eventbridge
+
+import (
+	"net/http"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// --- event buses ---
+
+func (h *Handler) createEventBus(w http.ResponseWriter, r *http.Request) {
+	var req createEventBusRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
+		Name: req.Name,
+		Tags: tagsToMap(req.Tags),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, createEventBusResponse{
+		EventBusArn: info.ARN,
+		Description: req.Description,
+	})
+}
+
+func (h *Handler) describeEventBus(w http.ResponseWriter, r *http.Request) {
+	var req nameRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.bus.GetEventBus(r.Context(), busNameOrDefault(req.Name))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, describeEventBusResponse{
+		Arn:          info.ARN,
+		Name:         info.Name,
+		CreationTime: epochSeconds(info.CreatedAt),
+	})
+}
+
+func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
+	infos, err := h.bus.ListEventBuses(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	entries := make([]eventBusEntry, 0, len(infos))
+	for i := range infos {
+		entries = append(entries, eventBusEntry{
+			Arn:          infos[i].ARN,
+			Name:         infos[i].Name,
+			CreationTime: epochSeconds(infos[i].CreatedAt),
+		})
+	}
+
+	wire.WriteJSON(w, listEventBusesResponse{EventBuses: entries})
+}
+
+func (h *Handler) deleteEventBus(w http.ResponseWriter, r *http.Request) {
+	var req nameRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.bus.DeleteEventBus(r.Context(), req.Name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+// --- rules ---
+
+func (h *Handler) putRule(w http.ResponseWriter, r *http.Request) {
+	var req putRuleRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rule, err := h.bus.PutRule(r.Context(), &ebdriver.RuleConfig{
+		Name:         req.Name,
+		EventBus:     req.EventBusName,
+		Description:  req.Description,
+		EventPattern: req.EventPattern,
+		State:        req.State,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, putRuleResponse{RuleArn: ruleARN(rule.EventBus, rule.Name)})
+}
+
+func (h *Handler) describeRule(w http.ResponseWriter, r *http.Request) {
+	var req ruleRefRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rule, err := h.bus.GetRule(r.Context(), busNameOrDefault(req.EventBusName), req.Name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, describeRuleResponse{
+		Arn:          ruleARN(rule.EventBus, rule.Name),
+		Name:         rule.Name,
+		EventBusName: rule.EventBus,
+		Description:  rule.Description,
+		EventPattern: rule.EventPattern,
+		State:        rule.State,
+	})
+}
+
+func (h *Handler) listRules(w http.ResponseWriter, r *http.Request) {
+	var req ruleRefRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rules, err := h.bus.ListRules(r.Context(), busNameOrDefault(req.EventBusName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	entries := make([]ruleEntry, 0, len(rules))
+	for i := range rules {
+		entries = append(entries, ruleEntry{
+			Arn:          ruleARN(rules[i].EventBus, rules[i].Name),
+			Name:         rules[i].Name,
+			EventBusName: rules[i].EventBus,
+			Description:  rules[i].Description,
+			EventPattern: rules[i].EventPattern,
+			State:        rules[i].State,
+		})
+	}
+
+	wire.WriteJSON(w, listRulesResponse{Rules: entries})
+}
+
+func (h *Handler) deleteRule(w http.ResponseWriter, r *http.Request) {
+	var req ruleRefRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.bus.DeleteRule(r.Context(), busNameOrDefault(req.EventBusName), req.Name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+func (h *Handler) enableRule(w http.ResponseWriter, r *http.Request) {
+	var req ruleRefRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.bus.EnableRule(r.Context(), busNameOrDefault(req.EventBusName), req.Name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+func (h *Handler) disableRule(w http.ResponseWriter, r *http.Request) {
+	var req ruleRefRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.bus.DisableRule(r.Context(), busNameOrDefault(req.EventBusName), req.Name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+// --- targets ---
+
+func (h *Handler) putTargets(w http.ResponseWriter, r *http.Request) {
+	var req putTargetsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	targets := make([]ebdriver.Target, 0, len(req.Targets))
+	for i := range req.Targets {
+		targets = append(targets, fromTargetJSON(&req.Targets[i]))
+	}
+
+	err := h.bus.PutTargets(r.Context(), busNameOrDefault(req.EventBusName), req.Rule, targets)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, putTargetsResponse{FailedEntries: []any{}})
+}
+
+func (h *Handler) removeTargets(w http.ResponseWriter, r *http.Request) {
+	var req removeTargetsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	err := h.bus.RemoveTargets(r.Context(), busNameOrDefault(req.EventBusName), req.Rule, req.Ids)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, removeTargetsResponse{FailedEntries: []any{}})
+}
+
+func (h *Handler) listTargetsByRule(w http.ResponseWriter, r *http.Request) {
+	var req listTargetsByRuleRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	targets, err := h.bus.ListTargets(r.Context(), busNameOrDefault(req.EventBusName), req.Rule)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]targetJSON, 0, len(targets))
+	for i := range targets {
+		out = append(out, toTargetJSON(&targets[i]))
+	}
+
+	wire.WriteJSON(w, listTargetsByRuleResponse{Targets: out})
+}
+
+// --- events ---
+
+func (h *Handler) putEvents(w http.ResponseWriter, r *http.Request) {
+	var req putEventsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	events := make([]ebdriver.Event, 0, len(req.Entries))
+	for i := range req.Entries {
+		e := &req.Entries[i]
+		events = append(events, ebdriver.Event{
+			Source:     e.Source,
+			DetailType: e.DetailType,
+			Detail:     e.Detail,
+			EventBus:   busNameOrDefault(e.EventBusName),
+			Resources:  e.Resources,
+		})
+	}
+
+	res, err := h.bus.PutEvents(r.Context(), events)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	entries := make([]putEventsResultEntry, 0, len(res.EventIDs))
+	for _, id := range res.EventIDs {
+		entries = append(entries, putEventsResultEntry{EventID: id})
+	}
+
+	wire.WriteJSON(w, putEventsResponse{
+		FailedEntryCount: res.FailCount,
+		Entries:          entries,
+	})
+}

--- a/server/aws/eventbridge/sdk_roundtrip_test.go
+++ b/server/aws/eventbridge/sdk_roundtrip_test.go
@@ -1,0 +1,249 @@
+package eventbridge_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newEventBridgeClient(t *testing.T) *awseb.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EventBridge: cloud.EventBridge})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awseb.NewFromConfig(cfg, func(o *awseb.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKEventBridgeLifecycle(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{
+		Name: aws.String("orders-bus"),
+		Tags: []ebtypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	if aws.ToString(created.EventBusArn) == "" {
+		t.Fatalf("CreateEventBus returned empty ARN: %+v", created)
+	}
+
+	desc, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{Name: aws.String("orders-bus")})
+	if err != nil {
+		t.Fatalf("DescribeEventBus: %v", err)
+	}
+
+	if aws.ToString(desc.Name) != "orders-bus" {
+		t.Fatalf("DescribeEventBus name = %q, want orders-bus", aws.ToString(desc.Name))
+	}
+
+	rule, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("order-created"),
+		EventBusName: aws.String("orders-bus"),
+		EventPattern: aws.String(`{"source":["orders"]}`),
+		State:        ebtypes.RuleStateEnabled,
+	})
+	if err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if aws.ToString(rule.RuleArn) == "" {
+		t.Fatalf("PutRule returned empty RuleArn")
+	}
+
+	if _, err := client.PutTargets(ctx, &awseb.PutTargetsInput{
+		Rule:         aws.String("order-created"),
+		EventBusName: aws.String("orders-bus"),
+		Targets: []ebtypes.Target{
+			{Id: aws.String("t1"), Arn: aws.String("arn:aws:lambda:us-east-1:111122223333:function:handler")},
+		},
+	}); err != nil {
+		t.Fatalf("PutTargets: %v", err)
+	}
+
+	targets, err := client.ListTargetsByRule(ctx, &awseb.ListTargetsByRuleInput{
+		Rule:         aws.String("order-created"),
+		EventBusName: aws.String("orders-bus"),
+	})
+	if err != nil {
+		t.Fatalf("ListTargetsByRule: %v", err)
+	}
+
+	if len(targets.Targets) != 1 || aws.ToString(targets.Targets[0].Id) != "t1" {
+		t.Fatalf("ListTargetsByRule = %+v, want one target t1", targets.Targets)
+	}
+
+	put, err := client.PutEvents(ctx, &awseb.PutEventsInput{
+		Entries: []ebtypes.PutEventsRequestEntry{
+			{
+				Source:       aws.String("orders"),
+				DetailType:   aws.String("OrderCreated"),
+				Detail:       aws.String(`{"orderId":"1"}`),
+				EventBusName: aws.String("orders-bus"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PutEvents: %v", err)
+	}
+
+	if put.FailedEntryCount != 0 {
+		t.Fatalf("PutEvents FailedEntryCount = %d, want 0", put.FailedEntryCount)
+	}
+
+	if len(put.Entries) != 1 || aws.ToString(put.Entries[0].EventId) == "" {
+		t.Fatalf("PutEvents Entries = %+v, want one entry with EventId", put.Entries)
+	}
+
+	rules, err := client.ListRules(ctx, &awseb.ListRulesInput{EventBusName: aws.String("orders-bus")})
+	if err != nil {
+		t.Fatalf("ListRules: %v", err)
+	}
+
+	if len(rules.Rules) != 1 || aws.ToString(rules.Rules[0].Name) != "order-created" {
+		t.Fatalf("ListRules = %+v, want one rule order-created", rules.Rules)
+	}
+
+	buses, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{})
+	if err != nil {
+		t.Fatalf("ListEventBuses: %v", err)
+	}
+
+	// The driver seeds a "default" bus, so we expect it plus orders-bus.
+	if !containsBus(buses.EventBuses, "orders-bus") {
+		t.Fatalf("ListEventBuses = %+v, want orders-bus present", buses.EventBuses)
+	}
+
+	if _, err := client.RemoveTargets(ctx, &awseb.RemoveTargetsInput{
+		Rule:         aws.String("order-created"),
+		EventBusName: aws.String("orders-bus"),
+		Ids:          []string{"t1"},
+	}); err != nil {
+		t.Fatalf("RemoveTargets: %v", err)
+	}
+
+	if _, err := client.DeleteRule(ctx, &awseb.DeleteRuleInput{
+		Name:         aws.String("order-created"),
+		EventBusName: aws.String("orders-bus"),
+	}); err != nil {
+		t.Fatalf("DeleteRule: %v", err)
+	}
+
+	if _, err := client.DeleteEventBus(ctx, &awseb.DeleteEventBusInput{Name: aws.String("orders-bus")}); err != nil {
+		t.Fatalf("DeleteEventBus: %v", err)
+	}
+
+	if _, err := client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{Name: aws.String("orders-bus")}); err == nil {
+		t.Fatal("DescribeEventBus after delete: want error, got nil")
+	}
+}
+
+func TestSDKEventBridgeRuleState(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("b")}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	if _, err := client.PutRule(ctx, &awseb.PutRuleInput{
+		Name:         aws.String("r"),
+		EventBusName: aws.String("b"),
+		State:        ebtypes.RuleStateEnabled,
+	}); err != nil {
+		t.Fatalf("PutRule: %v", err)
+	}
+
+	if _, err := client.DisableRule(ctx, &awseb.DisableRuleInput{
+		Name: aws.String("r"), EventBusName: aws.String("b"),
+	}); err != nil {
+		t.Fatalf("DisableRule: %v", err)
+	}
+
+	got, err := client.DescribeRule(ctx, &awseb.DescribeRuleInput{
+		Name: aws.String("r"), EventBusName: aws.String("b"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeRule: %v", err)
+	}
+
+	if got.State != ebtypes.RuleStateDisabled {
+		t.Fatalf("rule state = %q, want DISABLED", got.State)
+	}
+
+	if _, err := client.EnableRule(ctx, &awseb.EnableRuleInput{
+		Name: aws.String("r"), EventBusName: aws.String("b"),
+	}); err != nil {
+		t.Fatalf("EnableRule: %v", err)
+	}
+
+	got, err = client.DescribeRule(ctx, &awseb.DescribeRuleInput{
+		Name: aws.String("r"), EventBusName: aws.String("b"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeRule: %v", err)
+	}
+
+	if got.State != ebtypes.RuleStateEnabled {
+		t.Fatalf("rule state = %q, want ENABLED", got.State)
+	}
+}
+
+func TestSDKEventBridgeErrors(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("dup")}); err != nil {
+		t.Fatalf("CreateEventBus: %v", err)
+	}
+
+	_, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{Name: aws.String("dup")})
+
+	var exists *ebtypes.ResourceAlreadyExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("duplicate CreateEventBus: got %v, want ResourceAlreadyExistsException", err)
+	}
+
+	_, err = client.DescribeEventBus(ctx, &awseb.DescribeEventBusInput{Name: aws.String("missing")})
+
+	var notFound *ebtypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("DescribeEventBus(missing): got %v, want ResourceNotFoundException", err)
+	}
+}
+
+func containsBus(buses []ebtypes.EventBus, name string) bool {
+	for i := range buses {
+		if aws.ToString(buses[i].Name) == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/eventbridge/types.go
+++ b/server/aws/eventbridge/types.go
@@ -1,0 +1,207 @@
+package eventbridge
+
+import (
+	"time"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+)
+
+// defaultBusName is the implicit bus EventBridge routes to when a request omits
+// EventBusName; it mirrors the driver's own default.
+const defaultBusName = "default"
+
+type tagJSON struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+// --- request envelopes ---
+
+type createEventBusRequest struct {
+	Name        string    `json:"Name"`
+	Description string    `json:"Description"`
+	Tags        []tagJSON `json:"Tags"`
+}
+
+type nameRequest struct {
+	Name string `json:"Name"`
+}
+
+type putRuleRequest struct {
+	Name         string `json:"Name"`
+	EventBusName string `json:"EventBusName"`
+	Description  string `json:"Description"`
+	EventPattern string `json:"EventPattern"`
+	State        string `json:"State"`
+}
+
+type ruleRefRequest struct {
+	Name         string `json:"Name"`
+	EventBusName string `json:"EventBusName"`
+}
+
+type targetJSON struct {
+	ID    string `json:"Id"`
+	ARN   string `json:"Arn"`
+	Input string `json:"Input,omitempty"`
+}
+
+type putTargetsRequest struct {
+	Rule         string       `json:"Rule"`
+	EventBusName string       `json:"EventBusName"`
+	Targets      []targetJSON `json:"Targets"`
+}
+
+type removeTargetsRequest struct {
+	Rule         string   `json:"Rule"`
+	EventBusName string   `json:"EventBusName"`
+	Ids          []string `json:"Ids"`
+}
+
+type listTargetsByRuleRequest struct {
+	Rule         string `json:"Rule"`
+	EventBusName string `json:"EventBusName"`
+}
+
+type putEventsEntry struct {
+	Source       string   `json:"Source"`
+	DetailType   string   `json:"DetailType"`
+	Detail       string   `json:"Detail"`
+	EventBusName string   `json:"EventBusName"`
+	Resources    []string `json:"Resources"`
+}
+
+type putEventsRequest struct {
+	Entries []putEventsEntry `json:"Entries"`
+}
+
+// --- response envelopes ---
+
+type createEventBusResponse struct {
+	EventBusArn string `json:"EventBusArn"`
+	Description string `json:"Description,omitempty"`
+}
+
+type describeEventBusResponse struct {
+	Arn          string  `json:"Arn"`
+	Name         string  `json:"Name"`
+	Description  string  `json:"Description,omitempty"`
+	CreationTime float64 `json:"CreationTime,omitempty"`
+}
+
+type eventBusEntry struct {
+	Arn          string  `json:"Arn"`
+	Name         string  `json:"Name"`
+	Description  string  `json:"Description,omitempty"`
+	CreationTime float64 `json:"CreationTime,omitempty"`
+}
+
+type listEventBusesResponse struct {
+	EventBuses []eventBusEntry `json:"EventBuses"`
+}
+
+type putRuleResponse struct {
+	RuleArn string `json:"RuleArn"`
+}
+
+type describeRuleResponse struct {
+	Arn          string `json:"Arn"`
+	Name         string `json:"Name"`
+	EventBusName string `json:"EventBusName"`
+	Description  string `json:"Description,omitempty"`
+	EventPattern string `json:"EventPattern,omitempty"`
+	State        string `json:"State"`
+}
+
+type ruleEntry struct {
+	Arn          string `json:"Arn"`
+	Name         string `json:"Name"`
+	EventBusName string `json:"EventBusName"`
+	Description  string `json:"Description,omitempty"`
+	EventPattern string `json:"EventPattern,omitempty"`
+	State        string `json:"State"`
+}
+
+type listRulesResponse struct {
+	Rules []ruleEntry `json:"Rules"`
+}
+
+type putTargetsResponse struct {
+	FailedEntryCount int   `json:"FailedEntryCount"`
+	FailedEntries    []any `json:"FailedEntries"`
+}
+
+type removeTargetsResponse struct {
+	FailedEntryCount int   `json:"FailedEntryCount"`
+	FailedEntries    []any `json:"FailedEntries"`
+}
+
+type listTargetsByRuleResponse struct {
+	Targets []targetJSON `json:"Targets"`
+}
+
+type putEventsResultEntry struct {
+	EventID string `json:"EventId,omitempty"`
+}
+
+type putEventsResponse struct {
+	FailedEntryCount int                    `json:"FailedEntryCount"`
+	Entries          []putEventsResultEntry `json:"Entries"`
+}
+
+// --- helpers ---
+
+// busNameOrDefault resolves an optional EventBusName to the driver-facing bus
+// name, mirroring the driver's default-bus behavior.
+func busNameOrDefault(name string) string {
+	if name == "" {
+		return defaultBusName
+	}
+
+	return name
+}
+
+func tagsToMap(tags []tagJSON) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}
+
+// epochSeconds converts an RFC3339 timestamp to Unix epoch seconds, the form
+// the AWS JSON protocol uses for timestamp fields. Returns 0 on parse failure.
+func epochSeconds(iso string) float64 {
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return float64(t.Unix())
+}
+
+// ruleARN synthesizes an EventBridge rule ARN. The driver's Rule carries no
+// ARN, so we derive a stable identifier the SDK can round-trip. Real
+// EventBridge rule ARNs are "arn:aws:events:<region>:<account>:rule/<bus>/<rule>";
+// region/account aren't threaded into this handler, so they're left as
+// placeholders that keep the ARN shape recognizable.
+func ruleARN(bus, rule string) string {
+	if bus == "" {
+		bus = defaultBusName
+	}
+
+	return "arn:aws:events:::rule/" + bus + "/" + rule
+}
+
+func toTargetJSON(t *ebdriver.Target) targetJSON {
+	return targetJSON{ID: t.ID, ARN: t.ARN, Input: t.Input}
+}
+
+func fromTargetJSON(t *targetJSON) ebdriver.Target {
+	return ebdriver.Target{ID: t.ID, ARN: t.ARN, Input: t.Input}
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -12,6 +12,7 @@ import (
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	dbxdriver "github.com/stackshy/cloudemu/databricks/driver"
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
@@ -44,6 +45,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/databricks/wsfs"
 	"github.com/stackshy/cloudemu/server/azure/disks"
 	dnssrv "github.com/stackshy/cloudemu/server/azure/dns"
+	eventgridsrv "github.com/stackshy/cloudemu/server/azure/eventgrid"
 	"github.com/stackshy/cloudemu/server/azure/functions"
 	"github.com/stackshy/cloudemu/server/azure/iam"
 	"github.com/stackshy/cloudemu/server/azure/images"
@@ -96,6 +98,9 @@ type Drivers struct {
 	// LB serves the Azure Load Balancer (Microsoft.Network/loadBalancers) ARM
 	// API against the loadbalancer driver.
 	LB                  lbdriver.LoadBalancer
+	// EventGrid serves the Azure Event Grid (Microsoft.EventGrid/topics) ARM API
+	// against the eventbus driver, mapping topics to event buses.
+	EventGrid           ebdriver.EventBus
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -168,6 +173,11 @@ func New(d Drivers) *server.Server {
 	// unconstrained. Registered before the BlobStorage fallback.
 	if d.LB != nil {
 		srv.Register(lbsrv.New(d.LB))
+	// Event Grid claims Microsoft.EventGrid/topics — a distinct ARM provider
+	// name from every other Azure handler, so registration order is
+	// unconstrained. Registered before the BlobStorage fallback.
+	if d.EventGrid != nil {
+		srv.Register(eventgridsrv.New(d.EventGrid))
 	}
 
 	if d.Monitor != nil {

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -97,7 +97,7 @@ type Drivers struct {
 	DNS dnsdriver.DNS
 	// LB serves the Azure Load Balancer (Microsoft.Network/loadBalancers) ARM
 	// API against the loadbalancer driver.
-	LB                  lbdriver.LoadBalancer
+	LB lbdriver.LoadBalancer
 	// EventGrid serves the Azure Event Grid (Microsoft.EventGrid/topics) ARM API
 	// against the eventbus driver, mapping topics to event buses.
 	EventGrid           ebdriver.EventBus
@@ -173,6 +173,8 @@ func New(d Drivers) *server.Server {
 	// unconstrained. Registered before the BlobStorage fallback.
 	if d.LB != nil {
 		srv.Register(lbsrv.New(d.LB))
+	}
+
 	// Event Grid claims Microsoft.EventGrid/topics — a distinct ARM provider
 	// name from every other Azure handler, so registration order is
 	// unconstrained. Registered before the BlobStorage fallback.

--- a/server/azure/eventgrid/handler.go
+++ b/server/azure/eventgrid/handler.go
@@ -1,0 +1,96 @@
+// Package eventgrid implements the Azure Event Grid
+// (Microsoft.EventGrid/topics) ARM REST API as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2
+// clients configured with a custom endpoint hit this handler the same way they
+// hit management.azure.com, driving the shared eventbus driver.
+//
+// Event Grid topics map onto the eventbus driver's event buses: a topic is an
+// event bus keyed by its user-assigned name. The driver's rule/target and
+// event-publish model has no ARM management-plane surface — Event Grid models
+// those as event subscriptions and a separate data-plane publish endpoint on
+// the topic's own hostname — so this handler covers only the topic
+// (event-bus) lifecycle. See the package README note in the New docstring for
+// the honest scope.
+//
+// This handler claims Microsoft.EventGrid/topics only; it is disjoint from
+// every other Azure ARM provider, so registration order relative to them is
+// unconstrained. It must register before the permissive BlobStorage fallback.
+//
+// Coverage:
+//
+//	PUT    .../providers/Microsoft.EventGrid/topics/{t}   — Topics.CreateOrUpdate (LRO, completes inline)
+//	GET    .../providers/Microsoft.EventGrid/topics/{t}   — Topics.Get
+//	DELETE .../providers/Microsoft.EventGrid/topics/{t}   — Topics.Delete (LRO, completes inline)
+//	GET    .../providers/Microsoft.EventGrid/topics       — Topics.ListBySubscription / ListByResourceGroup
+package eventgrid
+
+import (
+	"net/http"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName = "Microsoft.EventGrid"
+	typeTopics   = "topics"
+)
+
+// Handler serves Microsoft.EventGrid/topics ARM requests against an eventbus
+// driver.
+type Handler struct {
+	bus ebdriver.EventBus
+}
+
+// New returns an Azure Event Grid handler backed by b.
+func New(b ebdriver.EventBus) *Handler {
+	return &Handler{bus: b}
+}
+
+// Matches claims ARM URLs targeting Microsoft.EventGrid/topics. Disjoint from
+// every other Azure ARM provider, so registration order is unconstrained.
+// Registered before the BlobStorage fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == typeTopics
+}
+
+// ServeHTTP routes on the parsed path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// Collection list: no topic name (subscription- or RG-scoped list).
+	if rp.ResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listTopics(w, r, &rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateTopic(w, r, &rp)
+	case http.MethodGet:
+		h.getTopic(w, r, &rp)
+	case http.MethodDelete:
+		h.deleteTopic(w, r, &rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -1,0 +1,71 @@
+package eventgrid
+
+import (
+	"net/http"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+func (h *Handler) createOrUpdateTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body topicJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// CreateOrUpdate is idempotent: if the topic already exists, echo it back.
+	if info, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
+		azurearm.WriteJSON(w, http.StatusCreated, toTopicJSON(rp, info))
+		return
+	}
+
+	info, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
+		Name: rp.ResourceName,
+		Tags: tagsFromPtr(body.Tags),
+	})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	// 201 Created with a terminal provisioningState completes the SDK's LRO
+	// poller on the first response.
+	azurearm.WriteJSON(w, http.StatusCreated, toTopicJSON(rp, info))
+}
+
+func (h *Handler) getTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	info, err := h.bus.GetEventBus(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toTopicJSON(rp, info))
+}
+
+// deleteTopic removes the topic. Topics.Delete is an LRO in the SDK whose
+// polling accepts 202/204; returning 204 with no body completes the poller on
+// the first response.
+func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.bus.DeleteEventBus(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	infos, err := h.bus.ListEventBuses(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]topicJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toTopicJSON(rp, &infos[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, topicListResult{Value: out})
+}

--- a/server/azure/eventgrid/sdk_roundtrip_test.go
+++ b/server/azure/eventgrid/sdk_roundtrip_test.go
@@ -1,0 +1,142 @@
+package eventgrid_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+const (
+	testRG  = "rg-1"
+	testSub = "sub-1"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newTopicsClient(t *testing.T) *armeventgrid.TopicsClient {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{EventGrid: cloudP.EventGrid})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armeventgrid.NewClientFactory(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("armeventgrid.NewClientFactory: %v", err)
+	}
+
+	return cf.NewTopicsClient()
+}
+
+func TestSDKAzureEventGridTopicLifecycle(t *testing.T) {
+	topics := newTopicsClient(t)
+	ctx := context.Background()
+
+	createPoller, err := topics.BeginCreateOrUpdate(ctx, testRG, "orders-topic", armeventgrid.Topic{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("Topics.BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := createPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "orders-topic" {
+		t.Fatalf("CreateOrUpdate name = %v, want orders-topic", created.Name)
+	}
+
+	got, err := topics.Get(ctx, testRG, "orders-topic", nil)
+	if err != nil {
+		t.Fatalf("Topics.Get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tags = %v, want env=test", got.Tags)
+	}
+
+	var names []string
+
+	pager := topics.NewListByResourceGroupPager(testRG, nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByResourceGroup: %v", perr)
+		}
+
+		for _, tp := range page.Value {
+			names = append(names, *tp.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "orders-topic" {
+		t.Fatalf("list = %v, want [orders-topic]", names)
+	}
+
+	delPoller, err := topics.BeginDelete(ctx, testRG, "orders-topic", nil)
+	if err != nil {
+		t.Fatalf("Topics.BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	_, err = topics.Get(ctx, testRG, "orders-topic", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKAzureEventGridErrors(t *testing.T) {
+	topics := newTopicsClient(t)
+	ctx := context.Background()
+
+	_, err := topics.Get(ctx, testRG, "missing", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+}

--- a/server/azure/eventgrid/types.go
+++ b/server/azure/eventgrid/types.go
@@ -1,0 +1,84 @@
+package eventgrid
+
+import (
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	topicResourceType    = "Microsoft.EventGrid/topics"
+	defaultTopicLocation = "global"
+	// provisioningSucceeded is the terminal ProvisioningState Event Grid
+	// reports once a topic is ready. Stamping it on the CreateOrUpdate response
+	// lets the SDK's body-based LRO poller complete on the first response.
+	provisioningSucceeded = "Succeeded"
+)
+
+// topicProperties carries the read-only provisioning state and endpoint the SDK
+// expects on a topic. The eventbus driver has no endpoint concept, so Endpoint
+// is left empty.
+type topicProperties struct {
+	ProvisioningState string `json:"provisioningState,omitempty"`
+	Endpoint          string `json:"endpoint,omitempty"`
+}
+
+// topicJSON is the ARM Topic resource shape. Only the fields the SDK reads back
+// are populated.
+type topicJSON struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name"`
+	Type       string             `json:"type"`
+	Location   string             `json:"location"`
+	Tags       map[string]*string `json:"tags,omitempty"`
+	Properties *topicProperties   `json:"properties,omitempty"`
+}
+
+type topicListResult struct {
+	Value []topicJSON `json:"value"`
+}
+
+// toTopicJSON converts a driver event bus into its ARM Topic element for the
+// given path scope. Event Grid topics are always "global" location.
+func toTopicJSON(rp *azurearm.ResourcePath, info *ebdriver.EventBusInfo) topicJSON {
+	return topicJSON{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeTopics, info.Name),
+		Name:     info.Name,
+		Type:     topicResourceType,
+		Location: defaultTopicLocation,
+		Tags:     tagsToPtr(info.Tags),
+		Properties: &topicProperties{
+			ProvisioningState: provisioningSucceeded,
+		},
+	}
+}
+
+// tagsToPtr converts the driver's flat tag map to ARM's map[string]*string.
+func tagsToPtr(tags map[string]string) map[string]*string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]*string, len(tags))
+	for k, v := range tags {
+		val := v
+		out[k] = &val
+	}
+
+	return out
+}
+
+// tagsFromPtr converts ARM's map[string]*string tags to the driver's flat map.
+func tagsFromPtr(tags map[string]*string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for k, v := range tags {
+		if v != nil {
+			out[k] = *v
+		}
+	}
+
+	return out
+}

--- a/server/gcp/eventarc/handler.go
+++ b/server/gcp/eventarc/handler.go
@@ -1,0 +1,134 @@
+// Package eventarc implements the eventarc.googleapis.com v1 REST API as a
+// server.Handler. Real google.golang.org/api/eventarc/v1 clients pointed at
+// this server create, get, list, and delete triggers end-to-end against the
+// shared eventbus driver.
+//
+// Mapping (and what does NOT fit):
+//
+// Eventarc's public trigger API models a trigger as a filter → destination
+// route; it has no first-class "event bus" in this surface (channels exist but
+// only for third-party/partner sources and are not exercised by the trigger
+// CRUD the SDK drives here). The eventbus driver, by contrast, requires a rule
+// to live under an event bus, and its rule shape is (name, event-pattern,
+// state, targets). We bridge the two by:
+//
+//   - Auto-provisioning one event bus per location, named "eventarc-<location>",
+//     the first time a trigger is created there. This is a synthesized
+//     container with no Eventarc analogue — the SDK never sees it.
+//   - Mapping each trigger onto a driver rule keyed by the trigger id, with the
+//     trigger's eventFilters serialized into the rule's EventPattern and the
+//     destination folded into a single target so Get/List can round-trip them.
+//
+// Consequences of the impedance mismatch: Eventarc's rich destination types
+// (Cloud Run, GKE, Cloud Functions, Workflows, HTTP), transport, channels, and
+// conditions collapse onto the driver's flat Target/EventPattern strings, so
+// only the subset the driver can store survives a round-trip. This is an honest
+// approximation, not a faithful Eventarc emulation.
+//
+// This handler claims /v1/projects/{p}/locations/{l}/triggers[...] — a
+// resource-type guard disjoint from the other /v1/projects/ GCP handlers
+// (Firestore, IAM, Secret Manager, GKE, …), so registration order among them is
+// unconstrained. Registered before the GCS fallback.
+//
+// Coverage (v1 REST):
+//
+//	POST   /v1/projects/{p}/locations/{l}/triggers?triggerId={id}   — Create (LRO, done inline)
+//	GET    /v1/projects/{p}/locations/{l}/triggers/{id}             — Get
+//	GET    /v1/projects/{p}/locations/{l}/triggers                  — List
+//	DELETE /v1/projects/{p}/locations/{l}/triggers/{id}             — Delete (LRO, done inline)
+package eventarc
+
+import (
+	"net/http"
+	"strings"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	pathPrefix   = "/v1/projects/"
+	locationsSeg = "locations"
+	triggersSeg  = "triggers"
+)
+
+// minTriggersCollectionParts is the segment count of a triggers collection
+// path: [projects, {p}, locations, {l}, triggers].
+const minTriggersCollectionParts = 5
+
+// Handler serves eventarc.googleapis.com v1 trigger requests against an
+// eventbus driver.
+type Handler struct {
+	bus ebdriver.EventBus
+}
+
+// New returns an Eventarc handler backed by b.
+func New(b ebdriver.EventBus) *Handler {
+	return &Handler{bus: b}
+}
+
+type route struct {
+	project  string
+	location string
+	trigger  string // trigger id; empty for the collection
+}
+
+// parseRoute extracts the components of an Eventarc v1 triggers path.
+func parseRoute(urlPath string) (route, bool) {
+	if !strings.HasPrefix(urlPath, pathPrefix) {
+		return route{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(urlPath, "/v1/"), "/")
+	// parts: [projects, {p}, locations, {l}, triggers, {id}?]
+	if len(parts) < minTriggersCollectionParts ||
+		parts[0] != "projects" || parts[2] != locationsSeg || parts[4] != triggersSeg {
+		return route{}, false
+	}
+
+	rt := route{project: parts[1], location: parts[3]}
+
+	if len(parts) > minTriggersCollectionParts {
+		rt.trigger = parts[5]
+	}
+
+	return rt, true
+}
+
+// Matches claims Eventarc v1 trigger paths. Disjoint from the other
+// /v1/projects/ GCP handlers, so registration order is unconstrained.
+func (*Handler) Matches(r *http.Request) bool {
+	_, ok := parseRoute(r.URL.Path)
+	return ok
+}
+
+// ServeHTTP dispatches on method and path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "malformed Eventarc v1 path")
+		return
+	}
+
+	if rt.trigger == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listTriggers(w, r, &rt)
+		case http.MethodPost:
+			h.createTrigger(w, r, &rt)
+		default:
+			gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported triggers operation")
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getTrigger(w, r, &rt)
+	case http.MethodDelete:
+		h.deleteTrigger(w, r, &rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported trigger operation")
+	}
+}

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -45,6 +45,9 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 
 	if target, ok := destinationTarget(body.Destination); ok {
 		if perr := h.bus.PutTargets(r.Context(), bus, triggerID, []ebdriver.Target{target}); perr != nil {
+			// Roll back the rule created above so a failed Create doesn't leave
+			// an orphaned trigger that blocks a later Create with the same id.
+			_ = h.bus.DeleteRule(r.Context(), bus, triggerID)
 			gcprest.WriteCErr(w, perr)
 			return
 		}

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -1,0 +1,130 @@
+package eventarc
+
+import (
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
+	triggerID := r.URL.Query().Get("triggerId")
+	if triggerID == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "triggerId is required")
+		return
+	}
+
+	var body triggerJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	bus := channelName(rt.location)
+
+	// Auto-provision the location's backing event bus on first use. Ignore an
+	// already-exists error so concurrent/repeat creates are idempotent.
+	if err := h.ensureChannel(r, bus); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if _, err := h.bus.GetRule(r.Context(), bus, triggerID); err == nil {
+		gcprest.WriteCErr(w, cerrors.Newf(cerrors.AlreadyExists, "trigger %q already exists", triggerID))
+		return
+	}
+
+	if _, err := h.bus.PutRule(r.Context(), &ebdriver.RuleConfig{
+		Name:         triggerID,
+		EventBus:     bus,
+		EventPattern: encodeEventPattern(body.EventFilters),
+	}); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	if target, ok := destinationTarget(body.Destination); ok {
+		if perr := h.bus.PutTargets(r.Context(), bus, triggerID, []ebdriver.Target{target}); perr != nil {
+			gcprest.WriteCErr(w, perr)
+			return
+		}
+	}
+
+	// Re-fetch so the response carries the stored targets/destination.
+	stored, err := h.bus.GetRule(r.Context(), bus, triggerID)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, triggerID,
+		toTriggerJSON(rt.project, rt.location, stored)))
+}
+
+func (h *Handler) getTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
+	rule, err := h.bus.GetRule(r.Context(), channelName(rt.location), rt.trigger)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toTriggerJSON(rt.project, rt.location, rule))
+}
+
+func (h *Handler) listTriggers(w http.ResponseWriter, r *http.Request, rt *route) {
+	bus := channelName(rt.location)
+
+	rules, err := h.bus.ListRules(r.Context(), bus)
+	if err != nil {
+		// A location with no triggers has no backing bus yet; report an empty
+		// list rather than an error, matching Eventarc's List semantics.
+		if cerrors.IsNotFound(err) {
+			gcprest.WriteJSON(w, http.StatusOK, listTriggersResponse{Triggers: []triggerJSON{}})
+			return
+		}
+
+		gcprest.WriteCErr(w, err)
+
+		return
+	}
+
+	out := make([]triggerJSON, 0, len(rules))
+	for i := range rules {
+		out = append(out, toTriggerJSON(rt.project, rt.location, &rules[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listTriggersResponse{Triggers: out})
+}
+
+func (h *Handler) deleteTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
+	if err := h.bus.DeleteRule(r.Context(), channelName(rt.location), rt.trigger); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt, rt.trigger, nil))
+}
+
+// ensureChannel creates the location's backing event bus if it does not already
+// exist. An already-exists result is treated as success.
+func (h *Handler) ensureChannel(r *http.Request, bus string) error {
+	if _, err := h.bus.GetEventBus(r.Context(), bus); err == nil {
+		return nil
+	}
+
+	_, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{Name: bus})
+	if err != nil && !cerrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+// doneOperation builds a completed long-running operation envelope.
+func doneOperation(rt *route, id string, response any) operationJSON {
+	return operationJSON{
+		Name:     "projects/" + rt.project + "/locations/" + rt.location + "/operations/op-" + id,
+		Done:     true,
+		Response: response,
+	}
+}

--- a/server/gcp/eventarc/sdk_roundtrip_test.go
+++ b/server/gcp/eventarc/sdk_roundtrip_test.go
@@ -1,0 +1,147 @@
+package eventarc_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	eventarc "google.golang.org/api/eventarc/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const (
+	testProject  = "demo"
+	testLocation = "us-central1"
+)
+
+func newEventarcService(t *testing.T) *eventarc.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{Eventarc: cloud.Eventarc})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := eventarc.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("eventarc.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func parent() string {
+	return "projects/" + testProject + "/locations/" + testLocation
+}
+
+func TestSDKEventarcTriggerLifecycle(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	trigger := &eventarc.Trigger{
+		EventFilters: []*eventarc.EventFilter{
+			{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"},
+		},
+		Destination: &eventarc.Destination{
+			CloudRun: &eventarc.CloudRun{Service: "my-service", Region: testLocation},
+		},
+	}
+
+	op, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+		TriggerId("obj-created").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Create: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatalf("Create operation not done: %+v", op)
+	}
+
+	got, err := svc.Projects.Locations.Triggers.Get(parent() + "/triggers/obj-created").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Get: %v", err)
+	}
+
+	if got.Name != parent()+"/triggers/obj-created" {
+		t.Fatalf("trigger name = %q, want .../triggers/obj-created", got.Name)
+	}
+
+	if len(got.EventFilters) != 1 || got.EventFilters[0].Value != "google.cloud.storage.object.v1.finalized" {
+		t.Fatalf("event filters = %+v, want one storage-finalized filter", got.EventFilters)
+	}
+
+	if got.Destination == nil || got.Destination.CloudRun == nil || got.Destination.CloudRun.Service != "my-service" {
+		t.Fatalf("destination = %+v, want cloudRun service my-service", got.Destination)
+	}
+
+	list, err := svc.Projects.Locations.Triggers.List(parent()).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.List: %v", err)
+	}
+
+	if len(list.Triggers) != 1 || list.Triggers[0].Name != parent()+"/triggers/obj-created" {
+		t.Fatalf("List = %+v, want one trigger obj-created", list.Triggers)
+	}
+
+	delOp, err := svc.Projects.Locations.Triggers.Delete(parent() + "/triggers/obj-created").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Triggers.Delete: %v", err)
+	}
+
+	if !delOp.Done {
+		t.Fatalf("Delete operation not done: %+v", delOp)
+	}
+
+	_, err = svc.Projects.Locations.Triggers.Get(parent() + "/triggers/obj-created").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKEventarcErrors(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	// Get on a location with no triggers yet is a 404.
+	_, err := svc.Projects.Locations.Triggers.Get(parent() + "/triggers/missing").Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+
+	// List on an empty location returns an empty list, not an error.
+	list, err := svc.Projects.Locations.Triggers.List(parent()).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("List(empty): %v", err)
+	}
+
+	if len(list.Triggers) != 0 {
+		t.Fatalf("List(empty) = %+v, want no triggers", list.Triggers)
+	}
+
+	// Duplicate create is a conflict.
+	tr := &eventarc.Trigger{
+		Destination: &eventarc.Destination{CloudRun: &eventarc.CloudRun{Service: "s"}},
+	}
+
+	if _, err := svc.Projects.Locations.Triggers.Create(parent(), tr).TriggerId("dup").Context(ctx).Do(); err != nil {
+		t.Fatalf("Create(dup): %v", err)
+	}
+
+	_, err = svc.Projects.Locations.Triggers.Create(parent(), tr).TriggerId("dup").Context(ctx).Do()
+	if !errors.As(err, &gerr) || gerr.Code != 409 {
+		t.Fatalf("duplicate Create: got %v, want 409", err)
+	}
+}

--- a/server/gcp/eventarc/types.go
+++ b/server/gcp/eventarc/types.go
@@ -1,0 +1,166 @@
+package eventarc
+
+import (
+	"encoding/json"
+
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
+)
+
+// destinationTargetID is the fixed target id under which a trigger's
+// destination is stored on the driver rule.
+const destinationTargetID = "destination"
+
+// eventFilterJSON is the Eventarc v1 EventFilter shape.
+type eventFilterJSON struct {
+	Attribute string `json:"attribute,omitempty"`
+	Operator  string `json:"operator,omitempty"`
+	Value     string `json:"value,omitempty"`
+}
+
+// cloudRunJSON is the subset of the Eventarc v1 CloudRun destination we
+// round-trip.
+type cloudRunJSON struct {
+	Service string `json:"service,omitempty"`
+	Region  string `json:"region,omitempty"`
+	Path    string `json:"path,omitempty"`
+}
+
+// destinationJSON is the Eventarc v1 Destination shape (subset).
+type destinationJSON struct {
+	CloudRun      *cloudRunJSON `json:"cloudRun,omitempty"`
+	CloudFunction string        `json:"cloudFunction,omitempty"`
+	Workflow      string        `json:"workflow,omitempty"`
+}
+
+// triggerJSON is the Eventarc v1 Trigger resource shape (subset the driver can
+// store).
+type triggerJSON struct {
+	Name           string            `json:"name,omitempty"`
+	EventFilters   []eventFilterJSON `json:"eventFilters,omitempty"`
+	ServiceAccount string            `json:"serviceAccount,omitempty"`
+	Destination    *destinationJSON  `json:"destination,omitempty"`
+	Labels         map[string]string `json:"labels,omitempty"`
+	CreateTime     string            `json:"createTime,omitempty"`
+	UpdateTime     string            `json:"updateTime,omitempty"`
+	UID            string            `json:"uid,omitempty"`
+}
+
+type listTriggersResponse struct {
+	Triggers      []triggerJSON `json:"triggers"`
+	NextPageToken string        `json:"nextPageToken,omitempty"`
+}
+
+// operationJSON is a google.longrunning.Operation. Eventarc's create and delete
+// are async; the mock returns a completed operation immediately with the
+// resulting resource in Response (create) or nil (delete).
+type operationJSON struct {
+	Name     string `json:"name"`
+	Done     bool   `json:"done"`
+	Response any    `json:"response,omitempty"`
+}
+
+// triggerResourceName builds the fully-qualified Eventarc trigger name.
+func triggerResourceName(project, location, id string) string {
+	return "projects/" + project + "/locations/" + location + "/triggers/" + id
+}
+
+// channelName is the synthesized event-bus name backing a location's triggers.
+// It has no Eventarc analogue and is never surfaced to the SDK.
+func channelName(location string) string {
+	return "eventarc-" + location
+}
+
+// encodeEventPattern serializes a trigger's event filters into the driver rule's
+// EventPattern string so getTrigger can reconstruct them. Returns "" when there
+// are no filters.
+func encodeEventPattern(filters []eventFilterJSON) string {
+	if len(filters) == 0 {
+		return ""
+	}
+
+	b, err := json.Marshal(filters)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
+}
+
+// decodeEventPattern is the inverse of encodeEventPattern.
+func decodeEventPattern(pattern string) []eventFilterJSON {
+	if pattern == "" {
+		return nil
+	}
+
+	var filters []eventFilterJSON
+	if err := json.Unmarshal([]byte(pattern), &filters); err != nil {
+		return nil
+	}
+
+	return filters
+}
+
+// destinationTarget folds a trigger destination into the single driver Target
+// the rule stores. The destination is serialized into the target's Input so it
+// round-trips faithfully; the ARN carries a human-readable summary.
+func destinationTarget(dest *destinationJSON) (ebdriver.Target, bool) {
+	if dest == nil {
+		return ebdriver.Target{}, false
+	}
+
+	input, err := json.Marshal(dest)
+	if err != nil {
+		return ebdriver.Target{}, false
+	}
+
+	return ebdriver.Target{
+		ID:    destinationTargetID,
+		ARN:   destinationSummary(dest),
+		Input: string(input),
+	}, true
+}
+
+// destinationFromTargets reconstructs the trigger destination from the driver
+// rule's targets.
+func destinationFromTargets(targets []ebdriver.Target) *destinationJSON {
+	for i := range targets {
+		if targets[i].ID != destinationTargetID || targets[i].Input == "" {
+			continue
+		}
+
+		var dest destinationJSON
+		if err := json.Unmarshal([]byte(targets[i].Input), &dest); err != nil {
+			return nil
+		}
+
+		return &dest
+	}
+
+	return nil
+}
+
+// destinationSummary is a short human-readable identifier for a destination,
+// used as the driver target's ARN.
+func destinationSummary(dest *destinationJSON) string {
+	switch {
+	case dest.CloudRun != nil && dest.CloudRun.Service != "":
+		return "cloudRun/" + dest.CloudRun.Service
+	case dest.CloudFunction != "":
+		return dest.CloudFunction
+	case dest.Workflow != "":
+		return dest.Workflow
+	default:
+		return ""
+	}
+}
+
+// toTriggerJSON converts a driver rule into its Eventarc Trigger element.
+func toTriggerJSON(project, location string, rule *ebdriver.Rule) triggerJSON {
+	return triggerJSON{
+		Name:         triggerResourceName(project, location, rule.Name),
+		EventFilters: decodeEventPattern(rule.EventPattern),
+		Destination:  destinationFromTargets(rule.Targets),
+		CreateTime:   rule.CreatedAt,
+		UpdateTime:   rule.CreatedAt,
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -11,6 +11,7 @@ import (
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
 	dnsdriver "github.com/stackshy/cloudemu/dns/driver"
+	ebdriver "github.com/stackshy/cloudemu/eventbus/driver"
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
@@ -28,6 +29,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
+	"github.com/stackshy/cloudemu/server/gcp/eventarc"
 	"github.com/stackshy/cloudemu/server/gcp/firestore"
 	"github.com/stackshy/cloudemu/server/gcp/gcs"
 	"github.com/stackshy/cloudemu/server/gcp/gke"
@@ -66,6 +68,9 @@ type Drivers struct {
 	// SecretManager serves the secretmanager.googleapis.com v1 REST API
 	// against the secrets driver.
 	SecretManager secretsdriver.Secrets
+	// Eventarc serves the eventarc.googleapis.com v1 REST API against the
+	// eventbus driver, mapping triggers to rules under a per-location bus.
+	Eventarc ebdriver.EventBus
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -178,6 +183,14 @@ func New(d Drivers) *server.Server {
 	// of the /v1/projects/ family. Registered before Firestore's catch-all.
 	if d.SecretManager != nil {
 		srv.Register(secretmanagersrv.New(d.SecretManager))
+	}
+
+	// Eventarc matches /v1/projects/{p}/locations/{l}/triggers[/…] — a
+	// resource-type guard disjoint from IAM, Artifact Registry, Secret Manager,
+	// GKE, and the rest of the /v1/projects/ family. Registered before
+	// Firestore's catch-all.
+	if d.Eventarc != nil {
+		srv.Register(eventarc.New(d.Eventarc))
 	}
 
 	// Cloud DNS matches /dns/v1/projects/{p}/managedZones[...] — a distinct


### PR DESCRIPTION
SDK-compat servers for the **Event** service across AWS/Azure/GCP — the Event slice of #143, following the merged Secrets/DNS pattern. Real-SDK roundtrip tests per provider; `go build ./...`, `go vet`, and the full `go test ./server/...` tree pass. See the implementing commit for per-provider ops, driver→wire mapping, and documented gaps.
Notes: Azure Event Grid publish is a data-plane endpoint (not in the ARM SDK) so PutEvents isn't reachable via the Azure slice; GCP Eventarc's rich trigger model is approximated onto the driver's bus/rule/target — documented in the package docs.