### PR TITLE
feat: standalone server mode — cloudemu serve (#224)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ CloudEmu_Research_Paper.docx
 _paper_imgs/
 generate_paper.py
 .claude/
+
+# standalone server binary
+/cloudemu

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory bac
 
 Equivalent setups for Azure (`azureserver.New`) and GCP (`gcpserver.New`) are in [docs/sdk-server.md](docs/sdk-server.md).
 
+### Standalone server
+
+Prefer a long-lived process you point out-of-process apps at? Run the emulator
+as a server and point any SDK — any language — at the printed endpoints:
+
+```sh
+go run ./cmd/cloudemu serve
+#   AWS         http://127.0.0.1:4566
+#   Azure       https://127.0.0.1:4568   (self-signed TLS)
+#   GCP         http://127.0.0.1:4569
+```
+
+Full flags, port scheme, and per-SDK wiring: [docs/standalone-server.md](docs/standalone-server.md).
+
 The snippet above is a quick taste. To adopt cloudemu in a real app, don't write a demo — wire it into your existing client and tests so your real code runs against it. See [docs/integration.md](docs/integration.md).
 
 ## Or use the Go API directly

--- a/cmd/cloudemu/endpoints.go
+++ b/cmd/cloudemu/endpoints.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// endpointSet is the machine-readable bundle of URLs a client points at. Empty
+// fields (a provider that wasn't started) are omitted from the JSON.
+type endpointSet struct {
+	AWS        string `json:"aws,omitempty"`
+	Azure      string `json:"azure,omitempty"`
+	GCP        string `json:"gcp,omitempty"`
+	Kubernetes string `json:"kubernetes,omitempty"`
+}
+
+func (e endpointSet) writeFile(path string) error {
+	b, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// printBanner writes the startup summary: the live endpoints and copy-paste
+// snippets for pointing each SDK at them.
+func printBanner(w io.Writer, e endpointSet) {
+	fmt.Fprintln(w, "cloudemu — standalone server")
+	fmt.Fprintln(w, "────────────────────────────")
+	if e.AWS != "" {
+		fmt.Fprintf(w, "  AWS         %s\n", e.AWS)
+	}
+	if e.Azure != "" {
+		fmt.Fprintf(w, "  Azure       %s   (self-signed TLS)\n", e.Azure)
+	}
+	if e.GCP != "" {
+		fmt.Fprintf(w, "  GCP         %s\n", e.GCP)
+	}
+	if e.Kubernetes != "" {
+		fmt.Fprintf(w, "  Kubernetes  %s\n", e.Kubernetes)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Point your SDKs at these endpoints:")
+	if e.AWS != "" {
+		fmt.Fprintf(w, "  AWS   export AWS_ENDPOINT_URL=%s   (or o.BaseEndpoint in aws-sdk-go-v2)\n", e.AWS)
+	}
+	if e.GCP != "" {
+		fmt.Fprintf(w, "  GCP   option.WithEndpoint(%q) + option.WithoutAuthentication()\n", e.GCP)
+	}
+	if e.Azure != "" {
+		fmt.Fprintf(w, "  Azure cloud.Configuration ResourceManager endpoint = %q (trust the cert or skip verify)\n", e.Azure)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Press Ctrl-C to stop.")
+}

--- a/cmd/cloudemu/main.go
+++ b/cmd/cloudemu/main.go
@@ -1,0 +1,49 @@
+// Command cloudemu runs the in-memory cloud emulator as a long-lived,
+// out-of-process HTTP server. Point real AWS, Azure, and GCP SDK clients at
+// the printed endpoints and they talk to cloudemu over the network exactly as
+// they would to the real cloud — no code changes, no accounts, no Docker.
+//
+// This is purely additive: the in-process test-double API
+// (cloudemu.NewAWS(), server/*.New(Drivers{...})) is unchanged.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const usage = `cloudemu — in-memory AWS/Azure/GCP emulator
+
+Usage:
+  cloudemu serve [flags]     Start the standalone server (see: cloudemu serve -h)
+  cloudemu version           Print the version
+  cloudemu help              Show this message
+
+Run "cloudemu serve -h" for the full list of serve flags.
+`
+
+// version is overridable at build time with
+// -ldflags "-X main.version=vX.Y.Z".
+var version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "serve":
+		if err := runServe(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "cloudemu:", err)
+			os.Exit(1)
+		}
+	case "version", "-v", "--version":
+		fmt.Println("cloudemu", version)
+	case "help", "-h", "--help":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "cloudemu: unknown command %q\n\n%s", os.Args[1], usage)
+		os.Exit(2)
+	}
+}

--- a/cmd/cloudemu/middleware.go
+++ b/cmd/cloudemu/middleware.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// wrap optionally decorates a provider handler with request logging. When
+// logging is off it returns the handler unchanged, so there is zero overhead
+// on the hot path.
+func wrap(h http.Handler, provider string, logReqs bool) http.Handler {
+	if !logReqs {
+		return h
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		h.ServeHTTP(sw, r)
+		log.Printf("[%s] %s %s → %d (%s)", provider, r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Microsecond))
+	})
+}
+
+// statusWriter captures the first response status for logging while remaining
+// a transparent http.ResponseWriter. Write is not overridden — it promotes from
+// the embedded writer, so a handler that writes a body without an explicit
+// WriteHeader is logged as the default 200.
+type statusWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (w *statusWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	"github.com/stackshy/cloudemu/v2/services/kubernetes"
+)
+
+// serveConfig holds the resolved serve flags.
+type serveConfig struct {
+	providers  string
+	host       string
+	awsPort    string
+	azurePort  string
+	gcpPort    string
+	k8sPort    string
+	accountID  string
+	region     string
+	projectID  string
+	latency    time.Duration
+	tlsCert    string
+	tlsKey     string
+	tlsHosts   stringList
+	endpoints  string
+	logReqs    bool
+	quiet      bool
+	shutdownTO time.Duration
+}
+
+// stringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+func (s *stringList) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+func runServe(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	var c serveConfig
+	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp")
+	fs.StringVar(&c.host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
+	fs.StringVar(&c.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
+	fs.StringVar(&c.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
+	fs.StringVar(&c.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
+	fs.StringVar(&c.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTP); empty to disable")
+	fs.StringVar(&c.accountID, "account-id", "000000000000", "AWS account ID / Azure subscription ID reported by the emulator")
+	fs.StringVar(&c.region, "region", "us-east-1", "default region reported by the emulator")
+	fs.StringVar(&c.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
+	fs.DurationVar(&c.latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
+	fs.StringVar(&c.tlsCert, "tls-cert", "", "PEM cert file for the Azure HTTPS endpoint (default: a self-signed cert generated in memory)")
+	fs.StringVar(&c.tlsKey, "tls-key", "", "PEM key file matching --tls-cert")
+	fs.Var(&c.tlsHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
+	fs.StringVar(&c.endpoints, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
+	fs.BoolVar(&c.logReqs, "log-requests", false, "log every HTTP request (method, path, status, duration)")
+	fs.BoolVar(&c.quiet, "quiet", false, "suppress the startup banner")
+	fs.DurationVar(&c.shutdownTO, "shutdown-timeout", 10*time.Second, "grace period for in-flight requests on shutdown")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if (c.tlsCert == "") != (c.tlsKey == "") {
+		return errors.New("--tls-cert and --tls-key must be given together")
+	}
+
+	sel, err := parseProviders(c.providers)
+	if err != nil {
+		return err
+	}
+
+	opts := []config.Option{
+		config.WithAccountID(c.accountID),
+		config.WithRegion(c.region),
+		config.WithProjectID(c.projectID),
+	}
+	if c.latency > 0 {
+		opts = append(opts, config.WithLatency(c.latency))
+	}
+
+	// One shared Kubernetes data-plane so a kubeconfig from any provider's
+	// control plane (EKS/AKS/GKE) reaches the same backend.
+	var k8s *kubernetes.APIServer
+	if c.k8sPort != "" {
+		k8s = kubernetes.NewAPIServer()
+	}
+
+	var (
+		servers []*namedServer
+		eps     = endpointSet{}
+	)
+
+	for _, p := range sel {
+		switch p {
+		case "aws":
+			cloud := cloudemu.NewAWS(opts...)
+			d := awsserver.DriversFrom(cloud)
+			d.K8sAPI = k8s
+			h := wrap(awsserver.New(d), "aws", c.logReqs)
+			addr := net.JoinHostPort(c.host, c.awsPort)
+			servers = append(servers, &namedServer{name: "aws", srv: &http.Server{Addr: addr, Handler: h}})
+			eps.AWS = fmt.Sprintf("http://%s", addr)
+		case "gcp":
+			cloud := cloudemu.NewGCP(opts...)
+			d := gcpserver.DriversFrom(cloud)
+			d.K8sAPI = k8s
+			h := wrap(gcpserver.New(d), "gcp", c.logReqs)
+			addr := net.JoinHostPort(c.host, c.gcpPort)
+			servers = append(servers, &namedServer{name: "gcp", srv: &http.Server{Addr: addr, Handler: h}})
+			eps.GCP = fmt.Sprintf("http://%s", addr)
+		case "azure":
+			cloud := cloudemu.NewAzure(opts...)
+			d := azureserver.DriversFrom(cloud)
+			d.K8sAPI = k8s
+			h := wrap(azureserver.New(d), "azure", c.logReqs)
+			addr := net.JoinHostPort(c.host, c.azurePort)
+			tlsCfg, err := tlsConfig(c, addr)
+			if err != nil {
+				return fmt.Errorf("azure TLS: %w", err)
+			}
+			servers = append(servers, &namedServer{name: "azure", srv: &http.Server{Addr: addr, Handler: h, TLSConfig: tlsCfg}, tls: true})
+			eps.Azure = fmt.Sprintf("https://%s", addr)
+		}
+	}
+
+	if k8s != nil {
+		addr := net.JoinHostPort(c.host, c.k8sPort)
+		servers = append(servers, &namedServer{name: "kubernetes", srv: &http.Server{Addr: addr, Handler: wrap(k8s, "kubernetes", c.logReqs)}})
+		eps.Kubernetes = fmt.Sprintf("http://%s", addr)
+	}
+
+	// Bind every listener before serving so a port clash fails fast, before
+	// we print a banner promising endpoints that never came up.
+	listeners := make([]net.Listener, len(servers))
+	for i, s := range servers {
+		ln, err := net.Listen("tcp", s.srv.Addr)
+		if err != nil {
+			for _, l := range listeners[:i] {
+				l.Close()
+			}
+			return fmt.Errorf("bind %s (%s): %w", s.name, s.srv.Addr, err)
+		}
+		listeners[i] = ln
+	}
+
+	errCh := make(chan error, len(servers))
+	for i, s := range servers {
+		s := s
+		ln := listeners[i]
+		go func() {
+			var err error
+			if s.tls {
+				err = s.srv.ServeTLS(ln, "", "")
+			} else {
+				err = s.srv.Serve(ln)
+			}
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("%s: %w", s.name, err)
+			}
+		}()
+	}
+
+	if !c.quiet {
+		printBanner(os.Stdout, eps)
+	}
+	if c.endpoints != "" {
+		if err := eps.writeFile(c.endpoints); err != nil {
+			return fmt.Errorf("write endpoints file: %w", err)
+		}
+	}
+
+	// Block until a signal or a fatal serve error.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case err := <-errCh:
+		return err
+	case <-sigCh:
+		if !c.quiet {
+			fmt.Fprintln(os.Stdout, "\nshutting down…")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.shutdownTO)
+	defer cancel()
+	var shutErr error
+	for _, s := range servers {
+		if err := s.srv.Shutdown(ctx); err != nil && shutErr == nil {
+			shutErr = err
+		}
+	}
+	return shutErr
+}
+
+type namedServer struct {
+	name string
+	srv  *http.Server
+	tls  bool
+}
+
+func parseProviders(s string) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+	for _, raw := range strings.Split(s, ",") {
+		p := strings.TrimSpace(strings.ToLower(raw))
+		if p == "" {
+			continue
+		}
+		if p != "aws" && p != "azure" && p != "gcp" {
+			return nil, fmt.Errorf("unknown provider %q (want aws, azure, or gcp)", p)
+		}
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no providers selected")
+	}
+	return out, nil
+}

--- a/cmd/cloudemu/serve_test.go
+++ b/cmd/cloudemu/serve_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// TestServeOutOfProcess builds the binary, runs it as a separate process, and
+// drives real cloud SDK clients against the listening sockets — the way an
+// actual user runs `cloudemu serve` and points an app at it. It exercises the
+// HTTP path (AWS) and the self-signed HTTPS path (Azure) end to end.
+func TestServeOutOfProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and execs a binary; skipped in -short")
+	}
+
+	awsPort := freePort(t)
+	azurePort := freePort(t)
+	gcpPort := freePort(t)
+
+	bin := filepath.Join(t.TempDir(), "cloudemu")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin, "serve",
+		"--host", "127.0.0.1",
+		"--aws-port", awsPort,
+		"--azure-port", azurePort,
+		"--gcp-port", gcpPort,
+		"--k8s-port", "", // Kubernetes data-plane not needed for this test
+		"--quiet",
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	awsEndpoint := "http://127.0.0.1:" + awsPort
+	if !waitReady(awsEndpoint+"/", 15*time.Second) {
+		t.Fatalf("AWS endpoint %s never became ready", awsEndpoint)
+	}
+
+	t.Run("aws-s3-over-http", func(t *testing.T) {
+		ctx := context.Background()
+		cfg, err := awsconfig.LoadDefaultConfig(ctx,
+			awsconfig.WithRegion("us-east-1"),
+			awsconfig.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider("test", "test", "")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(awsEndpoint)
+			o.UsePathStyle = true
+		})
+
+		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("demo")}); err != nil {
+			t.Fatalf("CreateBucket over the socket: %v", err)
+		}
+		out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+		if err != nil {
+			t.Fatalf("ListBuckets: %v", err)
+		}
+		if len(out.Buckets) != 1 || aws.ToString(out.Buckets[0].Name) != "demo" {
+			t.Fatalf("ListBuckets = %+v, want [demo]", out.Buckets)
+		}
+	})
+
+	t.Run("azure-arm-over-self-signed-https", func(t *testing.T) {
+		ctx := context.Background()
+		// A transport that trusts the emulator's self-signed cert. A real user
+		// either does this for local dev or installs the printed cert.
+		httpClient := &http.Client{Transport: &http.Transport{
+			// #nosec G402 -- local test trusts the emulator's self-signed cert.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+		azureEndpoint := "https://127.0.0.1:" + azurePort
+
+		cloudCfg := cloud.Configuration{
+			ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {Endpoint: azureEndpoint, Audience: "https://management.azure.com"},
+			},
+		}
+		opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+			Cloud:     cloudCfg,
+			Transport: httpClient,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		}}
+
+		cf, err := armservicebus.NewClientFactory("000000000000", fakeCred{}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := cf.NewNamespacesClient()
+
+		poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "ns-demo", armservicebus.SBNamespace{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate over HTTPS: %v", err)
+		}
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("poll: %v", err)
+		}
+		got, err := client.Get(ctx, "rg-1", "ns-demo", nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Name == nil || *got.Name != "ns-demo" {
+			t.Fatalf("Get namespace = %+v, want ns-demo", got.SBNamespace)
+		}
+	})
+}
+
+// fakeCred is a static-token Azure credential; cloudemu does not validate it.
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// waitReady polls url until it answers or the deadline passes.
+func waitReady(url string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+// freePort asks the OS for an unused TCP port and returns it as a string. The
+// listener is closed immediately; the small reuse window is acceptable in a
+// test.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port
+}

--- a/cmd/cloudemu/tlscert.go
+++ b/cmd/cloudemu/tlscert.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// tlsConfig returns the TLS config for the Azure HTTPS endpoint. If the user
+// supplied a cert/key pair we load it; otherwise we mint a self-signed cert in
+// memory covering localhost, the loopback IPs, the bind host, and any extra
+// --tls-host SANs.
+func tlsConfig(c serveConfig, addr string) (*tls.Config, error) {
+	if c.tlsCert != "" {
+		cert, err := tls.LoadX509KeyPair(c.tlsCert, c.tlsKey)
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = c.host
+	}
+	cert, err := selfSignedCert(append([]string{"localhost", host}, c.tlsHosts...))
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
+}
+
+// selfSignedCert generates an in-memory self-signed certificate valid for the
+// given hosts (DNS names and/or IP literals). It is a convenience for local
+// development only — clients must trust it or skip verification.
+func selfSignedCert(hosts []string) (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{Organization: []string{"cloudemu local"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	// Always cover the loopback IPs so https://127.0.0.1 / [::1] verify.
+	tmpl.IPAddresses = append(tmpl.IPAddresses, net.IPv4(127, 0, 0, 1), net.IPv6loopback)
+	seen := map[string]bool{}
+	for _, h := range hosts {
+		if h == "" || seen[h] {
+			continue
+		}
+		seen[h] = true
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else {
+			tmpl.DNSNames = append(tmpl.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("assemble keypair: %w", err)
+	}
+	return cert, nil
+}

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -1,0 +1,140 @@
+# Standalone server (`cloudemu serve`)
+
+`cloudemu serve` runs the emulator as a long-lived, out-of-process HTTP server.
+Point real AWS, Azure, and GCP SDK clients — in any language — at the printed
+endpoints and they talk to cloudemu over the network exactly as they would to
+the real cloud. No accounts, no Docker, no code changes.
+
+This is the "local dev cloud" mode. The in-process test-double API
+(`cloudemu.NewAWS()`, `awsserver.New(Drivers{…})`) is unchanged and still the
+right tool for unit tests.
+
+## Install & run
+
+```sh
+go install github.com/stackshy/cloudemu/v2/cmd/cloudemu@latest
+cloudemu serve
+```
+
+Or from a checkout:
+
+```sh
+go run ./cmd/cloudemu serve
+```
+
+On start it prints the live endpoints:
+
+```
+cloudemu — standalone server
+────────────────────────────
+  AWS         http://127.0.0.1:4566
+  Azure       https://127.0.0.1:4568   (self-signed TLS)
+  GCP         http://127.0.0.1:4569
+  Kubernetes  http://127.0.0.1:4570
+```
+
+## Ports
+
+| Provider   | Default | Protocol | Notes                                    |
+|------------|---------|----------|------------------------------------------|
+| AWS        | `4566`  | HTTP     | same port LocalStack uses                |
+| Azure      | `4568`  | HTTPS    | the ARM SDK requires TLS                 |
+| GCP        | `4569`  | HTTP     |                                          |
+| Kubernetes | `4570`  | HTTP     | shared data-plane for EKS/AKS/GKE        |
+
+Override with `--aws-port`, `--azure-port`, `--gcp-port`, `--k8s-port`. Start a
+subset with `--providers=aws,gcp`. Bind an interface with `--host 0.0.0.0` (the
+default `127.0.0.1` keeps it local-only).
+
+## Pointing SDKs at it
+
+### AWS (`aws-sdk-go-v2`)
+
+```go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(
+        credentials.NewStaticCredentialsProvider("test", "test", "")))
+
+client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String("http://127.0.0.1:4566")
+    o.UsePathStyle = true
+})
+```
+
+Other languages: set `AWS_ENDPOINT_URL=http://127.0.0.1:4566` (SDK v3 / CLI
+`--endpoint-url`). Any credentials are accepted — cloudemu does not validate
+signatures.
+
+### GCP (`cloud.google.com/go`)
+
+```go
+client, _ := storage.NewClient(ctx,
+    option.WithEndpoint("http://127.0.0.1:4569"),
+    option.WithoutAuthentication())
+```
+
+### Azure (`azure-sdk-for-go`)
+
+Azure is served over HTTPS with a self-signed cert. Point the SDK at it through
+a `cloud.Configuration`, and either trust the cert or use a transport that skips
+verification for local dev:
+
+```go
+cloudCfg := cloud.Configuration{
+    Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+        cloud.ResourceManager: {
+            Endpoint: "https://127.0.0.1:4568",
+            Audience: "https://management.azure.com",
+        },
+    },
+}
+opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{Cloud: cloudCfg}}
+```
+
+Any `azcore.TokenCredential` works — tokens are not validated.
+
+To supply your own cert instead of the generated one:
+
+```sh
+cloudemu serve --tls-cert cert.pem --tls-key key.pem
+# add SANs to the generated cert instead:
+cloudemu serve --tls-host myhost.local --tls-host 192.168.1.10
+```
+
+## Flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--providers` | `aws,azure,gcp` | which providers to start |
+| `--host` | `127.0.0.1` | bind interface |
+| `--aws-port` / `--azure-port` / `--gcp-port` / `--k8s-port` | `4566`/`4568`/`4569`/`4570` | listen ports (empty `--k8s-port` disables Kubernetes) |
+| `--account-id` | `000000000000` | AWS account ID / Azure subscription ID |
+| `--region` | `us-east-1` | default region |
+| `--project-id` | `cloudemu-local` | GCP project ID |
+| `--latency` | `0` | artificial per-call latency (e.g. `20ms`) |
+| `--tls-cert` / `--tls-key` | — | supply your own Azure cert (else self-signed) |
+| `--tls-host` | — | extra SAN for the generated cert (repeatable) |
+| `--endpoints-file` | — | write resolved endpoints as JSON |
+| `--log-requests` | `false` | log every request |
+| `--quiet` | `false` | suppress the startup banner |
+| `--shutdown-timeout` | `10s` | grace period for in-flight requests on Ctrl-C |
+
+`--endpoints-file cloudemu.json` emits a machine-readable bundle for wiring an
+app at the whole emulated cloud at once:
+
+```json
+{
+  "aws": "http://127.0.0.1:4566",
+  "azure": "https://127.0.0.1:4568",
+  "gcp": "http://127.0.0.1:4569",
+  "kubernetes": "http://127.0.0.1:4570"
+}
+```
+
+## Not yet included
+
+State **seeding** and **persistence** across restarts are not in this mode yet —
+they need a cross-service state-import loader (tracked in #250). Today the server
+starts empty each run. Docker packaging (#247) and a Testcontainers module (#248)
+build directly on this binary and are the natural next steps.

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -53,6 +53,8 @@ type Provider struct {
 	SageMaker         *sagemaker.Mock
 	SSM               *ssm.Mock
 	ResourceDiscovery *resourcediscovery.Engine
+	AccountID         string
+	Region            string
 }
 
 // New creates a new AWS provider with all mock services.
@@ -81,6 +83,8 @@ func New(opts ...config.Option) *Provider {
 		Bedrock:        bedrock.New(o),
 		SageMaker:      sagemaker.New(o),
 		SSM:            ssm.New(o),
+		AccountID:      o.AccountID,
+		Region:         o.Region,
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
 	p.S3.SetMonitoring(p.CloudWatch)

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -63,6 +63,13 @@ type Provider struct {
 	AzureSearch      *azuresearch.Mock
 
 	ResourceDiscovery *resourcediscovery.Engine
+
+	// SubscriptionID is the Azure subscription id this provider serves. Azure
+	// uses the account id as the subscription id (see the resourcediscovery.New
+	// call below, which passes o.AccountID as the subscription).
+	SubscriptionID string
+	// Region is the Azure location this provider serves.
+	Region string
 }
 
 // New creates a new Azure provider with all mock services.
@@ -94,6 +101,8 @@ func New(opts ...config.Option) *Provider {
 		Databricks:       databricks.New(o),
 		AzureAI:          azureai.New(o),
 		AzureSearch:      azuresearch.New(o),
+		SubscriptionID:   o.AccountID,
+		Region:           o.Region,
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
 	p.BlobStorage.SetMonitoring(p.Monitor)

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -48,6 +48,12 @@ type Provider struct {
 	VertexAI         *vertexai.Mock
 
 	ResourceDiscovery *resourcediscovery.Engine
+
+	// ProjectID and Region record the identity this provider was created with,
+	// so callers (e.g. a standalone server) can wire them without re-reading
+	// the options.
+	ProjectID string
+	Region    string
 }
 
 // New creates a new GCP provider with all mock services.
@@ -73,6 +79,8 @@ func New(opts ...config.Option) *Provider {
 		CloudSQL:         cloudsql.New(o),
 		GKE:              gke.New(o),
 		VertexAI:         vertexai.New(o),
+		ProjectID:        o.ProjectID,
+		Region:           o.Region,
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 	p.GCS.SetMonitoring(p.CloudMonitoring)

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -7,6 +7,7 @@
 package aws
 
 import (
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/server"
 	"github.com/stackshy/cloudemu/v2/server/aws/bedrock"
@@ -114,6 +115,49 @@ type Drivers struct {
 	ResourceDiscovery *resourcediscovery.Engine
 	AccountID         string
 	Region            string
+}
+
+// DriversFrom builds a Drivers bundle wiring every service handler to the
+// matching mock on p, so a standalone binary can serve a fully-constructed
+// provider without hand-mapping each field. STS is enabled (identity is
+// derived from AccountID/Region and is safe in standalone). K8sAPI is left
+// nil for the caller to inject when a shared cluster is desired.
+func DriversFrom(p *awsprovider.Provider) Drivers {
+	return Drivers{
+		S3:                p.S3,
+		DynamoDB:          p.DynamoDB,
+		EC2:               p.EC2,
+		VPC:               p.VPC,
+		CloudWatch:        p.CloudWatch,
+		Lambda:            p.Lambda,
+		SQS:               p.SQS,
+		RDS:               p.RDS,
+		Redshift:          p.Redshift,
+		EKS:               p.EKS,
+		IAM:               p.IAM,
+		ECR:               p.ECR,
+		Bedrock:           p.Bedrock,
+		SageMaker:         p.SageMaker,
+		SecretsManager:    p.SecretsManager,
+		SSM:               p.SSM,
+		CloudWatchLogs:    p.CloudWatchLogs,
+		Route53:           p.Route53,
+		ELB:               p.ELB,
+		EventBridge:       p.EventBridge,
+		ElastiCache:       p.ElastiCache,
+		SNS:               p.SNS,
+		STS:               true,
+		K8sAPI:            nil, // injected by the caller when a shared cluster is desired
+		ResourceDiscovery: p.ResourceDiscovery,
+		AccountID:         p.AccountID,
+		Region:            p.Region,
+	}
+}
+
+// NewFromProvider returns a server serving every service on p, using the
+// wiring built by DriversFrom.
+func NewFromProvider(p *awsprovider.Provider) *server.Server {
+	return New(DriversFrom(p))
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every

--- a/server/aws/fromprovider_test.go
+++ b/server/aws/fromprovider_test.go
@@ -1,0 +1,70 @@
+package aws_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestNewFromProvider verifies the convenience wiring: a fully-constructed
+// provider turned into a running server via NewFromProvider serves real
+// aws-sdk-go-v2 traffic (CreateBucket then HeadBucket).
+func TestNewFromProvider(t *testing.T) {
+	p := cloudemu.NewAWS()
+
+	srv := awsserver.NewFromProvider(p)
+	if srv == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.UsePathStyle = true
+	})
+
+	ctx := context.Background()
+	const bucket = "from-provider-bucket"
+
+	if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	out, err := client.ListBuckets(ctx, &awss3.ListBucketsInput{})
+	if err != nil {
+		t.Fatalf("ListBuckets: %v", err)
+	}
+
+	found := false
+	for _, b := range out.Buckets {
+		if aws.ToString(b.Name) == bucket {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created bucket %q not returned by ListBuckets: %+v", bucket, out.Buckets)
+	}
+}

--- a/server/azure/fromprovider.go
+++ b/server/azure/fromprovider.go
@@ -1,0 +1,79 @@
+package azure
+
+import (
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	"github.com/stackshy/cloudemu/v2/server"
+)
+
+// DriversFrom builds a Drivers bundle from a fully-constructed Azure provider,
+// wiring every server driver to the provider's corresponding mock. It lets a
+// standalone binary go from a *azure.Provider to a running server without
+// hand-mapping each field.
+//
+// The compute mock backs virtual machines, disks, snapshots, images and SSH
+// public keys (the compute driver's Volume*/Snapshot*/Image* methods). The
+// Databricks / Azure AI / Azure AI Search mocks each satisfy both the control
+// and data-plane driver interfaces, so a single mock feeds every related field.
+func DriversFrom(p *azureprovider.Provider) Drivers {
+	return Drivers{
+		// Compute mock backs all five compute-derived surfaces.
+		VirtualMachines: p.VirtualMachines,
+		Disks:           p.VirtualMachines,
+		Snapshots:       p.VirtualMachines,
+		Images:          p.VirtualMachines,
+		SSHPublicKeys:   p.VirtualMachines,
+
+		BlobStorage:  p.BlobStorage,
+		QueueStorage: p.QueueStorage,
+		TableStorage: p.TableStorage,
+		CosmosDB:     p.CosmosDB,
+		Network:      p.VNet,
+		Monitor:      p.Monitor,
+		Functions:    p.Functions,
+		ServiceBus:   p.ServiceBus,
+		SQL:          p.SQL,
+		PostgresFlex: p.PostgresFlex,
+		MySQLFlex:    p.MySQLFlex,
+		AKS:          p.AKS,
+		IAM:          p.IAM,
+		ACR:          p.ACR,
+		KeyVault:     p.KeyVault,
+		DNS:          p.DNS,
+		LB:           p.LB,
+		EventGrid:    p.EventGrid,
+		LogAnalytics: p.LogAnalytics,
+		Cache:        p.Cache,
+
+		NotificationHubs: p.NotificationHubs,
+
+		// Databricks mock satisfies both the control and data-plane drivers.
+		// DatabricksDataPlane must be set for registerDatabricksDataPlane to
+		// register the workspace data-plane handlers.
+		Databricks:          p.Databricks,
+		DatabricksDataPlane: p.Databricks,
+
+		// Azure AI mock satisfies CognitiveServices, MachineLearning and the
+		// inference/Assistants data plane.
+		CognitiveServices: p.AzureAI,
+		MachineLearning:   p.AzureAI,
+		AzureAIDataPlane:  p.AzureAI,
+
+		// Azure AI Search mock satisfies both the ARM control plane and the
+		// search data plane.
+		SearchControl:   p.AzureSearch,
+		SearchDataPlane: p.AzureSearch,
+
+		// K8sAPI is a shared handle with no provider source; the standalone
+		// server has no shared cluster by default.
+		K8sAPI: nil, // injected by the caller when a shared cluster is desired
+
+		ResourceDiscovery: p.ResourceDiscovery,
+		SubscriptionID:    p.SubscriptionID,
+	}
+}
+
+// NewFromProvider builds a ready-to-serve Azure server from a fully-constructed
+// provider, wiring every driver via DriversFrom.
+func NewFromProvider(p *azureprovider.Provider) *server.Server {
+	return New(DriversFrom(p))
+}

--- a/server/azure/fromprovider_test.go
+++ b/server/azure/fromprovider_test.go
@@ -1,0 +1,99 @@
+package azure_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const (
+	fpSubID  = "00000000-0000-0000-0000-000000000000"
+	fpRGName = "rg-fp"
+	fpNSName = "ns-fp"
+)
+
+// fakeCred is a static-token credential for tests.
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// TestNewFromProvider verifies that a server assembled straight from a
+// fully-constructed provider serves a real azure-sdk-for-go ARM call.
+func TestNewFromProvider(t *testing.T) {
+	p := cloudemu.NewAzure()
+
+	srv := azureserver.NewFromProvider(p)
+	if srv == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+
+	// The azure SDK refuses authenticated requests over plain HTTP, so the
+	// endpoint must be TLS (mirrors the existing server/azure roundtrip tests).
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armservicebus.NewClientFactory(fpSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("ClientFactory: %v", err)
+	}
+
+	client := cf.NewNamespacesClient()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, fpRGName, fpNSName,
+		armservicebus.SBNamespace{
+			Location: to.Ptr("eastus"),
+			SKU: &armservicebus.SBSKU{
+				Name: to.Ptr(armservicebus.SKUNameStandard),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != fpNSName {
+		t.Fatalf("created.Name = %v, want %s", created.Name, fpNSName)
+	}
+
+	got, err := client.Get(ctx, fpRGName, fpNSName, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != fpNSName {
+		t.Fatalf("got.Name = %v, want %s", got.Name, fpNSName)
+	}
+}

--- a/server/gcp/fromprovider.go
+++ b/server/gcp/fromprovider.go
@@ -1,0 +1,43 @@
+package gcp
+
+import (
+	gcpprovider "github.com/stackshy/cloudemu/v2/providers/gcp"
+	"github.com/stackshy/cloudemu/v2/server"
+)
+
+// DriversFrom maps a fully-constructed GCP provider onto a Drivers bundle,
+// wiring every service handler the standalone server can expose. It lets a
+// standalone binary go from a provider to a running server without
+// hand-mapping each field.
+func DriversFrom(p *gcpprovider.Provider) Drivers {
+	return Drivers{
+		Compute:          p.GCE,
+		Storage:          p.GCS,
+		Firestore:        p.Firestore,
+		Networking:       p.VPC,
+		Monitoring:       p.CloudMonitoring,
+		CloudFunctions:   p.CloudFunctions,
+		PubSub:           p.PubSub,
+		CloudSQL:         p.CloudSQL,
+		GKE:              p.GKE,
+		VertexAI:         p.VertexAI,
+		IAM:              p.IAM,
+		ArtifactRegistry: p.ArtifactRegistry,
+		CloudDNS:         p.CloudDNS,
+		LB:               p.LB,
+		CloudLogging:     p.CloudLogging,
+		SecretManager:    p.SecretManager,
+		Eventarc:         p.Eventarc,
+		Memorystore:      p.Memorystore,
+		FCM:              p.FCM,
+		// K8sAPI is left nil; injected by the caller when a shared cluster is desired.
+		K8sAPI:            nil,
+		ResourceDiscovery: p.ResourceDiscovery,
+		ProjectID:         p.ProjectID,
+	}
+}
+
+// NewFromProvider builds a GCP server from a fully-constructed provider.
+func NewFromProvider(p *gcpprovider.Provider) *server.Server {
+	return New(DriversFrom(p))
+}

--- a/server/gcp/fromprovider_test.go
+++ b/server/gcp/fromprovider_test.go
@@ -1,0 +1,55 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestNewFromProvider verifies that a server built straight from a
+// fully-constructed provider serves real cloud.google.com/go traffic.
+func TestNewFromProvider(t *testing.T) {
+	p := cloudemu.NewGCP()
+
+	srv := gcpserver.NewFromProvider(p)
+	if srv == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	bucket := client.Bucket("b1")
+
+	if err := bucket.Create(ctx, "p1", nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	attrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("bucket.Attrs: %v", err)
+	}
+
+	if attrs.Name != "b1" {
+		t.Errorf("bucket name mismatch: got=%q want=%q", attrs.Name, "b1")
+	}
+}


### PR DESCRIPTION
Implements the packaging half of #224 — the "minikube for cloud" standalone mode. The HTTP core was already reachable (each `server.New()` returns an `http.Handler`); this makes it a first-class, out-of-process server a real user can run and point any SDK at.

**Purely additive** — the in-process test-double API (`cloudemu.NewAWS()`, `awsserver.New(Drivers{…})`) is untouched.

## What's new

**`cmd/cloudemu serve`** — one binary boots all three providers on stable ports:

| Provider | Port | Proto |
|----------|------|-------|
| AWS | 4566 | HTTP (LocalStack's port) |
| Azure | 4568 | HTTPS (ARM SDK requires TLS) |
| GCP | 4569 | HTTP |
| Kubernetes | 4570 | HTTP (shared EKS/AKS/GKE data-plane) |

- **Self-signed TLS** generated in memory for Azure (SANs cover localhost + loopback + `--tls-host`); or supply your own with `--tls-cert`/`--tls-key`.
- **Endpoints bundle** printed on startup and written as JSON with `--endpoints-file`, so an app can be wired at the whole emulated cloud at once. Startup banner prints per-SDK snippets.
- **Config flags** map to existing `config.Option`s: `--account-id`, `--region`, `--project-id`, `--latency`. `--providers=aws,gcp` starts a subset; `--host 0.0.0.0` exposes on the network (default local-only).
- Graceful shutdown on SIGINT/SIGTERM; optional `--log-requests`; fail-fast port binding before the banner.

**Auto-wiring helpers** — `DriversFrom(provider)` + `NewFromProvider(provider)` in each `server/*` package turn a fully-constructed provider into a running server without hand-mapping 27/36/22 driver fields. Providers now expose their identity (`AccountID`/`Region`, `SubscriptionID`/`Region`, `ProjectID`/`Region`).

## Testing

`cmd/cloudemu/serve_test.go` builds the binary and runs it **as a separate process**, then drives:
- a real `aws-sdk-go-v2` S3 client (CreateBucket + ListBuckets) over the HTTP socket, and
- a real `azure-sdk-for-go` ARM client (namespace CreateOrUpdate + Get) over the **self-signed HTTPS** socket.

Plus per-provider `NewFromProvider` roundtrip tests. Full `go test ./...`, `go vet ./...`, `gofmt` all clean.

## Deferred (follow-ups)

- **State seeding / persistence** — needs a cross-service state-import loader (#250). The server starts empty each run; noted in the docs.
- **Docker image (#247)** and **Testcontainers module (#248)** build directly on this binary and are the natural next steps.

Docs: `docs/standalone-server.md` (quickstart, ports, per-SDK wiring, trust-the-cert) + README section.