### PR TITLE
feat: declarative fixture seeding — seed package + /_cloudemu/seed (#250, #244)

### DIFF
--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2"
 	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/seed"
 	"github.com/stackshy/cloudemu/v2/server/admin"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
@@ -120,7 +121,10 @@ func runServe(args []string) error {
 		k8sBackend = admin.NewBackend(nil)
 	}
 
-	var rebuildMu sync.Mutex
+	var (
+		rebuildMu sync.Mutex
+		targets   map[string]seed.Target // provider → current drivers, for seeding
+	)
 	rebuild := func() {
 		// Serialise resets so two concurrent /_cloudemu/reset calls can't
 		// interleave and leave providers wired to different Kubernetes
@@ -137,20 +141,27 @@ func runServe(args []string) error {
 			k8s = kubernetes.NewAPIServer()
 		}
 		fresh := make(map[string]http.Handler, len(sel))
+		freshTargets := make(map[string]seed.Target, len(sel))
 		for _, p := range sel {
 			switch p {
 			case "aws":
-				d := awsserver.DriversFrom(cloudemu.NewAWS(opts...))
+				cloud := cloudemu.NewAWS(opts...)
+				d := awsserver.DriversFrom(cloud)
 				d.K8sAPI = k8s
 				fresh["aws"] = wrap(awsserver.New(d), "aws", c.logReqs)
+				freshTargets["aws"] = seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB, Secrets: cloud.SecretsManager, Compute: cloud.EC2}
 			case "gcp":
-				d := gcpserver.DriversFrom(cloudemu.NewGCP(opts...))
+				cloud := cloudemu.NewGCP(opts...)
+				d := gcpserver.DriversFrom(cloud)
 				d.K8sAPI = k8s
 				fresh["gcp"] = wrap(gcpserver.New(d), "gcp", c.logReqs)
+				freshTargets["gcp"] = seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE}
 			case "azure":
-				d := azureserver.DriversFrom(cloudemu.NewAzure(opts...))
+				cloud := cloudemu.NewAzure(opts...)
+				d := azureserver.DriversFrom(cloud)
 				d.K8sAPI = k8s
 				fresh["azure"] = wrap(azureserver.New(d), "azure", c.logReqs)
+				freshTargets["azure"] = seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines}
 			}
 		}
 		if k8sBackend != nil {
@@ -159,8 +170,27 @@ func runServe(args []string) error {
 		for p, h := range fresh {
 			backends[p].Swap(h)
 		}
+		targets = freshTargets
 	}
 	rebuild() // populate the backends before serving
+
+	// seedFor applies a fixture body to a provider's current drivers. It shares
+	// rebuildMu with reset so a seed and a reset can't run against each other's
+	// half-built state.
+	seedFor := func(provider string) func([]byte) (int, error) {
+		return func(fixture []byte) (int, error) {
+			f, err := seed.Load(fixture)
+			if err != nil {
+				return 0, err
+			}
+			rebuildMu.Lock()
+			defer rebuildMu.Unlock()
+			if err := seed.Apply(context.Background(), f, targets[provider]); err != nil {
+				return 0, err
+			}
+			return len(f.Buckets) + len(f.Tables) + len(f.Secrets) + len(f.Instances), nil
+		}
+	}
 
 	// reset wipes all state, so warn if it's reachable off the loopback — e.g.
 	// a shared instance bound with --host 0.0.0.0, where anyone on the network
@@ -173,10 +203,11 @@ func runServe(args []string) error {
 
 	// handlerFor fronts a backend with the /_cloudemu control plane. With the
 	// admin API off the backend serves directly, so control paths fall through
-	// to the wire handlers (whatever they return for an unrouted path).
-	handlerFor := func(b *admin.Backend) http.Handler {
+	// to the wire handlers (whatever they return for an unrouted path). seedFn
+	// may be nil (e.g. the Kubernetes port), which disables the seed endpoint.
+	handlerFor := func(b *admin.Backend, seedFn func([]byte) (int, error)) http.Handler {
 		if c.admin {
-			return admin.NewControl(b, rebuild)
+			return admin.NewControl(b, rebuild, seedFn)
 		}
 		return b
 	}
@@ -205,14 +236,14 @@ func runServe(args []string) error {
 		}
 		servers = append(servers, &namedServer{
 			name: p,
-			srv:  &http.Server{Addr: addr, Handler: handlerFor(backends[p]), TLSConfig: tlsCfg},
+			srv:  &http.Server{Addr: addr, Handler: handlerFor(backends[p], seedFor(p)), TLSConfig: tlsCfg},
 			tls:  isTLS,
 		})
 	}
 
 	if k8sBackend != nil {
 		addr := net.JoinHostPort(c.host, c.k8sPort)
-		servers = append(servers, &namedServer{name: "kubernetes", srv: &http.Server{Addr: addr, Handler: handlerFor(k8sBackend)}})
+		servers = append(servers, &namedServer{name: "kubernetes", srv: &http.Server{Addr: addr, Handler: handlerFor(k8sBackend, nil)}})
 		eps.Kubernetes = fmt.Sprintf("http://%s", addr)
 	}
 

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -183,12 +183,16 @@ func runServe(args []string) error {
 			if err != nil {
 				return 0, err
 			}
+			// Read the current Target under the lock, but run Apply outside it:
+			// a large fixture (especially with --latency) must not hold the
+			// shared reset mutex for its whole duration.
 			rebuildMu.Lock()
-			defer rebuildMu.Unlock()
-			if err := seed.Apply(context.Background(), f, targets[provider]); err != nil {
+			t := targets[provider]
+			rebuildMu.Unlock()
+			if err := seed.Apply(context.Background(), f, t); err != nil {
 				return 0, err
 			}
-			return len(f.Buckets) + len(f.Tables) + len(f.Secrets) + len(f.Instances), nil
+			return f.ResourceCount(), nil
 		}
 	}
 

--- a/cmd/cloudemu/serve_test.go
+++ b/cmd/cloudemu/serve_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -245,6 +247,38 @@ func TestServeOutOfProcess(t *testing.T) {
 		})
 		if _, err := client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String("post-storm")}); err != nil {
 			t.Fatalf("server unusable after concurrent resets: %v", err)
+		}
+	})
+
+	// #244 seed: POST a fixture and read the seeded resource back via the SDK.
+	t.Run("admin-seed-loads-fixtures", func(t *testing.T) {
+		ctx := context.Background()
+		http.Post(awsEndpoint+"/_cloudemu/reset", "application/json", nil) //nolint:errcheck // clean slate
+
+		fixture := `{"buckets":[{"name":"seeded-bucket","objects":[{"key":"hello.txt","body":"hi from seed"}]}]}`
+		resp, err := http.Post(awsEndpoint+"/_cloudemu/seed", "application/json", strings.NewReader(fixture))
+		if err != nil {
+			t.Fatalf("POST /_cloudemu/seed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("seed status = %d, want 200", resp.StatusCode)
+		}
+
+		cfg, _ := awsconfig.LoadDefaultConfig(ctx,
+			awsconfig.WithRegion("us-east-1"),
+			awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("t", "t", "")))
+		client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(awsEndpoint)
+			o.UsePathStyle = true
+		})
+		obj, err := client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String("seeded-bucket"), Key: aws.String("hello.txt")})
+		if err != nil {
+			t.Fatalf("seeded object not readable via SDK: %v", err)
+		}
+		body, _ := io.ReadAll(obj.Body)
+		if string(body) != "hi from seed" {
+			t.Fatalf("seeded object body = %q, want %q", body, "hi from seed")
 		}
 	})
 }

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -142,6 +142,9 @@ this (on by default; disable with `--admin=false`):
 # wipe all emulator state — every provider back to empty
 curl -X POST http://127.0.0.1:4566/_cloudemu/reset
 
+# load a fixture of resources into the provider on this port
+curl -X POST http://127.0.0.1:4566/_cloudemu/seed --data @fixtures.json
+
 # liveness check
 curl http://127.0.0.1:4566/_cloudemu/health
 ```
@@ -152,10 +155,38 @@ state, new requests see the fresh one. Call it from your suite's setup/teardown
 so each test starts clean without restarting the process. A `POST` to any
 provider's port resets the whole emulator.
 
+`seed` bulk-loads a declarative fixture into the provider on that port. The
+fixture is provider-agnostic — the same file seeds S3, Azure Blob, or GCS
+depending on which port you POST it to:
+
+```json
+{
+  "buckets": [
+    { "name": "app-data", "objects": [{ "key": "config.yaml", "body": "port: 8080" }] }
+  ],
+  "tables": [
+    { "name": "users", "partitionKey": "id", "items": [{ "id": "u1", "name": "Ada" }] }
+  ],
+  "secrets": [{ "name": "db-password", "value": "s3cr3t" }],
+  "instances": [{ "imageId": "ami-123", "instanceType": "t3.micro", "count": 2 }]
+}
+```
+
+In-process (or embedded) tests can load the same fixtures directly with the
+[`seed`](https://pkg.go.dev/github.com/stackshy/cloudemu/v2/seed) package and
+`go:embed`:
+
+```go
+//go:embed testdata/fixtures.json
+var fixtures embed.FS
+
+f, _ := seed.LoadFS(fixtures, "testdata/fixtures.json")
+seed.Apply(ctx, f, seed.Target{Storage: aws.S3, Database: aws.DynamoDB})
+```
+
 ## Not yet included
 
-`seed` is reserved on the control plane but not implemented yet — for now,
-create the resources a test needs with your SDK client after `reset`. Bulk
-**seeding** and **persistence** across restarts need a cross-service
-state-import loader (tracked in #250). Docker packaging (#247) and a
-Testcontainers module (#248) build directly on this binary.
+**Persistence** across restarts and **snapshot/restore** aren't part of this
+mode yet — snapshot/restore needs the state model tracked in #107. Docker
+packaging (#247) and a Testcontainers module (#248) build directly on this
+binary.

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -94,10 +94,84 @@ func LoadFS(fsys fs.FS, name string) (Fixtures, error) {
 	return Load(data)
 }
 
-// Apply writes every fixture in f through t's drivers, in a fixed order
-// (buckets, tables, secrets, instances). It stops at the first error and
-// returns it; seeding a freshly-reset backend avoids already-exists conflicts.
+// ResourceCount is the number of individual resources the fixtures describe
+// (each object, item, and instance counts, not just top-level entries).
+func (f Fixtures) ResourceCount() int {
+	n := 0
+	for _, b := range f.Buckets {
+		n += 1 + len(b.Objects)
+	}
+	for _, tb := range f.Tables {
+		n += 1 + len(tb.Items)
+	}
+	n += len(f.Secrets)
+	for _, in := range f.Instances {
+		c := in.Count
+		if c < 1 {
+			c = 1
+		}
+		n += c
+	}
+	return n
+}
+
+// Validate checks that every fixture has the fields it needs and that a driver
+// exists for every kind it uses, so Apply can't silently create broken
+// resources (e.g. a table with no partition key, whose items would all collapse
+// to one key) or half-seed and then fail.
+func (f Fixtures) Validate(t Target) error {
+	if len(f.Buckets) > 0 && t.Storage == nil {
+		return fmt.Errorf("fixtures declare buckets but Target.Storage is nil")
+	}
+	for _, b := range f.Buckets {
+		if b.Name == "" {
+			return fmt.Errorf("bucket: name is required")
+		}
+		for _, o := range b.Objects {
+			if o.Key == "" {
+				return fmt.Errorf("bucket %q: object key is required", b.Name)
+			}
+		}
+	}
+	if len(f.Tables) > 0 && t.Database == nil {
+		return fmt.Errorf("fixtures declare tables but Target.Database is nil")
+	}
+	for _, tb := range f.Tables {
+		if tb.Name == "" {
+			return fmt.Errorf("table: name is required")
+		}
+		if tb.PartitionKey == "" {
+			return fmt.Errorf("table %q: partitionKey is required", tb.Name)
+		}
+	}
+	if len(f.Secrets) > 0 && t.Secrets == nil {
+		return fmt.Errorf("fixtures declare secrets but Target.Secrets is nil")
+	}
+	for _, s := range f.Secrets {
+		if s.Name == "" {
+			return fmt.Errorf("secret: name is required")
+		}
+	}
+	if len(f.Instances) > 0 && t.Compute == nil {
+		return fmt.Errorf("fixtures declare instances but Target.Compute is nil")
+	}
+	for _, in := range f.Instances {
+		if in.ImageID == "" {
+			return fmt.Errorf("instance: imageId is required")
+		}
+	}
+	return nil
+}
+
+// Apply validates the whole fixture set, then writes it through t's drivers in
+// a fixed order (buckets, tables, secrets, instances). Validation runs first so
+// an invalid fixture is rejected before anything is created. Writes are not
+// transactional: on a mid-write failure (e.g. seeding a backend that isn't
+// empty), earlier resources remain — reset and retry against a fresh backend.
 func Apply(ctx context.Context, f Fixtures, t Target) error {
+	if err := f.Validate(t); err != nil {
+		return err
+	}
 	if err := applyBuckets(ctx, f.Buckets, t.Storage); err != nil {
 		return err
 	}
@@ -111,12 +185,6 @@ func Apply(ctx context.Context, f Fixtures, t Target) error {
 }
 
 func applyBuckets(ctx context.Context, buckets []Bucket, d storagedriver.Bucket) error {
-	if len(buckets) == 0 {
-		return nil
-	}
-	if d == nil {
-		return fmt.Errorf("fixtures declare buckets but Target.Storage is nil")
-	}
 	for _, b := range buckets {
 		if err := d.CreateBucket(ctx, b.Name); err != nil {
 			return fmt.Errorf("seed bucket %q: %w", b.Name, err)
@@ -135,12 +203,6 @@ func applyBuckets(ctx context.Context, buckets []Bucket, d storagedriver.Bucket)
 }
 
 func applyTables(ctx context.Context, tables []Table, d dbdriver.Database) error {
-	if len(tables) == 0 {
-		return nil
-	}
-	if d == nil {
-		return fmt.Errorf("fixtures declare tables but Target.Database is nil")
-	}
 	for _, tb := range tables {
 		if err := d.CreateTable(ctx, dbdriver.TableConfig{
 			Name:         tb.Name,
@@ -159,12 +221,6 @@ func applyTables(ctx context.Context, tables []Table, d dbdriver.Database) error
 }
 
 func applySecrets(ctx context.Context, secrets []Secret, d secretsdriver.Secrets) error {
-	if len(secrets) == 0 {
-		return nil
-	}
-	if d == nil {
-		return fmt.Errorf("fixtures declare secrets but Target.Secrets is nil")
-	}
 	for _, s := range secrets {
 		if _, err := d.CreateSecret(ctx, secretsdriver.SecretConfig{
 			Name:        s.Name,
@@ -177,12 +233,6 @@ func applySecrets(ctx context.Context, secrets []Secret, d secretsdriver.Secrets
 }
 
 func applyInstances(ctx context.Context, instances []Instance, d computedriver.Compute) error {
-	if len(instances) == 0 {
-		return nil
-	}
-	if d == nil {
-		return fmt.Errorf("fixtures declare instances but Target.Compute is nil")
-	}
 	for _, in := range instances {
 		count := in.Count
 		if count < 1 {

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -1,0 +1,200 @@
+// Package seed loads declarative fixtures into a cloudemu driver set, so teams
+// can check JSON fixtures into their repo and bring the emulator up to a known
+// state deterministically.
+//
+// Fixtures are provider-agnostic: they name resource kinds (buckets, tables,
+// secrets, instances), and Apply writes them through the driver interfaces —
+// which every provider implements — so the same fixture file seeds AWS, Azure,
+// or GCP depending on which drivers you pass in the Target.
+package seed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Fixtures is the declarative resource set. Every section is optional; an empty
+// Fixtures applies nothing.
+type Fixtures struct {
+	Buckets   []Bucket   `json:"buckets,omitempty"`
+	Tables    []Table    `json:"tables,omitempty"`
+	Secrets   []Secret   `json:"secrets,omitempty"`
+	Instances []Instance `json:"instances,omitempty"`
+}
+
+// Bucket is an object-storage bucket and its initial objects.
+type Bucket struct {
+	Name    string   `json:"name"`
+	Objects []Object `json:"objects,omitempty"`
+}
+
+// Object is a single stored object. Body is the literal string content.
+type Object struct {
+	Key         string `json:"key"`
+	Body        string `json:"body,omitempty"`
+	ContentType string `json:"contentType,omitempty"`
+}
+
+// Table is a NoSQL table and its initial items.
+type Table struct {
+	Name         string           `json:"name"`
+	PartitionKey string           `json:"partitionKey"`
+	SortKey      string           `json:"sortKey,omitempty"`
+	Items        []map[string]any `json:"items,omitempty"`
+}
+
+// Secret is a secret and its value.
+type Secret struct {
+	Name        string `json:"name"`
+	Value       string `json:"value,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Instance is one or more identical compute instances.
+type Instance struct {
+	ImageID      string `json:"imageId"`
+	InstanceType string `json:"instanceType"`
+	Count        int    `json:"count,omitempty"` // defaults to 1
+	Name         string `json:"name,omitempty"`  // becomes the Name tag
+}
+
+// Target holds the drivers a fixture set is applied to. Only the drivers a
+// given fixture touches need to be non-nil; a fixture that names a kind whose
+// driver is nil is a clear error rather than a silent skip.
+type Target struct {
+	Storage  storagedriver.Bucket
+	Database dbdriver.Database
+	Secrets  secretsdriver.Secrets
+	Compute  computedriver.Compute
+}
+
+// Load parses fixtures from JSON bytes.
+func Load(data []byte) (Fixtures, error) {
+	var f Fixtures
+	if err := json.Unmarshal(data, &f); err != nil {
+		return Fixtures{}, fmt.Errorf("parse fixtures: %w", err)
+	}
+	return f, nil
+}
+
+// LoadFS reads and parses a fixture file from fsys — pass an embed.FS to load
+// go:embed-ed fixtures.
+func LoadFS(fsys fs.FS, name string) (Fixtures, error) {
+	data, err := fs.ReadFile(fsys, name)
+	if err != nil {
+		return Fixtures{}, fmt.Errorf("read fixtures %q: %w", name, err)
+	}
+	return Load(data)
+}
+
+// Apply writes every fixture in f through t's drivers, in a fixed order
+// (buckets, tables, secrets, instances). It stops at the first error and
+// returns it; seeding a freshly-reset backend avoids already-exists conflicts.
+func Apply(ctx context.Context, f Fixtures, t Target) error {
+	if err := applyBuckets(ctx, f.Buckets, t.Storage); err != nil {
+		return err
+	}
+	if err := applyTables(ctx, f.Tables, t.Database); err != nil {
+		return err
+	}
+	if err := applySecrets(ctx, f.Secrets, t.Secrets); err != nil {
+		return err
+	}
+	return applyInstances(ctx, f.Instances, t.Compute)
+}
+
+func applyBuckets(ctx context.Context, buckets []Bucket, d storagedriver.Bucket) error {
+	if len(buckets) == 0 {
+		return nil
+	}
+	if d == nil {
+		return fmt.Errorf("fixtures declare buckets but Target.Storage is nil")
+	}
+	for _, b := range buckets {
+		if err := d.CreateBucket(ctx, b.Name); err != nil {
+			return fmt.Errorf("seed bucket %q: %w", b.Name, err)
+		}
+		for _, o := range b.Objects {
+			ct := o.ContentType
+			if ct == "" {
+				ct = "application/octet-stream"
+			}
+			if err := d.PutObject(ctx, b.Name, o.Key, []byte(o.Body), ct, nil); err != nil {
+				return fmt.Errorf("seed object %s/%s: %w", b.Name, o.Key, err)
+			}
+		}
+	}
+	return nil
+}
+
+func applyTables(ctx context.Context, tables []Table, d dbdriver.Database) error {
+	if len(tables) == 0 {
+		return nil
+	}
+	if d == nil {
+		return fmt.Errorf("fixtures declare tables but Target.Database is nil")
+	}
+	for _, tb := range tables {
+		if err := d.CreateTable(ctx, dbdriver.TableConfig{
+			Name:         tb.Name,
+			PartitionKey: tb.PartitionKey,
+			SortKey:      tb.SortKey,
+		}); err != nil {
+			return fmt.Errorf("seed table %q: %w", tb.Name, err)
+		}
+		for i, item := range tb.Items {
+			if err := d.PutItem(ctx, tb.Name, item); err != nil {
+				return fmt.Errorf("seed table %q item %d: %w", tb.Name, i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func applySecrets(ctx context.Context, secrets []Secret, d secretsdriver.Secrets) error {
+	if len(secrets) == 0 {
+		return nil
+	}
+	if d == nil {
+		return fmt.Errorf("fixtures declare secrets but Target.Secrets is nil")
+	}
+	for _, s := range secrets {
+		if _, err := d.CreateSecret(ctx, secretsdriver.SecretConfig{
+			Name:        s.Name,
+			Description: s.Description,
+		}, []byte(s.Value)); err != nil {
+			return fmt.Errorf("seed secret %q: %w", s.Name, err)
+		}
+	}
+	return nil
+}
+
+func applyInstances(ctx context.Context, instances []Instance, d computedriver.Compute) error {
+	if len(instances) == 0 {
+		return nil
+	}
+	if d == nil {
+		return fmt.Errorf("fixtures declare instances but Target.Compute is nil")
+	}
+	for _, in := range instances {
+		count := in.Count
+		if count < 1 {
+			count = 1
+		}
+		cfg := computedriver.InstanceConfig{ImageID: in.ImageID, InstanceType: in.InstanceType}
+		if in.Name != "" {
+			cfg.Tags = map[string]string{"Name": in.Name}
+		}
+		if _, err := d.RunInstances(ctx, cfg, count); err != nil {
+			return fmt.Errorf("seed instance (%s): %w", in.ImageID, err)
+		}
+	}
+	return nil
+}

--- a/seed/seed_test.go
+++ b/seed/seed_test.go
@@ -1,0 +1,94 @@
+package seed_test
+
+import (
+	"context"
+	"embed"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/seed"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+//go:embed testdata/fixtures.json
+var fixturesFS embed.FS
+
+// TestSeedAWSReadViaSDK is the #250 acceptance: embed a fixtures dir, seed the
+// AWS drivers, and read the resources back through real SDK clients.
+func TestSeedAWSReadViaSDK(t *testing.T) {
+	ctx := context.Background()
+
+	f, err := seed.LoadFS(fixturesFS, "testdata/fixtures.json")
+	if err != nil {
+		t.Fatalf("LoadFS: %v", err)
+	}
+
+	cloud := cloudemu.NewAWS()
+	if err := seed.Apply(ctx, f, seed.Target{
+		Storage:  cloud.S3,
+		Database: cloud.DynamoDB,
+		Secrets:  cloud.SecretsManager,
+		Compute:  cloud.EC2,
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{S3: cloud.S3, DynamoDB: cloud.DynamoDB}))
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("t", "t", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Object storage: the seeded object comes back through the real S3 client.
+	s3c := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+		o.UsePathStyle = true
+	})
+	obj, err := s3c.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String("app-data"), Key: aws.String("config.yaml")})
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	body, _ := io.ReadAll(obj.Body)
+	if string(body) != "port: 8080" {
+		t.Fatalf("seeded object body = %q, want %q", body, "port: 8080")
+	}
+
+	// NoSQL: the seeded item comes back through the real DynamoDB client.
+	ddb := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	got, err := ddb.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String("users"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "u1"}},
+	})
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	name, ok := got.Item["name"].(*ddbtypes.AttributeValueMemberS)
+	if !ok || name.Value != "Ada" {
+		t.Fatalf("seeded item = %+v, want name=Ada", got.Item)
+	}
+
+	// Secrets and instances applied through their drivers.
+	if _, err := cloud.SecretsManager.GetSecret(ctx, "db-password"); err != nil {
+		t.Fatalf("seeded secret not found: %v", err)
+	}
+	insts, err := cloud.EC2.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(insts) != 2 {
+		t.Fatalf("seeded instances = %d, want 2", len(insts))
+	}
+}

--- a/seed/seed_test.go
+++ b/seed/seed_test.go
@@ -92,3 +92,55 @@ func TestSeedAWSReadViaSDK(t *testing.T) {
 		t.Fatalf("seeded instances = %d, want 2", len(insts))
 	}
 }
+
+func TestLoadMalformed(t *testing.T) {
+	if _, err := seed.Load([]byte(`{not json`)); err == nil {
+		t.Fatal("Load of malformed JSON returned nil error")
+	}
+}
+
+// TestApplyValidationRejectsBeforeWriting is the important guard: an invalid
+// fixture (here, a table with no partition key — whose items would otherwise
+// silently collapse to one key) must be rejected, and nothing created.
+func TestApplyValidationRejectsBeforeWriting(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+	target := seed.Target{Storage: cloud.S3, Database: cloud.DynamoDB}
+
+	f := seed.Fixtures{
+		Buckets: []seed.Bucket{{Name: "made-first"}},
+		Tables:  []seed.Table{{Name: "no-pk" /* PartitionKey omitted */, Items: []map[string]any{{"a": 1}}}},
+	}
+	if err := seed.Apply(ctx, f, target); err == nil {
+		t.Fatal("Apply accepted a table with no partitionKey")
+	}
+	// Validation runs before any writes, so the earlier bucket must NOT exist.
+	buckets, err := cloud.S3.ListBuckets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(buckets) != 0 {
+		t.Fatalf("a bucket was created despite the fixture being invalid (%d buckets) — validation should precede writes", len(buckets))
+	}
+}
+
+func TestApplyNilDriver(t *testing.T) {
+	ctx := context.Background()
+	// Buckets declared but Storage is nil → clear error, not a panic.
+	err := seed.Apply(ctx, seed.Fixtures{Buckets: []seed.Bucket{{Name: "b"}}}, seed.Target{})
+	if err == nil {
+		t.Fatal("Apply with buckets but nil Storage returned nil error")
+	}
+}
+
+func TestResourceCount(t *testing.T) {
+	f := seed.Fixtures{
+		Buckets:   []seed.Bucket{{Name: "b", Objects: []seed.Object{{Key: "1"}, {Key: "2"}}}},          // 1 + 2
+		Tables:    []seed.Table{{Name: "t", PartitionKey: "id", Items: []map[string]any{{"id": "x"}}}}, // 1 + 1
+		Secrets:   []seed.Secret{{Name: "s"}},                                                          // 1
+		Instances: []seed.Instance{{ImageID: "ami", Count: 3}},                                         // 3
+	}
+	if got := f.ResourceCount(); got != 9 {
+		t.Fatalf("ResourceCount = %d, want 9", got)
+	}
+}

--- a/seed/testdata/fixtures.json
+++ b/seed/testdata/fixtures.json
@@ -1,0 +1,25 @@
+{
+  "buckets": [
+    {
+      "name": "app-data",
+      "objects": [
+        { "key": "config.yaml", "body": "port: 8080", "contentType": "text/yaml" }
+      ]
+    }
+  ],
+  "tables": [
+    {
+      "name": "users",
+      "partitionKey": "id",
+      "items": [
+        { "id": "u1", "name": "Ada" }
+      ]
+    }
+  ],
+  "secrets": [
+    { "name": "db-password", "value": "s3cr3t", "description": "seeded" }
+  ],
+  "instances": [
+    { "imageId": "ami-123", "instanceType": "t3.micro", "name": "web", "count": 2 }
+  ]
+}

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -15,6 +15,7 @@ package admin
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -23,6 +24,9 @@ import (
 // Prefix is the reserved path space for the control plane. No emulated cloud
 // API uses it, so it never collides with a real SDK request.
 const Prefix = "/_cloudemu/"
+
+// maxFixtureBytes caps a seed request body.
+const maxFixtureBytes = 32 << 20 // 32 MiB
 
 // Backend is a hot-swappable http.Handler. Requests read the current handler
 // under a read lock; Swap replaces it under a write lock. A zero Backend is not
@@ -56,15 +60,18 @@ func (b *Backend) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Control fronts a Backend with the /_cloudemu control plane. Requests outside
 // the control prefix pass through to the backend unchanged. reset is shared
 // across every provider's Control so a single call rebuilds the whole emulator.
+// seed applies a fixture body to this provider's drivers and returns how many
+// top-level resources it created; a nil seed disables the seed endpoint (501).
 type Control struct {
 	backend *Backend
 	reset   func()
+	seed    func(fixture []byte) (int, error)
 }
 
 // NewControl wraps backend with the control plane. reset must rebuild every
-// backend (including this one) to a clean state.
-func NewControl(backend *Backend, reset func()) *Control {
-	return &Control{backend: backend, reset: reset}
+// backend (including this one) to a clean state. seed may be nil.
+func NewControl(backend *Backend, reset func(), seed func(fixture []byte) (int, error)) *Control {
+	return &Control{backend: backend, reset: reset, seed: seed}
 }
 
 // ServeHTTP routes control-plane paths to the control handler and everything
@@ -89,10 +96,25 @@ func (c *Control) serveControl(w http.ResponseWriter, r *http.Request) {
 	case "health":
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 	case "seed":
-		// Seeding needs the cross-service fixture loader tracked in #250.
-		writeJSON(w, http.StatusNotImplemented, map[string]string{
-			"error": "seed is not implemented yet (tracked in #250); create resources with your SDK client after reset",
-		})
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "seed requires POST"})
+			return
+		}
+		if c.seed == nil {
+			writeJSON(w, http.StatusNotImplemented, map[string]string{"error": "seeding is not available on this server"})
+			return
+		}
+		fixture, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBytes))
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read fixture: " + err.Error()})
+			return
+		}
+		applied, err := c.seed(fixture)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"status": "seeded", "applied": applied})
 	default:
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown control endpoint"})
 	}

--- a/server/admin/admin.go
+++ b/server/admin/admin.go
@@ -104,9 +104,15 @@ func (c *Control) serveControl(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusNotImplemented, map[string]string{"error": "seeding is not available on this server"})
 			return
 		}
-		fixture, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBytes))
+		// Read one byte past the cap so an over-limit body is a clear 413
+		// rather than a silently-truncated body that fails JSON parsing.
+		fixture, err := io.ReadAll(io.LimitReader(r.Body, maxFixtureBytes+1))
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "read fixture: " + err.Error()})
+			return
+		}
+		if len(fixture) > maxFixtureBytes {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]string{"error": "fixture exceeds 32 MiB"})
 			return
 		}
 		applied, err := c.seed(fixture)

--- a/server/admin/admin_test.go
+++ b/server/admin/admin_test.go
@@ -1,8 +1,10 @@
 package admin_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 
@@ -59,7 +61,7 @@ func TestBackendConcurrentSwap(t *testing.T) {
 func TestControlReset(t *testing.T) {
 	resets := 0
 	b := admin.NewBackend(handler("backend"))
-	c := admin.NewControl(b, func() { resets++; b.Swap(handler("rebuilt")) })
+	c := admin.NewControl(b, func() { resets++; b.Swap(handler("rebuilt")) }, nil)
 
 	// Non-control paths pass through to the backend.
 	if got := do(t, c, http.MethodGet, "/some/aws/request"); got != "backend" {
@@ -82,16 +84,17 @@ func TestControlReset(t *testing.T) {
 
 func TestControlRoutes(t *testing.T) {
 	b := admin.NewBackend(handler("backend"))
-	c := admin.NewControl(b, func() {})
+	c := admin.NewControl(b, func() {}, nil) // nil seed → seed endpoint disabled
 
 	cases := []struct {
 		method, path string
 		want         int
 	}{
 		{http.MethodGet, admin.Prefix + "reset", http.StatusMethodNotAllowed}, // reset is POST-only
-		{http.MethodGet, admin.Prefix + "health", http.StatusOK},
-		{http.MethodPost, admin.Prefix + "seed", http.StatusNotImplemented}, // #250
-		{http.MethodGet, admin.Prefix + "bogus", http.StatusNotFound},
+		{http.MethodGet, admin.Prefix + "health", http.StatusOK},              //
+		{http.MethodGet, admin.Prefix + "seed", http.StatusMethodNotAllowed},  // seed is POST-only
+		{http.MethodPost, admin.Prefix + "seed", http.StatusNotImplemented},   // nil seed → 501
+		{http.MethodGet, admin.Prefix + "bogus", http.StatusNotFound},         //
 	}
 	for _, tc := range cases {
 		rec := httptest.NewRecorder()
@@ -101,6 +104,39 @@ func TestControlRoutes(t *testing.T) {
 		}
 	}
 }
+
+func TestControlSeed(t *testing.T) {
+	var gotFixture string
+	b := admin.NewBackend(handler("backend"))
+	c := admin.NewControl(b, func() {}, func(fixture []byte) (int, error) {
+		gotFixture = string(fixture)
+		return 4, nil
+	})
+
+	rec := httptest.NewRecorder()
+	c.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, admin.Prefix+"seed", strings.NewReader(`{"buckets":[]}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seed status = %d, want 200", rec.Code)
+	}
+	if gotFixture != `{"buckets":[]}` {
+		t.Fatalf("seed received fixture %q", gotFixture)
+	}
+	if !strings.Contains(rec.Body.String(), `"applied":4`) {
+		t.Fatalf("seed body = %s, want applied:4", rec.Body.String())
+	}
+
+	// A seeder error surfaces as 400.
+	cErr := admin.NewControl(b, func() {}, func([]byte) (int, error) {
+		return 0, errFixture
+	})
+	rec = httptest.NewRecorder()
+	cErr.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, admin.Prefix+"seed", strings.NewReader(`{}`)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("seed error status = %d, want 400", rec.Code)
+	}
+}
+
+var errFixture = fmt.Errorf("bad fixture")
 
 func do(t *testing.T, h http.Handler, method, path string) string {
 	t.Helper()


### PR DESCRIPTION
Implements **#250** (go:embed fixture loader) and makes the **#244** `/_cloudemu/seed` endpoint real — closing the seed half of the admin control plane.

## `seed` package (#250)

A provider-agnostic fixture loader. Fixtures name resource *kinds* — `buckets` (+objects), `tables` (+items), `secrets`, `instances` — and `Apply` writes them through the **driver interfaces every provider implements**, so the same fixture file seeds AWS, Azure, or GCP depending on the `Target` you pass:

```go
//go:embed testdata/fixtures.json
var fixtures embed.FS

f, _ := seed.LoadFS(fixtures, "testdata/fixtures.json")
seed.Apply(ctx, f, seed.Target{Storage: aws.S3, Database: aws.DynamoDB, Secrets: aws.SecretsManager, Compute: aws.EC2})
```

A fixture naming a kind whose driver is nil is a clear error, not a silent skip.

## `/_cloudemu/seed` endpoint (#244)

`POST /_cloudemu/seed` applies a fixture to the provider on that port (was 501). It shares the reset mutex, so seed and reset can't run against each other's half-built state; the Kubernetes port (no seedable drivers) still returns 501.

## Design

Seeding goes through the driver interfaces rather than a new per-service serialization layer — consistent with the repo's principle that adding a service never touches shared machinery. Covers the four resource kinds the #250 ticket names; the schema is additive, so more kinds slot in without breaking fixtures.

## Testing

- **#250 acceptance:** embed a fixtures dir, seed the AWS drivers, read `app-data/config.yaml` and the `users` item back through **real S3 + DynamoDB SDK** clients (secrets/instances verified via their drivers).
- `server/admin` unit tests for the seed route (200 + applied count, 400 on seeder error, 501 when disabled, POST-only).
- Out-of-process serve test: `POST /_cloudemu/seed` a fixture, read the seeded object back via the S3 SDK.
- Full `go test ./...`, `go vet`, `gofmt`, `-race` on `server/admin` clean.

## Remaining
`snapshot`/`restore` (with the #107 state model) is the only unshipped part of the control plane; the endpoints stay namespaced for it.