### PR TITLE
feat(discovery): surface Kubernetes clusters and node groups (EKS/GKE/AKS)

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1190,9 +1190,24 @@ Shared in-memory K8s API server registered by every cluster from any provider. U
 
 ## 19. Resource Discovery
 
-**Engine:** `services/resourcediscovery/` — a cross-service inventory engine that walks the Compute, Networking, Storage, Database, and Serverless drivers of any provider and returns a normalized `Resource` view (provider, service, type, ID, ARN/URN, region, tags, created-at). Auto-wired by every provider factory and exposed as `Provider.ResourceDiscovery`.
+**Engine:** `services/resourcediscovery/` — a cross-service inventory engine that walks the Compute, Networking, Storage, Database, Serverless, Databricks, and Kubernetes drivers of any provider and returns a normalized `Resource` view (provider, service, type, ID, ARN/URN, region, tags, created-at). Auto-wired by every provider factory and exposed as `Provider.ResourceDiscovery`.
 
 **SDK-compat handlers:** AWS Resource Explorer Two + Resource Groups Tagging API, Azure Resource Graph, and GCP Cloud Asset Inventory. All three sit on top of the same engine, so a tag written through any one path is visible through the others.
+
+**Surfaced resource types** (portable `service/Type` → per-provider inventory string):
+
+| Portable | AWS RE2 | Azure Resource Graph | GCP Cloud Asset |
+|---|---|---|---|
+| `compute/Instance` | `compute:instance` | `microsoft.compute/virtualmachines` | `compute.googleapis.com/Instance` |
+| `networking/VPC` · `Subnet` · `SecurityGroup` · `NetworkInterface` · `ElasticIP` | `networking:*` | `microsoft.network/*` | `compute.googleapis.com/*` |
+| `storage/Bucket` | `storage:bucket` | `microsoft.storage/storageaccounts` | `storage.googleapis.com/Bucket` |
+| `database/Table` | `database:table` | `microsoft.documentdb/databaseaccounts` | `firestore.googleapis.com/Database` |
+| `serverless/Function` | `serverless:function` | `microsoft.web/sites` | `cloudfunctions.googleapis.com/Function` |
+| `databricks/Workspace` | — | `microsoft.databricks/workspaces` | — |
+| `kubernetes/Cluster` | `kubernetes:cluster` | `microsoft.containerservice/managedclusters` | `container.googleapis.com/Cluster` |
+| `kubernetes/NodeGroup` | `kubernetes:nodegroup` | `microsoft.containerservice/managedclusters/agentpools` | `container.googleapis.com/NodePool` |
+
+Kubernetes clusters (EKS/GKE/AKS) and their node groups (nodegroups / node pools / agent pools) are surfaced via a `KubernetesClusters` discovery adapter each provider wires in over its cluster mock.
 
 ### Engine (`services/resourcediscovery/`)
 

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -3,8 +3,10 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/aws/awsiam"
 	"github.com/stackshy/cloudemu/v2/providers/aws/bedrock"
 	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
@@ -13,6 +15,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/ec2"
 	"github.com/stackshy/cloudemu/v2/providers/aws/ecr"
 	"github.com/stackshy/cloudemu/v2/providers/aws/eks"
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	"github.com/stackshy/cloudemu/v2/providers/aws/elasticache"
 	"github.com/stackshy/cloudemu/v2/providers/aws/elb"
 	"github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
@@ -30,11 +33,19 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
 
+// eksClusters is the slice of the EKS mock that discovery reads — an interface
+// so the vanished-cluster (NotFound) skip can be tested with a fake.
+type eksClusters interface {
+	ListClusters(ctx context.Context) ([]string, error)
+	DescribeCluster(ctx context.Context, name string) (*eksdriver.Cluster, error)
+	ListNodegroups(ctx context.Context, clusterName string) ([]string, error)
+}
+
 // eksDiscovery adapts the EKS mock to the resourcediscovery KubernetesClusters
 // capability, so EKS clusters and their node groups surface in Resource
 // Explorer. Kept in the provider package (not services/) to avoid inverting
 // the layering — the discovery engine stays free of provider imports.
-type eksDiscovery struct{ m *eks.Mock }
+type eksDiscovery struct{ m eksClusters }
 
 func (a eksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery.DiscoveredCluster, error) {
 	names, err := a.m.ListClusters(ctx)
@@ -45,15 +56,25 @@ func (a eksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery
 	out := make([]resourcediscovery.DiscoveredCluster, 0, len(names))
 
 	for _, name := range names {
-		// Fail loud: a Describe/list error for a cluster ListClusters just
-		// returned would otherwise silently drop it (or its node groups) from
-		// the inventory — the "silent-empty hides inventory" pattern.
+		// Discovery is a shared, polled surface, so a DeleteCluster can race
+		// between ListClusters and these per-cluster reads. A vanished cluster
+		// (NotFound) is correct to omit — skip it rather than fail the whole
+		// walk, which engine.List would propagate into every provider's
+		// inventory. Any other error is real and propagates.
 		c, err := a.m.DescribeCluster(ctx, name)
+		if cerrors.IsNotFound(err) {
+			continue
+		}
+
 		if err != nil {
 			return nil, err
 		}
 
 		ngs, err := a.m.ListNodegroups(ctx, name)
+		if cerrors.IsNotFound(err) {
+			continue
+		}
+
 		if err != nil {
 			return nil, err
 		}
@@ -61,6 +82,9 @@ func (a eksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery
 		dc := resourcediscovery.DiscoveredCluster{Name: name, NodeGroups: ngs}
 		if c != nil {
 			dc.ARN = c.ARN // use the EKS mock's own ARN verbatim
+			// Keep Region in step with the verbatim ARN so the node-group ARN
+			// (built from Region) and Resource.Region can't diverge from it.
+			dc.Region = eksRegionFromARN(c.ARN)
 			dc.Tags = c.Tags
 		}
 
@@ -68,6 +92,20 @@ func (a eksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery
 	}
 
 	return out, nil
+}
+
+// eksRegionFromARN pulls the region out of an EKS ARN
+// (arn:aws:eks:<region>:<account>:cluster/<name>). Returns "" if unparseable,
+// which leaves the walker to fall back to the engine's default region.
+func eksRegionFromARN(arn string) string {
+	const regionField = 3
+
+	parts := strings.Split(arn, ":")
+	if len(parts) <= regionField {
+		return ""
+	}
+
+	return parts[regionField]
 }
 
 // Provider holds all AWS mock services.

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -45,14 +45,23 @@ func (a eksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery
 	out := make([]resourcediscovery.DiscoveredCluster, 0, len(names))
 
 	for _, name := range names {
-		dc := resourcediscovery.DiscoveredCluster{Name: name}
-
-		if c, cerr := a.m.DescribeCluster(ctx, name); cerr == nil && c != nil {
-			dc.Tags = c.Tags
+		// Fail loud: a Describe/list error for a cluster ListClusters just
+		// returned would otherwise silently drop it (or its node groups) from
+		// the inventory — the "silent-empty hides inventory" pattern.
+		c, err := a.m.DescribeCluster(ctx, name)
+		if err != nil {
+			return nil, err
 		}
 
-		if ngs, ngErr := a.m.ListNodegroups(ctx, name); ngErr == nil {
-			dc.NodeGroups = ngs
+		ngs, err := a.m.ListNodegroups(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+
+		dc := resourcediscovery.DiscoveredCluster{Name: name, NodeGroups: ngs}
+		if c != nil {
+			dc.ARN = c.ARN // use the EKS mock's own ARN verbatim
+			dc.Tags = c.Tags
 		}
 
 		out = append(out, dc)

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -2,6 +2,8 @@
 package aws
 
 import (
+	"context"
+
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/aws/awsiam"
 	"github.com/stackshy/cloudemu/v2/providers/aws/bedrock"
@@ -27,6 +29,37 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/vpc"
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
+
+// eksDiscovery adapts the EKS mock to the resourcediscovery KubernetesClusters
+// capability, so EKS clusters and their node groups surface in Resource
+// Explorer. Kept in the provider package (not services/) to avoid inverting
+// the layering — the discovery engine stays free of provider imports.
+type eksDiscovery struct{ m *eks.Mock }
+
+func (a eksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery.DiscoveredCluster, error) {
+	names, err := a.m.ListClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]resourcediscovery.DiscoveredCluster, 0, len(names))
+
+	for _, name := range names {
+		dc := resourcediscovery.DiscoveredCluster{Name: name}
+
+		if c, cerr := a.m.DescribeCluster(ctx, name); cerr == nil && c != nil {
+			dc.Tags = c.Tags
+		}
+
+		if ngs, ngErr := a.m.ListNodegroups(ctx, name); ngErr == nil {
+			dc.NodeGroups = ngs
+		}
+
+		out = append(out, dc)
+	}
+
+	return out, nil
+}
 
 // Provider holds all AWS mock services.
 type Provider struct {
@@ -112,6 +145,7 @@ func New(opts ...config.Option) *Provider {
 			Storage:    p.S3,
 			Database:   p.DynamoDB,
 			Serverless: p.Lambda,
+			Kubernetes: eksDiscovery{p.EKS},
 		},
 	)
 

--- a/providers/aws/eks_discovery_skip_test.go
+++ b/providers/aws/eks_discovery_skip_test.go
@@ -1,0 +1,93 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
+)
+
+// fakeEKS lets a test drive DescribeCluster/ListNodegroups outcomes per cluster
+// name without racing a real DeleteCluster.
+type fakeEKS struct {
+	names      []string
+	describe   func(name string) (*eksdriver.Cluster, error)
+	nodegroups func(name string) ([]string, error)
+}
+
+func (f fakeEKS) ListClusters(context.Context) ([]string, error) { return f.names, nil }
+
+func (f fakeEKS) DescribeCluster(_ context.Context, name string) (*eksdriver.Cluster, error) {
+	return f.describe(name)
+}
+
+func (f fakeEKS) ListNodegroups(_ context.Context, name string) ([]string, error) {
+	return f.nodegroups(name)
+}
+
+// A DeleteCluster racing between ListClusters and the per-cluster reads makes
+// DescribeCluster/ListNodegroups return NotFound. That cluster must be omitted,
+// not turned into an error — engine.List would otherwise propagate it and drop
+// every provider's inventory, not just this cluster.
+func TestEKSDiscoverySkipsVanishedCluster(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]fakeEKS{
+		"cluster deleted before describe": {
+			names: []string{"gone", "live"},
+			describe: func(name string) (*eksdriver.Cluster, error) {
+				if name == "gone" {
+					return nil, cerrors.New(cerrors.NotFound, "cluster gone")
+				}
+
+				return &eksdriver.Cluster{Name: name, ARN: "arn:aws:eks:us-east-1:123456789012:cluster/" + name}, nil
+			},
+			nodegroups: func(string) ([]string, error) { return []string{"ng"}, nil },
+		},
+		"cluster deleted before node-group list": {
+			names: []string{"gone", "live"},
+			describe: func(name string) (*eksdriver.Cluster, error) {
+				return &eksdriver.Cluster{Name: name, ARN: "arn:aws:eks:us-east-1:123456789012:cluster/" + name}, nil
+			},
+			nodegroups: func(name string) ([]string, error) {
+				if name == "gone" {
+					return nil, cerrors.New(cerrors.NotFound, "cluster gone")
+				}
+
+				return []string{"ng"}, nil
+			},
+		},
+	}
+
+	for name, f := range tests {
+		t.Run(name, func(t *testing.T) {
+			out, err := eksDiscovery{f}.DiscoverClusters(ctx)
+			if err != nil {
+				t.Fatalf("a vanished cluster must be skipped, not error: %v", err)
+			}
+
+			if len(out) != 1 || out[0].Name != "live" {
+				t.Fatalf("want only the live cluster, got %+v", out)
+			}
+
+			if out[0].Region != "us-east-1" {
+				t.Errorf("region = %q, want us-east-1 (parsed from the verbatim ARN)", out[0].Region)
+			}
+		})
+	}
+}
+
+// Any error that is not NotFound is a real fault and must propagate — a scan
+// that half-read the inventory must not be reported as complete.
+func TestEKSDiscoveryPropagatesRealErrors(t *testing.T) {
+	f := fakeEKS{
+		names:      []string{"x"},
+		describe:   func(string) (*eksdriver.Cluster, error) { return nil, cerrors.New(cerrors.Internal, "boom") },
+		nodegroups: func(string) ([]string, error) { return nil, nil },
+	}
+
+	if _, err := (eksDiscovery{f}).DiscoverClusters(context.Background()); err == nil {
+		t.Error("a non-NotFound error must propagate, not be swallowed")
+	}
+}

--- a/providers/aws/kubernetes_discovery_test.go
+++ b/providers/aws/kubernetes_discovery_test.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+)
+
+// A real EKS cluster and node group, created through the mock and wired into
+// the provider, must appear in the cross-service inventory — this exercises
+// the eksDiscovery adapter end to end (adapter -> engine walker -> Resource).
+func TestResourceDiscoverySurfacesEKS(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	if _, err := p.EKS.CreateCluster(ctx, eksdriver.ClusterConfig{
+		Name: "prod", Tags: map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := p.EKS.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName: "prod", NodegroupName: "ng-1",
+	}); err != nil {
+		t.Fatalf("CreateNodegroup: %v", err)
+	}
+
+	res, err := p.ResourceDiscovery.List(ctx, resourcediscovery.Query{
+		Services: []string{resourcediscovery.ServiceKubernetes},
+	})
+	if err != nil {
+		t.Fatalf("discovery List: %v", err)
+	}
+
+	var cluster, nodeGroup bool
+	for _, r := range res {
+		switch {
+		case r.Type == resourcediscovery.TypeCluster && r.ID == "prod":
+			cluster = true
+			if r.Tags["env"] != "prod" {
+				t.Errorf("cluster tags not surfaced: %+v", r.Tags)
+			}
+		case r.Type == resourcediscovery.TypeNodeGroup && r.ID == "ng-1":
+			nodeGroup = true
+		}
+	}
+
+	if !cluster || !nodeGroup {
+		t.Fatalf("EKS not fully surfaced: cluster=%v nodeGroup=%v (%d resources)", cluster, nodeGroup, len(res))
+	}
+}

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -2,6 +2,8 @@
 package azure
 
 import (
+	"context"
+
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/azure/acr"
 	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
@@ -29,6 +31,32 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/azure/vnet"
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
+
+// aksDiscovery adapts the AKS mock to the resourcediscovery KubernetesClusters
+// capability, so AKS managed clusters and agent pools surface in Resource
+// Graph.
+type aksDiscovery struct{ m *aks.Mock }
+
+func (a aksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery.DiscoveredCluster, error) {
+	clusters, err := a.m.ListClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]resourcediscovery.DiscoveredCluster, 0, len(clusters))
+
+	for i := range clusters {
+		c := clusters[i]
+		out = append(out, resourcediscovery.DiscoveredCluster{
+			Name:       c.Name,
+			Region:     c.Location,
+			Tags:       c.Tags,
+			NodeGroups: c.AgentPoolNames,
+		})
+	}
+
+	return out, nil
+}
 
 // Provider holds all Azure mock services.
 type Provider struct {
@@ -130,6 +158,7 @@ func New(opts ...config.Option) *Provider {
 			Database:   p.CosmosDB,
 			Serverless: p.Functions,
 			Databricks: p.Databricks,
+			Kubernetes: aksDiscovery{p.AKS},
 		},
 	)
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -48,10 +48,11 @@ func (a aksDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery
 	for i := range clusters {
 		c := clusters[i]
 		out = append(out, resourcediscovery.DiscoveredCluster{
-			Name:       c.Name,
-			Region:     c.Location,
-			Tags:       c.Tags,
-			NodeGroups: c.AgentPoolNames,
+			Name:          c.Name,
+			Region:        c.Location,
+			ResourceGroup: c.ResourceGroup,
+			Tags:          c.Tags,
+			NodeGroups:    c.AgentPoolNames,
 		})
 	}
 

--- a/providers/azure/kubernetes_discovery_test.go
+++ b/providers/azure/kubernetes_discovery_test.go
@@ -1,0 +1,53 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+)
+
+// A real AKS managed cluster and agent pool must appear in Resource Graph —
+// exercises the aksDiscovery adapter end to end.
+func TestResourceDiscoverySurfacesAKS(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	if _, err := p.AKS.CreateOrUpdateCluster(ctx, aks.ClusterInput{
+		ResourceGroup: "rg-1", Name: "prod", Location: "eastus",
+		Tags: map[string]string{"env": "prod"},
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster: %v", err)
+	}
+
+	if _, err := p.AKS.CreateOrUpdateAgentPool(ctx, "rg-1", "prod", aks.AgentPoolInput{
+		Name: "ap-1", Count: 1,
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateAgentPool: %v", err)
+	}
+
+	res, err := p.ResourceDiscovery.List(ctx, resourcediscovery.Query{
+		Services: []string{resourcediscovery.ServiceKubernetes},
+	})
+	if err != nil {
+		t.Fatalf("discovery List: %v", err)
+	}
+
+	var cluster, agentPool bool
+	for _, r := range res {
+		switch {
+		case r.Type == resourcediscovery.TypeCluster && r.ID == "prod":
+			cluster = true
+			if r.Region != "eastus" {
+				t.Errorf("cluster region = %q, want eastus", r.Region)
+			}
+		case r.Type == resourcediscovery.TypeNodeGroup && r.ID == "ap-1":
+			agentPool = true
+		}
+	}
+
+	if !cluster || !agentPool {
+		t.Fatalf("AKS not fully surfaced: cluster=%v agentPool=%v (%d resources)", cluster, agentPool, len(res))
+	}
+}

--- a/providers/azure/kubernetes_discovery_test.go
+++ b/providers/azure/kubernetes_discovery_test.go
@@ -57,3 +57,51 @@ func TestResourceDiscoverySurfacesAKS(t *testing.T) {
 		t.Fatalf("AKS not fully surfaced: cluster=%v agentPool=%v (%d resources)", cluster, agentPool, len(res))
 	}
 }
+
+// Two clusters with the same name in different resource groups must get
+// distinct canonical ARNs — each embedding its own resource group, not the
+// discovery default. The AKS mock keys on rg+name, so this is a real case.
+func TestResourceDiscoveryAKSSameNameDistinctARNs(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	for _, rg := range []string{"rg-a", "rg-b"} {
+		if _, err := p.AKS.CreateOrUpdateCluster(ctx, aks.ClusterInput{
+			ResourceGroup: rg, Name: "prod", Location: "eastus",
+		}); err != nil {
+			t.Fatalf("CreateOrUpdateCluster %s: %v", rg, err)
+		}
+	}
+
+	res, err := p.ResourceDiscovery.List(ctx, resourcediscovery.Query{
+		Services: []string{resourcediscovery.ServiceKubernetes},
+		Type:     resourcediscovery.TypeCluster,
+	})
+	if err != nil {
+		t.Fatalf("discovery List: %v", err)
+	}
+
+	arns := map[string]bool{}
+	for _, r := range res {
+		if r.ID == "prod" {
+			arns[r.ARN] = true
+		}
+	}
+
+	if len(arns) != 2 {
+		t.Fatalf("same-name clusters in two resource groups collapsed to %d distinct ARNs, want 2: %v", len(arns), arns)
+	}
+
+	for _, rg := range []string{"rg-a", "rg-b"} {
+		found := false
+		for arn := range arns {
+			if strings.Contains(arn, "resourceGroups/"+rg+"/") {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Errorf("no cluster ARN embeds resource group %q: %v", rg, arns)
+		}
+	}
+}

--- a/providers/azure/kubernetes_discovery_test.go
+++ b/providers/azure/kubernetes_discovery_test.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
@@ -41,6 +42,11 @@ func TestResourceDiscoverySurfacesAKS(t *testing.T) {
 			cluster = true
 			if r.Region != "eastus" {
 				t.Errorf("cluster region = %q, want eastus", r.Region)
+			}
+			// The ARM ID must carry the cluster's real resource group, not
+			// the discovery default.
+			if !strings.Contains(r.ARN, "resourceGroups/rg-1/") {
+				t.Errorf("cluster ARN %q missing real resource group rg-1", r.ARN)
 			}
 		case r.Type == resourcediscovery.TypeNodeGroup && r.ID == "ap-1":
 			agentPool = true

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -2,6 +2,8 @@
 package gcp
 
 import (
+	"context"
+
 	"github.com/stackshy/cloudemu/v2/config"
 	"github.com/stackshy/cloudemu/v2/providers/gcp/artifactregistry"
 	"github.com/stackshy/cloudemu/v2/providers/gcp/clouddns"
@@ -24,6 +26,32 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/gcp/vertexai"
 	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
 )
+
+// gkeDiscovery adapts the GKE mock to the resourcediscovery KubernetesClusters
+// capability, so GKE clusters and node pools surface in Cloud Asset Inventory.
+type gkeDiscovery struct{ m *gke.Mock }
+
+func (a gkeDiscovery) DiscoverClusters(ctx context.Context) ([]resourcediscovery.DiscoveredCluster, error) {
+	// Empty location lists clusters across all regions.
+	clusters, err := a.m.ListClusters(ctx, "")
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]resourcediscovery.DiscoveredCluster, 0, len(clusters))
+
+	for i := range clusters {
+		c := clusters[i]
+		out = append(out, resourcediscovery.DiscoveredCluster{
+			Name:       c.Name,
+			Region:     c.Location,
+			Tags:       c.ResourceLabels,
+			NodeGroups: c.NodePoolNames,
+		})
+	}
+
+	return out, nil
+}
 
 // Provider holds all GCP mock services.
 type Provider struct {
@@ -104,6 +132,7 @@ func New(opts ...config.Option) *Provider {
 			Storage:    p.GCS,
 			Database:   p.Firestore,
 			Serverless: p.CloudFunctions,
+			Kubernetes: gkeDiscovery{p.GKE},
 		},
 	)
 

--- a/providers/gcp/kubernetes_discovery_test.go
+++ b/providers/gcp/kubernetes_discovery_test.go
@@ -1,0 +1,52 @@
+package gcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/providers/gcp/gke"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+)
+
+// A real GKE cluster and node pool must appear in Cloud Asset inventory —
+// exercises the gkeDiscovery adapter end to end.
+func TestResourceDiscoverySurfacesGKE(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	if _, _, err := p.GKE.CreateCluster(ctx, &gke.CreateClusterInput{
+		Name: "prod", Location: "us-central1",
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, _, err := p.GKE.CreateNodePool(ctx, "us-central1", "prod", &gke.NodePoolSpec{
+		Name: "np-1", InitialNodeCount: 1,
+	}); err != nil {
+		t.Fatalf("CreateNodePool: %v", err)
+	}
+
+	res, err := p.ResourceDiscovery.List(ctx, resourcediscovery.Query{
+		Services: []string{resourcediscovery.ServiceKubernetes},
+	})
+	if err != nil {
+		t.Fatalf("discovery List: %v", err)
+	}
+
+	var cluster, nodePool bool
+	for _, r := range res {
+		switch {
+		case r.Type == resourcediscovery.TypeCluster && r.ID == "prod":
+			cluster = true
+			if r.Region != "us-central1" {
+				t.Errorf("cluster region = %q, want us-central1", r.Region)
+			}
+		case r.Type == resourcediscovery.TypeNodeGroup && r.ID == "np-1":
+			nodePool = true
+		}
+	}
+
+	if !cluster || !nodePool {
+		t.Fatalf("GKE not fully surfaced: cluster=%v nodePool=%v (%d resources)", cluster, nodePool, len(res))
+	}
+}

--- a/providers/gcp/kubernetes_discovery_test.go
+++ b/providers/gcp/kubernetes_discovery_test.go
@@ -2,6 +2,7 @@ package gcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/providers/gcp/gke"
@@ -48,5 +49,44 @@ func TestResourceDiscoverySurfacesGKE(t *testing.T) {
 
 	if !cluster || !nodePool {
 		t.Fatalf("GKE not fully surfaced: cluster=%v nodePool=%v (%d resources)", cluster, nodePool, len(res))
+	}
+}
+
+// Two clusters with the same name in different regions must get distinct
+// canonical ARNs — each embedding its own location, not the engine default.
+// A substring/single-scope check can't catch a collision here.
+func TestResourceDiscoveryGKESameNameDistinctARNs(t *testing.T) {
+	ctx := context.Background()
+	p := New()
+
+	for _, loc := range []string{"us-central1", "europe-west1"} {
+		if _, _, err := p.GKE.CreateCluster(ctx, &gke.CreateClusterInput{
+			Name: "prod", Location: loc,
+		}); err != nil {
+			t.Fatalf("CreateCluster %s: %v", loc, err)
+		}
+	}
+
+	res, err := p.ResourceDiscovery.List(ctx, resourcediscovery.Query{
+		Services: []string{resourcediscovery.ServiceKubernetes},
+		Type:     resourcediscovery.TypeCluster,
+	})
+	if err != nil {
+		t.Fatalf("discovery List: %v", err)
+	}
+
+	arns := map[string]bool{}
+	for _, r := range res {
+		if r.ID != "prod" {
+			continue
+		}
+		arns[r.ARN] = true
+		if !strings.Contains(r.ARN, "locations/"+r.Region+"/clusters/prod") {
+			t.Errorf("ARN %q does not embed its own region %q", r.ARN, r.Region)
+		}
+	}
+
+	if len(arns) != 2 {
+		t.Fatalf("same-name clusters in two regions collapsed to %d distinct ARNs, want 2: %v", len(arns), arns)
 	}
 }

--- a/server/aws/resourceexplorer2/sdk_test.go
+++ b/server/aws/resourceexplorer2/sdk_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stackshy/cloudemu/v2"
+	eksdriver "github.com/stackshy/cloudemu/v2/providers/aws/eks/driver"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -201,6 +202,79 @@ func TestSDKResourceExplorer2_BugFixes(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "123456789012", aws.ToString(got.View.Owner))
 	})
+}
+
+// TestSDKResourceExplorer2_KubernetesIndexing mirrors the Databricks/Azure/GCP
+// precedent for the EKS types added in this PR: a cluster and its node group
+// must be retrievable through the real Resource Explorer Search handler, and a
+// service filter must actually narrow to them.
+func TestSDKResourceExplorer2_KubernetesIndexing(t *testing.T) {
+	ctx := context.Background()
+	cloud := cloudemu.NewAWS()
+
+	_, err := cloud.EKS.CreateCluster(ctx, eksdriver.ClusterConfig{
+		Name: "prod", Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	_, err = cloud.EKS.CreateNodegroup(ctx, eksdriver.NodegroupConfig{
+		ClusterName: "prod", NodegroupName: "ng-1",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloud.S3.CreateBucket(ctx, "control-bucket"))
+
+	srv := awsserver.New(awsserver.Drivers{
+		S3:                cloud.S3,
+		ResourceDiscovery: cloud.ResourceDiscovery,
+		AccountID:         "123456789012",
+		Region:            "us-east-1",
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newREXClient(t, ts.URL)
+
+	t.Run("cluster + node group appear in unscoped Search", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{QueryString: aws.String("")})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Resources), 3, "control bucket + EKS cluster + node group")
+		assert.True(t, rexHasResourceType(out.Resources, "kubernetes:cluster"),
+			"EKS cluster must be indexed")
+		assert.True(t, rexHasResourceType(out.Resources, "kubernetes:nodegroup"),
+			"EKS node group must be indexed")
+	})
+
+	t.Run("service:kubernetes narrows to the EKS resources", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{QueryString: aws.String("service:kubernetes")})
+		require.NoError(t, err)
+		assert.Len(t, out.Resources, 2, "cluster + node group, not the bucket")
+	})
+
+	t.Run("cluster ARN is EKS-shaped", func(t *testing.T) {
+		out, err := client.Search(ctx, &rex.SearchInput{QueryString: aws.String("service:kubernetes")})
+		require.NoError(t, err)
+
+		var clusterARN string
+		for _, r := range out.Resources {
+			if aws.ToString(r.ResourceType) == "kubernetes:cluster" {
+				clusterARN = aws.ToString(r.Arn)
+			}
+		}
+
+		assert.Contains(t, clusterARN, ":eks:")
+		assert.Contains(t, clusterARN, ":cluster/prod")
+	})
+}
+
+func rexHasResourceType(resources []rextypes.Resource, want string) bool {
+	for i := range resources {
+		if aws.ToString(resources[i].ResourceType) == want {
+			return true
+		}
+	}
+
+	return false
 }
 
 func newREXClient(t *testing.T, baseURL string) *rex.Client {

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -270,6 +270,10 @@ func portableToAzureType(service, typ string) string {
 		return "microsoft.web/sites"
 	case "databricks/Workspace":
 		return "microsoft.databricks/workspaces"
+	case "kubernetes/Cluster":
+		return "microsoft.containerservice/managedclusters"
+	case "kubernetes/NodeGroup":
+		return "microsoft.containerservice/managedclusters/agentpools"
 	default:
 		return strings.ToLower(service + "/" + typ)
 	}

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -253,7 +253,7 @@ func extractSubscription(arn string) string {
 // (service, type) pair back to the dotted Azure type string a real ARG response
 // carries. A map lookup rather than a switch keeps gocyclo under the gate as the
 // pairs grow.
-var portableToAzureTypeMap = map[string]string{
+var portableToAzureTypeMap = map[string]string{ //nolint:gochecknoglobals // static lookup table
 	"compute/Instance":         "microsoft.compute/virtualmachines",
 	"networking/VPC":           "microsoft.network/virtualnetworks",
 	"networking/Subnet":        "microsoft.network/subnets",

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -249,34 +249,30 @@ func extractSubscription(arn string) string {
 	return rest
 }
 
-// portableToAzureType is the inverse of mapAzureType — it turns the engine's
-// (service, type) pair back into the dotted Azure type string a real ARG
-// response carries.
+// portableToAzureTypeMap is the inverse of mapAzureType's mapping — the engine's
+// (service, type) pair back to the dotted Azure type string a real ARG response
+// carries. A map lookup rather than a switch keeps gocyclo under the gate as the
+// pairs grow.
+var portableToAzureTypeMap = map[string]string{
+	"compute/Instance":         "microsoft.compute/virtualmachines",
+	"networking/VPC":           "microsoft.network/virtualnetworks",
+	"networking/Subnet":        "microsoft.network/subnets",
+	"networking/SecurityGroup": "microsoft.network/networksecuritygroups",
+	"storage/Bucket":           "microsoft.storage/storageaccounts",
+	"database/Table":           "microsoft.documentdb/databaseaccounts",
+	"serverless/Function":      "microsoft.web/sites",
+	"databricks/Workspace":     "microsoft.databricks/workspaces",
+	"kubernetes/Cluster":       "microsoft.containerservice/managedclusters",
+	"kubernetes/NodeGroup":     "microsoft.containerservice/managedclusters/agentpools",
+}
+
 func portableToAzureType(service, typ string) string {
-	switch service + "/" + typ {
-	case "compute/Instance":
-		return "microsoft.compute/virtualmachines"
-	case "networking/VPC":
-		return "microsoft.network/virtualnetworks"
-	case "networking/Subnet":
-		return "microsoft.network/subnets"
-	case "networking/SecurityGroup":
-		return "microsoft.network/networksecuritygroups"
-	case "storage/Bucket":
-		return "microsoft.storage/storageaccounts"
-	case "database/Table":
-		return "microsoft.documentdb/databaseaccounts"
-	case "serverless/Function":
-		return "microsoft.web/sites"
-	case "databricks/Workspace":
-		return "microsoft.databricks/workspaces"
-	case "kubernetes/Cluster":
-		return "microsoft.containerservice/managedclusters"
-	case "kubernetes/NodeGroup":
-		return "microsoft.containerservice/managedclusters/agentpools"
-	default:
-		return strings.ToLower(service + "/" + typ)
+	key := service + "/" + typ
+	if azureType, ok := portableToAzureTypeMap[key]; ok {
+		return azureType
 	}
+
+	return strings.ToLower(key)
 }
 
 // Compile-time check that Handler implements the Matches+ServeHTTP pair the

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -285,33 +285,33 @@ func addTag(out *parsedKQL, key, value string) {
 	out.Query.Tags[key] = value
 }
 
+// portableResourceType is a portable (service, type) pair.
+type portableResourceType struct{ service, typ string }
+
+// azureToPortableType maps a fully-qualified Azure resource type to the portable
+// pair the engine uses. A map lookup rather than a switch keeps gocyclo under
+// the gate as the type list grows.
+var azureToPortableType = map[string]portableResourceType{
+	azureTypeVM:        {portableCompute, "Instance"},
+	azureTypeVNet:      {portableNetworking, "VPC"},
+	azureTypeSubnet:    {portableNetworking, "Subnet"},
+	azureTypeSubnetN:   {portableNetworking, "Subnet"},
+	azureTypeNSG:       {portableNetworking, "SecurityGroup"},
+	azureTypeStorage:   {portableStorage, "Bucket"},
+	azureTypeStoCnt:    {portableStorage, "Bucket"},
+	azureTypeCosmos:    {portableDatabase, "Table"},
+	azureTypeCosmosC:   {portableDatabase, "Table"},
+	azureTypeWebSite:   {portableServerless, "Function"},
+	azureTypeDatabrick: {portableDatabricks, "Workspace"},
+	azureTypeAKS:       {portableKubernetes, "Cluster"},
+	azureTypeAgentPool: {portableKubernetes, "NodeGroup"},
+}
+
 // mapAzureType translates a fully-qualified Azure resource type to the
 // portable (service, type) pair the engine uses. Returns ("", "") for
 // unmapped types so the filter is treated as match-none rather than
 // match-all.
 func mapAzureType(azureType string) (service, typ string) {
-	switch azureType {
-	case azureTypeVM:
-		return portableCompute, "Instance"
-	case azureTypeVNet:
-		return portableNetworking, "VPC"
-	case azureTypeSubnet, azureTypeSubnetN:
-		return portableNetworking, "Subnet"
-	case azureTypeNSG:
-		return portableNetworking, "SecurityGroup"
-	case azureTypeStorage, azureTypeStoCnt:
-		return portableStorage, "Bucket"
-	case azureTypeCosmos, azureTypeCosmosC:
-		return portableDatabase, "Table"
-	case azureTypeWebSite:
-		return portableServerless, "Function"
-	case azureTypeDatabrick:
-		return portableDatabricks, "Workspace"
-	case azureTypeAKS:
-		return portableKubernetes, "Cluster"
-	case azureTypeAgentPool:
-		return portableKubernetes, "NodeGroup"
-	default:
-		return "", ""
-	}
+	p := azureToPortableType[azureType]
+	return p.service, p.typ
 }

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -291,7 +291,7 @@ type portableResourceType struct{ service, typ string }
 // azureToPortableType maps a fully-qualified Azure resource type to the portable
 // pair the engine uses. A map lookup rather than a switch keeps gocyclo under
 // the gate as the type list grows.
-var azureToPortableType = map[string]portableResourceType{
+var azureToPortableType = map[string]portableResourceType{ //nolint:gochecknoglobals // static lookup table
 	azureTypeVM:        {portableCompute, "Instance"},
 	azureTypeVNet:      {portableNetworking, "VPC"},
 	azureTypeSubnet:    {portableNetworking, "Subnet"},

--- a/server/azure/resourcegraph/kql.go
+++ b/server/azure/resourcegraph/kql.go
@@ -45,6 +45,8 @@ const (
 	azureTypeCosmosC   = "microsoft.documentdb/databaseaccounts/sqldatabases/containers"
 	azureTypeWebSite   = "microsoft.web/sites"
 	azureTypeDatabrick = "microsoft.databricks/workspaces"
+	azureTypeAKS       = "microsoft.containerservice/managedclusters"
+	azureTypeAgentPool = "microsoft.containerservice/managedclusters/agentpools"
 )
 
 // Portable service identifiers as emitted by the resourcediscovery walkers.
@@ -55,6 +57,7 @@ const (
 	portableDatabase   = "database"
 	portableServerless = "serverless"
 	portableDatabricks = "databricks"
+	portableKubernetes = "kubernetes"
 )
 
 // parsedKQL is the result of KQL parsing — an engine Query plus the limit
@@ -304,6 +307,10 @@ func mapAzureType(azureType string) (service, typ string) {
 		return portableServerless, "Function"
 	case azureTypeDatabrick:
 		return portableDatabricks, "Workspace"
+	case azureTypeAKS:
+		return portableKubernetes, "Cluster"
+	case azureTypeAgentPool:
+		return portableKubernetes, "NodeGroup"
 	default:
 		return "", ""
 	}

--- a/server/azure/resourcegraph/kql_test.go
+++ b/server/azure/resourcegraph/kql_test.go
@@ -111,6 +111,8 @@ func TestMapAzureType(t *testing.T) {
 		{"microsoft.storage/storageaccounts", "storage", "Bucket"},
 		{"microsoft.documentdb/databaseaccounts", "database", "Table"},
 		{"microsoft.web/sites", "serverless", "Function"},
+		{"microsoft.containerservice/managedclusters", "kubernetes", "Cluster"},
+		{"microsoft.containerservice/managedclusters/agentpools", "kubernetes", "NodeGroup"},
 		{"microsoft.unknown/widgets", "", ""},
 	}
 

--- a/server/azure/resourcegraph/portable_type_test.go
+++ b/server/azure/resourcegraph/portable_type_test.go
@@ -1,0 +1,24 @@
+package resourcegraph
+
+import "testing"
+
+// portableToAzureType is what stamps the `type` field on every Resource Graph
+// row, so a client filtering by the real ARM type must get the exact string
+// back. The kubernetes mappings were previously only exercised in the reverse
+// (mapAzureType) direction.
+func TestPortableToAzureType(t *testing.T) {
+	cases := []struct {
+		svc, typ, want string
+	}{
+		{"compute", "Instance", "microsoft.compute/virtualmachines"},
+		{"databricks", "Workspace", "microsoft.databricks/workspaces"},
+		{"kubernetes", "Cluster", "microsoft.containerservice/managedclusters"},
+		{"kubernetes", "NodeGroup", "microsoft.containerservice/managedclusters/agentpools"},
+	}
+
+	for _, c := range cases {
+		if got := portableToAzureType(c.svc, c.typ); got != c.want {
+			t.Errorf("portableToAzureType(%q,%q) = %q, want %q", c.svc, c.typ, got, c.want)
+		}
+	}
+}

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/providers/azure/aks"
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	dbxdriver "github.com/stackshy/cloudemu/v2/services/databricks/driver"
@@ -232,6 +233,90 @@ func TestSDKResourceGraph_DatabricksIndexing(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 		assert.EqualValues(t, 0, *out.TotalRecords, "an unmapped type must not widen to the whole inventory")
+	})
+
+	t.Run("type == an unmodeled type matches none, not all", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.keyvault/vaults'"),
+		}, nil)
+		require.NoError(t, err)
+		assert.EqualValues(t, 0, *out.TotalRecords)
+	})
+}
+
+// TestSDKResourceGraph_KubernetesIndexing mirrors the Databricks precedent for
+// the AKS types added in this PR: a managed cluster and its agent pool must be
+// retrievable through the real Resource Graph query handler, and a
+// `type ==`/`in~` predicate on the ARM container-service types must actually
+// filter to them rather than return every row (or none).
+func TestSDKResourceGraph_KubernetesIndexing(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.AKS.CreateOrUpdateCluster(ctx, aks.ClusterInput{
+		ResourceGroup: "rg-1", Name: "prod", Location: "eastus",
+		Tags: map[string]string{"env": "prod"},
+	})
+	require.NoError(t, err)
+
+	_, err = cloudP.AKS.CreateOrUpdateAgentPool(ctx, "rg-1", "prod", aks.AgentPoolInput{
+		Name: "ap-1", Count: 1,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloudP.BlobStorage.CreateBucket(ctx, "control-bucket"))
+
+	srv := azureserver.New(azureserver.Drivers{
+		BlobStorage:       cloudP.BlobStorage,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		SubscriptionID:    "123456789012",
+	})
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newResourceGraphClient(t, ts)
+
+	t.Run("cluster + agent pool appear in bare Resources query", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		assert.Len(t, data, 3, "control bucket + AKS cluster + agent pool")
+		assert.True(t, rowsHaveType(data, "microsoft.containerservice/managedclusters"),
+			"AKS cluster must be indexed")
+		assert.True(t, rowsHaveType(data, "microsoft.containerservice/managedclusters/agentpools"),
+			"AKS agent pool must be indexed")
+	})
+
+	t.Run("type == managedclusters narrows to the cluster", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.containerservice/managedclusters' | project id, name, type"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1, "must narrow to the one cluster, not all rows")
+
+		row := data[0].(map[string]any)
+		assert.Equal(t, "prod", row["name"])
+		assert.Equal(t, "microsoft.containerservice/managedclusters", row["type"])
+	})
+
+	t.Run("cluster id is ARM-shaped with its own resource group", func(t *testing.T) {
+		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
+			Query: to.Ptr("Resources | where type == 'microsoft.containerservice/managedclusters'"),
+		}, nil)
+		require.NoError(t, err)
+
+		data := out.Data.([]any)
+		require.Len(t, data, 1)
+
+		id := data[0].(map[string]any)["id"].(string)
+		assert.Contains(t, id, "/subscriptions/123456789012/")
+		assert.Contains(t, id, "resourceGroups/rg-1/")
+		assert.Contains(t, id, "Microsoft.ContainerService")
 	})
 
 	t.Run("type == an unmodeled type matches none, not all", func(t *testing.T) {

--- a/server/gcp/cloudasset/filter.go
+++ b/server/gcp/cloudasset/filter.go
@@ -44,6 +44,8 @@ const (
 	atFirestoreColl   = "firestore.googleapis.com/Collection"
 	atCloudFunction   = "cloudfunctions.googleapis.com/Function"
 	atCloudFunctionV1 = "cloudfunctions.googleapis.com/CloudFunction"
+	atGKECluster      = "container.googleapis.com/Cluster"
+	atGKENodePool     = "container.googleapis.com/NodePool"
 )
 
 // Portable service identifiers as emitted by resourcediscovery walkers.
@@ -53,6 +55,7 @@ const (
 	portableStorage    = "storage"
 	portableDatabase   = "database"
 	portableServerless = "serverless"
+	portableKubernetes = "kubernetes"
 )
 
 // parsedFilter is the result of filter parsing — an engine Query plus
@@ -244,6 +247,10 @@ func mapGCPAssetType(assetType string) (service, typ string) {
 		return portableDatabase, "Table"
 	case atCloudFunction, atCloudFunctionV1:
 		return portableServerless, "Function"
+	case atGKECluster:
+		return portableKubernetes, "Cluster"
+	case atGKENodePool:
+		return portableKubernetes, "NodeGroup"
 	default:
 		return "", ""
 	}
@@ -267,6 +274,10 @@ func portableToGCPAssetType(service, typ string) string {
 		return atFirestoreDB
 	case portableServerless + "/Function":
 		return atCloudFunction
+	case portableKubernetes + "/Cluster":
+		return atGKECluster
+	case portableKubernetes + "/NodeGroup":
+		return atGKENodePool
 	default:
 		return service + "/" + typ
 	}

--- a/server/gcp/cloudasset/filter_test.go
+++ b/server/gcp/cloudasset/filter_test.go
@@ -162,6 +162,8 @@ func TestMapGCPAssetType(t *testing.T) {
 		{"storage.googleapis.com/Bucket", "storage", "Bucket"},
 		{"firestore.googleapis.com/Database", "database", "Table"},
 		{"cloudfunctions.googleapis.com/Function", "serverless", "Function"},
+		{"container.googleapis.com/Cluster", "kubernetes", "Cluster"},
+		{"container.googleapis.com/NodePool", "kubernetes", "NodeGroup"},
 		{"unknown.googleapis.com/Widget", "", ""},
 	}
 
@@ -187,6 +189,8 @@ func TestPortableToGCPAssetType_Roundtrip(t *testing.T) {
 		{"storage", "Bucket", "storage.googleapis.com/Bucket"},
 		{"database", "Table", "firestore.googleapis.com/Database"},
 		{"serverless", "Function", "cloudfunctions.googleapis.com/Function"},
+		{"kubernetes", "Cluster", "container.googleapis.com/Cluster"},
+		{"kubernetes", "NodeGroup", "container.googleapis.com/NodePool"},
 	}
 
 	for _, c := range cases {

--- a/server/gcp/cloudasset/sdk_test.go
+++ b/server/gcp/cloudasset/sdk_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/providers/gcp/gke"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -224,6 +225,79 @@ func TestSDKCloudAsset(t *testing.T) {
 		_, err := client.Feeds.Get(feedName).Do()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "NOT_FOUND")
+	})
+}
+
+// TestSDKCloudAsset_KubernetesIndexing mirrors the Databricks/Azure precedent
+// for the GKE types added in this PR: a cluster and its node pool must be
+// retrievable through the real Cloud Asset search/list handler, and an
+// assetType filter on the container-service types must actually narrow to them.
+func TestSDKCloudAsset_KubernetesIndexing(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewGCP()
+	const projectID = "my-test-project"
+
+	_, _, err := cloudP.GKE.CreateCluster(ctx, &gke.CreateClusterInput{
+		Name: "prod", Location: "us-central1",
+	})
+	require.NoError(t, err)
+
+	_, _, err = cloudP.GKE.CreateNodePool(ctx, "us-central1", "prod", &gke.NodePoolSpec{
+		Name: "np-1", InitialNodeCount: 1,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, cloudP.GCS.CreateBucket(ctx, "control-bucket"))
+
+	srv := gcpserver.New(gcpserver.Drivers{
+		Storage:           cloudP.GCS,
+		ResourceDiscovery: cloudP.ResourceDiscovery,
+		ProjectID:         projectID,
+	})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	client, err := cloudasset.NewService(ctx,
+		option.WithEndpoint(ts.URL),
+		option.WithoutAuthentication(),
+	)
+	require.NoError(t, err)
+
+	scope := "projects/" + projectID
+
+	t.Run("cluster + node pool appear in searchAllResources", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).Do()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(out.Results), 3, "control bucket + GKE cluster + node pool")
+
+		var haveCluster, haveNodePool bool
+		for _, r := range out.Results {
+			switch r.AssetType {
+			case "container.googleapis.com/Cluster":
+				haveCluster = true
+			case "container.googleapis.com/NodePool":
+				haveNodePool = true
+			}
+		}
+
+		assert.True(t, haveCluster, "GKE cluster must be indexed")
+		assert.True(t, haveNodePool, "GKE node pool must be indexed")
+	})
+
+	t.Run("assetType filter narrows to just the cluster", func(t *testing.T) {
+		out, err := client.V1.SearchAllResources(scope).
+			Query("assetType:container.googleapis.com/Cluster").Do()
+		require.NoError(t, err)
+		require.Len(t, out.Results, 1, "assetType must narrow to the cluster, not return all rows")
+		assert.Equal(t, "container.googleapis.com/Cluster", out.Results[0].AssetType)
+		assert.Equal(t, "prod", out.Results[0].DisplayName)
+	})
+
+	t.Run("assets.list with GKE assetType narrows", func(t *testing.T) {
+		out, err := client.Assets.List(scope).
+			AssetTypes("container.googleapis.com/Cluster").Do()
+		require.NoError(t, err)
+		assert.Len(t, out.Assets, 1)
 	})
 }
 

--- a/services/resourcediscovery/arn.go
+++ b/services/resourcediscovery/arn.go
@@ -112,32 +112,43 @@ func (e *Engine) databaseTableARN(name string) string {
 	}
 }
 
-func (e *Engine) kubernetesClusterARN(name string) string {
+// region and resourceGroup come from the cluster (falling back to engine
+// defaults) so the identifier matches the resource's real location: GCP
+// self-links embed the region, Azure IDs embed the resource group.
+func (e *Engine) kubernetesClusterARN(region, resourceGroup, name string) string {
 	switch e.provider {
 	case ProviderAWS:
-		return idgen.AWSARN("eks", e.region, e.accountID, "cluster/"+name)
+		return idgen.AWSARN("eks", region, e.accountID, "cluster/"+name)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup,
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup),
 			"Microsoft.ContainerService", "managedClusters", name)
 	case ProviderGCP:
-		return idgen.GCPID(e.accountID, "locations/"+e.region+"/clusters", name)
+		return idgen.GCPID(e.accountID, "locations/"+region+"/clusters", name)
 	default:
 		return name
 	}
 }
 
-func (e *Engine) kubernetesNodeGroupARN(cluster, name string) string {
+func (e *Engine) kubernetesNodeGroupARN(region, resourceGroup, cluster, name string) string {
 	switch e.provider {
 	case ProviderAWS:
-		return idgen.AWSARN("eks", e.region, e.accountID, "nodegroup/"+cluster+"/"+name)
+		return idgen.AWSARN("eks", region, e.accountID, "nodegroup/"+cluster+"/"+name)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup,
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup),
 			"Microsoft.ContainerService", "managedClusters/"+cluster+"/agentPools", name)
 	case ProviderGCP:
-		return idgen.GCPID(e.accountID, "locations/"+e.region+"/clusters/"+cluster+"/nodePools", name)
+		return idgen.GCPID(e.accountID, "locations/"+region+"/clusters/"+cluster+"/nodePools", name)
 	default:
 		return name
 	}
+}
+
+func azureResourceGroupOrDefault(rg string) string {
+	if rg == "" {
+		return azureDefaultResourceGroup
+	}
+
+	return rg
 }
 
 func (e *Engine) serverlessFunctionARN(name string) string {

--- a/services/resourcediscovery/arn.go
+++ b/services/resourcediscovery/arn.go
@@ -112,6 +112,34 @@ func (e *Engine) databaseTableARN(name string) string {
 	}
 }
 
+func (e *Engine) kubernetesClusterARN(name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("eks", e.region, e.accountID, "cluster/"+name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup,
+			"Microsoft.ContainerService", "managedClusters", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "locations/"+e.region+"/clusters", name)
+	default:
+		return name
+	}
+}
+
+func (e *Engine) kubernetesNodeGroupARN(cluster, name string) string {
+	switch e.provider {
+	case ProviderAWS:
+		return idgen.AWSARN("eks", e.region, e.accountID, "nodegroup/"+cluster+"/"+name)
+	case ProviderAzure:
+		return idgen.AzureID(e.accountID, azureDefaultResourceGroup,
+			"Microsoft.ContainerService", "managedClusters/"+cluster+"/agentPools", name)
+	case ProviderGCP:
+		return idgen.GCPID(e.accountID, "locations/"+e.region+"/clusters/"+cluster+"/nodePools", name)
+	default:
+		return name
+	}
+}
+
 func (e *Engine) serverlessFunctionARN(name string) string {
 	switch e.provider {
 	case ProviderAWS:

--- a/services/resourcediscovery/engine.go
+++ b/services/resourcediscovery/engine.go
@@ -22,6 +22,29 @@ type Drivers struct {
 	Database   dbdriver.Database
 	Serverless serverlessdriver.Serverless
 	Databricks dbxdriver.Databricks
+	Kubernetes KubernetesClusters
+}
+
+// KubernetesClusters is the discovery capability for managed Kubernetes —
+// EKS, GKE, and AKS. Each cloud's cluster mock lives in its provider package
+// (there is no shared services/*/driver for it, unlike the portable services),
+// so rather than import providers here — which would invert the package
+// layering — each provider wires in a thin adapter that projects its clusters
+// onto DiscoveredCluster.
+type KubernetesClusters interface {
+	DiscoverClusters(ctx context.Context) ([]DiscoveredCluster, error)
+}
+
+// DiscoveredCluster is a provider-neutral projection of a managed Kubernetes
+// cluster for the inventory walk. Region and Tags may be empty (the walker
+// falls back to the engine's default region); NodeGroups holds the cluster's
+// node-group / node-pool / agent-pool names, each surfaced as its own
+// resource.
+type DiscoveredCluster struct {
+	Name       string
+	Region     string
+	Tags       map[string]string
+	NodeGroups []string
 }
 
 // Engine walks all configured service drivers and returns a normalized
@@ -124,6 +147,10 @@ func (e *Engine) walkers() []func(context.Context) ([]Resource, error) {
 
 	if e.drivers.Databricks != nil {
 		ws = append(ws, e.walkDatabricks)
+	}
+
+	if e.drivers.Kubernetes != nil {
+		ws = append(ws, e.walkKubernetes)
 	}
 
 	return ws

--- a/services/resourcediscovery/engine.go
+++ b/services/resourcediscovery/engine.go
@@ -36,15 +36,23 @@ type KubernetesClusters interface {
 }
 
 // DiscoveredCluster is a provider-neutral projection of a managed Kubernetes
-// cluster for the inventory walk. Region and Tags may be empty (the walker
-// falls back to the engine's default region); NodeGroups holds the cluster's
-// node-group / node-pool / agent-pool names, each surfaced as its own
-// resource.
+// cluster for the inventory walk. NodeGroups holds the cluster's node-group /
+// node-pool / agent-pool names, each surfaced as its own resource.
+//
+// Region and ResourceGroup feed the per-provider ARN/ID so the identifier
+// matches the resource's real location rather than the engine default (GCP
+// self-links embed the region; Azure IDs embed the resource group). Both may
+// be empty — the walker then falls back to the engine's defaults.
+//
+// ARN, when set, is used verbatim as the cluster's identifier (e.g. the EKS
+// mock's own ARN) instead of a rebuilt best-effort one; empty means build it.
 type DiscoveredCluster struct {
-	Name       string
-	Region     string
-	Tags       map[string]string
-	NodeGroups []string
+	Name          string
+	Region        string
+	ResourceGroup string
+	ARN           string
+	Tags          map[string]string
+	NodeGroups    []string
 }
 
 // Engine walks all configured service drivers and returns a normalized

--- a/services/resourcediscovery/kubernetes_walk_test.go
+++ b/services/resourcediscovery/kubernetes_walk_test.go
@@ -41,7 +41,9 @@ func TestWalkKubernetesSurfacesClustersAndNodeGroups(t *testing.T) {
 		arnSubstr string
 	}{
 		{ProviderAWS, "eks"},
-		{ProviderGCP, "clusters/prod"},
+		// exact: the GCP self-link must embed the cluster's own region
+		// (us-west-2), not the engine default (us-east-1).
+		{ProviderGCP, "projects/acct-1/locations/us-west-2/clusters/prod"},
 		{ProviderAzure, "Microsoft.ContainerService"},
 	}
 

--- a/services/resourcediscovery/kubernetes_walk_test.go
+++ b/services/resourcediscovery/kubernetes_walk_test.go
@@ -1,0 +1,125 @@
+package resourcediscovery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeK8s struct {
+	clusters []DiscoveredCluster
+	err      error
+}
+
+func (f fakeK8s) DiscoverClusters(context.Context) ([]DiscoveredCluster, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.clusters, nil
+}
+
+// A managed cluster that never appears in the inventory is one an operator
+// can't schedule, cost, or clean up. Each cluster and every node group must
+// surface, tagged to the right cloud's canonical ARN/ID.
+func TestWalkKubernetesSurfacesClustersAndNodeGroups(t *testing.T) {
+	ctx := context.Background()
+
+	drv := fakeK8s{clusters: []DiscoveredCluster{
+		{
+			Name:       "prod",
+			Region:     "us-west-2",
+			Tags:       map[string]string{"env": "prod"},
+			NodeGroups: []string{"ng-a", "ng-b"},
+		},
+		{Name: "bare"}, // no region, no node groups
+	}}
+
+	cases := []struct {
+		provider  string
+		arnSubstr string
+	}{
+		{ProviderAWS, "eks"},
+		{ProviderGCP, "clusters/prod"},
+		{ProviderAzure, "Microsoft.ContainerService"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.provider, func(t *testing.T) {
+			eng := New(tc.provider, "acct-1", "us-east-1", &Drivers{Kubernetes: drv})
+
+			got, err := eng.walkKubernetes(ctx)
+			if err != nil {
+				t.Fatalf("walkKubernetes: %v", err)
+			}
+
+			var clusters, nodeGroups int
+			var prodCluster *Resource
+
+			for i := range got {
+				r := got[i]
+				if r.Service != ServiceKubernetes {
+					t.Errorf("unexpected service %q", r.Service)
+				}
+
+				switch r.Type {
+				case TypeCluster:
+					clusters++
+					if r.ID == "prod" {
+						prodCluster = &got[i]
+					}
+				case TypeNodeGroup:
+					nodeGroups++
+				default:
+					t.Errorf("unexpected type %q", r.Type)
+				}
+			}
+
+			if clusters != 2 || nodeGroups != 2 {
+				t.Fatalf("got %d clusters / %d node groups, want 2 / 2", clusters, nodeGroups)
+			}
+
+			if prodCluster == nil {
+				t.Fatal("prod cluster missing")
+			}
+
+			if prodCluster.Region != "us-west-2" {
+				t.Errorf("prod region = %q, want us-west-2", prodCluster.Region)
+			}
+
+			if !strings.Contains(prodCluster.ARN, tc.arnSubstr) {
+				t.Errorf("prod ARN %q does not contain %q", prodCluster.ARN, tc.arnSubstr)
+			}
+		})
+	}
+}
+
+// A cluster with no explicit region inherits the engine default.
+func TestWalkKubernetesRegionFallback(t *testing.T) {
+	eng := New(ProviderAWS, "acct-1", "eu-west-1", &Drivers{
+		Kubernetes: fakeK8s{clusters: []DiscoveredCluster{{Name: "c"}}},
+	})
+
+	got, err := eng.walkKubernetes(context.Background())
+	if err != nil {
+		t.Fatalf("walkKubernetes: %v", err)
+	}
+
+	if len(got) != 1 || got[0].Region != "eu-west-1" {
+		t.Fatalf("region fallback failed: %+v", got)
+	}
+}
+
+// A driver that models clusters and then fails to list them has a real
+// problem; swallowing it would report an inventory missing whatever the walk
+// could not read.
+func TestWalkKubernetesPropagatesErrors(t *testing.T) {
+	eng := New(ProviderGCP, "acct-1", "us-east-1", &Drivers{
+		Kubernetes: fakeK8s{err: errors.New("list clusters failed")},
+	})
+
+	if _, err := eng.walkKubernetes(context.Background()); err == nil {
+		t.Error("a failing cluster listing should surface, not be swallowed")
+	}
+}

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -25,6 +25,7 @@ const (
 	ServiceDatabase   = "database"
 	ServiceServerless = "serverless"
 	ServiceDatabricks = "databricks"
+	ServiceKubernetes = "kubernetes"
 )
 
 // Resource type constants emitted by the walkers.
@@ -39,6 +40,8 @@ const (
 	TypeTable         = "Table"
 	TypeFunction      = "Function"
 	TypeWorkspace     = "Workspace"
+	TypeCluster       = "Cluster"
+	TypeNodeGroup     = "NodeGroup"
 )
 
 func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
@@ -284,6 +287,47 @@ func (e *Engine) walkDatabricks(ctx context.Context) ([]Resource, error) {
 			ARN:    workspaces[i].ID,
 			Region: region, Tags: copyTags(workspaces[i].Tags),
 		})
+	}
+
+	return out, nil
+}
+
+// walkKubernetes surfaces managed Kubernetes clusters (EKS/GKE/AKS) and their
+// node groups. The provider supplies a DiscoverClusters adapter; each cluster
+// becomes a Cluster resource and each node group / node pool / agent pool a
+// NodeGroup resource, so a client enumerating inventory sees them the way real
+// RE2 / Resource Graph / Cloud Asset would.
+func (e *Engine) walkKubernetes(ctx context.Context) ([]Resource, error) {
+	clusters, err := e.drivers.Kubernetes.DiscoverClusters(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("walkKubernetes: %w", err)
+	}
+
+	out := []Resource{}
+
+	for i := range clusters {
+		c := clusters[i]
+
+		region := c.Region
+		if region == "" {
+			region = e.region
+		}
+
+		out = append(out, Resource{
+			Provider: e.provider, Service: ServiceKubernetes, Type: TypeCluster,
+			ID:     c.Name,
+			ARN:    e.kubernetesClusterARN(c.Name),
+			Region: region, Tags: copyTags(c.Tags),
+		})
+
+		for _, ng := range c.NodeGroups {
+			out = append(out, Resource{
+				Provider: e.provider, Service: ServiceKubernetes, Type: TypeNodeGroup,
+				ID:     ng,
+				ARN:    e.kubernetesNodeGroupARN(c.Name, ng),
+				Region: region,
+			})
+		}
 	}
 
 	return out, nil

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -313,10 +313,15 @@ func (e *Engine) walkKubernetes(ctx context.Context) ([]Resource, error) {
 			region = e.region
 		}
 
+		clusterARN := c.ARN
+		if clusterARN == "" {
+			clusterARN = e.kubernetesClusterARN(region, c.ResourceGroup, c.Name)
+		}
+
 		out = append(out, Resource{
 			Provider: e.provider, Service: ServiceKubernetes, Type: TypeCluster,
 			ID:     c.Name,
-			ARN:    e.kubernetesClusterARN(c.Name),
+			ARN:    clusterARN,
 			Region: region, Tags: copyTags(c.Tags),
 		})
 
@@ -324,7 +329,7 @@ func (e *Engine) walkKubernetes(ctx context.Context) ([]Resource, error) {
 			out = append(out, Resource{
 				Provider: e.provider, Service: ServiceKubernetes, Type: TypeNodeGroup,
 				ID:     ng,
-				ARN:    e.kubernetesNodeGroupARN(c.Name, ng),
+				ARN:    e.kubernetesNodeGroupARN(region, c.ResourceGroup, c.Name, ng),
 				Region: region,
 			})
 		}


### PR DESCRIPTION
## What

Surfaces managed Kubernetes clusters and their node groups in resource discovery, so they appear in Resource Explorer 2 / Azure Resource Graph / GCP Cloud Asset alongside the other inventory types. Addresses the Kubernetes item of the discovery-parity backlog in #295.

- **EKS** — cluster + nodegroup
- **GKE** — cluster + node pool
- **AKS** — managed cluster + agent pool

| Portable | AWS RE2 | Azure Resource Graph | GCP Cloud Asset |
|---|---|---|---|
| `kubernetes/Cluster` | `kubernetes:cluster` | `microsoft.containerservice/managedclusters` | `container.googleapis.com/Cluster` |
| `kubernetes/NodeGroup` | `kubernetes:nodegroup` | `.../managedclusters/agentpools` | `container.googleapis.com/NodePool` |

## How

- **`services/resourcediscovery/`** — a `KubernetesClusters` capability with a provider-neutral `DiscoveredCluster` projection, a single `walkKubernetes` walker, `Cluster`/`NodeGroup` type constants, and per-provider ARN/ID builders. The discovery engine stays free of provider imports; each provider wires a thin adapter over its cluster mock (mirrors how Databricks is walked).
- **`providers/{aws,gcp,azure}`** — `eksDiscovery` / `gkeDiscovery` / `aksDiscovery` adapters projecting each cloud's cluster mock (clusters + node-group names, region, tags) onto `DiscoveredCluster`, wired into the discovery `Drivers`.
- **Inventory maps** — Azure Resource Graph (`kql.go` `mapAzureType` + `handler.go` `portableToAzureType`) and GCP Cloud Asset (`filter.go`) gain the ↔ mappings; AWS RE2 handles it via the generic `service:type`.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- **Walker unit tests** (`kubernetes_walk_test.go`): per-provider surfacing, ARN shape, region fallback, error propagation.
- **End-to-end per-provider tests** (`providers/{aws,gcp,azure}/kubernetes_discovery_test.go`): create real EKS/GKE/AKS clusters + node groups through the mocks and assert they surface via the wired `ResourceDiscovery`, with region/tags.
- **Map-table cases** added to the Azure/GCP filter tests.
- All touched suites pass.

## Notes

- Scope is clusters + node groups only (not Fargate profiles / addons), per the #295 backlog item.
- ARNs are best-effort canonical identifiers (consistent with the existing discovery ARN builders).

Refs #295
