### PR TITLE
test(aws): de-flake s3/dynamodb lifecycle suites (CI keep-alive flake)

### DIFF
--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -53,6 +54,11 @@ func newSuiteDDBEnv(t *testing.T, opts ...emuconfig.Option) (*dynamodb.Client, *
 	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
 		o.BaseEndpoint = aws.String(ts.URL)
 		o.Retryer = aws.NopRetryer{}
+		// Fresh connection per request. Retries are off (so error semantics are
+		// observed on one attempt), which means a reused keep-alive connection
+		// the httptest server has since closed would surface as a hard
+		// "use of closed network connection" under CI load instead of a retry.
+		o.HTTPClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	})
 
 	return client, provider

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"net/http"
 	"net/http/httptest"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -66,6 +67,10 @@ func newSuiteS3Client(t *testing.T) *s3.Client {
 		o.BaseEndpoint = aws.String(url)
 		o.UsePathStyle = true
 		o.Retryer = aws.NopRetryer{}
+		// Fresh connection per request: with retries off, a reused keep-alive
+		// connection the httptest server has closed would surface as a hard
+		// "use of closed network connection" under CI load instead of a retry.
+		o.HTTPClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	})
 }
 


### PR DESCRIPTION
`TestDDBItemJourney` failed CI twice (on unrelated PRs) with `use of closed network connection` on GetItem/UpdateItem at HTTP 200. Reruns didn't help — it reproduces under the parallel load of `go test ./...`.

## Cause
The `aws-sdk-go-v2` client reuses keep-alive connections. Under CI parallel-package load the `httptest` server can close a connection between two requests; the client then reuses the stale one and the read fails with `use of closed network connection`. These lifecycle suites set `o.Retryer = aws.NopRetryer{}` (deliberately — to observe error semantics on a single attempt), so the transient isn't retried and fails hard. Only `server/aws/s3` and `server/aws/dynamodb` use `NopRetryer`, so only they are affected.

## Fix
Give both suites' SDK clients an HTTP transport with `DisableKeepAlives: true` — a fresh connection per request, no stale reuse — while keeping the single-attempt (NopRetryer) error semantics intact.

## Verified
Both suites pass 20× under `-count=20`; `go vet` clean. Not a cloudemu server bug — a real long-running `cloudemu serve` keeps connections alive normally; this is specific to the tests' rapid sequential requests against short-lived `httptest` servers with retries off.