### PR TITLE
#259 PR 1/3: deterministic list ordering across the #143 slices

### DIFF
--- a/internal/memstore/store.go
+++ b/internal/memstore/store.go
@@ -1,7 +1,10 @@
 // Package memstore provides a generic thread-safe in-memory key-value store.
 package memstore
 
-import "sync"
+import (
+	"sort"
+	"sync"
+)
 
 // Store is a generic thread-safe in-memory key-value store.
 type Store[V any] struct {
@@ -142,4 +145,24 @@ func (s *Store[V]) Filter(fn func(key string, value V) bool) map[string]V {
 	}
 
 	return result
+}
+
+// SortedValues returns the values ordered by their keys. List endpoints
+// must iterate this instead of All(): map iteration order is random, and
+// real cloud APIs return deterministic list ordering.
+func (s *Store[V]) SortedValues() []V {
+	s.mu.RLock()
+	keys := make([]string, 0, len(s.items))
+	for k := range s.items {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]V, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, s.items[k])
+	}
+	s.mu.RUnlock()
+
+	return out
 }

--- a/internal/memstore/store_test.go
+++ b/internal/memstore/store_test.go
@@ -277,3 +277,17 @@ func TestStore_OverwriteValue(t *testing.T) {
 	assert.Equal(t, "second", val)
 	assert.Equal(t, 1, s.Len())
 }
+
+func TestSortedValues(t *testing.T) {
+	s := New[string]()
+	s.Set("zebra", "z")
+	s.Set("apple", "a")
+	s.Set("mango", "m")
+
+	for range 5 {
+		got := s.SortedValues()
+		if len(got) != 3 || got[0] != "a" || got[1] != "m" || got[2] != "z" {
+			t.Fatalf("SortedValues = %v, want [a m z] (key order, stable across calls)", got)
+		}
+	}
+}

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -133,7 +133,7 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 
 // ListLogGroups lists all CloudWatch log groups.
 func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
-	all := m.groups.All()
+	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
@@ -196,7 +196,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
 	}
 
-	all := g.streams.All()
+	all := g.streams.SortedValues()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
 

--- a/providers/aws/cloudwatchlogs/ordering_test.go
+++ b/providers/aws/cloudwatchlogs/ordering_test.go
@@ -1,0 +1,42 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListLogGroups(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -135,7 +135,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 
 // ListCaches lists all ElastiCache clusters.
 func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
-	all := m.caches.All()
+	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {

--- a/providers/aws/elasticache/ordering_test.go
+++ b/providers/aws/elasticache/ordering_test.go
@@ -1,0 +1,42 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateCache(ctx, driver.CacheConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListCaches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListCaches(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -152,7 +152,7 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 
 // ListEventBuses lists all EventBridge event buses.
 func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
-	all := m.buses.All()
+	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
@@ -268,7 +268,7 @@ func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, err
 		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
 	}
 
-	all := bd.rules.All()
+	all := bd.rules.SortedValues()
 
 	rules := make([]driver.Rule, 0, len(all))
 	for _, rd := range all {

--- a/providers/aws/eventbridge/ordering_test.go
+++ b/providers/aws/eventbridge/ordering_test.go
@@ -1,0 +1,43 @@
+package eventbridge
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateEventBus(ctx, driver.EventBusConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListEventBuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// EventBridge pre-creates the "default" bus, so 5 created + 1 default.
+	if len(first) < 5 {
+		t.Fatalf("list returned %d items, want >= 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListEventBuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/route53/healthcheck.go
+++ b/providers/aws/route53/healthcheck.go
@@ -82,7 +82,7 @@ func (m *Mock) GetHealthCheck(_ context.Context, id string) (*driver.HealthCheck
 
 // ListHealthChecks returns all Route 53 health checks.
 func (m *Mock) ListHealthChecks(_ context.Context) ([]driver.HealthCheckInfo, error) {
-	all := m.healthChecks.All()
+	all := m.healthChecks.SortedValues()
 
 	checks := make([]driver.HealthCheckInfo, 0, len(all))
 	for _, hc := range all {

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -1,0 +1,42 @@
+package route53
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateZone(ctx, driver.ZoneConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListZones(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListZones(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -104,7 +104,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 
 // ListZones returns all DNS hosted zones.
 func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
-	all := m.zones.All()
+	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {

--- a/providers/aws/sns/ordering_test.go
+++ b/providers/aws/sns/ordering_test.go
@@ -1,0 +1,42 @@
+package sns
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateTopic(ctx, driver.TopicConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListTopics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListTopics(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -124,7 +124,7 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 
 // ListTopics lists all SNS topics.
 func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
-	all := m.topics.All()
+	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
@@ -190,7 +190,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
 	}
 
-	all := td.subscriptions.All()
+	all := td.subscriptions.SortedValues()
 
 	subs := make([]driver.SubscriptionInfo, 0, len(all))
 	for _, s := range all {

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -145,7 +145,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 
 // ListCaches lists all Azure Cache for Redis instances.
 func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
-	all := m.caches.All()
+	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {

--- a/providers/azure/azurecache/ordering_test.go
+++ b/providers/azure/azurecache/ordering_test.go
@@ -1,0 +1,42 @@
+package azurecache
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateCache(ctx, driver.CacheConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListCaches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListCaches(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -102,7 +102,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 
 // ListZones returns all Azure DNS zones.
 func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
-	all := m.zones.All()
+	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {

--- a/providers/azure/azuredns/healthcheck.go
+++ b/providers/azure/azuredns/healthcheck.go
@@ -83,7 +83,7 @@ func (m *Mock) GetHealthCheck(_ context.Context, id string) (*driver.HealthCheck
 
 // ListHealthChecks returns all Azure DNS health checks.
 func (m *Mock) ListHealthChecks(_ context.Context) ([]driver.HealthCheckInfo, error) {
-	all := m.healthChecks.All()
+	all := m.healthChecks.SortedValues()
 
 	checks := make([]driver.HealthCheckInfo, 0, len(all))
 	for _, hc := range all {

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -1,0 +1,42 @@
+package azuredns
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateZone(ctx, driver.ZoneConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListZones(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListZones(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -143,7 +143,7 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 
 // ListEventBuses lists all Event Grid topics.
 func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
-	all := m.buses.All()
+	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
@@ -255,7 +255,7 @@ func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, err
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", eventBus)
 	}
 
-	all := bd.rules.All()
+	all := bd.rules.SortedValues()
 
 	rules := make([]driver.Rule, 0, len(all))
 	for _, rd := range all {

--- a/providers/azure/eventgrid/ordering_test.go
+++ b/providers/azure/eventgrid/ordering_test.go
@@ -1,0 +1,42 @@
+package eventgrid
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateEventBus(ctx, driver.EventBusConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListEventBuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListEventBuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -144,7 +144,7 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 
 // ListLogGroups lists all Log Analytics workspaces.
 func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
-	all := m.groups.All()
+	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
@@ -207,7 +207,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
 	}
 
-	all := g.streams.All()
+	all := g.streams.SortedValues()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
 

--- a/providers/azure/loganalytics/ordering_test.go
+++ b/providers/azure/loganalytics/ordering_test.go
@@ -1,0 +1,42 @@
+package loganalytics
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListLogGroups(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -136,7 +136,7 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 
 // ListTopics lists all notification hubs.
 func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
-	all := m.topics.All()
+	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
@@ -202,7 +202,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
 	}
 
-	all := td.subscriptions.All()
+	all := td.subscriptions.SortedValues()
 
 	subs := make([]driver.SubscriptionInfo, 0, len(all))
 	for _, s := range all {

--- a/providers/azure/notificationhubs/ordering_test.go
+++ b/providers/azure/notificationhubs/ordering_test.go
@@ -1,0 +1,42 @@
+package notificationhubs
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateTopic(ctx, driver.TopicConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListTopics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListTopics(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -103,7 +103,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 
 // ListZones returns all Cloud DNS managed zones.
 func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
-	all := m.zones.All()
+	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {

--- a/providers/gcp/clouddns/healthcheck.go
+++ b/providers/gcp/clouddns/healthcheck.go
@@ -82,7 +82,7 @@ func (m *Mock) GetHealthCheck(_ context.Context, id string) (*driver.HealthCheck
 
 // ListHealthChecks returns all Cloud DNS health checks.
 func (m *Mock) ListHealthChecks(_ context.Context) ([]driver.HealthCheckInfo, error) {
-	all := m.healthChecks.All()
+	all := m.healthChecks.SortedValues()
 
 	checks := make([]driver.HealthCheckInfo, 0, len(all))
 	for _, hc := range all {

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -1,0 +1,42 @@
+package clouddns
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateZone(ctx, driver.ZoneConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListZones(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListZones(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -139,7 +139,7 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 
 // ListLogGroups lists all Cloud Logging log buckets.
 func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
-	all := m.groups.All()
+	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
@@ -202,7 +202,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
 	}
 
-	all := g.streams.All()
+	all := g.streams.SortedValues()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
 

--- a/providers/gcp/cloudlogging/ordering_test.go
+++ b/providers/gcp/cloudlogging/ordering_test.go
@@ -1,0 +1,42 @@
+package cloudlogging
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListLogGroups(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/eventarc/eventarc.go
+++ b/providers/gcp/eventarc/eventarc.go
@@ -138,7 +138,7 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 
 // ListEventBuses lists all Eventarc channels.
 func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
-	all := m.buses.All()
+	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
@@ -250,7 +250,7 @@ func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, err
 		return nil, errors.Newf(errors.NotFound, "channel %q not found", eventBus)
 	}
 
-	all := bd.rules.All()
+	all := bd.rules.SortedValues()
 
 	rules := make([]driver.Rule, 0, len(all))
 	for _, rd := range all {

--- a/providers/gcp/eventarc/ordering_test.go
+++ b/providers/gcp/eventarc/ordering_test.go
@@ -1,0 +1,42 @@
+package eventarc
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateEventBus(ctx, driver.EventBusConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListEventBuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListEventBuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -130,7 +130,7 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 
 // ListTopics lists all FCM topics.
 func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
-	all := m.topics.All()
+	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
@@ -196,7 +196,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
 	}
 
-	all := td.subscriptions.All()
+	all := td.subscriptions.SortedValues()
 
 	subs := make([]driver.SubscriptionInfo, 0, len(all))
 	for _, s := range all {

--- a/providers/gcp/fcm/ordering_test.go
+++ b/providers/gcp/fcm/ordering_test.go
@@ -1,0 +1,42 @@
+package fcm
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateTopic(ctx, driver.TopicConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListTopics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListTopics(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -143,7 +143,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 
 // ListCaches lists all Memorystore instances.
 func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
-	all := m.caches.All()
+	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {

--- a/providers/gcp/memorystore/ordering_test.go
+++ b/providers/gcp/memorystore/ordering_test.go
@@ -1,0 +1,42 @@
+package memorystore
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateCache(ctx, driver.CacheConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListCaches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListCaches(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/server/aws/cloudwatchlogs/ordering_sdk_test.go
+++ b/server/aws/cloudwatchlogs/ordering_sdk_test.go
@@ -1,0 +1,58 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: DescribeLogGroups must return the same sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+			LogGroupName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateLogGroup(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{})
+		if err != nil {
+			t.Fatalf("DescribeLogGroups: %v", err)
+		}
+
+		got := make([]string, 0, len(out.LogGroups))
+		for i := range out.LogGroups {
+			got = append(got, aws.ToString(out.LogGroups[i].LogGroupName))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("DescribeLogGroups returned %d groups, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d groups, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/elasticache/ordering_sdk_test.go
+++ b/server/aws/elasticache/ordering_sdk_test.go
@@ -1,0 +1,61 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: DescribeCacheClusters must return the same sequence on every call.
+// The pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+			CacheClusterId: aws.String(name),
+			Engine:         aws.String("redis"),
+			CacheNodeType:  aws.String("cache.t3.micro"),
+			NumCacheNodes:  aws.Int32(1),
+		}); err != nil {
+			t.Fatalf("CreateCacheCluster(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{})
+		if err != nil {
+			t.Fatalf("DescribeCacheClusters: %v", err)
+		}
+
+		got := make([]string, 0, len(out.CacheClusters))
+		for i := range out.CacheClusters {
+			got = append(got, aws.ToString(out.CacheClusters[i].CacheClusterId))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("DescribeCacheClusters returned %d clusters, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d clusters, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/eventbridge/ordering_sdk_test.go
+++ b/server/aws/eventbridge/ordering_sdk_test.go
@@ -1,0 +1,60 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ListEventBuses must return the same sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+// The driver pre-seeds a "default" bus, so we only assert len >= 5 and an
+// identical sequence across calls.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{
+			Name: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateEventBus(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{})
+		if err != nil {
+			t.Fatalf("ListEventBuses: %v", err)
+		}
+
+		got := make([]string, 0, len(out.EventBuses))
+		for i := range out.EventBuses {
+			got = append(got, aws.ToString(out.EventBuses[i].Name))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) < len(names) {
+		t.Fatalf("ListEventBuses returned %d buses, want at least %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d buses, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/route53/ordering_sdk_test.go
+++ b/server/aws/route53/ordering_sdk_test.go
@@ -1,0 +1,59 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ListHostedZones must return the same sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	names := []string{"zeta.com.", "alpha.com.", "mid.com.", "beta.com.", "omega.com."}
+	for i, name := range names {
+		if _, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+			Name:            aws.String(name),
+			CallerReference: aws.String("ordering-ref-" + string(rune('a'+i))),
+		}); err != nil {
+			t.Fatalf("CreateHostedZone(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.ListHostedZones(ctx, &awsr53.ListHostedZonesInput{})
+		if err != nil {
+			t.Fatalf("ListHostedZones: %v", err)
+		}
+
+		got := make([]string, 0, len(out.HostedZones))
+		for i := range out.HostedZones {
+			got = append(got, aws.ToString(out.HostedZones[i].Name))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("ListHostedZones returned %d zones, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d zones, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/sns/ordering_sdk_test.go
+++ b/server/aws/sns/ordering_sdk_test.go
@@ -1,0 +1,58 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ListTopics must return the same TopicArn sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+			Name: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateTopic(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.ListTopics(ctx, &awssns.ListTopicsInput{})
+		if err != nil {
+			t.Fatalf("ListTopics: %v", err)
+		}
+
+		got := make([]string, 0, len(out.Topics))
+		for i := range out.Topics {
+			got = append(got, aws.ToString(out.Topics[i].TopicArn))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("ListTopics returned %d topics, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d topics, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/azure/cache/ordering_sdk_test.go
+++ b/server/azure/cache/ordering_sdk_test.go
@@ -1,0 +1,66 @@
+package cache_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	// Create caches deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		poller, err := client.BeginCreate(ctx, testRG, name, armredis.CreateParameters{
+			Location: to.Ptr("eastus"),
+			Properties: &armredis.CreateProperties{
+				SKU: &armredis.SKU{
+					Name:     to.Ptr(armredis.SKUNameStandard),
+					Family:   to.Ptr(armredis.SKUFamilyC),
+					Capacity: to.Ptr(int32(1)),
+				},
+			},
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := client.NewListBySubscriptionPager(nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListBySubscription: %v", perr)
+			}
+
+			for _, c := range page.Value {
+				names = append(names, *c.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 caches", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/dns/ordering_sdk_test.go
+++ b/server/azure/dns/ordering_sdk_test.go
@@ -1,0 +1,54 @@
+package dns_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	// Create zones deliberately out of alphabetical order.
+	for _, name := range []string{"zeta.com", "alpha.com", "mid.com", "beta.com", "omega.com"} {
+		if _, err := zones.CreateOrUpdate(ctx, testRG, name, armdns.Zone{
+			Location: to.Ptr("global"),
+		}, nil); err != nil {
+			t.Fatalf("Zones.CreateOrUpdate(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := zones.NewListByResourceGroupPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListByResourceGroup: %v", perr)
+			}
+
+			for _, z := range page.Value {
+				names = append(names, *z.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 zones", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/eventgrid/ordering_sdk_test.go
+++ b/server/azure/eventgrid/ordering_sdk_test.go
@@ -1,0 +1,59 @@
+package eventgrid_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	topics := newTopicsClient(t)
+	ctx := context.Background()
+
+	// Create topics deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		poller, err := topics.BeginCreateOrUpdate(ctx, testRG, name, armeventgrid.Topic{
+			Location: to.Ptr("global"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := topics.NewListByResourceGroupPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListByResourceGroup: %v", perr)
+			}
+
+			for _, tp := range page.Value {
+				names = append(names, *tp.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 topics", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/loganalytics/ordering_sdk_test.go
+++ b/server/azure/loganalytics/ordering_sdk_test.go
@@ -1,0 +1,59 @@
+package loganalytics_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	// Create workspaces deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		poller, err := client.BeginCreateOrUpdate(ctx, testRG, name, armoperationalinsights.Workspace{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := client.NewListByResourceGroupPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListByResourceGroup: %v", perr)
+			}
+
+			for _, ws := range page.Value {
+				names = append(names, *ws.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 workspaces", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/notificationhubs/ordering_sdk_test.go
+++ b/server/azure/notificationhubs/ordering_sdk_test.go
@@ -1,0 +1,54 @@
+package notificationhubs_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	namespaces, _ := newClients(t)
+	ctx := context.Background()
+
+	// Create namespaces deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := namespaces.CreateOrUpdate(ctx, testRG, name, armnotificationhubs.NamespaceCreateOrUpdateParameters{
+			Location: to.Ptr("global"),
+		}, nil); err != nil {
+			t.Fatalf("Namespaces.CreateOrUpdate(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := namespaces.NewListPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("Namespaces.List: %v", perr)
+			}
+
+			for _, ns := range page.Value {
+				names = append(names, *ns.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 namespaces", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/gcp/clouddns/ordering_sdk_test.go
+++ b/server/gcp/clouddns/ordering_sdk_test.go
@@ -1,0 +1,61 @@
+package clouddns_test
+
+import (
+	"context"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ManagedZones.List must return the same sequence of zone names on
+// every call, regardless of the order the zones were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	// Create five zones in a deliberately non-sorted order.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+			Name:    id,
+			DnsName: id + ".example.com.",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("ManagedZones.Create(%s): %v", id, err)
+		}
+	}
+
+	listZones := func() []string {
+		var names []string
+
+		call := svc.ManagedZones.List(testProject).Context(ctx)
+		if err := call.Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+			for _, z := range page.ManagedZones {
+				names = append(names, z.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("ManagedZones.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listZones()
+	if len(first) != 5 {
+		t.Fatalf("got %d zones, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listZones()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d zones, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/cloudlogging/ordering_sdk_test.go
+++ b/server/gcp/cloudlogging/ordering_sdk_test.go
@@ -1,0 +1,62 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"testing"
+
+	logging "google.golang.org/api/logging/v2"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: Projects.Logs.List must return the same sequence of log names on
+// every call, regardless of the order the logs were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	// Create five logs in a deliberately non-sorted order; a write lazily
+	// creates the log group.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.Entries.Write(&logging.WriteLogEntriesRequest{
+			LogName: "projects/" + testProject + "/logs/" + id,
+			Entries: []*logging.LogEntry{
+				{TextPayload: "entry for " + id},
+			},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Entries.Write(%s): %v", id, err)
+		}
+	}
+
+	listLogs := func() []string {
+		var names []string
+
+		call := svc.Projects.Logs.List("projects/" + testProject).Context(ctx)
+		if err := call.Pages(ctx, func(page *logging.ListLogsResponse) error {
+			names = append(names, page.LogNames...)
+			return nil
+		}); err != nil {
+			t.Fatalf("Projects.Logs.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listLogs()
+	if len(first) != 5 {
+		t.Fatalf("got %d logs, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listLogs()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d logs, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/eventarc/ordering_sdk_test.go
+++ b/server/gcp/eventarc/ordering_sdk_test.go
@@ -1,0 +1,68 @@
+package eventarc_test
+
+import (
+	"context"
+	"testing"
+
+	eventarc "google.golang.org/api/eventarc/v1"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: Triggers.List must return the same sequence of trigger names on
+// every call, regardless of the order the triggers were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	// Create five triggers in a deliberately non-sorted order.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		trigger := &eventarc.Trigger{
+			EventFilters: []*eventarc.EventFilter{
+				{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"},
+			},
+			Destination: &eventarc.Destination{
+				CloudRun: &eventarc.CloudRun{Service: "svc-" + id, Region: testLocation},
+			},
+		}
+
+		if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+			TriggerId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Triggers.Create(%s): %v", id, err)
+		}
+	}
+
+	listTriggers := func() []string {
+		var names []string
+
+		call := svc.Projects.Locations.Triggers.List(parent()).Context(ctx)
+		if err := call.Pages(ctx, func(page *eventarc.ListTriggersResponse) error {
+			for _, tr := range page.Triggers {
+				names = append(names, tr.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("Triggers.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listTriggers()
+	if len(first) != 5 {
+		t.Fatalf("got %d triggers, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listTriggers()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d triggers, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/fcm/ordering_sdk_test.go
+++ b/server/gcp/fcm/ordering_sdk_test.go
@@ -1,0 +1,93 @@
+package fcm_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	fcm "google.golang.org/api/fcm/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// newFCMServiceWithDriver mirrors newFCMService but also returns the backing
+// notification driver. FCM v1 is a send-only API with no ListTopics on the
+// wire, so ordering of the topics the handler auto-provisions is observed
+// through the driver.
+func newFCMServiceWithDriver(t *testing.T) (*fcm.Service, notifdriver.Notification) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{FCM: cloud.FCM})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := fcm.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("fcm.NewService: %v", err)
+	}
+
+	return svc, cloud.FCM
+}
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix for FCM:
+// sending to five topics via the real SDK auto-provisions them, and listing
+// the topics must return the same sequence on every call, regardless of the
+// order the topics were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc, driver := newFCMServiceWithDriver(t)
+	ctx := context.Background()
+
+	// Sends to five topics in a deliberately non-sorted order; each send
+	// auto-provisions its topic.
+	for _, topic := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.Projects.Messages.Send("projects/"+testProject, &fcm.SendMessageRequest{
+			Message: &fcm.Message{
+				Topic: topic,
+				Data:  map[string]string{"k": "v"},
+			},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Messages.Send(%s): %v", topic, err)
+		}
+	}
+
+	listTopics := func() []string {
+		topics, err := driver.ListTopics(ctx)
+		if err != nil {
+			t.Fatalf("ListTopics: %v", err)
+		}
+
+		names := make([]string, 0, len(topics))
+		for _, tp := range topics {
+			names = append(names, tp.Name)
+		}
+
+		return names
+	}
+
+	first := listTopics()
+	if len(first) != 5 {
+		t.Fatalf("got %d topics, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listTopics()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d topics, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/memorystore/ordering_sdk_test.go
+++ b/server/gcp/memorystore/ordering_sdk_test.go
@@ -1,0 +1,61 @@
+package memorystore_test
+
+import (
+	"context"
+	"testing"
+
+	redis "google.golang.org/api/redis/v1"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: Instances.List must return the same sequence of instance names on
+// every call, regardless of the order the instances were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	// Create five instances in a deliberately non-sorted order.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+			Tier:         "BASIC",
+			MemorySizeGb: 1,
+		}).InstanceId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Instances.Create(%s): %v", id, err)
+		}
+	}
+
+	listInstances := func() []string {
+		var names []string
+
+		call := svc.Projects.Locations.Instances.List(parent()).Context(ctx)
+		if err := call.Pages(ctx, func(page *redis.ListInstancesResponse) error {
+			for _, in := range page.Instances {
+				names = append(names, in.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("Instances.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listInstances()
+	if len(first) != 5 {
+		t.Fatalf("got %d instances, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listInstances()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d instances, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}


### PR DESCRIPTION
First of the three-PR series for #259 (plan and status audit in the issue comments).

## What
Real cloud APIs return lists in a defined order; cloudemu's `List*` endpoints iterated `memstore.All()` — a Go map with randomized iteration — so two identical list calls returned the same items shuffled differently, on both the SDK-compat and portable surfaces.

## How
- `memstore.SortedValues()`: values ordered by store key, the single chokepoint for the ordering invariant (companion to `pagination.PaginateSorted` from v2.0.1).
- Swept all 27 `List*` sites across the five #143 slices — logging, event bus, cache, notification, DNS — on all three providers.
- 15 `TestListOrderingDeterministic` regression tests (one per provider package, per the all-three-providers rule): create out-of-order, list repeatedly, assert an identical sequence every call.

## Not in this PR (next in the series)
- PR 2: scope-aware listing + `Update`-on-upsert + request-derived ARM IDs.
- PR 3: the #253 DNS deep pass (zone uniqueness, structured TXT, exact-match deletes, batch atomicity).

## Test plan
Full suite `go test ./... -count=1` — 0 failures; `go vet` clean; new tests fail against pre-fix code (map order diverges within a handful of iterations).