### PR TITLE
v2.1.0 — Standalone server mode + DNS/SDK-compat fidelity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ CloudEmu_Research_Paper.docx
 _paper_imgs/
 generate_paper.py
 .claude/
+
+# standalone server binary
+/cloudemu

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory bac
 
 Equivalent setups for Azure (`azureserver.New`) and GCP (`gcpserver.New`) are in [docs/sdk-server.md](docs/sdk-server.md).
 
+### Standalone server
+
+Prefer a long-lived process you point out-of-process apps at? Run the emulator
+as a server and point any SDK — any language — at the printed endpoints:
+
+```sh
+go run ./cmd/cloudemu serve
+#   AWS         http://127.0.0.1:4566
+#   Azure       https://127.0.0.1:4568   (self-signed TLS)
+#   GCP         http://127.0.0.1:4569
+```
+
+Full flags, port scheme, and per-SDK wiring: [docs/standalone-server.md](docs/standalone-server.md).
+
 The snippet above is a quick taste. To adopt cloudemu in a real app, don't write a demo — wire it into your existing client and tests so your real code runs against it. See [docs/integration.md](docs/integration.md).
 
 ## Or use the Go API directly

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -1861,7 +1861,7 @@ func testCacheWithDriver(t *testing.T, ctx context.Context, d cachedriver.Cache)
 	}
 
 	// List caches
-	caches, err := d.ListCaches(ctx)
+	caches, err := d.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatalf("ListCaches: %v", err)
 	}
@@ -2403,7 +2403,7 @@ func testNotificationWithDriver(t *testing.T, ctx context.Context, d notifdriver
 	}
 
 	// List topics
-	topics, err := d.ListTopics(ctx)
+	topics, err := d.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatalf("ListTopics: %v", err)
 	}
@@ -2581,7 +2581,7 @@ func TestCacheTagsPersistence(t *testing.T) {
 			}
 
 			// Verify tags appear in ListCaches
-			caches, err := p.d.ListCaches(ctx)
+			caches, err := p.d.ListCaches(ctx, scope.Scope{})
 			if err != nil {
 				t.Fatalf("ListCaches: %v", err)
 			}
@@ -3017,7 +3017,7 @@ func TestEventBusOperations(t *testing.T) {
 			}
 
 			// ListEventBuses
-			buses, err := p.d.ListEventBuses(ctx)
+			buses, err := p.d.ListEventBuses(ctx, scope.Scope{})
 			if err != nil {
 				t.Fatalf("ListEventBuses: %v", err)
 			}

--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -2,6 +2,7 @@ package cloudemu
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -1996,7 +1997,7 @@ func testLoggingWithDriver(t *testing.T, ctx context.Context, d loggingdriver.Lo
 	}
 
 	// List log groups
-	groups, err := d.ListLogGroups(ctx)
+	groups, err := d.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatalf("ListLogGroups: %v", err)
 	}

--- a/cmd/cloudemu/endpoints.go
+++ b/cmd/cloudemu/endpoints.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// endpointSet is the machine-readable bundle of URLs a client points at. Empty
+// fields (a provider that wasn't started) are omitted from the JSON.
+type endpointSet struct {
+	AWS        string `json:"aws,omitempty"`
+	Azure      string `json:"azure,omitempty"`
+	GCP        string `json:"gcp,omitempty"`
+	Kubernetes string `json:"kubernetes,omitempty"`
+}
+
+func (e endpointSet) writeFile(path string) error {
+	b, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// printBanner writes the startup summary: the live endpoints and copy-paste
+// snippets for pointing each SDK at them.
+func printBanner(w io.Writer, e endpointSet) {
+	fmt.Fprintln(w, "cloudemu — standalone server")
+	fmt.Fprintln(w, "────────────────────────────")
+	if e.AWS != "" {
+		fmt.Fprintf(w, "  AWS         %s\n", e.AWS)
+	}
+	if e.Azure != "" {
+		fmt.Fprintf(w, "  Azure       %s   (self-signed TLS)\n", e.Azure)
+	}
+	if e.GCP != "" {
+		fmt.Fprintf(w, "  GCP         %s\n", e.GCP)
+	}
+	if e.Kubernetes != "" {
+		fmt.Fprintf(w, "  Kubernetes  %s\n", e.Kubernetes)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Point your SDKs at these endpoints:")
+	if e.AWS != "" {
+		fmt.Fprintf(w, "  AWS   export AWS_ENDPOINT_URL=%s   (or o.BaseEndpoint in aws-sdk-go-v2)\n", e.AWS)
+	}
+	if e.GCP != "" {
+		fmt.Fprintf(w, "  GCP   option.WithEndpoint(%q) + option.WithoutAuthentication()\n", e.GCP)
+	}
+	if e.Azure != "" {
+		fmt.Fprintf(w, "  Azure cloud.Configuration ResourceManager endpoint = %q (trust the cert or skip verify)\n", e.Azure)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Press Ctrl-C to stop.")
+}

--- a/cmd/cloudemu/main.go
+++ b/cmd/cloudemu/main.go
@@ -1,0 +1,49 @@
+// Command cloudemu runs the in-memory cloud emulator as a long-lived,
+// out-of-process HTTP server. Point real AWS, Azure, and GCP SDK clients at
+// the printed endpoints and they talk to cloudemu over the network exactly as
+// they would to the real cloud — no code changes, no accounts, no Docker.
+//
+// This is purely additive: the in-process test-double API
+// (cloudemu.NewAWS(), server/*.New(Drivers{...})) is unchanged.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const usage = `cloudemu — in-memory AWS/Azure/GCP emulator
+
+Usage:
+  cloudemu serve [flags]     Start the standalone server (see: cloudemu serve -h)
+  cloudemu version           Print the version
+  cloudemu help              Show this message
+
+Run "cloudemu serve -h" for the full list of serve flags.
+`
+
+// version is overridable at build time with
+// -ldflags "-X main.version=vX.Y.Z".
+var version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "serve":
+		if err := runServe(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "cloudemu:", err)
+			os.Exit(1)
+		}
+	case "version", "-v", "--version":
+		fmt.Println("cloudemu", version)
+	case "help", "-h", "--help":
+		fmt.Print(usage)
+	default:
+		fmt.Fprintf(os.Stderr, "cloudemu: unknown command %q\n\n%s", os.Args[1], usage)
+		os.Exit(2)
+	}
+}

--- a/cmd/cloudemu/middleware.go
+++ b/cmd/cloudemu/middleware.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// wrap optionally decorates a provider handler with request logging. When
+// logging is off it returns the handler unchanged, so there is zero overhead
+// on the hot path.
+func wrap(h http.Handler, provider string, logReqs bool) http.Handler {
+	if !logReqs {
+		return h
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		h.ServeHTTP(sw, r)
+		log.Printf("[%s] %s %s → %d (%s)", provider, r.Method, r.URL.Path, sw.status, time.Since(start).Round(time.Microsecond))
+	})
+}
+
+// statusWriter captures the first response status for logging while remaining
+// a transparent http.ResponseWriter. Write is not overridden — it promotes from
+// the embedded writer, so a handler that writes a body without an explicit
+// WriteHeader is logged as the default 200.
+type statusWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (w *statusWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	"github.com/stackshy/cloudemu/v2/services/kubernetes"
+)
+
+// serveConfig holds the resolved serve flags.
+type serveConfig struct {
+	providers  string
+	host       string
+	awsPort    string
+	azurePort  string
+	gcpPort    string
+	k8sPort    string
+	accountID  string
+	region     string
+	projectID  string
+	latency    time.Duration
+	tlsCert    string
+	tlsKey     string
+	tlsHosts   stringList
+	endpoints  string
+	logReqs    bool
+	quiet      bool
+	shutdownTO time.Duration
+}
+
+// stringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
+type stringList []string
+
+func (s *stringList) String() string { return strings.Join(*s, ",") }
+func (s *stringList) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+func runServe(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	var c serveConfig
+	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp")
+	fs.StringVar(&c.host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
+	fs.StringVar(&c.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
+	fs.StringVar(&c.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
+	fs.StringVar(&c.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
+	fs.StringVar(&c.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTP); empty to disable")
+	fs.StringVar(&c.accountID, "account-id", "000000000000", "AWS account ID / Azure subscription ID reported by the emulator")
+	fs.StringVar(&c.region, "region", "us-east-1", "default region reported by the emulator")
+	fs.StringVar(&c.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
+	fs.DurationVar(&c.latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
+	fs.StringVar(&c.tlsCert, "tls-cert", "", "PEM cert file for the Azure HTTPS endpoint (default: a self-signed cert generated in memory)")
+	fs.StringVar(&c.tlsKey, "tls-key", "", "PEM key file matching --tls-cert")
+	fs.Var(&c.tlsHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
+	fs.StringVar(&c.endpoints, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
+	fs.BoolVar(&c.logReqs, "log-requests", false, "log every HTTP request (method, path, status, duration)")
+	fs.BoolVar(&c.quiet, "quiet", false, "suppress the startup banner")
+	fs.DurationVar(&c.shutdownTO, "shutdown-timeout", 10*time.Second, "grace period for in-flight requests on shutdown")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: cloudemu serve [flags]\n\nStart the standalone emulator. Flags:\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if (c.tlsCert == "") != (c.tlsKey == "") {
+		return errors.New("--tls-cert and --tls-key must be given together")
+	}
+
+	sel, err := parseProviders(c.providers)
+	if err != nil {
+		return err
+	}
+
+	opts := []config.Option{
+		config.WithAccountID(c.accountID),
+		config.WithRegion(c.region),
+		config.WithProjectID(c.projectID),
+	}
+	if c.latency > 0 {
+		opts = append(opts, config.WithLatency(c.latency))
+	}
+
+	// One shared Kubernetes data-plane so a kubeconfig from any provider's
+	// control plane (EKS/AKS/GKE) reaches the same backend.
+	var k8s *kubernetes.APIServer
+	if c.k8sPort != "" {
+		k8s = kubernetes.NewAPIServer()
+	}
+
+	var (
+		servers []*namedServer
+		eps     = endpointSet{}
+	)
+
+	for _, p := range sel {
+		switch p {
+		case "aws":
+			cloud := cloudemu.NewAWS(opts...)
+			d := awsserver.DriversFrom(cloud)
+			d.K8sAPI = k8s
+			h := wrap(awsserver.New(d), "aws", c.logReqs)
+			addr := net.JoinHostPort(c.host, c.awsPort)
+			servers = append(servers, &namedServer{name: "aws", srv: &http.Server{Addr: addr, Handler: h}})
+			eps.AWS = fmt.Sprintf("http://%s", addr)
+		case "gcp":
+			cloud := cloudemu.NewGCP(opts...)
+			d := gcpserver.DriversFrom(cloud)
+			d.K8sAPI = k8s
+			h := wrap(gcpserver.New(d), "gcp", c.logReqs)
+			addr := net.JoinHostPort(c.host, c.gcpPort)
+			servers = append(servers, &namedServer{name: "gcp", srv: &http.Server{Addr: addr, Handler: h}})
+			eps.GCP = fmt.Sprintf("http://%s", addr)
+		case "azure":
+			cloud := cloudemu.NewAzure(opts...)
+			d := azureserver.DriversFrom(cloud)
+			d.K8sAPI = k8s
+			h := wrap(azureserver.New(d), "azure", c.logReqs)
+			addr := net.JoinHostPort(c.host, c.azurePort)
+			tlsCfg, err := tlsConfig(c, addr)
+			if err != nil {
+				return fmt.Errorf("azure TLS: %w", err)
+			}
+			servers = append(servers, &namedServer{name: "azure", srv: &http.Server{Addr: addr, Handler: h, TLSConfig: tlsCfg}, tls: true})
+			eps.Azure = fmt.Sprintf("https://%s", addr)
+		}
+	}
+
+	if k8s != nil {
+		addr := net.JoinHostPort(c.host, c.k8sPort)
+		servers = append(servers, &namedServer{name: "kubernetes", srv: &http.Server{Addr: addr, Handler: wrap(k8s, "kubernetes", c.logReqs)}})
+		eps.Kubernetes = fmt.Sprintf("http://%s", addr)
+	}
+
+	// Bind every listener before serving so a port clash fails fast, before
+	// we print a banner promising endpoints that never came up.
+	listeners := make([]net.Listener, len(servers))
+	for i, s := range servers {
+		ln, err := net.Listen("tcp", s.srv.Addr)
+		if err != nil {
+			for _, l := range listeners[:i] {
+				l.Close()
+			}
+			return fmt.Errorf("bind %s (%s): %w", s.name, s.srv.Addr, err)
+		}
+		listeners[i] = ln
+	}
+
+	errCh := make(chan error, len(servers))
+	for i, s := range servers {
+		s := s
+		ln := listeners[i]
+		go func() {
+			var err error
+			if s.tls {
+				err = s.srv.ServeTLS(ln, "", "")
+			} else {
+				err = s.srv.Serve(ln)
+			}
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				errCh <- fmt.Errorf("%s: %w", s.name, err)
+			}
+		}()
+	}
+
+	if !c.quiet {
+		printBanner(os.Stdout, eps)
+	}
+	if c.endpoints != "" {
+		if err := eps.writeFile(c.endpoints); err != nil {
+			return fmt.Errorf("write endpoints file: %w", err)
+		}
+	}
+
+	// Block until a signal or a fatal serve error.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case err := <-errCh:
+		return err
+	case <-sigCh:
+		if !c.quiet {
+			fmt.Fprintln(os.Stdout, "\nshutting down…")
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.shutdownTO)
+	defer cancel()
+	var shutErr error
+	for _, s := range servers {
+		if err := s.srv.Shutdown(ctx); err != nil && shutErr == nil {
+			shutErr = err
+		}
+	}
+	return shutErr
+}
+
+type namedServer struct {
+	name string
+	srv  *http.Server
+	tls  bool
+}
+
+func parseProviders(s string) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+	for _, raw := range strings.Split(s, ",") {
+		p := strings.TrimSpace(strings.ToLower(raw))
+		if p == "" {
+			continue
+		}
+		if p != "aws" && p != "azure" && p != "gcp" {
+			return nil, fmt.Errorf("unknown provider %q (want aws, azure, or gcp)", p)
+		}
+		if !seen[p] {
+			seen[p] = true
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil, errors.New("no providers selected")
+	}
+	return out, nil
+}

--- a/cmd/cloudemu/serve_test.go
+++ b/cmd/cloudemu/serve_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// TestServeOutOfProcess builds the binary, runs it as a separate process, and
+// drives real cloud SDK clients against the listening sockets — the way an
+// actual user runs `cloudemu serve` and points an app at it. It exercises the
+// HTTP path (AWS) and the self-signed HTTPS path (Azure) end to end.
+func TestServeOutOfProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and execs a binary; skipped in -short")
+	}
+
+	awsPort := freePort(t)
+	azurePort := freePort(t)
+	gcpPort := freePort(t)
+
+	bin := filepath.Join(t.TempDir(), "cloudemu")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(bin, "serve",
+		"--host", "127.0.0.1",
+		"--aws-port", awsPort,
+		"--azure-port", azurePort,
+		"--gcp-port", gcpPort,
+		"--k8s-port", "", // Kubernetes data-plane not needed for this test
+		"--quiet",
+	)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+		}
+	})
+
+	awsEndpoint := "http://127.0.0.1:" + awsPort
+	if !waitReady(awsEndpoint+"/", 15*time.Second) {
+		t.Fatalf("AWS endpoint %s never became ready", awsEndpoint)
+	}
+
+	t.Run("aws-s3-over-http", func(t *testing.T) {
+		ctx := context.Background()
+		cfg, err := awsconfig.LoadDefaultConfig(ctx,
+			awsconfig.WithRegion("us-east-1"),
+			awsconfig.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider("test", "test", "")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(awsEndpoint)
+			o.UsePathStyle = true
+		})
+
+		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("demo")}); err != nil {
+			t.Fatalf("CreateBucket over the socket: %v", err)
+		}
+		out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+		if err != nil {
+			t.Fatalf("ListBuckets: %v", err)
+		}
+		if len(out.Buckets) != 1 || aws.ToString(out.Buckets[0].Name) != "demo" {
+			t.Fatalf("ListBuckets = %+v, want [demo]", out.Buckets)
+		}
+	})
+
+	t.Run("azure-arm-over-self-signed-https", func(t *testing.T) {
+		ctx := context.Background()
+		// A transport that trusts the emulator's self-signed cert. A real user
+		// either does this for local dev or installs the printed cert.
+		httpClient := &http.Client{Transport: &http.Transport{
+			// #nosec G402 -- local test trusts the emulator's self-signed cert.
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+		azureEndpoint := "https://127.0.0.1:" + azurePort
+
+		cloudCfg := cloud.Configuration{
+			ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				cloud.ResourceManager: {Endpoint: azureEndpoint, Audience: "https://management.azure.com"},
+			},
+		}
+		opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+			Cloud:     cloudCfg,
+			Transport: httpClient,
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		}}
+
+		cf, err := armservicebus.NewClientFactory("000000000000", fakeCred{}, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := cf.NewNamespacesClient()
+
+		poller, err := client.BeginCreateOrUpdate(ctx, "rg-1", "ns-demo", armservicebus.SBNamespace{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate over HTTPS: %v", err)
+		}
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("poll: %v", err)
+		}
+		got, err := client.Get(ctx, "rg-1", "ns-demo", nil)
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got.Name == nil || *got.Name != "ns-demo" {
+			t.Fatalf("Get namespace = %+v, want ns-demo", got.SBNamespace)
+		}
+	})
+}
+
+// fakeCred is a static-token Azure credential; cloudemu does not validate it.
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// waitReady polls url until it answers or the deadline passes.
+func waitReady(url string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+// freePort asks the OS for an unused TCP port and returns it as a string. The
+// listener is closed immediately; the small reuse window is acceptable in a
+// test.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port
+}

--- a/cmd/cloudemu/tlscert.go
+++ b/cmd/cloudemu/tlscert.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// tlsConfig returns the TLS config for the Azure HTTPS endpoint. If the user
+// supplied a cert/key pair we load it; otherwise we mint a self-signed cert in
+// memory covering localhost, the loopback IPs, the bind host, and any extra
+// --tls-host SANs.
+func tlsConfig(c serveConfig, addr string) (*tls.Config, error) {
+	if c.tlsCert != "" {
+		cert, err := tls.LoadX509KeyPair(c.tlsCert, c.tlsKey)
+		if err != nil {
+			return nil, err
+		}
+		return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = c.host
+	}
+	cert, err := selfSignedCert(append([]string{"localhost", host}, c.tlsHosts...))
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
+}
+
+// selfSignedCert generates an in-memory self-signed certificate valid for the
+// given hosts (DNS names and/or IP literals). It is a convenience for local
+// development only — clients must trust it or skip verification.
+func selfSignedCert(hosts []string) (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{Organization: []string{"cloudemu local"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	// Always cover the loopback IPs so https://127.0.0.1 / [::1] verify.
+	tmpl.IPAddresses = append(tmpl.IPAddresses, net.IPv4(127, 0, 0, 1), net.IPv6loopback)
+	seen := map[string]bool{}
+	for _, h := range hosts {
+		if h == "" || seen[h] {
+			continue
+		}
+		seen[h] = true
+		if ip := net.ParseIP(h); ip != nil {
+			tmpl.IPAddresses = append(tmpl.IPAddresses, ip)
+		} else {
+			tmpl.DNSNames = append(tmpl.DNSNames, h)
+		}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("assemble keypair: %w", err)
+	}
+	return cert, nil
+}

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -1,0 +1,140 @@
+# Standalone server (`cloudemu serve`)
+
+`cloudemu serve` runs the emulator as a long-lived, out-of-process HTTP server.
+Point real AWS, Azure, and GCP SDK clients — in any language — at the printed
+endpoints and they talk to cloudemu over the network exactly as they would to
+the real cloud. No accounts, no Docker, no code changes.
+
+This is the "local dev cloud" mode. The in-process test-double API
+(`cloudemu.NewAWS()`, `awsserver.New(Drivers{…})`) is unchanged and still the
+right tool for unit tests.
+
+## Install & run
+
+```sh
+go install github.com/stackshy/cloudemu/v2/cmd/cloudemu@latest
+cloudemu serve
+```
+
+Or from a checkout:
+
+```sh
+go run ./cmd/cloudemu serve
+```
+
+On start it prints the live endpoints:
+
+```
+cloudemu — standalone server
+────────────────────────────
+  AWS         http://127.0.0.1:4566
+  Azure       https://127.0.0.1:4568   (self-signed TLS)
+  GCP         http://127.0.0.1:4569
+  Kubernetes  http://127.0.0.1:4570
+```
+
+## Ports
+
+| Provider   | Default | Protocol | Notes                                    |
+|------------|---------|----------|------------------------------------------|
+| AWS        | `4566`  | HTTP     | same port LocalStack uses                |
+| Azure      | `4568`  | HTTPS    | the ARM SDK requires TLS                 |
+| GCP        | `4569`  | HTTP     |                                          |
+| Kubernetes | `4570`  | HTTP     | shared data-plane for EKS/AKS/GKE        |
+
+Override with `--aws-port`, `--azure-port`, `--gcp-port`, `--k8s-port`. Start a
+subset with `--providers=aws,gcp`. Bind an interface with `--host 0.0.0.0` (the
+default `127.0.0.1` keeps it local-only).
+
+## Pointing SDKs at it
+
+### AWS (`aws-sdk-go-v2`)
+
+```go
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(
+        credentials.NewStaticCredentialsProvider("test", "test", "")))
+
+client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String("http://127.0.0.1:4566")
+    o.UsePathStyle = true
+})
+```
+
+Other languages: set `AWS_ENDPOINT_URL=http://127.0.0.1:4566` (SDK v3 / CLI
+`--endpoint-url`). Any credentials are accepted — cloudemu does not validate
+signatures.
+
+### GCP (`cloud.google.com/go`)
+
+```go
+client, _ := storage.NewClient(ctx,
+    option.WithEndpoint("http://127.0.0.1:4569"),
+    option.WithoutAuthentication())
+```
+
+### Azure (`azure-sdk-for-go`)
+
+Azure is served over HTTPS with a self-signed cert. Point the SDK at it through
+a `cloud.Configuration`, and either trust the cert or use a transport that skips
+verification for local dev:
+
+```go
+cloudCfg := cloud.Configuration{
+    Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+        cloud.ResourceManager: {
+            Endpoint: "https://127.0.0.1:4568",
+            Audience: "https://management.azure.com",
+        },
+    },
+}
+opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{Cloud: cloudCfg}}
+```
+
+Any `azcore.TokenCredential` works — tokens are not validated.
+
+To supply your own cert instead of the generated one:
+
+```sh
+cloudemu serve --tls-cert cert.pem --tls-key key.pem
+# add SANs to the generated cert instead:
+cloudemu serve --tls-host myhost.local --tls-host 192.168.1.10
+```
+
+## Flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--providers` | `aws,azure,gcp` | which providers to start |
+| `--host` | `127.0.0.1` | bind interface |
+| `--aws-port` / `--azure-port` / `--gcp-port` / `--k8s-port` | `4566`/`4568`/`4569`/`4570` | listen ports (empty `--k8s-port` disables Kubernetes) |
+| `--account-id` | `000000000000` | AWS account ID / Azure subscription ID |
+| `--region` | `us-east-1` | default region |
+| `--project-id` | `cloudemu-local` | GCP project ID |
+| `--latency` | `0` | artificial per-call latency (e.g. `20ms`) |
+| `--tls-cert` / `--tls-key` | — | supply your own Azure cert (else self-signed) |
+| `--tls-host` | — | extra SAN for the generated cert (repeatable) |
+| `--endpoints-file` | — | write resolved endpoints as JSON |
+| `--log-requests` | `false` | log every request |
+| `--quiet` | `false` | suppress the startup banner |
+| `--shutdown-timeout` | `10s` | grace period for in-flight requests on Ctrl-C |
+
+`--endpoints-file cloudemu.json` emits a machine-readable bundle for wiring an
+app at the whole emulated cloud at once:
+
+```json
+{
+  "aws": "http://127.0.0.1:4566",
+  "azure": "https://127.0.0.1:4568",
+  "gcp": "http://127.0.0.1:4569",
+  "kubernetes": "http://127.0.0.1:4570"
+}
+```
+
+## Not yet included
+
+State **seeding** and **persistence** across restarts are not in this mode yet —
+they need a cross-service state-import loader (tracked in #250). Today the server
+starts empty each run. Docker packaging (#247) and a Testcontainers module (#248)
+build directly on this binary and are the natural next steps.

--- a/features/chaos/wrappers_baseline_test.go
+++ b/features/chaos/wrappers_baseline_test.go
@@ -200,7 +200,7 @@ func TestWrapNotificationBaseline(t *testing.T) {
 	ctx := context.Background()
 
 	tp, _ := n.CreateTopic(ctx, notifdriver.TopicConfig{Name: "b"})
-	_, _ = n.ListTopics(ctx)
+	_, _ = n.ListTopics(ctx, scope.Scope{})
 	if tp != nil {
 		_, _ = n.GetTopic(ctx, tp.ID)
 		sub, _ := n.Subscribe(ctx, notifdriver.SubscriptionConfig{TopicID: tp.ID, Protocol: "email", Endpoint: "x@y.z"})
@@ -233,7 +233,7 @@ func TestWrapEventBusBaseline(t *testing.T) {
 
 	_, _ = b.CreateEventBus(ctx, ebdriver.EventBusConfig{Name: "b"})
 	_, _ = b.GetEventBus(ctx, "b")
-	_, _ = b.ListEventBuses(ctx)
+	_, _ = b.ListEventBuses(ctx, scope.Scope{})
 	cfg := &ebdriver.RuleConfig{Name: "rule", EventBus: "b", EventPattern: `{"source":["x"]}`, State: "ENABLED"}
 	_, _ = b.PutRule(ctx, cfg)
 	_, _ = b.GetRule(ctx, "b", "rule")

--- a/features/chaos/wrappers_baseline_test.go
+++ b/features/chaos/wrappers_baseline_test.go
@@ -2,6 +2,7 @@ package chaos_test
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -182,7 +183,7 @@ func TestWrapLoggingBaseline(t *testing.T) {
 
 	_, _ = l.CreateLogGroup(ctx, logdriver.LogGroupConfig{Name: "b"})
 	_, _ = l.GetLogGroup(ctx, "b")
-	_, _ = l.ListLogGroups(ctx)
+	_, _ = l.ListLogGroups(ctx, scope.Scope{})
 	_, _ = l.CreateLogStream(ctx, "b", "s")
 	_ = l.PutLogEvents(ctx, "b", "s", []logdriver.LogEvent{{Timestamp: time.Now(), Message: "x"}})
 	_, _ = l.GetLogEvents(ctx, &logdriver.LogQueryInput{

--- a/features/chaos/wrappers_baseline_test.go
+++ b/features/chaos/wrappers_baseline_test.go
@@ -104,7 +104,7 @@ func TestWrapDNSBaseline(t *testing.T) {
 
 	z, _ := d.CreateZone(ctx, dnsdriver.ZoneConfig{Name: "b.test."})
 	_, _ = d.GetZone(ctx, z.ID)
-	_, _ = d.ListZones(ctx)
+	_, _ = d.ListZones(ctx, scope.Scope{})
 	rec := dnsdriver.RecordConfig{ZoneID: z.ID, Name: "x.b.test.", Type: "A", TTL: 300, Values: []string{"1.2.3.4"}}
 	_, _ = d.CreateRecord(ctx, rec)
 	_, _ = d.GetRecord(ctx, z.ID, "x.b.test.", "A")

--- a/features/chaos/wrappers_dns.go
+++ b/features/chaos/wrappers_dns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // chaosDNS wraps a DNS driver. Hot-path: zone and record CRUD.
@@ -42,12 +43,12 @@ func (c *chaosDNS) GetZone(ctx context.Context, id string) (*dnsdriver.ZoneInfo,
 	return c.DNS.GetZone(ctx, id)
 }
 
-func (c *chaosDNS) ListZones(ctx context.Context) ([]dnsdriver.ZoneInfo, error) {
+func (c *chaosDNS) ListZones(ctx context.Context, filter scope.Scope) ([]dnsdriver.ZoneInfo, error) {
 	if err := applyChaos(ctx, c.engine, "dns", "ListZones"); err != nil {
 		return nil, err
 	}
 
-	return c.DNS.ListZones(ctx)
+	return c.DNS.ListZones(ctx, filter)
 }
 
 //nolint:gocritic // cfg is a value type by interface contract

--- a/features/chaos/wrappers_dns_test.go
+++ b/features/chaos/wrappers_dns_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/features/chaos"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newChaosDNS(t *testing.T) (dnsdriver.DNS, *chaos.Engine) {
@@ -65,7 +66,7 @@ func TestWrapDNSListZonesChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("dns", time.Hour))
 
-	if _, err := d.ListZones(ctx); err == nil {
+	if _, err := d.ListZones(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListZones")
 	}
 }

--- a/features/chaos/wrappers_eventbus.go
+++ b/features/chaos/wrappers_eventbus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // chaosEventBus wraps an event bus driver. Hot-path: bus CRUD, rule CRUD,
@@ -45,12 +46,12 @@ func (c *chaosEventBus) GetEventBus(ctx context.Context, name string) (*ebdriver
 	return c.EventBus.GetEventBus(ctx, name)
 }
 
-func (c *chaosEventBus) ListEventBuses(ctx context.Context) ([]ebdriver.EventBusInfo, error) {
+func (c *chaosEventBus) ListEventBuses(ctx context.Context, filter scope.Scope) ([]ebdriver.EventBusInfo, error) {
 	if err := applyChaos(ctx, c.engine, "eventbus", "ListEventBuses"); err != nil {
 		return nil, err
 	}
 
-	return c.EventBus.ListEventBuses(ctx)
+	return c.EventBus.ListEventBuses(ctx, filter)
 }
 
 func (c *chaosEventBus) PutRule(ctx context.Context, cfg *ebdriver.RuleConfig) (*ebdriver.Rule, error) {

--- a/features/chaos/wrappers_eventbus_test.go
+++ b/features/chaos/wrappers_eventbus_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/features/chaos"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newChaosEventBus(t *testing.T) (ebdriver.EventBus, *chaos.Engine) {
@@ -65,7 +66,7 @@ func TestWrapEventBusListEventBusesChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("eventbus", time.Hour))
 
-	if _, err := b.ListEventBuses(ctx); err == nil {
+	if _, err := b.ListEventBuses(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListEventBuses")
 	}
 }

--- a/features/chaos/wrappers_logging.go
+++ b/features/chaos/wrappers_logging.go
@@ -2,6 +2,7 @@ package chaos
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
 )
@@ -46,12 +47,12 @@ func (c *chaosLogging) GetLogGroup(ctx context.Context, name string) (*logdriver
 	return c.Logging.GetLogGroup(ctx, name)
 }
 
-func (c *chaosLogging) ListLogGroups(ctx context.Context) ([]logdriver.LogGroupInfo, error) {
+func (c *chaosLogging) ListLogGroups(ctx context.Context, filter scope.Scope) ([]logdriver.LogGroupInfo, error) {
 	if err := applyChaos(ctx, c.engine, "logging", "ListLogGroups"); err != nil {
 		return nil, err
 	}
 
-	return c.Logging.ListLogGroups(ctx)
+	return c.Logging.ListLogGroups(ctx, filter)
 }
 
 func (c *chaosLogging) PutLogEvents(

--- a/features/chaos/wrappers_logging_test.go
+++ b/features/chaos/wrappers_logging_test.go
@@ -2,6 +2,7 @@ package chaos_test
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -65,7 +66,7 @@ func TestWrapLoggingListLogGroupsChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("logging", time.Hour))
 
-	if _, err := l.ListLogGroups(ctx); err == nil {
+	if _, err := l.ListLogGroups(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListLogGroups")
 	}
 }

--- a/features/chaos/wrappers_notification.go
+++ b/features/chaos/wrappers_notification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // chaosNotification wraps a notification driver. All ops are wrapped — the
@@ -45,12 +46,12 @@ func (c *chaosNotification) GetTopic(ctx context.Context, id string) (*notifdriv
 	return c.Notification.GetTopic(ctx, id)
 }
 
-func (c *chaosNotification) ListTopics(ctx context.Context) ([]notifdriver.TopicInfo, error) {
+func (c *chaosNotification) ListTopics(ctx context.Context, filter scope.Scope) ([]notifdriver.TopicInfo, error) {
 	if err := applyChaos(ctx, c.engine, "notification", "ListTopics"); err != nil {
 		return nil, err
 	}
 
-	return c.Notification.ListTopics(ctx)
+	return c.Notification.ListTopics(ctx, filter)
 }
 
 func (c *chaosNotification) Subscribe(

--- a/features/chaos/wrappers_notification_test.go
+++ b/features/chaos/wrappers_notification_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/features/chaos"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newChaosNotification(t *testing.T) (notifdriver.Notification, *chaos.Engine) {
@@ -65,7 +66,7 @@ func TestWrapNotificationListTopicsChaos(t *testing.T) {
 
 	e.Apply(chaos.ServiceOutage("notification", time.Hour))
 
-	if _, err := n.ListTopics(ctx); err == nil {
+	if _, err := n.ListTopics(ctx, scope.Scope{}); err == nil {
 		t.Error("expected chaos error on ListTopics")
 	}
 }

--- a/features/topology/resolve.go
+++ b/features/topology/resolve.go
@@ -3,11 +3,13 @@ package topology
 import (
 	"context"
 	"strings"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Resolve walks through DNS zones and returns matching record values for the hostname.
 func (e *Engine) Resolve(ctx context.Context, hostname string) ([]string, error) {
-	zones, err := e.dns.ListZones(ctx)
+	zones, err := e.dns.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/memstore/store.go
+++ b/internal/memstore/store.go
@@ -1,7 +1,10 @@
 // Package memstore provides a generic thread-safe in-memory key-value store.
 package memstore
 
-import "sync"
+import (
+	"sort"
+	"sync"
+)
 
 // Store is a generic thread-safe in-memory key-value store.
 type Store[V any] struct {
@@ -142,4 +145,24 @@ func (s *Store[V]) Filter(fn func(key string, value V) bool) map[string]V {
 	}
 
 	return result
+}
+
+// SortedValues returns the values ordered by their keys. List endpoints
+// must iterate this instead of All(): map iteration order is random, and
+// real cloud APIs return deterministic list ordering.
+func (s *Store[V]) SortedValues() []V {
+	s.mu.RLock()
+	keys := make([]string, 0, len(s.items))
+	for k := range s.items {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]V, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, s.items[k])
+	}
+	s.mu.RUnlock()
+
+	return out
 }

--- a/internal/memstore/store_test.go
+++ b/internal/memstore/store_test.go
@@ -277,3 +277,17 @@ func TestStore_OverwriteValue(t *testing.T) {
 	assert.Equal(t, "second", val)
 	assert.Equal(t, 1, s.Len())
 }
+
+func TestSortedValues(t *testing.T) {
+	s := New[string]()
+	s.Set("zebra", "z")
+	s.Set("apple", "a")
+	s.Set("mango", "m")
+
+	for range 5 {
+		got := s.SortedValues()
+		if len(got) != 3 || got[0] != "a" || got[1] != "m" || got[2] != "z" {
+			t.Fatalf("SortedValues = %v, want [a m z] (key order, stable across calls)", got)
+		}
+	}
+}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -53,6 +53,8 @@ type Provider struct {
 	SageMaker         *sagemaker.Mock
 	SSM               *ssm.Mock
 	ResourceDiscovery *resourcediscovery.Engine
+	AccountID         string
+	Region            string
 }
 
 // New creates a new AWS provider with all mock services.
@@ -81,6 +83,8 @@ func New(opts ...config.Option) *Provider {
 		Bedrock:        bedrock.New(o),
 		SageMaker:      sagemaker.New(o),
 		SSM:            ssm.New(o),
+		AccountID:      o.AccountID,
+		Region:         o.Region,
 	}
 	p.EC2.SetMonitoring(p.CloudWatch)
 	p.S3.SetMonitoring(p.CloudWatch)

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -3,6 +3,8 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -90,6 +92,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
+		Scope:         cfg.Scope,
 		ResourceID:    arn,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -132,11 +135,14 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 }
 
 // ListLogGroups lists all CloudWatch log groups.
-func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+func (m *Mock) ListLogGroups(_ context.Context, filter scope.Scope) ([]driver.LogGroupInfo, error) {
 	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
+		if !g.info.Scope.Matches(filter) {
+			continue
+		}
 		groups = append(groups, g.info)
 	}
 
@@ -493,4 +499,30 @@ func (m *Mock) DescribeMetricFilters(
 	}
 
 	return results, nil
+}
+
+// UpdateLogGroup replaces the mutable fields of an existing log group —
+// ARM CreateOrUpdate-on-existing semantics (retention and tags come from
+// the request; identity and CreatedAt are preserved).
+func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
+	}
+
+	if cfg.RetentionDays != 0 {
+		g.info.RetentionDays = cfg.RetentionDays
+	}
+	if cfg.Tags != nil {
+		g.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		g.info.Scope = cfg.Scope
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := g.info
+
+	return &result, nil
 }

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs.go
@@ -133,7 +133,7 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 
 // ListLogGroups lists all CloudWatch log groups.
 func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
-	all := m.groups.All()
+	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
@@ -196,7 +196,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
 	}
 
-	all := g.streams.All()
+	all := g.streams.SortedValues()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
 

--- a/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
+++ b/providers/aws/cloudwatchlogs/cloudwatchlogs_test.go
@@ -2,6 +2,7 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestListLogGroups(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		m := newTestMock()
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, len(groups))
@@ -170,7 +171,7 @@ func TestListLogGroups(t *testing.T) {
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
 		require.NoError(t, err)
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(groups))

--- a/providers/aws/cloudwatchlogs/ordering_test.go
+++ b/providers/aws/cloudwatchlogs/ordering_test.go
@@ -2,6 +2,7 @@ package cloudwatchlogs
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListLogGroups(ctx)
+	first, err := m.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListLogGroups(ctx)
+		again, err := m.ListLogGroups(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/cloudwatchlogs/ordering_test.go
+++ b/providers/aws/cloudwatchlogs/ordering_test.go
@@ -1,0 +1,42 @@
+package cloudwatchlogs
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListLogGroups(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -3,6 +3,7 @@ package dynamodb
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -151,6 +152,7 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 
 	key := itemKey(td.config, item)
 	oldItem, hadOld := td.items.Get(key)
+	item = maps.Clone(item)
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
 	m.mu.Unlock()
@@ -187,7 +189,7 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 	m.emitMetric("ConsumedReadCapacityUnits", 1, dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
-	return item, nil
+	return maps.Clone(item), nil
 }
 
 // UpdateItem applies partial updates to an existing item.
@@ -407,6 +409,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	for _, item := range items {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 
 		m.recordStreamEvent(td, oldItem, item, hadOld)
@@ -430,7 +433,7 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 
 	for _, key := range keys {
 		if item, ok := td.items.Get(itemKey(td.config, key)); ok {
-			results = append(results, item)
+			results = append(results, maps.Clone(item))
 		}
 	}
 
@@ -643,6 +646,7 @@ func (m *Mock) applyTransactPuts(td *tableData, puts []map[string]any) {
 	for _, item := range puts {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}

--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -233,7 +233,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	m.emitMetric("ConsumedWriteCapacityUnits", 1, dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
 
-	return updated, nil
+	return maps.Clone(updated), nil
 }
 
 func (m *Mock) DeleteItem(_ context.Context, table string, key map[string]any) error {

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -4,6 +4,7 @@ package elasticache
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const defaultRedisPort = 6379
@@ -92,6 +94,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
 		Status:    "available",
@@ -134,15 +137,44 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 }
 
 // ListCaches lists all ElastiCache clusters.
-func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {
+		if !cd.info.Scope.Matches(filter) {
+			continue
+		}
 		caches = append(caches, cd.info)
 	}
 
 	return caches, nil
+}
+
+// UpdateCache replaces the mutable fields of an existing cache — ARM
+// CreateOrUpdate-on-existing semantics (node type and tags come from the
+// request; identity, endpoint, and CreatedAt are preserved).
+func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
+	}
+
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.Tags != nil {
+		cd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		cd.info.Scope = cfg.Scope
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := cd.info
+
+	return &result, nil
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/aws/elasticache/elasticache.go
+++ b/providers/aws/elasticache/elasticache.go
@@ -135,7 +135,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 
 // ListCaches lists all ElastiCache clusters.
 func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
-	all := m.caches.All()
+	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {

--- a/providers/aws/elasticache/elasticache_test.go
+++ b/providers/aws/elasticache/elasticache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,7 +142,7 @@ func TestListCaches(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(caches))
 	})
@@ -150,7 +151,7 @@ func TestListCaches(t *testing.T) {
 	createTestCache(t, m, "cache-b")
 
 	t.Run("two caches", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(caches))
 	})

--- a/providers/aws/elasticache/ordering_test.go
+++ b/providers/aws/elasticache/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListCaches(ctx)
+	first, err := m.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListCaches(ctx)
+		again, err := m.ListCaches(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/elasticache/ordering_test.go
+++ b/providers/aws/elasticache/ordering_test.go
@@ -1,0 +1,42 @@
+package elasticache
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateCache(ctx, driver.CacheConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListCaches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListCaches(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -106,6 +108,7 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 
 	info := driver.EventBusInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		ARN:       busARN,
 		State:     activeBusState,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -151,11 +154,14 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 }
 
 // ListEventBuses lists all EventBridge event buses.
-func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.EventBusInfo, error) {
 	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
+		if !bd.info.Scope.Matches(filter) {
+			continue
+		}
 		buses = append(buses, bd.info)
 	}
 
@@ -516,6 +522,29 @@ func matchesField(value string, allowed any) bool {
 	}
 
 	return false
+}
+
+// UpdateEventBus replaces the mutable fields of an existing event bus —
+// ARM CreateOrUpdate-on-existing semantics (tags come from the request;
+// identity and CreatedAt are preserved).
+func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "event bus %q not found", cfg.Name)
+	}
+
+	if cfg.Tags != nil {
+		bd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		bd.info.Scope = cfg.Scope
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := bd.info
+
+	return &result, nil
 }
 
 // MatchedRules returns all rules that match the given event (exported for testing).

--- a/providers/aws/eventbridge/eventbridge.go
+++ b/providers/aws/eventbridge/eventbridge.go
@@ -152,7 +152,7 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 
 // ListEventBuses lists all EventBridge event buses.
 func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
-	all := m.buses.All()
+	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
@@ -268,7 +268,7 @@ func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, err
 		return nil, errors.Newf(errors.NotFound, "event bus %q not found", busName)
 	}
 
-	all := bd.rules.All()
+	all := bd.rules.SortedValues()
 
 	rules := make([]driver.Rule, 0, len(all))
 	for _, rd := range all {

--- a/providers/aws/eventbridge/eventbridge_test.go
+++ b/providers/aws/eventbridge/eventbridge_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -173,7 +174,7 @@ func TestListEventBuses(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("includes default bus", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, len(buses), 1)
 
@@ -190,7 +191,7 @@ func TestListEventBuses(t *testing.T) {
 	createTestBus(t, m, "bus-b")
 
 	t.Run("default plus two custom", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 3, len(buses))
 	})

--- a/providers/aws/eventbridge/ordering_test.go
+++ b/providers/aws/eventbridge/ordering_test.go
@@ -1,0 +1,43 @@
+package eventbridge
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateEventBus(ctx, driver.EventBusConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListEventBuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// EventBridge pre-creates the "default" bus, so 5 created + 1 default.
+	if len(first) < 5 {
+		t.Fatalf("list returned %d items, want >= 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListEventBuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/eventbridge/ordering_test.go
+++ b/providers/aws/eventbridge/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListEventBuses(ctx)
+	first, err := m.ListEventBuses(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +31,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListEventBuses(ctx)
+		again, err := m.ListEventBuses(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -36,7 +36,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Description:     cfg.Description,
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})

--- a/providers/aws/lambda/clock_test.go
+++ b/providers/aws/lambda/clock_test.go
@@ -1,0 +1,29 @@
+package lambda
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestTimestampsUseConfiguredClock locks LastModified to the configured
+// clock: with a fake clock pinned to 2025-01-01, function timestamps must
+// not leak wall-clock time.
+func TestTimestampsUseConfiguredClock(t *testing.T) {
+	m := newTestMock()
+
+	fn, err := m.CreateFunction(context.Background(), defaultFuncConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := time.Parse(time.RFC3339, fn.LastModified)
+	if err != nil {
+		t.Fatalf("LastModified %q not RFC3339: %v", fn.LastModified, err)
+	}
+
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("LastModified = %v, want fake-clock time %v (wall clock leaked)", got, want)
+	}
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -103,7 +103,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
 		Environment: cfg.Environment, Tags: cfg.Tags,
-		LastModified: time.Now().UTC().Format(time.RFC3339),
+		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	m.handlersMu.RLock()
@@ -162,7 +162,7 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	fd.info = info
 	m.funcs.Set(name, fd)
 

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -102,7 +103,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
-		Environment: cfg.Environment, Tags: cfg.Tags,
+		Environment: maps.Clone(cfg.Environment), Tags: maps.Clone(cfg.Tags),
 		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
@@ -138,6 +139,8 @@ func (m *Mock) GetFunction(_ context.Context, name string) (*driver.FunctionInfo
 	}
 
 	info := fd.info
+	info.Environment = maps.Clone(info.Environment)
+	info.Tags = maps.Clone(info.Tags)
 
 	return &info, nil
 }
@@ -240,11 +243,11 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 
 	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
+		info.Environment = maps.Clone(cfg.Environment)
 	}
 
 	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
+		info.Tags = maps.Clone(cfg.Tags)
 	}
 }
 

--- a/providers/aws/lambda/layers.go
+++ b/providers/aws/lambda/layers.go
@@ -44,7 +44,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 		ContentSHA256:      shaStr,
 		ContentSize:        int64(len(cfg.Content)),
 		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		ARN:                arn,
 	}
 

--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -27,7 +27,7 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 
 	verStr := strconv.Itoa(verNum)
 	sha := codeSHA(&fd.info)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
 		config:    snapshotConfig(&fd.info),

--- a/providers/aws/route53/healthcheck.go
+++ b/providers/aws/route53/healthcheck.go
@@ -82,7 +82,7 @@ func (m *Mock) GetHealthCheck(_ context.Context, id string) (*driver.HealthCheck
 
 // ListHealthChecks returns all Route 53 health checks.
 func (m *Mock) ListHealthChecks(_ context.Context) ([]driver.HealthCheckInfo, error) {
-	all := m.healthChecks.All()
+	all := m.healthChecks.SortedValues()
 
 	checks := make([]driver.HealthCheckInfo, 0, len(all))
 	for _, hc := range all {

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -1,0 +1,42 @@
+package route53
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateZone(ctx, driver.ZoneConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListZones(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListZones(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListZones(ctx)
+	first, err := m.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListZones(ctx)
+		again, err := m.ListZones(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -40,3 +40,48 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestListRecordsOrderingDeterministic locks the #259 ordering guarantee for
+// record listing: ListRecords must return the same, defined order on every
+// call (map iteration randomness must never reach the wire).
+func TestListRecordsOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name + ".example.com", Type: "A", TTL: 300,
+			Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("create record %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) < 5 {
+		t.Fatalf("list returned %d records, want >=5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListRecords(ctx, zone.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("list length changed: %d vs %d", len(again), len(first))
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name || again[i].Type != first[i].Type {
+				t.Fatalf("record order changed between calls at %d: %v vs %v", i, again[i], first[i])
+			}
+		}
+	}
+}

--- a/providers/aws/route53/ordering_test.go
+++ b/providers/aws/route53/ordering_test.go
@@ -85,3 +85,43 @@ func TestListRecordsOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestGetRecordWeightedDeterministic locks that GetRecord resolves a name+type
+// with several weighted records to the same one every call — the lowest set ID
+// in sorted order — instead of a map-order-random pick (#259).
+func TestGetRecordWeightedDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	weight := 10
+	for _, sid := range []string{"west", "east", "central"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: "api.example.com", Type: "A", TTL: 60,
+			Values: []string{"192.0.2.1"}, SetID: sid, Weight: &weight,
+		}); err != nil {
+			t.Fatalf("create weighted %s: %v", sid, err)
+		}
+	}
+
+	first, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	for range 5 {
+		again, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again.SetID != first.SetID {
+			t.Fatalf("GetRecord returned different weighted record across calls: %q vs %q", again.SetID, first.SetID)
+		}
+	}
+	if first.SetID != "central" {
+		t.Fatalf("GetRecord set ID = %q, want lowest in sorted order (central)", first.SetID)
+	}
+}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -104,7 +104,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 
 // ListZones returns all DNS hosted zones.
 func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
-	all := m.zones.All()
+	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -241,13 +241,16 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 		return nil, errors.Newf(errors.NotFound, "zone %q not found", zoneID)
 	}
 
-	filtered := m.records.Filter(func(_ string, rec driver.RecordInfo) bool {
-		return rec.ZoneID == zoneID
-	})
+	// SortedValues gives a stable order keyed by zoneID:name:type[:setID];
+	// filter to this zone in that order so ListRecords is deterministic
+	// (map iteration order must never reach the wire — #259).
+	all := m.records.SortedValues()
 
-	records := make([]driver.RecordInfo, 0, len(filtered))
-	for _, rec := range filtered {
-		records = append(records, rec)
+	records := make([]driver.RecordInfo, 0, len(all))
+	for _, rec := range all {
+		if rec.ZoneID == zoneID {
+			records = append(records, rec)
+		}
 	}
 
 	return records, nil

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -221,12 +221,12 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 		return &result, nil
 	}
 
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-	all := m.records.All()
-
-	for k, r := range all {
-		if strings.HasPrefix(k, prefix) {
+	// Search for weighted records (same name+type with a set ID). Iterate in
+	// sorted-key order and return the lowest set ID, so a name+type with
+	// several weighted records resolves to the same record every call rather
+	// than a map-order-random one (#259).
+	for _, r := range m.records.SortedValues() {
+		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
 			result := r
 			return &result, nil
 		}

--- a/providers/aws/route53/route53.go
+++ b/providers/aws/route53/route53.go
@@ -3,6 +3,7 @@ package route53
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.DNS.
@@ -64,6 +66,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Private:     cfg.Private,
 		RecordCount: 0,
 		Tags:        tags,
+		Scope:       cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)
@@ -102,16 +105,59 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	return &result, nil
 }
 
-// ListZones returns all DNS hosted zones.
-func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+// ListZones returns all DNS hosted zones matching the scope filter. Route 53
+// hosted zones are account-global, so zones are created unscoped and a zero
+// filter (the AWS default) returns everything.
+func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {
+		if !z.Scope.Matches(filter) {
+			continue
+		}
 		zones = append(zones, z)
 	}
 
 	return zones, nil
+}
+
+// UpdateZone applies the mutable fields (tags, scope) of an existing hosted
+// zone, matching the zone by name — ARM CreateOrUpdate-on-existing semantics.
+func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	var (
+		id    string
+		found bool
+	)
+
+	for zid, z := range m.zones.All() {
+		if z.Name == cfg.Name {
+			id = zid
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		return nil, errors.Newf(errors.NotFound, "zone %q not found", cfg.Name)
+	}
+
+	m.zones.Update(id, func(z driver.ZoneInfo) driver.ZoneInfo {
+		if cfg.Tags != nil {
+			z.Tags = maps.Clone(cfg.Tags)
+		}
+		if !cfg.Scope.IsZero() {
+			z.Scope = cfg.Scope
+		}
+
+		return z
+	})
+
+	updated, _ := m.zones.Get(id)
+	result := updated
+
+	return &result, nil
 }
 
 // CreateRecord creates a new DNS record in the specified zone.

--- a/providers/aws/route53/route53_test.go
+++ b/providers/aws/route53/route53_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func newTestMock() *Mock {
@@ -81,13 +82,13 @@ func TestListZones(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	zones, err := m.ListZones(ctx)
+	zones, err := m.ListZones(ctx, scope.Scope{})
 	requireNoError(t, err)
 	assertEqual(t, 0, len(zones))
 
 	createTestZone(m)
 
-	zones, err = m.ListZones(ctx)
+	zones, err = m.ListZones(ctx, scope.Scope{})
 	requireNoError(t, err)
 	assertEqual(t, 1, len(zones))
 }

--- a/providers/aws/route53/zone_update_test.go
+++ b/providers/aws/route53/zone_update_test.go
@@ -1,0 +1,45 @@
+package route53
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+func TestUpdateZoneAppliesTags(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	z, err := m.CreateZone(ctx, driver.ZoneConfig{
+		Name: "example.com",
+		Tags: map[string]string{"env": "test"},
+	})
+	requireNoError(t, err)
+
+	updated, err := m.UpdateZone(ctx, driver.ZoneConfig{
+		Name: "example.com",
+		Tags: map[string]string{"env": "prod", "team": "platform"},
+	})
+	requireNoError(t, err)
+	assertEqual(t, "prod", updated.Tags["env"])
+	assertEqual(t, "platform", updated.Tags["team"])
+
+	got, err := m.GetZone(ctx, z.ID)
+	requireNoError(t, err)
+	assertEqual(t, "prod", got.Tags["env"])
+	assertEqual(t, "platform", got.Tags["team"])
+
+	zones, err := m.ListZones(ctx, scope.Scope{})
+	requireNoError(t, err)
+	assertEqual(t, 1, len(zones))
+	assertEqual(t, "prod", zones[0].Tags["env"])
+}
+
+func TestUpdateZoneNotFound(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.UpdateZone(context.Background(), driver.ZoneConfig{Name: "missing.com"})
+	assertError(t, err, true)
+}

--- a/providers/aws/s3/isolation_test.go
+++ b/providers/aws/s3/isolation_test.go
@@ -1,0 +1,45 @@
+package s3
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMetadataIsolation locks the boundary-copy behavior: mutating the
+// metadata map a caller passed to PutObject, or the map returned from
+// HeadObject, must not change what the store holds.
+func TestMetadataIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "iso"); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]string{"owner": "team-a"}
+	if err := m.PutObject(ctx, "iso", "k", []byte("v"), "text/plain", meta); err != nil {
+		t.Fatal(err)
+	}
+
+	// Caller mutates their map after the put.
+	meta["owner"] = "attacker"
+	meta["extra"] = "leaked"
+
+	info, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Metadata["owner"] != "team-a" || len(info.Metadata) != 1 {
+		t.Fatalf("stored metadata corrupted by caller mutation: %v", info.Metadata)
+	}
+
+	// Caller mutates the returned map; the store must be unaffected.
+	info.Metadata["owner"] = "mutated"
+	again, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Metadata["owner"] != "team-a" {
+		t.Fatalf("stored metadata corrupted via returned map: %v", again.Metadata)
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -273,7 +273,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
 		})
 	}
 
@@ -292,6 +292,12 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	// Clone metadata only for the page actually returned — cloning every
+	// match would make a paged scan O(bucket) allocations per request.
+	for i := range page.Items {
+		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
 	}
 
 	dims := map[string]string{"BucketName": bucket}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -162,7 +163,7 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
 		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
-		Metadata:     metadata,
+		Metadata:     maps.Clone(metadata),
 	})
 
 	dims := map[string]string{"BucketName": bucket}
@@ -195,7 +196,7 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		},
 		Data: dataCopy,
 	}, nil
@@ -233,7 +234,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 	}, nil
 }
 
@@ -272,7 +273,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		})
 	}
 

--- a/providers/aws/sns/ordering_test.go
+++ b/providers/aws/sns/ordering_test.go
@@ -1,0 +1,42 @@
+package sns
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateTopic(ctx, driver.TopicConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListTopics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListTopics(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/aws/sns/ordering_test.go
+++ b/providers/aws/sns/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListTopics(ctx)
+	first, err := m.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListTopics(ctx)
+		again, err := m.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -3,6 +3,7 @@ package sns
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.Notification.
@@ -82,6 +84,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
+		Scope:             cfg.Scope,
 		ResourceID:        arn,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
@@ -122,19 +125,50 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 	return &result, nil
 }
 
-// ListTopics lists all SNS topics.
-func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+// ListTopics lists all SNS topics visible under the given scope filter.
+func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.TopicInfo, error) {
 	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
 	for _, td := range all {
+		if !td.info.Scope.Matches(filter) {
+			continue
+		}
+
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
 		topics = append(topics, info)
 	}
 
 	return topics, nil
+}
+
+// UpdateTopic replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (display name and tags come from the
+// request; identity is preserved).
+func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.DisplayName != "" {
+		td.info.DisplayName = cfg.DisplayName
+	}
+	if cfg.Tags != nil {
+		td.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		td.info.Scope = cfg.Scope
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
 }
 
 // Subscribe creates a subscription to an SNS topic.

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -124,7 +124,7 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 
 // ListTopics lists all SNS topics.
 func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
-	all := m.topics.All()
+	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
@@ -190,7 +190,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
 	}
 
-	all := td.subscriptions.All()
+	all := td.subscriptions.SortedValues()
 
 	subs := make([]driver.SubscriptionInfo, 0, len(all))
 	for _, s := range all {

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +157,7 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	err := m.DeleteTopic(ctx, info.Name)
 	require.NoError(t, err)
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 }
@@ -241,7 +242,7 @@ func TestListTopics(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 
@@ -249,7 +250,7 @@ func TestListTopics(t *testing.T) {
 	createTestTopic(t, m, "topic-2")
 	createTestTopic(t, m, "topic-3")
 
-	topics, err = m.ListTopics(ctx)
+	topics, err = m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(topics))
 }

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -63,6 +63,13 @@ type Provider struct {
 	AzureSearch      *azuresearch.Mock
 
 	ResourceDiscovery *resourcediscovery.Engine
+
+	// SubscriptionID is the Azure subscription id this provider serves. Azure
+	// uses the account id as the subscription id (see the resourcediscovery.New
+	// call below, which passes o.AccountID as the subscription).
+	SubscriptionID string
+	// Region is the Azure location this provider serves.
+	Region string
 }
 
 // New creates a new Azure provider with all mock services.
@@ -94,6 +101,8 @@ func New(opts ...config.Option) *Provider {
 		Databricks:       databricks.New(o),
 		AzureAI:          azureai.New(o),
 		AzureSearch:      azuresearch.New(o),
+		SubscriptionID:   o.AccountID,
+		Region:           o.Region,
 	}
 	p.VirtualMachines.SetMonitoring(p.Monitor)
 	p.BlobStorage.SetMonitoring(p.Monitor)

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -4,6 +4,7 @@ package azurecache
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const defaultRedisSSLPort = 6380
@@ -102,6 +104,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	info := driver.CacheInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
 		Status:    "Running",
@@ -144,15 +147,44 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 }
 
 // ListCaches lists all Azure Cache for Redis instances.
-func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {
+		if !cd.info.Scope.Matches(filter) {
+			continue
+		}
 		caches = append(caches, cd.info)
 	}
 
 	return caches, nil
+}
+
+// UpdateCache replaces the mutable fields of an existing cache — ARM
+// CreateOrUpdate-on-existing semantics (node type and tags come from the
+// request; identity, endpoint, and CreatedAt are preserved).
+func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
+	}
+
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.Tags != nil {
+		cd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		cd.info.Scope = cfg.Scope
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := cd.info
+
+	return &result, nil
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/azure/azurecache/azurecache.go
+++ b/providers/azure/azurecache/azurecache.go
@@ -145,7 +145,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 
 // ListCaches lists all Azure Cache for Redis instances.
 func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
-	all := m.caches.All()
+	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {

--- a/providers/azure/azurecache/azurecache_test.go
+++ b/providers/azure/azurecache/azurecache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,7 +142,7 @@ func TestListCaches(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(caches))
 	})
@@ -150,7 +151,7 @@ func TestListCaches(t *testing.T) {
 	createTestCache(t, m, "cache-b")
 
 	t.Run("two caches", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(caches))
 	})

--- a/providers/azure/azurecache/ordering_test.go
+++ b/providers/azure/azurecache/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListCaches(ctx)
+	first, err := m.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListCaches(ctx)
+		again, err := m.ListCaches(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/azurecache/ordering_test.go
+++ b/providers/azure/azurecache/ordering_test.go
@@ -1,0 +1,42 @@
+package azurecache
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateCache(ctx, driver.CacheConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListCaches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListCaches(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -102,7 +102,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 
 // ListZones returns all Azure DNS zones.
 func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
-	all := m.zones.All()
+	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -239,13 +239,16 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 		return nil, cerrors.Newf(cerrors.NotFound, "zone %q not found", zoneID)
 	}
 
-	filtered := m.records.Filter(func(_ string, rec driver.RecordInfo) bool {
-		return rec.ZoneID == zoneID
-	})
+	// SortedValues gives a stable order keyed by zoneID:name:type[:setID];
+	// filter to this zone in that order so ListRecords is deterministic
+	// (map iteration order must never reach the wire — #259).
+	all := m.records.SortedValues()
 
-	records := make([]driver.RecordInfo, 0, len(filtered))
-	for _, rec := range filtered {
-		records = append(records, rec)
+	records := make([]driver.RecordInfo, 0, len(all))
+	for _, rec := range all {
+		if rec.ZoneID == zoneID {
+			records = append(records, rec)
+		}
 	}
 
 	return records, nil

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -134,7 +134,9 @@ func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneIn
 // and record count are preserved.
 func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
 	for _, z := range m.zones.SortedValues() {
-		if z.Name != cfg.Name {
+		// Match on name AND scope: the same zone name can exist in different
+		// resource groups, and an update must not reach across into another.
+		if z.Name != cfg.Name || !z.Scope.Matches(cfg.Scope) {
 			continue
 		}
 

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -219,12 +219,12 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 		return &result, nil
 	}
 
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-
-	all := m.records.All()
-	for k, r := range all {
-		if strings.HasPrefix(k, prefix) {
+	// Search for weighted records (same name+type with a set ID). Iterate in
+	// sorted-key order and return the lowest set ID, so a name+type with
+	// several weighted records resolves to the same record every call rather
+	// than a map-order-random one (#259).
+	for _, r := range m.records.SortedValues() {
+		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
 			result := r
 			return &result, nil
 		}

--- a/providers/azure/azuredns/dns.go
+++ b/providers/azure/azuredns/dns.go
@@ -3,6 +3,7 @@ package azuredns
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.DNS.
@@ -50,7 +52,17 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		return nil, cerrors.New(cerrors.InvalidArgument, "zone name is required")
 	}
 
-	id := idgen.AzureID(m.opts.AccountID, "cloud-mock", "Microsoft.Network", "dnsZones", cfg.Name)
+	// Derive the ARM id's subscription/resource group from the request scope,
+	// falling back to the account default and "cloud-mock" when unscoped.
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = "cloud-mock"
+	}
+	id := idgen.AzureID(sub, rg, "Microsoft.Network", "dnsZones", cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -63,6 +75,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Private:     cfg.Private,
 		RecordCount: 0,
 		Tags:        tags,
+		Scope:       cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)
@@ -100,16 +113,45 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	return &result, nil
 }
 
-// ListZones returns all Azure DNS zones.
-func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+// ListZones returns the Azure DNS zones visible under filter. Iterating the
+// store's SortedValues keeps the order deterministic (#259).
+func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {
+		if !z.Scope.Matches(filter) {
+			continue
+		}
 		zones = append(zones, z)
 	}
 
 	return zones, nil
+}
+
+// UpdateZone applies the mutable fields (tags, scope) of an existing zone,
+// matching it by name — ARM CreateOrUpdate-on-existing semantics. Identity
+// and record count are preserved.
+func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	for _, z := range m.zones.SortedValues() {
+		if z.Name != cfg.Name {
+			continue
+		}
+
+		if cfg.Tags != nil {
+			z.Tags = maps.Clone(cfg.Tags)
+		}
+		if !cfg.Scope.IsZero() {
+			z.Scope = cfg.Scope
+		}
+
+		m.zones.Set(z.ID, z)
+		result := z
+
+		return &result, nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "zone %q not found", cfg.Name)
 }
 
 // CreateRecord creates a new DNS record set in the specified zone.

--- a/providers/azure/azuredns/dns_test.go
+++ b/providers/azure/azuredns/dns_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -115,7 +116,7 @@ func TestListZones(t *testing.T) {
 	m := newTestMock()
 
 	t.Run("empty", func(t *testing.T) {
-		zones, err := m.ListZones(ctx)
+		zones, err := m.ListZones(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Empty(t, zones)
 	})
@@ -124,7 +125,7 @@ func TestListZones(t *testing.T) {
 		_, _ = m.CreateZone(ctx, driver.ZoneConfig{Name: "a.com"})
 		_, _ = m.CreateZone(ctx, driver.ZoneConfig{Name: "b.com"})
 
-		zones, err := m.ListZones(ctx)
+		zones, err := m.ListZones(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Len(t, zones, 2)
 	})

--- a/providers/azure/azuredns/healthcheck.go
+++ b/providers/azure/azuredns/healthcheck.go
@@ -83,7 +83,7 @@ func (m *Mock) GetHealthCheck(_ context.Context, id string) (*driver.HealthCheck
 
 // ListHealthChecks returns all Azure DNS health checks.
 func (m *Mock) ListHealthChecks(_ context.Context) ([]driver.HealthCheckInfo, error) {
-	all := m.healthChecks.All()
+	all := m.healthChecks.SortedValues()
 
 	checks := make([]driver.HealthCheckInfo, 0, len(all))
 	for _, hc := range all {

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -1,0 +1,42 @@
+package azuredns
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateZone(ctx, driver.ZoneConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListZones(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListZones(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListZones(ctx)
+	first, err := m.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListZones(ctx)
+		again, err := m.ListZones(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -40,3 +40,48 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestListRecordsOrderingDeterministic locks the #259 ordering guarantee for
+// record listing: ListRecords must return the same, defined order on every
+// call (map iteration randomness must never reach the wire).
+func TestListRecordsOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name + ".example.com", Type: "A", TTL: 300,
+			Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("create record %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) < 5 {
+		t.Fatalf("list returned %d records, want >=5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListRecords(ctx, zone.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("list length changed: %d vs %d", len(again), len(first))
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name || again[i].Type != first[i].Type {
+				t.Fatalf("record order changed between calls at %d: %v vs %v", i, again[i], first[i])
+			}
+		}
+	}
+}

--- a/providers/azure/azuredns/ordering_test.go
+++ b/providers/azure/azuredns/ordering_test.go
@@ -85,3 +85,43 @@ func TestListRecordsOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestGetRecordWeightedDeterministic locks that GetRecord resolves a name+type
+// with several weighted records to the same one every call — the lowest set ID
+// in sorted order — instead of a map-order-random pick (#259).
+func TestGetRecordWeightedDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	weight := 10
+	for _, sid := range []string{"west", "east", "central"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: "api.example.com", Type: "A", TTL: 60,
+			Values: []string{"192.0.2.1"}, SetID: sid, Weight: &weight,
+		}); err != nil {
+			t.Fatalf("create weighted %s: %v", sid, err)
+		}
+	}
+
+	first, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	for range 5 {
+		again, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again.SetID != first.SetID {
+			t.Fatalf("GetRecord returned different weighted record across calls: %q vs %q", again.SetID, first.SetID)
+		}
+	}
+	if first.SetID != "central" {
+		t.Fatalf("GetRecord set ID = %q, want lowest in sorted order (central)", first.SetID)
+	}
+}

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -287,7 +287,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
 		})
 	}
 
@@ -306,6 +306,12 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	// Clone metadata only for the page actually returned — cloning every
+	// match would make a paged scan O(bucket) allocations per request.
+	for i := range page.Items {
+		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
 	}
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1})

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -180,7 +181,7 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 		ContentType:  contentType,
 		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
 		LastModified: m.opts.Clock.Now().UTC().Format(blobTimeFormat),
-		Metadata:     metadata,
+		Metadata:     maps.Clone(metadata),
 	})
 
 	m.emitMetric(bucket, map[string]float64{"Transactions": 1, "Ingress": float64(len(data))})
@@ -208,7 +209,7 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		},
 		Data: dataCopy,
 	}, nil
@@ -246,7 +247,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 	}, nil
 }
 
@@ -286,7 +287,7 @@ func (m *Mock) ListObjects(_ context.Context, bucket string, opts driver.ListOpt
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		})
 	}
 

--- a/providers/azure/blobstorage/isolation_test.go
+++ b/providers/azure/blobstorage/isolation_test.go
@@ -1,0 +1,43 @@
+package blobstorage
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMetadataIsolation locks the boundary-copy behavior: mutating the
+// metadata map a caller passed to PutObject, or the map returned from
+// HeadObject, must not change what the store holds.
+func TestMetadataIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "iso"); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]string{"owner": "team-a"}
+	if err := m.PutObject(ctx, "iso", "k", []byte("v"), "text/plain", meta); err != nil {
+		t.Fatal(err)
+	}
+
+	meta["owner"] = "attacker"
+	meta["extra"] = "leaked"
+
+	info, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Metadata["owner"] != "team-a" || len(info.Metadata) != 1 {
+		t.Fatalf("stored metadata corrupted by caller mutation: %v", info.Metadata)
+	}
+
+	info.Metadata["owner"] = "mutated"
+	again, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Metadata["owner"] != "team-a" {
+		t.Fatalf("stored metadata corrupted via returned map: %v", again.Metadata)
+	}
+}

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -247,7 +247,7 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 
 	m.emitMetric(input.Table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
-	return updated, nil
+	return maps.Clone(updated), nil
 }
 
 // DeleteItem deletes an item from a container by key.

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -4,6 +4,7 @@ package cosmosdb
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -170,6 +171,7 @@ func (m *Mock) PutItem(_ context.Context, table string, item map[string]any) err
 
 	key := itemKey(td.config, item)
 	oldItem, hadOld := td.items.Get(key)
+	item = maps.Clone(item)
 	td.items.Set(key, item)
 	m.recordStreamEvent(td, oldItem, item, hadOld)
 	m.mu.Unlock()
@@ -203,7 +205,7 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 
 	m.emitMetric(table, map[string]float64{"TotalRequests": 1, "TotalRequestUnits": 1})
 
-	return item, nil
+	return maps.Clone(item), nil
 }
 
 // UpdateItem applies partial updates to an existing document in a container.
@@ -388,6 +390,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	for _, item := range items {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}
@@ -411,7 +414,7 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 
 	for _, key := range keys {
 		if item, ok := td.items.Get(itemKey(td.config, key)); ok {
-			results = append(results, item)
+			results = append(results, maps.Clone(item))
 		}
 	}
 
@@ -656,6 +659,7 @@ func (m *Mock) applyTransactPuts(td *tableData, puts []map[string]any) {
 	for _, item := range puts {
 		key := itemKey(td.config, item)
 		oldItem, hadOld := td.items.Get(key)
+		item = maps.Clone(item)
 		td.items.Set(key, item)
 		m.recordStreamEvent(td, oldItem, item, hadOld)
 	}

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -143,7 +143,7 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 
 // ListEventBuses lists all Event Grid topics.
 func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
-	all := m.buses.All()
+	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
@@ -255,7 +255,7 @@ func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, err
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", eventBus)
 	}
 
-	all := bd.rules.All()
+	all := bd.rules.SortedValues()
 
 	rules := make([]driver.Rule, 0, len(all))
 	for _, rd := range all {

--- a/providers/azure/eventgrid/eventgrid.go
+++ b/providers/azure/eventgrid/eventgrid.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -92,7 +94,17 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
 	}
 
-	topicID := idgen.AzureID(m.opts.AccountID, m.opts.Region, resourceProvider, resourceType, cfg.Name)
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = m.opts.Region
+	}
+
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+
+	topicID := idgen.AzureID(sub, rg, resourceProvider, resourceType, cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -101,6 +113,7 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 
 	info := driver.EventBusInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		ARN:       topicID,
 		State:     activeTopicState,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -142,11 +155,14 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 }
 
 // ListEventBuses lists all Event Grid topics.
-func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.EventBusInfo, error) {
 	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
+		if !bd.info.Scope.Matches(filter) {
+			continue
+		}
 		buses = append(buses, bd.info)
 	}
 
@@ -500,6 +516,29 @@ func matchesField(value string, allowed any) bool {
 	}
 
 	return false
+}
+
+// UpdateEventBus replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (tags come from the request; identity
+// and CreatedAt are preserved).
+func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.Tags != nil {
+		bd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		bd.info.Scope = cfg.Scope
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := bd.info
+
+	return &result, nil
 }
 
 // MatchedRules returns all subscriptions that match the given event (exported for testing).

--- a/providers/azure/eventgrid/eventgrid_test.go
+++ b/providers/azure/eventgrid/eventgrid_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -127,7 +128,7 @@ func TestListEventBuses(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(buses))
 	})
@@ -136,7 +137,7 @@ func TestListEventBuses(t *testing.T) {
 	createTestTopic(t, m, "topic-b")
 
 	t.Run("two topics", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(buses))
 	})

--- a/providers/azure/eventgrid/ordering_test.go
+++ b/providers/azure/eventgrid/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListEventBuses(ctx)
+	first, err := m.ListEventBuses(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListEventBuses(ctx)
+		again, err := m.ListEventBuses(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/eventgrid/ordering_test.go
+++ b/providers/azure/eventgrid/ordering_test.go
@@ -1,0 +1,42 @@
+package eventgrid
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateEventBus(ctx, driver.EventBusConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListEventBuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListEventBuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/functions/aliases.go
+++ b/providers/azure/functions/aliases.go
@@ -36,7 +36,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Description:     cfg.Description,
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})

--- a/providers/azure/functions/clock_test.go
+++ b/providers/azure/functions/clock_test.go
@@ -1,0 +1,31 @@
+package functions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestTimestampsUseConfiguredClock locks LastModified to the configured
+// clock: with a fake clock pinned to 2025-01-01, function timestamps must
+// not leak wall-clock time.
+func TestTimestampsUseConfiguredClock(t *testing.T) {
+	m := newTestMock()
+
+	fn, err := m.CreateFunction(context.Background(), driver.FunctionConfig{Name: "clock-fn", Runtime: "r1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := time.Parse(time.RFC3339, fn.LastModified)
+	if err != nil {
+		t.Fatalf("LastModified %q not RFC3339: %v", fn.LastModified, err)
+	}
+
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("LastModified = %v, want fake-clock time %v (wall clock leaked)", got, want)
+	}
+}

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -117,7 +117,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 		Name: cfg.Name, ARN: resourceID, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
 		Environment: cfg.Environment, Tags: cfg.Tags,
-		LastModified: time.Now().UTC().Format(time.RFC3339),
+		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	m.handlersMu.RLock()
@@ -181,7 +181,7 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	fd.info = info
 	m.funcs.Set(name, fd)
 

--- a/providers/azure/functions/functions.go
+++ b/providers/azure/functions/functions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -116,7 +117,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: resourceID, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
-		Environment: cfg.Environment, Tags: cfg.Tags,
+		Environment: maps.Clone(cfg.Environment), Tags: maps.Clone(cfg.Tags),
 		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
@@ -154,6 +155,8 @@ func (m *Mock) GetFunction(_ context.Context, name string) (*driver.FunctionInfo
 	}
 
 	info := fd.info
+	info.Environment = maps.Clone(info.Environment)
+	info.Tags = maps.Clone(info.Tags)
 
 	return &info, nil
 }
@@ -257,11 +260,11 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 
 	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
+		info.Environment = maps.Clone(cfg.Environment)
 	}
 
 	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
+		info.Tags = maps.Clone(cfg.Tags)
 	}
 }
 

--- a/providers/azure/functions/layers.go
+++ b/providers/azure/functions/layers.go
@@ -44,7 +44,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 		ContentSHA256:      shaStr,
 		ContentSize:        int64(len(cfg.Content)),
 		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		ARN:                arn,
 	}
 

--- a/providers/azure/functions/versions.go
+++ b/providers/azure/functions/versions.go
@@ -27,7 +27,7 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 
 	verStr := strconv.Itoa(verNum)
 	sha := codeSHA(&fd.info)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
 		config:    snapshotConfig(&fd.info),

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -144,7 +144,7 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 
 // ListLogGroups lists all Log Analytics workspaces.
 func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
-	all := m.groups.All()
+	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
@@ -207,7 +207,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
 	}
 
-	all := g.streams.All()
+	all := g.streams.SortedValues()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
 

--- a/providers/azure/loganalytics/loganalytics.go
+++ b/providers/azure/loganalytics/loganalytics.go
@@ -3,6 +3,8 @@ package loganalytics
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -92,7 +94,15 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 		retentionDays = defaultRetentionDays
 	}
 
-	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.OperationalInsights", "workspaces", cfg.Name)
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = "rg-default"
+	}
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+	resourceID := idgen.AzureID(sub, rg, "Microsoft.OperationalInsights", "workspaces", cfg.Name)
 
 	tags := make(map[string]string, len(cfg.Tags))
 	for k, v := range cfg.Tags {
@@ -101,6 +111,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
+		Scope:         cfg.Scope,
 		ResourceID:    resourceID,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -143,11 +154,14 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 }
 
 // ListLogGroups lists all Log Analytics workspaces.
-func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+func (m *Mock) ListLogGroups(_ context.Context, filter scope.Scope) ([]driver.LogGroupInfo, error) {
 	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
+		if !g.info.Scope.Matches(filter) {
+			continue
+		}
 		groups = append(groups, g.info)
 	}
 
@@ -503,4 +517,30 @@ func (m *Mock) DescribeMetricFilters(
 	}
 
 	return results, nil
+}
+
+// UpdateLogGroup replaces the mutable fields of an existing log group —
+// ARM CreateOrUpdate-on-existing semantics (retention and tags come from
+// the request; identity and CreatedAt are preserved).
+func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
+	}
+
+	if cfg.RetentionDays != 0 {
+		g.info.RetentionDays = cfg.RetentionDays
+	}
+	if cfg.Tags != nil {
+		g.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		g.info.Scope = cfg.Scope
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := g.info
+
+	return &result, nil
 }

--- a/providers/azure/loganalytics/loganalytics_test.go
+++ b/providers/azure/loganalytics/loganalytics_test.go
@@ -2,6 +2,7 @@ package loganalytics
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestListLogGroups(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		m := newTestMock()
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, len(groups))
@@ -170,7 +171,7 @@ func TestListLogGroups(t *testing.T) {
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
 		require.NoError(t, err)
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(groups))

--- a/providers/azure/loganalytics/ordering_test.go
+++ b/providers/azure/loganalytics/ordering_test.go
@@ -1,0 +1,42 @@
+package loganalytics
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListLogGroups(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/loganalytics/ordering_test.go
+++ b/providers/azure/loganalytics/ordering_test.go
@@ -2,6 +2,7 @@ package loganalytics
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListLogGroups(ctx)
+	first, err := m.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListLogGroups(ctx)
+		again, err := m.ListLogGroups(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -136,7 +136,7 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 
 // ListTopics lists all notification hubs.
 func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
-	all := m.topics.All()
+	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
@@ -202,7 +202,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
 	}
 
-	all := td.subscriptions.All()
+	all := td.subscriptions.SortedValues()
 
 	subs := make([]driver.SubscriptionInfo, 0, len(all))
 	for _, s := range all {

--- a/providers/azure/notificationhubs/notificationhubs.go
+++ b/providers/azure/notificationhubs/notificationhubs.go
@@ -4,6 +4,7 @@ package notificationhubs
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -12,6 +13,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.Notification.
@@ -80,7 +82,15 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 		return nil, errors.New(errors.InvalidArgument, "topic name is required")
 	}
 
-	resourceID := idgen.AzureID(m.opts.AccountID, "rg-default", "Microsoft.NotificationHubs", "namespaces/default/notificationHubs", cfg.Name)
+	rg := cfg.Scope.ResourceGroup
+	if rg == "" {
+		rg = "rg-default"
+	}
+	sub := cfg.Scope.Subscription
+	if sub == "" {
+		sub = m.opts.AccountID
+	}
+	resourceID := idgen.AzureID(sub, rg, "Microsoft.NotificationHubs", "namespaces/default/notificationHubs", cfg.Name)
 
 	if m.topics.Has(cfg.Name) {
 		return nil, errors.Newf(errors.AlreadyExists, "topic %q already exists", cfg.Name)
@@ -94,6 +104,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
+		Scope:             cfg.Scope,
 		ResourceID:        resourceID,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
@@ -134,19 +145,50 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 	return &result, nil
 }
 
-// ListTopics lists all notification hubs.
-func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+// ListTopics lists all notification hubs visible under the given scope filter.
+func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.TopicInfo, error) {
 	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
 	for _, td := range all {
+		if !td.info.Scope.Matches(filter) {
+			continue
+		}
+
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
 		topics = append(topics, info)
 	}
 
 	return topics, nil
+}
+
+// UpdateTopic replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (display name and tags come from the
+// request; identity is preserved).
+func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.DisplayName != "" {
+		td.info.DisplayName = cfg.DisplayName
+	}
+	if cfg.Tags != nil {
+		td.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		td.info.Scope = cfg.Scope
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
 }
 
 // Subscribe creates a subscription to a notification hub.

--- a/providers/azure/notificationhubs/notificationhubs_test.go
+++ b/providers/azure/notificationhubs/notificationhubs_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +157,7 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	err := m.DeleteTopic(ctx, info.Name)
 	require.NoError(t, err)
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 }
@@ -241,7 +242,7 @@ func TestListTopics(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 
@@ -249,7 +250,7 @@ func TestListTopics(t *testing.T) {
 	createTestTopic(t, m, "hub-2")
 	createTestTopic(t, m, "hub-3")
 
-	topics, err = m.ListTopics(ctx)
+	topics, err = m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(topics))
 }

--- a/providers/azure/notificationhubs/ordering_test.go
+++ b/providers/azure/notificationhubs/ordering_test.go
@@ -1,0 +1,42 @@
+package notificationhubs
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateTopic(ctx, driver.TopicConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListTopics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListTopics(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/azure/notificationhubs/ordering_test.go
+++ b/providers/azure/notificationhubs/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListTopics(ctx)
+	first, err := m.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListTopics(ctx)
+		again, err := m.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -103,7 +103,7 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 
 // ListZones returns all Cloud DNS managed zones.
 func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
-	all := m.zones.All()
+	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -3,6 +3,7 @@ package clouddns
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -10,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.DNS.
@@ -63,6 +65,7 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		Private:     cfg.Private,
 		RecordCount: 0,
 		Tags:        tags,
+		Scope:       cfg.Scope,
 	}
 
 	m.zones.Set(id, zone)
@@ -101,16 +104,46 @@ func (m *Mock) GetZone(_ context.Context, id string) (*driver.ZoneInfo, error) {
 	return &result, nil
 }
 
-// ListZones returns all Cloud DNS managed zones.
-func (m *Mock) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+// ListZones returns the Cloud DNS managed zones visible under filter.
+func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	all := m.zones.SortedValues()
 
 	zones := make([]driver.ZoneInfo, 0, len(all))
 	for _, z := range all {
+		if !z.Scope.Matches(filter) {
+			continue
+		}
 		zones = append(zones, z)
 	}
 
 	return zones, nil
+}
+
+// UpdateZone applies the mutable fields (tags, scope) of an existing zone,
+// mirroring CreateOrUpdate-on-existing. It matches the zone by name.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
+func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	for _, z := range m.zones.SortedValues() {
+		if z.Name != cfg.Name {
+			continue
+		}
+
+		if cfg.Tags != nil {
+			z.Tags = maps.Clone(cfg.Tags)
+		}
+		if !cfg.Scope.IsZero() {
+			z.Scope = cfg.Scope
+		}
+
+		m.zones.Set(z.ID, z)
+
+		result := z
+
+		return &result, nil
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "managed zone %q not found", cfg.Name)
 }
 
 // CreateRecord creates a new resource record set in the specified managed zone.

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -245,13 +245,16 @@ func (m *Mock) ListRecords(_ context.Context, zoneID string) ([]driver.RecordInf
 		return nil, cerrors.Newf(cerrors.NotFound, "managed zone %q not found", zoneID)
 	}
 
-	filtered := m.records.Filter(func(_ string, rec driver.RecordInfo) bool {
-		return rec.ZoneID == zoneID
-	})
+	// SortedValues gives a stable order keyed by zoneID:name:type[:setID];
+	// filter to this zone in that order so ListRecords is deterministic
+	// (map iteration order must never reach the wire — #259).
+	all := m.records.SortedValues()
 
-	records := make([]driver.RecordInfo, 0, len(filtered))
-	for _, rec := range filtered {
-		records = append(records, rec)
+	records := make([]driver.RecordInfo, 0, len(all))
+	for _, rec := range all {
+		if rec.ZoneID == zoneID {
+			records = append(records, rec)
+		}
 	}
 
 	return records, nil

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -125,7 +125,9 @@ func (m *Mock) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneIn
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.ZoneInfo, error) {
 	for _, z := range m.zones.SortedValues() {
-		if z.Name != cfg.Name {
+		// Match on name AND scope: the same zone name can exist in different
+		// projects, and an update must not reach across into another.
+		if z.Name != cfg.Name || !z.Scope.Matches(cfg.Scope) {
 			continue
 		}
 

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -52,6 +52,18 @@ func (m *Mock) CreateZone(_ context.Context, cfg driver.ZoneConfig) (*driver.Zon
 		return nil, cerrors.New(cerrors.InvalidArgument, "zone name is required")
 	}
 
+	// Managed-zone names are unique within a project. Reject a duplicate in the
+	// same project (the wire always carries one); the portable API, which
+	// creates with a zero scope, is unaffected.
+	if cfg.Scope.Project != "" {
+		for _, z := range m.zones.SortedValues() {
+			if z.Name == cfg.Name && z.Scope.Project == cfg.Scope.Project {
+				return nil, cerrors.Newf(cerrors.AlreadyExists,
+					"managed zone %q already exists in project %q", cfg.Name, cfg.Scope.Project)
+			}
+		}
+	}
+
 	id := idgen.GenerateID("zone-")
 
 	tags := make(map[string]string, len(cfg.Tags))

--- a/providers/gcp/clouddns/dns.go
+++ b/providers/gcp/clouddns/dns.go
@@ -225,12 +225,12 @@ func (m *Mock) GetRecord(_ context.Context, zoneID, name, recordType string) (*d
 		return &result, nil
 	}
 
-	// Search for weighted records with a set ID.
-	prefix := zoneID + ":" + name + ":" + recordType + ":"
-	all := m.records.All()
-
-	for k, r := range all {
-		if strings.HasPrefix(k, prefix) {
+	// Search for weighted records (same name+type with a set ID). Iterate in
+	// sorted-key order and return the lowest set ID, so a name+type with
+	// several weighted records resolves to the same record every call rather
+	// than a map-order-random one (#259).
+	for _, r := range m.records.SortedValues() {
+		if r.ZoneID == zoneID && r.Name == name && r.Type == recordType && r.SetID != "" {
 			result := r
 			return &result, nil
 		}

--- a/providers/gcp/clouddns/dns_test.go
+++ b/providers/gcp/clouddns/dns_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -86,7 +87,7 @@ func TestListHostedZones(t *testing.T) {
 	ctx := context.Background()
 	m := newTestMock()
 
-	zones, err := m.ListZones(ctx)
+	zones, err := m.ListZones(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Empty(t, zones)
 
@@ -95,7 +96,7 @@ func TestListHostedZones(t *testing.T) {
 	_, err = m.CreateZone(ctx, driver.ZoneConfig{Name: "b.com"})
 	require.NoError(t, err)
 
-	zones, err = m.ListZones(ctx)
+	zones, err = m.ListZones(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Len(t, zones, 2)
 }

--- a/providers/gcp/clouddns/healthcheck.go
+++ b/providers/gcp/clouddns/healthcheck.go
@@ -82,7 +82,7 @@ func (m *Mock) GetHealthCheck(_ context.Context, id string) (*driver.HealthCheck
 
 // ListHealthChecks returns all Cloud DNS health checks.
 func (m *Mock) ListHealthChecks(_ context.Context) ([]driver.HealthCheckInfo, error) {
-	all := m.healthChecks.All()
+	all := m.healthChecks.SortedValues()
 
 	checks := make([]driver.HealthCheckInfo, 0, len(all))
 	for _, hc := range all {

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -1,0 +1,42 @@
+package clouddns
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateZone(ctx, driver.ZoneConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListZones(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListZones(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListZones(ctx)
+	first, err := m.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListZones(ctx)
+		again, err := m.ListZones(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -40,3 +40,48 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestListRecordsOrderingDeterministic locks the #259 ordering guarantee for
+// record listing: ListRecords must return the same, defined order on every
+// call (map iteration randomness must never reach the wire).
+func TestListRecordsOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: name + ".example.com", Type: "A", TTL: 300,
+			Values: []string{"192.0.2.1"},
+		}); err != nil {
+			t.Fatalf("create record %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListRecords(ctx, zone.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) < 5 {
+		t.Fatalf("list returned %d records, want >=5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListRecords(ctx, zone.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(again) != len(first) {
+			t.Fatalf("list length changed: %d vs %d", len(again), len(first))
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name || again[i].Type != first[i].Type {
+				t.Fatalf("record order changed between calls at %d: %v vs %v", i, again[i], first[i])
+			}
+		}
+	}
+}

--- a/providers/gcp/clouddns/ordering_test.go
+++ b/providers/gcp/clouddns/ordering_test.go
@@ -85,3 +85,43 @@ func TestListRecordsOrderingDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// TestGetRecordWeightedDeterministic locks that GetRecord resolves a name+type
+// with several weighted records to the same one every call — the lowest set ID
+// in sorted order — instead of a map-order-random pick (#259).
+func TestGetRecordWeightedDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	zone, err := m.CreateZone(ctx, driver.ZoneConfig{Name: "example.com"})
+	if err != nil {
+		t.Fatalf("create zone: %v", err)
+	}
+
+	weight := 10
+	for _, sid := range []string{"west", "east", "central"} {
+		if _, err := m.CreateRecord(ctx, driver.RecordConfig{
+			ZoneID: zone.ID, Name: "api.example.com", Type: "A", TTL: 60,
+			Values: []string{"192.0.2.1"}, SetID: sid, Weight: &weight,
+		}); err != nil {
+			t.Fatalf("create weighted %s: %v", sid, err)
+		}
+	}
+
+	first, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+	if err != nil {
+		t.Fatalf("GetRecord: %v", err)
+	}
+	for range 5 {
+		again, err := m.GetRecord(ctx, zone.ID, "api.example.com", "A")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again.SetID != first.SetID {
+			t.Fatalf("GetRecord returned different weighted record across calls: %q vs %q", again.SetID, first.SetID)
+		}
+	}
+	if first.SetID != "central" {
+		t.Fatalf("GetRecord set ID = %q, want lowest in sorted order (central)", first.SetID)
+	}
+}

--- a/providers/gcp/cloudfunctions/aliases.go
+++ b/providers/gcp/cloudfunctions/aliases.go
@@ -36,7 +36,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		Description:     cfg.Description,
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
-		CreatedAt:       time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})

--- a/providers/gcp/cloudfunctions/clock_test.go
+++ b/providers/gcp/cloudfunctions/clock_test.go
@@ -1,0 +1,31 @@
+package cloudfunctions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// TestTimestampsUseConfiguredClock locks LastModified to the configured
+// clock: with a fake clock pinned to 2025-01-01, function timestamps must
+// not leak wall-clock time.
+func TestTimestampsUseConfiguredClock(t *testing.T) {
+	m := newTestMock()
+
+	fn, err := m.CreateFunction(context.Background(), driver.FunctionConfig{Name: "clock-fn", Runtime: "r1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := time.Parse(time.RFC3339, fn.LastModified)
+	if err != nil {
+		t.Fatalf("LastModified %q not RFC3339: %v", fn.LastModified, err)
+	}
+
+	want := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("LastModified = %v, want fake-clock time %v (wall clock leaked)", got, want)
+	}
+}

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -157,6 +158,8 @@ func (m *Mock) GetFunction(_ context.Context, name string) (*driver.FunctionInfo
 	}
 
 	info := fd.info
+	info.Environment = maps.Clone(info.Environment)
+	info.Tags = maps.Clone(info.Tags)
 
 	return &info, nil
 }
@@ -256,11 +259,11 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 
 	if cfg.Environment != nil {
-		info.Environment = cfg.Environment
+		info.Environment = maps.Clone(cfg.Environment)
 	}
 
 	if cfg.Tags != nil {
-		info.Tags = cfg.Tags
+		info.Tags = maps.Clone(cfg.Tags)
 	}
 }
 

--- a/providers/gcp/cloudfunctions/functions.go
+++ b/providers/gcp/cloudfunctions/functions.go
@@ -122,7 +122,7 @@ func (m *Mock) CreateFunction(_ context.Context, cfg driver.FunctionConfig) (*dr
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "ACTIVE",
 		Environment: env, Tags: tags,
-		LastModified: time.Now().UTC().Format(time.RFC3339),
+		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
 	}
 
 	m.handlersMu.RLock()
@@ -181,7 +181,7 @@ func (m *Mock) UpdateFunction(_ context.Context, name string, cfg driver.Functio
 
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
-	info.LastModified = time.Now().UTC().Format(time.RFC3339)
+	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
 	fd.info = info
 	m.funcs.Set(name, fd)
 

--- a/providers/gcp/cloudfunctions/layers.go
+++ b/providers/gcp/cloudfunctions/layers.go
@@ -44,7 +44,7 @@ func (m *Mock) PublishLayerVersion(_ context.Context, cfg driver.LayerConfig) (*
 		ContentSHA256:      shaStr,
 		ContentSize:        int64(len(cfg.Content)),
 		CompatibleRuntimes: cfg.CompatibleRuntimes,
-		CreatedAt:          time.Now().UTC().Format(time.RFC3339),
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
 		ARN:                arn,
 	}
 

--- a/providers/gcp/cloudfunctions/versions.go
+++ b/providers/gcp/cloudfunctions/versions.go
@@ -27,7 +27,7 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 
 	verStr := strconv.Itoa(verNum)
 	sha := codeSHA(&fd.info)
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
 		config:    snapshotConfig(&fd.info),

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -3,6 +3,8 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -96,6 +98,7 @@ func (m *Mock) CreateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*dr
 
 	info := driver.LogGroupInfo{
 		Name:          cfg.Name,
+		Scope:         cfg.Scope,
 		ResourceID:    selfLink,
 		RetentionDays: retentionDays,
 		CreatedAt:     m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -138,11 +141,14 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 }
 
 // ListLogGroups lists all Cloud Logging log buckets.
-func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
+func (m *Mock) ListLogGroups(_ context.Context, filter scope.Scope) ([]driver.LogGroupInfo, error) {
 	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
+		if !g.info.Scope.Matches(filter) {
+			continue
+		}
 		groups = append(groups, g.info)
 	}
 
@@ -498,4 +504,30 @@ func (m *Mock) DescribeMetricFilters(
 	}
 
 	return results, nil
+}
+
+// UpdateLogGroup replaces the mutable fields of an existing log group —
+// ARM CreateOrUpdate-on-existing semantics (retention and tags come from
+// the request; identity and CreatedAt are preserved).
+func (m *Mock) UpdateLogGroup(_ context.Context, cfg driver.LogGroupConfig) (*driver.LogGroupInfo, error) {
+	g, ok := m.groups.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "log group %q not found", cfg.Name)
+	}
+
+	if cfg.RetentionDays != 0 {
+		g.info.RetentionDays = cfg.RetentionDays
+	}
+	if cfg.Tags != nil {
+		g.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		g.info.Scope = cfg.Scope
+	}
+
+	m.groups.Set(cfg.Name, g)
+
+	result := g.info
+
+	return &result, nil
 }

--- a/providers/gcp/cloudlogging/cloudlogging.go
+++ b/providers/gcp/cloudlogging/cloudlogging.go
@@ -139,7 +139,7 @@ func (m *Mock) GetLogGroup(_ context.Context, name string) (*driver.LogGroupInfo
 
 // ListLogGroups lists all Cloud Logging log buckets.
 func (m *Mock) ListLogGroups(_ context.Context) ([]driver.LogGroupInfo, error) {
-	all := m.groups.All()
+	all := m.groups.SortedValues()
 
 	groups := make([]driver.LogGroupInfo, 0, len(all))
 	for _, g := range all {
@@ -202,7 +202,7 @@ func (m *Mock) ListLogStreams(_ context.Context, logGroup string) ([]driver.LogS
 		return nil, errors.Newf(errors.NotFound, "log group %q not found", logGroup)
 	}
 
-	all := g.streams.All()
+	all := g.streams.SortedValues()
 
 	streams := make([]driver.LogStreamInfo, 0, len(all))
 

--- a/providers/gcp/cloudlogging/cloudlogging_test.go
+++ b/providers/gcp/cloudlogging/cloudlogging_test.go
@@ -2,6 +2,7 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 	"time"
 
@@ -155,7 +156,7 @@ func TestListLogGroups(t *testing.T) {
 	t.Run("empty list", func(t *testing.T) {
 		m := newTestMock()
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 0, len(groups))
@@ -170,7 +171,7 @@ func TestListLogGroups(t *testing.T) {
 		_, err = m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: "g2"})
 		require.NoError(t, err)
 
-		groups, err := m.ListLogGroups(ctx)
+		groups, err := m.ListLogGroups(ctx, scope.Scope{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, len(groups))

--- a/providers/gcp/cloudlogging/ordering_test.go
+++ b/providers/gcp/cloudlogging/ordering_test.go
@@ -2,6 +2,7 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListLogGroups(ctx)
+	first, err := m.ListLogGroups(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListLogGroups(ctx)
+		again, err := m.ListLogGroups(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/cloudlogging/ordering_test.go
+++ b/providers/gcp/cloudlogging/ordering_test.go
@@ -1,0 +1,42 @@
+package cloudlogging
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateLogGroup(ctx, driver.LogGroupConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListLogGroups(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListLogGroups(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/eventarc/eventarc.go
+++ b/providers/gcp/eventarc/eventarc.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -96,6 +98,7 @@ func (m *Mock) CreateEventBus(_ context.Context, cfg driver.EventBusConfig) (*dr
 
 	info := driver.EventBusInfo{
 		Name:      cfg.Name,
+		Scope:     cfg.Scope,
 		ARN:       channelID,
 		State:     activeChannelState,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
@@ -137,11 +140,14 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 }
 
 // ListEventBuses lists all Eventarc channels.
-func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
+func (m *Mock) ListEventBuses(_ context.Context, filter scope.Scope) ([]driver.EventBusInfo, error) {
 	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
+		if !bd.info.Scope.Matches(filter) {
+			continue
+		}
 		buses = append(buses, bd.info)
 	}
 
@@ -526,6 +532,29 @@ func matchesField(value string, allowed any) bool {
 	}
 
 	return false
+}
+
+// UpdateEventBus replaces the mutable fields of an existing channel — ARM
+// CreateOrUpdate-on-existing semantics (tags come from the request; identity
+// and CreatedAt are preserved).
+func (m *Mock) UpdateEventBus(_ context.Context, cfg driver.EventBusConfig) (*driver.EventBusInfo, error) {
+	bd, ok := m.buses.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "channel %q not found", cfg.Name)
+	}
+
+	if cfg.Tags != nil {
+		bd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		bd.info.Scope = cfg.Scope
+	}
+
+	m.buses.Set(cfg.Name, bd)
+
+	result := bd.info
+
+	return &result, nil
 }
 
 // MatchedRules returns all triggers that match the given event (exported for testing).

--- a/providers/gcp/eventarc/eventarc.go
+++ b/providers/gcp/eventarc/eventarc.go
@@ -138,7 +138,7 @@ func (m *Mock) GetEventBus(_ context.Context, name string) (*driver.EventBusInfo
 
 // ListEventBuses lists all Eventarc channels.
 func (m *Mock) ListEventBuses(_ context.Context) ([]driver.EventBusInfo, error) {
-	all := m.buses.All()
+	all := m.buses.SortedValues()
 
 	buses := make([]driver.EventBusInfo, 0, len(all))
 	for _, bd := range all {
@@ -250,7 +250,7 @@ func (m *Mock) ListRules(_ context.Context, eventBus string) ([]driver.Rule, err
 		return nil, errors.Newf(errors.NotFound, "channel %q not found", eventBus)
 	}
 
-	all := bd.rules.All()
+	all := bd.rules.SortedValues()
 
 	rules := make([]driver.Rule, 0, len(all))
 	for _, rd := range all {

--- a/providers/gcp/eventarc/eventarc_test.go
+++ b/providers/gcp/eventarc/eventarc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/gcp/cloudmonitoring"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,7 +158,7 @@ func TestListEventBuses(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(buses))
 	})
@@ -166,7 +167,7 @@ func TestListEventBuses(t *testing.T) {
 	createTestChannel(t, m, "channel-b")
 
 	t.Run("two channels", func(t *testing.T) {
-		buses, err := m.ListEventBuses(ctx)
+		buses, err := m.ListEventBuses(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(buses))
 	})

--- a/providers/gcp/eventarc/ordering_test.go
+++ b/providers/gcp/eventarc/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListEventBuses(ctx)
+	first, err := m.ListEventBuses(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListEventBuses(ctx)
+		again, err := m.ListEventBuses(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/eventarc/ordering_test.go
+++ b/providers/gcp/eventarc/ordering_test.go
@@ -1,0 +1,42 @@
+package eventarc
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateEventBus(ctx, driver.EventBusConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListEventBuses(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListEventBuses(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -3,6 +3,7 @@ package fcm
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -11,6 +12,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Compile-time check that Mock implements driver.Notification.
@@ -88,6 +90,7 @@ func (m *Mock) CreateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	info := driver.TopicInfo{
 		ID:                idgen.GenerateID("topic-"),
 		Name:              cfg.Name,
+		Scope:             cfg.Scope,
 		ResourceID:        selfLink,
 		DisplayName:       cfg.DisplayName,
 		SubscriptionCount: 0,
@@ -128,19 +131,50 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 	return &result, nil
 }
 
-// ListTopics lists all FCM topics.
-func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
+// ListTopics lists all FCM topics visible under the given scope filter.
+func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.TopicInfo, error) {
 	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
 	for _, td := range all {
+		if !td.info.Scope.Matches(filter) {
+			continue
+		}
+
 		info := td.info
 		info.SubscriptionCount = td.subscriptions.Len()
 		topics = append(topics, info)
 	}
 
 	return topics, nil
+}
+
+// UpdateTopic replaces the mutable fields of an existing topic — ARM
+// CreateOrUpdate-on-existing semantics (display name and tags come from the
+// request; identity is preserved).
+func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.TopicInfo, error) {
+	td, ok := m.topics.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", cfg.Name)
+	}
+
+	if cfg.DisplayName != "" {
+		td.info.DisplayName = cfg.DisplayName
+	}
+	if cfg.Tags != nil {
+		td.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		td.info.Scope = cfg.Scope
+	}
+
+	m.topics.Set(cfg.Name, td)
+
+	result := td.info
+	result.SubscriptionCount = td.subscriptions.Len()
+
+	return &result, nil
 }
 
 // Subscribe creates a subscription to an FCM topic.

--- a/providers/gcp/fcm/fcm.go
+++ b/providers/gcp/fcm/fcm.go
@@ -130,7 +130,7 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 
 // ListTopics lists all FCM topics.
 func (m *Mock) ListTopics(_ context.Context) ([]driver.TopicInfo, error) {
-	all := m.topics.All()
+	all := m.topics.SortedValues()
 
 	topics := make([]driver.TopicInfo, 0, len(all))
 
@@ -196,7 +196,7 @@ func (m *Mock) ListSubscriptions(_ context.Context, topicID string) ([]driver.Su
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
 	}
 
-	all := td.subscriptions.All()
+	all := td.subscriptions.SortedValues()
 
 	subs := make([]driver.SubscriptionInfo, 0, len(all))
 	for _, s := range all {

--- a/providers/gcp/fcm/fcm_test.go
+++ b/providers/gcp/fcm/fcm_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,7 +161,7 @@ func TestDeleteTopicRemovesFromList(t *testing.T) {
 	err := m.DeleteTopic(ctx, info.Name)
 	require.NoError(t, err)
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 }
@@ -245,7 +246,7 @@ func TestListTopics(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	topics, err := m.ListTopics(ctx)
+	topics, err := m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(topics))
 
@@ -253,7 +254,7 @@ func TestListTopics(t *testing.T) {
 	createTestTopic(t, m, "topic-2")
 	createTestTopic(t, m, "topic-3")
 
-	topics, err = m.ListTopics(ctx)
+	topics, err = m.ListTopics(ctx, scope.Scope{})
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(topics))
 }

--- a/providers/gcp/fcm/ordering_test.go
+++ b/providers/gcp/fcm/ordering_test.go
@@ -1,0 +1,42 @@
+package fcm
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateTopic(ctx, driver.TopicConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListTopics(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListTopics(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/fcm/ordering_test.go
+++ b/providers/gcp/fcm/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListTopics(ctx)
+	first, err := m.ListTopics(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListTopics(ctx)
+		again, err := m.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -4,6 +4,7 @@ package firestore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"sync"
@@ -159,6 +160,7 @@ func (m *Mock) PutItem(ctx context.Context, table string, item map[string]any) e
 
 	key := docKey(cd.config, item)
 	oldItem, hadOld := cd.items.Get(key)
+	item = maps.Clone(item)
 	cd.items.Set(key, item)
 	m.recordStreamEvent(cd, oldItem, item, hadOld)
 	m.mu.Unlock()
@@ -191,7 +193,7 @@ func (m *Mock) GetItem(ctx context.Context, table string, key map[string]any) (m
 
 	m.emitMetric(ctx, "document/read_count", 1, map[string]string{"collection_id": table})
 
-	return item, nil
+	return maps.Clone(item), nil
 }
 
 // UpdateItem applies partial updates to an existing document in a collection.
@@ -403,6 +405,7 @@ func (m *Mock) BatchPutItems(_ context.Context, table string, items []map[string
 	for _, item := range items {
 		key := docKey(cd.config, item)
 		oldItem, hadOld := cd.items.Get(key)
+		item = maps.Clone(item)
 		cd.items.Set(key, item)
 		m.recordStreamEvent(cd, oldItem, item, hadOld)
 	}
@@ -425,7 +428,7 @@ func (m *Mock) BatchGetItems(_ context.Context, table string, keys []map[string]
 
 	for _, key := range keys {
 		if item, ok := cd.items.Get(docKey(cd.config, key)); ok {
-			results = append(results, item)
+			results = append(results, maps.Clone(item))
 		}
 	}
 
@@ -638,6 +641,7 @@ func (m *Mock) applyTransactPuts(cd *collectionData, puts []map[string]any) {
 	for _, item := range puts {
 		key := docKey(cd.config, item)
 		oldItem, hadOld := cd.items.Get(key)
+		item = maps.Clone(item)
 		cd.items.Set(key, item)
 		m.recordStreamEvent(cd, oldItem, item, hadOld)
 	}

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -235,7 +235,7 @@ func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (ma
 
 	m.emitMetric(ctx, "document/write_count", 1, map[string]string{"collection_id": input.Table})
 
-	return updated, nil
+	return maps.Clone(updated), nil
 }
 
 func (m *Mock) DeleteItem(ctx context.Context, table string, key map[string]any) error {

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -48,6 +48,12 @@ type Provider struct {
 	VertexAI         *vertexai.Mock
 
 	ResourceDiscovery *resourcediscovery.Engine
+
+	// ProjectID and Region record the identity this provider was created with,
+	// so callers (e.g. a standalone server) can wire them without re-reading
+	// the options.
+	ProjectID string
+	Region    string
 }
 
 // New creates a new GCP provider with all mock services.
@@ -73,6 +79,8 @@ func New(opts ...config.Option) *Provider {
 		CloudSQL:         cloudsql.New(o),
 		GKE:              gke.New(o),
 		VertexAI:         vertexai.New(o),
+		ProjectID:        o.ProjectID,
+		Region:           o.Region,
 	}
 	p.GCE.SetMonitoring(p.CloudMonitoring)
 	p.GCS.SetMonitoring(p.CloudMonitoring)

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"maps"
 	"net/http"
 	"sort"
 	"strings"
@@ -207,7 +208,7 @@ func (m *Mock) GetObject(ctx context.Context, bucket, key string) (*driver.Objec
 	return &driver.Object{
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		},
 		Data: dataCopy,
 	}, nil
@@ -243,7 +244,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 	}, nil
 }
 
@@ -282,7 +283,7 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
 		})
 	}
 

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -283,7 +283,7 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 
 		matchedObjects = append(matchedObjects, driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
-			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: obj.Metadata,
 		})
 	}
 
@@ -302,6 +302,12 @@ func (m *Mock) ListObjects(ctx context.Context, bucket string, opts driver.ListO
 	page, err := pagination.Paginate(matchedObjects, opts.PageToken, maxKeys)
 	if err != nil {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
+	}
+
+	// Clone metadata only for the page actually returned — cloning every
+	// match would make a paged scan O(bucket) allocations per request.
+	for i := range page.Items {
+		page.Items[i].Metadata = maps.Clone(page.Items[i].Metadata)
 	}
 
 	m.emitMetric(ctx, "api/request_count", 1, map[string]string{"bucket_name": bucket})

--- a/providers/gcp/gcs/isolation_test.go
+++ b/providers/gcp/gcs/isolation_test.go
@@ -1,0 +1,43 @@
+package gcs
+
+import (
+	"context"
+	"testing"
+)
+
+// TestMetadataIsolation locks the boundary-copy behavior: mutating the
+// metadata map a caller passed to PutObject, or the map returned from
+// HeadObject, must not change what the store holds.
+func TestMetadataIsolation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "iso"); err != nil {
+		t.Fatal(err)
+	}
+
+	meta := map[string]string{"owner": "team-a"}
+	if err := m.PutObject(ctx, "iso", "k", []byte("v"), "text/plain", meta); err != nil {
+		t.Fatal(err)
+	}
+
+	meta["owner"] = "attacker"
+	meta["extra"] = "leaked"
+
+	info, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Metadata["owner"] != "team-a" || len(info.Metadata) != 1 {
+		t.Fatalf("stored metadata corrupted by caller mutation: %v", info.Metadata)
+	}
+
+	info.Metadata["owner"] = "mutated"
+	again, err := m.HeadObject(ctx, "iso", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if again.Metadata["owner"] != "team-a" {
+		t.Fatalf("stored metadata corrupted via returned map: %v", again.Metadata)
+	}
+}

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -143,7 +143,7 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 
 // ListCaches lists all Memorystore instances.
 func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
-	all := m.caches.All()
+	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {

--- a/providers/gcp/memorystore/memorystore.go
+++ b/providers/gcp/memorystore/memorystore.go
@@ -4,6 +4,7 @@ package memorystore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"strconv"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const defaultRedisPort = 6379
@@ -100,6 +102,7 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	info := driver.CacheInfo{
 		Name:      selfLink,
+		Scope:     cfg.Scope,
 		NodeType:  nodeType,
 		Engine:    engine,
 		Status:    "READY",
@@ -142,15 +145,44 @@ func (m *Mock) GetCache(_ context.Context, name string) (*driver.CacheInfo, erro
 }
 
 // ListCaches lists all Memorystore instances.
-func (m *Mock) ListCaches(_ context.Context) ([]driver.CacheInfo, error) {
+func (m *Mock) ListCaches(_ context.Context, filter scope.Scope) ([]driver.CacheInfo, error) {
 	all := m.caches.SortedValues()
 
 	caches := make([]driver.CacheInfo, 0, len(all))
 	for _, cd := range all {
+		if !cd.info.Scope.Matches(filter) {
+			continue
+		}
 		caches = append(caches, cd.info)
 	}
 
 	return caches, nil
+}
+
+// UpdateCache replaces the mutable fields of an existing cache — ARM
+// CreateOrUpdate-on-existing semantics (node type and tags come from the
+// request; identity, endpoint, and CreatedAt are preserved).
+func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.CacheInfo, error) {
+	cd, ok := m.caches.Get(cfg.Name)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "cache %q not found", cfg.Name)
+	}
+
+	if cfg.NodeType != "" {
+		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.Tags != nil {
+		cd.info.Tags = maps.Clone(cfg.Tags)
+	}
+	if !cfg.Scope.IsZero() {
+		cd.info.Scope = cfg.Scope
+	}
+
+	m.caches.Set(cfg.Name, cd)
+
+	result := cd.info
+
+	return &result, nil
 }
 
 // Set stores a value in the cache with an optional TTL.

--- a/providers/gcp/memorystore/memorystore_test.go
+++ b/providers/gcp/memorystore/memorystore_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -156,7 +157,7 @@ func TestListCaches(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty list", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(caches))
 	})
@@ -165,7 +166,7 @@ func TestListCaches(t *testing.T) {
 	createTestCache(t, m, "cache-b")
 
 	t.Run("two caches", func(t *testing.T) {
-		caches, err := m.ListCaches(ctx)
+		caches, err := m.ListCaches(ctx, scope.Scope{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(caches))
 	})

--- a/providers/gcp/memorystore/ordering_test.go
+++ b/providers/gcp/memorystore/ordering_test.go
@@ -1,0 +1,42 @@
+package memorystore
+
+import (
+	"context"
+	"testing"
+
+	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+)
+
+// TestListOrderingDeterministic locks the #259 ordering guarantee: list
+// endpoints return the same, defined order on every call (map iteration
+// randomness must never reach the wire).
+func TestListOrderingDeterministic(t *testing.T) {
+	m, _ := newTestMock()
+	ctx := context.Background()
+
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := m.CreateCache(ctx, driver.CacheConfig{Name: name}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	first, err := m.ListCaches(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 5 {
+		t.Fatalf("list returned %d items, want 5", len(first))
+	}
+
+	for range 5 {
+		again, err := m.ListCaches(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range first {
+			if again[i].Name != first[i].Name {
+				t.Fatalf("list order changed between calls: %v vs %v", again[i].Name, first[i].Name)
+			}
+		}
+	}
+}

--- a/providers/gcp/memorystore/ordering_test.go
+++ b/providers/gcp/memorystore/ordering_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	driver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // TestListOrderingDeterministic locks the #259 ordering guarantee: list
@@ -20,7 +21,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 		}
 	}
 
-	first, err := m.ListCaches(ctx)
+	first, err := m.ListCaches(ctx, scope.Scope{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +30,7 @@ func TestListOrderingDeterministic(t *testing.T) {
 	}
 
 	for range 5 {
-		again, err := m.ListCaches(ctx)
+		again, err := m.ListCaches(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -7,6 +7,7 @@
 package aws
 
 import (
+	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/server"
 	"github.com/stackshy/cloudemu/v2/server/aws/bedrock"
@@ -114,6 +115,49 @@ type Drivers struct {
 	ResourceDiscovery *resourcediscovery.Engine
 	AccountID         string
 	Region            string
+}
+
+// DriversFrom builds a Drivers bundle wiring every service handler to the
+// matching mock on p, so a standalone binary can serve a fully-constructed
+// provider without hand-mapping each field. STS is enabled (identity is
+// derived from AccountID/Region and is safe in standalone). K8sAPI is left
+// nil for the caller to inject when a shared cluster is desired.
+func DriversFrom(p *awsprovider.Provider) Drivers {
+	return Drivers{
+		S3:                p.S3,
+		DynamoDB:          p.DynamoDB,
+		EC2:               p.EC2,
+		VPC:               p.VPC,
+		CloudWatch:        p.CloudWatch,
+		Lambda:            p.Lambda,
+		SQS:               p.SQS,
+		RDS:               p.RDS,
+		Redshift:          p.Redshift,
+		EKS:               p.EKS,
+		IAM:               p.IAM,
+		ECR:               p.ECR,
+		Bedrock:           p.Bedrock,
+		SageMaker:         p.SageMaker,
+		SecretsManager:    p.SecretsManager,
+		SSM:               p.SSM,
+		CloudWatchLogs:    p.CloudWatchLogs,
+		Route53:           p.Route53,
+		ELB:               p.ELB,
+		EventBridge:       p.EventBridge,
+		ElastiCache:       p.ElastiCache,
+		SNS:               p.SNS,
+		STS:               true,
+		K8sAPI:            nil, // injected by the caller when a shared cluster is desired
+		ResourceDiscovery: p.ResourceDiscovery,
+		AccountID:         p.AccountID,
+		Region:            p.Region,
+	}
+}
+
+// NewFromProvider returns a server serving every service on p, using the
+// wiring built by DriversFrom.
+func NewFromProvider(p *awsprovider.Provider) *server.Server {
+	return New(DriversFrom(p))
 }
 
 // New returns a server that speaks the AWS SDK wire protocols for every

--- a/server/aws/cloudwatchlogs/operations.go
+++ b/server/aws/cloudwatchlogs/operations.go
@@ -1,6 +1,7 @@
 package cloudwatchlogs
 
 import (
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 	"strings"
 
@@ -34,7 +35,7 @@ func (h *Handler) describeLogGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	infos, err := h.logs.ListLogGroups(r.Context())
+	infos, err := h.logs.ListLogGroups(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/cloudwatchlogs/ordering_sdk_test.go
+++ b/server/aws/cloudwatchlogs/ordering_sdk_test.go
@@ -1,0 +1,58 @@
+package cloudwatchlogs_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cwl "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: DescribeLogGroups must return the same sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newLogsClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateLogGroup(ctx, &cwl.CreateLogGroupInput{
+			LogGroupName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateLogGroup(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.DescribeLogGroups(ctx, &cwl.DescribeLogGroupsInput{})
+		if err != nil {
+			t.Fatalf("DescribeLogGroups: %v", err)
+		}
+
+		got := make([]string, 0, len(out.LogGroups))
+		for i := range out.LogGroups {
+			got = append(got, aws.ToString(out.LogGroups[i].LogGroupName))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("DescribeLogGroups returned %d groups, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d groups, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/elasticache/operations.go
+++ b/server/aws/elasticache/operations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // parseTags parses ElastiCache-style Tags.Tag.N.{Key,Value} entries.
@@ -67,7 +68,7 @@ func (h *Handler) describeCacheClusters(w http.ResponseWriter, r *http.Request) 
 
 		infos = []cachedriver.CacheInfo{*info}
 	} else {
-		all, err := h.cache.ListCaches(r.Context())
+		all, err := h.cache.ListCaches(r.Context(), scope.Scope{})
 		if err != nil {
 			writeErr(w, err)
 			return

--- a/server/aws/elasticache/ordering_sdk_test.go
+++ b/server/aws/elasticache/ordering_sdk_test.go
@@ -1,0 +1,61 @@
+package elasticache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awselasticache "github.com/aws/aws-sdk-go-v2/service/elasticache"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: DescribeCacheClusters must return the same sequence on every call.
+// The pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateCacheCluster(ctx, &awselasticache.CreateCacheClusterInput{
+			CacheClusterId: aws.String(name),
+			Engine:         aws.String("redis"),
+			CacheNodeType:  aws.String("cache.t3.micro"),
+			NumCacheNodes:  aws.Int32(1),
+		}); err != nil {
+			t.Fatalf("CreateCacheCluster(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.DescribeCacheClusters(ctx, &awselasticache.DescribeCacheClustersInput{})
+		if err != nil {
+			t.Fatalf("DescribeCacheClusters: %v", err)
+		}
+
+		got := make([]string, 0, len(out.CacheClusters))
+		for i := range out.CacheClusters {
+			got = append(got, aws.ToString(out.CacheClusters[i].CacheClusterId))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("DescribeCacheClusters returned %d clusters, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d clusters, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/eventbridge/operations.go
+++ b/server/aws/eventbridge/operations.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // --- event buses ---
@@ -50,7 +51,7 @@ func (h *Handler) describeEventBus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listEventBuses(w http.ResponseWriter, r *http.Request) {
-	infos, err := h.bus.ListEventBuses(r.Context())
+	infos, err := h.bus.ListEventBuses(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/eventbridge/ordering_sdk_test.go
+++ b/server/aws/eventbridge/ordering_sdk_test.go
@@ -1,0 +1,60 @@
+package eventbridge_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awseb "github.com/aws/aws-sdk-go-v2/service/eventbridge"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ListEventBuses must return the same sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+// The driver pre-seeds a "default" bus, so we only assert len >= 5 and an
+// identical sequence across calls.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newEventBridgeClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateEventBus(ctx, &awseb.CreateEventBusInput{
+			Name: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateEventBus(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.ListEventBuses(ctx, &awseb.ListEventBusesInput{})
+		if err != nil {
+			t.Fatalf("ListEventBuses: %v", err)
+		}
+
+		got := make([]string, 0, len(out.EventBuses))
+		for i := range out.EventBuses {
+			got = append(got, aws.ToString(out.EventBuses[i].Name))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) < len(names) {
+		t.Fatalf("ListEventBuses returned %d buses, want at least %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d buses, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/fromprovider_test.go
+++ b/server/aws/fromprovider_test.go
@@ -1,0 +1,70 @@
+package aws_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+// TestNewFromProvider verifies the convenience wiring: a fully-constructed
+// provider turned into a running server via NewFromProvider serves real
+// aws-sdk-go-v2 traffic (CreateBucket then HeadBucket).
+func TestNewFromProvider(t *testing.T) {
+	p := cloudemu.NewAWS()
+
+	srv := awsserver.NewFromProvider(p)
+	if srv == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.UsePathStyle = true
+	})
+
+	ctx := context.Background()
+	const bucket = "from-provider-bucket"
+
+	if _, err := client.CreateBucket(ctx, &awss3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	}); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	out, err := client.ListBuckets(ctx, &awss3.ListBucketsInput{})
+	if err != nil {
+		t.Fatalf("ListBuckets: %v", err)
+	}
+
+	found := false
+	for _, b := range out.Buckets {
+		if aws.ToString(b.Name) == bucket {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created bucket %q not returned by ListBuckets: %+v", bucket, out.Buckets)
+	}
+}

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -8,6 +8,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // listMaxItems is the fixed page size echoed back to the SDK; the mock never
@@ -59,7 +60,8 @@ func (h *Handler) getHostedZone(w http.ResponseWriter, r *http.Request, id strin
 }
 
 func (h *Handler) listHostedZones(w http.ResponseWriter, r *http.Request) {
-	infos, err := h.dns.ListZones(r.Context())
+	// Route 53 hosted zones are account-global, so list them unscoped.
+	infos, err := h.dns.ListZones(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/route53/operations.go
+++ b/server/aws/route53/operations.go
@@ -3,6 +3,7 @@ package route53
 import (
 	"encoding/xml"
 	"net/http"
+	"strings"
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -93,9 +94,11 @@ func (h *Handler) deleteHostedZone(w http.ResponseWriter, r *http.Request, id st
 }
 
 // changeResourceRecordSets applies a CREATE/UPSERT/DELETE batch against the
-// zone. Changes are applied in order; the whole batch shares one INSYNC
-// ChangeInfo, matching Route 53's atomic-batch semantics closely enough for
-// the SDK's change poller.
+// zone. Route 53 validates the whole batch and applies nothing if any change is
+// invalid (InvalidChangeBatch), so we validate every change against the zone's
+// current state — tracking intra-batch effects so a DELETE followed by a CREATE
+// of the same record set is allowed — before mutating anything. The batch then
+// shares one INSYNC ChangeInfo for the SDK's change poller.
 func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Request, id string) {
 	var req changeResourceRecordSetsRequest
 	if !decodeXML(w, r, &req) {
@@ -103,6 +106,11 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 	}
 
 	zoneID := trimZonePrefix(id)
+
+	if err := h.validateChangeBatch(r, zoneID, req.ChangeBatch.Changes); err != nil {
+		writeChangeErr(w, err)
+		return
+	}
 
 	for i := range req.ChangeBatch.Changes {
 		if err := h.applyChange(r, zoneID, &req.ChangeBatch.Changes[i]); err != nil {
@@ -115,6 +123,61 @@ func (h *Handler) changeResourceRecordSets(w http.ResponseWriter, r *http.Reques
 		Xmlns:      xmlns,
 		ChangeInfo: newChangeInfo(),
 	})
+}
+
+// rrSetKey identifies a record set for batch validation, matching the driver's
+// identity (name is case-insensitive, type is case-insensitive, set ID
+// distinguishes weighted records at the same name+type).
+func rrSetKey(name, rtype, setID string) string {
+	return strings.ToLower(name) + "|" + strings.ToUpper(rtype) + "|" + setID
+}
+
+// validateChangeBatch checks every change would apply cleanly before any is
+// applied, so an invalid batch is rejected whole (nothing half-applied). It
+// simulates the batch against the zone's current record sets, folding in each
+// change's effect so ordering within the batch is respected.
+func (h *Handler) validateChangeBatch(r *http.Request, zoneID string, changes []changeItem) error {
+	existing, err := h.dns.ListRecords(r.Context(), zoneID)
+	if err != nil {
+		return err
+	}
+
+	present := make(map[string]bool, len(existing))
+	for i := range existing {
+		present[rrSetKey(existing[i].Name, existing[i].Type, existing[i].SetID)] = true
+	}
+
+	for i := range changes {
+		rr := &changes[i].ResourceRecordSet
+
+		if rr.Name == "" || rr.Type == "" {
+			return cerrors.New(cerrors.InvalidArgument, "record set name and type are required")
+		}
+
+		key := rrSetKey(rr.Name, rr.Type, rr.SetIdentifier)
+
+		switch changes[i].Action {
+		case actionCreate:
+			if present[key] {
+				return cerrors.Newf(cerrors.AlreadyExists,
+					"record set %q %s already exists", rr.Name, rr.Type)
+			}
+			present[key] = true
+		case actionDelete:
+			if !present[key] {
+				return cerrors.Newf(cerrors.NotFound,
+					"record set %q %s not found", rr.Name, rr.Type)
+			}
+			present[key] = false
+		case actionUpsert:
+			present[key] = true
+		default:
+			return cerrors.Newf(cerrors.InvalidArgument,
+				"unsupported change action %q", changes[i].Action)
+		}
+	}
+
+	return nil
 }
 
 // applyChange executes a single record change against the driver.

--- a/server/aws/route53/ordering_sdk_test.go
+++ b/server/aws/route53/ordering_sdk_test.go
@@ -1,0 +1,59 @@
+package route53_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsr53 "github.com/aws/aws-sdk-go-v2/service/route53"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ListHostedZones must return the same sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	names := []string{"zeta.com.", "alpha.com.", "mid.com.", "beta.com.", "omega.com."}
+	for i, name := range names {
+		if _, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+			Name:            aws.String(name),
+			CallerReference: aws.String("ordering-ref-" + string(rune('a'+i))),
+		}); err != nil {
+			t.Fatalf("CreateHostedZone(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.ListHostedZones(ctx, &awsr53.ListHostedZonesInput{})
+		if err != nil {
+			t.Fatalf("ListHostedZones: %v", err)
+		}
+
+		got := make([]string, 0, len(out.HostedZones))
+		for i := range out.HostedZones {
+			got = append(got, aws.ToString(out.HostedZones[i].Name))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("ListHostedZones returned %d zones, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d zones, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/aws/route53/sdk_roundtrip_test.go
+++ b/server/aws/route53/sdk_roundtrip_test.go
@@ -298,3 +298,61 @@ func TestSDKRoute53Errors(t *testing.T) {
 		t.Fatalf("delete missing record: got %v, want InvalidChangeBatch", err)
 	}
 }
+
+// TestSDKRoute53ChangeBatchAtomic asserts a ChangeResourceRecordSets batch is
+// all-or-nothing: a valid CREATE followed by an invalid DELETE rejects the
+// whole batch, and the CREATE must not have been applied.
+func TestSDKRoute53ChangeBatchAtomic(t *testing.T) {
+	client := newRoute53Client(t)
+	ctx := context.Background()
+
+	created, err := client.CreateHostedZone(ctx, &awsr53.CreateHostedZoneInput{
+		Name:            aws.String("atomic.com."),
+		CallerReference: aws.String("ref-atomic"),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedZone: %v", err)
+	}
+	zoneID := aws.ToString(created.HostedZone.Id)
+
+	_, err = client.ChangeResourceRecordSets(ctx, &awsr53.ChangeResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+		ChangeBatch: &r53types.ChangeBatch{
+			Changes: []r53types.Change{
+				{
+					Action: r53types.ChangeActionCreate,
+					ResourceRecordSet: &r53types.ResourceRecordSet{
+						Name:            aws.String("keep.atomic.com."),
+						Type:            r53types.RRTypeA,
+						TTL:             aws.Int64(300),
+						ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.1")}},
+					},
+				},
+				{
+					Action: r53types.ChangeActionDelete,
+					ResourceRecordSet: &r53types.ResourceRecordSet{
+						Name:            aws.String("ghost.atomic.com."),
+						Type:            r53types.RRTypeA,
+						TTL:             aws.Int64(300),
+						ResourceRecords: []r53types.ResourceRecord{{Value: aws.String("192.0.2.9")}},
+					},
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("ChangeResourceRecordSets with an invalid change returned nil error, want the batch rejected")
+	}
+
+	sets, lerr := client.ListResourceRecordSets(ctx, &awsr53.ListResourceRecordSetsInput{
+		HostedZoneId: aws.String(zoneID),
+	})
+	if lerr != nil {
+		t.Fatalf("ListResourceRecordSets: %v", lerr)
+	}
+	for _, rr := range sets.ResourceRecordSets {
+		if aws.ToString(rr.Name) == "keep.atomic.com." {
+			t.Fatal("keep.atomic.com. was applied despite the batch being rejected — batch is not atomic")
+		}
+	}
+}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -4,8 +4,8 @@
 package s3
 
 import (
-	"crypto/sha256"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -264,10 +264,15 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 		return
 	}
 
-	// Real S3 always returns the object's ETag on PutObject. The driver
-	// computes the ETag as the hex SHA-256 of the data (see
-	// providers/aws/s3), so mirror that here.
-	w.Header().Set("ETag", fmt.Sprintf("%q", fmt.Sprintf("%x", sha256.Sum256(data))))
+	// Real S3 always returns the object's ETag on PutObject. Read it back
+	// from the driver so there is a single source of truth for the ETag
+	// algorithm.
+	info, err := h.bucket.HeadObject(r.Context(), bucket, key)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -306,7 +311,10 @@ func writeObjectHeaders(w http.ResponseWriter, info *driver.ObjectInfo, size int
 }
 
 func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	if err := h.bucket.DeleteObject(r.Context(), bucket, key); err != nil {
+	err := h.bucket.DeleteObject(r.Context(), bucket, key)
+	// Real S3 DeleteObject is idempotent: deleting a missing KEY succeeds
+	// with 204. A missing BUCKET is still NoSuchBucket.
+	if err != nil && (!cerrors.IsNotFound(err) || bucketMissing(err)) {
 		writeErr(w, err)
 		return
 	}
@@ -696,14 +704,30 @@ func writeMultipartErr(w http.ResponseWriter, err error) {
 	writeErr(w, err)
 }
 
+// bucketMissing reports whether a NotFound error names the bucket itself
+// (the driver formats bucket misses as `bucket ... not found`).
+func bucketMissing(err error) bool {
+	var ce *cerrors.Error
+	return errors.As(err, &ce) && strings.HasPrefix(ce.Message, "bucket ")
+}
+
 func writeErr(w http.ResponseWriter, err error) {
 	switch {
 	case cerrors.IsNotFound(err):
+		// Real S3 distinguishes NoSuchBucket from NoSuchKey.
+		if bucketMissing(err) {
+			writeError(w, http.StatusNotFound, "NoSuchBucket", err.Error())
+			return
+		}
 		writeError(w, http.StatusNotFound, "NoSuchKey", err.Error())
 	case cerrors.IsAlreadyExists(err):
 		writeError(w, http.StatusConflict, "BucketAlreadyOwnedByYou", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidArgument", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		// Deleting a non-empty bucket is a client error in real S3, not a
+		// server fault — and a 5xx would trigger SDK retry backoff.
+		writeError(w, http.StatusConflict, "BucketNotEmpty", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
 	}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -4,6 +4,7 @@
 package s3
 
 import (
+	"crypto/sha256"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -266,13 +267,14 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 
 	// Real S3 always returns the object's ETag on PutObject. Read it back
 	// from the driver so there is a single source of truth for the ETag
-	// algorithm.
-	info, err := h.bucket.HeadObject(r.Context(), bucket, key)
-	if err != nil {
-		writeErr(w, err)
-		return
+	// algorithm; if a concurrent delete races the read-back, fall back to
+	// computing it from the body we just stored — a successful PUT must
+	// never answer 404.
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+	if info, err := h.bucket.HeadObject(r.Context(), bucket, key); err == nil {
+		etag = info.ETag
 	}
-	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -704,11 +706,20 @@ func writeMultipartErr(w http.ResponseWriter, err error) {
 	writeErr(w, err)
 }
 
-// bucketMissing reports whether a NotFound error names the bucket itself
-// (the driver formats bucket misses as `bucket ... not found`).
+// bucketMissing reports whether a NotFound error names a bucket rather
+// than an object. The driver formats object misses as `object ... not
+// found in bucket ...` and bucket misses as `[source |destination ]bucket
+// ... not found`, so exclude the object form first, then require the word
+// bucket — robust to the source/destination copy variants.
 func bucketMissing(err error) bool {
 	var ce *cerrors.Error
-	return errors.As(err, &ce) && strings.HasPrefix(ce.Message, "bucket ")
+	if !errors.As(err, &ce) {
+		return false
+	}
+	if strings.HasPrefix(ce.Message, "object ") {
+		return false
+	}
+	return strings.Contains(ce.Message, "bucket ")
 }
 
 func writeErr(w http.ResponseWriter, err error) {

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -385,13 +385,10 @@ func TestS3HeadMissingObjectTypedError(t *testing.T) {
 	assert.True(t, errors.As(err, &nf), "want *types.NotFound, got %T: %v", err, err)
 }
 
-// TestS3DeleteMissingObjectError documents the emulator's behavior
-// for deleting an absent key: it returns 404 NoSuchKey. NOTE: real S3
-// DeleteObject is idempotent and returns 204 for a missing key, so SDK code
-// that deletes defensively behaves differently against the emulator. The
-// survey documents "DeleteObject — NotFound if key absent" as intended driver
-// semantics, so this asserts the documented mapping.
-func TestS3DeleteMissingObjectError(t *testing.T) {
+// TestS3DeleteMissingObjectIdempotent asserts real-S3 semantics: deleting
+// an absent key succeeds (204) so defensive-delete SDK code just works,
+// while a missing BUCKET is still NoSuchBucket.
+func TestS3DeleteMissingObjectIdempotent(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
 
@@ -402,30 +399,34 @@ func TestS3DeleteMissingObjectError(t *testing.T) {
 		Bucket: aws.String(bucket),
 		Key:    aws.String("never-put"),
 	})
-	require.Error(t, err, "emulator returns NotFound for deleting an absent key")
+	require.NoError(t, err, "real S3 DeleteObject is idempotent for a missing key")
+
+	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String("ghost-bucket"),
+		Key:    aws.String("k"),
+	})
+	require.Error(t, err, "missing bucket must still fail")
 
 	var apiErr smithy.APIError
 	require.True(t, errors.As(err, &apiErr), "want smithy.APIError, got %T: %v", err, err)
-	assert.Equal(t, "NoSuchKey", apiErr.ErrorCode())
+	assert.Equal(t, "NoSuchBucket", apiErr.ErrorCode())
 }
 
 // TestS3MissingBucketError asserts GetObject against a bucket that
-// was never created fails with NoSuchKey. NOTE: real S3 would return
-// NoSuchBucket here; the emulator's writeErr maps every NotFound to NoSuchKey
-// (documented in the survey).
+// was never created fails with NoSuchBucket, matching real S3.
 func TestS3MissingBucketError(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
 
 	_, err := client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String("bucket-never-created"),
-		Key:    aws.String("any-key"),
+		Bucket: aws.String("never-created"),
+		Key:    aws.String("any"),
 	})
 	require.Error(t, err)
 
-	var nsk *types.NoSuchKey
-	assert.True(t, errors.As(err, &nsk),
-		"emulator maps missing bucket to NoSuchKey (real S3: NoSuchBucket); got %T: %v", err, err)
+	var apiErr smithy.APIError
+	require.True(t, errors.As(err, &apiErr), "want smithy.APIError, got %T: %v", err, err)
+	assert.Equal(t, "NoSuchBucket", apiErr.ErrorCode())
 }
 
 // TestS3DuplicateBucketTypedError asserts the second CreateBucket
@@ -448,9 +449,8 @@ func TestS3DuplicateBucketTypedError(t *testing.T) {
 }
 
 // TestS3DeleteNonEmptyBucketError asserts deleting a non-empty
-// bucket fails and the bucket's contents survive. NOTE: the emulator maps the
-// driver's FailedPrecondition to 500 InternalError (documented in the survey);
-// real S3 returns 409 BucketNotEmpty.
+// bucket fails with 409 BucketNotEmpty (real-S3 semantics) and the
+// bucket's contents survive.
 func TestS3DeleteNonEmptyBucketError(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
@@ -466,8 +466,7 @@ func TestS3DeleteNonEmptyBucketError(t *testing.T) {
 
 	var apiErr smithy.APIError
 	require.True(t, errors.As(err, &apiErr), "want smithy.APIError, got %T: %v", err, err)
-	assert.Equal(t, "InternalError", apiErr.ErrorCode(),
-		"emulator maps FailedPrecondition to InternalError (real S3: BucketNotEmpty)")
+	assert.Equal(t, "BucketNotEmpty", apiErr.ErrorCode())
 
 	// Bucket and object survive the failed delete.
 	body, _ := suiteGetBody(t, client, bucket, "keep.txt")

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -8,6 +8,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createTopic maps CreateTopic to Notification.CreateTopic. SNS CreateTopic is
@@ -87,7 +88,7 @@ func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -139,7 +140,7 @@ func (h *Handler) unsubscribe(w http.ResponseWriter, r *http.Request) {
 // ListSubscriptions aggregated across every topic, since the driver has no
 // global subscription index.
 func (h *Handler) listSubscriptions(w http.ResponseWriter, r *http.Request) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), scope.Scope{})
 	if err != nil {
 		writeErr(w, err)
 		return

--- a/server/aws/sns/ordering_sdk_test.go
+++ b/server/aws/sns/ordering_sdk_test.go
@@ -1,0 +1,58 @@
+package sns_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awssns "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ListTopics must return the same TopicArn sequence on every call. The
+// pre-fix bug was random map iteration order, so repetition is the signal.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	names := []string{"zeta", "alpha", "mid", "beta", "omega"}
+	for _, name := range names {
+		if _, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+			Name: aws.String(name),
+		}); err != nil {
+			t.Fatalf("CreateTopic(%s): %v", name, err)
+		}
+	}
+
+	list := func() []string {
+		out, err := client.ListTopics(ctx, &awssns.ListTopicsInput{})
+		if err != nil {
+			t.Fatalf("ListTopics: %v", err)
+		}
+
+		got := make([]string, 0, len(out.Topics))
+		for i := range out.Topics {
+			got = append(got, aws.ToString(out.Topics[i].TopicArn))
+		}
+
+		return got
+	}
+
+	first := list()
+	if len(first) != len(names) {
+		t.Fatalf("ListTopics returned %d topics, want %d: %v", len(first), len(names), first)
+	}
+
+	for call := 2; call <= 5; call++ {
+		got := list()
+		if len(got) != len(first) {
+			t.Fatalf("call %d: got %d topics, want %d", call, len(got), len(first))
+		}
+
+		for i := range first {
+			if got[i] != first[i] {
+				t.Fatalf("call %d: order diverged at index %d: got %v, first call %v", call, i, got, first)
+			}
+		}
+	}
+}

--- a/server/azure/blob/blob_lifecycle_test.go
+++ b/server/azure/blob/blob_lifecycle_test.go
@@ -14,14 +14,12 @@ package blob_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
@@ -533,25 +531,18 @@ func TestErrorCases(t *testing.T) {
 		t.Errorf("duplicate create: err=%v want ContainerAlreadyExists", err)
 	}
 
-	// Delete non-empty container. The driver returns FailedPrecondition,
-	// which the handler maps to 500 InternalError (real Azure deletes
-	// containers recursively, so this whole failure mode is emulator-only).
+	// Delete non-empty container: real Azure deletes containers together
+	// with their blobs, and the emulator now matches.
 	if _, err := env.client.UploadBuffer(ctx, "errs", "occupant", []byte("x"), nil); err != nil {
 		t.Fatalf("UploadBuffer: %v", err)
 	}
 
-	_, err := env.client.DeleteContainer(ctx, "errs", nil)
-	if err == nil {
-		t.Fatalf("delete non-empty container succeeded, want error")
+	if _, err := env.client.DeleteContainer(ctx, "errs", nil); err != nil {
+		t.Fatalf("delete non-empty container: %v (real Azure deletes recursively)", err)
 	}
 
-	var respErr *azcore.ResponseError
-	if !errors.As(err, &respErr) {
-		t.Fatalf("delete non-empty container: err=%T want *azcore.ResponseError", err)
-	}
-
-	if respErr.StatusCode != 500 || respErr.ErrorCode != "InternalError" {
-		t.Errorf("delete non-empty container: status=%d code=%q want 500 InternalError", respErr.StatusCode, respErr.ErrorCode)
+	if _, err := env.client.CreateContainer(ctx, "errs", nil); err != nil {
+		t.Fatalf("recreate container after recursive delete: %v", err)
 	}
 
 	// Copy from a missing source blob.

--- a/server/azure/blob/handler.go
+++ b/server/azure/blob/handler.go
@@ -22,6 +22,7 @@ package blob
 import (
 	"encoding/xml"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"net/url"
@@ -161,7 +162,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
 			Name: b.Name,
 			Properties: containerPropsXML{
 				LastModified: httpDate(b.CreatedAt),
-				ETag:         "\"0x8DAB0\"",
+				ETag:         containerETag(b.CreatedAt),
 			},
 		})
 	}
@@ -175,13 +176,46 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, contai
 		return
 	}
 
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	created := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(created))
+	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusCreated)
 }
 
+// containerCreatedAt looks up a container's creation time from the driver;
+// falls back to the zero string (httpDate then serves the current time).
+func (h *Handler) containerCreatedAt(r *http.Request, container string) string {
+	buckets, err := h.bucket.ListBuckets(r.Context())
+	if err != nil {
+		return ""
+	}
+	for _, b := range buckets {
+		if b.Name == container {
+			return b.CreatedAt
+		}
+	}
+	return ""
+}
+
+// containerETag derives a stable per-container ETag from its creation time,
+// replacing the old shared hard-coded value.
+func containerETag(createdAt string) string {
+	return fmt.Sprintf("%q", "0x"+strings.ToUpper(fmt.Sprintf("%x", crc32.ChecksumIEEE([]byte(createdAt)))))
+}
+
 func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, container string) {
-	if err := h.bucket.DeleteBucket(r.Context(), container); err != nil {
+	err := h.bucket.DeleteBucket(r.Context(), container)
+
+	// Real Azure deletes a container together with its blobs; the portable
+	// driver refuses non-empty deletes, so empty it here and retry.
+	if err != nil && cerrors.IsFailedPrecondition(err) {
+		if derr := h.emptyContainer(r, container); derr != nil {
+			writeErr(w, derr)
+			return
+		}
+		err = h.bucket.DeleteBucket(r.Context(), container)
+	}
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -189,9 +223,28 @@ func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, contai
 	w.WriteHeader(http.StatusAccepted)
 }
 
-func (*Handler) getContainerProperties(w http.ResponseWriter, _ *http.Request, _ string) {
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+// emptyContainer deletes every blob in the container.
+func (h *Handler) emptyContainer(r *http.Request, container string) error {
+	for {
+		list, err := h.bucket.ListObjects(r.Context(), container, storagedriver.ListOptions{})
+		if err != nil {
+			return err
+		}
+		if len(list.Objects) == 0 {
+			return nil
+		}
+		for _, obj := range list.Objects {
+			if err := h.bucket.DeleteObject(r.Context(), container, obj.Key); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (h *Handler) getContainerProperties(w http.ResponseWriter, r *http.Request, container string) {
+	created := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(created))
+	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -275,8 +328,13 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	info, err := h.bucket.HeadObject(r.Context(), container, blob)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+	w.Header().Set("Last-Modified", httpDate(info.LastModified))
 	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
 	w.WriteHeader(http.StatusCreated)
 }
@@ -408,6 +466,8 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "ContainerAlreadyExists", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "InvalidInput", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		writeError(w, http.StatusConflict, "Conflict", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "InternalError", err.Error())
 	}

--- a/server/azure/blob/handler.go
+++ b/server/azure/blob/handler.go
@@ -20,6 +20,7 @@
 package blob
 
 import (
+	"crypto/sha256"
 	"encoding/xml"
 	"fmt"
 	"hash/crc32"
@@ -162,7 +163,7 @@ func (h *Handler) listContainers(w http.ResponseWriter, r *http.Request) {
 			Name: b.Name,
 			Properties: containerPropsXML{
 				LastModified: httpDate(b.CreatedAt),
-				ETag:         containerETag(b.CreatedAt),
+				ETag:         containerETag(b.Name, b.CreatedAt),
 			},
 		})
 	}
@@ -176,31 +177,32 @@ func (h *Handler) createContainer(w http.ResponseWriter, r *http.Request, contai
 		return
 	}
 
-	created := h.containerCreatedAt(r, container)
-	w.Header().Set("ETag", containerETag(created))
+	created, _ := h.containerCreatedAt(r, container)
+	w.Header().Set("ETag", containerETag(container, created))
 	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusCreated)
 }
 
-// containerCreatedAt looks up a container's creation time from the driver;
-// falls back to the zero string (httpDate then serves the current time).
-func (h *Handler) containerCreatedAt(r *http.Request, container string) string {
+// containerCreatedAt looks up a container's creation time from the driver.
+func (h *Handler) containerCreatedAt(r *http.Request, container string) (string, bool) {
 	buckets, err := h.bucket.ListBuckets(r.Context())
 	if err != nil {
-		return ""
+		return "", false
 	}
 	for _, b := range buckets {
 		if b.Name == container {
-			return b.CreatedAt
+			return b.CreatedAt, true
 		}
 	}
-	return ""
+	return "", false
 }
 
-// containerETag derives a stable per-container ETag from its creation time,
-// replacing the old shared hard-coded value.
-func containerETag(createdAt string) string {
-	return fmt.Sprintf("%q", "0x"+strings.ToUpper(fmt.Sprintf("%x", crc32.ChecksumIEEE([]byte(createdAt)))))
+// containerETag derives a stable per-container ETag from the container's
+// name and creation time — unique even for containers created within the
+// same clock second (which is every container under a pinned fake clock).
+func containerETag(name, createdAt string) string {
+	sum := crc32.ChecksumIEEE([]byte(name + "|" + createdAt))
+	return fmt.Sprintf("%q", "0x"+strings.ToUpper(fmt.Sprintf("%x", sum)))
 }
 
 func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, container string) {
@@ -223,9 +225,12 @@ func (h *Handler) deleteContainer(w http.ResponseWriter, r *http.Request, contai
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// emptyContainer deletes every blob in the container.
+// emptyContainer deletes every blob in the container. A blob that vanishes
+// between list and delete (concurrent deletes) is fine; the pass budget
+// bounds the loop so a racing writer cannot spin it forever.
 func (h *Handler) emptyContainer(r *http.Request, container string) error {
-	for {
+	const maxPasses = 1000
+	for range maxPasses {
 		list, err := h.bucket.ListObjects(r.Context(), container, storagedriver.ListOptions{})
 		if err != nil {
 			return err
@@ -234,16 +239,24 @@ func (h *Handler) emptyContainer(r *http.Request, container string) error {
 			return nil
 		}
 		for _, obj := range list.Objects {
-			if err := h.bucket.DeleteObject(r.Context(), container, obj.Key); err != nil {
+			err := h.bucket.DeleteObject(r.Context(), container, obj.Key)
+			if err != nil && !cerrors.IsNotFound(err) {
 				return err
 			}
 		}
 	}
+	return cerrors.Newf(cerrors.FailedPrecondition,
+		"container %q kept receiving blobs during delete", container)
 }
 
 func (h *Handler) getContainerProperties(w http.ResponseWriter, r *http.Request, container string) {
-	created := h.containerCreatedAt(r, container)
-	w.Header().Set("ETag", containerETag(created))
+	created, ok := h.containerCreatedAt(r, container)
+	if !ok {
+		writeError(w, http.StatusNotFound, "ContainerNotFound",
+			"container "+container+" not found")
+		return
+	}
+	w.Header().Set("ETag", containerETag(container, created))
 	w.Header().Set("Last-Modified", httpDate(created))
 	w.WriteHeader(http.StatusOK)
 }
@@ -328,13 +341,17 @@ func (h *Handler) putBlob(w http.ResponseWriter, r *http.Request, container, blo
 		return
 	}
 
-	info, err := h.bucket.HeadObject(r.Context(), container, blob)
-	if err != nil {
-		writeErr(w, err)
-		return
+	// The driver's ETag is the hex sha256 of the body; if a concurrent
+	// delete races the read-back, fall back to computing it — a successful
+	// PUT must never answer 404.
+	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+	lastModified := ""
+	if info, err := h.bucket.HeadObject(r.Context(), container, blob); err == nil {
+		etag = info.ETag
+		lastModified = info.LastModified
 	}
-	w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
-	w.Header().Set("Last-Modified", httpDate(info.LastModified))
+	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
+	w.Header().Set("Last-Modified", httpDate(lastModified))
 	w.Header().Set("X-Ms-Request-Server-Encrypted", "true")
 	w.WriteHeader(http.StatusCreated)
 }
@@ -401,8 +418,10 @@ func (h *Handler) copyBlob(w http.ResponseWriter, r *http.Request, container, bl
 
 	w.Header().Set("X-Ms-Copy-Id", "00000000-0000-0000-0000-000000000001")
 	w.Header().Set("X-Ms-Copy-Status", "success")
-	w.Header().Set("ETag", "\"0x8DAB0\"")
-	w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+	if info, err := h.bucket.HeadObject(r.Context(), container, blob); err == nil {
+		w.Header().Set("ETag", fmt.Sprintf("%q", info.ETag))
+		w.Header().Set("Last-Modified", httpDate(info.LastModified))
+	}
 	w.WriteHeader(http.StatusAccepted)
 }
 

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -6,20 +6,17 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createOrUpdateCache handles PUT — Redis.BeginCreate. The LRO completes inline:
 // returning 201/200 with the resource body terminates the SDK's poller on the
-// first response.
+// first response. Create when absent, otherwise apply the request's mutable
+// fields (SKU, tags) via UpdateCache — ARM PUT semantics, so the caller's
+// changes are never silently discarded.
 func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body redisJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
-		return
-	}
-
-	// CreateOrUpdate is idempotent: if the cache already exists, echo it back.
-	if info, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
-		azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
 		return
 	}
 
@@ -28,6 +25,17 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		Engine:   "redis",
 		NodeType: nodeTypeFromBody(&body),
 		Tags:     body.Tags,
+		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	if _, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.cache.UpdateCache(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
+		azurearm.WriteJSON(w, http.StatusOK, toRedisJSON(rp, info))
+		return
 	}
 
 	info, err := h.cache.CreateCache(r.Context(), cfg)
@@ -83,10 +91,12 @@ func (h *Handler) deleteCache(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 // listCaches handles GET on the collection — Redis.ListByResourceGroup /
-// ListBySubscription. The cache driver is not scope-aware, so both list the
-// same set.
+// ListBySubscription. The filter carries the path's subscription and, for
+// RG-level lists, its resource group; subscription-level lists leave the
+// resource group empty so the filter spans the subscription's groups.
 func (h *Handler) listCaches(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.cache.ListCaches(r.Context())
+	infos, err := h.cache.ListCaches(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/cache/ordering_sdk_test.go
+++ b/server/azure/cache/ordering_sdk_test.go
@@ -1,0 +1,66 @@
+package cache_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	// Create caches deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		poller, err := client.BeginCreate(ctx, testRG, name, armredis.CreateParameters{
+			Location: to.Ptr("eastus"),
+			Properties: &armredis.CreateProperties{
+				SKU: &armredis.SKU{
+					Name:     to.Ptr(armredis.SKUNameStandard),
+					Family:   to.Ptr(armredis.SKUFamilyC),
+					Capacity: to.Ptr(int32(1)),
+				},
+			},
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := client.NewListBySubscriptionPager(nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListBySubscription: %v", perr)
+			}
+
+			for _, c := range page.Value {
+				names = append(names, *c.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 caches", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/cache/scope_update_sdk_test.go
+++ b/server/azure/cache/scope_update_sdk_test.go
@@ -1,0 +1,110 @@
+package cache_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
+)
+
+func createRedis(t *testing.T, client *armredis.Client, rg, name string, tags map[string]*string) armredis.ResourceInfo {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, rg, name, armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Tags:     tags,
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate %s/%s: %v", rg, name, err)
+	}
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+	return res.ResourceInfo
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: caches
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, "rg-team-a", "cache-a1", nil)
+	createRedis(t, client, "rg-team-a", "cache-a2", nil)
+	createRedis(t, client, "rg-team-b", "cache-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := client.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, c := range page.Value {
+				names = append(names, *c.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 caches", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "cache-b1" {
+		t.Fatalf("rg-team-b listed %v, want [cache-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// BeginCreate on an existing cache must apply the request's tags, not echo
+// the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	createRedis(t, client, testRG, "cache-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createRedis(t, client, testRG, "cache-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := client.Get(ctx, testRG, "cache-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	client := newRedisClient(t)
+
+	created := createRedis(t, client, "rg-id-check", "cache-id", nil)
+	if created.ID == nil {
+		t.Fatal("cache response has no id")
+	}
+	id := *created.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -88,13 +88,24 @@ func hostAndSSLPort(endpoint string) (string, int) {
 	return host, port
 }
 
-// toRedisJSON converts a driver CacheInfo into its ARM element for the given
-// path scope.
+// toRedisJSON converts a driver CacheInfo into its ARM element. The id carries
+// the scope the cache was created in; resources without a recorded scope
+// (portable-API creations) fall back to the request path's scope.
 func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJSON {
 	host, sslPort := hostAndSSLPort(info.Endpoint)
 
+	sub := info.Scope.Subscription
+	if sub == "" {
+		sub = rp.Subscription
+	}
+
+	rg := info.Scope.ResourceGroup
+	if rg == "" {
+		rg = rp.ResourceGroup
+	}
+
 	return redisJSON{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, typeRedis, info.Name),
+		ID:       azurearm.BuildResourceID(sub, rg, providerName, typeRedis, info.Name),
 		Name:     info.Name,
 		Type:     redisResourceType,
 		Location: defaultLocation,

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -6,6 +6,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // --- zones ---
@@ -21,11 +22,19 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		private = privateFromZoneType(body.Properties.ZoneType)
 	}
 
-	// CreateOrUpdate is idempotent: if the zone already exists, echo it back.
-	if id, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
-		info, gerr := h.dns.GetZone(r.Context(), id)
-		if gerr != nil {
-			azurearm.WriteCErr(w, gerr)
+	sc := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+
+	// CreateOrUpdate is upsert: if the zone already exists, apply the request's
+	// mutable fields (tags, scope) via UpdateZone rather than echoing it back.
+	if _, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
+			Name:    rp.ResourceName,
+			Private: private,
+			Tags:    body.Tags,
+			Scope:   sc,
+		})
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
 			return
 		}
 
@@ -38,6 +47,7 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		Name:    rp.ResourceName,
 		Private: private,
 		Tags:    body.Tags,
+		Scope:   sc,
 	})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
@@ -81,7 +91,8 @@ func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rp *azurear
 }
 
 func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.dns.ListZones(r.Context())
+	infos, err := h.dns.ListZones(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -51,7 +51,7 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 }
 
 func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	id, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	id, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -69,7 +69,7 @@ func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rp *azurearm.R
 // deleteZone removes the zone. Zones.Delete is an LRO in the SDK; returning
 // 200 with an empty body completes the poller on the first response.
 func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	id, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	id, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -107,7 +107,7 @@ func (h *Handler) createOrUpdateRecordSet(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -144,7 +144,7 @@ func (h *Handler) upsertRecord(r *http.Request, cfg dnsdriver.RecordConfig) (*dn
 }
 
 func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -160,7 +160,7 @@ func (h *Handler) getRecordSet(w http.ResponseWriter, r *http.Request, rp *azure
 }
 
 func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -183,7 +183,7 @@ func (h *Handler) deleteRecordSet(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) listRecordSets(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	zoneID, err := h.resolveZoneID(r.Context(), rp.ResourceName)
+	zoneID, err := h.resolveZoneID(r.Context(), rp)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/dns/operations.go
+++ b/server/azure/dns/operations.go
@@ -22,33 +22,26 @@ func (h *Handler) createOrUpdateZone(w http.ResponseWriter, r *http.Request, rp 
 		private = privateFromZoneType(body.Properties.ZoneType)
 	}
 
-	sc := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
-
-	// CreateOrUpdate is upsert: if the zone already exists, apply the request's
-	// mutable fields (tags, scope) via UpdateZone rather than echoing it back.
-	if _, err := h.resolveZoneID(r.Context(), rp.ResourceName); err == nil {
-		info, uerr := h.dns.UpdateZone(r.Context(), dnsdriver.ZoneConfig{
-			Name:    rp.ResourceName,
-			Private: private,
-			Tags:    body.Tags,
-			Scope:   sc,
-		})
-		if uerr != nil {
-			azurearm.WriteCErr(w, uerr)
-			return
-		}
-
-		azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
-
-		return
-	}
-
-	info, err := h.dns.CreateZone(r.Context(), dnsdriver.ZoneConfig{
+	cfg := dnsdriver.ZoneConfig{
 		Name:    rp.ResourceName,
 		Private: private,
 		Tags:    body.Tags,
-		Scope:   sc,
-	})
+		Scope:   scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	// CreateOrUpdate is upsert. Try to update a zone that already exists in
+	// THIS scope; only create when none does. Matching by scope (not just
+	// name) means a same-named zone in another resource group is never
+	// hijacked — it stays a distinct zone.
+	if info, uerr := h.dns.UpdateZone(r.Context(), cfg); uerr == nil {
+		azurearm.WriteJSON(w, http.StatusOK, toZoneJSON(rp, info))
+		return
+	} else if !cerrors.IsNotFound(uerr) {
+		azurearm.WriteCErr(w, uerr)
+		return
+	}
+
+	info, err := h.dns.CreateZone(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/dns/ordering_sdk_test.go
+++ b/server/azure/dns/ordering_sdk_test.go
@@ -1,0 +1,54 @@
+package dns_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	// Create zones deliberately out of alphabetical order.
+	for _, name := range []string{"zeta.com", "alpha.com", "mid.com", "beta.com", "omega.com"} {
+		if _, err := zones.CreateOrUpdate(ctx, testRG, name, armdns.Zone{
+			Location: to.Ptr("global"),
+		}, nil); err != nil {
+			t.Fatalf("Zones.CreateOrUpdate(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := zones.NewListByResourceGroupPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListByResourceGroup: %v", perr)
+			}
+
+			for _, z := range page.Value {
+				names = append(names, *z.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 zones", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -127,6 +127,42 @@ func TestSDKSameNameZonesStayIndependent(t *testing.T) {
 	}
 }
 
+// TestSDKGetResolvesWithinRequestScope asserts that when the same zone name
+// exists in two resource groups, a Get resolves to the zone in the request's
+// group — not an arbitrary same-named zone in another group.
+func TestSDKGetResolvesWithinRequestScope(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	mk := func(rg, env string) {
+		if _, err := zones.CreateOrUpdate(ctx, rg, "dup.com", armdns.Zone{
+			Location: to.Ptr("global"),
+			Tags:     map[string]*string{"env": to.Ptr(env)},
+		}, nil); err != nil {
+			t.Fatalf("CreateOrUpdate %s: %v", rg, err)
+		}
+	}
+	mk("rg-get-a", "a")
+	mk("rg-get-b", "b")
+
+	getEnv := func(rg string) string {
+		z, err := zones.Get(ctx, rg, "dup.com", nil)
+		if err != nil {
+			t.Fatalf("Get %s: %v", rg, err)
+		}
+		if z.Tags["env"] == nil {
+			t.Fatalf("Get %s: no env tag", rg)
+		}
+		return *z.Tags["env"]
+	}
+	if got := getEnv("rg-get-a"); got != "a" {
+		t.Fatalf("Get rg-get-a/dup.com env = %q, want a (must resolve within the request's group)", got)
+	}
+	if got := getEnv("rg-get-b"); got != "b" {
+		t.Fatalf("Get rg-get-b/dup.com env = %q, want b", got)
+	}
+}
+
 // TestSDKZoneIDMatchesRequestScope asserts through the real SDK that the
 // returned ARM id carries the request's subscription and resource group.
 func TestSDKZoneIDMatchesRequestScope(t *testing.T) {

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -127,6 +127,53 @@ func TestSDKSameNameZonesStayIndependent(t *testing.T) {
 	}
 }
 
+// TestSDKTXTRecordChunking asserts that a TXT value longer than 255 bytes is
+// returned as valid ≤255-byte character-strings whose concatenation preserves
+// the original value — Azure rejects a single oversized chunk.
+func TestSDKTXTRecordChunking(t *testing.T) {
+	zones, records := newDNSClients(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "txt.com", armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+		t.Fatalf("Zones.CreateOrUpdate: %v", err)
+	}
+
+	chunkA := strings.Repeat("a", 255)
+	chunkB := strings.Repeat("b", 100)
+	want := chunkA + chunkB // 355-byte logical value
+
+	if _, err := records.CreateOrUpdate(ctx, testRG, "txt.com", "long", armdns.RecordTypeTXT, armdns.RecordSet{
+		Properties: &armdns.RecordSetProperties{
+			TTL:        to.Ptr(int64(300)),
+			TxtRecords: []*armdns.TxtRecord{{Value: []*string{to.Ptr(chunkA), to.Ptr(chunkB)}}},
+		},
+	}, nil); err != nil {
+		t.Fatalf("RecordSets.CreateOrUpdate: %v", err)
+	}
+
+	got, err := records.Get(ctx, testRG, "txt.com", "long", armdns.RecordTypeTXT, nil)
+	if err != nil {
+		t.Fatalf("RecordSets.Get: %v", err)
+	}
+	if got.Properties == nil || len(got.Properties.TxtRecords) != 1 {
+		t.Fatalf("TxtRecords = %+v, want exactly one record", got.Properties)
+	}
+
+	var joined string
+	for _, c := range got.Properties.TxtRecords[0].Value {
+		if c == nil {
+			t.Fatal("nil TXT chunk")
+		}
+		if len(*c) > 255 {
+			t.Fatalf("TXT chunk length %d exceeds the 255-byte limit", len(*c))
+		}
+		joined += *c
+	}
+	if joined != want {
+		t.Fatalf("reassembled TXT = %d bytes, want the original %d-byte value", len(joined), len(want))
+	}
+}
+
 // TestSDKGetResolvesWithinRequestScope asserts that when the same zone name
 // exists in two resource groups, a Get resolves to the zone in the request's
 // group — not an arbitrary same-named zone in another group.

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -82,6 +82,51 @@ func TestSDKUpsertAppliesTags(t *testing.T) {
 	}
 }
 
+// TestSDKSameNameZonesStayIndependent asserts that CreateOrUpdate for a zone
+// name that already exists in a different resource group creates a distinct
+// zone rather than hijacking the existing one — the same name legitimately
+// exists in more than one group.
+func TestSDKSameNameZonesStayIndependent(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	mk := func(rg, env string) {
+		if _, err := zones.CreateOrUpdate(ctx, rg, "shared.com", armdns.Zone{
+			Location: to.Ptr("global"),
+			Tags:     map[string]*string{"env": to.Ptr(env)},
+		}, nil); err != nil {
+			t.Fatalf("CreateOrUpdate %s: %v", rg, err)
+		}
+	}
+	mk("rg-shared-a", "a")
+	mk("rg-shared-b", "b")
+
+	// Each group must still own its own shared.com with its own tag; the
+	// second create must not have moved or overwritten the first.
+	tagInRG := func(rg string) string {
+		var out string
+		pager := zones.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, z := range page.Value {
+				if z.Name != nil && *z.Name == "shared.com" && z.Tags["env"] != nil {
+					out = *z.Tags["env"]
+				}
+			}
+		}
+		return out
+	}
+	if got := tagInRG("rg-shared-a"); got != "a" {
+		t.Fatalf("rg-shared-a shared.com env = %q, want a (not hijacked by the rg-b create)", got)
+	}
+	if got := tagInRG("rg-shared-b"); got != "b" {
+		t.Fatalf("rg-shared-b shared.com env = %q, want b", got)
+	}
+}
+
 // TestSDKZoneIDMatchesRequestScope asserts through the real SDK that the
 // returned ARM id carries the request's subscription and resource group.
 func TestSDKZoneIDMatchesRequestScope(t *testing.T) {

--- a/server/azure/dns/scope_update_sdk_test.go
+++ b/server/azure/dns/scope_update_sdk_test.go
@@ -1,0 +1,104 @@
+package dns_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+// TestSDKScopedListing asserts through the real SDK that zones created in one
+// resource group do not appear in another group's ListByResourceGroup pager.
+func TestSDKScopedListing(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	create := func(rg, name string) {
+		if _, err := zones.CreateOrUpdate(ctx, rg, name, armdns.Zone{Location: to.Ptr("global")}, nil); err != nil {
+			t.Fatalf("CreateOrUpdate %s/%s: %v", rg, name, err)
+		}
+	}
+	create("rg-team-a", "a1.com")
+	create("rg-team-a", "a2.com")
+	create("rg-team-b", "b1.com")
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := zones.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, z := range page.Value {
+				names = append(names, *z.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 zones", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "b1.com" {
+		t.Fatalf("rg-team-b listed %v, want [b1.com]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesTags asserts through the real SDK that CreateOrUpdate on
+// an existing zone applies the request's tags, not echoing the stale resource.
+func TestSDKUpsertAppliesTags(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	if _, err := zones.CreateOrUpdate(ctx, testRG, "upsert.com", armdns.Zone{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("dev")},
+	}, nil); err != nil {
+		t.Fatalf("CreateOrUpdate (create): %v", err)
+	}
+
+	updated, err := zones.CreateOrUpdate(ctx, testRG, "upsert.com", armdns.Zone{
+		Location: to.Ptr("global"),
+		Tags:     map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate (update): %v", err)
+	}
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := zones.Get(ctx, testRG, "upsert.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKZoneIDMatchesRequestScope asserts through the real SDK that the
+// returned ARM id carries the request's subscription and resource group.
+func TestSDKZoneIDMatchesRequestScope(t *testing.T) {
+	zones, _ := newDNSClients(t)
+	ctx := context.Background()
+
+	created, err := zones.CreateOrUpdate(ctx, "rg-id-check", "id.com", armdns.Zone{
+		Location: to.Ptr("global"),
+	}, nil)
+	if err != nil {
+		t.Fatalf("CreateOrUpdate: %v", err)
+	}
+	if created.ID == nil {
+		t.Fatal("zone response has no id")
+	}
+	id := *created.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -232,10 +232,14 @@ func recordTypeSegment(s string) string {
 }
 
 // resolveZoneID maps the SDK-facing zone name to the driver's internal zone id
-// by scanning the zone list. Returns a NotFound error if no zone with that name
-// exists.
-func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
-	zones, err := h.dns.ListZones(ctx, scope.Scope{})
+// by scanning the zone list, scoped to the request's subscription and resource
+// group. Scoping matters because the same zone name can exist in more than one
+// resource group — a name-only scan could resolve to a zone in a different
+// group. Returns a NotFound error if no such zone exists in this scope.
+func (h *Handler) resolveZoneID(ctx context.Context, rp *azurearm.ResourcePath) (string, error) {
+	filter := scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+
+	zones, err := h.dns.ListZones(ctx, filter)
 	if err != nil {
 		return "", err
 	}
@@ -243,10 +247,10 @@ func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error
 	// Azure treats DNS zone names case-insensitively (and lowercases them on
 	// some URL paths), so match without regard to case.
 	for i := range zones {
-		if strings.EqualFold(zones[i].Name, name) {
+		if strings.EqualFold(zones[i].Name, rp.ResourceName) {
 			return zones[i].ID, nil
 		}
 	}
 
-	return "", cerrors.Newf(cerrors.NotFound, "dns zone %q not found", name)
+	return "", cerrors.Newf(cerrors.NotFound, "dns zone %q not found", rp.ResourceName)
 }

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -7,6 +7,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // ARM resource type strings stamped on responses.
@@ -234,7 +235,7 @@ func recordTypeSegment(s string) string {
 // by scanning the zone list. Returns a NotFound error if no zone with that name
 // exists.
 func (h *Handler) resolveZoneID(ctx context.Context, name string) (string, error) {
-	zones, err := h.dns.ListZones(ctx)
+	zones, err := h.dns.ListZones(ctx, scope.Scope{})
 	if err != nil {
 		return "", err
 	}

--- a/server/azure/dns/types.go
+++ b/server/azure/dns/types.go
@@ -62,6 +62,30 @@ type txtRecordJSON struct {
 	Value []string `json:"value,omitempty"`
 }
 
+// txtChunkSize is the maximum length of a single DNS TXT character-string.
+// Azure represents a TXT record as an array of these ≤255-byte chunks.
+const txtChunkSize = 255
+
+// chunkTXT splits a logical TXT value into ≤255-byte character-strings, as the
+// TXT wire format (and Azure's TxtRecords value array) requires. A value that
+// already fits returns a single chunk; the input side rejoins them.
+func chunkTXT(s string) []string {
+	if len(s) <= txtChunkSize {
+		return []string{s}
+	}
+
+	chunks := make([]string, 0, len(s)/txtChunkSize+1)
+	for len(s) > txtChunkSize {
+		chunks = append(chunks, s[:txtChunkSize])
+		s = s[txtChunkSize:]
+	}
+	if len(s) > 0 {
+		chunks = append(chunks, s)
+	}
+
+	return chunks
+}
+
 type nsRecordJSON struct {
 	Nsdname string `json:"nsdname,omitempty"`
 }
@@ -175,7 +199,7 @@ func toRecordSetProperties(rec *dnsdriver.RecordInfo) *recordSetProperties {
 		}
 	case "TXT":
 		for _, v := range rec.Values {
-			props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: []string{v}})
+			props.TxtRecords = append(props.TxtRecords, txtRecordJSON{Value: chunkTXT(v)})
 		}
 	case "NS":
 		for _, v := range rec.Values {

--- a/server/azure/eventgrid/operations.go
+++ b/server/azure/eventgrid/operations.go
@@ -5,24 +5,38 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
+// createOrUpdateTopic maps Topics.CreateOrUpdate onto the eventbus driver:
+// create when absent, otherwise apply the request's mutable fields (tags) via
+// UpdateEventBus — ARM PUT semantics, so the caller's changes are never
+// silently discarded.
 func (h *Handler) createOrUpdateTopic(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body topicJSON
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	// CreateOrUpdate is idempotent: if the topic already exists, echo it back.
-	if info, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
+	cfg := ebdriver.EventBusConfig{
+		Name:  rp.ResourceName,
+		Tags:  tagsFromPtr(body.Tags),
+		Scope: scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	if _, err := h.bus.GetEventBus(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.bus.UpdateEventBus(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
+		// The armeventgrid SDK accepts only 201 for Topics.CreateOrUpdate,
+		// so the update path answers 201 as well.
 		azurearm.WriteJSON(w, http.StatusCreated, toTopicJSON(rp, info))
 		return
 	}
 
-	info, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
-		Name: rp.ResourceName,
-		Tags: tagsFromPtr(body.Tags),
-	})
+	info, err := h.bus.CreateEventBus(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -56,7 +70,8 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request, rp *azurea
 }
 
 func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.bus.ListEventBuses(r.Context())
+	infos, err := h.bus.ListEventBuses(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/eventgrid/ordering_sdk_test.go
+++ b/server/azure/eventgrid/ordering_sdk_test.go
@@ -1,0 +1,59 @@
+package eventgrid_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	topics := newTopicsClient(t)
+	ctx := context.Background()
+
+	// Create topics deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		poller, err := topics.BeginCreateOrUpdate(ctx, testRG, name, armeventgrid.Topic{
+			Location: to.Ptr("global"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := topics.NewListByResourceGroupPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListByResourceGroup: %v", perr)
+			}
+
+			for _, tp := range page.Value {
+				names = append(names, *tp.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 topics", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/eventgrid/scope_update_sdk_test.go
+++ b/server/azure/eventgrid/scope_update_sdk_test.go
@@ -1,0 +1,103 @@
+package eventgrid_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2"
+)
+
+func createTopic(t *testing.T, client *armeventgrid.TopicsClient, rg, name string, tags map[string]*string) armeventgrid.Topic {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armeventgrid.Topic{
+		Location: to.Ptr("global"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+	return res.Topic
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: topics
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	client := newTopicsClient(t)
+	ctx := context.Background()
+
+	createTopic(t, client, "rg-team-a", "topic-a1", nil)
+	createTopic(t, client, "rg-team-a", "topic-a2", nil)
+	createTopic(t, client, "rg-team-b", "topic-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := client.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, tp := range page.Value {
+				names = append(names, *tp.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 topics", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "topic-b1" {
+		t.Fatalf("rg-team-b listed %v, want [topic-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// CreateOrUpdate on an existing topic must apply the request's tags, not
+// echo the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	client := newTopicsClient(t)
+	ctx := context.Background()
+
+	createTopic(t, client, testRG, "topic-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createTopic(t, client, testRG, "topic-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := client.Get(ctx, testRG, "topic-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	client := newTopicsClient(t)
+
+	tp := createTopic(t, client, "rg-id-check", "topic-id", nil)
+	if tp.ID == nil {
+		t.Fatal("topic response has no id")
+	}
+	id := *tp.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/fromprovider.go
+++ b/server/azure/fromprovider.go
@@ -1,0 +1,79 @@
+package azure
+
+import (
+	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
+	"github.com/stackshy/cloudemu/v2/server"
+)
+
+// DriversFrom builds a Drivers bundle from a fully-constructed Azure provider,
+// wiring every server driver to the provider's corresponding mock. It lets a
+// standalone binary go from a *azure.Provider to a running server without
+// hand-mapping each field.
+//
+// The compute mock backs virtual machines, disks, snapshots, images and SSH
+// public keys (the compute driver's Volume*/Snapshot*/Image* methods). The
+// Databricks / Azure AI / Azure AI Search mocks each satisfy both the control
+// and data-plane driver interfaces, so a single mock feeds every related field.
+func DriversFrom(p *azureprovider.Provider) Drivers {
+	return Drivers{
+		// Compute mock backs all five compute-derived surfaces.
+		VirtualMachines: p.VirtualMachines,
+		Disks:           p.VirtualMachines,
+		Snapshots:       p.VirtualMachines,
+		Images:          p.VirtualMachines,
+		SSHPublicKeys:   p.VirtualMachines,
+
+		BlobStorage:  p.BlobStorage,
+		QueueStorage: p.QueueStorage,
+		TableStorage: p.TableStorage,
+		CosmosDB:     p.CosmosDB,
+		Network:      p.VNet,
+		Monitor:      p.Monitor,
+		Functions:    p.Functions,
+		ServiceBus:   p.ServiceBus,
+		SQL:          p.SQL,
+		PostgresFlex: p.PostgresFlex,
+		MySQLFlex:    p.MySQLFlex,
+		AKS:          p.AKS,
+		IAM:          p.IAM,
+		ACR:          p.ACR,
+		KeyVault:     p.KeyVault,
+		DNS:          p.DNS,
+		LB:           p.LB,
+		EventGrid:    p.EventGrid,
+		LogAnalytics: p.LogAnalytics,
+		Cache:        p.Cache,
+
+		NotificationHubs: p.NotificationHubs,
+
+		// Databricks mock satisfies both the control and data-plane drivers.
+		// DatabricksDataPlane must be set for registerDatabricksDataPlane to
+		// register the workspace data-plane handlers.
+		Databricks:          p.Databricks,
+		DatabricksDataPlane: p.Databricks,
+
+		// Azure AI mock satisfies CognitiveServices, MachineLearning and the
+		// inference/Assistants data plane.
+		CognitiveServices: p.AzureAI,
+		MachineLearning:   p.AzureAI,
+		AzureAIDataPlane:  p.AzureAI,
+
+		// Azure AI Search mock satisfies both the ARM control plane and the
+		// search data plane.
+		SearchControl:   p.AzureSearch,
+		SearchDataPlane: p.AzureSearch,
+
+		// K8sAPI is a shared handle with no provider source; the standalone
+		// server has no shared cluster by default.
+		K8sAPI: nil, // injected by the caller when a shared cluster is desired
+
+		ResourceDiscovery: p.ResourceDiscovery,
+		SubscriptionID:    p.SubscriptionID,
+	}
+}
+
+// NewFromProvider builds a ready-to-serve Azure server from a fully-constructed
+// provider, wiring every driver via DriversFrom.
+func NewFromProvider(p *azureprovider.Provider) *server.Server {
+	return New(DriversFrom(p))
+}

--- a/server/azure/fromprovider_test.go
+++ b/server/azure/fromprovider_test.go
@@ -1,0 +1,99 @@
+package azure_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const (
+	fpSubID  = "00000000-0000-0000-0000-000000000000"
+	fpRGName = "rg-fp"
+	fpNSName = "ns-fp"
+)
+
+// fakeCred is a static-token credential for tests.
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+// TestNewFromProvider verifies that a server assembled straight from a
+// fully-constructed provider serves a real azure-sdk-for-go ARM call.
+func TestNewFromProvider(t *testing.T) {
+	p := cloudemu.NewAzure()
+
+	srv := azureserver.NewFromProvider(p)
+	if srv == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+
+	// The azure SDK refuses authenticated requests over plain HTTP, so the
+	// endpoint must be TLS (mirrors the existing server/azure roundtrip tests).
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Cloud:     myCloud,
+			Transport: ts.Client(),
+			Retry:     policy.RetryOptions{MaxRetries: -1},
+		},
+	}
+
+	cf, err := armservicebus.NewClientFactory(fpSubID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("ClientFactory: %v", err)
+	}
+
+	client := cf.NewNamespacesClient()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, fpRGName, fpNSName,
+		armservicebus.SBNamespace{
+			Location: to.Ptr("eastus"),
+			SKU: &armservicebus.SBSKU{
+				Name: to.Ptr(armservicebus.SKUNameStandard),
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	if created.Name == nil || *created.Name != fpNSName {
+		t.Fatalf("created.Name = %v, want %s", created.Name, fpNSName)
+	}
+
+	got, err := client.Get(ctx, fpRGName, fpNSName, nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Name == nil || *got.Name != fpNSName {
+		t.Fatalf("got.Name = %v, want %s", got.Name, fpNSName)
+	}
+}

--- a/server/azure/loganalytics/operations.go
+++ b/server/azure/loganalytics/operations.go
@@ -1,6 +1,7 @@
 package loganalytics
 
 import (
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
@@ -8,25 +9,33 @@ import (
 )
 
 // createOrUpdateWorkspace maps Workspaces.CreateOrUpdate onto the logging
-// driver's log-group create. It is idempotent: if the workspace already exists
-// it is echoed back (the driver has no update primitive for retention/tags, so
-// this mirrors CreateOrUpdate's upsert contract for the fields we model).
+// driver: create when absent, otherwise apply the request's mutable fields
+// (retention, tags) via UpdateLogGroup — ARM PUT semantics, so the caller's
+// changes are never silently discarded.
 func (h *Handler) createOrUpdateWorkspace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var req workspaceRequest
 	if !azurearm.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	if info, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName); err == nil {
+	cfg := logdriver.LogGroupConfig{
+		Name:          rp.ResourceName,
+		RetentionDays: req.retentionDays(),
+		Tags:          req.Tags,
+		Scope:         scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
+	}
+
+	if _, err := h.logs.GetLogGroup(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.logs.UpdateLogGroup(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 		azurearm.WriteJSON(w, http.StatusOK, toWorkspaceJSON(rp, info, req.Location))
 		return
 	}
 
-	info, err := h.logs.CreateLogGroup(r.Context(), logdriver.LogGroupConfig{
-		Name:          rp.ResourceName,
-		RetentionDays: req.retentionDays(),
-		Tags:          req.Tags,
-	})
+	info, err := h.logs.CreateLogGroup(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -57,7 +66,8 @@ func (h *Handler) deleteWorkspace(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) listWorkspaces(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	infos, err := h.logs.ListLogGroups(r.Context())
+	infos, err := h.logs.ListLogGroups(r.Context(),
+		scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return

--- a/server/azure/loganalytics/ordering_sdk_test.go
+++ b/server/azure/loganalytics/ordering_sdk_test.go
@@ -1,0 +1,59 @@
+package loganalytics_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	// Create workspaces deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		poller, err := client.BeginCreateOrUpdate(ctx, testRG, name, armoperationalinsights.Workspace{
+			Location: to.Ptr("eastus"),
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreateOrUpdate(%s): %v", name, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := client.NewListByResourceGroupPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("ListByResourceGroup: %v", perr)
+			}
+
+			for _, ws := range page.Value {
+				names = append(names, *ws.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 workspaces", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/loganalytics/scope_update_sdk_test.go
+++ b/server/azure/loganalytics/scope_update_sdk_test.go
@@ -1,0 +1,103 @@
+package loganalytics_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/operationalinsights/armoperationalinsights"
+)
+
+func createWS(t *testing.T, client *armoperationalinsights.WorkspacesClient, rg, name string, tags map[string]*string) armoperationalinsights.Workspace {
+	t.Helper()
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, rg, name, armoperationalinsights.Workspace{
+		Location: to.Ptr("eastus"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+	res, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+	return res.Workspace
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: workspaces
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	createWS(t, client, "rg-team-a", "ws-a1", nil)
+	createWS(t, client, "rg-team-a", "ws-a2", nil)
+	createWS(t, client, "rg-team-b", "ws-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := client.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, ws := range page.Value {
+				names = append(names, *ws.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 workspaces", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "ws-b1" {
+		t.Fatalf("rg-team-b listed %v, want [ws-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// CreateOrUpdate on an existing workspace must apply the request's tags,
+// not echo the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	client := newWorkspacesClient(t)
+	ctx := context.Background()
+
+	createWS(t, client, testRG, "ws-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createWS(t, client, testRG, "ws-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := client.Get(ctx, testRG, "ws-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	client := newWorkspacesClient(t)
+
+	ws := createWS(t, client, "rg-id-check", "ws-id", nil)
+	if ws.ID == nil {
+		t.Fatal("workspace response has no id")
+	}
+	id := *ws.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/notificationhubs/operations.go
+++ b/server/azure/notificationhubs/operations.go
@@ -6,27 +6,43 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
+
+// rpScope is the resource scope carried by the request path.
+func rpScope(rp *azurearm.ResourcePath) scope.Scope {
+	return scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup}
+}
 
 // --- namespaces ---
 
-// createOrUpdateNamespace maps Namespaces.CreateOrUpdate to the driver.
-// CreateOrUpdate is idempotent: if the namespace already exists, echo it back.
+// createOrUpdateNamespace maps Namespaces.CreateOrUpdate onto the driver:
+// create when absent, otherwise apply the request's mutable fields (tags) via
+// UpdateTopic — ARM PUT semantics, so the caller's changes are never silently
+// discarded.
 func (h *Handler) createOrUpdateNamespace(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body putBody
 	if !azurearm.DecodeJSON(w, r, &body) {
 		return
 	}
 
-	if info, err := h.notif.GetTopic(r.Context(), rp.ResourceName); err == nil {
+	cfg := notifdriver.TopicConfig{
+		Name:  rp.ResourceName,
+		Tags:  body.Tags,
+		Scope: rpScope(rp),
+	}
+
+	if _, err := h.notif.GetTopic(r.Context(), rp.ResourceName); err == nil {
+		info, uerr := h.notif.UpdateTopic(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 		azurearm.WriteJSON(w, http.StatusOK, toNamespaceJSON(rp, info))
 		return
 	}
 
-	info, err := h.notif.CreateTopic(r.Context(), notifdriver.TopicConfig{
-		Name: rp.ResourceName,
-		Tags: body.Tags,
-	})
+	info, err := h.notif.CreateTopic(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -55,7 +71,7 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request, rp *az
 	}
 
 	// Best-effort cleanup of nested hub topics.
-	for _, name := range h.hubTopicNames(r, rp.ResourceName) {
+	for _, name := range h.hubTopicNames(r, rp) {
 		_ = h.notif.DeleteTopic(r.Context(), name)
 	}
 
@@ -63,7 +79,7 @@ func (h *Handler) deleteNamespace(w http.ResponseWriter, r *http.Request, rp *az
 }
 
 func (h *Handler) listNamespaces(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), rpScope(rp))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -98,16 +114,24 @@ func (h *Handler) createOrUpdateHub(w http.ResponseWriter, r *http.Request, rp *
 		ttl = body.Properties.RegistrationTTL
 	}
 
-	if info, err := h.notif.GetTopic(r.Context(), key); err == nil {
+	cfg := notifdriver.TopicConfig{
+		Name:        key,
+		DisplayName: ttl,
+		Tags:        body.Tags,
+		Scope:       rpScope(rp),
+	}
+
+	if _, err := h.notif.GetTopic(r.Context(), key); err == nil {
+		info, uerr := h.notif.UpdateTopic(r.Context(), cfg)
+		if uerr != nil {
+			azurearm.WriteCErr(w, uerr)
+			return
+		}
 		azurearm.WriteJSON(w, http.StatusOK, toHubJSON(rp, rp.ResourceName, rp.SubResourceName, info))
 		return
 	}
 
-	info, err := h.notif.CreateTopic(r.Context(), notifdriver.TopicConfig{
-		Name:        key,
-		DisplayName: ttl,
-		Tags:        body.Tags,
-	})
+	info, err := h.notif.CreateTopic(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -136,7 +160,7 @@ func (h *Handler) deleteHub(w http.ResponseWriter, r *http.Request, rp *azurearm
 }
 
 func (h *Handler) listHubs(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
-	topics, err := h.notif.ListTopics(r.Context())
+	topics, err := h.notif.ListTopics(r.Context(), rpScope(rp))
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
@@ -159,14 +183,14 @@ func (h *Handler) listHubs(w http.ResponseWriter, r *http.Request, rp *azurearm.
 }
 
 // hubTopicNames returns the driver topic keys of every hub nested under the
-// given namespace.
-func (h *Handler) hubTopicNames(r *http.Request, namespace string) []string {
-	topics, err := h.notif.ListTopics(r.Context())
+// namespace named by the request path.
+func (h *Handler) hubTopicNames(r *http.Request, rp *azurearm.ResourcePath) []string {
+	topics, err := h.notif.ListTopics(r.Context(), rpScope(rp))
 	if err != nil {
 		return nil
 	}
 
-	prefix := namespace + hubKeySep
+	prefix := rp.ResourceName + hubKeySep
 
 	var names []string
 	for i := range topics {

--- a/server/azure/notificationhubs/ordering_sdk_test.go
+++ b/server/azure/notificationhubs/ordering_sdk_test.go
@@ -1,0 +1,54 @@
+package notificationhubs_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs"
+)
+
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	namespaces, _ := newClients(t)
+	ctx := context.Background()
+
+	// Create namespaces deliberately out of alphabetical order.
+	for _, name := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := namespaces.CreateOrUpdate(ctx, testRG, name, armnotificationhubs.NamespaceCreateOrUpdateParameters{
+			Location: to.Ptr("global"),
+		}, nil); err != nil {
+			t.Fatalf("Namespaces.CreateOrUpdate(%s): %v", name, err)
+		}
+	}
+
+	listNames := func() []string {
+		var names []string
+
+		pager := namespaces.NewListPager(testRG, nil)
+		for pager.More() {
+			page, perr := pager.NextPage(ctx)
+			if perr != nil {
+				t.Fatalf("Namespaces.List: %v", perr)
+			}
+
+			for _, ns := range page.Value {
+				names = append(names, *ns.Name)
+			}
+		}
+
+		return names
+	}
+
+	first := listNames()
+	if len(first) != 5 {
+		t.Fatalf("first list = %v, want 5 namespaces", first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listNames()
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("list #%d order = %v, want %v", i+2, got, first)
+		}
+	}
+}

--- a/server/azure/notificationhubs/scope_update_sdk_test.go
+++ b/server/azure/notificationhubs/scope_update_sdk_test.go
@@ -1,0 +1,100 @@
+package notificationhubs_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/notificationhubs/armnotificationhubs"
+)
+
+func createNS(t *testing.T, client *armnotificationhubs.NamespacesClient, rg, name string, tags map[string]*string) armnotificationhubs.NamespaceResource {
+	t.Helper()
+	ctx := context.Background()
+
+	res, err := client.CreateOrUpdate(ctx, rg, name, armnotificationhubs.NamespaceCreateOrUpdateParameters{
+		Location: to.Ptr("global"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("Namespaces.CreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+
+	return res.NamespaceResource
+}
+
+// TestSDKScopedListing asserts #259 item 1 through the real SDK: namespaces
+// created in one resource group must not appear in another group's list.
+func TestSDKScopedListing(t *testing.T) {
+	namespaces, _ := newClients(t)
+	ctx := context.Background()
+
+	createNS(t, namespaces, "rg-team-a", "ns-a1", nil)
+	createNS(t, namespaces, "rg-team-a", "ns-a2", nil)
+	createNS(t, namespaces, "rg-team-b", "ns-b1", nil)
+
+	listRG := func(rg string) []string {
+		var names []string
+		pager := namespaces.NewListPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, ns := range page.Value {
+				names = append(names, *ns.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-team-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-team-a listed %v, want exactly its own 2 namespaces", gotA)
+	}
+	gotB := listRG("rg-team-b")
+	if len(gotB) != 1 || gotB[0] != "ns-b1" {
+		t.Fatalf("rg-team-b listed %v, want [ns-b1]", gotB)
+	}
+}
+
+// TestSDKUpsertAppliesUpdates asserts #259 item 2 through the real SDK:
+// CreateOrUpdate on an existing namespace must apply the request's tags,
+// not echo the stale resource.
+func TestSDKUpsertAppliesUpdates(t *testing.T) {
+	namespaces, _ := newClients(t)
+	ctx := context.Background()
+
+	createNS(t, namespaces, testRG, "ns-upsert", map[string]*string{"env": to.Ptr("dev")})
+
+	updated := createNS(t, namespaces, testRG, "ns-upsert",
+		map[string]*string{"env": to.Ptr("prod"), "team": to.Ptr("core")})
+	if updated.Tags["env"] == nil || *updated.Tags["env"] != "prod" {
+		t.Fatalf("upsert response tags = %v, want env=prod applied", updated.Tags)
+	}
+
+	got, err := namespaces.Get(ctx, testRG, "ns-upsert", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" || got.Tags["team"] == nil {
+		t.Fatalf("stored tags = %v, want env=prod team=core (CreateOrUpdate must not discard updates)", got.Tags)
+	}
+}
+
+// TestSDKResourceIDMatchesRequestScope asserts #259 item 4 through the real
+// SDK: the returned ARM id carries the request's subscription and resource
+// group, not a hardcoded default.
+func TestSDKResourceIDMatchesRequestScope(t *testing.T) {
+	namespaces, _ := newClients(t)
+
+	ns := createNS(t, namespaces, "rg-id-check", "ns-id", nil)
+	if ns.ID == nil {
+		t.Fatal("namespace response has no id")
+	}
+	id := *ns.ID
+	if !strings.Contains(id, "/subscriptions/"+testSub+"/") || !strings.Contains(id, "/resourceGroups/rg-id-check/") {
+		t.Fatalf("id = %q, want it under subscription %q and resource group rg-id-check", id, testSub)
+	}
+}

--- a/server/azure/servicebus/handler.go
+++ b/server/azure/servicebus/handler.go
@@ -27,12 +27,15 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 const (
@@ -46,12 +49,13 @@ const (
 
 // Handler serves ARM Service Bus + raw-HTTP data-plane requests.
 type Handler struct {
-	mq mqdriver.MessageQueue
+	mq         mqdriver.MessageQueue
+	namespaces *memstore.Store[namespaceState]
 }
 
 // New returns a Service Bus handler backed by mq.
 func New(mq mqdriver.MessageQueue) *Handler {
-	return &Handler{mq: mq}
+	return &Handler{mq: mq, namespaces: memstore.New[namespaceState]()}
 }
 
 // Matches accepts ARM Microsoft.ServiceBus/namespaces[...] paths plus
@@ -84,7 +88,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// /providers/Microsoft.ServiceBus/namespaces (subscription-level list)
 	if rp.ResourceName == "" {
-		h.listNamespaces(w, r)
+		h.listNamespaces(w, rp)
 		return
 	}
 
@@ -146,7 +150,7 @@ func (h *Handler) serveQueue(w http.ResponseWriter, r *http.Request, rp azurearm
 // ---------- Namespace control plane ----------
 
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
+func (h *Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azurearm.ResourcePath) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 
 	var req createNamespaceRequest
@@ -160,45 +164,91 @@ func (*Handler) createNamespace(w http.ResponseWriter, r *http.Request, rp azure
 		location = "eastus"
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, namespaceResource{
-		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
-			providerName, resourceType, rp.ResourceName),
-		Name:     rp.ResourceName,
-		Type:     providerName + "/" + resourceType,
-		Location: location,
-		Properties: namespaceProperties{
-			ProvisioningState:  "Succeeded",
-			ServiceBusEndpoint: "https://" + rp.ResourceName + ".servicebus.windows.net:443/",
-		},
-		SKU: req.SKU,
-	})
+	// PUT is create-or-update: store (and thus overwrite) the record so the
+	// request's tags and SKU are applied, mirroring ARM CreateOrUpdate.
+	ns := namespaceState{
+		Name:          rp.ResourceName,
+		Location:      location,
+		Subscription:  rp.Subscription,
+		ResourceGroup: rp.ResourceGroup,
+		Tags:          maps.Clone(req.Tags),
+		SKU:           cloneSKU(req.SKU),
+	}
+	h.namespaces.Set(rp.ResourceName, ns)
+
+	azurearm.WriteJSON(w, http.StatusOK, toNamespaceResource(ns))
 }
 
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) getNamespace(w http.ResponseWriter, _ *http.Request, rp azurearm.ResourcePath) {
-	// Namespaces are virtual — there's no driver state. Always return Succeeded.
-	azurearm.WriteJSON(w, http.StatusOK, namespaceResource{
-		ID: azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup,
-			providerName, resourceType, rp.ResourceName),
-		Name:     rp.ResourceName,
-		Type:     providerName + "/" + resourceType,
-		Location: "eastus",
-		Properties: namespaceProperties{
-			ProvisioningState:  "Succeeded",
-			ServiceBusEndpoint: "https://" + rp.ResourceName + ".servicebus.windows.net:443/",
-		},
-	})
+func (h *Handler) getNamespace(w http.ResponseWriter, _ *http.Request, rp azurearm.ResourcePath) {
+	ns, ok := h.namespaces.Get(rp.ResourceName)
+	if !ok || !namespaceInScope(ns, rp) {
+		azurearm.WriteError(w, http.StatusNotFound, "ResourceNotFound",
+			"namespace not found: "+rp.ResourceName)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toNamespaceResource(ns))
 }
 
 //nolint:gocritic // rp is a request-scoped value
-func (*Handler) deleteNamespace(w http.ResponseWriter, _ azurearm.ResourcePath) {
-	// Virtual namespace: nothing to free.
+func (h *Handler) deleteNamespace(w http.ResponseWriter, rp azurearm.ResourcePath) {
+	// Delete only if the namespace actually lives under the path's
+	// subscription/resource group — a wrong-scope delete must not remove it.
+	if ns, ok := h.namespaces.Get(rp.ResourceName); ok && namespaceInScope(ns, rp) {
+		h.namespaces.Delete(rp.ResourceName)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
-func (*Handler) listNamespaces(w http.ResponseWriter, _ *http.Request) {
-	// We don't track namespaces in the driver; return an empty list.
-	azurearm.WriteJSON(w, http.StatusOK, listResponse{Value: []any{}})
+// cloneSKU copies the SKU so stored state never aliases the decoded request.
+func cloneSKU(s *sbSKU) *sbSKU {
+	if s == nil {
+		return nil
+	}
+	c := *s
+	return &c
+}
+
+// namespaceInScope reports whether the stored namespace belongs to the
+// subscription and resource group named in the request path. A named-resource
+// path always carries both, so this is an exact match.
+func namespaceInScope(ns namespaceState, rp azurearm.ResourcePath) bool {
+	nsScope := scope.Scope{Subscription: ns.Subscription, ResourceGroup: ns.ResourceGroup}
+	return nsScope.Matches(scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup})
+}
+
+//nolint:gocritic // rp is a request-scoped value
+func (h *Handler) listNamespaces(w http.ResponseWriter, rp azurearm.ResourcePath) {
+	// The same route serves subscription-level and resource-group-level lists;
+	// filter by whatever the request path carries (an empty resource group
+	// matches every group in the subscription).
+	out := listResponse{Value: []any{}}
+	for _, ns := range h.namespaces.SortedValues() {
+		if !namespaceInScope(ns, rp) {
+			continue
+		}
+		out.Value = append(out.Value, toNamespaceResource(ns))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// toNamespaceResource renders stored namespace state as the ARM JSON shape.
+func toNamespaceResource(ns namespaceState) namespaceResource {
+	return namespaceResource{
+		ID: azurearm.BuildResourceID(ns.Subscription, ns.ResourceGroup,
+			providerName, resourceType, ns.Name),
+		Name:     ns.Name,
+		Type:     providerName + "/" + resourceType,
+		Location: ns.Location,
+		Tags:     ns.Tags,
+		Properties: namespaceProperties{
+			ProvisioningState:  "Succeeded",
+			ServiceBusEndpoint: "https://" + ns.Name + ".servicebus.windows.net:443/",
+		},
+		SKU: ns.SKU,
+	}
 }
 
 // ---------- Queue control plane ----------

--- a/server/azure/servicebus/namespace_sdk_test.go
+++ b/server/azure/servicebus/namespace_sdk_test.go
@@ -1,0 +1,130 @@
+package servicebus_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/servicebus/armservicebus/v2"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newNamespacesClient(t *testing.T, ts *httptest.Server) *armservicebus.NamespacesClient {
+	t.Helper()
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+	opts := &arm.ClientOptions{ClientOptions: azcore.ClientOptions{
+		Cloud: myCloud, Transport: ts.Client(),
+		Retry: policy.RetryOptions{MaxRetries: -1},
+	}}
+
+	cf, err := armservicebus.NewClientFactory(subID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("ClientFactory: %v", err)
+	}
+	return cf.NewNamespacesClient()
+}
+
+func createNS(t *testing.T, c *armservicebus.NamespacesClient, rg, name string, tags map[string]*string) {
+	t.Helper()
+	ctx := context.Background()
+	poller, err := c.BeginCreateOrUpdate(ctx, rg, name, armservicebus.SBNamespace{
+		Location: to.Ptr("eastus"),
+		Tags:     tags,
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate %s/%s: %v", rg, name, err)
+	}
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("poll %s/%s: %v", rg, name, err)
+	}
+}
+
+// TestSDKNamespaceTagsAndScopedListing is the regression for #278: namespaces
+// created with tags must return them on Get, and ListByResourceGroup must
+// return only the namespaces in that resource group.
+func TestSDKNamespaceTagsAndScopedListing(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{ServiceBus: cloudP.ServiceBus})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	c := newNamespacesClient(t, ts)
+	ctx := context.Background()
+
+	createNS(t, c, "rg-a", "ns-a", map[string]*string{"env": to.Ptr("prod")})
+	createNS(t, c, "rg-a", "ns-a2", nil)
+	createNS(t, c, "rg-b", "ns-b", nil)
+
+	// Tags survive create → Get.
+	got, err := c.Get(ctx, "rg-a", "ns-a", nil)
+	if err != nil {
+		t.Fatalf("Get ns-a: %v", err)
+	}
+	if got.Tags["env"] == nil || *got.Tags["env"] != "prod" {
+		t.Fatalf("ns-a tags = %v, want env=prod", got.Tags)
+	}
+
+	// ListByResourceGroup is scoped to its resource group.
+	listRG := func(rg string) []string {
+		var names []string
+		pager := c.NewListByResourceGroupPager(rg, nil)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("list %s: %v", rg, err)
+			}
+			for _, ns := range page.Value {
+				names = append(names, *ns.Name)
+			}
+		}
+		return names
+	}
+
+	gotA := listRG("rg-a")
+	if len(gotA) != 2 {
+		t.Fatalf("rg-a list = %v, want its own 2 namespaces", gotA)
+	}
+	gotB := listRG("rg-b")
+	if len(gotB) != 1 || gotB[0] != "ns-b" {
+		t.Fatalf("rg-b list = %v, want [ns-b]", gotB)
+	}
+
+	// Get from the wrong resource group must 404 — ns-a lives in rg-a.
+	if _, err := c.Get(ctx, "rg-b", "ns-a", nil); err == nil {
+		t.Fatal("Get ns-a via rg-b returned nil error, want NotFound")
+	}
+
+	// Delete from the wrong resource group must not remove the namespace.
+	wrongDel, err := c.BeginDelete(ctx, "rg-b", "ns-a", nil)
+	if err == nil {
+		_, _ = wrongDel.PollUntilDone(ctx, nil)
+	}
+	if _, err := c.Get(ctx, "rg-a", "ns-a", nil); err != nil {
+		t.Fatalf("ns-a should survive a wrong-group delete, but Get failed: %v", err)
+	}
+
+	// A deleted namespace disappears from Get.
+	delPoller, err := c.BeginDelete(ctx, "rg-b", "ns-b", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete ns-b: %v", err)
+	}
+	if _, err := delPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Delete ns-b: %v", err)
+	}
+	if _, err := c.Get(ctx, "rg-b", "ns-b", nil); err == nil {
+		t.Fatal("Get after delete returned nil error, want NotFound")
+	}
+}

--- a/server/azure/servicebus/types.go
+++ b/server/azure/servicebus/types.go
@@ -6,8 +6,22 @@ type namespaceResource struct {
 	Name       string              `json:"name"`
 	Type       string              `json:"type"`
 	Location   string              `json:"location"`
+	Tags       map[string]string   `json:"tags,omitempty"`
 	Properties namespaceProperties `json:"properties"`
 	SKU        *sbSKU              `json:"sku,omitempty"`
+}
+
+// namespaceState is the stored control-plane record for a namespace. Namespaces
+// are Azure-only ARM containers with no portable-driver equivalent, so their
+// state lives here on the handler. Keyed by name (namespace names are globally
+// unique in Azure).
+type namespaceState struct {
+	Name          string
+	Location      string
+	Subscription  string
+	ResourceGroup string
+	Tags          map[string]string
+	SKU           *sbSKU
 }
 
 type namespaceProperties struct {
@@ -52,6 +66,7 @@ type createQueueRequest struct {
 
 // createNamespaceRequest is what we read from a PUT /namespaces/{ns} body.
 type createNamespaceRequest struct {
-	Location string `json:"location"`
-	SKU      *sbSKU `json:"sku,omitempty"`
+	Location string            `json:"location"`
+	Tags     map[string]string `json:"tags,omitempty"`
+	SKU      *sbSKU            `json:"sku,omitempty"`
 }

--- a/server/gcp/clouddns/operations.go
+++ b/server/gcp/clouddns/operations.go
@@ -6,9 +6,10 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
-func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
+func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, rt route) {
 	var req managedZoneJSON
 	if !gcprest.DecodeJSON(w, r, &req) {
 		return
@@ -18,6 +19,7 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
 		Name:    req.Name,
 		Private: privateFor(req.Visibility),
 		Tags:    req.Labels,
+		Scope:   scope.Scope{Project: rt.project},
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -28,7 +30,7 @@ func (h *Handler) createZone(w http.ResponseWriter, r *http.Request, _ route) {
 }
 
 func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rt route) {
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -43,8 +45,8 @@ func (h *Handler) getZone(w http.ResponseWriter, r *http.Request, rt route) {
 	gcprest.WriteJSON(w, http.StatusOK, toManagedZoneJSON(info))
 }
 
-func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, _ route) {
-	infos, err := h.dns.ListZones(r.Context())
+func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, rt route) {
+	infos, err := h.dns.ListZones(r.Context(), scope.Scope{Project: rt.project})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -62,7 +64,7 @@ func (h *Handler) listZones(w http.ResponseWriter, r *http.Request, _ route) {
 }
 
 func (h *Handler) deleteZone(w http.ResponseWriter, r *http.Request, rt route) {
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -86,7 +88,7 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 		return
 	}
 
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return
@@ -149,7 +151,7 @@ func (h *Handler) createChange(w http.ResponseWriter, r *http.Request, rt route)
 }
 
 func (h *Handler) listRRSets(w http.ResponseWriter, r *http.Request, rt route) {
-	id, err := h.resolveZoneID(r.Context(), rt.zone)
+	id, err := h.resolveZoneID(r.Context(), rt.project, rt.zone)
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/clouddns/ordering_sdk_test.go
+++ b/server/gcp/clouddns/ordering_sdk_test.go
@@ -1,0 +1,61 @@
+package clouddns_test
+
+import (
+	"context"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: ManagedZones.List must return the same sequence of zone names on
+// every call, regardless of the order the zones were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	// Create five zones in a deliberately non-sorted order.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.ManagedZones.Create(testProject, &dns.ManagedZone{
+			Name:    id,
+			DnsName: id + ".example.com.",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("ManagedZones.Create(%s): %v", id, err)
+		}
+	}
+
+	listZones := func() []string {
+		var names []string
+
+		call := svc.ManagedZones.List(testProject).Context(ctx)
+		if err := call.Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+			for _, z := range page.ManagedZones {
+				names = append(names, z.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("ManagedZones.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listZones()
+	if len(first) != 5 {
+		t.Fatalf("got %d zones, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listZones()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d zones, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/clouddns/scope_update_sdk_test.go
+++ b/server/gcp/clouddns/scope_update_sdk_test.go
@@ -1,0 +1,128 @@
+package clouddns_test
+
+import (
+	"context"
+	"testing"
+
+	dns "google.golang.org/api/dns/v1"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/gcp/clouddns"
+	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
+
+// TestSDKZonesScopedByProject verifies that Cloud DNS zone listing is isolated
+// per project: a real dns.Service pointed at the emulator and listing under
+// project A must return only A's zones, never zones created under project B.
+// The handler records each zone's scope from the {project} path segment at
+// create time and filters ManagedZones.List on it.
+func TestSDKZonesScopedByProject(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	const projectA = "project-a"
+	const projectB = "project-b"
+
+	// The dns.Service is endpoint-pinned, not project-pinned: the project is a
+	// per-call path segment, so two project paths exercise the isolation.
+	for _, name := range []string{"a-one", "a-two"} {
+		if _, err := svc.ManagedZones.Create(projectA, &dns.ManagedZone{
+			Name:    name,
+			DnsName: name + ".a.example.com.",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s/%s): %v", projectA, name, err)
+		}
+	}
+
+	for _, name := range []string{"b-one", "b-two", "b-three"} {
+		if _, err := svc.ManagedZones.Create(projectB, &dns.ManagedZone{
+			Name:    name,
+			DnsName: name + ".b.example.com.",
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Create(%s/%s): %v", projectB, name, err)
+		}
+	}
+
+	listNames := func(project string) []string {
+		var names []string
+
+		call := svc.ManagedZones.List(project).Context(ctx)
+		if err := call.Pages(ctx, func(page *dns.ManagedZonesListResponse) error {
+			for _, z := range page.ManagedZones {
+				names = append(names, z.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("List(%s): %v", project, err)
+		}
+
+		return names
+	}
+
+	gotA := listNames(projectA)
+	if len(gotA) != 2 {
+		t.Fatalf("project A list = %v, want exactly its 2 zones", gotA)
+	}
+	for _, n := range gotA {
+		if n != "a-one" && n != "a-two" {
+			t.Fatalf("project A list leaked zone %q from another project: %v", n, gotA)
+		}
+	}
+
+	gotB := listNames(projectB)
+	if len(gotB) != 3 {
+		t.Fatalf("project B list = %v, want exactly its 3 zones", gotB)
+	}
+	for _, n := range gotB {
+		if n != "b-one" && n != "b-two" && n != "b-three" {
+			t.Fatalf("project B list leaked zone %q from another project: %v", n, gotB)
+		}
+	}
+}
+
+// TestUpdateZoneProviderLevel exercises the driver's UpdateZone directly, since
+// Cloud DNS zone create is not an upsert and the wire has no update path. It
+// must match an existing zone by name, apply tags and scope, and return the
+// updated copy — NotFound when the zone is absent.
+func TestUpdateZoneProviderLevel(t *testing.T) {
+	ctx := context.Background()
+
+	opts := config.NewOptions(config.WithProjectID("test-project"))
+	m := clouddns.New(opts)
+
+	if _, err := m.CreateZone(ctx, dnsdriver.ZoneConfig{
+		Name: "up.example.com",
+		Tags: map[string]string{"env": "old"},
+	}); err != nil {
+		t.Fatalf("CreateZone: %v", err)
+	}
+
+	updated, err := m.UpdateZone(ctx, dnsdriver.ZoneConfig{
+		Name:  "up.example.com",
+		Tags:  map[string]string{"env": "new", "team": "dns"},
+		Scope: scope.Scope{Project: "project-x"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateZone: %v", err)
+	}
+
+	if updated.Tags["env"] != "new" || updated.Tags["team"] != "dns" {
+		t.Fatalf("tags not applied: %v", updated.Tags)
+	}
+	if updated.Scope.Project != "project-x" {
+		t.Fatalf("scope not applied: %+v", updated.Scope)
+	}
+
+	got, err := m.GetZone(ctx, updated.ID)
+	if err != nil {
+		t.Fatalf("GetZone: %v", err)
+	}
+	if got.Tags["env"] != "new" || got.Scope.Project != "project-x" {
+		t.Fatalf("update not persisted: tags=%v scope=%+v", got.Tags, got.Scope)
+	}
+
+	if _, err := m.UpdateZone(ctx, dnsdriver.ZoneConfig{Name: "missing.example.com"}); err == nil {
+		t.Fatal("UpdateZone(missing): expected NotFound error, got nil")
+	}
+}

--- a/server/gcp/clouddns/sdk_roundtrip_test.go
+++ b/server/gcp/clouddns/sdk_roundtrip_test.go
@@ -193,3 +193,20 @@ func TestSDKCloudDNSErrors(t *testing.T) {
 		t.Fatalf("Changes.Create(missing zone): got %v, want 404", err)
 	}
 }
+
+// TestSDKCloudDNSDuplicateZoneName asserts a managed-zone name must be unique
+// within a project: creating the same name twice fails the second time.
+func TestSDKCloudDNSDuplicateZoneName(t *testing.T) {
+	svc := newDNSService(t)
+	ctx := context.Background()
+
+	zone := &dns.ManagedZone{Name: "dup-zone", DnsName: "dup.example.com.", Visibility: "public"}
+	if _, err := svc.ManagedZones.Create(testProject, zone).Context(ctx).Do(); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	_, err := svc.ManagedZones.Create(testProject, zone).Context(ctx).Do()
+	if err == nil {
+		t.Fatal("second Create of the same managed-zone name returned nil error, want a conflict")
+	}
+}

--- a/server/gcp/clouddns/types.go
+++ b/server/gcp/clouddns/types.go
@@ -7,6 +7,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Kind values Cloud DNS stamps on its resources; the SDK tolerates them being
@@ -116,8 +117,8 @@ func toRecordSetJSON(rec *dnsdriver.RecordInfo) resourceRecordSetJSON {
 // name or its numeric id there, so both are matched (the numeric id is the
 // FNV-folded value this handler hands back as ManagedZone.Id). Returns NotFound
 // if no zone matches.
-func (h *Handler) resolveZoneID(ctx context.Context, nameOrID string) (string, error) {
-	zones, err := h.dns.ListZones(ctx)
+func (h *Handler) resolveZoneID(ctx context.Context, project, nameOrID string) (string, error) {
+	zones, err := h.dns.ListZones(ctx, scope.Scope{Project: project})
 	if err != nil {
 		return "", err
 	}

--- a/server/gcp/cloudlogging/operations.go
+++ b/server/gcp/cloudlogging/operations.go
@@ -2,6 +2,7 @@ package cloudlogging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"net/http"
 	"time"
 
@@ -115,7 +116,7 @@ func (h *Handler) listEntries(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listLogs(w http.ResponseWriter, r *http.Request) {
 	project := projectFromPath(r.URL.Path)
 
-	infos, err := h.logs.ListLogGroups(r.Context())
+	infos, err := h.logs.ListLogGroups(r.Context(), scope.Scope{Project: project})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/cloudlogging/ordering_sdk_test.go
+++ b/server/gcp/cloudlogging/ordering_sdk_test.go
@@ -1,0 +1,62 @@
+package cloudlogging_test
+
+import (
+	"context"
+	"testing"
+
+	logging "google.golang.org/api/logging/v2"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: Projects.Logs.List must return the same sequence of log names on
+// every call, regardless of the order the logs were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newLoggingService(t)
+	ctx := context.Background()
+
+	// Create five logs in a deliberately non-sorted order; a write lazily
+	// creates the log group.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.Entries.Write(&logging.WriteLogEntriesRequest{
+			LogName: "projects/" + testProject + "/logs/" + id,
+			Entries: []*logging.LogEntry{
+				{TextPayload: "entry for " + id},
+			},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Entries.Write(%s): %v", id, err)
+		}
+	}
+
+	listLogs := func() []string {
+		var names []string
+
+		call := svc.Projects.Logs.List("projects/" + testProject).Context(ctx)
+		if err := call.Pages(ctx, func(page *logging.ListLogsResponse) error {
+			names = append(names, page.LogNames...)
+			return nil
+		}); err != nil {
+			t.Fatalf("Projects.Logs.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listLogs()
+	if len(first) != 5 {
+		t.Fatalf("got %d logs, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listLogs()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d logs, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/eventarc/operations.go
+++ b/server/gcp/eventarc/operations.go
@@ -6,6 +6,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *route) {
@@ -24,7 +25,7 @@ func (h *Handler) createTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 
 	// Auto-provision the location's backing event bus on first use. Ignore an
 	// already-exists error so concurrent/repeat creates are idempotent.
-	if err := h.ensureChannel(r, bus); err != nil {
+	if err := h.ensureChannel(r, rt, bus); err != nil {
 		gcprest.WriteCErr(w, err)
 		return
 	}
@@ -109,13 +110,17 @@ func (h *Handler) deleteTrigger(w http.ResponseWriter, r *http.Request, rt *rout
 }
 
 // ensureChannel creates the location's backing event bus if it does not already
-// exist. An already-exists result is treated as success.
-func (h *Handler) ensureChannel(r *http.Request, bus string) error {
+// exist, recording the request's project as its scope. An already-exists result
+// is treated as success.
+func (h *Handler) ensureChannel(r *http.Request, rt *route, bus string) error {
 	if _, err := h.bus.GetEventBus(r.Context(), bus); err == nil {
 		return nil
 	}
 
-	_, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{Name: bus})
+	_, err := h.bus.CreateEventBus(r.Context(), ebdriver.EventBusConfig{
+		Name:  bus,
+		Scope: scope.Scope{Project: rt.project},
+	})
 	if err != nil && !cerrors.IsAlreadyExists(err) {
 		return err
 	}

--- a/server/gcp/eventarc/ordering_sdk_test.go
+++ b/server/gcp/eventarc/ordering_sdk_test.go
@@ -1,0 +1,68 @@
+package eventarc_test
+
+import (
+	"context"
+	"testing"
+
+	eventarc "google.golang.org/api/eventarc/v1"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: Triggers.List must return the same sequence of trigger names on
+// every call, regardless of the order the triggers were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newEventarcService(t)
+	ctx := context.Background()
+
+	// Create five triggers in a deliberately non-sorted order.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		trigger := &eventarc.Trigger{
+			EventFilters: []*eventarc.EventFilter{
+				{Attribute: "type", Value: "google.cloud.storage.object.v1.finalized"},
+			},
+			Destination: &eventarc.Destination{
+				CloudRun: &eventarc.CloudRun{Service: "svc-" + id, Region: testLocation},
+			},
+		}
+
+		if _, err := svc.Projects.Locations.Triggers.Create(parent(), trigger).
+			TriggerId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Triggers.Create(%s): %v", id, err)
+		}
+	}
+
+	listTriggers := func() []string {
+		var names []string
+
+		call := svc.Projects.Locations.Triggers.List(parent()).Context(ctx)
+		if err := call.Pages(ctx, func(page *eventarc.ListTriggersResponse) error {
+			for _, tr := range page.Triggers {
+				names = append(names, tr.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("Triggers.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listTriggers()
+	if len(first) != 5 {
+		t.Fatalf("got %d triggers, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listTriggers()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d triggers, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/fcm/ordering_sdk_test.go
+++ b/server/gcp/fcm/ordering_sdk_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stackshy/cloudemu/v2"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // newFCMServiceWithDriver mirrors newFCMService but also returns the backing
@@ -59,7 +60,7 @@ func TestSDKListOrderingDeterministic(t *testing.T) {
 	}
 
 	listTopics := func() []string {
-		topics, err := driver.ListTopics(ctx)
+		topics, err := driver.ListTopics(ctx, scope.Scope{})
 		if err != nil {
 			t.Fatalf("ListTopics: %v", err)
 		}

--- a/server/gcp/fcm/ordering_sdk_test.go
+++ b/server/gcp/fcm/ordering_sdk_test.go
@@ -1,0 +1,93 @@
+package fcm_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	fcm "google.golang.org/api/fcm/v1"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// newFCMServiceWithDriver mirrors newFCMService but also returns the backing
+// notification driver. FCM v1 is a send-only API with no ListTopics on the
+// wire, so ordering of the topics the handler auto-provisions is observed
+// through the driver.
+func newFCMServiceWithDriver(t *testing.T) (*fcm.Service, notifdriver.Notification) {
+	t.Helper()
+
+	cloud := cloudemu.NewGCP()
+	srv := gcpserver.New(gcpserver.Drivers{FCM: cloud.FCM})
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := fcm.NewService(context.Background(),
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		t.Fatalf("fcm.NewService: %v", err)
+	}
+
+	return svc, cloud.FCM
+}
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix for FCM:
+// sending to five topics via the real SDK auto-provisions them, and listing
+// the topics must return the same sequence on every call, regardless of the
+// order the topics were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc, driver := newFCMServiceWithDriver(t)
+	ctx := context.Background()
+
+	// Sends to five topics in a deliberately non-sorted order; each send
+	// auto-provisions its topic.
+	for _, topic := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.Projects.Messages.Send("projects/"+testProject, &fcm.SendMessageRequest{
+			Message: &fcm.Message{
+				Topic: topic,
+				Data:  map[string]string{"k": "v"},
+			},
+		}).Context(ctx).Do(); err != nil {
+			t.Fatalf("Messages.Send(%s): %v", topic, err)
+		}
+	}
+
+	listTopics := func() []string {
+		topics, err := driver.ListTopics(ctx)
+		if err != nil {
+			t.Fatalf("ListTopics: %v", err)
+		}
+
+		names := make([]string, 0, len(topics))
+		for _, tp := range topics {
+			names = append(names, tp.Name)
+		}
+
+		return names
+	}
+
+	first := listTopics()
+	if len(first) != 5 {
+		t.Fatalf("got %d topics, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listTopics()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d topics, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/server/gcp/fromprovider.go
+++ b/server/gcp/fromprovider.go
@@ -1,0 +1,43 @@
+package gcp
+
+import (
+	gcpprovider "github.com/stackshy/cloudemu/v2/providers/gcp"
+	"github.com/stackshy/cloudemu/v2/server"
+)
+
+// DriversFrom maps a fully-constructed GCP provider onto a Drivers bundle,
+// wiring every service handler the standalone server can expose. It lets a
+// standalone binary go from a provider to a running server without
+// hand-mapping each field.
+func DriversFrom(p *gcpprovider.Provider) Drivers {
+	return Drivers{
+		Compute:          p.GCE,
+		Storage:          p.GCS,
+		Firestore:        p.Firestore,
+		Networking:       p.VPC,
+		Monitoring:       p.CloudMonitoring,
+		CloudFunctions:   p.CloudFunctions,
+		PubSub:           p.PubSub,
+		CloudSQL:         p.CloudSQL,
+		GKE:              p.GKE,
+		VertexAI:         p.VertexAI,
+		IAM:              p.IAM,
+		ArtifactRegistry: p.ArtifactRegistry,
+		CloudDNS:         p.CloudDNS,
+		LB:               p.LB,
+		CloudLogging:     p.CloudLogging,
+		SecretManager:    p.SecretManager,
+		Eventarc:         p.Eventarc,
+		Memorystore:      p.Memorystore,
+		FCM:              p.FCM,
+		// K8sAPI is left nil; injected by the caller when a shared cluster is desired.
+		K8sAPI:            nil,
+		ResourceDiscovery: p.ResourceDiscovery,
+		ProjectID:         p.ProjectID,
+	}
+}
+
+// NewFromProvider builds a GCP server from a fully-constructed provider.
+func NewFromProvider(p *gcpprovider.Provider) *server.Server {
+	return New(DriversFrom(p))
+}

--- a/server/gcp/fromprovider_test.go
+++ b/server/gcp/fromprovider_test.go
@@ -1,0 +1,55 @@
+package gcp_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+
+	"github.com/stackshy/cloudemu/v2"
+	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+)
+
+// TestNewFromProvider verifies that a server built straight from a
+// fully-constructed provider serves real cloud.google.com/go traffic.
+func TestNewFromProvider(t *testing.T) {
+	p := cloudemu.NewGCP()
+
+	srv := gcpserver.NewFromProvider(p)
+	if srv == nil {
+		t.Fatal("NewFromProvider returned nil")
+	}
+
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx := context.Background()
+
+	client, err := storage.NewClient(ctx,
+		option.WithEndpoint(ts.URL+"/storage/v1/"),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(ts.Client()),
+	)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	bucket := client.Bucket("b1")
+
+	if err := bucket.Create(ctx, "p1", nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+
+	attrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("bucket.Attrs: %v", err)
+	}
+
+	if attrs.Name != "b1" {
+		t.Errorf("bucket name mismatch: got=%q want=%q", attrs.Name, "b1")
+	}
+}

--- a/server/gcp/gcs/handler.go
+++ b/server/gcp/gcs/handler.go
@@ -594,6 +594,10 @@ func writeErr(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, "conflict", err.Error())
 	case cerrors.IsInvalidArgument(err):
 		writeError(w, http.StatusBadRequest, "invalid", err.Error())
+	case cerrors.IsFailedPrecondition(err):
+		// Real GCS refuses to delete a non-empty bucket with 409 conflict,
+		// not a 5xx (which would trigger client retry backoff).
+		writeError(w, http.StatusConflict, "conflict", err.Error())
 	default:
 		writeError(w, http.StatusInternalServerError, "internalError", err.Error())
 	}

--- a/server/gcp/memorystore/operations.go
+++ b/server/gcp/memorystore/operations.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2/server/wire/gcprest"
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // createInstance handles POST .../instances?instanceId={i} — Create. The
@@ -28,6 +29,7 @@ func (h *Handler) createInstance(w http.ResponseWriter, r *http.Request, rt rout
 		Engine:   "redis",
 		NodeType: body.Tier,
 		Tags:     body.Labels,
+		Scope:    scope.Scope{Project: rt.project},
 	})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
@@ -58,9 +60,10 @@ func (h *Handler) getInstance(w http.ResponseWriter, r *http.Request, rt route) 
 	gcprest.WriteJSON(w, http.StatusOK, toInstanceJSON(rt.project, rt.location, rt.name, info))
 }
 
-// listInstances handles GET .../instances — List.
+// listInstances handles GET .../instances — List, scoped to the request's
+// project.
 func (h *Handler) listInstances(w http.ResponseWriter, r *http.Request, rt route) {
-	infos, err := h.cache.ListCaches(r.Context())
+	infos, err := h.cache.ListCaches(r.Context(), scope.Scope{Project: rt.project})
 	if err != nil {
 		gcprest.WriteCErr(w, err)
 		return

--- a/server/gcp/memorystore/ordering_sdk_test.go
+++ b/server/gcp/memorystore/ordering_sdk_test.go
@@ -1,0 +1,61 @@
+package memorystore_test
+
+import (
+	"context"
+	"testing"
+
+	redis "google.golang.org/api/redis/v1"
+)
+
+// TestSDKListOrderingDeterministic locks the #259 ordering fix at the wire
+// level: Instances.List must return the same sequence of instance names on
+// every call, regardless of the order the instances were created in.
+func TestSDKListOrderingDeterministic(t *testing.T) {
+	svc := newRedisService(t)
+	ctx := context.Background()
+
+	// Create five instances in a deliberately non-sorted order.
+	for _, id := range []string{"zeta", "alpha", "mid", "beta", "omega"} {
+		if _, err := svc.Projects.Locations.Instances.Create(parent(), &redis.Instance{
+			Tier:         "BASIC",
+			MemorySizeGb: 1,
+		}).InstanceId(id).Context(ctx).Do(); err != nil {
+			t.Fatalf("Instances.Create(%s): %v", id, err)
+		}
+	}
+
+	listInstances := func() []string {
+		var names []string
+
+		call := svc.Projects.Locations.Instances.List(parent()).Context(ctx)
+		if err := call.Pages(ctx, func(page *redis.ListInstancesResponse) error {
+			for _, in := range page.Instances {
+				names = append(names, in.Name)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("Instances.List: %v", err)
+		}
+
+		return names
+	}
+
+	first := listInstances()
+	if len(first) != 5 {
+		t.Fatalf("got %d instances, want 5: %v", len(first), first)
+	}
+
+	for i := 0; i < 4; i++ {
+		got := listInstances()
+		if len(got) != len(first) {
+			t.Fatalf("list #%d returned %d instances, want %d: %v", i+2, len(got), len(first), got)
+		}
+
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("list #%d order diverged at index %d: got %q, want %q (full: %v vs %v)",
+					i+2, j, got[j], first[j], got, first)
+			}
+		}
+	}
+}

--- a/services/cache/cache.go
+++ b/services/cache/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/cache/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Cache is the portable cache type wrapping a driver with cross-cutting concerns.
@@ -123,7 +124,7 @@ func (c *Cache) GetCache(ctx context.Context, name string) (*driver.CacheInfo, e
 
 // ListCaches lists all cache instances.
 func (c *Cache) ListCaches(ctx context.Context) ([]driver.CacheInfo, error) {
-	out, err := c.do(ctx, "ListCaches", nil, func() (any, error) { return c.driver.ListCaches(ctx) })
+	out, err := c.do(ctx, "ListCaches", nil, func() (any, error) { return c.driver.ListCaches(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -4,6 +4,8 @@ package driver
 import (
 	"context"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Item represents a cached item.
@@ -23,6 +25,7 @@ type CacheInfo struct {
 	Endpoint  string
 	CreatedAt string
 	Tags      map[string]string
+	Scope     scope.Scope
 }
 
 // CacheConfig describes a cache instance to create.
@@ -31,14 +34,22 @@ type CacheConfig struct {
 	NodeType string
 	Engine   string // "redis", "memcached"
 	Tags     map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // Cache is the interface that cache provider implementations must satisfy.
 type Cache interface {
 	CreateCache(ctx context.Context, config CacheConfig) (*CacheInfo, error)
+
+	// UpdateCache replaces the mutable fields (node type, tags) of an
+	// existing cache, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateCache(ctx context.Context, config CacheConfig) (*CacheInfo, error)
 	DeleteCache(ctx context.Context, name string) error
 	GetCache(ctx context.Context, name string) (*CacheInfo, error)
-	ListCaches(ctx context.Context) ([]CacheInfo, error)
+	ListCaches(ctx context.Context, filter scope.Scope) ([]CacheInfo, error)
 
 	Set(ctx context.Context, cacheName, key string, value []byte, ttl time.Duration) error
 	Get(ctx context.Context, cacheName, key string) (*Item, error)

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -381,8 +381,10 @@ func PageOrdered(
 	return res, nil
 }
 
-// cloneItems shallow-copies each result item so callers can mutate what
-// they receive without corrupting the store.
+// cloneItems shallow-copies each result item so callers mutating top-level
+// keys of what they receive cannot corrupt the store. Nested map/slice
+// values are still shared — deep-copying arbitrary attribute trees is a
+// deliberate non-goal (documented limitation).
 func cloneItems(items []map[string]any) []map[string]any {
 	out := make([]map[string]any, len(items))
 	for i, it := range items {

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -4,6 +4,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -361,7 +362,7 @@ func PageOrdered(
 			return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid ExclusiveStartKey")
 		}
 
-		res := &QueryResult{Items: items, Count: len(items)}
+		res := &QueryResult{Items: cloneItems(items), Count: len(items)}
 		if more && len(items) > 0 {
 			res.LastEvaluatedKey = KeyAttributes(items[len(items)-1], keyFields...)
 		}
@@ -373,9 +374,19 @@ func PageOrdered(
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid page token: %v", err)
 	}
 
-	res := &QueryResult{Items: page.Items, Count: len(page.Items), NextPageToken: page.NextPageToken}
+	res := &QueryResult{Items: cloneItems(page.Items), Count: len(page.Items), NextPageToken: page.NextPageToken}
 	if page.HasMore && len(page.Items) > 0 {
 		res.LastEvaluatedKey = KeyAttributes(page.Items[len(page.Items)-1], keyFields...)
 	}
 	return res, nil
+}
+
+// cloneItems shallow-copies each result item so callers can mutate what
+// they receive without corrupting the store.
+func cloneItems(items []map[string]any) []map[string]any {
+	out := make([]map[string]any, len(items))
+	for i, it := range items {
+		out[i] = maps.Clone(it)
+	}
+	return out
 }

--- a/services/dns/dns.go
+++ b/services/dns/dns.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 type DNS struct {
@@ -107,7 +108,7 @@ func (d *DNS) GetZone(ctx context.Context, id string) (*driver.ZoneInfo, error) 
 }
 
 func (d *DNS) ListZones(ctx context.Context) ([]driver.ZoneInfo, error) {
-	out, err := d.do(ctx, "ListZones", nil, func() (any, error) { return d.driver.ListZones(ctx) })
+	out, err := d.do(ctx, "ListZones", nil, func() (any, error) { return d.driver.ListZones(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/dns/dns_test.go
+++ b/services/dns/dns_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/metrics"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/dns/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,13 +74,28 @@ func (m *mockDriver) GetZone(_ context.Context, id string) (*driver.ZoneInfo, er
 	return info, nil
 }
 
-func (m *mockDriver) ListZones(_ context.Context) ([]driver.ZoneInfo, error) {
+func (m *mockDriver) ListZones(_ context.Context, filter scope.Scope) ([]driver.ZoneInfo, error) {
 	result := make([]driver.ZoneInfo, 0, len(m.zones))
 	for _, info := range m.zones {
+		if !info.Scope.Matches(filter) {
+			continue
+		}
 		result = append(result, *info)
 	}
 
 	return result, nil
+}
+
+func (m *mockDriver) UpdateZone(_ context.Context, config driver.ZoneConfig) (*driver.ZoneInfo, error) {
+	for _, info := range m.zones {
+		if info.Name == config.Name {
+			if config.Tags != nil {
+				info.Tags = config.Tags
+			}
+			return info, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
 }
 
 func (m *mockDriver) CreateRecord(_ context.Context, config driver.RecordConfig) (*driver.RecordInfo, error) {

--- a/services/dns/driver/driver.go
+++ b/services/dns/driver/driver.go
@@ -1,13 +1,20 @@
 // Package driver defines the interface for DNS service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
 
 // ZoneConfig describes a DNS zone to create.
 type ZoneConfig struct {
 	Name    string
 	Private bool
 	Tags    map[string]string
+	// Scope records the cloud-side container the zone was created in (Azure
+	// subscription/resource group or GCP project). The zero value is unscoped.
+	Scope scope.Scope
 }
 
 // ZoneInfo describes a DNS zone.
@@ -17,6 +24,9 @@ type ZoneInfo struct {
 	Private     bool
 	RecordCount int
 	Tags        map[string]string
+	// Scope is the container the zone lives in; scoped list endpoints filter
+	// on it. The zero value is unscoped and visible everywhere.
+	Scope scope.Scope
 }
 
 // RecordConfig describes a DNS record.
@@ -70,7 +80,10 @@ type DNS interface {
 	CreateZone(ctx context.Context, config ZoneConfig) (*ZoneInfo, error)
 	DeleteZone(ctx context.Context, id string) error
 	GetZone(ctx context.Context, id string) (*ZoneInfo, error)
-	ListZones(ctx context.Context) ([]ZoneInfo, error)
+	ListZones(ctx context.Context, filter scope.Scope) ([]ZoneInfo, error)
+	// UpdateZone applies the mutable fields (tags) of an existing zone,
+	// mirroring ARM CreateOrUpdate-on-existing. It matches the zone by name.
+	UpdateZone(ctx context.Context, config ZoneConfig) (*ZoneInfo, error)
 
 	CreateRecord(ctx context.Context, config RecordConfig) (*RecordInfo, error)
 	DeleteRecord(ctx context.Context, zoneID, name, recordType string) error

--- a/services/eventbus/driver/driver.go
+++ b/services/eventbus/driver/driver.go
@@ -4,6 +4,8 @@ package driver
 import (
 	"context"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // EventBusInfo describes an event bus.
@@ -13,12 +15,17 @@ type EventBusInfo struct {
 	State     string // "ACTIVE", "INACTIVE"
 	CreatedAt string
 	Tags      map[string]string
+	Scope     scope.Scope
 }
 
 // EventBusConfig configures a new event bus.
 type EventBusConfig struct {
 	Name string
 	Tags map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // Rule defines an event routing rule with filtering.
@@ -70,9 +77,13 @@ type PublishResult struct {
 type EventBus interface {
 	// Bus management
 	CreateEventBus(ctx context.Context, config EventBusConfig) (*EventBusInfo, error)
+
+	// UpdateEventBus replaces the mutable fields (tags) of an existing
+	// event bus, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateEventBus(ctx context.Context, config EventBusConfig) (*EventBusInfo, error)
 	DeleteEventBus(ctx context.Context, name string) error
 	GetEventBus(ctx context.Context, name string) (*EventBusInfo, error)
-	ListEventBuses(ctx context.Context) ([]EventBusInfo, error)
+	ListEventBuses(ctx context.Context, filter scope.Scope) ([]EventBusInfo, error)
 
 	// Rule management
 	PutRule(ctx context.Context, config *RuleConfig) (*Rule, error)

--- a/services/eventbus/eventbus.go
+++ b/services/eventbus/eventbus.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // EventBus is the portable event bus type wrapping a driver with cross-cutting concerns.
@@ -131,7 +132,7 @@ func (eb *EventBus) GetEventBus(ctx context.Context, name string) (*driver.Event
 // ListEventBuses lists all event buses.
 func (eb *EventBus) ListEventBuses(ctx context.Context) ([]driver.EventBusInfo, error) {
 	out, err := eb.do(ctx, "ListEventBuses", nil, func() (any, error) {
-		return eb.driver.ListEventBuses(ctx)
+		return eb.driver.ListEventBuses(ctx, scope.Scope{})
 	})
 	if err != nil {
 		return nil, err

--- a/services/logging/driver/driver.go
+++ b/services/logging/driver/driver.go
@@ -4,6 +4,8 @@ package driver
 import (
 	"context"
 	"time"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // LogGroupConfig describes a log group to create.
@@ -11,6 +13,10 @@ type LogGroupConfig struct {
 	Name          string
 	RetentionDays int
 	Tags          map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // LogGroupInfo describes a log group.
@@ -21,6 +27,7 @@ type LogGroupInfo struct {
 	CreatedAt     string
 	StoredBytes   int64
 	Tags          map[string]string
+	Scope         scope.Scope
 }
 
 // LogStreamInfo describes a log stream within a log group.
@@ -87,9 +94,13 @@ type MetricFilterInfo struct {
 // Logging is the interface that logging provider implementations must satisfy.
 type Logging interface {
 	CreateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
+
+	// UpdateLogGroup replaces the mutable fields (retention, tags) of an
+	// existing log group, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateLogGroup(ctx context.Context, config LogGroupConfig) (*LogGroupInfo, error)
 	DeleteLogGroup(ctx context.Context, name string) error
 	GetLogGroup(ctx context.Context, name string) (*LogGroupInfo, error)
-	ListLogGroups(ctx context.Context) ([]LogGroupInfo, error)
+	ListLogGroups(ctx context.Context, filter scope.Scope) ([]LogGroupInfo, error)
 
 	CreateLogStream(ctx context.Context, logGroup, streamName string) (*LogStreamInfo, error)
 	DeleteLogStream(ctx context.Context, logGroup, streamName string) error

--- a/services/logging/logging.go
+++ b/services/logging/logging.go
@@ -3,6 +3,7 @@ package logging
 
 import (
 	"context"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/features/inject"
@@ -123,7 +124,7 @@ func (l *Logging) GetLogGroup(ctx context.Context, name string) (*driver.LogGrou
 
 // ListLogGroups lists all log groups.
 func (l *Logging) ListLogGroups(ctx context.Context) ([]driver.LogGroupInfo, error) {
-	out, err := l.do(ctx, "ListLogGroups", nil, func() (any, error) { return l.driver.ListLogGroups(ctx) })
+	out, err := l.do(ctx, "ListLogGroups", nil, func() (any, error) { return l.driver.ListLogGroups(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -1,13 +1,21 @@
 // Package driver defines the interface for notification service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/scope"
+)
 
 // TopicConfig describes a notification topic to create.
 type TopicConfig struct {
 	Name        string
 	DisplayName string
 	Tags        map[string]string
+
+	// Scope records where the resource lives (Azure subscription/resource
+	// group, GCP project). Zero for AWS and unscoped portable callers.
+	Scope scope.Scope
 }
 
 // TopicInfo describes a notification topic.
@@ -18,6 +26,7 @@ type TopicInfo struct {
 	DisplayName       string
 	SubscriptionCount int
 	Tags              map[string]string
+	Scope             scope.Scope
 }
 
 // SubscriptionConfig describes a subscription to create.
@@ -52,9 +61,13 @@ type PublishOutput struct {
 // Notification is the interface that notification provider implementations must satisfy.
 type Notification interface {
 	CreateTopic(ctx context.Context, config TopicConfig) (*TopicInfo, error)
+
+	// UpdateTopic replaces the mutable fields (display name, tags) of an
+	// existing topic, mirroring ARM CreateOrUpdate-on-existing.
+	UpdateTopic(ctx context.Context, config TopicConfig) (*TopicInfo, error)
 	DeleteTopic(ctx context.Context, id string) error
 	GetTopic(ctx context.Context, id string) (*TopicInfo, error)
-	ListTopics(ctx context.Context) ([]TopicInfo, error)
+	ListTopics(ctx context.Context, filter scope.Scope) ([]TopicInfo, error)
 
 	Subscribe(ctx context.Context, config SubscriptionConfig) (*SubscriptionInfo, error)
 	Unsubscribe(ctx context.Context, subscriptionID string) error

--- a/services/notification/notification.go
+++ b/services/notification/notification.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"
 	"github.com/stackshy/cloudemu/v2/features/recorder"
 	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 // Notification is the portable notification type wrapping a driver with cross-cutting concerns.
@@ -123,7 +124,7 @@ func (n *Notification) GetTopic(ctx context.Context, id string) (*driver.TopicIn
 
 // ListTopics lists all topics.
 func (n *Notification) ListTopics(ctx context.Context) ([]driver.TopicInfo, error) {
-	out, err := n.do(ctx, "ListTopics", nil, func() (any, error) { return n.driver.ListTopics(ctx) })
+	out, err := n.do(ctx, "ListTopics", nil, func() (any, error) { return n.driver.ListTopics(ctx, scope.Scope{}) })
 	if err != nil {
 		return nil, err
 	}

--- a/services/scope/scope.go
+++ b/services/scope/scope.go
@@ -1,0 +1,41 @@
+// Package scope identifies the cloud-side container a resource lives in —
+// the Azure subscription/resource group or the GCP project. Drivers record
+// a resource's scope at create time and filter lists by it, so scoped list
+// endpoints (ListByResourceGroup, per-project lists) return only what the
+// caller's scope actually contains.
+package scope
+
+// Scope locates a resource. The zero value means "unscoped": AWS resources
+// and portable-API callers that don't care about scoping use it, and it
+// matches every filter.
+type Scope struct {
+	Subscription  string
+	ResourceGroup string
+	Project       string
+}
+
+// IsZero reports whether no scope information is set.
+func (s Scope) IsZero() bool {
+	return s == Scope{}
+}
+
+// Matches reports whether a resource created in scope s is visible under
+// filter f. Empty filter fields match anything, so a zero filter lists
+// everything and a subscription-only filter spans its resource groups.
+// Resources created without scope (portable API) are visible everywhere —
+// hiding them from scoped lists would make them unreachable over the wire.
+func (s Scope) Matches(f Scope) bool {
+	if s.IsZero() {
+		return true
+	}
+	if f.Subscription != "" && s.Subscription != f.Subscription {
+		return false
+	}
+	if f.ResourceGroup != "" && s.ResourceGroup != f.ResourceGroup {
+		return false
+	}
+	if f.Project != "" && s.Project != f.Project {
+		return false
+	}
+	return true
+}

--- a/services/scope/scope_test.go
+++ b/services/scope/scope_test.go
@@ -1,0 +1,24 @@
+package scope
+
+import "testing"
+
+func TestMatches(t *testing.T) {
+	rgA := Scope{Subscription: "sub1", ResourceGroup: "rg-a"}
+	rgB := Scope{Subscription: "sub1", ResourceGroup: "rg-b"}
+
+	if !rgA.Matches(Scope{}) {
+		t.Error("zero filter must match everything")
+	}
+	if !rgA.Matches(Scope{Subscription: "sub1"}) {
+		t.Error("subscription filter must span its resource groups")
+	}
+	if rgA.Matches(rgB) {
+		t.Error("different resource groups must not match")
+	}
+	if !(Scope{}).Matches(rgA) {
+		t.Error("unscoped resources stay visible under scoped filters")
+	}
+	if rgA.Matches(Scope{Subscription: "other"}) {
+		t.Error("different subscriptions must not match")
+	}
+}


### PR DESCRIPTION
## <img src="https://raw.githubusercontent.com/stackshy/cloudemu/development/.github/logo.svg" alt="cloudemu" width="28" height="28" align="absmiddle" /> Release Notes — v2.1.0
## ✨ Features

### Standalone server mode — `cloudemu serve`
Run cloudemu as a real server and point any SDK, in any language, at it over the network — not just the in-process test double.

- All three providers on stable ports: AWS `4566`, Azure `4568` (HTTPS), GCP `4569`, plus a shared Kubernetes data-plane
- Self-signed TLS for Azure, request logging, and graceful shutdown
- Prints the endpoints (and writes them as JSON) so an app can target the whole emulated cloud at once
- New `DriversFrom` / `NewFromProvider` helpers build a running server from a provider in one line
- Purely additive — the in-process `New(Drivers{…})` API is unchanged

## 🔧 Enhancements

### DNS fidelity
- Record and zone listing are now deterministic (were random order)
- Zones are scoped to their resource group / project on both list and lookup
- Azure `CreateOrUpdate` applies the request's tags instead of echoing the old zone
- Long TXT values are split into valid ≤255-byte chunks
- `ChangeResourceRecordSets` is all-or-nothing — a bad batch leaves the zone untouched
- GCP managed-zone names must be unique within a project

### SDK-compat listing & updates
- Logging, event bus, cache, and notification gained scoped listing, `CreateOrUpdate`-applies-updates, and request-derived Azure ARM ids (no more hardcoded `rg-default`)

### Azure Service Bus namespaces
- Namespaces now keep state: tags persist, listing is scoped to the resource group, and a wrong-group Get/Delete no longer touches another group's namespace

### Real-cloud semantics audit
- Typed errors, fake-clock time handling, and map/slice copying at store boundaries brought in line with the real services

## Technical Details

<details>
<summary><b>Standalone server (#224)</b></summary>

- `feat(cmd): standalone server mode — cloudemu serve` — `cmd/cloudemu` `serve` subcommand: per-provider ports, in-memory self-signed TLS, shared `kubernetes.APIServer`, request-logging middleware, SIGINT/SIGTERM shutdown, endpoints bundle.
- `server/{aws,azure,gcp}`: `DriversFrom` + `NewFromProvider`; providers expose their identity fields.
- Out-of-process test drives real AWS (HTTP) and Azure (self-signed HTTPS) SDK clients against the binary. Docs: `docs/standalone-server.md`.
</details>

<details>
<summary><b>DNS fidelity (#253)</b></summary>

- Deterministic `ListRecords` / weighted `GetRecord` via `SortedValues()`.
- `Scope` on zones; scoped `ListZones`; new `UpdateZone`; scoped `resolveZoneID`; upsert no longer hijacks a same-named zone in another group.
- TXT values chunked to ≤255 bytes; `ChangeResourceRecordSets` validated before apply; GCP managed-zone name uniqueness per project.
</details>

<details>
<summary><b>SDK-compat slices (#259)</b></summary>

- `services/scope` (`Scope` + wildcard `Matches`); each driver's `List*` takes a scope filter, providers store the creating scope, new `Update*` methods, Azure ids derived from the request path.
- Real-SDK regressions per domain: scoped listing, upsert-applies-updates, request-derived id.
</details>

<details>
<summary><b>Service Bus (#278) & audit (#274)</b></summary>

- `fix(servicebus)`: in-memory namespace store — CreateOrUpdate persists tags/SKU/scope; Get/List/Delete scope-checked.
- Deep audit: typed-error alignment, clock injection over wall-clock reads, `maps.Clone`/copy at store boundaries.
</details>
