### PR TITLE
fix(dns): scope-aware zone listing + CreateOrUpdate applies tags (#259 DNS slice)

### DIFF
--- a/features/chaos/wrappers_baseline_test.go
+++ b/features/chaos/wrappers_baseline_test.go
@@ -104,7 +104,7 @@ func TestWrapDNSBaseline(t *testing.T) {
 
 	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "b.test."})
 	_, _ = d.GetZone(ctx, z.ID)
-	_, _ = d.ListZones(ctx)
+	_, _ = d.ListZones(ctx, scope.Scope{})
 	rec := dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.b.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}}
 	_, _ = d.CreateRecord(ctx, rec)
 	_, _ = d.GetRecord(ctx, z.ID, "x.b.test.", "A")

--- a/features/chaos/wrappers_dns.go
+++ b/features/chaos/wrappers_dns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // chaosDNS wraps a DNS driver. Hot-path: zone and record CRUD.
@@ -42,12 +43,12 @@ func (c *chaosDNS) GetZone(ctx context.Context, id string) (*dnsdriver.ZoneInfo,
 	return c.DNS.GetZone(ctx, id)
 }
 
-func (c *chaosDNS) ListZones(ctx context.Context) ([]dnsdriver.ZoneInfo, error) {
+func (c *chaosDNS) ListZones(ctx context.Context, filter scope.Scope) ([]dnsdriver.ZoneInfo, error) {
 	if err := applyChaos(ctx, c.engine, "dns", "ListZones"); err != nil {
 		return nil, err
 	}
 
-	return c.DNS.ListZones(ctx)
+	return c.DNS.ListZones(ctx, filter)
 }
 
 //nolint:gocritic // cfg is a value type by interface contract

--- a/features/chaos/wrappers_dns_test.go
+++ b/features/chaos/wrappers_dns_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/features/chaos"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newChaosDNS(t *testing.T) (dnsdriver.DNS, *chaos.Engine) {
@@ -65,7 +66,7 @@ func TestWrapDNSListZonesChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("dns", time.Hour))
 
-	if _, err := d.ListZones(ctx); err == nil {
+	if _, err := d.ListZones(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListZones")
 	}
 }

--- a/features/topology/resolve.go
+++ b/features/topology/resolve.go
@@ -3,11 +3,13 @@ package topology
 import (
 	"context"
 	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Resolve walks through DNS zones and returns matching record values for the hostname.
 func (e *Engine) Resolve(ctx context.Context, hostname string) ([]string, error) {
-	zones, err := e.dns.ListZones(ctx)
+	zones, err := e.dns.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		return nil, err
 	}

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListZones(ctx)
+	first, err := m.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListZones(ctx)
+		again, err := m.ListZones(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -3,6 +3,7 @@ package route53
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.DNS.
@@ -64,6 +66,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Private:     cfg.Private,
 		RecordCount: 0,
 		Tags:        tags,
+		Scope:       cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)
@@ -102,16 +105,59 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	return &result, nil
 }
 
-// ListZones returns all DNS hosted zones.
-func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+// ListZones returns all DNS hosted zones matching the scope filter. Route 53
+// hosted zones are account-global, so zones are created unscoped and a zero
+// filter (the AWS default) returns everything.
+func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {
+		if !z.Scope.Matches(filter) {
+			continue
+		}
 		zones = append(zones, z)
 	}
 
 	return zones, nil
+}
+
+// UpdateZone applies the mutable fields (tags, scope) of an existing hosted
+// zone, matching the zone by name — ARM CreateOrUpdate-on-existing semantics.
+func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	var (
+		id    string
+		found bool
+	)
+
+	for zid, z := range m.zones.All() {
+		if z.Name == cfg.Name {
+			id = zid
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		return nil, errors.Newf(errors.NotFound, "zone %q not found", cfg.Name)
+	}
+
+	m.zones.Update(id, func(z driver.ZoneInfo) driver.ZoneInfo {
+		if cfg.Tags != nil {
+			z.Tags = maps.Clone(cfg.Tags)
+		}
+		if !cfg.Scope.IsZero() {
+			z.Scope = cfg.Scope
+		}
+
+		return z
+	})
+
+	updated, _ := m.zones.Get(id)
+	result := updated
+
+	return &result, nil
 }
 
 // CreateRecord creates a new DNS record in the specified zone.

--- a/providers/aws/route53/route53_test.go
+++ b/providers/aws/route53/route53_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newTestMock() *Mock {
@@ -81,13 +82,13 @@ func TestListZones(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	zones, err := m.ListZones(ctx)
+	zones, err := m.ListZones(ctx, scope.Scope{})
 	requireNoError(t, err)
 	assertEqual(t, 0, len(zones))
 
 	createTestZone(m)
 
-	zones, err = m.ListZones(ctx)
+	zones, err = m.ListZones(ctx, scope.Scope{})
 	requireNoError(t, err)
 	assertEqual(t, 1, len(zones))
 }

--- a/providers/aws/route53/zone_update_test.go
+++ b/providers/aws/route53/zone_update_test.go
@@ -1,0 +1,45 @@
+package route53
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+func TestUpdateZoneAppliesTags(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	z, err := m.CreateZone(ctx, driver.ZoneConfig{
+		Name: "example.com",
+		Tags: map[string]string{"env": "test"},
+	})
+	requireNoError(t, err)
+
+	updated, err := m.UpdateZone(ctx, driver.ZoneConfig{
+		Name: "example.com",
+		Tags: map[string]string{"env": "prod", "team": "platform"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "prod", updated.Tags["env"])
+	assertEqual(t, "platform", updated.Tags["team"])
+
+	got, err := m.GetZone(ctx, z.ID)
+	requireNoError(t, err)
+	assertEqual(t, "prod", got.Tags["env"])
+	assertEqual(t, "platform", got.Tags["team"])
+
+	zones, err := m.ListZones(ctx, scope.Scope{})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(zones))
+	assertEqual(t, "prod", zones[0].Tags["env"])
+}
+
+func TestUpdateZoneNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.UpdateZone(context.Background(), driver.ZoneConfig{Name: "missing.com"})
+	assertError(t, err, true)
+}

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -134,7 +134,9 @@ func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneIn
 // and record count are preserved.
 func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
 	for _, z := range m.zones.SortedValues() {
-		if z.Name != cfg.Name {
+		// Match on name AND scope: the same zone name can exist in different
+		// resource groups, and an update must not reach across into another.
+		if z.Name != cfg.Name || !z.Scope.Matches(cfg.Scope) {
 			continue
 		}
 

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -3,6 +3,7 @@ package azuredns
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.DNS.
@@ -50,7 +52,17 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		return nil, cerrors.New(cerrors.InvalidArgument, "zone name is required")
 	}
 
-	id := idgen.AzureID(m.opts.AccountID, "cloud-mock", "Microsoft.Network", "dnsZones", cfg.Name)
+	// Derive the ARM id's subscription/resource group from the request scope,
+	// falling back to the account default and "cloud-mock" when unscoped.
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = "cloud-mock"
+	}
+	id := idgen.AzureID(sub, rg, "Microsoft.Network", "dnsZones", cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -63,6 +75,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Private:     cfg.Private,
 		RecordCount: 0,
 		Tags:        tags,
+		Scope:       cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)
@@ -100,16 +113,45 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	return &result, nil
 }
 
-// ListZones returns all Azure DNS zones.
-func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+// ListZones returns the Azure DNS zones visible under filter. Iterating the
+// store's SortedValues keeps the order deterministic (#259).
+func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {
+		if !z.Scope.Matches(filter) {
+			continue
+		}
 		zones = append(zones, z)
 	}
 
 	return zones, nil
+}
+
+// UpdateZone applies the mutable fields (tags, scope) of an existing zone,
+// matching it by name — ARM CreateOrUpdate-on-existing semantics. Identity
+// and record count are preserved.
+func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	for _, z := range m.zones.SortedValues() {
+		if z.Name != cfg.Name {
+			continue
+		}
+
+		if cfg.Tags != nil {
+			z.Tags = maps.Clone(cfg.Tags)
+		}
+		if !cfg.Scope.IsZero() {
+			z.Scope = cfg.Scope
+		}
+
+		m.zones.Set(z.ID, z)
+		result := z
+
+		return &result, nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "zone %q not found", cfg.Name)
 }
 
 // CreateRecord creates a new DNS record set in the specified zone.

--- a/providers/azure/azuredns/dns_test.go
+++ b/providers/azure/azuredns/dns_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,7 +116,7 @@ func TestListZones(t *testing.T) {
 	m := newTestMock()
 
 	t.Run("empty", func(t *testing.T) {
-		zones, err := m.ListZones(ctx)
+		zones, err := m.ListZones(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Empty(t, zones)
 	})
@@ -124,7 +125,7 @@ func TestListZones(t *testing.T) {
 		_, _ = m.CreateZone(ctx, driver.ZoneConfig{Name: "a.com"})
 		_, _ = m.CreateZone(ctx, driver.ZoneConfig{Name: "b.com"})
 
-		zones, err := m.ListZones(ctx)
+		zones, err := m.ListZones(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Len(t, zones, 2)
 	})

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListZones(ctx)
+	first, err := m.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListZones(ctx)
+		again, err := m.ListZones(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -3,6 +3,7 @@ package clouddns
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.DNS.
@@ -63,6 +65,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Private:     cfg.Private,
 		RecordCount: 0,
 		Tags:        tags,
+		Scope:       cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)
@@ -101,16 +104,46 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	return &result, nil
 }
 
-// ListZones returns all Cloud DNS managed zones.
-func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+// ListZones returns the Cloud DNS managed zones visible under filter.
+func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {
+		if !z.Scope.Matches(filter) {
+			continue
+		}
 		zones = append(zones, z)
 	}
 
 	return zones, nil
+}
+
+// UpdateZone applies the mutable fields (tags, scope) of an existing zone,
+// mirroring CreateOrUpdate-on-existing. It matches the zone by name.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	for _, z := range m.zones.SortedValues() {
+		if z.Name != cfg.Name {
+			continue
+		}
+
+		if cfg.Tags != nil {
+			z.Tags = maps.Clone(cfg.Tags)
+		}
+		if !cfg.Scope.IsZero() {
+			z.Scope = cfg.Scope
+		}
+
+		m.zones.Set(z.ID, z)
+
+		result := z
+
+		return &result, nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "managed zone %q not found", cfg.Name)
 }
 
 // CreateRecord creates a new resource record set in the specified managed zone.

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -125,7 +125,9 @@ func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneIn
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
 	for _, z := range m.zones.SortedValues() {
-		if z.Name != cfg.Name {
+		// Match on name AND scope: the same zone name can exist in different
+		// projects, and an update must not reach across into another.
+		if z.Name != cfg.Name || !z.Scope.Matches(cfg.Scope) {
 			continue
 		}
 

--- a/providers/gcp/clouddns/dns_test.go
+++ b/providers/gcp/clouddns/dns_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +87,7 @@ func TestListHostedZones(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()
 
-	zones, err := m.ListZones(ctx)
+	zones, err := m.ListZones(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Empty(t, zones)
 
@@ -95,7 +96,7 @@ func TestListHostedZones(t *testing.T) {
 	_, err = m.CreateZone(ctx, driver.ZoneConfig{Name: "b.com"})
 	require.NoError(t, err)
 
-	zones, err = m.ListZones(ctx)
+	zones, err = m.ListZones(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Len(t, zones, 2)
 }

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListZones(ctx)
+	first, err := m.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListZones(ctx)
+		again, err := m.ListZones(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -8,6 +8,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // listMaxItems is the fixed page size echoed back to the SDK; the mock never
@@ -59,7 +60,8 @@ func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id strin
 }
 
 func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
-	infos, err := h.dns.ListZones(r.Context())
+	// Route 53 hosted zones are account-global, so list them unscoped.
+	infos, err := h.dns.ListZones(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -6,6 +6,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // --- zones ---
@@ -21,11 +22,19 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		private = privateFromZoneType(body.Properties.ZoneType)
 	}
 
-	// CreateOrUpdate is idempotent: if the zone already exists, echo it back.
-	if id, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
-		info, gerr := h.dns.GetZone(r.Context(), id)
-		if gerr != nil {
-			azurearm.WriteCErr(w, gerr)
+	sc := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+
+	// CreateOrUpdate is upsert: if the zone already exists, apply the request's
+	// mutable fields (tags, scope) via UpdateZone rather than echoing it back.
+	if _, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
+			Name:    rp.ResourceName,
+			Private: private,
+			Tags:    body.Tags,
+			Scope:   sc,
+		})
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
 			return
 		}
 
@@ -38,6 +47,7 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		Name:    rp.ResourceName,
 		Private: private,
 		Tags:    body.Tags,
+		Scope:   sc,
 	})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -81,7 +91,8 @@ func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rp *azurear
 }
 
 func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.dns.ListZones(r.Context())
+	infos, err := h.dns.ListZones(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -22,33 +22,26 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		private = privateFromZoneType(body.Properties.ZoneType)
 	}
 
-	sc := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
-
-	// CreateOrUpdate is upsert: if the zone already exists, apply the request's
-	// mutable fields (tags, scope) via UpdateZone rather than echoing it back.
-	if _, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
-		info, uerr := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
-			Name:    rp.ResourceName,
-			Private: private,
-			Tags:    body.Tags,
-			Scope:   sc,
-		})
-		if uerr != nil {
-			azurearm.WriteCErr(w, uerr)
-			return
-		}
-
-		azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
-
-		return
-	}
-
-	info, err := h.dns.CreateZone(r.Context(), dnsdriver.ZoneConfig{
+	cfg := dnsdriver.ZoneConfig{
 		Name:    rp.ResourceName,
 		Private: private,
 		Tags:    body.Tags,
-		Scope:   sc,
-	})
+		Scope:   scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	// CreateOrUpdate is upsert. Try to update a zone that already exists in
+	// THIS scope; only create when none does. Matching by scope (not just
+	// name) means a same-named zone in another resource group is never
+	// hijacked — it stays a distinct zone.
+	if info, uerr := h.dns.UpdateZone(r.Context(), cfg); uerr == nil {
+		azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
+		return
+	} else if !cerrors.IsNotFound(uerr) {
+		azurearm.WriteCErr(w, uerr)
+		return
+	}
+
+	info, err := h.dns.CreateZone(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -82,6 +82,51 @@ func TestSDKUpsertAppliesTags(t *testing.T) {
 	}
 }
 
+// TestSDKSameNameZonesStayIndependent asserts that CreateOrUpdate for a zone
+// name that already exists in a different resource group creates a distinct
+// zone rather than hijacking the existing one — the same name legitimately
+// exists in more than one group.
+func TestSDKSameNameZonesStayIndependent(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	mk := func(rg, env string) {
+		if _, err := zones.CreateOrUpdate(ctx, rg, "shared.com", armdns.Zone{
+			Location: to.Ptr("global"),
+			Tags:     map[string]*string{"env": to.Ptr(env)},
+		}, nil); err != nil {
+			t.Fatalf("CreateOrUpdate %s: %v", rg, err)
+		}
+	}
+	mk("rg-shared-a", "a")
+	mk("rg-shared-b", "b")
+
+	// Each group must still own its own shared.com with its own tag; the
+	// second create must not have moved or overwritten the first.
+	tagInRG := func(rg string) string {
+		var out string
+		pager := zones.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, z := range page.Value {
+				if z.Name != nil && *z.Name == "shared.com" && z.Tags["env"] != nil {
+					out = *z.Tags["env"]
+				}
+			}
+		}
+		return out
+	}
+	if got := tagInRG("rg-shared-a"); got != "a" {
+		t.Fatalf("rg-shared-a shared.com env = %q, want a (not hijacked by the rg-b create)", got)
+	}
+	if got := tagInRG("rg-shared-b"); got != "b" {
+		t.Fatalf("rg-shared-b shared.com env = %q, want b", got)
+	}
+}
+
 // TestSDKZoneIDMatchesRequestScope asserts through the real SDK that the
 // returned ARM id carries the request's subscription and resource group.
 func TestSDKZoneIDMatchesRequestScope(t *testing.T) {

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -1,0 +1,104 @@
+package dns_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+// TestSDKScopedListing asserts through the real SDK that zones created in one
+// resource group do not appear in another group's ListByResourceGroup pager.
+func TestSDKScopedListing(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	create := func(rg, name string) {
+		if _, err := zones.CreateOrUpdate(ctx, rg, name, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+			t.Fatalf("CreateOrUpdate %s/%s: %v", rg, name, err)
+		}
+	}
+	create("rg-team-a", "a1.com")
+	create("rg-team-a", "a2.com")
+	create("rg-team-b", "b1.com")
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := zones.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, z := range page.Value {
+				names = append(names, *z.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 zones", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "b1.com" {
+		t.Fatalf("rg-team-b listed %v, want [b1.com]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesTags asserts through the real SDK that CreateOrUpdate on
+// an existing zone applies the request's tags, not echoing the stale resource.
+func TestSDKUpsertAppliesTags(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "upsert.com", armdns.Zone{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("dev")},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate (create): %v", err)
+	}
+
+	updated, err := zones.CreateOrUpdate(ctx, testRG, "upsert.com", armdns.Zone{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate (update): %v", err)
+	}
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := zones.Get(ctx, testRG, "upsert.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKZoneIDMatchesRequestScope asserts through the real SDK that the
+// returned ARM id carries the request's subscription and resource group.
+func TestSDKZoneIDMatchesRequestScope(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	created, err := zones.CreateOrUpdate(ctx, "rg-id-check", "id.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+	if created.ID == nil {
+		t.Fatal("zone response has no id")
+	}
+	id := *created.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -7,6 +7,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // ARM resource type strings stamped on responses.
@@ -234,7 +235,7 @@ func recordTypeSegment(s string) string {
 // by scanning the zone list. Returns a NotFound error if no zone with that name
 // exists.
 func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
-	zones, err := h.dns.ListZones(ctx)
+	zones, err := h.dns.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		return "", err
 	}

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -6,9 +6,10 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
+func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 	var req managedZoneJSON
 	if !gcprest.DecodeJSON(w, r, &req) {
 		return
@@ -18,6 +19,7 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
 		Name:    req.Name,
 		Private: privateFor(req.Visibility),
 		Tags:    req.Labels,
+		Scope:   scope.Scope{Project: rt.project},
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -28,7 +30,7 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
 }
 
 func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rt route) {
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -43,8 +45,8 @@ func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rt route) {
 	gcprest.WriteJSON(w, http.StatusOK, toManagedZoneJSON(info))
 }
 
-func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, _ route) {
-	infos, err := h.dns.ListZones(r.Context())
+func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rt route) {
+	infos, err := h.dns.ListZones(r.Context(), scope.Scope{Project: rt.project})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -62,7 +64,7 @@ func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, _ route) {
 }
 
 func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -86,7 +88,7 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -149,7 +151,7 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 }
 
 func (h *Handler) listRRSets(w http.ResponseWriter, r *http.Request, rt route) {
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/clouddns/scope_update_sdk_test.go
+++ b/server/gcp/clouddns/scope_update_sdk_test.go
@@ -1,0 +1,128 @@
+package clouddns_test
+
+import (
+	"context"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/gcp/clouddns"
+	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+// TestSDKZonesScopedByProject verifies that Cloud DNS zone listing is isolated
+// per project: a real dns.Service pointed at the emulator and listing under
+// project A must return only A's zones, never zones created under project B.
+// The handler records each zone's scope from the {project} path segment at
+// create time and filters ManagedZones.List on it.
+func TestSDKZonesScopedByProject(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	const projectA = "project-a"
+	const projectB = "project-b"
+
+	// The dns.Service is endpoint-pinned, not project-pinned: the project is a
+	// per-call path segment, so two project paths exercise the isolation.
+	for _, name := range []string{"a-one", "a-two"} {
+		if _, err := svc.ManagedZones.Create(projectA, &dns.ManagedZone{
+			Name:    name,
+			DnsName: name + ".a.example.com.",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s/%s): %v", projectA, name, err)
+		}
+	}
+
+	for _, name := range []string{"b-one", "b-two", "b-three"} {
+		if _, err := svc.ManagedZones.Create(projectB, &dns.ManagedZone{
+			Name:    name,
+			DnsName: name + ".b.example.com.",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s/%s): %v", projectB, name, err)
+		}
+	}
+
+	listNames := func(project string) []string {
+		var names []string
+
+		call := svc.ManagedZones.List(project).Context(ctx)
+		if err := call.Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+			for _, z := range page.ManagedZones {
+				names = append(names, z.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("List(%s): %v", project, err)
+		}
+
+		return names
+	}
+
+	gotA := listNames(projectA)
+	if len(gotA) != 2 {
+		t.Fatalf("project A list = %v, want exactly its 2 zones", gotA)
+	}
+	for _, n := range gotA {
+		if n != "a-one" && n != "a-two" {
+			t.Fatalf("project A list leaked zone %q from another project: %v", n, gotA)
+		}
+	}
+
+	gotB := listNames(projectB)
+	if len(gotB) != 3 {
+		t.Fatalf("project B list = %v, want exactly its 3 zones", gotB)
+	}
+	for _, n := range gotB {
+		if n != "b-one" && n != "b-two" && n != "b-three" {
+			t.Fatalf("project B list leaked zone %q from another project: %v", n, gotB)
+		}
+	}
+}
+
+// TestUpdateZoneProviderLevel exercises the driver's UpdateZone directly, since
+// Cloud DNS zone create is not an upsert and the wire has no update path. It
+// must match an existing zone by name, apply tags and scope, and return the
+// updated copy — NotFound when the zone is absent.
+func TestUpdateZoneProviderLevel(t *testing.T) {
+	ctx := context.Background()
+
+	opts := config.NewOptions(config.WithProjectID("test-project"))
+	m := clouddns.New(opts)
+
+	if _, err := m.CreateZone(ctx, dnsdriver.ZoneConfig{
+		Name: "up.example.com",
+		Tags: map[string]string{"env": "old"},
+	}); err != nil {
+		t.Fatalf("CreateZone: %v", err)
+	}
+
+	updated, err := m.UpdateZone(ctx, dnsdriver.ZoneConfig{
+		Name:  "up.example.com",
+		Tags:  map[string]string{"env": "new", "team": "dns"},
+		Scope: scope.Scope{Project: "project-x"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateZone: %v", err)
+	}
+
+	if updated.Tags["env"] != "new" || updated.Tags["team"] != "dns" {
+		t.Fatalf("tags not applied: %v", updated.Tags)
+	}
+	if updated.Scope.Project != "project-x" {
+		t.Fatalf("scope not applied: %+v", updated.Scope)
+	}
+
+	got, err := m.GetZone(ctx, updated.ID)
+	if err != nil {
+		t.Fatalf("GetZone: %v", err)
+	}
+	if got.Tags["env"] != "new" || got.Scope.Project != "project-x" {
+		t.Fatalf("update not persisted: tags=%v scope=%+v", got.Tags, got.Scope)
+	}
+
+	if _, err := m.UpdateZone(ctx, dnsdriver.ZoneConfig{Name: "missing.example.com"}); err == nil {
+		t.Fatal("UpdateZone(missing): expected NotFound error, got nil")
+	}
+}

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -7,6 +7,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Kind values Cloud DNS stamps on its resources; the SDK tolerates them being
@@ -116,8 +117,8 @@ func toRecordSetJSON(rec *dnsdriver.RecordInfo) resourceRecordSetJSON {
 // name or its numeric id there, so both are matched (the numeric id is the
 // FNV-folded value this handler hands back as ManagedZone.Id). Returns NotFound
 // if no zone matches.
-func (h *Handler) resolveZoneID(ctx context.Context, nameOrID string) (string, error) {
-	zones, err := h.dns.ListZones(ctx)
+func (h *Handler) resolveZoneID(ctx context.Context, project, nameOrID string) (string, error) {
+	zones, err := h.dns.ListZones(ctx, scope.Scope{Project: project})
 	if err != nil {
 		return "", err
 	}

--- a/services/dns/dns.go
+++ b/services/dns/dns.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 type DNS struct {
@@ -107,7 +108,7 @@ func (d *DNS) GetZone(ctx context.Context, id string) (*driver.ZoneInfo, error) 
 }
 
 func (d *DNS) ListZones(ctx context.Context) ([]driver.ZoneInfo, error) {
-	out, err := d.do(ctx, "ListZones", nil, func() (any, error) { return d.driver.ListZones(ctx) })
+	out, err := d.do(ctx, "ListZones", nil, func() (any, error) { return d.driver.ListZones(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/dns/dns_test.go
+++ b/services/dns/dns_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/metrics"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,13 +74,28 @@ func (m *mockDriver) GetZone(_ context.Context, id string) (*driver.ZoneInfo, er
 	return info, nil
 }
 
-func (m *mockDriver) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+func (m *mockDriver) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	result := make([]driver.ZoneInfo, 0, len(m.zones))
 	for _, info := range m.zones {
+		if !info.Scope.Matches(filter) {
+			continue
+		}
 		result = append(result, *info)
 	}
 
 	return result, nil
+}
+
+func (m *mockDriver) UpdateZone(_ context.Context, config driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	for _, info := range m.zones {
+		if info.Name == config.Name {
+			if config.Tags != nil {
+				info.Tags = config.Tags
+			}
+			return info, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
 }
 
 func (m *mockDriver) CreateRecord(_ context.Context, config driver.RecordConfig) (*driver.RecordInfo, error) {

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -1,13 +1,20 @@
 // Package driver defines the interface for DNS service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
 
 // ZoneConfig describes a DNS zone to create.
 type ZoneConfig struct {
 	Name    string
 	Private bool
 	Tags    map[string]string
+	// Scope records the cloud-side container the zone was created in (Azure
+	// subscription/resource group or GCP project). The zero value is unscoped.
+	Scope scope.Scope
 }
 
 // ZoneInfo describes a DNS zone.
@@ -17,6 +24,9 @@ type ZoneInfo struct {
 	Private     bool
 	RecordCount int
 	Tags        map[string]string
+	// Scope is the container the zone lives in; scoped list endpoints filter
+	// on it. The zero value is unscoped and visible everywhere.
+	Scope scope.Scope
 }
 
 // RecordConfig describes a DNS record.
@@ -70,7 +80,10 @@ type DNS interface {
 	CreateZone(ctx context.Context, config ZoneConfig) (*ZoneInfo, error)
 	DeleteZone(ctx context.Context, id string) error
 	GetZone(ctx context.Context, id string) (*ZoneInfo, error)
-	ListZones(ctx context.Context) ([]ZoneInfo, error)
+	ListZones(ctx context.Context, filter scope.Scope) ([]ZoneInfo, error)
+	// UpdateZone applies the mutable fields (tags) of an existing zone,
+	// mirroring ARM CreateOrUpdate-on-existing. It matches the zone by name.
+	UpdateZone(ctx context.Context, config ZoneConfig) (*ZoneInfo, error)
 
 	CreateRecord(ctx context.Context, config RecordConfig) (*RecordInfo, error)
 	DeleteRecord(ctx context.Context, zoneID, name, recordType string) error


### PR DESCRIPTION
Completes the #259 fidelity work for the DNS slice — the same template PR #276 applied to logging/eventbus/cache/notification. With #280 (record-listing determinism) already merged, this closes out #259 for DNS.

## What changed

**Driver** (`services/dns/driver`): `ZoneConfig`/`ZoneInfo` gain a `Scope` field; `ListZones` takes a `scope.Scope` filter; new `UpdateZone` applies mutable fields (tags) with ARM CreateOrUpdate-on-existing semantics.

**Providers** (route53 / azuredns / clouddns): store the creating scope on each zone, filter `ListZones` by it in deterministic `SortedValues()` order, implement `UpdateZone`. azuredns derives its stored ARM id's subscription/resource-group from the scope.

**Handlers**:
- Azure `createOrUpdateZone` now applies the request's tags via `UpdateZone` on an existing zone instead of echoing the stale one; lists pass the request's `{subscription, resourceGroup}` scope.
- GCP lists filter by the request's project.
- AWS stays account-global (zero scope) — Route53 hosted zones aren't RG/project-scoped.

The portable wrapper keeps its no-arg `ListZones` (passing zero scope internally, like the other domains); the chaos wrapper threads the filter; topology resolves across all zones.

## Testing

New real-SDK tests: Azure scoped listing (rg-team-a vs rg-team-b), upsert-applies-tags, request-derived zone id; GCP per-project zone isolation; AWS provider-level `UpdateZone` (applies tags / NotFound). Full `go test ./...`, `go vet`, `gofmt` clean.

## Closes
Finishes the #259 series (ordering in #275/#280, scope+upsert+IDs in #276 and here). The broader #253 enhancements — zone-name uniqueness, structured TXT chunks (`[][]string`), and change-batch atomicity — remain as separate follow-ups.