### PR TITLE
feat(cache): SDK-compat servers for ElastiCache, Azure Cache, and Memorystore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2 v2.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
@@ -38,6 +39,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
+	github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armope
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0/go.mod h1:FwSGecUzQMdebvcN8JqqLlsfgfXZn+Gw+vX9xpHhUMc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 h1:HzqcSJWx32XQdr8KtxAu/SZJj0PqDo9tKf2YGPdynV0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0/go.mod h1:nKcJObAisSPDrO9lMuuCBoYY7Ki7ADt8p6XmBhpKNTk=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h1:EkL5dmUoy1OlzVfsbkcHayOvOJgheyRYL3wM/RHizzg=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0/go.mod h1:DiazWkJHUUKUZGpIdV7JhDTjebBxdfsJ386dE5w7G3o=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0 h1:zLzoX5+W2l95UJoVwiyNS4dX8vHyQ6x2xRLoBBL9wMk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph v0.9.0/go.mod h1:wVEOJfGTj0oPAUGA1JuRAvz/lxXQsWW16axmHPP47Bk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
@@ -134,6 +136,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0 h1:OJRqQ6G7R
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0/go.mod h1:qNnJkZTDHDL2sO8hyVH2yILcfSEkjP/pIns2JsF1g1o=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0 h1:LuPLDBMCmldgg779sq8swfEdRNMeKlaT852uxKYCOkk=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0/go.mod h1:3g/foYPw/4CT8yV7/A1QsbvnhDZW/2x2uzl4vkqX49o=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0 h1:aIfwo2WwNv4Ya/wdg6X7oCVkCjVzACErH/BSsy7EQGM=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0/go.mod h1:roYWQ6ZmGI1VshRoopJCfMYdDgI1z4ArMtTOJJjsHXg=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -8,6 +8,7 @@ package aws
 
 import (
 	bedrockdriver "github.com/stackshy/cloudemu/bedrock/driver"
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
@@ -33,6 +34,7 @@ import (
 	"github.com/stackshy/cloudemu/server/aws/ec2"
 	"github.com/stackshy/cloudemu/server/aws/ecr"
 	"github.com/stackshy/cloudemu/server/aws/eks"
+	"github.com/stackshy/cloudemu/server/aws/elasticache"
 	"github.com/stackshy/cloudemu/server/aws/elbv2"
 	"github.com/stackshy/cloudemu/server/aws/eventbridge"
 	"github.com/stackshy/cloudemu/server/aws/iam"
@@ -82,6 +84,9 @@ type Drivers struct {
 	// EventBridge serves the EventBridge JSON 1.1 protocol against the eventbus
 	// driver.
 	EventBridge ebdriver.EventBus
+	// ElastiCache serves the ElastiCache query protocol (cluster control plane)
+	// against the cache driver.
+	ElastiCache cachedriver.Cache
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -192,6 +197,14 @@ func New(d Drivers) *server.Server {
 	// the EC2 handler doesn't claim ELBv2 form bodies first.
 	if d.ELB != nil {
 		srv.Register(elbv2.New(d.ELB))
+	}
+
+	// ElastiCache is another AWS query-protocol handler; register before the
+	// EC2 catch-all. Its action set (CreateCacheCluster, DescribeCacheClusters,
+	// DeleteCacheCluster) is disjoint from RDS, Redshift, IAM, and EC2, so no
+	// shadowing occurs.
+	if d.ElastiCache != nil {
+		srv.Register(elasticache.New(d.ElastiCache))
 	}
 
 	if d.EC2 != nil || d.VPC != nil {

--- a/server/aws/elasticache/handler.go
+++ b/server/aws/elasticache/handler.go
@@ -1,0 +1,113 @@
+// Package elasticache implements the AWS ElastiCache query-protocol as a
+// server.Handler. Point the real aws-sdk-go-v2 ElastiCache client at a Server
+// registered with this handler and CacheCluster lifecycle operations
+// (CreateCacheCluster / DescribeCacheClusters / DeleteCacheCluster) work
+// against the in-memory cache driver.
+//
+// ElastiCache shares the AWS query wire shape with EC2, RDS, Redshift, and IAM
+// (POST + form-encoded body, XML response). To keep dispatch unambiguous, this
+// handler's Matches predicate parses the form body once and only claims
+// requests whose Action is one of the known ElastiCache operations. The EC2
+// handler is the catch-all for all other query-protocol actions, so this
+// handler MUST register before EC2. Its action set (CreateCacheCluster, …) is
+// disjoint from RDS (CreateDBInstance, …), Redshift (CreateCluster, …), IAM
+// (CreateUser, …), and EC2 (RunInstances, …), so no shadowing occurs.
+//
+// Only the cluster/instance control plane is mapped here — the real ElastiCache
+// SDK manages cache clusters, not the Redis data plane. The driver's Redis
+// data-plane methods (Set/Get/Incr/…) have no cloud-SDK surface and are
+// intentionally out of scope.
+package elasticache
+
+import (
+	"net/http"
+	"strings"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	cerrors "github.com/stackshy/cloudemu/errors"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// Namespace is the XML namespace for AWS ElastiCache responses.
+const Namespace = "http://elasticache.amazonaws.com/doc/2015-02-02/"
+
+const (
+	formContentType  = "application/x-www-form-urlencoded"
+	maxFormBodyBytes = 1 << 20
+)
+
+// elastiCacheActions is the set of Action values this handler recognizes.
+// Matches uses it to decide whether to claim a request.
+var elastiCacheActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"CreateCacheCluster":    {},
+	"DescribeCacheClusters": {},
+	"DeleteCacheCluster":    {},
+}
+
+// Handler serves ElastiCache query-protocol requests against a cache driver.
+type Handler struct {
+	cache cachedriver.Cache
+}
+
+// New returns an ElastiCache handler backed by c.
+func New(c cachedriver.Cache) *Handler {
+	return &Handler{cache: c}
+}
+
+// Matches returns true if the request looks like an AWS ElastiCache
+// query-protocol call (POST + form-encoded body whose Action is one of the
+// known ElastiCache operations). Calling ParseForm here caches the parsed form
+// on the request so ServeHTTP can use it without re-reading the body.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.Header.Get("X-Amz-Target") != "" {
+		return false
+	}
+
+	if r.Method != http.MethodPost {
+		return false
+	}
+
+	if !strings.HasPrefix(r.Header.Get("Content-Type"), formContentType) {
+		return false
+	}
+
+	r.Body = http.MaxBytesReader(nil, r.Body, maxFormBodyBytes)
+	if err := r.ParseForm(); err != nil {
+		return false
+	}
+
+	_, ok := elastiCacheActions[r.Form.Get("Action")]
+
+	return ok
+}
+
+// ServeHTTP dispatches on Action. The form has already been parsed by Matches.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Form.Get("Action") {
+	case "CreateCacheCluster":
+		h.createCacheCluster(w, r)
+	case "DescribeCacheClusters":
+		h.describeCacheClusters(w, r)
+	case "DeleteCacheCluster":
+		h.deleteCacheCluster(w, r)
+	default:
+		awsquery.WriteXMLError(w, http.StatusBadRequest,
+			"InvalidAction", "unknown ElastiCache action: "+r.Form.Get("Action"))
+	}
+}
+
+// writeErr maps cloudemu errors to ElastiCache XML error responses.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		awsquery.WriteXMLError(w, http.StatusNotFound, "CacheClusterNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "CacheClusterAlreadyExists", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidCacheClusterState", err.Error())
+	default:
+		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
+	}
+}

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -1,0 +1,115 @@
+package elasticache
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// parseTags parses ElastiCache-style Tags.Tag.N.{Key,Value} entries.
+func parseTags(form url.Values) map[string]string {
+	indices := awsquery.CollectIndices(form, "Tags.Tag")
+	if len(indices) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(indices))
+
+	for _, n := range indices {
+		base := "Tags.Tag." + strconv.Itoa(n)
+		if k := form.Get(base + ".Key"); k != "" {
+			out[k] = form.Get(base + ".Value")
+		}
+	}
+
+	return out
+}
+
+func (h *Handler) createCacheCluster(w http.ResponseWriter, r *http.Request) {
+	form := r.Form
+
+	cfg := cachedriver.CacheConfig{
+		Name:     form.Get("CacheClusterId"),
+		NodeType: form.Get("CacheNodeType"),
+		Engine:   form.Get("Engine"),
+		Tags:     parseTags(form),
+	}
+
+	info, err := h.cache.CreateCache(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, createCacheClusterResponse{
+		Xmlns:    Namespace,
+		Result:   cacheClusterResult{CacheCluster: toCacheClusterXML(info)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) describeCacheClusters(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("CacheClusterId")
+
+	// DescribeCacheClusters with a CacheClusterId scopes to that one cluster;
+	// without it, list them all.
+	var infos []cachedriver.CacheInfo
+
+	if id != "" {
+		info, err := h.cache.GetCache(r.Context(), id)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		infos = []cachedriver.CacheInfo{*info}
+	} else {
+		all, err := h.cache.ListCaches(r.Context())
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		infos = all
+	}
+
+	out := cacheClustersXML{CacheCluster: make([]cacheClusterXML, 0, len(infos))}
+	for i := range infos {
+		out.CacheCluster = append(out.CacheCluster, toCacheClusterXML(&infos[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, describeCacheClustersResponse{
+		Xmlns:    Namespace,
+		Result:   describeCacheClustersResult{CacheClusters: out},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) deleteCacheCluster(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("CacheClusterId")
+
+	// DeleteCacheCluster echoes the cluster (now in the "deleting" state) back
+	// in its response, so read it before removing it.
+	info, err := h.cache.GetCache(r.Context(), id)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if derr := h.cache.DeleteCache(r.Context(), id); derr != nil {
+		writeErr(w, derr)
+		return
+	}
+
+	last := *info
+	last.Status = "deleting"
+
+	awsquery.WriteXMLResponse(w, deleteCacheClusterResponse{
+		Xmlns:    Namespace,
+		Result:   cacheClusterResult{CacheCluster: toCacheClusterXML(&last)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/elasticache/sdk_roundtrip_test.go
+++ b/server/aws/elasticache/sdk_roundtrip_test.go
@@ -1,0 +1,185 @@
+package elasticache_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+	ectypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+func newSDKClient(t *testing.T) *awselasticache.Client {
+	t.Helper()
+
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		ElastiCache: cloud.ElastiCache,
+		// EC2 also wired so we exercise the dispatch precedence: a request for
+		// ElastiCache must claim the body before EC2 sees it.
+		EC2: cloud.EC2,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awselasticache.NewFromConfig(cfg, func(o *awselasticache.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKElastiCacheLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+		CacheClusterId: aws.String("session-cache"),
+		Engine:         aws.String("redis"),
+		CacheNodeType:  aws.String("cache.t3.micro"),
+		NumCacheNodes:  aws.Int32(1),
+		Tags: []ectypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("staging")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCacheCluster: %v", err)
+	}
+
+	if aws.ToString(out.CacheCluster.CacheClusterId) != "session-cache" {
+		t.Fatalf("got id %q, want session-cache", aws.ToString(out.CacheCluster.CacheClusterId))
+	}
+
+	if aws.ToString(out.CacheCluster.CacheClusterStatus) != "available" {
+		t.Fatalf("got status %q, want available", aws.ToString(out.CacheCluster.CacheClusterStatus))
+	}
+
+	if aws.ToString(out.CacheCluster.Engine) != "redis" {
+		t.Fatalf("got engine %q, want redis", aws.ToString(out.CacheCluster.Engine))
+	}
+
+	// Describe by id.
+	got, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId:    aws.String("session-cache"),
+		ShowCacheNodeInfo: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters: %v", err)
+	}
+
+	if len(got.CacheClusters) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(got.CacheClusters))
+	}
+
+	cc := got.CacheClusters[0]
+	if len(cc.CacheNodes) != 1 || cc.CacheNodes[0].Endpoint == nil ||
+		aws.ToString(cc.CacheNodes[0].Endpoint.Address) == "" {
+		t.Fatalf("expected a cache node with an endpoint, got %+v", cc.CacheNodes)
+	}
+
+	// List (no id): should include the one cluster.
+	list, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{})
+	if err != nil {
+		t.Fatalf("DescribeCacheClusters(all): %v", err)
+	}
+
+	if len(list.CacheClusters) != 1 {
+		t.Fatalf("list: got %d clusters, want 1", len(list.CacheClusters))
+	}
+
+	// Delete.
+	del, err := client.DeleteCacheCluster(ctx, &awselasticache.DeleteCacheClusterInput{
+		CacheClusterId: aws.String("session-cache"),
+	})
+	if err != nil {
+		t.Fatalf("DeleteCacheCluster: %v", err)
+	}
+
+	if aws.ToString(del.CacheCluster.CacheClusterStatus) != "deleting" {
+		t.Fatalf("delete status = %q, want deleting", aws.ToString(del.CacheCluster.CacheClusterStatus))
+	}
+
+	// Get after delete -> CacheClusterNotFound.
+	_, err = client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{
+		CacheClusterId: aws.String("session-cache"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "CacheClusterNotFound" {
+		t.Fatalf("Describe after delete: got %v, want CacheClusterNotFound", err)
+	}
+}
+
+func TestSDKElastiCacheNotFound(t *testing.T) {
+	client := newSDKClient(t)
+
+	_, err := client.DescribeCacheClusters(context.Background(),
+		&awselasticache.DescribeCacheClustersInput{
+			CacheClusterId: aws.String("missing"),
+		})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "CacheClusterNotFound" {
+		t.Fatalf("Describe(missing): got %v, want CacheClusterNotFound", err)
+	}
+}
+
+// Sanity check: when both ElastiCache and EC2 handlers are wired, an EC2
+// request still reaches the EC2 handler — the ElastiCache handler's Matches
+// must reject non-ElastiCache actions despite parsing the form first.
+func TestSDKElastiCacheDoesNotShadowEC2(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{
+		ElastiCache: cloud.ElastiCache,
+		EC2:         cloud.EC2,
+		VPC:         cloud.VPC,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	ec2Client := awsec2.NewFromConfig(cfg, func(o *awsec2.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	out, err := ec2Client.RunInstances(context.Background(), &awsec2.RunInstancesInput{
+		ImageId:  aws.String("ami-1"),
+		MinCount: aws.Int32(1),
+		MaxCount: aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("EC2 RunInstances through combined server: %v", err)
+	}
+
+	if len(out.Instances) == 0 {
+		t.Fatal("expected at least one EC2 instance")
+	}
+}

--- a/server/aws/elasticache/types.go
+++ b/server/aws/elasticache/types.go
@@ -1,0 +1,133 @@
+package elasticache
+
+import (
+	"encoding/xml"
+	"strconv"
+	"strings"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+)
+
+// All ElastiCache query-protocol responses are wrapped in <FooResponse> with a
+// <FooResult> child and a trailing <ResponseMetadata>. The structures below
+// mirror the AWS-published XML closely enough that aws-sdk-go-v2's ElastiCache
+// unmarshalers consume them without complaint.
+
+const defaultRedisPort = 6379
+
+type responseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+type endpointXML struct {
+	Address string `xml:"Address,omitempty"`
+	Port    int    `xml:"Port,omitempty"`
+}
+
+// cacheNodeXML mirrors AWS's CacheNode. The SDK reads the per-node Endpoint to
+// populate CacheCluster.CacheNodes[].Endpoint; that is where a single-node
+// Redis cluster's connection address lives.
+type cacheNodeXML struct {
+	CacheNodeID     string       `xml:"CacheNodeId"`
+	CacheNodeStatus string       `xml:"CacheNodeStatus"`
+	Endpoint        *endpointXML `xml:"Endpoint,omitempty"`
+}
+
+type cacheNodesXML struct {
+	CacheNode []cacheNodeXML `xml:"CacheNode,omitempty"`
+}
+
+// cacheClusterXML mirrors AWS's CacheCluster resource. Only the fields the
+// cache driver can populate are emitted; the rest are omitted.
+type cacheClusterXML struct {
+	CacheClusterID       string         `xml:"CacheClusterId"`
+	CacheClusterStatus   string         `xml:"CacheClusterStatus"`
+	CacheNodeType        string         `xml:"CacheNodeType,omitempty"`
+	Engine               string         `xml:"Engine,omitempty"`
+	NumCacheNodes        int            `xml:"NumCacheNodes,omitempty"`
+	CacheClusterCreateAt string         `xml:"CacheClusterCreateTime,omitempty"`
+	ARN                  string         `xml:"ARN,omitempty"`
+	ConfigurationEndpt   *endpointXML   `xml:"ConfigurationEndpoint,omitempty"`
+	CacheNodes           *cacheNodesXML `xml:"CacheNodes,omitempty"`
+}
+
+// --- response envelopes, one per Action ---
+
+type cacheClusterResult struct {
+	CacheCluster cacheClusterXML `xml:"CacheCluster"`
+}
+
+type createCacheClusterResponse struct {
+	XMLName  xml.Name           `xml:"CreateCacheClusterResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   cacheClusterResult `xml:"CreateCacheClusterResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+type deleteCacheClusterResponse struct {
+	XMLName  xml.Name           `xml:"DeleteCacheClusterResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   cacheClusterResult `xml:"DeleteCacheClusterResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+type cacheClustersXML struct {
+	CacheCluster []cacheClusterXML `xml:"CacheCluster,omitempty"`
+}
+
+type describeCacheClustersResult struct {
+	CacheClusters cacheClustersXML `xml:"CacheClusters"`
+}
+
+type describeCacheClustersResponse struct {
+	XMLName  xml.Name                    `xml:"DescribeCacheClustersResponse"`
+	Xmlns    string                      `xml:"xmlns,attr"`
+	Result   describeCacheClustersResult `xml:"DescribeCacheClustersResult"`
+	Metadata responseMetadata            `xml:"ResponseMetadata"`
+}
+
+// splitEndpoint separates the driver's "host:port" endpoint into an Address and
+// Port. Falls back to the default Redis port when no ":port" suffix is present.
+func splitEndpoint(endpoint string) *endpointXML {
+	if endpoint == "" {
+		return nil
+	}
+
+	host := endpoint
+	port := defaultRedisPort
+
+	if i := strings.LastIndex(endpoint, ":"); i >= 0 {
+		host = endpoint[:i]
+		if p, err := strconv.Atoi(endpoint[i+1:]); err == nil {
+			port = p
+		}
+	}
+
+	return &endpointXML{Address: host, Port: port}
+}
+
+// toCacheClusterXML converts a driver CacheInfo into its ElastiCache XML shape.
+// The driver models a single-node cache, so one CacheNode carrying the endpoint
+// is emitted (DescribeCacheClusters populates it only when ShowCacheNodeInfo is
+// set, but including it unconditionally is harmless).
+func toCacheClusterXML(info *cachedriver.CacheInfo) cacheClusterXML {
+	out := cacheClusterXML{
+		CacheClusterID:       info.Name,
+		CacheClusterStatus:   info.Status,
+		CacheNodeType:        info.NodeType,
+		Engine:               info.Engine,
+		NumCacheNodes:        1,
+		CacheClusterCreateAt: info.CreatedAt,
+	}
+
+	if ep := splitEndpoint(info.Endpoint); ep != nil {
+		out.ConfigurationEndpt = ep
+		out.CacheNodes = &cacheNodesXML{CacheNode: []cacheNodeXML{{
+			CacheNodeID:     "0001",
+			CacheNodeStatus: info.Status,
+			Endpoint:        ep,
+		}}}
+	}
+
+	return out
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -7,6 +7,7 @@
 package azure
 
 import (
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
@@ -28,6 +29,7 @@ import (
 	aksserver "github.com/stackshy/cloudemu/server/azure/aks"
 	"github.com/stackshy/cloudemu/server/azure/azuresql"
 	"github.com/stackshy/cloudemu/server/azure/blob"
+	cachesrv "github.com/stackshy/cloudemu/server/azure/cache"
 	"github.com/stackshy/cloudemu/server/azure/cosmos"
 	"github.com/stackshy/cloudemu/server/azure/databricks"
 	"github.com/stackshy/cloudemu/server/azure/databricks/dbfs"
@@ -107,7 +109,10 @@ type Drivers struct {
 	// (Microsoft.OperationalInsights/workspaces) ARM API against the logging
 	// driver. The workspace lifecycle maps onto the driver's log-group
 	// lifecycle; the data-plane log-query API is out of scope.
-	LogAnalytics        logdriver.Logging
+	LogAnalytics logdriver.Logging
+	// Cache serves the Azure Cache for Redis (Microsoft.Cache/redis) ARM API
+	// against the cache driver's cluster control plane.
+	Cache               cachedriver.Cache
 	Databricks          dbxdriver.Databricks
 	DatabricksDataPlane dbxdriver.DataPlane
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
@@ -194,6 +199,13 @@ func New(d Drivers) *server.Server {
 	// order is unconstrained. Registered before the BlobStorage fallback.
 	if d.LogAnalytics != nil {
 		srv.Register(loganalyticssrv.New(d.LogAnalytics))
+	}
+
+	// Azure Cache for Redis matches on the Microsoft.Cache ARM provider — a
+	// unique provider name among Azure handlers, so registration order is
+	// unconstrained. Registered before the BlobStorage fallback.
+	if d.Cache != nil {
+		srv.Register(cachesrv.New(d.Cache))
 	}
 
 	if d.Monitor != nil {

--- a/server/azure/cache/handler.go
+++ b/server/azure/cache/handler.go
@@ -1,0 +1,94 @@
+// Package cache implements the Azure Cache for Redis (Microsoft.Cache/redis)
+// ARM REST API as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis clients
+// configured with a custom endpoint hit this handler the same way they hit
+// management.azure.com, driving the shared cache driver's cluster control
+// plane (CreateOrUpdate/Get/List/Delete).
+//
+// Matches claims ONLY the Microsoft.Cache ARM provider — a distinct provider
+// name from every other Azure handler (compute, network, DBforMySQL, …) — so
+// registration order relative to them is unconstrained. It must register before
+// the permissive BlobStorage fallback.
+//
+// Coverage:
+//
+//	PUT    .../providers/Microsoft.Cache/redis/{name}   — Redis.BeginCreate (LRO, completes inline)
+//	GET    .../providers/Microsoft.Cache/redis/{name}   — Redis.Get
+//	DELETE .../providers/Microsoft.Cache/redis/{name}   — Redis.BeginDelete (LRO, completes inline)
+//	GET    .../providers/Microsoft.Cache/redis          — Redis.ListByResourceGroup
+//	GET    .../subscriptions/{sub}/providers/Microsoft.Cache/redis — Redis.ListBySubscription
+//
+// Only the cluster/instance control plane is mapped — the real Azure Cache SDK
+// manages Redis caches, not the Redis data plane. The driver's data-plane
+// methods (Set/Get/Incr/…) have no cloud-SDK surface and are out of scope.
+package cache
+
+import (
+	"net/http"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	providerName = "Microsoft.Cache"
+	typeRedis    = "redis"
+)
+
+// Handler serves Microsoft.Cache/redis ARM requests against a cache driver.
+type Handler struct {
+	cache cachedriver.Cache
+}
+
+// New returns an Azure Cache handler backed by c.
+func New(c cachedriver.Cache) *Handler {
+	return &Handler{cache: c}
+}
+
+// Matches claims ARM URLs targeting Microsoft.Cache/redis. The provider name is
+// unique among Azure handlers, so registration order is unconstrained;
+// registered before the BlobStorage fallback.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	return rp.Provider == providerName && rp.ResourceType == typeRedis
+}
+
+// ServeHTTP routes on the parsed path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	// Collection list: no cache name (subscription- or RG-scoped list).
+	if rp.ResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		h.listCaches(w, r, &rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateCache(w, r, &rp)
+	case http.MethodGet:
+		h.getCache(w, r, &rp)
+	case http.MethodDelete:
+		h.deleteCache(w, r, &rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -1,0 +1,101 @@
+package cache
+
+import (
+	"net/http"
+	"strconv"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+// createOrUpdateCache handles PUT — Redis.BeginCreate. The LRO completes inline:
+// returning 201/200 with the resource body terminates the SDK's poller on the
+// first response.
+func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body redisJSON
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	// CreateOrUpdate is idempotent: if the cache already exists, echo it back.
+	if info, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
+		azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
+		return
+	}
+
+	cfg := cachedriver.CacheConfig{
+		Name:     rp.ResourceName,
+		Engine:   "redis",
+		NodeType: nodeTypeFromBody(&body),
+		Tags:     body.Tags,
+	}
+
+	info, err := h.cache.CreateCache(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusCreated, toRedisJSON(rp, info))
+}
+
+// nodeTypeFromBody derives the driver's node-type string from the request SKU.
+// Azure node types look like "Standard_C1"; when the body carries a SKU we
+// reconstruct that shape, otherwise the driver's default applies.
+func nodeTypeFromBody(body *redisJSON) string {
+	if body.Properties == nil || body.Properties.SKU == nil {
+		return ""
+	}
+
+	sku := body.Properties.SKU
+	if sku.Name == "" {
+		return ""
+	}
+
+	family := sku.Family
+	if family == "" {
+		family = "C"
+	}
+
+	return sku.Name + "_" + family + strconv.Itoa(sku.Capacity)
+}
+
+// getCache handles GET on a single resource — Redis.Get.
+func (h *Handler) getCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	info, err := h.cache.GetCache(r.Context(), rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
+}
+
+// deleteCache handles DELETE — Redis.BeginDelete. Returning 200 with an empty
+// body completes the SDK's poller on the first response.
+func (h *Handler) deleteCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.cache.DeleteCache(r.Context(), rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// listCaches handles GET on the collection — Redis.ListByResourceGroup /
+// ListBySubscription. The cache driver is not scope-aware, so both list the
+// same set.
+func (h *Handler) listCaches(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	infos, err := h.cache.ListCaches(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]redisJSON, 0, len(infos))
+	for i := range infos {
+		out = append(out, toRedisJSON(rp, &infos[i]))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, redisListResult{Value: out})
+}

--- a/server/azure/cache/sdk_roundtrip_test.go
+++ b/server/azure/cache/sdk_roundtrip_test.go
@@ -1,0 +1,157 @@
+package cache_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+const (
+	testRG  = "rg-1"
+	testSub = "sub-1"
+)
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newRedisClient(t *testing.T) *armredis.Client {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{Cache: cloudP.Cache})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {
+				Endpoint: ts.URL,
+				Audience: "https://management.azure.com",
+			},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armredis.NewClientFactory(testSub, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("armredis.NewClientFactory: %v", err)
+	}
+
+	return cf.NewClient()
+}
+
+func TestSDKAzureCacheLifecycle(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "my-cache", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("test")},
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != "my-cache" {
+		t.Fatalf("Create name = %v, want my-cache", created.Name)
+	}
+
+	got, err := client.Get(ctx, testRG, "my-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Tags["env"] == nil || *got.Tags["env"] != "test" {
+		t.Fatalf("tags = %v, want env=test", got.Tags)
+	}
+
+	if got.Properties == nil || got.Properties.HostName == nil || *got.Properties.HostName == "" {
+		t.Fatalf("expected hostName to be set, got %+v", got.Properties)
+	}
+
+	if got.Properties.ProvisioningState == nil || *got.Properties.ProvisioningState != armredis.ProvisioningStateSucceeded {
+		t.Fatalf("provisioningState = %v, want Succeeded", got.Properties.ProvisioningState)
+	}
+
+	// List by subscription — should include the one cache.
+	var names []string
+
+	pager := client.NewListBySubscriptionPager(nil)
+	for pager.More() {
+		page, perr := pager.NextPage(ctx)
+		if perr != nil {
+			t.Fatalf("ListBySubscription: %v", perr)
+		}
+
+		for _, c := range page.Value {
+			names = append(names, *c.Name)
+		}
+	}
+
+	if len(names) != 1 || names[0] != "my-cache" {
+		t.Fatalf("list = %v, want [my-cache]", names)
+	}
+
+	delPoller, err := client.BeginDelete(ctx, testRG, "my-cache", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete PollUntilDone: %v", err)
+	}
+
+	_, err = client.Get(ctx, testRG, "my-cache", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKAzureCacheNotFound(t *testing.T) {
+	client := newRedisClient(t)
+
+	_, err := client.Get(context.Background(), testRG, "missing", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -1,0 +1,110 @@
+package cache
+
+import (
+	"strconv"
+	"strings"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/server/wire/azurearm"
+)
+
+const (
+	redisResourceType = "Microsoft.Cache/redis"
+	defaultLocation   = "eastus"
+	// provisioningStateSucceeded is the terminal LRO state; the mock applies
+	// mutations synchronously so every response is already Succeeded, which
+	// terminates the SDK's poller on the first response.
+	provisioningStateSucceeded = "Succeeded"
+	defaultRedisSSLPort        = 6380
+	defaultRedisVersion        = "6.0"
+)
+
+// skuJSON mirrors the armredis SKU. The cache driver only tracks a node-type
+// string, which maps onto SKU.Name (Basic/Standard/Premium); Family and
+// Capacity carry stub defaults so the SDK round-trips a well-formed SKU.
+type skuJSON struct {
+	Name     string `json:"name,omitempty"`
+	Family   string `json:"family,omitempty"`
+	Capacity int    `json:"capacity,omitempty"`
+}
+
+// redisProperties mirrors the subset of armredis Properties the cache driver
+// can populate.
+type redisProperties struct {
+	ProvisioningState string   `json:"provisioningState,omitempty"`
+	RedisVersion      string   `json:"redisVersion,omitempty"`
+	SKU               *skuJSON `json:"sku,omitempty"`
+	HostName          string   `json:"hostName,omitempty"`
+	SSLPort           int      `json:"sslPort,omitempty"`
+	Port              int      `json:"port,omitempty"`
+}
+
+// redisJSON mirrors the armredis ResourceInfo / CreateParameters resource.
+type redisJSON struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Location   string            `json:"location,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+	Properties *redisProperties  `json:"properties,omitempty"`
+}
+
+type redisListResult struct {
+	Value []redisJSON `json:"value"`
+}
+
+// skuNameFromNodeType extracts the SKU tier (Basic/Standard/Premium) from the
+// driver's node-type string. Azure node types look like "Standard_C1", so the
+// tier is the segment before the underscore. Falls back to "Standard".
+func skuNameFromNodeType(nodeType string) string {
+	if i := strings.Index(nodeType, "_"); i > 0 {
+		return nodeType[:i]
+	}
+
+	if nodeType != "" {
+		return nodeType
+	}
+
+	return "Standard"
+}
+
+// hostAndSSLPort splits the driver's "host:port" endpoint. Azure Redis exposes
+// an SSL port (default 6380); the port suffix, when present, is used.
+func hostAndSSLPort(endpoint string) (string, int) {
+	if endpoint == "" {
+		return "", defaultRedisSSLPort
+	}
+
+	host := endpoint
+	port := defaultRedisSSLPort
+
+	if i := strings.LastIndex(endpoint, ":"); i >= 0 {
+		host = endpoint[:i]
+		if p, err := strconv.Atoi(endpoint[i+1:]); err == nil {
+			port = p
+		}
+	}
+
+	return host, port
+}
+
+// toRedisJSON converts a driver CacheInfo into its ARM element for the given
+// path scope.
+func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJSON {
+	host, sslPort := hostAndSSLPort(info.Endpoint)
+
+	return redisJSON{
+		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRedis, info.Name),
+		Name:     info.Name,
+		Type:     redisResourceType,
+		Location: defaultLocation,
+		Tags:     info.Tags,
+		Properties: &redisProperties{
+			ProvisioningState: provisioningStateSucceeded,
+			RedisVersion:      defaultRedisVersion,
+			SKU:               &skuJSON{Name: skuNameFromNodeType(info.NodeType), Family: "C", Capacity: 1},
+			HostName:          host,
+			SSLPort:           sslPort,
+		},
+	}
+}

--- a/server/gcp/gcp.go
+++ b/server/gcp/gcp.go
@@ -7,6 +7,7 @@
 package gcp
 
 import (
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
 	computedriver "github.com/stackshy/cloudemu/compute/driver"
 	crdriver "github.com/stackshy/cloudemu/containerregistry/driver"
 	dbdriver "github.com/stackshy/cloudemu/database/driver"
@@ -37,6 +38,7 @@ import (
 	"github.com/stackshy/cloudemu/server/gcp/gke"
 	"github.com/stackshy/cloudemu/server/gcp/iam"
 	lbsrv "github.com/stackshy/cloudemu/server/gcp/loadbalancer"
+	memorystoresrv "github.com/stackshy/cloudemu/server/gcp/memorystore"
 	"github.com/stackshy/cloudemu/server/gcp/monitoring"
 	"github.com/stackshy/cloudemu/server/gcp/networks"
 	"github.com/stackshy/cloudemu/server/gcp/pubsub"
@@ -76,6 +78,9 @@ type Drivers struct {
 	// Eventarc serves the eventarc.googleapis.com v1 REST API against the
 	// eventbus driver, mapping triggers to rules under a per-location bus.
 	Eventarc ebdriver.EventBus
+	// Memorystore serves the redis.googleapis.com v1 REST API against the cache
+	// driver's instance control plane.
+	Memorystore cachedriver.Cache
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with awsserver.Drivers.K8sAPI and azureserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -212,6 +217,15 @@ func New(d Drivers) *server.Server {
 	// is unconstrained. Registered before the GCS fallback for consistency.
 	if d.CloudLogging != nil {
 		srv.Register(cloudloggingsrv.New(d.CloudLogging))
+	}
+
+	// Memorystore matches /v1/projects/{p}/locations/{l}/{instances|operations}
+	// — its resource-type guard is disjoint from GKE (clusters), Cloud Functions
+	// (functions), Vertex AI, and the rest of the /v1/projects/ family, so
+	// registration order among them is unconstrained. Registered before
+	// Firestore's permissive /v1/projects/ prefix so its paths aren't swallowed.
+	if d.Memorystore != nil {
+		srv.Register(memorystoresrv.New(d.Memorystore))
 	}
 
 	if d.Firestore != nil {

--- a/server/gcp/memorystore/handler.go
+++ b/server/gcp/memorystore/handler.go
@@ -1,0 +1,164 @@
+// Package memorystore implements the GCP Memorystore for Redis
+// (redis.googleapis.com) v1 REST API as a server.Handler. Real
+// google.golang.org/api/redis/v1 clients pointed at this server manage Redis
+// instances end-to-end against the shared cache driver's cluster control plane.
+//
+// Coverage (v1 REST):
+//
+//	POST   /v1/projects/{p}/locations/{l}/instances?instanceId={i}  — Create (LRO)
+//	GET    /v1/projects/{p}/locations/{l}/instances/{i}             — Get
+//	GET    /v1/projects/{p}/locations/{l}/instances                 — List
+//	DELETE /v1/projects/{p}/locations/{l}/instances/{i}             — Delete (LRO)
+//	GET    /v1/projects/{p}/locations/{l}/operations/{op}           — Operations.Get
+//
+// Mutating ops return a google.longrunning.Operation with done=true so SDK
+// pollers terminate on the first response. The operation's `response` carries
+// the Instance (Create) or an empty object (Delete).
+//
+// Matches claims /v1/projects/{p}/locations/{l}/{instances|operations}/... — a
+// distinct sub-path within the /v1/projects/ family used by Firestore, IAM,
+// Secret Manager, etc. Its {instances|operations} guard is disjoint from those
+// (Cloud Functions uses functions/, GKE uses clusters/, …), so registration
+// order relative to them is unconstrained. Registered before the permissive
+// Firestore / GCS fallbacks so its paths aren't swallowed.
+//
+// Only the instance control plane is mapped — the real Memorystore SDK manages
+// instances, not the Redis data plane. The driver's data-plane methods
+// (Set/Get/Incr/…) have no cloud-SDK surface and are out of scope.
+package memorystore
+
+import (
+	"net/http"
+	"strings"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+const (
+	pathPrefix       = "/v1/projects/"
+	locationsSeg     = "locations"
+	instancesSeg     = "instances"
+	operationsSeg    = "operations"
+	minResourceParts = 4 // [projects, {p}, locations, {l}]
+)
+
+// Handler serves redis.googleapis.com v1 requests against a cache driver.
+type Handler struct {
+	cache cachedriver.Cache
+}
+
+// New returns a Memorystore handler backed by c.
+func New(c cachedriver.Cache) *Handler {
+	return &Handler{cache: c}
+}
+
+// route holds the parsed components of a Memorystore v1 path.
+type route struct {
+	project  string
+	location string
+	resource string // "instances" or "operations"
+	name     string // instance id or operation id; empty for the collection
+}
+
+// parseRoute extracts the components of a Memorystore v1 path. It recognizes
+// only the instances and operations resources under a locations scope.
+func parseRoute(urlPath string) (route, bool) {
+	if !strings.HasPrefix(urlPath, pathPrefix) {
+		return route{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(urlPath, "/v1/"), "/")
+	if len(parts) < minResourceParts || parts[0] != "projects" || parts[2] != locationsSeg {
+		return route{}, false
+	}
+
+	rt := route{project: parts[1], location: parts[3]}
+
+	rest := parts[minResourceParts:]
+	if len(rest) == 0 {
+		return route{}, false
+	}
+
+	rt.resource = rest[0]
+	if rt.resource != instancesSeg && rt.resource != operationsSeg {
+		return route{}, false
+	}
+
+	switch len(rest) {
+	case 1:
+		return rt, true
+	case 2:
+		rt.name = rest[1]
+		return rt, true
+	default:
+		return route{}, false
+	}
+}
+
+// Matches claims /v1/projects/{p}/locations/{l}/{instances|operations}[/...]
+// paths. The {instances|operations} guard keeps it disjoint from the other
+// /v1/projects/ handlers (functions, clusters, secrets, databases, …).
+func (*Handler) Matches(r *http.Request) bool {
+	_, ok := parseRoute(r.URL.Path)
+	return ok
+}
+
+// ServeHTTP routes on the parsed path and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rt, ok := parseRoute(r.URL.Path)
+	if !ok {
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unrecognized Memorystore path")
+		return
+	}
+
+	switch rt.resource {
+	case operationsSeg:
+		h.serveOperation(w, r, rt)
+	case instancesSeg:
+		h.serveInstances(w, r, rt)
+	default:
+		gcprest.WriteError(w, http.StatusNotFound, "notFound", "unsupported resource: "+rt.resource)
+	}
+}
+
+func (h *Handler) serveInstances(w http.ResponseWriter, r *http.Request, rt route) {
+	if rt.name == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.createInstance(w, r, rt)
+		case http.MethodGet:
+			h.listInstances(w, r, rt)
+		default:
+			writeUnsupported(w)
+		}
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getInstance(w, r, rt)
+	case http.MethodDelete:
+		h.deleteInstance(w, r, rt)
+	default:
+		writeUnsupported(w)
+	}
+}
+
+// serveOperation handles Operations.Get. Because mutations complete inline (the
+// mutating handlers return a done=true operation), a subsequent poll GET simply
+// re-reports a completed operation. The operation state is not persisted, so we
+// synthesize a terminal operation for the requested id.
+func (h *Handler) serveOperation(w http.ResponseWriter, r *http.Request, rt route) {
+	if r.Method != http.MethodGet {
+		writeUnsupported(w)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, doneOperation(rt.project, rt.location, rt.name, nil))
+}
+
+func writeUnsupported(w http.ResponseWriter) {
+	gcprest.WriteError(w, http.StatusBadRequest, "badRequest", "unsupported Memorystore operation")
+}

--- a/server/gcp/memorystore/operations.go
+++ b/server/gcp/memorystore/operations.go
@@ -1,0 +1,91 @@
+package memorystore
+
+import (
+	"encoding/json"
+	"net/http"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+	"github.com/stackshy/cloudemu/server/wire/gcprest"
+)
+
+// createInstance handles POST .../instances?instanceId={i} — Create. The
+// operation completes inline, so a done=true Operation carrying the new
+// Instance is returned.
+func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt route) {
+	instanceID := r.URL.Query().Get("instanceId")
+	if instanceID == "" {
+		gcprest.WriteError(w, http.StatusBadRequest, "invalid", "instanceId query parameter is required")
+		return
+	}
+
+	var body instanceJSON
+	if !gcprest.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	info, err := h.cache.CreateCache(r.Context(), cachedriver.CacheConfig{
+		Name:     instanceID,
+		Engine:   "redis",
+		NodeType: body.Tier,
+		Tags:     body.Labels,
+	})
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	inst := toInstanceJSON(rt.project, rt.location, instanceID, info)
+
+	raw, mErr := json.Marshal(inst)
+	if mErr != nil {
+		gcprest.WriteError(w, http.StatusInternalServerError, "internalError", mErr.Error())
+		return
+	}
+
+	op := doneOperation(rt.project, rt.location, "create-"+instanceID, raw)
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}
+
+// getInstance handles GET .../instances/{i} — Get.
+func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rt route) {
+	info, err := h.cache.GetCache(r.Context(), rt.name)
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, toInstanceJSON(rt.project, rt.location, rt.name, info))
+}
+
+// listInstances handles GET .../instances — List.
+func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt route) {
+	infos, err := h.cache.ListCaches(r.Context())
+	if err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]instanceJSON, 0, len(infos))
+	for i := range infos {
+		// CacheInfo.Name carries the driver's own resource id; the short
+		// instance id (the map key) is recovered from its trailing segment.
+		id := shortInstanceID(infos[i].Name)
+		out = append(out, toInstanceJSON(rt.project, rt.location, id, &infos[i]))
+	}
+
+	gcprest.WriteJSON(w, http.StatusOK, listInstancesResponse{Instances: out})
+}
+
+// deleteInstance handles DELETE .../instances/{i} — Delete. The operation
+// completes inline, so a done=true Operation with an empty response is returned.
+func (h *Handler) deleteInstance(w http.ResponseWriter, r *http.Request, rt route) {
+	if err := h.cache.DeleteCache(r.Context(), rt.name); err != nil {
+		gcprest.WriteCErr(w, err)
+		return
+	}
+
+	op := doneOperation(rt.project, rt.location, "delete-"+rt.name, json.RawMessage("{}"))
+
+	gcprest.WriteJSON(w, http.StatusOK, op)
+}

--- a/server/gcp/memorystore/sdk_roundtrip_test.go
+++ b/server/gcp/memorystore/sdk_roundtrip_test.go
@@ -1,0 +1,130 @@
+package memorystore_test
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	redis "google.golang.org/api/redis/v1"
+
+	"github.com/stackshy/cloudemu"
+	gcpserver "github.com/stackshy/cloudemu/server/gcp"
+)
+
+const (
+	testProject  = "demo"
+	testLocation = "us-central1"
+)
+
+func newRedisService(t *testing.T) *redis.Service {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{
+		Memorystore: cloud.Memorystore,
+		// Firestore also wired so we exercise dispatch precedence: Memorystore's
+		// instances/operations guard must win over Firestore's /v1/projects/
+		// prefix match.
+		Firestore: cloud.Firestore,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := redis.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("redis.NewService: %v", err)
+	}
+
+	return svc
+}
+
+func parent() string {
+	return "projects/" + testProject + "/locations/" + testLocation
+}
+
+func instanceName(id string) string {
+	return parent() + "/instances/" + id
+}
+
+func TestSDKMemorystoreLifecycle(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	op, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+		Tier:         "BASIC",
+		MemorySizeGb: 1,
+		Labels:       map[string]string{"env": "test"},
+	}).InstanceId("cache1").Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Create: %v", err)
+	}
+
+	if !op.Done {
+		t.Fatalf("Create operation not done: %+v", op)
+	}
+
+	got, err := svc.Projects.Locations.Instances.Get(instanceName("cache1")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Get: %v", err)
+	}
+
+	if got.Name != instanceName("cache1") {
+		t.Fatalf("Get name = %q, want %q", got.Name, instanceName("cache1"))
+	}
+
+	if got.State != "READY" {
+		t.Fatalf("Get state = %q, want READY", got.State)
+	}
+
+	if got.Host == "" || got.Port == 0 {
+		t.Fatalf("expected host/port to be set, got host=%q port=%d", got.Host, got.Port)
+	}
+
+	if got.Labels["env"] != "test" {
+		t.Fatalf("labels = %v, want env=test", got.Labels)
+	}
+
+	list, err := svc.Projects.Locations.Instances.List(parent()).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.List: %v", err)
+	}
+
+	if len(list.Instances) != 1 || list.Instances[0].Name != instanceName("cache1") {
+		t.Fatalf("List = %+v, want one instance %q", list.Instances, instanceName("cache1"))
+	}
+
+	delOp, err := svc.Projects.Locations.Instances.Delete(instanceName("cache1")).Context(ctx).Do()
+	if err != nil {
+		t.Fatalf("Instances.Delete: %v", err)
+	}
+
+	if !delOp.Done {
+		t.Fatalf("Delete operation not done: %+v", delOp)
+	}
+
+	_, err = svc.Projects.Locations.Instances.Get(instanceName("cache1")).Context(ctx).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get after delete: got %v, want 404", err)
+	}
+}
+
+func TestSDKMemorystoreNotFound(t *testing.T) {
+	svc := newRedisService(t)
+
+	_, err := svc.Projects.Locations.Instances.Get(instanceName("missing")).
+		Context(context.Background()).Do()
+
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != 404 {
+		t.Fatalf("Get(missing): got %v, want 404", err)
+	}
+}

--- a/server/gcp/memorystore/types.go
+++ b/server/gcp/memorystore/types.go
@@ -1,0 +1,139 @@
+package memorystore
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	cachedriver "github.com/stackshy/cloudemu/cache/driver"
+)
+
+const (
+	defaultRedisPort    = 6379
+	defaultRedisVersion = "REDIS_6_X"
+	defaultTier         = "BASIC"
+	// stateReady is Memorystore's terminal instance state; the mock provisions
+	// synchronously so every instance reports READY.
+	stateReady = "READY"
+)
+
+// instanceJSON mirrors the subset of google.golang.org/api/redis/v1 Instance
+// the cache driver can populate. `name` is the full resource path
+// (projects/{p}/locations/{l}/instances/{i}); `memorySizeGb` is required by the
+// API surface so a stub default is emitted.
+type instanceJSON struct {
+	Name          string            `json:"name,omitempty"`
+	DisplayName   string            `json:"displayName,omitempty"`
+	Tier          string            `json:"tier,omitempty"`
+	MemorySizeGb  int64             `json:"memorySizeGb,omitempty"`
+	RedisVersion  string            `json:"redisVersion,omitempty"`
+	State         string            `json:"state,omitempty"`
+	Host          string            `json:"host,omitempty"`
+	Port          int64             `json:"port,omitempty"`
+	CreateTime    string            `json:"createTime,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
+	LocationID    string            `json:"locationId,omitempty"`
+	ReservedIPRng string            `json:"reservedIpRange,omitempty"`
+}
+
+// listInstancesResponse mirrors redis/v1 ListInstancesResponse.
+type listInstancesResponse struct {
+	Instances []instanceJSON `json:"instances"`
+}
+
+// operationJSON mirrors google.longrunning.Operation. Mutating ops complete
+// inline, so `done` is always true; `response` carries the resulting resource.
+type operationJSON struct {
+	Name     string          `json:"name"`
+	Done     bool            `json:"done"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+// instanceResourceName builds the full API resource name for an instance.
+func instanceResourceName(project, location, instanceID string) string {
+	return "projects/" + project + "/locations/" + location + "/instances/" + instanceID
+}
+
+// operationResourceName builds the full API resource name for an operation.
+func operationResourceName(project, location, operationID string) string {
+	return "projects/" + project + "/locations/" + location + "/operations/" + operationID
+}
+
+// shortInstanceID recovers the driver's map key (the short instance id) from a
+// CacheInfo.Name. The Memorystore driver stamps info.Name as
+// "projects/{p}/instances/{id}" (its own resource id, without a location
+// segment) but keys the store on the bare {id}; that trailing segment is the
+// key. Names without a "/" are returned unchanged.
+func shortInstanceID(name string) string {
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		return name[i+1:]
+	}
+
+	return name
+}
+
+// hostAndPort splits the driver's "host:port" endpoint into a host and a numeric
+// port, defaulting to the standard Redis port when no ":port" suffix is present.
+func hostAndPort(endpoint string) (string, int64) {
+	if endpoint == "" {
+		return "", defaultRedisPort
+	}
+
+	host := endpoint
+	port := int64(defaultRedisPort)
+
+	if i := strings.LastIndex(endpoint, ":"); i >= 0 {
+		host = endpoint[:i]
+		if p, err := strconv.ParseInt(endpoint[i+1:], 10, 64); err == nil {
+			port = p
+		}
+	}
+
+	return host, port
+}
+
+// toInstanceJSON converts a driver CacheInfo into its redis/v1 Instance shape.
+// The wire `name` must be the full locations-scoped resource path, which the
+// driver's CacheInfo.Name (which lacks the location segment) does not carry, so
+// it is rebuilt from the request scope and the short instance id.
+func toInstanceJSON(project, location, instanceID string, info *cachedriver.CacheInfo) instanceJSON {
+	host, port := hostAndPort(info.Endpoint)
+
+	tier := defaultTier
+	if info.NodeType != "" {
+		tier = info.NodeType
+	}
+
+	return instanceJSON{
+		Name:         instanceResourceName(project, location, instanceID),
+		Tier:         tier,
+		MemorySizeGb: 1,
+		RedisVersion: defaultRedisVersion,
+		State:        stateOrReady(info.Status),
+		Host:         host,
+		Port:         port,
+		CreateTime:   info.CreatedAt,
+		Labels:       info.Tags,
+		LocationID:   location,
+	}
+}
+
+// stateOrReady maps the driver status onto Memorystore's state enum, defaulting
+// to READY.
+func stateOrReady(status string) string {
+	if strings.EqualFold(status, "READY") || status == "" {
+		return stateReady
+	}
+
+	return status
+}
+
+// doneOperation builds a completed google.longrunning.Operation for the given
+// operation id. When resp is non-nil it is embedded as the operation response.
+func doneOperation(project, location, operationID string, resp json.RawMessage) operationJSON {
+	return operationJSON{
+		Name:     operationResourceName(project, location, operationID),
+		Done:     true,
+		Response: resp,
+	}
+}


### PR DESCRIPTION
SDK-compat servers for the **Cache** service across AWS/Azure/GCP — the Cache slice of #143, following the merged Secrets/DNS pattern. Real-SDK roundtrip tests per provider; `go build ./...`, `go vet`, and the full `go test ./server/...` tree pass. See the implementing commit for per-provider ops, driver→wire mapping, and documented gaps.
Notes: control-plane (cluster/instance lifecycle) only — the Redis data plane (Set/Get/Incr/...) has no cloud-SDK surface and is intentionally out of scope (documented).