### PR TITLE
feat(azure): Storage Queues + Table Storage SDK-compat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3
 	github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2
+	github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.4.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v3 v3.0.0-beta.3
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cognitiveservices/armcognitiveservices v1.8.0
@@ -31,6 +32,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:l
 github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2 h1:zqxnp53f5Jn5PFU5Av4mvyWEbZ7whg72AoOCEzlXFKc=
 github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos v1.4.2/go.mod h1:Krtog/7tz27z75TwM5cIS8bxEH4dcBUezcq+kGVeZEo=
+github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.4.1 h1:j0hhYS006eJ54vusoap0f2NVZ1YY3QnaAEnLM68f0SQ=
+github.com/Azure/azure-sdk-for-go/sdk/data/aztables v1.4.1/go.mod h1:AdtInaXmK8eYmbjezRWgLz+Qs46nc9Up9GWGwteWNfw=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appservice/armappservice/v3 v3.0.0 h1:FErSe/vQGefbSuVwBV9JlrRXgG1uOFyW6TCXERX89s4=
@@ -68,10 +70,10 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleserv
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.2.0/go.mod h1:0mKVz3WT8oNjBunT1zD/HPwMleQ72QClMa7Gmsm+6Kc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0 h1:hdC0QToUqJikvZXE/ZSHafNv10IcYYkCPY7B99QhNSc=
-github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0/go.mod h1:FwSGecUzQMdebvcN8JqqLlsfgfXZn+Gw+vX9xpHhUMc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs v1.2.0 h1:ZzshIzB4SnLLHFFHbBMxG5Sn2QCo9LWl4K5Nqz0Eysk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs v1.2.0/go.mod h1:YuV5NCOq5toIonfwdVfw2j99Uuy25Df2Tb5O83ZIuV4=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0 h1:hdC0QToUqJikvZXE/ZSHafNv10IcYYkCPY7B99QhNSc=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights v1.0.0/go.mod h1:FwSGecUzQMdebvcN8JqqLlsfgfXZn+Gw+vX9xpHhUMc=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0 h1:HzqcSJWx32XQdr8KtxAu/SZJj0PqDo9tKf2YGPdynV0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers v1.1.0/go.mod h1:nKcJObAisSPDrO9lMuuCBoYY7Ki7ADt8p6XmBhpKNTk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3 v3.3.0 h1:EkL5dmUoy1OlzVfsbkcHayOvOJgheyRYL3wM/RHizzg=
@@ -94,6 +96,8 @@ github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfg
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 h1:qvrrnQ2mIjwY7IVlQuNB0ma43Nr74+9ZTZJ60KlmlV4=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1/go.mod h1:FkF/Az07vR3S4sBdjCuisznWfFWOD8u6Ibm/g/oyDAk=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0 h1:4iB+IesclUXdP0ICgAabvq2FYLXrJWKx1fJQ+GxSo3Y=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
@@ -142,12 +146,12 @@ github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4 h1:fo6cmbxkKq/OtKUG0sK70fDsYjtK
 github.com/aws/aws-sdk-go-v2/service/ecr v1.58.4/go.mod h1:7VJFM2lSPHz2I1rRb0a+lbphoOp7hXIgYjGhSTOLY7k=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0 h1:aIfwo2WwNv4Ya/wdg6X7oCVkCjVzACErH/BSsy7EQGM=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0/go.mod h1:roYWQ6ZmGI1VshRoopJCfMYdDgI1z4ArMtTOJJjsHXg=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0 h1:OJRqQ6G7RjmwJ9fkhFgcJBSinjrLJxfd5AacBUrhKXc=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0/go.mod h1:qNnJkZTDHDL2sO8hyVH2yILcfSEkjP/pIns2JsF1g1o=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0 h1:LuPLDBMCmldgg779sq8swfEdRNMeKlaT852uxKYCOkk=
 github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0/go.mod h1:3g/foYPw/4CT8yV7/A1QsbvnhDZW/2x2uzl4vkqX49o=
-github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0 h1:aIfwo2WwNv4Ya/wdg6X7oCVkCjVzACErH/BSsy7EQGM=
-github.com/aws/aws-sdk-go-v2/service/elasticache v1.55.0/go.mod h1:roYWQ6ZmGI1VshRoopJCfMYdDgI1z4ArMtTOJJjsHXg=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackshy/cloudemu/providers/azure/notificationhubs"
 	"github.com/stackshy/cloudemu/providers/azure/postgresflex"
 	"github.com/stackshy/cloudemu/providers/azure/servicebus"
+	"github.com/stackshy/cloudemu/providers/azure/tablestorage"
 	"github.com/stackshy/cloudemu/providers/azure/virtualmachines"
 	"github.com/stackshy/cloudemu/providers/azure/vnet"
 	"github.com/stackshy/cloudemu/resourcediscovery"
@@ -41,6 +42,12 @@ type Provider struct {
 	DNS              *azuredns.Mock
 	LB               *azurelb.Mock
 	ServiceBus       *servicebus.Mock
+	// QueueStorage backs the Azure Queue Storage data-plane handler. It reuses
+	// the messagequeue provider, but is a distinct instance from ServiceBus so
+	// the two services keep separate queue namespaces.
+	QueueStorage *servicebus.Mock
+	// TableStorage backs the Azure Table Storage data-plane handler.
+	TableStorage     *tablestorage.Mock
 	Cache            *azurecache.Mock
 	KeyVault         *keyvault.Mock
 	LogAnalytics     *loganalytics.Mock
@@ -72,6 +79,8 @@ func New(opts ...config.Option) *Provider {
 		DNS:              azuredns.New(o),
 		LB:               azurelb.New(o),
 		ServiceBus:       servicebus.New(o),
+		QueueStorage:     servicebus.New(o),
+		TableStorage:     tablestorage.New(o),
 		Cache:            azurecache.New(o),
 		KeyVault:         keyvault.New(o),
 		LogAnalytics:     loganalytics.New(o),

--- a/providers/azure/tablestorage/tablestorage.go
+++ b/providers/azure/tablestorage/tablestorage.go
@@ -1,0 +1,292 @@
+// Package tablestorage provides an in-memory mock implementation of the
+// Azure Table Storage entity store, satisfying tablestorage/driver.TableStorage.
+package tablestorage
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/stackshy/cloudemu/config"
+	"github.com/stackshy/cloudemu/errors"
+	driver "github.com/stackshy/cloudemu/tablestorage/driver"
+)
+
+// Compile-time check that Mock implements driver.TableStorage.
+var _ driver.TableStorage = (*Mock)(nil)
+
+// tableData holds one table's entities, keyed by "partitionKey\x00rowKey".
+type tableData struct {
+	mu       sync.RWMutex
+	entities map[string]driver.Entity
+}
+
+// Mock is an in-memory Table Storage backend.
+type Mock struct {
+	mu     sync.RWMutex
+	tables map[string]*tableData
+	opts   *config.Options
+}
+
+// New creates a new Table Storage mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		tables: make(map[string]*tableData),
+		opts:   opts,
+	}
+}
+
+func entityKey(partitionKey, rowKey string) string {
+	return partitionKey + "\x00" + rowKey
+}
+
+// CreateTable creates a new empty table.
+func (m *Mock) CreateTable(_ context.Context, name string) error {
+	if name == "" {
+		return errors.New(errors.InvalidArgument, "table name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.tables[name]; ok {
+		return errors.Newf(errors.AlreadyExists, "table %q already exists", name)
+	}
+
+	m.tables[name] = &tableData{entities: make(map[string]driver.Entity)}
+
+	return nil
+}
+
+// DeleteTable removes a table and all its entities.
+func (m *Mock) DeleteTable(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.tables[name]; !ok {
+		return errors.Newf(errors.NotFound, "table %q not found", name)
+	}
+
+	delete(m.tables, name)
+
+	return nil
+}
+
+// ListTables returns the names of all tables.
+func (m *Mock) ListTables(_ context.Context) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.tables))
+	for name := range m.tables {
+		names = append(names, name)
+	}
+
+	return names, nil
+}
+
+func (m *Mock) table(name string) (*tableData, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, ok := m.tables[name]
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "table %q not found", name)
+	}
+
+	return td, nil
+}
+
+// InsertEntity adds a new entity. It fails if an entity with the same
+// PartitionKey/RowKey already exists.
+func (m *Mock) InsertEntity(_ context.Context, table, partitionKey, rowKey string, entity driver.Entity) error {
+	if partitionKey == "" || rowKey == "" {
+		return errors.New(errors.InvalidArgument, "PartitionKey and RowKey are required")
+	}
+
+	td, err := m.table(table)
+	if err != nil {
+		return err
+	}
+
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	key := entityKey(partitionKey, rowKey)
+	if _, ok := td.entities[key]; ok {
+		return errors.Newf(errors.AlreadyExists, "entity (%q,%q) already exists", partitionKey, rowKey)
+	}
+
+	td.entities[key] = cloneEntity(entity)
+
+	return nil
+}
+
+// GetEntity returns the entity addressed by partitionKey/rowKey.
+func (m *Mock) GetEntity(_ context.Context, table, partitionKey, rowKey string) (driver.Entity, error) {
+	td, err := m.table(table)
+	if err != nil {
+		return nil, err
+	}
+
+	td.mu.RLock()
+	defer td.mu.RUnlock()
+
+	ent, ok := td.entities[entityKey(partitionKey, rowKey)]
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
+	}
+
+	return cloneEntity(ent), nil
+}
+
+// UpdateEntity merges or replaces an existing entity.
+func (m *Mock) UpdateEntity(
+	_ context.Context, table, partitionKey, rowKey string, entity driver.Entity, mode driver.UpdateMode,
+) error {
+	td, err := m.table(table)
+	if err != nil {
+		return err
+	}
+
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	key := entityKey(partitionKey, rowKey)
+
+	existing, ok := td.entities[key]
+	if !ok {
+		return errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
+	}
+
+	if mode == driver.UpdateModeReplace {
+		td.entities[key] = cloneEntity(entity)
+		return nil
+	}
+
+	merged := cloneEntity(existing)
+	for k, v := range entity {
+		merged[k] = v
+	}
+
+	td.entities[key] = merged
+
+	return nil
+}
+
+// DeleteEntity removes an entity.
+func (m *Mock) DeleteEntity(_ context.Context, table, partitionKey, rowKey string) error {
+	td, err := m.table(table)
+	if err != nil {
+		return err
+	}
+
+	td.mu.Lock()
+	defer td.mu.Unlock()
+
+	key := entityKey(partitionKey, rowKey)
+	if _, ok := td.entities[key]; !ok {
+		return errors.Newf(errors.NotFound, "entity (%q,%q) not found", partitionKey, rowKey)
+	}
+
+	delete(td.entities, key)
+
+	return nil
+}
+
+// QueryEntities returns entities matching the given options. Filtering
+// supports a partition-key restriction plus a best-effort OData $filter parse
+// (see matchesFilter); unrecognized filters match everything.
+func (m *Mock) QueryEntities(_ context.Context, table string, opts driver.QueryOptions) ([]driver.Entity, error) {
+	td, err := m.table(table)
+	if err != nil {
+		return nil, err
+	}
+
+	td.mu.RLock()
+	defer td.mu.RUnlock()
+
+	conds := parseFilter(opts.Filter)
+
+	results := make([]driver.Entity, 0, len(td.entities))
+
+	for _, ent := range td.entities {
+		if opts.PartitionKey != "" && asString(ent["PartitionKey"]) != opts.PartitionKey {
+			continue
+		}
+
+		if !matchesConds(ent, conds) {
+			continue
+		}
+
+		results = append(results, cloneEntity(ent))
+	}
+
+	return results, nil
+}
+
+func cloneEntity(e driver.Entity) driver.Entity {
+	out := make(driver.Entity, len(e))
+	for k, v := range e {
+		out[k] = v
+	}
+
+	return out
+}
+
+// eqCond is a single "property eq value" equality condition.
+type eqCond struct {
+	prop string
+	val  string
+}
+
+// parseFilter extracts the equality conditions from a simple OData $filter of
+// the form "Prop eq 'val' and Prop2 eq 'val2'". Anything it can't parse is
+// dropped, so an unsupported filter degrades to "match all" rather than an
+// error — adequate for the common query-by-partition case.
+func parseFilter(filter string) []eqCond {
+	filter = strings.TrimSpace(filter)
+	if filter == "" {
+		return nil
+	}
+
+	var conds []eqCond
+
+	for _, clause := range strings.Split(filter, " and ") {
+		fields := strings.Fields(strings.TrimSpace(clause))
+
+		const eqParts = 3
+		if len(fields) != eqParts || !strings.EqualFold(fields[1], "eq") {
+			continue
+		}
+
+		conds = append(conds, eqCond{prop: fields[0], val: unquote(fields[2])})
+	}
+
+	return conds
+}
+
+func matchesConds(ent driver.Entity, conds []eqCond) bool {
+	for _, c := range conds {
+		if asString(ent[c.prop]) != c.val {
+			return false
+		}
+	}
+
+	return true
+}
+
+// unquote strips surrounding single quotes from an OData string literal.
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		return s[1 : len(s)-1]
+	}
+
+	return s
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -67,11 +67,14 @@ import (
 	"github.com/stackshy/cloudemu/server/azure/postgresflex"
 	"github.com/stackshy/cloudemu/server/azure/resourcegraph"
 	"github.com/stackshy/cloudemu/server/azure/servicebus"
+	"github.com/stackshy/cloudemu/server/azure/queue"
 	"github.com/stackshy/cloudemu/server/azure/snapshots"
 	"github.com/stackshy/cloudemu/server/azure/sshpublickeys"
+	tablesrv "github.com/stackshy/cloudemu/server/azure/table"
 	"github.com/stackshy/cloudemu/server/azure/virtualmachines"
 	sdrv "github.com/stackshy/cloudemu/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/storage/driver"
+	tabledriver "github.com/stackshy/cloudemu/tablestorage/driver"
 )
 
 // Drivers bundles the driver interfaces the Azure server can expose. Leave a
@@ -88,7 +91,13 @@ type Drivers struct {
 	Images          computedriver.Compute
 	SSHPublicKeys   computedriver.Compute
 	BlobStorage     storagedriver.Bucket
-	CosmosDB        dbdriver.Database
+	// QueueStorage serves the Azure Queue Storage data-plane REST API against
+	// the messagequeue driver.
+	QueueStorage mqdriver.MessageQueue
+	// TableStorage serves the Azure Table Storage data-plane REST API against
+	// the tablestorage driver.
+	TableStorage tabledriver.TableStorage
+	CosmosDB     dbdriver.Database
 	Network         netdriver.Networking
 	Monitor         mondriver.Monitoring
 	Functions       sdrv.Serverless
@@ -339,6 +348,24 @@ func New(d Drivers) *server.Server {
 	// register before the permissive BlobStorage fallback below.
 	if d.KeyVault != nil {
 		srv.Register(keyvaultsrv.New(d.KeyVault))
+	}
+
+	// Table Storage matches the OData table surface (/Tables, /Tables('name'),
+	// /{table}(…) entity predicates, and POST /{table} inserts) — path shapes
+	// that contain parentheses or a bare JSON POST, disjoint from Blob's
+	// container/blob paths and Queue's /messages surface. Registered before the
+	// permissive Blob fallback.
+	if d.TableStorage != nil {
+		srv.Register(tablesrv.New(d.TableStorage))
+	}
+
+	// Queue Storage matches the queue data-plane surface (/{queue}/messages,
+	// bare PUT/DELETE /{queue} without restype=container). These shapes are
+	// disjoint from Blob (which carries restype=container) and Table (which
+	// carries OData parentheses). Registered before the permissive Blob
+	// fallback.
+	if d.QueueStorage != nil {
+		srv.Register(queue.New(d.QueueStorage))
 	}
 
 	// BlobStorage handler is the data-plane fallback for non-ARM URLs. It

--- a/server/azure/queue/dispatch_test.go
+++ b/server/azure/queue/dispatch_test.go
@@ -1,0 +1,96 @@
+package queue_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// TestNoShadowing registers Blob, Queue and Table on the same server and
+// confirms each service's SDK routes to its own handler — i.e. the permissive
+// Blob fallback does not swallow Queue or Table requests, and Queue and Table
+// do not claim each other's or Blob's paths.
+func TestNoShadowing(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{
+		BlobStorage:  cloudP.BlobStorage,
+		QueueStorage: cloudP.QueueStorage,
+		TableStorage: cloudP.TableStorage,
+	})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+	transport := policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}}
+
+	// Blob: create a container.
+	blobClient, err := azblob.NewClientWithNoCredential(ts.URL+"/", &azblob.ClientOptions{ClientOptions: transport})
+	if err != nil {
+		t.Fatalf("azblob client: %v", err)
+	}
+
+	if _, err := blobClient.CreateContainer(ctx, "cont", nil); err != nil {
+		t.Fatalf("Blob CreateContainer routed wrong: %v", err)
+	}
+
+	// Note: the root GET /?comp=list shape (list-containers vs list-queues) is
+	// byte-for-byte identical on the wire — Azure disambiguates it only by the
+	// {account}.blob vs {account}.queue hostname, which a single test server
+	// can't see. When Blob and Queue coexist behind one endpoint, that one
+	// shape is inherently ambiguous; the Queue handler owns it (registered
+	// first). Every other surface is disjoint, which is what this test asserts:
+	// container/blob paths, /{queue}/messages, and OData table paths never
+	// collide.
+
+	// Blob: put+get a blob (a two-segment /{container}/{blob} path) — must
+	// reach the Blob handler, not Queue or Table.
+	if _, err := blobClient.UploadBuffer(ctx, "cont", "obj", []byte("data"), nil); err != nil {
+		t.Fatalf("Blob UploadBuffer routed wrong: %v", err)
+	}
+
+	// Queue: create a queue named "cont" (same name as the container) and
+	// enqueue — must hit the queue handler, not blob.
+	qSvc, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", &azqueue.ClientOptions{ClientOptions: transport})
+	if err != nil {
+		t.Fatalf("azqueue client: %v", err)
+	}
+
+	if _, err := qSvc.CreateQueue(ctx, "cont", nil); err != nil {
+		t.Fatalf("Queue CreateQueue routed wrong: %v", err)
+	}
+
+	qClient, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/cont", &azqueue.ClientOptions{ClientOptions: transport})
+	if err != nil {
+		t.Fatalf("azqueue queue client: %v", err)
+	}
+
+	if _, err := qClient.EnqueueMessage(ctx, "m", nil); err != nil {
+		t.Fatalf("Queue EnqueueMessage routed wrong: %v", err)
+	}
+
+	// Table: create a table named "cont" and insert — must hit the table
+	// handler.
+	tSvc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/", &aztables.ClientOptions{ClientOptions: transport})
+	if err != nil {
+		t.Fatalf("aztables client: %v", err)
+	}
+
+	if _, err := tSvc.CreateTable(ctx, "cont", nil); err != nil {
+		t.Fatalf("Table CreateTable routed wrong: %v", err)
+	}
+
+	ent, _ := json.Marshal(map[string]any{"PartitionKey": "p", "RowKey": "r", "V": "1"})
+	if _, err := tSvc.NewClient("cont").AddEntity(ctx, ent, nil); err != nil {
+		t.Fatalf("Table AddEntity routed wrong: %v", err)
+	}
+}

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -61,15 +61,22 @@ func New(mq mqdriver.MessageQueue) *Handler {
 // the Blob fallback:
 //
 //   - /{queue}/messages and /{queue}/messages/{id} — the "/messages" segment
-//     is the queue data-plane marker; Blob never uses it. Fully disjoint.
+//     is the queue data-plane marker. NOTE: this is not strictly disjoint from
+//     Blob — a blob literally named "messages" (or under a "messages/" prefix)
+//     has the same shape. Azure separates them only by the {account}.queue vs
+//     {account}.blob hostname, invisible behind a shared endpoint. When both
+//     handlers are wired, the Queue handler owns this shape; a blob named
+//     "messages" is a known collision.
 //   - PUT|DELETE /{queue} with no restype=container query — Blob container ops
 //     always carry restype=container, so a bare PUT/DELETE on a single path
-//     segment is a queue create/delete. Fully disjoint.
+//     segment is a queue create/delete. Disjoint from Blob container ops.
 //   - GET /?comp=list (list queues) — this shape is byte-for-byte identical to
-//     Blob's list-containers; Azure disambiguates only by the {account}.queue
-//     vs {account}.blob hostname, which is invisible behind a shared endpoint.
-//     When both handlers are registered, the Queue handler (registered first)
-//     owns this one shape. This is the sole non-disjoint case.
+//     Blob's list-containers; Azure disambiguates only by hostname. When both
+//     handlers are registered, the Queue handler (registered first) owns it.
+//
+// The two shared-hostname shapes above are inherent to serving Queue and Blob
+// on one endpoint (real Azure uses distinct hostnames); documented, not fixable
+// without host-based routing.
 //
 // Registered before the permissive Blob fallback so these shapes win.
 func (*Handler) Matches(r *http.Request) bool {

--- a/server/azure/queue/handler.go
+++ b/server/azure/queue/handler.go
@@ -1,0 +1,411 @@
+// Package queue implements the Azure Queue Storage REST+XML wire protocol as a
+// server.Handler. Real azure-sdk-for-go azqueue clients configured with a
+// custom service URL hit this handler the same way they hit
+// {account}.queue.core.windows.net.
+//
+// It maps the Azure Queue REST surface onto the shared messagequeue driver:
+//
+//	PUT    /{queue}                              — create queue
+//	DELETE /{queue}                              — delete queue
+//	GET    /?comp=list                           — list queues
+//	POST   /{queue}/messages                     — enqueue message
+//	GET    /{queue}/messages                     — dequeue messages
+//	DELETE /{queue}/messages/{messageid}?popreceipt=… — delete message
+//
+// Message bodies are XML <QueueMessage><MessageText>… envelopes; the SDK
+// base64-encodes application payloads into MessageText, so this handler treats
+// MessageText as an opaque string and round-trips it verbatim.
+//
+// Less-used surfaces (metadata, ACLs, message update/peek/clear, service
+// properties) are not yet wired and return 501.
+package queue
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	mqdriver "github.com/stackshy/cloudemu/messagequeue/driver"
+)
+
+const (
+	contentTypeXML = "application/xml"
+
+	// xmsVersion is the Queue Storage service version we report.
+	xmsVersion = "2018-03-28"
+
+	compList = "list"
+
+	// maxEnqueueBodyBytes caps a single enqueued message body. Azure allows up
+	// to 64 KiB; we use a generous 1 MiB cap.
+	maxEnqueueBodyBytes = 1 << 20
+)
+
+// Handler serves Azure Queue Storage REST requests against a messagequeue
+// driver.
+type Handler struct {
+	mq mqdriver.MessageQueue
+}
+
+// New returns a Queue handler backed by mq.
+func New(mq mqdriver.MessageQueue) *Handler {
+	return &Handler{mq: mq}
+}
+
+// Matches returns true for requests that look like Azure Queue Storage calls.
+// These are non-ARM data-plane URLs; the detection signals are disjoint from
+// the Blob fallback:
+//
+//   - /{queue}/messages and /{queue}/messages/{id} — the "/messages" segment
+//     is the queue data-plane marker; Blob never uses it. Fully disjoint.
+//   - PUT|DELETE /{queue} with no restype=container query — Blob container ops
+//     always carry restype=container, so a bare PUT/DELETE on a single path
+//     segment is a queue create/delete. Fully disjoint.
+//   - GET /?comp=list (list queues) — this shape is byte-for-byte identical to
+//     Blob's list-containers; Azure disambiguates only by the {account}.queue
+//     vs {account}.blob hostname, which is invisible behind a shared endpoint.
+//     When both handlers are registered, the Queue handler (registered first)
+//     owns this one shape. This is the sole non-disjoint case.
+//
+// Registered before the permissive Blob fallback so these shapes win.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, "/subscriptions/") {
+		return false
+	}
+
+	queue, sub, msgID := parseQueuePath(r.URL.Path)
+	q := r.URL.Query()
+
+	// /{queue}/messages[/{id}] — the unambiguous queue message surface.
+	if sub == "messages" {
+		_ = msgID
+
+		return true
+	}
+
+	// GET /?comp=list — list queues (see Matches doc: shares Blob's shape).
+	if queue == "" {
+		return r.Method == http.MethodGet && q.Get("comp") == compList && q.Get("restype") == ""
+	}
+
+	// Bare /{queue} create/delete: PUT or DELETE with no container/blob query
+	// markers. Blob container ops carry restype=container.
+	if sub == "" {
+		switch r.Method {
+		case http.MethodPut, http.MethodDelete:
+			return q.Get("restype") == ""
+		}
+	}
+
+	return false
+}
+
+// ServeHTTP routes on the parsed path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Ms-Version", xmsVersion)
+
+	queue, sub, msgID := parseQueuePath(r.URL.Path)
+	q := r.URL.Query()
+
+	switch {
+	case queue == "" && r.Method == http.MethodGet && q.Get("comp") == compList:
+		h.listQueues(w, r)
+	case queue == "":
+		writeError(w, http.StatusNotImplemented, "NotImplemented", "operation not supported on root")
+	case sub == "messages" && msgID == "":
+		h.messagesOp(w, r, queue)
+	case sub == "messages":
+		h.messageIDOp(w, r, queue, msgID)
+	case sub == "":
+		h.queueOp(w, r, queue)
+	default:
+		writeError(w, http.StatusBadRequest, "InvalidUri", "unrecognized queue path")
+	}
+}
+
+// parseQueuePath splits "/queue/messages/id" into ("queue", "messages", "id").
+// For "/queue" it returns ("queue", "", ""); for "/queue/messages" it returns
+// ("queue", "messages", "").
+func parseQueuePath(path string) (queue, sub, msgID string) {
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return "", "", ""
+	}
+
+	const maxParts = 3
+	parts := strings.SplitN(path, "/", maxParts)
+	queue = parts[0]
+
+	if len(parts) > 1 {
+		sub = parts[1]
+	}
+
+	if len(parts) > 2 {
+		msgID = parts[2]
+	}
+
+	return queue, sub, msgID
+}
+
+func (h *Handler) queueOp(w http.ResponseWriter, r *http.Request, queue string) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createQueue(w, r, queue)
+	case http.MethodDelete:
+		h.deleteQueue(w, r, queue)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) createQueue(w http.ResponseWriter, r *http.Request, queue string) {
+	_, err := h.mq.CreateQueue(r.Context(), mqdriver.QueueConfig{Name: queue})
+	if err != nil {
+		// Azure returns 204 No Content when the queue already exists with the
+		// same metadata (idempotent create).
+		if cerrors.IsAlreadyExists(err) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		writeErr(w, err)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *Handler) deleteQueue(w http.ResponseWriter, r *http.Request, queue string) {
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.mq.DeleteQueue(r.Context(), url); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listQueues(w http.ResponseWriter, r *http.Request) {
+	prefix := r.URL.Query().Get("prefix")
+
+	queues, err := h.mq.ListQueues(r.Context(), prefix)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listQueuesResult{Prefix: prefix}
+	for _, qi := range queues {
+		out.Queues.Queues = append(out.Queues.Queues, queueXML{Name: qi.Name})
+	}
+
+	writeXML(w, http.StatusOK, out)
+}
+
+// messagesOp handles POST (enqueue) and GET (dequeue) on /{queue}/messages.
+func (h *Handler) messagesOp(w http.ResponseWriter, r *http.Request, queue string) {
+	switch r.Method {
+	case http.MethodPost:
+		h.enqueue(w, r, queue)
+	case http.MethodGet:
+		h.dequeue(w, r, queue)
+	case http.MethodDelete:
+		// DELETE /{queue}/messages with no id = clear queue.
+		h.clearQueue(w, r, queue)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) enqueue(w http.ResponseWriter, r *http.Request, queue string) {
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxEnqueueBodyBytes))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "could not read body")
+		return
+	}
+
+	var req enqueueRequest
+	if err := xml.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidXmlDocument", "malformed request body")
+		return
+	}
+
+	visTimeout := atoiDefault(r.URL.Query().Get("visibilitytimeout"), 0)
+
+	out, err := h.mq.SendMessage(r.Context(), mqdriver.SendMessageInput{
+		QueueURL:     url,
+		Body:         req.MessageText,
+		DelaySeconds: visTimeout,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	now := time.Now().UTC()
+	resp := messagesList{Messages: []messageXML{{
+		MessageID:       out.MessageID,
+		InsertionTime:   now.Format(time.RFC1123),
+		ExpirationTime:  now.Add(7 * 24 * time.Hour).Format(time.RFC1123),
+		PopReceipt:      out.MessageID,
+		TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
+	}}}
+
+	writeXML(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) dequeue(w http.ResponseWriter, r *http.Request, queue string) {
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	q := r.URL.Query()
+	maxMsgs := atoiDefault(q.Get("numofmessages"), 1)
+	visTimeout := atoiDefault(q.Get("visibilitytimeout"), 0)
+
+	msgs, err := h.mq.ReceiveMessages(r.Context(), mqdriver.ReceiveMessageInput{
+		QueueURL:          url,
+		MaxMessages:       maxMsgs,
+		VisibilityTimeout: visTimeout,
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	now := time.Now().UTC()
+	out := messagesList{}
+
+	for _, m := range msgs {
+		out.Messages = append(out.Messages, messageXML{
+			MessageID:       m.MessageID,
+			InsertionTime:   now.Format(time.RFC1123),
+			ExpirationTime:  now.Add(7 * 24 * time.Hour).Format(time.RFC1123),
+			PopReceipt:      m.ReceiptHandle,
+			TimeNextVisible: now.Add(time.Duration(visTimeout) * time.Second).Format(time.RFC1123),
+			DequeueCount:    1,
+			MessageText:     m.Body,
+		})
+	}
+
+	writeXML(w, http.StatusOK, out)
+}
+
+func (h *Handler) clearQueue(w http.ResponseWriter, r *http.Request, queue string) {
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	if err := h.mq.PurgeQueue(r.Context(), url); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// messageIDOp handles DELETE /{queue}/messages/{messageid}?popreceipt=….
+func (h *Handler) messageIDOp(w http.ResponseWriter, r *http.Request, queue, _ string) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	url, err := h.resolveQueueURL(r, queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	popReceipt := r.URL.Query().Get("popreceipt")
+	if popReceipt == "" {
+		writeError(w, http.StatusBadRequest, "InvalidQueryParameterValue", "popreceipt is required")
+		return
+	}
+
+	if err := h.mq.DeleteMessage(r.Context(), url, popReceipt); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// resolveQueueURL maps an Azure queue name to the driver's internal queue URL
+// via ListQueues. The messagequeue driver keys queues by an opaque URL rather
+// than by name, so we look the name up.
+func (h *Handler) resolveQueueURL(r *http.Request, queue string) (string, error) {
+	queues, err := h.mq.ListQueues(r.Context(), "")
+	if err != nil {
+		return "", err
+	}
+
+	for _, qi := range queues {
+		if qi.Name == queue {
+			return qi.URL, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "queue %q not found", queue)
+}
+
+func atoiDefault(s string, def int) int {
+	if s == "" {
+		return def
+	}
+
+	if n, err := strconv.Atoi(s); err == nil {
+		return n
+	}
+
+	return def
+}
+
+func writeXML(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeXML)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", contentTypeXML)
+	w.Header().Set("X-Ms-Error-Code", code)
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(xml.Header))
+	_ = xml.NewEncoder(w).Encode(errorXML{Code: code, Message: msg})
+}
+
+// writeErr maps CloudEmu canonical errors to Azure Queue HTTP errors.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "QueueNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "QueueAlreadyExists", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
+}

--- a/server/azure/queue/sdk_roundtrip_test.go
+++ b/server/azure/queue/sdk_roundtrip_test.go
@@ -1,0 +1,121 @@
+package queue_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// TestSDKQueueRoundTrip drives Azure Queue Storage operations with the real
+// azqueue client against our handler. azqueue supports anonymous access, so
+// the test doesn't have to forge SharedKey signatures.
+func TestSDKQueueRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{QueueStorage: cloudP.QueueStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	svcOpts := &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	svcClient, err := azqueue.NewServiceClientWithNoCredential(ts.URL+"/", svcOpts)
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	// Create queue.
+	if _, err := svcClient.CreateQueue(ctx, "q1", nil); err != nil {
+		t.Fatalf("CreateQueue: %v", err)
+	}
+
+	// List queues and confirm q1 is present.
+	{
+		pager := svcClient.NewListQueuesPager(nil)
+
+		seen := map[string]bool{}
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("ListQueues: %v", err)
+			}
+
+			for _, q := range page.Queues {
+				if q.Name != nil {
+					seen[*q.Name] = true
+				}
+			}
+		}
+
+		if !seen["q1"] {
+			t.Errorf("q1 not in queue list: %v", seen)
+		}
+	}
+
+	qClient, err := azqueue.NewQueueClientWithNoCredential(ts.URL+"/q1", &azqueue.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("NewQueueClientWithNoCredential: %v", err)
+	}
+
+	// Enqueue a message.
+	const payload = "hello, azure queue"
+
+	enq, err := qClient.EnqueueMessage(ctx, payload, nil)
+	if err != nil {
+		t.Fatalf("EnqueueMessage: %v", err)
+	}
+
+	if len(enq.Messages) == 0 || enq.Messages[0].MessageID == nil {
+		t.Fatalf("EnqueueMessage returned no message id: %+v", enq)
+	}
+
+	// Dequeue and verify the message text round-trips.
+	deq, err := qClient.DequeueMessage(ctx, nil)
+	if err != nil {
+		t.Fatalf("DequeueMessage: %v", err)
+	}
+
+	if len(deq.Messages) != 1 {
+		t.Fatalf("DequeueMessage returned %d messages, want 1", len(deq.Messages))
+	}
+
+	msg := deq.Messages[0]
+	if msg.MessageText == nil || *msg.MessageText != payload {
+		t.Errorf("message text mismatch: got=%v want=%q", msg.MessageText, payload)
+	}
+
+	if msg.MessageID == nil || msg.PopReceipt == nil {
+		t.Fatalf("dequeued message missing id/popreceipt: %+v", msg)
+	}
+
+	// Delete the message using its id + pop receipt.
+	if _, err := qClient.DeleteMessage(ctx, *msg.MessageID, *msg.PopReceipt, nil); err != nil {
+		t.Fatalf("DeleteMessage: %v", err)
+	}
+
+	// Delete the queue.
+	if _, err := qClient.Delete(ctx, nil); err != nil {
+		t.Fatalf("Delete queue: %v", err)
+	}
+
+	// Confirm the queue is gone: enqueue should now fail with QueueNotFound.
+	if _, err := qClient.EnqueueMessage(ctx, "x", nil); err == nil ||
+		!strings.Contains(err.Error(), "QueueNotFound") {
+		t.Errorf("expected QueueNotFound after delete, got %v", err)
+	}
+}

--- a/server/azure/queue/types.go
+++ b/server/azure/queue/types.go
@@ -1,0 +1,56 @@
+package queue
+
+import "encoding/xml"
+
+// Azure Queue Storage XML wire shapes. Child element names match the
+// azqueue SDK's generated models exactly; the SDK unmarshals into structs and
+// ignores the root element name, so only child names are load-bearing.
+
+// enqueueRequest is the body of POST /{queue}/messages.
+type enqueueRequest struct {
+	XMLName     xml.Name `xml:"QueueMessage"`
+	MessageText string   `xml:"MessageText"`
+}
+
+// messagesList is the QueueMessagesList body returned by enqueue and dequeue.
+type messagesList struct {
+	XMLName  xml.Name     `xml:"QueueMessagesList"`
+	Messages []messageXML `xml:"QueueMessage"`
+}
+
+// messageXML carries the union of fields the SDK reads for enqueued and
+// dequeued messages. Empty fields are omitted so enqueue responses stay lean.
+type messageXML struct {
+	MessageID       string `xml:"MessageId"`
+	InsertionTime   string `xml:"InsertionTime"`
+	ExpirationTime  string `xml:"ExpirationTime"`
+	PopReceipt      string `xml:"PopReceipt"`
+	TimeNextVisible string `xml:"TimeNextVisible"`
+	DequeueCount    int64  `xml:"DequeueCount,omitempty"`
+	MessageText     string `xml:"MessageText,omitempty"`
+}
+
+// listQueuesResult is the EnumerationResults body for GET /?comp=list.
+type listQueuesResult struct {
+	XMLName    xml.Name   `xml:"EnumerationResults"`
+	Prefix     string     `xml:"Prefix,omitempty"`
+	Marker     string     `xml:"Marker,omitempty"`
+	MaxResults int        `xml:"MaxResults,omitempty"`
+	Queues     queuesList `xml:"Queues"`
+	NextMarker string     `xml:"NextMarker"`
+}
+
+type queuesList struct {
+	Queues []queueXML `xml:"Queue"`
+}
+
+type queueXML struct {
+	Name string `xml:"Name"`
+}
+
+// errorXML is the Azure Storage error envelope.
+type errorXML struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    string   `xml:"Code"`
+	Message string   `xml:"Message"`
+}

--- a/server/azure/table/handler.go
+++ b/server/azure/table/handler.go
@@ -15,8 +15,9 @@
 //	DELETE /{table}(PartitionKey='p',RowKey='r')          — delete entity
 //	GET    /{table}()?$filter=…                           — query entities
 //
-// Access policies, transactional batches, and merge-on-insert (upsert via
-// PUT/MERGE without an existing row) are out of scope.
+// Access policies and transactional batches are out of scope. Upsert (a PUT or
+// MERGE with no If-Match header against a missing row) is supported as an
+// insert-or-replace/merge, matching aztables UpsertEntity.
 package table
 
 import (
@@ -26,6 +27,7 @@ import (
 	"net/http"
 	"strings"
 
+	cerrors "github.com/stackshy/cloudemu/errors"
 	driver "github.com/stackshy/cloudemu/tablestorage/driver"
 )
 
@@ -310,6 +312,21 @@ func (h *Handler) updateEntity(
 	ent["RowKey"] = rk
 
 	if err := h.ts.UpdateEntity(r.Context(), table, pk, rk, driver.Entity(ent), mode); err != nil {
+		// aztables UpdateEntity sends an If-Match header; UpsertEntity does not.
+		// With no If-Match, a PUT/MERGE against a missing row is an insert
+		// (insert-or-replace/merge), so create it instead of returning 404.
+		if cerrors.IsNotFound(err) && r.Header.Get("If-Match") == "" {
+			if ierr := h.ts.InsertEntity(r.Context(), table, pk, rk, driver.Entity(ent)); ierr != nil {
+				writeErr(w, ierr)
+				return
+			}
+
+			w.Header().Set("ETag", entityETag())
+			w.WriteHeader(http.StatusNoContent)
+
+			return
+		}
+
 		writeErr(w, err)
 		return
 	}

--- a/server/azure/table/handler.go
+++ b/server/azure/table/handler.go
@@ -1,0 +1,342 @@
+// Package table implements the Azure Table Storage data-plane REST protocol
+// (OData/JSON) as a server.Handler. Real azure-sdk-for-go aztables clients
+// configured with a custom service URL hit this handler the same way they hit
+// {account}.table.core.windows.net.
+//
+// Supported operations:
+//
+//	POST   /Tables                                        — create table
+//	GET    /Tables                                        — list tables
+//	DELETE /Tables('name')                                — delete table
+//	POST   /{table}                                       — insert entity
+//	GET    /{table}(PartitionKey='p',RowKey='r')          — get entity
+//	PUT    /{table}(PartitionKey='p',RowKey='r')          — replace entity
+//	MERGE|PATCH /{table}(PartitionKey='p',RowKey='r')     — merge entity
+//	DELETE /{table}(PartitionKey='p',RowKey='r')          — delete entity
+//	GET    /{table}()?$filter=…                           — query entities
+//
+// Access policies, transactional batches, and merge-on-insert (upsert via
+// PUT/MERGE without an existing row) are out of scope.
+package table
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	driver "github.com/stackshy/cloudemu/tablestorage/driver"
+)
+
+const (
+	contentTypeJSON = "application/json"
+
+	// xmsVersion is the Table Storage service version we report.
+	xmsVersion = "2019-02-02"
+
+	// maxBodyBytes caps request bodies (entities / table-create payloads).
+	maxBodyBytes = 1 << 20
+)
+
+// Handler serves Azure Table Storage REST requests against a TableStorage
+// driver.
+type Handler struct {
+	ts driver.TableStorage
+}
+
+// New returns a Table handler backed by ts.
+func New(ts driver.TableStorage) *Handler {
+	return &Handler{ts: ts}
+}
+
+// Matches returns true for Azure Table Storage data-plane requests. The
+// detection signals are disjoint from every other Azure handler:
+//
+//   - The path is /Tables or /Tables('name') — the table lifecycle surface,
+//     which no other service uses.
+//   - The path's first segment carries an OData key predicate: it contains a
+//     "(" — either "()" (query entities) or
+//     "(PartitionKey='…',RowKey='…')" (entity CRUD). Blob/Queue paths never
+//     contain parentheses, and ARM paths start with /subscriptions/, so this
+//     is unambiguous.
+//   - POST /{table} (insert entity) is a bare single segment with a JSON body.
+//     Blob and Queue never use a bare POST on a single path segment, so the
+//     method+content-type discriminates it from their PUT/DELETE ops.
+//
+// Registered before the permissive Blob fallback so these shapes win.
+func (*Handler) Matches(r *http.Request) bool {
+	if strings.HasPrefix(r.URL.Path, "/subscriptions/") {
+		return false
+	}
+
+	path := strings.TrimPrefix(r.URL.Path, "/")
+
+	// /Tables and /Tables('name').
+	if path == "Tables" || strings.HasPrefix(path, "Tables(") {
+		return true
+	}
+
+	first := path
+	if i := strings.IndexByte(path, '/'); i >= 0 {
+		first = path[:i]
+	}
+
+	// Entity CRUD / query: first path segment contains an OData "(" predicate.
+	if strings.ContainsRune(first, '(') {
+		return true
+	}
+
+	// Insert entity: POST /{table} with a JSON body.
+	if r.Method == http.MethodPost && first != "" && !strings.Contains(first, "/") {
+		return isJSONContentType(r.Header.Get("Content-Type"))
+	}
+
+	return false
+}
+
+func isJSONContentType(ct string) bool {
+	return strings.Contains(strings.ToLower(ct), "application/json")
+}
+
+// ServeHTTP routes on the parsed path shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Ms-Version", xmsVersion)
+	w.Header().Set("Dataserviceversion", "3.0")
+
+	path := strings.TrimPrefix(r.URL.Path, "/")
+
+	switch {
+	case path == "Tables":
+		h.tablesCollectionOp(w, r)
+	case strings.HasPrefix(path, "Tables("):
+		h.deleteTable(w, r, tableNameFromDelete(path))
+	case r.Method == http.MethodPost && !strings.ContainsRune(path, '('):
+		// POST /{table} — insert entity into a bare table path.
+		h.insertEntity(w, r, path)
+	default:
+		h.entityOp(w, r, path)
+	}
+}
+
+// tablesCollectionOp handles POST (create) and GET (list) on /Tables.
+func (h *Handler) tablesCollectionOp(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.createTable(w, r)
+	case http.MethodGet:
+		h.listTables(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		TableName string `json:"TableName"`
+	}
+
+	if err := decodeJSON(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "malformed request body")
+		return
+	}
+
+	if err := h.ts.CreateTable(r.Context(), body.TableName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	resp := map[string]any{
+		"odata.metadata": fmt.Sprintf("%s://%s/$metadata#Tables/@Element", scheme(r), r.Host),
+		"TableName":      body.TableName,
+	}
+
+	writeJSON(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
+	names, err := h.ts.ListTables(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	value := make([]map[string]any, 0, len(names))
+	for _, n := range names {
+		value = append(value, map[string]any{"TableName": n})
+	}
+
+	resp := map[string]any{
+		"odata.metadata": fmt.Sprintf("%s://%s/$metadata#Tables", scheme(r), r.Host),
+		"value":          value,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) deleteTable(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method != http.MethodDelete {
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	if err := h.ts.DeleteTable(r.Context(), name); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// entityOp routes entity-level requests: /{table}() (query) and
+// /{table}(PartitionKey='p',RowKey='r') (CRUD).
+func (h *Handler) entityOp(w http.ResponseWriter, r *http.Request, path string) {
+	table, predicate, ok := splitEntityPath(path)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidUri", "unrecognized table path")
+		return
+	}
+
+	// Query: /{table}() with an empty predicate.
+	if strings.TrimSpace(predicate) == "" {
+		h.queryEntities(w, r, table)
+		return
+	}
+
+	pk, rk, ok := parseKeyPredicate(predicate)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "malformed entity key predicate")
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getEntity(w, r, table, pk, rk)
+	case http.MethodPut:
+		h.updateEntity(w, r, table, pk, rk, driver.UpdateModeReplace)
+	case http.MethodPatch, "MERGE":
+		h.updateEntity(w, r, table, pk, rk, driver.UpdateModeMerge)
+	case http.MethodDelete:
+		h.deleteEntity(w, r, table, pk, rk)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+	}
+}
+
+func (h *Handler) queryEntities(w http.ResponseWriter, r *http.Request, table string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	entities, err := h.ts.QueryEntities(r.Context(), table, driver.QueryOptions{
+		Filter: r.URL.Query().Get("$filter"),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	value := make([]map[string]any, 0, len(entities))
+	for _, e := range entities {
+		value = append(value, entityToJSON(e))
+	}
+
+	resp := map[string]any{
+		"odata.metadata": fmt.Sprintf("%s://%s/$metadata#%s", scheme(r), r.Host, table),
+		"value":          value,
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) getEntity(w http.ResponseWriter, r *http.Request, table, pk, rk string) {
+	ent, err := h.ts.GetEntity(r.Context(), table, pk, rk)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := entityToJSON(ent)
+	out["odata.metadata"] = fmt.Sprintf("%s://%s/$metadata#%s/@Element", scheme(r), r.Host, table)
+
+	w.Header().Set("ETag", entityETag())
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *Handler) insertEntity(w http.ResponseWriter, r *http.Request, table string) {
+	ent, err := readEntity(w, r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "malformed entity body")
+		return
+	}
+
+	pk := asString(ent["PartitionKey"])
+	rk := asString(ent["RowKey"])
+
+	if err := h.ts.InsertEntity(r.Context(), table, pk, rk, driver.Entity(ent)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	// Default (no Prefer header): return-content — echo the entity with 201.
+	out := entityToJSON(ent)
+	out["odata.metadata"] = fmt.Sprintf("%s://%s/$metadata#%s/@Element", scheme(r), r.Host, table)
+
+	w.Header().Set("ETag", entityETag())
+
+	if strings.EqualFold(r.Header.Get("Prefer"), "return-no-content") {
+		w.Header().Set("Preference-Applied", "return-no-content")
+		w.WriteHeader(http.StatusNoContent)
+
+		return
+	}
+
+	w.Header().Set("Preference-Applied", "return-content")
+	writeJSON(w, http.StatusCreated, out)
+}
+
+func (h *Handler) updateEntity(
+	w http.ResponseWriter, r *http.Request, table, pk, rk string, mode driver.UpdateMode,
+) {
+	ent, err := readEntity(w, r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "InvalidInput", "malformed entity body")
+		return
+	}
+
+	// The key comes from the URL; ensure it's present in the stored entity.
+	ent["PartitionKey"] = pk
+	ent["RowKey"] = rk
+
+	if err := h.ts.UpdateEntity(r.Context(), table, pk, rk, driver.Entity(ent), mode); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.Header().Set("ETag", entityETag())
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) deleteEntity(w http.ResponseWriter, r *http.Request, table, pk, rk string) {
+	if err := h.ts.DeleteEntity(r.Context(), table, pk, rk); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func readEntity(w http.ResponseWriter, r *http.Request) (map[string]any, error) {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBodyBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	var ent map[string]any
+	if err := json.Unmarshal(data, &ent); err != nil {
+		return nil, err
+	}
+
+	return ent, nil
+}

--- a/server/azure/table/helpers.go
+++ b/server/azure/table/helpers.go
@@ -1,0 +1,186 @@
+package table
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	cerrors "github.com/stackshy/cloudemu/errors"
+	driver "github.com/stackshy/cloudemu/tablestorage/driver"
+)
+
+// tableNameFromDelete extracts "name" from a "Tables('name')" path.
+func tableNameFromDelete(path string) string {
+	open := strings.IndexByte(path, '(')
+	closeIdx := strings.LastIndexByte(path, ')')
+
+	if open < 0 || closeIdx < 0 || closeIdx <= open {
+		return ""
+	}
+
+	inner := path[open+1 : closeIdx]
+
+	return strings.Trim(inner, "'")
+}
+
+// splitEntityPath splits "table(predicate)" into ("table", "predicate", true).
+// A bare "table" with no parentheses returns ok=false.
+func splitEntityPath(path string) (table, predicate string, ok bool) {
+	open := strings.IndexByte(path, '(')
+	if open < 0 {
+		return "", "", false
+	}
+
+	closeIdx := strings.LastIndexByte(path, ')')
+	if closeIdx < 0 || closeIdx <= open {
+		return "", "", false
+	}
+
+	return path[:open], path[open+1 : closeIdx], true
+}
+
+// parseKeyPredicate parses "PartitionKey='p',RowKey='r'" into ("p", "r").
+// The two clauses may appear in either order.
+func parseKeyPredicate(predicate string) (partitionKey, rowKey string, ok bool) {
+	for _, clause := range splitTopLevel(predicate) {
+		key, val, found := strings.Cut(clause, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		val = unquote(strings.TrimSpace(val))
+
+		switch key {
+		case "PartitionKey":
+			partitionKey = val
+		case "RowKey":
+			rowKey = val
+		}
+	}
+
+	if partitionKey == "" && rowKey == "" {
+		return "", "", false
+	}
+
+	return partitionKey, rowKey, true
+}
+
+// splitTopLevel splits on commas that are not inside single-quoted strings, so
+// a key value containing a comma survives.
+func splitTopLevel(s string) []string {
+	var (
+		parts   []string
+		start   int
+		inQuote bool
+	)
+
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\'':
+			inQuote = !inQuote
+		case ',':
+			if !inQuote {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+
+	parts = append(parts, s[start:])
+
+	return parts
+}
+
+// unquote strips surrounding single quotes and unescapes doubled quotes, which
+// is how OData escapes a literal apostrophe.
+func unquote(s string) string {
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		s = s[1 : len(s)-1]
+	}
+
+	return strings.ReplaceAll(s, "''", "'")
+}
+
+// entityToJSON copies an entity's properties into a fresh JSON map. The
+// PartitionKey/RowKey and user properties round-trip verbatim.
+func entityToJSON(e driver.Entity) map[string]any {
+	out := make(map[string]any, len(e)+1)
+	for k, v := range e {
+		out[k] = v
+	}
+
+	return out
+}
+
+func entityETag() string {
+	return fmt.Sprintf("W/\"datetime'%s'\"", time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+func scheme(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+
+	return "http"
+}
+
+func asString(v any) string {
+	s, _ := v.(string)
+	return s
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) error {
+	data, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBodyBytes))
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, v)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", contentTypeJSON+";odata=minimalmetadata;streaming=true;charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// tableError is the Azure Table Storage OData JSON error envelope.
+type tableError struct {
+	ODataError struct {
+		Code    string `json:"code"`
+		Message struct {
+			Lang  string `json:"lang"`
+			Value string `json:"value"`
+		} `json:"message"`
+	} `json:"odata.error"`
+}
+
+func writeError(w http.ResponseWriter, status int, code, msg string) {
+	var e tableError
+	e.ODataError.Code = code
+	e.ODataError.Message.Lang = "en-US"
+	e.ODataError.Message.Value = msg
+
+	w.Header().Set("Content-Type", contentTypeJSON)
+	w.Header().Set("X-Ms-Error-Code", code)
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(e)
+}
+
+// writeErr maps CloudEmu canonical errors to Azure Table HTTP errors.
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case cerrors.IsNotFound(err):
+		writeError(w, http.StatusNotFound, "ResourceNotFound", err.Error())
+	case cerrors.IsAlreadyExists(err):
+		writeError(w, http.StatusConflict, "EntityAlreadyExists", err.Error())
+	case cerrors.IsInvalidArgument(err):
+		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
+	}
+}

--- a/server/azure/table/sdk_roundtrip_test.go
+++ b/server/azure/table/sdk_roundtrip_test.go
@@ -1,0 +1,130 @@
+package table_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+
+	"github.com/stackshy/cloudemu"
+	azureserver "github.com/stackshy/cloudemu/server/azure"
+)
+
+// TestSDKTableRoundTrip drives Azure Table Storage operations with the real
+// aztables client against our handler. aztables supports anonymous access, so
+// the test doesn't have to forge SharedKey signatures.
+func TestSDKTableRoundTrip(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{TableStorage: cloudP.TableStorage})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	svcOpts := &aztables.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	svc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/", svcOpts)
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+
+	const tableName = "people"
+
+	// Create table.
+	if _, err := svc.CreateTable(ctx, tableName, nil); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	client := svc.NewClient(tableName)
+
+	// Insert entity.
+	entity := map[string]any{
+		"PartitionKey": "org",
+		"RowKey":       "alice",
+		"Email":        "alice@example.com",
+		"Age":          int64(30),
+	}
+
+	marshalled, err := json.Marshal(entity)
+	if err != nil {
+		t.Fatalf("marshal entity: %v", err)
+	}
+
+	if _, err := client.AddEntity(ctx, marshalled, nil); err != nil {
+		t.Fatalf("AddEntity: %v", err)
+	}
+
+	// Get entity and verify properties round-trip.
+	got, err := client.GetEntity(ctx, "org", "alice", nil)
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+
+	var props map[string]any
+	if err := json.Unmarshal(got.Value, &props); err != nil {
+		t.Fatalf("unmarshal entity: %v", err)
+	}
+
+	if props["Email"] != "alice@example.com" {
+		t.Errorf("Email mismatch: got=%v want=alice@example.com", props["Email"])
+	}
+
+	if props["PartitionKey"] != "org" || props["RowKey"] != "alice" {
+		t.Errorf("key mismatch: pk=%v rk=%v", props["PartitionKey"], props["RowKey"])
+	}
+
+	// Query by partition and confirm alice is returned.
+	{
+		filter := "PartitionKey eq 'org'"
+		pager := client.NewListEntitiesPager(&aztables.ListEntitiesOptions{Filter: &filter})
+
+		seen := map[string]bool{}
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("ListEntities: %v", err)
+			}
+
+			for _, raw := range page.Entities {
+				var e map[string]any
+				if err := json.Unmarshal(raw, &e); err != nil {
+					t.Fatalf("unmarshal query entity: %v", err)
+				}
+
+				if rk, ok := e["RowKey"].(string); ok {
+					seen[rk] = true
+				}
+			}
+		}
+
+		if !seen["alice"] {
+			t.Errorf("alice not returned by partition query: %v", seen)
+		}
+	}
+
+	// Delete entity.
+	if _, err := client.DeleteEntity(ctx, "org", "alice", nil); err != nil {
+		t.Fatalf("DeleteEntity: %v", err)
+	}
+
+	// Confirm the entity is gone.
+	if _, err := client.GetEntity(ctx, "org", "alice", nil); err == nil ||
+		!strings.Contains(err.Error(), "ResourceNotFound") {
+		t.Errorf("expected ResourceNotFound after delete, got %v", err)
+	}
+
+	// Delete table.
+	if _, err := client.Delete(ctx, nil); err != nil {
+		t.Fatalf("Delete table: %v", err)
+	}
+}

--- a/tablestorage/driver/driver.go
+++ b/tablestorage/driver/driver.go
@@ -1,0 +1,51 @@
+// Package driver defines the interface for Azure Table Storage-style
+// key/value entity stores. Entities live inside named tables and are addressed
+// by a (PartitionKey, RowKey) pair; each entity is a flat bag of named
+// properties.
+//
+// The interface is intentionally small — it mirrors the operations the Azure
+// Table data-plane REST API (aztables) exercises, nothing more.
+package driver
+
+import "context"
+
+// UpdateMode selects how UpdateEntity combines the supplied properties with an
+// existing entity.
+type UpdateMode int
+
+const (
+	// UpdateModeMerge merges the supplied properties into the existing entity,
+	// leaving unmentioned properties untouched.
+	UpdateModeMerge UpdateMode = iota
+	// UpdateModeReplace replaces the entity wholesale with the supplied
+	// properties.
+	UpdateModeReplace
+)
+
+// Entity is a single Table Storage row: a flat map of property name to value.
+// PartitionKey and RowKey are stored as ordinary properties (keys
+// "PartitionKey" and "RowKey") so callers get them back verbatim.
+type Entity map[string]any
+
+// QueryOptions filters a QueryEntities call.
+type QueryOptions struct {
+	// PartitionKey, when non-empty, restricts results to a single partition.
+	PartitionKey string
+	// Filter is an OData $filter expression. Only a small, common subset is
+	// supported (PartitionKey/RowKey/property eq comparisons joined by "and");
+	// an unsupported filter is ignored rather than rejected.
+	Filter string
+}
+
+// TableStorage is the interface a Table Storage backend implements.
+type TableStorage interface {
+	CreateTable(ctx context.Context, name string) error
+	DeleteTable(ctx context.Context, name string) error
+	ListTables(ctx context.Context) ([]string, error)
+
+	InsertEntity(ctx context.Context, table, partitionKey, rowKey string, entity Entity) error
+	GetEntity(ctx context.Context, table, partitionKey, rowKey string) (Entity, error)
+	UpdateEntity(ctx context.Context, table, partitionKey, rowKey string, entity Entity, mode UpdateMode) error
+	DeleteEntity(ctx context.Context, table, partitionKey, rowKey string) error
+	QueryEntities(ctx context.Context, table string, opts QueryOptions) ([]Entity, error)
+}


### PR DESCRIPTION
Closes #243. `server/azure/queue` (REST/XML over the messagequeue driver) and `server/azure/table` (OData/JSON over a new light `tablestorage` driver). Real `azqueue`/`aztables` roundtrip tests + a no-shadowing test (Blob+Queue+Table together). One documented non-disjoint case: `GET /?comp=list` is identical for list-queues vs list-containers (Azure separates by hostname); Queue handler owns it when both are wired. Full `go test ./server/...` green.