### PR TITLE
Deep audit: real-cloud error semantics, fake-clock fidelity, and boundary isolation

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -151,6 +152,7 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 
 	key := itemKey(td.config, item)
 	oldItem, hadOld := td.items.Get(key)
+	item = maps.Clone(item)
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
 	m.mu.Unlock()
@@ -187,7 +189,7 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 	m.emitMetric("ConsumedReadCapacityUnits", 1, dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
-	return item, nil
+	return maps.Clone(item), nil
 }
 
 // UpdateItem applies partial updates to an existing item.
@@ -407,6 +409,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	for _, item := range items {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 
 		m.recordStreamEvent(td, oldItem, item, hadOld)
@@ -430,7 +433,7 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 
 	for _, key := range keys {
 		if item, ok := td.items.Get(itemKey(td.config, key)); ok {
-			results = append(results, item)
+			results = append(results, maps.Clone(item))
 		}
 	}
 
@@ -643,6 +646,7 @@ func (m *Mock) applyTransactPuts(td *tableData, puts []map[string]any) {
 	for _, item := range puts {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -233,7 +233,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
-	return updated, nil
+	return maps.Clone(updated), nil
 }
 
 func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) error {

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -36,7 +36,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Description:     cfg.Description,
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})

--- a/providers/aws/lambda/clock_test.go
+++ b/providers/aws/lambda/clock_test.go
@@ -1,0 +1,29 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestTimestampsUseConfiguredClock locks LastModified to the configured
+// clock: with a fake clock pinned to 2025-01-01, function timestamps must
+// not leak wall-clock time.
+func TestTimestampsUseConfiguredClock(t *testing.T) {
+	m := newTestMock()
+
+	fn, err := m.CreateFunction(context.Background(), defaultFuncConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := time.Parse(time.RFC3339, fn.LastModified)
+	if err != nil {
+		t.Fatalf("LastModified %q not RFC3339: %v", fn.LastModified, err)
+	}
+
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("LastModified = %v, want fake-clock time %v (wall clock leaked)", got, want)
+	}
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -103,7 +103,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
 		Environment: cfg.Environment, Tags: cfg.Tags,
-		LastModified: time.Now().UTC().Format(time.RFC3339),
+		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	m.handlersMu.RLock()
@@ -162,7 +162,7 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	fd.info = info
 	m.funcs.Set(name, fd)
 

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -102,7 +103,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
-		Environment: cfg.Environment, Tags: cfg.Tags,
+		Environment: maps.Clone(cfg.Environment), Tags: maps.Clone(cfg.Tags),
 		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
@@ -138,6 +139,8 @@ func (m *Mock) GetFunction(_ context.Context, name string) (*driver.FunctionInfo
 	}
 
 	info := fd.info
+	info.Environment = maps.Clone(info.Environment)
+	info.Tags = maps.Clone(info.Tags)
 
 	return &info, nil
 }
@@ -240,11 +243,11 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 
 	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
+		info.Environment = maps.Clone(cfg.Environment)
 	}
 
 	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
+		info.Tags = maps.Clone(cfg.Tags)
 	}
 }
 

--- a/providers/aws/lambda/layers.go
+++ b/providers/aws/lambda/layers.go
@@ -44,7 +44,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 		ContentSHA256:      shaStr,
 		ContentSize:        int64(len(cfg.Content)),
 		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		ARN:                arn,
 	}
 

--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -27,7 +27,7 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 
 	verStr := strconv.Itoa(verNum)
 	sha := codeSHA(&fd.info)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
 		config:    snapshotConfig(&fd.info),

--- a/providers/aws/s3/isolation_test.go
+++ b/providers/aws/s3/isolation_test.go
@@ -1,0 +1,45 @@
+package s3
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMetadataIsolation locks the boundary-copy behavior: mutating the
+// metadata map a caller passed to PutObject, or the map returned from
+// HeadObject, must not change what the store holds.
+func TestMetadataIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "iso"); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]string{"owner": "team-a"}
+	if err := m.PutObject(ctx, "iso", "k", []byte("v"), "text/plain", meta); err != nil {
+		t.Fatal(err)
+	}
+
+	// Caller mutates their map after the put.
+	meta["owner"] = "attacker"
+	meta["extra"] = "leaked"
+
+	info, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Metadata["owner"] != "team-a" || len(info.Metadata) != 1 {
+		t.Fatalf("stored metadata corrupted by caller mutation: %v", info.Metadata)
+	}
+
+	// Caller mutates the returned map; the store must be unaffected.
+	info.Metadata["owner"] = "mutated"
+	again, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Metadata["owner"] != "team-a" {
+		t.Fatalf("stored metadata corrupted via returned map: %v", again.Metadata)
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -273,7 +273,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
 		})
 	}
 
@@ -292,6 +292,12 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	// Clone metadata only for the page actually returned — cloning every
+	// match would make a paged scan O(bucket) allocations per request.
+	for i := range page.Items {
+		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
 	}
 
 	dims := map[string]string{"BucketName": bucket}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -162,7 +163,7 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
 		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
-		Metadata:     metadata,
+		Metadata:     maps.Clone(metadata),
 	})
 
 	dims := map[string]string{"BucketName": bucket}
@@ -195,7 +196,7 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		},
 		Data: dataCopy,
 	}, nil
@@ -233,7 +234,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 	}, nil
 }
 
@@ -272,7 +273,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		})
 	}
 

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -287,7 +287,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
 		})
 	}
 
@@ -306,6 +306,12 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	// Clone metadata only for the page actually returned — cloning every
+	// match would make a paged scan O(bucket) allocations per request.
+	for i := range page.Items {
+		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
 	}
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1})

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -180,7 +181,7 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
 		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
-		Metadata:     metadata,
+		Metadata:     maps.Clone(metadata),
 	})
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
@@ -208,7 +209,7 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		},
 		Data: dataCopy,
 	}, nil
@@ -246,7 +247,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 	}, nil
 }
 
@@ -286,7 +287,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		})
 	}
 

--- a/providers/azure/blobstorage/isolation_test.go
+++ b/providers/azure/blobstorage/isolation_test.go
@@ -1,0 +1,43 @@
+package blobstorage
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMetadataIsolation locks the boundary-copy behavior: mutating the
+// metadata map a caller passed to PutObject, or the map returned from
+// HeadObject, must not change what the store holds.
+func TestMetadataIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "iso"); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]string{"owner": "team-a"}
+	if err := m.PutObject(ctx, "iso", "k", []byte("v"), "text/plain", meta); err != nil {
+		t.Fatal(err)
+	}
+
+	meta["owner"] = "attacker"
+	meta["extra"] = "leaked"
+
+	info, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Metadata["owner"] != "team-a" || len(info.Metadata) != 1 {
+		t.Fatalf("stored metadata corrupted by caller mutation: %v", info.Metadata)
+	}
+
+	info.Metadata["owner"] = "mutated"
+	again, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Metadata["owner"] != "team-a" {
+		t.Fatalf("stored metadata corrupted via returned map: %v", again.Metadata)
+	}
+}

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -247,7 +247,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 
 	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
-	return updated, nil
+	return maps.Clone(updated), nil
 }
 
 // DeleteItem deletes an item from a container by key.

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -4,6 +4,7 @@ package cosmosdb
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -170,6 +171,7 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 
 	key := itemKey(td.config, item)
 	oldItem, hadOld := td.items.Get(key)
+	item = maps.Clone(item)
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
 	m.mu.Unlock()
@@ -203,7 +205,7 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 
 	m.emitMetric(table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
-	return item, nil
+	return maps.Clone(item), nil
 }
 
 // UpdateItem applies partial updates to an existing document in a container.
@@ -388,6 +390,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	for _, item := range items {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}
@@ -411,7 +414,7 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 
 	for _, key := range keys {
 		if item, ok := td.items.Get(itemKey(td.config, key)); ok {
-			results = append(results, item)
+			results = append(results, maps.Clone(item))
 		}
 	}
 
@@ -656,6 +659,7 @@ func (m *Mock) applyTransactPuts(td *tableData, puts []map[string]any) {
 	for _, item := range puts {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}

--- a/providers/azure/functions/aliases.go
+++ b/providers/azure/functions/aliases.go
@@ -36,7 +36,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Description:     cfg.Description,
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})

--- a/providers/azure/functions/clock_test.go
+++ b/providers/azure/functions/clock_test.go
@@ -1,0 +1,31 @@
+package functions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestTimestampsUseConfiguredClock locks LastModified to the configured
+// clock: with a fake clock pinned to 2025-01-01, function timestamps must
+// not leak wall-clock time.
+func TestTimestampsUseConfiguredClock(t *testing.T) {
+	m := newTestMock()
+
+	fn, err := m.CreateFunction(context.Background(), driver.FunctionConfig{Name: "clock-fn", Runtime: "r1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := time.Parse(time.RFC3339, fn.LastModified)
+	if err != nil {
+		t.Fatalf("LastModified %q not RFC3339: %v", fn.LastModified, err)
+	}
+
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("LastModified = %v, want fake-clock time %v (wall clock leaked)", got, want)
+	}
+}

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -117,7 +117,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 		Name: cfg.Name, ARN: resourceID, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
 		Environment: cfg.Environment, Tags: cfg.Tags,
-		LastModified: time.Now().UTC().Format(time.RFC3339),
+		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	m.handlersMu.RLock()
@@ -181,7 +181,7 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	fd.info = info
 	m.funcs.Set(name, fd)
 

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -116,7 +117,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: resourceID, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
-		Environment: cfg.Environment, Tags: cfg.Tags,
+		Environment: maps.Clone(cfg.Environment), Tags: maps.Clone(cfg.Tags),
 		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
@@ -154,6 +155,8 @@ func (m *Mock) GetFunction(_ context.Context, name string) (*driver.FunctionInfo
 	}
 
 	info := fd.info
+	info.Environment = maps.Clone(info.Environment)
+	info.Tags = maps.Clone(info.Tags)
 
 	return &info, nil
 }
@@ -257,11 +260,11 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 
 	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
+		info.Environment = maps.Clone(cfg.Environment)
 	}
 
 	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
+		info.Tags = maps.Clone(cfg.Tags)
 	}
 }
 

--- a/providers/azure/functions/layers.go
+++ b/providers/azure/functions/layers.go
@@ -44,7 +44,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 		ContentSHA256:      shaStr,
 		ContentSize:        int64(len(cfg.Content)),
 		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		ARN:                arn,
 	}
 

--- a/providers/azure/functions/versions.go
+++ b/providers/azure/functions/versions.go
@@ -27,7 +27,7 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 
 	verStr := strconv.Itoa(verNum)
 	sha := codeSHA(&fd.info)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
 		config:    snapshotConfig(&fd.info),

--- a/providers/gcp/cloudfunctions/aliases.go
+++ b/providers/gcp/cloudfunctions/aliases.go
@@ -36,7 +36,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Description:     cfg.Description,
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})

--- a/providers/gcp/cloudfunctions/clock_test.go
+++ b/providers/gcp/cloudfunctions/clock_test.go
@@ -1,0 +1,31 @@
+package cloudfunctions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestTimestampsUseConfiguredClock locks LastModified to the configured
+// clock: with a fake clock pinned to 2025-01-01, function timestamps must
+// not leak wall-clock time.
+func TestTimestampsUseConfiguredClock(t *testing.T) {
+	m := newTestMock()
+
+	fn, err := m.CreateFunction(context.Background(), driver.FunctionConfig{Name: "clock-fn", Runtime: "r1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := time.Parse(time.RFC3339, fn.LastModified)
+	if err != nil {
+		t.Fatalf("LastModified %q not RFC3339: %v", fn.LastModified, err)
+	}
+
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("LastModified = %v, want fake-clock time %v (wall clock leaked)", got, want)
+	}
+}

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -157,6 +158,8 @@ func (m *Mock) GetFunction(_ context.Context, name string) (*driver.FunctionInfo
 	}
 
 	info := fd.info
+	info.Environment = maps.Clone(info.Environment)
+	info.Tags = maps.Clone(info.Tags)
 
 	return &info, nil
 }
@@ -256,11 +259,11 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 
 	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
+		info.Environment = maps.Clone(cfg.Environment)
 	}
 
 	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
+		info.Tags = maps.Clone(cfg.Tags)
 	}
 }
 

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -122,7 +122,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "ACTIVE",
 		Environment: env, Tags: tags,
-		LastModified: time.Now().UTC().Format(time.RFC3339),
+		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	m.handlersMu.RLock()
@@ -181,7 +181,7 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	fd.info = info
 	m.funcs.Set(name, fd)
 

--- a/providers/gcp/cloudfunctions/layers.go
+++ b/providers/gcp/cloudfunctions/layers.go
@@ -44,7 +44,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 		ContentSHA256:      shaStr,
 		ContentSize:        int64(len(cfg.Content)),
 		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		ARN:                arn,
 	}
 

--- a/providers/gcp/cloudfunctions/versions.go
+++ b/providers/gcp/cloudfunctions/versions.go
@@ -27,7 +27,7 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 
 	verStr := strconv.Itoa(verNum)
 	sha := codeSHA(&fd.info)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
 		config:    snapshotConfig(&fd.info),

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -4,6 +4,7 @@ package firestore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -159,6 +160,7 @@ func (m *Mock) PutItem(ctx context.Context, table string, item map[string]any) e
 
 	key := docKey(cd.config, item)
 	oldItem, hadOld := cd.items.Get(key)
+	item = maps.Clone(item)
 	cd.items.Set(key, item)
 	m.recordStreamEvent(cd, oldItem, item, hadOld)
 	m.mu.Unlock()
@@ -191,7 +193,7 @@ func (m *Mock) GetItem(ctx context.Context, table string, key map[string]any) (m
 
 	m.emitMetric(ctx, "document/read_count", 1, map[string]string{"collection_id": table})
 
-	return item, nil
+	return maps.Clone(item), nil
 }
 
 // UpdateItem applies partial updates to an existing document in a collection.
@@ -403,6 +405,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	for _, item := range items {
 		key := docKey(cd.config, item)
 		oldItem, hadOld := cd.items.Get(key)
+		item = maps.Clone(item)
 		cd.items.Set(key, item)
 		m.recordStreamEvent(cd, oldItem, item, hadOld)
 	}
@@ -425,7 +428,7 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 
 	for _, key := range keys {
 		if item, ok := cd.items.Get(docKey(cd.config, key)); ok {
-			results = append(results, item)
+			results = append(results, maps.Clone(item))
 		}
 	}
 
@@ -638,6 +641,7 @@ func (m *Mock) applyTransactPuts(cd *collectionData, puts []map[string]any) {
 	for _, item := range puts {
 		key := docKey(cd.config, item)
 		oldItem, hadOld := cd.items.Get(key)
+		item = maps.Clone(item)
 		cd.items.Set(key, item)
 		m.recordStreamEvent(cd, oldItem, item, hadOld)
 	}

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -235,7 +235,7 @@ func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (ma
 
 	m.emitMetric(ctx, "document/write_count", 1, map[string]string{"collection_id": input.Table})
 
-	return updated, nil
+	return maps.Clone(updated), nil
 }
 
 func (m *Mock) DeleteItem(ctx context.Context, table string, key map[string]any) error {

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -207,7 +208,7 @@ func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Objec
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		},
 		Data: dataCopy,
 	}, nil
@@ -243,7 +244,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 	}, nil
 }
 
@@ -282,7 +283,7 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		})
 	}
 

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -283,7 +283,7 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
 		})
 	}
 
@@ -302,6 +302,12 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	// Clone metadata only for the page actually returned — cloning every
+	// match would make a paged scan O(bucket) allocations per request.
+	for i := range page.Items {
+		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
 	}
 
 	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})

--- a/providers/gcp/gcs/isolation_test.go
+++ b/providers/gcp/gcs/isolation_test.go
@@ -1,0 +1,43 @@
+package gcs
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMetadataIsolation locks the boundary-copy behavior: mutating the
+// metadata map a caller passed to PutObject, or the map returned from
+// HeadObject, must not change what the store holds.
+func TestMetadataIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "iso"); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]string{"owner": "team-a"}
+	if err := m.PutObject(ctx, "iso", "k", []byte("v"), "text/plain", meta); err != nil {
+		t.Fatal(err)
+	}
+
+	meta["owner"] = "attacker"
+	meta["extra"] = "leaked"
+
+	info, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Metadata["owner"] != "team-a" || len(info.Metadata) != 1 {
+		t.Fatalf("stored metadata corrupted by caller mutation: %v", info.Metadata)
+	}
+
+	info.Metadata["owner"] = "mutated"
+	again, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Metadata["owner"] != "team-a" {
+		t.Fatalf("stored metadata corrupted via returned map: %v", again.Metadata)
+	}
+}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -4,8 +4,8 @@
 package s3
 
 import (
-	"crypto/sha256"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -264,10 +264,15 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 		return
 	}
 
-	// Real S3 always returns the object's ETag on PutObject. The driver
-	// computes the ETag as the hex SHA-256 of the data (see
-	// providers/aws/s3), so mirror that here.
-	w.Header().Set("ETag", fmt.Sprintf("%q", fmt.Sprintf("%x", sha256.Sum256(data))))
+	// Real S3 always returns the object's ETag on PutObject. Read it back
+	// from the driver so there is a single source of truth for the ETag
+	// algorithm.
+	info, err := h.bucket.HeadObject(r.Context(), bucket, key)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -306,7 +311,10 @@ func writeObjectHeaders(w http.ResponseWriter, info *driver.ObjectInfo, size int
 }
 
 func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	if err := h.bucket.DeleteObject(r.Context(), bucket, key); err != nil {
+	err := h.bucket.DeleteObject(r.Context(), bucket, key)
+	// Real S3 DeleteObject is idempotent: deleting a missing KEY succeeds
+	// with 204. A missing BUCKET is still NoSuchBucket.
+	if err != nil && (!cerrors.IsNotFound(err) || bucketMissing(err)) {
 		writeErr(w, err)
 		return
 	}
@@ -696,14 +704,30 @@ func writeMultipartErr(w http.ResponseWriter, err error) {
 	writeErr(w, err)
 }
 
+// bucketMissing reports whether a NotFound error names the bucket itself
+// (the driver formats bucket misses as `bucket ... not found`).
+func bucketMissing(err error) bool {
+	var ce *cerrors.Error
+	return errors.As(err, &ce) && strings.HasPrefix(ce.Message, "bucket ")
+}
+
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
+		// Real S3 distinguishes NoSuchBucket from NoSuchKey.
+		if bucketMissing(err) {
+			writeError(w, http.StatusNotFound, "NoSuchBucket", err.Error())
+			return
+		}
 		writeError(w, http.StatusNotFound, "NoSuchKey", err.Error())
 	case cerrors.IsAlreadyExists(err):
 		writeError(w, http.StatusConflict, "BucketAlreadyOwnedByYou", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidArgument", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		// Deleting a non-empty bucket is a client error in real S3, not a
+		// server fault — and a 5xx would trigger SDK retry backoff.
+		writeError(w, http.StatusConflict, "BucketNotEmpty", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
 	}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -4,6 +4,7 @@
 package s3
 
 import (
+	"crypto/sha256"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -266,13 +267,14 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 
 	// Real S3 always returns the object's ETag on PutObject. Read it back
 	// from the driver so there is a single source of truth for the ETag
-	// algorithm.
-	info, err := h.bucket.HeadObject(r.Context(), bucket, key)
-	if err != nil {
-		writeErr(w, err)
-		return
+	// algorithm; if a concurrent delete races the read-back, fall back to
+	// computing it from the body we just stored — a successful PUT must
+	// never answer 404.
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+	if info, err := h.bucket.HeadObject(r.Context(), bucket, key); err == nil {
+		etag = info.ETag
 	}
-	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -704,11 +706,20 @@ func writeMultipartErr(w http.ResponseWriter, err error) {
 	writeErr(w, err)
 }
 
-// bucketMissing reports whether a NotFound error names the bucket itself
-// (the driver formats bucket misses as `bucket ... not found`).
+// bucketMissing reports whether a NotFound error names a bucket rather
+// than an object. The driver formats object misses as `object ... not
+// found in bucket ...` and bucket misses as `[source |destination ]bucket
+// ... not found`, so exclude the object form first, then require the word
+// bucket — robust to the source/destination copy variants.
 func bucketMissing(err error) bool {
 	var ce *cerrors.Error
-	return errors.As(err, &ce) && strings.HasPrefix(ce.Message, "bucket ")
+	if !errors.As(err, &ce) {
+		return false
+	}
+	if strings.HasPrefix(ce.Message, "object ") {
+		return false
+	}
+	return strings.Contains(ce.Message, "bucket ")
 }
 
 func writeErr(w http.ResponseWriter, err error) {

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -385,13 +385,10 @@ func TestS3HeadMissingObjectTypedError(t *testing.T) {
 	assert.True(t, errors.As(err, &nf), "want *types.NotFound, got %T: %v", err, err)
 }
 
-// TestS3DeleteMissingObjectError documents the emulator's behavior
-// for deleting an absent key: it returns 404 NoSuchKey. NOTE: real S3
-// DeleteObject is idempotent and returns 204 for a missing key, so SDK code
-// that deletes defensively behaves differently against the emulator. The
-// survey documents "DeleteObject — NotFound if key absent" as intended driver
-// semantics, so this asserts the documented mapping.
-func TestS3DeleteMissingObjectError(t *testing.T) {
+// TestS3DeleteMissingObjectIdempotent asserts real-S3 semantics: deleting
+// an absent key succeeds (204) so defensive-delete SDK code just works,
+// while a missing BUCKET is still NoSuchBucket.
+func TestS3DeleteMissingObjectIdempotent(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
 
@@ -402,30 +399,34 @@ func TestS3DeleteMissingObjectError(t *testing.T) {
 		Bucket: aws.String(bucket),
 		Key:    aws.String("never-put"),
 	})
-	require.Error(t, err, "emulator returns NotFound for deleting an absent key")
+	require.NoError(t, err, "real S3 DeleteObject is idempotent for a missing key")
+
+	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String("ghost-bucket"),
+		Key:    aws.String("k"),
+	})
+	require.Error(t, err, "missing bucket must still fail")
 
 	var apiErr smithy.APIError
 	require.True(t, errors.As(err, &apiErr), "want smithy.APIError, got %T: %v", err, err)
-	assert.Equal(t, "NoSuchKey", apiErr.ErrorCode())
+	assert.Equal(t, "NoSuchBucket", apiErr.ErrorCode())
 }
 
 // TestS3MissingBucketError asserts GetObject against a bucket that
-// was never created fails with NoSuchKey. NOTE: real S3 would return
-// NoSuchBucket here; the emulator's writeErr maps every NotFound to NoSuchKey
-// (documented in the survey).
+// was never created fails with NoSuchBucket, matching real S3.
 func TestS3MissingBucketError(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
 
 	_, err := client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String("bucket-never-created"),
-		Key:    aws.String("any-key"),
+		Bucket: aws.String("never-created"),
+		Key:    aws.String("any"),
 	})
 	require.Error(t, err)
 
-	var nsk *types.NoSuchKey
-	assert.True(t, errors.As(err, &nsk),
-		"emulator maps missing bucket to NoSuchKey (real S3: NoSuchBucket); got %T: %v", err, err)
+	var apiErr smithy.APIError
+	require.True(t, errors.As(err, &apiErr), "want smithy.APIError, got %T: %v", err, err)
+	assert.Equal(t, "NoSuchBucket", apiErr.ErrorCode())
 }
 
 // TestS3DuplicateBucketTypedError asserts the second CreateBucket
@@ -448,9 +449,8 @@ func TestS3DuplicateBucketTypedError(t *testing.T) {
 }
 
 // TestS3DeleteNonEmptyBucketError asserts deleting a non-empty
-// bucket fails and the bucket's contents survive. NOTE: the emulator maps the
-// driver's FailedPrecondition to 500 InternalError (documented in the survey);
-// real S3 returns 409 BucketNotEmpty.
+// bucket fails with 409 BucketNotEmpty (real-S3 semantics) and the
+// bucket's contents survive.
 func TestS3DeleteNonEmptyBucketError(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
@@ -466,8 +466,7 @@ func TestS3DeleteNonEmptyBucketError(t *testing.T) {
 
 	var apiErr smithy.APIError
 	require.True(t, errors.As(err, &apiErr), "want smithy.APIError, got %T: %v", err, err)
-	assert.Equal(t, "InternalError", apiErr.ErrorCode(),
-		"emulator maps FailedPrecondition to InternalError (real S3: BucketNotEmpty)")
+	assert.Equal(t, "BucketNotEmpty", apiErr.ErrorCode())
 
 	// Bucket and object survive the failed delete.
 	body, _ := suiteGetBody(t, client, bucket, "keep.txt")

--- a/server/azure/blob/blob_lifecycle_test.go
+++ b/server/azure/blob/blob_lifecycle_test.go
@@ -14,14 +14,12 @@ package blob_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -533,25 +531,18 @@ func TestErrorCases(t *testing.T) {
 		t.Errorf("duplicate create: err=%v want ContainerAlreadyExists", err)
 	}
 
-	// Delete non-empty container. The driver returns FailedPrecondition,
-	// which the handler maps to 500 InternalError (real Azure deletes
-	// containers recursively, so this whole failure mode is emulator-only).
+	// Delete non-empty container: real Azure deletes containers together
+	// with their blobs, and the emulator now matches.
 	if _, err := env.client.UploadBuffer(ctx, "errs", "occupant", []byte("x"), nil); err != nil {
 		t.Fatalf("UploadBuffer: %v", err)
 	}
 
-	_, err := env.client.DeleteContainer(ctx, "errs", nil)
-	if err == nil {
-		t.Fatalf("delete non-empty container succeeded, want error")
+	if _, err := env.client.DeleteContainer(ctx, "errs", nil); err != nil {
+		t.Fatalf("delete non-empty container: %v (real Azure deletes recursively)", err)
 	}
 
-	var respErr *azcore.ResponseError
-	if !errors.As(err, &respErr) {
-		t.Fatalf("delete non-empty container: err=%T want *azcore.ResponseError", err)
-	}
-
-	if respErr.StatusCode != 500 || respErr.ErrorCode != "InternalError" {
-		t.Errorf("delete non-empty container: status=%d code=%q want 500 InternalError", respErr.StatusCode, respErr.ErrorCode)
+	if _, err := env.client.CreateContainer(ctx, "errs", nil); err != nil {
+		t.Fatalf("recreate container after recursive delete: %v", err)
 	}
 
 	// Copy from a missing source blob.

--- a/server/azure/blob/handler.go
+++ b/server/azure/blob/handler.go
@@ -22,6 +22,7 @@ package blob
 import (
 	"encoding/xml"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
@@ -161,7 +162,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
 			Name: b.Name,
 			Properties: containerPropsXML{
 				LastModified: httpDate(b.CreatedAt),
-				ETag:         "\"0x8DAB0\"",
+				ETag:         containerETag(b.CreatedAt),
 			},
 		})
 	}
@@ -175,13 +176,46 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, contai
 		return
 	}
 
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	created := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(created))
+	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusCreated)
 }
 
+// containerCreatedAt looks up a container's creation time from the driver;
+// falls back to the zero string (httpDate then serves the current time).
+func (h *Handler) containerCreatedAt(r *http.Request, container string) string {
+	buckets, err := h.bucket.ListBuckets(r.Context())
+	if err != nil {
+		return ""
+	}
+	for _, b := range buckets {
+		if b.Name == container {
+			return b.CreatedAt
+		}
+	}
+	return ""
+}
+
+// containerETag derives a stable per-container ETag from its creation time,
+// replacing the old shared hard-coded value.
+func containerETag(createdAt string) string {
+	return fmt.Sprintf("%q", "0x"+strings.ToUpper(fmt.Sprintf("%x", crc32.ChecksumIEEE([]byte(createdAt)))))
+}
+
 func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, container string) {
-	if err := h.bucket.DeleteBucket(r.Context(), container); err != nil {
+	err := h.bucket.DeleteBucket(r.Context(), container)
+
+	// Real Azure deletes a container together with its blobs; the portable
+	// driver refuses non-empty deletes, so empty it here and retry.
+	if err != nil && cerrors.IsFailedPrecondition(err) {
+		if derr := h.emptyContainer(r, container); derr != nil {
+			writeErr(w, derr)
+			return
+		}
+		err = h.bucket.DeleteBucket(r.Context(), container)
+	}
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -189,9 +223,28 @@ func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, contai
 	w.WriteHeader(http.StatusAccepted)
 }
 
-func (*Handler) getContainerProperties(w http.ResponseWriter, _ *http.Request, _ string) {
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+// emptyContainer deletes every blob in the container.
+func (h *Handler) emptyContainer(r *http.Request, container string) error {
+	for {
+		list, err := h.bucket.ListObjects(r.Context(), container, storagedriver.ListOptions{})
+		if err != nil {
+			return err
+		}
+		if len(list.Objects) == 0 {
+			return nil
+		}
+		for _, obj := range list.Objects {
+			if err := h.bucket.DeleteObject(r.Context(), container, obj.Key); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (h *Handler) getContainerProperties(w http.ResponseWriter, r *http.Request, container string) {
+	created := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(created))
+	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -275,8 +328,13 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	info, err := h.bucket.HeadObject(r.Context(), container, blob)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+	w.Header().Set("Last-Modified", httpDate(info.LastModified))
 	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
 	w.WriteHeader(http.StatusCreated)
 }
@@ -408,6 +466,8 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "ContainerAlreadyExists", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusConflict, "Conflict", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
 	}

--- a/server/azure/blob/handler.go
+++ b/server/azure/blob/handler.go
@@ -20,6 +20,7 @@
 package blob
 
 import (
+	"crypto/sha256"
 	"encoding/xml"
 	"fmt"
 	"hash/crc32"
@@ -162,7 +163,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
 			Name: b.Name,
 			Properties: containerPropsXML{
 				LastModified: httpDate(b.CreatedAt),
-				ETag:         containerETag(b.CreatedAt),
+				ETag:         containerETag(b.Name, b.CreatedAt),
 			},
 		})
 	}
@@ -176,31 +177,32 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, contai
 		return
 	}
 
-	created := h.containerCreatedAt(r, container)
-	w.Header().Set("ETag", containerETag(created))
+	created, _ := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(container, created))
 	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusCreated)
 }
 
-// containerCreatedAt looks up a container's creation time from the driver;
-// falls back to the zero string (httpDate then serves the current time).
-func (h *Handler) containerCreatedAt(r *http.Request, container string) string {
+// containerCreatedAt looks up a container's creation time from the driver.
+func (h *Handler) containerCreatedAt(r *http.Request, container string) (string, bool) {
 	buckets, err := h.bucket.ListBuckets(r.Context())
 	if err != nil {
-		return ""
+		return "", false
 	}
 	for _, b := range buckets {
 		if b.Name == container {
-			return b.CreatedAt
+			return b.CreatedAt, true
 		}
 	}
-	return ""
+	return "", false
 }
 
-// containerETag derives a stable per-container ETag from its creation time,
-// replacing the old shared hard-coded value.
-func containerETag(createdAt string) string {
-	return fmt.Sprintf("%q", "0x"+strings.ToUpper(fmt.Sprintf("%x", crc32.ChecksumIEEE([]byte(createdAt)))))
+// containerETag derives a stable per-container ETag from the container's
+// name and creation time — unique even for containers created within the
+// same clock second (which is every container under a pinned fake clock).
+func containerETag(name, createdAt string) string {
+	sum := crc32.ChecksumIEEE([]byte(name + "|" + createdAt))
+	return fmt.Sprintf("%q", "0x"+strings.ToUpper(fmt.Sprintf("%x", sum)))
 }
 
 func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, container string) {
@@ -223,9 +225,12 @@ func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, contai
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// emptyContainer deletes every blob in the container.
+// emptyContainer deletes every blob in the container. A blob that vanishes
+// between list and delete (concurrent deletes) is fine; the pass budget
+// bounds the loop so a racing writer cannot spin it forever.
 func (h *Handler) emptyContainer(r *http.Request, container string) error {
-	for {
+	const maxPasses = 1000
+	for range maxPasses {
 		list, err := h.bucket.ListObjects(r.Context(), container, storagedriver.ListOptions{})
 		if err != nil {
 			return err
@@ -234,16 +239,24 @@ func (h *Handler) emptyContainer(r *http.Request, container string) error {
 			return nil
 		}
 		for _, obj := range list.Objects {
-			if err := h.bucket.DeleteObject(r.Context(), container, obj.Key); err != nil {
+			err := h.bucket.DeleteObject(r.Context(), container, obj.Key)
+			if err != nil && !cerrors.IsNotFound(err) {
 				return err
 			}
 		}
 	}
+	return cerrors.Newf(cerrors.FailedPrecondition,
+		"container %q kept receiving blobs during delete", container)
 }
 
 func (h *Handler) getContainerProperties(w http.ResponseWriter, r *http.Request, container string) {
-	created := h.containerCreatedAt(r, container)
-	w.Header().Set("ETag", containerETag(created))
+	created, ok := h.containerCreatedAt(r, container)
+	if !ok {
+		writeError(w, http.StatusNotFound, "ContainerNotFound",
+			"container "+container+" not found")
+		return
+	}
+	w.Header().Set("ETag", containerETag(container, created))
 	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusOK)
 }
@@ -328,13 +341,17 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
-	info, err := h.bucket.HeadObject(r.Context(), container, blob)
-	if err != nil {
-		writeErr(w, err)
-		return
+	// The driver's ETag is the hex sha256 of the body; if a concurrent
+	// delete races the read-back, fall back to computing it — a successful
+	// PUT must never answer 404.
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+	lastModified := ""
+	if info, err := h.bucket.HeadObject(r.Context(), container, blob); err == nil {
+		etag = info.ETag
+		lastModified = info.LastModified
 	}
-	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
-	w.Header().Set("Last-Modified", httpDate(info.LastModified))
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
+	w.Header().Set("Last-Modified", httpDate(lastModified))
 	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
 	w.WriteHeader(http.StatusCreated)
 }
@@ -401,8 +418,10 @@ func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, bl
 
 	w.Header().Set("X-Ms-Copy-Id", "00000000-0000-0000-0000-000000000001")
 	w.Header().Set("X-Ms-Copy-Status", "success")
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	if info, err := h.bucket.HeadObject(r.Context(), container, blob); err == nil {
+		w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+		w.Header().Set("Last-Modified", httpDate(info.LastModified))
+	}
 	w.WriteHeader(http.StatusAccepted)
 }
 

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -594,6 +594,10 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "conflict", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		// Real GCS refuses to delete a non-empty bucket with 409 conflict,
+		// not a 5xx (which would trigger client retry backoff).
+		writeError(w, http.StatusConflict, "conflict", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "internalError", err.Error())
 	}

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -381,8 +381,10 @@ func PageOrdered(
 	return res, nil
 }
 
-// cloneItems shallow-copies each result item so callers can mutate what
-// they receive without corrupting the store.
+// cloneItems shallow-copies each result item so callers mutating top-level
+// keys of what they receive cannot corrupt the store. Nested map/slice
+// values are still shared — deep-copying arbitrary attribute trees is a
+// deliberate non-goal (documented limitation).
 func cloneItems(items []map[string]any) []map[string]any {
 	out := make([]map[string]any, len(items))
 	for i, it := range items {

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -4,6 +4,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -361,7 +362,7 @@ func PageOrdered(
 			return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid ExclusiveStartKey")
 		}
 
-		res := &QueryResult{Items: items, Count: len(items)}
+		res := &QueryResult{Items: cloneItems(items), Count: len(items)}
 		if more && len(items) > 0 {
 			res.LastEvaluatedKey = KeyAttributes(items[len(items)-1], keyFields...)
 		}
@@ -373,9 +374,19 @@ func PageOrdered(
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
 	}
 
-	res := &QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}
+	res := &QueryResult{Items: cloneItems(page.Items), Count: len(page.Items), NextPageToken: page.NextPageToken}
 	if page.HasMore && len(page.Items) > 0 {
 		res.LastEvaluatedKey = KeyAttributes(page.Items[len(page.Items)-1], keyFields...)
 	}
 	return res, nil
+}
+
+// cloneItems shallow-copies each result item so callers can mutate what
+// they receive without corrupting the store.
+func cloneItems(items []map[string]any) []map[string]any {
+	out := make([]map[string]any, len(items))
+	for i, it := range items {
+		out[i] = maps.Clone(it)
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

A deep end-to-end audit pass: first the five wire deviations flagged (and deferred) in the PR #270 review, then a codebase-wide hunt for systemic bug **classes** rather than per-domain journeys. Every fix is tested; two new regression tests lock the systemic classes. Full suite `go test ./... -count=1` = 0 failures, `go vet` clean.

## Fixed — known wire deviations (commit 1)

- **S3 `DeleteObject` is idempotent** for a missing key (204, real-S3 semantics) — defensive-delete SDK code now works. A missing **bucket** is `NoSuchBucket` everywhere instead of `NoSuchKey` (discriminated via the driver's structured error `Message`, not string-matching the formatted error).
- **Non-empty bucket deletion is a client error, not a 500**: S3 → `409 BucketNotEmpty`, GCS → `409 conflict` (the old `InternalError` triggered SDK retry backoff). **Azure matches real Azure instead**: `DeleteContainer` deletes blobs recursively and succeeds.
- **Azure Blob returns real ETags and clock-driven `Last-Modified`** — the shared hard-coded `"0x8DAB0"` and wall-clock `time.Now()` are gone from Put Blob and the container endpoints (per-container ETags derive from creation time).
- **S3 `PutObject` reads the ETag back from the driver** instead of recomputing sha256 inline — one source of truth for the algorithm. (Trade-off: puts now also tick the Head request metric.)

## Fixed — systemic classes (commit 2)

- **Wall-clock leaks that break the fake clock**: all 15 `time.Now()` sites across the lambda / Azure Functions / Cloud Functions mocks (functions, versions, aliases, layers) now use `opts.Clock`. Deterministic-time tests previously got real timestamps.
- **Reference-shared maps**: storage drivers clone object metadata on write **and** on every `ObjectInfo` read; database drivers clone item maps at every public boundary (`PutItem`/batch/transact in, `GetItem`/`BatchGetItems` out, and Query/Scan page outputs centrally in `driver.PageOrdered`). Caller mutations can no longer corrupt stored state — and stream/change-feed images now capture isolated snapshots.
- **Swallowed-error sweep** of `providers/`, `server/`, `services/`: no remaining real cases (survivors are hash writes, ok-pattern lookups, and state-returning calls).

## Regression tests
`TestMetadataIsolation` (mutate passed + returned maps → store unaffected) and `TestTimestampsUseConfiguredClock` (fake clock pinned to 2025-01-01 → no wall-clock leak). Lifecycle tests that pinned the old deviations (delete-missing-key 404, `NoSuchKey`-for-bucket, 500-on-non-empty, Azure non-empty-delete failure) were flipped to assert real-cloud semantics.

## Review notes
Self-reviewed the diff for the classic traps: recursive-delete loop termination, `maps.Clone(nil)` behavior, clone placement relative to stream-event capture, and error-type discrimination through `*cerrors.Error` (wrapped-error safe via `errors.As`).