### PR TITLE
fix(dns): enforce GCP managed-zone name uniqueness within a project (#253)

### DIFF
--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -52,6 +52,18 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		return nil, cerrors.New(cerrors.InvalidArgument, "zone name is required")
 	}
 
+	// Managed-zone names are unique within a project. Reject a duplicate in the
+	// same project (the wire always carries one); the portable API, which
+	// creates with a zero scope, is unaffected.
+	if cfg.Scope.Project != "" {
+		for _, z := range m.zones.SortedValues() {
+			if z.Name == cfg.Name && z.Scope.Project == cfg.Scope.Project {
+				return nil, cerrors.Newf(cerrors.AlreadyExists,
+					"managed zone %q already exists in project %q", cfg.Name, cfg.Scope.Project)
+			}
+		}
+	}
+
 	id := idgen.GenerateID("zone-")
 
 	tags := make(map[string]string, len(cfg.Tags))

--- a/server/gcp/clouddns/sdk_roundtrip_test.go
+++ b/server/gcp/clouddns/sdk_roundtrip_test.go
@@ -193,3 +193,20 @@ func TestSDKCloudDNSErrors(t *testing.T) {
 		t.Fatalf("Changes.Create(missing zone): got %v, want 404", err)
 	}
 }
+
+// TestSDKCloudDNSDuplicateZoneName asserts a managed-zone name must be unique
+// within a project: creating the same name twice fails the second time.
+func TestSDKCloudDNSDuplicateZoneName(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	zone := &dns.ManagedZone{Name: "dup-zone", DnsName: "dup.example.com.", Visibility: "public"}
+	if _, err := svc.ManagedZones.Create(testProject, zone).Context(ctx).Do(); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	_, err := svc.ManagedZones.Create(testProject, zone).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("second Create of the same managed-zone name returned nil error, want a conflict")
+	}
+}


### PR DESCRIPTION
Final #253 follow-up — zone-name uniqueness.

## Problem

GCP Cloud DNS `clouddns` keyed zones by a random id, so the same managed-zone name could be created any number of times in one project. Real Cloud DNS requires the managed-zone name to be **unique within a project**.

## Fix

`CreateZone` now rejects a duplicate name in the same project with `AlreadyExists` (mapped to HTTP 409 by the GCP wire layer). The check is gated on a non-empty project scope, so it targets the wire path exactly and leaves the portable API (which creates with a zero scope) unaffected.

**Scope:** GCP-only. AWS Route 53 legitimately allows duplicate zone names (each gets a distinct id — correct as-is), and Azure DNS is already unique by construction (its ARM id is `f(subscription, resource group, name)`, so a same-name+scope create maps to the same key, and the handler routes an existing zone to `UpdateZone`).

## Testing

`TestSDKCloudDNSDuplicateZoneName`: creating `dup-zone` twice in the same project — the second create fails. Full `go test ./...`, `go vet`, `gofmt` clean.

## #253 complete
With this, all #253 items are addressed: record-listing determinism (#280), scope-aware zone listing + `UpdateZone` (#281), `resolveZoneID` read-path scoping (#282), TXT ≤255-byte chunking (#283), change-batch atomicity (#284), and zone-name uniqueness (this PR).