### PR TITLE
feat(sts): AWS STS SDK-compat handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.42.5
 	github.com/aws/aws-sdk-go-v2/service/sns v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/aws/smithy-go v1.27.3
 	github.com/databricks/databricks-sdk-go v0.144.0
 	github.com/fxamacker/cbor/v2 v2.9.1
@@ -101,7 +102,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -50,6 +50,7 @@ import (
 	secretsmanagersrv "github.com/stackshy/cloudemu/server/aws/secretsmanager"
 	"github.com/stackshy/cloudemu/server/aws/sns"
 	"github.com/stackshy/cloudemu/server/aws/sqs"
+	stssrv "github.com/stackshy/cloudemu/server/aws/sts"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
 )
@@ -91,6 +92,11 @@ type Drivers struct {
 	ElastiCache cachedriver.Cache
 	// SNS serves the SNS query protocol against the notification driver.
 	SNS notifdriver.Notification
+	// STS serves the AWS STS query protocol (GetCallerIdentity, AssumeRole,
+	// GetSessionToken). It has no backing driver — identity is derived from
+	// AccountID and Region — so it is gated on this bool. Enable it so SDK code
+	// paths that call sts:GetCallerIdentity or sts:AssumeRole on init succeed.
+	STS bool
 	// K8sAPI is the shared in-memory Kubernetes data-plane API server. It is
 	// shared with azureserver.Drivers.K8sAPI and gcpserver.Drivers.K8sAPI so a
 	// kubeconfig issued by any provider's control plane (EKS/AKS/GKE) reaches
@@ -216,6 +222,14 @@ func New(d Drivers) *server.Server {
 	// no shadowing occurs. Registered before the EC2 catch-all.
 	if d.SNS != nil {
 		srv.Register(sns.New(d.SNS))
+	}
+
+	// STS also speaks the AWS query protocol; its action set (GetCallerIdentity,
+	// AssumeRole, GetSessionToken) is disjoint from RDS, Redshift, IAM, ELBv2,
+	// ElastiCache, SNS, and EC2, so no shadowing occurs. It has no driver, so
+	// it's gated on the STS bool. Registered before the EC2 catch-all.
+	if d.STS {
+		srv.Register(stssrv.New(d.AccountID, d.Region))
 	}
 
 	if d.EC2 != nil || d.VPC != nil {

--- a/server/aws/sts/handler.go
+++ b/server/aws/sts/handler.go
@@ -1,0 +1,110 @@
+// Package sts implements the AWS STS query-protocol as a server.Handler.
+// Point the real aws-sdk-go-v2 STS client at a Server registered with this
+// handler and GetCallerIdentity / AssumeRole / GetSessionToken work against
+// cloudemu's configured identity.
+//
+// STS has no backing driver: identity is derived from the AccountID and Region
+// the AWS server was configured with. This exists so SDK code paths that call
+// sts:GetCallerIdentity or sts:AssumeRole on init succeed against cloudemu.
+//
+// STS shares the AWS query wire shape with EC2, RDS, Redshift, IAM, and the
+// other query-protocol handlers (POST + form-encoded body, XML response). To
+// keep dispatch unambiguous, this handler's Matches predicate parses the form
+// body once and only claims requests whose Action is one of the known STS
+// operations. The EC2 handler is the catch-all for all other query-protocol
+// actions, so this handler MUST register before EC2. Its action set
+// (GetCallerIdentity, AssumeRole, GetSessionToken) is disjoint from RDS,
+// Redshift, IAM, ELBv2, ElastiCache, SNS, and EC2, so no shadowing occurs.
+package sts
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// Namespace is the XML namespace for AWS STS responses.
+const Namespace = "https://sts.amazonaws.com/doc/2011-06-15/"
+
+const (
+	formContentType  = "application/x-www-form-urlencoded"
+	maxFormBodyBytes = 1 << 20
+)
+
+// stsActions is the set of Action values this handler recognizes. Matches uses
+// it to decide whether to claim a request.
+var stsActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"GetCallerIdentity": {},
+	"AssumeRole":        {},
+	"GetSessionToken":   {},
+}
+
+// Handler serves STS query-protocol requests. It carries the account and region
+// the AWS server was configured with; there is no backing driver.
+type Handler struct {
+	accountID string
+	region    string
+}
+
+// New returns an STS handler that reports the given accountID and region.
+// Empty values fall back to sensible defaults so a well-formed identity is
+// always returned.
+func New(accountID, region string) *Handler {
+	if accountID == "" {
+		accountID = defaultAccountID
+	}
+
+	if region == "" {
+		region = defaultRegion
+	}
+
+	return &Handler{accountID: accountID, region: region}
+}
+
+const (
+	defaultAccountID = "000000000000"
+	defaultRegion    = "us-east-1"
+)
+
+// Matches returns true if the request looks like an AWS STS query-protocol call
+// (POST + form-encoded body whose Action is one of the known STS operations).
+// Calling ParseForm here caches the parsed form on the request so ServeHTTP can
+// use it without re-reading the body.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.Header.Get("X-Amz-Target") != "" {
+		return false
+	}
+
+	if r.Method != http.MethodPost {
+		return false
+	}
+
+	if !strings.HasPrefix(r.Header.Get("Content-Type"), formContentType) {
+		return false
+	}
+
+	r.Body = http.MaxBytesReader(nil, r.Body, maxFormBodyBytes)
+	if err := r.ParseForm(); err != nil {
+		return false
+	}
+
+	_, ok := stsActions[r.Form.Get("Action")]
+
+	return ok
+}
+
+// ServeHTTP dispatches on Action. The form has already been parsed by Matches.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Form.Get("Action") {
+	case "GetCallerIdentity":
+		h.getCallerIdentity(w, r)
+	case "AssumeRole":
+		h.assumeRole(w, r)
+	case "GetSessionToken":
+		h.getSessionToken(w, r)
+	default:
+		awsquery.WriteXMLError(w, http.StatusBadRequest,
+			"InvalidAction", "unknown STS action: "+r.Form.Get("Action"))
+	}
+}

--- a/server/aws/sts/operations.go
+++ b/server/aws/sts/operations.go
@@ -95,8 +95,14 @@ func roleNameFromArn(arn string) string {
 		name = after
 	}
 
-	if i := strings.LastIndex(name, "/"); i >= 0 && i+1 < len(name) {
-		return name[i+1:]
+	// Trim any trailing slash(es) so a stray "MyRole/" doesn't yield an empty
+	// last segment.
+	name = strings.TrimRight(name, "/")
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	if name == "" {
+		return "cloudemu-role"
 	}
 
 	return name

--- a/server/aws/sts/operations.go
+++ b/server/aws/sts/operations.go
@@ -1,0 +1,103 @@
+package sts
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stackshy/cloudemu/server/wire/awsquery"
+)
+
+// callerUserName is the synthetic IAM user name reported by GetCallerIdentity.
+const callerUserName = "cloudemu"
+
+// sessionDuration is the lifetime baked into synthetic temporary credentials.
+// Real STS defaults to 1h for AssumeRole and 12h for GetSessionToken; a fixed
+// value in the future is all any SDK requires.
+const sessionDuration = time.Hour
+
+// getCallerIdentity reports the configured account, a synthetic user ARN, and a
+// synthetic user id. This is the call most SDK init paths make.
+func (h *Handler) getCallerIdentity(w http.ResponseWriter, _ *http.Request) {
+	awsquery.WriteXMLResponse(w, getCallerIdentityResponse{
+		Xmlns: Namespace,
+		Result: getCallerIdentityResult{
+			Account: h.accountID,
+			Arn:     "arn:aws:iam::" + h.accountID + ":user/" + callerUserName,
+			UserID:  "AIDACLOUDEMU0000000000",
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// assumeRole returns synthetic temporary credentials and an AssumedRoleUser
+// derived from the requested RoleArn and RoleSessionName.
+func (h *Handler) assumeRole(w http.ResponseWriter, r *http.Request) {
+	roleArn := r.Form.Get("RoleArn")
+	sessionName := r.Form.Get("RoleSessionName")
+
+	if sessionName == "" {
+		sessionName = "cloudemu-session"
+	}
+
+	// The assumed-role ARN AWS returns is
+	//   arn:aws:sts::{account}:assumed-role/{role-name}/{session-name}
+	// where role-name is the last path segment of the requested RoleArn.
+	roleName := roleNameFromArn(roleArn)
+	assumedArn := "arn:aws:sts::" + h.accountID + ":assumed-role/" + roleName + "/" + sessionName
+
+	awsquery.WriteXMLResponse(w, assumeRoleResponse{
+		Xmlns: Namespace,
+		Result: assumeRoleResult{
+			Credentials: h.synthCredentials(),
+			AssumedRoleUser: assumedRoleUser{
+				AssumedRoleID: "AROACLOUDEMU0000000000:" + sessionName,
+				Arn:           assumedArn,
+			},
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// getSessionToken returns synthetic temporary credentials.
+func (h *Handler) getSessionToken(w http.ResponseWriter, _ *http.Request) {
+	awsquery.WriteXMLResponse(w, getSessionTokenResponse{
+		Xmlns:    Namespace,
+		Result:   getSessionTokenResult{Credentials: h.synthCredentials()},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// synthCredentials builds a deterministic set of temporary credentials with an
+// expiration in the future. cloudemu does not validate signatures, so any
+// non-empty values satisfy SDK clients.
+func (h *Handler) synthCredentials() credentials {
+	return credentials{
+		AccessKeyID:     "ASIACLOUDEMU000000000",
+		SecretAccessKey: "cloudemuSecretAccessKey0000000000000000",
+		SessionToken:    "cloudemu-session-token",
+		Expiration:      time.Now().UTC().Add(sessionDuration).Format(time.RFC3339),
+	}
+}
+
+// roleNameFromArn extracts the role name (last path segment) from a role ARN
+// such as "arn:aws:iam::123456789012:role/path/MyRole". Falls back to a stable
+// placeholder when the ARN is missing or malformed.
+func roleNameFromArn(arn string) string {
+	if arn == "" {
+		return "cloudemu-role"
+	}
+
+	// Role ARNs are "...:role/<name>" (name may itself contain a path with
+	// slashes); take the segment after ":role/", then its last path element.
+	name := arn
+	if _, after, ok := strings.Cut(arn, ":role/"); ok {
+		name = after
+	}
+
+	if i := strings.LastIndex(name, "/"); i >= 0 && i+1 < len(name) {
+		return name[i+1:]
+	}
+
+	return name
+}

--- a/server/aws/sts/sdk_roundtrip_test.go
+++ b/server/aws/sts/sdk_roundtrip_test.go
@@ -1,0 +1,204 @@
+package sts_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	awssts "github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/stackshy/cloudemu"
+	awsserver "github.com/stackshy/cloudemu/server/aws"
+)
+
+const (
+	testAccountID = "123456789012"
+	testRegion    = "us-west-2"
+)
+
+func newServer(t *testing.T, d awsserver.Drivers) *httptest.Server {
+	t.Helper()
+
+	ts := httptest.NewServer(awsserver.New(d))
+	t.Cleanup(ts.Close)
+
+	return ts
+}
+
+func stsClient(t *testing.T, url string) *awssts.Client {
+	t.Helper()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(testRegion),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awssts.NewFromConfig(cfg, func(o *awssts.Options) {
+		o.BaseEndpoint = aws.String(url)
+	})
+}
+
+func TestSDKGetCallerIdentity(t *testing.T) {
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	out, err := stsClient(t, ts.URL).GetCallerIdentity(
+		context.Background(), &awssts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity: %v", err)
+	}
+
+	if aws.ToString(out.Account) != testAccountID {
+		t.Errorf("Account = %q, want %q", aws.ToString(out.Account), testAccountID)
+	}
+
+	if arn := aws.ToString(out.Arn); !strings.Contains(arn, testAccountID) {
+		t.Errorf("Arn = %q, want it to contain account id", arn)
+	}
+
+	if aws.ToString(out.UserId) == "" {
+		t.Error("UserId is empty")
+	}
+}
+
+func TestSDKAssumeRole(t *testing.T) {
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	const roleArn = "arn:aws:iam::123456789012:role/MyTestRole"
+
+	out, err := stsClient(t, ts.URL).AssumeRole(context.Background(), &awssts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String("my-session"),
+	})
+	if err != nil {
+		t.Fatalf("AssumeRole: %v", err)
+	}
+
+	if out.AssumedRoleUser == nil {
+		t.Fatal("AssumedRoleUser is nil")
+	}
+
+	gotArn := aws.ToString(out.AssumedRoleUser.Arn)
+	wantArn := "arn:aws:sts::" + testAccountID + ":assumed-role/MyTestRole/my-session"
+
+	if gotArn != wantArn {
+		t.Errorf("AssumedRoleUser.Arn = %q, want %q", gotArn, wantArn)
+	}
+
+	if out.Credentials == nil {
+		t.Fatal("Credentials is nil")
+	}
+
+	if aws.ToString(out.Credentials.AccessKeyId) == "" {
+		t.Error("AccessKeyId is empty")
+	}
+
+	if aws.ToString(out.Credentials.SecretAccessKey) == "" {
+		t.Error("SecretAccessKey is empty")
+	}
+
+	if aws.ToString(out.Credentials.SessionToken) == "" {
+		t.Error("SessionToken is empty")
+	}
+
+	if out.Credentials.Expiration == nil {
+		t.Error("Expiration is nil")
+	}
+}
+
+func TestSDKGetSessionToken(t *testing.T) {
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	out, err := stsClient(t, ts.URL).GetSessionToken(
+		context.Background(), &awssts.GetSessionTokenInput{})
+	if err != nil {
+		t.Fatalf("GetSessionToken: %v", err)
+	}
+
+	if out.Credentials == nil {
+		t.Fatal("Credentials is nil")
+	}
+
+	if aws.ToString(out.Credentials.AccessKeyId) == "" {
+		t.Error("AccessKeyId is empty")
+	}
+
+	if aws.ToString(out.Credentials.SessionToken) == "" {
+		t.Error("SessionToken is empty")
+	}
+}
+
+// TestSTSDoesNotShadowEC2 wires STS alongside EC2 and proves an EC2 action
+// (RunInstances) still reaches the EC2 handler: STS's Matches only claims its
+// own action set, so a query-protocol body bound for EC2 falls through.
+func TestSTSDoesNotShadowEC2(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+
+	ts := newServer(t, awsserver.Drivers{
+		STS:       true,
+		EC2:       cloud.EC2,
+		AccountID: testAccountID,
+		Region:    testRegion,
+	})
+
+	ec2cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(testRegion),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	ec2c := awsec2.NewFromConfig(ec2cfg, func(o *awsec2.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+
+	runOut, err := ec2c.RunInstances(context.Background(), &awsec2.RunInstancesInput{
+		ImageId:      aws.String("ami-12345678"),
+		InstanceType: ec2types.InstanceTypeT2Micro,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("RunInstances (should reach EC2, not STS): %v", err)
+	}
+
+	if len(runOut.Instances) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(runOut.Instances))
+	}
+
+	// And STS still works on the same server.
+	idOut, err := stsClient(t, ts.URL).GetCallerIdentity(
+		context.Background(), &awssts.GetCallerIdentityInput{})
+	if err != nil {
+		t.Fatalf("GetCallerIdentity alongside EC2: %v", err)
+	}
+
+	if aws.ToString(idOut.Account) != testAccountID {
+		t.Errorf("Account = %q, want %q", aws.ToString(idOut.Account), testAccountID)
+	}
+}

--- a/server/aws/sts/xml.go
+++ b/server/aws/sts/xml.go
@@ -48,9 +48,9 @@ type assumeRoleResponse struct {
 }
 
 type assumeRoleResult struct {
-	Credentials     credentials     `xml:"Credentials"`
-	AssumedRoleUser assumedRoleUser `xml:"AssumedRoleUser"`
-	PackedPolicySize int            `xml:"PackedPolicySize"`
+	Credentials      credentials     `xml:"Credentials"`
+	AssumedRoleUser  assumedRoleUser `xml:"AssumedRoleUser"`
+	PackedPolicySize int             `xml:"PackedPolicySize"`
 }
 
 // GetSessionToken -----------------------------------------------------------

--- a/server/aws/sts/xml.go
+++ b/server/aws/sts/xml.go
@@ -1,0 +1,67 @@
+package sts
+
+import "encoding/xml"
+
+// responseMetadata is the <ResponseMetadata><RequestId/></ResponseMetadata>
+// trailer every STS response carries.
+type responseMetadata struct {
+	RequestID string `xml:"RequestId"`
+}
+
+// credentials mirrors the STS <Credentials> element. The SDK deserializes
+// AccessKeyId, SecretAccessKey, SessionToken, and Expiration (ISO-8601).
+type credentials struct {
+	AccessKeyID     string `xml:"AccessKeyId"`
+	SecretAccessKey string `xml:"SecretAccessKey"`
+	SessionToken    string `xml:"SessionToken"`
+	Expiration      string `xml:"Expiration"`
+}
+
+// assumedRoleUser mirrors the STS <AssumedRoleUser> element.
+type assumedRoleUser struct {
+	AssumedRoleID string `xml:"AssumedRoleId"`
+	Arn           string `xml:"Arn"`
+}
+
+// GetCallerIdentity ---------------------------------------------------------
+
+type getCallerIdentityResponse struct {
+	XMLName  xml.Name                `xml:"GetCallerIdentityResponse"`
+	Xmlns    string                  `xml:"xmlns,attr"`
+	Result   getCallerIdentityResult `xml:"GetCallerIdentityResult"`
+	Metadata responseMetadata        `xml:"ResponseMetadata"`
+}
+
+type getCallerIdentityResult struct {
+	Arn     string `xml:"Arn"`
+	UserID  string `xml:"UserId"`
+	Account string `xml:"Account"`
+}
+
+// AssumeRole ----------------------------------------------------------------
+
+type assumeRoleResponse struct {
+	XMLName  xml.Name         `xml:"AssumeRoleResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   assumeRoleResult `xml:"AssumeRoleResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type assumeRoleResult struct {
+	Credentials     credentials     `xml:"Credentials"`
+	AssumedRoleUser assumedRoleUser `xml:"AssumedRoleUser"`
+	PackedPolicySize int            `xml:"PackedPolicySize"`
+}
+
+// GetSessionToken -----------------------------------------------------------
+
+type getSessionTokenResponse struct {
+	XMLName  xml.Name              `xml:"GetSessionTokenResponse"`
+	Xmlns    string                `xml:"xmlns,attr"`
+	Result   getSessionTokenResult `xml:"GetSessionTokenResult"`
+	Metadata responseMetadata      `xml:"ResponseMetadata"`
+}
+
+type getSessionTokenResult struct {
+	Credentials credentials `xml:"Credentials"`
+}


### PR DESCRIPTION
Closes #241. AWS STS over the query protocol: GetCallerIdentity, AssumeRole, GetSessionToken — no new driver (identity from Drivers.AccountID/Region). Registered before EC2 with a disjoint action set. Real-SDK roundtrip tests + a no-shadow-EC2 test; `go build/vet` clean, full `go test ./server/...` green.