### PR TITLE
fix(dns): scope Azure resolveZoneID to the request's resource group (#253)

### DIFF
--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -51,7 +51,7 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 }
 
 func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	id, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	id, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -69,7 +69,7 @@ func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.R
 // deleteZone removes the zone. Zones.Delete is an LRO in the SDK; returning
 // 200 with an empty body completes the poller on the first response.
 func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	id, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	id, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -107,7 +107,7 @@ func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -144,7 +144,7 @@ func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) (*dn
 }
 
 func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -160,7 +160,7 @@ func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azure
 }
 
 func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -183,7 +183,7 @@ func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) listRecordSets(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -127,6 +127,42 @@ func TestSDKSameNameZonesStayIndependent(t *testing.T) {
 	}
 }
 
+// TestSDKGetResolvesWithinRequestScope asserts that when the same zone name
+// exists in two resource groups, a Get resolves to the zone in the request's
+// group — not an arbitrary same-named zone in another group.
+func TestSDKGetResolvesWithinRequestScope(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	mk := func(rg, env string) {
+		if _, err := zones.CreateOrUpdate(ctx, rg, "dup.com", armdns.Zone{
+			Location: to.Ptr("global"),
+			Tags:     map[string]*string{"env": to.Ptr(env)},
+		}, nil); err != nil {
+			t.Fatalf("CreateOrUpdate %s: %v", rg, err)
+		}
+	}
+	mk("rg-get-a", "a")
+	mk("rg-get-b", "b")
+
+	getEnv := func(rg string) string {
+		z, err := zones.Get(ctx, rg, "dup.com", nil)
+		if err != nil {
+			t.Fatalf("Get %s: %v", rg, err)
+		}
+		if z.Tags["env"] == nil {
+			t.Fatalf("Get %s: no env tag", rg)
+		}
+		return *z.Tags["env"]
+	}
+	if got := getEnv("rg-get-a"); got != "a" {
+		t.Fatalf("Get rg-get-a/dup.com env = %q, want a (must resolve within the request's group)", got)
+	}
+	if got := getEnv("rg-get-b"); got != "b" {
+		t.Fatalf("Get rg-get-b/dup.com env = %q, want b", got)
+	}
+}
+
 // TestSDKZoneIDMatchesRequestScope asserts through the real SDK that the
 // returned ARM id carries the request's subscription and resource group.
 func TestSDKZoneIDMatchesRequestScope(t *testing.T) {

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -232,10 +232,14 @@ func recordTypeSegment(s string) string {
 }
 
 // resolveZoneID maps the SDK-facing zone name to the driver's internal zone id
-// by scanning the zone list. Returns a NotFound error if no zone with that name
-// exists.
-func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
-	zones, err := h.dns.ListZones(ctx, scope.Scope{})
+// by scanning the zone list, scoped to the request's subscription and resource
+// group. Scoping matters because the same zone name can exist in more than one
+// resource group — a name-only scan could resolve to a zone in a different
+// group. Returns a NotFound error if no such zone exists in this scope.
+func (h *Handler) resolveZoneID(ctx context.Context, rp *azurearm.ResourcePath) (string, error) {
+	filter := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+
+	zones, err := h.dns.ListZones(ctx, filter)
 	if err != nil {
 		return "", err
 	}
@@ -243,10 +247,10 @@ func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error
 	// Azure treats DNS zone names case-insensitively (and lowercases them on
 	// some URL paths), so match without regard to case.
 	for i := range zones {
-		if strings.EqualFold(zones[i].Name, name) {
+		if strings.EqualFold(zones[i].Name, rp.ResourceName) {
 			return zones[i].ID, nil
 		}
 	}
 
-	return "", cerrors.Newf(cerrors.NotFound, "dns zone %q not found", name)
+	return "", cerrors.Newf(cerrors.NotFound, "dns zone %q not found", rp.ResourceName)
 }


### PR DESCRIPTION
Follow-up to #281 (the DNS scope/upsert work), closing the read-path counterpart of the same bug.

## Problem

Azure `resolveZoneID` scanned **all** zones by name across every scope:

```go
zones, _ := h.dns.ListZones(ctx, scope.Scope{})  // every subscription/RG
```

The same DNS zone name legitimately exists in more than one resource group, so a `Get` or any record-set operation for such a name could resolve to a zone in a **different** group — returning the wrong zone's id, tags, and records.

## Fix

Scope the scan to the request's subscription + resource group (parsed from the ARM path). `resolveZoneID` now takes the `*azurearm.ResourcePath` and filters `ListZones` by `{subscription, resourceGroup}`; the six call sites pass `rp`. GCP's `resolveZoneID` already scoped by project — this brings Azure in line.

## Testing

New real-SDK regression `TestSDKGetResolvesWithinRequestScope`: create `dup.com` in two resource groups with different tags, then `Get` each group's `dup.com` and confirm each returns its own tag (not the other group's). Existing DNS zone/record/error SDK tests still pass. Full `go test ./...`, `go vet`, `gofmt` clean.

## #253 status
This clears the `resolveZoneID` item noted on #281. Remaining #253 follow-ups: zone-name uniqueness, structured TXT chunks (`[][]string`), and change-batch atomicity.