### PR TITLE
fix(dns): chunk Azure TXT values into ≤255-byte character-strings (#253)

### DIFF
--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -127,6 +127,53 @@ func TestSDKSameNameZonesStayIndependent(t *testing.T) {
 	}
 }
 
+// TestSDKTXTRecordChunking asserts that a TXT value longer than 255 bytes is
+// returned as valid ≤255-byte character-strings whose concatenation preserves
+// the original value — Azure rejects a single oversized chunk.
+func TestSDKTXTRecordChunking(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "txt.com", armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	chunkA := strings.Repeat("a", 255)
+	chunkB := strings.Repeat("b", 100)
+	want := chunkA + chunkB // 355-byte logical value
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "txt.com", "long", armdns.RecordTypeTXT, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:        to.Ptr(int64(300)),
+			TxtRecords: []*armdns.TxtRecord{{Value: []*string{to.Ptr(chunkA), to.Ptr(chunkB)}}},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate: %v", err)
+	}
+
+	got, err := records.Get(ctx, testRG, "txt.com", "long", armdns.RecordTypeTXT, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get: %v", err)
+	}
+	if got.Properties == nil || len(got.Properties.TxtRecords) != 1 {
+		t.Fatalf("TxtRecords = %+v, want exactly one record", got.Properties)
+	}
+
+	var joined string
+	for _, c := range got.Properties.TxtRecords[0].Value {
+		if c == nil {
+			t.Fatal("nil TXT chunk")
+		}
+		if len(*c) > 255 {
+			t.Fatalf("TXT chunk length %d exceeds the 255-byte limit", len(*c))
+		}
+		joined += *c
+	}
+	if joined != want {
+		t.Fatalf("reassembled TXT = %d bytes, want the original %d-byte value", len(joined), len(want))
+	}
+}
+
 // TestSDKGetResolvesWithinRequestScope asserts that when the same zone name
 // exists in two resource groups, a Get resolves to the zone in the request's
 // group — not an arbitrary same-named zone in another group.

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -62,6 +62,30 @@ type txtRecordJSON struct {
 	Value []string `json:"value,omitempty"`
 }
 
+// txtChunkSize is the maximum length of a single DNS TXT character-string.
+// Azure represents a TXT record as an array of these ≤255-byte chunks.
+const txtChunkSize = 255
+
+// chunkTXT splits a logical TXT value into ≤255-byte character-strings, as the
+// TXT wire format (and Azure's TxtRecords value array) requires. A value that
+// already fits returns a single chunk; the input side rejoins them.
+func chunkTXT(s string) []string {
+	if len(s) <= txtChunkSize {
+		return []string{s}
+	}
+
+	chunks := make([]string, 0, len(s)/txtChunkSize+1)
+	for len(s) > txtChunkSize {
+		chunks = append(chunks, s[:txtChunkSize])
+		s = s[txtChunkSize:]
+	}
+	if len(s) > 0 {
+		chunks = append(chunks, s)
+	}
+
+	return chunks
+}
+
 type nsRecordJSON struct {
 	Nsdname string `json:"nsdname,omitempty"`
 }
@@ -175,7 +199,7 @@ func toRecordSetProperties(rec *dnsdriver.RecordInfo) *recordSetProperties {
 		}
 	case "TXT":
 		for _, v := range rec.Values {
-			props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: []string{v}})
+			props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: chunkTXT(v)})
 		}
 	case "NS":
 		for _, v := range rec.Values {


### PR DESCRIPTION
Next #253 follow-up — TXT record chunking fidelity.

## Problem

A DNS TXT record is a sequence of character-strings, each capped at 255 bytes; Azure models this as `TxtRecords: [{value: [chunk1, chunk2, …]}]`. But `toRecordSetProperties` emitted each logical value as a **single** array element:

```go
props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: []string{v}})
```

So a TXT value longer than 255 bytes (a DKIM key, a long SPF record) went out as one oversized chunk — invalid on the Azure wire.

## Fix

Split TXT values into ≤255-byte chunks on output (`chunkTXT`). The input side already rejoins the chunks into the logical value (`strings.Join(t.Value, "")`), so a long value that comes in as valid ≤255 chunks round-trips back to the same chunks.

**Scope:** Azure-only. Route53 and GCP Cloud DNS carry TXT values in presentation format (the SDK sends the quoted string as-is) and store/return them verbatim, so they need no chunking here.

## Design note

I kept the driver's `Values []string` flat (one logical value per TXT record) rather than widening it to `[][]string`, and chunk at the wire layer where the 255-byte rule actually lives — the same place every other record type's wire shape is built. This fixes the real fidelity gap (valid chunked TXT on the wire) without a TXT-specific field rippling through every record type and provider. Happy to go to `[][]string` if you want byte-exact preservation of arbitrary user-chosen chunk boundaries.

## Testing

`TestSDKTXTRecordChunking`: a 355-byte TXT value round-trips as ≤255-byte chunks whose concatenation equals the original. Full `go test ./...`, `go vet`, `gofmt` clean.

## #253 status
Remaining follow-ups: zone-name uniqueness on create, and change-batch atomicity.