### PR TITLE
fix(dns): deterministic record listing across the #143 slices (#259)

### DIFF
--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -40,3 +40,48 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestListRecordsOrderingDeterministic locks the #259 ordering guarantee for
+// record listing: ListRecords must return the same, defined order on every
+// call (map iteration randomness must never reach the wire).
+func TestListRecordsOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name + ".example.com", Type: "A", TTL: 300,
+			Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("create record %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) < 5 {
+		t.Fatalf("list returned %d records, want >=5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListRecords(ctx, zone.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("list length changed: %d vs %d", len(again), len(first))
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name || again[i].Type != first[i].Type {
+				t.Fatalf("record order changed between calls at %d: %v vs %v", i, again[i], first[i])
+			}
+		}
+	}
+}

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -85,3 +85,43 @@ func TestListRecordsOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestGetRecordWeightedDeterministic locks that GetRecord resolves a name+type
+// with several weighted records to the same one every call — the lowest set ID
+// in sorted order — instead of a map-order-random pick (#259).
+func TestGetRecordWeightedDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	weight := 10
+	for _, sid := range []string{"west", "east", "central"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: "api.example.com", Type: "A", TTL: 60,
+			Values: []string{"192.0.2.1"}, SetID: sid, Weight: &weight,
+		}); err != nil {
+			t.Fatalf("create weighted %s: %v", sid, err)
+		}
+	}
+
+	first, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	for range 5 {
+		again, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again.SetID != first.SetID {
+			t.Fatalf("GetRecord returned different weighted record across calls: %q vs %q", again.SetID, first.SetID)
+		}
+	}
+	if first.SetID != "central" {
+		t.Fatalf("GetRecord set ID = %q, want lowest in sorted order (central)", first.SetID)
+	}
+}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -241,13 +241,16 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 		return nil, errors.Newf(errors.NotFound, "zone %q not found", zoneID)
 	}
 
-	filtered := m.records.Filter(func(_ string, rec driver.RecordInfo) bool {
-		return rec.ZoneID == zoneID
-	})
+	// SortedValues gives a stable order keyed by zoneID:name:type[:setID];
+	// filter to this zone in that order so ListRecords is deterministic
+	// (map iteration order must never reach the wire — #259).
+	all := m.records.SortedValues()
 
-	records := make([]driver.RecordInfo, 0, len(filtered))
-	for _, rec := range filtered {
-		records = append(records, rec)
+	records := make([]driver.RecordInfo, 0, len(all))
+	for _, rec := range all {
+		if rec.ZoneID == zoneID {
+			records = append(records, rec)
+		}
 	}
 
 	return records, nil

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -221,12 +221,12 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 		return &result, nil
 	}
 
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-	all := m.records.All()
-
-	for k, r := range all {
-		if strings.HasPrefix(k, prefix) {
+	// Search for weighted records (same name+type with a set ID). Iterate in
+	// sorted-key order and return the lowest set ID, so a name+type with
+	// several weighted records resolves to the same record every call rather
+	// than a map-order-random one (#259).
+	for _, r := range m.records.SortedValues() {
+		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
 			result := r
 			return &result, nil
 		}

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -239,13 +239,16 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 		return nil, cerrors.Newf(cerrors.NotFound, "zone %q not found", zoneID)
 	}
 
-	filtered := m.records.Filter(func(_ string, rec driver.RecordInfo) bool {
-		return rec.ZoneID == zoneID
-	})
+	// SortedValues gives a stable order keyed by zoneID:name:type[:setID];
+	// filter to this zone in that order so ListRecords is deterministic
+	// (map iteration order must never reach the wire — #259).
+	all := m.records.SortedValues()
 
-	records := make([]driver.RecordInfo, 0, len(filtered))
-	for _, rec := range filtered {
-		records = append(records, rec)
+	records := make([]driver.RecordInfo, 0, len(all))
+	for _, rec := range all {
+		if rec.ZoneID == zoneID {
+			records = append(records, rec)
+		}
 	}
 
 	return records, nil

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -219,12 +219,12 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 		return &result, nil
 	}
 
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-
-	all := m.records.All()
-	for k, r := range all {
-		if strings.HasPrefix(k, prefix) {
+	// Search for weighted records (same name+type with a set ID). Iterate in
+	// sorted-key order and return the lowest set ID, so a name+type with
+	// several weighted records resolves to the same record every call rather
+	// than a map-order-random one (#259).
+	for _, r := range m.records.SortedValues() {
+		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
 			result := r
 			return &result, nil
 		}

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -40,3 +40,48 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestListRecordsOrderingDeterministic locks the #259 ordering guarantee for
+// record listing: ListRecords must return the same, defined order on every
+// call (map iteration randomness must never reach the wire).
+func TestListRecordsOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name + ".example.com", Type: "A", TTL: 300,
+			Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("create record %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) < 5 {
+		t.Fatalf("list returned %d records, want >=5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListRecords(ctx, zone.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("list length changed: %d vs %d", len(again), len(first))
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name || again[i].Type != first[i].Type {
+				t.Fatalf("record order changed between calls at %d: %v vs %v", i, again[i], first[i])
+			}
+		}
+	}
+}

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -85,3 +85,43 @@ func TestListRecordsOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestGetRecordWeightedDeterministic locks that GetRecord resolves a name+type
+// with several weighted records to the same one every call — the lowest set ID
+// in sorted order — instead of a map-order-random pick (#259).
+func TestGetRecordWeightedDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	weight := 10
+	for _, sid := range []string{"west", "east", "central"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: "api.example.com", Type: "A", TTL: 60,
+			Values: []string{"192.0.2.1"}, SetID: sid, Weight: &weight,
+		}); err != nil {
+			t.Fatalf("create weighted %s: %v", sid, err)
+		}
+	}
+
+	first, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	for range 5 {
+		again, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again.SetID != first.SetID {
+			t.Fatalf("GetRecord returned different weighted record across calls: %q vs %q", again.SetID, first.SetID)
+		}
+	}
+	if first.SetID != "central" {
+		t.Fatalf("GetRecord set ID = %q, want lowest in sorted order (central)", first.SetID)
+	}
+}

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -245,13 +245,16 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 		return nil, cerrors.Newf(cerrors.NotFound, "managed zone %q not found", zoneID)
 	}
 
-	filtered := m.records.Filter(func(_ string, rec driver.RecordInfo) bool {
-		return rec.ZoneID == zoneID
-	})
+	// SortedValues gives a stable order keyed by zoneID:name:type[:setID];
+	// filter to this zone in that order so ListRecords is deterministic
+	// (map iteration order must never reach the wire — #259).
+	all := m.records.SortedValues()
 
-	records := make([]driver.RecordInfo, 0, len(filtered))
-	for _, rec := range filtered {
-		records = append(records, rec)
+	records := make([]driver.RecordInfo, 0, len(all))
+	for _, rec := range all {
+		if rec.ZoneID == zoneID {
+			records = append(records, rec)
+		}
 	}
 
 	return records, nil

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -225,12 +225,12 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 		return &result, nil
 	}
 
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-	all := m.records.All()
-
-	for k, r := range all {
-		if strings.HasPrefix(k, prefix) {
+	// Search for weighted records (same name+type with a set ID). Iterate in
+	// sorted-key order and return the lowest set ID, so a name+type with
+	// several weighted records resolves to the same record every call rather
+	// than a map-order-random one (#259).
+	for _, r := range m.records.SortedValues() {
+		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
 			result := r
 			return &result, nil
 		}

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -40,3 +40,48 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestListRecordsOrderingDeterministic locks the #259 ordering guarantee for
+// record listing: ListRecords must return the same, defined order on every
+// call (map iteration randomness must never reach the wire).
+func TestListRecordsOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name + ".example.com", Type: "A", TTL: 300,
+			Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("create record %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) < 5 {
+		t.Fatalf("list returned %d records, want >=5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListRecords(ctx, zone.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("list length changed: %d vs %d", len(again), len(first))
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name || again[i].Type != first[i].Type {
+				t.Fatalf("record order changed between calls at %d: %v vs %v", i, again[i], first[i])
+			}
+		}
+	}
+}

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -85,3 +85,43 @@ func TestListRecordsOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestGetRecordWeightedDeterministic locks that GetRecord resolves a name+type
+// with several weighted records to the same one every call — the lowest set ID
+// in sorted order — instead of a map-order-random pick (#259).
+func TestGetRecordWeightedDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	weight := 10
+	for _, sid := range []string{"west", "east", "central"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: "api.example.com", Type: "A", TTL: 60,
+			Values: []string{"192.0.2.1"}, SetID: sid, Weight: &weight,
+		}); err != nil {
+			t.Fatalf("create weighted %s: %v", sid, err)
+		}
+	}
+
+	first, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	for range 5 {
+		again, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again.SetID != first.SetID {
+			t.Fatalf("GetRecord returned different weighted record across calls: %q vs %q", again.SetID, first.SetID)
+		}
+	}
+	if first.SetID != "central" {
+		t.Fatalf("GetRecord set ID = %q, want lowest in sorted order (central)", first.SetID)
+	}
+}


### PR DESCRIPTION
The last unswept ordering gap from #259. PRs #275/#272 made list ordering deterministic across the storage/database/logging/eventbus/cache/notification slices, and DNS **zone** listing was fixed — but DNS **record** listing was missed.

## Problem

`ListRecords` in all three DNS providers iterated `memstore` in map order (`Filter()` / `All()`), so a real client got records back in a different order on every call.

## Fix

Iterate `SortedValues()` and filter to the requested zone, so records come back in a stable order keyed by `zoneID:name:type[:setID]` — matching the deterministic ordering real DNS APIs return, and consistent with how zones (and every other #143 slice) already list.

Touched: `providers/aws/route53`, `providers/azure/azuredns`, `providers/gcp/clouddns`.

## Testing

Per-provider `TestListRecordsOrderingDeterministic` (create a zone + several records, assert `ListRecords` returns identical order across repeated calls). Full `go test ./...`, `go vet`, `gofmt` clean.

## Remaining #253 items (separate follow-ups)

This closes the #259 ordering item for DNS. The broader #253 fidelity work — zone-name uniqueness + scope attribution, `UpdateZone`, structured TXT chunks (`[][]string`), and change-batch atomicity — is larger and independent; I'll take it as its own PR(s).