### PR TITLE
Fix all #271 follow-ups: driver key continuation, type-aware ordering, GSI keys, Firestore query/mask, Cosmos paging

### DIFF
--- a/internal/pagination/pagination.go
+++ b/internal/pagination/pagination.go
@@ -1,5 +1,7 @@
 package pagination
 
+import "sort"
+
 // Page represents a page of results.
 type Page[T any] struct {
 	Items         []T
@@ -7,7 +9,12 @@ type Page[T any] struct {
 	HasMore       bool
 }
 
-// Paginate paginates a slice of items given a page token and max results per page.
+// Paginate slices one page out of items using an offset-based token.
+//
+// CONTRACT: offset tokens are only meaningful over a STABLE ordering — the
+// caller must present items in the same order on every call (Go map
+// iteration is not stable). Callers that cannot guarantee ordering should
+// use PaginateSorted, which enforces it.
 func Paginate[T any](items []T, pageToken string, maxResults int) (Page[T], error) {
 	if maxResults <= 0 {
 		maxResults = 100
@@ -42,4 +49,12 @@ func Paginate[T any](items []T, pageToken string, maxResults int) (Page[T], erro
 	}
 
 	return page, nil
+}
+
+// PaginateSorted stable-sorts items with less, then paginates. This is the
+// misuse-proof entry point for offset tokens: the required ordering
+// invariant is enforced here rather than trusted to the caller.
+func PaginateSorted[T any](items []T, less func(a, b T) bool, pageToken string, maxResults int) (Page[T], error) {
+	sort.SliceStable(items, func(i, j int) bool { return less(items[i], items[j]) })
+	return Paginate(items, pageToken, maxResults)
 }

--- a/internal/pagination/pagination_test.go
+++ b/internal/pagination/pagination_test.go
@@ -159,3 +159,31 @@ func TestPaginate_InvalidToken(t *testing.T) {
 	_, err := Paginate([]string{"a"}, "bad-token", 10)
 	assert.Error(t, err)
 }
+
+func TestPaginateSorted_StableAcrossShuffledInput(t *testing.T) {
+	// Same logical set presented in different orders must yield identical
+	// pages — the invariant PaginateSorted exists to enforce.
+	a := []string{"c", "a", "e", "b", "d"}
+	b := []string{"e", "d", "c", "b", "a"}
+	less := func(x, y string) bool { return x < y }
+
+	p1, err := PaginateSorted(a, less, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := PaginateSorted(b, less, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1.Items[0] != p2.Items[0] || p1.Items[1] != p2.Items[1] {
+		t.Fatalf("pages differ across input orders: %v vs %v", p1.Items, p2.Items)
+	}
+
+	p3, err := PaginateSorted(b, less, p2.NextPageToken, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p3.Items[0] != "c" || p3.Items[1] != "d" {
+		t.Fatalf("page 2 = %v, want [c d]", p3.Items)
+	}
+}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -283,7 +283,7 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		limit = 100
 	}
 
-	driver.SortStableByKey(matched, func(it map[string]any) string { return itemKey(td.config, it) })
+	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
 	page, err := pagination.Paginate(matched, input.PageToken, limit)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
@@ -373,7 +373,7 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		limit = 100
 	}
 
-	driver.SortStableByKey(matched, func(it map[string]any) string { return itemKey(td.config, it) })
+	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
 	page, err := pagination.Paginate(matched, input.PageToken, limit)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -282,8 +282,14 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
-		input.ExclusiveStartKey, input.SortDescending,
+	// Order by the queried keys (index keys for GSI queries); the
+	// continuation key carries base + index keys like the real service.
+	keyFields := []string{td.config.PartitionKey, td.config.SortKey}
+	if input.IndexName != "" {
+		keyFields = append(keyFields, pkField, skField)
+	}
+	result, err := driver.PageOrdered(matched, pkField, skField, keyFields,
+		limit, input.PageToken, input.ExclusiveStartKey, input.SortDescending,
 		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
 		return nil, err
@@ -373,8 +379,10 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
-		input.ExclusiveStartKey, false,
+	result, err := driver.PageOrdered(matched,
+		td.config.PartitionKey, td.config.SortKey,
+		[]string{td.config.PartitionKey, td.config.SortKey},
+		limit, input.PageToken, input.ExclusiveStartKey, false,
 		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
 		return nil, err

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
-	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -283,17 +282,18 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		limit = 100
 	}
 
-	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
-	page, err := pagination.Paginate(matched, input.PageToken, limit)
+	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
+		input.ExclusiveStartKey, input.SortDescending,
+		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+		return nil, err
 	}
 
 	dims := map[string]string{"TableName": input.Table}
-	m.emitMetric("ConsumedReadCapacityUnits", float64(len(page.Items)), dims)
+	m.emitMetric("ConsumedReadCapacityUnits", float64(len(result.Items)), dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
-	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
+	return result, nil
 }
 
 func resolveKeyFields(td *tableData, indexName string) (pkField, skField string, err error) {
@@ -373,17 +373,18 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		limit = 100
 	}
 
-	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
-	page, err := pagination.Paginate(matched, input.PageToken, limit)
+	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
+		input.ExclusiveStartKey, false,
+		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+		return nil, err
 	}
 
 	dims := map[string]string{"TableName": input.Table}
-	m.emitMetric("ConsumedReadCapacityUnits", float64(len(page.Items)), dims)
+	m.emitMetric("ConsumedReadCapacityUnits", float64(len(result.Items)), dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
-	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
+	return result, nil
 }
 
 func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -288,7 +288,10 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 		maxKeys = s3DefaultMaxKeys
 	}
 
-	page, _ := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
 
 	dims := map[string]string{"BucketName": bucket}
 	m.emitMetric("AllRequests", 1, "Count", dims)

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -302,7 +302,10 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 		maxKeys = blobDefaultMaxKeys
 	}
 
-	page, _ := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1})
 

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
-	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -298,15 +297,16 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		limit = 100
 	}
 
-	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
-	page, err := pagination.Paginate(matched, input.PageToken, limit)
+	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
+		input.ExclusiveStartKey, input.SortDescending,
+		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+		return nil, err
 	}
 
-	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": float64(len(page.Items))})
+	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": float64(len(result.Items))})
 
-	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
+	return result, nil
 }
 
 func resolveKeyFields(td *tableData, indexName string) (pkField, skField string, err error) {
@@ -355,15 +355,16 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		limit = 100
 	}
 
-	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
-	page, err := pagination.Paginate(matched, input.PageToken, limit)
+	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
+		input.ExclusiveStartKey, false,
+		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+		return nil, err
 	}
 
-	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": float64(len(page.Items))})
+	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": float64(len(result.Items))})
 
-	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
+	return result, nil
 }
 
 // BatchPutItems stores multiple items in a container.

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -297,8 +297,14 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
-		input.ExclusiveStartKey, input.SortDescending,
+	// Order by the queried keys (index keys for GSI queries); the
+	// continuation key carries base + index keys like the real service.
+	keyFields := []string{td.config.PartitionKey, td.config.SortKey}
+	if input.IndexName != "" {
+		keyFields = append(keyFields, pkField, skField)
+	}
+	result, err := driver.PageOrdered(matched, pkField, skField, keyFields,
+		limit, input.PageToken, input.ExclusiveStartKey, input.SortDescending,
 		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
 		return nil, err
@@ -355,8 +361,10 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(td.config, matched, limit, input.PageToken,
-		input.ExclusiveStartKey, false,
+	result, err := driver.PageOrdered(matched,
+		td.config.PartitionKey, td.config.SortKey,
+		[]string{td.config.PartitionKey, td.config.SortKey},
+		limit, input.PageToken, input.ExclusiveStartKey, false,
 		func(it map[string]any) string { return itemKey(td.config, it) })
 	if err != nil {
 		return nil, err

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -298,7 +298,7 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		limit = 100
 	}
 
-	driver.SortStableByKey(matched, func(it map[string]any) string { return itemKey(td.config, it) })
+	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
 	page, err := pagination.Paginate(matched, input.PageToken, limit)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
@@ -355,7 +355,7 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		limit = 100
 	}
 
-	driver.SortStableByKey(matched, func(it map[string]any) string { return itemKey(td.config, it) })
+	driver.SortByFields(matched, td.config.PartitionKey, td.config.SortKey)
 	page, err := pagination.Paginate(matched, input.PageToken, limit)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -283,7 +283,7 @@ func (m *Mock) Query(ctx context.Context, input driver.QueryInput) (*driver.Quer
 		limit = 100
 	}
 
-	driver.SortStableByKey(matched, func(it map[string]any) string { return docKey(cd.config, it) })
+	driver.SortByFields(matched, cd.config.PartitionKey, cd.config.SortKey)
 	page, err := pagination.Paginate(matched, input.PageToken, limit)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
@@ -371,7 +371,7 @@ func (m *Mock) Scan(ctx context.Context, input driver.ScanInput) (*driver.QueryR
 		limit = 100
 	}
 
-	driver.SortStableByKey(matched, func(it map[string]any) string { return docKey(cd.config, it) })
+	driver.SortByFields(matched, cd.config.PartitionKey, cd.config.SortKey)
 	page, err := pagination.Paginate(matched, input.PageToken, limit)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -282,8 +282,14 @@ func (m *Mock) Query(ctx context.Context, input driver.QueryInput) (*driver.Quer
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(cd.config, matched, limit, input.PageToken,
-		input.ExclusiveStartKey, input.SortDescending,
+	// Order by the queried keys (index keys for GSI queries); the
+	// continuation key carries base + index keys like the real service.
+	keyFields := []string{cd.config.PartitionKey, cd.config.SortKey}
+	if input.IndexName != "" {
+		keyFields = append(keyFields, pkField, skField)
+	}
+	result, err := driver.PageOrdered(matched, pkField, skField, keyFields,
+		limit, input.PageToken, input.ExclusiveStartKey, input.SortDescending,
 		func(it map[string]any) string { return docKey(cd.config, it) })
 	if err != nil {
 		return nil, err
@@ -371,8 +377,10 @@ func (m *Mock) Scan(ctx context.Context, input driver.ScanInput) (*driver.QueryR
 		limit = 100
 	}
 
-	result, err := driver.PageOrdered(cd.config, matched, limit, input.PageToken,
-		input.ExclusiveStartKey, false,
+	result, err := driver.PageOrdered(matched,
+		cd.config.PartitionKey, cd.config.SortKey,
+		[]string{cd.config.PartitionKey, cd.config.SortKey},
+		limit, input.PageToken, input.ExclusiveStartKey, false,
 		func(it map[string]any) string { return docKey(cd.config, it) })
 	if err != nil {
 		return nil, err

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
-	"github.com/stackshy/cloudemu/v2/internal/pagination"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
@@ -283,15 +282,16 @@ func (m *Mock) Query(ctx context.Context, input driver.QueryInput) (*driver.Quer
 		limit = 100
 	}
 
-	driver.SortByFields(matched, cd.config.PartitionKey, cd.config.SortKey)
-	page, err := pagination.Paginate(matched, input.PageToken, limit)
+	result, err := driver.PageOrdered(cd.config, matched, limit, input.PageToken,
+		input.ExclusiveStartKey, input.SortDescending,
+		func(it map[string]any) string { return docKey(cd.config, it) })
 	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+		return nil, err
 	}
 
-	m.emitMetric(ctx, "document/read_count", float64(len(page.Items)), map[string]string{"collection_id": input.Table})
+	m.emitMetric(ctx, "document/read_count", float64(len(result.Items)), map[string]string{"collection_id": input.Table})
 
-	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
+	return result, nil
 }
 
 func resolveKeyFields(cd *collectionData, indexName string) (pkField, skField string, err error) {
@@ -371,15 +371,16 @@ func (m *Mock) Scan(ctx context.Context, input driver.ScanInput) (*driver.QueryR
 		limit = 100
 	}
 
-	driver.SortByFields(matched, cd.config.PartitionKey, cd.config.SortKey)
-	page, err := pagination.Paginate(matched, input.PageToken, limit)
+	result, err := driver.PageOrdered(cd.config, matched, limit, input.PageToken,
+		input.ExclusiveStartKey, false,
+		func(it map[string]any) string { return docKey(cd.config, it) })
 	if err != nil {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+		return nil, err
 	}
 
-	m.emitMetric(ctx, "document/read_count", float64(len(page.Items)), map[string]string{"collection_id": input.Table})
+	m.emitMetric(ctx, "document/read_count", float64(len(result.Items)), map[string]string{"collection_id": input.Table})
 
-	return &driver.QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}, nil
+	return result, nil
 }
 
 func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string]any) error {

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -298,7 +298,10 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 		maxKeys = gcsDefaultMaxKeys
 	}
 
-	page, _ := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
 
 	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})
 

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -232,36 +232,28 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	filters := parseFilterExpression(req.FilterExpression, vals, req.ExpressionAttributeNames)
 
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
-		Table:   req.TableName,
-		Filters: filters,
-		Limit:   fetchAll,
+		Table:             req.TableName,
+		Filters:           filters,
+		Limit:             req.Limit,
+		ExclusiveStartKey: fromWireItem(req.ExclusiveStartKey),
 	})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	page, lastKey, err := h.paginateWire(
-		r.Context(), req.TableName, result.Items,
-		fromWireItem(req.ExclusiveStartKey), req.Limit,
-	)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	items := make([]map[string]any, 0, len(page))
-	for _, item := range page {
+	items := make([]map[string]any, 0, len(result.Items))
+	for _, item := range result.Items {
 		items = append(items, toWireItem(item))
 	}
 
 	resp := map[string]any{
 		"Items":        items,
 		"Count":        len(items),
-		"ScannedCount": result.Count,
+		"ScannedCount": len(items),
 	}
-	if lastKey != nil {
-		resp["LastEvaluatedKey"] = toWireItem(lastKey)
+	if result.LastEvaluatedKey != nil {
+		resp["LastEvaluatedKey"] = toWireItem(result.LastEvaluatedKey)
 	}
 
 	wire.WriteJSON(w, resp)

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -6,7 +6,6 @@ package dynamodb
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -360,73 +359,6 @@ func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{})
 }
 
-// fetchAll asks the driver for the entire result set so the handler can
-// implement DynamoDB-style key pagination over a stable ordering.
-const fetchAll = 1 << 30
-
-// paginateWire implements ExclusiveStartKey/LastEvaluatedKey semantics over
-// the driver's stably-ordered full result set. Returns the page and, when
-// more items remain, the key attributes of the last returned item.
-func (h *Handler) paginateWire(
-	ctx context.Context,
-	table string,
-	items []map[string]any,
-	startKey map[string]any,
-	limit int,
-) ([]map[string]any, map[string]any, error) {
-	cfg, err := h.db.DescribeTable(ctx, table)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Same composite scheme as the driver's itemKey so the two layers can
-	// never disagree about identity.
-	keyOf := func(it map[string]any) string {
-		k := fmt.Sprintf("%v", it[cfg.PartitionKey])
-		if cfg.SortKey != "" {
-			k += ":" + fmt.Sprintf("%v", it[cfg.SortKey])
-		}
-		return k
-	}
-
-	start := 0
-	if len(startKey) > 0 {
-		want := keyOf(startKey)
-		found := false
-		for i, it := range items {
-			if keyOf(it) == want {
-				start = i + 1
-				found = true
-				break
-			}
-		}
-		// A start key that matches nothing (deleted anchor item, foreign
-		// token) must not silently restart from page 1 — that re-serves
-		// items the client already consumed.
-		if !found {
-			return nil, nil, cerrors.Newf(cerrors.InvalidArgument,
-				"invalid ExclusiveStartKey")
-		}
-	}
-
-	end := len(items)
-	if limit > 0 && start+limit < end {
-		end = start + limit
-	}
-	page := items[start:end]
-
-	var lastKey map[string]any
-	if end < len(items) && len(page) > 0 {
-		last := page[len(page)-1]
-		lastKey = map[string]any{cfg.PartitionKey: last[cfg.PartitionKey]}
-		if cfg.SortKey != "" {
-			lastKey[cfg.SortKey] = last[cfg.SortKey]
-		}
-	}
-
-	return page, lastKey, nil
-}
-
 func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TableName                 string            `json:"TableName"`
@@ -452,36 +384,20 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result, err := h.db.Query(r.Context(), dbdriver.QueryInput{
-		Table:        req.TableName,
-		IndexName:    req.IndexName,
-		KeyCondition: kc,
-		Limit:        fetchAll,
-		ScanForward:  forward,
+		Table:             req.TableName,
+		IndexName:         req.IndexName,
+		KeyCondition:      kc,
+		Limit:             req.Limit,
+		SortDescending:    !forward,
+		ExclusiveStartKey: fromWireItem(req.ExclusiveStartKey),
 	})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	// The driver returns a stable ascending order; apply ScanIndexForward
-	// here so descending queries page in the right direction too.
-	if !forward {
-		for i, j := 0, len(result.Items)-1; i < j; i, j = i+1, j-1 {
-			result.Items[i], result.Items[j] = result.Items[j], result.Items[i]
-		}
-	}
-
-	page, lastKey, err := h.paginateWire(
-		r.Context(), req.TableName, result.Items,
-		fromWireItem(req.ExclusiveStartKey), req.Limit,
-	)
-	if err != nil {
-		writeErr(w, err)
-		return
-	}
-
-	items := make([]map[string]any, 0, len(page))
-	for _, item := range page {
+	items := make([]map[string]any, 0, len(result.Items))
+	for _, item := range result.Items {
 		items = append(items, toWireItem(item))
 	}
 
@@ -489,8 +405,8 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 		"Items": items,
 		"Count": len(items),
 	}
-	if lastKey != nil {
-		resp["LastEvaluatedKey"] = toWireItem(lastKey)
+	if result.LastEvaluatedKey != nil {
+		resp["LastEvaluatedKey"] = toWireItem(result.LastEvaluatedKey)
 	}
 
 	wire.WriteJSON(w, resp)

--- a/server/azure/cosmos/handler.go
+++ b/server/azure/cosmos/handler.go
@@ -306,7 +306,20 @@ func (h *Handler) createDocument(w http.ResponseWriter, r *http.Request, _, coll
 }
 
 func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll string) {
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: coll})
+	// Same paging contract as the query path: x-ms-max-item-count is the
+	// page size, x-ms-continuation round-trips the driver page token.
+	limit := 100
+	if v := r.Header.Get("X-Ms-Max-Item-Count"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
+		Table:     coll,
+		Limit:     limit,
+		PageToken: r.Header.Get("X-Ms-Continuation"),
+	})
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -314,6 +327,10 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll str
 
 	for i := range result.Items {
 		addSystemProps(result.Items[i])
+	}
+
+	if result.NextPageToken != "" {
+		w.Header().Set("X-Ms-Continuation", result.NextPageToken)
 	}
 
 	writeJSON(w, http.StatusOK, documentsList{

--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -511,10 +511,9 @@ func TestDatabaseConditionalWrites(t *testing.T) {
 	}
 }
 
-// TestDatabaseUpdateReplaceSemantics documents the emulator's
-// survey-listed divergence: field-masked Update (and PATCH) fully REPLACE
-// the stored document instead of merging, so unmentioned fields are lost.
-func TestDatabaseUpdateReplaceSemantics(t *testing.T) {
+// TestDatabaseUpdateMergeSemantics asserts field-masked Update merges
+// like real Firestore: masked paths are written, everything else kept.
+func TestDatabaseUpdateMergeSemantics(t *testing.T) {
 	ctx, client, _ := newDBClient(t, "merge")
 
 	doc := client.Collection("merge").Doc("m1")
@@ -539,11 +538,9 @@ func TestDatabaseUpdateReplaceSemantics(t *testing.T) {
 	}
 
 	// DIVERGENCE (survey: "PATCH and :commit Set fully REPLACE the document,
-	// no field-mask merge semantics"): real Firestore would preserve "keep";
-	// the emulator drops it. Assert the documented emulator behavior.
-	if v, present := got["keep"]; present {
-		t.Logf("NOTE: 'keep'=%v survived Update — emulator gained merge semantics? Survey says full replace.", v)
-		t.Errorf("expected survey-documented full-replace behavior (keep dropped), but keep=%v is present", v)
+	// Real Firestore merge semantics: unmasked fields survive the update.
+	if got["keep"] != "original" {
+		t.Errorf("keep=%v want original (masked update must preserve unmentioned fields)", got["keep"])
 	}
 }
 

--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -547,10 +547,9 @@ func TestDatabaseUpdateReplaceSemantics(t *testing.T) {
 	}
 }
 
-// TestDatabaseQueryFiltersIgnored documents the survey-listed
-// behavior that documents:runQuery only honors from.collectionId — where
-// clauses are ignored and every document comes back (full scan).
-func TestDatabaseQueryFiltersIgnored(t *testing.T) {
+// TestDatabaseQueryFilters asserts documents:runQuery honors
+// structuredQuery.where and limit like real Firestore.
+func TestDatabaseQueryFilters(t *testing.T) {
 	ctx, client, _ := newDBClient(t, "accts")
 
 	coll := client.Collection("accts")
@@ -561,13 +560,19 @@ func TestDatabaseQueryFiltersIgnored(t *testing.T) {
 		}
 	}
 
-	// Real Firestore would return 1 doc (age > 25); the emulator's runQuery
-	// ignores structuredQuery.where entirely → full scan of 3 docs.
-	it := coll.Where("age", ">", 25).Documents(ctx)
+	got := dbCollectAll(t, coll.Where("age", ">", 25).Documents(ctx))
+	if len(got) != 1 {
+		t.Errorf("age>25 returned %d docs (%v), want 1", len(got), keysOfDB(got))
+	}
 
-	got := dbCollectAll(t, it)
-	if len(got) != 3 {
-		t.Errorf("filtered query returned %d docs (%v); survey documents filters-ignored full scan of 3", len(got), keysOfDB(got))
+	got = dbCollectAll(t, coll.Where("age", ">=", 20).Where("age", "<", 30).Documents(ctx))
+	if len(got) != 1 {
+		t.Errorf("20<=age<30 returned %d docs (%v), want 1", len(got), keysOfDB(got))
+	}
+
+	got = dbCollectAll(t, coll.Limit(2).Documents(ctx))
+	if len(got) != 2 {
+		t.Errorf("limit 2 returned %d docs, want 2", len(got))
 	}
 }
 

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -282,12 +282,136 @@ func (h *Handler) batchGet(w http.ResponseWriter, r *http.Request, _ string) {
 }
 
 // runQuery handles POST .../documents:runQuery — for collection scans.
+// allResults asks the driver for the entire matched set (runQuery streams
+// rather than pages; the driver's zero-limit default is 100).
+const allResults = 1 << 30
+
 type runQueryRequest struct {
 	StructuredQuery struct {
 		From []struct {
 			CollectionID string `json:"collectionId"`
 		} `json:"from"`
+		Where *queryFilter `json:"where"`
+		Limit int          `json:"limit"`
 	} `json:"structuredQuery"`
+}
+
+// queryFilter mirrors StructuredQuery.Filter: either a single fieldFilter
+// or a compositeFilter AND of nested filters.
+type queryFilter struct {
+	FieldFilter *struct {
+		Field struct {
+			FieldPath string `json:"fieldPath"`
+		} `json:"field"`
+		Op    fieldOp `json:"op"`
+		Value value   `json:"value"`
+	} `json:"fieldFilter"`
+	CompositeFilter *struct {
+		Op      compositeOp   `json:"op"`
+		Filters []queryFilter `json:"filters"`
+	} `json:"compositeFilter"`
+}
+
+// fieldOp decodes a FieldFilter operator sent either as its enum name
+// ("EQUAL") or its protobuf number (5), as the REST client does.
+type fieldOp string
+
+var fieldOpNames = map[int]fieldOp{
+	1: "LESS_THAN",
+	2: "LESS_THAN_OR_EQUAL",
+	3: "GREATER_THAN",
+	4: "GREATER_THAN_OR_EQUAL",
+	5: "EQUAL",
+	6: "NOT_EQUAL",
+}
+
+func (o *fieldOp) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*o = fieldOp(v)
+		return nil
+	}
+
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*o = fieldOpNames[n] // unknown numbers stay "" and fail downstream
+	return nil
+}
+
+// compositeOp decodes a CompositeFilter operator name or number (AND=1).
+type compositeOp string
+
+func (o *compositeOp) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*o = compositeOp(v)
+		return nil
+	}
+
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	if n == 1 {
+		*o = "AND"
+	}
+	return nil
+}
+
+// firestoreOps maps StructuredQuery operators onto driver scan filter ops.
+var firestoreOps = map[string]string{
+	"EQUAL":                 "=",
+	"NOT_EQUAL":             "!=",
+	"LESS_THAN":             "<",
+	"LESS_THAN_OR_EQUAL":    "<=",
+	"GREATER_THAN":          ">",
+	"GREATER_THAN_OR_EQUAL": ">=",
+}
+
+// filtersFromQuery flattens a where clause into driver scan filters.
+// Only AND composites are supported; anything else is an error so queries
+// are never silently answered with the wrong result set.
+func filtersFromQuery(f *queryFilter) ([]dbdriver.ScanFilter, error) {
+	if f == nil {
+		return nil, nil
+	}
+
+	if f.FieldFilter != nil {
+		op, ok := firestoreOps[string(f.FieldFilter.Op)]
+		if !ok {
+			return nil, fmt.Errorf("unsupported filter op %q", f.FieldFilter.Op)
+		}
+		return []dbdriver.ScanFilter{{
+			Field: f.FieldFilter.Field.FieldPath,
+			Op:    op,
+			Value: firestoreValueToGo(f.FieldFilter.Value),
+		}}, nil
+	}
+
+	if f.CompositeFilter != nil {
+		if f.CompositeFilter.Op != "AND" {
+			return nil, fmt.Errorf("unsupported composite op %q", f.CompositeFilter.Op)
+		}
+		var out []dbdriver.ScanFilter
+		for i := range f.CompositeFilter.Filters {
+			sub, err := filtersFromQuery(&f.CompositeFilter.Filters[i])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, sub...)
+		}
+		return out, nil
+	}
+
+	return nil, nil
 }
 
 type runQueryResponseEntry struct {
@@ -313,7 +437,24 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 	p, _ := parseFirestorePath(base)
 	p.collection = collection
 
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: collection})
+	filters, ferr := filtersFromQuery(req.StructuredQuery.Where)
+	if ferr != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", ferr.Error())
+		return
+	}
+
+	// runQuery is not paged: honor an explicit limit, otherwise stream the
+	// full result set (the driver treats limit<=0 as a 100-item default).
+	limit := req.StructuredQuery.Limit
+	if limit <= 0 {
+		limit = allResults
+	}
+
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
+		Table:   collection,
+		Filters: filters,
+		Limit:   limit,
+	})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -155,6 +155,9 @@ type writeOp struct {
 	Update          *document     `json:"update,omitempty"`
 	Delete          string        `json:"delete,omitempty"`
 	CurrentDocument *precondition `json:"currentDocument,omitempty"`
+	UpdateMask      *struct {
+		FieldPaths []string `json:"fieldPaths"`
+	} `json:"updateMask,omitempty"`
 }
 
 // precondition mirrors google.firestore.v1.Precondition (exists only).
@@ -194,6 +197,29 @@ func (h *Handler) commit(w http.ResponseWriter, r *http.Request, _ string) {
 
 			item := fieldsToMap(op.Update.Fields)
 			item["id"] = id
+
+			// updateMask selects merge semantics: masked paths written (or
+			// deleted when absent from the body), all other fields kept.
+			if op.UpdateMask != nil && len(op.UpdateMask.FieldPaths) > 0 {
+				existing, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{"id": id})
+				if gerr != nil && !cerrors.IsNotFound(gerr) {
+					writeErr(w, gerr)
+					return
+				}
+
+				merged := map[string]any{"id": id}
+				for k, v := range existing {
+					merged[k] = v
+				}
+				for _, path := range op.UpdateMask.FieldPaths {
+					if v, ok := item[path]; ok {
+						merged[path] = v
+					} else {
+						delete(merged, path)
+					}
+				}
+				item = merged
+			}
 
 			if op.CurrentDocument != nil && op.CurrentDocument.Exists != nil {
 				_, gerr := h.db.GetItem(r.Context(), p.collection, map[string]any{"id": id})
@@ -621,6 +647,31 @@ func (h *Handler) updateDocument(w http.ResponseWriter, r *http.Request, p fires
 
 	item := fieldsToMap(inDoc.Fields)
 	item["id"] = p.documentID
+
+	// With an updateMask, real Firestore merges: only the masked field
+	// paths are written; every other stored field is preserved. A masked
+	// path absent from the body is a field delete. Without a mask, the
+	// document is replaced wholesale.
+	if mask := r.URL.Query()["updateMask.fieldPaths"]; len(mask) > 0 {
+		existing, err := h.db.GetItem(r.Context(), p.collection, map[string]any{"id": p.documentID})
+		if err != nil && !cerrors.IsNotFound(err) {
+			writeErr(w, err)
+			return
+		}
+
+		merged := map[string]any{"id": p.documentID}
+		for k, v := range existing {
+			merged[k] = v
+		}
+		for _, path := range mask {
+			if v, ok := item[path]; ok {
+				merged[path] = v
+			} else {
+				delete(merged, path)
+			}
+		}
+		item = merged
+	}
 
 	if err := h.db.PutItem(r.Context(), p.collection, item); err != nil {
 		writeErr(w, err)

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -3,7 +3,9 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -156,23 +158,98 @@ type Database interface {
 	ListTagsOfResource(ctx context.Context, table string) (map[string]string, error)
 }
 
-// SortStableByKey orders items by a caller-derived key so offset-based page
-// tokens from internal/pagination stay valid across calls (map iteration
-// order is random). Keys are computed once per item, not per comparison.
-func SortStableByKey(items []map[string]any, key func(map[string]any) string) {
-	type keyed struct {
-		k    string
-		item map[string]any
+// CompareValues orders two attribute values the way the real services do:
+// numbers numerically, strings lexically, bools false<true. Mixed types
+// order by a fixed type rank so the ordering stays total and deterministic
+// (numbers < strings < bools < everything else).
+func CompareValues(a, b any) int {
+	an, aIsNum := toFloat(a)
+	bn, bIsNum := toFloat(b)
+
+	switch {
+	case aIsNum && bIsNum:
+		switch {
+		case an < bn:
+			return -1
+		case an > bn:
+			return 1
+		}
+		return 0
+	case aIsNum:
+		return -1
+	case bIsNum:
+		return 1
 	}
 
-	decorated := make([]keyed, len(items))
-	for i, it := range items {
-		decorated[i] = keyed{k: key(it), item: it}
+	as, aIsStr := a.(string)
+	bs, bIsStr := b.(string)
+
+	switch {
+	case aIsStr && bIsStr:
+		return strings.Compare(as, bs)
+	case aIsStr:
+		return -1
+	case bIsStr:
+		return 1
 	}
 
-	sort.Slice(decorated, func(i, j int) bool { return decorated[i].k < decorated[j].k })
+	ab, aIsBool := a.(bool)
+	bb, bIsBool := b.(bool)
 
-	for i := range decorated {
-		items[i] = decorated[i].item
+	switch {
+	case aIsBool && bIsBool:
+		switch {
+		case !ab && bb:
+			return -1
+		case ab && !bb:
+			return 1
+		}
+		return 0
+	case aIsBool:
+		return -1
+	case bIsBool:
+		return 1
 	}
+
+	return strings.Compare(fmt.Sprintf("%v", a), fmt.Sprintf("%v", b))
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+// SortByFields stably orders items by the given attribute fields in order
+// (typically partition key, then sort key), comparing values type-aware via
+// CompareValues. A stable, deterministic ordering is what keeps offset-based
+// page tokens from internal/pagination valid across calls.
+func SortByFields(items []map[string]any, fields ...string) {
+	sort.SliceStable(items, func(i, j int) bool {
+		for _, f := range fields {
+			if f == "" {
+				continue
+			}
+			if c := CompareValues(items[i][f], items[j][f]); c != 0 {
+				return c < 0
+			}
+		}
+		return false
+	})
 }

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -334,16 +334,20 @@ func KeyAttributes(item map[string]any, fields ...string) map[string]any {
 // descending queries, then slices one page — key-based continuation when
 // startKey is set, offset tokens otherwise. LastEvaluatedKey is populated
 // whenever more items remain, on both paths.
+// orderPK/orderSK are the fields to order by (the index keys for GSI
+// queries); keyFields is the LastEvaluatedKey shape (base table keys, plus
+// the index keys for GSI queries, matching real DynamoDB).
 func PageOrdered(
-	cfg TableConfig,
 	matched []map[string]any,
+	orderPK, orderSK string,
+	keyFields []string,
 	limit int,
 	pageToken string,
 	startKey map[string]any,
 	descending bool,
 	identity func(map[string]any) string,
 ) (*QueryResult, error) {
-	SortByFields(matched, cfg.PartitionKey, cfg.SortKey)
+	SortByFields(matched, orderPK, orderSK)
 
 	if descending {
 		for i, j := 0, len(matched)-1; i < j; i, j = i+1, j-1 {
@@ -359,7 +363,7 @@ func PageOrdered(
 
 		res := &QueryResult{Items: items, Count: len(items)}
 		if more && len(items) > 0 {
-			res.LastEvaluatedKey = KeyAttributes(items[len(items)-1], cfg.PartitionKey, cfg.SortKey)
+			res.LastEvaluatedKey = KeyAttributes(items[len(items)-1], keyFields...)
 		}
 		return res, nil
 	}
@@ -371,7 +375,7 @@ func PageOrdered(
 
 	res := &QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}
 	if page.HasMore && len(page.Items) > 0 {
-		res.LastEvaluatedKey = KeyAttributes(page.Items[len(page.Items)-1], cfg.PartitionKey, cfg.SortKey)
+		res.LastEvaluatedKey = KeyAttributes(page.Items[len(page.Items)-1], keyFields...)
 	}
 	return res, nil
 }

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -7,6 +7,9 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/pagination"
 )
 
 // TTLConfig configures TTL for a table.
@@ -92,7 +95,19 @@ type QueryInput struct {
 	KeyCondition KeyCondition
 	Limit        int
 	PageToken    string
-	ScanForward  bool
+
+	// ExclusiveStartKey selects key-based continuation (DynamoDB-style):
+	// the page starts after the item with these key attributes. Mutually
+	// exclusive with PageToken.
+	ExclusiveStartKey map[string]any
+
+	// SortDescending reverses the stable key ordering before paging.
+	// The zero value (ascending) matches the historical behavior.
+	SortDescending bool
+
+	// Deprecated: never implemented; use SortDescending. Retained so
+	// existing constructors keep compiling.
+	ScanForward bool
 }
 
 // ScanInput configures a scan operation.
@@ -101,6 +116,9 @@ type ScanInput struct {
 	Filters   []ScanFilter
 	Limit     int
 	PageToken string
+
+	// ExclusiveStartKey selects key-based continuation; see QueryInput.
+	ExclusiveStartKey map[string]any
 }
 
 // QueryResult is the result of a query or scan.
@@ -108,6 +126,10 @@ type QueryResult struct {
 	Items         []map[string]any
 	Count         int
 	NextPageToken string
+
+	// LastEvaluatedKey holds the key attributes of the last returned item
+	// whenever more items remain, enabling DynamoDB-style continuation.
+	LastEvaluatedKey map[string]any
 }
 
 // IndexInfo describes a Global Secondary Index.
@@ -252,4 +274,104 @@ func SortByFields(items []map[string]any, fields ...string) {
 		}
 		return false
 	})
+}
+
+// PageByKey slices one page out of a stably-ordered result set using
+// key-based continuation: the page starts after the item whose identity
+// matches startKey. A startKey that matches no item is an error — silently
+// restarting from the beginning would re-serve consumed items.
+func PageByKey(
+	items []map[string]any,
+	startKey map[string]any,
+	limit int,
+	identity func(map[string]any) string,
+) (page []map[string]any, more bool, err error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	start := 0
+	if len(startKey) > 0 {
+		want := identity(startKey)
+		found := false
+		for i, it := range items {
+			if identity(it) == want {
+				start = i + 1
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, false, fmt.Errorf("start key matches no item")
+		}
+	}
+
+	end := start + limit
+	if end > len(items) {
+		end = len(items)
+	}
+
+	return items[start:end], end < len(items), nil
+}
+
+// KeyAttributes extracts the named fields from an item — the shape handed
+// back as LastEvaluatedKey. Empty field names are skipped.
+func KeyAttributes(item map[string]any, fields ...string) map[string]any {
+	out := make(map[string]any, len(fields))
+	for _, f := range fields {
+		if f == "" {
+			continue
+		}
+		if v, ok := item[f]; ok {
+			out[f] = v
+		}
+	}
+	return out
+}
+
+// PageOrdered is the one paging path for query/scan results: it stably
+// orders matched items by the table keys, optionally reverses for
+// descending queries, then slices one page — key-based continuation when
+// startKey is set, offset tokens otherwise. LastEvaluatedKey is populated
+// whenever more items remain, on both paths.
+func PageOrdered(
+	cfg TableConfig,
+	matched []map[string]any,
+	limit int,
+	pageToken string,
+	startKey map[string]any,
+	descending bool,
+	identity func(map[string]any) string,
+) (*QueryResult, error) {
+	SortByFields(matched, cfg.PartitionKey, cfg.SortKey)
+
+	if descending {
+		for i, j := 0, len(matched)-1; i < j; i, j = i+1, j-1 {
+			matched[i], matched[j] = matched[j], matched[i]
+		}
+	}
+
+	if len(startKey) > 0 {
+		items, more, err := PageByKey(matched, startKey, limit, identity)
+		if err != nil {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid ExclusiveStartKey")
+		}
+
+		res := &QueryResult{Items: items, Count: len(items)}
+		if more && len(items) > 0 {
+			res.LastEvaluatedKey = KeyAttributes(items[len(items)-1], cfg.PartitionKey, cfg.SortKey)
+		}
+		return res, nil
+	}
+
+	page, err := pagination.Paginate(matched, pageToken, limit)
+	if err != nil {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	res := &QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}
+	if page.HasMore && len(page.Items) > 0 {
+		res.LastEvaluatedKey = KeyAttributes(page.Items[len(page.Items)-1], cfg.PartitionKey, cfg.SortKey)
+	}
+	return res, nil
 }


### PR DESCRIPTION
Closes #271. One commit per item, each tested locally (full suite `go test ./... -count=1` = 0 failures, `go vet` clean after every commit).

1. **Type-aware ordering** (`fix(driver)`): `driver.CompareValues` + `SortByFields` — numeric sort keys now order numerically (`9 < 10`), fixing the lexicographic `"10" < "9"` divergence.
2. **Key-based continuation in the driver** (`fix(dynamodb)`): `ExclusiveStartKey`/`SortDescending` on inputs, `LastEvaluatedKey` on results, one shared `driver.PageOrdered` paging path. The DynamoDB wire handler passes `Limit` and the start key straight through — the `fetchAll` full-table materialization and `paginateWire` are gone, so per-page cost is O(page) and `ConsumedReadCapacityUnits`/`ScannedCount` reflect the returned page. Unknown start keys are still `ValidationException`.
3. **GSI queries** (`fix(driver)`): ordering uses the index keys, and `LastEvaluatedKey` carries index + base keys, matching real DynamoDB.
4. **Firestore `runQuery`** honors `structuredQuery.where` (fieldFilter + AND composites, enum names or protobuf numbers as the REST client sends) and `limit`; unsupported shapes return `INVALID_ARGUMENT` instead of a silently-wrong full scan. The 100-doc cap is gone.
5. **Firestore `updateMask`** merges on both write paths (`:commit` write ops — what the Go client's `Update` uses — and PATCH query params): masked paths written or deleted-when-absent, unmentioned fields preserved.
6. **Cosmos GET document list** pages via `x-ms-max-item-count`/`x-ms-continuation` like the query path, instead of silently truncating at 100.
7. **Central invariant** (`fix(pagination)`): `Paginate` documents its stable-ordering contract, `PaginateSorted` enforces it (with a shuffled-input regression test), and the three storage drivers stop swallowing page-token decode errors (malformed token → `InvalidArgument`, not an empty 200 page).

Lifecycle tests that had pinned the old divergences (filters-ignored, full-replace update) were flipped to assert real-cloud semantics.