### PR TITLE
feat: /_cloudemu/reset control plane for standalone-server test isolation (#244)

### DIFF
--- a/cmd/cloudemu/endpoints.go
+++ b/cmd/cloudemu/endpoints.go
@@ -26,7 +26,7 @@ func (e endpointSet) writeFile(path string) error {
 
 // printBanner writes the startup summary: the live endpoints and copy-paste
 // snippets for pointing each SDK at them.
-func printBanner(w io.Writer, e endpointSet) {
+func printBanner(w io.Writer, e endpointSet, adminOn bool) {
 	fmt.Fprintln(w, "cloudemu — standalone server")
 	fmt.Fprintln(w, "────────────────────────────")
 	if e.AWS != "" {
@@ -51,6 +51,10 @@ func printBanner(w io.Writer, e endpointSet) {
 	}
 	if e.Azure != "" {
 		fmt.Fprintf(w, "  Azure cloud.Configuration ResourceManager endpoint = %q (trust the cert or skip verify)\n", e.Azure)
+	}
+	if adminOn {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Reset state between tests: POST /_cloudemu/reset")
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Press Ctrl-C to stop.")

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,11 +11,13 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/admin"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
@@ -37,6 +40,7 @@ type serveConfig struct {
 	tlsKey     string
 	tlsHosts   stringList
 	endpoints  string
+	admin      bool
 	logReqs    bool
 	quiet      bool
 	shutdownTO time.Duration
@@ -68,6 +72,7 @@ func runServe(args []string) error {
 	fs.StringVar(&c.tlsKey, "tls-key", "", "PEM key file matching --tls-cert")
 	fs.Var(&c.tlsHosts, "tls-host", "extra SAN host/IP for the generated self-signed cert (repeatable)")
 	fs.StringVar(&c.endpoints, "endpoints-file", "", "write the resolved endpoints as JSON to this path")
+	fs.BoolVar(&c.admin, "admin", true, "mount the /_cloudemu control plane (reset, health) for test isolation")
 	fs.BoolVar(&c.logReqs, "log-requests", false, "log every HTTP request (method, path, status, duration)")
 	fs.BoolVar(&c.quiet, "quiet", false, "suppress the startup banner")
 	fs.DurationVar(&c.shutdownTO, "shutdown-timeout", 10*time.Second, "grace period for in-flight requests on shutdown")
@@ -96,54 +101,118 @@ func runServe(args []string) error {
 		opts = append(opts, config.WithLatency(c.latency))
 	}
 
-	// One shared Kubernetes data-plane so a kubeconfig from any provider's
-	// control plane (EKS/AKS/GKE) reaches the same backend.
-	var k8s *kubernetes.APIServer
-	if c.k8sPort != "" {
-		k8s = kubernetes.NewAPIServer()
-	}
-
 	var (
 		servers []*namedServer
 		eps     = endpointSet{}
 	)
 
+	// Each provider (and the shared Kubernetes data-plane) sits behind a
+	// hot-swappable backend. rebuild reconstructs a fresh Kubernetes server and
+	// every selected provider from scratch and swaps them in atomically — this
+	// is what /_cloudemu/reset calls to hand a test suite a clean slate without
+	// restarting the process.
+	backends := make(map[string]*admin.Backend, len(sel))
 	for _, p := range sel {
-		switch p {
-		case "aws":
-			cloud := cloudemu.NewAWS(opts...)
-			d := awsserver.DriversFrom(cloud)
-			d.K8sAPI = k8s
-			h := wrap(awsserver.New(d), "aws", c.logReqs)
-			addr := net.JoinHostPort(c.host, c.awsPort)
-			servers = append(servers, &namedServer{name: "aws", srv: &http.Server{Addr: addr, Handler: h}})
-			eps.AWS = fmt.Sprintf("http://%s", addr)
-		case "gcp":
-			cloud := cloudemu.NewGCP(opts...)
-			d := gcpserver.DriversFrom(cloud)
-			d.K8sAPI = k8s
-			h := wrap(gcpserver.New(d), "gcp", c.logReqs)
-			addr := net.JoinHostPort(c.host, c.gcpPort)
-			servers = append(servers, &namedServer{name: "gcp", srv: &http.Server{Addr: addr, Handler: h}})
-			eps.GCP = fmt.Sprintf("http://%s", addr)
-		case "azure":
-			cloud := cloudemu.NewAzure(opts...)
-			d := azureserver.DriversFrom(cloud)
-			d.K8sAPI = k8s
-			h := wrap(azureserver.New(d), "azure", c.logReqs)
-			addr := net.JoinHostPort(c.host, c.azurePort)
-			tlsCfg, err := tlsConfig(c, addr)
-			if err != nil {
-				return fmt.Errorf("azure TLS: %w", err)
-			}
-			servers = append(servers, &namedServer{name: "azure", srv: &http.Server{Addr: addr, Handler: h, TLSConfig: tlsCfg}, tls: true})
-			eps.Azure = fmt.Sprintf("https://%s", addr)
-		}
+		backends[p] = admin.NewBackend(nil)
+	}
+	var k8sBackend *admin.Backend
+	if c.k8sPort != "" {
+		k8sBackend = admin.NewBackend(nil)
 	}
 
-	if k8s != nil {
+	var rebuildMu sync.Mutex
+	rebuild := func() {
+		// Serialise resets so two concurrent /_cloudemu/reset calls can't
+		// interleave and leave providers wired to different Kubernetes
+		// instances.
+		rebuildMu.Lock()
+		defer rebuildMu.Unlock()
+
+		// Build every fresh handler first, then swap them in. Building first
+		// means a construction panic leaves the running set untouched, and all
+		// providers in one reset share the single new Kubernetes data-plane
+		// (so a kubeconfig from any control plane reaches the same backend).
+		var k8s *kubernetes.APIServer
+		if k8sBackend != nil {
+			k8s = kubernetes.NewAPIServer()
+		}
+		fresh := make(map[string]http.Handler, len(sel))
+		for _, p := range sel {
+			switch p {
+			case "aws":
+				d := awsserver.DriversFrom(cloudemu.NewAWS(opts...))
+				d.K8sAPI = k8s
+				fresh["aws"] = wrap(awsserver.New(d), "aws", c.logReqs)
+			case "gcp":
+				d := gcpserver.DriversFrom(cloudemu.NewGCP(opts...))
+				d.K8sAPI = k8s
+				fresh["gcp"] = wrap(gcpserver.New(d), "gcp", c.logReqs)
+			case "azure":
+				d := azureserver.DriversFrom(cloudemu.NewAzure(opts...))
+				d.K8sAPI = k8s
+				fresh["azure"] = wrap(azureserver.New(d), "azure", c.logReqs)
+			}
+		}
+		if k8sBackend != nil {
+			k8sBackend.Swap(wrap(k8s, "kubernetes", c.logReqs))
+		}
+		for p, h := range fresh {
+			backends[p].Swap(h)
+		}
+	}
+	rebuild() // populate the backends before serving
+
+	// reset wipes all state, so warn if it's reachable off the loopback — e.g.
+	// a shared instance bound with --host 0.0.0.0, where anyone on the network
+	// could POST /_cloudemu/reset.
+	if c.admin && !isLoopbackHost(c.host) {
+		fmt.Fprintf(os.Stderr,
+			"warning: --admin control plane (POST /_cloudemu/reset wipes all state) is reachable on non-loopback host %q; pass --admin=false to disable it\n",
+			c.host)
+	}
+
+	// handlerFor fronts a backend with the /_cloudemu control plane. With the
+	// admin API off the backend serves directly, so control paths fall through
+	// to the wire handlers (whatever they return for an unrouted path).
+	handlerFor := func(b *admin.Backend) http.Handler {
+		if c.admin {
+			return admin.NewControl(b, rebuild)
+		}
+		return b
+	}
+
+	for _, p := range sel {
+		var (
+			addr   string
+			tlsCfg *tls.Config
+			isTLS  bool
+		)
+		switch p {
+		case "aws":
+			addr = net.JoinHostPort(c.host, c.awsPort)
+			eps.AWS = fmt.Sprintf("http://%s", addr)
+		case "gcp":
+			addr = net.JoinHostPort(c.host, c.gcpPort)
+			eps.GCP = fmt.Sprintf("http://%s", addr)
+		case "azure":
+			addr = net.JoinHostPort(c.host, c.azurePort)
+			var err error
+			if tlsCfg, err = tlsConfig(c, addr); err != nil {
+				return fmt.Errorf("azure TLS: %w", err)
+			}
+			isTLS = true
+			eps.Azure = fmt.Sprintf("https://%s", addr)
+		}
+		servers = append(servers, &namedServer{
+			name: p,
+			srv:  &http.Server{Addr: addr, Handler: handlerFor(backends[p]), TLSConfig: tlsCfg},
+			tls:  isTLS,
+		})
+	}
+
+	if k8sBackend != nil {
 		addr := net.JoinHostPort(c.host, c.k8sPort)
-		servers = append(servers, &namedServer{name: "kubernetes", srv: &http.Server{Addr: addr, Handler: wrap(k8s, "kubernetes", c.logReqs)}})
+		servers = append(servers, &namedServer{name: "kubernetes", srv: &http.Server{Addr: addr, Handler: handlerFor(k8sBackend)}})
 		eps.Kubernetes = fmt.Sprintf("http://%s", addr)
 	}
 
@@ -179,7 +248,7 @@ func runServe(args []string) error {
 	}
 
 	if !c.quiet {
-		printBanner(os.Stdout, eps)
+		printBanner(os.Stdout, eps, c.admin)
 	}
 	if c.endpoints != "" {
 		if err := eps.writeFile(c.endpoints); err != nil {
@@ -214,6 +283,18 @@ type namedServer struct {
 	name string
 	srv  *http.Server
 	tls  bool
+}
+
+// isLoopbackHost reports whether binding to h keeps the server local-only.
+func isLoopbackHost(h string) bool {
+	switch h {
+	case "127.0.0.1", "::1", "localhost":
+		return true
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func parseProviders(s string) ([]string, error) {

--- a/cmd/cloudemu/serve_test.go
+++ b/cmd/cloudemu/serve_test.go
@@ -3,14 +3,17 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
@@ -21,6 +24,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"google.golang.org/api/option"
 )
 
 // TestServeOutOfProcess builds the binary, runs it as a separate process, and
@@ -138,6 +142,109 @@ func TestServeOutOfProcess(t *testing.T) {
 		}
 		if got.Name == nil || *got.Name != "ns-demo" {
 			t.Fatalf("Get namespace = %+v, want ns-demo", got.SBNamespace)
+		}
+	})
+
+	// #244 acceptance: seed resources (via the real SDK), reset, confirm empty.
+	t.Run("admin-reset-clears-state", func(t *testing.T) {
+		ctx := context.Background()
+		cfg, err := awsconfig.LoadDefaultConfig(ctx,
+			awsconfig.WithRegion("us-east-1"),
+			awsconfig.WithCredentialsProvider(
+				credentials.NewStaticCredentialsProvider("test", "test", "")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(awsEndpoint)
+			o.UsePathStyle = true
+		})
+
+		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("reset-me")}); err != nil {
+			t.Fatalf("CreateBucket: %v", err)
+		}
+		before, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(before.Buckets) == 0 {
+			t.Fatal("expected at least the bucket we just created before reset")
+		}
+
+		// A second provider, to prove reset is global: a POST to the AWS port
+		// must also clear GCP state.
+		gcs, err := storage.NewClient(ctx,
+			option.WithEndpoint("http://127.0.0.1:"+gcpPort+"/storage/v1/"),
+			option.WithoutAuthentication())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := gcs.Bucket("gcp-reset-me").Create(ctx, "cloudemu-local", nil); err != nil {
+			t.Fatalf("GCS Bucket.Create: %v", err)
+		}
+		if _, err := gcs.Bucket("gcp-reset-me").Attrs(ctx); err != nil {
+			t.Fatalf("GCS bucket should exist before reset: %v", err)
+		}
+
+		resp, err := http.Post(awsEndpoint+"/_cloudemu/reset", "application/json", nil)
+		if err != nil {
+			t.Fatalf("POST /_cloudemu/reset: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("reset status = %d, want 200", resp.StatusCode)
+		}
+
+		after, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
+		if err != nil {
+			t.Fatalf("ListBuckets after reset: %v", err)
+		}
+		if len(after.Buckets) != 0 {
+			t.Fatalf("after reset the backend still has %d buckets, want 0", len(after.Buckets))
+		}
+		// GCP was reset too, even though we POSTed to the AWS port.
+		if _, err := gcs.Bucket("gcp-reset-me").Attrs(ctx); err == nil {
+			t.Fatal("GCP bucket survived a reset issued on the AWS port — reset is not global")
+		}
+	})
+
+	// Concurrent resets must serialise and stay consistent, not deadlock or
+	// corrupt the swap — this exercises the rebuild mutex.
+	t.Run("admin-reset-concurrent", func(t *testing.T) {
+		var wg sync.WaitGroup
+		errs := make(chan error, 6)
+		for range 6 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resp, err := http.Post(awsEndpoint+"/_cloudemu/reset", "application/json", nil)
+				if err != nil {
+					errs <- err
+					return
+				}
+				resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					errs <- fmt.Errorf("status %d", resp.StatusCode)
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Fatalf("concurrent reset failed: %v", err)
+		}
+
+		// The server is still usable after the storm of resets.
+		ctx := context.Background()
+		cfg, _ := awsconfig.LoadDefaultConfig(ctx,
+			awsconfig.WithRegion("us-east-1"),
+			awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("t", "t", "")))
+		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(awsEndpoint)
+			o.UsePathStyle = true
+		})
+		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("post-storm")}); err != nil {
+			t.Fatalf("server unusable after concurrent resets: %v", err)
 		}
 	})
 }

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -132,9 +132,30 @@ app at the whole emulated cloud at once:
 }
 ```
 
+## Resetting state between tests (`/_cloudemu`)
+
+A long-lived server keeps state across requests, so a shared or parallel test
+suite needs a way to get a clean slate. The control plane at `/_cloudemu` does
+this (on by default; disable with `--admin=false`):
+
+```sh
+# wipe all emulator state — every provider back to empty
+curl -X POST http://127.0.0.1:4566/_cloudemu/reset
+
+# liveness check
+curl http://127.0.0.1:4566/_cloudemu/health
+```
+
+`reset` rebuilds every provider (and the shared Kubernetes data-plane) to empty
+state and swaps it in atomically — in-flight requests finish against the old
+state, new requests see the fresh one. Call it from your suite's setup/teardown
+so each test starts clean without restarting the process. A `POST` to any
+provider's port resets the whole emulator.
+
 ## Not yet included
 
-State **seeding** and **persistence** across restarts are not in this mode yet —
-they need a cross-service state-import loader (tracked in #250). Today the server
-starts empty each run. Docker packaging (#247) and a Testcontainers module (#248)
-build directly on this binary and are the natural next steps.
+`seed` is reserved on the control plane but not implemented yet — for now,
+create the resources a test needs with your SDK client after `reset`. Bulk
+**seeding** and **persistence** across restarts need a cross-service
+state-import loader (tracked in #250). Docker packaging (#247) and a
+Testcontainers module (#248) build directly on this binary.

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -1,0 +1,105 @@
+// Package admin serves the cloudemu control plane at /_cloudemu/*, in front of
+// a hot-swappable backend handler.
+//
+// It exists for the standalone server (cmd/cloudemu): out-of-process or
+// parallel test suites share one long-lived process, so they need a way to get
+// a clean slate between tests without restarting it. A POST to
+// /_cloudemu/reset runs a caller-supplied reset — which rebuilds every provider
+// backend to empty state and swaps it in atomically — so in-flight requests
+// finish against the old state while new requests see the fresh one.
+//
+// State lifecycle only lives here; the wire handlers and the core server.Server
+// are untouched. In-process users don't need this — they just construct a fresh
+// provider.
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// Prefix is the reserved path space for the control plane. No emulated cloud
+// API uses it, so it never collides with a real SDK request.
+const Prefix = "/_cloudemu/"
+
+// Backend is a hot-swappable http.Handler. Requests read the current handler
+// under a read lock; Swap replaces it under a write lock. A zero Backend is not
+// usable — construct with NewBackend.
+type Backend struct {
+	mu sync.RWMutex
+	h  http.Handler
+}
+
+// NewBackend wraps an initial handler.
+func NewBackend(h http.Handler) *Backend {
+	return &Backend{h: h}
+}
+
+// Swap atomically replaces the current handler. In-flight requests already
+// dispatched to the old handler are unaffected.
+func (b *Backend) Swap(h http.Handler) {
+	b.mu.Lock()
+	b.h = h
+	b.mu.Unlock()
+}
+
+// ServeHTTP dispatches to the current handler.
+func (b *Backend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	b.mu.RLock()
+	h := b.h
+	b.mu.RUnlock()
+	h.ServeHTTP(w, r)
+}
+
+// Control fronts a Backend with the /_cloudemu control plane. Requests outside
+// the control prefix pass through to the backend unchanged. reset is shared
+// across every provider's Control so a single call rebuilds the whole emulator.
+type Control struct {
+	backend *Backend
+	reset   func()
+}
+
+// NewControl wraps backend with the control plane. reset must rebuild every
+// backend (including this one) to a clean state.
+func NewControl(backend *Backend, reset func()) *Control {
+	return &Control{backend: backend, reset: reset}
+}
+
+// ServeHTTP routes control-plane paths to the control handler and everything
+// else to the wrapped backend.
+func (c *Control) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, Prefix) {
+		c.serveControl(w, r)
+		return
+	}
+	c.backend.ServeHTTP(w, r)
+}
+
+func (c *Control) serveControl(w http.ResponseWriter, r *http.Request) {
+	switch strings.TrimPrefix(r.URL.Path, Prefix) {
+	case "reset":
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "reset requires POST"})
+			return
+		}
+		c.reset()
+		writeJSON(w, http.StatusOK, map[string]string{"status": "reset"})
+	case "health":
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	case "seed":
+		// Seeding needs the cross-service fixture loader tracked in #250.
+		writeJSON(w, http.StatusNotImplemented, map[string]string{
+			"error": "seed is not implemented yet (tracked in #250); create resources with your SDK client after reset",
+		})
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown control endpoint"})
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/server/admin/admin_test.go
+++ b/server/admin/admin_test.go
@@ -1,0 +1,110 @@
+package admin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/server/admin"
+)
+
+func handler(body string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+func TestBackendSwap(t *testing.T) {
+	b := admin.NewBackend(handler("first"))
+
+	if got := do(t, b, http.MethodGet, "/"); got != "first" {
+		t.Fatalf("before swap = %q, want first", got)
+	}
+
+	b.Swap(handler("second"))
+	if got := do(t, b, http.MethodGet, "/"); got != "second" {
+		t.Fatalf("after swap = %q, want second", got)
+	}
+}
+
+// TestBackendConcurrentSwap exercises the hot-swap under the race detector:
+// many readers serving while a writer swaps the handler must never race.
+func TestBackendConcurrentSwap(t *testing.T) {
+	b := admin.NewBackend(handler("a"))
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_ = do(t, b, http.MethodGet, "/")
+				}
+			}
+		}()
+	}
+	for i := range 200 {
+		b.Swap(handler(string(rune('a' + i%26))))
+	}
+	close(done)
+	wg.Wait()
+}
+
+func TestControlReset(t *testing.T) {
+	resets := 0
+	b := admin.NewBackend(handler("backend"))
+	c := admin.NewControl(b, func() { resets++; b.Swap(handler("rebuilt")) })
+
+	// Non-control paths pass through to the backend.
+	if got := do(t, c, http.MethodGet, "/some/aws/request"); got != "backend" {
+		t.Fatalf("passthrough = %q, want backend", got)
+	}
+
+	// POST /_cloudemu/reset runs the reset and swaps the backend.
+	rec := httptest.NewRecorder()
+	c.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, admin.Prefix+"reset", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want 200", rec.Code)
+	}
+	if resets != 1 {
+		t.Fatalf("reset ran %d times, want 1", resets)
+	}
+	if got := do(t, c, http.MethodGet, "/some/aws/request"); got != "rebuilt" {
+		t.Fatalf("after reset the backend = %q, want rebuilt", got)
+	}
+}
+
+func TestControlRoutes(t *testing.T) {
+	b := admin.NewBackend(handler("backend"))
+	c := admin.NewControl(b, func() {})
+
+	cases := []struct {
+		method, path string
+		want         int
+	}{
+		{http.MethodGet, admin.Prefix + "reset", http.StatusMethodNotAllowed}, // reset is POST-only
+		{http.MethodGet, admin.Prefix + "health", http.StatusOK},
+		{http.MethodPost, admin.Prefix + "seed", http.StatusNotImplemented}, // #250
+		{http.MethodGet, admin.Prefix + "bogus", http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		rec := httptest.NewRecorder()
+		c.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+		if rec.Code != tc.want {
+			t.Errorf("%s %s = %d, want %d", tc.method, tc.path, rec.Code, tc.want)
+		}
+	}
+}
+
+func do(t *testing.T, h http.Handler, method, path string) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec.Body.String()
+}


### PR DESCRIPTION
Implements the **reset** half of #244 — the biggest DX gap left after the standalone server (#224): a long-lived `cloudemu serve` process shared by an out-of-process or parallel test suite had no way to get a clean slate between tests.

## What's new

A control plane at `/_cloudemu` on the standalone server (on by default; `--admin=false` to disable):

- **`POST /_cloudemu/reset`** — rebuild every provider (and the shared Kubernetes data-plane) to empty state and swap it in atomically. In-flight requests finish against the old state; new requests see the fresh one. A POST to any provider's port resets the whole emulator.
- **`GET /_cloudemu/health`** — liveness.
- **`/_cloudemu/seed`** — reserved, returns `501` (bulk seeding needs the cross-service fixture loader in #250; until then, create resources with your SDK after reset).

## Why this shape

New `server/admin` package: a hot-swappable `Backend` + a `Control` that routes the `/_cloudemu` prefix and passes everything else through. `reset` reuses the existing `NewAWS(opts)` / `DriversFrom` construction path to build a fresh provider+server and swap it in — so **no mock, wire-handler, driver, or core `server.Server` code changes**. The state lifecycle lives only in the standalone binary's wiring, exactly where out-of-process reset belongs (in-process users just construct a fresh provider).

## Testing

- **Acceptance (out-of-process, real SDK):** `serve_test.go` boots the binary, creates an S3 bucket with a real `aws-sdk-go-v2` client, `POST`s `/_cloudemu/reset`, and confirms `ListBuckets` is empty — #244's stated acceptance.
- `server/admin` unit tests: backend hot-swap, reset routing, and method/route table (reset POST-only, health 200, seed 501, unknown 404).
- Full `go test ./...`, `go vet`, `gofmt` clean.

## Follow-ups
`seed` (with #250) and `snapshot`/`restore` (with #107) remain; the endpoints are namespaced so they slot in without breaking callers.