### PR TITLE
feat(s3): real object versioning (#266)

### DIFF
--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -696,7 +696,9 @@ func (m *Mock) CompleteMultipartUpload(_ context.Context, bucket, key, uploadID 
 	data := assemblePartsInOrder(mp.parts, parts)
 	mp.mu.Unlock()
 
-	bkt.objects.Set(key, &s3Object{
+	// storeObject (not a bare objects.Set) so a completed multipart upload is
+	// versioned like a PutObject on a versioning-enabled bucket.
+	m.storeObject(bkt, key, &s3Object{
 		Key:          key,
 		Data:         data,
 		ContentType:  mp.contentType,
@@ -1025,7 +1027,7 @@ func findVersion(bkt *bucketMeta, key, versionID string) *s3Version {
 func objectFromVersion(key string, v *s3Version) *s3Object {
 	return &s3Object{
 		Key: key, Data: v.data, ContentType: v.contentType,
-		ETag: v.etag, LastModified: v.lastModified, Metadata: v.metadata,
+		ETag: v.etag, LastModified: v.lastModified, Metadata: maps.Clone(v.metadata),
 		VersionID: v.versionID,
 	}
 }

--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -28,7 +28,10 @@ const (
 	hoursPerDay            = 24
 )
 
-var _ driver.Bucket = (*Mock)(nil)
+var (
+	_ driver.Bucket          = (*Mock)(nil)
+	_ driver.VersionedBucket = (*Mock)(nil)
+)
 
 type s3Object struct {
 	Key          string
@@ -38,6 +41,21 @@ type s3Object struct {
 	LastModified string
 	Metadata     map[string]string
 	Tags         map[string]string
+	// VersionID is the version id of the current object on a versioned bucket
+	// ("null" when suspended, empty when the bucket never had versioning).
+	VersionID string
+}
+
+// s3Version is one entry in a key's version history (a stored object or a
+// delete marker), oldest-first within bucketMeta.versions.
+type s3Version struct {
+	versionID    string
+	data         []byte
+	contentType  string
+	etag         string
+	lastModified string
+	metadata     map[string]string
+	deleteMarker bool
 }
 
 type multipartUpload struct {
@@ -58,11 +76,16 @@ type bucketMeta struct {
 	objects    *memstore.Store[*s3Object]
 	lifecycle  *driver.LifecycleConfig
 	multiparts *memstore.Store[*multipartUpload]
-	versioning bool
-	policy     *driver.BucketPolicy
-	corsConfig *driver.CORSConfig
-	encryption *driver.EncryptionConfig
-	tags       map[string]string
+	// versionStatus is "" (never configured), "Enabled", or "Suspended".
+	// versionsMu guards versionStatus and the versions history map; versions
+	// maps a key to its ordered (oldest-first) version chain.
+	versionStatus string
+	versionsMu    sync.Mutex
+	versions      map[string][]*s3Version
+	policy        *driver.BucketPolicy
+	corsConfig    *driver.CORSConfig
+	encryption    *driver.EncryptionConfig
+	tags          map[string]string
 }
 
 // Mock is an in-memory mock implementation of the AWS S3 service.
@@ -161,7 +184,7 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
-	bkt.objects.Set(key, &s3Object{
+	m.storeObject(bkt, key, &s3Object{
 		Key:          key,
 		Data:         dataCopy,
 		ContentType:  contentType,
@@ -176,6 +199,69 @@ func (m *Mock) PutObject(_ context.Context, bucket, key string, data []byte, con
 	m.emitMetric("BytesUploaded", float64(len(data)), "Bytes", dims)
 
 	return nil
+}
+
+// Versioning status constants and the reserved id for the pre-/non-versioned
+// object version.
+const (
+	versioningEnabled   = "Enabled"
+	versioningSuspended = "Suspended"
+	nullVersionID       = "null"
+)
+
+func newVersionID() string { return idgen.GenerateID("") }
+
+// storeObject sets key's current object and, on a versioned bucket, records the
+// new version in history (stamping obj.VersionID). Enabled appends a fresh
+// version; Suspended overwrites the reusable "null" version; an unversioned
+// bucket keeps no history.
+func (m *Mock) storeObject(bkt *bucketMeta, key string, obj *s3Object) {
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	switch bkt.versionStatus {
+	case versioningEnabled:
+		obj.VersionID = newVersionID()
+		bkt.appendVersion(key, versionFromObject(obj))
+	case versioningSuspended:
+		obj.VersionID = nullVersionID
+		bkt.replaceNullVersion(key, versionFromObject(obj))
+	}
+
+	bkt.objects.Set(key, obj)
+}
+
+func versionFromObject(obj *s3Object) *s3Version {
+	return &s3Version{
+		versionID:    obj.VersionID,
+		data:         obj.Data,
+		contentType:  obj.ContentType,
+		etag:         obj.ETag,
+		lastModified: obj.LastModified,
+		metadata:     obj.Metadata,
+	}
+}
+
+// appendVersion / replaceNullVersion mutate the history map; callers hold
+// versionsMu.
+func (b *bucketMeta) appendVersion(key string, v *s3Version) {
+	if b.versions == nil {
+		b.versions = make(map[string][]*s3Version)
+	}
+	b.versions[key] = append(b.versions[key], v)
+}
+
+func (b *bucketMeta) replaceNullVersion(key string, v *s3Version) {
+	if b.versions == nil {
+		b.versions = make(map[string][]*s3Version)
+	}
+	kept := make([]*s3Version, 0, len(b.versions[key])+1)
+	for _, ex := range b.versions[key] {
+		if ex.versionID != nullVersionID {
+			kept = append(kept, ex)
+		}
+	}
+	b.versions[key] = append(kept, v)
 }
 
 func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object, error) {
@@ -201,6 +287,7 @@ func (m *Mock) GetObject(_ context.Context, bucket, key string) (*driver.Object,
 		Info: driver.ObjectInfo{
 			Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
 			ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+			VersionID: obj.VersionID,
 		},
 		Data: dataCopy,
 	}, nil
@@ -212,17 +299,50 @@ func (m *Mock) DeleteObject(_ context.Context, bucket, key string) error {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
-	if !bkt.objects.Has(key) {
+	bkt.versionsMu.Lock()
+	_, _, existed := m.deleteTopLevelLocked(bkt, key)
+	bkt.versionsMu.Unlock()
+
+	// On an unversioned bucket, deleting a missing key is NotFound (the wire
+	// handler maps that to an idempotent 204). A versioned bucket always records
+	// a delete marker, so existed is true there.
+	if !existed {
 		return cerrors.Newf(cerrors.NotFound, "object %q not found in bucket %q", key, bucket)
 	}
-
-	bkt.objects.Delete(key)
 
 	dims := map[string]string{"BucketName": bucket}
 	m.emitMetric("AllRequests", 1, "Count", dims)
 	m.emitMetric("DeleteRequests", 1, "Count", dims)
 
 	return nil
+}
+
+// deleteTopLevelLocked applies a top-level (no versionId) delete. On Enabled it
+// appends a delete marker; on Suspended it overwrites the null version with a
+// null delete marker; unversioned removes the current object. Returns the
+// affected version id, whether a delete marker was created, and whether
+// anything existed to delete (always true when a marker is recorded). Callers
+// hold versionsMu.
+func (m *Mock) deleteTopLevelLocked(bkt *bucketMeta, key string) (versionID string, deleteMarker, existed bool) {
+	now := m.opts.Clock.Now().UTC().Format(s3TimeFormat)
+
+	switch bkt.versionStatus {
+	case versioningEnabled:
+		vid := newVersionID()
+		bkt.appendVersion(key, &s3Version{versionID: vid, deleteMarker: true, lastModified: now})
+		bkt.objects.Delete(key)
+		return vid, true, true
+	case versioningSuspended:
+		bkt.replaceNullVersion(key, &s3Version{versionID: nullVersionID, deleteMarker: true, lastModified: now})
+		bkt.objects.Delete(key)
+		return nullVersionID, true, true
+	default:
+		if !bkt.objects.Has(key) {
+			return "", false, false
+		}
+		bkt.objects.Delete(key)
+		return "", false, true
+	}
 }
 
 func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.ObjectInfo, error) {
@@ -239,6 +359,7 @@ func (m *Mock) HeadObject(_ context.Context, bucket, key string) (*driver.Object
 	return &driver.ObjectInfo{
 		Key: obj.Key, Size: int64(len(obj.Data)), ContentType: obj.ContentType,
 		ETag: obj.ETag, LastModified: obj.LastModified, Metadata: maps.Clone(obj.Metadata),
+		VersionID: obj.VersionID,
 	}, nil
 }
 
@@ -340,7 +461,7 @@ func (m *Mock) CopyObject(_ context.Context, dstBucket, dstKey string, src drive
 		meta[k] = v
 	}
 
-	dstBkt.objects.Set(dstKey, &s3Object{
+	m.storeObject(dstBkt, dstKey, &s3Object{
 		Key: dstKey, Data: dataCopy, ContentType: srcObj.ContentType,
 		ETag: srcObj.ETag, LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata: meta,
@@ -649,26 +770,272 @@ func (m *Mock) ListMultipartUploads(_ context.Context, bucket string) ([]driver.
 	return result, nil
 }
 
-// SetBucketVersioning enables or disables versioning on a bucket.
-// Note: this sets the flag but does not maintain object version history — mock limitation.
+// SetBucketVersioning enables (Enabled) or, when disabled, suspends versioning.
+// Real S3 has no "off" once configured, only Suspended. Prefer
+// SetVersioningStatus for the full tri-state.
 func (m *Mock) SetBucketVersioning(_ context.Context, bucket string, enabled bool) error {
+	status := versioningSuspended
+	if enabled {
+		status = versioningEnabled
+	}
+
+	return m.SetVersioningStatus(context.Background(), bucket, status)
+}
+
+func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, error) {
+	status, err := m.VersioningStatus(context.Background(), bucket)
+	if err != nil {
+		return false, err
+	}
+
+	return status == versioningEnabled, nil
+}
+
+// SetVersioningStatus sets the bucket versioning status ("Enabled" or
+// "Suspended"), retaining any existing version history.
+func (m *Mock) SetVersioningStatus(_ context.Context, bucket, status string) error {
+	if status != versioningEnabled && status != versioningSuspended {
+		return cerrors.Newf(cerrors.InvalidArgument, "invalid versioning status %q", status)
+	}
+
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
-	bkt.versioning = enabled
+	bkt.versionsMu.Lock()
+	bkt.versionStatus = status
+	bkt.versionsMu.Unlock()
 
 	return nil
 }
 
-func (m *Mock) GetBucketVersioning(_ context.Context, bucket string) (bool, error) {
+// VersioningStatus returns "Enabled", "Suspended", or "" (never configured).
+func (m *Mock) VersioningStatus(_ context.Context, bucket string) (string, error) {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
-		return false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+		return "", cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
 	}
 
-	return bkt.versioning, nil
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	return bkt.versionStatus, nil
+}
+
+// GetObjectVersion returns a specific version (versionID != "") or the current
+// object (versionID == ""). A delete-marker version is reported as NotFound.
+func (m *Mock) GetObjectVersion(ctx context.Context, bucket, key, versionID string) (*driver.Object, error) {
+	if versionID == "" {
+		return m.GetObject(ctx, bucket, key)
+	}
+
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	v := findVersion(bkt, key, versionID)
+	bkt.versionsMu.Unlock()
+
+	if v == nil || v.deleteMarker {
+		return nil, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
+	}
+
+	dataCopy := make([]byte, len(v.data))
+	copy(dataCopy, v.data)
+
+	return &driver.Object{Info: infoFromVersion(key, v), Data: dataCopy}, nil
+}
+
+// HeadObjectVersion returns metadata for a specific version.
+func (m *Mock) HeadObjectVersion(ctx context.Context, bucket, key, versionID string) (*driver.ObjectInfo, error) {
+	if versionID == "" {
+		return m.HeadObject(ctx, bucket, key)
+	}
+
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	v := findVersion(bkt, key, versionID)
+	bkt.versionsMu.Unlock()
+
+	if v == nil || v.deleteMarker {
+		return nil, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
+	}
+
+	info := infoFromVersion(key, v)
+
+	return &info, nil
+}
+
+// DeleteObjectVersion removes a specific version, or (versionID == "") performs
+// a top-level delete (delete marker on Enabled). Returns the affected version
+// id and whether it was/created a delete marker.
+func (m *Mock) DeleteObjectVersion(_ context.Context, bucket, key, versionID string) (string, bool, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return "", false, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	if versionID == "" {
+		vid, marker, _ := m.deleteTopLevelLocked(bkt, key)
+		return vid, marker, nil
+	}
+
+	chain := bkt.versions[key]
+	idx := -1
+
+	var removed *s3Version
+
+	for i, v := range chain {
+		if v.versionID == versionID {
+			idx, removed = i, v
+			break
+		}
+	}
+
+	if idx < 0 {
+		return "", false, cerrors.Newf(cerrors.NotFound, "version %q of %q not found", versionID, key)
+	}
+
+	bkt.versions[key] = append(chain[:idx], chain[idx+1:]...)
+	if len(bkt.versions[key]) == 0 {
+		delete(bkt.versions, key)
+	}
+
+	m.recomputeCurrentLocked(bkt, key)
+
+	return versionID, removed.deleteMarker, nil
+}
+
+// ListObjectVersions returns the full version history matching opts, newest
+// version first within each key.
+func (m *Mock) ListObjectVersions(_ context.Context, bucket string, opts driver.ListOptions) (*driver.VersionListResult, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.versionsMu.Lock()
+	defer bkt.versionsMu.Unlock()
+
+	// Union of keys with history and keys present only as current objects
+	// (written before versioning was enabled → reported as the "null" version).
+	keySet := make(map[string]struct{})
+	for k := range bkt.versions {
+		keySet[k] = struct{}{}
+	}
+
+	for _, k := range bkt.objects.Keys() {
+		keySet[k] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(keySet))
+	for k := range keySet {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	result := &driver.VersionListResult{}
+	prefixSet := make(map[string]struct{})
+
+	for _, k := range keys {
+		if opts.Prefix != "" && !strings.HasPrefix(k, opts.Prefix) {
+			continue
+		}
+
+		if opts.Delimiter != "" {
+			rest := k[len(opts.Prefix):]
+			if idx := strings.Index(rest, opts.Delimiter); idx >= 0 {
+				prefixSet[opts.Prefix+rest[:idx+len(opts.Delimiter)]] = struct{}{}
+				continue
+			}
+		}
+
+		chain := bkt.versions[k]
+		if len(chain) == 0 {
+			if obj, has := bkt.objects.Get(k); has {
+				result.Versions = append(result.Versions, driver.ObjectVersion{
+					Key: k, VersionID: nullVersionID, IsLatest: true,
+					Size: int64(len(obj.Data)), ETag: obj.ETag,
+					ContentType: obj.ContentType, LastModified: obj.LastModified,
+				})
+			}
+
+			continue
+		}
+
+		for i := len(chain) - 1; i >= 0; i-- {
+			v := chain[i]
+			result.Versions = append(result.Versions, driver.ObjectVersion{
+				Key: k, VersionID: v.versionID, IsLatest: i == len(chain)-1,
+				DeleteMarker: v.deleteMarker, Size: int64(len(v.data)), ETag: v.etag,
+				ContentType: v.contentType, LastModified: v.lastModified,
+			})
+		}
+	}
+
+	for p := range prefixSet {
+		result.CommonPrefixes = append(result.CommonPrefixes, p)
+	}
+
+	sort.Strings(result.CommonPrefixes)
+
+	return result, nil
+}
+
+// recomputeCurrentLocked resets key's current object to its newest non-delete
+// version, or removes it if the newest is a delete marker (or none remain).
+// Callers hold versionsMu.
+func (m *Mock) recomputeCurrentLocked(bkt *bucketMeta, key string) {
+	chain := bkt.versions[key]
+	if len(chain) == 0 {
+		bkt.objects.Delete(key)
+		return
+	}
+
+	latest := chain[len(chain)-1]
+	if latest.deleteMarker {
+		bkt.objects.Delete(key)
+		return
+	}
+
+	bkt.objects.Set(key, objectFromVersion(key, latest))
+}
+
+func findVersion(bkt *bucketMeta, key, versionID string) *s3Version {
+	for _, v := range bkt.versions[key] {
+		if v.versionID == versionID {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func objectFromVersion(key string, v *s3Version) *s3Object {
+	return &s3Object{
+		Key: key, Data: v.data, ContentType: v.contentType,
+		ETag: v.etag, LastModified: v.lastModified, Metadata: v.metadata,
+		VersionID: v.versionID,
+	}
+}
+
+func infoFromVersion(key string, v *s3Version) driver.ObjectInfo {
+	return driver.ObjectInfo{
+		Key: key, Size: int64(len(v.data)), ContentType: v.contentType,
+		ETag: v.etag, LastModified: v.lastModified, Metadata: maps.Clone(v.metadata),
+		VersionID: v.versionID, DeleteMarker: v.deleteMarker,
+	}
 }
 
 // PutBucketPolicy sets the bucket policy.

--- a/providers/aws/s3/versioning_test.go
+++ b/providers/aws/s3/versioning_test.go
@@ -1,0 +1,106 @@
+package s3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// TestVersioningSuspendedReusesNull covers #266: while Suspended, writes use the
+// reserved "null" version id and overwrite the existing null version, but any
+// versions created while Enabled are retained.
+func TestVersioningSuspendedReusesNull(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if err := m.SetVersioningStatus(ctx, "b", "Enabled"); err != nil {
+		t.Fatalf("SetVersioningStatus Enabled: %v", err)
+	}
+	if err := m.PutObject(ctx, "b", "k", []byte("v1"), "", nil); err != nil {
+		t.Fatalf("PutObject v1: %v", err)
+	}
+
+	if err := m.SetVersioningStatus(ctx, "b", "Suspended"); err != nil {
+		t.Fatalf("SetVersioningStatus Suspended: %v", err)
+	}
+	if err := m.PutObject(ctx, "b", "k", []byte("v2"), "", nil); err != nil {
+		t.Fatalf("PutObject v2: %v", err)
+	}
+	if err := m.PutObject(ctx, "b", "k", []byte("v3"), "", nil); err != nil {
+		t.Fatalf("PutObject v3: %v", err)
+	}
+
+	vl, err := m.ListObjectVersions(ctx, "b", driver.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListObjectVersions: %v", err)
+	}
+
+	nullCount := 0
+	for _, v := range vl.Versions {
+		if v.VersionID == "null" {
+			nullCount++
+		}
+	}
+	if nullCount != 1 {
+		t.Fatalf("null versions = %d, want 1 (suspended writes reuse the null version)", nullCount)
+	}
+	if len(vl.Versions) != 2 {
+		t.Fatalf("versions = %d, want 2 (the Enabled v1 plus the single null)", len(vl.Versions))
+	}
+
+	cur, err := m.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("GetObject current: %v", err)
+	}
+	if string(cur.Data) != "v3" || cur.Info.VersionID != "null" {
+		t.Fatalf("current = %q/%q, want v3/null", cur.Data, cur.Info.VersionID)
+	}
+}
+
+// TestDeleteVersionRecomputesCurrent covers #266: permanently deleting the
+// latest version promotes the previous version back to current.
+func TestDeleteVersionRecomputesCurrent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if err := m.SetVersioningStatus(ctx, "b", "Enabled"); err != nil {
+		t.Fatalf("SetVersioningStatus: %v", err)
+	}
+
+	if err := m.PutObject(ctx, "b", "k", []byte("v1"), "", nil); err != nil {
+		t.Fatalf("PutObject v1: %v", err)
+	}
+	first, err := m.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("GetObject v1: %v", err)
+	}
+	v1 := first.Info.VersionID
+
+	if err := m.PutObject(ctx, "b", "k", []byte("v2"), "", nil); err != nil {
+		t.Fatalf("PutObject v2: %v", err)
+	}
+	second, err := m.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("GetObject v2: %v", err)
+	}
+	v2 := second.Info.VersionID
+
+	if _, _, err := m.DeleteObjectVersion(ctx, "b", "k", v2); err != nil {
+		t.Fatalf("DeleteObjectVersion v2: %v", err)
+	}
+
+	cur, err := m.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("GetObject after deleting latest: %v", err)
+	}
+	if string(cur.Data) != "v1" || cur.Info.VersionID != v1 {
+		t.Fatalf("current = %q/%q, want v1/%s", cur.Data, cur.Info.VersionID, v1)
+	}
+}

--- a/providers/aws/s3/versioning_test.go
+++ b/providers/aws/s3/versioning_test.go
@@ -104,3 +104,76 @@ func TestDeleteVersionRecomputesCurrent(t *testing.T) {
 		t.Fatalf("current = %q/%q, want v1/%s", cur.Data, cur.Info.VersionID, v1)
 	}
 }
+
+// TestMultipartUploadIsVersioned covers a review finding: a completed multipart
+// upload on a versioned bucket must be recorded as a version (not bypass the
+// version store).
+func TestMultipartUploadIsVersioned(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if err := m.SetVersioningStatus(ctx, "b", "Enabled"); err != nil {
+		t.Fatalf("SetVersioningStatus: %v", err)
+	}
+
+	up, err := m.CreateMultipartUpload(ctx, "b", "k", "text/plain")
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+	part, err := m.UploadPart(ctx, "b", "k", up.UploadID, 1, []byte("hello"))
+	if err != nil {
+		t.Fatalf("UploadPart: %v", err)
+	}
+	if err := m.CompleteMultipartUpload(ctx, "b", "k", up.UploadID,
+		[]driver.UploadPart{{PartNumber: 1, ETag: part.ETag}}); err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	cur, err := m.GetObject(ctx, "b", "k")
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	if cur.Info.VersionID == "" || cur.Info.VersionID == "null" {
+		t.Fatalf("completed multipart upload version id = %q, want a real version id", cur.Info.VersionID)
+	}
+
+	vl, err := m.ListObjectVersions(ctx, "b", driver.ListOptions{})
+	if err != nil {
+		t.Fatalf("ListObjectVersions: %v", err)
+	}
+	if len(vl.Versions) != 1 {
+		t.Fatalf("versions = %d, want 1", len(vl.Versions))
+	}
+}
+
+// TestGetDeleteMarkerVersionErrors covers a review edge: fetching a delete
+// marker by its version id is not a readable object.
+func TestGetDeleteMarkerVersionErrors(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if err := m.CreateBucket(ctx, "b"); err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if err := m.SetVersioningStatus(ctx, "b", "Enabled"); err != nil {
+		t.Fatalf("SetVersioningStatus: %v", err)
+	}
+	if err := m.PutObject(ctx, "b", "k", []byte("v1"), "", nil); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	markerID, isMarker, err := m.DeleteObjectVersion(ctx, "b", "k", "")
+	if err != nil {
+		t.Fatalf("DeleteObjectVersion (top-level): %v", err)
+	}
+	if !isMarker {
+		t.Fatal("top-level delete on Enabled bucket should create a delete marker")
+	}
+
+	if _, err := m.GetObjectVersion(ctx, "b", "k", markerID); err == nil {
+		t.Fatal("GetObjectVersion of a delete marker should error, got nil")
+	}
+}

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -31,11 +31,19 @@ const (
 // Handler serves S3 REST requests against a storage.Bucket driver.
 type Handler struct {
 	bucket driver.Bucket
+	// versioned is set when the driver retains per-object version history; the
+	// handler then honors versioning status, ?versionId, and ListObjectVersions.
+	versioned driver.VersionedBucket
 }
 
 // New returns an S3 handler backed by b.
 func New(b driver.Bucket) *Handler {
-	return &Handler{bucket: b}
+	h := &Handler{bucket: b}
+	if vb, ok := b.(driver.VersionedBucket); ok {
+		h.versioned = vb
+	}
+
+	return h
 }
 
 // Matches returns true for requests that look like S3 REST calls: no
@@ -282,15 +290,29 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 	// computing it from the body we just stored — a successful PUT must
 	// never answer 404.
 	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+
+	var versionID string
 	if info, err := h.bucket.HeadObject(r.Context(), bucket, key); err == nil {
 		etag = info.ETag
+		versionID = info.VersionID
 	}
 	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
+	if versionID != "" {
+		w.Header().Set("x-amz-version-id", versionID)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
 func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	obj, err := h.bucket.GetObject(r.Context(), bucket, key)
+	var (
+		obj *driver.Object
+		err error
+	)
+	if versionID := r.URL.Query().Get("versionId"); versionID != "" && h.versioned != nil {
+		obj, err = h.versioned.GetObjectVersion(r.Context(), bucket, key, versionID)
+	} else {
+		obj, err = h.bucket.GetObject(r.Context(), bucket, key)
+	}
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -302,7 +324,15 @@ func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key 
 }
 
 func (h *Handler) headObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
-	info, err := h.bucket.HeadObject(r.Context(), bucket, key)
+	var (
+		info *driver.ObjectInfo
+		err  error
+	)
+	if versionID := r.URL.Query().Get("versionId"); versionID != "" && h.versioned != nil {
+		info, err = h.versioned.HeadObjectVersion(r.Context(), bucket, key, versionID)
+	} else {
+		info, err = h.bucket.HeadObject(r.Context(), bucket, key)
+	}
 	if err != nil {
 		writeErr(w, err)
 		return
@@ -318,12 +348,40 @@ func writeObjectHeaders(w http.ResponseWriter, info *driver.ObjectInfo, size int
 	w.Header().Set("Last-Modified", wire.ToHTTPDate(info.LastModified))
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
 
+	if info.VersionID != "" {
+		w.Header().Set("x-amz-version-id", info.VersionID)
+	}
+
+	if info.DeleteMarker {
+		w.Header().Set("x-amz-delete-marker", "true")
+	}
+
 	for k, v := range info.Metadata {
 		w.Header().Set("X-Amz-Meta-"+k, v)
 	}
 }
 
 func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	versionID := r.URL.Query().Get("versionId")
+
+	if h.versioned != nil {
+		// Versioned driver: a top-level delete (no versionId) appends a delete
+		// marker on an Enabled bucket; ?versionId permanently removes a version.
+		vid, marker, err := h.versioned.DeleteObjectVersion(r.Context(), bucket, key, versionID)
+		if err != nil && (!cerrors.IsNotFound(err) || bucketMissing(err)) {
+			writeErr(w, err)
+			return
+		}
+		if vid != "" {
+			w.Header().Set("x-amz-version-id", vid)
+		}
+		if marker {
+			w.Header().Set("x-amz-delete-marker", "true")
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	err := h.bucket.DeleteObject(r.Context(), bucket, key)
 	// Real S3 DeleteObject is idempotent: deleting a missing KEY succeeds
 	// with 204. A missing BUCKET is still NoSuchBucket.
@@ -607,9 +665,19 @@ func (h *Handler) putBucketVersioning(w http.ResponseWriter, r *http.Request, bu
 		return
 	}
 
-	enabled := body.Status == "Enabled"
+	if body.Status != "Enabled" && body.Status != "Suspended" {
+		writeError(w, http.StatusBadRequest, "IllegalVersioningConfigurationException",
+			"the versioning status must be Enabled or Suspended")
+		return
+	}
 
-	if err := h.bucket.SetBucketVersioning(r.Context(), bucket, enabled); err != nil {
+	var err error
+	if h.versioned != nil {
+		err = h.versioned.SetVersioningStatus(r.Context(), bucket, body.Status)
+	} else {
+		err = h.bucket.SetBucketVersioning(r.Context(), bucket, body.Status == "Enabled")
+	}
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
@@ -618,37 +686,38 @@ func (h *Handler) putBucketVersioning(w http.ResponseWriter, r *http.Request, bu
 }
 
 func (h *Handler) getBucketVersioning(w http.ResponseWriter, r *http.Request, bucket string) {
-	enabled, err := h.bucket.GetBucketVersioning(r.Context(), bucket)
-	if err != nil {
-		writeErr(w, err)
-		return
+	// Status is "Enabled", "Suspended", or "" (never configured → empty
+	// <VersioningConfiguration/>, matching real S3).
+	var status string
+
+	if h.versioned != nil {
+		s, err := h.versioned.VersioningStatus(r.Context(), bucket)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+		status = s
+	} else {
+		enabled, err := h.bucket.GetBucketVersioning(r.Context(), bucket)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+		if enabled {
+			status = "Enabled"
+		}
 	}
 
-	// The driver tracks versioning as a boolean only. Enabled reports "Enabled";
-	// a disabled bucket returns an empty <VersioningConfiguration/> (matching a
-	// never-versioned bucket) since "Suspended" vs. never-set isn't tracked.
-	resp := versioningConfiguration{Xmlns: xmlns}
-	if enabled {
-		resp.Status = "Enabled"
-	}
-
-	wire.WriteXML(w, http.StatusOK, resp)
+	wire.WriteXML(w, http.StatusOK, versioningConfiguration{Xmlns: xmlns, Status: status})
 }
 
-// listObjectVersions handles GET /{bucket}?versions. The storage driver tracks
-// bucket-level versioning as a boolean flag only and does NOT retain per-object
-// version history, so no versionId-addressable versions exist. We return the
-// current objects as the sole (null) version rather than fabricating history.
+// listObjectVersions handles GET /{bucket}?versions. When the driver retains
+// version history it returns the full history (versions + delete markers);
+// otherwise it falls back to listing current objects as the sole "null" version.
 func (h *Handler) listObjectVersions(w http.ResponseWriter, r *http.Request, bucket string) {
 	opts := driver.ListOptions{
 		Prefix:    r.URL.Query().Get("prefix"),
 		Delimiter: r.URL.Query().Get("delimiter"),
-	}
-
-	result, err := h.bucket.ListObjects(r.Context(), bucket, opts)
-	if err != nil {
-		writeErr(w, err)
-		return
 	}
 
 	resp := listVersionsResult{
@@ -659,15 +728,47 @@ func (h *Handler) listObjectVersions(w http.ResponseWriter, r *http.Request, buc
 		MaxKeys:   defaultMaxKeys,
 	}
 
+	if h.versioned != nil {
+		result, err := h.versioned.ListObjectVersions(r.Context(), bucket, opts)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		for _, v := range result.Versions {
+			if v.DeleteMarker {
+				resp.DeleteMarkers = append(resp.DeleteMarkers, deleteMarkerXML{
+					Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
+				})
+				continue
+			}
+
+			resp.Versions = append(resp.Versions, objectVersionXML{
+				Key: v.Key, VersionID: v.VersionID, IsLatest: v.IsLatest, LastModified: v.LastModified,
+				ETag: fmt.Sprintf("%q", v.ETag), Size: v.Size, StorageClass: "STANDARD",
+			})
+		}
+
+		for _, p := range result.CommonPrefixes {
+			resp.CommonPrefixes = append(resp.CommonPrefixes, prefixXML{Prefix: p})
+		}
+
+		wire.WriteXML(w, http.StatusOK, resp)
+
+		return
+	}
+
+	// Fallback: no version history — list current objects as the "null" version.
+	result, err := h.bucket.ListObjects(r.Context(), bucket, opts)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	for _, obj := range result.Objects {
 		resp.Versions = append(resp.Versions, objectVersionXML{
-			Key:          obj.Key,
-			VersionID:    "null",
-			IsLatest:     true,
-			LastModified: obj.LastModified,
-			ETag:         fmt.Sprintf("%q", obj.ETag),
-			Size:         obj.Size,
-			StorageClass: "STANDARD",
+			Key: obj.Key, VersionID: "null", IsLatest: true, LastModified: obj.LastModified,
+			ETag: fmt.Sprintf("%q", obj.ETag), Size: obj.Size, StorageClass: "STANDARD",
 		})
 	}
 

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -746,23 +746,82 @@ func TestS3VersioningAndListVersions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, types.BucketVersioningStatusEnabled, enabled.Status)
 
-	// Even with versioning "enabled", overwrites keep no history: a key has
-	// exactly one version with the null version id.
-	suitePut(t, client, bucket, "doc.txt", []byte("v1"), "text/plain")
-	suitePut(t, client, bucket, "doc.txt", []byte("v2"), "text/plain")
-
-	versions, err := client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
-		Bucket: aws.String(bucket),
+	// Two overwrites create two distinct, retained versions.
+	putV1, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("doc.txt"), Body: bytes.NewReader([]byte("v1")),
 	})
 	require.NoError(t, err)
-	require.Len(t, versions.Versions, 1, "flag-only versioning keeps no history")
+	putV2, err := client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("doc.txt"), Body: bytes.NewReader([]byte("v2")),
+	})
+	require.NoError(t, err)
 
-	v := versions.Versions[0]
-	assert.Equal(t, "doc.txt", aws.ToString(v.Key))
-	assert.Equal(t, "null", aws.ToString(v.VersionId))
-	assert.True(t, aws.ToBool(v.IsLatest))
-	assert.Equal(t, quotedSHA256([]byte("v2")), aws.ToString(v.ETag),
-		"the sole version reflects the latest overwrite")
+	v1ID, v2ID := aws.ToString(putV1.VersionId), aws.ToString(putV2.VersionId)
+	require.NotEmpty(t, v1ID)
+	require.NotEmpty(t, v2ID)
+	require.NotEqual(t, v1ID, v2ID, "each put gets a distinct version id")
+
+	// ListObjectVersions returns both, newest first, only the latest flagged.
+	versions, err := client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+	require.Len(t, versions.Versions, 2, "both versions retained")
+	assert.Equal(t, v2ID, aws.ToString(versions.Versions[0].VersionId))
+	assert.True(t, aws.ToBool(versions.Versions[0].IsLatest))
+	assert.False(t, aws.ToBool(versions.Versions[1].IsLatest))
+
+	// Current GET returns v2; version-addressable GET returns the older v1.
+	assert.Equal(t, "v2", suiteVersionBody(t, client, bucket, "doc.txt", ""))
+	assert.Equal(t, "v1", suiteVersionBody(t, client, bucket, "doc.txt", v1ID))
+
+	// A top-level delete on a versioned bucket writes a delete marker; the
+	// current object is then hidden (GET 404s) but old versions remain.
+	del, err := client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("doc.txt"),
+	})
+	require.NoError(t, err)
+	assert.True(t, aws.ToBool(del.DeleteMarker), "delete on a versioned bucket is a marker")
+	require.NotEmpty(t, aws.ToString(del.VersionId))
+
+	_, err = client.GetObject(ctx, &s3.GetObjectInput{Bucket: aws.String(bucket), Key: aws.String("doc.txt")})
+	require.Error(t, err, "current object hidden behind the delete marker")
+	assert.Equal(t, "v1", suiteVersionBody(t, client, bucket, "doc.txt", v1ID), "old version still retrievable")
+
+	after, err := client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+	require.Len(t, after.DeleteMarkers, 1)
+	assert.True(t, aws.ToBool(after.DeleteMarkers[0].IsLatest))
+	require.Len(t, after.Versions, 2, "both object versions still present alongside the marker")
+
+	// Deleting a specific version permanently removes just that version.
+	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String("doc.txt"), VersionId: aws.String(v1ID),
+	})
+	require.NoError(t, err)
+	final, err := client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{Bucket: aws.String(bucket)})
+	require.NoError(t, err)
+	for _, v := range final.Versions {
+		assert.NotEqual(t, v1ID, aws.ToString(v.VersionId), "the specific version was permanently deleted")
+	}
+}
+
+// suiteVersionBody GETs an object (optionally a specific version) and returns
+// its body as a string.
+func suiteVersionBody(t *testing.T, client *s3.Client, bucket, key, versionID string) string {
+	t.Helper()
+
+	in := &s3.GetObjectInput{Bucket: aws.String(bucket), Key: aws.String(key)}
+	if versionID != "" {
+		in.VersionId = aws.String(versionID)
+	}
+
+	out, err := client.GetObject(context.Background(), in)
+	require.NoError(t, err, "GetObject %s/%s version=%q", bucket, key, versionID)
+	defer out.Body.Close()
+
+	b, err := io.ReadAll(out.Body)
+	require.NoError(t, err)
+
+	return string(b)
 }
 
 // TestS3ListBucketsSorted verifies ListBuckets returns all buckets

--- a/server/aws/s3/xml.go
+++ b/server/aws/s3/xml.go
@@ -141,6 +141,7 @@ type listVersionsResult struct {
 	MaxKeys        int                `xml:"MaxKeys"`
 	IsTruncated    bool               `xml:"IsTruncated"`
 	Versions       []objectVersionXML `xml:"Version"`
+	DeleteMarkers  []deleteMarkerXML  `xml:"DeleteMarker"`
 	CommonPrefixes []prefixXML        `xml:"CommonPrefixes,omitempty"`
 }
 
@@ -152,6 +153,14 @@ type objectVersionXML struct {
 	ETag         string `xml:"ETag"`
 	Size         int64  `xml:"Size"`
 	StorageClass string `xml:"StorageClass"`
+}
+
+// deleteMarkerXML is a <DeleteMarker> entry in a ListObjectVersions response.
+type deleteMarkerXML struct {
+	Key          string `xml:"Key"`
+	VersionID    string `xml:"VersionId"`
+	IsLatest     bool   `xml:"IsLatest"`
+	LastModified string `xml:"LastModified"`
 }
 
 // versioningConfiguration is the XML request/response body for bucket versioning.

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -21,6 +21,12 @@ type ObjectInfo struct {
 	ETag         string
 	LastModified string
 	Metadata     map[string]string
+	// VersionID is the object's version identifier on a versioning-enabled
+	// bucket ("null" on a suspended/unversioned bucket, empty when the bucket
+	// never had versioning). Providers without versioning leave it empty.
+	VersionID string
+	// DeleteMarker reports whether this version is a delete marker.
+	DeleteMarker bool
 }
 
 // Object is an object with its data.
@@ -43,6 +49,57 @@ type ListResult struct {
 	CommonPrefixes []string
 	NextPageToken  string
 	IsTruncated    bool
+}
+
+// ObjectVersion is one version (or delete marker) of a key, as reported by
+// ListObjectVersions.
+type ObjectVersion struct {
+	Key          string
+	VersionID    string
+	IsLatest     bool
+	DeleteMarker bool
+	Size         int64
+	ETag         string
+	ContentType  string
+	LastModified string
+}
+
+// VersionListResult is the result of a ListObjectVersions operation: every
+// version and delete marker matching the options, newest-first within each key.
+type VersionListResult struct {
+	Versions       []ObjectVersion
+	CommonPrefixes []string
+}
+
+// VersionedBucket is an optional extension a storage provider implements when
+// it retains per-object version history (real S3 semantics). The S3 handler
+// uses it, when present, to honor bucket versioning status, version-addressable
+// GET/HEAD/DELETE, and ListObjectVersions. Providers that don't implement it
+// keep the flat single-version behavior of Bucket.
+type VersionedBucket interface {
+	Bucket
+
+	// SetVersioningStatus sets the bucket's versioning status: "Enabled" or
+	// "Suspended". VersioningStatus returns "Enabled", "Suspended", or "" (never
+	// configured).
+	SetVersioningStatus(ctx context.Context, bucket, status string) error
+	VersioningStatus(ctx context.Context, bucket string) (string, error)
+
+	// GetObjectVersion / HeadObjectVersion fetch a specific version by ID. A
+	// delete-marker version yields a NotFound (with DeleteMarker set on the
+	// returned info where applicable).
+	GetObjectVersion(ctx context.Context, bucket, key, versionID string) (*Object, error)
+	HeadObjectVersion(ctx context.Context, bucket, key, versionID string) (*ObjectInfo, error)
+
+	// DeleteObjectVersion removes a specific version when versionID != "".
+	// With versionID == "" it performs a top-level delete: on an Enabled bucket
+	// that appends a delete marker (deleteMarker=true) and returns its new ID;
+	// otherwise it removes the current object. deletedVersionID is the affected
+	// version's ID (empty when nothing was deleted on an unversioned bucket).
+	DeleteObjectVersion(ctx context.Context, bucket, key, versionID string) (deletedVersionID string, deleteMarker bool, err error)
+
+	// ListObjectVersions returns the full version history matching opts.
+	ListObjectVersions(ctx context.Context, bucket string, opts ListOptions) (*VersionListResult, error)
 }
 
 // CopySource identifies the source for a copy operation.


### PR DESCRIPTION
Implements real S3 object versioning, the largest deferred #266 item — replacing the flag-only stub that retained no history. Scoped to the AWS S3 provider + wire handler so Azure Blob / GCS are untouched.

## What works now (verified via the real aws-sdk-go-v2 client)
- **Tri-state bucket versioning**: `PutBucketVersioning` Enabled/Suspended; `GetBucketVersioning` reports Enabled, Suspended, or empty (never configured) — fixes the Suspended-vs-unset gap.
- **Version history**: each `PutObject` on an Enabled bucket gets a distinct `versionId` (returned as `x-amz-version-id`); Suspended writes reuse the `null` version; unversioned buckets keep no history.
- **Version-addressable ops**: `GET`/`HEAD`/`DELETE` honor `?versionId`.
- **Delete markers**: a top-level `DELETE` on an Enabled bucket appends a delete marker (current object hidden → `GET` 404s, old versions still directly retrievable); response carries `x-amz-delete-marker` + `x-amz-version-id`.
- **Version delete**: `DELETE ?versionId` permanently removes that version and promotes the previous version back to current.
- **ListObjectVersions**: real history — `<Version>` + `<DeleteMarker>` entries, newest-first per key, correct `IsLatest`.

## Design
- New optional `driver.VersionedBucket` interface (implemented only by the S3 mock; the handler type-asserts it and falls back to flat behavior otherwise). `VersionID`/`DeleteMarker` added to the shared `ObjectInfo` (empty for other providers).
- S3 mock stores a per-key version chain guarded by a per-bucket mutex; `objects` remains the current-view store, kept in sync on put/delete/copy.

## Tests
- Rewrote the lifecycle versioning test (it previously asserted the "no history" limitation) to exercise the full lifecycle via the SDK.
- Added driver-level tests: Suspended null-version reuse; current recompute after deleting the latest version.

## Deferred (still tracked in #266)
Azure Blob / GCS object versioning (their SDK-compat surfaces don't expose S3-style versioning); versioning-aware lifecycle expiry.

## Verification
`go build ./...`, `go vet ./...`, full `go test ./...`, and `-race` on storage/s3 all green locally.