### PR TITLE
Add Azure Cosmos DB for PostgreSQL Full-Parity Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ SDK-compat coverage across AWS, Azure, and GCP:
 | Storage | S3 | Blob Storage | GCS |
 | Compute | EC2 (+ VPC, EBS, Snapshots, AMIs, Spot, Launch Templates, Auto Scaling) | Virtual Machines (+ Disks, Snapshots, Images, SSH keys) | Compute Engine (+ Disks, Snapshots, Images) |
 | NoSQL DB | DynamoDB | Cosmos DB | Firestore |
-| Relational DB | RDS + Aurora (incl. Neptune & DocumentDB engines), Redshift | SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server | Cloud SQL, AlloyDB |
+| Relational DB | RDS + Aurora (incl. Neptune & DocumentDB engines), Redshift | SQL Database, PostgreSQL Flexible Server, MySQL Flexible Server, Cosmos DB for PostgreSQL (Citus) | Cloud SQL, AlloyDB |
 | Wide-column NoSQL | Keyspaces (Cassandra) | Managed Instance for Apache Cassandra | Bigtable |
 | In-memory / Redis | ElastiCache, MemoryDB | Cache for Redis | Memorystore |
 | Kubernetes | EKS (control plane + data plane) | AKS (control plane + data plane) | GKE (control plane + data plane) |

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -197,6 +197,7 @@ All handlers speak ARM JSON over HTTPS unless noted.
 | **SQL Database** | `Microsoft.Sql/servers[/databases]` — servers and databases, full CRUD lifecycle |
 | **Managed Cassandra** | `Microsoft.DocumentDB/cassandraClusters[/dataCenters]` — clusters (CreateOrUpdate, Get, ListByResourceGroup, ListBySubscription, Update, Delete, deallocate, start, invokeCommand, status) and datacenters (CreateOrUpdate, Get, List, Update, Delete). Real `armcosmos` `CassandraClusters`/`CassandraDataCenters` clients round-trip end-to-end, including the LRO pollers. |
 | **PostgreSQL Flexible Server** | `Microsoft.DBforPostgreSQL/flexibleServers` — full CRUD lifecycle |
+| **Cosmos DB for PostgreSQL** | `Microsoft.DBforPostgreSQL/serverGroupsv2` — clusters (CreateOrUpdate, Get, ListByResourceGroup, ListBySubscription, Update, Delete, restart, start, stop, promote, checkNameAvailability), firewall rules, roles, derived servers/nodes, configurations (cluster/coordinator/node reads + updates), and private endpoint connections/links. Real `armcosmosforpostgresql` clients round-trip end-to-end, including the LRO pollers. |
 | **MySQL Flexible Server** | `Microsoft.DBforMySQL/flexibleServers` — full CRUD lifecycle |
 | **AKS** | `Microsoft.ContainerService/managedClusters` — ManagedClusters (CreateOrUpdate, Get, UpdateTags, Delete, List/ListByResourceGroup), AgentPools (CreateOrUpdate, Get, Delete, List), MaintenanceConfigurations (CreateOrUpdate, Get, Delete, List), ListClusterAdmin/User/MonitoringUser Credentials, RotateClusterCertificates. Stub kubeconfig only — data plane deferred to Wave 2. |
 | **IAM (armauthorization)** | `Microsoft.Authorization` — RoleDefinitions (CreateOrUpdate, Get, List, Delete) and RoleAssignments (Create, Get, ListForScope, Delete) at any scope (subscription, resource group, resource, management group). Real `armauthorization` SDK clients round-trip end-to-end. Microsoft Graph (users/groups) is out of scope — deferred to a future handler. |
@@ -297,6 +298,7 @@ Each handler uses a different signal so dispatch is unambiguous within a provide
 | Azure SQL | ARM provider `Microsoft.Sql` |
 | Azure Managed Cassandra | ARM provider `Microsoft.DocumentDB/cassandraClusters` |
 | Azure PostgreSQL Flexible | ARM provider `Microsoft.DBforPostgreSQL/flexibleServers` |
+| Azure Cosmos DB for PostgreSQL | ARM provider `Microsoft.DBforPostgreSQL/serverGroupsv2` |
 | Azure MySQL Flexible | ARM provider `Microsoft.DBforMySQL/flexibleServers` |
 | Azure AKS | ARM provider `Microsoft.ContainerService/managedClusters` |
 | Azure Databricks (ARM) | ARM provider `Microsoft.Databricks/workspaces` |

--- a/docs/services.md
+++ b/docs/services.md
@@ -26,6 +26,7 @@ This document lists every service and operation available in CloudEmu across all
 | 17a | In-memory Database (Redis/Valkey) | `memorydb` | — | — |
 | 17b | Wide-column (Cassandra) | `keyspaces` | `managedcassandra` | — |
 | 17c | Wide-column (Bigtable) | — | — | `bigtable` |
+| 17d | Distributed PostgreSQL (Citus) | — | `cosmospostgresql` | — |
 | 18 | Kubernetes | `eks` + shared `services/kubernetes/` | `aks` + shared `services/kubernetes/` | `gke` + shared `services/kubernetes/` |
 | 19 | Resource Discovery | `resourceexplorer2` + `resourcegroupstaggingapi` | `resourcegraph` | `cloudasset` |
 | 20 | Generative AI | `bedrock` (+ `bedrock-runtime`), `bedrock-agent` (+ `bedrock-agent-runtime`) | — | — |
@@ -1222,6 +1223,57 @@ counts are bounded; clone-on-read on every path.
 
 ---
 
+## 11e. Cosmos DB for PostgreSQL (Azure)
+
+**Driver interface:** `services/cosmospostgresql/driver/driver.go`
+**Azure:** Cosmos DB for PostgreSQL (Citus) — `Microsoft.DBforPostgreSQL/serverGroupsv2`
+
+Real `armcosmosforpostgresql` clients configured with a custom endpoint hit the
+ARM handler (`server/azure/cosmospostgresql`) the same way they hit
+management.azure.com. Create/update RPCs return the resource inline with a
+terminal `provisioningState`; the cluster start/stop/restart/promote actions
+reply `202` + `Location` and the poller reads a terminal status from the
+`operationStatuses` URL.
+
+### Clusters (server groups)
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateOrUpdateCluster` | `(ctx, CreateClusterConfig) (*Cluster, error)` |
+| `GetCluster` / `ListClustersByResourceGroup` / `ListClustersBySubscription` | cluster reads |
+| `UpdateCluster` | `(ctx, rg, name, ClusterPatch) (*Cluster, error)` (PATCH) |
+| `DeleteCluster` | `(ctx, rg, name) error` |
+| `RestartCluster` / `StartCluster` / `StopCluster` | lifecycle actions (LRO) |
+| `PromoteReadReplica` | `(ctx, rg, name) error` — detach a replica |
+| `CheckNameAvailability` | `(ctx, name, type) (*NameAvailability, error)` |
+
+### Firewall Rules & Roles
+
+| Operation | Signature |
+|-----------|-----------|
+| `CreateOrUpdateFirewallRule` / `GetFirewallRule` / `ListFirewallRules` / `DeleteFirewallRule` | IP allow-list CRUD |
+| `CreateRole` / `GetRole` / `ListRoles` / `DeleteRole` | Postgres role CRUD |
+
+### Servers (nodes), Configurations & Private Endpoints
+
+| Operation | Signature |
+|-----------|-----------|
+| `GetServer` / `ListServers` | read-only derived nodes (coordinator + workers) |
+| `ListConfigurations` / `GetConfiguration` | cluster-wide server parameters (per-role values) |
+| `GetCoordinatorConfiguration` / `GetNodeConfiguration` / `ListServerConfigurations` | server-scoped parameter reads |
+| `UpdateCoordinatorConfiguration` / `UpdateNodeConfiguration` | per-role parameter updates (LRO) |
+| `CreateOrUpdatePrivateEndpointConnection` / `GetPrivateEndpointConnection` / `ListPrivateEndpointConnections` / `DeletePrivateEndpointConnection` | private-endpoint CRUD |
+| `GetPrivateLinkResource` / `ListPrivateLinkResources` | private-link resource reads |
+
+Modeling: a cluster owns its firewall rules, roles, configurations, and
+private-endpoint connections (parent linkage, cascade delete); nodes are derived
+from the cluster shape (one coordinator + N workers); read replicas link back to
+a source cluster and detach on promote; clone-on-read on every path.
+
+**Total: 34 operations**
+
+---
+
 ## 12. Secrets
 
 **Driver interface:** `services/secrets/driver/driver.go`
@@ -2199,6 +2251,7 @@ still sees success.
 | Keyspaces — AWS (Cassandra control plane) | 18 (+1 optional) |
 | Managed Cassandra — Azure (Cosmos DB) | 15 |
 | Bigtable — GCP (wide-column NoSQL) | 38 |
+| Cosmos DB for PostgreSQL — Azure (Citus) | 34 |
 | Secrets | 7 |
 | Logging | 13 |
 | Notification | 8 |
@@ -2218,7 +2271,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1381** (+138 optional) |
+| **Grand Total** | **1415** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.7.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/eventgrid/armeventgrid/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontai
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v6 v6.6.0/go.mod h1:OWKfCmX4X3Vp2w7GSx1LZn8566tOHJBA6K0IAUVNYx0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0 h1:+EhRnIOLvffCvUMUfP+MgOp6PrtN1d6xt94DZtrC3lA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmos/armcosmos/v3 v3.4.0/go.mod h1:Bb7kqorvA2acMCNFac+2ldoQWi7QrcMdH+9Gg9C7fSM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0 h1:TyXI0pf9V67/vn7Vo2BebOz4B/fLj9Kt3UcrQBXMrvE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql v1.1.0/go.mod h1:s//ycXE53yRslaDdkNrCEANgvrdSOaUuqcBCJg5VEX0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0 h1:rQyNHB/4ntzvm5F9WAiaAl7jWII+jaI4rL6sSWxTNeM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/databricks/armdatabricks v1.1.0/go.mod h1:4jtknLqzaPtwIz8Y9NBp2rXxeA7BbSICWBD0FDzG2VM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/azure/azuresql"
 	"github.com/stackshy/cloudemu/v2/providers/azure/blobstorage"
 	"github.com/stackshy/cloudemu/v2/providers/azure/cosmosdb"
+	"github.com/stackshy/cloudemu/v2/providers/azure/cosmospostgresql"
 	"github.com/stackshy/cloudemu/v2/providers/azure/databricks"
 	"github.com/stackshy/cloudemu/v2/providers/azure/eventgrid"
 	"github.com/stackshy/cloudemu/v2/providers/azure/functions"
@@ -67,6 +68,7 @@ type Provider struct {
 	VirtualMachines  *virtualmachines.Mock
 	CosmosDB         *cosmosdb.Mock
 	ManagedCassandra *managedcassandra.Mock
+	CosmosPostgreSQL *cosmospostgresql.Mock
 	Functions        *functions.Mock
 	VNet             *vnet.Mock
 	Monitor          *azuremonitor.Mock
@@ -112,6 +114,7 @@ func New(opts ...config.Option) *Provider {
 		VirtualMachines:  virtualmachines.New(o),
 		CosmosDB:         cosmosdb.New(o),
 		ManagedCassandra: managedcassandra.New(o),
+		CosmosPostgreSQL: cosmospostgresql.New(o),
 		Functions:        functions.New(o),
 		VNet:             vnet.New(o),
 		Monitor:          azuremonitor.New(o),

--- a/providers/azure/cosmospostgresql/configurations.go
+++ b/providers/azure/cosmospostgresql/configurations.go
@@ -1,0 +1,240 @@
+package cosmospostgresql
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// configCatalog is the fixed set of well-known server parameters the mock
+// exposes, with their default coordinator/node values. Real Cosmos DB for
+// PostgreSQL surfaces hundreds; the mock models a representative subset so the
+// Get/List/Update surface round-trips faithfully.
+//
+//nolint:gochecknoglobals // static server-parameter catalog
+var configCatalog = map[string]struct {
+	dataType     string
+	defaultValue string
+	allowed      string
+	requiresRest bool
+	description  string
+}{
+	"array_nulls":         {"Boolean", "on", "on,off", false, "Enable input of NULL elements in arrays."},
+	"max_connections":     {"Integer", "300", "25-3000", true, "Maximum concurrent connections."},
+	"citus.node_conninfo": {"String", "sslmode=require", "", false, "libpq connection parameters used between nodes."},
+	"work_mem":            {"Integer", "4096", "64-2097151", false, "Memory for internal sort/hash operations (KB)."},
+}
+
+func catalogNames() []string {
+	names := make([]string, 0, len(configCatalog))
+	for name := range configCatalog {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+func configKey(rg, cluster, role, name string) string {
+	return rg + "/" + cluster + "/" + role + "/" + name
+}
+
+// storedOrDefault returns the coordinator/node value for a parameter: an
+// operator-set override if present, else the catalog default. The caller holds
+// a read lock.
+func (m *Mock) storedOrDefault(rg, cluster, role, name string) (value, source string) {
+	entry := configCatalog[name]
+
+	if sc, ok := m.serverConfigs.Get(configKey(rg, cluster, role, name)); ok {
+		return sc.Value, "user-override"
+	}
+
+	return entry.defaultValue, "system-default"
+}
+
+// ListConfigurations returns the cluster-wide parameters with per-role values.
+func (m *Mock) ListConfigurations(_ context.Context, rg, cluster string) ([]cpgdriver.Configuration, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	names := catalogNames()
+	out := make([]cpgdriver.Configuration, 0, len(names))
+
+	for _, name := range names {
+		out = append(out, m.configuration(rg, cluster, name))
+	}
+
+	return out, nil
+}
+
+// GetConfiguration returns a single cluster-wide parameter.
+func (m *Mock) GetConfiguration(_ context.Context, rg, cluster, name string) (*cpgdriver.Configuration, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	if _, ok := configCatalog[name]; !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "configuration %q not found", name)
+	}
+
+	c := m.configuration(rg, cluster, name)
+
+	return &c, nil
+}
+
+func (m *Mock) configuration(rg, cluster, name string) cpgdriver.Configuration {
+	entry := configCatalog[name]
+
+	coordVal, coordSrc := m.storedOrDefault(rg, cluster, cpgdriver.RoleCoordinator, name)
+	nodeVal, nodeSrc := m.storedOrDefault(rg, cluster, cpgdriver.RoleWorker, name)
+
+	return cpgdriver.Configuration{
+		Name:              name,
+		ClusterName:       cluster,
+		ResourceGroup:     rg,
+		ProvisioningState: cpgdriver.ProvisioningSucceeded,
+		Description:       entry.description,
+		DataType:          entry.dataType,
+		AllowedValues:     entry.allowed,
+		RequiresRestart:   entry.requiresRest,
+		RoleGroups: []cpgdriver.RoleGroupValue{
+			{Role: cpgdriver.RoleCoordinator, Value: coordVal, DefaultValue: entry.defaultValue, Source: coordSrc},
+			{Role: cpgdriver.RoleWorker, Value: nodeVal, DefaultValue: entry.defaultValue, Source: nodeSrc},
+		},
+	}
+}
+
+// GetCoordinatorConfiguration returns a parameter's coordinator-role value.
+func (m *Mock) GetCoordinatorConfiguration(_ context.Context, rg, cluster, name string) (*cpgdriver.ServerConfiguration, error) {
+	return m.getServerConfig(rg, cluster, cpgdriver.RoleCoordinator, name)
+}
+
+// GetNodeConfiguration returns a parameter's node-role value.
+func (m *Mock) GetNodeConfiguration(_ context.Context, rg, cluster, name string) (*cpgdriver.ServerConfiguration, error) {
+	return m.getServerConfig(rg, cluster, cpgdriver.RoleWorker, name)
+}
+
+func (m *Mock) getServerConfig(rg, cluster, role, name string) (*cpgdriver.ServerConfiguration, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	entry, ok := configCatalog[name]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "configuration %q not found", name)
+	}
+
+	value, source := m.storedOrDefault(rg, cluster, role, name)
+
+	return &cpgdriver.ServerConfiguration{
+		Name:              name,
+		ClusterName:       cluster,
+		ResourceGroup:     rg,
+		ServerName:        serverName(cluster, role, 0),
+		ProvisioningState: cpgdriver.ProvisioningSucceeded,
+		Value:             value,
+		DefaultValue:      entry.defaultValue,
+		Description:       entry.description,
+		DataType:          entry.dataType,
+		AllowedValues:     entry.allowed,
+		Source:            source,
+		RequiresRestart:   entry.requiresRest,
+	}, nil
+}
+
+// ListServerConfigurations returns the parameters for a specific node.
+func (m *Mock) ListServerConfigurations(_ context.Context, rg, cluster, server string) ([]cpgdriver.ServerConfiguration, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	role := cpgdriver.RoleWorker
+	if strings.HasSuffix(server, "-c") {
+		role = cpgdriver.RoleCoordinator
+	}
+
+	names := catalogNames()
+	out := make([]cpgdriver.ServerConfiguration, 0, len(names))
+
+	for _, name := range names {
+		entry := configCatalog[name]
+		value, source := m.storedOrDefault(rg, cluster, role, name)
+		out = append(out, cpgdriver.ServerConfiguration{
+			Name:              name,
+			ClusterName:       cluster,
+			ResourceGroup:     rg,
+			ServerName:        server,
+			ProvisioningState: cpgdriver.ProvisioningSucceeded,
+			Value:             value,
+			DefaultValue:      entry.defaultValue,
+			Description:       entry.description,
+			DataType:          entry.dataType,
+			AllowedValues:     entry.allowed,
+			Source:            source,
+			RequiresRestart:   entry.requiresRest,
+		})
+	}
+
+	return out, nil
+}
+
+// UpdateCoordinatorConfiguration sets a parameter's coordinator-role value.
+func (m *Mock) UpdateCoordinatorConfiguration(_ context.Context, rg, cluster, name, value string) (*cpgdriver.ServerConfiguration, error) {
+	return m.updateServerConfig(rg, cluster, cpgdriver.RoleCoordinator, name, value)
+}
+
+// UpdateNodeConfiguration sets a parameter's node-role value.
+func (m *Mock) UpdateNodeConfiguration(_ context.Context, rg, cluster, name, value string) (*cpgdriver.ServerConfiguration, error) {
+	return m.updateServerConfig(rg, cluster, cpgdriver.RoleWorker, name, value)
+}
+
+func (m *Mock) updateServerConfig(rg, cluster, role, name, value string) (*cpgdriver.ServerConfiguration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	entry, ok := configCatalog[name]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unknown configuration %q", name)
+	}
+
+	sc := cpgdriver.ServerConfiguration{
+		Name:              name,
+		ClusterName:       cluster,
+		ResourceGroup:     rg,
+		ServerName:        serverName(cluster, role, 0),
+		ProvisioningState: cpgdriver.ProvisioningSucceeded,
+		Value:             value,
+		DefaultValue:      entry.defaultValue,
+		Description:       entry.description,
+		DataType:          entry.dataType,
+		AllowedValues:     entry.allowed,
+		Source:            "user-override",
+		RequiresRestart:   entry.requiresRest,
+	}
+	m.serverConfigs.Set(configKey(rg, cluster, role, name), sc)
+
+	out := sc
+
+	return &out, nil
+}

--- a/providers/azure/cosmospostgresql/configurations.go
+++ b/providers/azure/cosmospostgresql/configurations.go
@@ -280,7 +280,7 @@ func (m *Mock) updateServerConfig(rg, cluster, role, name, value string) (*cpgdr
 
 	entry, ok := configCatalog[name]
 	if !ok {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "unknown configuration %q", name)
+		return nil, cerrors.Newf(cerrors.NotFound, "configuration %q not found", name)
 	}
 
 	if err := validateConfigValue(name, entry.allowed, value); err != nil {

--- a/providers/azure/cosmospostgresql/configurations.go
+++ b/providers/azure/cosmospostgresql/configurations.go
@@ -3,6 +3,7 @@ package cosmospostgresql
 import (
 	"context"
 	"sort"
+	"strconv"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -41,6 +42,70 @@ func catalogNames() []string {
 
 func configKey(rg, cluster, role, name string) string {
 	return rg + "/" + cluster + "/" + role + "/" + name
+}
+
+// validateConfigValue rejects an empty value and enforces the parameter's
+// AllowedValues: a comma-list is treated as an enum, a "min-max" string as an
+// inclusive integer range, anything else as freeform.
+func validateConfigValue(name, allowed, value string) error {
+	if value == "" {
+		return cerrors.Newf(cerrors.InvalidArgument, "value is required for configuration %q", name)
+	}
+
+	switch {
+	case strings.Contains(allowed, ","):
+		for _, opt := range strings.Split(allowed, ",") {
+			if value == strings.TrimSpace(opt) {
+				return nil
+			}
+		}
+
+		return cerrors.Newf(cerrors.InvalidArgument, "value %q for %q must be one of: %s", value, name, allowed)
+	case isRange(allowed):
+		return validateRange(name, allowed, value)
+	default:
+		return nil
+	}
+}
+
+func isRange(allowed string) bool {
+	lo, hi, found := strings.Cut(allowed, "-")
+	if !found {
+		return false
+	}
+
+	return isDigits(lo) && isDigits(hi)
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func validateRange(name, allowed, value string) error {
+	loStr, hiStr, _ := strings.Cut(allowed, "-")
+	lo, _ := strconv.Atoi(loStr)
+	hi, _ := strconv.Atoi(hiStr)
+
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return cerrors.Newf(cerrors.InvalidArgument, "value %q for %q must be an integer", value, name)
+	}
+
+	if n < lo || n > hi {
+		return cerrors.Newf(cerrors.InvalidArgument, "value %d for %q must be within %s", n, name, allowed)
+	}
+
+	return nil
 }
 
 // storedOrDefault returns the coordinator/node value for a parameter: an
@@ -216,6 +281,10 @@ func (m *Mock) updateServerConfig(rg, cluster, role, name, value string) (*cpgdr
 	entry, ok := configCatalog[name]
 	if !ok {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "unknown configuration %q", name)
+	}
+
+	if err := validateConfigValue(name, entry.allowed, value); err != nil {
+		return nil, err
 	}
 
 	sc := cpgdriver.ServerConfiguration{

--- a/providers/azure/cosmospostgresql/cosmospostgresql.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql.go
@@ -152,30 +152,31 @@ func (m *Mock) clusterResourceID(rg, name string) string {
 // CreateOrUpdateCluster creates or replaces a server-group cluster.
 //
 //nolint:gocritic // cfg matches the driver signature.
-func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClusterConfig) (*cpgdriver.Cluster, error) {
+func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClusterConfig) (*cpgdriver.Cluster, bool, error) {
 	if err := validName("cluster", cfg.Name); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if err := validateSizing(&cfg); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	key := clusterKey(cfg.ResourceGroup, cfg.Name)
+	existing, isUpdate := m.clusters.Get(key)
 
 	// A create (no existing cluster at this rg/name) must have a globally-unique
 	// name and, for a replica, a valid primary source.
-	if !m.clusters.Has(key) {
+	if !isUpdate {
 		if err := m.ensureNameAvailableLocked(cfg.Name); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		if cfg.SourceResourceID != "" {
 			if err := m.validateReplicaSourceLocked(cfg.SourceResourceID); err != nil {
-				return nil, err
+				return nil, false, err
 			}
 		}
 	}
@@ -207,15 +208,13 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClus
 		SourceLocation:                  cfg.SourceLocation,
 	}
 
-	// Preserve service-computed fields across a re-PUT.
-	if existing, ok := m.clusters.Get(key); ok {
+	if isUpdate {
+		// Preserve service-computed fields, and treat the replica source as
+		// immutable — a re-PUT must not re-point (or corrupt) the replica graph.
 		c.State = existing.State
 		c.ReadReplicas = cloneStrings(existing.ReadReplicas)
-
-		if c.SourceResourceID == "" {
-			c.SourceResourceID = existing.SourceResourceID
-			c.SourceLocation = existing.SourceLocation
-		}
+		c.SourceResourceID = existing.SourceResourceID
+		c.SourceLocation = existing.SourceLocation
 	} else if cfg.SourceResourceID != "" {
 		// A newly-created replica registers itself on its source cluster.
 		m.linkReplicaLocked(cfg.SourceResourceID, m.clusterResourceID(cfg.ResourceGroup, cfg.Name))
@@ -225,7 +224,7 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClus
 
 	out := cloneCluster(&c)
 
-	return &out, nil
+	return &out, !isUpdate, nil
 }
 
 // validateSizing bounds the node count and rejects negative vCore/storage
@@ -413,6 +412,22 @@ func applyClusterPatch(c *cpgdriver.Cluster, patch *cpgdriver.ClusterPatch) erro
 	if patch.EnableHa != nil {
 		c.EnableHa = *patch.EnableHa
 	}
+
+	if patch.CoordinatorEnablePublicIPAccess != nil {
+		c.CoordinatorEnablePublicIPAccess = *patch.CoordinatorEnablePublicIPAccess
+	}
+
+	if patch.NodeEnablePublicIPAccess != nil {
+		c.NodeEnablePublicIPAccess = *patch.NodeEnablePublicIPAccess
+	}
+
+	if patch.EnableShardsOnCoordinator != nil {
+		c.EnableShardsOnCoordinator = *patch.EnableShardsOnCoordinator
+	}
+
+	// AdministratorLoginPassword is a write-only secret: accepted here but never
+	// stored or surfaced (the real API never returns it).
+	_ = patch.AdministratorLoginPassword
 
 	if patch.MaintenanceWindow != nil {
 		c.MaintenanceWindow = cloneMaintenanceWindow(patch.MaintenanceWindow)

--- a/providers/azure/cosmospostgresql/cosmospostgresql.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql.go
@@ -62,6 +62,17 @@ func clusterKey(rg, name string) string { return rg + "/" + name }
 
 func childKey(rg, cluster, name string) string { return rg + "/" + cluster + "/" + name }
 
+// requireClusterLocked returns NotFound if the parent cluster doesn't exist.
+// Real Azure returns 404 for a missing parent on every child operation. The
+// caller holds a lock.
+func (m *Mock) requireClusterLocked(rg, cluster string) error {
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", cluster)
+	}
+
+	return nil
+}
+
 func validName(kind, name string) error {
 	if name == "" {
 		return cerrors.Newf(cerrors.InvalidArgument, "%s name is required", kind)
@@ -146,14 +157,28 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClus
 		return nil, err
 	}
 
-	if cfg.NodeCount < 0 || cfg.NodeCount > maxNodeCount {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "nodeCount must be between 0 and %d", maxNodeCount)
+	if err := validateSizing(&cfg); err != nil {
+		return nil, err
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	key := clusterKey(cfg.ResourceGroup, cfg.Name)
+
+	// A create (no existing cluster at this rg/name) must have a globally-unique
+	// name and, for a replica, a valid primary source.
+	if !m.clusters.Has(key) {
+		if err := m.ensureNameAvailableLocked(cfg.Name); err != nil {
+			return nil, err
+		}
+
+		if cfg.SourceResourceID != "" {
+			if err := m.validateReplicaSourceLocked(cfg.SourceResourceID); err != nil {
+				return nil, err
+			}
+		}
+	}
 
 	c := cpgdriver.Cluster{
 		Name:                            cfg.Name,
@@ -201,6 +226,58 @@ func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClus
 	out := cloneCluster(&c)
 
 	return &out, nil
+}
+
+// validateSizing bounds the node count and rejects negative vCore/storage
+// sizing. Zero means "use the default", so only negatives are rejected there.
+func validateSizing(cfg *cpgdriver.CreateClusterConfig) error {
+	if cfg.NodeCount < 0 || cfg.NodeCount > maxNodeCount {
+		return cerrors.Newf(cerrors.InvalidArgument, "nodeCount must be between 0 and %d", maxNodeCount)
+	}
+
+	if cfg.CoordinatorVCores < 0 || cfg.NodeVCores < 0 {
+		return cerrors.New(cerrors.InvalidArgument, "vCores must not be negative")
+	}
+
+	if cfg.CoordinatorStorageQuotaInMb < 0 || cfg.NodeStorageQuotaInMb < 0 {
+		return cerrors.New(cerrors.InvalidArgument, "storageQuotaInMb must not be negative")
+	}
+
+	return nil
+}
+
+// ensureNameAvailableLocked rejects a create whose name is already used by any
+// cluster in the subscription (Cosmos-PG names are globally unique — they form
+// the coordinator FQDN). The caller holds the lock.
+func (m *Mock) ensureNameAvailableLocked(name string) error {
+	all := m.clusters.SortedValues()
+	for i := range all {
+		if all[i].Name == name {
+			return cerrors.Newf(cerrors.AlreadyExists, "cluster name %q is already in use", name)
+		}
+	}
+
+	return nil
+}
+
+// validateReplicaSourceLocked requires the replica's source to exist and itself
+// be a primary (no replica-of-a-replica chains). The caller holds the lock.
+func (m *Mock) validateReplicaSourceLocked(sourceID string) error {
+	rg, name, ok := parseClusterID(sourceID)
+	if !ok {
+		return cerrors.Newf(cerrors.InvalidArgument, "malformed sourceResourceId %q", sourceID)
+	}
+
+	src, ok := m.clusters.Get(clusterKey(rg, name))
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "source cluster %q not found", name)
+	}
+
+	if src.SourceResourceID != "" {
+		return cerrors.Newf(cerrors.InvalidArgument, "cannot create a read replica of a read replica (%q)", name)
+	}
+
+	return nil
 }
 
 // linkReplicaLocked adds replicaID to the ReadReplicas of the source cluster
@@ -300,7 +377,10 @@ func (m *Mock) UpdateCluster(_ context.Context, rg, name string, patch cpgdriver
 		return nil, cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
 	}
 
-	applyClusterPatch(&c, &patch)
+	if err := applyClusterPatch(&c, &patch); err != nil {
+		return nil, err
+	}
+
 	m.clusters.Set(key, c)
 
 	out := cloneCluster(&c)
@@ -308,7 +388,13 @@ func (m *Mock) UpdateCluster(_ context.Context, rg, name string, patch cpgdriver
 	return &out, nil
 }
 
-func applyClusterPatch(c *cpgdriver.Cluster, patch *cpgdriver.ClusterPatch) {
+func applyClusterPatch(c *cpgdriver.Cluster, patch *cpgdriver.ClusterPatch) error {
+	// A PATCH must re-validate the same bounds as create — otherwise a negative
+	// or huge nodeCount is stored and later crashes node derivation.
+	if err := validatePatchSizing(patch); err != nil {
+		return err
+	}
+
 	if patch.Tags != nil {
 		c.Tags = copyTags(patch.Tags)
 	}
@@ -331,6 +417,29 @@ func applyClusterPatch(c *cpgdriver.Cluster, patch *cpgdriver.ClusterPatch) {
 	if patch.MaintenanceWindow != nil {
 		c.MaintenanceWindow = cloneMaintenanceWindow(patch.MaintenanceWindow)
 	}
+
+	return nil
+}
+
+// validatePatchSizing bounds any sizing fields present in a PATCH.
+func validatePatchSizing(patch *cpgdriver.ClusterPatch) error {
+	if patch.NodeCount != nil && (*patch.NodeCount < 0 || *patch.NodeCount > maxNodeCount) {
+		return cerrors.Newf(cerrors.InvalidArgument, "nodeCount must be between 0 and %d", maxNodeCount)
+	}
+
+	for _, v := range []*int{patch.CoordinatorVCores, patch.NodeVCores} {
+		if v != nil && *v < 0 {
+			return cerrors.New(cerrors.InvalidArgument, "vCores must not be negative")
+		}
+	}
+
+	for _, s := range []*int{patch.CoordinatorStorageQuotaInMb, patch.NodeStorageQuotaInMb} {
+		if s != nil && *s < 0 {
+			return cerrors.New(cerrors.InvalidArgument, "storageQuotaInMb must not be negative")
+		}
+	}
+
+	return nil
 }
 
 func setStr(dst, v *string) {
@@ -351,9 +460,19 @@ func (m *Mock) DeleteCluster(_ context.Context, rg, name string) error {
 	defer m.mu.Unlock()
 
 	key := clusterKey(rg, name)
-	if !m.clusters.Has(key) {
+
+	c, ok := m.clusters.Get(key)
+	if !ok {
 		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
 	}
+
+	// Keep replica links consistent: if this is a replica, drop it from its
+	// source's list; if it's a source, orphan its replicas (clear their link).
+	if c.SourceResourceID != "" {
+		m.unlinkReplicaLocked(c.SourceResourceID, m.clusterResourceID(rg, name))
+	}
+
+	m.clearReplicaSourcesLocked(c.ReadReplicas)
 
 	prefix := rg + "/" + name + "/"
 
@@ -364,6 +483,27 @@ func (m *Mock) DeleteCluster(_ context.Context, rg, name string) error {
 	m.clusters.Delete(key)
 
 	return nil
+}
+
+// clearReplicaSourcesLocked clears SourceResourceID/SourceLocation on each
+// replica whose resource ID is listed, orphaning them when their source is
+// deleted. The caller holds the lock.
+func (m *Mock) clearReplicaSourcesLocked(replicaIDs []string) {
+	for _, id := range replicaIDs {
+		rg, name, ok := parseClusterID(id)
+		if !ok {
+			continue
+		}
+
+		rep, ok := m.clusters.Get(clusterKey(rg, name))
+		if !ok {
+			continue
+		}
+
+		rep.SourceResourceID = ""
+		rep.SourceLocation = ""
+		m.clusters.Set(clusterKey(rg, name), rep)
+	}
 }
 
 func deletePrefixed[T any](store *memstore.Store[T], prefix string) {
@@ -390,33 +530,24 @@ func listChildren[T any](store *memstore.Store[T], rg, cluster string, keyOf fun
 	return out
 }
 
-// RestartCluster validates the cluster exists (no state change in the mock).
+// RestartCluster restarts a running cluster (must be Ready).
 func (m *Mock) RestartCluster(_ context.Context, rg, name string) error {
-	return m.requireCluster(rg, name)
+	return m.transitionState(rg, name, "Ready", "Ready")
 }
 
-// StartCluster marks the cluster Ready.
+// StartCluster starts a stopped cluster (must be Stopped → Ready).
 func (m *Mock) StartCluster(_ context.Context, rg, name string) error {
-	return m.setClusterState(rg, name, "Ready")
+	return m.transitionState(rg, name, "Stopped", "Ready")
 }
 
-// StopCluster marks the cluster Stopped.
+// StopCluster stops a running cluster (must be Ready → Stopped).
 func (m *Mock) StopCluster(_ context.Context, rg, name string) error {
-	return m.setClusterState(rg, name, "Stopped")
+	return m.transitionState(rg, name, "Ready", "Stopped")
 }
 
-func (m *Mock) requireCluster(rg, name string) error {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	if !m.clusters.Has(clusterKey(rg, name)) {
-		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
-	}
-
-	return nil
-}
-
-func (m *Mock) setClusterState(rg, name, state string) error {
+// transitionState moves a cluster from want to next, rejecting the action when
+// the cluster isn't in the expected state (real Azure 409s these).
+func (m *Mock) transitionState(rg, name, want, next string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -427,7 +558,11 @@ func (m *Mock) setClusterState(rg, name, state string) error {
 		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
 	}
 
-	c.State = state
+	if c.State != want {
+		return cerrors.Newf(cerrors.FailedPrecondition, "cluster %q is %q; expected %q for this action", name, c.State, want)
+	}
+
+	c.State = next
 	m.clusters.Set(key, c)
 
 	return nil

--- a/providers/azure/cosmospostgresql/cosmospostgresql.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql.go
@@ -1,0 +1,512 @@
+// Package cosmospostgresql provides an in-memory mock of Azure Cosmos DB for
+// PostgreSQL (Microsoft.DBforPostgreSQL/serverGroupsv2), the Citus-based
+// distributed-Postgres offering. It models server-group clusters and their
+// firewall rules, roles, derived nodes, server parameters (configurations),
+// private-endpoint connections/links, the start/stop/restart lifecycle, and
+// read-replica promotion.
+package cosmospostgresql
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+const (
+	providerNamespace = "Microsoft.DBforPostgreSQL"
+	clusterType       = "serverGroupsv2"
+
+	defaultCitusVersion      = "12.1"
+	defaultPostgresqlVersion = "16"
+	defaultServerEdition     = "GeneralPurpose"
+	defaultCoordinatorVCores = 4
+	defaultNodeVCores        = 4
+	defaultStorageQuotaInMb  = 131072
+	maxNodeCount             = 20
+)
+
+var _ cpgdriver.CosmosPostgreSQL = (*Mock)(nil)
+
+// Mock is the in-memory Cosmos DB for PostgreSQL implementation. All stores are
+// keyed by full resource path segments (rg[/cluster[/child]]).
+type Mock struct {
+	mu sync.RWMutex
+
+	clusters      *memstore.Store[cpgdriver.Cluster]                   // key = "rg/name"
+	firewallRules *memstore.Store[cpgdriver.FirewallRule]              // key = "rg/cluster/name"
+	roles         *memstore.Store[cpgdriver.Role]                      // key = "rg/cluster/name"
+	privateEPs    *memstore.Store[cpgdriver.PrivateEndpointConnection] // key = "rg/cluster/name"
+	serverConfigs *memstore.Store[cpgdriver.ServerConfiguration]       // key = "rg/cluster/role/name"
+
+	opts *config.Options
+}
+
+// New creates a new Cosmos DB for PostgreSQL mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		clusters:      memstore.New[cpgdriver.Cluster](),
+		firewallRules: memstore.New[cpgdriver.FirewallRule](),
+		roles:         memstore.New[cpgdriver.Role](),
+		privateEPs:    memstore.New[cpgdriver.PrivateEndpointConnection](),
+		serverConfigs: memstore.New[cpgdriver.ServerConfiguration](),
+		opts:          opts,
+	}
+}
+
+func clusterKey(rg, name string) string { return rg + "/" + name }
+
+func childKey(rg, cluster, name string) string { return rg + "/" + cluster + "/" + name }
+
+func validName(kind, name string) error {
+	if name == "" {
+		return cerrors.Newf(cerrors.InvalidArgument, "%s name is required", kind)
+	}
+
+	if strings.Contains(name, "/") {
+		return cerrors.Newf(cerrors.InvalidArgument, "%s name %q must not contain '/'", kind, name)
+	}
+
+	return nil
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func cloneStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+
+	return append([]string(nil), s...)
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+func orDefaultInt(v, def int) int {
+	if v == 0 {
+		return def
+	}
+
+	return v
+}
+
+func cloneMaintenanceWindow(in *cpgdriver.MaintenanceWindow) *cpgdriver.MaintenanceWindow {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+
+	return &out
+}
+
+func cloneCluster(in *cpgdriver.Cluster) cpgdriver.Cluster {
+	c := *in
+	c.Tags = copyTags(c.Tags)
+	c.ReadReplicas = cloneStrings(c.ReadReplicas)
+	c.MaintenanceWindow = cloneMaintenanceWindow(c.MaintenanceWindow)
+
+	return c
+}
+
+// clusterResourceID builds the ARM resource ID of a cluster in this mock's
+// subscription (AccountID).
+func (m *Mock) clusterResourceID(rg, name string) string {
+	return "/subscriptions/" + m.opts.AccountID +
+		"/resourceGroups/" + rg +
+		"/providers/" + providerNamespace + "/" + clusterType + "/" + name
+}
+
+// CreateOrUpdateCluster creates or replaces a server-group cluster.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateOrUpdateCluster(_ context.Context, cfg cpgdriver.CreateClusterConfig) (*cpgdriver.Cluster, error) {
+	if err := validName("cluster", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	if cfg.NodeCount < 0 || cfg.NodeCount > maxNodeCount {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "nodeCount must be between 0 and %d", maxNodeCount)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(cfg.ResourceGroup, cfg.Name)
+
+	c := cpgdriver.Cluster{
+		Name:                            cfg.Name,
+		ResourceGroup:                   cfg.ResourceGroup,
+		Location:                        cfg.Location,
+		Tags:                            copyTags(cfg.Tags),
+		ProvisioningState:               cpgdriver.ProvisioningSucceeded,
+		State:                           "Ready",
+		AdministratorLogin:              "citus",
+		CitusVersion:                    orDefault(cfg.CitusVersion, defaultCitusVersion),
+		PostgresqlVersion:               orDefault(cfg.PostgresqlVersion, defaultPostgresqlVersion),
+		CoordinatorServerEdition:        orDefault(cfg.CoordinatorServerEdition, defaultServerEdition),
+		CoordinatorVCores:               orDefaultInt(cfg.CoordinatorVCores, defaultCoordinatorVCores),
+		CoordinatorStorageQuotaInMb:     orDefaultInt(cfg.CoordinatorStorageQuotaInMb, defaultStorageQuotaInMb),
+		CoordinatorEnablePublicIPAccess: cfg.CoordinatorEnablePublicIPAccess,
+		EnableShardsOnCoordinator:       cfg.EnableShardsOnCoordinator,
+		NodeServerEdition:               orDefault(cfg.NodeServerEdition, defaultServerEdition),
+		NodeCount:                       cfg.NodeCount,
+		NodeVCores:                      orDefaultInt(cfg.NodeVCores, defaultNodeVCores),
+		NodeStorageQuotaInMb:            orDefaultInt(cfg.NodeStorageQuotaInMb, defaultStorageQuotaInMb),
+		NodeEnablePublicIPAccess:        cfg.NodeEnablePublicIPAccess,
+		EnableHa:                        cfg.EnableHa,
+		PreferredPrimaryZone:            cfg.PreferredPrimaryZone,
+		MaintenanceWindow:               cloneMaintenanceWindow(cfg.MaintenanceWindow),
+		SourceResourceID:                cfg.SourceResourceID,
+		SourceLocation:                  cfg.SourceLocation,
+	}
+
+	// Preserve service-computed fields across a re-PUT.
+	if existing, ok := m.clusters.Get(key); ok {
+		c.State = existing.State
+		c.ReadReplicas = cloneStrings(existing.ReadReplicas)
+
+		if c.SourceResourceID == "" {
+			c.SourceResourceID = existing.SourceResourceID
+			c.SourceLocation = existing.SourceLocation
+		}
+	} else if cfg.SourceResourceID != "" {
+		// A newly-created replica registers itself on its source cluster.
+		m.linkReplicaLocked(cfg.SourceResourceID, m.clusterResourceID(cfg.ResourceGroup, cfg.Name))
+	}
+
+	m.clusters.Set(key, c)
+
+	out := cloneCluster(&c)
+
+	return &out, nil
+}
+
+// linkReplicaLocked adds replicaID to the ReadReplicas of the source cluster
+// identified by sourceID (a full resource ID). The caller holds the lock.
+func (m *Mock) linkReplicaLocked(sourceID, replicaID string) {
+	rg, name, ok := parseClusterID(sourceID)
+	if !ok {
+		return
+	}
+
+	src, ok := m.clusters.Get(clusterKey(rg, name))
+	if !ok {
+		return
+	}
+
+	src.ReadReplicas = append(cloneStrings(src.ReadReplicas), replicaID)
+	m.clusters.Set(clusterKey(rg, name), src)
+}
+
+// parseClusterID extracts (resourceGroup, name) from a serverGroupsv2 resource
+// ID. Returns ok=false if the ID isn't shaped as expected.
+func parseClusterID(id string) (rg, name string, ok bool) {
+	parts := strings.Split(strings.Trim(id, "/"), "/")
+
+	for i := 0; i+1 < len(parts); i++ {
+		switch {
+		case strings.EqualFold(parts[i], "resourceGroups"):
+			rg = parts[i+1]
+		case strings.EqualFold(parts[i], clusterType):
+			name = parts[i+1]
+		}
+	}
+
+	if rg == "" || name == "" {
+		return "", "", false
+	}
+
+	return rg, name, true
+}
+
+// GetCluster returns a cluster by resource group + name.
+func (m *Mock) GetCluster(_ context.Context, rg, name string) (*cpgdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	c, ok := m.clusters.Get(clusterKey(rg, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
+	}
+
+	out := cloneCluster(&c)
+
+	return &out, nil
+}
+
+// ListClustersByResourceGroup returns all clusters in a resource group.
+func (m *Mock) ListClustersByResourceGroup(_ context.Context, rg string) ([]cpgdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.filterClusters(func(c *cpgdriver.Cluster) bool { return c.ResourceGroup == rg }), nil
+}
+
+// ListClustersBySubscription returns all clusters (the mock serves one
+// subscription).
+func (m *Mock) ListClustersBySubscription(_ context.Context) ([]cpgdriver.Cluster, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.filterClusters(func(*cpgdriver.Cluster) bool { return true }), nil
+}
+
+func (m *Mock) filterClusters(keep func(*cpgdriver.Cluster) bool) []cpgdriver.Cluster {
+	all := m.clusters.SortedValues()
+	out := make([]cpgdriver.Cluster, 0, len(all))
+
+	for i := range all {
+		if keep(&all[i]) {
+			out = append(out, cloneCluster(&all[i]))
+		}
+	}
+
+	return out
+}
+
+// UpdateCluster applies a PATCH to a cluster.
+//
+//nolint:gocritic // patch matches the driver signature.
+func (m *Mock) UpdateCluster(_ context.Context, rg, name string, patch cpgdriver.ClusterPatch) (*cpgdriver.Cluster, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(rg, name)
+
+	c, ok := m.clusters.Get(key)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
+	}
+
+	applyClusterPatch(&c, &patch)
+	m.clusters.Set(key, c)
+
+	out := cloneCluster(&c)
+
+	return &out, nil
+}
+
+func applyClusterPatch(c *cpgdriver.Cluster, patch *cpgdriver.ClusterPatch) {
+	if patch.Tags != nil {
+		c.Tags = copyTags(patch.Tags)
+	}
+
+	setStr(&c.CitusVersion, patch.CitusVersion)
+	setStr(&c.PostgresqlVersion, patch.PostgresqlVersion)
+	setStr(&c.CoordinatorServerEdition, patch.CoordinatorServerEdition)
+	setInt(&c.CoordinatorVCores, patch.CoordinatorVCores)
+	setInt(&c.CoordinatorStorageQuotaInMb, patch.CoordinatorStorageQuotaInMb)
+	setStr(&c.NodeServerEdition, patch.NodeServerEdition)
+	setInt(&c.NodeCount, patch.NodeCount)
+	setInt(&c.NodeVCores, patch.NodeVCores)
+	setInt(&c.NodeStorageQuotaInMb, patch.NodeStorageQuotaInMb)
+	setStr(&c.PreferredPrimaryZone, patch.PreferredPrimaryZone)
+
+	if patch.EnableHa != nil {
+		c.EnableHa = *patch.EnableHa
+	}
+
+	if patch.MaintenanceWindow != nil {
+		c.MaintenanceWindow = cloneMaintenanceWindow(patch.MaintenanceWindow)
+	}
+}
+
+func setStr(dst, v *string) {
+	if v != nil {
+		*dst = *v
+	}
+}
+
+func setInt(dst, v *int) {
+	if v != nil {
+		*dst = *v
+	}
+}
+
+// DeleteCluster removes a cluster and cascade-deletes its children.
+func (m *Mock) DeleteCluster(_ context.Context, rg, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(rg, name)
+	if !m.clusters.Has(key) {
+		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
+	}
+
+	prefix := rg + "/" + name + "/"
+
+	deletePrefixed(m.firewallRules, prefix)
+	deletePrefixed(m.roles, prefix)
+	deletePrefixed(m.privateEPs, prefix)
+	deletePrefixed(m.serverConfigs, prefix)
+	m.clusters.Delete(key)
+
+	return nil
+}
+
+func deletePrefixed[T any](store *memstore.Store[T], prefix string) {
+	for _, k := range store.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			store.Delete(k)
+		}
+	}
+}
+
+// listChildren returns the store's values whose key is under rg/cluster/,
+// cloned via clone.
+func listChildren[T any](store *memstore.Store[T], rg, cluster string, keyOf func(*T) string, clone func(*T) T) []T {
+	prefix := rg + "/" + cluster + "/"
+	all := store.SortedValues()
+	out := make([]T, 0, len(all))
+
+	for i := range all {
+		if strings.HasPrefix(keyOf(&all[i]), prefix) {
+			out = append(out, clone(&all[i]))
+		}
+	}
+
+	return out
+}
+
+// RestartCluster validates the cluster exists (no state change in the mock).
+func (m *Mock) RestartCluster(_ context.Context, rg, name string) error {
+	return m.requireCluster(rg, name)
+}
+
+// StartCluster marks the cluster Ready.
+func (m *Mock) StartCluster(_ context.Context, rg, name string) error {
+	return m.setClusterState(rg, name, "Ready")
+}
+
+// StopCluster marks the cluster Stopped.
+func (m *Mock) StopCluster(_ context.Context, rg, name string) error {
+	return m.setClusterState(rg, name, "Stopped")
+}
+
+func (m *Mock) requireCluster(rg, name string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, name)) {
+		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
+	}
+
+	return nil
+}
+
+func (m *Mock) setClusterState(rg, name, state string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(rg, name)
+
+	c, ok := m.clusters.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
+	}
+
+	c.State = state
+	m.clusters.Set(key, c)
+
+	return nil
+}
+
+// PromoteReadReplica detaches a replica from its source, making it an
+// independent cluster.
+func (m *Mock) PromoteReadReplica(_ context.Context, rg, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := clusterKey(rg, name)
+
+	c, ok := m.clusters.Get(key)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "cosmos postgresql cluster %q not found", name)
+	}
+
+	if c.SourceResourceID == "" {
+		return cerrors.Newf(cerrors.FailedPrecondition, "cluster %q is not a read replica", name)
+	}
+
+	m.unlinkReplicaLocked(c.SourceResourceID, m.clusterResourceID(rg, name))
+
+	c.SourceResourceID = ""
+	c.SourceLocation = ""
+	m.clusters.Set(key, c)
+
+	return nil
+}
+
+func (m *Mock) unlinkReplicaLocked(sourceID, replicaID string) {
+	rg, name, ok := parseClusterID(sourceID)
+	if !ok {
+		return
+	}
+
+	src, ok := m.clusters.Get(clusterKey(rg, name))
+	if !ok {
+		return
+	}
+
+	kept := src.ReadReplicas[:0:0]
+
+	for _, r := range src.ReadReplicas {
+		if r != replicaID {
+			kept = append(kept, r)
+		}
+	}
+
+	src.ReadReplicas = kept
+	m.clusters.Set(clusterKey(rg, name), src)
+}
+
+// CheckNameAvailability reports whether a cluster name is free in the
+// subscription.
+func (m *Mock) CheckNameAvailability(_ context.Context, name, typ string) (*cpgdriver.NameAvailability, error) {
+	if name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "name is required")
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := &cpgdriver.NameAvailability{
+		Name:          name,
+		Type:          orDefault(typ, providerNamespace+"/"+clusterType),
+		NameAvailable: true,
+	}
+
+	all := m.clusters.SortedValues()
+	for i := range all {
+		if all[i].Name == name {
+			out.NameAvailable = false
+			out.Message = "Name already in use."
+
+			break
+		}
+	}
+
+	return out, nil
+}

--- a/providers/azure/cosmospostgresql/cosmospostgresql_test.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql_test.go
@@ -106,11 +106,11 @@ func TestFirewallRulesAndRoles(t *testing.T) {
 	ctx := context.Background()
 	mustCluster(t, m, "rg1", "pg1", 2)
 
-	// A firewall rule under a missing cluster is rejected.
+	// A firewall rule under a missing cluster is rejected with NotFound.
 	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
 		ResourceGroup: "rg1", ClusterName: "ghost", Name: "all", StartIPAddress: "0.0.0.0", EndIPAddress: "255.255.255.255",
-	}); !cerrors.IsInvalidArgument(err) {
-		t.Fatalf("fw under missing cluster: got %v, want InvalidArgument", err)
+	}); !cerrors.IsNotFound(err) {
+		t.Fatalf("fw under missing cluster: got %v, want NotFound", err)
 	}
 
 	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
@@ -124,11 +124,13 @@ func TestFirewallRulesAndRoles(t *testing.T) {
 		t.Fatalf("list fw wrong: %+v", rules)
 	}
 
-	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app"}); err != nil {
+	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app", Password: "R0lePass!"}); err != nil {
 		t.Fatalf("CreateRole: %v", err)
 	}
 
-	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app"}); !cerrors.IsAlreadyExists(err) {
+	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{
+		ResourceGroup: "rg1", ClusterName: "pg1", Name: "app", Password: "R0lePass!",
+	}); !cerrors.IsAlreadyExists(err) {
 		t.Fatalf("duplicate role: got %v, want AlreadyExists", err)
 	}
 
@@ -284,3 +286,341 @@ func TestClusterResultDoesNotAliasStore(t *testing.T) {
 }
 
 func intPtr(i int) *int { return &i }
+
+func TestPatchNodeCountValidated(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 2)
+
+	// A negative PATCH nodeCount must be rejected (would otherwise store a bad
+	// cap and crash node derivation).
+	if _, err := m.UpdateCluster(ctx, "rg1", "pg1", cpgdriver.ClusterPatch{NodeCount: intPtr(-2)}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("negative PATCH nodeCount: got %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.UpdateCluster(ctx, "rg1", "pg1", cpgdriver.ClusterPatch{NodeCount: intPtr(maxNodeCount + 1)}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("oversized PATCH nodeCount: got %v, want InvalidArgument", err)
+	}
+
+	// The stored cluster is unchanged, and node derivation still works.
+	if _, err := m.ListServers(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("ListServers after rejected patch: %v", err)
+	}
+}
+
+func TestClusterNameGloballyUnique(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	// Same name in a different resource group is rejected.
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "pg1", ResourceGroup: "rg2", Location: "eastus",
+	}); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate name across RGs: got %v, want AlreadyExists", err)
+	}
+
+	// Re-PUT of the same rg/name is an update, not a conflict.
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "pg1", ResourceGroup: "rg1", Location: "eastus", NodeCount: 3,
+	}); err != nil {
+		t.Fatalf("re-PUT same cluster: %v", err)
+	}
+}
+
+func TestReplicaSourceValidated(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "primary", 2)
+
+	// A bogus source is rejected.
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "ghost"),
+	}); !cerrors.IsNotFound(err) {
+		t.Fatalf("bogus replica source: got %v, want NotFound", err)
+	}
+
+	// A valid replica, then a replica-of-a-replica is rejected.
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
+	}); err != nil {
+		t.Fatalf("valid replica: %v", err)
+	}
+
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "rep2", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "rep1"),
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("chained replica: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestDeleteUnlinksReplicas(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "primary", 2)
+
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
+	}); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+
+	// Deleting the source orphans the replica (clears its SourceResourceID).
+	if err := m.DeleteCluster(ctx, "rg1", "primary"); err != nil {
+		t.Fatalf("delete primary: %v", err)
+	}
+
+	rep, _ := m.GetCluster(ctx, "rg1", "rep1")
+	if rep.SourceResourceID != "" {
+		t.Fatalf("replica still links a deleted source: %+v", rep.SourceResourceID)
+	}
+}
+
+func TestDeleteReplicaUnlinksFromSource(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "primary", 2)
+
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
+	}); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+
+	if err := m.DeleteCluster(ctx, "rg1", "rep1"); err != nil {
+		t.Fatalf("delete replica: %v", err)
+	}
+
+	primary, _ := m.GetCluster(ctx, "rg1", "primary")
+	if len(primary.ReadReplicas) != 0 {
+		t.Fatalf("source still lists a deleted replica: %+v", primary.ReadReplicas)
+	}
+}
+
+func TestFirewallIPValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	// Non-IPv4.
+	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: "rg1", ClusterName: "pg1", Name: "bad", StartIPAddress: "not-an-ip", EndIPAddress: "1.2.3.4",
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("bad IP: got %v, want InvalidArgument", err)
+	}
+
+	// Reversed range.
+	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: "rg1", ClusterName: "pg1", Name: "rev", StartIPAddress: "203.0.113.50", EndIPAddress: "203.0.113.10",
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("reversed range: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestListChildrenRequireParent(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.ListFirewallRules(ctx, "rg1", "ghost"); !cerrors.IsNotFound(err) {
+		t.Fatalf("list fw missing parent: got %v, want NotFound", err)
+	}
+
+	if _, err := m.ListRoles(ctx, "rg1", "ghost"); !cerrors.IsNotFound(err) {
+		t.Fatalf("list roles missing parent: got %v, want NotFound", err)
+	}
+
+	if _, err := m.ListPrivateEndpointConnections(ctx, "rg1", "ghost"); !cerrors.IsNotFound(err) {
+		t.Fatalf("list PE missing parent: got %v, want NotFound", err)
+	}
+}
+
+func TestClusterStateGuards(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	// Can't start an already-running cluster.
+	if err := m.StartCluster(ctx, "rg1", "pg1"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("start running cluster: got %v, want FailedPrecondition", err)
+	}
+
+	// Stop → can't stop again; start brings it back.
+	if err := m.StopCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	if err := m.StopCluster(ctx, "rg1", "pg1"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("stop stopped cluster: got %v, want FailedPrecondition", err)
+	}
+
+	if err := m.StartCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	if err := m.RestartCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("restart running cluster: %v", err)
+	}
+}
+
+func TestConfigValueValidation(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	// Empty value rejected.
+	if _, err := m.UpdateCoordinatorConfiguration(ctx, "rg1", "pg1", "max_connections", ""); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("empty value: got %v, want InvalidArgument", err)
+	}
+
+	// Out-of-range integer rejected (max_connections range is 25-3000).
+	if _, err := m.UpdateCoordinatorConfiguration(ctx, "rg1", "pg1", "max_connections", "999999"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("out-of-range: got %v, want InvalidArgument", err)
+	}
+
+	// Enum violation rejected (array_nulls allows on,off).
+	if _, err := m.UpdateNodeConfiguration(ctx, "rg1", "pg1", "array_nulls", "maybe"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("enum violation: got %v, want InvalidArgument", err)
+	}
+
+	// A valid in-range value is accepted.
+	if _, err := m.UpdateCoordinatorConfiguration(ctx, "rg1", "pg1", "max_connections", "500"); err != nil {
+		t.Fatalf("valid value: %v", err)
+	}
+}
+
+func TestRolePasswordRequired(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app"}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("role without password: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestFirewallAndRoleGetDelete(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: "rg1", ClusterName: "pg1", Name: "fw", StartIPAddress: "10.0.0.0", EndIPAddress: "10.0.0.255",
+	}); err != nil {
+		t.Fatalf("create fw: %v", err)
+	}
+
+	if _, err := m.GetFirewallRule(ctx, "rg1", "pg1", "fw"); err != nil {
+		t.Fatalf("GetFirewallRule: %v", err)
+	}
+
+	if err := m.DeleteFirewallRule(ctx, "rg1", "pg1", "fw"); err != nil {
+		t.Fatalf("DeleteFirewallRule: %v", err)
+	}
+
+	if _, err := m.GetFirewallRule(ctx, "rg1", "pg1", "fw"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get deleted fw: got %v, want NotFound", err)
+	}
+
+	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app", Password: "R0lePass!"}); err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+
+	if _, err := m.GetRole(ctx, "rg1", "pg1", "app"); err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	if err := m.DeleteRole(ctx, "rg1", "pg1", "app"); err != nil {
+		t.Fatalf("DeleteRole: %v", err)
+	}
+
+	if err := m.DeleteRole(ctx, "rg1", "pg1", "app"); !cerrors.IsNotFound(err) {
+		t.Fatalf("delete missing role: got %v, want NotFound", err)
+	}
+}
+
+func TestConfigurationsListingAndServerConfigs(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	cfgs, err := m.ListConfigurations(ctx, "rg1", "pg1")
+	if err != nil || len(cfgs) == 0 {
+		t.Fatalf("ListConfigurations: %v len=%d", err, len(cfgs))
+	}
+
+	scs, err := m.ListServerConfigurations(ctx, "rg1", "pg1", "pg1-c")
+	if err != nil || len(scs) == 0 {
+		t.Fatalf("ListServerConfigurations: %v len=%d", err, len(scs))
+	}
+
+	if _, err := m.GetNodeConfiguration(ctx, "rg1", "pg1", "work_mem"); err != nil {
+		t.Fatalf("GetNodeConfiguration: %v", err)
+	}
+
+	// Listing under a missing cluster is NotFound.
+	if _, err := m.ListConfigurations(ctx, "rg1", "ghost"); !cerrors.IsNotFound(err) {
+		t.Fatalf("ListConfigurations missing parent: got %v, want NotFound", err)
+	}
+}
+
+func TestPrivateEndpointsAndLinks(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	// Invalid connection status is rejected.
+	if _, err := m.CreateOrUpdatePrivateEndpointConnection(ctx, "rg1", "pg1", "pe1", "Bogus", ""); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("bad PE status: got %v, want InvalidArgument", err)
+	}
+
+	pec, err := m.CreateOrUpdatePrivateEndpointConnection(ctx, "rg1", "pg1", "pe1", "Approved", "ok")
+	if err != nil || pec.ActionsRequired != "None" {
+		t.Fatalf("create PE: %v %+v", err, pec)
+	}
+
+	if _, err := m.GetPrivateEndpointConnection(ctx, "rg1", "pg1", "pe1"); err != nil {
+		t.Fatalf("GetPrivateEndpointConnection: %v", err)
+	}
+
+	pecs, _ := m.ListPrivateEndpointConnections(ctx, "rg1", "pg1")
+	if len(pecs) != 1 {
+		t.Fatalf("ListPrivateEndpointConnections: got %d, want 1", len(pecs))
+	}
+
+	if err := m.DeletePrivateEndpointConnection(ctx, "rg1", "pg1", "pe1"); err != nil {
+		t.Fatalf("DeletePrivateEndpointConnection: %v", err)
+	}
+
+	// Private-link resources: one "coordinator" group.
+	plrs, err := m.ListPrivateLinkResources(ctx, "rg1", "pg1")
+	if err != nil || len(plrs) != 1 {
+		t.Fatalf("ListPrivateLinkResources: %v len=%d", err, len(plrs))
+	}
+
+	if _, err := m.GetPrivateLinkResource(ctx, "rg1", "pg1", "coordinator"); err != nil {
+		t.Fatalf("GetPrivateLinkResource: %v", err)
+	}
+
+	if _, err := m.GetPrivateLinkResource(ctx, "rg1", "pg1", "nope"); !cerrors.IsNotFound(err) {
+		t.Fatalf("GetPrivateLinkResource missing: got %v, want NotFound", err)
+	}
+}
+
+func TestReplicaNodesReadOnly(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "primary", 2)
+
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "rep1", ResourceGroup: "rg1", NodeCount: 2, SourceResourceID: m.clusterResourceID("rg1", "primary"),
+	}); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+
+	nodes, _ := m.ListServers(ctx, "rg1", "rep1")
+	for i := range nodes {
+		if !nodes[i].IsReadOnly {
+			t.Fatalf("replica node %q (%s) is not read-only", nodes[i].Name, nodes[i].Role)
+		}
+	}
+}

--- a/providers/azure/cosmospostgresql/cosmospostgresql_test.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql_test.go
@@ -22,7 +22,7 @@ func newTestMock() *Mock {
 func mustCluster(t *testing.T, m *Mock, rg, name string, nodeCount int) string {
 	t.Helper()
 
-	if _, err := m.CreateOrUpdateCluster(context.Background(), cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(context.Background(), cpgdriver.CreateClusterConfig{
 		Name: name, ResourceGroup: rg, Location: "eastus", NodeCount: nodeCount,
 	}); err != nil {
 		t.Fatalf("CreateOrUpdateCluster %s: %v", name, err)
@@ -35,7 +35,7 @@ func TestClusterLifecycle(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	c, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	c, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "pg1", ResourceGroup: "rg1", Location: "eastus", NodeCount: 2,
 		Tags: map[string]string{"env": "prod"}, EnableHa: true,
 	})
@@ -94,7 +94,7 @@ func TestClusterLifecycle(t *testing.T) {
 func TestNodeCountBounded(t *testing.T) {
 	m := newTestMock()
 
-	if _, err := m.CreateOrUpdateCluster(context.Background(), cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(context.Background(), cpgdriver.CreateClusterConfig{
 		Name: "big", ResourceGroup: "rg1", NodeCount: maxNodeCount + 1,
 	}); !cerrors.IsInvalidArgument(err) {
 		t.Fatalf("oversized nodeCount: got %v, want InvalidArgument", err)
@@ -213,7 +213,7 @@ func TestReadReplicaPromotion(t *testing.T) {
 	srcID := m.clusterResourceID("rg1", "primary")
 
 	// Create a replica pointing at the primary.
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "replica", ResourceGroup: "rg1", Location: "westus",
 		SourceResourceID: srcID, SourceLocation: "eastus",
 	}); err != nil {
@@ -268,7 +268,7 @@ func TestClusterResultDoesNotAliasStore(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "pg1", ResourceGroup: "rg1", Tags: map[string]string{"env": "prod"},
 		MaintenanceWindow: &cpgdriver.MaintenanceWindow{DayOfWeek: 1, StartHour: 2},
 	}); err != nil {
@@ -314,14 +314,14 @@ func TestClusterNameGloballyUnique(t *testing.T) {
 	mustCluster(t, m, "rg1", "pg1", 1)
 
 	// Same name in a different resource group is rejected.
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "pg1", ResourceGroup: "rg2", Location: "eastus",
 	}); !cerrors.IsAlreadyExists(err) {
 		t.Fatalf("duplicate name across RGs: got %v, want AlreadyExists", err)
 	}
 
 	// Re-PUT of the same rg/name is an update, not a conflict.
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "pg1", ResourceGroup: "rg1", Location: "eastus", NodeCount: 3,
 	}); err != nil {
 		t.Fatalf("re-PUT same cluster: %v", err)
@@ -334,20 +334,20 @@ func TestReplicaSourceValidated(t *testing.T) {
 	mustCluster(t, m, "rg1", "primary", 2)
 
 	// A bogus source is rejected.
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "ghost"),
 	}); !cerrors.IsNotFound(err) {
 		t.Fatalf("bogus replica source: got %v, want NotFound", err)
 	}
 
 	// A valid replica, then a replica-of-a-replica is rejected.
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
 	}); err != nil {
 		t.Fatalf("valid replica: %v", err)
 	}
 
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "rep2", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "rep1"),
 	}); !cerrors.IsInvalidArgument(err) {
 		t.Fatalf("chained replica: got %v, want InvalidArgument", err)
@@ -359,7 +359,7 @@ func TestDeleteUnlinksReplicas(t *testing.T) {
 	ctx := context.Background()
 	mustCluster(t, m, "rg1", "primary", 2)
 
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
 	}); err != nil {
 		t.Fatalf("create replica: %v", err)
@@ -381,7 +381,7 @@ func TestDeleteReplicaUnlinksFromSource(t *testing.T) {
 	ctx := context.Background()
 	mustCluster(t, m, "rg1", "primary", 2)
 
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "rep1", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
 	}); err != nil {
 		t.Fatalf("create replica: %v", err)
@@ -606,12 +606,89 @@ func TestPrivateEndpointsAndLinks(t *testing.T) {
 	}
 }
 
+func TestReplicaSourceImmutableOnRePut(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "primary", 2)
+	mustCluster(t, m, "rg1", "other", 2)
+
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "replica", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "primary"),
+	}); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+
+	// Re-PUT the replica trying to re-point it at "other": the source is
+	// immutable, so the link graph must not change.
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "replica", ResourceGroup: "rg1", SourceResourceID: m.clusterResourceID("rg1", "other"),
+	}); err != nil {
+		t.Fatalf("re-PUT replica: %v", err)
+	}
+
+	rep, _ := m.GetCluster(ctx, "rg1", "replica")
+	if rep.SourceResourceID != m.clusterResourceID("rg1", "primary") {
+		t.Fatalf("replica source changed on re-PUT: %q", rep.SourceResourceID)
+	}
+
+	other, _ := m.GetCluster(ctx, "rg1", "other")
+	if len(other.ReadReplicas) != 0 {
+		t.Fatalf("re-PUT wrongly linked 'other': %+v", other.ReadReplicas)
+	}
+
+	primary, _ := m.GetCluster(ctx, "rg1", "primary")
+	if len(primary.ReadReplicas) != 1 {
+		t.Fatalf("primary lost its replica link: %+v", primary.ReadReplicas)
+	}
+}
+
+func TestCreatedFlag(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	_, created, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{Name: "pg1", ResourceGroup: "rg1"})
+	if err != nil || !created {
+		t.Fatalf("first PUT: created=%v err=%v", created, err)
+	}
+
+	_, created, err = m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{Name: "pg1", ResourceGroup: "rg1"})
+	if err != nil || created {
+		t.Fatalf("re-PUT: created=%v err=%v", created, err)
+	}
+}
+
+func TestPatchAppliesWritableFields(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 2)
+
+	pub, shards := true, true
+	up, err := m.UpdateCluster(ctx, "rg1", "pg1", cpgdriver.ClusterPatch{
+		CoordinatorEnablePublicIPAccess: &pub,
+		NodeEnablePublicIPAccess:        &pub,
+		EnableShardsOnCoordinator:       &shards,
+		NodeCount:                       intPtr(0),
+	})
+	if err != nil {
+		t.Fatalf("UpdateCluster: %v", err)
+	}
+
+	if !up.CoordinatorEnablePublicIPAccess || !up.NodeEnablePublicIPAccess || !up.EnableShardsOnCoordinator {
+		t.Fatalf("public-IP / shards flags not applied: %+v", up)
+	}
+
+	// PATCH scale-to-single-node (nodeCount 0) must take effect.
+	if up.NodeCount != 0 {
+		t.Fatalf("scale-to-single-node not applied: %d", up.NodeCount)
+	}
+}
+
 func TestReplicaNodesReadOnly(t *testing.T) {
 	m := newTestMock()
 	ctx := context.Background()
 	mustCluster(t, m, "rg1", "primary", 2)
 
-	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+	if _, _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
 		Name: "rep1", ResourceGroup: "rg1", NodeCount: 2, SourceResourceID: m.clusterResourceID("rg1", "primary"),
 	}); err != nil {
 		t.Fatalf("create replica: %v", err)

--- a/providers/azure/cosmospostgresql/cosmospostgresql_test.go
+++ b/providers/azure/cosmospostgresql/cosmospostgresql_test.go
@@ -1,0 +1,286 @@
+package cosmospostgresql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+const sub = "sub-123"
+
+func newTestMock() *Mock {
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	opts := config.NewOptions(config.WithClock(fc), config.WithRegion("eastus"), config.WithAccountID(sub))
+
+	return New(opts)
+}
+
+func mustCluster(t *testing.T, m *Mock, rg, name string, nodeCount int) string {
+	t.Helper()
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), cpgdriver.CreateClusterConfig{
+		Name: name, ResourceGroup: rg, Location: "eastus", NodeCount: nodeCount,
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateCluster %s: %v", name, err)
+	}
+
+	return name
+}
+
+func TestClusterLifecycle(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	c, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "pg1", ResourceGroup: "rg1", Location: "eastus", NodeCount: 2,
+		Tags: map[string]string{"env": "prod"}, EnableHa: true,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if c.ProvisioningState != cpgdriver.ProvisioningSucceeded || c.CitusVersion != defaultCitusVersion {
+		t.Fatalf("defaults wrong: %+v", c)
+	}
+
+	// PATCH: scale nodes + change HA.
+	ha := false
+	up, err := m.UpdateCluster(ctx, "rg1", "pg1", cpgdriver.ClusterPatch{
+		NodeCount: intPtr(4), EnableHa: &ha, Tags: map[string]string{"env": "dev"},
+	})
+	if err != nil || up.NodeCount != 4 || up.EnableHa {
+		t.Fatalf("patch not applied: %+v err=%v", up, err)
+	}
+
+	if up.Tags["env"] != "dev" {
+		t.Fatalf("tags not replaced: %+v", up.Tags)
+	}
+
+	// List by RG + subscription.
+	byRG, _ := m.ListClustersByResourceGroup(ctx, "rg1")
+	bySub, _ := m.ListClustersBySubscription(ctx)
+
+	if len(byRG) != 1 || len(bySub) != 1 {
+		t.Fatalf("list wrong: rg=%d sub=%d", len(byRG), len(bySub))
+	}
+
+	// Stop / start toggles state.
+	if err := m.StopCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	if got, _ := m.GetCluster(ctx, "rg1", "pg1"); got.State != "Stopped" {
+		t.Fatalf("state after stop: %q", got.State)
+	}
+
+	if err := m.StartCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Delete.
+	if err := m.DeleteCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	if _, err := m.GetCluster(ctx, "rg1", "pg1"); !cerrors.IsNotFound(err) {
+		t.Fatalf("get after delete: got %v, want NotFound", err)
+	}
+}
+
+func TestNodeCountBounded(t *testing.T) {
+	m := newTestMock()
+
+	if _, err := m.CreateOrUpdateCluster(context.Background(), cpgdriver.CreateClusterConfig{
+		Name: "big", ResourceGroup: "rg1", NodeCount: maxNodeCount + 1,
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("oversized nodeCount: got %v, want InvalidArgument", err)
+	}
+}
+
+func TestFirewallRulesAndRoles(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 2)
+
+	// A firewall rule under a missing cluster is rejected.
+	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: "rg1", ClusterName: "ghost", Name: "all", StartIPAddress: "0.0.0.0", EndIPAddress: "255.255.255.255",
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("fw under missing cluster: got %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.CreateOrUpdateFirewallRule(ctx, cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: "rg1", ClusterName: "pg1", Name: "all", StartIPAddress: "0.0.0.0", EndIPAddress: "255.255.255.255",
+	}); err != nil {
+		t.Fatalf("CreateOrUpdateFirewallRule: %v", err)
+	}
+
+	rules, _ := m.ListFirewallRules(ctx, "rg1", "pg1")
+	if len(rules) != 1 || rules[0].EndIPAddress != "255.255.255.255" {
+		t.Fatalf("list fw wrong: %+v", rules)
+	}
+
+	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app"}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := m.CreateRole(ctx, cpgdriver.CreateRoleConfig{ResourceGroup: "rg1", ClusterName: "pg1", Name: "app"}); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate role: got %v, want AlreadyExists", err)
+	}
+
+	// Cascade delete removes children.
+	if err := m.DeleteCluster(ctx, "rg1", "pg1"); err != nil {
+		t.Fatalf("delete cluster: %v", err)
+	}
+
+	if r, _ := m.ListFirewallRules(ctx, "rg1", "pg1"); len(r) != 0 {
+		t.Fatalf("firewall rules survived cluster delete: %+v", r)
+	}
+}
+
+func TestDerivedServers(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 2)
+
+	servers, err := m.ListServers(ctx, "rg1", "pg1")
+	if err != nil {
+		t.Fatalf("ListServers: %v", err)
+	}
+
+	// One coordinator + two workers.
+	if len(servers) != 3 || servers[0].Role != cpgdriver.RoleCoordinator {
+		t.Fatalf("derived nodes wrong: %+v", servers)
+	}
+
+	if _, err := m.GetServer(ctx, "rg1", "pg1", "pg1-c"); err != nil {
+		t.Fatalf("GetServer coordinator: %v", err)
+	}
+
+	if _, err := m.GetServer(ctx, "rg1", "pg1", "pg1-w9"); !cerrors.IsNotFound(err) {
+		t.Fatalf("GetServer missing: got %v, want NotFound", err)
+	}
+}
+
+func TestConfigurations(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "pg1", 1)
+
+	// Default value comes from the catalog.
+	sc, err := m.GetCoordinatorConfiguration(ctx, "rg1", "pg1", "max_connections")
+	if err != nil || sc.Value != "300" || sc.Source != "system-default" {
+		t.Fatalf("default coordinator config wrong: %+v err=%v", sc, err)
+	}
+
+	// Update overrides the coordinator value only.
+	if _, err := m.UpdateCoordinatorConfiguration(ctx, "rg1", "pg1", "max_connections", "500"); err != nil {
+		t.Fatalf("UpdateCoordinatorConfiguration: %v", err)
+	}
+
+	sc, _ = m.GetCoordinatorConfiguration(ctx, "rg1", "pg1", "max_connections")
+	if sc.Value != "500" || sc.Source != "user-override" {
+		t.Fatalf("coordinator override not applied: %+v", sc)
+	}
+
+	node, _ := m.GetNodeConfiguration(ctx, "rg1", "pg1", "max_connections")
+	if node.Value != "300" {
+		t.Fatalf("node value should be unchanged default: %+v", node)
+	}
+
+	// Cluster-wide view shows both role groups.
+	cfg, err := m.GetConfiguration(ctx, "rg1", "pg1", "max_connections")
+	if err != nil || len(cfg.RoleGroups) != 2 {
+		t.Fatalf("GetConfiguration wrong: %+v err=%v", cfg, err)
+	}
+
+	if _, err := m.GetConfiguration(ctx, "rg1", "pg1", "no_such_param"); !cerrors.IsNotFound(err) {
+		t.Fatalf("unknown config: got %v, want NotFound", err)
+	}
+}
+
+func TestReadReplicaPromotion(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+	mustCluster(t, m, "rg1", "primary", 2)
+
+	srcID := m.clusterResourceID("rg1", "primary")
+
+	// Create a replica pointing at the primary.
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "replica", ResourceGroup: "rg1", Location: "westus",
+		SourceResourceID: srcID, SourceLocation: "eastus",
+	}); err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+
+	// The primary now lists the replica.
+	primary, _ := m.GetCluster(ctx, "rg1", "primary")
+	if len(primary.ReadReplicas) != 1 {
+		t.Fatalf("primary should list one replica: %+v", primary.ReadReplicas)
+	}
+
+	// Promote detaches it.
+	if err := m.PromoteReadReplica(ctx, "rg1", "replica"); err != nil {
+		t.Fatalf("PromoteReadReplica: %v", err)
+	}
+
+	rep, _ := m.GetCluster(ctx, "rg1", "replica")
+	if rep.SourceResourceID != "" {
+		t.Fatalf("replica still linked after promote: %+v", rep)
+	}
+
+	primary, _ = m.GetCluster(ctx, "rg1", "primary")
+	if len(primary.ReadReplicas) != 0 {
+		t.Fatalf("primary should have no replicas after promote: %+v", primary.ReadReplicas)
+	}
+
+	// Promoting a non-replica fails.
+	if err := m.PromoteReadReplica(ctx, "rg1", "primary"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("promote non-replica: got %v, want FailedPrecondition", err)
+	}
+}
+
+func TestCheckNameAvailability(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	na, err := m.CheckNameAvailability(ctx, "free", "")
+	if err != nil || !na.NameAvailable {
+		t.Fatalf("free name should be available: %+v err=%v", na, err)
+	}
+
+	mustCluster(t, m, "rg1", "taken", 1)
+
+	na, _ = m.CheckNameAvailability(ctx, "taken", "")
+	if na.NameAvailable {
+		t.Fatalf("taken name should be unavailable: %+v", na)
+	}
+}
+
+func TestClusterResultDoesNotAliasStore(t *testing.T) {
+	m := newTestMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateOrUpdateCluster(ctx, cpgdriver.CreateClusterConfig{
+		Name: "pg1", ResourceGroup: "rg1", Tags: map[string]string{"env": "prod"},
+		MaintenanceWindow: &cpgdriver.MaintenanceWindow{DayOfWeek: 1, StartHour: 2},
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	got, _ := m.GetCluster(ctx, "rg1", "pg1")
+	got.Tags["env"] = "hacked"
+	got.MaintenanceWindow.StartHour = 23
+
+	again, _ := m.GetCluster(ctx, "rg1", "pg1")
+	if again.Tags["env"] != "prod" || again.MaintenanceWindow.StartHour != 2 {
+		t.Fatal("returned cluster aliases the store (clone-on-read broken)")
+	}
+}
+
+func intPtr(i int) *int { return &i }

--- a/providers/azure/cosmospostgresql/firewallrules.go
+++ b/providers/azure/cosmospostgresql/firewallrules.go
@@ -63,6 +63,10 @@ func (m *Mock) GetFirewallRule(_ context.Context, rg, cluster, name string) (*cp
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
+	}
+
 	fr, ok := m.firewallRules.Get(childKey(rg, cluster, name))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", name)
@@ -95,6 +99,10 @@ func identity[T any](v *T) T { return *v }
 func (m *Mock) DeleteFirewallRule(_ context.Context, rg, cluster, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return err
+	}
 
 	key := childKey(rg, cluster, name)
 	if !m.firewallRules.Has(key) {

--- a/providers/azure/cosmospostgresql/firewallrules.go
+++ b/providers/azure/cosmospostgresql/firewallrules.go
@@ -1,11 +1,28 @@
 package cosmospostgresql
 
 import (
+	"bytes"
 	"context"
+	"net"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
 )
+
+// validateIPRange rejects non-IPv4 endpoints and reversed ranges, matching the
+// real Azure firewall-rule validation.
+func validateIPRange(start, end string) error {
+	s, e := net.ParseIP(start).To4(), net.ParseIP(end).To4()
+	if s == nil || e == nil {
+		return cerrors.New(cerrors.InvalidArgument, "startIpAddress and endIpAddress must be valid IPv4 addresses")
+	}
+
+	if bytes.Compare(s, e) > 0 {
+		return cerrors.New(cerrors.InvalidArgument, "startIpAddress must be less than or equal to endIpAddress")
+	}
+
+	return nil
+}
 
 // CreateOrUpdateFirewallRule creates or replaces a firewall rule on a cluster.
 //
@@ -15,11 +32,15 @@ func (m *Mock) CreateOrUpdateFirewallRule(_ context.Context, cfg cpgdriver.Creat
 		return nil, err
 	}
 
+	if err := validateIPRange(cfg.StartIPAddress, cfg.EndIPAddress); err != nil {
+		return nil, err
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.clusters.Has(clusterKey(cfg.ResourceGroup, cfg.ClusterName)) {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "cluster %q not found", cfg.ClusterName)
+	if err := m.requireClusterLocked(cfg.ResourceGroup, cfg.ClusterName); err != nil {
+		return nil, err
 	}
 
 	fr := cpgdriver.FirewallRule{
@@ -56,6 +77,10 @@ func (m *Mock) GetFirewallRule(_ context.Context, rg, cluster, name string) (*cp
 func (m *Mock) ListFirewallRules(_ context.Context, rg, cluster string) ([]cpgdriver.FirewallRule, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
+	}
 
 	return listChildren(m.firewallRules, rg, cluster, firewallRuleKey, identity[cpgdriver.FirewallRule]), nil
 }

--- a/providers/azure/cosmospostgresql/firewallrules.go
+++ b/providers/azure/cosmospostgresql/firewallrules.go
@@ -1,0 +1,82 @@
+package cosmospostgresql
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// CreateOrUpdateFirewallRule creates or replaces a firewall rule on a cluster.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateOrUpdateFirewallRule(_ context.Context, cfg cpgdriver.CreateFirewallRuleConfig) (*cpgdriver.FirewallRule, error) {
+	if err := validName("firewall rule", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.clusters.Has(clusterKey(cfg.ResourceGroup, cfg.ClusterName)) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "cluster %q not found", cfg.ClusterName)
+	}
+
+	fr := cpgdriver.FirewallRule{
+		Name:              cfg.Name,
+		ClusterName:       cfg.ClusterName,
+		ResourceGroup:     cfg.ResourceGroup,
+		ProvisioningState: cpgdriver.ProvisioningSucceeded,
+		StartIPAddress:    cfg.StartIPAddress,
+		EndIPAddress:      cfg.EndIPAddress,
+	}
+	m.firewallRules.Set(childKey(cfg.ResourceGroup, cfg.ClusterName, cfg.Name), fr)
+
+	out := fr
+
+	return &out, nil
+}
+
+// GetFirewallRule returns a firewall rule by name.
+func (m *Mock) GetFirewallRule(_ context.Context, rg, cluster, name string) (*cpgdriver.FirewallRule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	fr, ok := m.firewallRules.Get(childKey(rg, cluster, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", name)
+	}
+
+	out := fr
+
+	return &out, nil
+}
+
+// ListFirewallRules returns the firewall rules of a cluster.
+func (m *Mock) ListFirewallRules(_ context.Context, rg, cluster string) ([]cpgdriver.FirewallRule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return listChildren(m.firewallRules, rg, cluster, firewallRuleKey, identity[cpgdriver.FirewallRule]), nil
+}
+
+func firewallRuleKey(fr *cpgdriver.FirewallRule) string {
+	return childKey(fr.ResourceGroup, fr.ClusterName, fr.Name)
+}
+
+func identity[T any](v *T) T { return *v }
+
+// DeleteFirewallRule removes a firewall rule.
+func (m *Mock) DeleteFirewallRule(_ context.Context, rg, cluster, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := childKey(rg, cluster, name)
+	if !m.firewallRules.Has(key) {
+		return cerrors.Newf(cerrors.NotFound, "firewall rule %q not found", name)
+	}
+
+	m.firewallRules.Delete(key)
+
+	return nil
+}

--- a/providers/azure/cosmospostgresql/privateendpoints.go
+++ b/providers/azure/cosmospostgresql/privateendpoints.go
@@ -1,0 +1,139 @@
+package cosmospostgresql
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+func clonePEC(in *cpgdriver.PrivateEndpointConnection) cpgdriver.PrivateEndpointConnection {
+	pec := *in
+	pec.GroupIDs = cloneStrings(in.GroupIDs)
+
+	return pec
+}
+
+// CreateOrUpdatePrivateEndpointConnection creates or updates a private-endpoint
+// connection (approving/rejecting the link).
+func (m *Mock) CreateOrUpdatePrivateEndpointConnection(
+	_ context.Context, rg, cluster, name, status, description string,
+) (*cpgdriver.PrivateEndpointConnection, error) {
+	if err := validName("private endpoint connection", name); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "cluster %q not found", cluster)
+	}
+
+	key := childKey(rg, cluster, name)
+
+	pec := cpgdriver.PrivateEndpointConnection{
+		Name:              name,
+		ClusterName:       cluster,
+		ResourceGroup:     rg,
+		ProvisioningState: cpgdriver.ProvisioningSucceeded,
+		GroupIDs:          []string{"coordinator"},
+		PrivateEndpointID: m.clusterResourceID(rg, cluster) + "/privateEndpoints/" + name,
+		ConnectionStatus:  orDefault(status, "Approved"),
+		ConnectionDesc:    description,
+	}
+
+	if existing, ok := m.privateEPs.Get(key); ok {
+		pec.PrivateEndpointID = existing.PrivateEndpointID
+	}
+
+	m.privateEPs.Set(key, pec)
+
+	out := clonePEC(&pec)
+
+	return &out, nil
+}
+
+// GetPrivateEndpointConnection returns a connection by name.
+func (m *Mock) GetPrivateEndpointConnection(_ context.Context, rg, cluster, name string) (*cpgdriver.PrivateEndpointConnection, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	pec, ok := m.privateEPs.Get(childKey(rg, cluster, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "private endpoint connection %q not found", name)
+	}
+
+	out := clonePEC(&pec)
+
+	return &out, nil
+}
+
+// ListPrivateEndpointConnections returns the connections of a cluster.
+func (m *Mock) ListPrivateEndpointConnections(_ context.Context, rg, cluster string) ([]cpgdriver.PrivateEndpointConnection, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return listChildren(m.privateEPs, rg, cluster, pecKey, clonePEC), nil
+}
+
+func pecKey(pec *cpgdriver.PrivateEndpointConnection) string {
+	return childKey(pec.ResourceGroup, pec.ClusterName, pec.Name)
+}
+
+// DeletePrivateEndpointConnection removes a connection.
+func (m *Mock) DeletePrivateEndpointConnection(_ context.Context, rg, cluster, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := childKey(rg, cluster, name)
+	if !m.privateEPs.Has(key) {
+		return cerrors.Newf(cerrors.NotFound, "private endpoint connection %q not found", name)
+	}
+
+	m.privateEPs.Delete(key)
+
+	return nil
+}
+
+// GetPrivateLinkResource returns a private-link resource (group) of a cluster.
+// The mock exposes a single "coordinator" group.
+func (m *Mock) GetPrivateLinkResource(_ context.Context, rg, cluster, name string) (*cpgdriver.PrivateLinkResource, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	if name != "coordinator" {
+		return nil, cerrors.Newf(cerrors.NotFound, "private link resource %q not found", name)
+	}
+
+	plr := privateLinkResource(rg, cluster, name)
+
+	return &plr, nil
+}
+
+// ListPrivateLinkResources returns the private-link resources of a cluster.
+func (m *Mock) ListPrivateLinkResources(_ context.Context, rg, cluster string) ([]cpgdriver.PrivateLinkResource, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.clusters.Has(clusterKey(rg, cluster)) {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	return []cpgdriver.PrivateLinkResource{privateLinkResource(rg, cluster, "coordinator")}, nil
+}
+
+func privateLinkResource(rg, cluster, name string) cpgdriver.PrivateLinkResource {
+	return cpgdriver.PrivateLinkResource{
+		Name:              name,
+		ClusterName:       cluster,
+		ResourceGroup:     rg,
+		GroupID:           name,
+		RequiredMembers:   []string{"coordinator"},
+		RequiredZoneNames: []string{"privatelink.postgres.cosmos.azure.com"},
+	}
+}

--- a/providers/azure/cosmospostgresql/privateendpoints.go
+++ b/providers/azure/cosmospostgresql/privateendpoints.go
@@ -23,11 +23,16 @@ func (m *Mock) CreateOrUpdatePrivateEndpointConnection(
 		return nil, err
 	}
 
+	status = orDefault(status, "Approved")
+	if status != "Approved" && status != "Rejected" && status != "Pending" {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid connection status %q", status)
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.clusters.Has(clusterKey(rg, cluster)) {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "cluster %q not found", cluster)
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
 	}
 
 	key := childKey(rg, cluster, name)
@@ -39,8 +44,9 @@ func (m *Mock) CreateOrUpdatePrivateEndpointConnection(
 		ProvisioningState: cpgdriver.ProvisioningSucceeded,
 		GroupIDs:          []string{"coordinator"},
 		PrivateEndpointID: m.clusterResourceID(rg, cluster) + "/privateEndpoints/" + name,
-		ConnectionStatus:  orDefault(status, "Approved"),
+		ConnectionStatus:  status,
 		ConnectionDesc:    description,
+		ActionsRequired:   "None",
 	}
 
 	if existing, ok := m.privateEPs.Get(key); ok {
@@ -73,6 +79,10 @@ func (m *Mock) GetPrivateEndpointConnection(_ context.Context, rg, cluster, name
 func (m *Mock) ListPrivateEndpointConnections(_ context.Context, rg, cluster string) ([]cpgdriver.PrivateEndpointConnection, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
+	}
 
 	return listChildren(m.privateEPs, rg, cluster, pecKey, clonePEC), nil
 }

--- a/providers/azure/cosmospostgresql/privateendpoints.go
+++ b/providers/azure/cosmospostgresql/privateendpoints.go
@@ -65,6 +65,10 @@ func (m *Mock) GetPrivateEndpointConnection(_ context.Context, rg, cluster, name
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
+	}
+
 	pec, ok := m.privateEPs.Get(childKey(rg, cluster, name))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "private endpoint connection %q not found", name)
@@ -95,6 +99,10 @@ func pecKey(pec *cpgdriver.PrivateEndpointConnection) string {
 func (m *Mock) DeletePrivateEndpointConnection(_ context.Context, rg, cluster, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return err
+	}
 
 	key := childKey(rg, cluster, name)
 	if !m.privateEPs.Has(key) {

--- a/providers/azure/cosmospostgresql/roles.go
+++ b/providers/azure/cosmospostgresql/roles.go
@@ -47,6 +47,10 @@ func (m *Mock) GetRole(_ context.Context, rg, cluster, name string) (*cpgdriver.
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
+	}
+
 	role, ok := m.roles.Get(childKey(rg, cluster, name))
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "role %q not found", name)
@@ -77,6 +81,10 @@ func roleKey(role *cpgdriver.Role) string {
 func (m *Mock) DeleteRole(_ context.Context, rg, cluster, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return err
+	}
 
 	key := childKey(rg, cluster, name)
 	if !m.roles.Has(key) {

--- a/providers/azure/cosmospostgresql/roles.go
+++ b/providers/azure/cosmospostgresql/roles.go
@@ -1,0 +1,81 @@
+package cosmospostgresql
+
+import (
+	"context"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// CreateRole provisions a Postgres role on a cluster.
+func (m *Mock) CreateRole(_ context.Context, cfg cpgdriver.CreateRoleConfig) (*cpgdriver.Role, error) {
+	if err := validName("role", cfg.Name); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.clusters.Has(clusterKey(cfg.ResourceGroup, cfg.ClusterName)) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "cluster %q not found", cfg.ClusterName)
+	}
+
+	key := childKey(cfg.ResourceGroup, cfg.ClusterName, cfg.Name)
+	if m.roles.Has(key) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "role %q already exists", cfg.Name)
+	}
+
+	role := cpgdriver.Role{
+		Name:              cfg.Name,
+		ClusterName:       cfg.ClusterName,
+		ResourceGroup:     cfg.ResourceGroup,
+		ProvisioningState: cpgdriver.ProvisioningSucceeded,
+	}
+	m.roles.Set(key, role)
+
+	out := role
+
+	return &out, nil
+}
+
+// GetRole returns a role by name.
+func (m *Mock) GetRole(_ context.Context, rg, cluster, name string) (*cpgdriver.Role, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	role, ok := m.roles.Get(childKey(rg, cluster, name))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "role %q not found", name)
+	}
+
+	out := role
+
+	return &out, nil
+}
+
+// ListRoles returns the roles of a cluster.
+func (m *Mock) ListRoles(_ context.Context, rg, cluster string) ([]cpgdriver.Role, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return listChildren(m.roles, rg, cluster, roleKey, identity[cpgdriver.Role]), nil
+}
+
+func roleKey(role *cpgdriver.Role) string {
+	return childKey(role.ResourceGroup, role.ClusterName, role.Name)
+}
+
+// DeleteRole removes a role.
+func (m *Mock) DeleteRole(_ context.Context, rg, cluster, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := childKey(rg, cluster, name)
+	if !m.roles.Has(key) {
+		return cerrors.Newf(cerrors.NotFound, "role %q not found", name)
+	}
+
+	m.roles.Delete(key)
+
+	return nil
+}

--- a/providers/azure/cosmospostgresql/roles.go
+++ b/providers/azure/cosmospostgresql/roles.go
@@ -13,11 +13,15 @@ func (m *Mock) CreateRole(_ context.Context, cfg cpgdriver.CreateRoleConfig) (*c
 		return nil, err
 	}
 
+	if cfg.Password == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "role password is required")
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.clusters.Has(clusterKey(cfg.ResourceGroup, cfg.ClusterName)) {
-		return nil, cerrors.Newf(cerrors.InvalidArgument, "cluster %q not found", cfg.ClusterName)
+	if err := m.requireClusterLocked(cfg.ResourceGroup, cfg.ClusterName); err != nil {
+		return nil, err
 	}
 
 	key := childKey(cfg.ResourceGroup, cfg.ClusterName, cfg.Name)
@@ -57,6 +61,10 @@ func (m *Mock) GetRole(_ context.Context, rg, cluster, name string) (*cpgdriver.
 func (m *Mock) ListRoles(_ context.Context, rg, cluster string) ([]cpgdriver.Role, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	if err := m.requireClusterLocked(rg, cluster); err != nil {
+		return nil, err
+	}
 
 	return listChildren(m.roles, rg, cluster, roleKey, identity[cpgdriver.Role]), nil
 }

--- a/providers/azure/cosmospostgresql/servers.go
+++ b/providers/azure/cosmospostgresql/servers.go
@@ -1,0 +1,103 @@
+package cosmospostgresql
+
+import (
+	"context"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// serverName returns the derived node name: "<cluster>-c" for the coordinator
+// and "<cluster>-w<idx>" for worker nodes.
+func serverName(cluster, role string, idx int) string {
+	if role == cpgdriver.RoleCoordinator {
+		return cluster + "-c"
+	}
+
+	return fmt.Sprintf("%s-w%d", cluster, idx)
+}
+
+// nodesForCluster derives the (read-only) node list from a cluster's shape: one
+// coordinator plus NodeCount workers.
+func (m *Mock) nodesForCluster(c *cpgdriver.Cluster) []cpgdriver.Server {
+	out := make([]cpgdriver.Server, 0, c.NodeCount+1)
+
+	out = append(out, m.node(c, cpgdriver.RoleCoordinator, 0))
+	for i := 0; i < c.NodeCount; i++ {
+		out = append(out, m.node(c, cpgdriver.RoleWorker, i))
+	}
+
+	return out
+}
+
+func (m *Mock) node(c *cpgdriver.Cluster, role string, idx int) cpgdriver.Server {
+	name := serverName(c.Name, role, idx)
+
+	vcores, edition := c.NodeVCores, c.NodeServerEdition
+	storage, public := c.NodeStorageQuotaInMb, c.NodeEnablePublicIPAccess
+
+	if role == cpgdriver.RoleCoordinator {
+		vcores, edition = c.CoordinatorVCores, c.CoordinatorServerEdition
+		storage, public = c.CoordinatorStorageQuotaInMb, c.CoordinatorEnablePublicIPAccess
+	}
+
+	haState := ""
+	if c.EnableHa {
+		haState = "Healthy"
+	}
+
+	return cpgdriver.Server{
+		Name:                     name,
+		ClusterName:              c.Name,
+		ResourceGroup:            c.ResourceGroup,
+		Role:                     role,
+		State:                    orDefault(c.State, "Ready"),
+		HaState:                  haState,
+		FullyQualifiedDomainName: name + "." + orDefault(m.opts.Region, "eastus") + ".postgres.cosmos.azure.com",
+		AdministratorLogin:       c.AdministratorLogin,
+		ServerEdition:            edition,
+		VCores:                   vcores,
+		StorageQuotaInMb:         storage,
+		CitusVersion:             c.CitusVersion,
+		PostgresqlVersion:        c.PostgresqlVersion,
+		EnableHa:                 c.EnableHa,
+		EnablePublicIPAccess:     public,
+		IsReadOnly:               role == cpgdriver.RoleWorker && c.SourceResourceID != "",
+	}
+}
+
+// GetServer returns a derived node by name.
+func (m *Mock) GetServer(_ context.Context, rg, cluster, name string) (*cpgdriver.Server, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	c, ok := m.clusters.Get(clusterKey(rg, cluster))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	nodes := m.nodesForCluster(&c)
+	for i := range nodes {
+		if nodes[i].Name == name {
+			out := nodes[i]
+
+			return &out, nil
+		}
+	}
+
+	return nil, cerrors.Newf(cerrors.NotFound, "server %q not found", name)
+}
+
+// ListServers returns the derived nodes of a cluster.
+func (m *Mock) ListServers(_ context.Context, rg, cluster string) ([]cpgdriver.Server, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	c, ok := m.clusters.Get(clusterKey(rg, cluster))
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "cluster %q not found", cluster)
+	}
+
+	return m.nodesForCluster(&c), nil
+}

--- a/providers/azure/cosmospostgresql/servers.go
+++ b/providers/azure/cosmospostgresql/servers.go
@@ -42,7 +42,7 @@ func (m *Mock) nodesForCluster(c *cpgdriver.Cluster) []cpgdriver.Server {
 	return out
 }
 
-func (m *Mock) node(c *cpgdriver.Cluster, role string, idx int) cpgdriver.Server {
+func (*Mock) node(c *cpgdriver.Cluster, role string, idx int) cpgdriver.Server {
 	name := serverName(c.Name, role, idx)
 
 	vcores, edition := c.NodeVCores, c.NodeServerEdition
@@ -65,7 +65,7 @@ func (m *Mock) node(c *cpgdriver.Cluster, role string, idx int) cpgdriver.Server
 		Role:                     role,
 		State:                    orDefault(c.State, "Ready"),
 		HaState:                  haState,
-		FullyQualifiedDomainName: name + "." + orDefault(m.opts.Region, "eastus") + ".postgres.cosmos.azure.com",
+		FullyQualifiedDomainName: name + "." + orDefault(c.Location, "eastus") + ".postgres.cosmos.azure.com",
 		AdministratorLogin:       c.AdministratorLogin,
 		ServerEdition:            edition,
 		VCores:                   vcores,

--- a/providers/azure/cosmospostgresql/servers.go
+++ b/providers/azure/cosmospostgresql/servers.go
@@ -21,10 +21,21 @@ func serverName(cluster, role string, idx int) string {
 // nodesForCluster derives the (read-only) node list from a cluster's shape: one
 // coordinator plus NodeCount workers.
 func (m *Mock) nodesForCluster(c *cpgdriver.Cluster) []cpgdriver.Server {
-	out := make([]cpgdriver.Server, 0, c.NodeCount+1)
+	// Clamp defensively: create/PATCH validate the bound, but a bad stored value
+	// must never reach make() with a negative/huge cap.
+	workers := c.NodeCount
+	if workers < 0 {
+		workers = 0
+	}
+
+	if workers > maxNodeCount {
+		workers = maxNodeCount
+	}
+
+	out := make([]cpgdriver.Server, 0, workers+1)
 
 	out = append(out, m.node(c, cpgdriver.RoleCoordinator, 0))
-	for i := 0; i < c.NodeCount; i++ {
+	for i := 0; i < workers; i++ {
 		out = append(out, m.node(c, cpgdriver.RoleWorker, i))
 	}
 
@@ -63,7 +74,8 @@ func (m *Mock) node(c *cpgdriver.Cluster, role string, idx int) cpgdriver.Server
 		PostgresqlVersion:        c.PostgresqlVersion,
 		EnableHa:                 c.EnableHa,
 		EnablePublicIPAccess:     public,
-		IsReadOnly:               role == cpgdriver.RoleWorker && c.SourceResourceID != "",
+		// Every node of a read replica is read-only (coordinator included).
+		IsReadOnly: c.SourceResourceID != "",
 	}
 }
 

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/server/azure/blob"
 	cachesrv "github.com/stackshy/cloudemu/v2/server/azure/cache"
 	"github.com/stackshy/cloudemu/v2/server/azure/cosmos"
+	"github.com/stackshy/cloudemu/v2/server/azure/cosmospostgresql"
 	"github.com/stackshy/cloudemu/v2/server/azure/databricks"
 	"github.com/stackshy/cloudemu/v2/server/azure/databricks/dbfs"
 	"github.com/stackshy/cloudemu/v2/server/azure/databricks/gitcredentials"
@@ -60,6 +61,7 @@ import (
 	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	dbxdriver "github.com/stackshy/cloudemu/v2/services/databricks/driver"
 	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
@@ -105,6 +107,9 @@ type Drivers struct {
 	// ManagedCassandra serves Microsoft.DocumentDB/cassandraClusters (Azure
 	// Managed Instance for Apache Cassandra) via the ARM protocol.
 	ManagedCassandra mcdriver.ManagedCassandra
+	// CosmosPostgreSQL serves Microsoft.DBforPostgreSQL/serverGroupsv2 (Azure
+	// Cosmos DB for PostgreSQL, Citus) via the ARM protocol.
+	CosmosPostgreSQL cpgdriver.CosmosPostgreSQL
 	Network          netdriver.Networking
 	Monitor          mondriver.Monitoring
 	Functions        sdrv.Serverless
@@ -207,6 +212,10 @@ func New(d Drivers) *server.Server {
 	// (disjoint from every other Azure handler).
 	if d.ManagedCassandra != nil {
 		srv.Register(managedcassandra.New(d.ManagedCassandra))
+	}
+
+	if d.CosmosPostgreSQL != nil {
+		srv.Register(cosmospostgresql.New(d.CosmosPostgreSQL))
 	}
 
 	if d.Network != nil {

--- a/server/azure/cosmospostgresql/clusters.go
+++ b/server/azure/cosmospostgresql/clusters.go
@@ -38,14 +38,14 @@ func (h *Handler) createOrUpdateCluster(w http.ResponseWriter, r *http.Request, 
 		cfg.CitusVersion = p.CitusVersion
 		cfg.PostgresqlVersion = p.PostgresqlVersion
 		cfg.CoordinatorServerEdition = p.CoordinatorServerEdition
-		cfg.CoordinatorVCores = p.CoordinatorVCores
-		cfg.CoordinatorStorageQuotaInMb = p.CoordinatorStorageQuotaInMb
+		cfg.CoordinatorVCores = derefInt(p.CoordinatorVCores)
+		cfg.CoordinatorStorageQuotaInMb = derefInt(p.CoordinatorStorageQuotaInMb)
 		cfg.CoordinatorEnablePublicIPAccess = derefBool(p.CoordinatorEnablePublicIPAccess)
 		cfg.EnableShardsOnCoordinator = derefBool(p.EnableShardsOnCoordinator)
 		cfg.NodeServerEdition = p.NodeServerEdition
-		cfg.NodeCount = p.NodeCount
-		cfg.NodeVCores = p.NodeVCores
-		cfg.NodeStorageQuotaInMb = p.NodeStorageQuotaInMb
+		cfg.NodeCount = derefInt(p.NodeCount)
+		cfg.NodeVCores = derefInt(p.NodeVCores)
+		cfg.NodeStorageQuotaInMb = derefInt(p.NodeStorageQuotaInMb)
 		cfg.NodeEnablePublicIPAccess = derefBool(p.NodeEnablePublicIPAccess)
 		cfg.EnableHa = derefBool(p.EnableHa)
 		cfg.PreferredPrimaryZone = p.PreferredPrimaryZone
@@ -54,13 +54,18 @@ func (h *Handler) createOrUpdateCluster(w http.ResponseWriter, r *http.Request, 
 		cfg.MaintenanceWindow = fromWireMW(p.MaintenanceWindow)
 	}
 
-	c, err := h.db.CreateOrUpdateCluster(r.Context(), cfg)
+	c, created, err := h.db.CreateOrUpdateCluster(r.Context(), cfg)
 	if err != nil {
 		azurearm.WriteCErr(w, err)
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMCluster(c, h.clusterID(rp, c.Name)))
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+
+	azurearm.WriteJSON(w, status, toARMCluster(c, h.clusterID(rp, c.Name)))
 }
 
 func (h *Handler) getCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
@@ -82,22 +87,22 @@ func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, rp *azur
 	patch := cpgdriver.ClusterPatch{Tags: body.Tags}
 
 	if p := body.Properties; p != nil {
+		patch.AdministratorLoginPassword = strPtrIfSet(p.AdministratorLoginPassword)
 		patch.CitusVersion = strPtrIfSet(p.CitusVersion)
 		patch.PostgresqlVersion = strPtrIfSet(p.PostgresqlVersion)
 		patch.CoordinatorServerEdition = strPtrIfSet(p.CoordinatorServerEdition)
-		patch.CoordinatorVCores = intPtrIfSet(p.CoordinatorVCores)
-		patch.CoordinatorStorageQuotaInMb = intPtrIfSet(p.CoordinatorStorageQuotaInMb)
+		patch.CoordinatorVCores = p.CoordinatorVCores
+		patch.CoordinatorStorageQuotaInMb = p.CoordinatorStorageQuotaInMb
+		patch.CoordinatorEnablePublicIPAccess = p.CoordinatorEnablePublicIPAccess
+		patch.EnableShardsOnCoordinator = p.EnableShardsOnCoordinator
 		patch.NodeServerEdition = strPtrIfSet(p.NodeServerEdition)
-		patch.NodeVCores = intPtrIfSet(p.NodeVCores)
-		patch.NodeStorageQuotaInMb = intPtrIfSet(p.NodeStorageQuotaInMb)
+		patch.NodeCount = p.NodeCount
+		patch.NodeVCores = p.NodeVCores
+		patch.NodeStorageQuotaInMb = p.NodeStorageQuotaInMb
+		patch.NodeEnablePublicIPAccess = p.NodeEnablePublicIPAccess
 		patch.PreferredPrimaryZone = strPtrIfSet(p.PreferredPrimaryZone)
 		patch.EnableHa = p.EnableHa
 		patch.MaintenanceWindow = fromWireMW(p.MaintenanceWindow)
-
-		if p.NodeCount != 0 {
-			nc := p.NodeCount
-			patch.NodeCount = &nc
-		}
 	}
 
 	c, err := h.db.UpdateCluster(r.Context(), rp.ResourceGroup, rp.ResourceName, patch)
@@ -228,12 +233,12 @@ func strPtrIfSet(s string) *string {
 	return &s
 }
 
-func intPtrIfSet(v int) *int {
-	if v == 0 {
-		return nil
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
 	}
 
-	return &v
+	return *p
 }
 
 func fromWireMW(mw *maintenanceWindow) *cpgdriver.MaintenanceWindow {
@@ -242,7 +247,7 @@ func fromWireMW(mw *maintenanceWindow) *cpgdriver.MaintenanceWindow {
 	}
 
 	return &cpgdriver.MaintenanceWindow{
-		CustomWindow: mw.CustomWindow, DayOfWeek: mw.DayOfWeek,
-		StartHour: mw.StartHour, StartMinute: mw.StartMinute,
+		CustomWindow: mw.CustomWindow, DayOfWeek: derefInt(mw.DayOfWeek),
+		StartHour: derefInt(mw.StartHour), StartMinute: derefInt(mw.StartMinute),
 	}
 }

--- a/server/azure/cosmospostgresql/clusters.go
+++ b/server/azure/cosmospostgresql/clusters.go
@@ -1,0 +1,248 @@
+package cosmospostgresql
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+const apiVersion = "2023-03-02-preview"
+
+func (*Handler) clusterID(rp *azurearm.ResourcePath, name string) string {
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name)
+}
+
+// childID builds the resource ID of a cluster sub-resource
+// (.../serverGroupsv2/{cluster}/{sub}/{child}).
+func (h *Handler) childID(rp *azurearm.ResourcePath, sub, child string) string {
+	return h.clusterID(rp, rp.ResourceName) + "/" + sub + "/" + child
+}
+
+func (h *Handler) createOrUpdateCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body clusterResource
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := cpgdriver.CreateClusterConfig{
+		Name:          rp.ResourceName,
+		ResourceGroup: rp.ResourceGroup,
+		Location:      body.Location,
+		Tags:          body.Tags,
+	}
+
+	if p := body.Properties; p != nil {
+		cfg.AdministratorLoginPassword = p.AdministratorLoginPassword
+		cfg.CitusVersion = p.CitusVersion
+		cfg.PostgresqlVersion = p.PostgresqlVersion
+		cfg.CoordinatorServerEdition = p.CoordinatorServerEdition
+		cfg.CoordinatorVCores = p.CoordinatorVCores
+		cfg.CoordinatorStorageQuotaInMb = p.CoordinatorStorageQuotaInMb
+		cfg.CoordinatorEnablePublicIPAccess = derefBool(p.CoordinatorEnablePublicIPAccess)
+		cfg.EnableShardsOnCoordinator = derefBool(p.EnableShardsOnCoordinator)
+		cfg.NodeServerEdition = p.NodeServerEdition
+		cfg.NodeCount = p.NodeCount
+		cfg.NodeVCores = p.NodeVCores
+		cfg.NodeStorageQuotaInMb = p.NodeStorageQuotaInMb
+		cfg.NodeEnablePublicIPAccess = derefBool(p.NodeEnablePublicIPAccess)
+		cfg.EnableHa = derefBool(p.EnableHa)
+		cfg.PreferredPrimaryZone = p.PreferredPrimaryZone
+		cfg.SourceResourceID = p.SourceResourceID
+		cfg.SourceLocation = p.SourceLocation
+		cfg.MaintenanceWindow = fromWireMW(p.MaintenanceWindow)
+	}
+
+	c, err := h.db.CreateOrUpdateCluster(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMCluster(c, h.clusterID(rp, c.Name)))
+}
+
+func (h *Handler) getCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	c, err := h.db.GetCluster(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMCluster(c, h.clusterID(rp, c.Name)))
+}
+
+func (h *Handler) updateCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body clusterResource
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	patch := cpgdriver.ClusterPatch{Tags: body.Tags}
+
+	if p := body.Properties; p != nil {
+		patch.CitusVersion = strPtrIfSet(p.CitusVersion)
+		patch.PostgresqlVersion = strPtrIfSet(p.PostgresqlVersion)
+		patch.CoordinatorServerEdition = strPtrIfSet(p.CoordinatorServerEdition)
+		patch.CoordinatorVCores = intPtrIfSet(p.CoordinatorVCores)
+		patch.CoordinatorStorageQuotaInMb = intPtrIfSet(p.CoordinatorStorageQuotaInMb)
+		patch.NodeServerEdition = strPtrIfSet(p.NodeServerEdition)
+		patch.NodeVCores = intPtrIfSet(p.NodeVCores)
+		patch.NodeStorageQuotaInMb = intPtrIfSet(p.NodeStorageQuotaInMb)
+		patch.PreferredPrimaryZone = strPtrIfSet(p.PreferredPrimaryZone)
+		patch.EnableHa = p.EnableHa
+		patch.MaintenanceWindow = fromWireMW(p.MaintenanceWindow)
+
+		if p.NodeCount != 0 {
+			nc := p.NodeCount
+			patch.NodeCount = &nc
+		}
+	}
+
+	c, err := h.db.UpdateCluster(r.Context(), rp.ResourceGroup, rp.ResourceName, patch)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMCluster(c, h.clusterID(rp, c.Name)))
+}
+
+func (h *Handler) deleteCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.db.DeleteCluster(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listClusters(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	var (
+		clusters []cpgdriver.Cluster
+		err      error
+	)
+
+	if rp.ResourceGroup == "" {
+		clusters, err = h.db.ListClustersBySubscription(r.Context())
+	} else {
+		clusters, err = h.db.ListClustersByResourceGroup(r.Context(), rp.ResourceGroup)
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := armList[clusterResource]{Value: make([]clusterResource, 0, len(clusters))}
+
+	for i := range clusters {
+		id := azurearm.BuildResourceID(rp.Subscription, clusters[i].ResourceGroup, providerName, resourceType, clusters[i].Name)
+		out.Value = append(out.Value, toARMCluster(&clusters[i], id))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, out)
+}
+
+// postClusterAction handles restart/start/stop/promote. These are long-running
+// actions with no result body; reply 202 + Location so the SDK's Location
+// poller reads a terminal status from the operationStatuses URL.
+func (*Handler) postClusterAction(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+	action func(context.Context, string, string) error,
+) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	if err := action(r.Context(), rp.ResourceGroup, rp.ResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	opID := rp.ResourceName + "-" + rp.SubResource
+	w.Header().Set("Location", asyncStatusURL(r, rp.Subscription, opID))
+	w.Header().Set("Retry-After", "0")
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// asyncStatusURL builds an operationStatuses URL for a synthetic operation id.
+func asyncStatusURL(r *http.Request, sub, opID string) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	return scheme + "://" + r.Host +
+		"/subscriptions/" + sub +
+		"/providers/" + providerName + "/" + resourceLocations + "/global/" + subOperationStatuses + "/" + opID +
+		"?api-version=" + apiVersion
+}
+
+// operationStatus reports a completed LRO for the poll the SDK issues.
+func (*Handler) operationStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, map[string]string{"status": "Succeeded"})
+}
+
+func (h *Handler) checkNameAvailability(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	var body nameAvailabilityRequest
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	na, err := h.db.CheckNameAvailability(r.Context(), body.Name, body.Type)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, nameAvailabilityResult{
+		Name: na.Name, Type: na.Type, NameAvailable: boolPtr(na.NameAvailable), Message: na.Message,
+	})
+}
+
+func derefBool(p *bool) bool { return p != nil && *p }
+
+func strPtrIfSet(s string) *string {
+	if s == "" {
+		return nil
+	}
+
+	return &s
+}
+
+func intPtrIfSet(v int) *int {
+	if v == 0 {
+		return nil
+	}
+
+	return &v
+}
+
+func fromWireMW(mw *maintenanceWindow) *cpgdriver.MaintenanceWindow {
+	if mw == nil {
+		return nil
+	}
+
+	return &cpgdriver.MaintenanceWindow{
+		CustomWindow: mw.CustomWindow, DayOfWeek: mw.DayOfWeek,
+		StartHour: mw.StartHour, StartMinute: mw.StartMinute,
+	}
+}

--- a/server/azure/cosmospostgresql/configurations.go
+++ b/server/azure/cosmospostgresql/configurations.go
@@ -1,0 +1,108 @@
+package cosmospostgresql
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// serveConfigurations handles the cluster-wide configurations collection and
+// single-resource GET.
+func (h *Handler) serveConfigurations(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	serveReadOnly(w, r, rp, h.listConfigurations, h.getConfiguration)
+}
+
+func (h *Handler) getConfiguration(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	c, err := h.db.GetConfiguration(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMConfiguration(c, h.childID(rp, subConfigurations, c.Name)))
+}
+
+func (h *Handler) listConfigurations(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	cfgs, err := h.db.ListConfigurations(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(cfgs, func(c *cpgdriver.Configuration) configurationResource {
+		return toARMConfiguration(c, h.childID(rp, subConfigurations, c.Name))
+	}))
+}
+
+// serveServerConfig handles the coordinator/node configuration GET + PUT
+// (update). coordinator selects the coordinator role group; otherwise node.
+func (h *Handler) serveServerConfig(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, coordinator bool) {
+	if rp.SubResourceName == "" {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.getServerConfig(w, r, rp, coordinator)
+	case http.MethodPut:
+		h.updateServerConfig(w, r, rp, coordinator)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) getServerConfig(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, coordinator bool) {
+	var (
+		sc  *cpgdriver.ServerConfiguration
+		err error
+		sub = subNodeCfgs
+	)
+
+	if coordinator {
+		sub = subCoordinatorCfgs
+		sc, err = h.db.GetCoordinatorConfiguration(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	} else {
+		sc, err = h.db.GetNodeConfiguration(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMServerConfiguration(sc, h.childID(rp, sub, sc.Name)))
+}
+
+func (h *Handler) updateServerConfig(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, coordinator bool) {
+	var body serverConfigurationResource
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	value := ""
+	if body.Properties != nil {
+		value = body.Properties.Value
+	}
+
+	var (
+		sc  *cpgdriver.ServerConfiguration
+		err error
+		sub = subNodeCfgs
+	)
+
+	if coordinator {
+		sub = subCoordinatorCfgs
+		sc, err = h.db.UpdateCoordinatorConfiguration(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, value)
+	} else {
+		sc, err = h.db.UpdateNodeConfiguration(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, value)
+	}
+
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMServerConfiguration(sc, h.childID(rp, sub, sc.Name)))
+}

--- a/server/azure/cosmospostgresql/configurations.go
+++ b/server/azure/cosmospostgresql/configurations.go
@@ -72,7 +72,7 @@ func (h *Handler) getServerConfig(w http.ResponseWriter, r *http.Request, rp *az
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMServerConfiguration(sc, h.childID(rp, sub, sc.Name)))
+	azurearm.WriteJSON(w, http.StatusOK, toARMServerConfiguration(sc, h.childID(rp, sub, sc.Name), sub))
 }
 
 func (h *Handler) updateServerConfig(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, coordinator bool) {
@@ -104,5 +104,5 @@ func (h *Handler) updateServerConfig(w http.ResponseWriter, r *http.Request, rp 
 		return
 	}
 
-	azurearm.WriteJSON(w, http.StatusOK, toARMServerConfiguration(sc, h.childID(rp, sub, sc.Name)))
+	azurearm.WriteJSON(w, http.StatusOK, toARMServerConfiguration(sc, h.childID(rp, sub, sc.Name), sub))
 }

--- a/server/azure/cosmospostgresql/firewallrules.go
+++ b/server/azure/cosmospostgresql/firewallrules.go
@@ -1,0 +1,74 @@
+package cosmospostgresql
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+func (h *Handler) serveFirewallRules(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	serveCRUD(w, r, rp, crudHandlers{
+		put:  h.createOrUpdateFirewallRule,
+		get:  h.getFirewallRule,
+		del:  h.deleteFirewallRule,
+		list: h.listFirewallRules,
+	})
+}
+
+func (h *Handler) createOrUpdateFirewallRule(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body firewallRuleResource
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := cpgdriver.CreateFirewallRuleConfig{
+		ResourceGroup: rp.ResourceGroup,
+		ClusterName:   rp.ResourceName,
+		Name:          rp.SubResourceName,
+	}
+
+	if p := body.Properties; p != nil {
+		cfg.StartIPAddress = p.StartIPAddress
+		cfg.EndIPAddress = p.EndIPAddress
+	}
+
+	fr, err := h.db.CreateOrUpdateFirewallRule(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMFirewallRule(fr, h.childID(rp, subFirewallRules, fr.Name)))
+}
+
+func (h *Handler) getFirewallRule(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	fr, err := h.db.GetFirewallRule(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMFirewallRule(fr, h.childID(rp, subFirewallRules, fr.Name)))
+}
+
+func (h *Handler) deleteFirewallRule(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.db.DeleteFirewallRule(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listFirewallRules(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	rules, err := h.db.ListFirewallRules(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(rules, func(fr *cpgdriver.FirewallRule) firewallRuleResource {
+		return toARMFirewallRule(fr, h.childID(rp, subFirewallRules, fr.Name))
+	}))
+}

--- a/server/azure/cosmospostgresql/handler.go
+++ b/server/azure/cosmospostgresql/handler.go
@@ -1,0 +1,215 @@
+// Package cosmospostgresql implements the Azure Cosmos DB for PostgreSQL ARM
+// REST API (Microsoft.DBforPostgreSQL/serverGroupsv2) as a server.Handler. Real
+// github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql
+// clients configured with a custom endpoint hit this handler the same way they
+// hit management.azure.com.
+//
+// Create/update RPCs return the resource inline with a terminal
+// provisioningState so the SDK's LRO poller completes on the first response;
+// the cluster start/stop/restart/promote actions reply 202 + Location and the
+// poller reads a terminal status from the operationStatuses URL.
+package cosmospostgresql
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+// Handler serves Microsoft.DBforPostgreSQL/serverGroupsv2 ARM requests.
+type Handler struct {
+	db cpgdriver.CosmosPostgreSQL
+}
+
+// New returns a Cosmos DB for PostgreSQL handler backed by db.
+func New(db cpgdriver.CosmosPostgreSQL) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches claims ARM Microsoft.DBforPostgreSQL/serverGroupsv2 paths, the
+// subscription-scoped checkNameAvailability path, and the
+// locations/operationStatuses paths its long-running actions poll.
+func (*Handler) Matches(r *http.Request) bool {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		return false
+	}
+
+	if rp.Provider != providerName {
+		return false
+	}
+
+	switch rp.ResourceType {
+	case resourceType, resourceCheckName:
+		return true
+	case resourceLocations:
+		return rp.SubResource == subOperationStatuses
+	default:
+		return false
+	}
+}
+
+// ServeHTTP routes the request based on path shape and method.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	rp, ok := azurearm.ParsePath(r.URL.Path)
+	if !ok {
+		azurearm.WriteError(w, http.StatusBadRequest, "InvalidPath", "malformed ARM path")
+		return
+	}
+
+	switch rp.ResourceType {
+	case resourceLocations:
+		h.operationStatus(w, r)
+	case resourceCheckName:
+		h.checkNameAvailability(w, r)
+	case resourceType:
+		h.serveServerGroups(w, r, &rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported path: "+r.URL.Path)
+	}
+}
+
+func (h *Handler) serveServerGroups(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	// Collection: .../serverGroupsv2 (resource-group- or subscription-scoped).
+	if rp.ResourceName == "" {
+		h.listClusters(w, r, rp)
+		return
+	}
+
+	// Child paths: .../serverGroupsv2/{name}/{subResource}[/{subName}].
+	if rp.SubResource != "" {
+		h.serveClusterChild(w, r, rp)
+		return
+	}
+
+	h.serveCluster(w, r, rp)
+}
+
+func (h *Handler) serveCluster(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	switch r.Method {
+	case http.MethodPut:
+		h.createOrUpdateCluster(w, r, rp)
+	case http.MethodGet:
+		h.getCluster(w, r, rp)
+	case http.MethodPatch:
+		h.updateCluster(w, r, rp)
+	case http.MethodDelete:
+		h.deleteCluster(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+func (h *Handler) serveClusterChild(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if action := h.clusterAction(rp.SubResource); action != nil {
+		h.postClusterAction(w, r, rp, action)
+		return
+	}
+
+	switch rp.SubResource {
+	case subFirewallRules:
+		h.serveFirewallRules(w, r, rp)
+	case subRoles:
+		h.serveRoles(w, r, rp)
+	case subServers:
+		h.serveServers(w, r, rp)
+	case subConfigurations:
+		h.serveConfigurations(w, r, rp)
+	case subCoordinatorCfgs:
+		h.serveServerConfig(w, r, rp, true)
+	case subNodeCfgs:
+		h.serveServerConfig(w, r, rp, false)
+	case subPrivateEPs:
+		h.servePrivateEndpoints(w, r, rp)
+	case subPrivateLinks:
+		h.servePrivateLinks(w, r, rp)
+	default:
+		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "unsupported sub-resource: "+rp.SubResource)
+	}
+}
+
+// clusterAction returns the driver action for a POST verb sub-resource, or nil
+// if the sub-resource isn't a cluster action.
+func (h *Handler) clusterAction(sub string) func(context.Context, string, string) error {
+	switch sub {
+	case actionRestart:
+		return h.db.RestartCluster
+	case actionStart:
+		return h.db.StartCluster
+	case actionStop:
+		return h.db.StopCluster
+	case actionPromote:
+		return h.db.PromoteReadReplica
+	default:
+		return nil
+	}
+}
+
+// crudHandlers is the set of method handlers for a cluster child collection.
+type crudHandlers struct {
+	put  func(http.ResponseWriter, *http.Request, *azurearm.ResourcePath)
+	get  func(http.ResponseWriter, *http.Request, *azurearm.ResourcePath)
+	del  func(http.ResponseWriter, *http.Request, *azurearm.ResourcePath)
+	list func(http.ResponseWriter, *http.Request, *azurearm.ResourcePath)
+}
+
+// serveCRUD routes a child collection: GET on the collection lists, and
+// PUT/GET/DELETE on a named item dispatch to the item handlers.
+func serveCRUD(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath, hs crudHandlers) {
+	if rp.SubResourceName == "" {
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w)
+			return
+		}
+
+		hs.list(w, r, rp)
+
+		return
+	}
+
+	switch r.Method {
+	case http.MethodPut:
+		hs.put(w, r, rp)
+	case http.MethodGet:
+		hs.get(w, r, rp)
+	case http.MethodDelete:
+		hs.del(w, r, rp)
+	default:
+		writeMethodNotAllowed(w)
+	}
+}
+
+// serveReadOnly routes a read-only child collection: GET on the collection
+// lists, GET on a named item fetches it; any other method is rejected.
+func serveReadOnly(
+	w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath,
+	list, get func(http.ResponseWriter, *http.Request, *azurearm.ResourcePath),
+) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	if rp.SubResourceName == "" {
+		list(w, r, rp)
+		return
+	}
+
+	get(w, r, rp)
+}
+
+// armListOf builds an ARM list envelope by converting each driver value.
+func armListOf[D any, W any](items []D, conv func(*D) W) armList[W] {
+	out := armList[W]{Value: make([]W, 0, len(items))}
+	for i := range items {
+		out.Value = append(out.Value, conv(&items[i]))
+	}
+
+	return out
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter) {
+	azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+}

--- a/server/azure/cosmospostgresql/privateendpoints.go
+++ b/server/azure/cosmospostgresql/privateendpoints.go
@@ -1,0 +1,97 @@
+package cosmospostgresql
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+func (h *Handler) servePrivateEndpoints(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	serveCRUD(w, r, rp, crudHandlers{
+		put:  h.createOrUpdatePrivateEndpoint,
+		get:  h.getPrivateEndpoint,
+		del:  h.deletePrivateEndpoint,
+		list: h.listPrivateEndpoints,
+	})
+}
+
+func (h *Handler) createOrUpdatePrivateEndpoint(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body privateEndpointConnectionResource
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	status, description := "", ""
+	if p := body.Properties; p != nil && p.PrivateLinkServiceConnectionState != nil {
+		status = p.PrivateLinkServiceConnectionState.Status
+		description = p.PrivateLinkServiceConnectionState.Description
+	}
+
+	pec, err := h.db.CreateOrUpdatePrivateEndpointConnection(
+		r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName, status, description,
+	)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMPrivateEndpointConnection(pec, h.childID(rp, subPrivateEPs, pec.Name)))
+}
+
+func (h *Handler) getPrivateEndpoint(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	pec, err := h.db.GetPrivateEndpointConnection(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMPrivateEndpointConnection(pec, h.childID(rp, subPrivateEPs, pec.Name)))
+}
+
+func (h *Handler) deletePrivateEndpoint(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.db.DeletePrivateEndpointConnection(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listPrivateEndpoints(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	pecs, err := h.db.ListPrivateEndpointConnections(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(pecs, func(pec *cpgdriver.PrivateEndpointConnection) privateEndpointConnectionResource {
+		return toARMPrivateEndpointConnection(pec, h.childID(rp, subPrivateEPs, pec.Name))
+	}))
+}
+
+func (h *Handler) servePrivateLinks(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	serveReadOnly(w, r, rp, h.listPrivateLinks, h.getPrivateLink)
+}
+
+func (h *Handler) getPrivateLink(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	plr, err := h.db.GetPrivateLinkResource(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMPrivateLinkResource(plr, h.childID(rp, subPrivateLinks, plr.Name)))
+}
+
+func (h *Handler) listPrivateLinks(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	plrs, err := h.db.ListPrivateLinkResources(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(plrs, func(plr *cpgdriver.PrivateLinkResource) privateLinkResource {
+		return toARMPrivateLinkResource(plr, h.childID(rp, subPrivateLinks, plr.Name))
+	}))
+}

--- a/server/azure/cosmospostgresql/roles.go
+++ b/server/azure/cosmospostgresql/roles.go
@@ -1,0 +1,72 @@
+package cosmospostgresql
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+func (h *Handler) serveRoles(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	serveCRUD(w, r, rp, crudHandlers{
+		put:  h.createRole,
+		get:  h.getRole,
+		del:  h.deleteRole,
+		list: h.listRoles,
+	})
+}
+
+func (h *Handler) createRole(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	var body roleResource
+	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	cfg := cpgdriver.CreateRoleConfig{
+		ResourceGroup: rp.ResourceGroup,
+		ClusterName:   rp.ResourceName,
+		Name:          rp.SubResourceName,
+	}
+	if p := body.Properties; p != nil {
+		cfg.Password = p.Password
+	}
+
+	role, err := h.db.CreateRole(r.Context(), cfg)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMRole(role, h.childID(rp, subRoles, role.Name)))
+}
+
+func (h *Handler) getRole(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	role, err := h.db.GetRole(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMRole(role, h.childID(rp, subRoles, role.Name)))
+}
+
+func (h *Handler) deleteRole(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if err := h.db.DeleteRole(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName); err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	roles, err := h.db.ListRoles(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(roles, func(role *cpgdriver.Role) roleResource {
+		return toARMRole(role, h.childID(rp, subRoles, role.Name))
+	}))
+}

--- a/server/azure/cosmospostgresql/sdk_roundtrip_test.go
+++ b/server/azure/cosmospostgresql/sdk_roundtrip_test.go
@@ -1,0 +1,355 @@
+package cosmospostgresql_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/cosmosforpostgresql/armcosmosforpostgresql"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+const subID = "sub-123"
+
+func deref[T any](p *T) (v T) {
+	if p != nil {
+		return *p
+	}
+
+	return v
+}
+
+type fakeCred struct{}
+
+func (fakeCred) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
+
+func newFactory(t *testing.T) *armcosmosforpostgresql.ClientFactory {
+	t.Helper()
+
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewTLSServer(azureserver.NewFromProvider(cloudP))
+	t.Cleanup(ts.Close)
+
+	myCloud := cloud.Configuration{
+		ActiveDirectoryAuthorityHost: "https://login.microsoftonline.com/",
+		Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+			cloud.ResourceManager: {Endpoint: ts.URL, Audience: "https://management.azure.com"},
+		},
+	}
+
+	opts := &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Cloud: myCloud, Transport: ts.Client()},
+	}
+
+	f, err := armcosmosforpostgresql.NewClientFactory(subID, fakeCred{}, opts)
+	if err != nil {
+		t.Fatalf("client factory: %v", err)
+	}
+
+	return f
+}
+
+func mustCreateCluster(t *testing.T, cc *armcosmosforpostgresql.ClustersClient, ctx context.Context, nodeCount int32) {
+	t.Helper()
+
+	poller, err := cc.BeginCreate(ctx, "rg1", "pg1", armcosmosforpostgresql.Cluster{
+		Location: to.Ptr("eastus"),
+		Properties: &armcosmosforpostgresql.ClusterProperties{
+			AdministratorLoginPassword: to.Ptr("Sup3rSecret!"),
+			CoordinatorVCores:          to.Ptr[int32](4),
+			NodeCount:                  to.Ptr(nodeCount),
+			CitusVersion:               to.Ptr("12.1"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("create poll: %v", err)
+	}
+}
+
+func TestSDKClusterLifecycle(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	poller, err := cc.BeginCreate(ctx, "rg1", "pg1", armcosmosforpostgresql.Cluster{
+		Location: to.Ptr("eastus"),
+		Tags:     map[string]*string{"env": to.Ptr("prod")},
+		Properties: &armcosmosforpostgresql.ClusterProperties{
+			AdministratorLoginPassword: to.Ptr("Sup3rSecret!"),
+			NodeCount:                  to.Ptr[int32](2),
+			CitusVersion:               to.Ptr("12.1"),
+			EnableHa:                   to.Ptr(true),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	created, err := poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("create poll: %v", err)
+	}
+
+	if deref(created.Name) != "pg1" || deref(created.Properties.ProvisioningState) != "Succeeded" {
+		t.Fatalf("created wrong: name=%q state=%q", deref(created.Name), deref(created.Properties.ProvisioningState))
+	}
+
+	if deref(created.Properties.NodeCount) != 2 || !deref(created.Properties.EnableHa) {
+		t.Fatalf("created props wrong: %+v", created.Properties)
+	}
+
+	got, err := cc.Get(ctx, "rg1", "pg1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if deref(got.Properties.CitusVersion) != "12.1" {
+		t.Fatalf("get props wrong: %+v", got.Properties)
+	}
+
+	pager := cc.NewListByResourceGroupPager("rg1", nil)
+
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("list by rg: %v", err)
+	}
+
+	if len(page.Value) != 1 {
+		t.Fatalf("list by rg: got %d, want 1", len(page.Value))
+	}
+
+	del, err := cc.BeginDelete(ctx, "rg1", "pg1", nil)
+	if err != nil {
+		t.Fatalf("BeginDelete: %v", err)
+	}
+
+	if _, err := del.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("delete poll: %v", err)
+	}
+
+	if _, err := cc.Get(ctx, "rg1", "pg1", nil); err == nil {
+		t.Fatal("get after delete: expected error")
+	}
+}
+
+func TestSDKUpdateActionsAndList(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	mustCreateCluster(t, cc, ctx, 2)
+
+	// PATCH: scale nodes + tags.
+	up, err := cc.BeginUpdate(ctx, "rg1", "pg1", armcosmosforpostgresql.ClusterForUpdate{
+		Tags:       map[string]*string{"tier": to.Ptr("gold")},
+		Properties: &armcosmosforpostgresql.ClusterPropertiesForUpdate{NodeCount: to.Ptr[int32](4)},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate: %v", err)
+	}
+
+	updated, err := up.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("update poll: %v", err)
+	}
+
+	if deref(updated.Properties.NodeCount) != 4 || deref(updated.Tags["tier"]) != "gold" {
+		t.Fatalf("patch not applied: %+v tags=%v", updated.Properties, updated.Tags)
+	}
+
+	// List by subscription.
+	subPager := cc.NewListPager(nil)
+
+	subPage, err := subPager.NextPage(ctx)
+	if err != nil {
+		t.Fatalf("list by sub: %v", err)
+	}
+
+	if len(subPage.Value) != 1 {
+		t.Fatalf("list by sub: got %d, want 1", len(subPage.Value))
+	}
+
+	// Stop / start / restart round-trip (Location LRO).
+	for _, action := range []func() error{
+		func() error { p, e := cc.BeginStop(ctx, "rg1", "pg1", nil); return pollErr(ctx, p, e) },
+		func() error { p, e := cc.BeginStart(ctx, "rg1", "pg1", nil); return pollErr(ctx, p, e) },
+		func() error { p, e := cc.BeginRestart(ctx, "rg1", "pg1", nil); return pollErr(ctx, p, e) },
+	} {
+		if err := action(); err != nil {
+			t.Fatalf("cluster action: %v", err)
+		}
+	}
+}
+
+func pollErr[T any](ctx context.Context, p *runtime.Poller[T], err error) error {
+	if err != nil {
+		return err
+	}
+
+	_, err = p.PollUntilDone(ctx, nil)
+
+	return err
+}
+
+func TestSDKFirewallRulesRolesServers(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	mustCreateCluster(t, cc, ctx, 2)
+
+	// Firewall rule.
+	fwc := f.NewFirewallRulesClient()
+
+	fwPoller, err := fwc.BeginCreateOrUpdate(ctx, "rg1", "pg1", "allow-all", armcosmosforpostgresql.FirewallRule{
+		Properties: &armcosmosforpostgresql.FirewallRuleProperties{
+			StartIPAddress: to.Ptr("0.0.0.0"), EndIPAddress: to.Ptr("255.255.255.255"),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("fw BeginCreateOrUpdate: %v", err)
+	}
+
+	fw, err := fwPoller.PollUntilDone(ctx, nil)
+	if err != nil {
+		t.Fatalf("fw poll: %v", err)
+	}
+
+	if deref(fw.Properties.EndIPAddress) != "255.255.255.255" {
+		t.Fatalf("fw props wrong: %+v", fw.Properties)
+	}
+
+	fwPage, err := fwc.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx)
+	if err != nil || len(fwPage.Value) != 1 {
+		t.Fatalf("fw list: %v len=%d", err, len(fwPage.Value))
+	}
+
+	// Role.
+	rc := f.NewRolesClient()
+
+	rolePoller, err := rc.BeginCreate(ctx, "rg1", "pg1", "app", armcosmosforpostgresql.Role{
+		Properties: &armcosmosforpostgresql.RoleProperties{Password: to.Ptr("R0lePass!")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("role BeginCreate: %v", err)
+	}
+
+	if _, err := rolePoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("role poll: %v", err)
+	}
+
+	if _, err := rc.Get(ctx, "rg1", "pg1", "app", nil); err != nil {
+		t.Fatalf("role Get: %v", err)
+	}
+
+	// Servers (derived nodes): one coordinator + two workers.
+	sc := f.NewServersClient()
+
+	srvPage, err := sc.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx)
+	if err != nil {
+		t.Fatalf("server list: %v", err)
+	}
+
+	if len(srvPage.Value) != 3 {
+		t.Fatalf("server list: got %d, want 3", len(srvPage.Value))
+	}
+
+	if _, err := sc.Get(ctx, "rg1", "pg1", "pg1-c", nil); err != nil {
+		t.Fatalf("server Get coordinator: %v", err)
+	}
+}
+
+func TestSDKConfigurationsAndReplicaAndErrors(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	mustCreateCluster(t, cc, ctx, 1)
+
+	// Configurations: list, get coordinator, update coordinator.
+	cfgc := f.NewConfigurationsClient()
+
+	cfgPage, err := cfgc.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx)
+	if err != nil || len(cfgPage.Value) == 0 {
+		t.Fatalf("config list: %v len=%d", err, len(cfgPage.Value))
+	}
+
+	coord, err := cfgc.GetCoordinator(ctx, "rg1", "pg1", "max_connections", nil)
+	if err != nil || deref(coord.Properties.Value) != "300" {
+		t.Fatalf("get coordinator config: %v %+v", err, coord.Properties)
+	}
+
+	upPoller, err := cfgc.BeginUpdateOnCoordinator(ctx, "rg1", "pg1", "max_connections", armcosmosforpostgresql.ServerConfiguration{
+		Properties: &armcosmosforpostgresql.ServerConfigurationProperties{Value: to.Ptr("500")},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdateOnCoordinator: %v", err)
+	}
+
+	updatedCfg, err := upPoller.PollUntilDone(ctx, nil)
+	if err != nil || deref(updatedCfg.Properties.Value) != "500" {
+		t.Fatalf("coordinator config update: %v %+v", err, updatedCfg.Properties)
+	}
+
+	// checkNameAvailability.
+	na, err := cc.CheckNameAvailability(ctx, armcosmosforpostgresql.NameAvailabilityRequest{Name: to.Ptr("pg1")}, nil)
+	if err != nil {
+		t.Fatalf("CheckNameAvailability: %v", err)
+	}
+
+	if deref(na.NameAvailable) {
+		t.Fatal("existing name should be unavailable")
+	}
+
+	// Typed 404 for a missing cluster.
+	_, err = cc.Get(ctx, "rg1", "ghost", nil)
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 404 {
+		t.Fatalf("get missing cluster: got %v, want 404 ResponseError", err)
+	}
+}
+
+func TestMalformedBodyRejected(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewServer(azureserver.NewFromProvider(cloudP))
+	t.Cleanup(ts.Close)
+
+	url := ts.URL + "/subscriptions/" + subID +
+		"/resourceGroups/rg1/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/pg1?api-version=2023-03-02-preview"
+
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader("{not json"))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("malformed body: got %d, want 400", resp.StatusCode)
+	}
+}

--- a/server/azure/cosmospostgresql/sdk_roundtrip_test.go
+++ b/server/azure/cosmospostgresql/sdk_roundtrip_test.go
@@ -379,8 +379,9 @@ func TestSDKChildGetDeleteAndPrivateLinks(t *testing.T) {
 		t.Fatalf("role create: %v", err)
 	}
 
-	if _, err := rc.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx); err != nil {
-		t.Fatalf("role list: %v", err)
+	rolePage, err := rc.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx)
+	if err != nil || len(rolePage.Value) != 1 || deref(rolePage.Value[0].Name) != "app" {
+		t.Fatalf("role list: err=%v page=%+v", err, rolePage.Value)
 	}
 
 	roleDel, err := rc.BeginDelete(ctx, "rg1", "pg1", "app", nil)
@@ -465,6 +466,147 @@ func TestSDKChildGetDeleteAndPrivateLinks(t *testing.T) {
 	}
 }
 
+func TestSDKReplicaPromoteAndStateGuards(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	// Primary + replica.
+	primary, err := cc.BeginCreate(ctx, "rg1", "primary", armcosmosforpostgresql.Cluster{
+		Location:   to.Ptr("eastus"),
+		Properties: &armcosmosforpostgresql.ClusterProperties{AdministratorLoginPassword: to.Ptr("Sup3rSecret!"), NodeCount: to.Ptr[int32](2)},
+	}, nil)
+	if err == nil {
+		_, err = primary.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("create primary: %v", err)
+	}
+
+	srcID := "/subscriptions/" + subID + "/resourceGroups/rg1/providers/Microsoft.DBforPostgreSQL/serverGroupsv2/primary"
+
+	rep, err := cc.BeginCreate(ctx, "rg1", "replica", armcosmosforpostgresql.Cluster{
+		Location: to.Ptr("westus"),
+		Properties: &armcosmosforpostgresql.ClusterProperties{
+			SourceResourceID: to.Ptr(srcID), SourceLocation: to.Ptr("eastus"),
+		},
+	}, nil)
+	if err == nil {
+		_, err = rep.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("create replica: %v", err)
+	}
+
+	// Promote the replica (Location LRO).
+	prom, err := cc.BeginPromoteReadReplica(ctx, "rg1", "replica", nil)
+	if err == nil {
+		_, err = prom.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+
+	promoted, err := cc.Get(ctx, "rg1", "replica", nil)
+	if err != nil {
+		t.Fatalf("get promoted: %v", err)
+	}
+
+	if promoted.Properties.SourceResourceID != nil && deref(promoted.Properties.SourceResourceID) != "" {
+		t.Fatalf("replica still linked after promote: %+v", promoted.Properties.SourceResourceID)
+	}
+
+	// Restart-while-Stopped is rejected (409).
+	stop, err := cc.BeginStop(ctx, "rg1", "primary", nil)
+	if err == nil {
+		_, err = stop.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	restart, err := cc.BeginRestart(ctx, "rg1", "primary", nil)
+	if err == nil {
+		_, err = restart.PollUntilDone(ctx, nil)
+	}
+
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) || respErr.StatusCode != 409 {
+		t.Fatalf("restart while stopped: got %v, want 409", err)
+	}
+}
+
+func TestSDKSingleNodeAndServerNames(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	// A single-node cluster (nodeCount=0) must round-trip: the response carries
+	// an explicit 0, not an omitted key that deserializes to nil.
+	single, err := cc.BeginCreate(ctx, "rg1", "solo", armcosmosforpostgresql.Cluster{
+		Location:   to.Ptr("eastus"),
+		Properties: &armcosmosforpostgresql.ClusterProperties{AdministratorLoginPassword: to.Ptr("Sup3rSecret!"), NodeCount: to.Ptr[int32](0)},
+	}, nil)
+	if err == nil {
+		_, err = single.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("create single-node: %v", err)
+	}
+
+	got, err := cc.Get(ctx, "rg1", "solo", nil)
+	if err != nil {
+		t.Fatalf("get single-node: %v", err)
+	}
+
+	if got.Properties.NodeCount == nil || *got.Properties.NodeCount != 0 {
+		t.Fatalf("single-node NodeCount not represented: %v", got.Properties.NodeCount)
+	}
+
+	// serverNames enumerates the coordinator only (no workers).
+	if len(got.Properties.ServerNames) != 1 {
+		t.Fatalf("single-node serverNames: got %d, want 1", len(got.Properties.ServerNames))
+	}
+
+	// A 2-worker cluster reports coordinator + 2 workers, and the coordinator
+	// FQDN matches the servers sub-resource.
+	multi, err := cc.BeginCreate(ctx, "rg1", "multi", armcosmosforpostgresql.Cluster{
+		Location:   to.Ptr("eastus"),
+		Properties: &armcosmosforpostgresql.ClusterProperties{AdministratorLoginPassword: to.Ptr("Sup3rSecret!"), NodeCount: to.Ptr[int32](2)},
+	}, nil)
+	if err == nil {
+		_, err = multi.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("create multi: %v", err)
+	}
+
+	m, err := cc.Get(ctx, "rg1", "multi", nil)
+	if err != nil {
+		t.Fatalf("get multi: %v", err)
+	}
+
+	if len(m.Properties.ServerNames) != 3 {
+		t.Fatalf("multi serverNames: got %d, want 3", len(m.Properties.ServerNames))
+	}
+
+	srv, err := f.NewServersClient().Get(ctx, "rg1", "multi", "multi-c", nil)
+	if err != nil {
+		t.Fatalf("servers Get: %v", err)
+	}
+
+	if deref(m.Properties.ServerNames[0].FullyQualifiedDomainName) != deref(srv.Properties.FullyQualifiedDomainName) {
+		t.Fatalf("coordinator FQDN mismatch: serverNames=%q servers=%q",
+			deref(m.Properties.ServerNames[0].FullyQualifiedDomainName), deref(srv.Properties.FullyQualifiedDomainName))
+	}
+}
+
 func TestMalformedBodyRejected(t *testing.T) {
 	cloudP := cloudemu.NewAzure()
 	ts := httptest.NewServer(azureserver.NewFromProvider(cloudP))
@@ -524,8 +666,13 @@ func TestServerErrorPaths(t *testing.T) {
 	}
 
 	// Create a cluster so child error paths are distinct from a missing parent.
+	// A create returns 201; a re-PUT of the same cluster returns 200.
+	if code := do(http.MethodPut, base+"/serverGroupsv2/pg1"+ver, `{"location":"eastus","properties":{"nodeCount":1}}`); code != http.StatusCreated {
+		t.Fatalf("create cluster: got %d, want 201", code)
+	}
+
 	if code := do(http.MethodPut, base+"/serverGroupsv2/pg1"+ver, `{"location":"eastus","properties":{"nodeCount":1}}`); code != http.StatusOK {
-		t.Fatalf("create cluster: got %d, want 200", code)
+		t.Fatalf("re-PUT cluster: got %d, want 200", code)
 	}
 
 	cases := []struct {

--- a/server/azure/cosmospostgresql/sdk_roundtrip_test.go
+++ b/server/azure/cosmospostgresql/sdk_roundtrip_test.go
@@ -3,6 +3,7 @@ package cosmospostgresql_test
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -328,6 +329,142 @@ func TestSDKConfigurationsAndReplicaAndErrors(t *testing.T) {
 	}
 }
 
+func TestSDKChildGetDeleteAndPrivateLinks(t *testing.T) {
+	f := newFactory(t)
+	cc := f.NewClustersClient()
+	ctx := context.Background()
+
+	mustCreateCluster(t, cc, ctx, 2)
+
+	// Firewall rule get + delete.
+	fwc := f.NewFirewallRulesClient()
+
+	fwPoller, err := fwc.BeginCreateOrUpdate(ctx, "rg1", "pg1", "fw", armcosmosforpostgresql.FirewallRule{
+		Properties: &armcosmosforpostgresql.FirewallRuleProperties{
+			StartIPAddress: to.Ptr("10.0.0.0"), EndIPAddress: to.Ptr("10.0.0.255"),
+		},
+	}, nil)
+	if err == nil {
+		_, err = fwPoller.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("fw create: %v", err)
+	}
+
+	if _, err := fwc.Get(ctx, "rg1", "pg1", "fw", nil); err != nil {
+		t.Fatalf("fw Get: %v", err)
+	}
+
+	fwDel, err := fwc.BeginDelete(ctx, "rg1", "pg1", "fw", nil)
+	if err == nil {
+		_, err = fwDel.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("fw delete: %v", err)
+	}
+
+	// Role delete + list.
+	rc := f.NewRolesClient()
+
+	rolePoller, err := rc.BeginCreate(ctx, "rg1", "pg1", "app", armcosmosforpostgresql.Role{
+		Properties: &armcosmosforpostgresql.RoleProperties{Password: to.Ptr("R0lePass!")},
+	}, nil)
+	if err == nil {
+		_, err = rolePoller.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("role create: %v", err)
+	}
+
+	if _, err := rc.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx); err != nil {
+		t.Fatalf("role list: %v", err)
+	}
+
+	roleDel, err := rc.BeginDelete(ctx, "rg1", "pg1", "app", nil)
+	if err == nil {
+		_, err = roleDel.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("role delete: %v", err)
+	}
+
+	// Node configuration get + update + single get + list-by-server.
+	cfgc := f.NewConfigurationsClient()
+
+	if _, err := cfgc.GetNode(ctx, "rg1", "pg1", "max_connections", nil); err != nil {
+		t.Fatalf("config GetNode: %v", err)
+	}
+
+	nodePoller, err := cfgc.BeginUpdateOnNode(ctx, "rg1", "pg1", "max_connections", armcosmosforpostgresql.ServerConfiguration{
+		Properties: &armcosmosforpostgresql.ServerConfigurationProperties{Value: to.Ptr("400")},
+	}, nil)
+	if err == nil {
+		_, err = nodePoller.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("config UpdateOnNode: %v", err)
+	}
+
+	if _, err := cfgc.Get(ctx, "rg1", "pg1", "max_connections", nil); err != nil {
+		t.Fatalf("config Get: %v", err)
+	}
+
+	if _, err := cfgc.NewListByServerPager("rg1", "pg1", "pg1-c", nil).NextPage(ctx); err != nil {
+		t.Fatalf("config ListByServer: %v", err)
+	}
+
+	// Private-endpoint connection full CRUD.
+	pec := f.NewPrivateEndpointConnectionsClient()
+
+	pecPoller, err := pec.BeginCreateOrUpdate(ctx, "rg1", "pg1", "pe1", armcosmosforpostgresql.PrivateEndpointConnection{
+		Properties: &armcosmosforpostgresql.PrivateEndpointConnectionProperties{
+			PrivateLinkServiceConnectionState: &armcosmosforpostgresql.PrivateLinkServiceConnectionState{
+				Status: to.Ptr(armcosmosforpostgresql.PrivateEndpointServiceConnectionStatusApproved),
+			},
+		},
+	}, nil)
+	if err == nil {
+		_, err = pecPoller.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("PE create: %v", err)
+	}
+
+	if _, err := pec.Get(ctx, "rg1", "pg1", "pe1", nil); err != nil {
+		t.Fatalf("PE Get: %v", err)
+	}
+
+	if _, err := pec.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx); err != nil {
+		t.Fatalf("PE list: %v", err)
+	}
+
+	peDel, err := pec.BeginDelete(ctx, "rg1", "pg1", "pe1", nil)
+	if err == nil {
+		_, err = peDel.PollUntilDone(ctx, nil)
+	}
+
+	if err != nil {
+		t.Fatalf("PE delete: %v", err)
+	}
+
+	// Private-link resources list + get.
+	plr := f.NewPrivateLinkResourcesClient()
+
+	if _, err := plr.NewListByClusterPager("rg1", "pg1", nil).NextPage(ctx); err != nil {
+		t.Fatalf("PLR list: %v", err)
+	}
+
+	if _, err := plr.Get(ctx, "rg1", "pg1", "coordinator", nil); err != nil {
+		t.Fatalf("PLR get: %v", err)
+	}
+}
+
 func TestMalformedBodyRejected(t *testing.T) {
 	cloudP := cloudemu.NewAzure()
 	ts := httptest.NewServer(azureserver.NewFromProvider(cloudP))
@@ -351,5 +488,66 @@ func TestMalformedBodyRejected(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("malformed body: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestServerErrorPaths(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	ts := httptest.NewServer(azureserver.NewFromProvider(cloudP))
+	t.Cleanup(ts.Close)
+
+	base := ts.URL + "/subscriptions/" + subID + "/resourceGroups/rg1/providers/Microsoft.DBforPostgreSQL"
+	const ver = "?api-version=2023-03-02-preview"
+
+	do := func(method, path, body string) int {
+		t.Helper()
+
+		var rdr io.Reader
+		if body != "" {
+			rdr = strings.NewReader(body)
+		}
+
+		req, err := http.NewRequest(method, path, rdr)
+		if err != nil {
+			t.Fatalf("new request: %v", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("do: %v", err)
+		}
+		defer resp.Body.Close()
+
+		return resp.StatusCode
+	}
+
+	// Create a cluster so child error paths are distinct from a missing parent.
+	if code := do(http.MethodPut, base+"/serverGroupsv2/pg1"+ver, `{"location":"eastus","properties":{"nodeCount":1}}`); code != http.StatusOK {
+		t.Fatalf("create cluster: got %d, want 200", code)
+	}
+
+	cases := []struct {
+		name, method, path string
+		want               int
+	}{
+		{"get missing firewall rule", http.MethodGet, base + "/serverGroupsv2/pg1/firewallRules/nope" + ver, http.StatusNotFound},
+		{"method not allowed on firewall item", http.MethodPost, base + "/serverGroupsv2/pg1/firewallRules/fw" + ver, http.StatusMethodNotAllowed},
+		{"delete missing role", http.MethodDelete, base + "/serverGroupsv2/pg1/roles/ghost" + ver, http.StatusNotFound},
+		{"unsupported sub-resource", http.MethodGet, base + "/serverGroupsv2/pg1/bogus" + ver, http.StatusNotFound},
+		{"get missing cluster", http.MethodGet, base + "/serverGroupsv2/ghost" + ver, http.StatusNotFound},
+		{"checkNameAvailability wrong method", http.MethodGet, base + "/checkNameAvailability" + ver, http.StatusMethodNotAllowed},
+		{"get missing private endpoint", http.MethodGet, base + "/serverGroupsv2/pg1/privateEndpointConnections/nope" + ver, http.StatusNotFound},
+		{"get missing private link", http.MethodGet, base + "/serverGroupsv2/pg1/privateLinkResources/nope" + ver, http.StatusNotFound},
+		{"get missing server node", http.MethodGet, base + "/serverGroupsv2/pg1/servers/nope" + ver, http.StatusNotFound},
+		{"get missing configuration", http.MethodGet, base + "/serverGroupsv2/pg1/configurations/nope" + ver, http.StatusNotFound},
+		{"method not allowed on coordinator config", http.MethodDelete, base + "/serverGroupsv2/pg1/coordinatorConfigurations/max_connections" + ver, http.StatusMethodNotAllowed},
+	}
+
+	for _, c := range cases {
+		if got := do(c.method, c.path, ""); got != c.want {
+			t.Errorf("%s: got %d, want %d", c.name, got, c.want)
+		}
 	}
 }

--- a/server/azure/cosmospostgresql/sdk_roundtrip_test.go
+++ b/server/azure/cosmospostgresql/sdk_roundtrip_test.go
@@ -310,14 +310,25 @@ func TestSDKConfigurationsAndReplicaAndErrors(t *testing.T) {
 		t.Fatalf("coordinator config update: %v %+v", err, updatedCfg.Properties)
 	}
 
-	// checkNameAvailability.
+	// checkNameAvailability: a taken name is explicitly unavailable (assert the
+	// pointer is present so a dropped field would regress loudly)...
 	na, err := cc.CheckNameAvailability(ctx, armcosmosforpostgresql.NameAvailabilityRequest{Name: to.Ptr("pg1")}, nil)
 	if err != nil {
-		t.Fatalf("CheckNameAvailability: %v", err)
+		t.Fatalf("CheckNameAvailability taken: %v", err)
 	}
 
-	if deref(na.NameAvailable) {
-		t.Fatal("existing name should be unavailable")
+	if na.NameAvailable == nil || *na.NameAvailable {
+		t.Fatalf("existing name should be explicitly unavailable: %v", na.NameAvailable)
+	}
+
+	// ...and a free name is explicitly available.
+	free, err := cc.CheckNameAvailability(ctx, armcosmosforpostgresql.NameAvailabilityRequest{Name: to.Ptr("brand-new")}, nil)
+	if err != nil {
+		t.Fatalf("CheckNameAvailability free: %v", err)
+	}
+
+	if free.NameAvailable == nil || !*free.NameAvailable {
+		t.Fatalf("free name should be explicitly available: %v", free.NameAvailable)
 	}
 
 	// Typed 404 for a missing cluster.

--- a/server/azure/cosmospostgresql/servers.go
+++ b/server/azure/cosmospostgresql/servers.go
@@ -55,6 +55,6 @@ func (h *Handler) listServerConfigurations(w http.ResponseWriter, r *http.Reques
 	azurearm.WriteJSON(w, http.StatusOK, armListOf(cfgs, func(sc *cpgdriver.ServerConfiguration) serverConfigurationResource {
 		id := h.childID(rp, subServers, rp.SubResourceName) + "/" + subConfigurations + "/" + sc.Name
 
-		return toARMServerConfiguration(sc, id)
+		return toARMServerConfiguration(sc, id, subConfigurations)
 	}))
 }

--- a/server/azure/cosmospostgresql/servers.go
+++ b/server/azure/cosmospostgresql/servers.go
@@ -1,0 +1,60 @@
+package cosmospostgresql
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+func (h *Handler) serveServers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w)
+		return
+	}
+
+	switch {
+	case rp.SubResourceName == "":
+		h.listServers(w, r, rp)
+	case rp.SubResourceAction == subConfigurations:
+		h.listServerConfigurations(w, r, rp)
+	default:
+		h.getServer(w, r, rp)
+	}
+}
+
+func (h *Handler) listServers(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	servers, err := h.db.ListServers(r.Context(), rp.ResourceGroup, rp.ResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(servers, func(s *cpgdriver.Server) serverResource {
+		return toARMServer(s, h.childID(rp, subServers, s.Name))
+	}))
+}
+
+func (h *Handler) getServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	s, err := h.db.GetServer(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, toARMServer(s, h.childID(rp, subServers, s.Name)))
+}
+
+func (h *Handler) listServerConfigurations(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	cfgs, err := h.db.ListServerConfigurations(r.Context(), rp.ResourceGroup, rp.ResourceName, rp.SubResourceName)
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armListOf(cfgs, func(sc *cpgdriver.ServerConfiguration) serverConfigurationResource {
+		id := h.childID(rp, subServers, rp.SubResourceName) + "/" + subConfigurations + "/" + sc.Name
+
+		return toARMServerConfiguration(sc, id)
+	}))
+}

--- a/server/azure/cosmospostgresql/types.go
+++ b/server/azure/cosmospostgresql/types.go
@@ -367,11 +367,14 @@ func toARMConfiguration(c *cpgdriver.Configuration, id string) configurationReso
 	}
 }
 
-func toARMServerConfiguration(sc *cpgdriver.ServerConfiguration, id string) serverConfigurationResource {
+// toARMServerConfiguration renders a server-scoped configuration. typeSuffix is
+// the collection segment used in the id (coordinatorConfigurations /
+// nodeConfigurations / configurations) so type and id agree.
+func toARMServerConfiguration(sc *cpgdriver.ServerConfiguration, id, typeSuffix string) serverConfigurationResource {
 	return serverConfigurationResource{
 		ID:   id,
 		Name: sc.Name,
-		Type: clusterResourceType + "/" + subConfigurations,
+		Type: clusterResourceType + "/" + typeSuffix,
 		Properties: &serverConfigurationProperties{
 			Value:             sc.Value,
 			DefaultValue:      sc.DefaultValue,

--- a/server/azure/cosmospostgresql/types.go
+++ b/server/azure/cosmospostgresql/types.go
@@ -1,6 +1,8 @@
 package cosmospostgresql
 
 import (
+	"fmt"
+
 	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
 )
 
@@ -37,9 +39,9 @@ type armList[T any] struct {
 
 type maintenanceWindow struct {
 	CustomWindow string `json:"customWindow,omitempty"`
-	DayOfWeek    int    `json:"dayOfWeek,omitempty"`
-	StartHour    int    `json:"startHour,omitempty"`
-	StartMinute  int    `json:"startMinute,omitempty"`
+	DayOfWeek    *int   `json:"dayOfWeek,omitempty"`
+	StartHour    *int   `json:"startHour,omitempty"`
+	StartMinute  *int   `json:"startMinute,omitempty"`
 }
 
 type serverNameItem struct {
@@ -65,14 +67,14 @@ type clusterProperties struct {
 	ProvisioningState               string             `json:"provisioningState,omitempty"`
 	State                           string             `json:"state,omitempty"`
 	CoordinatorServerEdition        string             `json:"coordinatorServerEdition,omitempty"`
-	CoordinatorVCores               int                `json:"coordinatorVCores,omitempty"`
-	CoordinatorStorageQuotaInMb     int                `json:"coordinatorStorageQuotaInMb,omitempty"`
+	CoordinatorVCores               *int               `json:"coordinatorVCores,omitempty"`
+	CoordinatorStorageQuotaInMb     *int               `json:"coordinatorStorageQuotaInMb,omitempty"`
 	CoordinatorEnablePublicIPAccess *bool              `json:"coordinatorEnablePublicIpAccess,omitempty"`
 	EnableShardsOnCoordinator       *bool              `json:"enableShardsOnCoordinator,omitempty"`
 	NodeServerEdition               string             `json:"nodeServerEdition,omitempty"`
-	NodeCount                       int                `json:"nodeCount,omitempty"`
-	NodeVCores                      int                `json:"nodeVCores,omitempty"`
-	NodeStorageQuotaInMb            int                `json:"nodeStorageQuotaInMb,omitempty"`
+	NodeCount                       *int               `json:"nodeCount,omitempty"`
+	NodeVCores                      *int               `json:"nodeVCores,omitempty"`
+	NodeStorageQuotaInMb            *int               `json:"nodeStorageQuotaInMb,omitempty"`
 	NodeEnablePublicIPAccess        *bool              `json:"nodeEnablePublicIpAccess,omitempty"`
 	EnableHa                        *bool              `json:"enableHa,omitempty"`
 	PreferredPrimaryZone            string             `json:"preferredPrimaryZone,omitempty"`
@@ -223,22 +225,39 @@ type nameAvailabilityResult struct {
 
 func boolPtr(b bool) *bool { return &b }
 
+func intPtr(i int) *int { return &i }
+
 func cloneMW(in *cpgdriver.MaintenanceWindow) *maintenanceWindow {
 	if in == nil {
 		return nil
 	}
 
 	return &maintenanceWindow{
-		CustomWindow: in.CustomWindow, DayOfWeek: in.DayOfWeek,
-		StartHour: in.StartHour, StartMinute: in.StartMinute,
+		CustomWindow: in.CustomWindow, DayOfWeek: intPtr(in.DayOfWeek),
+		StartHour: intPtr(in.StartHour), StartMinute: intPtr(in.StartMinute),
 	}
 }
 
+// nodeFQDN builds a node's fully-qualified domain name, matching the servers
+// sub-resource: <node>.<location>.postgres.cosmos.azure.com.
+func nodeFQDN(node, location string) string {
+	if location == "" {
+		location = "eastus"
+	}
+
+	return node + "." + location + ".postgres.cosmos.azure.com"
+}
+
+// serverNames enumerates the cluster's nodes (coordinator + workers), matching
+// the servers sub-resource in both the set and the FQDN.
 func serverNames(c *cpgdriver.Cluster) []serverNameItem {
-	items := []serverNameItem{{
-		Name:                     c.Name + "-c",
-		FullyQualifiedDomainName: c.Name + "-c.postgres.cosmos.azure.com",
-	}}
+	coord := c.Name + "-c"
+	items := []serverNameItem{{Name: coord, FullyQualifiedDomainName: nodeFQDN(coord, c.Location)}}
+
+	for i := 0; i < c.NodeCount; i++ {
+		w := fmt.Sprintf("%s-w%d", c.Name, i)
+		items = append(items, serverNameItem{Name: w, FullyQualifiedDomainName: nodeFQDN(w, c.Location)})
+	}
 
 	return items
 }
@@ -258,14 +277,14 @@ func toARMCluster(c *cpgdriver.Cluster, id string) clusterResource {
 			ProvisioningState:               c.ProvisioningState,
 			State:                           c.State,
 			CoordinatorServerEdition:        c.CoordinatorServerEdition,
-			CoordinatorVCores:               c.CoordinatorVCores,
-			CoordinatorStorageQuotaInMb:     c.CoordinatorStorageQuotaInMb,
+			CoordinatorVCores:               intPtr(c.CoordinatorVCores),
+			CoordinatorStorageQuotaInMb:     intPtr(c.CoordinatorStorageQuotaInMb),
 			CoordinatorEnablePublicIPAccess: boolPtr(c.CoordinatorEnablePublicIPAccess),
 			EnableShardsOnCoordinator:       boolPtr(c.EnableShardsOnCoordinator),
 			NodeServerEdition:               c.NodeServerEdition,
-			NodeCount:                       c.NodeCount,
-			NodeVCores:                      c.NodeVCores,
-			NodeStorageQuotaInMb:            c.NodeStorageQuotaInMb,
+			NodeCount:                       intPtr(c.NodeCount),
+			NodeVCores:                      intPtr(c.NodeVCores),
+			NodeStorageQuotaInMb:            intPtr(c.NodeStorageQuotaInMb),
 			NodeEnablePublicIPAccess:        boolPtr(c.NodeEnablePublicIPAccess),
 			EnableHa:                        boolPtr(c.EnableHa),
 			PreferredPrimaryZone:            c.PreferredPrimaryZone,

--- a/server/azure/cosmospostgresql/types.go
+++ b/server/azure/cosmospostgresql/types.go
@@ -1,0 +1,396 @@
+package cosmospostgresql
+
+import (
+	cpgdriver "github.com/stackshy/cloudemu/v2/services/cosmospostgresql/driver"
+)
+
+const (
+	providerName = "Microsoft.DBforPostgreSQL"
+	resourceType = "serverGroupsv2"
+
+	subFirewallRules   = "firewallRules"
+	subRoles           = "roles"
+	subServers         = "servers"
+	subConfigurations  = "configurations"
+	subCoordinatorCfgs = "coordinatorConfigurations"
+	subNodeCfgs        = "nodeConfigurations"
+	subPrivateEPs      = "privateEndpointConnections"
+	subPrivateLinks    = "privateLinkResources"
+
+	actionRestart = "restart"
+	actionStart   = "start"
+	actionStop    = "stop"
+	actionPromote = "promote"
+
+	resourceCheckName    = "checkNameAvailability"
+	resourceLocations    = "locations"
+	subOperationStatuses = "operationStatuses"
+
+	clusterResourceType = providerName + "/" + resourceType
+)
+
+// armList is the ARM list-response envelope.
+type armList[T any] struct {
+	Value    []T    `json:"value"`
+	NextLink string `json:"nextLink,omitempty"`
+}
+
+type maintenanceWindow struct {
+	CustomWindow string `json:"customWindow,omitempty"`
+	DayOfWeek    int    `json:"dayOfWeek,omitempty"`
+	StartHour    int    `json:"startHour,omitempty"`
+	StartMinute  int    `json:"startMinute,omitempty"`
+}
+
+type serverNameItem struct {
+	Name                     string `json:"name,omitempty"`
+	FullyQualifiedDomainName string `json:"fullyQualifiedDomainName,omitempty"`
+}
+
+// clusterResource is the ARM JSON shape for a server-group cluster.
+type clusterResource struct {
+	ID         string             `json:"id,omitempty"`
+	Name       string             `json:"name,omitempty"`
+	Type       string             `json:"type,omitempty"`
+	Location   string             `json:"location,omitempty"`
+	Tags       map[string]string  `json:"tags,omitempty"`
+	Properties *clusterProperties `json:"properties,omitempty"`
+}
+
+type clusterProperties struct {
+	AdministratorLogin              string             `json:"administratorLogin,omitempty"`
+	AdministratorLoginPassword      string             `json:"administratorLoginPassword,omitempty"`
+	CitusVersion                    string             `json:"citusVersion,omitempty"`
+	PostgresqlVersion               string             `json:"postgresqlVersion,omitempty"`
+	ProvisioningState               string             `json:"provisioningState,omitempty"`
+	State                           string             `json:"state,omitempty"`
+	CoordinatorServerEdition        string             `json:"coordinatorServerEdition,omitempty"`
+	CoordinatorVCores               int                `json:"coordinatorVCores,omitempty"`
+	CoordinatorStorageQuotaInMb     int                `json:"coordinatorStorageQuotaInMb,omitempty"`
+	CoordinatorEnablePublicIPAccess *bool              `json:"coordinatorEnablePublicIpAccess,omitempty"`
+	EnableShardsOnCoordinator       *bool              `json:"enableShardsOnCoordinator,omitempty"`
+	NodeServerEdition               string             `json:"nodeServerEdition,omitempty"`
+	NodeCount                       int                `json:"nodeCount,omitempty"`
+	NodeVCores                      int                `json:"nodeVCores,omitempty"`
+	NodeStorageQuotaInMb            int                `json:"nodeStorageQuotaInMb,omitempty"`
+	NodeEnablePublicIPAccess        *bool              `json:"nodeEnablePublicIpAccess,omitempty"`
+	EnableHa                        *bool              `json:"enableHa,omitempty"`
+	PreferredPrimaryZone            string             `json:"preferredPrimaryZone,omitempty"`
+	MaintenanceWindow               *maintenanceWindow `json:"maintenanceWindow,omitempty"`
+	SourceResourceID                string             `json:"sourceResourceId,omitempty"`
+	SourceLocation                  string             `json:"sourceLocation,omitempty"`
+	ReadReplicas                    []string           `json:"readReplicas,omitempty"`
+	ServerNames                     []serverNameItem   `json:"serverNames,omitempty"`
+}
+
+type firewallRuleResource struct {
+	ID         string                  `json:"id,omitempty"`
+	Name       string                  `json:"name,omitempty"`
+	Type       string                  `json:"type,omitempty"`
+	Properties *firewallRuleProperties `json:"properties,omitempty"`
+}
+
+type firewallRuleProperties struct {
+	ProvisioningState string `json:"provisioningState,omitempty"`
+	StartIPAddress    string `json:"startIpAddress,omitempty"`
+	EndIPAddress      string `json:"endIpAddress,omitempty"`
+}
+
+type roleResource struct {
+	ID         string          `json:"id,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	Type       string          `json:"type,omitempty"`
+	Properties *roleProperties `json:"properties,omitempty"`
+}
+
+type roleProperties struct {
+	Password          string `json:"password,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+}
+
+type serverResource struct {
+	ID         string            `json:"id,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Type       string            `json:"type,omitempty"`
+	Properties *serverProperties `json:"properties,omitempty"`
+}
+
+type serverProperties struct {
+	AdministratorLogin       string `json:"administratorLogin,omitempty"`
+	Role                     string `json:"role,omitempty"`
+	State                    string `json:"state,omitempty"`
+	HaState                  string `json:"haState,omitempty"`
+	FullyQualifiedDomainName string `json:"fullyQualifiedDomainName,omitempty"`
+	ServerEdition            string `json:"serverEdition,omitempty"`
+	VCores                   int    `json:"vCores,omitempty"`
+	StorageQuotaInMb         int    `json:"storageQuotaInMb,omitempty"`
+	CitusVersion             string `json:"citusVersion,omitempty"`
+	PostgresqlVersion        string `json:"postgresqlVersion,omitempty"`
+	EnableHa                 *bool  `json:"enableHa,omitempty"`
+	EnablePublicIPAccess     *bool  `json:"enablePublicIpAccess,omitempty"`
+	IsReadOnly               *bool  `json:"isReadOnly,omitempty"`
+}
+
+type configurationResource struct {
+	ID         string                   `json:"id,omitempty"`
+	Name       string                   `json:"name,omitempty"`
+	Type       string                   `json:"type,omitempty"`
+	Properties *configurationProperties `json:"properties,omitempty"`
+}
+
+type configurationProperties struct {
+	ProvisioningState             string            `json:"provisioningState,omitempty"`
+	Description                   string            `json:"description,omitempty"`
+	DataType                      string            `json:"dataType,omitempty"`
+	AllowedValues                 string            `json:"allowedValues,omitempty"`
+	RequiresRestart               *bool             `json:"requiresRestart,omitempty"`
+	ServerRoleGroupConfigurations []roleGroupConfig `json:"serverRoleGroupConfigurations,omitempty"`
+}
+
+type roleGroupConfig struct {
+	Role         string `json:"role,omitempty"`
+	Value        string `json:"value,omitempty"`
+	DefaultValue string `json:"defaultValue,omitempty"`
+	Source       string `json:"source,omitempty"`
+}
+
+type serverConfigurationResource struct {
+	ID         string                         `json:"id,omitempty"`
+	Name       string                         `json:"name,omitempty"`
+	Type       string                         `json:"type,omitempty"`
+	Properties *serverConfigurationProperties `json:"properties,omitempty"`
+}
+
+type serverConfigurationProperties struct {
+	Value             string `json:"value,omitempty"`
+	DefaultValue      string `json:"defaultValue,omitempty"`
+	Description       string `json:"description,omitempty"`
+	DataType          string `json:"dataType,omitempty"`
+	AllowedValues     string `json:"allowedValues,omitempty"`
+	Source            string `json:"source,omitempty"`
+	ProvisioningState string `json:"provisioningState,omitempty"`
+	RequiresRestart   *bool  `json:"requiresRestart,omitempty"`
+}
+
+type privateEndpointConnectionResource struct {
+	ID         string                    `json:"id,omitempty"`
+	Name       string                    `json:"name,omitempty"`
+	Type       string                    `json:"type,omitempty"`
+	Properties *privateEndpointConnProps `json:"properties,omitempty"`
+}
+
+type privateEndpointConnProps struct {
+	ProvisioningState                 string                `json:"provisioningState,omitempty"`
+	GroupIDs                          []string              `json:"groupIds,omitempty"`
+	PrivateEndpoint                   *privateEndpointRef   `json:"privateEndpoint,omitempty"`
+	PrivateLinkServiceConnectionState *linkServiceConnState `json:"privateLinkServiceConnectionState,omitempty"`
+}
+
+type privateEndpointRef struct {
+	ID string `json:"id,omitempty"`
+}
+
+type linkServiceConnState struct {
+	Status          string `json:"status,omitempty"`
+	Description     string `json:"description,omitempty"`
+	ActionsRequired string `json:"actionsRequired,omitempty"`
+}
+
+type privateLinkResource struct {
+	ID         string                    `json:"id,omitempty"`
+	Name       string                    `json:"name,omitempty"`
+	Type       string                    `json:"type,omitempty"`
+	Properties *privateLinkResourceProps `json:"properties,omitempty"`
+}
+
+type privateLinkResourceProps struct {
+	GroupID           string   `json:"groupId,omitempty"`
+	RequiredMembers   []string `json:"requiredMembers,omitempty"`
+	RequiredZoneNames []string `json:"requiredZoneNames,omitempty"`
+}
+
+type nameAvailabilityRequest struct {
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+type nameAvailabilityResult struct {
+	Name          string `json:"name,omitempty"`
+	Type          string `json:"type,omitempty"`
+	NameAvailable *bool  `json:"nameAvailable,omitempty"`
+	Message       string `json:"message,omitempty"`
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+func cloneMW(in *cpgdriver.MaintenanceWindow) *maintenanceWindow {
+	if in == nil {
+		return nil
+	}
+
+	return &maintenanceWindow{
+		CustomWindow: in.CustomWindow, DayOfWeek: in.DayOfWeek,
+		StartHour: in.StartHour, StartMinute: in.StartMinute,
+	}
+}
+
+func serverNames(c *cpgdriver.Cluster) []serverNameItem {
+	items := []serverNameItem{{
+		Name:                     c.Name + "-c",
+		FullyQualifiedDomainName: c.Name + "-c.postgres.cosmos.azure.com",
+	}}
+
+	return items
+}
+
+// toARMCluster converts a driver Cluster to ARM JSON.
+func toARMCluster(c *cpgdriver.Cluster, id string) clusterResource {
+	return clusterResource{
+		ID:       id,
+		Name:     c.Name,
+		Type:     clusterResourceType,
+		Location: c.Location,
+		Tags:     c.Tags,
+		Properties: &clusterProperties{
+			AdministratorLogin:              c.AdministratorLogin,
+			CitusVersion:                    c.CitusVersion,
+			PostgresqlVersion:               c.PostgresqlVersion,
+			ProvisioningState:               c.ProvisioningState,
+			State:                           c.State,
+			CoordinatorServerEdition:        c.CoordinatorServerEdition,
+			CoordinatorVCores:               c.CoordinatorVCores,
+			CoordinatorStorageQuotaInMb:     c.CoordinatorStorageQuotaInMb,
+			CoordinatorEnablePublicIPAccess: boolPtr(c.CoordinatorEnablePublicIPAccess),
+			EnableShardsOnCoordinator:       boolPtr(c.EnableShardsOnCoordinator),
+			NodeServerEdition:               c.NodeServerEdition,
+			NodeCount:                       c.NodeCount,
+			NodeVCores:                      c.NodeVCores,
+			NodeStorageQuotaInMb:            c.NodeStorageQuotaInMb,
+			NodeEnablePublicIPAccess:        boolPtr(c.NodeEnablePublicIPAccess),
+			EnableHa:                        boolPtr(c.EnableHa),
+			PreferredPrimaryZone:            c.PreferredPrimaryZone,
+			MaintenanceWindow:               cloneMW(c.MaintenanceWindow),
+			SourceResourceID:                c.SourceResourceID,
+			SourceLocation:                  c.SourceLocation,
+			ReadReplicas:                    c.ReadReplicas,
+			ServerNames:                     serverNames(c),
+		},
+	}
+}
+
+func toARMFirewallRule(fr *cpgdriver.FirewallRule, id string) firewallRuleResource {
+	return firewallRuleResource{
+		ID:   id,
+		Name: fr.Name,
+		Type: clusterResourceType + "/" + subFirewallRules,
+		Properties: &firewallRuleProperties{
+			ProvisioningState: fr.ProvisioningState,
+			StartIPAddress:    fr.StartIPAddress,
+			EndIPAddress:      fr.EndIPAddress,
+		},
+	}
+}
+
+func toARMRole(role *cpgdriver.Role, id string) roleResource {
+	return roleResource{
+		ID:         id,
+		Name:       role.Name,
+		Type:       clusterResourceType + "/" + subRoles,
+		Properties: &roleProperties{ProvisioningState: role.ProvisioningState},
+	}
+}
+
+func toARMServer(s *cpgdriver.Server, id string) serverResource {
+	return serverResource{
+		ID:   id,
+		Name: s.Name,
+		Type: clusterResourceType + "/" + subServers,
+		Properties: &serverProperties{
+			AdministratorLogin:       s.AdministratorLogin,
+			Role:                     s.Role,
+			State:                    s.State,
+			HaState:                  s.HaState,
+			FullyQualifiedDomainName: s.FullyQualifiedDomainName,
+			ServerEdition:            s.ServerEdition,
+			VCores:                   s.VCores,
+			StorageQuotaInMb:         s.StorageQuotaInMb,
+			CitusVersion:             s.CitusVersion,
+			PostgresqlVersion:        s.PostgresqlVersion,
+			EnableHa:                 boolPtr(s.EnableHa),
+			EnablePublicIPAccess:     boolPtr(s.EnablePublicIPAccess),
+			IsReadOnly:               boolPtr(s.IsReadOnly),
+		},
+	}
+}
+
+func toARMConfiguration(c *cpgdriver.Configuration, id string) configurationResource {
+	groups := make([]roleGroupConfig, 0, len(c.RoleGroups))
+
+	for i := range c.RoleGroups {
+		g := &c.RoleGroups[i]
+		groups = append(groups, roleGroupConfig{
+			Role: g.Role, Value: g.Value, DefaultValue: g.DefaultValue, Source: g.Source,
+		})
+	}
+
+	return configurationResource{
+		ID:   id,
+		Name: c.Name,
+		Type: clusterResourceType + "/" + subConfigurations,
+		Properties: &configurationProperties{
+			ProvisioningState:             c.ProvisioningState,
+			Description:                   c.Description,
+			DataType:                      c.DataType,
+			AllowedValues:                 c.AllowedValues,
+			RequiresRestart:               boolPtr(c.RequiresRestart),
+			ServerRoleGroupConfigurations: groups,
+		},
+	}
+}
+
+func toARMServerConfiguration(sc *cpgdriver.ServerConfiguration, id string) serverConfigurationResource {
+	return serverConfigurationResource{
+		ID:   id,
+		Name: sc.Name,
+		Type: clusterResourceType + "/" + subConfigurations,
+		Properties: &serverConfigurationProperties{
+			Value:             sc.Value,
+			DefaultValue:      sc.DefaultValue,
+			Description:       sc.Description,
+			DataType:          sc.DataType,
+			AllowedValues:     sc.AllowedValues,
+			Source:            sc.Source,
+			ProvisioningState: sc.ProvisioningState,
+			RequiresRestart:   boolPtr(sc.RequiresRestart),
+		},
+	}
+}
+
+func toARMPrivateEndpointConnection(pec *cpgdriver.PrivateEndpointConnection, id string) privateEndpointConnectionResource {
+	return privateEndpointConnectionResource{
+		ID:   id,
+		Name: pec.Name,
+		Type: clusterResourceType + "/" + subPrivateEPs,
+		Properties: &privateEndpointConnProps{
+			ProvisioningState: pec.ProvisioningState,
+			GroupIDs:          pec.GroupIDs,
+			PrivateEndpoint:   &privateEndpointRef{ID: pec.PrivateEndpointID},
+			PrivateLinkServiceConnectionState: &linkServiceConnState{
+				Status: pec.ConnectionStatus, Description: pec.ConnectionDesc, ActionsRequired: pec.ActionsRequired,
+			},
+		},
+	}
+}
+
+func toARMPrivateLinkResource(plr *cpgdriver.PrivateLinkResource, id string) privateLinkResource {
+	return privateLinkResource{
+		ID:   id,
+		Name: plr.Name,
+		Type: clusterResourceType + "/" + subPrivateLinks,
+		Properties: &privateLinkResourceProps{
+			GroupID:           plr.GroupID,
+			RequiredMembers:   plr.RequiredMembers,
+			RequiredZoneNames: plr.RequiredZoneNames,
+		},
+	}
+}

--- a/server/azure/fromprovider.go
+++ b/server/azure/fromprovider.go
@@ -28,6 +28,7 @@ func DriversFrom(p *azureprovider.Provider) Drivers {
 		TableStorage:     p.TableStorage,
 		CosmosDB:         p.CosmosDB,
 		ManagedCassandra: p.ManagedCassandra,
+		CosmosPostgreSQL: p.CosmosPostgreSQL,
 		Network:          p.VNet,
 		Monitor:          p.Monitor,
 		Functions:        p.Functions,

--- a/services/cosmospostgresql/driver/driver.go
+++ b/services/cosmospostgresql/driver/driver.go
@@ -1,0 +1,285 @@
+// Package driver defines the portable interface for Azure Cosmos DB for
+// PostgreSQL (Microsoft.DBforPostgreSQL/serverGroupsv2), the Citus-based
+// distributed-Postgres offering. It is control-plane only — server-group
+// clusters and their firewall rules, roles, nodes, configurations, and private
+// endpoints — so it is independent of the relational/database drivers.
+package driver
+
+import "context"
+
+// Provisioning states reported on resources.
+const (
+	ProvisioningSucceeded = "Succeeded"
+	ProvisioningCanceled  = "Canceled"
+	ProvisioningFailed    = "Failed"
+)
+
+// Server roles within a cluster.
+const (
+	RoleCoordinator = "Coordinator"
+	RoleWorker      = "Worker"
+)
+
+// Cluster is a Cosmos DB for PostgreSQL server group (serverGroupsv2).
+type Cluster struct {
+	Name              string
+	ResourceGroup     string
+	Location          string
+	Tags              map[string]string
+	ProvisioningState string
+	State             string
+
+	AdministratorLogin              string
+	CitusVersion                    string
+	PostgresqlVersion               string
+	CoordinatorServerEdition        string
+	CoordinatorVCores               int
+	CoordinatorStorageQuotaInMb     int
+	CoordinatorEnablePublicIPAccess bool
+	EnableShardsOnCoordinator       bool
+	NodeServerEdition               string
+	NodeCount                       int
+	NodeVCores                      int
+	NodeStorageQuotaInMb            int
+	NodeEnablePublicIPAccess        bool
+	EnableHa                        bool
+	PreferredPrimaryZone            string
+	MaintenanceWindow               *MaintenanceWindow
+
+	// Read-replica linkage. SourceResourceID/SourceLocation are set on a replica;
+	// ReadReplicas lists the replicas of a primary.
+	SourceResourceID string
+	SourceLocation   string
+	ReadReplicas     []string
+}
+
+// MaintenanceWindow is the weekly maintenance schedule.
+type MaintenanceWindow struct {
+	CustomWindow string
+	DayOfWeek    int
+	StartHour    int
+	StartMinute  int
+}
+
+// FirewallRule is an IP allow-list entry on a cluster.
+type FirewallRule struct {
+	Name              string
+	ClusterName       string
+	ResourceGroup     string
+	ProvisioningState string
+	StartIPAddress    string
+	EndIPAddress      string
+}
+
+// Role is a Postgres role provisioned on a cluster.
+type Role struct {
+	Name              string
+	ClusterName       string
+	ResourceGroup     string
+	ProvisioningState string
+}
+
+// Server is a node (coordinator or worker) within a cluster. Nodes are derived
+// from the cluster's shape and are read-only.
+type Server struct {
+	Name                     string
+	ClusterName              string
+	ResourceGroup            string
+	Role                     string
+	State                    string
+	HaState                  string
+	FullyQualifiedDomainName string
+	AdministratorLogin       string
+	ServerEdition            string
+	VCores                   int
+	StorageQuotaInMb         int
+	CitusVersion             string
+	PostgresqlVersion        string
+	EnableHa                 bool
+	EnablePublicIPAccess     bool
+	IsReadOnly               bool
+}
+
+// RoleGroupValue is one role's value for a cluster-wide configuration.
+type RoleGroupValue struct {
+	Role         string
+	Value        string
+	DefaultValue string
+	Source       string
+}
+
+// Configuration is a cluster-wide server parameter with per-role values.
+type Configuration struct {
+	Name              string
+	ClusterName       string
+	ResourceGroup     string
+	ProvisioningState string
+	Description       string
+	DataType          string
+	AllowedValues     string
+	RequiresRestart   bool
+	RoleGroups        []RoleGroupValue
+}
+
+// ServerConfiguration is a single server-scoped parameter value (coordinator or
+// node role group).
+type ServerConfiguration struct {
+	Name              string
+	ClusterName       string
+	ResourceGroup     string
+	ServerName        string
+	ProvisioningState string
+	Value             string
+	DefaultValue      string
+	Description       string
+	DataType          string
+	AllowedValues     string
+	Source            string
+	RequiresRestart   bool
+}
+
+// PrivateEndpointConnection is a private-endpoint connection on a cluster.
+type PrivateEndpointConnection struct {
+	Name              string
+	ClusterName       string
+	ResourceGroup     string
+	ProvisioningState string
+	GroupIDs          []string
+	PrivateEndpointID string
+	ConnectionStatus  string
+	ConnectionDesc    string
+	ActionsRequired   string
+}
+
+// PrivateLinkResource is a private-link resource (group) exposed by a cluster.
+type PrivateLinkResource struct {
+	Name              string
+	ClusterName       string
+	ResourceGroup     string
+	GroupID           string
+	RequiredMembers   []string
+	RequiredZoneNames []string
+}
+
+// NameAvailability is the result of a CheckNameAvailability call.
+type NameAvailability struct {
+	Name          string
+	Type          string
+	NameAvailable bool
+	Message       string
+}
+
+// CreateClusterConfig is the input to CreateOrUpdateCluster.
+type CreateClusterConfig struct {
+	Name                            string
+	ResourceGroup                   string
+	Location                        string
+	Tags                            map[string]string
+	AdministratorLoginPassword      string
+	CitusVersion                    string
+	PostgresqlVersion               string
+	CoordinatorServerEdition        string
+	CoordinatorVCores               int
+	CoordinatorStorageQuotaInMb     int
+	CoordinatorEnablePublicIPAccess bool
+	EnableShardsOnCoordinator       bool
+	NodeServerEdition               string
+	NodeCount                       int
+	NodeVCores                      int
+	NodeStorageQuotaInMb            int
+	NodeEnablePublicIPAccess        bool
+	EnableHa                        bool
+	PreferredPrimaryZone            string
+	MaintenanceWindow               *MaintenanceWindow
+	SourceResourceID                string
+	SourceLocation                  string
+}
+
+// ClusterPatch carries the mutable fields of an UpdateCluster (PATCH). Nil
+// pointers leave the field unchanged.
+type ClusterPatch struct {
+	Tags                        map[string]string
+	AdministratorLoginPassword  *string
+	CitusVersion                *string
+	PostgresqlVersion           *string
+	CoordinatorServerEdition    *string
+	CoordinatorVCores           *int
+	CoordinatorStorageQuotaInMb *int
+	NodeServerEdition           *string
+	NodeCount                   *int
+	NodeVCores                  *int
+	NodeStorageQuotaInMb        *int
+	EnableHa                    *bool
+	PreferredPrimaryZone        *string
+	MaintenanceWindow           *MaintenanceWindow
+}
+
+// CreateFirewallRuleConfig is the input to CreateOrUpdateFirewallRule.
+type CreateFirewallRuleConfig struct {
+	ResourceGroup  string
+	ClusterName    string
+	Name           string
+	StartIPAddress string
+	EndIPAddress   string
+}
+
+// CreateRoleConfig is the input to CreateRole.
+type CreateRoleConfig struct {
+	ResourceGroup string
+	ClusterName   string
+	Name          string
+	Password      string
+}
+
+// CosmosPostgreSQL is the Azure Cosmos DB for PostgreSQL control plane.
+//
+//nolint:interfacebloat // mirrors the Microsoft.DBforPostgreSQL/serverGroupsv2 surface.
+type CosmosPostgreSQL interface {
+	// Clusters (server groups).
+	CreateOrUpdateCluster(ctx context.Context, cfg CreateClusterConfig) (*Cluster, error)
+	GetCluster(ctx context.Context, resourceGroup, name string) (*Cluster, error)
+	ListClustersByResourceGroup(ctx context.Context, resourceGroup string) ([]Cluster, error)
+	ListClustersBySubscription(ctx context.Context) ([]Cluster, error)
+	UpdateCluster(ctx context.Context, resourceGroup, name string, patch ClusterPatch) (*Cluster, error)
+	DeleteCluster(ctx context.Context, resourceGroup, name string) error
+	RestartCluster(ctx context.Context, resourceGroup, name string) error
+	StartCluster(ctx context.Context, resourceGroup, name string) error
+	StopCluster(ctx context.Context, resourceGroup, name string) error
+	PromoteReadReplica(ctx context.Context, resourceGroup, name string) error
+	CheckNameAvailability(ctx context.Context, name, typ string) (*NameAvailability, error)
+
+	// Firewall rules.
+	CreateOrUpdateFirewallRule(ctx context.Context, cfg CreateFirewallRuleConfig) (*FirewallRule, error)
+	GetFirewallRule(ctx context.Context, resourceGroup, cluster, name string) (*FirewallRule, error)
+	ListFirewallRules(ctx context.Context, resourceGroup, cluster string) ([]FirewallRule, error)
+	DeleteFirewallRule(ctx context.Context, resourceGroup, cluster, name string) error
+
+	// Roles.
+	CreateRole(ctx context.Context, cfg CreateRoleConfig) (*Role, error)
+	GetRole(ctx context.Context, resourceGroup, cluster, name string) (*Role, error)
+	ListRoles(ctx context.Context, resourceGroup, cluster string) ([]Role, error)
+	DeleteRole(ctx context.Context, resourceGroup, cluster, name string) error
+
+	// Servers (nodes, read-only).
+	GetServer(ctx context.Context, resourceGroup, cluster, name string) (*Server, error)
+	ListServers(ctx context.Context, resourceGroup, cluster string) ([]Server, error)
+
+	// Configurations.
+	ListConfigurations(ctx context.Context, resourceGroup, cluster string) ([]Configuration, error)
+	GetConfiguration(ctx context.Context, resourceGroup, cluster, name string) (*Configuration, error)
+	GetCoordinatorConfiguration(ctx context.Context, resourceGroup, cluster, name string) (*ServerConfiguration, error)
+	GetNodeConfiguration(ctx context.Context, resourceGroup, cluster, name string) (*ServerConfiguration, error)
+	ListServerConfigurations(ctx context.Context, resourceGroup, cluster, server string) ([]ServerConfiguration, error)
+	UpdateCoordinatorConfiguration(ctx context.Context, resourceGroup, cluster, name, value string) (*ServerConfiguration, error)
+	UpdateNodeConfiguration(ctx context.Context, resourceGroup, cluster, name, value string) (*ServerConfiguration, error)
+
+	// Private endpoints / links.
+	CreateOrUpdatePrivateEndpointConnection(
+		ctx context.Context, resourceGroup, cluster, name, status, description string,
+	) (*PrivateEndpointConnection, error)
+	GetPrivateEndpointConnection(ctx context.Context, resourceGroup, cluster, name string) (*PrivateEndpointConnection, error)
+	ListPrivateEndpointConnections(ctx context.Context, resourceGroup, cluster string) ([]PrivateEndpointConnection, error)
+	DeletePrivateEndpointConnection(ctx context.Context, resourceGroup, cluster, name string) error
+	GetPrivateLinkResource(ctx context.Context, resourceGroup, cluster, name string) (*PrivateLinkResource, error)
+	ListPrivateLinkResources(ctx context.Context, resourceGroup, cluster string) ([]PrivateLinkResource, error)
+}

--- a/services/cosmospostgresql/driver/driver.go
+++ b/services/cosmospostgresql/driver/driver.go
@@ -198,20 +198,23 @@ type CreateClusterConfig struct {
 // ClusterPatch carries the mutable fields of an UpdateCluster (PATCH). Nil
 // pointers leave the field unchanged.
 type ClusterPatch struct {
-	Tags                        map[string]string
-	AdministratorLoginPassword  *string
-	CitusVersion                *string
-	PostgresqlVersion           *string
-	CoordinatorServerEdition    *string
-	CoordinatorVCores           *int
-	CoordinatorStorageQuotaInMb *int
-	NodeServerEdition           *string
-	NodeCount                   *int
-	NodeVCores                  *int
-	NodeStorageQuotaInMb        *int
-	EnableHa                    *bool
-	PreferredPrimaryZone        *string
-	MaintenanceWindow           *MaintenanceWindow
+	Tags                            map[string]string
+	AdministratorLoginPassword      *string
+	CitusVersion                    *string
+	PostgresqlVersion               *string
+	CoordinatorServerEdition        *string
+	CoordinatorVCores               *int
+	CoordinatorStorageQuotaInMb     *int
+	CoordinatorEnablePublicIPAccess *bool
+	EnableShardsOnCoordinator       *bool
+	NodeServerEdition               *string
+	NodeCount                       *int
+	NodeVCores                      *int
+	NodeStorageQuotaInMb            *int
+	NodeEnablePublicIPAccess        *bool
+	EnableHa                        *bool
+	PreferredPrimaryZone            *string
+	MaintenanceWindow               *MaintenanceWindow
 }
 
 // CreateFirewallRuleConfig is the input to CreateOrUpdateFirewallRule.
@@ -235,8 +238,9 @@ type CreateRoleConfig struct {
 //
 //nolint:interfacebloat // mirrors the Microsoft.DBforPostgreSQL/serverGroupsv2 surface.
 type CosmosPostgreSQL interface {
-	// Clusters (server groups).
-	CreateOrUpdateCluster(ctx context.Context, cfg CreateClusterConfig) (*Cluster, error)
+	// Clusters (server groups). CreateOrUpdateCluster reports whether the cluster
+	// was created (true) or updated (false) so the ARM layer can return 201/200.
+	CreateOrUpdateCluster(ctx context.Context, cfg CreateClusterConfig) (cluster *Cluster, created bool, err error)
 	GetCluster(ctx context.Context, resourceGroup, name string) (*Cluster, error)
 	ListClustersByResourceGroup(ctx context.Context, resourceGroup string) ([]Cluster, error)
 	ListClustersBySubscription(ctx context.Context) ([]Cluster, error)

--- a/services/cost/cost.go
+++ b/services/cost/cost.go
@@ -100,6 +100,11 @@ func defaultRates() map[string]float64 {
 		"bigtable:CreateTable":    0.0,
 		"bigtable:CreateBackup":   0.0,
 
+		// Azure Cosmos DB for PostgreSQL (Citus): billed per node vCore-hour (+
+		// storage). The emulator books a flat proxy charge on cluster create (a
+		// coordinator plus the worker nodes); child resources are free.
+		"cosmospostgresql:CreateOrUpdateCluster": 0.52, // flat proxy (~1h of a small coordinator + 2 workers)
+
 		// Serverless (per invocation)
 		"serverless:Invoke": 0.0000002, // $0.20 per 1M
 

--- a/services/cost/cost_test.go
+++ b/services/cost/cost_test.go
@@ -75,6 +75,16 @@ func TestTracker_BigtableRates(t *testing.T) {
 	assert.InDelta(t, want, tracker.CostByService()["bigtable"], 1e-9)
 }
 
+func TestTracker_CosmosPostgreSQLRates(t *testing.T) {
+	tracker := New()
+
+	// Two clusters priced at the flat node proxy; child resources are free.
+	tracker.Record("cosmospostgresql", "CreateOrUpdateCluster", 2)
+
+	want := 0.52 * 2
+	assert.InDelta(t, want, tracker.CostByService()["cosmospostgresql"], 1e-9)
+}
+
 func TestTracker_Record_And_TotalCost(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Objective
Add **Azure Cosmos DB for PostgreSQL** (`Microsoft.DBforPostgreSQL/serverGroupsv2`, the Citus-based distributed-Postgres offering) as a first-class Azure service, at full parity, so a real `armcosmosforpostgresql` client works unchanged against a custom endpoint. Next missing managed database-server surface after GCP Bigtable (#309).

## What we found
Cosmos DB for PostgreSQL was entirely absent. The related `Microsoft.DBforPostgreSQL/flexibleServers` (single-server) is covered, but the `serverGroupsv2` (Citus server group) surface — with its coordinator/worker nodes, firewall rules, roles, per-role server parameters, private endpoints, and read-replica model — had no driver, provider, or handler. Blast radius: a client using the real SDK against cloudemu could not create or manage a server group at all.

## How we fixed it
Standard three-layer vertical, mirroring the Managed Cassandra ARM service:

- **Driver** (`services/cosmospostgresql/driver`): 34 operations — clusters (11, incl. restart/start/stop/promote + checkNameAvailability), firewall rules (4), roles (4), servers/nodes (2, read-only), configurations (7), private endpoints/links (6).
- **Provider** (`providers/azure/cosmospostgresql`): in-memory mock with clone-on-read/write, parent→child cascade delete, start/stop/restart lifecycle, read-replica linkage + promotion, derived coordinator/worker nodes, a well-known server-parameter catalog with per-role overrides, and `checkNameAvailability`.
- **Server** (`server/azure/cosmospostgresql`): ARM REST handler. PUT/PATCH return the resource inline with a terminal `provisioningState` (SDK LRO completes on the first response); cluster start/stop/restart/promote reply `202` + `Location` and complete via `operationStatuses`. Parallel child handlers share generic `serveCRUD` / `serveReadOnly` / `armListOf` helpers.
- **Wiring**: registered in the Azure provider/server bundles + `DriversFrom`; `cosmospostgresql:CreateOrUpdateCluster` cost key.

## Alternatives not taken
- **Hand-rolling every SDK model as a distinct wire struct** — used hand-rolled camelCase structs only where the driver diverges from the SDK shape, matching the Managed Cassandra convention (ARM has no single "SDK types as wire format" story like Bigtable's `bigtableadmin/v2`).
- **Modeling nodes as stored resources** — nodes (`servers`) are read-only in the real API, so they're derived from the cluster shape (one coordinator + N workers) rather than stored.

## Docs / Test / Playground
- `docs/services.md` (new §11e + master-table row 17d + summary row + Grand Total 1381→1415), `README.md`, `docs/sdk-server.md`.
- Provider unit tests (lifecycle, node bounds, firewall/roles + cascade, derived nodes, configurations, read-replica promotion, checkNameAvailability, clone-on-read) + real-SDK round-trip tests driving `armcosmosforpostgresql` against an httptest server, covering every client and all LRO pollers.

## Test plan
- [ ] `go build ./... && go vet ./...`
- [ ] `go test ./providers/azure/cosmospostgresql/... ./server/azure/cosmospostgresql/... ./services/cost/...`
- [ ] `go mod tidy` clean; `golangci-lint run` 0 issues; CodeQL 0 new alerts

## Risk & Rollback
Purely additive — a new service behind a new `Drivers.CosmosPostgreSQL` field (nil for consumers that don't wire it). No existing behavior changes. Rollback = revert the commit.

## Conclusion
Cosmos DB for PostgreSQL now works end-to-end through the real SDK, including the distributed (coordinator/worker) node model, configurations, and read-replica promotion.
