### PR TITLE
fix: scope-aware listing, real CreateOrUpdate, request-derived ARM IDs (#259 — PR 2)

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -1861,7 +1861,7 @@ func testCacheWithDriver(t *testing.T, ctx context.Context, d cachedriver.Cache)
 	}
 
 	// List caches
-	caches, err := d.ListCaches(ctx)
+	caches, err := d.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatalf("ListCaches: %v", err)
 	}
@@ -2403,7 +2403,7 @@ func testNotificationWithDriver(t *testing.T, ctx context.Context, d notifdriver
 	}
 
 	// List topics
-	topics, err := d.ListTopics(ctx)
+	topics, err := d.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatalf("ListTopics: %v", err)
 	}
@@ -2581,7 +2581,7 @@ func TestCacheTagsPersistence(t *testing.T) {
 			}
 
 			// Verify tags appear in ListCaches
-			caches, err := p.d.ListCaches(ctx)
+			caches, err := p.d.ListCaches(ctx, scope.Scope{})
 			if err != nil {
 				t.Fatalf("ListCaches: %v", err)
 			}
@@ -3017,7 +3017,7 @@ func TestEventBusOperations(t *testing.T) {
 			}
 
 			// ListEventBuses
-			buses, err := p.d.ListEventBuses(ctx)
+			buses, err := p.d.ListEventBuses(ctx, scope.Scope{})
 			if err != nil {
 				t.Fatalf("ListEventBuses: %v", err)
 			}

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -2,6 +2,7 @@ package cloudemu
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -1996,7 +1997,7 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 	}
 
 	// List log groups
-	groups, err := d.ListLogGroups(ctx)
+	groups, err := d.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatalf("ListLogGroups: %v", err)
 	}

--- a/features/chaos/wrappers_baseline_test.go
+++ b/features/chaos/wrappers_baseline_test.go
@@ -200,7 +200,7 @@ func TestWrapNotificationBaseline(t *testing.T) {
 	ctx := context.Background()
 
 	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "b"})
-	_, _ = n.ListTopics(ctx)
+	_, _ = n.ListTopics(ctx, scope.Scope{})
 	if tp != nil {
 		_, _ = n.GetTopic(ctx, tp.ID)
 		sub, _ := n.Subscribe(ctx, notifdriver.SubscriptionConfig{TopicID: tp.ID, Protocol: "email", Endpoint: "x@y.z"})
@@ -233,7 +233,7 @@ func TestWrapEventBusBaseline(t *testing.T) {
 
 	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "b"})
 	_, _ = b.GetEventBus(ctx, "b")
-	_, _ = b.ListEventBuses(ctx)
+	_, _ = b.ListEventBuses(ctx, scope.Scope{})
 	cfg := &ebdriver.RuleConfig{Name: "rule", EventBus: "b", EventPattern: `{"source":["x"]}`, State: "ENABLED"}
 	_, _ = b.PutRule(ctx, cfg)
 	_, _ = b.GetRule(ctx, "b", "rule")

--- a/features/chaos/wrappers_baseline_test.go
+++ b/features/chaos/wrappers_baseline_test.go
@@ -2,6 +2,7 @@ package chaos_test
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -182,7 +183,7 @@ func TestWrapLoggingBaseline(t *testing.T) {
 
 	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "b"})
 	_, _ = l.GetLogGroup(ctx, "b")
-	_, _ = l.ListLogGroups(ctx)
+	_, _ = l.ListLogGroups(ctx, scope.Scope{})
 	_, _ = l.CreateLogStream(ctx, "b", "s")
 	_ = l.PutLogEvents(ctx, "b", "s", []logdriver.LogEvent{{Timestamp: time.Now(), Message: "x"}})
 	_, _ = l.GetLogEvents(ctx, &logdriver.LogQueryInput{

--- a/features/chaos/wrappers_eventbus.go
+++ b/features/chaos/wrappers_eventbus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // chaosEventBus wraps an event bus driver. Hot-path: bus CRUD, rule CRUD,
@@ -45,12 +46,12 @@ func (c *chaosEventBus) GetEventBus(ctx context.Context, name string) (*ebdriver
 	return c.EventBus.GetEventBus(ctx, name)
 }
 
-func (c *chaosEventBus) ListEventBuses(ctx context.Context) ([]ebdriver.EventBusInfo, error) {
+func (c *chaosEventBus) ListEventBuses(ctx context.Context, filter scope.Scope) ([]ebdriver.EventBusInfo, error) {
 	if err := applyChaos(ctx, c.engine, "eventbus", "ListEventBuses"); err != nil {
 		return nil, err
 	}
 
-	return c.EventBus.ListEventBuses(ctx)
+	return c.EventBus.ListEventBuses(ctx, filter)
 }
 
 func (c *chaosEventBus) PutRule(ctx context.Context, cfg *ebdriver.RuleConfig) (*ebdriver.Rule, error) {

--- a/features/chaos/wrappers_eventbus_test.go
+++ b/features/chaos/wrappers_eventbus_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/features/chaos"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newChaosEventBus(t *testing.T) (ebdriver.EventBus, *chaos.Engine) {
@@ -65,7 +66,7 @@ func TestWrapEventBusListEventBusesChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
 
-	if _, err := b.ListEventBuses(ctx); err == nil {
+	if _, err := b.ListEventBuses(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListEventBuses")
 	}
 }

--- a/features/chaos/wrappers_logging.go
+++ b/features/chaos/wrappers_logging.go
@@ -2,6 +2,7 @@ package chaos
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 )
@@ -46,12 +47,12 @@ func (c *chaosLogging) GetLogGroup(ctx context.Context, name string) (*logdriver
 	return c.Logging.GetLogGroup(ctx, name)
 }
 
-func (c *chaosLogging) ListLogGroups(ctx context.Context) ([]logdriver.LogGroupInfo, error) {
+func (c *chaosLogging) ListLogGroups(ctx context.Context, filter scope.Scope) ([]logdriver.LogGroupInfo, error) {
 	if err := applyChaos(ctx, c.engine, "logging", "ListLogGroups"); err != nil {
 		return nil, err
 	}
 
-	return c.Logging.ListLogGroups(ctx)
+	return c.Logging.ListLogGroups(ctx, filter)
 }
 
 func (c *chaosLogging) PutLogEvents(

--- a/features/chaos/wrappers_logging_test.go
+++ b/features/chaos/wrappers_logging_test.go
@@ -2,6 +2,7 @@ package chaos_test
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestWrapLoggingListLogGroupsChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("logging", time.Hour))
 
-	if _, err := l.ListLogGroups(ctx); err == nil {
+	if _, err := l.ListLogGroups(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListLogGroups")
 	}
 }

--- a/features/chaos/wrappers_notification.go
+++ b/features/chaos/wrappers_notification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // chaosNotification wraps a notification driver. All ops are wrapped — the
@@ -45,12 +46,12 @@ func (c *chaosNotification) GetTopic(ctx context.Context, id string) (*notifdriv
 	return c.Notification.GetTopic(ctx, id)
 }
 
-func (c *chaosNotification) ListTopics(ctx context.Context) ([]notifdriver.TopicInfo, error) {
+func (c *chaosNotification) ListTopics(ctx context.Context, filter scope.Scope) ([]notifdriver.TopicInfo, error) {
 	if err := applyChaos(ctx, c.engine, "notification", "ListTopics"); err != nil {
 		return nil, err
 	}
 
-	return c.Notification.ListTopics(ctx)
+	return c.Notification.ListTopics(ctx, filter)
 }
 
 func (c *chaosNotification) Subscribe(

--- a/features/chaos/wrappers_notification_test.go
+++ b/features/chaos/wrappers_notification_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/features/chaos"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newChaosNotification(t *testing.T) (notifdriver.Notification, *chaos.Engine) {
@@ -65,7 +66,7 @@ func TestWrapNotificationListTopicsChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("notification", time.Hour))
 
-	if _, err := n.ListTopics(ctx); err == nil {
+	if _, err := n.ListTopics(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListTopics")
 	}
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -3,6 +3,8 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -90,6 +92,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
+		Scope:         cfg.Scope,
 		ResourceID:    arn,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -132,11 +135,14 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 }
 
 // ListLogGroups lists all CloudWatch log groups.
-func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+func (m *Mock) ListLogGroups(_ context.Context, filter scope.Scope) ([]driver.LogGroupInfo, error) {
 	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
+		if !g.info.Scope.Matches(filter) {
+			continue
+		}
 		groups = append(groups, g.info)
 	}
 
@@ -493,4 +499,30 @@ func (m *Mock) DescribeMetricFilters(
 	}
 
 	return results, nil
+}
+
+// UpdateLogGroup replaces the mutable fields of an existing log group —
+// ARM CreateOrUpdate-on-existing semantics (retention and tags come from
+// the request; identity and CreatedAt are preserved).
+func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
+	}
+
+	if cfg.RetentionDays != 0 {
+		g.info.RetentionDays = cfg.RetentionDays
+	}
+	if cfg.Tags != nil {
+		g.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		g.info.Scope = cfg.Scope
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := g.info
+
+	return &result, nil
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -2,6 +2,7 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestListLogGroups(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		m := newTestMock()
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, len(groups))
@@ -170,7 +171,7 @@ func TestListLogGroups(t *testing.T) {
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
 		require.NoError(t, err)
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(groups))

--- a/providers/aws/cloudwatchlogs/ordering_test.go
+++ b/providers/aws/cloudwatchlogs/ordering_test.go
@@ -2,6 +2,7 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListLogGroups(ctx)
+	first, err := m.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListLogGroups(ctx)
+		again, err := m.ListLogGroups(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -4,6 +4,7 @@ package elasticache
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const defaultRedisPort = 6379
@@ -92,6 +94,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
 		Status:    "available",
@@ -134,15 +137,44 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 }
 
 // ListCaches lists all ElastiCache clusters.
-func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {
+		if !cd.info.Scope.Matches(filter) {
+			continue
+		}
 		caches = append(caches, cd.info)
 	}
 
 	return caches, nil
+}
+
+// UpdateCache replaces the mutable fields of an existing cache — ARM
+// CreateOrUpdate-on-existing semantics (node type and tags come from the
+// request; identity, endpoint, and CreatedAt are preserved).
+func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
+	}
+
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.Tags != nil {
+		cd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		cd.info.Scope = cfg.Scope
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := cd.info
+
+	return &result, nil
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/aws/elasticache/elasticache_test.go
+++ b/providers/aws/elasticache/elasticache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,7 +142,7 @@ func TestListCaches(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(caches))
 	})
@@ -150,7 +151,7 @@ func TestListCaches(t *testing.T) {
 	createTestCache(t, m, "cache-b")
 
 	t.Run("two caches", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(caches))
 	})

--- a/providers/aws/elasticache/ordering_test.go
+++ b/providers/aws/elasticache/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListCaches(ctx)
+	first, err := m.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListCaches(ctx)
+		again, err := m.ListCaches(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -106,6 +108,7 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 
 	info := driver.EventBusInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		ARN:       busARN,
 		State:     activeBusState,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -151,11 +154,14 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 }
 
 // ListEventBuses lists all EventBridge event buses.
-func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.EventBusInfo, error) {
 	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
+		if !bd.info.Scope.Matches(filter) {
+			continue
+		}
 		buses = append(buses, bd.info)
 	}
 
@@ -516,6 +522,29 @@ func matchesField(value string, allowed any) bool {
 	}
 
 	return false
+}
+
+// UpdateEventBus replaces the mutable fields of an existing event bus —
+// ARM CreateOrUpdate-on-existing semantics (tags come from the request;
+// identity and CreatedAt are preserved).
+func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", cfg.Name)
+	}
+
+	if cfg.Tags != nil {
+		bd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		bd.info.Scope = cfg.Scope
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := bd.info
+
+	return &result, nil
 }
 
 // MatchedRules returns all rules that match the given event (exported for testing).

--- a/providers/aws/eventbridge/eventbridge_test.go
+++ b/providers/aws/eventbridge/eventbridge_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -173,7 +174,7 @@ func TestListEventBuses(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("includes default bus", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, len(buses), 1)
 
@@ -190,7 +191,7 @@ func TestListEventBuses(t *testing.T) {
 	createTestBus(t, m, "bus-b")
 
 	t.Run("default plus two custom", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 3, len(buses))
 	})

--- a/providers/aws/eventbridge/ordering_test.go
+++ b/providers/aws/eventbridge/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListEventBuses(ctx)
+	first, err := m.ListEventBuses(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +31,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListEventBuses(ctx)
+		again, err := m.ListEventBuses(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/sns/ordering_test.go
+++ b/providers/aws/sns/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListTopics(ctx)
+	first, err := m.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListTopics(ctx)
+		again, err := m.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -3,6 +3,7 @@ package sns
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.Notification.
@@ -82,6 +84,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
+		Scope:             cfg.Scope,
 		ResourceID:        arn,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
@@ -122,19 +125,50 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 	return &result, nil
 }
 
-// ListTopics lists all SNS topics.
-func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+// ListTopics lists all SNS topics visible under the given scope filter.
+func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.TopicInfo, error) {
 	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
 	for _, td := range all {
+		if !td.info.Scope.Matches(filter) {
+			continue
+		}
+
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
 		topics = append(topics, info)
 	}
 
 	return topics, nil
+}
+
+// UpdateTopic replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (display name and tags come from the
+// request; identity is preserved).
+func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.DisplayName != "" {
+		td.info.DisplayName = cfg.DisplayName
+	}
+	if cfg.Tags != nil {
+		td.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		td.info.Scope = cfg.Scope
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
 }
 
 // Subscribe creates a subscription to an SNS topic.

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +157,7 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	err := m.DeleteTopic(ctx, info.Name)
 	require.NoError(t, err)
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 }
@@ -241,7 +242,7 @@ func TestListTopics(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 
@@ -249,7 +250,7 @@ func TestListTopics(t *testing.T) {
 	createTestTopic(t, m, "topic-2")
 	createTestTopic(t, m, "topic-3")
 
-	topics, err = m.ListTopics(ctx)
+	topics, err = m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(topics))
 }

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -4,6 +4,7 @@ package azurecache
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const defaultRedisSSLPort = 6380
@@ -102,6 +104,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
 		Status:    "Running",
@@ -144,15 +147,44 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 }
 
 // ListCaches lists all Azure Cache for Redis instances.
-func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {
+		if !cd.info.Scope.Matches(filter) {
+			continue
+		}
 		caches = append(caches, cd.info)
 	}
 
 	return caches, nil
+}
+
+// UpdateCache replaces the mutable fields of an existing cache — ARM
+// CreateOrUpdate-on-existing semantics (node type and tags come from the
+// request; identity, endpoint, and CreatedAt are preserved).
+func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
+	}
+
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.Tags != nil {
+		cd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		cd.info.Scope = cfg.Scope
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := cd.info
+
+	return &result, nil
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/azure/azurecache/azurecache_test.go
+++ b/providers/azure/azurecache/azurecache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,7 +142,7 @@ func TestListCaches(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(caches))
 	})
@@ -150,7 +151,7 @@ func TestListCaches(t *testing.T) {
 	createTestCache(t, m, "cache-b")
 
 	t.Run("two caches", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(caches))
 	})

--- a/providers/azure/azurecache/ordering_test.go
+++ b/providers/azure/azurecache/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListCaches(ctx)
+	first, err := m.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListCaches(ctx)
+		again, err := m.ListCaches(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -92,7 +94,17 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
 	}
 
-	topicID := idgen.AzureID(m.opts.AccountID, m.opts.Region, resourceProvider, resourceType, cfg.Name)
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = m.opts.Region
+	}
+
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+
+	topicID := idgen.AzureID(sub, rg, resourceProvider, resourceType, cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -101,6 +113,7 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 
 	info := driver.EventBusInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		ARN:       topicID,
 		State:     activeTopicState,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -142,11 +155,14 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 }
 
 // ListEventBuses lists all Event Grid topics.
-func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.EventBusInfo, error) {
 	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
+		if !bd.info.Scope.Matches(filter) {
+			continue
+		}
 		buses = append(buses, bd.info)
 	}
 
@@ -500,6 +516,29 @@ func matchesField(value string, allowed any) bool {
 	}
 
 	return false
+}
+
+// UpdateEventBus replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (tags come from the request; identity
+// and CreatedAt are preserved).
+func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.Tags != nil {
+		bd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		bd.info.Scope = cfg.Scope
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := bd.info
+
+	return &result, nil
 }
 
 // MatchedRules returns all subscriptions that match the given event (exported for testing).

--- a/providers/azure/eventgrid/eventgrid_test.go
+++ b/providers/azure/eventgrid/eventgrid_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,7 +128,7 @@ func TestListEventBuses(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(buses))
 	})
@@ -136,7 +137,7 @@ func TestListEventBuses(t *testing.T) {
 	createTestTopic(t, m, "topic-b")
 
 	t.Run("two topics", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(buses))
 	})

--- a/providers/azure/eventgrid/ordering_test.go
+++ b/providers/azure/eventgrid/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListEventBuses(ctx)
+	first, err := m.ListEventBuses(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListEventBuses(ctx)
+		again, err := m.ListEventBuses(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -3,6 +3,8 @@ package loganalytics
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -92,7 +94,15 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		retentionDays = defaultRetentionDays
 	}
 
-	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.OperationalInsights", "workspaces", cfg.Name)
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = "rg-default"
+	}
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+	resourceID := idgen.AzureID(sub, rg, "Microsoft.OperationalInsights", "workspaces", cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -101,6 +111,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
+		Scope:         cfg.Scope,
 		ResourceID:    resourceID,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -143,11 +154,14 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 }
 
 // ListLogGroups lists all Log Analytics workspaces.
-func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+func (m *Mock) ListLogGroups(_ context.Context, filter scope.Scope) ([]driver.LogGroupInfo, error) {
 	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
+		if !g.info.Scope.Matches(filter) {
+			continue
+		}
 		groups = append(groups, g.info)
 	}
 
@@ -503,4 +517,30 @@ func (m *Mock) DescribeMetricFilters(
 	}
 
 	return results, nil
+}
+
+// UpdateLogGroup replaces the mutable fields of an existing log group —
+// ARM CreateOrUpdate-on-existing semantics (retention and tags come from
+// the request; identity and CreatedAt are preserved).
+func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
+	}
+
+	if cfg.RetentionDays != 0 {
+		g.info.RetentionDays = cfg.RetentionDays
+	}
+	if cfg.Tags != nil {
+		g.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		g.info.Scope = cfg.Scope
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := g.info
+
+	return &result, nil
 }

--- a/providers/azure/loganalytics/loganalytics_test.go
+++ b/providers/azure/loganalytics/loganalytics_test.go
@@ -2,6 +2,7 @@ package loganalytics
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestListLogGroups(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		m := newTestMock()
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, len(groups))
@@ -170,7 +171,7 @@ func TestListLogGroups(t *testing.T) {
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
 		require.NoError(t, err)
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(groups))

--- a/providers/azure/loganalytics/ordering_test.go
+++ b/providers/azure/loganalytics/ordering_test.go
@@ -2,6 +2,7 @@ package loganalytics
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListLogGroups(ctx)
+	first, err := m.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListLogGroups(ctx)
+		again, err := m.ListLogGroups(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -4,6 +4,7 @@ package notificationhubs
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.Notification.
@@ -80,7 +82,15 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
 	}
 
-	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.NotificationHubs", "namespaces/default/notificationHubs", cfg.Name)
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = "rg-default"
+	}
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+	resourceID := idgen.AzureID(sub, rg, "Microsoft.NotificationHubs", "namespaces/default/notificationHubs", cfg.Name)
 
 	if m.topics.Has(cfg.Name) {
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
@@ -94,6 +104,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
+		Scope:             cfg.Scope,
 		ResourceID:        resourceID,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
@@ -134,19 +145,50 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 	return &result, nil
 }
 
-// ListTopics lists all notification hubs.
-func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+// ListTopics lists all notification hubs visible under the given scope filter.
+func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.TopicInfo, error) {
 	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
 	for _, td := range all {
+		if !td.info.Scope.Matches(filter) {
+			continue
+		}
+
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
 		topics = append(topics, info)
 	}
 
 	return topics, nil
+}
+
+// UpdateTopic replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (display name and tags come from the
+// request; identity is preserved).
+func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.DisplayName != "" {
+		td.info.DisplayName = cfg.DisplayName
+	}
+	if cfg.Tags != nil {
+		td.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		td.info.Scope = cfg.Scope
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
 }
 
 // Subscribe creates a subscription to a notification hub.

--- a/providers/azure/notificationhubs/notificationhubs_test.go
+++ b/providers/azure/notificationhubs/notificationhubs_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +157,7 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	err := m.DeleteTopic(ctx, info.Name)
 	require.NoError(t, err)
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 }
@@ -241,7 +242,7 @@ func TestListTopics(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 
@@ -249,7 +250,7 @@ func TestListTopics(t *testing.T) {
 	createTestTopic(t, m, "hub-2")
 	createTestTopic(t, m, "hub-3")
 
-	topics, err = m.ListTopics(ctx)
+	topics, err = m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(topics))
 }

--- a/providers/azure/notificationhubs/ordering_test.go
+++ b/providers/azure/notificationhubs/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListTopics(ctx)
+	first, err := m.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListTopics(ctx)
+		again, err := m.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -3,6 +3,8 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -96,6 +98,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
+		Scope:         cfg.Scope,
 		ResourceID:    selfLink,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -138,11 +141,14 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 }
 
 // ListLogGroups lists all Cloud Logging log buckets.
-func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+func (m *Mock) ListLogGroups(_ context.Context, filter scope.Scope) ([]driver.LogGroupInfo, error) {
 	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
+		if !g.info.Scope.Matches(filter) {
+			continue
+		}
 		groups = append(groups, g.info)
 	}
 
@@ -498,4 +504,30 @@ func (m *Mock) DescribeMetricFilters(
 	}
 
 	return results, nil
+}
+
+// UpdateLogGroup replaces the mutable fields of an existing log group —
+// ARM CreateOrUpdate-on-existing semantics (retention and tags come from
+// the request; identity and CreatedAt are preserved).
+func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
+	}
+
+	if cfg.RetentionDays != 0 {
+		g.info.RetentionDays = cfg.RetentionDays
+	}
+	if cfg.Tags != nil {
+		g.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		g.info.Scope = cfg.Scope
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := g.info
+
+	return &result, nil
 }

--- a/providers/gcp/cloudlogging/cloudlogging_test.go
+++ b/providers/gcp/cloudlogging/cloudlogging_test.go
@@ -2,6 +2,7 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestListLogGroups(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		m := newTestMock()
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, len(groups))
@@ -170,7 +171,7 @@ func TestListLogGroups(t *testing.T) {
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
 		require.NoError(t, err)
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(groups))

--- a/providers/gcp/cloudlogging/ordering_test.go
+++ b/providers/gcp/cloudlogging/ordering_test.go
@@ -2,6 +2,7 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListLogGroups(ctx)
+	first, err := m.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListLogGroups(ctx)
+		again, err := m.ListLogGroups(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/eventarc/eventarc.go
+++ b/providers/gcp/eventarc/eventarc.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -96,6 +98,7 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 
 	info := driver.EventBusInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		ARN:       channelID,
 		State:     activeChannelState,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -137,11 +140,14 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 }
 
 // ListEventBuses lists all Eventarc channels.
-func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.EventBusInfo, error) {
 	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
+		if !bd.info.Scope.Matches(filter) {
+			continue
+		}
 		buses = append(buses, bd.info)
 	}
 
@@ -526,6 +532,29 @@ func matchesField(value string, allowed any) bool {
 	}
 
 	return false
+}
+
+// UpdateEventBus replaces the mutable fields of an existing channel — ARM
+// CreateOrUpdate-on-existing semantics (tags come from the request; identity
+// and CreatedAt are preserved).
+func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", cfg.Name)
+	}
+
+	if cfg.Tags != nil {
+		bd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		bd.info.Scope = cfg.Scope
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := bd.info
+
+	return &result, nil
 }
 
 // MatchedRules returns all triggers that match the given event (exported for testing).

--- a/providers/gcp/eventarc/eventarc_test.go
+++ b/providers/gcp/eventarc/eventarc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/gcp/cloudmonitoring"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,7 +158,7 @@ func TestListEventBuses(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(buses))
 	})
@@ -166,7 +167,7 @@ func TestListEventBuses(t *testing.T) {
 	createTestChannel(t, m, "channel-b")
 
 	t.Run("two channels", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(buses))
 	})

--- a/providers/gcp/eventarc/ordering_test.go
+++ b/providers/gcp/eventarc/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListEventBuses(ctx)
+	first, err := m.ListEventBuses(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListEventBuses(ctx)
+		again, err := m.ListEventBuses(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -3,6 +3,7 @@ package fcm
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.Notification.
@@ -88,6 +90,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
+		Scope:             cfg.Scope,
 		ResourceID:        selfLink,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
@@ -128,19 +131,50 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 	return &result, nil
 }
 
-// ListTopics lists all FCM topics.
-func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+// ListTopics lists all FCM topics visible under the given scope filter.
+func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.TopicInfo, error) {
 	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
 	for _, td := range all {
+		if !td.info.Scope.Matches(filter) {
+			continue
+		}
+
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
 		topics = append(topics, info)
 	}
 
 	return topics, nil
+}
+
+// UpdateTopic replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (display name and tags come from the
+// request; identity is preserved).
+func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.DisplayName != "" {
+		td.info.DisplayName = cfg.DisplayName
+	}
+	if cfg.Tags != nil {
+		td.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		td.info.Scope = cfg.Scope
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
 }
 
 // Subscribe creates a subscription to an FCM topic.

--- a/providers/gcp/fcm/fcm_test.go
+++ b/providers/gcp/fcm/fcm_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,7 +161,7 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	err := m.DeleteTopic(ctx, info.Name)
 	require.NoError(t, err)
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 }
@@ -245,7 +246,7 @@ func TestListTopics(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 
@@ -253,7 +254,7 @@ func TestListTopics(t *testing.T) {
 	createTestTopic(t, m, "topic-2")
 	createTestTopic(t, m, "topic-3")
 
-	topics, err = m.ListTopics(ctx)
+	topics, err = m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(topics))
 }

--- a/providers/gcp/fcm/ordering_test.go
+++ b/providers/gcp/fcm/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListTopics(ctx)
+	first, err := m.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListTopics(ctx)
+		again, err := m.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -4,6 +4,7 @@ package memorystore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const defaultRedisPort = 6379
@@ -100,6 +102,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	info := driver.CacheInfo{
 		Name:      selfLink,
+		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
 		Status:    "READY",
@@ -142,15 +145,44 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 }
 
 // ListCaches lists all Memorystore instances.
-func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {
+		if !cd.info.Scope.Matches(filter) {
+			continue
+		}
 		caches = append(caches, cd.info)
 	}
 
 	return caches, nil
+}
+
+// UpdateCache replaces the mutable fields of an existing cache — ARM
+// CreateOrUpdate-on-existing semantics (node type and tags come from the
+// request; identity, endpoint, and CreatedAt are preserved).
+func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
+	}
+
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.Tags != nil {
+		cd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		cd.info.Scope = cfg.Scope
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := cd.info
+
+	return &result, nil
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/gcp/memorystore/memorystore_test.go
+++ b/providers/gcp/memorystore/memorystore_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +157,7 @@ func TestListCaches(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(caches))
 	})
@@ -165,7 +166,7 @@ func TestListCaches(t *testing.T) {
 	createTestCache(t, m, "cache-b")
 
 	t.Run("two caches", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(caches))
 	})

--- a/providers/gcp/memorystore/ordering_test.go
+++ b/providers/gcp/memorystore/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListCaches(ctx)
+	first, err := m.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListCaches(ctx)
+		again, err := m.ListCaches(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -1,6 +1,7 @@
 package cloudwatchlogs
 
 import (
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 	"strings"
 
@@ -34,7 +35,7 @@ func (h *Handler) describeLogGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	infos, err := h.logs.ListLogGroups(r.Context())
+	infos, err := h.logs.ListLogGroups(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // parseTags parses ElastiCache-style Tags.Tag.N.{Key,Value} entries.
@@ -67,7 +68,7 @@ func (h *Handler) describeCacheClusters(w http.ResponseWriter, r *http.Request) 
 
 		infos = []cachedriver.CacheInfo{*info}
 	} else {
-		all, err := h.cache.ListCaches(r.Context())
+		all, err := h.cache.ListCaches(r.Context(), scope.Scope{})
 		if err != nil {
 			writeErr(w, err)
 			return

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // --- event buses ---
@@ -50,7 +51,7 @@ func (h *Handler) describeEventBus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
-	infos, err := h.bus.ListEventBuses(r.Context())
+	infos, err := h.bus.ListEventBuses(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -8,6 +8,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createTopic maps CreateTopic to Notification.CreateTopic. SNS CreateTopic is
@@ -87,7 +88,7 @@ func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -139,7 +140,7 @@ func (h *Handler) unsubscribe(w http.ResponseWriter, r *http.Request) {
 // ListSubscriptions aggregated across every topic, since the driver has no
 // global subscription index.
 func (h *Handler) listSubscriptions(w http.ResponseWriter, r *http.Request) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -6,20 +6,17 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createOrUpdateCache handles PUT — Redis.BeginCreate. The LRO completes inline:
 // returning 201/200 with the resource body terminates the SDK's poller on the
-// first response.
+// first response. Create when absent, otherwise apply the request's mutable
+// fields (SKU, tags) via UpdateCache — ARM PUT semantics, so the caller's
+// changes are never silently discarded.
 func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body redisJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
-		return
-	}
-
-	// CreateOrUpdate is idempotent: if the cache already exists, echo it back.
-	if info, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
-		azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
 		return
 	}
 
@@ -28,6 +25,17 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		Engine:   "redis",
 		NodeType: nodeTypeFromBody(&body),
 		Tags:     body.Tags,
+		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	if _, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.cache.UpdateCache(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
+		azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
+		return
 	}
 
 	info, err := h.cache.CreateCache(r.Context(), cfg)
@@ -83,10 +91,12 @@ func (h *Handler) deleteCache(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 // listCaches handles GET on the collection — Redis.ListByResourceGroup /
-// ListBySubscription. The cache driver is not scope-aware, so both list the
-// same set.
+// ListBySubscription. The filter carries the path's subscription and, for
+// RG-level lists, its resource group; subscription-level lists leave the
+// resource group empty so the filter spans the subscription's groups.
 func (h *Handler) listCaches(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.cache.ListCaches(r.Context())
+	infos, err := h.cache.ListCaches(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/cache/scope_update_sdk_test.go
+++ b/server/azure/cache/scope_update_sdk_test.go
@@ -1,0 +1,110 @@
+package cache_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+func createRedis(t *testing.T, client *armredis.Client, rg, name string, tags map[string]*string) armredis.ResourceInfo {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, rg, name, armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Tags:     tags,
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate %s/%s: %v", rg, name, err)
+	}
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+	return res.ResourceInfo
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: caches
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, "rg-team-a", "cache-a1", nil)
+	createRedis(t, client, "rg-team-a", "cache-a2", nil)
+	createRedis(t, client, "rg-team-b", "cache-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := client.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, c := range page.Value {
+				names = append(names, *c.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 caches", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "cache-b1" {
+		t.Fatalf("rg-team-b listed %v, want [cache-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// BeginCreate on an existing cache must apply the request's tags, not echo
+// the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, testRG, "cache-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createRedis(t, client, testRG, "cache-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := client.Get(ctx, testRG, "cache-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	client := newRedisClient(t)
+
+	created := createRedis(t, client, "rg-id-check", "cache-id", nil)
+	if created.ID == nil {
+		t.Fatal("cache response has no id")
+	}
+	id := *created.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -88,13 +88,24 @@ func hostAndSSLPort(endpoint string) (string, int) {
 	return host, port
 }
 
-// toRedisJSON converts a driver CacheInfo into its ARM element for the given
-// path scope.
+// toRedisJSON converts a driver CacheInfo into its ARM element. The id carries
+// the scope the cache was created in; resources without a recorded scope
+// (portable-API creations) fall back to the request path's scope.
 func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJSON {
 	host, sslPort := hostAndSSLPort(info.Endpoint)
 
+	sub := info.Scope.Subscription
+	if sub == "" {
+		sub = rp.Subscription
+	}
+
+	rg := info.Scope.ResourceGroup
+	if rg == "" {
+		rg = rp.ResourceGroup
+	}
+
 	return redisJSON{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRedis, info.Name),
+		ID:       azurearm.BuildResourceID(sub, rg, providerName, typeRedis, info.Name),
 		Name:     info.Name,
 		Type:     redisResourceType,
 		Location: defaultLocation,

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -5,24 +5,38 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
+// createOrUpdateTopic maps Topics.CreateOrUpdate onto the eventbus driver:
+// create when absent, otherwise apply the request's mutable fields (tags) via
+// UpdateEventBus — ARM PUT semantics, so the caller's changes are never
+// silently discarded.
 func (h *Handler) createOrUpdateTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body topicJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	// CreateOrUpdate is idempotent: if the topic already exists, echo it back.
-	if info, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
+	cfg := ebdriver.EventBusConfig{
+		Name:  rp.ResourceName,
+		Tags:  tagsFromPtr(body.Tags),
+		Scope: scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	if _, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.bus.UpdateEventBus(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
+		// The armeventgrid SDK accepts only 201 for Topics.CreateOrUpdate,
+		// so the update path answers 201 as well.
 		azurearm.WriteJSON(w, http.StatusCreated, toTopicJSON(rp, info))
 		return
 	}
 
-	info, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
-		Name: rp.ResourceName,
-		Tags: tagsFromPtr(body.Tags),
-	})
+	info, err := h.bus.CreateEventBus(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -56,7 +70,8 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.bus.ListEventBuses(r.Context())
+	infos, err := h.bus.ListEventBuses(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/eventgrid/scope_update_sdk_test.go
+++ b/server/azure/eventgrid/scope_update_sdk_test.go
@@ -1,0 +1,103 @@
+package eventgrid_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+func createTopic(t *testing.T, client *armeventgrid.TopicsClient, rg, name string, tags map[string]*string) armeventgrid.Topic {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armeventgrid.Topic{
+		Location: to.Ptr("global"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+	return res.Topic
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: topics
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	client := newTopicsClient(t)
+	ctx := context.Background()
+
+	createTopic(t, client, "rg-team-a", "topic-a1", nil)
+	createTopic(t, client, "rg-team-a", "topic-a2", nil)
+	createTopic(t, client, "rg-team-b", "topic-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := client.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, tp := range page.Value {
+				names = append(names, *tp.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 topics", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "topic-b1" {
+		t.Fatalf("rg-team-b listed %v, want [topic-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// CreateOrUpdate on an existing topic must apply the request's tags, not
+// echo the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	client := newTopicsClient(t)
+	ctx := context.Background()
+
+	createTopic(t, client, testRG, "topic-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createTopic(t, client, testRG, "topic-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := client.Get(ctx, testRG, "topic-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	client := newTopicsClient(t)
+
+	tp := createTopic(t, client, "rg-id-check", "topic-id", nil)
+	if tp.ID == nil {
+		t.Fatal("topic response has no id")
+	}
+	id := *tp.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/loganalytics/operations.go
+++ b/server/azure/loganalytics/operations.go
@@ -1,6 +1,7 @@
 package loganalytics
 
 import (
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -8,25 +9,33 @@ import (
 )
 
 // createOrUpdateWorkspace maps Workspaces.CreateOrUpdate onto the logging
-// driver's log-group create. It is idempotent: if the workspace already exists
-// it is echoed back (the driver has no update primitive for retention/tags, so
-// this mirrors CreateOrUpdate's upsert contract for the fields we model).
+// driver: create when absent, otherwise apply the request's mutable fields
+// (retention, tags) via UpdateLogGroup — ARM PUT semantics, so the caller's
+// changes are never silently discarded.
 func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var req workspaceRequest
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	if info, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName); err == nil {
+	cfg := logdriver.LogGroupConfig{
+		Name:          rp.ResourceName,
+		RetentionDays: req.retentionDays(),
+		Tags:          req.Tags,
+		Scope:         scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	if _, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.logs.UpdateLogGroup(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 		azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(rp, info, req.Location))
 		return
 	}
 
-	info, err := h.logs.CreateLogGroup(r.Context(), logdriver.LogGroupConfig{
-		Name:          rp.ResourceName,
-		RetentionDays: req.retentionDays(),
-		Tags:          req.Tags,
-	})
+	info, err := h.logs.CreateLogGroup(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -57,7 +66,8 @@ func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.logs.ListLogGroups(r.Context())
+	infos, err := h.logs.ListLogGroups(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/loganalytics/scope_update_sdk_test.go
+++ b/server/azure/loganalytics/scope_update_sdk_test.go
@@ -1,0 +1,103 @@
+package loganalytics_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+)
+
+func createWS(t *testing.T, client *armoperationalinsights.WorkspacesClient, rg, name string, tags map[string]*string) armoperationalinsights.Workspace {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armoperationalinsights.Workspace{
+		Location: to.Ptr("eastus"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+	return res.Workspace
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: workspaces
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	createWS(t, client, "rg-team-a", "ws-a1", nil)
+	createWS(t, client, "rg-team-a", "ws-a2", nil)
+	createWS(t, client, "rg-team-b", "ws-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := client.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, ws := range page.Value {
+				names = append(names, *ws.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 workspaces", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "ws-b1" {
+		t.Fatalf("rg-team-b listed %v, want [ws-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// CreateOrUpdate on an existing workspace must apply the request's tags,
+// not echo the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	createWS(t, client, testRG, "ws-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createWS(t, client, testRG, "ws-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := client.Get(ctx, testRG, "ws-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	client := newWorkspacesClient(t)
+
+	ws := createWS(t, client, "rg-id-check", "ws-id", nil)
+	if ws.ID == nil {
+		t.Fatal("workspace response has no id")
+	}
+	id := *ws.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/notificationhubs/operations.go
+++ b/server/azure/notificationhubs/operations.go
@@ -6,27 +6,43 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
+
+// rpScope is the resource scope carried by the request path.
+func rpScope(rp *azurearm.ResourcePath) scope.Scope {
+	return scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+}
 
 // --- namespaces ---
 
-// createOrUpdateNamespace maps Namespaces.CreateOrUpdate to the driver.
-// CreateOrUpdate is idempotent: if the namespace already exists, echo it back.
+// createOrUpdateNamespace maps Namespaces.CreateOrUpdate onto the driver:
+// create when absent, otherwise apply the request's mutable fields (tags) via
+// UpdateTopic — ARM PUT semantics, so the caller's changes are never silently
+// discarded.
 func (h *Handler) createOrUpdateNamespace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body putBody
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	if info, err := h.notif.GetTopic(r.Context(), rp.ResourceName); err == nil {
+	cfg := notifdriver.TopicConfig{
+		Name:  rp.ResourceName,
+		Tags:  body.Tags,
+		Scope: rpScope(rp),
+	}
+
+	if _, err := h.notif.GetTopic(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.notif.UpdateTopic(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 		azurearm.WriteJSON(w, http.StatusOK, toNamespaceJSON(rp, info))
 		return
 	}
 
-	info, err := h.notif.CreateTopic(r.Context(), notifdriver.TopicConfig{
-		Name: rp.ResourceName,
-		Tags: body.Tags,
-	})
+	info, err := h.notif.CreateTopic(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -55,7 +71,7 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request, rp *az
 	}
 
 	// Best-effort cleanup of nested hub topics.
-	for _, name := range h.hubTopicNames(r, rp.ResourceName) {
+	for _, name := range h.hubTopicNames(r, rp) {
 		_ = h.notif.DeleteTopic(r.Context(), name)
 	}
 
@@ -63,7 +79,7 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) listNamespaces(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), rpScope(rp))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -98,16 +114,24 @@ func (h *Handler) createOrUpdateHub(w http.ResponseWriter, r *http.Request, rp *
 		ttl = body.Properties.RegistrationTTL
 	}
 
-	if info, err := h.notif.GetTopic(r.Context(), key); err == nil {
+	cfg := notifdriver.TopicConfig{
+		Name:        key,
+		DisplayName: ttl,
+		Tags:        body.Tags,
+		Scope:       rpScope(rp),
+	}
+
+	if _, err := h.notif.GetTopic(r.Context(), key); err == nil {
+		info, uerr := h.notif.UpdateTopic(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 		azurearm.WriteJSON(w, http.StatusOK, toHubJSON(rp, rp.ResourceName, rp.SubResourceName, info))
 		return
 	}
 
-	info, err := h.notif.CreateTopic(r.Context(), notifdriver.TopicConfig{
-		Name:        key,
-		DisplayName: ttl,
-		Tags:        body.Tags,
-	})
+	info, err := h.notif.CreateTopic(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -136,7 +160,7 @@ func (h *Handler) deleteHub(w http.ResponseWriter, r *http.Request, rp *azurearm
 }
 
 func (h *Handler) listHubs(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), rpScope(rp))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -159,14 +183,14 @@ func (h *Handler) listHubs(w http.ResponseWriter, r *http.Request, rp *azurearm.
 }
 
 // hubTopicNames returns the driver topic keys of every hub nested under the
-// given namespace.
-func (h *Handler) hubTopicNames(r *http.Request, namespace string) []string {
-	topics, err := h.notif.ListTopics(r.Context())
+// namespace named by the request path.
+func (h *Handler) hubTopicNames(r *http.Request, rp *azurearm.ResourcePath) []string {
+	topics, err := h.notif.ListTopics(r.Context(), rpScope(rp))
 	if err != nil {
 		return nil
 	}
 
-	prefix := namespace + hubKeySep
+	prefix := rp.ResourceName + hubKeySep
 
 	var names []string
 	for i := range topics {

--- a/server/azure/notificationhubs/scope_update_sdk_test.go
+++ b/server/azure/notificationhubs/scope_update_sdk_test.go
@@ -1,0 +1,100 @@
+package notificationhubs_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs"
+)
+
+func createNS(t *testing.T, client *armnotificationhubs.NamespacesClient, rg, name string, tags map[string]*string) armnotificationhubs.NamespaceResource {
+	t.Helper()
+	ctx := context.Background()
+
+	res, err := client.CreateOrUpdate(ctx, rg, name, armnotificationhubs.NamespaceCreateOrUpdateParameters{
+		Location: to.Ptr("global"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Namespaces.CreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+
+	return res.NamespaceResource
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: namespaces
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	namespaces, _ := newClients(t)
+	ctx := context.Background()
+
+	createNS(t, namespaces, "rg-team-a", "ns-a1", nil)
+	createNS(t, namespaces, "rg-team-a", "ns-a2", nil)
+	createNS(t, namespaces, "rg-team-b", "ns-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := namespaces.NewListPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, ns := range page.Value {
+				names = append(names, *ns.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 namespaces", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "ns-b1" {
+		t.Fatalf("rg-team-b listed %v, want [ns-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// CreateOrUpdate on an existing namespace must apply the request's tags,
+// not echo the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	namespaces, _ := newClients(t)
+	ctx := context.Background()
+
+	createNS(t, namespaces, testRG, "ns-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createNS(t, namespaces, testRG, "ns-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := namespaces.Get(ctx, testRG, "ns-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	namespaces, _ := newClients(t)
+
+	ns := createNS(t, namespaces, "rg-id-check", "ns-id", nil)
+	if ns.ID == nil {
+		t.Fatal("namespace response has no id")
+	}
+	id := *ns.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/gcp/cloudlogging/operations.go
+++ b/server/gcp/cloudlogging/operations.go
@@ -2,6 +2,7 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 	"time"
 
@@ -115,7 +116,7 @@ func (h *Handler) listEntries(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listLogs(w http.ResponseWriter, r *http.Request) {
 	project := projectFromPath(r.URL.Path)
 
-	infos, err := h.logs.ListLogGroups(r.Context())
+	infos, err := h.logs.ListLogGroups(r.Context(), scope.Scope{Project: project})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -6,6 +6,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -24,7 +25,7 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 
 	// Auto-provision the location's backing event bus on first use. Ignore an
 	// already-exists error so concurrent/repeat creates are idempotent.
-	if err := h.ensureChannel(r, bus); err != nil {
+	if err := h.ensureChannel(r, rt, bus); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
@@ -109,13 +110,17 @@ func (h *Handler) deleteTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 }
 
 // ensureChannel creates the location's backing event bus if it does not already
-// exist. An already-exists result is treated as success.
-func (h *Handler) ensureChannel(r *http.Request, bus string) error {
+// exist, recording the request's project as its scope. An already-exists result
+// is treated as success.
+func (h *Handler) ensureChannel(r *http.Request, rt *route, bus string) error {
 	if _, err := h.bus.GetEventBus(r.Context(), bus); err == nil {
 		return nil
 	}
 
-	_, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{Name: bus})
+	_, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
+		Name:  bus,
+		Scope: scope.Scope{Project: rt.project},
+	})
 	if err != nil && !cerrors.IsAlreadyExists(err) {
 		return err
 	}

--- a/server/gcp/fcm/ordering_sdk_test.go
+++ b/server/gcp/fcm/ordering_sdk_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // newFCMServiceWithDriver mirrors newFCMService but also returns the backing
@@ -59,7 +60,7 @@ func TestSDKListOrderingDeterministic(t *testing.T) {
 	}
 
 	listTopics := func() []string {
-		topics, err := driver.ListTopics(ctx)
+		topics, err := driver.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatalf("ListTopics: %v", err)
 		}

--- a/server/gcp/memorystore/operations.go
+++ b/server/gcp/memorystore/operations.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createInstance handles POST .../instances?instanceId={i} — Create. The
@@ -28,6 +29,7 @@ func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt rout
 		Engine:   "redis",
 		NodeType: body.Tier,
 		Tags:     body.Labels,
+		Scope:    scope.Scope{Project: rt.project},
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -58,9 +60,10 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rt route) 
 	gcprest.WriteJSON(w, http.StatusOK, toInstanceJSON(rt.project, rt.location, rt.name, info))
 }
 
-// listInstances handles GET .../instances — List.
+// listInstances handles GET .../instances — List, scoped to the request's
+// project.
 func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt route) {
-	infos, err := h.cache.ListCaches(r.Context())
+	infos, err := h.cache.ListCaches(r.Context(), scope.Scope{Project: rt.project})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/services/cache/cache.go
+++ b/services/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Cache is the portable cache type wrapping a driver with cross-cutting concerns.
@@ -123,7 +124,7 @@ func (c *Cache) GetCache(ctx context.Context, name string) (*driver.CacheInfo, e
 
 // ListCaches lists all cache instances.
 func (c *Cache) ListCaches(ctx context.Context) ([]driver.CacheInfo, error) {
-	out, err := c.do(ctx, "ListCaches", nil, func() (any, error) { return c.driver.ListCaches(ctx) })
+	out, err := c.do(ctx, "ListCaches", nil, func() (any, error) { return c.driver.ListCaches(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -4,6 +4,8 @@ package driver
 import (
 	"context"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Item represents a cached item.
@@ -23,6 +25,7 @@ type CacheInfo struct {
 	Endpoint  string
 	CreatedAt string
 	Tags      map[string]string
+	Scope     scope.Scope
 }
 
 // CacheConfig describes a cache instance to create.
@@ -31,14 +34,22 @@ type CacheConfig struct {
 	NodeType string
 	Engine   string // "redis", "memcached"
 	Tags     map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // Cache is the interface that cache provider implementations must satisfy.
 type Cache interface {
 	CreateCache(ctx context.Context, config CacheConfig) (*CacheInfo, error)
+
+	// UpdateCache replaces the mutable fields (node type, tags) of an
+	// existing cache, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateCache(ctx context.Context, config CacheConfig) (*CacheInfo, error)
 	DeleteCache(ctx context.Context, name string) error
 	GetCache(ctx context.Context, name string) (*CacheInfo, error)
-	ListCaches(ctx context.Context) ([]CacheInfo, error)
+	ListCaches(ctx context.Context, filter scope.Scope) ([]CacheInfo, error)
 
 	Set(ctx context.Context, cacheName, key string, value []byte, ttl time.Duration) error
 	Get(ctx context.Context, cacheName, key string) (*Item, error)

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -4,6 +4,8 @@ package driver
 import (
 	"context"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // EventBusInfo describes an event bus.
@@ -13,12 +15,17 @@ type EventBusInfo struct {
 	State     string // "ACTIVE", "INACTIVE"
 	CreatedAt string
 	Tags      map[string]string
+	Scope     scope.Scope
 }
 
 // EventBusConfig configures a new event bus.
 type EventBusConfig struct {
 	Name string
 	Tags map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // Rule defines an event routing rule with filtering.
@@ -70,9 +77,13 @@ type PublishResult struct {
 type EventBus interface {
 	// Bus management
 	CreateEventBus(ctx context.Context, config EventBusConfig) (*EventBusInfo, error)
+
+	// UpdateEventBus replaces the mutable fields (tags) of an existing
+	// event bus, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateEventBus(ctx context.Context, config EventBusConfig) (*EventBusInfo, error)
 	DeleteEventBus(ctx context.Context, name string) error
 	GetEventBus(ctx context.Context, name string) (*EventBusInfo, error)
-	ListEventBuses(ctx context.Context) ([]EventBusInfo, error)
+	ListEventBuses(ctx context.Context, filter scope.Scope) ([]EventBusInfo, error)
 
 	// Rule management
 	PutRule(ctx context.Context, config *RuleConfig) (*Rule, error)

--- a/services/eventbus/eventbus.go
+++ b/services/eventbus/eventbus.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // EventBus is the portable event bus type wrapping a driver with cross-cutting concerns.
@@ -131,7 +132,7 @@ func (eb *EventBus) GetEventBus(ctx context.Context, name string) (*driver.Event
 // ListEventBuses lists all event buses.
 func (eb *EventBus) ListEventBuses(ctx context.Context) ([]driver.EventBusInfo, error) {
 	out, err := eb.do(ctx, "ListEventBuses", nil, func() (any, error) {
-		return eb.driver.ListEventBuses(ctx)
+		return eb.driver.ListEventBuses(ctx, scope.Scope{})
 	})
 	if err != nil {
 		return nil, err

--- a/services/logging/driver/driver.go
+++ b/services/logging/driver/driver.go
@@ -4,6 +4,8 @@ package driver
 import (
 	"context"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // LogGroupConfig describes a log group to create.
@@ -11,6 +13,10 @@ type LogGroupConfig struct {
 	Name          string
 	RetentionDays int
 	Tags          map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // LogGroupInfo describes a log group.
@@ -21,6 +27,7 @@ type LogGroupInfo struct {
 	CreatedAt     string
 	StoredBytes   int64
 	Tags          map[string]string
+	Scope         scope.Scope
 }
 
 // LogStreamInfo describes a log stream within a log group.
@@ -87,9 +94,13 @@ type MetricFilterInfo struct {
 // Logging is the interface that logging provider implementations must satisfy.
 type Logging interface {
 	CreateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
+
+	// UpdateLogGroup replaces the mutable fields (retention, tags) of an
+	// existing log group, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
 	DeleteLogGroup(ctx context.Context, name string) error
 	GetLogGroup(ctx context.Context, name string) (*LogGroupInfo, error)
-	ListLogGroups(ctx context.Context) ([]LogGroupInfo, error)
+	ListLogGroups(ctx context.Context, filter scope.Scope) ([]LogGroupInfo, error)
 
 	CreateLogStream(ctx context.Context, logGroup, streamName string) (*LogStreamInfo, error)
 	DeleteLogStream(ctx context.Context, logGroup, streamName string) error

--- a/services/logging/logging.go
+++ b/services/logging/logging.go
@@ -3,6 +3,7 @@ package logging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/features/inject"
@@ -123,7 +124,7 @@ func (l *Logging) GetLogGroup(ctx context.Context, name string) (*driver.LogGrou
 
 // ListLogGroups lists all log groups.
 func (l *Logging) ListLogGroups(ctx context.Context) ([]driver.LogGroupInfo, error) {
-	out, err := l.do(ctx, "ListLogGroups", nil, func() (any, error) { return l.driver.ListLogGroups(ctx) })
+	out, err := l.do(ctx, "ListLogGroups", nil, func() (any, error) { return l.driver.ListLogGroups(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -1,13 +1,21 @@
 // Package driver defines the interface for notification service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
 
 // TopicConfig describes a notification topic to create.
 type TopicConfig struct {
 	Name        string
 	DisplayName string
 	Tags        map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // TopicInfo describes a notification topic.
@@ -18,6 +26,7 @@ type TopicInfo struct {
 	DisplayName       string
 	SubscriptionCount int
 	Tags              map[string]string
+	Scope             scope.Scope
 }
 
 // SubscriptionConfig describes a subscription to create.
@@ -52,9 +61,13 @@ type PublishOutput struct {
 // Notification is the interface that notification provider implementations must satisfy.
 type Notification interface {
 	CreateTopic(ctx context.Context, config TopicConfig) (*TopicInfo, error)
+
+	// UpdateTopic replaces the mutable fields (display name, tags) of an
+	// existing topic, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateTopic(ctx context.Context, config TopicConfig) (*TopicInfo, error)
 	DeleteTopic(ctx context.Context, id string) error
 	GetTopic(ctx context.Context, id string) (*TopicInfo, error)
-	ListTopics(ctx context.Context) ([]TopicInfo, error)
+	ListTopics(ctx context.Context, filter scope.Scope) ([]TopicInfo, error)
 
 	Subscribe(ctx context.Context, config SubscriptionConfig) (*SubscriptionInfo, error)
 	Unsubscribe(ctx context.Context, subscriptionID string) error

--- a/services/notification/notification.go
+++ b/services/notification/notification.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Notification is the portable notification type wrapping a driver with cross-cutting concerns.
@@ -123,7 +124,7 @@ func (n *Notification) GetTopic(ctx context.Context, id string) (*driver.TopicIn
 
 // ListTopics lists all topics.
 func (n *Notification) ListTopics(ctx context.Context) ([]driver.TopicInfo, error) {
-	out, err := n.do(ctx, "ListTopics", nil, func() (any, error) { return n.driver.ListTopics(ctx) })
+	out, err := n.do(ctx, "ListTopics", nil, func() (any, error) { return n.driver.ListTopics(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/scope/scope.go
+++ b/services/scope/scope.go
@@ -1,0 +1,41 @@
+// Package scope identifies the cloud-side container a resource lives in —
+// the Azure subscription/resource group or the GCP project. Drivers record
+// a resource's scope at create time and filter lists by it, so scoped list
+// endpoints (ListByResourceGroup, per-project lists) return only what the
+// caller's scope actually contains.
+package scope
+
+// Scope locates a resource. The zero value means "unscoped": AWS resources
+// and portable-API callers that don't care about scoping use it, and it
+// matches every filter.
+type Scope struct {
+	Subscription  string
+	ResourceGroup string
+	Project       string
+}
+
+// IsZero reports whether no scope information is set.
+func (s Scope) IsZero() bool {
+	return s == Scope{}
+}
+
+// Matches reports whether a resource created in scope s is visible under
+// filter f. Empty filter fields match anything, so a zero filter lists
+// everything and a subscription-only filter spans its resource groups.
+// Resources created without scope (portable API) are visible everywhere —
+// hiding them from scoped lists would make them unreachable over the wire.
+func (s Scope) Matches(f Scope) bool {
+	if s.IsZero() {
+		return true
+	}
+	if f.Subscription != "" && s.Subscription != f.Subscription {
+		return false
+	}
+	if f.ResourceGroup != "" && s.ResourceGroup != f.ResourceGroup {
+		return false
+	}
+	if f.Project != "" && s.Project != f.Project {
+		return false
+	}
+	return true
+}

--- a/services/scope/scope_test.go
+++ b/services/scope/scope_test.go
@@ -1,0 +1,24 @@
+package scope
+
+import "testing"
+
+func TestMatches(t *testing.T) {
+	rgA := Scope{Subscription: "sub1", ResourceGroup: "rg-a"}
+	rgB := Scope{Subscription: "sub1", ResourceGroup: "rg-b"}
+
+	if !rgA.Matches(Scope{}) {
+		t.Error("zero filter must match everything")
+	}
+	if !rgA.Matches(Scope{Subscription: "sub1"}) {
+		t.Error("subscription filter must span its resource groups")
+	}
+	if rgA.Matches(rgB) {
+		t.Error("different resource groups must not match")
+	}
+	if !(Scope{}).Matches(rgA) {
+		t.Error("unscoped resources stay visible under scoped filters")
+	}
+	if rgA.Matches(Scope{Subscription: "other"}) {
+		t.Error("different subscriptions must not match")
+	}
+}


### PR DESCRIPTION
Part 2 of the #259 series (after #275 landed deterministic list ordering). Covers items 1, 2, and 4 across the four #143 domains: **logging, eventbus, cache, notification**.

## What changed

**New `services/scope` package** — `Scope{Subscription, ResourceGroup, Project}` with wildcard `Matches` semantics: a zero scope on a resource means unscoped (visible everywhere), an empty filter field means "don't filter on this".

**Item 1 — scope-aware listing.** Each domain driver's `List*` now takes a `scope.Scope` filter, and each provider stores the creating request's scope on the resource. The Azure handlers pass the subscription/resource-group parsed from the URL, GCP handlers pass the request project, AWS handlers pass a zero scope (account-global, as before). Result: `ListByResourceGroup` no longer returns other groups' resources, and a GCP list no longer returns other projects' resources.

**Item 2 — CreateOrUpdate applies updates.** New `Update*` driver method per domain with ARM PUT semantics (mutable fields: tags, retention, node type, display name). The Azure CreateOrUpdate handlers now do Get → Update-with-request-fields instead of echoing the stale stored resource.

**Item 4 — request-derived ARM IDs.** Azure resource IDs are built from the request's subscription/resource group instead of hardcoded `rg-default` (fixed in loganalytics and notificationhubs providers; eventgrid topic IDs now derive from the creating scope). Note: the `rg-default` in `providers/azure/keyvault` is dead on the wire — the keyvault handler builds secret IDs from the request path — so it was left alone.

Portable wrappers (`services/<domain>`) keep their public signatures unchanged, passing a zero scope internally — portable-API users see everything, exactly as before.

## Testing

12 new real-SDK wire tests (3 per domain, in `server/azure/<svc>/scope_update_sdk_test.go`), using the same `httptest` + real Azure SDK bootstraps as the existing roundtrip suites:

- `TestSDKScopedListing` — resources created in `rg-team-a` don't appear in `rg-team-b`'s pager
- `TestSDKUpsertAppliesUpdates` — CreateOrUpdate on an existing resource applies the request's tags; a follow-up Get confirms
- `TestSDKResourceIDMatchesRequestScope` — the returned ARM id carries the request's subscription and resource group

Plus `services/scope` unit tests. Full `go test ./...` and `go vet ./...` clean; eventgrid packages verified stable with `-count=3`.

## Remaining for PR 3

#253 DNS deep pass (zone name uniqueness, structured TXT records, exact-match delete, upsert, batch atomicity).

Closes nothing yet — #259 stays open until PR 3 lands.