### PR TITLE
feat: publishable Docker image for the standalone server (#247)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Keep the build context small and reproducible.
+.git
+.github
+.claude
+docs
+*.md
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Docker
+
+# Publish a container image to GHCR on every release tag. The image is the
+# standalone server (cmd/cloudemu serve) — see docs/standalone-server.md.
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          # v2.2.0 -> :2.2.0, :2.2, :latest
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# --- build stage -------------------------------------------------------------
+FROM golang:1.25 AS build
+
+WORKDIR /src
+
+# Warm the module cache on just the manifests, so code changes don't refetch.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+
+# Static binary so it runs on a distroless/scratch base with no libc.
+ARG VERSION=docker
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
+    -o /out/cloudemu ./cmd/cloudemu
+
+# --- runtime stage -----------------------------------------------------------
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=build /out/cloudemu /usr/local/bin/cloudemu
+
+# AWS (LocalStack-compatible), Azure (HTTPS), GCP, Kubernetes data-plane.
+EXPOSE 4566 4568 4569 4570
+
+# Bind all interfaces so the container is reachable from the host / other
+# containers. The control plane (/_cloudemu/reset) is on by default — see the
+# docs for --admin=false if you don't want it exposed.
+ENTRYPOINT ["cloudemu"]
+CMD ["serve", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+# Run the whole emulated cloud with one command:
+#
+#   docker compose up
+#
+# Then point your SDKs at the published ports (AWS_ENDPOINT_URL=http://localhost:4566,
+# etc.). Reset state between tests with:  curl -X POST http://localhost:4566/_cloudemu/reset
+services:
+  cloudemu:
+    image: ghcr.io/stackshy/cloudemu:latest
+    # Or build locally instead of pulling:
+    # build: .
+    ports:
+      - "4566:4566" # AWS
+      - "4568:4568" # Azure (HTTPS, self-signed)
+      - "4569:4569" # GCP
+      - "4570:4570" # Kubernetes data-plane
+    # command: ["serve", "--host", "0.0.0.0", "--admin=false"]  # disable the control plane

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -22,6 +22,20 @@ Or from a checkout:
 go run ./cmd/cloudemu serve
 ```
 
+### Docker
+
+No Go toolchain needed — pull the published image (it runs `serve --host 0.0.0.0`):
+
+```sh
+docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 ghcr.io/stackshy/cloudemu:latest
+```
+
+Or bring up the whole emulated cloud with the example compose file:
+
+```sh
+docker compose up
+```
+
 On start it prints the live endpoints:
 
 ```


### PR DESCRIPTION
Fixes #247. A container image is the biggest reach-expander for the standalone server (#224) — it unblocks non-Go users and the Testcontainers module (#248).

## What's added
- **`Dockerfile`** — multi-stage: builds `cmd/cloudemu` into a static (`CGO_ENABLED=0`, `-trimpath`, stripped) binary, then copies it onto `gcr.io/distroless/static-debian12:nonroot`. Runs `serve --host 0.0.0.0`, exposes `4566/4568/4569/4570`. The `VERSION` build-arg flows into `main.version`.
- **`.github/workflows/docker.yml`** — on a `v*` tag, logs into GHCR and pushes `ghcr.io/stackshy/cloudemu` tagged `:X.Y.Z`, `:X.Y`, and `:latest` (docker/metadata + build-push actions, gha layer cache).
- **`docker-compose.yml`** — one-command bring-up of the whole emulated cloud.
- **`.dockerignore`** + a Docker section in `docs/standalone-server.md`.

## Acceptance (verified locally with a real build + run)
```
docker build -t cloudemu . && docker run -p 4566:4566 cloudemu
```
Driving the running container over the mapped port: S3 `CreateBucket` → `PutObject` → `GetObject` round-trips (`hi from docker`), and `POST /_cloudemu/reset` clears it. The container correctly binds `0.0.0.0` and emits the non-loopback admin warning (expected in a container).

Note: the GHCR push only runs on release tags, so it won't fire on this PR — the image build itself is exercised by the local acceptance above.