### PR TITLE
Add AWS Keyspaces (Cassandra) Full-Parity Support

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -1010,6 +1010,83 @@ base64 offset token; a malformed token yields `InvalidParameterValueException`.
 
 ---
 
+## 11b. Keyspaces (AWS)
+
+**Driver interface:** `services/keyspaces/driver/driver.go`
+**AWS:** Amazon Keyspaces (for Apache Cassandra) | **Azure:** — | **GCP:** —
+
+A managed, Cassandra-compatible wide-column service. Control-plane only (CQL
+data operations are out of scope), so it has its own driver rather than reusing
+the relational/cache drivers. Served as AWS JSON 1.0 on the `KeyspacesService.`
+target prefix (`server/aws/keyspaces`); a real
+`aws-sdk-go-v2/service/keyspaces` client with a custom endpoint works unchanged.
+Because Keyspaces models its members in lowerCamelCase, the server lowercases
+response keys so the SDK's case-sensitive deserializer decodes them.
+
+### Keyspaces
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateKeyspace` | `(ctx, CreateKeyspaceConfig) (*Keyspace, error)` |
+| `GetKeyspace` | `(ctx, name) (*Keyspace, error)` |
+| `ListKeyspaces` | `(ctx) ([]Keyspace, error)` |
+| `UpdateKeyspace` | `(ctx, name, addRegions) (*Keyspace, error)` |
+| `DeleteKeyspace` | `(ctx, name) error` |
+
+Single- or multi-region replication (`ReplicationSpecification`); a keyspace
+must be empty to delete.
+
+### Tables
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateTable` | `(ctx, CreateTableConfig) (*Table, error)` |
+| `GetTable` | `(ctx, keyspace, table) (*Table, error)` |
+| `ListTables` | `(ctx, keyspace) ([]Table, error)` |
+| `UpdateTable` | `(ctx, UpdateTableConfig) (*Table, error)` |
+| `DeleteTable` | `(ctx, keyspace, table) error` |
+| `RestoreTable` | `(ctx, RestoreTableConfig) (*Table, error)` |
+
+Full `SchemaDefinition` (partition/clustering keys, static & regular columns),
+`CapacitySpecification` (PAY_PER_REQUEST / PROVISIONED + RCU/WCU), encryption,
+point-in-time recovery, TTL, client-side timestamps, CDC, comment, and
+multi-region replica specs. `RestoreTable` is point-in-time recovery into a new
+table.
+
+### User-Defined Types
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateType` | `(ctx, keyspace, name, fields) (*UDT, error)` |
+| `GetType` | `(ctx, keyspace, name) (*UDT, error)` |
+| `ListTypes` | `(ctx, keyspace) ([]UDT, error)` |
+| `DeleteType` | `(ctx, keyspace, name) (*UDT, error)` |
+
+### Tags
+
+| Operation | Signature |
+|-----------|-----------|
+| `TagResource` | `(ctx, arn, tags) error` |
+| `UntagResource` | `(ctx, arn, keys) error` |
+| `ListTagsForResource` | `(ctx, arn) ([]Tag, error)` |
+
+### Auto Scaling (optional capability — `AutoScaling`)
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetTableAutoScalingSettings` | `(ctx, keyspace, table) (*Table, error)` |
+
+Target-tracking auto scaling for PROVISIONED tables, discovered by type
+assertion; errors for PAY_PER_REQUEST tables (matching AWS).
+
+**Pagination:** `ListKeyspaces`/`ListTables`/`ListTypes`/`ListTagsForResource`
+honor `MaxResults`/`NextToken` (server-side opaque base64 offset token over the
+deterministic result set; a malformed token yields `ValidationException`).
+
+**Total: 18 operations (+1 optional)**
+
+---
+
 ## 12. Secrets
 
 **Driver interface:** `services/secrets/driver/driver.go`
@@ -1984,6 +2061,7 @@ still sees success.
 | Message Queue | 14 |
 | Cache | 16 (+7 optional) |
 | MemoryDB — AWS (Redis/Valkey control plane) | 33 (+13 optional) |
+| Keyspaces — AWS (Cassandra control plane) | 18 (+1 optional) |
 | Secrets | 7 |
 | Logging | 13 |
 | Notification | 8 |
@@ -2003,7 +2081,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1310** (+137 optional) |
+| **Grand Total** | **1328** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
+	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.28.2
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.32 h1:dWFHhQpb
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.32/go.mod h1:oN4Iix8rAbyTx6tFMP9mS8RFLJnDeZSbSsHwXYSs3tE=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21 h1:ZlvrNcHSFFWURB8avufQq9gFsheUgjVD9536obIknfM=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.21/go.mod h1:cv3TNhVrssKR0O/xxLJVRfd2oazSnZnkUeTf6ctUwfQ=
+github.com/aws/aws-sdk-go-v2/service/keyspaces v1.28.2 h1:8mC/rZ/5fgG+Uh1jm5TbinGAxys98+g1F94ROXiWkuI=
+github.com/aws/aws-sdk-go-v2/service/keyspaces v1.28.2/go.mod h1:oQzLKUVgisO2sgRlgbQ+mrWflb7wkYmVjZojITjQn1E=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2 h1:GKkUvwhxKF5JVSWERui4bvPNKEv7BQe3+i7h5v8klpQ=

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/elasticache"
 	"github.com/stackshy/cloudemu/v2/providers/aws/elb"
 	"github.com/stackshy/cloudemu/v2/providers/aws/eventbridge"
+	"github.com/stackshy/cloudemu/v2/providers/aws/keyspaces"
 	"github.com/stackshy/cloudemu/v2/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/v2/providers/aws/memorydb"
 	"github.com/stackshy/cloudemu/v2/providers/aws/rds"
@@ -125,6 +126,7 @@ type Provider struct {
 	ELB                 *elb.Mock
 	SQS                 *sqs.Mock
 	ElastiCache         *elasticache.Mock
+	Keyspaces           *keyspaces.Mock
 	MemoryDB            *memorydb.Mock
 	SecretsManager      *secretsmanager.Mock
 	CloudWatchLogs      *cloudwatchlogs.Mock
@@ -160,6 +162,7 @@ func New(opts ...config.Option) *Provider {
 		ELB:                 elb.New(o),
 		SQS:                 sqs.New(o),
 		ElastiCache:         elasticache.New(o),
+		Keyspaces:           keyspaces.New(o),
 		MemoryDB:            memorydb.New(o),
 		SecretsManager:      secretsmanager.New(o),
 		CloudWatchLogs:      cloudwatchlogs.New(o),

--- a/providers/aws/keyspaces/autoscaling.go
+++ b/providers/aws/keyspaces/autoscaling.go
@@ -1,0 +1,31 @@
+package keyspaces
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+// GetTableAutoScalingSettings returns the table with its stored auto-scaling
+// specification. It errors if the table is not in provisioned throughput mode
+// (auto scaling applies only to PROVISIONED tables), matching AWS.
+func (m *Mock) GetTableAutoScalingSettings(_ context.Context, keyspace, table string) (*ksdriver.Table, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	t, err := m.getTableLocked(keyspace, table)
+	if err != nil {
+		return nil, err
+	}
+
+	if t.CapacitySpecification.ThroughputMode != ksdriver.ThroughputProvisioned {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"auto scaling settings are only available for PROVISIONED tables; %q is %s",
+			table, t.CapacitySpecification.ThroughputMode)
+	}
+
+	out := cloneTable(&t)
+
+	return &out, nil
+}

--- a/providers/aws/keyspaces/keyspaces.go
+++ b/providers/aws/keyspaces/keyspaces.go
@@ -114,9 +114,15 @@ func (m *Mock) CreateKeyspace(_ context.Context, cfg ksdriver.CreateKeyspaceConf
 		strategy = ksdriver.SingleRegion
 	}
 
+	if strategy != ksdriver.SingleRegion && strategy != ksdriver.MultiRegion {
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"replicationStrategy %q must be SINGLE_REGION or MULTI_REGION", strategy)
+	}
+
 	const minMultiRegionRegions = 2
 
-	regions := cfg.ReplicationRegions
+	// Clone the caller's slice so a later mutation can't reach into the store.
+	regions := append([]string(nil), cfg.ReplicationRegions...)
 	if strategy == ksdriver.SingleRegion {
 		regions = []string{m.opts.Region}
 	} else if len(regions) < minMultiRegionRegions {
@@ -132,7 +138,7 @@ func (m *Mock) CreateKeyspace(_ context.Context, cfg ksdriver.CreateKeyspaceConf
 
 	ks := ksdriver.Keyspace{
 		Name: cfg.Name, ARN: m.keyspaceARN(cfg.Name),
-		ReplicationStrategy: strategy, ReplicationRegions: regions, Tags: copyTags(cfg.Tags),
+		ReplicationStrategy: strategy, ReplicationRegions: regions,
 	}
 	m.keyspaces.Set(cfg.Name, ks)
 	m.setTags(ks.ARN, cfg.Tags)
@@ -209,8 +215,16 @@ func (m *Mock) DeleteKeyspace(_ context.Context, name string) error {
 		return cerrors.Newf(cerrors.NotFound, "keyspace %q not found", name)
 	}
 
+	if isSystemKeyspace(name) {
+		return cerrors.Newf(cerrors.InvalidArgument, "system keyspace %q cannot be deleted", name)
+	}
+
 	if m.keyspaceHasTables(name) {
 		return cerrors.Newf(cerrors.FailedPrecondition, "keyspace %q still contains tables", name)
+	}
+
+	if m.keyspaceHasTypes(name) {
+		return cerrors.Newf(cerrors.FailedPrecondition, "keyspace %q still contains user-defined types", name)
 	}
 
 	m.keyspaces.Delete(name)
@@ -219,9 +233,25 @@ func (m *Mock) DeleteKeyspace(_ context.Context, name string) error {
 	return nil
 }
 
+func isSystemKeyspace(name string) bool {
+	switch name {
+	case "system", "system_schema", "system_multiregion_info":
+		return true
+	default:
+		return false
+	}
+}
+
 func (m *Mock) keyspaceHasTables(keyspace string) bool {
-	prefix := keyspace + "/"
-	for _, k := range m.tables.Keys() {
+	return hasPrefixKey(m.tables.Keys(), keyspace+"/")
+}
+
+func (m *Mock) keyspaceHasTypes(keyspace string) bool {
+	return hasPrefixKey(m.udts.Keys(), keyspace+"/")
+}
+
+func hasPrefixKey(keys []string, prefix string) bool {
+	for _, k := range keys {
 		if strings.HasPrefix(k, prefix) {
 			return true
 		}

--- a/providers/aws/keyspaces/keyspaces.go
+++ b/providers/aws/keyspaces/keyspaces.go
@@ -1,0 +1,241 @@
+// Package keyspaces provides an in-memory mock of Amazon Keyspaces, the managed
+// Apache Cassandra–compatible service. Keyspaces is control-plane only here, so
+// this mock models keyspaces, tables (schema/capacity/encryption/PITR/TTL),
+// user-defined types, tags, and provisioned auto-scaling settings.
+package keyspaces
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+var (
+	_ ksdriver.Keyspaces   = (*Mock)(nil)
+	_ ksdriver.AutoScaling = (*Mock)(nil)
+)
+
+// Mock is the in-memory Amazon Keyspaces implementation.
+type Mock struct {
+	mu sync.RWMutex
+
+	keyspaces *memstore.Store[ksdriver.Keyspace]
+	tables    *memstore.Store[ksdriver.Table] // keyed by "keyspace/table"
+	udts      *memstore.Store[ksdriver.UDT]   // keyed by "keyspace/typename"
+
+	// tags holds tag maps keyed by resource ARN.
+	tags map[string]map[string]string
+
+	opts *config.Options
+}
+
+// New creates a new Keyspaces mock with the account-default "system" keyspaces
+// that real Amazon Keyspaces provisions.
+func New(opts *config.Options) *Mock {
+	m := &Mock{
+		keyspaces: memstore.New[ksdriver.Keyspace](),
+		tables:    memstore.New[ksdriver.Table](),
+		udts:      memstore.New[ksdriver.UDT](),
+		tags:      make(map[string]map[string]string),
+		opts:      opts,
+	}
+
+	for _, sys := range []string{"system", "system_schema", "system_multiregion_info"} {
+		m.keyspaces.Set(sys, ksdriver.Keyspace{
+			Name: sys, ARN: m.keyspaceARN(sys), ReplicationStrategy: ksdriver.SingleRegion,
+			ReplicationRegions: []string{opts.Region},
+		})
+	}
+
+	return m
+}
+
+func (m *Mock) keyspaceARN(name string) string {
+	return fmt.Sprintf("arn:aws:cassandra:%s:%s:/keyspace/%s/", m.opts.Region, m.opts.AccountID, name)
+}
+
+func (m *Mock) tableARN(keyspace, table string) string {
+	return fmt.Sprintf("arn:aws:cassandra:%s:%s:/keyspace/%s/table/%s/", m.opts.Region, m.opts.AccountID, keyspace, table)
+}
+
+func tableKey(keyspace, table string) string { return keyspace + "/" + table }
+
+func typeKey(keyspace, name string) string { return keyspace + "/" + name }
+
+func validName(kind, name string) error {
+	if name == "" {
+		return cerrors.Newf(cerrors.InvalidArgument, "%s name is required", kind)
+	}
+
+	if strings.Contains(name, "/") {
+		return cerrors.Newf(cerrors.InvalidArgument, "%s name %q must not contain '/'", kind, name)
+	}
+
+	return nil
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func cloneKeyspace(in *ksdriver.Keyspace) ksdriver.Keyspace {
+	k := *in
+	k.ReplicationRegions = append([]string(nil), k.ReplicationRegions...)
+	k.Tags = copyTags(k.Tags)
+
+	return k
+}
+
+// ---- Keyspaces ----
+
+// CreateKeyspace creates a keyspace with single- or multi-region replication.
+func (m *Mock) CreateKeyspace(_ context.Context, cfg ksdriver.CreateKeyspaceConfig) (*ksdriver.Keyspace, error) {
+	if err := validName("keyspace", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	strategy := cfg.ReplicationStrategy
+	if strategy == "" {
+		strategy = ksdriver.SingleRegion
+	}
+
+	const minMultiRegionRegions = 2
+
+	regions := cfg.ReplicationRegions
+	if strategy == ksdriver.SingleRegion {
+		regions = []string{m.opts.Region}
+	} else if len(regions) < minMultiRegionRegions {
+		return nil, cerrors.New(cerrors.InvalidArgument, "MULTI_REGION replication requires at least two regions")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.keyspaces.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "keyspace %q already exists", cfg.Name)
+	}
+
+	ks := ksdriver.Keyspace{
+		Name: cfg.Name, ARN: m.keyspaceARN(cfg.Name),
+		ReplicationStrategy: strategy, ReplicationRegions: regions, Tags: copyTags(cfg.Tags),
+	}
+	m.keyspaces.Set(cfg.Name, ks)
+	m.setTags(ks.ARN, cfg.Tags)
+
+	out := cloneKeyspace(&ks)
+
+	return &out, nil
+}
+
+// GetKeyspace returns a keyspace by name.
+func (m *Mock) GetKeyspace(_ context.Context, name string) (*ksdriver.Keyspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ks, ok := m.keyspaces.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "keyspace %q not found", name)
+	}
+
+	out := cloneKeyspace(&ks)
+
+	return &out, nil
+}
+
+// ListKeyspaces returns all keyspaces in deterministic order.
+func (m *Mock) ListKeyspaces(_ context.Context) ([]ksdriver.Keyspace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.keyspaces.SortedValues()
+	out := make([]ksdriver.Keyspace, 0, len(all))
+
+	for i := range all {
+		out = append(out, cloneKeyspace(&all[i]))
+	}
+
+	return out, nil
+}
+
+// UpdateKeyspace adds regions to a keyspace's replication (single→multi).
+func (m *Mock) UpdateKeyspace(_ context.Context, name string, addRegions []string) (*ksdriver.Keyspace, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ks, ok := m.keyspaces.Get(name)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "keyspace %q not found", name)
+	}
+
+	for _, r := range addRegions {
+		if !containsStr(ks.ReplicationRegions, r) {
+			ks.ReplicationRegions = append(ks.ReplicationRegions, r)
+		}
+	}
+
+	if len(ks.ReplicationRegions) > 1 {
+		ks.ReplicationStrategy = ksdriver.MultiRegion
+	}
+
+	m.keyspaces.Set(name, ks)
+
+	out := cloneKeyspace(&ks)
+
+	return &out, nil
+}
+
+// DeleteKeyspace removes a keyspace; it must contain no tables.
+func (m *Mock) DeleteKeyspace(_ context.Context, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ks, ok := m.keyspaces.Get(name)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "keyspace %q not found", name)
+	}
+
+	if m.keyspaceHasTables(name) {
+		return cerrors.Newf(cerrors.FailedPrecondition, "keyspace %q still contains tables", name)
+	}
+
+	m.keyspaces.Delete(name)
+	delete(m.tags, ks.ARN)
+
+	return nil
+}
+
+func (m *Mock) keyspaceHasTables(keyspace string) bool {
+	prefix := keyspace + "/"
+	for _, k := range m.tables.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsStr(items []string, s string) bool {
+	for _, v := range items {
+		if v == s {
+			return true
+		}
+	}
+
+	return false
+}

--- a/providers/aws/keyspaces/keyspaces_test.go
+++ b/providers/aws/keyspaces/keyspaces_test.go
@@ -301,6 +301,138 @@ func TestAutoScalingRequiresProvisioned(t *testing.T) {
 	}
 }
 
+func TestUDTInUseGuard(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateType(ctx, "app", "address", []ksdriver.FieldDefinition{{Name: "street", Type: "text"}}); err != nil {
+		t.Fatalf("CreateType: %v", err)
+	}
+
+	// A table with a frozen<address> column registers a reference.
+	schema := sampleSchema()
+	schema.AllColumns = append(schema.AllColumns, ksdriver.ColumnDefinition{Name: "addr", Type: "frozen<address>"})
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{KeyspaceName: "app", Name: "people", SchemaDefinition: schema}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	// DeleteType is now blocked (guard is live).
+	if _, err := m.DeleteType(ctx, "app", "address"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete in-use type: got %v, want FailedPrecondition", err)
+	}
+
+	// Dropping the referring table unblocks the delete.
+	if err := m.DeleteTable(ctx, "app", "people"); err != nil {
+		t.Fatalf("DeleteTable: %v", err)
+	}
+
+	if _, err := m.DeleteType(ctx, "app", "address"); err != nil {
+		t.Fatalf("delete type after table gone: %v", err)
+	}
+}
+
+func TestSchemaRejectsUndeclaredStaticColumn(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	schema := sampleSchema()
+	schema.StaticColumns = []ksdriver.StaticColumn{{Name: "undeclared"}}
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{KeyspaceName: "app", Name: "t", SchemaDefinition: schema}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("undeclared static column: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestDeleteKeyspaceGuardsTypesAndSystem(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateType(ctx, "app", "address", []ksdriver.FieldDefinition{{Name: "s", Type: "text"}}); err != nil {
+		t.Fatalf("CreateType: %v", err)
+	}
+
+	if err := m.DeleteKeyspace(ctx, "app"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete keyspace with types: got %v, want FailedPrecondition", err)
+	}
+
+	// System keyspaces cannot be deleted.
+	if err := m.DeleteKeyspace(ctx, "system"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("delete system keyspace: got %v, want InvalidArgument", err)
+	}
+
+	// GetType on a missing keyspace is NotFound (not an orphan lookup).
+	if _, err := m.GetType(ctx, "ghost", "address"); !cerrors.IsNotFound(err) {
+		t.Fatalf("GetType missing keyspace: got %v, want NotFound", err)
+	}
+}
+
+func TestCreateKeyspaceClonesRegions(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	regions := []string{"us-east-1", "us-west-2"}
+	if _, err := m.CreateKeyspace(ctx, ksdriver.CreateKeyspaceConfig{
+		Name: "mr", ReplicationStrategy: ksdriver.MultiRegion, ReplicationRegions: regions,
+	}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	regions[0] = "MUTATED" // must not reach the store
+
+	got, _ := m.GetKeyspace(ctx, "mr")
+	if got.ReplicationRegions[0] != "us-east-1" {
+		t.Fatalf("stored keyspace aliases caller slice: %v", got.ReplicationRegions)
+	}
+}
+
+func TestCreateKeyspaceRejectsBadStrategy(t *testing.T) {
+	m := newTestMock()
+
+	if _, err := m.CreateKeyspace(context.Background(), ksdriver.CreateKeyspaceConfig{
+		Name: "bad", ReplicationStrategy: "GARBAGE",
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("bad strategy: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestUpdateTableRejectsDuplicateColumn(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{KeyspaceName: "app", Name: "t", SchemaDefinition: sampleSchema()}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	// "val" already exists in sampleSchema.
+	if _, err := m.UpdateTable(ctx, ksdriver.UpdateTableConfig{
+		KeyspaceName: "app", Name: "t", AddColumns: []ksdriver.ColumnDefinition{{Name: "val", Type: "text"}},
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("duplicate column: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestRestoreTableRejectsFutureTimestamp(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{KeyspaceName: "app", Name: "src", SchemaDefinition: sampleSchema()}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	future := m.opts.Clock.Now().Add(24 * time.Hour)
+	if _, err := m.RestoreTable(ctx, ksdriver.RestoreTableConfig{
+		SourceKeyspace: "app", SourceTable: "src", TargetKeyspace: "app", TargetTable: "dst", RestoreTimestamp: future,
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("future restore timestamp: got %v, want InvalidArgument", err)
+	}
+}
+
 func TestTableResultDoesNotAliasStore(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()

--- a/providers/aws/keyspaces/keyspaces_test.go
+++ b/providers/aws/keyspaces/keyspaces_test.go
@@ -1,0 +1,322 @@
+package keyspaces
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+
+	return New(opts)
+}
+
+func mustKeyspace(t *testing.T, m *Mock, name string) {
+	t.Helper()
+
+	if _, err := m.CreateKeyspace(context.Background(), ksdriver.CreateKeyspaceConfig{Name: name}); err != nil {
+		t.Fatalf("CreateKeyspace %s: %v", name, err)
+	}
+}
+
+func sampleSchema() ksdriver.SchemaDefinition {
+	return ksdriver.SchemaDefinition{
+		AllColumns: []ksdriver.ColumnDefinition{
+			{Name: "id", Type: "uuid"}, {Name: "ts", Type: "timestamp"}, {Name: "val", Type: "text"},
+		},
+		PartitionKeys:  []ksdriver.PartitionKey{{Name: "id"}},
+		ClusteringKeys: []ksdriver.ClusteringKey{{Name: "ts", OrderBy: "DESC"}},
+	}
+}
+
+func TestKeyspaceLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	ks, err := m.CreateKeyspace(ctx, ksdriver.CreateKeyspaceConfig{Name: "app"})
+	if err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	if ks.ReplicationStrategy != ksdriver.SingleRegion || len(ks.ReplicationRegions) != 1 {
+		t.Fatalf("default replication wrong: %+v", ks)
+	}
+
+	// Duplicate rejected.
+	if _, err := m.CreateKeyspace(ctx, ksdriver.CreateKeyspaceConfig{Name: "app"}); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate keyspace: got %v, want AlreadyExists", err)
+	}
+
+	// Update to multi-region.
+	upd, err := m.UpdateKeyspace(ctx, "app", []string{"us-west-2"})
+	if err != nil {
+		t.Fatalf("UpdateKeyspace: %v", err)
+	}
+
+	if upd.ReplicationStrategy != ksdriver.MultiRegion || len(upd.ReplicationRegions) != 2 {
+		t.Fatalf("update to multi-region failed: %+v", upd)
+	}
+
+	// List includes the three system keyspaces + app.
+	list, err := m.ListKeyspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListKeyspaces: %v", err)
+	}
+
+	if len(list) != 4 {
+		t.Fatalf("expected 4 keyspaces, got %d", len(list))
+	}
+}
+
+func TestKeyspaceMultiRegionRequiresTwoRegions(t *testing.T) {
+	m := newTestMock()
+
+	_, err := m.CreateKeyspace(context.Background(), ksdriver.CreateKeyspaceConfig{
+		Name: "mr", ReplicationStrategy: ksdriver.MultiRegion, ReplicationRegions: []string{"us-east-1"},
+	})
+	if !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("multi-region with one region: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestDeleteKeyspaceBlockedWithTables(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "t1", SchemaDefinition: sampleSchema(),
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	if err := m.DeleteKeyspace(ctx, "app"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete non-empty keyspace: got %v, want FailedPrecondition", err)
+	}
+
+	if err := m.DeleteTable(ctx, "app", "t1"); err != nil {
+		t.Fatalf("DeleteTable: %v", err)
+	}
+
+	if err := m.DeleteKeyspace(ctx, "app"); err != nil {
+		t.Fatalf("delete empty keyspace: %v", err)
+	}
+}
+
+func TestTableLifecycleAndValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	// Missing keyspace rejected.
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "ghost", Name: "t", SchemaDefinition: sampleSchema(),
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("table in missing keyspace: got %v, want InvalidArgument", err)
+	}
+
+	// No partition key rejected.
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "bad",
+		SchemaDefinition: ksdriver.SchemaDefinition{AllColumns: []ksdriver.ColumnDefinition{{Name: "id", Type: "uuid"}}},
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("no partition key: got %v, want InvalidArgument", err)
+	}
+
+	// Undeclared partition key rejected.
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "bad2",
+		SchemaDefinition: ksdriver.SchemaDefinition{PartitionKeys: []ksdriver.PartitionKey{{Name: "missing"}}},
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("undeclared partition key: got %v, want InvalidArgument", err)
+	}
+
+	tbl, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "t1", SchemaDefinition: sampleSchema(),
+	})
+	if err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	// Default capacity mode is PAY_PER_REQUEST; PITR/TTL default DISABLED.
+	if tbl.CapacitySpecification.ThroughputMode != ksdriver.ThroughputPayPerRequest {
+		t.Fatalf("default throughput mode: %+v", tbl.CapacitySpecification)
+	}
+
+	if tbl.EncryptionSpecification.Type != "AWS_OWNED_KMS_KEY" {
+		t.Fatalf("default encryption: %+v", tbl.EncryptionSpecification)
+	}
+
+	// Update: add a column, enable PITR, switch to provisioned.
+	ttl := 3600
+	upd, err := m.UpdateTable(ctx, ksdriver.UpdateTableConfig{
+		KeyspaceName: "app", Name: "t1",
+		AddColumns:            []ksdriver.ColumnDefinition{{Name: "extra", Type: "int"}},
+		PointInTimeRecovery:   "ENABLED",
+		DefaultTimeToLive:     &ttl,
+		CapacitySpecification: &ksdriver.CapacitySpecification{ThroughputMode: ksdriver.ThroughputProvisioned},
+	})
+	if err != nil {
+		t.Fatalf("UpdateTable: %v", err)
+	}
+
+	if len(upd.SchemaDefinition.AllColumns) != 4 || upd.PointInTimeRecoveryStatus != "ENABLED" || upd.DefaultTimeToLive != 3600 {
+		t.Fatalf("update not applied: %+v", upd)
+	}
+
+	if upd.CapacitySpecification.ReadCapacityUnits != 1 || upd.CapacitySpecification.WriteCapacityUnits != 1 {
+		t.Fatalf("provisioned defaults not set: %+v", upd.CapacitySpecification)
+	}
+}
+
+func TestRestoreTable(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "src", SchemaDefinition: sampleSchema(), Comment: "original",
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	restored, err := m.RestoreTable(ctx, ksdriver.RestoreTableConfig{
+		SourceKeyspace: "app", SourceTable: "src", TargetKeyspace: "app", TargetTable: "dst",
+		RestoreTimestamp: m.opts.Clock.Now(),
+	})
+	if err != nil {
+		t.Fatalf("RestoreTable: %v", err)
+	}
+
+	if restored.Name != "dst" || restored.Comment != "original" || len(restored.SchemaDefinition.PartitionKeys) != 1 {
+		t.Fatalf("restore lost shape: %+v", restored)
+	}
+}
+
+func TestUserDefinedTypes(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateType(ctx, "app", "empty", nil); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("type with no fields: got %v, want InvalidArgument", err)
+	}
+
+	u, err := m.CreateType(ctx, "app", "address", []ksdriver.FieldDefinition{
+		{Name: "street", Type: "text"}, {Name: "zip", Type: "int"},
+	})
+	if err != nil {
+		t.Fatalf("CreateType: %v", err)
+	}
+
+	if u.Status != ksdriver.StatusActive || len(u.FieldDefinitions) != 2 {
+		t.Fatalf("type wrong: %+v", u)
+	}
+
+	got, err := m.GetType(ctx, "app", "address")
+	if err != nil || got.Name != "address" {
+		t.Fatalf("GetType: %v %+v", err, got)
+	}
+
+	types, err := m.ListTypes(ctx, "app")
+	if err != nil || len(types) != 1 {
+		t.Fatalf("ListTypes: %v %+v", err, types)
+	}
+
+	if _, err := m.DeleteType(ctx, "app", "address"); err != nil {
+		t.Fatalf("DeleteType: %v", err)
+	}
+}
+
+func TestTagsDeterministic(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	arn := m.keyspaceARN("app")
+	if err := m.TagResource(ctx, arn, map[string]string{"team": "data", "env": "prod"}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	tags, err := m.ListTagsForResource(ctx, arn)
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+
+	// Sorted by key: env, team.
+	if len(tags) != 2 || tags[0].Key != "env" || tags[1].Key != "team" {
+		t.Fatalf("tags not sorted deterministically: %+v", tags)
+	}
+
+	if err := m.UntagResource(ctx, arn, []string{"env"}); err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	tags, _ = m.ListTagsForResource(ctx, arn)
+	if len(tags) != 1 || tags[0].Key != "team" {
+		t.Fatalf("untag failed: %+v", tags)
+	}
+}
+
+func TestAutoScalingRequiresProvisioned(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	// PAY_PER_REQUEST table has no auto scaling.
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "ppr", SchemaDefinition: sampleSchema(),
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	if _, err := m.GetTableAutoScalingSettings(ctx, "app", "ppr"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("autoscaling on PPR table: got %v, want InvalidArgument", err)
+	}
+
+	// PROVISIONED table with auto scaling returns settings.
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "prov", SchemaDefinition: sampleSchema(),
+		CapacitySpecification: ksdriver.CapacitySpecification{ThroughputMode: ksdriver.ThroughputProvisioned},
+		AutoScaling: &ksdriver.AutoScalingSpecification{
+			Read: &ksdriver.AutoScalingSettings{MinimumUnits: 1, MaximumUnits: 10, TargetValue: 70},
+		},
+	}); err != nil {
+		t.Fatalf("CreateTable provisioned: %v", err)
+	}
+
+	as, err := m.GetTableAutoScalingSettings(ctx, "app", "prov")
+	if err != nil {
+		t.Fatalf("GetTableAutoScalingSettings: %v", err)
+	}
+
+	if as.AutoScaling == nil || as.AutoScaling.Read == nil || as.AutoScaling.Read.MaximumUnits != 10 {
+		t.Fatalf("autoscaling settings not returned: %+v", as.AutoScaling)
+	}
+}
+
+func TestTableResultDoesNotAliasStore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustKeyspace(t, m, "app")
+
+	if _, err := m.CreateTable(ctx, ksdriver.CreateTableConfig{
+		KeyspaceName: "app", Name: "t1", SchemaDefinition: sampleSchema(),
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	got, _ := m.GetTable(ctx, "app", "t1")
+	got.SchemaDefinition.AllColumns[0].Name = "MUTATED"
+
+	again, _ := m.GetTable(ctx, "app", "t1")
+	if again.SchemaDefinition.AllColumns[0].Name == "MUTATED" {
+		t.Fatal("returned table aliases the store (clone-on-read broken)")
+	}
+}

--- a/providers/aws/keyspaces/tables.go
+++ b/providers/aws/keyspaces/tables.go
@@ -56,16 +56,35 @@ func disabledIfEmpty(v string) string {
 	return v
 }
 
-// validateSchema requires at least one partition key and rejects clustering/
-// static/partition columns that are not declared in AllColumns.
+// validateSchema requires at least one partition key, rejects empty/duplicate
+// column names, and rejects partition/clustering/static columns not declared in
+// AllColumns.
+func declaredColumns(s *ksdriver.SchemaDefinition) (map[string]struct{}, error) {
+	declared := make(map[string]struct{}, len(s.AllColumns))
+
+	for _, c := range s.AllColumns {
+		if c.Name == "" {
+			return nil, cerrors.New(cerrors.InvalidArgument, "column name must not be empty")
+		}
+
+		if _, dup := declared[c.Name]; dup {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "duplicate column %q in schema", c.Name)
+		}
+
+		declared[c.Name] = struct{}{}
+	}
+
+	return declared, nil
+}
+
 func validateSchema(s *ksdriver.SchemaDefinition) error {
 	if len(s.PartitionKeys) == 0 {
 		return cerrors.New(cerrors.InvalidArgument, "schema requires at least one partition key")
 	}
 
-	declared := make(map[string]struct{}, len(s.AllColumns))
-	for _, c := range s.AllColumns {
-		declared[c.Name] = struct{}{}
+	declared, err := declaredColumns(s)
+	if err != nil {
+		return err
 	}
 
 	for _, pk := range s.PartitionKeys {
@@ -77,6 +96,12 @@ func validateSchema(s *ksdriver.SchemaDefinition) error {
 	for _, ck := range s.ClusteringKeys {
 		if _, ok := declared[ck.Name]; !ok {
 			return cerrors.Newf(cerrors.InvalidArgument, "clustering key %q is not declared in the schema columns", ck.Name)
+		}
+	}
+
+	for _, sc := range s.StaticColumns {
+		if _, ok := declared[sc.Name]; !ok {
+			return cerrors.Newf(cerrors.InvalidArgument, "static column %q is not declared in the schema columns", sc.Name)
 		}
 	}
 
@@ -124,10 +149,10 @@ func (m *Mock) CreateTable(_ context.Context, cfg ksdriver.CreateTableConfig) (*
 		ReplicaRegions:            append([]string(nil), cfg.ReplicaRegions...),
 		AutoScaling:               cloneAutoScaling(cfg.AutoScaling),
 		CreationTimestamp:         m.opts.Clock.Now().UTC(),
-		Tags:                      copyTags(cfg.Tags),
 	}
 	m.tables.Set(key, t)
 	m.setTags(t.ARN, cfg.Tags)
+	m.registerTableUDTRefs(cfg.KeyspaceName, cfg.Name, &t.SchemaDefinition)
 
 	out := cloneTable(&t)
 
@@ -220,6 +245,19 @@ func (m *Mock) UpdateTable(_ context.Context, cfg ksdriver.UpdateTableConfig) (*
 		return nil, err
 	}
 
+	existing := make(map[string]struct{}, len(t.SchemaDefinition.AllColumns))
+	for _, c := range t.SchemaDefinition.AllColumns {
+		existing[c.Name] = struct{}{}
+	}
+
+	for _, c := range cfg.AddColumns {
+		if _, dup := existing[c.Name]; dup {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "column %q already exists", c.Name)
+		}
+
+		existing[c.Name] = struct{}{}
+	}
+
 	t.SchemaDefinition.AllColumns = append(t.SchemaDefinition.AllColumns, cfg.AddColumns...)
 
 	if cfg.CapacitySpecification != nil {
@@ -269,6 +307,7 @@ func (m *Mock) DeleteTable(_ context.Context, keyspace, table string) error {
 
 	m.tables.Delete(key)
 	delete(m.tags, t.ARN)
+	m.unregisterTableUDTRefs(keyspace, table)
 
 	return nil
 }
@@ -279,6 +318,14 @@ func (m *Mock) DeleteTable(_ context.Context, keyspace, table string) error {
 func (m *Mock) RestoreTable(_ context.Context, cfg ksdriver.RestoreTableConfig) (*ksdriver.Table, error) {
 	if err := validName("table", cfg.TargetTable); err != nil {
 		return nil, err
+	}
+
+	if cfg.RestoreTimestamp.IsZero() {
+		return nil, cerrors.New(cerrors.InvalidArgument, "restoreTimestamp is required")
+	}
+
+	if cfg.RestoreTimestamp.After(m.opts.Clock.Now().UTC()) {
+		return nil, cerrors.New(cerrors.InvalidArgument, "restoreTimestamp must not be in the future")
 	}
 
 	m.mu.Lock()
@@ -304,7 +351,7 @@ func (m *Mock) RestoreTable(_ context.Context, cfg ksdriver.RestoreTableConfig) 
 	restored.ARN = m.tableARN(cfg.TargetKeyspace, cfg.TargetTable)
 	restored.Status = ksdriver.StatusActive
 	restored.CreationTimestamp = m.opts.Clock.Now().UTC()
-	restored.Tags = copyTags(cfg.Tags)
+	restored.Tags = nil
 
 	if cfg.CapacitySpecification != nil {
 		restored.CapacitySpecification = resolveCapacity(*cfg.CapacitySpecification)
@@ -318,6 +365,7 @@ func (m *Mock) RestoreTable(_ context.Context, cfg ksdriver.RestoreTableConfig) 
 
 	m.tables.Set(targetKey, restored)
 	m.setTags(restored.ARN, cfg.Tags)
+	m.registerTableUDTRefs(cfg.TargetKeyspace, cfg.TargetTable, &restored.SchemaDefinition)
 
 	out := cloneTable(&restored)
 

--- a/providers/aws/keyspaces/tables.go
+++ b/providers/aws/keyspaces/tables.go
@@ -1,0 +1,325 @@
+package keyspaces
+
+import (
+	"context"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func cloneSchema(s *ksdriver.SchemaDefinition) ksdriver.SchemaDefinition {
+	return ksdriver.SchemaDefinition{
+		AllColumns:     append([]ksdriver.ColumnDefinition(nil), s.AllColumns...),
+		PartitionKeys:  append([]ksdriver.PartitionKey(nil), s.PartitionKeys...),
+		ClusteringKeys: append([]ksdriver.ClusteringKey(nil), s.ClusteringKeys...),
+		StaticColumns:  append([]ksdriver.StaticColumn(nil), s.StaticColumns...),
+	}
+}
+
+func cloneAutoScaling(a *ksdriver.AutoScalingSpecification) *ksdriver.AutoScalingSpecification {
+	if a == nil {
+		return nil
+	}
+
+	out := ksdriver.AutoScalingSpecification{}
+
+	if a.Read != nil {
+		r := *a.Read
+		out.Read = &r
+	}
+
+	if a.Write != nil {
+		w := *a.Write
+		out.Write = &w
+	}
+
+	return &out
+}
+
+func cloneTable(in *ksdriver.Table) ksdriver.Table {
+	t := *in
+	t.SchemaDefinition = cloneSchema(&t.SchemaDefinition)
+	t.ReplicaRegions = append([]string(nil), t.ReplicaRegions...)
+	t.AutoScaling = cloneAutoScaling(t.AutoScaling)
+	t.Tags = copyTags(t.Tags)
+
+	return t
+}
+
+// disabledIfEmpty defaults an unset status field to "DISABLED".
+func disabledIfEmpty(v string) string {
+	if v == "" {
+		return "DISABLED"
+	}
+
+	return v
+}
+
+// validateSchema requires at least one partition key and rejects clustering/
+// static/partition columns that are not declared in AllColumns.
+func validateSchema(s *ksdriver.SchemaDefinition) error {
+	if len(s.PartitionKeys) == 0 {
+		return cerrors.New(cerrors.InvalidArgument, "schema requires at least one partition key")
+	}
+
+	declared := make(map[string]struct{}, len(s.AllColumns))
+	for _, c := range s.AllColumns {
+		declared[c.Name] = struct{}{}
+	}
+
+	for _, pk := range s.PartitionKeys {
+		if _, ok := declared[pk.Name]; !ok {
+			return cerrors.Newf(cerrors.InvalidArgument, "partition key %q is not declared in the schema columns", pk.Name)
+		}
+	}
+
+	for _, ck := range s.ClusteringKeys {
+		if _, ok := declared[ck.Name]; !ok {
+			return cerrors.Newf(cerrors.InvalidArgument, "clustering key %q is not declared in the schema columns", ck.Name)
+		}
+	}
+
+	return nil
+}
+
+// CreateTable creates a table in an existing keyspace.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateTable(_ context.Context, cfg ksdriver.CreateTableConfig) (*ksdriver.Table, error) {
+	if err := validName("table", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	if err := validateSchema(&cfg.SchemaDefinition); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.keyspaces.Has(cfg.KeyspaceName) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "keyspace %q not found", cfg.KeyspaceName)
+	}
+
+	key := tableKey(cfg.KeyspaceName, cfg.Name)
+	if m.tables.Has(key) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "table %q already exists in keyspace %q", cfg.Name, cfg.KeyspaceName)
+	}
+
+	t := ksdriver.Table{
+		KeyspaceName:              cfg.KeyspaceName,
+		Name:                      cfg.Name,
+		ARN:                       m.tableARN(cfg.KeyspaceName, cfg.Name),
+		Status:                    ksdriver.StatusActive,
+		SchemaDefinition:          cloneSchema(&cfg.SchemaDefinition),
+		CapacitySpecification:     resolveCapacity(cfg.CapacitySpecification),
+		EncryptionSpecification:   resolveEncryption(cfg.EncryptionSpecification),
+		PointInTimeRecoveryStatus: disabledIfEmpty(cfg.PointInTimeRecovery),
+		TTLStatus:                 disabledIfEmpty(cfg.TTLStatus),
+		DefaultTimeToLive:         cfg.DefaultTimeToLive,
+		ClientSideTimestamps:      disabledIfEmpty(cfg.ClientSideTimestamps),
+		CdcStatus:                 disabledIfEmpty(cfg.CdcStatus),
+		Comment:                   cfg.Comment,
+		ReplicaRegions:            append([]string(nil), cfg.ReplicaRegions...),
+		AutoScaling:               cloneAutoScaling(cfg.AutoScaling),
+		CreationTimestamp:         m.opts.Clock.Now().UTC(),
+		Tags:                      copyTags(cfg.Tags),
+	}
+	m.tables.Set(key, t)
+	m.setTags(t.ARN, cfg.Tags)
+
+	out := cloneTable(&t)
+
+	return &out, nil
+}
+
+func resolveCapacity(c ksdriver.CapacitySpecification) ksdriver.CapacitySpecification {
+	if c.ThroughputMode == "" {
+		c.ThroughputMode = ksdriver.ThroughputPayPerRequest
+	}
+
+	if c.ThroughputMode == ksdriver.ThroughputProvisioned {
+		if c.ReadCapacityUnits == 0 {
+			c.ReadCapacityUnits = 1
+		}
+
+		if c.WriteCapacityUnits == 0 {
+			c.WriteCapacityUnits = 1
+		}
+	}
+
+	return c
+}
+
+func resolveEncryption(e ksdriver.EncryptionSpecification) ksdriver.EncryptionSpecification {
+	if e.Type == "" {
+		e.Type = "AWS_OWNED_KMS_KEY"
+	}
+
+	return e
+}
+
+func (m *Mock) getTableLocked(keyspace, table string) (ksdriver.Table, error) {
+	t, ok := m.tables.Get(tableKey(keyspace, table))
+	if !ok {
+		return ksdriver.Table{}, cerrors.Newf(cerrors.NotFound, "table %q not found in keyspace %q", table, keyspace)
+	}
+
+	return t, nil
+}
+
+// GetTable returns a table by keyspace + name.
+func (m *Mock) GetTable(_ context.Context, keyspace, table string) (*ksdriver.Table, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	t, err := m.getTableLocked(keyspace, table)
+	if err != nil {
+		return nil, err
+	}
+
+	out := cloneTable(&t)
+
+	return &out, nil
+}
+
+// ListTables returns all tables in a keyspace, deterministically ordered.
+//
+//nolint:dupl // the per-keyspace prefix filter mirrors ListTypes by design.
+func (m *Mock) ListTables(_ context.Context, keyspace string) ([]ksdriver.Table, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.keyspaces.Has(keyspace) {
+		return nil, cerrors.Newf(cerrors.NotFound, "keyspace %q not found", keyspace)
+	}
+
+	prefix := keyspace + "/"
+	all := m.tables.SortedValues()
+	out := make([]ksdriver.Table, 0, len(all))
+
+	for i := range all {
+		if strings.HasPrefix(tableKey(all[i].KeyspaceName, all[i].Name), prefix) {
+			out = append(out, cloneTable(&all[i]))
+		}
+	}
+
+	return out, nil
+}
+
+// UpdateTable applies in-place changes; unset fields are preserved.
+//
+//nolint:gocritic // cfg matches the driver signature; per-field optional updates.
+func (m *Mock) UpdateTable(_ context.Context, cfg ksdriver.UpdateTableConfig) (*ksdriver.Table, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	t, err := m.getTableLocked(cfg.KeyspaceName, cfg.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	t.SchemaDefinition.AllColumns = append(t.SchemaDefinition.AllColumns, cfg.AddColumns...)
+
+	if cfg.CapacitySpecification != nil {
+		t.CapacitySpecification = resolveCapacity(*cfg.CapacitySpecification)
+	}
+
+	t.PointInTimeRecoveryStatus = orKeep(cfg.PointInTimeRecovery, t.PointInTimeRecoveryStatus)
+	t.TTLStatus = orKeep(cfg.TTLStatus, t.TTLStatus)
+	t.ClientSideTimestamps = orKeep(cfg.ClientSideTimestamps, t.ClientSideTimestamps)
+	t.CdcStatus = orKeep(cfg.CdcStatus, t.CdcStatus)
+	t.Comment = orKeep(cfg.Comment, t.Comment)
+
+	if cfg.DefaultTimeToLive != nil {
+		t.DefaultTimeToLive = *cfg.DefaultTimeToLive
+	}
+
+	if cfg.AutoScaling != nil {
+		t.AutoScaling = cloneAutoScaling(cfg.AutoScaling)
+	}
+
+	m.tables.Set(tableKey(cfg.KeyspaceName, cfg.Name), t)
+
+	out := cloneTable(&t)
+
+	return &out, nil
+}
+
+func orKeep(v, cur string) string {
+	if v == "" {
+		return cur
+	}
+
+	return v
+}
+
+// DeleteTable removes a table.
+func (m *Mock) DeleteTable(_ context.Context, keyspace, table string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := tableKey(keyspace, table)
+
+	t, ok := m.tables.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "table %q not found in keyspace %q", table, keyspace)
+	}
+
+	m.tables.Delete(key)
+	delete(m.tags, t.ARN)
+
+	return nil
+}
+
+// RestoreTable creates a new table from a source table's point-in-time state.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) RestoreTable(_ context.Context, cfg ksdriver.RestoreTableConfig) (*ksdriver.Table, error) {
+	if err := validName("table", cfg.TargetTable); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, err := m.getTableLocked(cfg.SourceKeyspace, cfg.SourceTable)
+	if err != nil {
+		return nil, err
+	}
+
+	if !m.keyspaces.Has(cfg.TargetKeyspace) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "target keyspace %q not found", cfg.TargetKeyspace)
+	}
+
+	targetKey := tableKey(cfg.TargetKeyspace, cfg.TargetTable)
+	if m.tables.Has(targetKey) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "table %q already exists in keyspace %q", cfg.TargetTable, cfg.TargetKeyspace)
+	}
+
+	restored := cloneTable(&src)
+	restored.KeyspaceName = cfg.TargetKeyspace
+	restored.Name = cfg.TargetTable
+	restored.ARN = m.tableARN(cfg.TargetKeyspace, cfg.TargetTable)
+	restored.Status = ksdriver.StatusActive
+	restored.CreationTimestamp = m.opts.Clock.Now().UTC()
+	restored.Tags = copyTags(cfg.Tags)
+
+	if cfg.CapacitySpecification != nil {
+		restored.CapacitySpecification = resolveCapacity(*cfg.CapacitySpecification)
+	}
+
+	if cfg.EncryptionSpecification != nil {
+		restored.EncryptionSpecification = resolveEncryption(*cfg.EncryptionSpecification)
+	}
+
+	restored.PointInTimeRecoveryStatus = orKeep(cfg.PointInTimeRecovery, restored.PointInTimeRecoveryStatus)
+
+	m.tables.Set(targetKey, restored)
+	m.setTags(restored.ARN, cfg.Tags)
+
+	out := cloneTable(&restored)
+
+	return &out, nil
+}

--- a/providers/aws/keyspaces/tags.go
+++ b/providers/aws/keyspaces/tags.go
@@ -1,0 +1,77 @@
+package keyspaces
+
+import (
+	"context"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+// setTags merges tags onto a resource ARN. The caller holds the write lock.
+func (m *Mock) setTags(arn string, tags map[string]string) {
+	if len(tags) == 0 {
+		return
+	}
+
+	cur := m.tags[arn]
+	if cur == nil {
+		cur = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		cur[k] = v
+	}
+
+	m.tags[arn] = cur
+}
+
+// TagResource adds tags to a resource by ARN.
+func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string) error {
+	if arn == "" {
+		return cerrors.New(cerrors.InvalidArgument, "resourceArn is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.setTags(arn, tags)
+
+	return nil
+}
+
+// UntagResource removes tag keys from a resource by ARN.
+func (m *Mock) UntagResource(_ context.Context, arn string, keys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	cur := m.tags[arn]
+	for _, k := range keys {
+		delete(cur, k)
+	}
+
+	return nil
+}
+
+// ListTagsForResource returns a resource's tags in deterministic (sorted)
+// order (AWS leaves tag order unspecified).
+func (m *Mock) ListTagsForResource(_ context.Context, arn string) ([]ksdriver.Tag, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	tags := m.tags[arn]
+
+	names := make([]string, 0, len(tags))
+	for k := range tags {
+		names = append(names, k)
+	}
+
+	sort.Strings(names)
+
+	out := make([]ksdriver.Tag, 0, len(names))
+	for _, k := range names {
+		out = append(out, ksdriver.Tag{Key: k, Value: tags[k]})
+	}
+
+	return out, nil
+}

--- a/providers/aws/keyspaces/udt.go
+++ b/providers/aws/keyspaces/udt.go
@@ -8,6 +8,88 @@ import (
 	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
 )
 
+// typeMentions reports whether a Cassandra column type string references the
+// named UDT as an identifier token (e.g. "address", "frozen<address>",
+// "list<frozen<address>>"), without matching substrings of other identifiers.
+func typeMentions(colType, name string) bool {
+	for _, tok := range strings.FieldsFunc(colType, func(r rune) bool {
+		return !(r == '_' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9')
+	}) {
+		if tok == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// registerTableUDTRefs records table→UDT references so DeleteType's in-use guard
+// is live: for every UDT in the keyspace mentioned by a column type, the table
+// is added to that UDT's DirectReferringTables. The caller holds the lock.
+func (m *Mock) registerTableUDTRefs(keyspace, table string, schema *ksdriver.SchemaDefinition) {
+	prefix := keyspace + "/"
+
+	for _, key := range m.udts.Keys() {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		u, ok := m.udts.Get(key)
+		if !ok {
+			continue
+		}
+
+		if schemaMentionsType(schema, u.Name) && !containsStr(u.DirectReferringTables, table) {
+			u.DirectReferringTables = append(u.DirectReferringTables, table)
+			m.udts.Set(key, u)
+		}
+	}
+}
+
+// unregisterTableUDTRefs drops a table from every UDT's referring-tables list in
+// the keyspace. The caller holds the lock.
+func (m *Mock) unregisterTableUDTRefs(keyspace, table string) {
+	prefix := keyspace + "/"
+
+	for _, key := range m.udts.Keys() {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		u, ok := m.udts.Get(key)
+		if !ok {
+			continue
+		}
+
+		if containsStr(u.DirectReferringTables, table) {
+			u.DirectReferringTables = removeStr(u.DirectReferringTables, table)
+			m.udts.Set(key, u)
+		}
+	}
+}
+
+func schemaMentionsType(s *ksdriver.SchemaDefinition, name string) bool {
+	for _, c := range s.AllColumns {
+		if typeMentions(c.Type, name) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func removeStr(items []string, s string) []string {
+	out := items[:0:0]
+
+	for _, v := range items {
+		if v != s {
+			out = append(out, v)
+		}
+	}
+
+	return out
+}
+
 func cloneUDT(in *ksdriver.UDT) ksdriver.UDT {
 	u := *in
 	u.FieldDefinitions = append([]ksdriver.FieldDefinition(nil), u.FieldDefinitions...)
@@ -74,6 +156,10 @@ func (m *Mock) GetType(_ context.Context, keyspace, name string) (*ksdriver.UDT,
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if !m.keyspaces.Has(keyspace) {
+		return nil, cerrors.Newf(cerrors.NotFound, "keyspace %q not found", keyspace)
+	}
+
 	u, ok := m.udts.Get(typeKey(keyspace, name))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "type %q not found in keyspace %q", name, keyspace)
@@ -114,6 +200,10 @@ func (m *Mock) DeleteType(_ context.Context, keyspace, name string) (*ksdriver.U
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if !m.keyspaces.Has(keyspace) {
+		return nil, cerrors.Newf(cerrors.NotFound, "keyspace %q not found", keyspace)
+	}
+
 	key := typeKey(keyspace, name)
 
 	u, ok := m.udts.Get(key)
@@ -122,7 +212,7 @@ func (m *Mock) DeleteType(_ context.Context, keyspace, name string) (*ksdriver.U
 	}
 
 	if len(u.DirectReferringTables) > 0 || len(u.DirectParentTypes) > 0 {
-		return nil, cerrors.Newf(cerrors.FailedPrecondition, "type %q is still referenced", name)
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "type %q is still referenced by %v", name, u.DirectReferringTables)
 	}
 
 	m.udts.Delete(key)

--- a/providers/aws/keyspaces/udt.go
+++ b/providers/aws/keyspaces/udt.go
@@ -1,0 +1,133 @@
+package keyspaces
+
+import (
+	"context"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func cloneUDT(in *ksdriver.UDT) ksdriver.UDT {
+	u := *in
+	u.FieldDefinitions = append([]ksdriver.FieldDefinition(nil), u.FieldDefinitions...)
+	u.DirectParentTypes = append([]string(nil), u.DirectParentTypes...)
+	u.DirectReferringTables = append([]string(nil), u.DirectReferringTables...)
+
+	return u
+}
+
+// CreateType creates a user-defined type in an existing keyspace.
+func (m *Mock) CreateType(_ context.Context, keyspace, name string, fields []ksdriver.FieldDefinition) (*ksdriver.UDT, error) {
+	if err := validName("type", name); err != nil {
+		return nil, err
+	}
+
+	if len(fields) == 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument, "a user-defined type requires at least one field")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.keyspaces.Has(keyspace) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "keyspace %q not found", keyspace)
+	}
+
+	key := typeKey(keyspace, name)
+	if m.udts.Has(key) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "type %q already exists in keyspace %q", name, keyspace)
+	}
+
+	u := ksdriver.UDT{
+		KeyspaceName:     keyspace,
+		KeyspaceARN:      m.keyspaceARN(keyspace),
+		Name:             name,
+		Status:           ksdriver.StatusActive,
+		FieldDefinitions: append([]ksdriver.FieldDefinition(nil), fields...),
+		MaxNestingDepth:  nestingDepth(fields),
+		LastModified:     m.opts.Clock.Now().UTC(),
+	}
+	m.udts.Set(key, u)
+
+	out := cloneUDT(&u)
+
+	return &out, nil
+}
+
+// nestingDepth is 1 plus the number of frozen-collection frozen<> wrappers seen
+// in the field types — a simple approximation for the mock.
+func nestingDepth(fields []ksdriver.FieldDefinition) int {
+	depth := 1
+
+	for _, f := range fields {
+		if d := 1 + strings.Count(f.Type, "frozen<"); d > depth {
+			depth = d
+		}
+	}
+
+	return depth
+}
+
+// GetType returns a user-defined type.
+func (m *Mock) GetType(_ context.Context, keyspace, name string) (*ksdriver.UDT, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	u, ok := m.udts.Get(typeKey(keyspace, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "type %q not found in keyspace %q", name, keyspace)
+	}
+
+	out := cloneUDT(&u)
+
+	return &out, nil
+}
+
+// ListTypes returns the type names of a keyspace, deterministically ordered.
+//
+//nolint:dupl // the per-keyspace prefix filter mirrors ListTables by design.
+func (m *Mock) ListTypes(_ context.Context, keyspace string) ([]ksdriver.UDT, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.keyspaces.Has(keyspace) {
+		return nil, cerrors.Newf(cerrors.NotFound, "keyspace %q not found", keyspace)
+	}
+
+	prefix := keyspace + "/"
+	all := m.udts.SortedValues()
+	out := make([]ksdriver.UDT, 0, len(all))
+
+	for i := range all {
+		if strings.HasPrefix(typeKey(all[i].KeyspaceName, all[i].Name), prefix) {
+			out = append(out, cloneUDT(&all[i]))
+		}
+	}
+
+	return out, nil
+}
+
+// DeleteType removes a user-defined type; it must not be referenced by a table
+// or another type.
+func (m *Mock) DeleteType(_ context.Context, keyspace, name string) (*ksdriver.UDT, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := typeKey(keyspace, name)
+
+	u, ok := m.udts.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "type %q not found in keyspace %q", name, keyspace)
+	}
+
+	if len(u.DirectReferringTables) > 0 || len(u.DirectParentTypes) > 0 {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "type %q is still referenced", name)
+	}
+
+	m.udts.Delete(key)
+
+	out := cloneUDT(&u)
+
+	return &out, nil
+}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/aws/elbv2"
 	"github.com/stackshy/cloudemu/v2/server/aws/eventbridge"
 	"github.com/stackshy/cloudemu/v2/server/aws/iam"
+	keyspacessrv "github.com/stackshy/cloudemu/v2/server/aws/keyspaces"
 	"github.com/stackshy/cloudemu/v2/server/aws/lambda"
 	memorydbsrv "github.com/stackshy/cloudemu/v2/server/aws/memorydb"
 	"github.com/stackshy/cloudemu/v2/server/aws/rds"
@@ -49,6 +50,7 @@ import (
 	ecsdriver "github.com/stackshy/cloudemu/v2/services/ecs/driver"
 	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
 	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
@@ -109,6 +111,9 @@ type Drivers struct {
 	// ElastiCache serves the ElastiCache query protocol (cluster control plane)
 	// against the cache driver.
 	ElastiCache cachedriver.Cache
+	// Keyspaces serves the Amazon Keyspaces JSON 1.0 protocol (Cassandra
+	// control plane) against the keyspaces driver.
+	Keyspaces ksdriver.Keyspaces
 	// MemoryDB serves the AWS MemoryDB JSON 1.1 protocol (Redis/Valkey cluster
 	// control plane) against the memorydb driver.
 	MemoryDB mdbdriver.MemoryDB
@@ -164,6 +169,7 @@ func DriversFrom(p *awsprovider.Provider) Drivers {
 		ELB:                 p.ELB,
 		EventBridge:         p.EventBridge,
 		ElastiCache:         p.ElastiCache,
+		Keyspaces:           p.Keyspaces,
 		MemoryDB:            p.MemoryDB,
 		SNS:                 p.SNS,
 		STS:                 true,
@@ -200,7 +206,7 @@ func NewFromProvider(p *awsprovider.Provider) *server.Server {
 //
 // keeps the caller API ergonomic (awsserver.New(Drivers{...})).
 //
-//nolint:gocritic,gocyclo,funlen // Drivers is by-value for ergonomics; the dispatch is one if-per-driver and grows with the bundle.
+//nolint:gocritic,gocyclo,funlen,gocognit // by-value Drivers for ergonomics; one if-per-driver dispatch grows with the bundle.
 func New(d Drivers) *server.Server {
 	srv := server.New()
 
@@ -305,6 +311,12 @@ func New(d Drivers) *server.Server {
 	// registration order relative to the EC2 catch-all does not matter.
 	if d.MemoryDB != nil {
 		srv.Register(memorydbsrv.New(d.MemoryDB))
+	}
+
+	// Keyspaces speaks AWS JSON 1.0 and matches on the "KeyspacesService." target
+	// prefix, so its dispatch is disjoint from every other handler.
+	if d.Keyspaces != nil {
+		srv.Register(keyspacessrv.New(d.Keyspaces))
 	}
 
 	// SNS also speaks the AWS query protocol; its action set (CreateTopic,

--- a/server/aws/keyspaces/handler.go
+++ b/server/aws/keyspaces/handler.go
@@ -1,0 +1,109 @@
+// Package keyspaces implements the Amazon Keyspaces control-plane API as a
+// server.Handler. Keyspaces uses AWS JSON 1.0 with the X-Amz-Target header
+// prefix "KeyspacesService.", so a real aws-sdk-go-v2/service/keyspaces client
+// configured with a custom endpoint hits this handler unchanged.
+package keyspaces
+
+import (
+	stderrors "errors"
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+const targetPrefix = "KeyspacesService."
+
+// Handler serves Keyspaces requests against a keyspaces driver.
+type Handler struct {
+	db ksdriver.Keyspaces
+}
+
+// New returns a Keyspaces handler backed by db.
+func New(db ksdriver.Keyspaces) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches claims requests whose X-Amz-Target names a Keyspaces operation.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches on the operation named in X-Amz-Target.
+//
+//nolint:gocyclo // a flat operation switch is the clearest dispatch shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "CreateKeyspace":
+		h.createKeyspace(w, r)
+	case "GetKeyspace":
+		h.getKeyspace(w, r)
+	case "ListKeyspaces":
+		h.listKeyspaces(w, r)
+	case "UpdateKeyspace":
+		h.updateKeyspace(w, r)
+	case "DeleteKeyspace":
+		h.deleteKeyspace(w, r)
+	case "CreateTable":
+		h.createTable(w, r)
+	case "GetTable":
+		h.getTable(w, r)
+	case "ListTables":
+		h.listTables(w, r)
+	case "UpdateTable":
+		h.updateTable(w, r)
+	case "DeleteTable":
+		h.deleteTable(w, r)
+	case "RestoreTable":
+		h.restoreTable(w, r)
+	case "CreateType":
+		h.createType(w, r)
+	case "GetType":
+		h.getType(w, r)
+	case "ListTypes":
+		h.listTypes(w, r)
+	case "DeleteType":
+		h.deleteType(w, r)
+	case "TagResource":
+		h.tagResource(w, r)
+	case "UntagResource":
+		h.untagResource(w, r)
+	case "ListTagsForResource":
+		h.listTagsForResource(w, r)
+	default:
+		if h.serveOptional(w, r, op) {
+			return
+		}
+
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "unknown Keyspaces operation: "+op)
+	}
+}
+
+// writeErr maps a canonical error to a Keyspaces exception.
+func writeErr(w http.ResponseWriter, err error) {
+	msg := wireMessage(err)
+
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
+	case cerrors.IsAlreadyExists(err), cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ConflictException", msg)
+	case cerrors.IsInvalidArgument(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerException", msg)
+	}
+}
+
+func wireMessage(err error) string {
+	var ce *cerrors.Error
+	if stderrors.As(err, &ce) {
+		return ce.Message
+	}
+
+	return err.Error()
+}

--- a/server/aws/keyspaces/keyspaces.go
+++ b/server/aws/keyspaces/keyspaces.go
@@ -1,0 +1,113 @@
+package keyspaces
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces/types"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func (h *Handler) createKeyspace(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.CreateKeyspaceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := ksdriver.CreateKeyspaceConfig{Name: aws.ToString(in.KeyspaceName), Tags: tagMap(in.Tags)}
+	if in.ReplicationSpecification != nil {
+		cfg.ReplicationStrategy = string(in.ReplicationSpecification.ReplicationStrategy)
+		cfg.ReplicationRegions = in.ReplicationSpecification.RegionList
+	}
+
+	ks, err := h.db.CreateKeyspace(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.CreateKeyspaceOutput{ResourceArn: aws.String(ks.ARN)})
+}
+
+func (h *Handler) getKeyspace(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.GetKeyspaceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	ks, err := h.db.GetKeyspace(r.Context(), aws.ToString(in.KeyspaceName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.GetKeyspaceOutput{
+		KeyspaceName:        aws.String(ks.Name),
+		ResourceArn:         aws.String(ks.ARN),
+		ReplicationStrategy: types.Rs(ks.ReplicationStrategy),
+		ReplicationRegions:  ks.ReplicationRegions,
+	})
+}
+
+func (h *Handler) listKeyspaces(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.ListKeyspacesInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	all, err := h.db.ListKeyspaces(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	page, next, err := paginate(all, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := keyspaces.ListKeyspacesOutput{NextToken: next}
+	for i := range page {
+		out.Keyspaces = append(out.Keyspaces, toWireKeyspaceSummary(&page[i]))
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) updateKeyspace(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.UpdateKeyspaceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	var addRegions []string
+	if in.ReplicationSpecification != nil {
+		addRegions = in.ReplicationSpecification.RegionList
+	}
+
+	ks, err := h.db.UpdateKeyspace(r.Context(), aws.ToString(in.KeyspaceName), addRegions)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.UpdateKeyspaceOutput{ResourceArn: aws.String(ks.ARN)})
+}
+
+func (h *Handler) deleteKeyspace(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.DeleteKeyspaceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	if err := h.db.DeleteKeyspace(r.Context(), aws.ToString(in.KeyspaceName)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.DeleteKeyspaceOutput{})
+}

--- a/server/aws/keyspaces/optional.go
+++ b/server/aws/keyspaces/optional.go
@@ -1,0 +1,45 @@
+package keyspaces
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+// serveOptional handles the auto-scaling operation, an optional driver
+// capability discovered by type assertion.
+func (h *Handler) serveOptional(w http.ResponseWriter, r *http.Request, op string) bool {
+	if op != "GetTableAutoScalingSettings" {
+		return false
+	}
+
+	as, ok := h.db.(ksdriver.AutoScaling)
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", "auto scaling not supported")
+		return true
+	}
+
+	var in keyspaces.GetTableAutoScalingSettingsInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return true
+	}
+
+	t, err := as.GetTableAutoScalingSettings(r.Context(), aws.ToString(in.KeyspaceName), aws.ToString(in.TableName))
+	if err != nil {
+		writeErr(w, err)
+		return true
+	}
+
+	writeJSON(w, keyspaces.GetTableAutoScalingSettingsOutput{
+		KeyspaceName:             aws.String(t.KeyspaceName),
+		TableName:                aws.String(t.Name),
+		ResourceArn:              aws.String(t.ARN),
+		AutoScalingSpecification: toWireAutoScaling(t.AutoScaling),
+	})
+
+	return true
+}

--- a/server/aws/keyspaces/paging.go
+++ b/server/aws/keyspaces/paging.go
@@ -1,0 +1,59 @@
+package keyspaces
+
+import (
+	"encoding/base64"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// paginate returns the slice of items beginning at the offset encoded in token
+// and limited to maxResults, plus the token for the next page (nil when the
+// page reaches the end). The token is an opaque base64 offset — stable because
+// the driver returns results in a deterministic order. A malformed token yields
+// a ValidationException.
+func paginate[T any](items []T, maxResults *int32, token *string) (page []T, next *string, err error) {
+	start, err := decodeToken(token)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if start > len(items) {
+		start = len(items)
+	}
+
+	end := len(items)
+	if maxResults != nil && int(*maxResults) > 0 && start+int(*maxResults) < end {
+		end = start + int(*maxResults)
+	}
+
+	if end < len(items) {
+		next = encodeToken(end)
+	}
+
+	return items[start:end], next, nil
+}
+
+func decodeToken(token *string) (int, error) {
+	if token == nil || *token == "" {
+		return 0, nil
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(*token)
+	if err != nil {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid nextToken")
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid nextToken")
+	}
+
+	return n, nil
+}
+
+func encodeToken(offset int) *string {
+	s := base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+
+	return &s
+}

--- a/server/aws/keyspaces/sdk_roundtrip_test.go
+++ b/server/aws/keyspaces/sdk_roundtrip_test.go
@@ -1,0 +1,332 @@
+package keyspaces_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awskeyspaces "github.com/aws/aws-sdk-go-v2/service/keyspaces"
+	kstypes "github.com/aws/aws-sdk-go-v2/service/keyspaces/types"
+	"github.com/aws/smithy-go"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	ksprovider "github.com/stackshy/cloudemu/v2/providers/aws/keyspaces"
+	ksserver "github.com/stackshy/cloudemu/v2/server/aws/keyspaces"
+)
+
+func newSDKClient(t *testing.T) *awskeyspaces.Client {
+	t.Helper()
+
+	opts := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	srv := httptest.NewServer(ksserver.New(ksprovider.New(opts)))
+	t.Cleanup(srv.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("aws config: %v", err)
+	}
+
+	return awskeyspaces.NewFromConfig(cfg, func(o *awskeyspaces.Options) {
+		o.BaseEndpoint = aws.String(srv.URL)
+	})
+}
+
+func sampleSchema() *kstypes.SchemaDefinition {
+	return &kstypes.SchemaDefinition{
+		AllColumns: []kstypes.ColumnDefinition{
+			{Name: aws.String("id"), Type: aws.String("uuid")},
+			{Name: aws.String("ts"), Type: aws.String("timestamp")},
+			{Name: aws.String("val"), Type: aws.String("text")},
+		},
+		PartitionKeys:  []kstypes.PartitionKey{{Name: aws.String("id")}},
+		ClusteringKeys: []kstypes.ClusteringKey{{Name: aws.String("ts"), OrderBy: kstypes.SortOrderDesc}},
+	}
+}
+
+func TestSDKKeyspaceLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKeyspace(ctx, &awskeyspaces.CreateKeyspaceInput{
+		KeyspaceName: aws.String("app"),
+		Tags:         []kstypes.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+	}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	got, err := client.GetKeyspace(ctx, &awskeyspaces.GetKeyspaceInput{KeyspaceName: aws.String("app")})
+	if err != nil {
+		t.Fatalf("GetKeyspace: %v", err)
+	}
+
+	if aws.ToString(got.KeyspaceName) != "app" || got.ReplicationStrategy != kstypes.RsSingleRegion {
+		t.Fatalf("keyspace wrong: %+v", got)
+	}
+
+	list, err := client.ListKeyspaces(ctx, &awskeyspaces.ListKeyspacesInput{})
+	if err != nil {
+		t.Fatalf("ListKeyspaces: %v", err)
+	}
+
+	if len(list.Keyspaces) != 4 { // 3 system + app
+		t.Fatalf("expected 4 keyspaces, got %d", len(list.Keyspaces))
+	}
+
+	if _, err := client.DeleteKeyspace(ctx, &awskeyspaces.DeleteKeyspaceInput{KeyspaceName: aws.String("app")}); err != nil {
+		t.Fatalf("DeleteKeyspace: %v", err)
+	}
+
+	_, err = client.GetKeyspace(ctx, &awskeyspaces.GetKeyspaceInput{KeyspaceName: aws.String("app")})
+
+	var nf *kstypes.ResourceNotFoundException
+	if !errors.As(err, &nf) {
+		t.Fatalf("get after delete: got %v, want ResourceNotFoundException", err)
+	}
+}
+
+func TestSDKTableLifecycle(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKeyspace(ctx, &awskeyspaces.CreateKeyspaceInput{KeyspaceName: aws.String("app")}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	if _, err := client.CreateTable(ctx, &awskeyspaces.CreateTableInput{
+		KeyspaceName:     aws.String("app"),
+		TableName:        aws.String("events"),
+		SchemaDefinition: sampleSchema(),
+		Comment:          &kstypes.Comment{Message: aws.String("event log")},
+	}); err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	got, err := client.GetTable(ctx, &awskeyspaces.GetTableInput{
+		KeyspaceName: aws.String("app"), TableName: aws.String("events"),
+	})
+	if err != nil {
+		t.Fatalf("GetTable: %v", err)
+	}
+
+	if got.Status != kstypes.TableStatusActive || len(got.SchemaDefinition.PartitionKeys) != 1 {
+		t.Fatalf("table wrong: status=%s schema=%+v", got.Status, got.SchemaDefinition)
+	}
+
+	if got.CapacitySpecification == nil || got.CapacitySpecification.ThroughputMode != kstypes.ThroughputModePayPerRequest {
+		t.Fatalf("capacity wrong: %+v", got.CapacitySpecification)
+	}
+
+	if aws.ToString(got.Comment.Message) != "event log" {
+		t.Fatalf("comment lost: %+v", got.Comment)
+	}
+
+	// Update: enable PITR + switch to provisioned.
+	if _, err := client.UpdateTable(ctx, &awskeyspaces.UpdateTableInput{
+		KeyspaceName:        aws.String("app"),
+		TableName:           aws.String("events"),
+		PointInTimeRecovery: &kstypes.PointInTimeRecovery{Status: kstypes.PointInTimeRecoveryStatusEnabled},
+		CapacitySpecification: &kstypes.CapacitySpecification{
+			ThroughputMode: kstypes.ThroughputModeProvisioned, ReadCapacityUnits: aws.Int64(5), WriteCapacityUnits: aws.Int64(5),
+		},
+	}); err != nil {
+		t.Fatalf("UpdateTable: %v", err)
+	}
+
+	got, _ = client.GetTable(ctx, &awskeyspaces.GetTableInput{KeyspaceName: aws.String("app"), TableName: aws.String("events")})
+	if got.PointInTimeRecovery.Status != kstypes.PointInTimeRecoveryStatusEnabled ||
+		got.CapacitySpecification.ThroughputMode != kstypes.ThroughputModeProvisioned {
+		t.Fatalf("update not applied: %+v %+v", got.PointInTimeRecovery, got.CapacitySpecification)
+	}
+
+	// Restore into a new table.
+	if _, err := client.RestoreTable(ctx, &awskeyspaces.RestoreTableInput{
+		SourceKeyspaceName: aws.String("app"), SourceTableName: aws.String("events"),
+		TargetKeyspaceName: aws.String("app"), TargetTableName: aws.String("events_restored"),
+	}); err != nil {
+		t.Fatalf("RestoreTable: %v", err)
+	}
+
+	if _, err := client.DeleteTable(ctx, &awskeyspaces.DeleteTableInput{
+		KeyspaceName: aws.String("app"), TableName: aws.String("events"),
+	}); err != nil {
+		t.Fatalf("DeleteTable: %v", err)
+	}
+}
+
+func TestSDKUserDefinedTypes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKeyspace(ctx, &awskeyspaces.CreateKeyspaceInput{KeyspaceName: aws.String("app")}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	if _, err := client.CreateType(ctx, &awskeyspaces.CreateTypeInput{
+		KeyspaceName: aws.String("app"), TypeName: aws.String("address"),
+		FieldDefinitions: []kstypes.FieldDefinition{
+			{Name: aws.String("street"), Type: aws.String("text")},
+			{Name: aws.String("zip"), Type: aws.String("int")},
+		},
+	}); err != nil {
+		t.Fatalf("CreateType: %v", err)
+	}
+
+	got, err := client.GetType(ctx, &awskeyspaces.GetTypeInput{KeyspaceName: aws.String("app"), TypeName: aws.String("address")})
+	if err != nil {
+		t.Fatalf("GetType: %v", err)
+	}
+
+	if len(got.FieldDefinitions) != 2 || got.Status != kstypes.TypeStatusActive {
+		t.Fatalf("type wrong: %+v", got)
+	}
+
+	types, err := client.ListTypes(ctx, &awskeyspaces.ListTypesInput{KeyspaceName: aws.String("app")})
+	if err != nil {
+		t.Fatalf("ListTypes: %v", err)
+	}
+
+	if len(types.Types) != 1 || types.Types[0] != "address" {
+		t.Fatalf("list types wrong: %+v", types.Types)
+	}
+
+	if _, err := client.DeleteType(ctx, &awskeyspaces.DeleteTypeInput{
+		KeyspaceName: aws.String("app"), TypeName: aws.String("address"),
+	}); err != nil {
+		t.Fatalf("DeleteType: %v", err)
+	}
+}
+
+func TestSDKTagsAndAutoScaling(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKeyspace(ctx, &awskeyspaces.CreateKeyspaceInput{KeyspaceName: aws.String("app")}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	created, err := client.CreateTable(ctx, &awskeyspaces.CreateTableInput{
+		KeyspaceName: aws.String("app"), TableName: aws.String("t"), SchemaDefinition: sampleSchema(),
+		CapacitySpecification: &kstypes.CapacitySpecification{ThroughputMode: kstypes.ThroughputModeProvisioned},
+		AutoScalingSpecification: &kstypes.AutoScalingSpecification{
+			ReadCapacityAutoScaling: &kstypes.AutoScalingSettings{
+				MinimumUnits: aws.Int64(1), MaximumUnits: aws.Int64(10),
+				ScalingPolicy: &kstypes.AutoScalingPolicy{
+					TargetTrackingScalingPolicyConfiguration: &kstypes.TargetTrackingScalingPolicyConfiguration{TargetValue: 70},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTable: %v", err)
+	}
+
+	arn := aws.ToString(created.ResourceArn)
+	if _, err := client.TagResource(ctx, &awskeyspaces.TagResourceInput{
+		ResourceArn: aws.String(arn), Tags: []kstypes.Tag{{Key: aws.String("team"), Value: aws.String("data")}},
+	}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	tags, err := client.ListTagsForResource(ctx, &awskeyspaces.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+
+	if len(tags.Tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags.Tags))
+	}
+
+	as, err := client.GetTableAutoScalingSettings(ctx, &awskeyspaces.GetTableAutoScalingSettingsInput{
+		KeyspaceName: aws.String("app"), TableName: aws.String("t"),
+	})
+	if err != nil {
+		t.Fatalf("GetTableAutoScalingSettings: %v", err)
+	}
+
+	if as.AutoScalingSpecification == nil || as.AutoScalingSpecification.ReadCapacityAutoScaling == nil ||
+		aws.ToInt64(as.AutoScalingSpecification.ReadCapacityAutoScaling.MaximumUnits) != 10 {
+		t.Fatalf("autoscaling not returned: %+v", as.AutoScalingSpecification)
+	}
+}
+
+func TestSDKPaginationAndFaults(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateKeyspace(ctx, &awskeyspaces.CreateKeyspaceInput{KeyspaceName: aws.String("app")}); err != nil {
+		t.Fatalf("CreateKeyspace: %v", err)
+	}
+
+	for _, n := range []string{"t1", "t2", "t3"} {
+		if _, err := client.CreateTable(ctx, &awskeyspaces.CreateTableInput{
+			KeyspaceName: aws.String("app"), TableName: aws.String(n), SchemaDefinition: sampleSchema(),
+		}); err != nil {
+			t.Fatalf("CreateTable %s: %v", n, err)
+		}
+	}
+
+	first, err := client.ListTables(ctx, &awskeyspaces.ListTablesInput{KeyspaceName: aws.String("app"), MaxResults: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("ListTables page 1: %v", err)
+	}
+
+	if len(first.Tables) != 2 || first.NextToken == nil {
+		t.Fatalf("page 1: got %d tables, token=%v", len(first.Tables), first.NextToken)
+	}
+
+	second, err := client.ListTables(ctx, &awskeyspaces.ListTablesInput{
+		KeyspaceName: aws.String("app"), MaxResults: aws.Int32(2), NextToken: first.NextToken,
+	})
+	if err != nil {
+		t.Fatalf("ListTables page 2: %v", err)
+	}
+
+	if len(second.Tables) != 1 || second.NextToken != nil {
+		t.Fatalf("page 2: got %d tables, token=%v", len(second.Tables), second.NextToken)
+	}
+
+	// Duplicate keyspace → ConflictException.
+	_, err = client.CreateKeyspace(ctx, &awskeyspaces.CreateKeyspaceInput{KeyspaceName: aws.String("app")})
+
+	var conflict *kstypes.ConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("duplicate keyspace: got %v, want ConflictException", err)
+	}
+
+	// Bad token → ValidationException.
+	_, err = client.ListTables(ctx, &awskeyspaces.ListTablesInput{
+		KeyspaceName: aws.String("app"), NextToken: aws.String("!!bad!!"),
+	})
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "ValidationException" {
+		t.Fatalf("bad token: got %v, want ValidationException", err)
+	}
+}
+
+func TestSDKUnknownOperation(t *testing.T) {
+	opts := config.NewOptions(config.WithRegion("us-east-1"), config.WithAccountID("123456789012"))
+	h := ksserver.New(ksprovider.New(opts))
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set("X-Amz-Target", "KeyspacesService.CreateKeyspace")
+
+	if !h.Matches(req) {
+		t.Fatal("expected Matches to claim a KeyspacesService target")
+	}
+
+	other := httptest.NewRequest(http.MethodPost, "/", nil)
+	other.Header.Set("X-Amz-Target", "AmazonMemoryDB.CreateCluster")
+
+	if h.Matches(other) {
+		t.Fatal("expected Matches to reject a non-Keyspaces target")
+	}
+}

--- a/server/aws/keyspaces/sdk_roundtrip_test.go
+++ b/server/aws/keyspaces/sdk_roundtrip_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -150,6 +151,7 @@ func TestSDKTableLifecycle(t *testing.T) {
 	if _, err := client.RestoreTable(ctx, &awskeyspaces.RestoreTableInput{
 		SourceKeyspaceName: aws.String("app"), SourceTableName: aws.String("events"),
 		TargetKeyspaceName: aws.String("app"), TargetTableName: aws.String("events_restored"),
+		RestoreTimestamp: aws.Time(time.Unix(1735689600, 0)),
 	}); err != nil {
 		t.Fatalf("RestoreTable: %v", err)
 	}

--- a/server/aws/keyspaces/tables.go
+++ b/server/aws/keyspaces/tables.go
@@ -1,0 +1,224 @@
+package keyspaces
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces/types"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.CreateTableInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := ksdriver.CreateTableConfig{
+		KeyspaceName:            aws.ToString(in.KeyspaceName),
+		Name:                    aws.ToString(in.TableName),
+		SchemaDefinition:        fromWireSchema(in.SchemaDefinition),
+		CapacitySpecification:   fromWireCapacity(in.CapacitySpecification),
+		EncryptionSpecification: fromWireEncryption(in.EncryptionSpecification),
+		DefaultTimeToLive:       int(aws.ToInt32(in.DefaultTimeToLive)),
+		ReplicaRegions:          replicaRegions(in.ReplicaSpecifications),
+		AutoScaling:             fromWireAutoScaling(in.AutoScalingSpecification),
+		Tags:                    tagMap(in.Tags),
+	}
+
+	if in.PointInTimeRecovery != nil {
+		cfg.PointInTimeRecovery = string(in.PointInTimeRecovery.Status)
+	}
+
+	if in.Ttl != nil {
+		cfg.TTLStatus = string(in.Ttl.Status)
+	}
+
+	if in.ClientSideTimestamps != nil {
+		cfg.ClientSideTimestamps = string(in.ClientSideTimestamps.Status)
+	}
+
+	if in.CdcSpecification != nil {
+		cfg.CdcStatus = string(in.CdcSpecification.Status)
+	}
+
+	if in.Comment != nil {
+		cfg.Comment = aws.ToString(in.Comment.Message)
+	}
+
+	t, err := h.db.CreateTable(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.CreateTableOutput{ResourceArn: aws.String(t.ARN)})
+}
+
+func (h *Handler) getTable(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.GetTableInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	t, err := h.db.GetTable(r.Context(), aws.ToString(in.KeyspaceName), aws.ToString(in.TableName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, tableOutput(t))
+}
+
+// tableOutput builds the GetTable response. CreationTimestamp is omitted: AWS
+// JSON 1.0 encodes timestamps as epoch numbers, which encoding/json cannot emit
+// for a time.Time.
+func tableOutput(t *ksdriver.Table) keyspaces.GetTableOutput {
+	out := keyspaces.GetTableOutput{
+		KeyspaceName:            aws.String(t.KeyspaceName),
+		TableName:               aws.String(t.Name),
+		ResourceArn:             aws.String(t.ARN),
+		Status:                  types.TableStatus(t.Status),
+		SchemaDefinition:        toWireSchema(&t.SchemaDefinition),
+		CapacitySpecification:   toWireCapacity(t.CapacitySpecification),
+		EncryptionSpecification: toWireEncryption(t.EncryptionSpecification),
+		DefaultTimeToLive:       aws.Int32(int32(t.DefaultTimeToLive)), //nolint:gosec // mock TTL seconds never overflow int32.
+		PointInTimeRecovery:     &types.PointInTimeRecoverySummary{Status: types.PointInTimeRecoveryStatus(t.PointInTimeRecoveryStatus)},
+		Ttl:                     &types.TimeToLive{Status: types.TimeToLiveStatus(t.TTLStatus)},
+		ClientSideTimestamps:    &types.ClientSideTimestamps{Status: types.ClientSideTimestampsStatus(t.ClientSideTimestamps)},
+		CdcSpecification:        &types.CdcSpecificationSummary{Status: types.CdcStatus(t.CdcStatus)},
+	}
+	if t.Comment != "" {
+		out.Comment = &types.Comment{Message: aws.String(t.Comment)}
+	}
+
+	return out
+}
+
+func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.ListTablesInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	all, err := h.db.ListTables(r.Context(), aws.ToString(in.KeyspaceName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	page, next, err := paginate(all, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := keyspaces.ListTablesOutput{NextToken: next}
+	for i := range page {
+		out.Tables = append(out.Tables, toWireTableSummary(&page[i]))
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.UpdateTableInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := ksdriver.UpdateTableConfig{
+		KeyspaceName: aws.ToString(in.KeyspaceName),
+		Name:         aws.ToString(in.TableName),
+		AddColumns:   fromWireSchema(&types.SchemaDefinition{AllColumns: in.AddColumns}).AllColumns,
+		AutoScaling:  fromWireAutoScaling(in.AutoScalingSpecification),
+	}
+
+	if in.CapacitySpecification != nil {
+		c := fromWireCapacity(in.CapacitySpecification)
+		cfg.CapacitySpecification = &c
+	}
+
+	if in.PointInTimeRecovery != nil {
+		cfg.PointInTimeRecovery = string(in.PointInTimeRecovery.Status)
+	}
+
+	if in.Ttl != nil {
+		cfg.TTLStatus = string(in.Ttl.Status)
+	}
+
+	if in.ClientSideTimestamps != nil {
+		cfg.ClientSideTimestamps = string(in.ClientSideTimestamps.Status)
+	}
+
+	if in.CdcSpecification != nil {
+		cfg.CdcStatus = string(in.CdcSpecification.Status)
+	}
+
+	if in.DefaultTimeToLive != nil {
+		v := int(aws.ToInt32(in.DefaultTimeToLive))
+		cfg.DefaultTimeToLive = &v
+	}
+
+	t, err := h.db.UpdateTable(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.UpdateTableOutput{ResourceArn: aws.String(t.ARN)})
+}
+
+func (h *Handler) deleteTable(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.DeleteTableInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	if err := h.db.DeleteTable(r.Context(), aws.ToString(in.KeyspaceName), aws.ToString(in.TableName)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.DeleteTableOutput{})
+}
+
+func (h *Handler) restoreTable(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.RestoreTableInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	cfg := ksdriver.RestoreTableConfig{
+		SourceKeyspace: aws.ToString(in.SourceKeyspaceName),
+		SourceTable:    aws.ToString(in.SourceTableName),
+		TargetKeyspace: aws.ToString(in.TargetKeyspaceName),
+		TargetTable:    aws.ToString(in.TargetTableName),
+		Tags:           tagMap(in.TagsOverride),
+	}
+
+	if in.CapacitySpecificationOverride != nil {
+		c := fromWireCapacity(in.CapacitySpecificationOverride)
+		cfg.CapacitySpecification = &c
+	}
+
+	if in.EncryptionSpecificationOverride != nil {
+		e := fromWireEncryption(in.EncryptionSpecificationOverride)
+		cfg.EncryptionSpecification = &e
+	}
+
+	if in.PointInTimeRecoveryOverride != nil {
+		cfg.PointInTimeRecovery = string(in.PointInTimeRecoveryOverride.Status)
+	}
+
+	t, err := h.db.RestoreTable(r.Context(), cfg)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.RestoreTableOutput{RestoredTableARN: aws.String(t.ARN)})
+}

--- a/server/aws/keyspaces/tables.go
+++ b/server/aws/keyspaces/tables.go
@@ -1,7 +1,10 @@
 package keyspaces
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
@@ -10,6 +13,46 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
 )
+
+// extractRestoreTimestamp reads the request body, removes the epoch-number
+// restoreTimestamp field (which cannot decode into a time.Time), and returns
+// the resolved timestamp (defaulting to now when absent) plus the remaining
+// body for normal decoding. It writes an error and returns ok=false on failure.
+func extractRestoreTimestamp(w http.ResponseWriter, r *http.Request) (time.Time, []byte, bool) {
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "SerializationException", "cannot read body: "+err.Error())
+		return time.Time{}, nil, false
+	}
+
+	var fields map[string]json.RawMessage
+	if err = json.Unmarshal(raw, &fields); err != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "SerializationException", "invalid JSON: "+err.Error())
+		return time.Time{}, nil, false
+	}
+
+	at := time.Now().UTC()
+
+	if tok, present := fields["restoreTimestamp"]; present {
+		var epoch float64
+		if err = json.Unmarshal(tok, &epoch); err != nil {
+			wire.WriteJSONError(w, http.StatusBadRequest, "SerializationException", "invalid restoreTimestamp")
+			return time.Time{}, nil, false
+		}
+
+		at = time.Unix(int64(epoch), 0).UTC()
+
+		delete(fields, "restoreTimestamp")
+	}
+
+	rest, err := json.Marshal(fields)
+	if err != nil {
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+		return time.Time{}, nil, false
+	}
+
+	return at, rest, true
+}
 
 func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 	var in keyspaces.CreateTableInput
@@ -187,17 +230,27 @@ func (h *Handler) deleteTable(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) restoreTable(w http.ResponseWriter, r *http.Request) {
+	// restoreTimestamp arrives as an AWS-JSON epoch number, which can't decode
+	// into the SDK input's time.Time. Pull it out (it's optional — default to
+	// now) and decode the rest of the body normally.
+	restoreAt, body, ok := extractRestoreTimestamp(w, r)
+	if !ok {
+		return
+	}
+
 	var in keyspaces.RestoreTableInput
-	if !wire.DecodeJSON(w, r, &in) {
+	if err := json.Unmarshal(body, &in); err != nil {
+		wire.WriteJSONError(w, http.StatusBadRequest, "SerializationException", "invalid JSON: "+err.Error())
 		return
 	}
 
 	cfg := ksdriver.RestoreTableConfig{
-		SourceKeyspace: aws.ToString(in.SourceKeyspaceName),
-		SourceTable:    aws.ToString(in.SourceTableName),
-		TargetKeyspace: aws.ToString(in.TargetKeyspaceName),
-		TargetTable:    aws.ToString(in.TargetTableName),
-		Tags:           tagMap(in.TagsOverride),
+		SourceKeyspace:   aws.ToString(in.SourceKeyspaceName),
+		SourceTable:      aws.ToString(in.SourceTableName),
+		TargetKeyspace:   aws.ToString(in.TargetKeyspaceName),
+		TargetTable:      aws.ToString(in.TargetTableName),
+		RestoreTimestamp: restoreAt,
+		Tags:             tagMap(in.TagsOverride),
 	}
 
 	if in.CapacitySpecificationOverride != nil {

--- a/server/aws/keyspaces/tags.go
+++ b/server/aws/keyspaces/tags.go
@@ -1,0 +1,64 @@
+package keyspaces
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.TagResourceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	if err := h.db.TagResource(r.Context(), aws.ToString(in.ResourceArn), tagMap(in.Tags)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.TagResourceOutput{})
+}
+
+func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.UntagResourceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	keys := make([]string, 0, len(in.Tags))
+	for i := range in.Tags {
+		keys = append(keys, aws.ToString(in.Tags[i].Key))
+	}
+
+	if err := h.db.UntagResource(r.Context(), aws.ToString(in.ResourceArn), keys); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.UntagResourceOutput{})
+}
+
+func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.ListTagsForResourceInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	tags, err := h.db.ListTagsForResource(r.Context(), aws.ToString(in.ResourceArn))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	page, next, err := paginate(tags, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.ListTagsForResourceOutput{Tags: toWireTags(page), NextToken: next})
+}

--- a/server/aws/keyspaces/types.go
+++ b/server/aws/keyspaces/types.go
@@ -1,0 +1,207 @@
+package keyspaces
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces/types"
+
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func toWireSchema(s *ksdriver.SchemaDefinition) *types.SchemaDefinition {
+	out := &types.SchemaDefinition{}
+
+	for _, c := range s.AllColumns {
+		out.AllColumns = append(out.AllColumns, types.ColumnDefinition{Name: aws.String(c.Name), Type: aws.String(c.Type)})
+	}
+
+	for _, p := range s.PartitionKeys {
+		out.PartitionKeys = append(out.PartitionKeys, types.PartitionKey{Name: aws.String(p.Name)})
+	}
+
+	for _, c := range s.ClusteringKeys {
+		out.ClusteringKeys = append(out.ClusteringKeys,
+			types.ClusteringKey{Name: aws.String(c.Name), OrderBy: types.SortOrder(c.OrderBy)})
+	}
+
+	for _, sc := range s.StaticColumns {
+		out.StaticColumns = append(out.StaticColumns, types.StaticColumn{Name: aws.String(sc.Name)})
+	}
+
+	return out
+}
+
+func toWireCapacity(c ksdriver.CapacitySpecification) *types.CapacitySpecificationSummary {
+	return &types.CapacitySpecificationSummary{
+		ThroughputMode:     types.ThroughputMode(c.ThroughputMode),
+		ReadCapacityUnits:  aws.Int64(c.ReadCapacityUnits),
+		WriteCapacityUnits: aws.Int64(c.WriteCapacityUnits),
+	}
+}
+
+func toWireEncryption(e ksdriver.EncryptionSpecification) *types.EncryptionSpecification {
+	out := &types.EncryptionSpecification{Type: types.EncryptionType(e.Type)}
+	if e.KmsKeyIdentifier != "" {
+		out.KmsKeyIdentifier = aws.String(e.KmsKeyIdentifier)
+	}
+
+	return out
+}
+
+func toWireAutoScalingSettings(s *ksdriver.AutoScalingSettings) *types.AutoScalingSettings {
+	if s == nil {
+		return nil
+	}
+
+	return &types.AutoScalingSettings{
+		AutoScalingDisabled: s.AutoScalingDisabled,
+		MinimumUnits:        aws.Int64(s.MinimumUnits),
+		MaximumUnits:        aws.Int64(s.MaximumUnits),
+		ScalingPolicy: &types.AutoScalingPolicy{
+			TargetTrackingScalingPolicyConfiguration: &types.TargetTrackingScalingPolicyConfiguration{
+				TargetValue:      s.TargetValue,
+				DisableScaleIn:   s.DisableScaleIn,
+				ScaleInCooldown:  int32(s.ScaleInCooldown),  //nolint:gosec // mock cooldown seconds never overflow int32.
+				ScaleOutCooldown: int32(s.ScaleOutCooldown), //nolint:gosec // mock cooldown seconds never overflow int32.
+			},
+		},
+	}
+}
+
+func toWireAutoScaling(a *ksdriver.AutoScalingSpecification) *types.AutoScalingSpecification {
+	if a == nil {
+		return nil
+	}
+
+	return &types.AutoScalingSpecification{
+		ReadCapacityAutoScaling:  toWireAutoScalingSettings(a.Read),
+		WriteCapacityAutoScaling: toWireAutoScalingSettings(a.Write),
+	}
+}
+
+func toWireKeyspaceSummary(k *ksdriver.Keyspace) types.KeyspaceSummary {
+	return types.KeyspaceSummary{
+		KeyspaceName:        aws.String(k.Name),
+		ResourceArn:         aws.String(k.ARN),
+		ReplicationStrategy: types.Rs(k.ReplicationStrategy),
+		ReplicationRegions:  append([]string(nil), k.ReplicationRegions...),
+	}
+}
+
+func toWireTableSummary(t *ksdriver.Table) types.TableSummary {
+	return types.TableSummary{
+		KeyspaceName: aws.String(t.KeyspaceName),
+		TableName:    aws.String(t.Name),
+		ResourceArn:  aws.String(t.ARN),
+	}
+}
+
+func toWireTags(tags []ksdriver.Tag) []types.Tag {
+	out := make([]types.Tag, 0, len(tags))
+	for i := range tags {
+		out = append(out, types.Tag{Key: aws.String(tags[i].Key), Value: aws.String(tags[i].Value)})
+	}
+
+	return out
+}
+
+func fromWireSchema(s *types.SchemaDefinition) ksdriver.SchemaDefinition {
+	out := ksdriver.SchemaDefinition{}
+	if s == nil {
+		return out
+	}
+
+	for _, c := range s.AllColumns {
+		out.AllColumns = append(out.AllColumns,
+			ksdriver.ColumnDefinition{Name: aws.ToString(c.Name), Type: aws.ToString(c.Type)})
+	}
+
+	for _, p := range s.PartitionKeys {
+		out.PartitionKeys = append(out.PartitionKeys, ksdriver.PartitionKey{Name: aws.ToString(p.Name)})
+	}
+
+	for _, c := range s.ClusteringKeys {
+		out.ClusteringKeys = append(out.ClusteringKeys,
+			ksdriver.ClusteringKey{Name: aws.ToString(c.Name), OrderBy: string(c.OrderBy)})
+	}
+
+	for _, sc := range s.StaticColumns {
+		out.StaticColumns = append(out.StaticColumns, ksdriver.StaticColumn{Name: aws.ToString(sc.Name)})
+	}
+
+	return out
+}
+
+func fromWireCapacity(c *types.CapacitySpecification) ksdriver.CapacitySpecification {
+	if c == nil {
+		return ksdriver.CapacitySpecification{}
+	}
+
+	return ksdriver.CapacitySpecification{
+		ThroughputMode:     string(c.ThroughputMode),
+		ReadCapacityUnits:  aws.ToInt64(c.ReadCapacityUnits),
+		WriteCapacityUnits: aws.ToInt64(c.WriteCapacityUnits),
+	}
+}
+
+func fromWireEncryption(e *types.EncryptionSpecification) ksdriver.EncryptionSpecification {
+	if e == nil {
+		return ksdriver.EncryptionSpecification{}
+	}
+
+	return ksdriver.EncryptionSpecification{Type: string(e.Type), KmsKeyIdentifier: aws.ToString(e.KmsKeyIdentifier)}
+}
+
+func fromWireAutoScalingSettings(s *types.AutoScalingSettings) *ksdriver.AutoScalingSettings {
+	if s == nil {
+		return nil
+	}
+
+	out := &ksdriver.AutoScalingSettings{
+		AutoScalingDisabled: s.AutoScalingDisabled,
+		MinimumUnits:        aws.ToInt64(s.MinimumUnits),
+		MaximumUnits:        aws.ToInt64(s.MaximumUnits),
+	}
+
+	if s.ScalingPolicy != nil && s.ScalingPolicy.TargetTrackingScalingPolicyConfiguration != nil {
+		cfg := s.ScalingPolicy.TargetTrackingScalingPolicyConfiguration
+		out.TargetValue = cfg.TargetValue
+		out.DisableScaleIn = cfg.DisableScaleIn
+		out.ScaleInCooldown = int(cfg.ScaleInCooldown)
+		out.ScaleOutCooldown = int(cfg.ScaleOutCooldown)
+	}
+
+	return out
+}
+
+func fromWireAutoScaling(a *types.AutoScalingSpecification) *ksdriver.AutoScalingSpecification {
+	if a == nil {
+		return nil
+	}
+
+	return &ksdriver.AutoScalingSpecification{
+		Read:  fromWireAutoScalingSettings(a.ReadCapacityAutoScaling),
+		Write: fromWireAutoScalingSettings(a.WriteCapacityAutoScaling),
+	}
+}
+
+func replicaRegions(specs []types.ReplicaSpecification) []string {
+	out := make([]string, 0, len(specs))
+	for i := range specs {
+		out = append(out, aws.ToString(specs[i].Region))
+	}
+
+	return out
+}
+
+func tagMap(tags []types.Tag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for i := range tags {
+		out[aws.ToString(tags[i].Key)] = aws.ToString(tags[i].Value)
+	}
+
+	return out
+}

--- a/server/aws/keyspaces/udt.go
+++ b/server/aws/keyspaces/udt.go
@@ -1,0 +1,108 @@
+package keyspaces
+
+import (
+	"net/http"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces"
+	"github.com/aws/aws-sdk-go-v2/service/keyspaces/types"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	ksdriver "github.com/stackshy/cloudemu/v2/services/keyspaces/driver"
+)
+
+func (h *Handler) createType(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.CreateTypeInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	fields := make([]ksdriver.FieldDefinition, 0, len(in.FieldDefinitions))
+	for _, f := range in.FieldDefinitions {
+		fields = append(fields, ksdriver.FieldDefinition{Name: aws.ToString(f.Name), Type: aws.ToString(f.Type)})
+	}
+
+	u, err := h.db.CreateType(r.Context(), aws.ToString(in.KeyspaceName), aws.ToString(in.TypeName), fields)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.CreateTypeOutput{
+		KeyspaceArn: aws.String(u.KeyspaceARN), TypeName: aws.String(u.Name),
+	})
+}
+
+// getType builds the GetType response. LastModifiedTimestamp is omitted (AWS
+// JSON 1.0 epoch-encoded timestamps can't be produced by encoding/json).
+func (h *Handler) getType(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.GetTypeInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	u, err := h.db.GetType(r.Context(), aws.ToString(in.KeyspaceName), aws.ToString(in.TypeName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := keyspaces.GetTypeOutput{
+		KeyspaceName:          aws.String(u.KeyspaceName),
+		KeyspaceArn:           aws.String(u.KeyspaceARN),
+		TypeName:              aws.String(u.Name),
+		Status:                types.TypeStatus(u.Status),
+		MaxNestingDepth:       int32(u.MaxNestingDepth), //nolint:gosec // mock nesting depth never overflows int32.
+		DirectParentTypes:     u.DirectParentTypes,
+		DirectReferringTables: u.DirectReferringTables,
+	}
+	for _, f := range u.FieldDefinitions {
+		out.FieldDefinitions = append(out.FieldDefinitions,
+			types.FieldDefinition{Name: aws.String(f.Name), Type: aws.String(f.Type)})
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) listTypes(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.ListTypesInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	all, err := h.db.ListTypes(r.Context(), aws.ToString(in.KeyspaceName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	page, next, err := paginate(all, in.MaxResults, in.NextToken)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := keyspaces.ListTypesOutput{NextToken: next}
+	for i := range page {
+		out.Types = append(out.Types, page[i].Name)
+	}
+
+	writeJSON(w, out)
+}
+
+func (h *Handler) deleteType(w http.ResponseWriter, r *http.Request) {
+	var in keyspaces.DeleteTypeInput
+	if !wire.DecodeJSON(w, r, &in) {
+		return
+	}
+
+	u, err := h.db.DeleteType(r.Context(), aws.ToString(in.KeyspaceName), aws.ToString(in.TypeName))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, keyspaces.DeleteTypeOutput{
+		KeyspaceArn: aws.String(u.KeyspaceARN), TypeName: aws.String(u.Name),
+	})
+}

--- a/server/aws/keyspaces/wirejson.go
+++ b/server/aws/keyspaces/wirejson.go
@@ -32,12 +32,18 @@ func writeJSON(w http.ResponseWriter, v any) {
 }
 
 // lowerCamelKeys returns v with the first letter of every map key lowercased,
-// recursively.
+// recursively. It also drops null values and the SDK's always-empty
+// resultMetadata envelope so the response carries only meaningful fields.
 func lowerCamelKeys(v any) any {
 	switch t := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(t))
+
 		for k, val := range t {
+			if val == nil || k == "ResultMetadata" {
+				continue
+			}
+
 			out[lowerFirst(k)] = lowerCamelKeys(val)
 		}
 

--- a/server/aws/keyspaces/wirejson.go
+++ b/server/aws/keyspaces/wirejson.go
@@ -1,0 +1,64 @@
+package keyspaces
+
+import (
+	"encoding/json"
+	"net/http"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+)
+
+// writeJSON encodes v as an Amazon Keyspaces response body. The AWS SDK models
+// Keyspaces members in lowerCamelCase and its awsjson1.0 deserializer matches
+// keys case-sensitively, but encoding/json emits the SDK structs' Go field
+// names (UpperCamelCase). This lowercases the first letter of every object key
+// so the real client decodes the response — the smithy member name for a
+// generated field is exactly its Go name with the leading letter lowered.
+func writeJSON(w http.ResponseWriter, v any) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+		return
+	}
+
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerException", err.Error())
+		return
+	}
+
+	wire.WriteJSON(w, lowerCamelKeys(decoded))
+}
+
+// lowerCamelKeys returns v with the first letter of every map key lowercased,
+// recursively.
+func lowerCamelKeys(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			out[lowerFirst(k)] = lowerCamelKeys(val)
+		}
+
+		return out
+	case []any:
+		for i := range t {
+			t[i] = lowerCamelKeys(t[i])
+		}
+
+		return t
+	default:
+		return v
+	}
+}
+
+func lowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+
+	r, size := utf8.DecodeRuneInString(s)
+
+	return string(unicode.ToLower(r)) + s[size:]
+}

--- a/services/cost/cost.go
+++ b/services/cost/cost.go
@@ -82,9 +82,9 @@ func defaultRates() map[string]float64 {
 		// keyspaces, types, restores and tags are free control-plane ops. A
 		// provisioned table is proxied at a small hourly base at create.
 		"keyspaces:CreateTable":    0.01, // provisioned-capacity table-hour proxy
+		"keyspaces:RestoreTable":   0.01, // restore provisions a new table
 		"keyspaces:CreateKeyspace": 0.0,
 		"keyspaces:CreateType":     0.0,
-		"keyspaces:RestoreTable":   0.0,
 
 		// Serverless (per invocation)
 		"serverless:Invoke": 0.0000002, // $0.20 per 1M

--- a/services/cost/cost.go
+++ b/services/cost/cost.go
@@ -78,6 +78,14 @@ func defaultRates() map[string]float64 {
 		"memorydb:CopySnapshot":                  0.0,
 		"memorydb:PurchaseReservedNodesOffering": 0.0,
 
+		// Amazon Keyspaces (Cassandra): tables billed per throughput/storage;
+		// keyspaces, types, restores and tags are free control-plane ops. A
+		// provisioned table is proxied at a small hourly base at create.
+		"keyspaces:CreateTable":    0.01, // provisioned-capacity table-hour proxy
+		"keyspaces:CreateKeyspace": 0.0,
+		"keyspaces:CreateType":     0.0,
+		"keyspaces:RestoreTable":   0.0,
+
 		// Serverless (per invocation)
 		"serverless:Invoke": 0.0000002, // $0.20 per 1M
 

--- a/services/cost/cost_test.go
+++ b/services/cost/cost_test.go
@@ -40,14 +40,14 @@ func TestTracker_MemoryDBRates(t *testing.T) {
 func TestTracker_KeyspacesRates(t *testing.T) {
 	tracker := New()
 
-	// Two provisioned tables priced at the table-hour rate; keyspace, type and
-	// restore are free.
+	// Two created tables + one restore priced at the table-hour rate; keyspace
+	// and type creation are free.
 	tracker.Record("keyspaces", "CreateTable", 2)
+	tracker.Record("keyspaces", "RestoreTable", 1)
 	tracker.Record("keyspaces", "CreateKeyspace", 1)
 	tracker.Record("keyspaces", "CreateType", 1)
-	tracker.Record("keyspaces", "RestoreTable", 1)
 
-	want := 0.01 * 2
+	want := 0.01 * 3
 	assert.InDelta(t, want, tracker.CostByService()["keyspaces"], 1e-9)
 }
 

--- a/services/cost/cost_test.go
+++ b/services/cost/cost_test.go
@@ -37,6 +37,20 @@ func TestTracker_MemoryDBRates(t *testing.T) {
 	assert.InDelta(t, want, tracker.CostByService()["memorydb"], 1e-9)
 }
 
+func TestTracker_KeyspacesRates(t *testing.T) {
+	tracker := New()
+
+	// Two provisioned tables priced at the table-hour rate; keyspace, type and
+	// restore are free.
+	tracker.Record("keyspaces", "CreateTable", 2)
+	tracker.Record("keyspaces", "CreateKeyspace", 1)
+	tracker.Record("keyspaces", "CreateType", 1)
+	tracker.Record("keyspaces", "RestoreTable", 1)
+
+	want := 0.01 * 2
+	assert.InDelta(t, want, tracker.CostByService()["keyspaces"], 1e-9)
+}
+
 func TestTracker_Record_And_TotalCost(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/services/keyspaces/driver/driver.go
+++ b/services/keyspaces/driver/driver.go
@@ -1,0 +1,232 @@
+// Package driver defines the portable interface for an Amazon Keyspaces
+// (Apache Cassandra–compatible) control plane. Keyspaces is control-plane only
+// here — CQL data operations are out of scope — so this driver is independent
+// of the cache/relational drivers.
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// Resource lifecycle states.
+const (
+	StatusCreating  = "CREATING"
+	StatusActive    = "ACTIVE"
+	StatusUpdating  = "UPDATING"
+	StatusDeleting  = "DELETING"
+	StatusRestoring = "RESTORING"
+)
+
+// Replication strategies for a keyspace.
+const (
+	SingleRegion = "SINGLE_REGION"
+	MultiRegion  = "MULTI_REGION"
+)
+
+// Throughput modes for a table's capacity specification.
+const (
+	ThroughputPayPerRequest = "PAY_PER_REQUEST"
+	ThroughputProvisioned   = "PROVISIONED"
+)
+
+// Tag is a key/value label on a keyspace or table.
+type Tag struct {
+	Key   string
+	Value string
+}
+
+// Keyspace is a Cassandra keyspace (a namespace of tables).
+type Keyspace struct {
+	Name                string
+	ARN                 string
+	ReplicationStrategy string
+	ReplicationRegions  []string
+	Tags                map[string]string
+}
+
+// PartitionKey names a column that is part of the partition key.
+type PartitionKey struct{ Name string }
+
+// ClusteringKey names a clustering column and its sort order (ASC/DESC).
+type ClusteringKey struct {
+	Name    string
+	OrderBy string
+}
+
+// ColumnDefinition is a regular column name + Cassandra type.
+type ColumnDefinition struct {
+	Name string
+	Type string
+}
+
+// StaticColumn names a static column (shared across a partition's rows).
+type StaticColumn struct{ Name string }
+
+// SchemaDefinition describes a table's columns and primary key.
+type SchemaDefinition struct {
+	AllColumns     []ColumnDefinition
+	PartitionKeys  []PartitionKey
+	ClusteringKeys []ClusteringKey
+	StaticColumns  []StaticColumn
+}
+
+// CapacitySpecification is a table's read/write capacity mode + provisioned
+// units (units apply only in PROVISIONED mode).
+type CapacitySpecification struct {
+	ThroughputMode     string
+	ReadCapacityUnits  int64
+	WriteCapacityUnits int64
+}
+
+// EncryptionSpecification is a table's encryption-at-rest configuration.
+type EncryptionSpecification struct {
+	Type             string
+	KmsKeyIdentifier string
+}
+
+// AutoScalingSettings holds the target-tracking auto-scaling config for one
+// capacity dimension (read or write) of a provisioned table.
+type AutoScalingSettings struct {
+	AutoScalingDisabled bool
+	MinimumUnits        int64
+	MaximumUnits        int64
+	TargetValue         float64
+	DisableScaleIn      bool
+	ScaleInCooldown     int
+	ScaleOutCooldown    int
+}
+
+// AutoScalingSpecification bundles the read/write auto-scaling settings.
+type AutoScalingSpecification struct {
+	Read  *AutoScalingSettings
+	Write *AutoScalingSettings
+}
+
+// Table is a Cassandra table within a keyspace.
+type Table struct {
+	KeyspaceName              string
+	Name                      string
+	ARN                       string
+	Status                    string
+	SchemaDefinition          SchemaDefinition
+	CapacitySpecification     CapacitySpecification
+	EncryptionSpecification   EncryptionSpecification
+	PointInTimeRecoveryStatus string
+	TTLStatus                 string
+	DefaultTimeToLive         int
+	ClientSideTimestamps      string
+	CdcStatus                 string
+	Comment                   string
+	ReplicaRegions            []string
+	AutoScaling               *AutoScalingSpecification
+	CreationTimestamp         time.Time
+	Tags                      map[string]string
+}
+
+// FieldDefinition is a name/type pair inside a user-defined type.
+type FieldDefinition struct {
+	Name string
+	Type string
+}
+
+// UDT is a user-defined type within a keyspace.
+type UDT struct {
+	KeyspaceName          string
+	KeyspaceARN           string
+	Name                  string
+	Status                string
+	FieldDefinitions      []FieldDefinition
+	DirectParentTypes     []string
+	DirectReferringTables []string
+	MaxNestingDepth       int
+	LastModified          time.Time
+}
+
+// CreateKeyspaceConfig is the input to CreateKeyspace.
+type CreateKeyspaceConfig struct {
+	Name                string
+	ReplicationStrategy string
+	ReplicationRegions  []string
+	Tags                map[string]string
+}
+
+// CreateTableConfig is the input to CreateTable.
+type CreateTableConfig struct {
+	KeyspaceName            string
+	Name                    string
+	SchemaDefinition        SchemaDefinition
+	CapacitySpecification   CapacitySpecification
+	EncryptionSpecification EncryptionSpecification
+	PointInTimeRecovery     string
+	TTLStatus               string
+	DefaultTimeToLive       int
+	ClientSideTimestamps    string
+	CdcStatus               string
+	Comment                 string
+	ReplicaRegions          []string
+	AutoScaling             *AutoScalingSpecification
+	Tags                    map[string]string
+}
+
+// UpdateTableConfig is the input to UpdateTable. Zero-valued fields are left
+// unchanged; AddColumns are appended to the schema.
+type UpdateTableConfig struct {
+	KeyspaceName          string
+	Name                  string
+	AddColumns            []ColumnDefinition
+	CapacitySpecification *CapacitySpecification
+	PointInTimeRecovery   string
+	TTLStatus             string
+	DefaultTimeToLive     *int
+	ClientSideTimestamps  string
+	CdcStatus             string
+	Comment               string
+	AutoScaling           *AutoScalingSpecification
+}
+
+// RestoreTableConfig is the input to RestoreTable (point-in-time recovery).
+type RestoreTableConfig struct {
+	SourceKeyspace          string
+	SourceTable             string
+	TargetKeyspace          string
+	TargetTable             string
+	CapacitySpecification   *CapacitySpecification
+	EncryptionSpecification *EncryptionSpecification
+	PointInTimeRecovery     string
+	RestoreTimestamp        time.Time
+	Tags                    map[string]string
+}
+
+// Keyspaces is the core Amazon Keyspaces control plane.
+//
+//nolint:interfacebloat // mirrors the AWS Keyspaces control-plane surface.
+type Keyspaces interface {
+	CreateKeyspace(ctx context.Context, cfg CreateKeyspaceConfig) (*Keyspace, error)
+	GetKeyspace(ctx context.Context, name string) (*Keyspace, error)
+	ListKeyspaces(ctx context.Context) ([]Keyspace, error)
+	UpdateKeyspace(ctx context.Context, name string, addRegions []string) (*Keyspace, error)
+	DeleteKeyspace(ctx context.Context, name string) error
+
+	CreateTable(ctx context.Context, cfg CreateTableConfig) (*Table, error)
+	GetTable(ctx context.Context, keyspace, table string) (*Table, error)
+	ListTables(ctx context.Context, keyspace string) ([]Table, error)
+	UpdateTable(ctx context.Context, cfg UpdateTableConfig) (*Table, error)
+	DeleteTable(ctx context.Context, keyspace, table string) error
+	RestoreTable(ctx context.Context, cfg RestoreTableConfig) (*Table, error)
+
+	CreateType(ctx context.Context, keyspace, name string, fields []FieldDefinition) (*UDT, error)
+	GetType(ctx context.Context, keyspace, name string) (*UDT, error)
+	ListTypes(ctx context.Context, keyspace string) ([]UDT, error)
+	DeleteType(ctx context.Context, keyspace, name string) (*UDT, error)
+
+	TagResource(ctx context.Context, arn string, tags map[string]string) error
+	UntagResource(ctx context.Context, arn string, keys []string) error
+	ListTagsForResource(ctx context.Context, arn string) ([]Tag, error)
+}
+
+// AutoScaling is an OPTIONAL capability (provisioned-throughput tables),
+// discovered by type assertion.
+type AutoScaling interface {
+	GetTableAutoScalingSettings(ctx context.Context, keyspace, table string) (*Table, error)
+}


### PR DESCRIPTION
## Objective

Add full-parity support for **Amazon Keyspaces (for Apache Cassandra)** — the next missing managed database-server surface after MemoryDB (#305). Covers every control-plane resource, child resource, pagination, and provisioned auto-scaling, so a real `aws-sdk-go-v2/service/keyspaces` client works unchanged against a custom endpoint.

## What we found

- Keyspaces is a **control-plane-only** wide-column (Cassandra) service; CQL data operations aren't in this SDK. It doesn't fit the relational or cache drivers → dedicated `services/keyspaces/driver`.
- Wire protocol is **AWS JSON 1.0** on the `KeyspacesService.` target prefix — disjoint from every existing handler.
- Keyspaces models its members in **lowerCamelCase**, and the SDK's smithy deserializer matches response keys **case-sensitively** (unlike MemoryDB's PascalCase). Marshaling SDK output structs with `encoding/json` yields PascalCase keys the client can't decode.

## How we fixed it

- **Driver** (`services/keyspaces/driver`): 18 core operations (keyspaces, tables, user-defined types, tags) + an `AutoScaling` optional capability (`GetTableAutoScalingSettings`), type-asserted.
- **Provider** (`providers/aws/keyspaces`): in-memory `Mock` — keyspaces (single/multi-region replication), tables (full `SchemaDefinition`, capacity mode + RCU/WCU, encryption, PITR, TTL, client-side timestamps, CDC, replicas, provisioned auto-scaling), point-in-time `RestoreTable`, UDTs, tags. Schema validation (partition key required, keys declared), reference validation, empty-keyspace delete guard, clone-on-read on every path, account-default system keyspaces.
- **Server** (`server/aws/keyspaces`): JSON 1.0 handler; canonical errors → typed faults (`ResourceNotFoundException` / `ConflictException` / `ValidationException`). Responses are emitted with **lower-camel keys** (a recursive key transform) so the case-sensitive SDK deserializer decodes them. Server-side **pagination** (`MaxResults`/`NextToken`) over the deterministic result set.
- **Wiring**: registered in the AWS provider/server bundles; dedicated `keyspaces:*` cost keys; `docs/services.md` section + counts (Grand Total 1310 → 1328).

## Alternatives not taken

- **Reusing the relational/cache driver**: rejected — Keyspaces is Cassandra wide-column, control-plane only.
- **Marshaling SDK output structs directly** (as MemoryDB does): rejected — Keyspaces' camelCase + case-sensitive deserializer needs the key transform.
- **Emitting `CreationTimestamp`/`LastModifiedTimestamp`**: omitted — AWS JSON 1.0 encodes timestamps as epoch numbers `encoding/json` can't produce for a `time.Time` (same mitigation as MemoryDB). All other fields round-trip through the real SDK.
- **Driver-level pagination**: rejected in favor of server-side paging over the deterministic result set.

## Docs / Test / Playground

- `docs/services.md`: Keyspaces section (per-resource tables incl. Auto Scaling capability + pagination note) + recomputed totals.
- Tests: provider unit tests (keyspace lifecycle incl. multi-region + empty-delete guard, table lifecycle + schema validation, restore, UDTs, deterministic tags, auto-scaling requires-provisioned, clone-on-read aliasing) + server SDK round-trip tests via the real client (keyspaces, tables, UDTs, tags, auto-scaling, pagination, and typed faults incl. `ConflictException`/`ResourceNotFoundException`/`ValidationException`). Cost rate-catalog test.

## Test plan

- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (full module, green)
- [x] `golangci-lint` — 0 issues on all new/changed packages
- [x] CodeQL (security-extended) — 0 findings in-package
- [x] `go mod tidy` clean
- [x] Coverage: provider 83.0%, server 70.7%

## Risk & Rollback

Additive: a new driver + provider/server packages plus opt-in bundle registration (nil driver ⇒ handler not registered). No existing behavior changes. Rollback = revert the commit.

## Conclusion

Keyspaces reaches full parity — keyspaces, tables (with PITR restore), user-defined types, tags, provisioned auto-scaling, and pagination — with the established driver→provider→server layering. Follow-ups (separate PRs, missing-database-server initiative): AWS Timestream, GCP Spanner & Bigtable, Azure Managed Cassandra.