### PR TITLE
fix: back Azure Service Bus namespaces with state — tags + scoped listing (#278)

### DIFF
--- a/server/azure/servicebus/handler.go
+++ b/server/azure/servicebus/handler.go
@@ -27,12 +27,15 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -46,12 +49,13 @@ const (
 
 // Handler serves ARM Service Bus + raw-HTTP data-plane requests.
 type Handler struct {
-	mq mqdriver.MessageQueue
+	mq         mqdriver.MessageQueue
+	namespaces *memstore.Store[namespaceState]
 }
 
 // New returns a Service Bus handler backed by mq.
 func New(mq mqdriver.MessageQueue) *Handler {
-	return &Handler{mq: mq}
+	return &Handler{mq: mq, namespaces: memstore.New[namespaceState]()}
 }
 
 // Matches accepts ARM Microsoft.ServiceBus/namespaces[...] paths plus
@@ -84,7 +88,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// /providers/Microsoft.ServiceBus/namespaces (subscription-level list)
 	if rp.ResourceName == "" {
-		h.listNamespaces(w, r)
+		h.listNamespaces(w, rp)
 		return
 	}
 
@@ -146,7 +150,7 @@ func (h *Handler) serveQueue(w http.ResponseWriter, r *http.Request, rp azurearm
 // ---------- Namespace control plane ----------
 
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+func (h *Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 
 	var req createNamespaceRequest
@@ -160,45 +164,91 @@ func (*Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azure
 		location = "eastus"
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, namespaceResource{
-		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
-			providerName, resourceType, rp.ResourceName),
-		Name:     rp.ResourceName,
-		Type:     providerName + "/" + resourceType,
-		Location: location,
-		Properties: namespaceProperties{
-			ProvisioningState:  "Succeeded",
-			ServiceBusEndpoint: "https://" + rp.ResourceName + ".servicebus.windows.net:443/",
-		},
-		SKU: req.SKU,
-	})
+	// PUT is create-or-update: store (and thus overwrite) the record so the
+	// request's tags and SKU are applied, mirroring ARM CreateOrUpdate.
+	ns := namespaceState{
+		Name:          rp.ResourceName,
+		Location:      location,
+		Subscription:  rp.Subscription,
+		ResourceGroup: rp.ResourceGroup,
+		Tags:          maps.Clone(req.Tags),
+		SKU:           cloneSKU(req.SKU),
+	}
+	h.namespaces.Set(rp.ResourceName, ns)
+
+	azurearm.WriteJSON(w, http.StatusOK, toNamespaceResource(ns))
 }
 
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) getNamespace(w http.ResponseWriter, _ *http.Request, rp azurearm.ResourcePath) {
-	// Namespaces are virtual — there's no driver state. Always return Succeeded.
-	azurearm.WriteJSON(w, http.StatusOK, namespaceResource{
-		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
-			providerName, resourceType, rp.ResourceName),
-		Name:     rp.ResourceName,
-		Type:     providerName + "/" + resourceType,
-		Location: "eastus",
-		Properties: namespaceProperties{
-			ProvisioningState:  "Succeeded",
-			ServiceBusEndpoint: "https://" + rp.ResourceName + ".servicebus.windows.net:443/",
-		},
-	})
+func (h *Handler) getNamespace(w http.ResponseWriter, _ *http.Request, rp azurearm.ResourcePath) {
+	ns, ok := h.namespaces.Get(rp.ResourceName)
+	if !ok || !namespaceInScope(ns, rp) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"namespace not found: "+rp.ResourceName)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toNamespaceResource(ns))
 }
 
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) deleteNamespace(w http.ResponseWriter, _ azurearm.ResourcePath) {
-	// Virtual namespace: nothing to free.
+func (h *Handler) deleteNamespace(w http.ResponseWriter, rp azurearm.ResourcePath) {
+	// Delete only if the namespace actually lives under the path's
+	// subscription/resource group — a wrong-scope delete must not remove it.
+	if ns, ok := h.namespaces.Get(rp.ResourceName); ok && namespaceInScope(ns, rp) {
+		h.namespaces.Delete(rp.ResourceName)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
-func (*Handler) listNamespaces(w http.ResponseWriter, _ *http.Request) {
-	// We don't track namespaces in the driver; return an empty list.
-	azurearm.WriteJSON(w, http.StatusOK, listResponse{Value: []any{}})
+// cloneSKU copies the SKU so stored state never aliases the decoded request.
+func cloneSKU(s *sbSKU) *sbSKU {
+	if s == nil {
+		return nil
+	}
+	c := *s
+	return &c
+}
+
+// namespaceInScope reports whether the stored namespace belongs to the
+// subscription and resource group named in the request path. A named-resource
+// path always carries both, so this is an exact match.
+func namespaceInScope(ns namespaceState, rp azurearm.ResourcePath) bool {
+	nsScope := scope.Scope{Subscription: ns.Subscription, ResourceGroup: ns.ResourceGroup}
+	return nsScope.Matches(scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listNamespaces(w http.ResponseWriter, rp azurearm.ResourcePath) {
+	// The same route serves subscription-level and resource-group-level lists;
+	// filter by whatever the request path carries (an empty resource group
+	// matches every group in the subscription).
+	out := listResponse{Value: []any{}}
+	for _, ns := range h.namespaces.SortedValues() {
+		if !namespaceInScope(ns, rp) {
+			continue
+		}
+		out.Value = append(out.Value, toNamespaceResource(ns))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// toNamespaceResource renders stored namespace state as the ARM JSON shape.
+func toNamespaceResource(ns namespaceState) namespaceResource {
+	return namespaceResource{
+		ID: azurearm.BuildResourceID(ns.Subscription, ns.ResourceGroup,
+			providerName, resourceType, ns.Name),
+		Name:     ns.Name,
+		Type:     providerName + "/" + resourceType,
+		Location: ns.Location,
+		Tags:     ns.Tags,
+		Properties: namespaceProperties{
+			ProvisioningState:  "Succeeded",
+			ServiceBusEndpoint: "https://" + ns.Name + ".servicebus.windows.net:443/",
+		},
+		SKU: ns.SKU,
+	}
 }
 
 // ---------- Queue control plane ----------

--- a/server/azure/servicebus/namespace_sdk_test.go
+++ b/server/azure/servicebus/namespace_sdk_test.go
@@ -1,0 +1,130 @@
+package servicebus_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newNamespacesClient(t *testing.T, ts *httptest.Server) *armservicebus.NamespacesClient {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+	opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud: myCloud, Transport: ts.Client(),
+		Retry: policy.RetryOptions{MaxRetries: -1},
+	}}
+
+	cf, err := armservicebus.NewClientFactory(subID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("ClientFactory: %v", err)
+	}
+	return cf.NewNamespacesClient()
+}
+
+func createNS(t *testing.T, c *armservicebus.NamespacesClient, rg, name string, tags map[string]*string) {
+	t.Helper()
+	ctx := context.Background()
+	poller, err := c.BeginCreateOrUpdate(ctx, rg, name, armservicebus.SBNamespace{
+		Location: to.Ptr("eastus"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+}
+
+// TestSDKNamespaceTagsAndScopedListing is the regression for #278: namespaces
+// created with tags must return them on Get, and ListByResourceGroup must
+// return only the namespaces in that resource group.
+func TestSDKNamespaceTagsAndScopedListing(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ServiceBus: cloudP.ServiceBus})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	c := newNamespacesClient(t, ts)
+	ctx := context.Background()
+
+	createNS(t, c, "rg-a", "ns-a", map[string]*string{"env": to.Ptr("prod")})
+	createNS(t, c, "rg-a", "ns-a2", nil)
+	createNS(t, c, "rg-b", "ns-b", nil)
+
+	// Tags survive create → Get.
+	got, err := c.Get(ctx, "rg-a", "ns-a", nil)
+	if err != nil {
+		t.Fatalf("Get ns-a: %v", err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Fatalf("ns-a tags = %v, want env=prod", got.Tags)
+	}
+
+	// ListByResourceGroup is scoped to its resource group.
+	listRG := func(rg string) []string {
+		var names []string
+		pager := c.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, ns := range page.Value {
+				names = append(names, *ns.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-a list = %v, want its own 2 namespaces", gotA)
+	}
+	gotB := listRG("rg-b")
+	if len(gotB) != 1 || gotB[0] != "ns-b" {
+		t.Fatalf("rg-b list = %v, want [ns-b]", gotB)
+	}
+
+	// Get from the wrong resource group must 404 — ns-a lives in rg-a.
+	if _, err := c.Get(ctx, "rg-b", "ns-a", nil); err == nil {
+		t.Fatal("Get ns-a via rg-b returned nil error, want NotFound")
+	}
+
+	// Delete from the wrong resource group must not remove the namespace.
+	wrongDel, err := c.BeginDelete(ctx, "rg-b", "ns-a", nil)
+	if err == nil {
+		_, _ = wrongDel.PollUntilDone(ctx, nil)
+	}
+	if _, err := c.Get(ctx, "rg-a", "ns-a", nil); err != nil {
+		t.Fatalf("ns-a should survive a wrong-group delete, but Get failed: %v", err)
+	}
+
+	// A deleted namespace disappears from Get.
+	delPoller, err := c.BeginDelete(ctx, "rg-b", "ns-b", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete ns-b: %v", err)
+	}
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete ns-b: %v", err)
+	}
+	if _, err := c.Get(ctx, "rg-b", "ns-b", nil); err == nil {
+		t.Fatal("Get after delete returned nil error, want NotFound")
+	}
+}

--- a/server/azure/servicebus/types.go
+++ b/server/azure/servicebus/types.go
@@ -6,8 +6,22 @@ type namespaceResource struct {
 	Name       string              `json:"name"`
 	Type       string              `json:"type"`
 	Location   string              `json:"location"`
+	Tags       map[string]string   `json:"tags,omitempty"`
 	Properties namespaceProperties `json:"properties"`
 	SKU        *sbSKU              `json:"sku,omitempty"`
+}
+
+// namespaceState is the stored control-plane record for a namespace. Namespaces
+// are Azure-only ARM containers with no portable-driver equivalent, so their
+// state lives here on the handler. Keyed by name (namespace names are globally
+// unique in Azure).
+type namespaceState struct {
+	Name          string
+	Location      string
+	Subscription  string
+	ResourceGroup string
+	Tags          map[string]string
+	SKU           *sbSKU
 }
 
 type namespaceProperties struct {
@@ -52,6 +66,7 @@ type createQueueRequest struct {
 
 // createNamespaceRequest is what we read from a PUT /namespaces/{ns} body.
 type createNamespaceRequest struct {
-	Location string `json:"location"`
-	SKU      *sbSKU `json:"sku,omitempty"`
+	Location string            `json:"location"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	SKU      *sbSKU            `json:"sku,omitempty"`
 }


### PR DESCRIPTION
Fixes #278.

Surfaced by an out-of-process real-SDK run against `cloudemu serve`: Service Bus namespaces were a stub, so a real `armservicebus` client got wrong results.

## Problem

`server/azure/servicebus/handler.go` didn't track namespaces:
- `createNamespace` never persisted or echoed `req.Tags` (no `Tags` field existed),
- `getNamespace` returned a synthetic `Succeeded` namespace regardless of what was created,
- `listNamespaces` always returned `[]` ("We don't track namespaces in the driver").

(The *queue* control plane, which is driver-backed, already worked — only the virtual *namespace* container was stubbed.)

## Fix

Give the handler an in-memory namespace store keyed by name (namespace names are globally unique in Azure):
- **CreateOrUpdate** stores location, tags, SKU, and the request's subscription/resource-group scope, and re-applies them on a repeat PUT (ARM PUT semantics).
- **Get** returns the stored record — and a proper `404 ResourceNotFound` when the namespace doesn't exist, instead of a fake `Succeeded`.
- **List** filters by the request path's subscription/resource-group through `services/scope` (the same scope semantics as the #259 series), in deterministic sorted order.

## Testing

New real-SDK regression `TestSDKNamespaceTagsAndScopedListing` (armservicebus over TLS): tags survive create→Get, `ListByResourceGroup` returns only that group's namespaces, and a deleted namespace 404s on Get. Existing namespace/queue/data-plane tests still pass.

Verified end-to-end: the same real-user run that found this now passes 19/19 across S3, DynamoDB, SQS, GCS, and Service Bus against the running `cloudemu serve` binary. Full `go test ./...`, `go vet ./...`, `gofmt` clean.