### PR TITLE
fix: fidelity gaps (#266) — SSM, Azure Tables, S3 (batches 1+2)

### DIFF
--- a/providers/aws/s3/race_test.go
+++ b/providers/aws/s3/race_test.go
@@ -1,0 +1,51 @@
+package s3
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+// TestListPartsConcurrentWithUploadPart exercises ListParts against concurrent
+// UploadPart writes on the same upload (as the SDK's manager.Uploader does).
+// Run with -race it proves the parts map is synchronized; without the mutex it
+// trips "concurrent map iteration and map write".
+func TestListPartsConcurrentWithUploadPart(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	const bucket = "race"
+	if err := m.CreateBucket(ctx, bucket); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+
+	up, err := m.CreateMultipartUpload(ctx, bucket, "key", "")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+	uploadID := up.UploadID
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := 1; i <= n; i++ {
+		wg.Add(2)
+		go func(pn int) {
+			defer wg.Done()
+			_, _ = m.UploadPart(ctx, bucket, "key", uploadID, pn, []byte(strconv.Itoa(pn)))
+		}(i)
+		go func() {
+			defer wg.Done()
+			_, _ = m.ListParts(ctx, bucket, "key", uploadID)
+		}()
+	}
+	wg.Wait()
+
+	parts, err := m.ListParts(ctx, bucket, "key", uploadID)
+	if err != nil {
+		t.Fatalf("ListParts: %v", err)
+	}
+	if len(parts) != n {
+		t.Fatalf("final parts = %d, want %d", len(parts), n)
+	}
+}

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -43,8 +44,11 @@ type multipartUpload struct {
 	id          string
 	key         string
 	contentType string
-	parts       map[int][]byte
-	createdAt   string
+	// mu guards parts: the SDK uploader sends parts concurrently (UploadPart
+	// writes) while ListParts/CompleteMultipartUpload read them.
+	mu        sync.Mutex
+	parts     map[int][]byte
+	createdAt string
 }
 
 type bucketMeta struct {
@@ -502,7 +506,10 @@ func (m *Mock) UploadPart(_ context.Context, bucket, _, uploadID string, partNum
 
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
+
+	mp.mu.Lock()
 	mp.parts[partNumber] = dataCopy
+	mp.mu.Unlock()
 
 	etag := fmt.Sprintf("%x", sha256.Sum256(data))
 
@@ -524,6 +531,9 @@ func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]drive
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
+
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
 
 	nums := make([]int, 0, len(mp.parts))
 	for n := range mp.parts {
@@ -555,13 +565,15 @@ func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID 
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
+	mp.mu.Lock()
 	for _, p := range parts {
 		if _, exists := mp.parts[p.PartNumber]; !exists {
+			mp.mu.Unlock()
 			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
 		}
 	}
-
 	data := assemblePartsInOrder(mp.parts, parts)
+	mp.mu.Unlock()
 
 	bkt.objects.Set(key, &s3Object{
 		Key:          key,

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -511,6 +511,39 @@ func (m *Mock) UploadPart(_ context.Context, bucket, _, uploadID string, partNum
 	}, nil
 }
 
+// ListParts returns the parts buffered so far for an in-progress upload,
+// ordered by part number (the driver keeps each part's bytes, so ETag and Size
+// are reported exactly as UploadPart returned them).
+func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]driver.UploadPart, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	mp, ok := bkt.multiparts.Get(uploadID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	nums := make([]int, 0, len(mp.parts))
+	for n := range mp.parts {
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+
+	out := make([]driver.UploadPart, 0, len(nums))
+	for _, n := range nums {
+		data := mp.parts[n]
+		out = append(out, driver.UploadPart{
+			PartNumber: n,
+			ETag:       fmt.Sprintf("%x", sha256.Sum256(data)),
+			Size:       int64(len(data)),
+		})
+	}
+
+	return out, nil
+}
+
 func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID string, parts []driver.UploadPart) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -338,10 +338,13 @@ func (m *Mock) GetParametersByPath(_ context.Context, in driver.GetByPathInput) 
 	return out, nil
 }
 
-// DeleteParameter removes a parameter and all its versions.
+// DeleteParameter removes a parameter and all its versions. A ":version"/
+// ":label" selector is stripped first, matching the read paths — SSM has no
+// per-version delete, so a selector addresses the base parameter.
 func (m *Mock) DeleteParameter(_ context.Context, name string) error {
-	if !m.params.Delete(name) {
-		return errors.Newf(errors.NotFound, "parameter %q not found", name)
+	base, _ := resolveSelector(name)
+	if !m.params.Delete(base) {
+		return errors.Newf(errors.NotFound, "parameter %q not found", base)
 	}
 
 	return nil
@@ -353,7 +356,8 @@ func (m *Mock) DeleteParameters(_ context.Context, names []string) ([]string, []
 	var deleted, invalid []string
 
 	for _, name := range names {
-		if m.params.Delete(name) {
+		base, _ := resolveSelector(name)
+		if m.params.Delete(base) {
 			deleted = append(deleted, name)
 		} else {
 			invalid = append(invalid, name)

--- a/providers/aws/ssm/ssm.go
+++ b/providers/aws/ssm/ssm.go
@@ -250,7 +250,10 @@ func (m *Mock) GetParameter(_ context.Context, name string, _ bool) (*driver.Par
 
 	v, ok := pd.pick(selector)
 	if !ok {
-		return nil, errors.Newf(errors.NotFound, "parameter %q version/label %q not found", base, selector)
+		// Parameter exists but this version/label doesn't — distinct from the
+		// parameter being absent, so the handler can return the specific
+		// ParameterVersionNotFound wire error.
+		return nil, driver.ErrVersionNotFound
 	}
 
 	p := m.toParameter(pd, v, selector)

--- a/providers/aws/ssm/ssm_test.go
+++ b/providers/aws/ssm/ssm_test.go
@@ -123,6 +123,26 @@ func TestGetParametersByPathRecursive(t *testing.T) {
 	}
 }
 
+// TestDeleteParameterStripsSelector covers #266: DeleteParameter strips a
+// ":version"/":label" selector (like the read paths) so a selector addresses
+// the base parameter rather than a literal name containing ':'.
+func TestDeleteParameterStripsSelector(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, _, err := m.PutParameter(ctx, driver.PutConfig{Name: "/del/p", Value: "v", Type: driver.TypeString}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	if err := m.DeleteParameter(ctx, "/del/p:1"); err != nil {
+		t.Fatalf("DeleteParameter with selector: %v", err)
+	}
+
+	if _, err := m.GetParameter(ctx, "/del/p", false); !cerrors.IsNotFound(err) {
+		t.Fatalf("after delete, GetParameter err = %v, want NotFound", err)
+	}
+}
+
 func TestDeleteParameters(t *testing.T) {
 	m := newMock()
 	ctx := context.Background()

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -527,6 +527,38 @@ func (m *Mock) UploadPart(
 	}, nil
 }
 
+// ListParts returns the parts buffered so far for an in-progress upload,
+// ordered by part number.
+func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]driver.UploadPart, error) {
+	ctr, ok := m.containers.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "container %q not found", bucket)
+	}
+
+	mp, ok := ctr.multiparts.Get(uploadID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	nums := make([]int, 0, len(mp.parts))
+	for n := range mp.parts {
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+
+	out := make([]driver.UploadPart, 0, len(nums))
+	for _, n := range nums {
+		data := mp.parts[n]
+		out = append(out, driver.UploadPart{
+			PartNumber: n,
+			ETag:       fmt.Sprintf("%x", sha256.Sum256(data)),
+			Size:       int64(len(data)),
+		})
+	}
+
+	return out, nil
+}
+
 func (m *Mock) CompleteMultipartUpload(
 	_ context.Context, bucket, key, uploadID string, parts []driver.UploadPart,
 ) error {

--- a/providers/azure/blobstorage/blobstorage.go
+++ b/providers/azure/blobstorage/blobstorage.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -45,8 +46,11 @@ type blobMultipartUpload struct {
 	id          string
 	key         string
 	contentType string
-	parts       map[int][]byte
-	createdAt   string
+	// mu guards parts: the SDK uploader sends parts concurrently (UploadPart
+	// writes) while ListParts/CompleteMultipartUpload read them.
+	mu        sync.Mutex
+	parts     map[int][]byte
+	createdAt string
 }
 
 type containerMeta struct {
@@ -518,7 +522,10 @@ func (m *Mock) UploadPart(
 
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
+
+	mp.mu.Lock()
 	mp.parts[partNumber] = dataCopy
+	mp.mu.Unlock()
 
 	etag := fmt.Sprintf("%x", sha256.Sum256(data))
 
@@ -539,6 +546,9 @@ func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]drive
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
+
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
 
 	nums := make([]int, 0, len(mp.parts))
 	for n := range mp.parts {
@@ -572,13 +582,15 @@ func (m *Mock) CompleteMultipartUpload(
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
+	mp.mu.Lock()
 	for _, p := range parts {
 		if _, exists := mp.parts[p.PartNumber]; !exists {
+			mp.mu.Unlock()
 			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
 		}
 	}
-
 	data := assembleBlobPartsInOrder(mp.parts, parts)
+	mp.mu.Unlock()
 
 	ctr.objects.Set(key, &blobObject{
 		Key:          key,

--- a/providers/azure/tablestorage/tablestorage.go
+++ b/providers/azure/tablestorage/tablestorage.go
@@ -294,22 +294,27 @@ func hasUnsupportedFilterToken(filter string) bool {
 }
 
 // parseEqClause parses one "Prop eq 'value'" clause. The value may be a quoted
-// string literal or a bare token; a leftover quote or extra tokens (the sign of
-// a value we couldn't parse cleanly) make it unsupported.
+// string literal (which can contain spaces) or a bare token; a leftover quote
+// or a non-eq operator makes it unsupported. Runs of whitespace between the
+// property, operator, and value are tolerated.
 func parseEqClause(clause string) (prop, val string, ok bool) {
-	const eqParts = 3
-
-	fields := strings.SplitN(strings.TrimSpace(clause), " ", eqParts)
-	if len(fields) != eqParts || !strings.EqualFold(fields[1], "eq") {
+	// property = first token; then the operator; then the (possibly quoted,
+	// space-containing) value is whatever remains. Splitting token-by-token
+	// with TrimSpace tolerates extra spaces that a fixed SplitN would not.
+	prop, rest, found := cutToken(strings.TrimSpace(clause))
+	if !found {
 		return "", "", false
 	}
 
-	prop = fields[0]
+	op, raw, found := cutToken(rest)
+	if !found || !strings.EqualFold(op, "eq") {
+		return "", "", false
+	}
+
 	if strings.ContainsAny(prop, "'()") {
 		return "", "", false
 	}
 
-	raw := strings.TrimSpace(fields[2])
 	// A quoted literal must be well-formed: a lone or unbalanced quote means we
 	// split through a value (e.g. it contained " and ") — reject it.
 	if strings.HasPrefix(raw, "'") && !(len(raw) >= 2 && strings.HasSuffix(raw, "'")) {
@@ -317,6 +322,17 @@ func parseEqClause(clause string) (prop, val string, ok bool) {
 	}
 
 	return prop, unquote(raw), true
+}
+
+// cutToken splits the first whitespace-delimited token off s, returning it and
+// the trimmed remainder. found is false when s has no token or no remainder.
+func cutToken(s string) (token, rest string, found bool) {
+	i := strings.IndexByte(s, ' ')
+	if i < 0 {
+		return "", "", false
+	}
+
+	return s[:i], strings.TrimSpace(s[i+1:]), true
 }
 
 func matchesConds(ent driver.Entity, conds []eqCond) bool {

--- a/providers/azure/tablestorage/tablestorage.go
+++ b/providers/azure/tablestorage/tablestorage.go
@@ -203,10 +203,13 @@ func (m *Mock) QueryEntities(_ context.Context, table string, opts driver.QueryO
 		return nil, err
 	}
 
+	conds, err := parseFilter(opts.Filter)
+	if err != nil {
+		return nil, err
+	}
+
 	td.mu.RLock()
 	defer td.mu.RUnlock()
-
-	conds := parseFilter(opts.Filter)
 
 	results := make([]driver.Entity, 0, len(td.entities))
 
@@ -240,30 +243,80 @@ type eqCond struct {
 	val  string
 }
 
-// parseFilter extracts the equality conditions from a simple OData $filter of
-// the form "Prop eq 'val' and Prop2 eq 'val2'". Anything it can't parse is
-// dropped, so an unsupported filter degrades to "match all" rather than an
-// error — adequate for the common query-by-partition case.
-func parseFilter(filter string) []eqCond {
+// errUnsupportedFilter marks an OData $filter cloudemu can't evaluate. Rather
+// than silently matching everything (a data-correctness hazard — a client that
+// asked for a subset would get the whole table), QueryEntities surfaces it so
+// the handler returns 400 InvalidInput.
+var errUnsupportedFilter = errors.New(errors.InvalidArgument,
+	"unsupported $filter: only \"Prop eq 'value'\" clauses joined by \"and\" are supported")
+
+// parseFilter extracts equality conditions from an OData $filter of the form
+// "Prop eq 'val' and Prop2 eq 'val2'". Only eq clauses joined by "and" are
+// supported; any other operator (ne/gt/ge/lt/le/or, grouping, functions) —
+// or a value literal containing " and "/" or " — returns errUnsupportedFilter
+// rather than degrading to match-all.
+func parseFilter(filter string) ([]eqCond, error) {
 	filter = strings.TrimSpace(filter)
 	if filter == "" {
-		return nil
+		return nil, nil
+	}
+
+	if hasUnsupportedFilterToken(filter) {
+		return nil, errUnsupportedFilter
 	}
 
 	var conds []eqCond
 
 	for _, clause := range strings.Split(filter, " and ") {
-		fields := strings.Fields(strings.TrimSpace(clause))
-
-		const eqParts = 3
-		if len(fields) != eqParts || !strings.EqualFold(fields[1], "eq") {
-			continue
+		prop, val, ok := parseEqClause(clause)
+		if !ok {
+			return nil, errUnsupportedFilter
 		}
 
-		conds = append(conds, eqCond{prop: fields[0], val: unquote(fields[2])})
+		conds = append(conds, eqCond{prop: prop, val: val})
 	}
 
-	return conds
+	return conds, nil
+}
+
+// hasUnsupportedFilterToken reports whether the filter uses an operator or
+// construct beyond eq/and. Tokens are matched space-delimited so they don't
+// trip on substrings inside identifiers or quoted values (e.g. "coordinator").
+func hasUnsupportedFilterToken(filter string) bool {
+	padded := " " + strings.ToLower(filter) + " "
+	for _, tok := range []string{" or ", " ne ", " gt ", " ge ", " lt ", " le ", " not ", " and and "} {
+		if strings.Contains(padded, tok) {
+			return true
+		}
+	}
+
+	return strings.ContainsAny(filter, "()")
+}
+
+// parseEqClause parses one "Prop eq 'value'" clause. The value may be a quoted
+// string literal or a bare token; a leftover quote or extra tokens (the sign of
+// a value we couldn't parse cleanly) make it unsupported.
+func parseEqClause(clause string) (prop, val string, ok bool) {
+	const eqParts = 3
+
+	fields := strings.SplitN(strings.TrimSpace(clause), " ", eqParts)
+	if len(fields) != eqParts || !strings.EqualFold(fields[1], "eq") {
+		return "", "", false
+	}
+
+	prop = fields[0]
+	if strings.ContainsAny(prop, "'()") {
+		return "", "", false
+	}
+
+	raw := strings.TrimSpace(fields[2])
+	// A quoted literal must be well-formed: a lone or unbalanced quote means we
+	// split through a value (e.g. it contained " and ") — reject it.
+	if strings.HasPrefix(raw, "'") && !(len(raw) >= 2 && strings.HasSuffix(raw, "'")) {
+		return "", "", false
+	}
+
+	return prop, unquote(raw), true
 }
 
 func matchesConds(ent driver.Entity, conds []eqCond) bool {

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -522,6 +522,38 @@ func (m *Mock) UploadPart(
 	}, nil
 }
 
+// ListParts returns the parts buffered so far for an in-progress upload,
+// ordered by part number.
+func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]driver.UploadPart, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	mp, ok := bkt.multiparts.Get(uploadID)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
+	}
+
+	nums := make([]int, 0, len(mp.parts))
+	for n := range mp.parts {
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+
+	out := make([]driver.UploadPart, 0, len(nums))
+	for _, n := range nums {
+		data := mp.parts[n]
+		out = append(out, driver.UploadPart{
+			PartNumber: n,
+			ETag:       fmt.Sprintf("%x", sha256.Sum256(data)),
+			Size:       int64(len(data)),
+		})
+	}
+
+	return out, nil
+}
+
 func (m *Mock) CompleteMultipartUpload(
 	ctx context.Context, bucket, key, uploadID string, parts []driver.UploadPart,
 ) error {

--- a/providers/gcp/gcs/gcs.go
+++ b/providers/gcp/gcs/gcs.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -45,8 +46,11 @@ type gcsMultipartUpload struct {
 	id          string
 	key         string
 	contentType string
-	parts       map[int][]byte
-	createdAt   string
+	// mu guards parts: the SDK uploader sends parts concurrently (UploadPart
+	// writes) while ListParts/CompleteMultipartUpload read them.
+	mu        sync.Mutex
+	parts     map[int][]byte
+	createdAt string
 }
 
 type bucketMeta struct {
@@ -513,7 +517,10 @@ func (m *Mock) UploadPart(
 
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
+
+	mp.mu.Lock()
 	mp.parts[partNumber] = dataCopy
+	mp.mu.Unlock()
 
 	etag := fmt.Sprintf("%x", sha256.Sum256(data))
 
@@ -534,6 +541,9 @@ func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]drive
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
+
+	mp.mu.Lock()
+	defer mp.mu.Unlock()
 
 	nums := make([]int, 0, len(mp.parts))
 	for n := range mp.parts {
@@ -567,13 +577,15 @@ func (m *Mock) CompleteMultipartUpload(
 		return cerrors.Newf(cerrors.NotFound, "upload %q not found", uploadID)
 	}
 
+	mp.mu.Lock()
 	for _, p := range parts {
 		if _, exists := mp.parts[p.PartNumber]; !exists {
+			mp.mu.Unlock()
 			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
 		}
 	}
-
 	data := assembleGCSPartsInOrder(mp.parts, parts)
+	mp.mu.Unlock()
 
 	bkt.objects.Set(key, &gcsObject{
 		Key:          key,

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -34,6 +35,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// retryClosedNetConn marks the transient "use of closed network connection"
+// that httptest surfaces during response-body reads under parallel load as
+// retryable; every other error defers to the standard retryer's classifiers.
+type retryClosedNetConn struct{}
+
+func (retryClosedNetConn) IsErrorRetryable(err error) aws.Ternary {
+	if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+		return aws.TrueTernary
+	}
+
+	return aws.UnknownTernary
+}
 
 func newSuiteDDBEnv(t *testing.T, opts ...emuconfig.Option) (*dynamodb.Client, *awsprovider.Provider) {
 	t.Helper()
@@ -53,11 +67,16 @@ func newSuiteDDBEnv(t *testing.T, opts ...emuconfig.Option) (*dynamodb.Client, *
 
 	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
 		o.BaseEndpoint = aws.String(ts.URL)
-		o.Retryer = aws.NopRetryer{}
-		// Fresh connection per request. Retries are off (so error semantics are
-		// observed on one attempt), which means a reused keep-alive connection
-		// the httptest server has since closed would surface as a hard
-		// "use of closed network connection" under CI load instead of a retry.
+		// httptest servers under parallel CI load occasionally close the TCP
+		// connection while the SDK is still reading a (200) response body,
+		// surfacing as "use of closed network connection". Retry ONLY that
+		// transient transport error — the retryables list is replaced (not
+		// extended), so API errors and the emulator's 500s are still observed on
+		// exactly one attempt, as the negative-path assertions expect.
+		o.Retryer = retry.NewStandard(func(so *retry.StandardOptions) {
+			so.Retryables = []retry.IsErrorRetryable{retryClosedNetConn{}}
+		})
+		// Fresh connection per request avoids reusing a since-closed keep-alive.
 		o.HTTPClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	})
 

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -42,7 +43,12 @@ import (
 type retryClosedNetConn struct{}
 
 func (retryClosedNetConn) IsErrorRetryable(err error) aws.Ternary {
-	if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+	// The teardown race surfaces as net.ErrClosed ("use of closed network
+	// connection"), wrapped by the SDK's deserialization layer. Match the typed
+	// sentinel (robust to wording changes) with a string fallback (robust to a
+	// wrapper that breaks the Unwrap chain).
+	if err != nil && (errors.Is(err, net.ErrClosed) ||
+		strings.Contains(err.Error(), "use of closed network connection")) {
 		return aws.TrueTernary
 	}
 

--- a/server/aws/s3/fidelity_test.go
+++ b/server/aws/s3/fidelity_test.go
@@ -1,0 +1,97 @@
+package s3_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// TestSDKListParts covers #266: ListParts now reports the parts buffered so
+// far (ordered by part number) instead of an empty list, so resumable-upload
+// tooling can reconstruct its state.
+func TestSDKListParts(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "lp-bucket"
+	const key = "obj"
+
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+	uploadID := aws.ToString(created.UploadId)
+
+	// Upload part 2 before part 1 to confirm ListParts sorts by part number.
+	sizes := map[int32]int{1: 1024, 2: 2048}
+	for _, pn := range []int32{2, 1} {
+		if _, err := client.UploadPart(ctx, &awss3.UploadPartInput{
+			Bucket: aws.String(bucket), Key: aws.String(key), UploadId: aws.String(uploadID),
+			PartNumber: aws.Int32(pn), Body: bytes.NewReader(bytes.Repeat([]byte("x"), sizes[pn])),
+		}); err != nil {
+			t.Fatalf("UploadPart %d: %v", pn, err)
+		}
+	}
+
+	out, err := client.ListParts(ctx, &awss3.ListPartsInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), UploadId: aws.String(uploadID),
+	})
+	if err != nil {
+		t.Fatalf("ListParts: %v", err)
+	}
+	if len(out.Parts) != 2 {
+		t.Fatalf("ListParts returned %d parts, want 2", len(out.Parts))
+	}
+	if aws.ToInt32(out.Parts[0].PartNumber) != 1 || aws.ToInt32(out.Parts[1].PartNumber) != 2 {
+		t.Fatalf("parts not sorted ascending: got %d then %d",
+			aws.ToInt32(out.Parts[0].PartNumber), aws.ToInt32(out.Parts[1].PartNumber))
+	}
+	if aws.ToInt64(out.Parts[0].Size) != 1024 || aws.ToInt64(out.Parts[1].Size) != 2048 {
+		t.Fatalf("part sizes = %d, %d; want 1024, 2048",
+			aws.ToInt64(out.Parts[0].Size), aws.ToInt64(out.Parts[1].Size))
+	}
+	for _, p := range out.Parts {
+		if aws.ToString(p.ETag) == "" {
+			t.Fatalf("part %d has empty ETag", aws.ToInt32(p.PartNumber))
+		}
+	}
+}
+
+// TestSDKUploadPartNumberOutOfRange covers #266: part numbers must be within
+// 1..10000; anything larger is rejected with InvalidArgument.
+func TestSDKUploadPartNumberOutOfRange(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "pn-bucket"
+	const key = "obj"
+
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+	uploadID := aws.ToString(created.UploadId)
+
+	_, err = client.UploadPart(ctx, &awss3.UploadPartInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), UploadId: aws.String(uploadID),
+		PartNumber: aws.Int32(10001), Body: bytes.NewReader([]byte("x")),
+	})
+	if err == nil {
+		t.Fatal("UploadPart with partNumber 10001 succeeded, want InvalidArgument")
+	}
+	if !strings.Contains(err.Error(), "InvalidArgument") {
+		t.Fatalf("error = %v, want InvalidArgument", err)
+	}
+}

--- a/server/aws/s3/fidelity_test.go
+++ b/server/aws/s3/fidelity_test.go
@@ -3,11 +3,16 @@ package s3_test
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
 
 // TestSDKListParts covers #266: ListParts now reports the parts buffered so
@@ -93,5 +98,39 @@ func TestSDKUploadPartNumberOutOfRange(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "InvalidArgument") {
 		t.Fatalf("error = %v, want InvalidArgument", err)
+	}
+}
+
+// TestSubResourceMethodNotAllowed covers #266: a non-GET request carrying the
+// ?uploads/?versions sub-resource must be rejected (405), not silently routed
+// to create/delete-bucket (which ignored the sub-resource).
+func TestSubResourceMethodNotAllowed(t *testing.T) {
+	cloud := cloudemu.NewAWS()
+	ts := httptest.NewServer(awsserver.New(awsserver.Drivers{S3: cloud.S3}))
+	t.Cleanup(ts.Close)
+
+	status := func(method, path string) int {
+		req, err := http.NewRequest(method, ts.URL+path, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("do request: %v", err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	// PUT /{bucket}?uploads previously fell through to CreateBucket (200).
+	if code := status(http.MethodPut, "/b?uploads"); code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT ?uploads status = %d, want 405", code)
+	}
+	if code := status(http.MethodDelete, "/b?versions"); code != http.StatusMethodNotAllowed {
+		t.Fatalf("DELETE ?versions status = %d, want 405", code)
+	}
+	// The bucket must NOT have been created by the misrouted PUT above.
+	if code := status(http.MethodGet, "/b"); code == http.StatusOK {
+		t.Fatal("bucket 'b' exists — a ?uploads PUT was misrouted to CreateBucket")
 	}
 }

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -122,17 +122,23 @@ func (h *Handler) bucketOp(w http.ResponseWriter, r *http.Request, bucket string
 		h.bucketVersioningOp(w, r, bucket)
 		return
 	case q.Has("uploads"):
-		// GET /{bucket}?uploads => ListMultipartUploads.
+		// GET /{bucket}?uploads => ListMultipartUploads. Any other method on the
+		// sub-resource is rejected rather than falling through to create/delete
+		// the bucket (which would ignore the ?uploads sub-resource entirely).
 		if r.Method == http.MethodGet {
 			h.listMultipartUploads(w, r, bucket)
 			return
 		}
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed on ?uploads")
+		return
 	case q.Has("versions"):
-		// GET /{bucket}?versions => ListObjectVersions.
+		// GET /{bucket}?versions => ListObjectVersions (see note above re: fallthrough).
 		if r.Method == http.MethodGet {
 			h.listObjectVersions(w, r, bucket)
 			return
 		}
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed on ?versions")
+		return
 	}
 
 	switch r.Method {
@@ -218,11 +224,14 @@ func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, key s
 		h.objectTaggingOp(w, r, bucket, key)
 		return
 	case q.Has("uploads"):
-		// POST /{bucket}/{key}?uploads => CreateMultipartUpload.
+		// POST /{bucket}/{key}?uploads => CreateMultipartUpload. Any other method
+		// is rejected rather than falling through to a plain object PUT/GET/DELETE.
 		if r.Method == http.MethodPost {
 			h.createMultipartUpload(w, r, bucket, key)
 			return
 		}
+		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed on ?uploads")
+		return
 	case q.Has("uploadId"):
 		h.multipartUploadOp(w, r, bucket, key, q.Get("uploadId"))
 		return

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -24,6 +24,8 @@ const (
 	xmlns          = "http://s3.amazonaws.com/doc/2006-03-01/"
 	// maxPutObjectSize caps PutObject bodies at 5 GiB (S3 single-PUT limit).
 	maxPutObjectSize = 5 << 30
+	// maxUploadPartNumber is S3's upper bound on multipart part numbers.
+	maxUploadPartNumber = 10000
 )
 
 // Handler serves S3 REST requests against a storage.Bucket driver.
@@ -393,8 +395,9 @@ func (h *Handler) createMultipartUpload(w http.ResponseWriter, r *http.Request, 
 
 func (h *Handler) uploadPart(w http.ResponseWriter, r *http.Request, bucket, key, uploadID string) {
 	partNumber, err := strconv.Atoi(r.URL.Query().Get("partNumber"))
-	if err != nil || partNumber < 1 {
-		writeError(w, http.StatusBadRequest, "InvalidArgument", "invalid partNumber")
+	if err != nil || partNumber < 1 || partNumber > maxUploadPartNumber {
+		writeError(w, http.StatusBadRequest, "InvalidArgument",
+			"Part number must be an integer between 1 and 10000, inclusive")
 		return
 	}
 
@@ -465,36 +468,31 @@ func (h *Handler) abortMultipartUpload(w http.ResponseWriter, r *http.Request, b
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// listParts lists the parts uploaded so far for a multipart upload. The driver
-// exposes uploads but not their individual parts, so this returns the upload's
-// existence with an empty part list rather than fabricating part data.
+// listParts lists the parts uploaded so far for a multipart upload, so
+// resumable-upload tooling can read back the parts it has already sent.
 func (h *Handler) listParts(w http.ResponseWriter, r *http.Request, bucket, key, uploadID string) {
-	uploads, err := h.bucket.ListMultipartUploads(r.Context(), bucket)
+	parts, err := h.bucket.ListParts(r.Context(), bucket, key, uploadID)
 	if err != nil {
-		writeErr(w, err)
+		writeMultipartErr(w, err)
 		return
 	}
 
-	found := false
-	for _, u := range uploads {
-		if u.UploadID == uploadID {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		writeError(w, http.StatusNotFound, "NoSuchUpload", "the specified upload does not exist")
-		return
-	}
-
-	wire.WriteXML(w, http.StatusOK, listPartsResult{
+	result := listPartsResult{
 		Xmlns:       xmlns,
 		Bucket:      bucket,
 		Key:         key,
 		UploadID:    uploadID,
 		IsTruncated: false,
-	})
+	}
+	for _, p := range parts {
+		result.Parts = append(result.Parts, partXML{
+			PartNumber: p.PartNumber,
+			ETag:       fmt.Sprintf("%q", p.ETag),
+			Size:       p.Size,
+		})
+	}
+
+	wire.WriteXML(w, http.StatusOK, result)
 }
 
 func (h *Handler) listMultipartUploads(w http.ResponseWriter, r *http.Request, bucket string) {

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"testing"
 
@@ -88,7 +89,12 @@ func newSuiteS3Client(t *testing.T) *s3.Client {
 type retryClosedNetConn struct{}
 
 func (retryClosedNetConn) IsErrorRetryable(err error) aws.Ternary {
-	if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+	// The teardown race surfaces as net.ErrClosed ("use of closed network
+	// connection"), wrapped by the SDK's deserialization layer. Match the typed
+	// sentinel (robust to wording changes) with a string fallback (robust to a
+	// wrapper that breaks the Unwrap chain).
+	if err != nil && (errors.Is(err, net.ErrClosed) ||
+		strings.Contains(err.Error(), "use of closed network connection")) {
 		return aws.TrueTernary
 	}
 

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -12,9 +12,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
@@ -66,12 +68,31 @@ func newSuiteS3Client(t *testing.T) *s3.Client {
 	return s3.NewFromConfig(cfg, func(o *s3.Options) {
 		o.BaseEndpoint = aws.String(url)
 		o.UsePathStyle = true
-		o.Retryer = aws.NopRetryer{}
-		// Fresh connection per request: with retries off, a reused keep-alive
-		// connection the httptest server has closed would surface as a hard
-		// "use of closed network connection" under CI load instead of a retry.
+		// httptest servers under parallel CI load occasionally close the TCP
+		// connection while the SDK is still reading a (200) response body,
+		// surfacing as "use of closed network connection". Retry ONLY that
+		// transient transport error — the retryables list is replaced (not
+		// extended), so API errors and the emulator's 500s are still observed on
+		// exactly one attempt, as the negative-path assertions expect.
+		o.Retryer = retry.NewStandard(func(so *retry.StandardOptions) {
+			so.Retryables = []retry.IsErrorRetryable{retryClosedNetConn{}}
+		})
+		// Fresh connection per request avoids reusing a since-closed keep-alive.
 		o.HTTPClient = &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	})
+}
+
+// retryClosedNetConn marks the transient "use of closed network connection"
+// that httptest surfaces during response-body reads under parallel load as
+// retryable; every other error is left non-retryable.
+type retryClosedNetConn struct{}
+
+func (retryClosedNetConn) IsErrorRetryable(err error) aws.Ternary {
+	if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+		return aws.TrueTernary
+	}
+
+	return aws.UnknownTernary
 }
 
 func suiteCreateBucket(t *testing.T, client *s3.Client, bucket string) {

--- a/server/aws/ssm/fidelity_test.go
+++ b/server/aws/ssm/fidelity_test.go
@@ -1,0 +1,121 @@
+package ssm_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsssm "github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// TestSDKGetParametersByPathPagination covers #266: GetParametersByPath now
+// honors MaxResults/NextToken instead of returning everything at once.
+func TestSDKGetParametersByPathPagination(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"/pg/a", "/pg/b", "/pg/c", "/pg/d", "/pg/e"} {
+		if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+			Name: aws.String(n), Value: aws.String("v"), Type: ssmtypes.ParameterTypeString,
+		}); err != nil {
+			t.Fatalf("PutParameter %s: %v", n, err)
+		}
+	}
+
+	// First page: MaxResults=2 yields exactly 2 items and a continuation token.
+	p1, err := client.GetParametersByPath(ctx, &awsssm.GetParametersByPathInput{
+		Path: aws.String("/pg/"), MaxResults: aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("page1: %v", err)
+	}
+	if len(p1.Parameters) != 2 {
+		t.Fatalf("page1 len = %d, want 2", len(p1.Parameters))
+	}
+	if aws.ToString(p1.NextToken) == "" {
+		t.Fatal("page1 missing NextToken with more results available")
+	}
+
+	// The SDK paginator walks every page; assert it collects all 5 in stable
+	// sorted order with no duplicates or drops.
+	pager := awsssm.NewGetParametersByPathPaginator(client, &awsssm.GetParametersByPathInput{
+		Path: aws.String("/pg/"), MaxResults: aws.Int32(2),
+	})
+	var names []string
+	for pager.HasMorePages() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			t.Fatalf("paginator NextPage: %v", err)
+		}
+		for _, p := range page.Parameters {
+			names = append(names, aws.ToString(p.Name))
+		}
+	}
+	want := []string{"/pg/a", "/pg/b", "/pg/c", "/pg/d", "/pg/e"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("paginated names = %v, want %v", names, want)
+	}
+}
+
+// TestSDKDescribeParametersPagination covers #266: DescribeParameters now
+// paginates too.
+func TestSDKDescribeParametersPagination(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"/d/1", "/d/2", "/d/3"} {
+		if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+			Name: aws.String(n), Value: aws.String("v"), Type: ssmtypes.ParameterTypeString,
+		}); err != nil {
+			t.Fatalf("PutParameter %s: %v", n, err)
+		}
+	}
+
+	p1, err := client.DescribeParameters(ctx, &awsssm.DescribeParametersInput{MaxResults: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("describe page1: %v", err)
+	}
+	if len(p1.Parameters) != 2 || aws.ToString(p1.NextToken) == "" {
+		t.Fatalf("page1 = %d params, token=%q; want 2 + token", len(p1.Parameters), aws.ToString(p1.NextToken))
+	}
+
+	p2, err := client.DescribeParameters(ctx, &awsssm.DescribeParametersInput{NextToken: p1.NextToken})
+	if err != nil {
+		t.Fatalf("describe page2: %v", err)
+	}
+	if len(p2.Parameters) != 1 {
+		t.Fatalf("page2 len = %d, want 1", len(p2.Parameters))
+	}
+	if aws.ToString(p2.NextToken) != "" {
+		t.Fatalf("page2 NextToken = %q, want empty (last page)", aws.ToString(p2.NextToken))
+	}
+}
+
+// TestSDKGetParameterVersionNotFound covers #266: a missing *version* of an
+// existing parameter returns the distinct ParameterVersionNotFound, while a
+// missing parameter still returns ParameterNotFound.
+func TestSDKGetParameterVersionNotFound(t *testing.T) {
+	client := newSSMClient(t)
+	ctx := context.Background()
+
+	if _, err := client.PutParameter(ctx, &awsssm.PutParameterInput{
+		Name: aws.String("/v/p"), Value: aws.String("v"), Type: ssmtypes.ParameterTypeString,
+	}); err != nil {
+		t.Fatalf("PutParameter: %v", err)
+	}
+
+	_, err := client.GetParameter(ctx, &awsssm.GetParameterInput{Name: aws.String("/v/p:99")})
+	var vnf *ssmtypes.ParameterVersionNotFound
+	if !errors.As(err, &vnf) {
+		t.Fatalf("missing version error = %v, want *ParameterVersionNotFound", err)
+	}
+
+	_, err = client.GetParameter(ctx, &awsssm.GetParameterInput{Name: aws.String("/v/missing")})
+	var pnf *ssmtypes.ParameterNotFound
+	if !errors.As(err, &pnf) {
+		t.Fatalf("missing parameter error = %v, want *ParameterNotFound", err)
+	}
+}

--- a/server/aws/ssm/operations.go
+++ b/server/aws/ssm/operations.go
@@ -1,6 +1,7 @@
 package ssm
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/stackshy/cloudemu/v2/server/wire"
@@ -38,6 +39,12 @@ func (h *Handler) getParameter(w http.ResponseWriter, r *http.Request) {
 
 	p, err := h.store.GetParameter(r.Context(), req.Name, req.WithDecryption)
 	if err != nil {
+		// The parameter existed but the requested version/label didn't — AWS
+		// returns the distinct ParameterVersionNotFound, not ParameterNotFound.
+		if errors.Is(err, ssmdriver.ErrVersionNotFound) {
+			wire.WriteJSONError(w, http.StatusBadRequest, "ParameterVersionNotFound", err.Error())
+			return
+		}
 		writeErr(w, err)
 		return
 	}
@@ -81,12 +88,20 @@ func (h *Handler) getParametersByPath(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := make([]parameterJSON, 0, len(found))
-	for _, p := range found {
+	// The driver returns the full matching set sorted by name; paginate here so
+	// MaxResults/NextToken (and the SDK's paginator) work over a stable order.
+	start, end, next, err := pageWindow(req.NextToken, req.MaxResults, maxResultsByPath, len(found))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	params := make([]parameterJSON, 0, end-start)
+	for _, p := range found[start:end] {
 		params = append(params, toParameterJSON(p))
 	}
 
-	wire.WriteJSON(w, getParametersByPathResponse{Parameters: params})
+	wire.WriteJSON(w, getParametersByPathResponse{Parameters: params, NextToken: next})
 }
 
 func (h *Handler) deleteParameter(w http.ResponseWriter, r *http.Request) {
@@ -119,14 +134,26 @@ func (h *Handler) deleteParameters(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) describeParameters(w http.ResponseWriter, r *http.Request) {
+	var req describeParametersRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
 	metas, err := h.store.DescribeParameters(r.Context())
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	out := make([]parameterMetadataJSON, 0, len(metas))
-	for _, md := range metas {
+	// Sorted-by-name from the driver; paginate here (MaxResults/NextToken).
+	start, end, next, err := pageWindow(req.NextToken, req.MaxResults, maxResultsDescribe, len(metas))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := make([]parameterMetadataJSON, 0, end-start)
+	for _, md := range metas[start:end] {
 		out = append(out, parameterMetadataJSON{
 			ARN:              md.ARN,
 			DataType:         md.DataType,
@@ -140,7 +167,7 @@ func (h *Handler) describeParameters(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	wire.WriteJSON(w, describeParametersResponse{Parameters: out})
+	wire.WriteJSON(w, describeParametersResponse{Parameters: out, NextToken: next})
 }
 
 func (h *Handler) getParameterHistory(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/ssm/paginate.go
+++ b/server/aws/ssm/paginate.go
@@ -1,0 +1,65 @@
+package ssm
+
+import (
+	"encoding/base64"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// AWS MaxResults ceilings (and defaults when unset) for the paginated SSM
+// operations, matching the real service limits.
+const (
+	maxResultsByPath   = 10 // GetParametersByPath: 1..10
+	maxResultsDescribe = 50 // DescribeParameters:  1..50
+)
+
+// pageWindow resolves an opaque NextToken + MaxResults into a [start,end) slice
+// window over a stable, fully-sorted result set of length total, and the token
+// to return for the next page ("" once the last page is reached). The driver
+// already returns results sorted by name, so an offset-based token is stable.
+// A malformed token is a validation error the caller maps to the wire response.
+func pageWindow(token string, maxResults int32, defaultMax, total int) (start, end int, next string, err error) {
+	start, err = decodePageToken(token)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	if start > total {
+		start = total
+	}
+
+	limit := int(maxResults)
+	if limit <= 0 || limit > defaultMax {
+		limit = defaultMax
+	}
+
+	end = start + limit
+	if end >= total {
+		return start, total, "", nil
+	}
+
+	return start, end, encodePageToken(end), nil
+}
+
+func encodePageToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+func decodePageToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+
+	b, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid NextToken")
+	}
+
+	n, err := strconv.Atoi(string(b))
+	if err != nil || n < 0 {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid NextToken")
+	}
+
+	return n, nil
+}

--- a/server/aws/ssm/types.go
+++ b/server/aws/ssm/types.go
@@ -58,6 +58,13 @@ type getParametersByPathRequest struct {
 	Path           string `json:"Path"`
 	Recursive      bool   `json:"Recursive"`
 	WithDecryption bool   `json:"WithDecryption"`
+	MaxResults     int32  `json:"MaxResults"`
+	NextToken      string `json:"NextToken"`
+}
+
+type describeParametersRequest struct {
+	MaxResults int32  `json:"MaxResults"`
+	NextToken  string `json:"NextToken"`
 }
 
 type nameRequest struct {
@@ -92,6 +99,7 @@ type getParametersResponse struct {
 
 type getParametersByPathResponse struct {
 	Parameters []parameterJSON `json:"Parameters"`
+	NextToken  string          `json:"NextToken,omitempty"`
 }
 
 type deleteParametersResponse struct {
@@ -101,6 +109,7 @@ type deleteParametersResponse struct {
 
 type describeParametersResponse struct {
 	Parameters []parameterMetadataJSON `json:"Parameters"`
+	NextToken  string                  `json:"NextToken,omitempty"`
 }
 
 type labelParameterVersionResponse struct {

--- a/server/azure/table/fidelity_test.go
+++ b/server/azure/table/fidelity_test.go
@@ -98,6 +98,15 @@ func TestQueryFilterActuallyFilters(t *testing.T) {
 	if len(rks) != 0 {
 		t.Fatalf("no-match filter = %v, want []", rks)
 	}
+
+	// Extra whitespace between tokens is tolerated (not rejected as unsupported).
+	rks, err = listRowKeys(t, client, "PartitionKey  eq  'org'")
+	if err != nil {
+		t.Fatalf("whitespace filter: %v", err)
+	}
+	if len(rks) != 2 {
+		t.Fatalf("whitespace filter = %v, want 2 rows", rks)
+	}
 }
 
 // TestQueryUnsupportedFilterRejected covers #266: an unsupported operator must

--- a/server/azure/table/fidelity_test.go
+++ b/server/azure/table/fidelity_test.go
@@ -1,0 +1,143 @@
+package table_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/aztables"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+func newTableClient(t *testing.T, table string) (*aztables.Client, *httptest.Server) {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{TableStorage: cloudP.TableStorage})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	svc, err := aztables.NewServiceClientWithNoCredential(ts.URL+"/", &aztables.ClientOptions{
+		ClientOptions: policy.ClientOptions{Transport: ts.Client(), Retry: policy.RetryOptions{MaxRetries: -1}},
+	})
+	if err != nil {
+		t.Fatalf("NewServiceClientWithNoCredential: %v", err)
+	}
+	if _, err := svc.CreateTable(context.Background(), table, nil); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	return svc.NewClient(table), ts
+}
+
+func addEntity(t *testing.T, client *aztables.Client, pk, rk string, extra map[string]any) {
+	t.Helper()
+
+	e := map[string]any{"PartitionKey": pk, "RowKey": rk}
+	for k, v := range extra {
+		e[k] = v
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal entity: %v", err)
+	}
+	if _, err := client.AddEntity(context.Background(), b, nil); err != nil {
+		t.Fatalf("AddEntity %s/%s: %v", pk, rk, err)
+	}
+}
+
+func listRowKeys(t *testing.T, client *aztables.Client, filter string) ([]string, error) {
+	t.Helper()
+
+	pager := client.NewListEntitiesPager(&aztables.ListEntitiesOptions{Filter: &filter})
+	var rks []string
+	for pager.More() {
+		page, err := pager.NextPage(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		for _, raw := range page.Entities {
+			var e map[string]any
+			if err := json.Unmarshal(raw, &e); err != nil {
+				t.Fatalf("unmarshal entity: %v", err)
+			}
+			if rk, ok := e["RowKey"].(string); ok {
+				rks = append(rks, rk)
+			}
+		}
+	}
+	return rks, nil
+}
+
+// TestQueryFilterActuallyFilters covers #266: a supported eq/and $filter must
+// narrow the result set rather than degrade to match-all.
+func TestQueryFilterActuallyFilters(t *testing.T) {
+	client, _ := newTableClient(t, "flt")
+	addEntity(t, client, "org", "alice", nil)
+	addEntity(t, client, "org", "bob", nil)
+	addEntity(t, client, "other", "carol", nil)
+
+	rks, err := listRowKeys(t, client, "PartitionKey eq 'org' and RowKey eq 'alice'")
+	if err != nil {
+		t.Fatalf("filtered list: %v", err)
+	}
+	if len(rks) != 1 || rks[0] != "alice" {
+		t.Fatalf("eq/and filter = %v, want [alice]", rks)
+	}
+
+	rks, err = listRowKeys(t, client, "PartitionKey eq 'nope'")
+	if err != nil {
+		t.Fatalf("no-match list: %v", err)
+	}
+	if len(rks) != 0 {
+		t.Fatalf("no-match filter = %v, want []", rks)
+	}
+}
+
+// TestQueryUnsupportedFilterRejected covers #266: an unsupported operator must
+// return 400 InvalidInput, not silently match everything.
+func TestQueryUnsupportedFilterRejected(t *testing.T) {
+	client, _ := newTableClient(t, "flt2")
+	addEntity(t, client, "org", "alice", map[string]any{"Age": int64(30)})
+	addEntity(t, client, "org", "bob", map[string]any{"Age": int64(20)})
+
+	if _, err := listRowKeys(t, client, "Age gt 25"); err == nil {
+		t.Fatal("unsupported $filter 'Age gt 25' returned no error (degraded to match-all)")
+	} else if !strings.Contains(err.Error(), "InvalidInput") {
+		t.Fatalf("error = %v, want InvalidInput (400)", err)
+	}
+}
+
+// TestGetEntitySingleKeyPredicateRejected covers #266: a key predicate that
+// names only one of the two keys is malformed → 400, not a 404 not-found.
+func TestGetEntitySingleKeyPredicateRejected(t *testing.T) {
+	client, ts := newTableClient(t, "kp")
+	addEntity(t, client, "org", "alice", nil)
+
+	status := func(path string) int {
+		req, err := http.NewRequest(http.MethodGet, ts.URL+path, nil)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+		req.Header.Set("Accept", "application/json")
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("do request: %v", err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if code := status("/kp(PartitionKey='org')"); code != http.StatusBadRequest {
+		t.Fatalf("single-key predicate status = %d, want 400", code)
+	}
+	if code := status("/kp(PartitionKey='org',RowKey='alice')"); code != http.StatusOK {
+		t.Fatalf("both-keys predicate status = %d, want 200", code)
+	}
+}

--- a/server/azure/table/helpers.go
+++ b/server/azure/table/helpers.go
@@ -42,13 +42,18 @@ func splitEntityPath(path string) (table, predicate string, ok bool) {
 	return path[:open], path[open+1 : closeIdx], true
 }
 
-// parseKeyPredicate parses "PartitionKey='p',RowKey='r'" into ("p", "r").
-// The two clauses may appear in either order.
+// parseKeyPredicate parses "PartitionKey='p',RowKey='r'" into ("p", "r"). The
+// two clauses may appear in either order, but a single-entity key predicate
+// must name BOTH keys: a malformed clause, an unknown key, or a missing key
+// makes it invalid (ok=false → 400 InvalidInput) rather than a partial key that
+// then reports the entity as not-found (404).
 func parseKeyPredicate(predicate string) (partitionKey, rowKey string, ok bool) {
+	var havePK, haveRK bool
+
 	for _, clause := range splitTopLevel(predicate) {
 		key, val, found := strings.Cut(clause, "=")
 		if !found {
-			continue
+			return "", "", false
 		}
 
 		key = strings.TrimSpace(key)
@@ -56,13 +61,15 @@ func parseKeyPredicate(predicate string) (partitionKey, rowKey string, ok bool) 
 
 		switch key {
 		case "PartitionKey":
-			partitionKey = val
+			partitionKey, havePK = val, true
 		case "RowKey":
-			rowKey = val
+			rowKey, haveRK = val, true
+		default:
+			return "", "", false
 		}
 	}
 
-	if partitionKey == "" && rowKey == "" {
+	if !havePK || !haveRK {
 		return "", "", false
 	}
 

--- a/services/parameterstore/driver/driver.go
+++ b/services/parameterstore/driver/driver.go
@@ -1,7 +1,19 @@
 // Package driver defines the interface for SSM Parameter Store service implementations.
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// ErrVersionNotFound is returned by GetParameter when the parameter itself
+// exists but the requested version or label does not — distinct from the
+// parameter being absent. It carries the NotFound code so generic handling
+// still treats it as not-found, while the SDK-compat layer can match it with
+// errors.Is to return AWS's distinct ParameterVersionNotFound error instead of
+// ParameterNotFound.
+var ErrVersionNotFound = errors.New(errors.NotFound, "requested parameter version or label not found")
 
 // Parameter types, matching AWS SSM Parameter Store.
 const (

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -160,6 +160,9 @@ type Bucket interface {
 	CompleteMultipartUpload(ctx context.Context, bucket, key, uploadID string, parts []UploadPart) error
 	AbortMultipartUpload(ctx context.Context, bucket, key, uploadID string) error
 	ListMultipartUploads(ctx context.Context, bucket string) ([]MultipartUpload, error)
+	// ListParts returns the parts buffered so far for an in-progress upload,
+	// ordered by part number. It errors with NotFound if the upload is unknown.
+	ListParts(ctx context.Context, bucket, key, uploadID string) ([]UploadPart, error)
 
 	// Versioning
 	SetBucketVersioning(ctx context.Context, bucket string, enabled bool) error


### PR DESCRIPTION
Addresses the tractable, well-scoped items from #266 across SSM, Azure Tables, and S3 multipart, each with real-SDK roundtrip tests. Correctness gaps are fixed; feature-scale / cross-service-risky items are deferred (listed below) and stay tracked in #266.

## SSM Parameter Store
- **Pagination**: `GetParametersByPath` and `DescribeParameters` honor `MaxResults`/`NextToken` (handler-side over the driver's stable name-sorted set; opaque offset token; malformed token → `ValidationException`).
- **Distinct error**: `GetParameter` on an existing parameter with a missing version/label returns `ParameterVersionNotFound`, not `ParameterNotFound`.
- **Delete selector**: `DeleteParameter`/`DeleteParameters` strip a `:version`/`:label` selector like the read paths.

## Azure Tables
- **`$filter`**: operators beyond `eq`/`and` (`ne`/`gt`/`ge`/`lt`/`le`/`or`, grouping, or a value that splits through `" and "`/`" or "`) → **400 InvalidInput** instead of silent **match-all** (data-correctness hazard). Whitespace between tokens is tolerated.
- **`parseKeyPredicate`**: a single-entity key predicate must name **both** keys → 400, not a partial key that 404s.

## S3 multipart
- **`ListParts`**: returns the buffered parts (ordered, with ETag/Size) via a new shared `Bucket.ListParts` (S3/Blob/GCS) instead of an empty list.
- **`UploadPart`**: rejects part numbers outside `1..10000`.
- **Sub-resource routing**: non-GET `?uploads`/`?versions` (and non-POST object `?uploads`) → **405** instead of silently falling through to create/delete-bucket or put-object.

## Review fixes (from `/review` of this PR)
- **Data race**: `ListParts` iterated the multipart `parts` map with no lock while `UploadPart` writes it (the SDK uploader sends parts concurrently) — added a `sync.Mutex` to the multipart struct in all three providers and guarded `UploadPart`/`ListParts`/`CompleteMultipartUpload`; new `-race` concurrency test.
- **`$filter` whitespace**: `parseEqClause` no longer rejects `Prop  eq  'v'` (extra spaces).

## CI flake fix
- `TestDDBItemJourney` (+ the S3 lifecycle suite) flaked on `use of closed network connection` — httptest closing the connection mid-body under parallel load. The standard retryer classifies that read error as non-retryable and `NopRetryer` turned it into a hard failure. Replaced `NopRetryer` with a standard retryer whose retryables list is **only** a classifier for that transport error, so transient blips retry while API errors and the emulator's 500s are still observed on exactly one attempt.

## Deferred (still tracked in #266 — recommend separate PRs)
- SSM `ParameterFilters`/tags, parameter policies, SecureString KMS.
- S3 object-level `versionId` history / real `ListObjectVersions`.
- Azure Queue enqueue `PopReceipt` (needs a `ReceiptHandle` on the shared messagequeue `SendMessageOutput`, changing SQS/ServiceBus/PubSub) and the Queue/Blob shared-hostname collision (needs host-based routing, tied to #224).

## Verification
- `go build ./...`, `go vet ./...`, full `go test ./...`, and `-race` on storage/table all green locally.
- New real-SDK roundtrip tests for every fix above.