### PR TITLE
Add AWS MemoryDB Full-Parity Support

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -894,6 +894,106 @@ Both interfaces are AWS-only concepts, discovered by type assertion.
 
 ---
 
+## 11a. MemoryDB (AWS)
+
+**Driver interface:** `services/memorydb/driver/driver.go`
+**AWS:** MemoryDB for Redis/Valkey | **Azure:** — | **GCP:** —
+
+A durable, in-VPC Redis/Valkey cluster service. Unlike Cache, MemoryDB is a
+control-plane-only surface (no `Set`/`Get` data plane), so it has its own driver
+rather than reusing `services/cache`. Served as AWS JSON 1.1 on the
+`AmazonMemoryDB.` target prefix (`server/aws/memorydb`), so a real
+`aws-sdk-go-v2/service/memorydb` client with a custom endpoint works unchanged.
+
+### Clusters (shards, nodes, endpoints)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateCluster` | `(ctx, CreateClusterConfig) (*Cluster, error)` |
+| `DescribeClusters` | `(ctx, names) ([]Cluster, error)` |
+| `UpdateCluster` | `(ctx, UpdateClusterConfig) (*Cluster, error)` |
+| `DeleteCluster` | `(ctx, name, finalSnapshotName) (*Cluster, error)` |
+| `FailoverShard` | `(ctx, clusterName, shardName) (*Cluster, error)` |
+| `ListAllowedNodeTypeUpdates` | `(ctx, clusterName) (scaleUp, scaleDown []string, error)` |
+
+### ACLs & Users
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateACL` | `(ctx, name, userNames, tags) (*ACL, error)` |
+| `DescribeACLs` | `(ctx, names) ([]ACL, error)` |
+| `UpdateACL` | `(ctx, name, add, remove) (*ACL, error)` |
+| `DeleteACL` | `(ctx, name) (*ACL, error)` |
+| `CreateUser` | `(ctx, CreateUserConfig) (*User, error)` |
+| `DescribeUsers` | `(ctx, names) ([]User, error)` |
+| `UpdateUser` | `(ctx, UpdateUserConfig) (*User, error)` |
+| `DeleteUser` | `(ctx, name) (*User, error)` |
+
+### Parameter Groups
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateParameterGroup` | `(ctx, name, family, description, tags) (*ParameterGroup, error)` |
+| `DescribeParameterGroups` | `(ctx, names) ([]ParameterGroup, error)` |
+| `UpdateParameterGroup` | `(ctx, name, params) (*ParameterGroup, error)` |
+| `ResetParameterGroup` | `(ctx, name, all, names) (*ParameterGroup, error)` |
+| `DeleteParameterGroup` | `(ctx, name) (*ParameterGroup, error)` |
+| `DescribeParameters` | `(ctx, groupName) ([]Parameter, error)` |
+
+### Subnet Groups
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSubnetGroup` | `(ctx, CreateSubnetGroupConfig) (*SubnetGroup, error)` |
+| `DescribeSubnetGroups` | `(ctx, names) ([]SubnetGroup, error)` |
+| `UpdateSubnetGroup` | `(ctx, UpdateSubnetGroupConfig) (*SubnetGroup, error)` |
+| `DeleteSubnetGroup` | `(ctx, name) (*SubnetGroup, error)` |
+
+### Snapshots
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateSnapshot` | `(ctx, CreateSnapshotConfig) (*Snapshot, error)` |
+| `DescribeSnapshots` | `(ctx, names, clusterName) ([]Snapshot, error)` |
+| `CopySnapshot` | `(ctx, CopySnapshotConfig) (*Snapshot, error)` |
+| `DeleteSnapshot` | `(ctx, name) (*Snapshot, error)` |
+
+### Tags & Catalogs
+
+| Operation | Signature |
+|-----------|-----------|
+| `TagResource` | `(ctx, arn, tags) ([]Tag, error)` |
+| `UntagResource` | `(ctx, arn, keys) ([]Tag, error)` |
+| `ListTags` | `(ctx, arn) ([]Tag, error)` |
+| `DescribeEngineVersions` | `(ctx, engine) ([]EngineVersionInfo, error)` |
+| `DescribeEvents` | `(ctx, sourceName, sourceType) ([]Event, error)` |
+
+### Multi-Region Clusters (optional capability — `MultiRegion`)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateMultiRegionCluster` | `(ctx, CreateMultiRegionClusterConfig) (*MultiRegionCluster, error)` |
+| `DescribeMultiRegionClusters` | `(ctx, names) ([]MultiRegionCluster, error)` |
+| `UpdateMultiRegionCluster` | `(ctx, name, nodeType, engineVersion, shardCount) (*MultiRegionCluster, error)` |
+| `DeleteMultiRegionCluster` | `(ctx, name) (*MultiRegionCluster, error)` |
+| `ListAllowedMultiRegionClusterUpdates` | `(ctx, name) ([]string, error)` |
+| `DescribeMultiRegionParameterGroups` | `(ctx, names) ([]MultiRegionParameterGroup, error)` |
+| `DescribeMultiRegionParameters` | `(ctx, groupName) ([]Parameter, error)` |
+
+### Reserved Nodes (optional capability — `ReservedNodes`)
+
+| Operation | Signature |
+|-----------|-----------|
+| `DescribeReservedNodes` | `(ctx) ([]ReservedNode, error)` |
+| `DescribeReservedNodesOfferings` | `(ctx) ([]ReservedNodesOffering, error)` |
+| `PurchaseReservedNodesOffering` | `(ctx, offeringID, reservationID, count) (*ReservedNode, error)` |
+
+Both optional interfaces are AWS-only concepts, discovered by type assertion.
+
+**Total: 33 operations (+10 optional)**
+
+---
+
 ## 12. Secrets
 
 **Driver interface:** `services/secrets/driver/driver.go`
@@ -1867,6 +1967,7 @@ still sees success.
 | Load Balancer | 21 |
 | Message Queue | 14 |
 | Cache | 16 (+7 optional) |
+| MemoryDB — AWS (Redis/Valkey control plane) | 33 (+10 optional) |
 | Secrets | 7 |
 | Logging | 13 |
 | Notification | 8 |
@@ -1886,7 +1987,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1277** (+124 optional) |
+| **Grand Total** | **1310** (+134 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/docs/services.md
+++ b/docs/services.md
@@ -965,8 +965,8 @@ rather than reusing `services/cache`. Served as AWS JSON 1.1 on the
 | `TagResource` | `(ctx, arn, tags) ([]Tag, error)` |
 | `UntagResource` | `(ctx, arn, keys) ([]Tag, error)` |
 | `ListTags` | `(ctx, arn) ([]Tag, error)` |
-| `DescribeEngineVersions` | `(ctx, engine) ([]EngineVersionInfo, error)` |
-| `DescribeEvents` | `(ctx, sourceName, sourceType) ([]Event, error)` |
+| `DescribeEngineVersions` | `(ctx, engine, version) ([]EngineVersionInfo, error)` |
+| `DescribeEvents` | `(ctx) ([]Event, error)` |
 
 ### Multi-Region Clusters (optional capability — `MultiRegion`)
 
@@ -988,9 +988,25 @@ rather than reusing `services/cache`. Served as AWS JSON 1.1 on the
 | `DescribeReservedNodesOfferings` | `(ctx) ([]ReservedNodesOffering, error)` |
 | `PurchaseReservedNodesOffering` | `(ctx, offeringID, reservationID, count) (*ReservedNode, error)` |
 
-Both optional interfaces are AWS-only concepts, discovered by type assertion.
+### Service Updates (optional capability — `ServiceUpdates`)
 
-**Total: 33 operations (+10 optional)**
+| Operation | Signature |
+|-----------|-----------|
+| `DescribeServiceUpdates` | `(ctx, serviceUpdateName, clusterNames, status) ([]ServiceUpdate, error)` |
+| `BatchUpdateCluster` | `(ctx, clusterNames, serviceUpdateName) (processed []Cluster, unprocessed []UnprocessedCluster, error)` |
+
+`BatchUpdateCluster` applies a service update to each named cluster; a name that
+does not exist is returned in `unprocessed` (with `ClusterNotFoundFault`) rather
+than failing the whole batch — matching AWS's partial-success semantics.
+
+The three optional interfaces are AWS-only concepts, discovered by type
+assertion.
+
+**Pagination:** every `Describe*` operation honors `MaxResults`/`NextToken`.
+The server pages the deterministic (sorted) result set and returns an opaque
+base64 offset token; a malformed token yields `InvalidParameterValueException`.
+
+**Total: 33 operations (+13 optional)**
 
 ---
 
@@ -1967,7 +1983,7 @@ still sees success.
 | Load Balancer | 21 |
 | Message Queue | 14 |
 | Cache | 16 (+7 optional) |
-| MemoryDB — AWS (Redis/Valkey control plane) | 33 (+10 optional) |
+| MemoryDB — AWS (Redis/Valkey control plane) | 33 (+13 optional) |
 | Secrets | 7 |
 | Logging | 13 |
 | Notification | 8 |
@@ -1987,7 +2003,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1310** (+134 optional) |
+| **Grand Total** | **1310** (+137 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7
@@ -109,7 +110,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.32 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1
-	github.com/aws/aws-sdk-go-v2 v1.43.1
+	github.com/aws/aws-sdk-go-v2 v1.43.2
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -100,8 +100,8 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.32 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.14 // indirect
@@ -109,6 +109,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.32 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
 github.com/aws/aws-sdk-go-v2 v1.43.1 h1:t6AQIB1uQ7HJA+0CDRWjOYG5MfwnOyyDsN4vRDHcwIY=
 github.com/aws/aws-sdk-go-v2 v1.43.1/go.mod h1:WEzLKBh/mEjXvx1FtQMWgSxMSTVqxQzjkRtk5fa3wkg=
+github.com/aws/aws-sdk-go-v2 v1.43.2 h1:cl+IXwWb3qazClUcm08tGSsB6OiuV83JVJO9B0jQcPc=
+github.com/aws/aws-sdk-go-v2 v1.43.2/go.mod h1:WEzLKBh/mEjXvx1FtQMWgSxMSTVqxQzjkRtk5fa3wkg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14/go.mod h1:zwM6veDkhGgQFqkBy+uT28AAYpLu+uFMlPl+rCg/73E=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
@@ -120,8 +122,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.32 h1:PqiNS1QVFVctiMX30IwaY6pM3cUUfZFe+HPKmlZVY4I=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.32/go.mod h1:jqisrvz2jliDnF3dW4wO9ZT1lHz1d6pXjftFyyZyqjY=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33 h1:HAp1wLFZzch054uh3FK7rcVYg4v7J2FxVf3h3IGNZas=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33/go.mod h1:mJk5fmqnF+WUlMdPG37pR2Fh3oh6r8F6ZGUgPKvzu0c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.32 h1:bWzam6cUCb/BRiZYmmdwPg+FvZy3/QygB9u6z7BIlnM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.32/go.mod h1:VGTWlYbW4qvz9djYt2lj35gSAZS5aZ2xKn85wXziw6A=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33 h1:0YA0aCKgsJyno6xkFfaIgjE3/wK08+Qxo9nQfe1UrWM=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33/go.mod h1:UZqj4WIdTH+ga8Y/DgpAuy/8cGjM3h7gDCliJYGg2SE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1O1b3Erl5CePYIAeQ=
@@ -172,6 +178,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWUR
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2 h1:GKkUvwhxKF5JVSWERui4bvPNKEv7BQe3+i7h5v8klpQ=
+github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2/go.mod h1:wRcgz/DYIlZldpS/RpJDgjtMPsk0a6hLvwMl/2tGKuY=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5 h1:v+XVk5OQnhm6EasbClY036A1gTtVdtdNdG8/Q3rLYU4=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5/go.mod h1:Y/yH7q6R/qaO4g6YTBbAMSu5T4NjVo+7+P1UNZ2NlzA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPPJTGt0GkWahlLYzMA=

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0/go.mod h1:vB2GH9GAYYJTO3mEn8oYwzEdhlayZIdQz6zdzgUIRvA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
-github.com/aws/aws-sdk-go-v2 v1.43.1 h1:t6AQIB1uQ7HJA+0CDRWjOYG5MfwnOyyDsN4vRDHcwIY=
-github.com/aws/aws-sdk-go-v2 v1.43.1/go.mod h1:WEzLKBh/mEjXvx1FtQMWgSxMSTVqxQzjkRtk5fa3wkg=
 github.com/aws/aws-sdk-go-v2 v1.43.2 h1:cl+IXwWb3qazClUcm08tGSsB6OiuV83JVJO9B0jQcPc=
 github.com/aws/aws-sdk-go-v2 v1.43.2/go.mod h1:WEzLKBh/mEjXvx1FtQMWgSxMSTVqxQzjkRtk5fa3wkg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
@@ -120,12 +118,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.32 h1:PqiNS1QVFVctiMX30IwaY6pM3cUUfZFe+HPKmlZVY4I=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.32/go.mod h1:jqisrvz2jliDnF3dW4wO9ZT1lHz1d6pXjftFyyZyqjY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33 h1:HAp1wLFZzch054uh3FK7rcVYg4v7J2FxVf3h3IGNZas=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33/go.mod h1:mJk5fmqnF+WUlMdPG37pR2Fh3oh6r8F6ZGUgPKvzu0c=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.32 h1:bWzam6cUCb/BRiZYmmdwPg+FvZy3/QygB9u6z7BIlnM=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.32/go.mod h1:VGTWlYbW4qvz9djYt2lj35gSAZS5aZ2xKn85wXziw6A=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33 h1:0YA0aCKgsJyno6xkFfaIgjE3/wK08+Qxo9nQfe1UrWM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33/go.mod h1:UZqj4WIdTH+ga8Y/DgpAuy/8cGjM3h7gDCliJYGg2SE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/elb"
 	"github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
 	"github.com/stackshy/cloudemu/v2/providers/aws/lambda"
+	"github.com/stackshy/cloudemu/v2/providers/aws/memorydb"
 	"github.com/stackshy/cloudemu/v2/providers/aws/rds"
 	"github.com/stackshy/cloudemu/v2/providers/aws/redshift"
 	"github.com/stackshy/cloudemu/v2/providers/aws/route53"
@@ -124,6 +125,7 @@ type Provider struct {
 	ELB                 *elb.Mock
 	SQS                 *sqs.Mock
 	ElastiCache         *elasticache.Mock
+	MemoryDB            *memorydb.Mock
 	SecretsManager      *secretsmanager.Mock
 	CloudWatchLogs      *cloudwatchlogs.Mock
 	SNS                 *sns.Mock
@@ -158,6 +160,7 @@ func New(opts ...config.Option) *Provider {
 		ELB:                 elb.New(o),
 		SQS:                 sqs.New(o),
 		ElastiCache:         elasticache.New(o),
+		MemoryDB:            memorydb.New(o),
 		SecretsManager:      secretsmanager.New(o),
 		CloudWatchLogs:      cloudwatchlogs.New(o),
 		SNS:                 sns.New(o),
@@ -181,6 +184,7 @@ func New(opts ...config.Option) *Provider {
 	p.Lambda.SetMonitoring(p.CloudWatch)
 	p.SQS.SetMonitoring(p.CloudWatch)
 	p.ElastiCache.SetMonitoring(p.CloudWatch)
+	p.MemoryDB.SetMonitoring(p.CloudWatch)
 	p.CloudWatchLogs.SetMonitoring(p.CloudWatch)
 	p.SNS.SetMonitoring(p.CloudWatch)
 	p.ECR.SetMonitoring(p.CloudWatch)

--- a/providers/aws/memorydb/acls_users.go
+++ b/providers/aws/memorydb/acls_users.go
@@ -1,0 +1,282 @@
+package memorydb
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func cloneACL(in *mdbdriver.ACL) mdbdriver.ACL {
+	a := *in
+	a.UserNames = cloneStrings(a.UserNames)
+	a.Clusters = cloneStrings(a.Clusters)
+	a.Tags = copyTags(a.Tags)
+
+	return a
+}
+
+func cloneUser(in *mdbdriver.User) mdbdriver.User {
+	u := *in
+	u.ACLNames = cloneStrings(u.ACLNames)
+	u.Tags = copyTags(u.Tags)
+
+	return u
+}
+
+// linkACLCluster adds/removes a cluster name on an ACL's Clusters list. The
+// caller holds the write lock.
+func (m *Mock) linkACLCluster(aclName, clusterName string, add bool) {
+	acl, ok := m.acls.Get(aclName)
+	if !ok {
+		return
+	}
+
+	acl.Clusters = removeStr(acl.Clusters, clusterName)
+	if add {
+		acl.Clusters = append(acl.Clusters, clusterName)
+	}
+
+	m.acls.Set(aclName, acl)
+}
+
+func removeStr(items []string, s string) []string {
+	out := items[:0:0]
+
+	for _, v := range items {
+		if v != s {
+			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
+func containsStr(items []string, s string) bool {
+	for _, v := range items {
+		if v == s {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ---- ACLs ----
+
+// CreateACL creates an ACL over existing users.
+func (m *Mock) CreateACL(_ context.Context, name string, userNames []string, tags map[string]string) (*mdbdriver.ACL, error) {
+	if err := validName("ACL", name); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.acls.Has(name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "ACL %q already exists", name)
+	}
+
+	for _, u := range userNames {
+		if !m.users.Has(u) {
+			return nil, cerrors.Newf(cerrors.NotFound, "user %q not found", u)
+		}
+	}
+
+	acl := mdbdriver.ACL{
+		Name: name, ARN: m.arn("acl", name), Status: mdbdriver.StatusAvailable,
+		MinimumEngineVersion: "6.2", UserNames: cloneStrings(userNames), Tags: copyTags(tags),
+	}
+	m.acls.Set(name, acl)
+	m.attachUsersToACL(name, userNames)
+
+	out := cloneACL(&acl)
+
+	return &out, nil
+}
+
+func (m *Mock) attachUsersToACL(aclName string, userNames []string) {
+	for _, un := range userNames {
+		if u, ok := m.users.Get(un); ok && !containsStr(u.ACLNames, aclName) {
+			u.ACLNames = append(u.ACLNames, aclName)
+			m.users.Set(un, u)
+		}
+	}
+}
+
+// DescribeACLs returns all ACLs, or the named ones.
+func (m *Mock) DescribeACLs(_ context.Context, names []string) ([]mdbdriver.ACL, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeByName(m.acls, names, cloneACL, func(n string) error {
+		return cerrors.Newf(cerrors.NotFound, "ACL %q not found", n)
+	})
+}
+
+// UpdateACL adds and/or removes user names on an ACL.
+func (m *Mock) UpdateACL(_ context.Context, name string, add, remove []string) (*mdbdriver.ACL, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	acl, ok := m.acls.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "ACL %q not found", name)
+	}
+
+	for _, u := range add {
+		if !m.users.Has(u) {
+			return nil, cerrors.Newf(cerrors.NotFound, "user %q not found", u)
+		}
+	}
+
+	for _, u := range add {
+		if !containsStr(acl.UserNames, u) {
+			acl.UserNames = append(acl.UserNames, u)
+		}
+	}
+
+	for _, u := range remove {
+		acl.UserNames = removeStr(acl.UserNames, u)
+		m.detachUserFromACL(u, name)
+	}
+
+	m.acls.Set(name, acl)
+	m.attachUsersToACL(name, add)
+
+	out := cloneACL(&acl)
+
+	return &out, nil
+}
+
+func (m *Mock) detachUserFromACL(userName, aclName string) {
+	if u, ok := m.users.Get(userName); ok {
+		u.ACLNames = removeStr(u.ACLNames, aclName)
+		m.users.Set(userName, u)
+	}
+}
+
+// DeleteACL removes an ACL; it must not be attached to any cluster.
+func (m *Mock) DeleteACL(_ context.Context, name string) (*mdbdriver.ACL, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	acl, ok := m.acls.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "ACL %q not found", name)
+	}
+
+	if len(acl.Clusters) > 0 {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "ACL %q is attached to clusters %v", name, acl.Clusters)
+	}
+
+	for _, un := range acl.UserNames {
+		m.detachUserFromACL(un, name)
+	}
+
+	m.acls.Delete(name)
+
+	out := cloneACL(&acl)
+
+	return &out, nil
+}
+
+// ---- Users ----
+
+const authTypePassword = "password"
+
+func authType(t string) string {
+	if t == "" {
+		return authTypePassword
+	}
+
+	return t
+}
+
+// CreateUser creates a MemoryDB user.
+//
+//nolint:gocritic // cfg is large but matches the driver signature.
+func (m *Mock) CreateUser(_ context.Context, cfg mdbdriver.CreateUserConfig) (*mdbdriver.User, error) {
+	if err := validName("user", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	if cfg.AccessString == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "accessString is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.users.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "user %q already exists", cfg.Name)
+	}
+
+	user := mdbdriver.User{
+		Name: cfg.Name, ARN: m.arn("user", cfg.Name), Status: mdbdriver.StatusAvailable,
+		AccessString: cfg.AccessString, MinimumEngineVersion: "6.2",
+		Authentication: mdbdriver.Authentication{Type: authType(cfg.AuthenticationType), PasswordCount: len(cfg.Passwords)},
+		Tags:           copyTags(cfg.Tags),
+	}
+	m.users.Set(cfg.Name, user)
+
+	out := cloneUser(&user)
+
+	return &out, nil
+}
+
+// DescribeUsers returns all users, or the named ones.
+func (m *Mock) DescribeUsers(_ context.Context, names []string) ([]mdbdriver.User, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeByName(m.users, names, cloneUser, func(n string) error {
+		return cerrors.Newf(cerrors.NotFound, "user %q not found", n)
+	})
+}
+
+// UpdateUser updates a user's access string and/or authentication.
+func (m *Mock) UpdateUser(_ context.Context, cfg mdbdriver.UpdateUserConfig) (*mdbdriver.User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.users.Get(cfg.Name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "user %q not found", cfg.Name)
+	}
+
+	if cfg.AccessString != "" {
+		u.AccessString = cfg.AccessString
+	}
+
+	if cfg.AuthenticationType != "" {
+		u.Authentication = mdbdriver.Authentication{Type: authType(cfg.AuthenticationType), PasswordCount: len(cfg.Passwords)}
+	}
+
+	m.users.Set(cfg.Name, u)
+
+	out := cloneUser(&u)
+
+	return &out, nil
+}
+
+// DeleteUser removes a user; it must not be a member of any ACL.
+func (m *Mock) DeleteUser(_ context.Context, name string) (*mdbdriver.User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.users.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "user %q not found", name)
+	}
+
+	if len(u.ACLNames) > 0 {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "user %q belongs to ACLs %v", name, u.ACLNames)
+	}
+
+	m.users.Delete(name)
+
+	out := cloneUser(&u)
+
+	return &out, nil
+}

--- a/providers/aws/memorydb/acls_users.go
+++ b/providers/aws/memorydb/acls_users.go
@@ -52,6 +52,25 @@ func removeStr(items []string, s string) []string {
 	return out
 }
 
+// dedupeStrings returns items with duplicates removed, preserving first-seen
+// order.
+func dedupeStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+
+	for _, v := range items {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+
+		seen[v] = struct{}{}
+
+		out = append(out, v)
+	}
+
+	return out
+}
+
 func containsStr(items []string, s string) bool {
 	for _, v := range items {
 		if v == s {
@@ -83,12 +102,14 @@ func (m *Mock) CreateACL(_ context.Context, name string, userNames []string, tag
 		}
 	}
 
+	users := dedupeStrings(userNames)
+
 	acl := mdbdriver.ACL{
 		Name: name, ARN: m.arn("acl", name), Status: mdbdriver.StatusAvailable,
-		MinimumEngineVersion: "6.2", UserNames: cloneStrings(userNames), Tags: copyTags(tags),
+		MinimumEngineVersion: "6.2", UserNames: users, Tags: copyTags(tags),
 	}
 	m.acls.Set(name, acl)
-	m.attachUsersToACL(name, userNames)
+	m.attachUsersToACL(name, users)
 
 	out := cloneACL(&acl)
 

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -28,7 +28,31 @@ func cloneCluster(in *mdbdriver.Cluster) mdbdriver.Cluster {
 	return c
 }
 
+// MemoryDB service limits on cluster topology. Enforcing them before the mock
+// allocates the shard/node slices keeps a caller-supplied count from driving
+// unbounded memory use.
+const (
+	maxShardsPerCluster = 500
+	maxReplicasPerShard = 5
+)
+
+// validateShardTopology bounds caller-supplied shard/replica counts to the
+// MemoryDB service limits, rejecting out-of-range requests before allocation.
+func validateShardTopology(numShards, replicasPerShard int) error {
+	if numShards < 0 || numShards > maxShardsPerCluster {
+		return cerrors.Newf(cerrors.InvalidArgument, "NumShards must be between 1 and %d", maxShardsPerCluster)
+	}
+
+	if replicasPerShard < 0 || replicasPerShard > maxReplicasPerShard {
+		return cerrors.Newf(cerrors.InvalidArgument, "ReplicasPerShard must be between 0 and %d", maxReplicasPerShard)
+	}
+
+	return nil
+}
+
 // buildShards constructs the shard/node topology + endpoints for a cluster.
+// Callers must validate numShards/replicasPerShard via validateShardTopology
+// first; the values are bounded to the MemoryDB service limits.
 func (m *Mock) buildShards(clusterName string, numShards, replicasPerShard int) []mdbdriver.Shard {
 	if numShards <= 0 {
 		numShards = 1
@@ -149,6 +173,10 @@ func (m *Mock) CreateCluster(_ context.Context, cfg mdbdriver.CreateClusterConfi
 		}
 	}
 
+	if err := validateShardTopology(numShards, cfg.NumReplicasPerShard); err != nil {
+		return nil, err
+	}
+
 	sgs := make([]mdbdriver.SecurityGroupMembership, 0, len(cfg.SecurityGroupIDs))
 	for _, id := range cfg.SecurityGroupIDs {
 		sgs = append(sgs, mdbdriver.SecurityGroupMembership{SecurityGroupID: id, Status: mdbdriver.StatusAvailable})
@@ -251,14 +279,8 @@ func (m *Mock) UpdateCluster(_ context.Context, cfg mdbdriver.UpdateClusterConfi
 		c.SnapshotRetentionLimit = *cfg.SnapshotRetentionLimit
 	}
 
-	if cfg.ShardCount != nil && *cfg.ShardCount > 0 {
-		c.NumberOfShards = *cfg.ShardCount
-		c.Shards = m.buildShards(cfg.Name, *cfg.ShardCount, len(c.Shards[0].Nodes)-1)
-	}
-
-	if cfg.ReplicaCount != nil {
-		c.Shards = m.buildShards(cfg.Name, c.NumberOfShards, *cfg.ReplicaCount)
-		c.AvailabilityMode = availabilityMode(*cfg.ReplicaCount)
+	if err := m.reconfigureShards(&c, &cfg); err != nil {
+		return nil, err
 	}
 
 	m.clusters.Set(cfg.Name, c)
@@ -267,6 +289,31 @@ func (m *Mock) UpdateCluster(_ context.Context, cfg mdbdriver.UpdateClusterConfi
 	out := cloneCluster(&c)
 
 	return &out, nil
+}
+
+// reconfigureShards rebuilds the shard/node topology for an in-place shard-count
+// or replica-count change, enforcing the MemoryDB service limits before any
+// allocation. The caller holds the lock.
+func (m *Mock) reconfigureShards(c *mdbdriver.Cluster, cfg *mdbdriver.UpdateClusterConfig) error {
+	if cfg.ShardCount != nil && *cfg.ShardCount > 0 {
+		if err := validateShardTopology(*cfg.ShardCount, len(c.Shards[0].Nodes)-1); err != nil {
+			return err
+		}
+
+		c.NumberOfShards = *cfg.ShardCount
+		c.Shards = m.buildShards(c.Name, *cfg.ShardCount, len(c.Shards[0].Nodes)-1)
+	}
+
+	if cfg.ReplicaCount != nil {
+		if err := validateShardTopology(c.NumberOfShards, *cfg.ReplicaCount); err != nil {
+			return err
+		}
+
+		c.Shards = m.buildShards(c.Name, c.NumberOfShards, *cfg.ReplicaCount)
+		c.AvailabilityMode = availabilityMode(*cfg.ReplicaCount)
+	}
+
+	return nil
 }
 
 // DeleteCluster removes a cluster (optionally taking a final snapshot).

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -1,0 +1,383 @@
+package memorydb
+
+import (
+	"context"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+// cloneCluster deep-copies slice/map fields so a returned value never aliases
+// the store (copy-on-read).
+func cloneCluster(in *mdbdriver.Cluster) mdbdriver.Cluster {
+	c := *in
+	c.Tags = copyTags(c.Tags)
+	c.SecurityGroups = append([]mdbdriver.SecurityGroupMembership(nil), c.SecurityGroups...)
+
+	shards := make([]mdbdriver.Shard, len(c.Shards))
+
+	for i := range c.Shards {
+		s := c.Shards[i]
+		s.Nodes = append([]mdbdriver.Node(nil), c.Shards[i].Nodes...)
+		shards[i] = s
+	}
+
+	c.Shards = shards
+
+	return c
+}
+
+// buildShards constructs the shard/node topology + endpoints for a cluster.
+func (m *Mock) buildShards(clusterName string, numShards, replicasPerShard int) []mdbdriver.Shard {
+	if numShards <= 0 {
+		numShards = 1
+	}
+
+	nodesPerShard := replicasPerShard + 1 // primary + replicas
+	shards := make([]mdbdriver.Shard, 0, numShards)
+	now := m.opts.Clock.Now().UTC()
+
+	for s := 1; s <= numShards; s++ {
+		shardName := fmt.Sprintf("%04d", s)
+		nodes := make([]mdbdriver.Node, 0, nodesPerShard)
+
+		for n := 1; n <= nodesPerShard; n++ {
+			nodeName := fmt.Sprintf("%s-%s-%03d", clusterName, shardName, n)
+			nodes = append(nodes, mdbdriver.Node{
+				Name:             nodeName,
+				Status:           mdbdriver.StatusAvailable,
+				AvailabilityZone: m.opts.Region + azSuffix(n),
+				CreateTime:       now,
+				Endpoint: mdbdriver.Endpoint{
+					Address: fmt.Sprintf("%s.%s.memorydb.%s.amazonaws.com", nodeName, clusterName, m.opts.Region),
+					Port:    defaultPort,
+				},
+			})
+		}
+
+		shards = append(shards, mdbdriver.Shard{
+			Name:          shardName,
+			Status:        mdbdriver.StatusAvailable,
+			Slots:         slotRange(s, numShards),
+			NumberOfNodes: nodesPerShard,
+			Nodes:         nodes,
+		})
+	}
+
+	return shards
+}
+
+func azSuffix(n int) string {
+	return string(rune('a' + ((n - 1) % 3)))
+}
+
+// slotRange splits the 16384 Redis slots evenly across shards.
+func slotRange(shard, total int) string {
+	const slots = 16384
+	per := slots / total
+	start := (shard - 1) * per
+	end := start + per - 1
+
+	if shard == total {
+		end = slots - 1
+	}
+
+	return fmt.Sprintf("%d-%d", start, end)
+}
+
+// validateClusterRefs checks that referenced ACL/parameter-group/subnet-group
+// exist. A dangling reference is an invalid input to the create/update call
+// (not a missing cluster), so it surfaces as InvalidArgument — real MemoryDB
+// answers CreateCluster with a bad ACLName as InvalidParameterValueException.
+// The caller holds the lock.
+func (m *Mock) validateClusterRefs(aclName, paramGroup, subnetGroup string) error {
+	if aclName != "" && !m.acls.Has(aclName) {
+		return cerrors.Newf(cerrors.InvalidArgument, "ACL %q not found", aclName)
+	}
+
+	if paramGroup != "" && !m.parameterGroups.Has(paramGroup) {
+		return cerrors.Newf(cerrors.InvalidArgument, "parameter group %q not found", paramGroup)
+	}
+
+	if subnetGroup != "" && !m.subnetGroups.Has(subnetGroup) {
+		return cerrors.Newf(cerrors.InvalidArgument, "subnet group %q not found", subnetGroup)
+	}
+
+	return nil
+}
+
+// CreateCluster creates a MemoryDB cluster.
+//
+//nolint:gocritic // cfg is large but matches the driver signature.
+func (m *Mock) CreateCluster(_ context.Context, cfg mdbdriver.CreateClusterConfig) (*mdbdriver.Cluster, error) {
+	if err := validName("cluster", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.clusters.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "cluster %q already exists", cfg.Name)
+	}
+
+	if err := m.validateClusterRefs(cfg.ACLName, cfg.ParameterGroupName, cfg.SubnetGroupName); err != nil {
+		return nil, err
+	}
+
+	numShards := cfg.NumShards
+	engine := orDefault(cfg.Engine, defaultEngine)
+	engineVersion := orDefault(cfg.EngineVersion, defaultEngineVersion)
+	nodeType := orDefault(cfg.NodeType, defaultNodeType)
+	acl := orDefault(cfg.ACLName, "open-access")
+	pg := orDefault(cfg.ParameterGroupName, "default.memorydb-redis7")
+
+	// Restore-from-snapshot inherits the source's shape.
+	if cfg.SnapshotName != "" {
+		snap, ok := m.snapshots.Get(cfg.SnapshotName)
+		if !ok {
+			return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", cfg.SnapshotName)
+		}
+
+		if numShards == 0 {
+			numShards = snap.ClusterConfiguration.NumShards
+		}
+
+		if cfg.NodeType == "" {
+			nodeType = snap.ClusterConfiguration.NodeType
+		}
+	}
+
+	sgs := make([]mdbdriver.SecurityGroupMembership, 0, len(cfg.SecurityGroupIDs))
+	for _, id := range cfg.SecurityGroupIDs {
+		sgs = append(sgs, mdbdriver.SecurityGroupMembership{SecurityGroupID: id, Status: mdbdriver.StatusAvailable})
+	}
+
+	cluster := mdbdriver.Cluster{
+		Name:                 cfg.Name,
+		ARN:                  m.arn("cluster", cfg.Name),
+		Description:          cfg.Description,
+		Status:               mdbdriver.StatusAvailable,
+		NodeType:             nodeType,
+		Engine:               engine,
+		EngineVersion:        engineVersion,
+		EnginePatchVersion:   engineVersion + ".0",
+		NumberOfShards:       maxInt(numShards, 1),
+		ACLName:              acl,
+		ParameterGroupName:   pg,
+		ParameterGroupStatus: mdbdriver.StatusAvailable,
+		SubnetGroupName:      cfg.SubnetGroupName,
+		SecurityGroups:       sgs,
+		Shards:               m.buildShards(cfg.Name, numShards, cfg.NumReplicasPerShard),
+		ClusterEndpoint: mdbdriver.Endpoint{
+			Address: fmt.Sprintf("clustercfg.%s.memorydb.%s.amazonaws.com", cfg.Name, m.opts.Region),
+			Port:    portOr(cfg.Port),
+		},
+		TLSEnabled:              cfg.TLSEnabled,
+		KmsKeyID:                cfg.KmsKeyID,
+		MaintenanceWindow:       orDefault(cfg.MaintenanceWindow, "sun:23:00-mon:01:30"),
+		SnapshotWindow:          orDefault(cfg.SnapshotWindow, "05:00-06:00"),
+		SnapshotRetentionLimit:  cfg.SnapshotRetentionLimit,
+		SnsTopicARN:             cfg.SnsTopicARN,
+		AutoMinorVersionUpgrade: cfg.AutoMinorVersionUpgrade,
+		DataTiering:             cfg.DataTiering,
+		AvailabilityMode:        availabilityMode(cfg.NumReplicasPerShard),
+		NetworkType:             orDefault(cfg.NetworkType, "ipv4"),
+		IPDiscovery:             orDefault(cfg.IPDiscovery, "ipv4"),
+		MultiRegionClusterName:  cfg.MultiRegionClusterName,
+		Tags:                    copyTags(cfg.Tags),
+		CreatedAt:               m.opts.Clock.Now().UTC(),
+	}
+
+	m.clusters.Set(cfg.Name, cluster)
+	m.linkACLCluster(acl, cfg.Name, true)
+	m.emitClusterMetrics(cfg.Name)
+	m.recordClusterEvent(cfg.Name, "Cluster created")
+
+	out := cloneCluster(&cluster)
+
+	return &out, nil
+}
+
+// DescribeClusters returns all clusters, or the named ones.
+func (m *Mock) DescribeClusters(_ context.Context, names []string) ([]mdbdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeByName(m.clusters, names, cloneCluster, func(n string) error {
+		return cerrors.Newf(cerrors.NotFound, "cluster %q not found", n)
+	})
+}
+
+// UpdateCluster applies the non-zero fields of cfg to an existing cluster.
+//
+//nolint:gocritic // cfg is large but matches the driver signature.
+func (m *Mock) UpdateCluster(_ context.Context, cfg mdbdriver.UpdateClusterConfig) (*mdbdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(cfg.Name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.Name)
+	}
+
+	if cfg.ACLName != "" {
+		if !m.acls.Has(cfg.ACLName) {
+			return nil, cerrors.Newf(cerrors.NotFound, "ACL %q not found", cfg.ACLName)
+		}
+
+		m.linkACLCluster(c.ACLName, cfg.Name, false)
+		m.linkACLCluster(cfg.ACLName, cfg.Name, true)
+		c.ACLName = cfg.ACLName
+	}
+
+	if cfg.ParameterGroupName != "" {
+		if !m.parameterGroups.Has(cfg.ParameterGroupName) {
+			return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", cfg.ParameterGroupName)
+		}
+
+		c.ParameterGroupName = cfg.ParameterGroupName
+	}
+
+	c.Description = orKeep(cfg.Description, c.Description)
+	c.NodeType = orKeep(cfg.NodeType, c.NodeType)
+	c.EngineVersion = orKeep(cfg.EngineVersion, c.EngineVersion)
+	c.MaintenanceWindow = orKeep(cfg.MaintenanceWindow, c.MaintenanceWindow)
+	c.SnapshotWindow = orKeep(cfg.SnapshotWindow, c.SnapshotWindow)
+	c.SnsTopicARN = orKeep(cfg.SnsTopicARN, c.SnsTopicARN)
+
+	if cfg.SnapshotRetentionLimit != nil {
+		c.SnapshotRetentionLimit = *cfg.SnapshotRetentionLimit
+	}
+
+	if cfg.ShardCount != nil && *cfg.ShardCount > 0 {
+		c.NumberOfShards = *cfg.ShardCount
+		c.Shards = m.buildShards(cfg.Name, *cfg.ShardCount, len(c.Shards[0].Nodes)-1)
+	}
+
+	if cfg.ReplicaCount != nil {
+		c.Shards = m.buildShards(cfg.Name, c.NumberOfShards, *cfg.ReplicaCount)
+		c.AvailabilityMode = availabilityMode(*cfg.ReplicaCount)
+	}
+
+	m.clusters.Set(cfg.Name, c)
+	m.recordClusterEvent(cfg.Name, "Cluster modified")
+
+	out := cloneCluster(&c)
+
+	return &out, nil
+}
+
+// DeleteCluster removes a cluster (optionally taking a final snapshot).
+func (m *Mock) DeleteCluster(_ context.Context, name, finalSnapshotName string) (*mdbdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", name)
+	}
+
+	if finalSnapshotName != "" {
+		m.snapshots.Set(finalSnapshotName, m.snapshotFromCluster(finalSnapshotName, &c, "manual", nil))
+	}
+
+	m.clusters.Delete(name)
+	m.linkACLCluster(c.ACLName, name, false)
+	m.recordClusterEvent(name, "Cluster deleted")
+
+	c.Status = mdbdriver.StatusDeleting
+	out := cloneCluster(&c)
+
+	return &out, nil
+}
+
+// FailoverShard triggers a failover of a shard's primary; the shard stays
+// available.
+func (m *Mock) FailoverShard(_ context.Context, clusterName, shardName string) (*mdbdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(clusterName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
+	}
+
+	found := false
+
+	for i := range c.Shards {
+		if c.Shards[i].Name == shardName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil, cerrors.Newf(cerrors.NotFound, "shard %q not found in cluster %q", shardName, clusterName)
+	}
+
+	if len(c.Shards) > 0 && c.Shards[0].NumberOfNodes < 2 {
+		return nil, cerrors.New(cerrors.FailedPrecondition, "failover requires at least one replica in the shard")
+	}
+
+	m.recordClusterEvent(clusterName, "Failover started for shard "+shardName)
+
+	out := cloneCluster(&c)
+
+	return &out, nil
+}
+
+// ListAllowedNodeTypeUpdates returns the scale-up/scale-down node types.
+func (m *Mock) ListAllowedNodeTypeUpdates(_ context.Context, clusterName string) (scaleUp, scaleDown []string, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterName) {
+		return nil, nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
+	}
+
+	return []string{"db.r7g.large", "db.r7g.xlarge"}, []string{"db.t4g.medium"}, nil
+}
+
+// ---- small helpers ----
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+func orKeep(v, cur string) string {
+	if v == "" {
+		return cur
+	}
+
+	return v
+}
+
+func portOr(p int) int {
+	if p == 0 {
+		return defaultPort
+	}
+
+	return p
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+
+	return b
+}
+
+func availabilityMode(replicas int) string {
+	if replicas > 0 {
+		return "MultiAZ"
+	}
+
+	return "SingleAZ"
+}

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -34,6 +34,8 @@ func cloneCluster(in *mdbdriver.Cluster) mdbdriver.Cluster {
 const (
 	maxShardsPerCluster = 500
 	maxReplicasPerShard = 5
+	// minNodesForFailover is a primary plus at least one replica.
+	minNodesForFailover = 2
 )
 
 // validateShardTopology bounds caller-supplied shard/replica counts to the
@@ -152,6 +154,63 @@ func (m *Mock) validateClusterRefs(aclName, paramGroup, subnetGroup string) erro
 	return nil
 }
 
+func buildSecurityGroups(ids []string) []mdbdriver.SecurityGroupMembership {
+	sgs := make([]mdbdriver.SecurityGroupMembership, 0, len(ids))
+	for _, id := range ids {
+		sgs = append(sgs, mdbdriver.SecurityGroupMembership{SecurityGroupID: id, Status: mdbdriver.StatusAvailable})
+	}
+
+	return sgs
+}
+
+// clusterShape holds the resolvable cluster dimensions that a restore may fill
+// in from the source snapshot when the caller leaves them unset.
+type clusterShape struct {
+	numShards   int
+	replicas    int
+	nodeType    string
+	subnetGroup string
+	pg          string
+	tls         bool
+}
+
+// applySnapshotShape fills any unset shape field from the named snapshot's
+// stored configuration. Referenced subnet/parameter groups are honored only if
+// they still exist. The caller holds the lock.
+func (m *Mock) applySnapshotShape(cfg *mdbdriver.CreateClusterConfig, shape *clusterShape) error {
+	snap, ok := m.snapshots.Get(cfg.SnapshotName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "snapshot %q not found", cfg.SnapshotName)
+	}
+
+	sc := snap.ClusterConfiguration
+	if cfg.NumShards == 0 {
+		shape.numShards = sc.NumShards
+	}
+
+	if cfg.NumReplicasPerShard == 0 {
+		shape.replicas = sc.ReplicasPerShard
+	}
+
+	if cfg.NodeType == "" {
+		shape.nodeType = orDefault(sc.NodeType, shape.nodeType)
+	}
+
+	if cfg.SubnetGroupName == "" && m.subnetGroups.Has(sc.SubnetGroupName) {
+		shape.subnetGroup = sc.SubnetGroupName
+	}
+
+	if cfg.ParameterGroupName == "" && m.parameterGroups.Has(sc.ParameterGroupName) {
+		shape.pg = sc.ParameterGroupName
+	}
+
+	if !cfg.TLSEnabled {
+		shape.tls = sc.TLSEnabled
+	}
+
+	return nil
+}
+
 // CreateCluster creates a MemoryDB cluster.
 //
 //nolint:gocritic // cfg is large but matches the driver signature.
@@ -171,59 +230,56 @@ func (m *Mock) CreateCluster(_ context.Context, cfg mdbdriver.CreateClusterConfi
 		return nil, err
 	}
 
-	numShards := cfg.NumShards
+	shape := clusterShape{
+		numShards:   cfg.NumShards,
+		replicas:    cfg.NumReplicasPerShard,
+		nodeType:    orDefault(cfg.NodeType, defaultNodeType),
+		subnetGroup: cfg.SubnetGroupName,
+		pg:          orDefault(cfg.ParameterGroupName, "default.memorydb-redis7"),
+		tls:         cfg.TLSEnabled,
+	}
 	engine := orDefault(cfg.Engine, defaultEngine)
 	engineVersion := orDefault(cfg.EngineVersion, defaultEngineVersion)
-	nodeType := orDefault(cfg.NodeType, defaultNodeType)
 	acl := orDefault(cfg.ACLName, "open-access")
-	pg := orDefault(cfg.ParameterGroupName, "default.memorydb-redis7")
 
-	// Restore-from-snapshot inherits the source's shape.
 	if cfg.SnapshotName != "" {
-		snap, ok := m.snapshots.Get(cfg.SnapshotName)
-		if !ok {
-			return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", cfg.SnapshotName)
-		}
-
-		if numShards == 0 {
-			numShards = snap.ClusterConfiguration.NumShards
-		}
-
-		if cfg.NodeType == "" {
-			nodeType = snap.ClusterConfiguration.NodeType
+		if err := m.applySnapshotShape(&cfg, &shape); err != nil {
+			return nil, err
 		}
 	}
 
-	if err := validateShardTopology(numShards, cfg.NumReplicasPerShard); err != nil {
+	if err := validateShardTopology(shape.numShards, shape.replicas); err != nil {
 		return nil, err
 	}
 
-	sgs := make([]mdbdriver.SecurityGroupMembership, 0, len(cfg.SecurityGroupIDs))
-	for _, id := range cfg.SecurityGroupIDs {
-		sgs = append(sgs, mdbdriver.SecurityGroupMembership{SecurityGroupID: id, Status: mdbdriver.StatusAvailable})
+	if cfg.MultiRegionClusterName != "" && !m.multiRegion.Has(cfg.MultiRegionClusterName) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"multi-region cluster %q not found", cfg.MultiRegionClusterName)
 	}
+
+	sgs := buildSecurityGroups(cfg.SecurityGroupIDs)
 
 	cluster := mdbdriver.Cluster{
 		Name:                 cfg.Name,
 		ARN:                  m.arn("cluster", cfg.Name),
 		Description:          cfg.Description,
 		Status:               mdbdriver.StatusAvailable,
-		NodeType:             nodeType,
+		NodeType:             shape.nodeType,
 		Engine:               engine,
 		EngineVersion:        engineVersion,
 		EnginePatchVersion:   engineVersion + ".0",
-		NumberOfShards:       maxInt(numShards, 1),
+		NumberOfShards:       maxInt(shape.numShards, 1),
 		ACLName:              acl,
-		ParameterGroupName:   pg,
+		ParameterGroupName:   shape.pg,
 		ParameterGroupStatus: mdbdriver.StatusAvailable,
-		SubnetGroupName:      cfg.SubnetGroupName,
+		SubnetGroupName:      shape.subnetGroup,
 		SecurityGroups:       sgs,
-		Shards:               m.buildShards(cfg.Name, numShards, cfg.NumReplicasPerShard),
+		Shards:               m.buildShards(cfg.Name, shape.numShards, shape.replicas),
 		ClusterEndpoint: mdbdriver.Endpoint{
 			Address: fmt.Sprintf("clustercfg.%s.memorydb.%s.amazonaws.com", cfg.Name, m.opts.Region),
 			Port:    portOr(cfg.Port),
 		},
-		TLSEnabled:              cfg.TLSEnabled,
+		TLSEnabled:              shape.tls,
 		KmsKeyID:                cfg.KmsKeyID,
 		MaintenanceWindow:       orDefault(cfg.MaintenanceWindow, "sun:23:00-mon:01:30"),
 		SnapshotWindow:          orDefault(cfg.SnapshotWindow, "05:00-06:00"),
@@ -231,7 +287,7 @@ func (m *Mock) CreateCluster(_ context.Context, cfg mdbdriver.CreateClusterConfi
 		SnsTopicARN:             cfg.SnsTopicARN,
 		AutoMinorVersionUpgrade: cfg.AutoMinorVersionUpgrade,
 		DataTiering:             cfg.DataTiering,
-		AvailabilityMode:        availabilityMode(cfg.NumReplicasPerShard),
+		AvailabilityMode:        availabilityMode(shape.replicas),
 		NetworkType:             orDefault(cfg.NetworkType, "ipv4"),
 		IPDiscovery:             orDefault(cfg.IPDiscovery, "ipv4"),
 		MultiRegionClusterName:  cfg.MultiRegionClusterName,
@@ -241,6 +297,11 @@ func (m *Mock) CreateCluster(_ context.Context, cfg mdbdriver.CreateClusterConfi
 
 	m.clusters.Set(cfg.Name, cluster)
 	m.linkACLCluster(acl, cfg.Name, true)
+
+	if cfg.MultiRegionClusterName != "" {
+		m.registerMRCMember(cfg.MultiRegionClusterName, cfg.Name, cluster.ARN)
+	}
+
 	m.emitClusterMetrics(cfg.Name)
 	m.recordClusterEvent(cfg.Name, "Cluster created")
 
@@ -273,7 +334,7 @@ func (m *Mock) UpdateCluster(_ context.Context, cfg mdbdriver.UpdateClusterConfi
 
 	if cfg.ACLName != "" {
 		if !m.acls.Has(cfg.ACLName) {
-			return nil, cerrors.Newf(cerrors.NotFound, "ACL %q not found", cfg.ACLName)
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "ACL %q not found", cfg.ACLName)
 		}
 
 		m.linkACLCluster(c.ACLName, cfg.Name, false)
@@ -283,7 +344,7 @@ func (m *Mock) UpdateCluster(_ context.Context, cfg mdbdriver.UpdateClusterConfi
 
 	if cfg.ParameterGroupName != "" {
 		if !m.parameterGroups.Has(cfg.ParameterGroupName) {
-			return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", cfg.ParameterGroupName)
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "parameter group %q not found", cfg.ParameterGroupName)
 		}
 
 		c.ParameterGroupName = cfg.ParameterGroupName
@@ -348,11 +409,20 @@ func (m *Mock) DeleteCluster(_ context.Context, name, finalSnapshotName string) 
 	}
 
 	if finalSnapshotName != "" {
+		if m.snapshots.Has(finalSnapshotName) {
+			return nil, cerrors.Newf(cerrors.AlreadyExists, "snapshot %q already exists", finalSnapshotName)
+		}
+
 		m.snapshots.Set(finalSnapshotName, m.snapshotFromCluster(finalSnapshotName, &c, "manual", nil))
 	}
 
 	m.clusters.Delete(name)
 	m.linkACLCluster(c.ACLName, name, false)
+
+	if c.MultiRegionClusterName != "" {
+		m.unregisterMRCMember(c.MultiRegionClusterName, name)
+	}
+
 	m.recordClusterEvent(name, "Cluster deleted")
 
 	c.Status = mdbdriver.StatusDeleting
@@ -372,20 +442,20 @@ func (m *Mock) FailoverShard(_ context.Context, clusterName, shardName string) (
 		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", clusterName)
 	}
 
-	found := false
+	shard := -1
 
 	for i := range c.Shards {
 		if c.Shards[i].Name == shardName {
-			found = true
+			shard = i
 			break
 		}
 	}
 
-	if !found {
+	if shard < 0 {
 		return nil, cerrors.Newf(cerrors.NotFound, "shard %q not found in cluster %q", shardName, clusterName)
 	}
 
-	if len(c.Shards) > 0 && c.Shards[0].NumberOfNodes < 2 {
+	if c.Shards[shard].NumberOfNodes < minNodesForFailover {
 		return nil, cerrors.New(cerrors.FailedPrecondition, "failover requires at least one replica in the shard")
 	}
 

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -58,6 +58,21 @@ func (m *Mock) buildShards(clusterName string, numShards, replicasPerShard int) 
 		numShards = 1
 	}
 
+	// Defensive clamp to the service limits. Callers reject out-of-range counts
+	// via validateShardTopology first, so this never triggers for valid input;
+	// it keeps the allocations below bounded regardless of the call path.
+	if numShards > maxShardsPerCluster {
+		numShards = maxShardsPerCluster
+	}
+
+	if replicasPerShard < 0 {
+		replicasPerShard = 0
+	}
+
+	if replicasPerShard > maxReplicasPerShard {
+		replicasPerShard = maxReplicasPerShard
+	}
+
 	nodesPerShard := replicasPerShard + 1 // primary + replicas
 	shards := make([]mdbdriver.Shard, 0, numShards)
 	now := m.opts.Clock.Now().UTC()

--- a/providers/aws/memorydb/clusters.go
+++ b/providers/aws/memorydb/clusters.go
@@ -74,12 +74,18 @@ func (m *Mock) buildShards(clusterName string, numShards, replicasPerShard int) 
 	}
 
 	nodesPerShard := replicasPerShard + 1 // primary + replicas
-	shards := make([]mdbdriver.Shard, 0, numShards)
 	now := m.opts.Clock.Now().UTC()
+
+	// Capacities are intentionally left unhinted: the counts, though clamped to
+	// the service limits above, originate from caller input, and a tainted
+	// make() size is an uncontrolled-allocation risk. The clamped loop bounds
+	// keep the append-driven growth bounded.
+	var shards []mdbdriver.Shard
 
 	for s := 1; s <= numShards; s++ {
 		shardName := fmt.Sprintf("%04d", s)
-		nodes := make([]mdbdriver.Node, 0, nodesPerShard)
+
+		var nodes []mdbdriver.Node
 
 		for n := 1; n <= nodesPerShard; n++ {
 			nodeName := fmt.Sprintf("%s-%s-%03d", clusterName, shardName, n)

--- a/providers/aws/memorydb/memorydb.go
+++ b/providers/aws/memorydb/memorydb.go
@@ -8,6 +8,7 @@ package memorydb
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -199,9 +200,18 @@ func containsSlash(s string) bool {
 // ---- Tags (addressed by ARN) ----
 
 func (m *Mock) tagList(arn string) []mdbdriver.Tag {
-	out := []mdbdriver.Tag{}
-	for k, v := range m.tags[arn] {
-		out = append(out, mdbdriver.Tag{Key: k, Value: v})
+	tags := m.tags[arn]
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys) // deterministic order (AWS leaves it unspecified)
+
+	out := make([]mdbdriver.Tag, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, mdbdriver.Tag{Key: k, Value: tags[k]})
 	}
 
 	return out

--- a/providers/aws/memorydb/memorydb.go
+++ b/providers/aws/memorydb/memorydb.go
@@ -1,0 +1,279 @@
+// Package memorydb provides an in-memory mock of AWS MemoryDB, a
+// Redis/Valkey-compatible managed database. MemoryDB is control-plane only, so
+// this mock models clusters (with shards/nodes/endpoints), ACLs, users,
+// parameter groups, subnet groups, snapshots and multi-region clusters, and the
+// cross-references between them.
+package memorydb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+const (
+	defaultPort          = 6379
+	defaultEngine        = "redis"
+	defaultEngineVersion = "7.1"
+	defaultNodeType      = "db.t4g.small"
+	metricsNamespace     = "AWS/MemoryDB"
+)
+
+var (
+	_ mdbdriver.MemoryDB      = (*Mock)(nil)
+	_ mdbdriver.MultiRegion   = (*Mock)(nil)
+	_ mdbdriver.ReservedNodes = (*Mock)(nil)
+)
+
+// Mock is the in-memory AWS MemoryDB implementation.
+type Mock struct {
+	mu sync.RWMutex
+
+	clusters        *memstore.Store[mdbdriver.Cluster]
+	acls            *memstore.Store[mdbdriver.ACL]
+	users           *memstore.Store[mdbdriver.User]
+	parameterGroups *memstore.Store[mdbdriver.ParameterGroup]
+	subnetGroups    *memstore.Store[mdbdriver.SubnetGroup]
+	snapshots       *memstore.Store[mdbdriver.Snapshot]
+	multiRegion     *memstore.Store[mdbdriver.MultiRegionCluster]
+	reservedNodes   *memstore.Store[mdbdriver.ReservedNode]
+
+	// paramOverrides holds user-set parameter values per parameter group name.
+	paramOverrides map[string]map[string]string
+	// tags holds tag maps keyed by resource ARN.
+	tags map[string]map[string]string
+	// events is an append-only lifecycle log surfaced by DescribeEvents.
+	events []mdbdriver.Event
+
+	opts       *config.Options
+	monitoring mondriver.Monitoring
+}
+
+// New creates a new MemoryDB mock with the default ACL and parameter group that
+// real MemoryDB provisions in every account.
+func New(opts *config.Options) *Mock {
+	m := &Mock{
+		clusters:        memstore.New[mdbdriver.Cluster](),
+		acls:            memstore.New[mdbdriver.ACL](),
+		users:           memstore.New[mdbdriver.User](),
+		parameterGroups: memstore.New[mdbdriver.ParameterGroup](),
+		subnetGroups:    memstore.New[mdbdriver.SubnetGroup](),
+		snapshots:       memstore.New[mdbdriver.Snapshot](),
+		multiRegion:     memstore.New[mdbdriver.MultiRegionCluster](),
+		reservedNodes:   memstore.New[mdbdriver.ReservedNode](),
+		paramOverrides:  make(map[string]map[string]string),
+		tags:            make(map[string]map[string]string),
+		opts:            opts,
+	}
+
+	// Account-default resources (present in every real MemoryDB account).
+	m.acls.Set("open-access", mdbdriver.ACL{
+		Name: "open-access", ARN: m.arn("acl", "open-access"),
+		Status: mdbdriver.StatusAvailable, MinimumEngineVersion: "6.2",
+	})
+	m.parameterGroups.Set("default.memorydb-redis7", mdbdriver.ParameterGroup{
+		Name: "default.memorydb-redis7", ARN: m.arn("parametergroup", "default.memorydb-redis7"),
+		Family: "memorydb_redis7", Description: "Default parameter group for redis7",
+	})
+
+	return m
+}
+
+// SetMonitoring wires a CloudWatch backend for auto-metric emission.
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) {
+	m.monitoring = mon
+}
+
+func (m *Mock) arn(resourceType, name string) string {
+	return fmt.Sprintf("arn:aws:memorydb:%s:%s:%s/%s", m.opts.Region, m.opts.AccountID, resourceType, name)
+}
+
+// emitClusterMetrics pushes representative AWS/MemoryDB datapoints on cluster
+// create (mirrors the sibling ElastiCache/Cloud SQL behavior).
+func (m *Mock) emitClusterMetrics(clusterName string) {
+	if m.monitoring == nil {
+		return
+	}
+
+	now := m.opts.Clock.Now()
+	dims := map[string]string{"ClusterName": clusterName}
+
+	_ = m.monitoring.PutMetricData(context.Background(), []mondriver.MetricDatum{
+		{Namespace: metricsNamespace, MetricName: "CPUUtilization", Value: 5, Unit: "Percent", Dimensions: dims, Timestamp: now},
+		{Namespace: metricsNamespace, MetricName: "CurrConnections", Value: 1, Unit: "Count", Dimensions: dims, Timestamp: now},
+		{Namespace: metricsNamespace, MetricName: "BytesUsedForMemoryDB", Value: 1048576, Unit: "Bytes", Dimensions: dims, Timestamp: now},
+		{Namespace: metricsNamespace, MetricName: "DatabaseMemoryUsagePercentage", Value: 2, Unit: "Percent", Dimensions: dims, Timestamp: now},
+	})
+}
+
+// recordClusterEvent appends a cluster lifecycle event. The caller holds the
+// write lock.
+func (m *Mock) recordClusterEvent(clusterName, message string) {
+	m.events = append(m.events, mdbdriver.Event{
+		SourceName: clusterName, SourceType: "cluster", Message: message, Date: m.opts.Clock.Now().UTC(),
+	})
+}
+
+// describeByName returns all values (when names is empty) or the named ones,
+// each cloned, from a store — the shared shape of every Describe* method.
+func describeByName[T any](
+	store *memstore.Store[T], names []string, clone func(*T) T, notFound func(string) error,
+) ([]T, error) {
+	if len(names) == 0 {
+		all := store.SortedValues()
+		out := make([]T, 0, len(all))
+
+		for i := range all {
+			out = append(out, clone(&all[i]))
+		}
+
+		return out, nil
+	}
+
+	out := make([]T, 0, len(names))
+
+	for _, n := range names {
+		v, ok := store.Get(n)
+		if !ok {
+			return nil, notFound(n)
+		}
+
+		out = append(out, clone(&v))
+	}
+
+	return out, nil
+}
+
+// ---- tag helpers ----
+
+func copyTags(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func cloneStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+
+	return append([]string(nil), s...)
+}
+
+// validName rejects an empty or '/'-containing resource name.
+func validName(kind, name string) error {
+	if name == "" {
+		return cerrors.Newf(cerrors.InvalidArgument, "%s name is required", kind)
+	}
+
+	if containsSlash(name) {
+		return cerrors.Newf(cerrors.InvalidArgument, "%s name %q must not contain '/'", kind, name)
+	}
+
+	return nil
+}
+
+func containsSlash(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '/' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ---- Tags (addressed by ARN) ----
+
+func (m *Mock) tagList(arn string) []mdbdriver.Tag {
+	out := []mdbdriver.Tag{}
+	for k, v := range m.tags[arn] {
+		out = append(out, mdbdriver.Tag{Key: k, Value: v})
+	}
+
+	return out
+}
+
+// TagResource adds tags to a resource by ARN.
+func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string) ([]mdbdriver.Tag, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.tags[arn] == nil {
+		m.tags[arn] = make(map[string]string)
+	}
+
+	for k, v := range tags {
+		m.tags[arn][k] = v
+	}
+
+	return m.tagList(arn), nil
+}
+
+// UntagResource removes tag keys from a resource by ARN.
+func (m *Mock) UntagResource(_ context.Context, arn string, keys []string) ([]mdbdriver.Tag, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, k := range keys {
+		delete(m.tags[arn], k)
+	}
+
+	return m.tagList(arn), nil
+}
+
+// ListTags returns a resource's tags by ARN.
+func (m *Mock) ListTags(_ context.Context, arn string) ([]mdbdriver.Tag, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.tagList(arn), nil
+}
+
+// ---- Catalogs ----
+
+// DescribeEngineVersions returns the supported engine-version catalog.
+func (*Mock) DescribeEngineVersions(_ context.Context, engine, version string) ([]mdbdriver.EngineVersionInfo, error) {
+	all := []mdbdriver.EngineVersionInfo{
+		{Engine: "redis", EngineVersion: "7.1", EnginePatchVersion: "7.1.1", ParameterGroupFamily: "memorydb_redis7"},
+		{Engine: "redis", EngineVersion: "6.2", EnginePatchVersion: "6.2.6", ParameterGroupFamily: "memorydb_redis6"},
+		{Engine: "valkey", EngineVersion: "7.2", EnginePatchVersion: "7.2.0", ParameterGroupFamily: "memorydb_valkey7"},
+	}
+
+	out := make([]mdbdriver.EngineVersionInfo, 0, len(all))
+
+	for _, v := range all {
+		if engine != "" && v.Engine != engine {
+			continue
+		}
+
+		if version != "" && v.EngineVersion != version {
+			continue
+		}
+
+		out = append(out, v)
+	}
+
+	return out, nil
+}
+
+// DescribeEvents returns the lifecycle event log.
+func (m *Mock) DescribeEvents(_ context.Context) ([]mdbdriver.Event, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return append([]mdbdriver.Event(nil), m.events...), nil
+}

--- a/providers/aws/memorydb/memorydb_test.go
+++ b/providers/aws/memorydb/memorydb_test.go
@@ -129,6 +129,124 @@ func TestClusterReferenceValidation(t *testing.T) {
 	}
 }
 
+func TestMultiRegionParentLinkage(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	mrc, err := m.CreateMultiRegionCluster(ctx, mdbdriver.CreateMultiRegionClusterConfig{NameSuffix: "g", NumShards: 1})
+	requireNoError(t, err)
+
+	// A cluster referencing a non-existent MRC is rejected.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "bad", MultiRegionClusterName: "virtual-nope"}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("dangling MRC ref: got %v, want InvalidArgument", err)
+	}
+
+	// A valid regional member registers into the MRC and blocks its delete.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "regional", MultiRegionClusterName: mrc.Name}); err != nil {
+		t.Fatalf("CreateCluster (member): %v", err)
+	}
+
+	if _, err := m.DeleteMultiRegionCluster(ctx, mrc.Name); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete MRC with member: got %v, want FailedPrecondition", err)
+	}
+
+	// Removing the member unblocks the MRC delete.
+	if _, err := m.DeleteCluster(ctx, "regional", ""); err != nil {
+		t.Fatalf("DeleteCluster (member): %v", err)
+	}
+
+	if _, err := m.DeleteMultiRegionCluster(ctx, mrc.Name); err != nil {
+		t.Fatalf("delete MRC after member removed: %v", err)
+	}
+}
+
+func TestRestorePreservesTopology(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{
+		Name: "src", NumShards: 2, NumReplicasPerShard: 2, TLSEnabled: true,
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.CreateSnapshot(ctx, mdbdriver.CreateSnapshotConfig{Name: "snap", ClusterName: "src"}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	restored, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "dst", SnapshotName: "snap"})
+	requireNoError(t, err)
+
+	// Replica count (nodes-per-shard) and TLS are inherited from the snapshot.
+	if restored.NumberOfShards != 2 || len(restored.Shards) != 2 || restored.Shards[0].NumberOfNodes != 3 {
+		t.Fatalf("restore lost topology: shards=%d nodes/shard=%d", restored.NumberOfShards, restored.Shards[0].NumberOfNodes)
+	}
+
+	if !restored.TLSEnabled {
+		t.Error("restore lost TLSEnabled")
+	}
+}
+
+func TestDeleteClusterDuplicateSnapshotRejected(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", NumShards: 1}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.CreateSnapshot(ctx, mdbdriver.CreateSnapshotConfig{Name: "final", ClusterName: "c1"}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if _, err := m.DeleteCluster(ctx, "c1", "final"); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("delete with existing final snapshot: got %v, want AlreadyExists", err)
+	}
+}
+
+func TestCreateACLDedupesUsers(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateUser(ctx, mdbdriver.CreateUserConfig{Name: "u1", AccessString: "on ~* +@all"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	acl, err := m.CreateACL(ctx, "acl", []string{"u1", "u1", "u1"}, nil)
+	requireNoError(t, err)
+
+	if len(acl.UserNames) != 1 {
+		t.Fatalf("ACL user names not deduped: %v", acl.UserNames)
+	}
+}
+
+func TestServiceUpdates(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", NumShards: 1}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	updates, err := m.DescribeServiceUpdates(ctx, "", nil, nil)
+	requireNoError(t, err)
+
+	if len(updates) != 1 || updates[0].ClusterName != "c1" || updates[0].Status != "available" {
+		t.Fatalf("service updates wrong: %+v", updates)
+	}
+
+	processed, unprocessed, err := m.BatchUpdateCluster(ctx, []string{"c1", "ghost"}, defaultServiceUpdate)
+	requireNoError(t, err)
+
+	if len(processed) != 1 || processed[0].Name != "c1" {
+		t.Fatalf("processed wrong: %+v", processed)
+	}
+
+	if len(unprocessed) != 1 || unprocessed[0].ClusterName != "ghost" || unprocessed[0].ErrorType != "ClusterNotFoundFault" {
+		t.Fatalf("unprocessed wrong: %+v", unprocessed)
+	}
+}
+
 func TestFailoverRequiresReplica(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/memorydb/memorydb_test.go
+++ b/providers/aws/memorydb/memorydb_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
 	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
 )
@@ -22,6 +23,30 @@ func requireNoError(t *testing.T, err error) {
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClusterShardTopologyLimits(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{
+		Name: "too-many-shards", NumShards: maxShardsPerCluster + 1,
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("NumShards over limit: got %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{
+		Name: "too-many-replicas", NumShards: 1, NumReplicasPerShard: maxReplicasPerShard + 1,
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("ReplicasPerShard over limit: got %v, want InvalidArgument", err)
+	}
+
+	// At the limits it succeeds.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{
+		Name: "at-limit", NumShards: 1, NumReplicasPerShard: maxReplicasPerShard,
+	}); err != nil {
+		t.Fatalf("at-limit create: unexpected error %v", err)
 	}
 }
 

--- a/providers/aws/memorydb/memorydb_test.go
+++ b/providers/aws/memorydb/memorydb_test.go
@@ -1,0 +1,426 @@
+package memorydb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+
+	return New(opts)
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClusterLifecycleAndTopology(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	c, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{
+		Name: "c1", NumShards: 2, NumReplicasPerShard: 1, TLSEnabled: true,
+	})
+	requireNoError(t, err)
+
+	if c.Status != mdbdriver.StatusAvailable || c.ACLName != "open-access" || c.ParameterGroupName != "default.memorydb-redis7" {
+		t.Fatalf("cluster defaults wrong: %+v", c)
+	}
+
+	// Topology: 2 shards, each 2 nodes (primary+replica) with endpoints; cluster endpoint set.
+	if len(c.Shards) != 2 || len(c.Shards[0].Nodes) != 2 {
+		t.Fatalf("topology wrong: %d shards, %d nodes", len(c.Shards), len(c.Shards[0].Nodes))
+	}
+
+	if c.Shards[0].Nodes[0].Endpoint.Address == "" || c.Shards[0].Nodes[0].Endpoint.Port != defaultPort {
+		t.Errorf("node endpoint not populated: %+v", c.Shards[0].Nodes[0].Endpoint)
+	}
+
+	if c.ClusterEndpoint.Address == "" {
+		t.Error("cluster endpoint not populated")
+	}
+
+	// The default ACL now records the cluster.
+	acls, err := m.DescribeACLs(ctx, []string{"open-access"})
+	requireNoError(t, err)
+
+	if len(acls[0].Clusters) != 1 || acls[0].Clusters[0] != "c1" {
+		t.Errorf("ACL not linked to cluster: %+v", acls[0].Clusters)
+	}
+
+	// Duplicate create rejected.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1"}); err == nil {
+		t.Error("duplicate cluster: expected AlreadyExists")
+	}
+
+	// Failover works (has a replica); node-type updates listed.
+	if _, err := m.FailoverShard(ctx, "c1", "0001"); err != nil {
+		t.Errorf("FailoverShard: %v", err)
+	}
+
+	up, down, err := m.ListAllowedNodeTypeUpdates(ctx, "c1")
+	requireNoError(t, err)
+
+	if len(up) == 0 || len(down) == 0 {
+		t.Errorf("node-type updates empty: up=%v down=%v", up, down)
+	}
+
+	// Delete cluster + verify ACL detached.
+	if _, err := m.DeleteCluster(ctx, "c1", ""); err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	acls, _ = m.DescribeACLs(ctx, []string{"open-access"})
+	if len(acls[0].Clusters) != 0 {
+		t.Errorf("ACL still linked after cluster delete: %v", acls[0].Clusters)
+	}
+}
+
+func TestClusterReferenceValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c", ACLName: "ghost"}); err == nil {
+		t.Error("missing ACL: expected NotFound")
+	}
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c", ParameterGroupName: "ghost"}); err == nil {
+		t.Error("missing parameter group: expected NotFound")
+	}
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c", SubnetGroupName: "ghost"}); err == nil {
+		t.Error("missing subnet group: expected NotFound")
+	}
+}
+
+func TestFailoverRequiresReplica(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", NumShards: 1, NumReplicasPerShard: 0}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.FailoverShard(ctx, "c1", "0001"); err == nil {
+		t.Error("failover on a replica-less shard: expected FailedPrecondition")
+	}
+
+	if _, err := m.FailoverShard(ctx, "c1", "9999"); err == nil {
+		t.Error("failover on a missing shard: expected NotFound")
+	}
+}
+
+func TestACLUserLinkage(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateUser(ctx, mdbdriver.CreateUserConfig{Name: "u1", AccessString: "on ~* +@all"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	acl, err := m.CreateACL(ctx, "acl1", []string{"u1"}, nil)
+	requireNoError(t, err)
+
+	if len(acl.UserNames) != 1 {
+		t.Fatalf("ACL users: %+v", acl.UserNames)
+	}
+
+	// User now belongs to the ACL → delete blocked.
+	if _, err := m.DeleteUser(ctx, "u1"); err == nil {
+		t.Error("delete user in ACL: expected FailedPrecondition")
+	}
+
+	// Attach the ACL to a cluster → ACL delete blocked.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", ACLName: "acl1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.DeleteACL(ctx, "acl1"); err == nil {
+		t.Error("delete ACL attached to cluster: expected FailedPrecondition")
+	}
+
+	// ACL over a missing user rejected.
+	if _, err := m.CreateACL(ctx, "acl2", []string{"ghost"}, nil); err == nil {
+		t.Error("ACL over missing user: expected NotFound")
+	}
+
+	// Update ACL removes the user; then user delete works.
+	if _, err := m.UpdateACL(ctx, "acl1", nil, []string{"u1"}); err != nil {
+		t.Fatalf("UpdateACL: %v", err)
+	}
+
+	if _, err := m.DeleteUser(ctx, "u1"); err != nil {
+		t.Errorf("delete user after ACL removal: %v", err)
+	}
+}
+
+func TestParameterGroups(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateParameterGroup(ctx, "pg1", "memorydb_redis7", "custom", nil); err != nil {
+		t.Fatalf("CreateParameterGroup: %v", err)
+	}
+
+	if _, err := m.UpdateParameterGroup(ctx, "pg1", []mdbdriver.ParameterNameValue{{Name: "maxmemory-policy", Value: "allkeys-lru"}}); err != nil {
+		t.Fatalf("UpdateParameterGroup: %v", err)
+	}
+
+	params, err := m.DescribeParameters(ctx, "pg1")
+	requireNoError(t, err)
+
+	var sawOverride bool
+	for _, p := range params {
+		if p.Name == "maxmemory-policy" && p.Value == "allkeys-lru" {
+			sawOverride = true
+		}
+	}
+
+	if !sawOverride {
+		t.Error("parameter override not reflected in DescribeParameters")
+	}
+
+	// Unknown parameter rejected.
+	if _, err := m.UpdateParameterGroup(ctx, "pg1", []mdbdriver.ParameterNameValue{{Name: "bogus", Value: "1"}}); err == nil {
+		t.Error("unknown parameter: expected InvalidArgument")
+	}
+
+	// Reset restores the default.
+	if _, err := m.ResetParameterGroup(ctx, "pg1", true, nil); err != nil {
+		t.Fatalf("ResetParameterGroup: %v", err)
+	}
+
+	params, _ = m.DescribeParameters(ctx, "pg1")
+	for _, p := range params {
+		if p.Name == "maxmemory-policy" && p.Value != "noeviction" {
+			t.Errorf("reset did not restore default: %q", p.Value)
+		}
+	}
+
+	// Default parameter group cannot be deleted.
+	if _, err := m.DeleteParameterGroup(ctx, "default.memorydb-redis7"); err == nil {
+		t.Error("delete default parameter group: expected error")
+	}
+
+	// In-use parameter group cannot be deleted.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", ParameterGroupName: "pg1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.DeleteParameterGroup(ctx, "pg1"); err == nil {
+		t.Error("delete in-use parameter group: expected FailedPrecondition")
+	}
+}
+
+func TestSubnetGroups(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateSubnetGroup(ctx, mdbdriver.CreateSubnetGroupConfig{Name: "sg1", SubnetIDs: []string{"subnet-a", "subnet-b"}}); err != nil {
+		t.Fatalf("CreateSubnetGroup: %v", err)
+	}
+
+	got, err := m.DescribeSubnetGroups(ctx, []string{"sg1"})
+	requireNoError(t, err)
+
+	if len(got[0].Subnets) != 2 || got[0].VpcID == "" {
+		t.Errorf("subnet group: %+v", got[0])
+	}
+
+	// Empty subnet list rejected.
+	if _, err := m.CreateSubnetGroup(ctx, mdbdriver.CreateSubnetGroupConfig{Name: "x"}); err == nil {
+		t.Error("empty subnet ids: expected InvalidArgument")
+	}
+
+	// In-use subnet group cannot be deleted.
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", SubnetGroupName: "sg1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := m.DeleteSubnetGroup(ctx, "sg1"); err == nil {
+		t.Error("delete in-use subnet group: expected FailedPrecondition")
+	}
+}
+
+func TestSnapshotsAndRestore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "src", NumShards: 3, NodeType: "db.r7g.large"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	snap, err := m.CreateSnapshot(ctx, mdbdriver.CreateSnapshotConfig{Name: "snap1", ClusterName: "src"})
+	requireNoError(t, err)
+
+	if snap.ClusterConfiguration.NumShards != 3 || snap.ClusterConfiguration.NodeType != "db.r7g.large" {
+		t.Errorf("snapshot config not captured: %+v", snap.ClusterConfiguration)
+	}
+
+	// Snapshot of a missing cluster rejected.
+	if _, err := m.CreateSnapshot(ctx, mdbdriver.CreateSnapshotConfig{Name: "x", ClusterName: "ghost"}); err == nil {
+		t.Error("snapshot of missing cluster: expected NotFound")
+	}
+
+	// Copy.
+	if _, err := m.CopySnapshot(ctx, mdbdriver.CopySnapshotConfig{SourceName: "snap1", TargetName: "snap2"}); err != nil {
+		t.Fatalf("CopySnapshot: %v", err)
+	}
+
+	snaps, err := m.DescribeSnapshots(ctx, nil, "src")
+	requireNoError(t, err)
+
+	if len(snaps) != 2 {
+		t.Fatalf("expected 2 snapshots for src, got %d", len(snaps))
+	}
+
+	// Restore into a new cluster inherits the shape.
+	restored, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "restored", SnapshotName: "snap1"})
+	requireNoError(t, err)
+
+	if restored.NumberOfShards != 3 || restored.NodeType != "db.r7g.large" {
+		t.Errorf("restore did not inherit shape: %+v", restored)
+	}
+
+	if _, err := m.DeleteSnapshot(ctx, "snap1"); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+}
+
+func TestMultiRegionAndReservedNodes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	mrc, err := m.CreateMultiRegionCluster(ctx, mdbdriver.CreateMultiRegionClusterConfig{NameSuffix: "app", NumShards: 2})
+	requireNoError(t, err)
+
+	if mrc.Name != "virtual-app" {
+		t.Errorf("multi-region name: %q", mrc.Name)
+	}
+
+	if _, err := m.UpdateMultiRegionCluster(ctx, "virtual-app", "db.r7g.xlarge", "", nil); err != nil {
+		t.Fatalf("UpdateMultiRegionCluster: %v", err)
+	}
+
+	if _, err := m.DeleteMultiRegionCluster(ctx, "virtual-app"); err != nil {
+		t.Fatalf("DeleteMultiRegionCluster: %v", err)
+	}
+
+	// Reserved nodes: offerings + purchase.
+	offerings, err := m.DescribeReservedNodesOfferings(ctx)
+	requireNoError(t, err)
+
+	if len(offerings) == 0 {
+		t.Fatal("expected reserved-node offerings")
+	}
+
+	if _, err := m.PurchaseReservedNodesOffering(ctx, offerings[0].OfferingID, "res1", 2); err != nil {
+		t.Fatalf("PurchaseReservedNodesOffering: %v", err)
+	}
+
+	nodes, err := m.DescribeReservedNodes(ctx)
+	requireNoError(t, err)
+
+	if len(nodes) != 1 || nodes[0].NodeCount != 2 {
+		t.Errorf("reserved nodes: %+v", nodes)
+	}
+
+	if _, err := m.PurchaseReservedNodesOffering(ctx, "ghost", "res2", 1); err == nil {
+		t.Error("purchase unknown offering: expected NotFound")
+	}
+}
+
+func TestClusterResultDoesNotAliasStore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1", Tags: map[string]string{"env": "prod"}}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	got, err := m.DescribeClusters(ctx, []string{"c1"})
+	requireNoError(t, err)
+
+	got[0].Tags["env"] = "tampered"
+	got[0].Shards[0].Nodes[0].Name = "tampered"
+
+	reread, err := m.DescribeClusters(ctx, []string{"c1"})
+	requireNoError(t, err)
+
+	if reread[0].Tags["env"] != "prod" {
+		t.Errorf("Tags aliased: %q", reread[0].Tags["env"])
+	}
+
+	if reread[0].Shards[0].Nodes[0].Name == "tampered" {
+		t.Error("Shards/Nodes aliased")
+	}
+}
+
+func TestClusterMetricsEmitted(t *testing.T) {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+
+	m := New(opts)
+	cw := cloudwatch.New(opts)
+	m.SetMonitoring(cw)
+
+	ctx := context.Background()
+	if _, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1"}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	names, err := cw.ListMetrics(ctx, metricsNamespace)
+	requireNoError(t, err)
+
+	if len(names) == 0 {
+		t.Fatal("expected AWS/MemoryDB metrics to be emitted")
+	}
+}
+
+func TestTagsAndCatalogs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	c, err := m.CreateCluster(ctx, mdbdriver.CreateClusterConfig{Name: "c1"})
+	requireNoError(t, err)
+
+	if _, err := m.TagResource(ctx, c.ARN, map[string]string{"team": "data"}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	tags, err := m.ListTags(ctx, c.ARN)
+	requireNoError(t, err)
+
+	if len(tags) != 1 || tags[0].Key != "team" {
+		t.Errorf("tags: %+v", tags)
+	}
+
+	if _, err := m.UntagResource(ctx, c.ARN, []string{"team"}); err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	versions, err := m.DescribeEngineVersions(ctx, "redis", "")
+	requireNoError(t, err)
+
+	if len(versions) == 0 {
+		t.Error("expected engine versions")
+	}
+
+	events, err := m.DescribeEvents(ctx)
+	requireNoError(t, err)
+
+	if len(events) == 0 {
+		t.Error("expected lifecycle events after cluster create")
+	}
+}

--- a/providers/aws/memorydb/multiregion.go
+++ b/providers/aws/memorydb/multiregion.go
@@ -1,0 +1,139 @@
+package memorydb
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func cloneMultiRegion(in *mdbdriver.MultiRegionCluster) mdbdriver.MultiRegionCluster {
+	c := *in
+	c.Tags = copyTags(c.Tags)
+	c.Members = append([]mdbdriver.RegionalCluster(nil), c.Members...)
+
+	return c
+}
+
+// CreateMultiRegionCluster creates a cross-region cluster. Real MemoryDB
+// prefixes the name with "virtual-"; the caller supplies the suffix.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateMultiRegionCluster(
+	_ context.Context, cfg mdbdriver.CreateMultiRegionClusterConfig,
+) (*mdbdriver.MultiRegionCluster, error) {
+	if err := validName("multi-region cluster", cfg.NameSuffix); err != nil {
+		return nil, err
+	}
+
+	name := "virtual-" + cfg.NameSuffix
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.multiRegion.Has(name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "multi-region cluster %q already exists", name)
+	}
+
+	c := mdbdriver.MultiRegionCluster{
+		Name: name, ARN: m.arn("multiregioncluster", name), Status: mdbdriver.StatusAvailable,
+		NodeType: orDefault(cfg.NodeType, defaultNodeType), Engine: orDefault(cfg.Engine, defaultEngine),
+		EngineVersion: orDefault(cfg.EngineVersion, defaultEngineVersion), NumberOfShards: maxInt(cfg.NumShards, 1),
+		TLSEnabled: cfg.TLSEnabled, MultiRegionParameterGroupName: cfg.MultiRegionParameterGroupName,
+		Tags: copyTags(cfg.Tags),
+	}
+	m.multiRegion.Set(name, c)
+
+	out := cloneMultiRegion(&c)
+
+	return &out, nil
+}
+
+// DescribeMultiRegionClusters returns all multi-region clusters, or named ones.
+func (m *Mock) DescribeMultiRegionClusters(_ context.Context, names []string) ([]mdbdriver.MultiRegionCluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeByName(m.multiRegion, names, cloneMultiRegion, func(n string) error {
+		return cerrors.Newf(cerrors.NotFound, "multi-region cluster %q not found", n)
+	})
+}
+
+// UpdateMultiRegionCluster updates node type / engine version / shard count.
+func (m *Mock) UpdateMultiRegionCluster(
+	_ context.Context, name, nodeType, engineVersion string, shardCount *int,
+) (*mdbdriver.MultiRegionCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.multiRegion.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "multi-region cluster %q not found", name)
+	}
+
+	c.NodeType = orKeep(nodeType, c.NodeType)
+	c.EngineVersion = orKeep(engineVersion, c.EngineVersion)
+
+	if shardCount != nil && *shardCount > 0 {
+		c.NumberOfShards = *shardCount
+	}
+
+	m.multiRegion.Set(name, c)
+
+	out := cloneMultiRegion(&c)
+
+	return &out, nil
+}
+
+// DeleteMultiRegionCluster removes a multi-region cluster; it must have no
+// regional members still attached.
+func (m *Mock) DeleteMultiRegionCluster(_ context.Context, name string) (*mdbdriver.MultiRegionCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.multiRegion.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "multi-region cluster %q not found", name)
+	}
+
+	if len(c.Members) > 0 {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "multi-region cluster %q still has regional members", name)
+	}
+
+	m.multiRegion.Delete(name)
+
+	c.Status = mdbdriver.StatusDeleting
+
+	out := cloneMultiRegion(&c)
+
+	return &out, nil
+}
+
+// ListAllowedMultiRegionClusterUpdates returns allowed node-type updates.
+func (m *Mock) ListAllowedMultiRegionClusterUpdates(_ context.Context, name string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.multiRegion.Has(name) {
+		return nil, cerrors.Newf(cerrors.NotFound, "multi-region cluster %q not found", name)
+	}
+
+	return []string{"db.r7g.large", "db.r7g.xlarge"}, nil
+}
+
+// DescribeMultiRegionParameterGroups returns the default multi-region parameter
+// group catalog.
+func (m *Mock) DescribeMultiRegionParameterGroups(_ context.Context, _ []string) ([]mdbdriver.MultiRegionParameterGroup, error) {
+	return []mdbdriver.MultiRegionParameterGroup{{
+		Name: "default.memorydb-multiregion-redis7", ARN: m.arn("multiregionparametergroup", "default.memorydb-multiregion-redis7"),
+		Family: "memorydb_multiregion_redis7", Description: "Default multi-region parameter group",
+	}}, nil
+}
+
+// DescribeMultiRegionParameters returns the effective parameters (defaults).
+func (*Mock) DescribeMultiRegionParameters(_ context.Context, _ string) ([]mdbdriver.Parameter, error) {
+	return []mdbdriver.Parameter{
+		defaultParameters["maxmemory-policy"],
+		defaultParameters["timeout"],
+	}, nil
+}

--- a/providers/aws/memorydb/multiregion.go
+++ b/providers/aws/memorydb/multiregion.go
@@ -49,6 +49,47 @@ func (m *Mock) CreateMultiRegionCluster(
 	return &out, nil
 }
 
+// registerMRCMember records a regional cluster as a member of a multi-region
+// cluster so the delete guard is live. The caller holds the write lock; the
+// MRC's existence is validated by the caller before this runs.
+func (m *Mock) registerMRCMember(mrcName, clusterName, arn string) {
+	mrc, ok := m.multiRegion.Get(mrcName)
+	if !ok {
+		return
+	}
+
+	for i := range mrc.Members {
+		if mrc.Members[i].ClusterName == clusterName {
+			return
+		}
+	}
+
+	mrc.Members = append(mrc.Members, mdbdriver.RegionalCluster{
+		ClusterName: clusterName, Region: m.opts.Region, Status: mdbdriver.StatusAvailable, ARN: arn,
+	})
+	m.multiRegion.Set(mrcName, mrc)
+}
+
+// unregisterMRCMember drops a regional cluster from its multi-region cluster's
+// member list. The caller holds the write lock.
+func (m *Mock) unregisterMRCMember(mrcName, clusterName string) {
+	mrc, ok := m.multiRegion.Get(mrcName)
+	if !ok {
+		return
+	}
+
+	kept := mrc.Members[:0:0]
+
+	for _, mem := range mrc.Members {
+		if mem.ClusterName != clusterName {
+			kept = append(kept, mem)
+		}
+	}
+
+	mrc.Members = kept
+	m.multiRegion.Set(mrcName, mrc)
+}
+
 // DescribeMultiRegionClusters returns all multi-region clusters, or named ones.
 func (m *Mock) DescribeMultiRegionClusters(_ context.Context, names []string) ([]mdbdriver.MultiRegionCluster, error) {
 	m.mu.RLock()

--- a/providers/aws/memorydb/parametergroups.go
+++ b/providers/aws/memorydb/parametergroups.go
@@ -1,0 +1,197 @@
+package memorydb
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+// defaultParameters is a representative subset of the MemoryDB parameter
+// catalog, keyed by name with its default value.
+//
+//nolint:gochecknoglobals // immutable default-parameter catalog.
+var defaultParameters = map[string]mdbdriver.Parameter{
+	"maxmemory-policy": {
+		Name: "maxmemory-policy", Value: "noeviction", DataType: "string",
+		AllowedValues:        "noeviction,allkeys-lru,volatile-lru,allkeys-lfu,volatile-lfu,allkeys-random,volatile-random,volatile-ttl",
+		MinimumEngineVersion: "6.2",
+	},
+	"timeout":           {Name: "timeout", Value: "0", DataType: "integer", AllowedValues: "0-", MinimumEngineVersion: "6.2"},
+	"maxmemory-samples": {Name: "maxmemory-samples", Value: "3", DataType: "integer", AllowedValues: "1-", MinimumEngineVersion: "6.2"},
+	"activedefrag":      {Name: "activedefrag", Value: "no", DataType: "string", AllowedValues: "yes,no", MinimumEngineVersion: "6.2"},
+	"tcp-keepalive":     {Name: "tcp-keepalive", Value: "300", DataType: "integer", AllowedValues: "0-", MinimumEngineVersion: "6.2"},
+}
+
+func cloneParameterGroup(in *mdbdriver.ParameterGroup) mdbdriver.ParameterGroup {
+	p := *in
+	p.Tags = copyTags(p.Tags)
+
+	return p
+}
+
+// clusterUsesParameterGroup reports whether any cluster references the group.
+// The caller holds the lock.
+func (m *Mock) clusterUsesParameterGroup(name string) bool {
+	all := m.clusters.SortedValues()
+	for i := range all {
+		if all[i].ParameterGroupName == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CreateParameterGroup creates a parameter group.
+func (m *Mock) CreateParameterGroup(
+	_ context.Context, name, family, description string, tags map[string]string,
+) (*mdbdriver.ParameterGroup, error) {
+	if err := validName("parameter group", name); err != nil {
+		return nil, err
+	}
+
+	if family == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "family is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.parameterGroups.Has(name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "parameter group %q already exists", name)
+	}
+
+	pg := mdbdriver.ParameterGroup{
+		Name: name, ARN: m.arn("parametergroup", name),
+		Family: family, Description: description, Tags: copyTags(tags),
+	}
+	m.parameterGroups.Set(name, pg)
+
+	out := cloneParameterGroup(&pg)
+
+	return &out, nil
+}
+
+// DescribeParameterGroups returns all parameter groups, or the named ones.
+func (m *Mock) DescribeParameterGroups(_ context.Context, names []string) ([]mdbdriver.ParameterGroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeByName(m.parameterGroups, names, cloneParameterGroup, func(n string) error {
+		return cerrors.Newf(cerrors.NotFound, "parameter group %q not found", n)
+	})
+}
+
+// UpdateParameterGroup applies parameter overrides.
+func (m *Mock) UpdateParameterGroup(
+	_ context.Context, name string, params []mdbdriver.ParameterNameValue,
+) (*mdbdriver.ParameterGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
+	}
+
+	for _, p := range params {
+		if _, known := defaultParameters[p.Name]; !known {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "unknown parameter %q", p.Name)
+		}
+	}
+
+	if m.paramOverrides[name] == nil {
+		m.paramOverrides[name] = make(map[string]string)
+	}
+
+	for _, p := range params {
+		m.paramOverrides[name][p.Name] = p.Value
+	}
+
+	out := cloneParameterGroup(&pg)
+
+	return &out, nil
+}
+
+// ResetParameterGroup clears all overrides (or the named ones).
+func (m *Mock) ResetParameterGroup(_ context.Context, name string, all bool, names []string) (*mdbdriver.ParameterGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
+	}
+
+	if all {
+		delete(m.paramOverrides, name)
+	} else {
+		for _, n := range names {
+			delete(m.paramOverrides[name], n)
+		}
+	}
+
+	out := cloneParameterGroup(&pg)
+
+	return &out, nil
+}
+
+// DeleteParameterGroup removes a parameter group; defaults and in-use groups
+// cannot be deleted.
+func (m *Mock) DeleteParameterGroup(_ context.Context, name string) (*mdbdriver.ParameterGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pg, ok := m.parameterGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", name)
+	}
+
+	if len(name) >= len("default.") && name[:len("default.")] == "default." {
+		return nil, cerrors.New(cerrors.InvalidArgument, "cannot delete a default parameter group")
+	}
+
+	if m.clusterUsesParameterGroup(name) {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "parameter group %q is in use by a cluster", name)
+	}
+
+	m.parameterGroups.Delete(name)
+	delete(m.paramOverrides, name)
+
+	out := cloneParameterGroup(&pg)
+
+	return &out, nil
+}
+
+// DescribeParameters returns the effective parameters of a group (catalog
+// defaults with any overrides applied).
+func (m *Mock) DescribeParameters(_ context.Context, groupName string) ([]mdbdriver.Parameter, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.parameterGroups.Has(groupName) {
+		return nil, cerrors.Newf(cerrors.NotFound, "parameter group %q not found", groupName)
+	}
+
+	names := make([]string, 0, len(defaultParameters))
+	for n := range defaultParameters {
+		names = append(names, n)
+	}
+
+	sort.Strings(names)
+
+	out := make([]mdbdriver.Parameter, 0, len(names))
+
+	for _, n := range names {
+		p := defaultParameters[n]
+		if ov, ok := m.paramOverrides[groupName][n]; ok {
+			p.Value = ov
+		}
+
+		out = append(out, p)
+	}
+
+	return out, nil
+}

--- a/providers/aws/memorydb/reservednodes.go
+++ b/providers/aws/memorydb/reservednodes.go
@@ -1,0 +1,88 @@
+package memorydb
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+const oneYearSeconds = 31536000
+
+// staticOfferings is the fixed reserved-node offering catalog.
+//
+//nolint:gochecknoglobals // immutable offering catalog.
+var staticOfferings = []mdbdriver.ReservedNodesOffering{
+	{
+		OfferingID: "offer-r7g-large-1yr-noupfront", NodeType: "db.r7g.large",
+		Duration: oneYearSeconds, FixedPrice: 0, OfferingType: "No Upfront",
+	},
+	{
+		OfferingID: "offer-r7g-large-1yr-allupfront", NodeType: "db.r7g.large",
+		Duration: oneYearSeconds, FixedPrice: 1200, OfferingType: "All Upfront",
+	},
+	{
+		OfferingID: "offer-r7g-xlarge-1yr-allupfront", NodeType: "db.r7g.xlarge",
+		Duration: oneYearSeconds, FixedPrice: 2400, OfferingType: "All Upfront",
+	},
+}
+
+// DescribeReservedNodes returns purchased reserved nodes.
+func (m *Mock) DescribeReservedNodes(_ context.Context) ([]mdbdriver.ReservedNode, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.reservedNodes.SortedValues()
+
+	return append([]mdbdriver.ReservedNode(nil), all...), nil
+}
+
+// DescribeReservedNodesOfferings returns the static offering catalog.
+func (*Mock) DescribeReservedNodesOfferings(_ context.Context) ([]mdbdriver.ReservedNodesOffering, error) {
+	return append([]mdbdriver.ReservedNodesOffering(nil), staticOfferings...), nil
+}
+
+// PurchaseReservedNodesOffering records a reserved-node purchase.
+func (m *Mock) PurchaseReservedNodesOffering(
+	_ context.Context, offeringID, reservationID string, nodeCount int,
+) (*mdbdriver.ReservedNode, error) {
+	var offering *mdbdriver.ReservedNodesOffering
+
+	for i := range staticOfferings {
+		if staticOfferings[i].OfferingID == offeringID {
+			offering = &staticOfferings[i]
+			break
+		}
+	}
+
+	if offering == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "reserved-nodes offering %q not found", offeringID)
+	}
+
+	if nodeCount <= 0 {
+		nodeCount = 1
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if reservationID == "" {
+		reservationID = "rn-" + offeringID
+	}
+
+	if m.reservedNodes.Has(reservationID) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "reservation %q already exists", reservationID)
+	}
+
+	rn := mdbdriver.ReservedNode{
+		ReservationID: reservationID, OfferingID: offeringID, ReservedNodesOfferingID: offeringID,
+		NodeType: offering.NodeType, NodeCount: nodeCount, Duration: offering.Duration,
+		FixedPrice: offering.FixedPrice, OfferingType: offering.OfferingType,
+		State: "active", StartTime: m.opts.Clock.Now().UTC(),
+	}
+	m.reservedNodes.Set(reservationID, rn)
+
+	out := rn
+
+	return &out, nil
+}

--- a/providers/aws/memorydb/serviceupdates.go
+++ b/providers/aws/memorydb/serviceupdates.go
@@ -1,0 +1,93 @@
+package memorydb
+
+import (
+	"context"
+	"fmt"
+
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+// defaultServiceUpdate is the single security update the mock advertises as
+// available for every cluster.
+const defaultServiceUpdate = "memorydb-20240101-001"
+
+// serviceUpdateFor projects the available service update for one cluster.
+func (m *Mock) serviceUpdateFor(c *mdbdriver.Cluster) mdbdriver.ServiceUpdate {
+	now := m.opts.Clock.Now().UTC()
+
+	return mdbdriver.ServiceUpdate{
+		ClusterName:         c.Name,
+		ServiceUpdateName:   defaultServiceUpdate,
+		ReleaseDate:         now,
+		AutoUpdateStartDate: now,
+		Description:         "Security and stability update",
+		Status:              "available",
+		Type:                "security-update",
+		Engine:              c.Engine,
+		NodesUpdated:        fmt.Sprintf("0/%d", c.NumberOfShards),
+	}
+}
+
+// DescribeServiceUpdates lists the service updates available across clusters,
+// optionally filtered by update name, cluster names, and status.
+func (m *Mock) DescribeServiceUpdates(
+	_ context.Context, serviceUpdateName string, clusterNames, status []string,
+) ([]mdbdriver.ServiceUpdate, error) {
+	if serviceUpdateName != "" && serviceUpdateName != defaultServiceUpdate {
+		return nil, nil
+	}
+
+	if len(status) > 0 && !containsStr(status, "available") {
+		return nil, nil
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	clusters := m.clusters.SortedValues()
+	out := make([]mdbdriver.ServiceUpdate, 0, len(clusters))
+
+	for i := range clusters {
+		if len(clusterNames) > 0 && !containsStr(clusterNames, clusters[i].Name) {
+			continue
+		}
+
+		out = append(out, m.serviceUpdateFor(&clusters[i]))
+	}
+
+	return out, nil
+}
+
+// BatchUpdateCluster applies a service update to the named clusters, returning
+// the processed clusters and, for any name that does not exist, an entry in the
+// unprocessed list (rather than failing the whole batch).
+func (m *Mock) BatchUpdateCluster(
+	_ context.Context, clusterNames []string, _ string,
+) ([]mdbdriver.Cluster, []mdbdriver.UnprocessedCluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	processed := make([]mdbdriver.Cluster, 0, len(clusterNames))
+	unprocessed := make([]mdbdriver.UnprocessedCluster, 0)
+
+	for _, name := range clusterNames {
+		c, ok := m.clusters.Get(name)
+		if !ok {
+			unprocessed = append(unprocessed, mdbdriver.UnprocessedCluster{
+				ClusterName:  name,
+				ErrorType:    "ClusterNotFoundFault",
+				ErrorMessage: fmt.Sprintf("cluster %q not found", name),
+			})
+
+			continue
+		}
+
+		m.recordClusterEvent(name, "Service update "+defaultServiceUpdate+" applied")
+
+		processed = append(processed, cloneCluster(&c))
+	}
+
+	return processed, unprocessed, nil
+}
+
+var _ mdbdriver.ServiceUpdates = (*Mock)(nil)

--- a/providers/aws/memorydb/snapshots.go
+++ b/providers/aws/memorydb/snapshots.go
@@ -1,0 +1,152 @@
+package memorydb
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func cloneSnapshot(in *mdbdriver.Snapshot) mdbdriver.Snapshot {
+	s := *in
+	s.Tags = copyTags(s.Tags)
+
+	return s
+}
+
+// snapshotFromCluster captures a cluster's shape into a snapshot. The caller
+// holds the write lock.
+func (m *Mock) snapshotFromCluster(name string, c *mdbdriver.Cluster, source string, tags map[string]string) mdbdriver.Snapshot {
+	return mdbdriver.Snapshot{
+		Name:        name,
+		ARN:         m.arn("snapshot", name),
+		Status:      mdbdriver.StatusAvailable,
+		Source:      source,
+		DataTiering: c.DataTiering,
+		ClusterConfiguration: mdbdriver.ClusterConfiguration{
+			Name:                   c.Name,
+			NodeType:               c.NodeType,
+			Engine:                 c.Engine,
+			EngineVersion:          c.EngineVersion,
+			ParameterGroupName:     c.ParameterGroupName,
+			SubnetGroupName:        c.SubnetGroupName,
+			MaintenanceWindow:      c.MaintenanceWindow,
+			SnapshotWindow:         c.SnapshotWindow,
+			TopicARN:               c.SnsTopicARN,
+			NumShards:              c.NumberOfShards,
+			Port:                   c.ClusterEndpoint.Port,
+			SnapshotRetentionLimit: c.SnapshotRetentionLimit,
+		},
+		Tags:      copyTags(tags),
+		CreatedAt: m.opts.Clock.Now().UTC(),
+	}
+}
+
+// CreateSnapshot takes a manual snapshot of a cluster.
+func (m *Mock) CreateSnapshot(_ context.Context, cfg mdbdriver.CreateSnapshotConfig) (*mdbdriver.Snapshot, error) {
+	if err := validName("snapshot", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	c, ok := m.clusters.Get(cfg.ClusterName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cfg.ClusterName)
+	}
+
+	if m.snapshots.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "snapshot %q already exists", cfg.Name)
+	}
+
+	snap := m.snapshotFromCluster(cfg.Name, &c, "manual", cfg.Tags)
+	snap.KmsKeyID = cfg.KmsKeyID
+	m.snapshots.Set(cfg.Name, snap)
+
+	out := cloneSnapshot(&snap)
+
+	return &out, nil
+}
+
+// DescribeSnapshots returns snapshots, optionally filtered by name and/or
+// source cluster.
+func (m *Mock) DescribeSnapshots(_ context.Context, names []string, clusterName string) ([]mdbdriver.Snapshot, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	nameSet := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameSet[n] = struct{}{}
+	}
+
+	out := []mdbdriver.Snapshot{}
+
+	all := m.snapshots.SortedValues()
+	for i := range all {
+		if clusterName != "" && all[i].ClusterConfiguration.Name != clusterName {
+			continue
+		}
+
+		if len(nameSet) > 0 {
+			if _, ok := nameSet[all[i].Name]; !ok {
+				continue
+			}
+		}
+
+		out = append(out, cloneSnapshot(&all[i]))
+	}
+
+	return out, nil
+}
+
+// CopySnapshot copies an existing snapshot to a new name.
+func (m *Mock) CopySnapshot(_ context.Context, cfg mdbdriver.CopySnapshotConfig) (*mdbdriver.Snapshot, error) {
+	if err := validName("snapshot", cfg.TargetName); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.snapshots.Get(cfg.SourceName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", cfg.SourceName)
+	}
+
+	if m.snapshots.Has(cfg.TargetName) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "snapshot %q already exists", cfg.TargetName)
+	}
+
+	copySnap := src
+	copySnap.Name = cfg.TargetName
+	copySnap.ARN = m.arn("snapshot", cfg.TargetName)
+	copySnap.Source = "copied"
+	copySnap.KmsKeyID = cfg.KmsKeyID
+	copySnap.Tags = copyTags(cfg.Tags)
+	copySnap.CreatedAt = m.opts.Clock.Now().UTC()
+	m.snapshots.Set(cfg.TargetName, copySnap)
+
+	out := cloneSnapshot(&copySnap)
+
+	return &out, nil
+}
+
+// DeleteSnapshot removes a snapshot.
+func (m *Mock) DeleteSnapshot(_ context.Context, name string) (*mdbdriver.Snapshot, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snap, ok := m.snapshots.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "snapshot %q not found", name)
+	}
+
+	m.snapshots.Delete(name)
+
+	snap.Status = mdbdriver.StatusDeleting
+
+	out := cloneSnapshot(&snap)
+
+	return &out, nil
+}

--- a/providers/aws/memorydb/snapshots.go
+++ b/providers/aws/memorydb/snapshots.go
@@ -17,6 +17,13 @@ func cloneSnapshot(in *mdbdriver.Snapshot) mdbdriver.Snapshot {
 // snapshotFromCluster captures a cluster's shape into a snapshot. The caller
 // holds the write lock.
 func (m *Mock) snapshotFromCluster(name string, c *mdbdriver.Cluster, source string, tags map[string]string) mdbdriver.Snapshot {
+	// Replicas-per-shard is uniform across shards; derive it from the first
+	// shard's node count (primary + replicas).
+	replicas := 0
+	if len(c.Shards) > 0 && c.Shards[0].NumberOfNodes > 1 {
+		replicas = c.Shards[0].NumberOfNodes - 1
+	}
+
 	return mdbdriver.Snapshot{
 		Name:        name,
 		ARN:         m.arn("snapshot", name),
@@ -34,8 +41,10 @@ func (m *Mock) snapshotFromCluster(name string, c *mdbdriver.Cluster, source str
 			SnapshotWindow:         c.SnapshotWindow,
 			TopicARN:               c.SnsTopicARN,
 			NumShards:              c.NumberOfShards,
+			ReplicasPerShard:       replicas,
 			Port:                   c.ClusterEndpoint.Port,
 			SnapshotRetentionLimit: c.SnapshotRetentionLimit,
+			TLSEnabled:             c.TLSEnabled,
 		},
 		Tags:      copyTags(tags),
 		CreatedAt: m.opts.Clock.Now().UTC(),

--- a/providers/aws/memorydb/subnetgroups.go
+++ b/providers/aws/memorydb/subnetgroups.go
@@ -1,0 +1,136 @@
+package memorydb
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func cloneSubnetGroup(in *mdbdriver.SubnetGroup) mdbdriver.SubnetGroup {
+	g := *in
+	g.Tags = copyTags(g.Tags)
+	g.SupportedNetworkTypes = cloneStrings(g.SupportedNetworkTypes)
+
+	subnets := make([]mdbdriver.Subnet, len(g.Subnets))
+
+	for i := range g.Subnets {
+		s := g.Subnets[i]
+		s.SupportedNetworkTypes = cloneStrings(g.Subnets[i].SupportedNetworkTypes)
+		subnets[i] = s
+	}
+
+	g.Subnets = subnets
+
+	return g
+}
+
+func (m *Mock) buildSubnets(ids []string) []mdbdriver.Subnet {
+	out := make([]mdbdriver.Subnet, 0, len(ids))
+	for i, id := range ids {
+		out = append(out, mdbdriver.Subnet{
+			Identifier:            id,
+			AvailabilityZone:      m.opts.Region + azSuffix(i+1),
+			SupportedNetworkTypes: []string{"ipv4"},
+		})
+	}
+
+	return out
+}
+
+// clusterUsesSubnetGroup reports whether any cluster references the group.
+func (m *Mock) clusterUsesSubnetGroup(name string) bool {
+	all := m.clusters.SortedValues()
+	for i := range all {
+		if all[i].SubnetGroupName == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CreateSubnetGroup creates a subnet group.
+func (m *Mock) CreateSubnetGroup(_ context.Context, cfg mdbdriver.CreateSubnetGroupConfig) (*mdbdriver.SubnetGroup, error) {
+	if err := validName("subnet group", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	if len(cfg.SubnetIDs) == 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "at least one subnet id is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.subnetGroups.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "subnet group %q already exists", cfg.Name)
+	}
+
+	g := mdbdriver.SubnetGroup{
+		Name: cfg.Name, ARN: m.arn("subnetgroup", cfg.Name), Description: cfg.Description,
+		VpcID: "vpc-mock", Subnets: m.buildSubnets(cfg.SubnetIDs),
+		SupportedNetworkTypes: []string{"ipv4"}, Tags: copyTags(cfg.Tags),
+	}
+	m.subnetGroups.Set(cfg.Name, g)
+
+	out := cloneSubnetGroup(&g)
+
+	return &out, nil
+}
+
+// DescribeSubnetGroups returns all subnet groups, or the named ones.
+func (m *Mock) DescribeSubnetGroups(_ context.Context, names []string) ([]mdbdriver.SubnetGroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeByName(m.subnetGroups, names, cloneSubnetGroup, func(n string) error {
+		return cerrors.Newf(cerrors.NotFound, "subnet group %q not found", n)
+	})
+}
+
+// UpdateSubnetGroup updates a subnet group's description and/or subnets.
+func (m *Mock) UpdateSubnetGroup(_ context.Context, cfg mdbdriver.UpdateSubnetGroupConfig) (*mdbdriver.SubnetGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	g, ok := m.subnetGroups.Get(cfg.Name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "subnet group %q not found", cfg.Name)
+	}
+
+	if cfg.Description != "" {
+		g.Description = cfg.Description
+	}
+
+	if len(cfg.SubnetIDs) > 0 {
+		g.Subnets = m.buildSubnets(cfg.SubnetIDs)
+	}
+
+	m.subnetGroups.Set(cfg.Name, g)
+
+	out := cloneSubnetGroup(&g)
+
+	return &out, nil
+}
+
+// DeleteSubnetGroup removes a subnet group; in-use groups cannot be deleted.
+func (m *Mock) DeleteSubnetGroup(_ context.Context, name string) (*mdbdriver.SubnetGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	g, ok := m.subnetGroups.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "subnet group %q not found", name)
+	}
+
+	if m.clusterUsesSubnetGroup(name) {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "subnet group %q is in use by a cluster", name)
+	}
+
+	m.subnetGroups.Delete(name)
+
+	out := cloneSubnetGroup(&g)
+
+	return &out, nil
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/aws/eventbridge"
 	"github.com/stackshy/cloudemu/v2/server/aws/iam"
 	"github.com/stackshy/cloudemu/v2/server/aws/lambda"
+	memorydbsrv "github.com/stackshy/cloudemu/v2/server/aws/memorydb"
 	"github.com/stackshy/cloudemu/v2/server/aws/rds"
 	"github.com/stackshy/cloudemu/v2/server/aws/redshift"
 	"github.com/stackshy/cloudemu/v2/server/aws/resourceexplorer2"
@@ -51,6 +52,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -107,6 +109,9 @@ type Drivers struct {
 	// ElastiCache serves the ElastiCache query protocol (cluster control plane)
 	// against the cache driver.
 	ElastiCache cachedriver.Cache
+	// MemoryDB serves the AWS MemoryDB JSON 1.1 protocol (Redis/Valkey cluster
+	// control plane) against the memorydb driver.
+	MemoryDB mdbdriver.MemoryDB
 	// SNS serves the SNS query protocol against the notification driver.
 	SNS notifdriver.Notification
 	// STS serves the AWS STS query protocol (GetCallerIdentity, AssumeRole,
@@ -159,6 +164,7 @@ func DriversFrom(p *awsprovider.Provider) Drivers {
 		ELB:                 p.ELB,
 		EventBridge:         p.EventBridge,
 		ElastiCache:         p.ElastiCache,
+		MemoryDB:            p.MemoryDB,
 		SNS:                 p.SNS,
 		STS:                 true,
 		K8sAPI:              nil, // injected by the caller when a shared cluster is desired
@@ -194,7 +200,7 @@ func NewFromProvider(p *awsprovider.Provider) *server.Server {
 //
 // keeps the caller API ergonomic (awsserver.New(Drivers{...})).
 //
-//nolint:gocritic,gocyclo // Drivers is by-value for ergonomics; the dispatch is one if-per-driver and grows with the bundle.
+//nolint:gocritic,gocyclo,funlen // Drivers is by-value for ergonomics; the dispatch is one if-per-driver and grows with the bundle.
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
@@ -292,6 +298,13 @@ func New(d Drivers) *server.Server {
 	// shadowing occurs.
 	if d.ElastiCache != nil {
 		srv.Register(elasticache.New(d.ElastiCache))
+	}
+
+	// MemoryDB speaks AWS JSON 1.1 and matches on the "AmazonMemoryDB." target
+	// prefix, so its dispatch is disjoint from every query-protocol handler and
+	// registration order relative to the EC2 catch-all does not matter.
+	if d.MemoryDB != nil {
+		srv.Register(memorydbsrv.New(d.MemoryDB))
 	}
 
 	// SNS also speaks the AWS query protocol; its action set (CreateTopic,

--- a/server/aws/memorydb/acls_users.go
+++ b/server/aws/memorydb/acls_users.go
@@ -43,9 +43,15 @@ func (h *Handler) describeACLs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeACLsOutput{}
-	for i := range acls {
-		out.ACLs = append(out.ACLs, *toWireACL(&acls[i]))
+	page, next, err := paginate(acls, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "ACL", err)
+		return
+	}
+
+	out := memorydb.DescribeACLsOutput{NextToken: next}
+	for i := range page {
+		out.ACLs = append(out.ACLs, *toWireACL(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)
@@ -122,9 +128,15 @@ func (h *Handler) describeUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeUsersOutput{}
-	for i := range users {
-		out.Users = append(out.Users, *toWireUser(&users[i]))
+	page, next, err := paginate(users, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "User", err)
+		return
+	}
+
+	out := memorydb.DescribeUsersOutput{NextToken: next}
+	for i := range page {
+		out.Users = append(out.Users, *toWireUser(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)

--- a/server/aws/memorydb/acls_users.go
+++ b/server/aws/memorydb/acls_users.go
@@ -1,0 +1,167 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func (h *Handler) createACL(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CreateACLInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	acl, err := h.db.CreateACL(r.Context(), aws.ToString(in.ACLName), in.UserNames, tagMap(in.Tags))
+	if err != nil {
+		writeErr(w, "ACL", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CreateACLOutput{ACL: toWireACL(acl)})
+}
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) describeACLs(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeACLsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var names []string
+	if in.ACLName != nil {
+		names = []string{aws.ToString(in.ACLName)}
+	}
+
+	acls, err := h.db.DescribeACLs(r.Context(), names)
+	if err != nil {
+		writeErr(w, "ACL", err)
+		return
+	}
+
+	out := memorydb.DescribeACLsOutput{}
+	for i := range acls {
+		out.ACLs = append(out.ACLs, *toWireACL(&acls[i]))
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) updateACL(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.UpdateACLInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	acl, err := h.db.UpdateACL(r.Context(), aws.ToString(in.ACLName), in.UserNamesToAdd, in.UserNamesToRemove)
+	if err != nil {
+		writeErr(w, "ACL", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.UpdateACLOutput{ACL: toWireACL(acl)})
+}
+
+func (h *Handler) deleteACL(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DeleteACLInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	acl, err := h.db.DeleteACL(r.Context(), aws.ToString(in.ACLName))
+	if err != nil {
+		writeErr(w, "ACL", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.DeleteACLOutput{ACL: toWireACL(acl)})
+}
+
+func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CreateUserInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := mdbdriver.CreateUserConfig{
+		Name: aws.ToString(in.UserName), AccessString: aws.ToString(in.AccessString), Tags: tagMap(in.Tags),
+	}
+	if in.AuthenticationMode != nil {
+		cfg.AuthenticationType = string(in.AuthenticationMode.Type)
+		cfg.Passwords = in.AuthenticationMode.Passwords
+	}
+
+	u, err := h.db.CreateUser(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, "User", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CreateUserOutput{User: toWireUser(u)})
+}
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) describeUsers(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeUsersInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var names []string
+	if in.UserName != nil {
+		names = []string{aws.ToString(in.UserName)}
+	}
+
+	users, err := h.db.DescribeUsers(r.Context(), names)
+	if err != nil {
+		writeErr(w, "User", err)
+		return
+	}
+
+	out := memorydb.DescribeUsersOutput{}
+	for i := range users {
+		out.Users = append(out.Users, *toWireUser(&users[i]))
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) updateUser(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.UpdateUserInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := mdbdriver.UpdateUserConfig{Name: aws.ToString(in.UserName), AccessString: aws.ToString(in.AccessString)}
+	if in.AuthenticationMode != nil {
+		cfg.AuthenticationType = string(in.AuthenticationMode.Type)
+		cfg.Passwords = in.AuthenticationMode.Passwords
+	}
+
+	u, err := h.db.UpdateUser(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, "User", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.UpdateUserOutput{User: toWireUser(u)})
+}
+
+func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DeleteUserInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	u, err := h.db.DeleteUser(r.Context(), aws.ToString(in.UserName))
+	if err != nil {
+		writeErr(w, "User", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.DeleteUserOutput{User: toWireUser(u)})
+}

--- a/server/aws/memorydb/catalogs_tags.go
+++ b/server/aws/memorydb/catalogs_tags.go
@@ -67,8 +67,14 @@ func (h *Handler) describeEngineVersions(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	out := memorydb.DescribeEngineVersionsOutput{}
-	for _, v := range versions {
+	page, next, err := paginate(versions, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	out := memorydb.DescribeEngineVersionsOutput{NextToken: next}
+	for _, v := range page {
 		out.EngineVersions = append(out.EngineVersions, types.EngineVersionInfo{
 			Engine: aws.String(v.Engine), EngineVersion: aws.String(v.EngineVersion),
 			EnginePatchVersion: aws.String(v.EnginePatchVersion), ParameterGroupFamily: aws.String(v.ParameterGroupFamily),
@@ -90,8 +96,14 @@ func (h *Handler) describeEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeEventsOutput{}
-	for _, e := range events {
+	page, next, err := paginate(events, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	out := memorydb.DescribeEventsOutput{NextToken: next}
+	for _, e := range page {
 		out.Events = append(out.Events, types.Event{
 			SourceName: aws.String(e.SourceName), SourceType: types.SourceType(e.SourceType),
 			Message: aws.String(e.Message),

--- a/server/aws/memorydb/catalogs_tags.go
+++ b/server/aws/memorydb/catalogs_tags.go
@@ -1,0 +1,104 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb/types"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.TagResourceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	tags, err := h.db.TagResource(r.Context(), aws.ToString(in.ResourceArn), tagMap(in.Tags))
+	if err != nil {
+		writeErr(w, "Tag", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.TagResourceOutput{TagList: toWireTags(tags)})
+}
+
+func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.UntagResourceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	tags, err := h.db.UntagResource(r.Context(), aws.ToString(in.ResourceArn), in.TagKeys)
+	if err != nil {
+		writeErr(w, "Tag", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.UntagResourceOutput{TagList: toWireTags(tags)})
+}
+
+func (h *Handler) listTags(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.ListTagsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	tags, err := h.db.ListTags(r.Context(), aws.ToString(in.ResourceArn))
+	if err != nil {
+		writeErr(w, "Tag", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.ListTagsOutput{TagList: toWireTags(tags)})
+}
+
+func (h *Handler) describeEngineVersions(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeEngineVersionsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	versions, err := h.db.DescribeEngineVersions(r.Context(), aws.ToString(in.Engine), aws.ToString(in.EngineVersion))
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	out := memorydb.DescribeEngineVersionsOutput{}
+	for _, v := range versions {
+		out.EngineVersions = append(out.EngineVersions, types.EngineVersionInfo{
+			Engine: aws.String(v.Engine), EngineVersion: aws.String(v.EngineVersion),
+			EnginePatchVersion: aws.String(v.EnginePatchVersion), ParameterGroupFamily: aws.String(v.ParameterGroupFamily),
+		})
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) describeEvents(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeEventsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	events, err := h.db.DescribeEvents(r.Context())
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	out := memorydb.DescribeEventsOutput{}
+	for _, e := range events {
+		out.Events = append(out.Events, types.Event{
+			SourceName: aws.String(e.SourceName), SourceType: types.SourceType(e.SourceType),
+			Message: aws.String(e.Message),
+			// Date omitted: AWS JSON 1.1 encodes timestamps as epoch numbers,
+			// which encoding/json cannot emit for a time.Time.
+		})
+	}
+
+	wire.WriteJSON(w, out)
+}

--- a/server/aws/memorydb/clusters.go
+++ b/server/aws/memorydb/clusters.go
@@ -71,9 +71,15 @@ func (h *Handler) describeClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeClustersOutput{}
-	for i := range clusters {
-		out.Clusters = append(out.Clusters, *toWireCluster(&clusters[i]))
+	page, next, err := paginate(clusters, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	out := memorydb.DescribeClustersOutput{NextToken: next}
+	for i := range page {
+		out.Clusters = append(out.Clusters, *toWireCluster(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)

--- a/server/aws/memorydb/clusters.go
+++ b/server/aws/memorydb/clusters.go
@@ -1,0 +1,171 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func (h *Handler) createCluster(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CreateClusterInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := mdbdriver.CreateClusterConfig{
+		Name:                    aws.ToString(in.ClusterName),
+		Description:             aws.ToString(in.Description),
+		NodeType:                aws.ToString(in.NodeType),
+		Engine:                  aws.ToString(in.Engine),
+		EngineVersion:           aws.ToString(in.EngineVersion),
+		NumShards:               int(aws.ToInt32(in.NumShards)),
+		NumReplicasPerShard:     int(aws.ToInt32(in.NumReplicasPerShard)),
+		ACLName:                 aws.ToString(in.ACLName),
+		ParameterGroupName:      aws.ToString(in.ParameterGroupName),
+		SubnetGroupName:         aws.ToString(in.SubnetGroupName),
+		SecurityGroupIDs:        in.SecurityGroupIds,
+		Port:                    int(aws.ToInt32(in.Port)),
+		TLSEnabled:              aws.ToBool(in.TLSEnabled),
+		AutoMinorVersionUpgrade: aws.ToBool(in.AutoMinorVersionUpgrade),
+		DataTiering:             aws.ToBool(in.DataTiering),
+		KmsKeyID:                aws.ToString(in.KmsKeyId),
+		MaintenanceWindow:       aws.ToString(in.MaintenanceWindow),
+		SnapshotWindow:          aws.ToString(in.SnapshotWindow),
+		SnapshotRetentionLimit:  int(aws.ToInt32(in.SnapshotRetentionLimit)),
+		SnsTopicARN:             aws.ToString(in.SnsTopicArn),
+		SnapshotName:            aws.ToString(in.SnapshotName),
+		MultiRegionClusterName:  aws.ToString(in.MultiRegionClusterName),
+		NetworkType:             string(in.NetworkType),
+		IPDiscovery:             string(in.IpDiscovery),
+		Tags:                    tagMap(in.Tags),
+	}
+
+	c, err := h.db.CreateCluster(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CreateClusterOutput{Cluster: toWireCluster(c)})
+}
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) describeClusters(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeClustersInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var names []string
+	if in.ClusterName != nil {
+		names = []string{aws.ToString(in.ClusterName)}
+	}
+
+	clusters, err := h.db.DescribeClusters(r.Context(), names)
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	out := memorydb.DescribeClustersOutput{}
+	for i := range clusters {
+		out.Clusters = append(out.Clusters, *toWireCluster(&clusters[i]))
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.UpdateClusterInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := mdbdriver.UpdateClusterConfig{
+		Name:               aws.ToString(in.ClusterName),
+		Description:        aws.ToString(in.Description),
+		NodeType:           aws.ToString(in.NodeType),
+		EngineVersion:      aws.ToString(in.EngineVersion),
+		ACLName:            aws.ToString(in.ACLName),
+		ParameterGroupName: aws.ToString(in.ParameterGroupName),
+		MaintenanceWindow:  aws.ToString(in.MaintenanceWindow),
+		SnapshotWindow:     aws.ToString(in.SnapshotWindow),
+		SnsTopicARN:        aws.ToString(in.SnsTopicArn),
+		SnsTopicStatus:     aws.ToString(in.SnsTopicStatus),
+		SecurityGroupIDs:   in.SecurityGroupIds,
+	}
+
+	if in.SnapshotRetentionLimit != nil {
+		v := int(aws.ToInt32(in.SnapshotRetentionLimit))
+		cfg.SnapshotRetentionLimit = &v
+	}
+
+	if in.ShardConfiguration != nil {
+		v := int(in.ShardConfiguration.ShardCount)
+		cfg.ShardCount = &v
+	}
+
+	if in.ReplicaConfiguration != nil {
+		v := int(in.ReplicaConfiguration.ReplicaCount)
+		cfg.ReplicaCount = &v
+	}
+
+	c, err := h.db.UpdateCluster(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.UpdateClusterOutput{Cluster: toWireCluster(c)})
+}
+
+func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DeleteClusterInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	c, err := h.db.DeleteCluster(r.Context(), aws.ToString(in.ClusterName), aws.ToString(in.FinalSnapshotName))
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.DeleteClusterOutput{Cluster: toWireCluster(c)})
+}
+
+func (h *Handler) failoverShard(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.FailoverShardInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	c, err := h.db.FailoverShard(r.Context(), aws.ToString(in.ClusterName), aws.ToString(in.ShardName))
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.FailoverShardOutput{Cluster: toWireCluster(c)})
+}
+
+func (h *Handler) listAllowedNodeTypeUpdates(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.ListAllowedNodeTypeUpdatesInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	up, down, err := h.db.ListAllowedNodeTypeUpdates(r.Context(), aws.ToString(in.ClusterName))
+	if err != nil {
+		writeErr(w, "Cluster", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.ListAllowedNodeTypeUpdatesOutput{
+		ScaleUpNodeTypes: up, ScaleDownNodeTypes: down,
+	})
+}

--- a/server/aws/memorydb/handler.go
+++ b/server/aws/memorydb/handler.go
@@ -1,0 +1,140 @@
+// Package memorydb implements the AWS MemoryDB control-plane API as a
+// server.Handler. MemoryDB uses AWS JSON 1.1 with the X-Amz-Target header
+// prefix "AmazonMemoryDB.", so real aws-sdk-go-v2 memorydb clients configured
+// with a custom endpoint hit this handler unchanged.
+package memorydb
+
+import (
+	stderrors "errors"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+const targetPrefix = "AmazonMemoryDB."
+
+// Handler serves MemoryDB requests against a memorydb driver.
+type Handler struct {
+	db mdbdriver.MemoryDB
+}
+
+// New returns a MemoryDB handler backed by db.
+func New(db mdbdriver.MemoryDB) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches claims requests whose X-Amz-Target names a MemoryDB operation.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches on the operation named in X-Amz-Target.
+//
+//nolint:gocyclo,funlen // a flat operation switch is the clearest dispatch shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "CreateCluster":
+		h.createCluster(w, r)
+	case "DescribeClusters":
+		h.describeClusters(w, r)
+	case "UpdateCluster":
+		h.updateCluster(w, r)
+	case "DeleteCluster":
+		h.deleteCluster(w, r)
+	case "FailoverShard":
+		h.failoverShard(w, r)
+	case "ListAllowedNodeTypeUpdates":
+		h.listAllowedNodeTypeUpdates(w, r)
+	case "CreateACL":
+		h.createACL(w, r)
+	case "DescribeACLs":
+		h.describeACLs(w, r)
+	case "UpdateACL":
+		h.updateACL(w, r)
+	case "DeleteACL":
+		h.deleteACL(w, r)
+	case "CreateUser":
+		h.createUser(w, r)
+	case "DescribeUsers":
+		h.describeUsers(w, r)
+	case "UpdateUser":
+		h.updateUser(w, r)
+	case "DeleteUser":
+		h.deleteUser(w, r)
+	case "CreateParameterGroup":
+		h.createParameterGroup(w, r)
+	case "DescribeParameterGroups":
+		h.describeParameterGroups(w, r)
+	case "UpdateParameterGroup":
+		h.updateParameterGroup(w, r)
+	case "ResetParameterGroup":
+		h.resetParameterGroup(w, r)
+	case "DeleteParameterGroup":
+		h.deleteParameterGroup(w, r)
+	case "DescribeParameters":
+		h.describeParameters(w, r)
+	case "CreateSubnetGroup":
+		h.createSubnetGroup(w, r)
+	case "DescribeSubnetGroups":
+		h.describeSubnetGroups(w, r)
+	case "UpdateSubnetGroup":
+		h.updateSubnetGroup(w, r)
+	case "DeleteSubnetGroup":
+		h.deleteSubnetGroup(w, r)
+	case "CreateSnapshot":
+		h.createSnapshot(w, r)
+	case "DescribeSnapshots":
+		h.describeSnapshots(w, r)
+	case "CopySnapshot":
+		h.copySnapshot(w, r)
+	case "DeleteSnapshot":
+		h.deleteSnapshot(w, r)
+	case "TagResource":
+		h.tagResource(w, r)
+	case "UntagResource":
+		h.untagResource(w, r)
+	case "ListTags":
+		h.listTags(w, r)
+	case "DescribeEngineVersions":
+		h.describeEngineVersions(w, r)
+	case "DescribeEvents":
+		h.describeEvents(w, r)
+	default:
+		if h.serveOptional(w, r, op) {
+			return
+		}
+
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValueException", "unknown MemoryDB operation: "+op)
+	}
+}
+
+// writeErr maps a canonical error to a MemoryDB fault for the given resource
+// (e.g. resource="Cluster" → ClusterNotFoundFault / ClusterAlreadyExistsFault).
+func writeErr(w http.ResponseWriter, resource string, err error) {
+	msg := wireMessage(err)
+
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, resource+"NotFoundFault", msg)
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, resource+"AlreadyExistsFault", msg)
+	case cerrors.IsInvalidArgument(err), cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValueException", msg)
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerErrorException", msg)
+	}
+}
+
+func wireMessage(err error) string {
+	var ce *cerrors.Error
+	if stderrors.As(err, &ce) {
+		return ce.Message
+	}
+
+	return err.Error()
+}

--- a/server/aws/memorydb/optional.go
+++ b/server/aws/memorydb/optional.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/memorydb"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
 )
@@ -21,6 +22,8 @@ const (
 	opDescribeRNs      = "DescribeReservedNodes"
 	opDescribeRNOffers = "DescribeReservedNodesOfferings"
 	opPurchaseRNOffer  = "PurchaseReservedNodesOffering"
+	opDescribeSvcUpd   = "DescribeServiceUpdates"
+	opBatchUpdate      = "BatchUpdateCluster"
 )
 
 // serveOptional handles the multi-region-cluster and reserved-node operations,
@@ -47,6 +50,16 @@ func (h *Handler) serveOptional(w http.ResponseWriter, r *http.Request, op strin
 		}
 
 		h.serveReservedNodes(w, r, op, rn)
+
+		return true
+	case opDescribeSvcUpd, opBatchUpdate:
+		su, ok := h.db.(mdbdriver.ServiceUpdates)
+		if !ok {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValueException", "service updates not supported")
+			return true
+		}
+
+		h.serveServiceUpdates(w, r, op, su)
 
 		return true
 	default:
@@ -92,9 +105,15 @@ func (*Handler) serveMultiRegion(w http.ResponseWriter, r *http.Request, op stri
 			return
 		}
 
-		out := memorydb.DescribeMultiRegionClustersOutput{}
-		for i := range clusters {
-			out.MultiRegionClusters = append(out.MultiRegionClusters, *toWireMultiRegion(&clusters[i]))
+		page, next, err := paginate(clusters, in.MaxResults, in.NextToken)
+		if err != nil {
+			writeErr(w, "MultiRegionCluster", err)
+			return
+		}
+
+		out := memorydb.DescribeMultiRegionClustersOutput{NextToken: next}
+		for i := range page {
+			out.MultiRegionClusters = append(out.MultiRegionClusters, *toWireMultiRegion(&page[i]))
 		}
 
 		wire.WriteJSON(w, out)
@@ -148,7 +167,7 @@ func (*Handler) serveMultiRegion(w http.ResponseWriter, r *http.Request, op stri
 	case opDescribeMRPGs:
 		groups, err := mr.DescribeMultiRegionParameterGroups(r.Context(), nil)
 		if err != nil {
-			writeErr(w, "ParameterGroup", err)
+			writeErr(w, "MultiRegionParameterGroup", err)
 			return
 		}
 
@@ -166,7 +185,7 @@ func (*Handler) serveMultiRegion(w http.ResponseWriter, r *http.Request, op stri
 
 		params, err := mr.DescribeMultiRegionParameters(r.Context(), aws.ToString(in.MultiRegionParameterGroupName))
 		if err != nil {
-			writeErr(w, "ParameterGroup", err)
+			writeErr(w, "MultiRegionParameterGroup", err)
 			return
 		}
 
@@ -179,31 +198,54 @@ func (*Handler) serveMultiRegion(w http.ResponseWriter, r *http.Request, op stri
 	}
 }
 
+//nolint:dupl,gocyclo // per-op decode/paginate/encode blocks are structurally similar by design.
 func (*Handler) serveReservedNodes(w http.ResponseWriter, r *http.Request, op string, rn mdbdriver.ReservedNodes) {
 	switch op {
 	case opDescribeRNs:
+		var in memorydb.DescribeReservedNodesInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
 		nodes, err := rn.DescribeReservedNodes(r.Context())
 		if err != nil {
 			writeErr(w, "ReservedNode", err)
 			return
 		}
 
-		out := memorydb.DescribeReservedNodesOutput{}
-		for i := range nodes {
-			out.ReservedNodes = append(out.ReservedNodes, reservedNodeWire(&nodes[i]))
+		page, next, err := paginate(nodes, in.MaxResults, in.NextToken)
+		if err != nil {
+			writeErr(w, "ReservedNode", err)
+			return
+		}
+
+		out := memorydb.DescribeReservedNodesOutput{NextToken: next}
+		for i := range page {
+			out.ReservedNodes = append(out.ReservedNodes, reservedNodeWire(&page[i]))
 		}
 
 		wire.WriteJSON(w, out)
 	case opDescribeRNOffers:
+		var in memorydb.DescribeReservedNodesOfferingsInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
 		offerings, err := rn.DescribeReservedNodesOfferings(r.Context())
 		if err != nil {
 			writeErr(w, "ReservedNodesOffering", err)
 			return
 		}
 
-		out := memorydb.DescribeReservedNodesOfferingsOutput{}
-		for i := range offerings {
-			out.ReservedNodesOfferings = append(out.ReservedNodesOfferings, offeringWire(&offerings[i]))
+		page, next, err := paginate(offerings, in.MaxResults, in.NextToken)
+		if err != nil {
+			writeErr(w, "ReservedNodesOffering", err)
+			return
+		}
+
+		out := memorydb.DescribeReservedNodesOfferingsOutput{NextToken: next}
+		for i := range page {
+			out.ReservedNodesOfferings = append(out.ReservedNodesOfferings, offeringWire(&page[i]))
 		}
 
 		wire.WriteJSON(w, out)
@@ -216,11 +258,82 @@ func (*Handler) serveReservedNodes(w http.ResponseWriter, r *http.Request, op st
 		node, err := rn.PurchaseReservedNodesOffering(r.Context(),
 			aws.ToString(in.ReservedNodesOfferingId), aws.ToString(in.ReservationId), int(aws.ToInt32(in.NodeCount)))
 		if err != nil {
+			// A missing offering is a ReservedNodesOffering fault; a duplicate
+			// reservation is a ReservedNode fault (the SDK models
+			// ReservedNodeAlreadyExistsFault, not the *Offering* variant).
+			if cerrors.IsAlreadyExists(err) {
+				writeErr(w, "ReservedNode", err)
+				return
+			}
+
 			writeErr(w, "ReservedNodesOffering", err)
+
 			return
 		}
 
 		rnw := reservedNodeWire(node)
 		wire.WriteJSON(w, memorydb.PurchaseReservedNodesOfferingOutput{ReservedNode: &rnw})
+	}
+}
+
+//nolint:gocyclo // a flat op switch over the service-update operations is the clearest shape.
+func (*Handler) serveServiceUpdates(w http.ResponseWriter, r *http.Request, op string, su mdbdriver.ServiceUpdates) {
+	switch op {
+	case opDescribeSvcUpd:
+		var in memorydb.DescribeServiceUpdatesInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		status := make([]string, 0, len(in.Status))
+		for _, s := range in.Status {
+			status = append(status, string(s))
+		}
+
+		updates, err := su.DescribeServiceUpdates(r.Context(), aws.ToString(in.ServiceUpdateName), in.ClusterNames, status)
+		if err != nil {
+			writeErr(w, "ServiceUpdate", err)
+			return
+		}
+
+		page, next, err := paginate(updates, in.MaxResults, in.NextToken)
+		if err != nil {
+			writeErr(w, "ServiceUpdate", err)
+			return
+		}
+
+		out := memorydb.DescribeServiceUpdatesOutput{NextToken: next}
+		for i := range page {
+			out.ServiceUpdates = append(out.ServiceUpdates, serviceUpdateWire(&page[i]))
+		}
+
+		wire.WriteJSON(w, out)
+	case opBatchUpdate:
+		var in memorydb.BatchUpdateClusterInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		name := ""
+		if in.ServiceUpdate != nil {
+			name = aws.ToString(in.ServiceUpdate.ServiceUpdateNameToApply)
+		}
+
+		processed, unprocessed, err := su.BatchUpdateCluster(r.Context(), in.ClusterNames, name)
+		if err != nil {
+			writeErr(w, "Cluster", err)
+			return
+		}
+
+		out := memorydb.BatchUpdateClusterOutput{}
+		for i := range processed {
+			out.ProcessedClusters = append(out.ProcessedClusters, *toWireCluster(&processed[i]))
+		}
+
+		for i := range unprocessed {
+			out.UnprocessedClusters = append(out.UnprocessedClusters, unprocessedWire(&unprocessed[i]))
+		}
+
+		wire.WriteJSON(w, out)
 	}
 }

--- a/server/aws/memorydb/optional.go
+++ b/server/aws/memorydb/optional.go
@@ -1,0 +1,226 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+const (
+	opCreateMRC        = "CreateMultiRegionCluster"
+	opDescribeMRCs     = "DescribeMultiRegionClusters"
+	opUpdateMRC        = "UpdateMultiRegionCluster"
+	opDeleteMRC        = "DeleteMultiRegionCluster"
+	opListMRCUpdates   = "ListAllowedMultiRegionClusterUpdates"
+	opDescribeMRPGs    = "DescribeMultiRegionParameterGroups"
+	opDescribeMRParams = "DescribeMultiRegionParameters"
+	opDescribeRNs      = "DescribeReservedNodes"
+	opDescribeRNOffers = "DescribeReservedNodesOfferings"
+	opPurchaseRNOffer  = "PurchaseReservedNodesOffering"
+)
+
+// serveOptional handles the multi-region-cluster and reserved-node operations,
+// which are optional driver capabilities discovered by type assertion.
+func (h *Handler) serveOptional(w http.ResponseWriter, r *http.Request, op string) bool {
+	switch op {
+	case opCreateMRC, opDescribeMRCs, opUpdateMRC,
+		opDeleteMRC, opListMRCUpdates,
+		opDescribeMRPGs, opDescribeMRParams:
+		mr, ok := h.db.(mdbdriver.MultiRegion)
+		if !ok {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValueException", "multi-region not supported")
+			return true
+		}
+
+		h.serveMultiRegion(w, r, op, mr)
+
+		return true
+	case opDescribeRNs, opDescribeRNOffers, opPurchaseRNOffer:
+		rn, ok := h.db.(mdbdriver.ReservedNodes)
+		if !ok {
+			wire.WriteJSONError(w, http.StatusBadRequest, "InvalidParameterValueException", "reserved nodes not supported")
+			return true
+		}
+
+		h.serveReservedNodes(w, r, op, rn)
+
+		return true
+	default:
+		return false
+	}
+}
+
+//nolint:gocyclo,gocognit,funlen // flat op switch over the multi-region operations.
+func (*Handler) serveMultiRegion(w http.ResponseWriter, r *http.Request, op string, mr mdbdriver.MultiRegion) {
+	switch op {
+	case opCreateMRC:
+		var in memorydb.CreateMultiRegionClusterInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		c, err := mr.CreateMultiRegionCluster(r.Context(), mdbdriver.CreateMultiRegionClusterConfig{
+			NameSuffix: aws.ToString(in.MultiRegionClusterNameSuffix), Description: aws.ToString(in.Description),
+			NodeType: aws.ToString(in.NodeType), Engine: aws.ToString(in.Engine), EngineVersion: aws.ToString(in.EngineVersion),
+			NumShards: int(aws.ToInt32(in.NumShards)), TLSEnabled: aws.ToBool(in.TLSEnabled),
+			MultiRegionParameterGroupName: aws.ToString(in.MultiRegionParameterGroupName), Tags: tagMap(in.Tags),
+		})
+		if err != nil {
+			writeErr(w, "MultiRegionCluster", err)
+			return
+		}
+
+		wire.WriteJSON(w, memorydb.CreateMultiRegionClusterOutput{MultiRegionCluster: toWireMultiRegion(c)})
+	case opDescribeMRCs:
+		var in memorydb.DescribeMultiRegionClustersInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		var names []string
+		if in.MultiRegionClusterName != nil {
+			names = []string{aws.ToString(in.MultiRegionClusterName)}
+		}
+
+		clusters, err := mr.DescribeMultiRegionClusters(r.Context(), names)
+		if err != nil {
+			writeErr(w, "MultiRegionCluster", err)
+			return
+		}
+
+		out := memorydb.DescribeMultiRegionClustersOutput{}
+		for i := range clusters {
+			out.MultiRegionClusters = append(out.MultiRegionClusters, *toWireMultiRegion(&clusters[i]))
+		}
+
+		wire.WriteJSON(w, out)
+	case opUpdateMRC:
+		var in memorydb.UpdateMultiRegionClusterInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		var shardCount *int
+
+		if in.ShardConfiguration != nil {
+			v := int(in.ShardConfiguration.ShardCount)
+			shardCount = &v
+		}
+
+		c, err := mr.UpdateMultiRegionCluster(r.Context(),
+			aws.ToString(in.MultiRegionClusterName), aws.ToString(in.NodeType), aws.ToString(in.EngineVersion), shardCount)
+		if err != nil {
+			writeErr(w, "MultiRegionCluster", err)
+			return
+		}
+
+		wire.WriteJSON(w, memorydb.UpdateMultiRegionClusterOutput{MultiRegionCluster: toWireMultiRegion(c)})
+	case opDeleteMRC:
+		var in memorydb.DeleteMultiRegionClusterInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		c, err := mr.DeleteMultiRegionCluster(r.Context(), aws.ToString(in.MultiRegionClusterName))
+		if err != nil {
+			writeErr(w, "MultiRegionCluster", err)
+			return
+		}
+
+		wire.WriteJSON(w, memorydb.DeleteMultiRegionClusterOutput{MultiRegionCluster: toWireMultiRegion(c)})
+	case opListMRCUpdates:
+		var in memorydb.ListAllowedMultiRegionClusterUpdatesInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		nodeTypes, err := mr.ListAllowedMultiRegionClusterUpdates(r.Context(), aws.ToString(in.MultiRegionClusterName))
+		if err != nil {
+			writeErr(w, "MultiRegionCluster", err)
+			return
+		}
+
+		wire.WriteJSON(w, memorydb.ListAllowedMultiRegionClusterUpdatesOutput{ScaleUpNodeTypes: nodeTypes})
+	case opDescribeMRPGs:
+		groups, err := mr.DescribeMultiRegionParameterGroups(r.Context(), nil)
+		if err != nil {
+			writeErr(w, "ParameterGroup", err)
+			return
+		}
+
+		out := memorydb.DescribeMultiRegionParameterGroupsOutput{}
+		for _, g := range groups {
+			out.MultiRegionParameterGroups = append(out.MultiRegionParameterGroups, mrParamGroupWire(g))
+		}
+
+		wire.WriteJSON(w, out)
+	case opDescribeMRParams:
+		var in memorydb.DescribeMultiRegionParametersInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		params, err := mr.DescribeMultiRegionParameters(r.Context(), aws.ToString(in.MultiRegionParameterGroupName))
+		if err != nil {
+			writeErr(w, "ParameterGroup", err)
+			return
+		}
+
+		out := memorydb.DescribeMultiRegionParametersOutput{}
+		for _, p := range params {
+			out.MultiRegionParameters = append(out.MultiRegionParameters, mrParamWire(&p))
+		}
+
+		wire.WriteJSON(w, out)
+	}
+}
+
+func (*Handler) serveReservedNodes(w http.ResponseWriter, r *http.Request, op string, rn mdbdriver.ReservedNodes) {
+	switch op {
+	case opDescribeRNs:
+		nodes, err := rn.DescribeReservedNodes(r.Context())
+		if err != nil {
+			writeErr(w, "ReservedNode", err)
+			return
+		}
+
+		out := memorydb.DescribeReservedNodesOutput{}
+		for i := range nodes {
+			out.ReservedNodes = append(out.ReservedNodes, reservedNodeWire(&nodes[i]))
+		}
+
+		wire.WriteJSON(w, out)
+	case opDescribeRNOffers:
+		offerings, err := rn.DescribeReservedNodesOfferings(r.Context())
+		if err != nil {
+			writeErr(w, "ReservedNodesOffering", err)
+			return
+		}
+
+		out := memorydb.DescribeReservedNodesOfferingsOutput{}
+		for i := range offerings {
+			out.ReservedNodesOfferings = append(out.ReservedNodesOfferings, offeringWire(&offerings[i]))
+		}
+
+		wire.WriteJSON(w, out)
+	case opPurchaseRNOffer:
+		var in memorydb.PurchaseReservedNodesOfferingInput
+		if !wire.DecodeJSON(w, r, &in) {
+			return
+		}
+
+		node, err := rn.PurchaseReservedNodesOffering(r.Context(),
+			aws.ToString(in.ReservedNodesOfferingId), aws.ToString(in.ReservationId), int(aws.ToInt32(in.NodeCount)))
+		if err != nil {
+			writeErr(w, "ReservedNodesOffering", err)
+			return
+		}
+
+		rnw := reservedNodeWire(node)
+		wire.WriteJSON(w, memorydb.PurchaseReservedNodesOfferingOutput{ReservedNode: &rnw})
+	}
+}

--- a/server/aws/memorydb/paging.go
+++ b/server/aws/memorydb/paging.go
@@ -1,0 +1,59 @@
+package memorydb
+
+import (
+	"encoding/base64"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// paginate returns the slice of items beginning at the offset encoded in token
+// and limited to maxResults, together with the token for the next page (nil
+// when the returned page reaches the end). The token is an opaque base64 offset
+// — stable because the driver returns results in a deterministic order. A
+// malformed token yields an InvalidArgument error.
+func paginate[T any](items []T, maxResults *int32, token *string) (page []T, next *string, err error) {
+	start, err := decodeToken(token)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if start > len(items) {
+		start = len(items)
+	}
+
+	end := len(items)
+	if maxResults != nil && int(*maxResults) > 0 && start+int(*maxResults) < end {
+		end = start + int(*maxResults)
+	}
+
+	if end < len(items) {
+		next = encodeToken(end)
+	}
+
+	return items[start:end], next, nil
+}
+
+func decodeToken(token *string) (int, error) {
+	if token == nil || *token == "" {
+		return 0, nil
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(*token)
+	if err != nil {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid NextToken")
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid NextToken")
+	}
+
+	return n, nil
+}
+
+func encodeToken(offset int) *string {
+	s := base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+
+	return &s
+}

--- a/server/aws/memorydb/parametergroups.go
+++ b/server/aws/memorydb/parametergroups.go
@@ -44,9 +44,15 @@ func (h *Handler) describeParameterGroups(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	out := memorydb.DescribeParameterGroupsOutput{}
-	for i := range groups {
-		out.ParameterGroups = append(out.ParameterGroups, *toWireParameterGroup(&groups[i]))
+	page, next, err := paginate(groups, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	out := memorydb.DescribeParameterGroupsOutput{NextToken: next}
+	for i := range page {
+		out.ParameterGroups = append(out.ParameterGroups, *toWireParameterGroup(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)
@@ -117,9 +123,15 @@ func (h *Handler) describeParameters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeParametersOutput{}
-	for _, p := range params {
-		out.Parameters = append(out.Parameters, toWireParameter(&p))
+	page, next, err := paginate(params, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	out := memorydb.DescribeParametersOutput{NextToken: next}
+	for i := range page {
+		out.Parameters = append(out.Parameters, toWireParameter(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)

--- a/server/aws/memorydb/parametergroups.go
+++ b/server/aws/memorydb/parametergroups.go
@@ -1,0 +1,126 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func (h *Handler) createParameterGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CreateParameterGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	pg, err := h.db.CreateParameterGroup(r.Context(),
+		aws.ToString(in.ParameterGroupName), aws.ToString(in.Family), aws.ToString(in.Description), tagMap(in.Tags))
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CreateParameterGroupOutput{ParameterGroup: toWireParameterGroup(pg)})
+}
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) describeParameterGroups(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeParameterGroupsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var names []string
+	if in.ParameterGroupName != nil {
+		names = []string{aws.ToString(in.ParameterGroupName)}
+	}
+
+	groups, err := h.db.DescribeParameterGroups(r.Context(), names)
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	out := memorydb.DescribeParameterGroupsOutput{}
+	for i := range groups {
+		out.ParameterGroups = append(out.ParameterGroups, *toWireParameterGroup(&groups[i]))
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) updateParameterGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.UpdateParameterGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	params := make([]mdbdriver.ParameterNameValue, 0, len(in.ParameterNameValues))
+	for _, p := range in.ParameterNameValues {
+		params = append(params, mdbdriver.ParameterNameValue{Name: aws.ToString(p.ParameterName), Value: aws.ToString(p.ParameterValue)})
+	}
+
+	pg, err := h.db.UpdateParameterGroup(r.Context(), aws.ToString(in.ParameterGroupName), params)
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.UpdateParameterGroupOutput{ParameterGroup: toWireParameterGroup(pg)})
+}
+
+func (h *Handler) resetParameterGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.ResetParameterGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	names := make([]string, 0, len(in.ParameterNames))
+	names = append(names, in.ParameterNames...)
+
+	pg, err := h.db.ResetParameterGroup(r.Context(), aws.ToString(in.ParameterGroupName), in.AllParameters, names)
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.ResetParameterGroupOutput{ParameterGroup: toWireParameterGroup(pg)})
+}
+
+func (h *Handler) deleteParameterGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DeleteParameterGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	pg, err := h.db.DeleteParameterGroup(r.Context(), aws.ToString(in.ParameterGroupName))
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.DeleteParameterGroupOutput{ParameterGroup: toWireParameterGroup(pg)})
+}
+
+func (h *Handler) describeParameters(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeParametersInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	params, err := h.db.DescribeParameters(r.Context(), aws.ToString(in.ParameterGroupName))
+	if err != nil {
+		writeErr(w, "ParameterGroup", err)
+		return
+	}
+
+	out := memorydb.DescribeParametersOutput{}
+	for _, p := range params {
+		out.Parameters = append(out.Parameters, toWireParameter(&p))
+	}
+
+	wire.WriteJSON(w, out)
+}

--- a/server/aws/memorydb/sdk_roundtrip_test.go
+++ b/server/aws/memorydb/sdk_roundtrip_test.go
@@ -1,0 +1,630 @@
+package memorydb_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awsmemorydb "github.com/aws/aws-sdk-go-v2/service/memorydb"
+	mdbtypes "github.com/aws/aws-sdk-go-v2/service/memorydb/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	mdbprovider "github.com/stackshy/cloudemu/v2/providers/aws/memorydb"
+	mdbserver "github.com/stackshy/cloudemu/v2/server/aws/memorydb"
+)
+
+func newSDKClient(t *testing.T) *awsmemorydb.Client {
+	t.Helper()
+
+	opts := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	srv := httptest.NewServer(mdbserver.New(mdbprovider.New(opts)))
+	t.Cleanup(srv.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider("test", "test", ""),
+		),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awsmemorydb.NewFromConfig(cfg, func(o *awsmemorydb.Options) {
+		o.BaseEndpoint = aws.String(srv.URL)
+	})
+}
+
+func TestSDKClusterLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	out, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName:         aws.String("orders"),
+		NodeType:            aws.String("db.r6g.large"),
+		ACLName:             aws.String("open-access"),
+		NumShards:           aws.Int32(2),
+		NumReplicasPerShard: aws.Int32(1),
+		Tags: []mdbtypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("prod")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if aws.ToString(out.Cluster.Name) != "orders" {
+		t.Fatalf("name = %q, want orders", aws.ToString(out.Cluster.Name))
+	}
+
+	if aws.ToInt32(out.Cluster.NumberOfShards) != 2 {
+		t.Fatalf("shards = %d, want 2", aws.ToInt32(out.Cluster.NumberOfShards))
+	}
+
+	if out.Cluster.ClusterEndpoint == nil || aws.ToString(out.Cluster.ClusterEndpoint.Address) == "" {
+		t.Fatalf("expected a cluster endpoint, got %+v", out.Cluster.ClusterEndpoint)
+	}
+
+	got, err := client.DescribeClusters(ctx, &awsmemorydb.DescribeClustersInput{
+		ClusterName:      aws.String("orders"),
+		ShowShardDetails: aws.Bool(true),
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters: %v", err)
+	}
+
+	if len(got.Clusters) != 1 || len(got.Clusters[0].Shards) != 2 {
+		t.Fatalf("expected 1 cluster with 2 shards, got %+v", got.Clusters)
+	}
+
+	upd, err := client.UpdateCluster(ctx, &awsmemorydb.UpdateClusterInput{
+		ClusterName:        aws.String("orders"),
+		ShardConfiguration: &mdbtypes.ShardConfigurationRequest{ShardCount: 3},
+	})
+	if err != nil {
+		t.Fatalf("UpdateCluster: %v", err)
+	}
+
+	if aws.ToInt32(upd.Cluster.NumberOfShards) != 3 {
+		t.Fatalf("after update shards = %d, want 3", aws.ToInt32(upd.Cluster.NumberOfShards))
+	}
+
+	del, err := client.DeleteCluster(ctx, &awsmemorydb.DeleteClusterInput{
+		ClusterName: aws.String("orders"),
+	})
+	if err != nil {
+		t.Fatalf("DeleteCluster: %v", err)
+	}
+
+	if aws.ToString(del.Cluster.Status) != "deleting" {
+		t.Fatalf("delete status = %q, want deleting", aws.ToString(del.Cluster.Status))
+	}
+
+	_, err = client.DescribeClusters(ctx, &awsmemorydb.DescribeClustersInput{
+		ClusterName: aws.String("orders"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ClusterNotFoundFault" {
+		t.Fatalf("Describe after delete: got %v, want ClusterNotFoundFault", err)
+	}
+}
+
+func TestSDKACLsAndUsers(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &awsmemorydb.CreateUserInput{
+		UserName:     aws.String("app"),
+		AccessString: aws.String("on ~* +@all"),
+		AuthenticationMode: &mdbtypes.AuthenticationMode{
+			Type:      mdbtypes.InputAuthenticationTypePassword,
+			Passwords: []string{"averylongpasswordvalue1234"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.CreateACL(ctx, &awsmemorydb.CreateACLInput{
+		ACLName:   aws.String("app-acl"),
+		UserNames: []string{"app"},
+	}); err != nil {
+		t.Fatalf("CreateACL: %v", err)
+	}
+
+	got, err := client.DescribeACLs(ctx, &awsmemorydb.DescribeACLsInput{ACLName: aws.String("app-acl")})
+	if err != nil {
+		t.Fatalf("DescribeACLs: %v", err)
+	}
+
+	if len(got.ACLs) != 1 || len(got.ACLs[0].UserNames) != 1 {
+		t.Fatalf("expected acl with 1 user, got %+v", got.ACLs)
+	}
+
+	// Deleting a user still attached to an ACL must fail.
+	_, err = client.DeleteUser(ctx, &awsmemorydb.DeleteUserInput{UserName: aws.String("app")})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("DeleteUser in-use: got %v, want InvalidParameterValueException", err)
+	}
+}
+
+func TestSDKParameterAndSubnetGroups(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateParameterGroup(ctx, &awsmemorydb.CreateParameterGroupInput{
+		ParameterGroupName: aws.String("pg1"),
+		Family:             aws.String("memorydb_redis7"),
+		Description:        aws.String("custom"),
+	}); err != nil {
+		t.Fatalf("CreateParameterGroup: %v", err)
+	}
+
+	if _, err := client.UpdateParameterGroup(ctx, &awsmemorydb.UpdateParameterGroupInput{
+		ParameterGroupName: aws.String("pg1"),
+		ParameterNameValues: []mdbtypes.ParameterNameValue{
+			{ParameterName: aws.String("maxmemory-policy"), ParameterValue: aws.String("allkeys-lru")},
+		},
+	}); err != nil {
+		t.Fatalf("UpdateParameterGroup: %v", err)
+	}
+
+	params, err := client.DescribeParameters(ctx, &awsmemorydb.DescribeParametersInput{
+		ParameterGroupName: aws.String("pg1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeParameters: %v", err)
+	}
+
+	if len(params.Parameters) == 0 {
+		t.Fatal("expected parameters, got none")
+	}
+
+	if _, err := client.CreateSubnetGroup(ctx, &awsmemorydb.CreateSubnetGroupInput{
+		SubnetGroupName: aws.String("sg1"),
+		SubnetIds:       []string{"subnet-a", "subnet-b"},
+	}); err != nil {
+		t.Fatalf("CreateSubnetGroup: %v", err)
+	}
+
+	sgs, err := client.DescribeSubnetGroups(ctx, &awsmemorydb.DescribeSubnetGroupsInput{
+		SubnetGroupName: aws.String("sg1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSubnetGroups: %v", err)
+	}
+
+	if len(sgs.SubnetGroups) != 1 || len(sgs.SubnetGroups[0].Subnets) != 2 {
+		t.Fatalf("expected subnet group with 2 subnets, got %+v", sgs.SubnetGroups)
+	}
+}
+
+func TestSDKSnapshotAndRestore(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("src"),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+		NumShards:   aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := client.CreateSnapshot(ctx, &awsmemorydb.CreateSnapshotInput{
+		ClusterName:  aws.String("src"),
+		SnapshotName: aws.String("snap1"),
+	}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	snaps, err := client.DescribeSnapshots(ctx, &awsmemorydb.DescribeSnapshotsInput{
+		SnapshotName: aws.String("snap1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeSnapshots: %v", err)
+	}
+
+	if len(snaps.Snapshots) != 1 {
+		t.Fatalf("expected 1 snapshot, got %d", len(snaps.Snapshots))
+	}
+
+	// Restore into a new cluster from the snapshot.
+	restored, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName:  aws.String("restored"),
+		NodeType:     aws.String("db.r6g.large"),
+		ACLName:      aws.String("open-access"),
+		SnapshotName: aws.String("snap1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster from snapshot: %v", err)
+	}
+
+	if aws.ToString(restored.Cluster.Name) != "restored" {
+		t.Fatalf("restored name = %q", aws.ToString(restored.Cluster.Name))
+	}
+}
+
+func TestSDKMultiRegionAndReservedNodes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mrc, err := client.CreateMultiRegionCluster(ctx, &awsmemorydb.CreateMultiRegionClusterInput{
+		MultiRegionClusterNameSuffix: aws.String("global"),
+		NodeType:                     aws.String("db.r6g.large"),
+		NumShards:                    aws.Int32(2),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultiRegionCluster: %v", err)
+	}
+
+	if aws.ToString(mrc.MultiRegionCluster.MultiRegionClusterName) == "" {
+		t.Fatal("expected a multi-region cluster name")
+	}
+
+	offers, err := client.DescribeReservedNodesOfferings(ctx, &awsmemorydb.DescribeReservedNodesOfferingsInput{})
+	if err != nil {
+		t.Fatalf("DescribeReservedNodesOfferings: %v", err)
+	}
+
+	if len(offers.ReservedNodesOfferings) == 0 {
+		t.Fatal("expected at least one reserved-nodes offering")
+	}
+
+	if _, err := client.PurchaseReservedNodesOffering(ctx, &awsmemorydb.PurchaseReservedNodesOfferingInput{
+		ReservedNodesOfferingId: offers.ReservedNodesOfferings[0].ReservedNodesOfferingId,
+		ReservationId:           aws.String("res1"),
+	}); err != nil {
+		t.Fatalf("PurchaseReservedNodesOffering: %v", err)
+	}
+
+	nodes, err := client.DescribeReservedNodes(ctx, &awsmemorydb.DescribeReservedNodesInput{})
+	if err != nil {
+		t.Fatalf("DescribeReservedNodes: %v", err)
+	}
+
+	if len(nodes.ReservedNodes) == 0 {
+		t.Fatal("expected a purchased reserved node")
+	}
+}
+
+func TestSDKFailoverAndNodeTypeUpdates(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName:         aws.String("ha"),
+		NodeType:            aws.String("db.r6g.large"),
+		ACLName:             aws.String("open-access"),
+		NumShards:           aws.Int32(1),
+		NumReplicasPerShard: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	if _, err := client.FailoverShard(ctx, &awsmemorydb.FailoverShardInput{
+		ClusterName: aws.String("ha"),
+		ShardName:   aws.String("0001"),
+	}); err != nil {
+		t.Fatalf("FailoverShard: %v", err)
+	}
+
+	up, err := client.ListAllowedNodeTypeUpdates(ctx, &awsmemorydb.ListAllowedNodeTypeUpdatesInput{
+		ClusterName: aws.String("ha"),
+	})
+	if err != nil {
+		t.Fatalf("ListAllowedNodeTypeUpdates: %v", err)
+	}
+
+	if len(up.ScaleUpNodeTypes) == 0 && len(up.ScaleDownNodeTypes) == 0 {
+		t.Fatal("expected some allowed node-type updates")
+	}
+}
+
+func TestSDKACLUpdateDeleteAndUserUpdate(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &awsmemorydb.CreateUserInput{
+		UserName:     aws.String("u1"),
+		AccessString: aws.String("on ~* +@read"),
+		AuthenticationMode: &mdbtypes.AuthenticationMode{
+			Type:      mdbtypes.InputAuthenticationTypePassword,
+			Passwords: []string{"averylongpasswordvalue1234"},
+		},
+	}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.UpdateUser(ctx, &awsmemorydb.UpdateUserInput{
+		UserName:     aws.String("u1"),
+		AccessString: aws.String("on ~* +@all"),
+	}); err != nil {
+		t.Fatalf("UpdateUser: %v", err)
+	}
+
+	users, err := client.DescribeUsers(ctx, &awsmemorydb.DescribeUsersInput{})
+	if err != nil {
+		t.Fatalf("DescribeUsers: %v", err)
+	}
+
+	if len(users.Users) == 0 {
+		t.Fatal("expected at least one user")
+	}
+
+	if _, err := client.CreateACL(ctx, &awsmemorydb.CreateACLInput{ACLName: aws.String("acl2")}); err != nil {
+		t.Fatalf("CreateACL: %v", err)
+	}
+
+	upd, err := client.UpdateACL(ctx, &awsmemorydb.UpdateACLInput{
+		ACLName:        aws.String("acl2"),
+		UserNamesToAdd: []string{"u1"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateACL: %v", err)
+	}
+
+	if len(upd.ACL.UserNames) != 1 {
+		t.Fatalf("expected 1 user on acl2, got %d", len(upd.ACL.UserNames))
+	}
+
+	if _, err := client.DeleteACL(ctx, &awsmemorydb.DeleteACLInput{ACLName: aws.String("acl2")}); err != nil {
+		t.Fatalf("DeleteACL: %v", err)
+	}
+}
+
+func TestSDKParameterAndSubnetGroupUpdateDelete(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateParameterGroup(ctx, &awsmemorydb.CreateParameterGroupInput{
+		ParameterGroupName: aws.String("pg2"),
+		Family:             aws.String("memorydb_redis7"),
+	}); err != nil {
+		t.Fatalf("CreateParameterGroup: %v", err)
+	}
+
+	if _, err := client.ResetParameterGroup(ctx, &awsmemorydb.ResetParameterGroupInput{
+		ParameterGroupName: aws.String("pg2"),
+		AllParameters:      true,
+	}); err != nil {
+		t.Fatalf("ResetParameterGroup: %v", err)
+	}
+
+	groups, err := client.DescribeParameterGroups(ctx, &awsmemorydb.DescribeParameterGroupsInput{})
+	if err != nil {
+		t.Fatalf("DescribeParameterGroups: %v", err)
+	}
+
+	if len(groups.ParameterGroups) == 0 {
+		t.Fatal("expected parameter groups")
+	}
+
+	if _, err := client.DeleteParameterGroup(ctx, &awsmemorydb.DeleteParameterGroupInput{
+		ParameterGroupName: aws.String("pg2"),
+	}); err != nil {
+		t.Fatalf("DeleteParameterGroup: %v", err)
+	}
+
+	if _, err := client.CreateSubnetGroup(ctx, &awsmemorydb.CreateSubnetGroupInput{
+		SubnetGroupName: aws.String("sg2"),
+		SubnetIds:       []string{"subnet-a"},
+	}); err != nil {
+		t.Fatalf("CreateSubnetGroup: %v", err)
+	}
+
+	if _, err := client.UpdateSubnetGroup(ctx, &awsmemorydb.UpdateSubnetGroupInput{
+		SubnetGroupName: aws.String("sg2"),
+		SubnetIds:       []string{"subnet-a", "subnet-c"},
+	}); err != nil {
+		t.Fatalf("UpdateSubnetGroup: %v", err)
+	}
+
+	if _, err := client.DeleteSubnetGroup(ctx, &awsmemorydb.DeleteSubnetGroupInput{
+		SubnetGroupName: aws.String("sg2"),
+	}); err != nil {
+		t.Fatalf("DeleteSubnetGroup: %v", err)
+	}
+}
+
+func TestSDKSnapshotCopyDeleteTagsCatalogs(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("tagged"),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+		NumShards:   aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	arn := aws.ToString(created.Cluster.ARN)
+
+	if _, err := client.CreateSnapshot(ctx, &awsmemorydb.CreateSnapshotInput{
+		ClusterName:  aws.String("tagged"),
+		SnapshotName: aws.String("s1"),
+	}); err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+
+	if _, err := client.CopySnapshot(ctx, &awsmemorydb.CopySnapshotInput{
+		SourceSnapshotName: aws.String("s1"),
+		TargetSnapshotName: aws.String("s1-copy"),
+	}); err != nil {
+		t.Fatalf("CopySnapshot: %v", err)
+	}
+
+	if _, err := client.DeleteSnapshot(ctx, &awsmemorydb.DeleteSnapshotInput{
+		SnapshotName: aws.String("s1-copy"),
+	}); err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+
+	if _, err := client.TagResource(ctx, &awsmemorydb.TagResourceInput{
+		ResourceArn: aws.String(arn),
+		Tags:        []mdbtypes.Tag{{Key: aws.String("team"), Value: aws.String("data")}},
+	}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	tags, err := client.ListTags(ctx, &awsmemorydb.ListTagsInput{ResourceArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+
+	if len(tags.TagList) == 0 {
+		t.Fatal("expected tags on the cluster")
+	}
+
+	if _, err := client.UntagResource(ctx, &awsmemorydb.UntagResourceInput{
+		ResourceArn: aws.String(arn),
+		TagKeys:     []string{"team"},
+	}); err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	vers, err := client.DescribeEngineVersions(ctx, &awsmemorydb.DescribeEngineVersionsInput{})
+	if err != nil {
+		t.Fatalf("DescribeEngineVersions: %v", err)
+	}
+
+	if len(vers.EngineVersions) == 0 {
+		t.Fatal("expected engine versions")
+	}
+
+	if _, err := client.DescribeEvents(ctx, &awsmemorydb.DescribeEventsInput{}); err != nil {
+		t.Fatalf("DescribeEvents: %v", err)
+	}
+}
+
+func TestSDKMultiRegionFullSurface(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateMultiRegionCluster(ctx, &awsmemorydb.CreateMultiRegionClusterInput{
+		MultiRegionClusterNameSuffix: aws.String("mr"),
+		NodeType:                     aws.String("db.r6g.large"),
+		NumShards:                    aws.Int32(1),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultiRegionCluster: %v", err)
+	}
+
+	name := aws.ToString(created.MultiRegionCluster.MultiRegionClusterName)
+
+	if _, err := client.UpdateMultiRegionCluster(ctx, &awsmemorydb.UpdateMultiRegionClusterInput{
+		MultiRegionClusterName: aws.String(name),
+		NodeType:               aws.String("db.r6g.xlarge"),
+	}); err != nil {
+		t.Fatalf("UpdateMultiRegionCluster: %v", err)
+	}
+
+	list, err := client.DescribeMultiRegionClusters(ctx, &awsmemorydb.DescribeMultiRegionClustersInput{})
+	if err != nil {
+		t.Fatalf("DescribeMultiRegionClusters: %v", err)
+	}
+
+	if len(list.MultiRegionClusters) == 0 {
+		t.Fatal("expected a multi-region cluster")
+	}
+
+	if _, err := client.ListAllowedMultiRegionClusterUpdates(ctx,
+		&awsmemorydb.ListAllowedMultiRegionClusterUpdatesInput{MultiRegionClusterName: aws.String(name)}); err != nil {
+		t.Fatalf("ListAllowedMultiRegionClusterUpdates: %v", err)
+	}
+
+	if _, err := client.DescribeMultiRegionParameterGroups(ctx,
+		&awsmemorydb.DescribeMultiRegionParameterGroupsInput{}); err != nil {
+		t.Fatalf("DescribeMultiRegionParameterGroups: %v", err)
+	}
+
+	if _, err := client.DeleteMultiRegionCluster(ctx, &awsmemorydb.DeleteMultiRegionClusterInput{
+		MultiRegionClusterName: aws.String(name),
+	}); err != nil {
+		t.Fatalf("DeleteMultiRegionCluster: %v", err)
+	}
+}
+
+func TestHandlerMatches(t *testing.T) {
+	opts := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	h := mdbserver.New(mdbprovider.New(opts))
+
+	yes := httptest.NewRequest(http.MethodPost, "/", nil)
+	yes.Header.Set("X-Amz-Target", "AmazonMemoryDB.CreateCluster")
+
+	if !h.Matches(yes) {
+		t.Fatal("expected Matches to claim an AmazonMemoryDB target")
+	}
+
+	no := httptest.NewRequest(http.MethodPost, "/", nil)
+	no.Header.Set("X-Amz-Target", "AmazonElastiCache.CreateCacheCluster")
+
+	if h.Matches(no) {
+		t.Fatal("expected Matches to reject a non-MemoryDB target")
+	}
+}
+
+func TestSDKErrorFaults(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("dup"),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+		NumShards:   aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	// Duplicate name -> ClusterAlreadyExistsFault (writeErr AlreadyExists).
+	_, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("dup"),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("open-access"),
+		NumShards:   aws.Int32(1),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ClusterAlreadyExistsFault" {
+		t.Fatalf("duplicate create: got %v, want ClusterAlreadyExistsFault", err)
+	}
+
+	// Referencing a missing ACL -> InvalidParameterValueException (writeErr
+	// InvalidArgument / FailedPrecondition).
+	_, err = client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("badref"),
+		NodeType:    aws.String("db.r6g.large"),
+		ACLName:     aws.String("no-such-acl"),
+		NumShards:   aws.Int32(1),
+	})
+
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("bad ACL ref: got %v, want InvalidParameterValueException", err)
+	}
+}
+
+func TestSDKUnknownOperation(t *testing.T) {
+	client := newSDKClient(t)
+
+	_, err := client.DescribeClusters(context.Background(), &awsmemorydb.DescribeClustersInput{
+		ClusterName: aws.String("nope"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ClusterNotFoundFault" {
+		t.Fatalf("Describe(missing): got %v, want ClusterNotFoundFault", err)
+	}
+}

--- a/server/aws/memorydb/sdk_roundtrip_test.go
+++ b/server/aws/memorydb/sdk_roundtrip_test.go
@@ -616,6 +616,112 @@ func TestSDKErrorFaults(t *testing.T) {
 	}
 }
 
+func TestSDKReservedNodeDuplicateFault(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	offers, err := client.DescribeReservedNodesOfferings(ctx, &awsmemorydb.DescribeReservedNodesOfferingsInput{})
+	if err != nil {
+		t.Fatalf("DescribeReservedNodesOfferings: %v", err)
+	}
+
+	in := &awsmemorydb.PurchaseReservedNodesOfferingInput{
+		ReservedNodesOfferingId: offers.ReservedNodesOfferings[0].ReservedNodesOfferingId,
+		ReservationId:           aws.String("dup-res"),
+	}
+
+	if _, err := client.PurchaseReservedNodesOffering(ctx, in); err != nil {
+		t.Fatalf("first purchase: %v", err)
+	}
+
+	// Second purchase with the same ReservationId must surface the SDK-modeled
+	// ReservedNodeAlreadyExistsFault (not the unmodeled *Offering* variant).
+	_, err = client.PurchaseReservedNodesOffering(ctx, in)
+
+	var dup *mdbtypes.ReservedNodeAlreadyExistsFault
+	if !errors.As(err, &dup) {
+		t.Fatalf("duplicate purchase: got %v, want ReservedNodeAlreadyExistsFault", err)
+	}
+}
+
+func TestSDKPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"c1", "c2", "c3"} {
+		if _, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+			ClusterName: aws.String(n), NodeType: aws.String("db.r6g.large"),
+			ACLName: aws.String("open-access"), NumShards: aws.Int32(1),
+		}); err != nil {
+			t.Fatalf("CreateCluster %s: %v", n, err)
+		}
+	}
+
+	first, err := client.DescribeClusters(ctx, &awsmemorydb.DescribeClustersInput{MaxResults: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("DescribeClusters page 1: %v", err)
+	}
+
+	if len(first.Clusters) != 2 || first.NextToken == nil {
+		t.Fatalf("page 1: got %d clusters, token=%v; want 2 + token", len(first.Clusters), first.NextToken)
+	}
+
+	second, err := client.DescribeClusters(ctx, &awsmemorydb.DescribeClustersInput{
+		MaxResults: aws.Int32(2), NextToken: first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("DescribeClusters page 2: %v", err)
+	}
+
+	if len(second.Clusters) != 1 || second.NextToken != nil {
+		t.Fatalf("page 2: got %d clusters, token=%v; want 1 + no token", len(second.Clusters), second.NextToken)
+	}
+
+	// A malformed token is rejected.
+	_, err = client.DescribeClusters(ctx, &awsmemorydb.DescribeClustersInput{NextToken: aws.String("!!not-base64!!")})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterValueException" {
+		t.Fatalf("bad token: got %v, want InvalidParameterValueException", err)
+	}
+}
+
+func TestSDKServiceUpdates(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateCluster(ctx, &awsmemorydb.CreateClusterInput{
+		ClusterName: aws.String("su"), NodeType: aws.String("db.r6g.large"),
+		ACLName: aws.String("open-access"), NumShards: aws.Int32(1),
+	}); err != nil {
+		t.Fatalf("CreateCluster: %v", err)
+	}
+
+	updates, err := client.DescribeServiceUpdates(ctx, &awsmemorydb.DescribeServiceUpdatesInput{})
+	if err != nil {
+		t.Fatalf("DescribeServiceUpdates: %v", err)
+	}
+
+	if len(updates.ServiceUpdates) != 1 || aws.ToString(updates.ServiceUpdates[0].ClusterName) != "su" {
+		t.Fatalf("service updates wrong: %+v", updates.ServiceUpdates)
+	}
+
+	batch, err := client.BatchUpdateCluster(ctx, &awsmemorydb.BatchUpdateClusterInput{
+		ClusterNames: []string{"su", "ghost"},
+	})
+	if err != nil {
+		t.Fatalf("BatchUpdateCluster: %v", err)
+	}
+
+	if len(batch.ProcessedClusters) != 1 || len(batch.UnprocessedClusters) != 1 {
+		t.Fatalf("batch: processed=%d unprocessed=%d; want 1/1", len(batch.ProcessedClusters), len(batch.UnprocessedClusters))
+	}
+
+	if aws.ToString(batch.UnprocessedClusters[0].ErrorType) != "ClusterNotFoundFault" {
+		t.Fatalf("unprocessed error type = %q", aws.ToString(batch.UnprocessedClusters[0].ErrorType))
+	}
+}
+
 func TestSDKUnknownOperation(t *testing.T) {
 	client := newSDKClient(t)
 

--- a/server/aws/memorydb/snapshots.go
+++ b/server/aws/memorydb/snapshots.go
@@ -46,9 +46,15 @@ func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeSnapshotsOutput{}
-	for i := range snaps {
-		out.Snapshots = append(out.Snapshots, *toWireSnapshot(&snaps[i]))
+	page, next, err := paginate(snaps, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "Snapshot", err)
+		return
+	}
+
+	out := memorydb.DescribeSnapshotsOutput{NextToken: next}
+	for i := range page {
+		out.Snapshots = append(out.Snapshots, *toWireSnapshot(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)

--- a/server/aws/memorydb/snapshots.go
+++ b/server/aws/memorydb/snapshots.go
@@ -1,0 +1,89 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) createSnapshot(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CreateSnapshotInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	s, err := h.db.CreateSnapshot(r.Context(), mdbdriver.CreateSnapshotConfig{
+		Name: aws.ToString(in.SnapshotName), ClusterName: aws.ToString(in.ClusterName),
+		KmsKeyID: aws.ToString(in.KmsKeyId), Tags: tagMap(in.Tags),
+	})
+	if err != nil {
+		writeErr(w, "Snapshot", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CreateSnapshotOutput{Snapshot: toWireSnapshot(s)})
+}
+
+func (h *Handler) describeSnapshots(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeSnapshotsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var names []string
+	if in.SnapshotName != nil {
+		names = []string{aws.ToString(in.SnapshotName)}
+	}
+
+	snaps, err := h.db.DescribeSnapshots(r.Context(), names, aws.ToString(in.ClusterName))
+	if err != nil {
+		writeErr(w, "Snapshot", err)
+		return
+	}
+
+	out := memorydb.DescribeSnapshotsOutput{}
+	for i := range snaps {
+		out.Snapshots = append(out.Snapshots, *toWireSnapshot(&snaps[i]))
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) copySnapshot(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CopySnapshotInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	s, err := h.db.CopySnapshot(r.Context(), mdbdriver.CopySnapshotConfig{
+		SourceName: aws.ToString(in.SourceSnapshotName), TargetName: aws.ToString(in.TargetSnapshotName),
+		KmsKeyID: aws.ToString(in.KmsKeyId), Tags: tagMap(in.Tags),
+	})
+	if err != nil {
+		writeErr(w, "Snapshot", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CopySnapshotOutput{Snapshot: toWireSnapshot(s)})
+}
+
+func (h *Handler) deleteSnapshot(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DeleteSnapshotInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	s, err := h.db.DeleteSnapshot(r.Context(), aws.ToString(in.SnapshotName))
+	if err != nil {
+		writeErr(w, "Snapshot", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.DeleteSnapshotOutput{Snapshot: toWireSnapshot(s)})
+}

--- a/server/aws/memorydb/subnetgroups.go
+++ b/server/aws/memorydb/subnetgroups.go
@@ -46,9 +46,15 @@ func (h *Handler) describeSubnetGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := memorydb.DescribeSubnetGroupsOutput{}
-	for i := range groups {
-		out.SubnetGroups = append(out.SubnetGroups, *toWireSubnetGroup(&groups[i]))
+	page, next, err := paginate(groups, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, "SubnetGroup", err)
+		return
+	}
+
+	out := memorydb.DescribeSubnetGroupsOutput{NextToken: next}
+	for i := range page {
+		out.SubnetGroups = append(out.SubnetGroups, *toWireSubnetGroup(&page[i]))
 	}
 
 	wire.WriteJSON(w, out)

--- a/server/aws/memorydb/subnetgroups.go
+++ b/server/aws/memorydb/subnetgroups.go
@@ -1,0 +1,87 @@
+package memorydb
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+func (h *Handler) createSubnetGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.CreateSubnetGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	g, err := h.db.CreateSubnetGroup(r.Context(), mdbdriver.CreateSubnetGroupConfig{
+		Name: aws.ToString(in.SubnetGroupName), Description: aws.ToString(in.Description),
+		SubnetIDs: in.SubnetIds, Tags: tagMap(in.Tags),
+	})
+	if err != nil {
+		writeErr(w, "SubnetGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.CreateSubnetGroupOutput{SubnetGroup: toWireSubnetGroup(g)})
+}
+
+//nolint:dupl // per-operation handlers share the decode-call-encode shape.
+func (h *Handler) describeSubnetGroups(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DescribeSubnetGroupsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var names []string
+	if in.SubnetGroupName != nil {
+		names = []string{aws.ToString(in.SubnetGroupName)}
+	}
+
+	groups, err := h.db.DescribeSubnetGroups(r.Context(), names)
+	if err != nil {
+		writeErr(w, "SubnetGroup", err)
+		return
+	}
+
+	out := memorydb.DescribeSubnetGroupsOutput{}
+	for i := range groups {
+		out.SubnetGroups = append(out.SubnetGroups, *toWireSubnetGroup(&groups[i]))
+	}
+
+	wire.WriteJSON(w, out)
+}
+
+func (h *Handler) updateSubnetGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.UpdateSubnetGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	g, err := h.db.UpdateSubnetGroup(r.Context(), mdbdriver.UpdateSubnetGroupConfig{
+		Name: aws.ToString(in.SubnetGroupName), Description: aws.ToString(in.Description), SubnetIDs: in.SubnetIds,
+	})
+	if err != nil {
+		writeErr(w, "SubnetGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.UpdateSubnetGroupOutput{SubnetGroup: toWireSubnetGroup(g)})
+}
+
+func (h *Handler) deleteSubnetGroup(w http.ResponseWriter, r *http.Request) {
+	var in memorydb.DeleteSubnetGroupInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	g, err := h.db.DeleteSubnetGroup(r.Context(), aws.ToString(in.SubnetGroupName))
+	if err != nil {
+		writeErr(w, "SubnetGroup", err)
+		return
+	}
+
+	wire.WriteJSON(w, memorydb.DeleteSubnetGroupOutput{SubnetGroup: toWireSubnetGroup(g)})
+}

--- a/server/aws/memorydb/types.go
+++ b/server/aws/memorydb/types.go
@@ -1,0 +1,227 @@
+package memorydb
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/memorydb/types"
+
+	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
+)
+
+// i32 narrows a mock-scale int to int32.
+//
+//nolint:gosec // mock-scale values (shard/node counts, ports) never overflow int32.
+func i32(n int) int32 { return int32(n) }
+
+func toWireEndpoint(e mdbdriver.Endpoint) *types.Endpoint {
+	if e.Address == "" {
+		return nil
+	}
+
+	return &types.Endpoint{Address: aws.String(e.Address), Port: i32(e.Port)}
+}
+
+func toWireCluster(c *mdbdriver.Cluster) *types.Cluster {
+	shards := make([]types.Shard, 0, len(c.Shards))
+
+	for i := range c.Shards {
+		s := c.Shards[i]
+		nodes := make([]types.Node, 0, len(s.Nodes))
+
+		for j := range s.Nodes {
+			n := s.Nodes[j]
+			nodes = append(nodes, types.Node{
+				Name: aws.String(n.Name), Status: aws.String(n.Status),
+				AvailabilityZone: aws.String(n.AvailabilityZone),
+				// CreateTime omitted: AWS JSON 1.1 encodes timestamps as epoch
+				// numbers, which encoding/json cannot emit for a time.Time.
+				Endpoint: toWireEndpoint(n.Endpoint),
+			})
+		}
+
+		shards = append(shards, types.Shard{
+			Name: aws.String(s.Name), Status: aws.String(s.Status), Slots: aws.String(s.Slots),
+			NumberOfNodes: aws.Int32(i32(s.NumberOfNodes)), Nodes: nodes,
+		})
+	}
+
+	sgs := make([]types.SecurityGroupMembership, 0, len(c.SecurityGroups))
+	for _, sg := range c.SecurityGroups {
+		sgs = append(sgs, types.SecurityGroupMembership{SecurityGroupId: aws.String(sg.SecurityGroupID), Status: aws.String(sg.Status)})
+	}
+
+	out := &types.Cluster{
+		Name: aws.String(c.Name), ARN: aws.String(c.ARN), Description: aws.String(c.Description),
+		Status: aws.String(c.Status), NodeType: aws.String(c.NodeType), Engine: aws.String(c.Engine),
+		EngineVersion: aws.String(c.EngineVersion), EnginePatchVersion: aws.String(c.EnginePatchVersion),
+		NumberOfShards: aws.Int32(i32(c.NumberOfShards)), ACLName: aws.String(c.ACLName),
+		ParameterGroupName: aws.String(c.ParameterGroupName), ParameterGroupStatus: aws.String(c.ParameterGroupStatus),
+		SubnetGroupName: aws.String(c.SubnetGroupName), SecurityGroups: sgs, Shards: shards,
+		ClusterEndpoint: toWireEndpoint(c.ClusterEndpoint), TLSEnabled: aws.Bool(c.TLSEnabled),
+		KmsKeyId: aws.String(c.KmsKeyID), MaintenanceWindow: aws.String(c.MaintenanceWindow),
+		SnapshotWindow: aws.String(c.SnapshotWindow), SnapshotRetentionLimit: aws.Int32(i32(c.SnapshotRetentionLimit)),
+		SnsTopicArn: aws.String(c.SnsTopicARN), AutoMinorVersionUpgrade: aws.Bool(c.AutoMinorVersionUpgrade),
+		DataTiering: dataTieringStatus(c.DataTiering), AvailabilityMode: azStatus(c.AvailabilityMode),
+		NetworkType: types.NetworkType(c.NetworkType), IpDiscovery: types.IpDiscovery(c.IPDiscovery),
+	}
+
+	if c.MultiRegionClusterName != "" {
+		out.MultiRegionClusterName = aws.String(c.MultiRegionClusterName)
+	}
+
+	return out
+}
+
+func dataTieringStatus(on bool) types.DataTieringStatus {
+	if on {
+		return types.DataTieringStatusTrue
+	}
+
+	return types.DataTieringStatusFalse
+}
+
+func azStatus(mode string) types.AZStatus {
+	if mode == "MultiAZ" {
+		return types.AZStatusMultiAZ
+	}
+
+	return types.AZStatusSingleAZ
+}
+
+func toWireACL(a *mdbdriver.ACL) *types.ACL {
+	return &types.ACL{
+		Name: aws.String(a.Name), ARN: aws.String(a.ARN), Status: aws.String(a.Status),
+		MinimumEngineVersion: aws.String(a.MinimumEngineVersion),
+		UserNames:            a.UserNames, Clusters: a.Clusters,
+	}
+}
+
+func toWireUser(u *mdbdriver.User) *types.User {
+	return &types.User{
+		Name: aws.String(u.Name), ARN: aws.String(u.ARN), Status: aws.String(u.Status),
+		AccessString: aws.String(u.AccessString), MinimumEngineVersion: aws.String(u.MinimumEngineVersion),
+		ACLNames: u.ACLNames,
+		Authentication: &types.Authentication{
+			Type: types.AuthenticationType(u.Authentication.Type), PasswordCount: aws.Int32(i32(u.Authentication.PasswordCount)),
+		},
+	}
+}
+
+func toWireParameterGroup(p *mdbdriver.ParameterGroup) *types.ParameterGroup {
+	return &types.ParameterGroup{
+		Name: aws.String(p.Name), ARN: aws.String(p.ARN),
+		Family: aws.String(p.Family), Description: aws.String(p.Description),
+	}
+}
+
+func toWireParameter(p *mdbdriver.Parameter) types.Parameter {
+	return types.Parameter{
+		Name: aws.String(p.Name), Value: aws.String(p.Value), Description: aws.String(p.Description),
+		DataType: aws.String(p.DataType), AllowedValues: aws.String(p.AllowedValues),
+		MinimumEngineVersion: aws.String(p.MinimumEngineVersion),
+	}
+}
+
+func toWireSubnetGroup(g *mdbdriver.SubnetGroup) *types.SubnetGroup {
+	subnets := make([]types.Subnet, 0, len(g.Subnets))
+	for _, s := range g.Subnets {
+		subnets = append(subnets, types.Subnet{
+			Identifier:       aws.String(s.Identifier),
+			AvailabilityZone: &types.AvailabilityZone{Name: aws.String(s.AvailabilityZone)},
+		})
+	}
+
+	return &types.SubnetGroup{
+		Name: aws.String(g.Name), ARN: aws.String(g.ARN), Description: aws.String(g.Description),
+		VpcId: aws.String(g.VpcID), Subnets: subnets,
+	}
+}
+
+func toWireSnapshot(s *mdbdriver.Snapshot) *types.Snapshot {
+	cc := s.ClusterConfiguration
+
+	return &types.Snapshot{
+		Name: aws.String(s.Name), ARN: aws.String(s.ARN), Status: aws.String(s.Status),
+		Source: aws.String(s.Source), KmsKeyId: aws.String(s.KmsKeyID),
+		DataTiering: dataTieringStatus(s.DataTiering),
+		ClusterConfiguration: &types.ClusterConfiguration{
+			Name: aws.String(cc.Name), NodeType: aws.String(cc.NodeType), Engine: aws.String(cc.Engine),
+			EngineVersion: aws.String(cc.EngineVersion), ParameterGroupName: aws.String(cc.ParameterGroupName),
+			SubnetGroupName: aws.String(cc.SubnetGroupName), VpcId: aws.String(cc.VpcID),
+			MaintenanceWindow: aws.String(cc.MaintenanceWindow), SnapshotWindow: aws.String(cc.SnapshotWindow),
+			TopicArn: aws.String(cc.TopicARN), NumShards: aws.Int32(i32(cc.NumShards)),
+			Port: aws.Int32(i32(cc.Port)), SnapshotRetentionLimit: aws.Int32(i32(cc.SnapshotRetentionLimit)),
+		},
+	}
+}
+
+func toWireMultiRegion(c *mdbdriver.MultiRegionCluster) *types.MultiRegionCluster {
+	members := make([]types.RegionalCluster, 0, len(c.Members))
+	for _, r := range c.Members {
+		members = append(members, types.RegionalCluster{
+			ClusterName: aws.String(r.ClusterName), Region: aws.String(r.Region),
+			Status: aws.String(r.Status), ARN: aws.String(r.ARN),
+		})
+	}
+
+	return &types.MultiRegionCluster{
+		MultiRegionClusterName: aws.String(c.Name), ARN: aws.String(c.ARN), Status: aws.String(c.Status),
+		NodeType: aws.String(c.NodeType), Engine: aws.String(c.Engine), EngineVersion: aws.String(c.EngineVersion),
+		NumberOfShards: aws.Int32(i32(c.NumberOfShards)), TLSEnabled: aws.Bool(c.TLSEnabled),
+		MultiRegionParameterGroupName: aws.String(c.MultiRegionParameterGroupName), Clusters: members,
+	}
+}
+
+func toWireTags(tags []mdbdriver.Tag) []types.Tag {
+	out := make([]types.Tag, 0, len(tags))
+	for _, t := range tags {
+		out = append(out, types.Tag{Key: aws.String(t.Key), Value: aws.String(t.Value)})
+	}
+
+	return out
+}
+
+func mrParamGroupWire(g mdbdriver.MultiRegionParameterGroup) types.MultiRegionParameterGroup {
+	return types.MultiRegionParameterGroup{
+		Name: aws.String(g.Name), ARN: aws.String(g.ARN),
+		Family: aws.String(g.Family), Description: aws.String(g.Description),
+	}
+}
+
+func mrParamWire(p *mdbdriver.Parameter) types.MultiRegionParameter {
+	return types.MultiRegionParameter{
+		Name: aws.String(p.Name), Value: aws.String(p.Value), Description: aws.String(p.Description),
+		DataType: aws.String(p.DataType), AllowedValues: aws.String(p.AllowedValues),
+		MinimumEngineVersion: aws.String(p.MinimumEngineVersion),
+	}
+}
+
+func reservedNodeWire(n *mdbdriver.ReservedNode) types.ReservedNode {
+	return types.ReservedNode{
+		ReservationId: aws.String(n.ReservationID), ReservedNodesOfferingId: aws.String(n.ReservedNodesOfferingID),
+		NodeType: aws.String(n.NodeType), NodeCount: i32(n.NodeCount), Duration: i32(n.Duration),
+		FixedPrice: n.FixedPrice, OfferingType: aws.String(n.OfferingType), State: aws.String(n.State),
+		// StartTime omitted: AWS JSON 1.1 encodes timestamps as epoch numbers,
+		// which encoding/json cannot emit for a time.Time.
+	}
+}
+
+func offeringWire(o *mdbdriver.ReservedNodesOffering) types.ReservedNodesOffering {
+	return types.ReservedNodesOffering{
+		ReservedNodesOfferingId: aws.String(o.OfferingID), NodeType: aws.String(o.NodeType),
+		Duration: i32(o.Duration), FixedPrice: o.FixedPrice, OfferingType: aws.String(o.OfferingType),
+	}
+}
+
+// tagMap converts SDK request tags to a plain map.
+func tagMap(in []types.Tag) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for _, t := range in {
+		out[aws.ToString(t.Key)] = aws.ToString(t.Value)
+	}
+
+	return out
+}

--- a/server/aws/memorydb/types.go
+++ b/server/aws/memorydb/types.go
@@ -195,6 +195,25 @@ func mrParamWire(p *mdbdriver.Parameter) types.MultiRegionParameter {
 	}
 }
 
+func serviceUpdateWire(s *mdbdriver.ServiceUpdate) types.ServiceUpdate {
+	return types.ServiceUpdate{
+		ClusterName: aws.String(s.ClusterName), ServiceUpdateName: aws.String(s.ServiceUpdateName),
+		Description: aws.String(s.Description), Status: types.ServiceUpdateStatus(s.Status),
+		Type: types.ServiceUpdateType(s.Type), Engine: aws.String(s.Engine),
+		NodesUpdated: aws.String(s.NodesUpdated),
+		// ReleaseDate/AutoUpdateStartDate omitted: AWS JSON 1.1 encodes
+		// timestamps as epoch numbers, which encoding/json cannot emit for a
+		// time.Time.
+	}
+}
+
+func unprocessedWire(u *mdbdriver.UnprocessedCluster) types.UnprocessedCluster {
+	return types.UnprocessedCluster{
+		ClusterName: aws.String(u.ClusterName), ErrorType: aws.String(u.ErrorType),
+		ErrorMessage: aws.String(u.ErrorMessage),
+	}
+}
+
 func reservedNodeWire(n *mdbdriver.ReservedNode) types.ReservedNode {
 	return types.ReservedNode{
 		ReservationId: aws.String(n.ReservationID), ReservedNodesOfferingId: aws.String(n.ReservedNodesOfferingID),

--- a/services/cost/cost.go
+++ b/services/cost/cost.go
@@ -69,6 +69,15 @@ func defaultRates() map[string]float64 {
 		"relationaldb:StartInstance":               0.0,
 		"relationaldb:StopInstance":                0.0,
 
+		// MemoryDB (Redis/Valkey): clusters billed per node-hour proxy at
+		// create; multi-region grouping, snapshots and reserved-node purchases
+		// proxied at 0 (metered via member clusters / storage / reservations).
+		"memorydb:CreateCluster":                 0.226, // db.r6g.large-equivalent node-hour
+		"memorydb:CreateMultiRegionCluster":      0.0,
+		"memorydb:CreateSnapshot":                0.0,
+		"memorydb:CopySnapshot":                  0.0,
+		"memorydb:PurchaseReservedNodesOffering": 0.0,
+
 		// Serverless (per invocation)
 		"serverless:Invoke": 0.0000002, // $0.20 per 1M
 

--- a/services/cost/cost_test.go
+++ b/services/cost/cost_test.go
@@ -22,6 +22,21 @@ func TestTracker_RelationalDBRates(t *testing.T) {
 	assert.InDelta(t, want, tracker.CostByService()["relationaldb"], 1e-9)
 }
 
+func TestTracker_MemoryDBRates(t *testing.T) {
+	tracker := New()
+
+	// Two clusters priced at the node-hour rate; a snapshot, a copy, a
+	// multi-region grouping and a reserved-node purchase are all free.
+	tracker.Record("memorydb", "CreateCluster", 2)
+	tracker.Record("memorydb", "CreateSnapshot", 1)
+	tracker.Record("memorydb", "CopySnapshot", 1)
+	tracker.Record("memorydb", "CreateMultiRegionCluster", 1)
+	tracker.Record("memorydb", "PurchaseReservedNodesOffering", 1)
+
+	want := 0.226 * 2
+	assert.InDelta(t, want, tracker.CostByService()["memorydb"], 1e-9)
+}
+
 func TestTracker_Record_And_TotalCost(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/services/memorydb/driver/driver.go
+++ b/services/memorydb/driver/driver.go
@@ -1,0 +1,446 @@
+// Package driver defines the interface for AWS MemoryDB, a Redis/Valkey-
+// compatible in-memory database. MemoryDB is control-plane only (there is no
+// Set/Get data plane in its API), so this driver models clusters and their
+// shards/nodes/endpoints plus the ACL, user, parameter-group, subnet-group,
+// snapshot and multi-region resources and their cross-references.
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// Cluster lifecycle statuses (a representative subset of MemoryDB's).
+const (
+	StatusCreating     = "creating"
+	StatusAvailable    = "available"
+	StatusUpdating     = "updating"
+	StatusDeleting     = "deleting"
+	StatusSnapshotting = "snapshotting"
+)
+
+// Endpoint is an address:port a client connects to.
+type Endpoint struct {
+	Address string
+	Port    int
+}
+
+// Node is one node within a shard.
+type Node struct {
+	Name             string
+	Status           string
+	AvailabilityZone string
+	CreateTime       time.Time
+	Endpoint         Endpoint
+}
+
+// Shard is a collection of nodes (one primary + replicas) owning a slot range.
+type Shard struct {
+	Name          string
+	Status        string
+	Slots         string
+	NumberOfNodes int
+	Nodes         []Node
+}
+
+// SecurityGroupMembership is a security group attached to a cluster.
+type SecurityGroupMembership struct {
+	SecurityGroupID string
+	Status          string
+}
+
+// Cluster is a MemoryDB cluster.
+type Cluster struct {
+	Name                    string
+	ARN                     string
+	Description             string
+	Status                  string
+	NodeType                string
+	Engine                  string
+	EngineVersion           string
+	EnginePatchVersion      string
+	NumberOfShards          int
+	ACLName                 string
+	ParameterGroupName      string
+	ParameterGroupStatus    string
+	SubnetGroupName         string
+	SecurityGroups          []SecurityGroupMembership
+	Shards                  []Shard
+	ClusterEndpoint         Endpoint
+	TLSEnabled              bool
+	KmsKeyID                string
+	MaintenanceWindow       string
+	SnapshotWindow          string
+	SnapshotRetentionLimit  int
+	SnsTopicARN             string
+	SnsTopicStatus          string
+	AutoMinorVersionUpgrade bool
+	DataTiering             bool
+	AvailabilityMode        string
+	NetworkType             string
+	IPDiscovery             string
+	MultiRegionClusterName  string
+	Tags                    map[string]string
+	CreatedAt               time.Time
+}
+
+// CreateClusterConfig configures a new cluster.
+type CreateClusterConfig struct {
+	Name                    string
+	Description             string
+	NodeType                string
+	Engine                  string
+	EngineVersion           string
+	NumShards               int
+	NumReplicasPerShard     int
+	ACLName                 string
+	ParameterGroupName      string
+	SubnetGroupName         string
+	SecurityGroupIDs        []string
+	Port                    int
+	TLSEnabled              bool
+	AutoMinorVersionUpgrade bool
+	DataTiering             bool
+	KmsKeyID                string
+	MaintenanceWindow       string
+	SnapshotWindow          string
+	SnapshotRetentionLimit  int
+	SnsTopicARN             string
+	SnapshotName            string // restore source
+	MultiRegionClusterName  string
+	NetworkType             string
+	IPDiscovery             string
+	Tags                    map[string]string
+}
+
+// UpdateClusterConfig holds the mutable cluster fields; zero values mean "no
+// change". ShardCount/ReplicaCount are pointers so 0 is expressible.
+type UpdateClusterConfig struct {
+	Name                   string
+	Description            string
+	NodeType               string
+	EngineVersion          string
+	ACLName                string
+	ParameterGroupName     string
+	MaintenanceWindow      string
+	SnapshotWindow         string
+	SnsTopicARN            string
+	SnsTopicStatus         string
+	SecurityGroupIDs       []string
+	ShardCount             *int
+	ReplicaCount           *int
+	SnapshotRetentionLimit *int
+}
+
+// ACL is an Access Control List linking users to clusters.
+type ACL struct {
+	Name                 string
+	ARN                  string
+	Status               string
+	MinimumEngineVersion string
+	UserNames            []string
+	Clusters             []string
+	Tags                 map[string]string
+}
+
+// Authentication describes a user's auth configuration.
+type Authentication struct {
+	Type          string // password | iam | no-password-required
+	PasswordCount int
+}
+
+// User is a MemoryDB user.
+type User struct {
+	Name                 string
+	ARN                  string
+	Status               string
+	AccessString         string
+	Authentication       Authentication
+	MinimumEngineVersion string
+	ACLNames             []string
+	Tags                 map[string]string
+}
+
+// CreateUserConfig configures a new user.
+type CreateUserConfig struct {
+	Name               string
+	AccessString       string
+	AuthenticationType string
+	Passwords          []string
+	Tags               map[string]string
+}
+
+// UpdateUserConfig holds mutable user fields.
+type UpdateUserConfig struct {
+	Name               string
+	AccessString       string
+	AuthenticationType string
+	Passwords          []string
+}
+
+// Parameter is one server parameter.
+type Parameter struct {
+	Name                 string
+	Value                string
+	Description          string
+	DataType             string
+	AllowedValues        string
+	MinimumEngineVersion string
+}
+
+// ParameterGroup is a named set of parameters.
+type ParameterGroup struct {
+	Name        string
+	ARN         string
+	Family      string
+	Description string
+	Tags        map[string]string
+}
+
+// ParameterNameValue is a parameter override in an update request.
+type ParameterNameValue struct {
+	Name  string
+	Value string
+}
+
+// Subnet is a subnet in a subnet group.
+type Subnet struct {
+	Identifier            string
+	AvailabilityZone      string
+	SupportedNetworkTypes []string
+}
+
+// SubnetGroup is a set of subnets a cluster is placed into.
+type SubnetGroup struct {
+	Name                  string
+	ARN                   string
+	Description           string
+	VpcID                 string
+	Subnets               []Subnet
+	SupportedNetworkTypes []string
+	Tags                  map[string]string
+}
+
+// CreateSubnetGroupConfig configures a subnet group.
+type CreateSubnetGroupConfig struct {
+	Name        string
+	Description string
+	SubnetIDs   []string
+	Tags        map[string]string
+}
+
+// UpdateSubnetGroupConfig holds mutable subnet-group fields.
+type UpdateSubnetGroupConfig struct {
+	Name        string
+	Description string
+	SubnetIDs   []string
+}
+
+// ClusterConfiguration captures a cluster's shape at snapshot time.
+type ClusterConfiguration struct {
+	Name                   string
+	NodeType               string
+	Engine                 string
+	EngineVersion          string
+	ParameterGroupName     string
+	SubnetGroupName        string
+	VpcID                  string
+	MaintenanceWindow      string
+	SnapshotWindow         string
+	TopicARN               string
+	NumShards              int
+	Port                   int
+	SnapshotRetentionLimit int
+}
+
+// Snapshot is a point-in-time copy of a cluster.
+type Snapshot struct {
+	Name                 string
+	ARN                  string
+	Status               string
+	Source               string
+	KmsKeyID             string
+	DataTiering          bool
+	ClusterConfiguration ClusterConfiguration
+	Tags                 map[string]string
+	CreatedAt            time.Time
+}
+
+// CreateSnapshotConfig configures a snapshot.
+type CreateSnapshotConfig struct {
+	Name        string
+	ClusterName string
+	KmsKeyID    string
+	Tags        map[string]string
+}
+
+// CopySnapshotConfig configures a snapshot copy.
+type CopySnapshotConfig struct {
+	SourceName string
+	TargetName string
+	KmsKeyID   string
+	Tags       map[string]string
+}
+
+// EngineVersionInfo is a supported engine version.
+type EngineVersionInfo struct {
+	Engine               string
+	EngineVersion        string
+	EnginePatchVersion   string
+	ParameterGroupFamily string
+}
+
+// Event is a lifecycle event.
+type Event struct {
+	SourceName string
+	SourceType string
+	Message    string
+	Date       time.Time
+}
+
+// MemoryDB is the core capability every MemoryDB provider implements.
+//
+//nolint:interfacebloat // MemoryDB genuinely exposes this many control-plane operations.
+type MemoryDB interface {
+	// Clusters
+	CreateCluster(ctx context.Context, cfg CreateClusterConfig) (*Cluster, error)
+	DescribeClusters(ctx context.Context, names []string) ([]Cluster, error)
+	UpdateCluster(ctx context.Context, cfg UpdateClusterConfig) (*Cluster, error)
+	DeleteCluster(ctx context.Context, name, finalSnapshotName string) (*Cluster, error)
+	FailoverShard(ctx context.Context, clusterName, shardName string) (*Cluster, error)
+	ListAllowedNodeTypeUpdates(ctx context.Context, clusterName string) (scaleUp, scaleDown []string, err error)
+
+	// ACLs
+	CreateACL(ctx context.Context, name string, userNames []string, tags map[string]string) (*ACL, error)
+	DescribeACLs(ctx context.Context, names []string) ([]ACL, error)
+	UpdateACL(ctx context.Context, name string, add, remove []string) (*ACL, error)
+	DeleteACL(ctx context.Context, name string) (*ACL, error)
+
+	// Users
+	CreateUser(ctx context.Context, cfg CreateUserConfig) (*User, error)
+	DescribeUsers(ctx context.Context, names []string) ([]User, error)
+	UpdateUser(ctx context.Context, cfg UpdateUserConfig) (*User, error)
+	DeleteUser(ctx context.Context, name string) (*User, error)
+
+	// Parameter groups
+	CreateParameterGroup(ctx context.Context, name, family, description string, tags map[string]string) (*ParameterGroup, error)
+	DescribeParameterGroups(ctx context.Context, names []string) ([]ParameterGroup, error)
+	UpdateParameterGroup(ctx context.Context, name string, params []ParameterNameValue) (*ParameterGroup, error)
+	ResetParameterGroup(ctx context.Context, name string, all bool, names []string) (*ParameterGroup, error)
+	DeleteParameterGroup(ctx context.Context, name string) (*ParameterGroup, error)
+	DescribeParameters(ctx context.Context, groupName string) ([]Parameter, error)
+
+	// Subnet groups
+	CreateSubnetGroup(ctx context.Context, cfg CreateSubnetGroupConfig) (*SubnetGroup, error)
+	DescribeSubnetGroups(ctx context.Context, names []string) ([]SubnetGroup, error)
+	UpdateSubnetGroup(ctx context.Context, cfg UpdateSubnetGroupConfig) (*SubnetGroup, error)
+	DeleteSubnetGroup(ctx context.Context, name string) (*SubnetGroup, error)
+
+	// Snapshots
+	CreateSnapshot(ctx context.Context, cfg CreateSnapshotConfig) (*Snapshot, error)
+	DescribeSnapshots(ctx context.Context, names []string, clusterName string) ([]Snapshot, error)
+	CopySnapshot(ctx context.Context, cfg CopySnapshotConfig) (*Snapshot, error)
+	DeleteSnapshot(ctx context.Context, name string) (*Snapshot, error)
+
+	// Tags (resource addressed by ARN)
+	TagResource(ctx context.Context, arn string, tags map[string]string) ([]Tag, error)
+	UntagResource(ctx context.Context, arn string, keys []string) ([]Tag, error)
+	ListTags(ctx context.Context, arn string) ([]Tag, error)
+
+	// Catalogs
+	DescribeEngineVersions(ctx context.Context, engine, version string) ([]EngineVersionInfo, error)
+	DescribeEvents(ctx context.Context) ([]Event, error)
+}
+
+// Tag is a resource tag.
+type Tag struct {
+	Key   string
+	Value string
+}
+
+// MultiRegionCluster is a cross-region cluster grouping regional clusters.
+type MultiRegionCluster struct {
+	Name                          string
+	ARN                           string
+	Status                        string
+	NodeType                      string
+	Engine                        string
+	EngineVersion                 string
+	NumberOfShards                int
+	TLSEnabled                    bool
+	MultiRegionParameterGroupName string
+	Members                       []RegionalCluster
+	Tags                          map[string]string
+}
+
+// RegionalCluster is one region's membership in a multi-region cluster.
+type RegionalCluster struct {
+	ClusterName string
+	Region      string
+	Status      string
+	ARN         string
+}
+
+// MultiRegionParameterGroup is a parameter group for multi-region clusters.
+type MultiRegionParameterGroup struct {
+	Name        string
+	ARN         string
+	Family      string
+	Description string
+}
+
+// CreateMultiRegionClusterConfig configures a multi-region cluster.
+type CreateMultiRegionClusterConfig struct {
+	NameSuffix                    string
+	Description                   string
+	NodeType                      string
+	Engine                        string
+	EngineVersion                 string
+	NumShards                     int
+	TLSEnabled                    bool
+	MultiRegionParameterGroupName string
+	Tags                          map[string]string
+}
+
+// MultiRegion is an OPTIONAL capability (cross-region clusters), discovered by
+// type assertion.
+type MultiRegion interface {
+	CreateMultiRegionCluster(ctx context.Context, cfg CreateMultiRegionClusterConfig) (*MultiRegionCluster, error)
+	DescribeMultiRegionClusters(ctx context.Context, names []string) ([]MultiRegionCluster, error)
+	UpdateMultiRegionCluster(ctx context.Context, name, nodeType, engineVersion string, shardCount *int) (*MultiRegionCluster, error)
+	DeleteMultiRegionCluster(ctx context.Context, name string) (*MultiRegionCluster, error)
+	ListAllowedMultiRegionClusterUpdates(ctx context.Context, name string) (nodeTypes []string, err error)
+	DescribeMultiRegionParameterGroups(ctx context.Context, names []string) ([]MultiRegionParameterGroup, error)
+	DescribeMultiRegionParameters(ctx context.Context, groupName string) ([]Parameter, error)
+}
+
+// ReservedNode is a purchased reserved node.
+type ReservedNode struct {
+	ReservationID           string
+	OfferingID              string
+	NodeType                string
+	NodeCount               int
+	Duration                int
+	FixedPrice              float64
+	OfferingType            string
+	State                   string
+	StartTime               time.Time
+	ReservedNodesOfferingID string
+}
+
+// ReservedNodesOffering is a purchasable reserved-node offering.
+type ReservedNodesOffering struct {
+	OfferingID   string
+	NodeType     string
+	Duration     int
+	FixedPrice   float64
+	OfferingType string
+}
+
+// ReservedNodes is an OPTIONAL capability (billing), discovered by type
+// assertion.
+type ReservedNodes interface {
+	DescribeReservedNodes(ctx context.Context) ([]ReservedNode, error)
+	DescribeReservedNodesOfferings(ctx context.Context) ([]ReservedNodesOffering, error)
+	PurchaseReservedNodesOffering(ctx context.Context, offeringID, reservationID string, nodeCount int) (*ReservedNode, error)
+}

--- a/services/memorydb/driver/driver.go
+++ b/services/memorydb/driver/driver.go
@@ -249,8 +249,10 @@ type ClusterConfiguration struct {
 	SnapshotWindow         string
 	TopicARN               string
 	NumShards              int
+	ReplicasPerShard       int
 	Port                   int
 	SnapshotRetentionLimit int
+	TLSEnabled             bool
 }
 
 // Snapshot is a point-in-time copy of a cluster.
@@ -443,4 +445,33 @@ type ReservedNodes interface {
 	DescribeReservedNodes(ctx context.Context) ([]ReservedNode, error)
 	DescribeReservedNodesOfferings(ctx context.Context) ([]ReservedNodesOffering, error)
 	PurchaseReservedNodesOffering(ctx context.Context, offeringID, reservationID string, nodeCount int) (*ReservedNode, error)
+}
+
+// ServiceUpdate is a maintenance/security update available for clusters.
+type ServiceUpdate struct {
+	ClusterName         string
+	ServiceUpdateName   string
+	ReleaseDate         time.Time
+	Description         string
+	Status              string
+	Type                string
+	Engine              string
+	NodesUpdated        string
+	AutoUpdateStartDate time.Time
+}
+
+// UnprocessedCluster reports a cluster a batch update could not be applied to.
+type UnprocessedCluster struct {
+	ClusterName  string
+	ErrorType    string
+	ErrorMessage string
+}
+
+// ServiceUpdates is an OPTIONAL capability (fleet maintenance), discovered by
+// type assertion.
+type ServiceUpdates interface {
+	DescribeServiceUpdates(ctx context.Context, serviceUpdateName string, clusterNames, status []string) ([]ServiceUpdate, error)
+	BatchUpdateCluster(
+		ctx context.Context, clusterNames []string, serviceUpdateName string,
+	) (processed []Cluster, unprocessed []UnprocessedCluster, err error)
 }


### PR DESCRIPTION
## Objective

Add full-parity support for **AWS MemoryDB for Redis/Valkey** — the next missing managed database-server surface after AlloyDB (#304). Covers every control-plane resource, connection, child resource, metric, cost dimension, pagination, and fleet-maintenance operation, so a real `aws-sdk-go-v2/service/memorydb` client works unchanged against a custom endpoint.

## What we found

- MemoryDB is a **control-plane-only** service (durable Redis/Valkey clusters, no `Set`/`Get` data plane), so it does **not** fit `services/cache/driver`. It gets its own driver.
- Broad resource graph: clusters (shards → nodes → endpoints), ACLs & users, parameter groups, subnet groups, snapshots, tags, engine-version/event catalogs, multi-region clusters, reserved nodes, and service updates.

## How we fixed it

- **Driver** (`services/memorydb/driver`): 33 core operations + three type-asserted optional capabilities — `MultiRegion` (7), `ReservedNodes` (3), `ServiceUpdates` (2).
- **Provider** (`providers/aws/memorydb`): in-memory `Mock` with shard/node/endpoint topology, reference validation, restore-from-snapshot (full shape incl. replicas/subnet/param/TLS), shard failover, multi-region parent linkage (members registered on create, guarded on delete), CloudWatch metrics, and clone-on-read on every return path.
- **Server** (`server/aws/memorydb`): AWS JSON 1.1 handler on the `AmazonMemoryDB.` target prefix; canonical errors map to typed faults; **pagination** (`MaxResults`/`NextToken`) on every `Describe*` op via an opaque base64 offset token over the deterministic result set.
- **Wiring**: registered in the AWS provider/server bundles; dedicated `memorydb:*` cost keys; `docs/services.md` section + counts.

## Review round (thanks @NitinKumar004)

Medium: multi-region parent linkage now live; reserved-node duplicate purchase → `ReservedNodeAlreadyExistsFault`.
Low: restore preserves replica count (+subnet/param/TLS); `UpdateCluster` dangling refs → `InvalidArgument`; `FailoverShard` checks the requested shard; `DeleteCluster` rejects a duplicate final snapshot; `CreateACL` de-dupes users; MR param-group noun fixed; `ListTags` deterministic; doc typos fixed.
Extras (opted in): **pagination** across all `Describe*` ops; **service updates** (`DescribeServiceUpdates` + `BatchUpdateCluster` with partial-success `UnprocessedClusters`).

## Alternatives not taken

- **Reusing the cache driver**: rejected — MemoryDB has no data plane.
- **Emitting nullable timestamps** (node `CreateTime`, reserved-node `StartTime`, event `Date`, service-update dates): AWS JSON 1.1 encodes timestamps as epoch numbers, which `encoding/json` can't produce for a `time.Time`; those nullable fields are omitted so SDK deserialization stays clean. All other fields round-trip through the real SDK.
- **Driver-level pagination**: rejected in favor of server-side paging over the deterministic result set — keeps the driver interface clean and the token stable.

## Docs / Test / Playground

- `docs/services.md`: MemoryDB section (per-resource tables incl. Service Updates + a pagination note) + recomputed totals (Grand Total 1310, +137 optional).
- Tests: provider unit tests (topology, ref validation, failover, ACL/user linkage + dedupe, param/subnet groups, snapshot/restore incl. replica/TLS fidelity, multi-region parent linkage, reserved nodes, service updates, clone-on-read aliasing, metrics, tags/catalogs) + server SDK round-trip tests via the real client (clusters, ACLs/users, param/subnet groups, snapshots, multi-region, reserved nodes, **pagination**, **service updates**, typed wire-error assertions incl. `ReservedNodeAlreadyExistsFault`). Cost rate-catalog test.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (full module, green)
- [x] `golangci-lint` — 0 issues on all new/changed packages
- [x] CodeQL (security-extended) — 0 findings in-package
- [x] `go mod tidy` clean
- [x] Coverage: provider 75.5%, server 71.3%

## Risk & Rollback

Additive: new driver capability + provider/server packages plus opt-in bundle registration (nil driver ⇒ handler not registered). Behavioral changes are limited to more-accurate error codes (dangling refs → InvalidArgument; duplicate final snapshot rejected). Rollback = revert the branch.

## Conclusion

MemoryDB reaches full parity — core control plane, multi-region, reserved nodes, service updates, and pagination — with the established driver→provider→server layering. Follow-ups (separate PRs, tracked in the missing-database-server initiative): AWS Timestream & Keyspaces, GCP Spanner & Bigtable, Azure Managed Cassandra.