### PR TITLE
fix(dns): make Route53 ChangeResourceRecordSets atomic (#253)

### DIFF
--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -3,6 +3,7 @@ package route53
 import (
 	"encoding/xml"
 	"net/http"
+	"strings"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -93,9 +94,11 @@ func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id st
 }
 
 // changeResourceRecordSets applies a CREATE/UPSERT/DELETE batch against the
-// zone. Changes are applied in order; the whole batch shares one INSYNC
-// ChangeInfo, matching Route 53's atomic-batch semantics closely enough for
-// the SDK's change poller.
+// zone. Route 53 validates the whole batch and applies nothing if any change is
+// invalid (InvalidChangeBatch), so we validate every change against the zone's
+// current state — tracking intra-batch effects so a DELETE followed by a CREATE
+// of the same record set is allowed — before mutating anything. The batch then
+// shares one INSYNC ChangeInfo for the SDK's change poller.
 func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Request, id string) {
 	var req changeResourceRecordSetsRequest
 	if !decodeXML(w, r, &req) {
@@ -103,6 +106,11 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 	}
 
 	zoneID := trimZonePrefix(id)
+
+	if err := h.validateChangeBatch(r, zoneID, req.ChangeBatch.Changes); err != nil {
+		writeChangeErr(w, err)
+		return
+	}
 
 	for i := range req.ChangeBatch.Changes {
 		if err := h.applyChange(r, zoneID, &req.ChangeBatch.Changes[i]); err != nil {
@@ -115,6 +123,61 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 		Xmlns:      xmlns,
 		ChangeInfo: newChangeInfo(),
 	})
+}
+
+// rrSetKey identifies a record set for batch validation, matching the driver's
+// identity (name is case-insensitive, type is case-insensitive, set ID
+// distinguishes weighted records at the same name+type).
+func rrSetKey(name, rtype, setID string) string {
+	return strings.ToLower(name) + "|" + strings.ToUpper(rtype) + "|" + setID
+}
+
+// validateChangeBatch checks every change would apply cleanly before any is
+// applied, so an invalid batch is rejected whole (nothing half-applied). It
+// simulates the batch against the zone's current record sets, folding in each
+// change's effect so ordering within the batch is respected.
+func (h *Handler) validateChangeBatch(r *http.Request, zoneID string, changes []changeItem) error {
+	existing, err := h.dns.ListRecords(r.Context(), zoneID)
+	if err != nil {
+		return err
+	}
+
+	present := make(map[string]bool, len(existing))
+	for i := range existing {
+		present[rrSetKey(existing[i].Name, existing[i].Type, existing[i].SetID)] = true
+	}
+
+	for i := range changes {
+		rr := &changes[i].ResourceRecordSet
+
+		if rr.Name == "" || rr.Type == "" {
+			return cerrors.New(cerrors.InvalidArgument, "record set name and type are required")
+		}
+
+		key := rrSetKey(rr.Name, rr.Type, rr.SetIdentifier)
+
+		switch changes[i].Action {
+		case actionCreate:
+			if present[key] {
+				return cerrors.Newf(cerrors.AlreadyExists,
+					"record set %q %s already exists", rr.Name, rr.Type)
+			}
+			present[key] = true
+		case actionDelete:
+			if !present[key] {
+				return cerrors.Newf(cerrors.NotFound,
+					"record set %q %s not found", rr.Name, rr.Type)
+			}
+			present[key] = false
+		case actionUpsert:
+			present[key] = true
+		default:
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"unsupported change action %q", changes[i].Action)
+		}
+	}
+
+	return nil
 }
 
 // applyChange executes a single record change against the driver.

--- a/server/aws/route53/sdk_roundtrip_test.go
+++ b/server/aws/route53/sdk_roundtrip_test.go
@@ -298,3 +298,61 @@ func TestSDKRoute53Errors(t *testing.T) {
 		t.Fatalf("delete missing record: got %v, want InvalidChangeBatch", err)
 	}
 }
+
+// TestSDKRoute53ChangeBatchAtomic asserts a ChangeResourceRecordSets batch is
+// all-or-nothing: a valid CREATE followed by an invalid DELETE rejects the
+// whole batch, and the CREATE must not have been applied.
+func TestSDKRoute53ChangeBatchAtomic(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("atomic.com."),
+		CallerReference: aws.String("ref-atomic"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{
+				{
+					Action: r53types.ChangeActionCreate,
+					ResourceRecordSet: &r53types.ResourceRecordSet{
+						Name:            aws.String("keep.atomic.com."),
+						Type:            r53types.RRTypeA,
+						TTL:             aws.Int64(300),
+						ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+					},
+				},
+				{
+					Action: r53types.ChangeActionDelete,
+					ResourceRecordSet: &r53types.ResourceRecordSet{
+						Name:            aws.String("ghost.atomic.com."),
+						Type:            r53types.RRTypeA,
+						TTL:             aws.Int64(300),
+						ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.9")}},
+					},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("ChangeResourceRecordSets with an invalid change returned nil error, want the batch rejected")
+	}
+
+	sets, lerr := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if lerr != nil {
+		t.Fatalf("ListResourceRecordSets: %v", lerr)
+	}
+	for _, rr := range sets.ResourceRecordSets {
+		if aws.ToString(rr.Name) == "keep.atomic.com." {
+			t.Fatal("keep.atomic.com. was applied despite the batch being rejected — batch is not atomic")
+		}
+	}
+}


### PR DESCRIPTION
Next #253 follow-up — change-batch atomicity.

## Problem

`changeResourceRecordSets` applied a batch's changes in a loop and returned on the first failure:

```go
for i := range req.ChangeBatch.Changes {
    if err := h.applyChange(...); err != nil { writeChangeErr(w, err); return }
}
```

So a batch that failed on, say, the third change left the first two **committed** — a half-applied batch. Real Route 53 validates the entire batch and applies nothing if any change is invalid (`InvalidChangeBatch`).

## Fix

Validate every change against the zone's current record sets *before* mutating anything, folding each change's effect into a simulated state so intra-batch ordering is respected (a DELETE followed by a CREATE of the same record set is allowed). Only if the whole batch is valid are the changes applied. This mirrors the pre-validation the **GCP Cloud DNS** `changes` handler already does — so both wire surfaces are now atomic. (Azure DNS has no batch API; record sets are individual PUTs, each already atomic.)

Validation rejects: an unknown action, a CREATE of an already-present set, and a DELETE of a missing set — the deterministic InvalidChangeBatch cases. A mid-apply transient/injected error remains out of scope (same caveat noted in the GCP handler).

## Testing

`TestSDKRoute53ChangeBatchAtomic`: a batch of `[CREATE keep, DELETE ghost(missing)]` is rejected, and `keep` is confirmed **absent** afterward — proving nothing half-applied. Fails pre-fix, passes after. Full `go test ./...`, `go vet`, `gofmt` clean.

## #253 status
Remaining: zone-name uniqueness on create (the last item).