### PR TITLE
feat(logging): SDK-compat servers for CloudWatch Logs, Log Analytics, and Cloud Logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
@@ -31,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/bedrock v1.64.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.2
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
@@ -77,7 +79,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleserv
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0/go.mod h1:0mKVz3WT8oNjBunT1zD/HPwMleQ72QClMa7Gmsm+6Kc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0 h1:hdC0QToUqJikvZXE/ZSHafNv10IcYYkCPY7B99QhNSc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0/go.mod h1:FwSGecUzQMdebvcN8JqqLlsfgfXZn+Gw+vX9xpHhUMc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 h1:HzqcSJWx32XQdr8KtxAu/SZJj0PqDo9tKf2YGPdynV0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0/go.mod h1:nKcJObAisSPDrO9lMuuCBoYY7Ki7ADt8p6XmBhpKNTk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
@@ -92,8 +94,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
 github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 h1:p1BBrg/Hhp6uK7zpejeI8QFXHJeC/mynzi04Sl03k9g=
-github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13/go.mod h1:8cIfkE9MDhkRZGpQ22aV6/lkYeYSozpz16Smrs5x4Ls=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14/go.mod h1:zwM6veDkhGgQFqkBy+uT28AAYpLu+uFMlPl+rCg/73E=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
@@ -116,6 +118,8 @@ github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5 h1:gWz8Ax1W8BXOoWe3o
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5/go.mod h1:8m0vIhh44Mmgb+x5o2WzTt0T5NKVtTBhO1j+t7AyvJI=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.2 h1:AEdVlfaKtqjQgnAZ71TAghxd2We92jSez2VAnjOx1vg=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.56.2/go.mod h1:/s52Xxp5LWbfLCWtelG67FDNtpoOoxdnZEzcixGQwcM=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0 h1:5W/KOwsnZrdi7RD97G5Vto3XEuM70FAavWScfsli7gA=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.79.0/go.mod h1:h1Iw2nkdpmAUJaa89RvX3cg/HGLgdSkCWpMNgKvBSHA=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15 h1:jvP746CYJno9fSBqvPMShLPVu+P9wetNsSb+xYk52ag=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.48.15/go.mod h1:wMMgRe7xZVJu58h7CI06EV6n/QUOILSk53/3EYzkorg=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8eX6NDtFSBGfzuauMEWYQ=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -16,6 +16,7 @@ import (
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -27,6 +28,7 @@ import (
 	"github.com/stackshy/cloudemu/server"
 	"github.com/stackshy/cloudemu/server/aws/bedrock"
 	"github.com/stackshy/cloudemu/server/aws/cloudwatch"
+	cloudwatchlogssrv "github.com/stackshy/cloudemu/server/aws/cloudwatchlogs"
 	"github.com/stackshy/cloudemu/server/aws/dynamodb"
 	"github.com/stackshy/cloudemu/server/aws/ec2"
 	"github.com/stackshy/cloudemu/server/aws/ecr"
@@ -69,6 +71,9 @@ type Drivers struct {
 	// SecretsManager serves the Secrets Manager JSON 1.1 protocol against
 	// the secrets driver.
 	SecretsManager secretsdriver.Secrets
+	// CloudWatchLogs serves the CloudWatch Logs JSON 1.1 protocol against the
+	// logging driver.
+	CloudWatchLogs logdriver.Logging
 	// Route53 serves the Route 53 REST/XML protocol against the dns driver.
 	Route53 dnsdriver.DNS
 	// ELB serves the Elastic Load Balancing v2 (ALB/NLB) query protocol
@@ -164,6 +169,13 @@ func New(d Drivers) *server.Server {
 	// DynamoDB, SQS, ECR, SageMaker, Secrets Manager, and the tagging API.
 	if d.EventBridge != nil {
 		srv.Register(eventbridge.New(d.EventBridge))
+	}
+
+	// CloudWatch Logs matches the X-Amz-Target prefix "Logs_20140328." —
+	// disjoint from DynamoDB, SQS, Secrets Manager, ECR, SageMaker, and the
+	// tagging API, so registration order relative to them is unconstrained.
+	if d.CloudWatchLogs != nil {
+		srv.Register(cloudwatchlogssrv.New(d.CloudWatchLogs))
 	}
 
 	// Redshift sits with the other query-protocol handlers before the EC2

--- a/server/aws/cloudwatchlogs/handler.go
+++ b/server/aws/cloudwatchlogs/handler.go
@@ -1,0 +1,97 @@
+// Package cloudwatchlogs implements the AWS CloudWatch Logs JSON-RPC protocol
+// as a server.Handler. Point the real aws-sdk-go-v2 CloudWatch Logs client at a
+// Server registered with this handler and log-group, log-stream, and log-event
+// operations work against the shared logging driver.
+//
+// CloudWatch Logs uses the AWS JSON 1.1 wire shape (POST + JSON body,
+// dispatched on the X-Amz-Target header), the same family as DynamoDB, SQS, and
+// Secrets Manager. Its target prefix is "Logs_20140328." — disjoint from every
+// other JSON-RPC AWS handler, so registration order relative to them is
+// unconstrained.
+//
+// Coverage (Logs_20140328):
+//
+//	CreateLogGroup      DescribeLogGroups   DeleteLogGroup
+//	CreateLogStream     DescribeLogStreams  DeleteLogStream
+//	PutLogEvents        GetLogEvents        FilterLogEvents
+package cloudwatchlogs
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// targetPrefix roots every CloudWatch Logs X-Amz-Target value. The API version
+// segment (20140328) is fixed.
+const targetPrefix = "Logs_20140328."
+
+// Handler serves CloudWatch Logs JSON-RPC requests against a logging driver.
+type Handler struct {
+	logs logdriver.Logging
+}
+
+// New returns a CloudWatch Logs handler backed by l.
+func New(l logdriver.Logging) *Handler {
+	return &Handler{logs: l}
+}
+
+// Matches returns true for CloudWatch Logs-shaped requests, identified by an
+// X-Amz-Target header of "Logs_20140328.<Operation>". The prefix is disjoint
+// from DynamoDB (DynamoDB_20120810.), SQS (AmazonSQS.), Secrets Manager
+// (secretsmanager.), and SageMaker (SageMaker.), so no shadowing occurs.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches CloudWatch Logs operations based on X-Amz-Target.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "CreateLogGroup":
+		h.createLogGroup(w, r)
+	case "DescribeLogGroups":
+		h.describeLogGroups(w, r)
+	case "DeleteLogGroup":
+		h.deleteLogGroup(w, r)
+	case "CreateLogStream":
+		h.createLogStream(w, r)
+	case "DescribeLogStreams":
+		h.describeLogStreams(w, r)
+	case "DeleteLogStream":
+		h.deleteLogStream(w, r)
+	case "PutLogEvents":
+		h.putLogEvents(w, r)
+	case "GetLogEvents":
+		h.getLogEvents(w, r)
+	case "FilterLogEvents":
+		h.filterLogEvents(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"UnknownOperationException", "unknown CloudWatch Logs operation: "+op)
+	}
+}
+
+// writeErr maps canonical cloudemu errors to CloudWatch Logs JSON error
+// responses. Like the other AWS JSON 1.1 services, errors are HTTP 400 with a
+// "__type" body the SDK maps to a typed exception.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceAlreadyExistsException", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterException", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidOperationException", err.Error())
+	case cerrors.GetCode(err) == cerrors.ResourceExhausted:
+		wire.WriteJSONError(w, http.StatusBadRequest, "LimitExceededException", err.Error())
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "ServiceUnavailableException", err.Error())
+	}
+}

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -1,0 +1,218 @@
+package cloudwatchlogs
+
+import (
+	"net/http"
+	"strings"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire"
+)
+
+// --- log groups ---
+
+func (h *Handler) createLogGroup(w http.ResponseWriter, r *http.Request) {
+	var req createLogGroupRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if _, err := h.logs.CreateLogGroup(r.Context(), logdriver.LogGroupConfig{
+		Name: req.LogGroupName,
+		Tags: req.Tags,
+	}); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// CreateLogGroup has an empty response body.
+	wire.WriteJSON(w, struct{}{})
+}
+
+func (h *Handler) describeLogGroups(w http.ResponseWriter, r *http.Request) {
+	var req describeLogGroupsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	infos, err := h.logs.ListLogGroups(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]logGroupJSON, 0, len(infos))
+
+	for i := range infos {
+		if req.LogGroupNamePrefix != "" && !strings.HasPrefix(infos[i].Name, req.LogGroupNamePrefix) {
+			continue
+		}
+
+		out = append(out, toLogGroupJSON(&infos[i]))
+	}
+
+	wire.WriteJSON(w, describeLogGroupsResponse{LogGroups: out})
+}
+
+func (h *Handler) deleteLogGroup(w http.ResponseWriter, r *http.Request) {
+	var req deleteLogGroupRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.logs.DeleteLogGroup(r.Context(), req.LogGroupName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+// --- log streams ---
+
+func (h *Handler) createLogStream(w http.ResponseWriter, r *http.Request) {
+	var req createLogStreamRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if _, err := h.logs.CreateLogStream(r.Context(), req.LogGroupName, req.LogStreamName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+func (h *Handler) describeLogStreams(w http.ResponseWriter, r *http.Request) {
+	var req describeLogStreamsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	infos, err := h.logs.ListLogStreams(r.Context(), req.LogGroupName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]logStreamJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toLogStreamJSON(&infos[i]))
+	}
+
+	wire.WriteJSON(w, describeLogStreamsResponse{LogStreams: out})
+}
+
+func (h *Handler) deleteLogStream(w http.ResponseWriter, r *http.Request) {
+	var req deleteLogStreamRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.logs.DeleteLogStream(r.Context(), req.LogGroupName, req.LogStreamName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, struct{}{})
+}
+
+// --- log events ---
+
+func (h *Handler) putLogEvents(w http.ResponseWriter, r *http.Request) {
+	var req putLogEventsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	events := make([]logdriver.LogEvent, 0, len(req.LogEvents))
+	for _, e := range req.LogEvents {
+		events = append(events, logdriver.LogEvent{
+			Timestamp: millisToTime(e.Timestamp),
+			Message:   e.Message,
+		})
+	}
+
+	if err := h.logs.PutLogEvents(r.Context(), req.LogGroupName, req.LogStreamName, events); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// The sequence token is deprecated and ignored by the modern SDK, but a
+	// non-empty value keeps older callers happy.
+	wire.WriteJSON(w, putLogEventsResponse{NextSequenceToken: "0"})
+}
+
+func (h *Handler) getLogEvents(w http.ResponseWriter, r *http.Request) {
+	var req getLogEventsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{
+		LogGroup:  req.LogGroupName,
+		LogStream: req.LogStreamName,
+		StartTime: millisToTime(req.StartTime),
+		EndTime:   millisToTime(req.EndTime),
+		Limit:     int(req.Limit),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]outputLogEvent, 0, len(events))
+	for _, e := range events {
+		out = append(out, outputLogEvent{
+			Timestamp:     epochMillis(e.Timestamp),
+			Message:       e.Message,
+			IngestionTime: epochMillis(e.Timestamp),
+		})
+	}
+
+	// Token values are opaque to the SDK; a stable pair terminates paging.
+	wire.WriteJSON(w, getLogEventsResponse{
+		Events:            out,
+		NextForwardToken:  "f/0",
+		NextBackwardToken: "b/0",
+	})
+}
+
+func (h *Handler) filterLogEvents(w http.ResponseWriter, r *http.Request) {
+	var req filterLogEventsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// The driver filters one stream at a time; when the caller scopes the query
+	// to a single stream, honor it, otherwise search across all streams.
+	stream := ""
+	if len(req.LogStreamNames) == 1 {
+		stream = req.LogStreamNames[0]
+	}
+
+	events, err := h.logs.FilterLogEvents(r.Context(), &logdriver.FilterLogEventsInput{
+		LogGroup:      req.LogGroupName,
+		LogStream:     stream,
+		FilterPattern: req.FilterPattern,
+		StartTime:     millisToTime(req.StartTime),
+		EndTime:       millisToTime(req.EndTime),
+		Limit:         int(req.Limit),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]filteredLogEvent, 0, len(events))
+	for _, e := range events {
+		out = append(out, filteredLogEvent{
+			LogStreamName: e.LogStream,
+			Timestamp:     epochMillis(e.Timestamp),
+			Message:       e.Message,
+			IngestionTime: epochMillis(e.Timestamp),
+		})
+	}
+
+	wire.WriteJSON(w, filterLogEventsResponse{Events: out})
+}

--- a/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
+++ b/server/aws/cloudwatchlogs/sdk_roundtrip_test.go
@@ -1,0 +1,201 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cwltypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newLogsClient(t *testing.T) *cwl.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{CloudWatchLogs: cloud.CloudWatchLogs})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return cwl.NewFromConfig(cfg, func(o *cwl.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKLogGroupLifecycle(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+		LogGroupName: aws.String("/app/api"),
+		Tags:         map[string]string{"env": "test"},
+	}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	desc, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{
+		LogGroupNamePrefix: aws.String("/app"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups: %v", err)
+	}
+
+	if len(desc.LogGroups) != 1 || aws.ToString(desc.LogGroups[0].LogGroupName) != "/app/api" {
+		t.Fatalf("DescribeLogGroups = %+v, want one group /app/api", desc.LogGroups)
+	}
+
+	if aws.ToString(desc.LogGroups[0].Arn) == "" {
+		t.Fatalf("log group ARN is empty: %+v", desc.LogGroups[0])
+	}
+
+	if _, err := client.DeleteLogGroup(ctx, &cwl.DeleteLogGroupInput{
+		LogGroupName: aws.String("/app/api"),
+	}); err != nil {
+		t.Fatalf("DeleteLogGroup: %v", err)
+	}
+
+	after, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeLogGroups after delete: %v", err)
+	}
+
+	if len(after.LogGroups) != 0 {
+		t.Fatalf("got %d groups after delete, want 0", len(after.LogGroups))
+	}
+}
+
+func TestSDKPutAndGetLogEvents(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+		LogGroupName: aws.String("/app/svc"),
+	}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	if _, err := client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName:  aws.String("/app/svc"),
+		LogStreamName: aws.String("instance-1"),
+	}); err != nil {
+		t.Fatalf("CreateLogStream: %v", err)
+	}
+
+	streams, err := client.DescribeLogStreams(ctx, &cwl.DescribeLogStreamsInput{
+		LogGroupName: aws.String("/app/svc"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeLogStreams: %v", err)
+	}
+
+	if len(streams.LogStreams) != 1 || aws.ToString(streams.LogStreams[0].LogStreamName) != "instance-1" {
+		t.Fatalf("DescribeLogStreams = %+v, want one stream instance-1", streams.LogStreams)
+	}
+
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	if _, err := client.PutLogEvents(ctx, &cwl.PutLogEventsInput{
+		LogGroupName:  aws.String("/app/svc"),
+		LogStreamName: aws.String("instance-1"),
+		LogEvents: []cwltypes.InputLogEvent{
+			{Timestamp: aws.Int64(base.UnixMilli()), Message: aws.String("hello world")},
+			{Timestamp: aws.Int64(base.Add(time.Second).UnixMilli()), Message: aws.String("error: boom")},
+		},
+	}); err != nil {
+		t.Fatalf("PutLogEvents: %v", err)
+	}
+
+	got, err := client.GetLogEvents(ctx, &cwl.GetLogEventsInput{
+		LogGroupName:  aws.String("/app/svc"),
+		LogStreamName: aws.String("instance-1"),
+	})
+	if err != nil {
+		t.Fatalf("GetLogEvents: %v", err)
+	}
+
+	if len(got.Events) != 2 {
+		t.Fatalf("got %d events, want 2: %+v", len(got.Events), got.Events)
+	}
+
+	if aws.ToString(got.Events[0].Message) != "hello world" {
+		t.Fatalf("first event = %q, want hello world", aws.ToString(got.Events[0].Message))
+	}
+
+	if aws.ToInt64(got.Events[0].Timestamp) != base.UnixMilli() {
+		t.Fatalf("first event ts = %d, want %d", aws.ToInt64(got.Events[0].Timestamp), base.UnixMilli())
+	}
+
+	// FilterLogEvents across the group with a substring pattern.
+	filtered, err := client.FilterLogEvents(ctx, &cwl.FilterLogEventsInput{
+		LogGroupName:  aws.String("/app/svc"),
+		FilterPattern: aws.String("error"),
+	})
+	if err != nil {
+		t.Fatalf("FilterLogEvents: %v", err)
+	}
+
+	if len(filtered.Events) != 1 || aws.ToString(filtered.Events[0].Message) != "error: boom" {
+		t.Fatalf("FilterLogEvents = %+v, want [error: boom]", filtered.Events)
+	}
+
+	if aws.ToString(filtered.Events[0].LogStreamName) != "instance-1" {
+		t.Fatalf("filtered event stream = %q, want instance-1", aws.ToString(filtered.Events[0].LogStreamName))
+	}
+
+	if _, err := client.DeleteLogStream(ctx, &cwl.DeleteLogStreamInput{
+		LogGroupName:  aws.String("/app/svc"),
+		LogStreamName: aws.String("instance-1"),
+	}); err != nil {
+		t.Fatalf("DeleteLogStream: %v", err)
+	}
+}
+
+func TestSDKLogsErrors(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+		LogGroupName: aws.String("dup"),
+	}); err != nil {
+		t.Fatalf("CreateLogGroup: %v", err)
+	}
+
+	_, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{LogGroupName: aws.String("dup")})
+
+	var exists *cwltypes.ResourceAlreadyExistsException
+	if !errors.As(err, &exists) {
+		t.Fatalf("duplicate CreateLogGroup: got %v, want ResourceAlreadyExistsException", err)
+	}
+
+	_, err = client.CreateLogStream(ctx, &cwl.CreateLogStreamInput{
+		LogGroupName:  aws.String("missing"),
+		LogStreamName: aws.String("s"),
+	})
+
+	var notFound *cwltypes.ResourceNotFoundException
+	if !errors.As(err, &notFound) {
+		t.Fatalf("CreateLogStream(missing group): got %v, want ResourceNotFoundException", err)
+	}
+
+	_, err = client.DeleteLogGroup(ctx, &cwl.DeleteLogGroupInput{LogGroupName: aws.String("missing")})
+	if !errors.As(err, &notFound) {
+		t.Fatalf("DeleteLogGroup(missing): got %v, want ResourceNotFoundException", err)
+	}
+}

--- a/server/aws/cloudwatchlogs/types.go
+++ b/server/aws/cloudwatchlogs/types.go
@@ -1,0 +1,179 @@
+package cloudwatchlogs
+
+import (
+	"time"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+)
+
+// --- request envelopes ---
+
+type createLogGroupRequest struct {
+	LogGroupName string            `json:"logGroupName"`
+	Tags         map[string]string `json:"tags"`
+}
+
+type describeLogGroupsRequest struct {
+	LogGroupNamePrefix string `json:"logGroupNamePrefix"`
+	Limit              int32  `json:"limit"`
+}
+
+type deleteLogGroupRequest struct {
+	LogGroupName string `json:"logGroupName"`
+}
+
+type createLogStreamRequest struct {
+	LogGroupName  string `json:"logGroupName"`
+	LogStreamName string `json:"logStreamName"`
+}
+
+type describeLogStreamsRequest struct {
+	LogGroupName string `json:"logGroupName"`
+	Limit        int32  `json:"limit"`
+}
+
+type deleteLogStreamRequest struct {
+	LogGroupName  string `json:"logGroupName"`
+	LogStreamName string `json:"logStreamName"`
+}
+
+type inputLogEvent struct {
+	Timestamp int64  `json:"timestamp"`
+	Message   string `json:"message"`
+}
+
+type putLogEventsRequest struct {
+	LogGroupName  string          `json:"logGroupName"`
+	LogStreamName string          `json:"logStreamName"`
+	LogEvents     []inputLogEvent `json:"logEvents"`
+}
+
+type getLogEventsRequest struct {
+	LogGroupName  string `json:"logGroupName"`
+	LogStreamName string `json:"logStreamName"`
+	StartTime     int64  `json:"startTime"`
+	EndTime       int64  `json:"endTime"`
+	Limit         int32  `json:"limit"`
+}
+
+type filterLogEventsRequest struct {
+	LogGroupName   string   `json:"logGroupName"`
+	LogStreamNames []string `json:"logStreamNames"`
+	FilterPattern  string   `json:"filterPattern"`
+	StartTime      int64    `json:"startTime"`
+	EndTime        int64    `json:"endTime"`
+	Limit          int32    `json:"limit"`
+}
+
+// --- response envelopes ---
+
+// logGroupJSON is the CloudWatch Logs LogGroup shape. Timestamps are epoch
+// milliseconds, which is what the AWS JSON protocol uses for the SDK's
+// *int64 CreationTime field.
+type logGroupJSON struct {
+	LogGroupName    string `json:"logGroupName"`
+	Arn             string `json:"arn"`
+	CreationTime    int64  `json:"creationTime"`
+	RetentionInDays int32  `json:"retentionInDays,omitempty"`
+	StoredBytes     int64  `json:"storedBytes"`
+}
+
+type describeLogGroupsResponse struct {
+	LogGroups []logGroupJSON `json:"logGroups"`
+}
+
+type logStreamJSON struct {
+	LogStreamName       string `json:"logStreamName"`
+	CreationTime        int64  `json:"creationTime"`
+	LastEventTimestamp  int64  `json:"lastEventTimestamp,omitempty"`
+	LastIngestionTime   int64  `json:"lastIngestionTime,omitempty"`
+	FirstEventTimestamp int64  `json:"firstEventTimestamp,omitempty"`
+}
+
+type describeLogStreamsResponse struct {
+	LogStreams []logStreamJSON `json:"logStreams"`
+}
+
+type putLogEventsResponse struct {
+	NextSequenceToken string `json:"nextSequenceToken"`
+}
+
+type outputLogEvent struct {
+	Timestamp     int64  `json:"timestamp"`
+	Message       string `json:"message"`
+	IngestionTime int64  `json:"ingestionTime"`
+}
+
+type getLogEventsResponse struct {
+	Events            []outputLogEvent `json:"events"`
+	NextForwardToken  string           `json:"nextForwardToken"`
+	NextBackwardToken string           `json:"nextBackwardToken"`
+}
+
+type filteredLogEvent struct {
+	LogStreamName string `json:"logStreamName"`
+	Timestamp     int64  `json:"timestamp"`
+	Message       string `json:"message"`
+	IngestionTime int64  `json:"ingestionTime"`
+}
+
+type filterLogEventsResponse struct {
+	Events []filteredLogEvent `json:"events"`
+}
+
+// epochMillis converts a time to Unix epoch milliseconds, the form the AWS JSON
+// protocol uses for CloudWatch Logs timestamp fields. A zero time yields 0.
+func epochMillis(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+
+	return t.UnixMilli()
+}
+
+// millisToTime is the inverse of epochMillis: epoch milliseconds to time. Zero
+// yields the zero time so callers can distinguish "unset".
+func millisToTime(ms int64) time.Time {
+	if ms == 0 {
+		return time.Time{}
+	}
+
+	return time.UnixMilli(ms).UTC()
+}
+
+// isoToEpochMillis converts an RFC3339 timestamp (the form the driver stores
+// LogGroupInfo.CreatedAt / LogStreamInfo timestamps in) to epoch milliseconds.
+// Returns 0 on empty input or a parse failure.
+func isoToEpochMillis(iso string) int64 {
+	if iso == "" {
+		return 0
+	}
+
+	t, err := time.Parse(time.RFC3339, iso)
+	if err != nil {
+		return 0
+	}
+
+	return t.UnixMilli()
+}
+
+func toLogGroupJSON(info *logdriver.LogGroupInfo) logGroupJSON {
+	return logGroupJSON{
+		LogGroupName:    info.Name,
+		Arn:             info.ResourceID,
+		CreationTime:    isoToEpochMillis(info.CreatedAt),
+		RetentionInDays: int32(info.RetentionDays), //nolint:gosec // retention days is a small positive value
+		StoredBytes:     info.StoredBytes,
+	}
+}
+
+func toLogStreamJSON(info *logdriver.LogStreamInfo) logStreamJSON {
+	last := isoToEpochMillis(info.LastEvent)
+
+	return logStreamJSON{
+		LogStreamName:      info.Name,
+		CreationTime:       isoToEpochMillis(info.CreatedAt),
+		LastEventTimestamp: last,
+		LastIngestionTime:  last,
+	}
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -16,6 +16,7 @@ import (
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -51,6 +52,7 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/images"
 	keyvaultsrv "github.com/stackshy/cloudemu/server/azure/keyvault"
 	lbsrv "github.com/stackshy/cloudemu/server/azure/loadbalancer"
+	loganalyticssrv "github.com/stackshy/cloudemu/server/azure/loganalytics"
 	"github.com/stackshy/cloudemu/server/azure/monitor"
 	"github.com/stackshy/cloudemu/server/azure/mysqlflex"
 	"github.com/stackshy/cloudemu/server/azure/network"
@@ -100,7 +102,12 @@ type Drivers struct {
 	LB lbdriver.LoadBalancer
 	// EventGrid serves the Azure Event Grid (Microsoft.EventGrid/topics) ARM API
 	// against the eventbus driver, mapping topics to event buses.
-	EventGrid           ebdriver.EventBus
+	EventGrid ebdriver.EventBus
+	// LogAnalytics serves the Log Analytics
+	// (Microsoft.OperationalInsights/workspaces) ARM API against the logging
+	// driver. The workspace lifecycle maps onto the driver's log-group
+	// lifecycle; the data-plane log-query API is out of scope.
+	LogAnalytics        logdriver.Logging
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -180,6 +187,13 @@ func New(d Drivers) *server.Server {
 	// unconstrained. Registered before the BlobStorage fallback.
 	if d.EventGrid != nil {
 		srv.Register(eventgridsrv.New(d.EventGrid))
+	}
+
+	// Log Analytics matches on Microsoft.OperationalInsights/workspaces — a
+	// distinct ARM provider name from every other Azure handler, so registration
+	// order is unconstrained. Registered before the BlobStorage fallback.
+	if d.LogAnalytics != nil {
+		srv.Register(loganalyticssrv.New(d.LogAnalytics))
 	}
 
 	if d.Monitor != nil {

--- a/server/azure/loganalytics/handler.go
+++ b/server/azure/loganalytics/handler.go
@@ -1,0 +1,114 @@
+// Package loganalytics implements the Azure Log Analytics
+// (Microsoft.OperationalInsights/workspaces) ARM REST API as a server.Handler.
+// Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights
+// clients configured with a custom endpoint hit this handler the same way they
+// hit management.azure.com, driving the shared logging driver.
+//
+// The workspace lifecycle (CreateOrUpdate / Get / List / Delete) maps onto the
+// logging driver's log-group lifecycle: a workspace is a log group. The
+// retention-in-days and tags carry across; ARM read-only fields
+// (provisioningState, customerId, sku) are synthesized. The data-plane
+// log-query API (api.loganalytics.io "query" / ingestion) is a separate wire
+// surface and is out of scope for this slice — see the package README note in
+// the roundtrip test.
+//
+// Microsoft.OperationalInsights is a distinct ARM provider name from every
+// other Azure handler (compute, network, DNS, sql, …), so registration order is
+// unconstrained. It must register before the permissive BlobStorage fallback.
+//
+// Coverage:
+//
+//	PUT    .../workspaces/{w}                                — Workspaces.BeginCreateOrUpdate (LRO, completes inline)
+//	GET    .../workspaces/{w}                                — Workspaces.Get
+//	DELETE .../workspaces/{w}                                — Workspaces.BeginDelete (LRO, completes inline)
+//	GET    .../providers/Microsoft.OperationalInsights/workspaces — Workspaces.NewListPager (subscription scope)
+//	GET    .../resourceGroups/{rg}/…/workspaces             — Workspaces.NewListByResourceGroupPager
+package loganalytics
+
+import (
+	"net/http"
+	"strings"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName = "Microsoft.OperationalInsights"
+	// typeWorkspaces is the ARM resource type. The subscription-scoped list path
+	// may serialize it lowercase, so matching is case-insensitive.
+	typeWorkspaces = "workspaces"
+)
+
+// Handler serves Microsoft.OperationalInsights/workspaces ARM requests against
+// a logging driver.
+type Handler struct {
+	logs logdriver.Logging
+}
+
+// New returns an Azure Log Analytics handler backed by l.
+func New(l logdriver.Logging) *Handler {
+	return &Handler{logs: l}
+}
+
+// isWorkspacesType reports whether the ARM resource type is workspaces,
+// case-insensitively.
+func isWorkspacesType(resourceType string) bool {
+	return strings.EqualFold(resourceType, typeWorkspaces)
+}
+
+// Matches claims ARM URLs targeting Microsoft.OperationalInsights/workspaces.
+// Its provider name is disjoint from every other Azure handler, so registration
+// order is unconstrained. Registered before the BlobStorage fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && isWorkspacesType(rp.ResourceType)
+}
+
+// ServeHTTP routes on the parsed path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// Collection list: no workspace name (subscription- or RG-scoped list).
+	if rp.ResourceName == "" {
+		h.serveWorkspaceCollection(w, r, &rp)
+		return
+	}
+
+	h.serveWorkspace(w, r, &rp)
+}
+
+func (h *Handler) serveWorkspaceCollection(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.listWorkspaces(w, r, rp)
+}
+
+func (h *Handler) serveWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateWorkspace(w, r, rp)
+	case http.MethodGet:
+		h.getWorkspace(w, r, rp)
+	case http.MethodDelete:
+		h.deleteWorkspace(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/loganalytics/operations.go
+++ b/server/azure/loganalytics/operations.go
@@ -1,0 +1,72 @@
+package loganalytics
+
+import (
+	"net/http"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// createOrUpdateWorkspace maps Workspaces.CreateOrUpdate onto the logging
+// driver's log-group create. It is idempotent: if the workspace already exists
+// it is echoed back (the driver has no update primitive for retention/tags, so
+// this mirrors CreateOrUpdate's upsert contract for the fields we model).
+func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var req workspaceRequest
+	if !azurearm.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if info, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName); err == nil {
+		azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(rp, info, req.Location))
+		return
+	}
+
+	info, err := h.logs.CreateLogGroup(r.Context(), logdriver.LogGroupConfig{
+		Name:          rp.ResourceName,
+		RetentionDays: req.retentionDays(),
+		Tags:          req.Tags,
+	})
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusCreated, toWorkspaceJSON(rp, info, req.Location))
+}
+
+func (h *Handler) getWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	info, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(rp, info, ""))
+}
+
+// deleteWorkspace removes the workspace. Workspaces.Delete is an LRO in the SDK;
+// returning 200 with an empty body completes the poller on the first response.
+func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.logs.DeleteLogGroup(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	infos, err := h.logs.ListLogGroups(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]workspaceJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toWorkspaceJSON(rp, &infos[i], ""))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, workspaceListResult{Value: out})
+}

--- a/server/azure/loganalytics/sdk_roundtrip_test.go
+++ b/server/azure/loganalytics/sdk_roundtrip_test.go
@@ -1,0 +1,190 @@
+package loganalytics_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// NOTE: This slice covers the Log Analytics workspace lifecycle
+// (Microsoft.OperationalInsights/workspaces ARM control plane), mapped onto the
+// logging driver's log-group lifecycle. The data-plane log-query / ingestion
+// API (api.loganalytics.io) is a separate wire surface and is intentionally out
+// of scope — put/get log-event round-trips for Azure are exercised via the AWS
+// and GCP slices, which drive the same shared driver methods.
+
+const (
+	testRG  = "rg-1"
+	testSub = "sub-1"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newWorkspacesClient(t *testing.T) *armoperationalinsights.WorkspacesClient {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{LogAnalytics: cloudP.LogAnalytics})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	client, err := armoperationalinsights.NewWorkspacesClient(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("NewWorkspacesClient: %v", err)
+	}
+
+	return client
+}
+
+func TestSDKLogAnalyticsWorkspaceLifecycle(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, testRG, "logs-ws", armoperationalinsights.Workspace{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armoperationalinsights.WorkspaceProperties{
+			RetentionInDays: to.Ptr(int32(90)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "logs-ws" {
+		t.Fatalf("CreateOrUpdate name = %v, want logs-ws", created.Name)
+	}
+
+	got, err := client.Get(ctx, testRG, "logs-ws", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tags = %v, want env=test", got.Tags)
+	}
+
+	if got.Properties == nil || got.Properties.RetentionInDays == nil || *got.Properties.RetentionInDays != 90 {
+		t.Fatalf("retention = %+v, want 90", got.Properties)
+	}
+
+	var names []string
+
+	pager := client.NewListByResourceGroupPager(testRG, nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListByResourceGroup: %v", perr)
+		}
+
+		for _, ws := range page.Value {
+			names = append(names, *ws.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "logs-ws" {
+		t.Fatalf("list = %v, want [logs-ws]", names)
+	}
+
+	delPoller, err := client.BeginDelete(ctx, testRG, "logs-ws", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	_, err = client.Get(ctx, testRG, "logs-ws", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKLogAnalyticsSubscriptionList(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"ws-a", "ws-b"} {
+		poller, err := client.BeginCreateOrUpdate(ctx, testRG, name, armoperationalinsights.Workspace{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	count := 0
+
+	pager := client.NewListPager(nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("List: %v", perr)
+		}
+
+		count += len(page.Value)
+	}
+
+	if count != 2 {
+		t.Fatalf("subscription list count = %d, want 2", count)
+	}
+}
+
+func TestSDKLogAnalyticsErrors(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	_, err := client.Get(ctx, testRG, "missing", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+}

--- a/server/azure/loganalytics/types.go
+++ b/server/azure/loganalytics/types.go
@@ -1,0 +1,76 @@
+package loganalytics
+
+import (
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// provisioningSucceeded is the terminal provisioning state. The azcore body
+// poller treats it as done, so CreateOrUpdate/Delete complete on the first
+// response without a follow-up poll.
+const provisioningSucceeded = "Succeeded"
+
+// workspaceProperties is the subset of Log Analytics workspace properties we
+// model. RetentionInDays round-trips through the driver; provisioningState is
+// synthesized so the SDK's LRO poller sees a terminal state.
+type workspaceProperties struct {
+	ProvisioningState string `json:"provisioningState,omitempty"`
+	RetentionInDays   *int32 `json:"retentionInDays,omitempty"`
+	CustomerID        string `json:"customerId,omitempty"`
+	CreatedDate       string `json:"createdDate,omitempty"`
+}
+
+// workspaceJSON is the ARM Workspace resource envelope.
+type workspaceJSON struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Type       string              `json:"type"`
+	Location   string              `json:"location,omitempty"`
+	Tags       map[string]string   `json:"tags,omitempty"`
+	Properties workspaceProperties `json:"properties"`
+}
+
+// workspaceListResult is the paged list envelope (SDK reads `.value`).
+type workspaceListResult struct {
+	Value []workspaceJSON `json:"value"`
+}
+
+// workspaceRequest is the inbound CreateOrUpdate body.
+type workspaceRequest struct {
+	Location   string            `json:"location"`
+	Tags       map[string]string `json:"tags"`
+	Properties *struct {
+		RetentionInDays *int32 `json:"retentionInDays"`
+	} `json:"properties"`
+}
+
+// retentionDays returns the requested retention, or 0 when unset (the driver
+// then applies its default).
+func (req *workspaceRequest) retentionDays() int {
+	if req.Properties == nil || req.Properties.RetentionInDays == nil {
+		return 0
+	}
+
+	return int(*req.Properties.RetentionInDays)
+}
+
+// toWorkspaceJSON renders a driver log group as an ARM workspace. location is
+// echoed from the request on create; on read paths it is empty (the driver does
+// not persist location), which the SDK tolerates.
+func toWorkspaceJSON(rp *azurearm.ResourcePath, info *logdriver.LogGroupInfo, location string) workspaceJSON {
+	retention := int32(info.RetentionDays) //nolint:gosec // retention days is a small positive value
+
+	return workspaceJSON{
+		ID:       info.ResourceID,
+		Name:     info.Name,
+		Type:     providerName + "/" + typeWorkspaces,
+		Location: location,
+		Tags:     info.Tags,
+		Properties: workspaceProperties{
+			ProvisioningState: provisioningSucceeded,
+			RetentionInDays:   &retention,
+			CustomerID:        info.ResourceID,
+			CreatedDate:       info.CreatedAt,
+		},
+	}
+}

--- a/server/gcp/cloudlogging/handler.go
+++ b/server/gcp/cloudlogging/handler.go
@@ -1,0 +1,151 @@
+// Package cloudlogging implements the Cloud Logging (logging.googleapis.com) v2
+// REST API as a server.Handler. Real google.golang.org/api/logging/v2 clients
+// pointed at this server write log entries, list them back, and manage logs
+// end-to-end against the shared logging driver.
+//
+// GCP Cloud Logging has no explicit "create log group" call: a log springs into
+// existence on the first entries:write. This handler mirrors that — a write to
+// logName "projects/{p}/logs/{logid}" lazily creates the driver log group named
+// {logid} plus a default log stream, then appends the events. entries:list maps
+// onto GetLogEvents, honoring a `logName=` filter to scope the query.
+//
+// Driver -> wire mapping:
+//
+//	POST   /v2/entries:write              — WriteLogEntries -> (lazy CreateLogGroup) + PutLogEvents
+//	POST   /v2/entries:list               — ListLogEntries  -> GetLogEvents
+//	GET    /v2/projects/{p}/logs          — ListLogs        -> ListLogGroups
+//	DELETE /v2/projects/{p}/logs/{logid}  — DeleteLog       -> DeleteLogGroup
+//
+// The /v2/ URL space is disjoint from the /v1/projects/ family (Firestore, IAM,
+// …), /compute/v1/, and /dns/v1/, so registration order relative to them is
+// unconstrained. Registered before the GCS fallback for consistency.
+//
+// Out of scope for this slice: log buckets / sinks / metrics
+// (projects.locations.buckets, projects.sinks, projects.metrics) — a separate
+// resource surface not backed by the logging driver's group/stream model.
+package cloudlogging
+
+import (
+	"net/http"
+	"strings"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	basePrefix     = "/v2/"
+	entriesWrite   = "/v2/entries:write"
+	entriesList    = "/v2/entries:list"
+	logsCollection = "logs"
+	projectsSeg    = "projects"
+)
+
+// defaultStream is the implicit log stream every Cloud Logging write lands in.
+// GCP has no stream concept at this layer, but the driver requires one, so we
+// funnel all entries for a log through a single well-known stream.
+const defaultStream = "default"
+
+// Handler serves logging.googleapis.com v2 requests against a logging driver.
+type Handler struct {
+	logs logdriver.Logging
+}
+
+// New returns a Cloud Logging handler backed by l.
+func New(l logdriver.Logging) *Handler {
+	return &Handler{logs: l}
+}
+
+// Matches claims /v2/entries:{write,list} and /v2/projects/{p}/logs[...] paths —
+// the logging.googleapis.com v2 URL space, disjoint from the /v1/projects/
+// family and from /compute/v1/ and /dns/v1/. Registered before the GCS
+// fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	p := r.URL.Path
+	if p == entriesWrite || p == entriesList {
+		return true
+	}
+
+	return logsPath(p) != ""
+}
+
+// logsPath returns the tail after "/v2/projects/{p}/logs" for a logs URL, or ""
+// when p is not a logs path. A bare collection returns "/".
+func logsPath(p string) string {
+	if !strings.HasPrefix(p, basePrefix) {
+		return ""
+	}
+
+	parts := strings.Split(strings.TrimPrefix(p, basePrefix), "/")
+	if len(parts) < 3 || parts[0] != projectsSeg || parts[2] != logsCollection {
+		return ""
+	}
+
+	if len(parts) == 3 {
+		return "/"
+	}
+
+	return "/" + strings.Join(parts[3:], "/")
+}
+
+// ServeHTTP routes on the path and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case entriesWrite:
+		h.serveEntriesWrite(w, r)
+		return
+	case entriesList:
+		h.serveEntriesList(w, r)
+		return
+	}
+
+	tail := logsPath(r.URL.Path)
+	switch {
+	case tail == "/":
+		h.serveLogsCollection(w, r)
+	case tail != "":
+		h.serveLog(w, r, strings.TrimPrefix(tail, "/"))
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unrecognized Cloud Logging path")
+	}
+}
+
+func (h *Handler) serveEntriesWrite(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.writeEntries(w, r)
+}
+
+func (h *Handler) serveEntriesList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.listEntries(w, r)
+}
+
+func (h *Handler) serveLogsCollection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.listLogs(w, r)
+}
+
+func (h *Handler) serveLog(w http.ResponseWriter, r *http.Request, logID string) {
+	if r.Method != http.MethodDelete {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	h.deleteLog(w, r, logID)
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	gcprest.WriteError(w, http.StatusMethodNotAllowed, "methodNotAllowed", "method not allowed")
+}

--- a/server/gcp/cloudlogging/operations.go
+++ b/server/gcp/cloudlogging/operations.go
@@ -1,0 +1,142 @@
+package cloudlogging
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+// writeEntries maps WriteLogEntries onto the driver. Cloud Logging creates a log
+// lazily on first write, so we ensure the log group and its default stream exist
+// (idempotently) before appending the events. Entries are grouped by their
+// effective logName so a single request can target multiple logs.
+func (h *Handler) writeEntries(w http.ResponseWriter, r *http.Request) {
+	var req writeLogEntriesRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	// Group event batches by log id (each entry may override the request-level
+	// logName).
+	byLog := make(map[string][]logdriver.LogEvent)
+
+	now := time.Now().UTC()
+
+	for i := range req.Entries {
+		e := &req.Entries[i]
+
+		name := e.LogName
+		if name == "" {
+			name = req.LogName
+		}
+
+		logID := logIDFromName(name)
+		if logID == "" {
+			gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument", "log entry is missing a logName")
+			return
+		}
+
+		byLog[logID] = append(byLog[logID], logdriver.LogEvent{
+			Timestamp: parseTimestamp(e.Timestamp, now),
+			Message:   e.TextPayload,
+		})
+	}
+
+	for logID, events := range byLog {
+		if err := h.ensureLog(r.Context(), logID); err != nil {
+			gcprest.WriteCErr(w, err)
+			return
+		}
+
+		if err := h.logs.PutLogEvents(r.Context(), logID, defaultStream, events); err != nil {
+			gcprest.WriteCErr(w, err)
+			return
+		}
+	}
+
+	// WriteLogEntries returns an empty response body on success.
+	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
+}
+
+// ensureLog creates the log group and its default stream if they do not already
+// exist. Both AlreadyExists results are benign — a log accreting more entries.
+func (h *Handler) ensureLog(ctx context.Context, logID string) error {
+	if _, err := h.logs.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: logID}); err != nil && !cerrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	if _, err := h.logs.CreateLogStream(ctx, logID, defaultStream); err != nil && !cerrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+// listEntries maps ListLogEntries onto GetLogEvents. The log to read is taken
+// from the filter's `logName=` clause; the project comes from resourceNames.
+func (h *Handler) listEntries(w http.ResponseWriter, r *http.Request) {
+	var req listLogEntriesRequest
+	if !gcprest.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	project := projectFromResourceNames(req.ResourceNames)
+
+	logID := logIDFromFilter(req.Filter)
+	if logID == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalidArgument",
+			"a logName filter is required to list entries")
+		return
+	}
+
+	events, err := h.logs.GetLogEvents(r.Context(), &logdriver.LogQueryInput{
+		LogGroup: logID,
+		Limit:    req.PageSize,
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]logEntryJSON, 0, len(events))
+	for i := range events {
+		out = append(out, toLogEntryJSON(project, logID, &events[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listLogEntriesResponse{Entries: out})
+}
+
+// listLogs maps ListLogs onto ListLogGroups, returning fully-qualified log
+// names under the project.
+func (h *Handler) listLogs(w http.ResponseWriter, r *http.Request) {
+	project := projectFromPath(r.URL.Path)
+
+	infos, err := h.logs.ListLogGroups(r.Context())
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	names := make([]string, 0, len(infos))
+	for i := range infos {
+		names = append(names, logNameFor(project, infos[i].Name))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listLogsResponse{LogNames: names})
+}
+
+// deleteLog maps DeleteLog onto DeleteLogGroup. The {logID} URL segment arrives
+// percent-decoded by net/http, so it is used directly.
+func (h *Handler) deleteLog(w http.ResponseWriter, r *http.Request, logID string) {
+	if err := h.logs.DeleteLogGroup(r.Context(), logID); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	// DeleteLog returns an empty (Empty) response body.
+	gcprest.WriteJSON(w, http.StatusOK, struct{}{})
+}

--- a/server/gcp/cloudlogging/sdk_roundtrip_test.go
+++ b/server/gcp/cloudlogging/sdk_roundtrip_test.go
@@ -1,0 +1,138 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	logging "google.golang.org/api/logging/v2"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const testProject = "demo"
+
+func newLoggingService(t *testing.T) *logging.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{CloudLogging: cloud.CloudLogging})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := logging.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("logging.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func TestSDKCloudLoggingWriteAndList(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	logName := "projects/" + testProject + "/logs/app-log"
+	base := time.Now().UTC().Truncate(time.Millisecond)
+
+	if _, err := svc.Entries.Write(&logging.WriteLogEntriesRequest{
+		LogName: logName,
+		Resource: &logging.MonitoredResource{
+			Type:   "global",
+			Labels: map[string]string{"project_id": testProject},
+		},
+		Entries: []*logging.LogEntry{
+			{Timestamp: base.Format(time.RFC3339Nano), TextPayload: "hello world"},
+			{Timestamp: base.Add(time.Second).Format(time.RFC3339Nano), TextPayload: "error: boom"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Entries.Write: %v", err)
+	}
+
+	resp, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + testProject},
+		Filter:        `logName="` + logName + `"`,
+	}).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Entries.List: %v", err)
+	}
+
+	if len(resp.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(resp.Entries), resp.Entries)
+	}
+
+	if resp.Entries[0].TextPayload != "hello world" {
+		t.Fatalf("first entry payload = %q, want hello world", resp.Entries[0].TextPayload)
+	}
+
+	if resp.Entries[0].LogName != logName {
+		t.Fatalf("first entry logName = %q, want %q", resp.Entries[0].LogName, logName)
+	}
+}
+
+func TestSDKCloudLoggingLogsLifecycle(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	// A write lazily creates the log.
+	if _, err := svc.Entries.Write(&logging.WriteLogEntriesRequest{
+		LogName: "projects/" + testProject + "/logs/svc-log",
+		Entries: []*logging.LogEntry{
+			{TextPayload: "started"},
+		},
+	}).Context(ctx).Do(); err != nil {
+		t.Fatalf("Entries.Write: %v", err)
+	}
+
+	list, err := svc.Projects.Logs.List("projects/" + testProject).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Projects.Logs.List: %v", err)
+	}
+
+	found := false
+	for _, n := range list.LogNames {
+		if n == "projects/"+testProject+"/logs/svc-log" {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("Logs.List = %v, want it to contain svc-log", list.LogNames)
+	}
+
+	if _, err := svc.Projects.Logs.Delete("projects/" + testProject + "/logs/svc-log").Context(ctx).Do(); err != nil {
+		t.Fatalf("Projects.Logs.Delete: %v", err)
+	}
+
+	after, err := svc.Projects.Logs.List("projects/" + testProject).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Projects.Logs.List after delete: %v", err)
+	}
+
+	for _, n := range after.LogNames {
+		if n == "projects/"+testProject+"/logs/svc-log" {
+			t.Fatalf("svc-log still present after delete: %v", after.LogNames)
+		}
+	}
+}
+
+func TestSDKCloudLoggingErrors(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	// Listing entries for a log that was never written is a not-found.
+	_, err := svc.Entries.List(&logging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + testProject},
+		Filter:        `logName="projects/` + testProject + `/logs/missing"`,
+	}).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("Entries.List(missing log): want error, got nil")
+	}
+}

--- a/server/gcp/cloudlogging/types.go
+++ b/server/gcp/cloudlogging/types.go
@@ -111,13 +111,40 @@ func projectFromPath(p string) string {
 func logIDFromFilter(filter string) string {
 	const key = "logName"
 
-	i := strings.Index(filter, key)
+	// Find "logName" as a whole token, not as a substring of e.g.
+	// "logName_suffix": the char after the key must be a separator (space,
+	// '=' or ':'), and the char before it must not be an identifier char.
+	i := -1
+	for from := 0; ; {
+		j := strings.Index(filter[from:], key)
+		if j < 0 {
+			break
+		}
+		at := from + j
+		before := byte(' ')
+		if at > 0 {
+			before = filter[at-1]
+		}
+		after := byte(' ')
+		if at+len(key) < len(filter) {
+			after = filter[at+len(key)]
+		}
+		isIdent := func(b byte) bool {
+			return b == '_' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
+		}
+		if !isIdent(before) && (after == ' ' || after == '\t' || after == '=' || after == ':') {
+			i = at
+			break
+		}
+		from = at + len(key)
+	}
 	if i < 0 {
 		return ""
 	}
 
 	rest := strings.TrimSpace(filter[i+len(key):])
 	rest = strings.TrimPrefix(rest, "=")
+	rest = strings.TrimPrefix(rest, ":")
 	rest = strings.TrimSpace(rest)
 	rest = strings.Trim(rest, `"`)
 

--- a/server/gcp/cloudlogging/types.go
+++ b/server/gcp/cloudlogging/types.go
@@ -1,0 +1,154 @@
+package cloudlogging
+
+import (
+	"net/url"
+	"strings"
+	"time"
+
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
+)
+
+// logEntryJSON is the subset of the Cloud Logging LogEntry resource we model:
+// a text payload plus a timestamp, keyed by logName. The driver has no notion
+// of severity or structured payloads, so only textPayload round-trips.
+type logEntryJSON struct {
+	LogName     string `json:"logName,omitempty"`
+	Timestamp   string `json:"timestamp,omitempty"`
+	TextPayload string `json:"textPayload,omitempty"`
+	InsertID    string `json:"insertId,omitempty"`
+	Severity    string `json:"severity,omitempty"`
+}
+
+// writeLogEntriesRequest is the entries:write body. logName/resource may be set
+// at the request level and inherited by entries that omit their own logName.
+type writeLogEntriesRequest struct {
+	LogName string         `json:"logName"`
+	Entries []logEntryJSON `json:"entries"`
+}
+
+// listLogEntriesRequest is the entries:list body.
+type listLogEntriesRequest struct {
+	ResourceNames []string `json:"resourceNames"`
+	Filter        string   `json:"filter"`
+	PageSize      int      `json:"pageSize"`
+	OrderBy       string   `json:"orderBy"`
+}
+
+type listLogEntriesResponse struct {
+	Entries []logEntryJSON `json:"entries"`
+}
+
+type listLogsResponse struct {
+	LogNames []string `json:"logNames,omitempty"`
+}
+
+// logIDFromName extracts the log id (the last path segment) from a Cloud
+// Logging logName, which has the form "projects/{project}/logs/{logID}". The
+// logID itself may be URL-encoded (it can contain slashes). Returns "" when the
+// name is empty or malformed.
+func logIDFromName(logName string) string {
+	if logName == "" {
+		return ""
+	}
+
+	const marker = "/logs/"
+
+	i := strings.Index(logName, marker)
+	if i < 0 {
+		// Bare log id (no projects/.../logs/ prefix): treat as-is.
+		if decoded, err := url.PathUnescape(logName); err == nil {
+			return decoded
+		}
+
+		return logName
+	}
+
+	id := logName[i+len(marker):]
+	if decoded, err := url.PathUnescape(id); err == nil {
+		return decoded
+	}
+
+	return id
+}
+
+// logNameFor builds a fully-qualified logName for a log id under project.
+func logNameFor(project, logID string) string {
+	return "projects/" + project + "/logs/" + url.PathEscape(logID)
+}
+
+// projectFromResourceNames pulls the project id out of the first
+// "projects/{project}" resource name in an entries:list request. Returns ""
+// when none is present.
+func projectFromResourceNames(names []string) string {
+	for _, n := range names {
+		parts := strings.Split(n, "/")
+		if len(parts) >= 2 && parts[0] == projectsSeg {
+			return parts[1]
+		}
+	}
+
+	return ""
+}
+
+// projectFromPath pulls {project} out of a /v2/projects/{project}/logs[...]
+// URL path. Returns "" when the path is not a logs path.
+func projectFromPath(p string) string {
+	if !strings.HasPrefix(p, basePrefix) {
+		return ""
+	}
+
+	parts := strings.Split(strings.TrimPrefix(p, basePrefix), "/")
+	if len(parts) < 2 || parts[0] != projectsSeg {
+		return ""
+	}
+
+	return parts[1]
+}
+
+// logIDFromFilter extracts the log id from a Cloud Logging filter expression of
+// the form `logName="projects/p/logs/mylog"` (quotes optional). Returns "" when
+// the filter does not scope by logName.
+func logIDFromFilter(filter string) string {
+	const key = "logName"
+
+	i := strings.Index(filter, key)
+	if i < 0 {
+		return ""
+	}
+
+	rest := strings.TrimSpace(filter[i+len(key):])
+	rest = strings.TrimPrefix(rest, "=")
+	rest = strings.TrimSpace(rest)
+	rest = strings.Trim(rest, `"`)
+
+	// rest may carry a trailing clause (e.g. "... AND severity=ERROR"); cut at
+	// the first whitespace so only the logName value remains.
+	if j := strings.IndexAny(rest, " \t"); j >= 0 {
+		rest = rest[:j]
+	}
+
+	return logIDFromName(rest)
+}
+
+// parseTimestamp parses an RFC3339(Nano) Cloud Logging timestamp. A zero/empty
+// or unparseable value yields the current time so an entry is never dropped for
+// a bad clock.
+func parseTimestamp(ts string, now time.Time) time.Time {
+	if ts == "" {
+		return now
+	}
+
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t
+	}
+
+	return now
+}
+
+func toLogEntryJSON(project, logID string, e *logdriver.LogEvent) logEntryJSON {
+	return logEntryJSON{
+		LogName:     logNameFor(project, logID),
+		Timestamp:   e.Timestamp.UTC().Format(time.RFC3339Nano),
+		TextPayload: e.Message,
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -15,6 +15,7 @@ import (
 	iamdriver "github.com/stackshy/cloudemu/iam/driver"
 	"github.com/stackshy/cloudemu/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/loadbalancer/driver"
+	logdriver "github.com/stackshy/cloudemu/logging/driver"
 	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/networking/driver"
@@ -27,6 +28,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/cloudasset"
 	"github.com/stackshy/cloudemu/server/gcp/clouddns"
 	"github.com/stackshy/cloudemu/server/gcp/cloudfunctions"
+	cloudloggingsrv "github.com/stackshy/cloudemu/server/gcp/cloudlogging"
 	"github.com/stackshy/cloudemu/server/gcp/cloudsql"
 	"github.com/stackshy/cloudemu/server/gcp/compute"
 	"github.com/stackshy/cloudemu/server/gcp/eventarc"
@@ -65,6 +67,9 @@ type Drivers struct {
 	// LB serves the Cloud Load Balancing REST API (backendServices +
 	// forwardingRules on the compute API) against the loadbalancer driver.
 	LB lbdriver.LoadBalancer
+	// CloudLogging serves the logging.googleapis.com v2 REST API
+	// (entries:write/list, logs list/delete) against the logging driver.
+	CloudLogging logdriver.Logging
 	// SecretManager serves the secretmanager.googleapis.com v1 REST API
 	// against the secrets driver.
 	SecretManager secretsdriver.Secrets
@@ -199,6 +204,14 @@ func New(d Drivers) *server.Server {
 	// GCS fallback for consistency with the other handlers.
 	if d.CloudDNS != nil {
 		srv.Register(clouddns.New(d.CloudDNS))
+	}
+
+	// Cloud Logging matches /v2/entries:{write,list} and /v2/projects/{p}/logs
+	// — the logging.googleapis.com v2 URL space, disjoint from the /v1/projects/
+	// family, /compute/v1/, and /dns/v1/, so registration order relative to them
+	// is unconstrained. Registered before the GCS fallback for consistency.
+	if d.CloudLogging != nil {
+		srv.Register(cloudloggingsrv.New(d.CloudLogging))
 	}
 
 	if d.Firestore != nil {

--- a/server/wire/azurearm/azurearm.go
+++ b/server/wire/azurearm/azurearm.go
@@ -83,9 +83,11 @@ func ParsePath(urlPath string) (ResourcePath, bool) {
 }
 
 // parseResourceGroup advances past an optional resourceGroups/{rg} pair and
-// records the group on rp. Returns the next index to inspect.
+// records the group on rp. Returns the next index to inspect. The keyword match
+// is case-insensitive: armdns emits "resourceGroups" while other SDKs (e.g.
+// armoperationalinsights) emit the lowercase "resourcegroups".
 func parseResourceGroup(parts []string, i int, rp *ResourcePath) int {
-	if i >= len(parts) || parts[i] != "resourceGroups" {
+	if i >= len(parts) || !strings.EqualFold(parts[i], "resourceGroups") {
 		return i
 	}
 


### PR DESCRIPTION
SDK-compat servers for the **Logging** service across AWS/Azure/GCP — the Logging slice of #143, following the merged Secrets/DNS pattern. Real-SDK roundtrip tests per provider; `go build ./...`, `go vet`, and the full `go test ./server/...` tree pass. See the implementing commit for per-provider ops, driver→wire mapping, and documented gaps.
Notes: also makes the shared `server/wire/azurearm` resourceGroups path keyword case-insensitive. Azure data-plane log query (api.loganalytics.io) and GCP log buckets/sinks are out of scope (documented).