### PR TITLE
AWS networking parity: Transit Gateway, VPN, DHCP, prefix lists, egress-only IGW, endpoint services, Client VPN, Network Firewall

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -543,15 +543,15 @@ assertion, like `NetworkInterfaces`/`VPCAttributes`) implemented by
 
 | Capability | Operations |
 |-----------|-----------|
-| Transit Gateway | CreateTransitGateway, DeleteTransitGateway, DescribeTransitGateways; VPC attachments (Create/Delete/Describe); route tables (Create/Delete/Describe) |
-| VPN | CustomerGateway (Create/Delete/Describe); VpnGateway (Create/Delete/Describe/Attach/Detach); VpnConnection (Create/Delete/Describe) |
+| Transit Gateway | CreateTransitGateway, DeleteTransitGateway, DescribeTransitGateways; VPC attachments (Create/Delete/Describe); route tables (Create/Delete/Describe); routes (Create/Delete/Search); route-table Associate + Enable/DisableRouteTablePropagation |
+| VPN | CustomerGateway (Create/Delete/Describe); VpnGateway (Create/Delete/Describe/Attach/Detach); VpnConnection (Create/Delete/Describe/ModifyVpnConnection); VpnConnectionRoute (Create/Delete) |
 | DHCP option sets | Create, Delete, Describe, Associate |
-| Managed prefix lists | Create, Delete, Describe, GetEntries |
+| Managed prefix lists | Create, Delete, Describe, GetEntries, Modify |
 | Egress-only internet gateways | Create, Delete, Describe |
-| VPC endpoint services (PrivateLink) | Create, Delete, Describe |
-| Client VPN | CreateEndpoint, DeleteEndpoint, DescribeEndpoints, Associate/DisassociateTargetNetwork |
+| VPC endpoint services (PrivateLink) | Create, Delete, Describe; ModifyPermissions, DescribePermissions |
+| Client VPN | CreateEndpoint, DeleteEndpoint, DescribeEndpoints, Associate/DisassociateTargetNetwork, DescribeTargetNetworks; Authorize/RevokeIngress, DescribeAuthorizationRules; Route (Create/Delete/Describe) |
 
-**AWS-specific total: 35 operations**
+**AWS-specific total: 54 operations**
 
 ---
 
@@ -2261,8 +2261,8 @@ still sees success.
 | Database | 21 |
 | Serverless | 26 |
 | Networking | 51 |
-| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN) | 35 |
-| Network Firewall — AWS | 12 |
+| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN) | 54 |
+| Network Firewall — AWS | 20 |
 | Monitoring | 12 |
 | IAM | 35 |
 | DNS | 15 |
@@ -2293,7 +2293,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1462** (+138 optional) |
+| **Grand Total** | **1489** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/docs/services.md
+++ b/docs/services.md
@@ -10,7 +10,8 @@ This document lists every service and operation available in CloudEmu across all
 | 2 | Compute | `ec2` | `virtualmachines` | `gce` |
 | 3 | Database | `dynamodb` | `cosmosdb` | `firestore` |
 | 4 | Serverless | `lambda` | `functions` | `cloudfunctions` |
-| 5 | Networking | `vpc` | `vnet` | `gcpvpc` |
+| 5 | Networking | `vpc` (+ AWS-specific: Transit Gateway, VPN, DHCP options, prefix lists, egress-only IGW, endpoint services, Client VPN) | `vnet` | `gcpvpc` |
+| 5a | Network Firewall | `network-firewall` | — | — |
 | 6 | Monitoring | `cloudwatch` | `azuremonitor` | `cloudmonitoring` |
 | 7 | IAM | `awsiam` | `azureiam` | `gcpiam` |
 | 8 | DNS | `route53` | `azuredns` | `clouddns` |
@@ -532,6 +533,25 @@ DNS hostnames off.
 | `ModifyVPCEndpoint` | `(ctx, id, config) (*VPCEndpoint, error)` |
 
 **Total: 47 operations**
+
+### AWS-specific networking (optional capabilities)
+
+AWS models several networking resources that don't map cleanly across clouds.
+These are **AWS-only optional capability interfaces** (discovered by type
+assertion, like `NetworkInterfaces`/`VPCAttributes`) implemented by
+`providers/aws/vpc` and served by the EC2 handler — no Azure/GCP stubs.
+
+| Capability | Operations |
+|-----------|-----------|
+| Transit Gateway | CreateTransitGateway, DeleteTransitGateway, DescribeTransitGateways; VPC attachments (Create/Delete/Describe); route tables (Create/Delete/Describe) |
+| VPN | CustomerGateway (Create/Delete/Describe); VpnGateway (Create/Delete/Describe/Attach/Detach); VpnConnection (Create/Delete/Describe) |
+| DHCP option sets | Create, Delete, Describe, Associate |
+| Managed prefix lists | Create, Delete, Describe, GetEntries |
+| Egress-only internet gateways | Create, Delete, Describe |
+| VPC endpoint services (PrivateLink) | Create, Delete, Describe |
+| Client VPN | CreateEndpoint, DeleteEndpoint, DescribeEndpoints, Associate/DisassociateTargetNetwork |
+
+**AWS-specific total: 35 operations**
 
 ---
 
@@ -2241,6 +2261,8 @@ still sees success.
 | Database | 21 |
 | Serverless | 26 |
 | Networking | 51 |
+| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN) | 35 |
+| Network Firewall — AWS | 12 |
 | Monitoring | 12 |
 | IAM | 35 |
 | DNS | 15 |
@@ -2271,7 +2293,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1415** (+138 optional) |
+| **Grand Total** | **1462** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/docs/services.md
+++ b/docs/services.md
@@ -551,7 +551,7 @@ assertion, like `NetworkInterfaces`/`VPCAttributes`) implemented by
 | VPC endpoint services (PrivateLink) | Create, Delete, Describe; ModifyPermissions, DescribePermissions |
 | Client VPN | CreateEndpoint, DeleteEndpoint, DescribeEndpoints, Associate/DisassociateTargetNetwork, DescribeTargetNetworks; Authorize/RevokeIngress, DescribeAuthorizationRules; Route (Create/Delete/Describe) |
 
-**AWS-specific total: 54 operations**
+**AWS-specific total: 58 operations**
 
 ---
 
@@ -2261,7 +2261,7 @@ still sees success.
 | Database | 21 |
 | Serverless | 26 |
 | Networking | 51 |
-| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN) | 54 |
+| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN) | 58 |
 | Network Firewall — AWS | 20 |
 | Monitoring | 12 |
 | IAM | 35 |
@@ -2293,7 +2293,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1489** (+138 optional) |
+| **Grand Total** | **1493** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.5.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1
-	github.com/aws/aws-sdk-go-v2 v1.43.2
+	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -60,6 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5
+	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.66.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.118.2
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.23.6
@@ -74,7 +75,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.27
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
-	github.com/aws/smithy-go v1.27.5
+	github.com/aws/smithy-go v1.27.6
 	github.com/databricks/databricks-sdk-go v0.144.0
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/google/gnostic-models v0.6.8
@@ -104,8 +105,8 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0/go.mod h1:vB2GH9GAYYJTO3mEn8oYwzEdhlayZIdQz6zdzgUIRvA=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 h1:0s6TxfCu2KHkkZPnBfsQ2y5qia0jl3MMrmBhu3nCOYk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0/go.mod h1:Mf6O40IAyB9zR/1J8nGDDPirZQQPbYJni8Yisy7NTMc=
-github.com/aws/aws-sdk-go-v2 v1.43.2 h1:cl+IXwWb3qazClUcm08tGSsB6OiuV83JVJO9B0jQcPc=
-github.com/aws/aws-sdk-go-v2 v1.43.2/go.mod h1:WEzLKBh/mEjXvx1FtQMWgSxMSTVqxQzjkRtk5fa3wkg=
+github.com/aws/aws-sdk-go-v2 v1.43.3 h1:XJIcfv8uDs2ukdQsoAC8/Ebu1ejxwzlayl2ZsiFns2A=
+github.com/aws/aws-sdk-go-v2 v1.43.3/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14/go.mod h1:zwM6veDkhGgQFqkBy+uT28AAYpLu+uFMlPl+rCg/73E=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
@@ -122,10 +122,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8TH
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14/go.mod h1:cJKuyWB59Mqi0jM3nFYQRmnHVQIcgoxjEMAbLkpr62w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeDLaS3bmHD0YndtA6UP884g=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33 h1:HAp1wLFZzch054uh3FK7rcVYg4v7J2FxVf3h3IGNZas=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.33/go.mod h1:mJk5fmqnF+WUlMdPG37pR2Fh3oh6r8F6ZGUgPKvzu0c=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33 h1:0YA0aCKgsJyno6xkFfaIgjE3/wK08+Qxo9nQfe1UrWM=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.33/go.mod h1:UZqj4WIdTH+ga8Y/DgpAuy/8cGjM3h7gDCliJYGg2SE=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 h1:vuIfjzoeqhQMGJyOBU3t0ZEjn2jrN8Bbg1N4CgjzM5Q=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34/go.mod h1:hP28cN4CPJLZHirdQPrZR50JcLN4ApRJP2tzG8cRlhY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 h1:9faHsnqxJ1vDvB4wMZy/ajIDyz5QhllQjjc72RJpXAw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34/go.mod h1:Yp6nIyejpa23nzlB/LhT63KTla9Jdi06nv/HH/OkAH8=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1O1b3Erl5CePYIAeQ=
@@ -182,6 +182,8 @@ github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2 h1:GKkUvwhxKF5JVSWERui4bvP
 github.com/aws/aws-sdk-go-v2/service/memorydb v1.36.2/go.mod h1:wRcgz/DYIlZldpS/RpJDgjtMPsk0a6hLvwMl/2tGKuY=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5 h1:v+XVk5OQnhm6EasbClY036A1gTtVdtdNdG8/Q3rLYU4=
 github.com/aws/aws-sdk-go-v2/service/neptune v1.44.5/go.mod h1:Y/yH7q6R/qaO4g6YTBbAMSu5T4NjVo+7+P1UNZ2NlzA=
+github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.66.0 h1:VrfvjFVgN2ZJZUvMBsW0YGW7hN3zsqdVYy/wpko9hkQ=
+github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.66.0/go.mod h1:tR82E7iVkRt7zwjxj39m/TNt161xEH/pWuJFXtRhI0I=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2 h1:pkEeQneYFpTAnGhyqSbyp/DlCPPJTGt0GkWahlLYzMA=
 github.com/aws/aws-sdk-go-v2/service/rds v1.118.2/go.mod h1:7gS+cGrKF0mH253QHFlStmx79ws+DlNk+04ZRfmw3U0=
 github.com/aws/aws-sdk-go-v2/service/redshift v1.62.7 h1:6NCQBp9IIEs51YI9/jT5/ckSd6Ka9956gAGlw0a0yFI=
@@ -216,8 +218,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6f
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19/go.mod h1:YO8TrYtFdl5w/4vmjL8zaBSsiNp3w0L1FfKVKenZT7w=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
-github.com/aws/smithy-go v1.27.5 h1:d1ro7KpYOYwP6m73YFa+Kc/A130VsAdX68SpsJwARMM=
-github.com/aws/smithy-go v1.27.5/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.6 h1:0zjT8jgK3jbrTT7JJ3EE6JsMhX8JTrZ+f1sEndYDXrA=
+github.com/aws/smithy-go v1.27.6/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/keyspaces"
 	"github.com/stackshy/cloudemu/v2/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/v2/providers/aws/memorydb"
+	"github.com/stackshy/cloudemu/v2/providers/aws/networkfirewall"
 	"github.com/stackshy/cloudemu/v2/providers/aws/rds"
 	"github.com/stackshy/cloudemu/v2/providers/aws/redshift"
 	"github.com/stackshy/cloudemu/v2/providers/aws/route53"
@@ -128,6 +129,7 @@ type Provider struct {
 	ElastiCache         *elasticache.Mock
 	Keyspaces           *keyspaces.Mock
 	MemoryDB            *memorydb.Mock
+	NetworkFirewall     *networkfirewall.Mock
 	SecretsManager      *secretsmanager.Mock
 	CloudWatchLogs      *cloudwatchlogs.Mock
 	SNS                 *sns.Mock
@@ -164,6 +166,7 @@ func New(opts ...config.Option) *Provider {
 		ElastiCache:         elasticache.New(o),
 		Keyspaces:           keyspaces.New(o),
 		MemoryDB:            memorydb.New(o),
+		NetworkFirewall:     networkfirewall.New(o),
 		SecretsManager:      secretsmanager.New(o),
 		CloudWatchLogs:      cloudwatchlogs.New(o),
 		SNS:                 sns.New(o),

--- a/providers/aws/networkfirewall/networkfirewall.go
+++ b/providers/aws/networkfirewall/networkfirewall.go
@@ -1,0 +1,338 @@
+// Package networkfirewall provides an in-memory mock of AWS Network Firewall.
+package networkfirewall
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+)
+
+var _ nfdriver.NetworkFirewall = (*Mock)(nil)
+
+// Mock is the in-memory AWS Network Firewall implementation. Resources are
+// keyed by name (unique per account/region, as in the real service).
+type Mock struct {
+	firewalls  *memstore.Store[*nfdriver.Firewall]
+	policies   *memstore.Store[*nfdriver.FirewallPolicy]
+	ruleGroups *memstore.Store[*nfdriver.RuleGroup]
+	opts       *config.Options
+}
+
+// New creates a new Network Firewall mock.
+func New(opts *config.Options) *Mock {
+	return &Mock{
+		firewalls:  memstore.New[*nfdriver.Firewall](),
+		policies:   memstore.New[*nfdriver.FirewallPolicy](),
+		ruleGroups: memstore.New[*nfdriver.RuleGroup](),
+		opts:       opts,
+	}
+}
+
+func (m *Mock) arn(kind, name string) string {
+	return idgen.AWSARN("network-firewall", m.opts.Region, m.opts.AccountID, kind+"/"+name)
+}
+
+func copyTags(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+
+	return out
+}
+
+func cloneStrings(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+
+	return append([]string(nil), s...)
+}
+
+// ---- Firewalls ----
+
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateFirewall(_ context.Context, cfg nfdriver.CreateFirewallConfig) (*nfdriver.Firewall, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "FirewallName is required")
+	}
+
+	if m.firewalls.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "firewall %q already exists", cfg.Name)
+	}
+
+	fw := &nfdriver.Firewall{
+		Name:             cfg.Name,
+		ARN:              m.arn("firewall", cfg.Name),
+		PolicyARN:        cfg.PolicyARN,
+		VPCID:            cfg.VPCID,
+		SubnetIDs:        cloneStrings(cfg.SubnetIDs),
+		Description:      cfg.Description,
+		DeleteProtection: cfg.DeleteProtection,
+		Status:           "READY",
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.firewalls.Set(cfg.Name, fw)
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeFirewall(_ context.Context, name, arn string) (*nfdriver.Firewall, error) {
+	fw, ok := m.lookupFirewall(name, arn)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", nonEmpty(name, arn))
+	}
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteFirewall(_ context.Context, name, arn string) (*nfdriver.Firewall, error) {
+	fw, ok := m.lookupFirewall(name, arn)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", nonEmpty(name, arn))
+	}
+
+	if fw.DeleteProtection {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "firewall %q has delete protection enabled", fw.Name)
+	}
+
+	fw.Status = "DELETING"
+	m.firewalls.Delete(fw.Name)
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+func (m *Mock) ListFirewalls(_ context.Context) ([]nfdriver.Firewall, error) {
+	all := m.firewalls.SortedValues()
+	out := make([]nfdriver.Firewall, 0, len(all))
+
+	for _, f := range all {
+		out = append(out, cloneFirewall(f))
+	}
+
+	return out, nil
+}
+
+func (m *Mock) lookupFirewall(name, arn string) (*nfdriver.Firewall, bool) {
+	if name != "" {
+		return m.firewalls.Get(name)
+	}
+
+	for _, f := range m.firewalls.SortedValues() {
+		if f.ARN == arn {
+			return f, true
+		}
+	}
+
+	return nil, false
+}
+
+func cloneFirewall(f *nfdriver.Firewall) nfdriver.Firewall {
+	out := *f
+	out.SubnetIDs = cloneStrings(f.SubnetIDs)
+	out.Tags = copyTags(f.Tags)
+
+	return out
+}
+
+// ---- Firewall Policies ----
+
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateFirewallPolicy(_ context.Context, cfg nfdriver.CreateFirewallPolicyConfig) (*nfdriver.FirewallPolicy, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "FirewallPolicyName is required")
+	}
+
+	if m.policies.Has(cfg.Name) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "firewall policy %q already exists", cfg.Name)
+	}
+
+	p := &nfdriver.FirewallPolicy{
+		Name:                            cfg.Name,
+		ARN:                             m.arn("firewall-policy", cfg.Name),
+		ID:                              idgen.GenerateID(""),
+		Description:                     cfg.Description,
+		StatelessDefaultActions:         cloneStrings(cfg.StatelessDefaultActions),
+		StatelessFragmentDefaultActions: cloneStrings(cfg.StatelessFragmentDefaultActions),
+		Tags:                            copyTags(cfg.Tags),
+	}
+	m.policies.Set(cfg.Name, p)
+
+	out := cloneFirewallPolicy(p)
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeFirewallPolicy(_ context.Context, name, arn string) (*nfdriver.FirewallPolicy, error) {
+	p, ok := m.lookupPolicy(name, arn)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", nonEmpty(name, arn))
+	}
+
+	out := cloneFirewallPolicy(p)
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteFirewallPolicy(_ context.Context, name, arn string) (*nfdriver.FirewallPolicy, error) {
+	p, ok := m.lookupPolicy(name, arn)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", nonEmpty(name, arn))
+	}
+
+	m.policies.Delete(p.Name)
+
+	out := cloneFirewallPolicy(p)
+
+	return &out, nil
+}
+
+func (m *Mock) ListFirewallPolicies(_ context.Context) ([]nfdriver.FirewallPolicy, error) {
+	all := m.policies.SortedValues()
+	out := make([]nfdriver.FirewallPolicy, 0, len(all))
+
+	for _, p := range all {
+		out = append(out, cloneFirewallPolicy(p))
+	}
+
+	return out, nil
+}
+
+func (m *Mock) lookupPolicy(name, arn string) (*nfdriver.FirewallPolicy, bool) {
+	if name != "" {
+		return m.policies.Get(name)
+	}
+
+	for _, p := range m.policies.SortedValues() {
+		if p.ARN == arn {
+			return p, true
+		}
+	}
+
+	return nil, false
+}
+
+func cloneFirewallPolicy(p *nfdriver.FirewallPolicy) nfdriver.FirewallPolicy {
+	out := *p
+	out.StatelessDefaultActions = cloneStrings(p.StatelessDefaultActions)
+	out.StatelessFragmentDefaultActions = cloneStrings(p.StatelessFragmentDefaultActions)
+	out.Tags = copyTags(p.Tags)
+
+	return out
+}
+
+// ---- Rule Groups ----
+
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateRuleGroup(_ context.Context, cfg nfdriver.CreateRuleGroupConfig) (*nfdriver.RuleGroup, error) {
+	if cfg.Name == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "RuleGroupName is required")
+	}
+
+	if cfg.Type != "STATEFUL" && cfg.Type != "STATELESS" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "Type must be STATEFUL or STATELESS")
+	}
+
+	key := ruleGroupKey(cfg.Name, cfg.Type)
+	if m.ruleGroups.Has(key) {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "rule group %q already exists", cfg.Name)
+	}
+
+	rg := &nfdriver.RuleGroup{
+		Name:        cfg.Name,
+		ARN:         m.arn("stateful-rulegroup", cfg.Name),
+		ID:          idgen.GenerateID(""),
+		Type:        cfg.Type,
+		Capacity:    cfg.Capacity,
+		Description: cfg.Description,
+		Tags:        copyTags(cfg.Tags),
+	}
+	m.ruleGroups.Set(key, rg)
+
+	out := cloneRuleGroup(rg)
+
+	return &out, nil
+}
+
+func (m *Mock) DescribeRuleGroup(_ context.Context, name, arn, ruleType string) (*nfdriver.RuleGroup, error) {
+	rg, ok := m.lookupRuleGroup(name, arn, ruleType)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "rule group %q not found", nonEmpty(name, arn))
+	}
+
+	out := cloneRuleGroup(rg)
+
+	return &out, nil
+}
+
+func (m *Mock) DeleteRuleGroup(_ context.Context, name, arn, ruleType string) (*nfdriver.RuleGroup, error) {
+	rg, ok := m.lookupRuleGroup(name, arn, ruleType)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "rule group %q not found", nonEmpty(name, arn))
+	}
+
+	m.ruleGroups.Delete(ruleGroupKey(rg.Name, rg.Type))
+
+	out := cloneRuleGroup(rg)
+
+	return &out, nil
+}
+
+func (m *Mock) ListRuleGroups(_ context.Context) ([]nfdriver.RuleGroup, error) {
+	all := m.ruleGroups.SortedValues()
+	out := make([]nfdriver.RuleGroup, 0, len(all))
+
+	for _, rg := range all {
+		out = append(out, cloneRuleGroup(rg))
+	}
+
+	return out, nil
+}
+
+func (m *Mock) lookupRuleGroup(name, arn, ruleType string) (*nfdriver.RuleGroup, bool) {
+	if name != "" && ruleType != "" {
+		return m.ruleGroups.Get(ruleGroupKey(name, ruleType))
+	}
+
+	for _, rg := range m.ruleGroups.SortedValues() {
+		if (name != "" && rg.Name == name) || (arn != "" && rg.ARN == arn) {
+			return rg, true
+		}
+	}
+
+	return nil, false
+}
+
+func ruleGroupKey(name, ruleType string) string {
+	return fmt.Sprintf("%s/%s", ruleType, name)
+}
+
+func cloneRuleGroup(rg *nfdriver.RuleGroup) nfdriver.RuleGroup {
+	out := *rg
+	out.Tags = copyTags(rg.Tags)
+
+	return out
+}
+
+func nonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+
+	return b
+}

--- a/providers/aws/networkfirewall/networkfirewall.go
+++ b/providers/aws/networkfirewall/networkfirewall.go
@@ -20,6 +20,7 @@ type Mock struct {
 	firewalls  *memstore.Store[*nfdriver.Firewall]
 	policies   *memstore.Store[*nfdriver.FirewallPolicy]
 	ruleGroups *memstore.Store[*nfdriver.RuleGroup]
+	logging    map[string][]string
 	opts       *config.Options
 }
 
@@ -29,6 +30,7 @@ func New(opts *config.Options) *Mock {
 		firewalls:  memstore.New[*nfdriver.Firewall](),
 		policies:   memstore.New[*nfdriver.FirewallPolicy](),
 		ruleGroups: memstore.New[*nfdriver.RuleGroup](),
+		logging:    map[string][]string{},
 		opts:       opts,
 	}
 }
@@ -334,4 +336,176 @@ func nonEmpty(a, b string) string {
 	}
 
 	return b
+}
+
+// ---- Firewall depth: associations, protection, logging, tags ----
+
+// AssociateFirewallPolicy attaches a firewall policy to a firewall.
+func (m *Mock) AssociateFirewallPolicy(_ context.Context, firewallName, policyARN string) (*nfdriver.Firewall, error) {
+	fw, ok := m.firewalls.Get(firewallName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	fw.PolicyARN = policyARN
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+// AssociateSubnets adds subnet mappings to a firewall.
+//
+//nolint:gocritic // slice matches the driver signature.
+func (m *Mock) AssociateSubnets(_ context.Context, firewallName string, subnetIDs []string) (*nfdriver.Firewall, error) {
+	fw, ok := m.firewalls.Get(firewallName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	seen := make(map[string]bool, len(fw.SubnetIDs))
+	for _, s := range fw.SubnetIDs {
+		seen[s] = true
+	}
+
+	for _, s := range subnetIDs {
+		if !seen[s] {
+			fw.SubnetIDs = append(fw.SubnetIDs, s)
+			seen[s] = true
+		}
+	}
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+// DisassociateSubnets removes subnet mappings from a firewall.
+//
+//nolint:gocritic // slice matches the driver signature.
+func (m *Mock) DisassociateSubnets(_ context.Context, firewallName string, subnetIDs []string) (*nfdriver.Firewall, error) {
+	fw, ok := m.firewalls.Get(firewallName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	remove := make(map[string]bool, len(subnetIDs))
+	for _, s := range subnetIDs {
+		remove[s] = true
+	}
+
+	kept := fw.SubnetIDs[:0:0]
+
+	for _, s := range fw.SubnetIDs {
+		if !remove[s] {
+			kept = append(kept, s)
+		}
+	}
+
+	fw.SubnetIDs = kept
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+// UpdateFirewallDeleteProtection toggles delete protection on a firewall.
+func (m *Mock) UpdateFirewallDeleteProtection(_ context.Context, firewallName string, enabled bool) (*nfdriver.Firewall, error) {
+	fw, ok := m.firewalls.Get(firewallName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	fw.DeleteProtection = enabled
+
+	out := cloneFirewall(fw)
+
+	return &out, nil
+}
+
+// UpdateLoggingConfiguration sets the firewall's log types.
+//
+//nolint:gocritic // slice matches the driver signature.
+func (m *Mock) UpdateLoggingConfiguration(_ context.Context, firewallName string, logTypes []string) error {
+	if !m.firewalls.Has(firewallName) {
+		return cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	m.logging[firewallName] = append([]string(nil), logTypes...)
+
+	return nil
+}
+
+// DescribeLoggingConfiguration returns the firewall's log types.
+func (m *Mock) DescribeLoggingConfiguration(_ context.Context, firewallName string) ([]string, error) {
+	if !m.firewalls.Has(firewallName) {
+		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	return append([]string(nil), m.logging[firewallName]...), nil
+}
+
+// TagResource adds tags to a firewall / policy / rule group by ARN.
+func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string) error {
+	if t := m.taggableByARN(arn); t != nil {
+		for k, v := range tags {
+			t[k] = v
+		}
+
+		return nil
+	}
+
+	return cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)
+}
+
+// UntagResource removes tags from a firewall / policy / rule group by ARN.
+//
+//nolint:gocritic // keys slice matches the driver signature.
+func (m *Mock) UntagResource(_ context.Context, arn string, keys []string) error {
+	t := m.taggableByARN(arn)
+	if t == nil {
+		return cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)
+	}
+
+	for _, k := range keys {
+		delete(t, k)
+	}
+
+	return nil
+}
+
+// taggableByARN returns the mutable Tags map of the resource with the given ARN,
+// creating it if nil, or nil when no resource matches.
+func (m *Mock) taggableByARN(arn string) map[string]string {
+	for _, f := range m.firewalls.SortedValues() {
+		if f.ARN == arn {
+			if f.Tags == nil {
+				f.Tags = map[string]string{}
+			}
+
+			return f.Tags
+		}
+	}
+
+	for _, p := range m.policies.SortedValues() {
+		if p.ARN == arn {
+			if p.Tags == nil {
+				p.Tags = map[string]string{}
+			}
+
+			return p.Tags
+		}
+	}
+
+	for _, rg := range m.ruleGroups.SortedValues() {
+		if rg.ARN == arn {
+			if rg.Tags == nil {
+				rg.Tags = map[string]string{}
+			}
+
+			return rg.Tags
+		}
+	}
+
+	return nil
 }

--- a/providers/aws/networkfirewall/networkfirewall.go
+++ b/providers/aws/networkfirewall/networkfirewall.go
@@ -4,6 +4,7 @@ package networkfirewall
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/stackshy/cloudemu/v2/config"
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -12,11 +13,21 @@ import (
 	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
 )
 
+const (
+	ruleTypeStateful  = "STATEFUL"
+	ruleTypeStateless = "STATELESS"
+)
+
 var _ nfdriver.NetworkFirewall = (*Mock)(nil)
 
 // Mock is the in-memory AWS Network Firewall implementation. Resources are
 // keyed by name (unique per account/region, as in the real service).
+//
+// The stores hand back shared pointers whose fields are mutated in place
+// (associate/tag/protection/subnets) and logging is a plain map, so every
+// public method serializes on mu: mutators take Lock, readers take RLock.
 type Mock struct {
+	mu         sync.RWMutex
 	firewalls  *memstore.Store[*nfdriver.Firewall]
 	policies   *memstore.Store[*nfdriver.FirewallPolicy]
 	ruleGroups *memstore.Store[*nfdriver.RuleGroup]
@@ -64,12 +75,19 @@ func cloneStrings(s []string) []string {
 
 //nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateFirewall(_ context.Context, cfg nfdriver.CreateFirewallConfig) (*nfdriver.Firewall, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "FirewallName is required")
 	}
 
 	if m.firewalls.Has(cfg.Name) {
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "firewall %q already exists", cfg.Name)
+	}
+
+	if cfg.PolicyARN != "" && !m.policyExists(cfg.PolicyARN) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "firewall policy %q not found", cfg.PolicyARN)
 	}
 
 	fw := &nfdriver.Firewall{
@@ -91,6 +109,9 @@ func (m *Mock) CreateFirewall(_ context.Context, cfg nfdriver.CreateFirewallConf
 }
 
 func (m *Mock) DescribeFirewall(_ context.Context, name, arn string) (*nfdriver.Firewall, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	fw, ok := m.lookupFirewall(name, arn)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", nonEmpty(name, arn))
@@ -102,6 +123,9 @@ func (m *Mock) DescribeFirewall(_ context.Context, name, arn string) (*nfdriver.
 }
 
 func (m *Mock) DeleteFirewall(_ context.Context, name, arn string) (*nfdriver.Firewall, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fw, ok := m.lookupFirewall(name, arn)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", nonEmpty(name, arn))
@@ -120,6 +144,9 @@ func (m *Mock) DeleteFirewall(_ context.Context, name, arn string) (*nfdriver.Fi
 }
 
 func (m *Mock) ListFirewalls(_ context.Context) ([]nfdriver.Firewall, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	all := m.firewalls.SortedValues()
 	out := make([]nfdriver.Firewall, 0, len(all))
 
@@ -156,6 +183,9 @@ func cloneFirewall(f *nfdriver.Firewall) nfdriver.Firewall {
 
 //nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateFirewallPolicy(_ context.Context, cfg nfdriver.CreateFirewallPolicyConfig) (*nfdriver.FirewallPolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "FirewallPolicyName is required")
 	}
@@ -181,6 +211,9 @@ func (m *Mock) CreateFirewallPolicy(_ context.Context, cfg nfdriver.CreateFirewa
 }
 
 func (m *Mock) DescribeFirewallPolicy(_ context.Context, name, arn string) (*nfdriver.FirewallPolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	p, ok := m.lookupPolicy(name, arn)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", nonEmpty(name, arn))
@@ -192,9 +225,16 @@ func (m *Mock) DescribeFirewallPolicy(_ context.Context, name, arn string) (*nfd
 }
 
 func (m *Mock) DeleteFirewallPolicy(_ context.Context, name, arn string) (*nfdriver.FirewallPolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	p, ok := m.lookupPolicy(name, arn)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall policy %q not found", nonEmpty(name, arn))
+	}
+
+	if m.policyInUse(p.ARN) {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition, "firewall policy %q is in use by a firewall", p.Name)
 	}
 
 	m.policies.Delete(p.Name)
@@ -205,6 +245,9 @@ func (m *Mock) DeleteFirewallPolicy(_ context.Context, name, arn string) (*nfdri
 }
 
 func (m *Mock) ListFirewallPolicies(_ context.Context) ([]nfdriver.FirewallPolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	all := m.policies.SortedValues()
 	out := make([]nfdriver.FirewallPolicy, 0, len(all))
 
@@ -229,6 +272,28 @@ func (m *Mock) lookupPolicy(name, arn string) (*nfdriver.FirewallPolicy, bool) {
 	return nil, false
 }
 
+// policyExists reports whether a firewall policy with the given ARN is present.
+func (m *Mock) policyExists(arn string) bool {
+	for _, p := range m.policies.SortedValues() {
+		if p.ARN == arn {
+			return true
+		}
+	}
+
+	return false
+}
+
+// policyInUse reports whether any firewall references the policy ARN.
+func (m *Mock) policyInUse(arn string) bool {
+	for _, f := range m.firewalls.SortedValues() {
+		if f.PolicyARN == arn {
+			return true
+		}
+	}
+
+	return false
+}
+
 func cloneFirewallPolicy(p *nfdriver.FirewallPolicy) nfdriver.FirewallPolicy {
 	out := *p
 	out.StatelessDefaultActions = cloneStrings(p.StatelessDefaultActions)
@@ -241,11 +306,14 @@ func cloneFirewallPolicy(p *nfdriver.FirewallPolicy) nfdriver.FirewallPolicy {
 // ---- Rule Groups ----
 
 func (m *Mock) CreateRuleGroup(_ context.Context, cfg nfdriver.CreateRuleGroupConfig) (*nfdriver.RuleGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "RuleGroupName is required")
 	}
 
-	if cfg.Type != "STATEFUL" && cfg.Type != "STATELESS" {
+	if cfg.Type != ruleTypeStateful && cfg.Type != ruleTypeStateless {
 		return nil, cerrors.New(cerrors.InvalidArgument, "Type must be STATEFUL or STATELESS")
 	}
 
@@ -254,9 +322,14 @@ func (m *Mock) CreateRuleGroup(_ context.Context, cfg nfdriver.CreateRuleGroupCo
 		return nil, cerrors.Newf(cerrors.AlreadyExists, "rule group %q already exists", cfg.Name)
 	}
 
+	rgKind := "stateful-rulegroup"
+	if cfg.Type == ruleTypeStateless {
+		rgKind = "stateless-rulegroup"
+	}
+
 	rg := &nfdriver.RuleGroup{
 		Name:        cfg.Name,
-		ARN:         m.arn("stateful-rulegroup", cfg.Name),
+		ARN:         m.arn(rgKind, cfg.Name),
 		ID:          idgen.GenerateID(""),
 		Type:        cfg.Type,
 		Capacity:    cfg.Capacity,
@@ -271,6 +344,9 @@ func (m *Mock) CreateRuleGroup(_ context.Context, cfg nfdriver.CreateRuleGroupCo
 }
 
 func (m *Mock) DescribeRuleGroup(_ context.Context, name, arn, ruleType string) (*nfdriver.RuleGroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	rg, ok := m.lookupRuleGroup(name, arn, ruleType)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "rule group %q not found", nonEmpty(name, arn))
@@ -282,6 +358,9 @@ func (m *Mock) DescribeRuleGroup(_ context.Context, name, arn, ruleType string) 
 }
 
 func (m *Mock) DeleteRuleGroup(_ context.Context, name, arn, ruleType string) (*nfdriver.RuleGroup, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rg, ok := m.lookupRuleGroup(name, arn, ruleType)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "rule group %q not found", nonEmpty(name, arn))
@@ -295,6 +374,9 @@ func (m *Mock) DeleteRuleGroup(_ context.Context, name, arn, ruleType string) (*
 }
 
 func (m *Mock) ListRuleGroups(_ context.Context) ([]nfdriver.RuleGroup, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	all := m.ruleGroups.SortedValues()
 	out := make([]nfdriver.RuleGroup, 0, len(all))
 
@@ -342,9 +424,16 @@ func nonEmpty(a, b string) string {
 
 // AssociateFirewallPolicy attaches a firewall policy to a firewall.
 func (m *Mock) AssociateFirewallPolicy(_ context.Context, firewallName, policyARN string) (*nfdriver.Firewall, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fw, ok := m.firewalls.Get(firewallName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
+	}
+
+	if !m.policyExists(policyARN) {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "firewall policy %q not found", policyARN)
 	}
 
 	fw.PolicyARN = policyARN
@@ -355,9 +444,10 @@ func (m *Mock) AssociateFirewallPolicy(_ context.Context, firewallName, policyAR
 }
 
 // AssociateSubnets adds subnet mappings to a firewall.
-//
-//nolint:gocritic // slice matches the driver signature.
 func (m *Mock) AssociateSubnets(_ context.Context, firewallName string, subnetIDs []string) (*nfdriver.Firewall, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fw, ok := m.firewalls.Get(firewallName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
@@ -381,9 +471,10 @@ func (m *Mock) AssociateSubnets(_ context.Context, firewallName string, subnetID
 }
 
 // DisassociateSubnets removes subnet mappings from a firewall.
-//
-//nolint:gocritic // slice matches the driver signature.
 func (m *Mock) DisassociateSubnets(_ context.Context, firewallName string, subnetIDs []string) (*nfdriver.Firewall, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fw, ok := m.firewalls.Get(firewallName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
@@ -411,6 +502,9 @@ func (m *Mock) DisassociateSubnets(_ context.Context, firewallName string, subne
 
 // UpdateFirewallDeleteProtection toggles delete protection on a firewall.
 func (m *Mock) UpdateFirewallDeleteProtection(_ context.Context, firewallName string, enabled bool) (*nfdriver.Firewall, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	fw, ok := m.firewalls.Get(firewallName)
 	if !ok {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
@@ -424,9 +518,10 @@ func (m *Mock) UpdateFirewallDeleteProtection(_ context.Context, firewallName st
 }
 
 // UpdateLoggingConfiguration sets the firewall's log types.
-//
-//nolint:gocritic // slice matches the driver signature.
 func (m *Mock) UpdateLoggingConfiguration(_ context.Context, firewallName string, logTypes []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if !m.firewalls.Has(firewallName) {
 		return cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
 	}
@@ -438,6 +533,9 @@ func (m *Mock) UpdateLoggingConfiguration(_ context.Context, firewallName string
 
 // DescribeLoggingConfiguration returns the firewall's log types.
 func (m *Mock) DescribeLoggingConfiguration(_ context.Context, firewallName string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if !m.firewalls.Has(firewallName) {
 		return nil, cerrors.Newf(cerrors.NotFound, "firewall %q not found", firewallName)
 	}
@@ -447,6 +545,9 @@ func (m *Mock) DescribeLoggingConfiguration(_ context.Context, firewallName stri
 
 // TagResource adds tags to a firewall / policy / rule group by ARN.
 func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if t := m.taggableByARN(arn); t != nil {
 		for k, v := range tags {
 			t[k] = v
@@ -459,9 +560,10 @@ func (m *Mock) TagResource(_ context.Context, arn string, tags map[string]string
 }
 
 // UntagResource removes tags from a firewall / policy / rule group by ARN.
-//
-//nolint:gocritic // keys slice matches the driver signature.
 func (m *Mock) UntagResource(_ context.Context, arn string, keys []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	t := m.taggableByARN(arn)
 	if t == nil {
 		return cerrors.Newf(cerrors.NotFound, "resource %q not found", arn)

--- a/providers/aws/networkfirewall/networkfirewall.go
+++ b/providers/aws/networkfirewall/networkfirewall.go
@@ -238,7 +238,6 @@ func cloneFirewallPolicy(p *nfdriver.FirewallPolicy) nfdriver.FirewallPolicy {
 
 // ---- Rule Groups ----
 
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateRuleGroup(_ context.Context, cfg nfdriver.CreateRuleGroupConfig) (*nfdriver.RuleGroup, error) {
 	if cfg.Name == "" {
 		return nil, cerrors.New(cerrors.InvalidArgument, "RuleGroupName is required")

--- a/providers/aws/networkfirewall/networkfirewall_test.go
+++ b/providers/aws/networkfirewall/networkfirewall_test.go
@@ -1,0 +1,91 @@
+package networkfirewall
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+)
+
+func newMock() *Mock { return New(config.NewOptions()) }
+
+func TestFirewallLifecycle(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("firewall without name: got %v, want InvalidArgument", err)
+	}
+
+	fw, err := m.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{
+		Name: "fw-1", VPCID: "vpc-1", SubnetIDs: []string{"subnet-1"}, DeleteProtection: true,
+	})
+	if err != nil || fw.ARN == "" || fw.Status != "READY" {
+		t.Fatalf("CreateFirewall: %v %+v", err, fw)
+	}
+
+	if _, err := m.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{Name: "fw-1"}); !cerrors.IsAlreadyExists(err) {
+		t.Fatalf("duplicate firewall: got %v, want AlreadyExists", err)
+	}
+
+	// Delete protection blocks deletion.
+	if _, err := m.DeleteFirewall(ctx, "fw-1", ""); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete protected firewall: got %v, want FailedPrecondition", err)
+	}
+
+	// Lookup by ARN works too.
+	got, err := m.DescribeFirewall(ctx, "", fw.ARN)
+	if err != nil || got.Name != "fw-1" {
+		t.Fatalf("DescribeFirewall by ARN: %v %+v", err, got)
+	}
+
+	list, _ := m.ListFirewalls(ctx)
+	if len(list) != 1 {
+		t.Fatalf("ListFirewalls: %+v", list)
+	}
+}
+
+func TestFirewallPolicyAndRuleGroup(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	pol, err := m.CreateFirewallPolicy(ctx, nfdriver.CreateFirewallPolicyConfig{
+		Name: "pol-1", StatelessDefaultActions: []string{"aws:forward_to_sfe"},
+	})
+	if err != nil || pol.ID == "" {
+		t.Fatalf("CreateFirewallPolicy: %v %+v", err, pol)
+	}
+
+	if _, err := m.DescribeFirewallPolicy(ctx, "pol-1", ""); err != nil {
+		t.Fatalf("DescribeFirewallPolicy: %v", err)
+	}
+
+	if _, err := m.DeleteFirewallPolicy(ctx, "pol-1", ""); err != nil {
+		t.Fatalf("DeleteFirewallPolicy: %v", err)
+	}
+
+	// Rule group: type is validated.
+	if _, err := m.CreateRuleGroup(ctx, nfdriver.CreateRuleGroupConfig{Name: "rg", Type: "BOGUS"}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("bad rule group type: got %v, want InvalidArgument", err)
+	}
+
+	rg, err := m.CreateRuleGroup(ctx, nfdriver.CreateRuleGroupConfig{Name: "rg-1", Type: "STATEFUL", Capacity: 100})
+	if err != nil {
+		t.Fatalf("CreateRuleGroup: %v", err)
+	}
+
+	got, err := m.DescribeRuleGroup(ctx, "rg-1", "", "STATEFUL")
+	if err != nil || got.Capacity != 100 {
+		t.Fatalf("DescribeRuleGroup: %v %+v", err, got)
+	}
+
+	if _, err := m.DeleteRuleGroup(ctx, rg.Name, "", "STATEFUL"); err != nil {
+		t.Fatalf("DeleteRuleGroup: %v", err)
+	}
+
+	if _, err := m.DescribeRuleGroup(ctx, "rg-1", "", "STATEFUL"); !cerrors.IsNotFound(err) {
+		t.Fatalf("describe deleted rule group: got %v, want NotFound", err)
+	}
+}

--- a/providers/aws/networkfirewall/networkfirewall_test.go
+++ b/providers/aws/networkfirewall/networkfirewall_test.go
@@ -2,6 +2,7 @@ package networkfirewall
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -94,13 +95,28 @@ func TestFirewallDepth(t *testing.T) {
 	m := newMock()
 	ctx := context.Background()
 
+	pol, err := m.CreateFirewallPolicy(ctx, nfdriver.CreateFirewallPolicyConfig{Name: "pol-dep"})
+	if err != nil {
+		t.Fatalf("CreateFirewallPolicy: %v", err)
+	}
+
 	fw, err := m.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{Name: "fw-1", SubnetIDs: []string{"subnet-1"}})
 	if err != nil {
 		t.Fatalf("CreateFirewall: %v", err)
 	}
 
-	if _, err := m.AssociateFirewallPolicy(ctx, "fw-1", "arn:policy"); err != nil {
+	// Associating a nonexistent policy is rejected.
+	if _, err := m.AssociateFirewallPolicy(ctx, "fw-1", "arn:nope"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("associate missing policy: got %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.AssociateFirewallPolicy(ctx, "fw-1", pol.ARN); err != nil {
 		t.Fatalf("AssociateFirewallPolicy: %v", err)
+	}
+
+	// The policy is now in use, so deleting it is blocked.
+	if _, err := m.DeleteFirewallPolicy(ctx, "pol-dep", ""); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete in-use policy: got %v, want FailedPrecondition", err)
 	}
 
 	assoc, err := m.AssociateSubnets(ctx, "fw-1", []string{"subnet-1", "subnet-2"})
@@ -153,4 +169,35 @@ func TestFirewallDepth(t *testing.T) {
 	if err := m.TagResource(ctx, "arn:nope", map[string]string{"a": "b"}); !cerrors.IsNotFound(err) {
 		t.Fatalf("tag unknown arn: got %v, want NotFound", err)
 	}
+}
+
+// TestFirewallConcurrentAccess exercises the mutex under the race detector:
+// concurrent logging writes + describes + tag mutations must not race or trip
+// "concurrent map writes". Run with -race for it to be meaningful.
+func TestFirewallConcurrentAccess(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	if _, err := m.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{Name: "fw-1"}); err != nil {
+		t.Fatalf("CreateFirewall: %v", err)
+	}
+
+	fw, _ := m.DescribeFirewall(ctx, "fw-1", "")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			_ = m.UpdateLoggingConfiguration(ctx, "fw-1", []string{"FLOW", "ALERT"})
+			_, _ = m.DescribeLoggingConfiguration(ctx, "fw-1")
+			_, _ = m.DescribeFirewall(ctx, "fw-1", "")
+			_ = m.TagResource(ctx, fw.ARN, map[string]string{"k": "v"})
+			_, _ = m.ListFirewalls(ctx)
+		}()
+	}
+
+	wg.Wait()
 }

--- a/providers/aws/networkfirewall/networkfirewall_test.go
+++ b/providers/aws/networkfirewall/networkfirewall_test.go
@@ -89,3 +89,68 @@ func TestFirewallPolicyAndRuleGroup(t *testing.T) {
 		t.Fatalf("describe deleted rule group: got %v, want NotFound", err)
 	}
 }
+
+func TestFirewallDepth(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	fw, err := m.CreateFirewall(ctx, nfdriver.CreateFirewallConfig{Name: "fw-1", SubnetIDs: []string{"subnet-1"}})
+	if err != nil {
+		t.Fatalf("CreateFirewall: %v", err)
+	}
+
+	if _, err := m.AssociateFirewallPolicy(ctx, "fw-1", "arn:policy"); err != nil {
+		t.Fatalf("AssociateFirewallPolicy: %v", err)
+	}
+
+	assoc, err := m.AssociateSubnets(ctx, "fw-1", []string{"subnet-1", "subnet-2"})
+	if err != nil || len(assoc.SubnetIDs) != 2 {
+		t.Fatalf("AssociateSubnets: %v %+v", err, assoc)
+	}
+
+	dis, err := m.DisassociateSubnets(ctx, "fw-1", []string{"subnet-1"})
+	if err != nil || len(dis.SubnetIDs) != 1 || dis.SubnetIDs[0] != "subnet-2" {
+		t.Fatalf("DisassociateSubnets: %v %+v", err, dis)
+	}
+
+	prot, err := m.UpdateFirewallDeleteProtection(ctx, "fw-1", true)
+	if err != nil || !prot.DeleteProtection {
+		t.Fatalf("UpdateFirewallDeleteProtection: %v %+v", err, prot)
+	}
+
+	if err := m.UpdateLoggingConfiguration(ctx, "fw-1", []string{"FLOW", "ALERT"}); err != nil {
+		t.Fatalf("UpdateLoggingConfiguration: %v", err)
+	}
+
+	logs, err := m.DescribeLoggingConfiguration(ctx, "fw-1")
+	if err != nil || len(logs) != 2 {
+		t.Fatalf("DescribeLoggingConfiguration: %v %+v", err, logs)
+	}
+
+	if err := m.TagResource(ctx, fw.ARN, map[string]string{"env": "prod"}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	got, _ := m.DescribeFirewall(ctx, "fw-1", "")
+	if got.Tags["env"] != "prod" {
+		t.Fatalf("tag not applied: %+v", got.Tags)
+	}
+
+	if err := m.UntagResource(ctx, fw.ARN, []string{"env"}); err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	got, _ = m.DescribeFirewall(ctx, "fw-1", "")
+	if _, ok := got.Tags["env"]; ok {
+		t.Fatalf("tag not removed: %+v", got.Tags)
+	}
+
+	// Unknown firewall / ARN error paths.
+	if _, err := m.AssociateFirewallPolicy(ctx, "missing", "x"); !cerrors.IsNotFound(err) {
+		t.Fatalf("associate missing firewall: got %v, want NotFound", err)
+	}
+
+	if err := m.TagResource(ctx, "arn:nope", map[string]string{"a": "b"}); !cerrors.IsNotFound(err) {
+		t.Fatalf("tag unknown arn: got %v, want NotFound", err)
+	}
+}

--- a/providers/aws/vpc/clientvpn.go
+++ b/providers/aws/vpc/clientvpn.go
@@ -101,3 +101,110 @@ func cloneClientVPNEndpoint(e *driver.ClientVPNEndpoint) driver.ClientVPNEndpoin
 
 	return out
 }
+
+// DescribeClientVPNTargetNetworks returns the target-network associations.
+func (m *Mock) DescribeClientVPNTargetNetworks(_ context.Context, endpointID string) ([]driver.ClientVPNTargetNetwork, error) {
+	if !m.clientVPNEndpoints.Has(endpointID) {
+		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
+	}
+
+	var out []driver.ClientVPNTargetNetwork
+
+	for _, a := range m.clientVPNAssocs.SortedValues() {
+		if a.EndpointID == endpointID {
+			out = append(out, *a)
+		}
+	}
+
+	return out, nil
+}
+
+// AuthorizeClientVPNIngress authorizes a client CIDR to reach a target network.
+func (m *Mock) AuthorizeClientVPNIngress(
+	_ context.Context, endpointID, targetCIDR, groupID string, accessAll bool,
+) (*driver.ClientVPNAuthorizationRule, error) {
+	if !m.clientVPNEndpoints.Has(endpointID) {
+		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
+	}
+
+	rule := &driver.ClientVPNAuthorizationRule{
+		EndpointID: endpointID, TargetCIDR: targetCIDR, GroupID: groupID,
+		AccessAll: accessAll, Status: "active",
+	}
+	m.clientVPNAuthRules.Set(endpointID+"|"+targetCIDR, rule)
+
+	out := *rule
+
+	return &out, nil
+}
+
+// RevokeClientVPNIngress revokes an authorization rule.
+func (m *Mock) RevokeClientVPNIngress(_ context.Context, endpointID, targetCIDR string) error {
+	if !m.clientVPNAuthRules.Delete(endpointID + "|" + targetCIDR) {
+		return errors.Newf(errors.NotFound, "authorization rule for %q not found", targetCIDR)
+	}
+
+	return nil
+}
+
+// DescribeClientVPNAuthorizationRules returns the endpoint's authorization rules.
+func (m *Mock) DescribeClientVPNAuthorizationRules(_ context.Context, endpointID string) ([]driver.ClientVPNAuthorizationRule, error) {
+	if !m.clientVPNEndpoints.Has(endpointID) {
+		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
+	}
+
+	var out []driver.ClientVPNAuthorizationRule
+
+	for _, rule := range m.clientVPNAuthRules.SortedValues() {
+		if rule.EndpointID == endpointID {
+			out = append(out, *rule)
+		}
+	}
+
+	return out, nil
+}
+
+// CreateClientVPNRoute adds a route to a Client VPN endpoint.
+func (m *Mock) CreateClientVPNRoute(
+	_ context.Context, endpointID, destinationCIDR, targetSubnetID string,
+) (*driver.ClientVPNRoute, error) {
+	if !m.clientVPNEndpoints.Has(endpointID) {
+		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
+	}
+
+	route := &driver.ClientVPNRoute{
+		EndpointID: endpointID, DestinationCIDR: destinationCIDR,
+		TargetSubnetID: targetSubnetID, Status: "active",
+	}
+	m.clientVPNRoutes.Set(endpointID+"|"+destinationCIDR+"|"+targetSubnetID, route)
+
+	out := *route
+
+	return &out, nil
+}
+
+// DeleteClientVPNRoute removes a route from a Client VPN endpoint.
+func (m *Mock) DeleteClientVPNRoute(_ context.Context, endpointID, destinationCIDR, targetSubnetID string) error {
+	if !m.clientVPNRoutes.Delete(endpointID + "|" + destinationCIDR + "|" + targetSubnetID) {
+		return errors.Newf(errors.NotFound, "client vpn route %q not found", destinationCIDR)
+	}
+
+	return nil
+}
+
+// DescribeClientVPNRoutes returns the endpoint's routes.
+func (m *Mock) DescribeClientVPNRoutes(_ context.Context, endpointID string) ([]driver.ClientVPNRoute, error) {
+	if !m.clientVPNEndpoints.Has(endpointID) {
+		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
+	}
+
+	var out []driver.ClientVPNRoute
+
+	for _, route := range m.clientVPNRoutes.SortedValues() {
+		if route.EndpointID == endpointID {
+			out = append(out, *route)
+		}
+	}
+
+	return out, nil
+}

--- a/providers/aws/vpc/clientvpn.go
+++ b/providers/aws/vpc/clientvpn.go
@@ -9,6 +9,8 @@ import (
 )
 
 // CreateClientVPNEndpoint creates a Client VPN endpoint.
+//
+//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateClientVPNEndpoint(_ context.Context, cfg driver.ClientVPNEndpointConfig) (*driver.ClientVPNEndpoint, error) {
 	if cfg.ClientCIDRBlock == "" {
 		return nil, errors.New(errors.InvalidArgument, "clientCidrBlock is required")
@@ -18,11 +20,16 @@ func (m *Mock) CreateClientVPNEndpoint(_ context.Context, cfg driver.ClientVPNEn
 		return nil, errors.New(errors.InvalidArgument, "serverCertificateArn is required")
 	}
 
+	if len(cfg.AuthenticationTypes) == 0 {
+		return nil, errors.New(errors.InvalidArgument, "at least one authentication option is required")
+	}
+
 	ep := &driver.ClientVPNEndpoint{
 		ID:                   idgen.GenerateID("cvpn-endpoint-"),
 		Description:          cfg.Description,
 		ClientCIDRBlock:      cfg.ClientCIDRBlock,
 		ServerCertificateARN: cfg.ServerCertificateARN,
+		AuthenticationTypes:  append([]string(nil), cfg.AuthenticationTypes...),
 		State:                "pending-associate",
 		SplitTunnel:          cfg.SplitTunnel,
 		Tags:                 copyTags(cfg.Tags),
@@ -45,6 +52,9 @@ func (m *Mock) DeleteClientVPNEndpoint(_ context.Context, id string) error {
 
 // DescribeClientVPNEndpoints returns Client VPN endpoints matching ids.
 func (m *Mock) DescribeClientVPNEndpoints(_ context.Context, ids []string) ([]driver.ClientVPNEndpoint, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.clientVPNEndpoints, ids, cloneClientVPNEndpoint), nil
 }
 
@@ -97,6 +107,7 @@ func (m *Mock) DisassociateClientVPNTargetNetwork(_ context.Context, endpointID,
 
 func cloneClientVPNEndpoint(e *driver.ClientVPNEndpoint) driver.ClientVPNEndpoint {
 	out := *e
+	out.AuthenticationTypes = append([]string(nil), e.AuthenticationTypes...)
 	out.Tags = copyTags(e.Tags)
 
 	return out
@@ -104,6 +115,9 @@ func cloneClientVPNEndpoint(e *driver.ClientVPNEndpoint) driver.ClientVPNEndpoin
 
 // DescribeClientVPNTargetNetworks returns the target-network associations.
 func (m *Mock) DescribeClientVPNTargetNetworks(_ context.Context, endpointID string) ([]driver.ClientVPNTargetNetwork, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if !m.clientVPNEndpoints.Has(endpointID) {
 		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
 	}
@@ -149,6 +163,9 @@ func (m *Mock) RevokeClientVPNIngress(_ context.Context, endpointID, targetCIDR 
 
 // DescribeClientVPNAuthorizationRules returns the endpoint's authorization rules.
 func (m *Mock) DescribeClientVPNAuthorizationRules(_ context.Context, endpointID string) ([]driver.ClientVPNAuthorizationRule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if !m.clientVPNEndpoints.Has(endpointID) {
 		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
 	}
@@ -194,6 +211,9 @@ func (m *Mock) DeleteClientVPNRoute(_ context.Context, endpointID, destinationCI
 
 // DescribeClientVPNRoutes returns the endpoint's routes.
 func (m *Mock) DescribeClientVPNRoutes(_ context.Context, endpointID string) ([]driver.ClientVPNRoute, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if !m.clientVPNEndpoints.Has(endpointID) {
 		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
 	}

--- a/providers/aws/vpc/clientvpn.go
+++ b/providers/aws/vpc/clientvpn.go
@@ -9,8 +9,6 @@ import (
 )
 
 // CreateClientVPNEndpoint creates a Client VPN endpoint.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateClientVPNEndpoint(_ context.Context, cfg driver.ClientVPNEndpointConfig) (*driver.ClientVPNEndpoint, error) {
 	if cfg.ClientCIDRBlock == "" {
 		return nil, errors.New(errors.InvalidArgument, "clientCidrBlock is required")

--- a/providers/aws/vpc/clientvpn.go
+++ b/providers/aws/vpc/clientvpn.go
@@ -1,0 +1,105 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateClientVPNEndpoint creates a Client VPN endpoint.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateClientVPNEndpoint(_ context.Context, cfg driver.ClientVPNEndpointConfig) (*driver.ClientVPNEndpoint, error) {
+	if cfg.ClientCIDRBlock == "" {
+		return nil, errors.New(errors.InvalidArgument, "clientCidrBlock is required")
+	}
+
+	if cfg.ServerCertificateARN == "" {
+		return nil, errors.New(errors.InvalidArgument, "serverCertificateArn is required")
+	}
+
+	ep := &driver.ClientVPNEndpoint{
+		ID:                   idgen.GenerateID("cvpn-endpoint-"),
+		Description:          cfg.Description,
+		ClientCIDRBlock:      cfg.ClientCIDRBlock,
+		ServerCertificateARN: cfg.ServerCertificateARN,
+		State:                "pending-associate",
+		SplitTunnel:          cfg.SplitTunnel,
+		Tags:                 copyTags(cfg.Tags),
+	}
+	m.clientVPNEndpoints.Set(ep.ID, ep)
+
+	out := cloneClientVPNEndpoint(ep)
+
+	return &out, nil
+}
+
+// DeleteClientVPNEndpoint deletes a Client VPN endpoint.
+func (m *Mock) DeleteClientVPNEndpoint(_ context.Context, id string) error {
+	if !m.clientVPNEndpoints.Delete(id) {
+		return errors.Newf(errors.NotFound, "client vpn endpoint %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeClientVPNEndpoints returns Client VPN endpoints matching ids.
+func (m *Mock) DescribeClientVPNEndpoints(_ context.Context, ids []string) ([]driver.ClientVPNEndpoint, error) {
+	return describeResources(m.clientVPNEndpoints, ids, cloneClientVPNEndpoint), nil
+}
+
+// AssociateClientVPNTargetNetwork associates a subnet with a Client VPN endpoint,
+// moving the endpoint to the available state.
+func (m *Mock) AssociateClientVPNTargetNetwork(
+	_ context.Context, endpointID, subnetID string,
+) (*driver.ClientVPNTargetNetwork, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ep, ok := m.clientVPNEndpoints.Get(endpointID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "client vpn endpoint %q not found", endpointID)
+	}
+
+	subnet, ok := m.subnets.Get(subnetID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "subnet %q not found", subnetID)
+	}
+
+	assoc := &driver.ClientVPNTargetNetwork{
+		AssociationID: idgen.GenerateID("cvpn-assoc-"),
+		EndpointID:    endpointID,
+		SubnetID:      subnetID,
+		VPCID:         subnet.VPCID,
+		State:         "associated",
+	}
+	m.clientVPNAssocs.Set(assoc.AssociationID, assoc)
+
+	ep.State = "available"
+	ep.VPCID = subnet.VPCID
+
+	out := *assoc
+
+	return &out, nil
+}
+
+// DisassociateClientVPNTargetNetwork removes a target-network association.
+func (m *Mock) DisassociateClientVPNTargetNetwork(_ context.Context, endpointID, associationID string) error {
+	assoc, ok := m.clientVPNAssocs.Get(associationID)
+	if !ok || assoc.EndpointID != endpointID {
+		return errors.Newf(errors.NotFound, "association %q not found on endpoint %q", associationID, endpointID)
+	}
+
+	m.clientVPNAssocs.Delete(associationID)
+
+	return nil
+}
+
+func cloneClientVPNEndpoint(e *driver.ClientVPNEndpoint) driver.ClientVPNEndpoint {
+	out := *e
+	out.Tags = copyTags(e.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/dhcpoptions.go
+++ b/providers/aws/vpc/dhcpoptions.go
@@ -1,0 +1,74 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateDHCPOptions creates a DHCP option set.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateDHCPOptions(_ context.Context, cfg driver.DHCPOptionsConfig) (*driver.DHCPOptions, error) {
+	opt := &driver.DHCPOptions{
+		ID:            idgen.GenerateID("dopt-"),
+		Configuration: cloneDHCPConfig(cfg.Configuration),
+		Tags:          copyTags(cfg.Tags),
+	}
+	m.dhcpOptions.Set(opt.ID, opt)
+
+	out := cloneDHCPOptions(opt)
+
+	return &out, nil
+}
+
+// DeleteDHCPOptions deletes a DHCP option set.
+func (m *Mock) DeleteDHCPOptions(_ context.Context, id string) error {
+	if !m.dhcpOptions.Delete(id) {
+		return errors.Newf(errors.NotFound, "dhcp options %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeDHCPOptions returns DHCP option sets matching ids.
+func (m *Mock) DescribeDHCPOptions(_ context.Context, ids []string) ([]driver.DHCPOptions, error) {
+	return describeResources(m.dhcpOptions, ids, cloneDHCPOptions), nil
+}
+
+// AssociateDHCPOptions associates a DHCP option set with a VPC. The special id
+// "default" resets the VPC to the default (Amazon-provided) options.
+func (m *Mock) AssociateDHCPOptions(_ context.Context, dhcpOptionsID, vpcID string) error {
+	if !m.vpcs.Has(vpcID) {
+		return errors.Newf(errors.InvalidArgument, "vpc %q not found", vpcID)
+	}
+
+	if dhcpOptionsID != "default" && !m.dhcpOptions.Has(dhcpOptionsID) {
+		return errors.Newf(errors.NotFound, "dhcp options %q not found", dhcpOptionsID)
+	}
+
+	return nil
+}
+
+func cloneDHCPConfig(in map[string][]string) map[string][]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		out[k] = append([]string(nil), v...)
+	}
+
+	return out
+}
+
+func cloneDHCPOptions(d *driver.DHCPOptions) driver.DHCPOptions {
+	out := *d
+	out.Configuration = cloneDHCPConfig(d.Configuration)
+	out.Tags = copyTags(d.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/dhcpoptions.go
+++ b/providers/aws/vpc/dhcpoptions.go
@@ -33,6 +33,9 @@ func (m *Mock) DeleteDHCPOptions(_ context.Context, id string) error {
 
 // DescribeDHCPOptions returns DHCP option sets matching ids.
 func (m *Mock) DescribeDHCPOptions(_ context.Context, ids []string) ([]driver.DHCPOptions, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.dhcpOptions, ids, cloneDHCPOptions), nil
 }
 

--- a/providers/aws/vpc/dhcpoptions.go
+++ b/providers/aws/vpc/dhcpoptions.go
@@ -9,8 +9,6 @@ import (
 )
 
 // CreateDHCPOptions creates a DHCP option set.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateDHCPOptions(_ context.Context, cfg driver.DHCPOptionsConfig) (*driver.DHCPOptions, error) {
 	opt := &driver.DHCPOptions{
 		ID:            idgen.GenerateID("dopt-"),

--- a/providers/aws/vpc/egressonlyigw.go
+++ b/providers/aws/vpc/egressonlyigw.go
@@ -41,6 +41,9 @@ func (m *Mock) DeleteEgressOnlyInternetGateway(_ context.Context, id string) err
 
 // DescribeEgressOnlyInternetGateways returns egress-only IGWs matching ids.
 func (m *Mock) DescribeEgressOnlyInternetGateways(_ context.Context, ids []string) ([]driver.EgressOnlyInternetGateway, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.egressOnlyIGWs, ids, cloneEgressOnlyIGW), nil
 }
 

--- a/providers/aws/vpc/egressonlyigw.go
+++ b/providers/aws/vpc/egressonlyigw.go
@@ -1,0 +1,52 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateEgressOnlyInternetGateway creates an egress-only internet gateway
+// (outbound-only IPv6) attached to a VPC.
+func (m *Mock) CreateEgressOnlyInternetGateway(
+	_ context.Context, vpcID string, tags map[string]string,
+) (*driver.EgressOnlyInternetGateway, error) {
+	if !m.vpcs.Has(vpcID) {
+		return nil, errors.Newf(errors.InvalidArgument, "vpc %q not found", vpcID)
+	}
+
+	eigw := &driver.EgressOnlyInternetGateway{
+		ID:            idgen.GenerateID("eigw-"),
+		AttachedVPCID: vpcID,
+		State:         "attached",
+		Tags:          copyTags(tags),
+	}
+	m.egressOnlyIGWs.Set(eigw.ID, eigw)
+
+	out := cloneEgressOnlyIGW(eigw)
+
+	return &out, nil
+}
+
+// DeleteEgressOnlyInternetGateway deletes an egress-only internet gateway.
+func (m *Mock) DeleteEgressOnlyInternetGateway(_ context.Context, id string) error {
+	if !m.egressOnlyIGWs.Delete(id) {
+		return errors.Newf(errors.NotFound, "egress-only internet gateway %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeEgressOnlyInternetGateways returns egress-only IGWs matching ids.
+func (m *Mock) DescribeEgressOnlyInternetGateways(_ context.Context, ids []string) ([]driver.EgressOnlyInternetGateway, error) {
+	return describeResources(m.egressOnlyIGWs, ids, cloneEgressOnlyIGW), nil
+}
+
+func cloneEgressOnlyIGW(e *driver.EgressOnlyInternetGateway) driver.EgressOnlyInternetGateway {
+	out := *e
+	out.Tags = copyTags(e.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/endpointservice.go
+++ b/providers/aws/vpc/endpointservice.go
@@ -57,3 +57,47 @@ func cloneEndpointService(s *driver.EndpointService) driver.EndpointService {
 
 	return out
 }
+
+// ModifyVPCEndpointServicePermissions adds/removes allowed principals on a service.
+//
+//nolint:gocritic // slices match the driver signature.
+func (m *Mock) ModifyVPCEndpointServicePermissions(
+	_ context.Context, serviceID string, addPrincipals, removePrincipals []string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.endpointServices.Has(serviceID) {
+		return errors.Newf(errors.NotFound, "endpoint service %q not found", serviceID)
+	}
+
+	remove := make(map[string]bool, len(removePrincipals))
+	for _, p := range removePrincipals {
+		remove[p] = true
+	}
+
+	current := m.endpointServicePerms[serviceID]
+	kept := current[:0:0]
+
+	for _, p := range current {
+		if !remove[p] {
+			kept = append(kept, p)
+		}
+	}
+
+	m.endpointServicePerms[serviceID] = append(kept, addPrincipals...)
+
+	return nil
+}
+
+// DescribeVPCEndpointServicePermissions returns the allowed principals.
+func (m *Mock) DescribeVPCEndpointServicePermissions(_ context.Context, serviceID string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.endpointServices.Has(serviceID) {
+		return nil, errors.Newf(errors.NotFound, "endpoint service %q not found", serviceID)
+	}
+
+	return append([]string(nil), m.endpointServicePerms[serviceID]...), nil
+}

--- a/providers/aws/vpc/endpointservice.go
+++ b/providers/aws/vpc/endpointservice.go
@@ -46,6 +46,9 @@ func (m *Mock) DeleteVPCEndpointServiceConfiguration(_ context.Context, id strin
 
 // DescribeVPCEndpointServiceConfigurations returns endpoint services matching ids.
 func (m *Mock) DescribeVPCEndpointServiceConfigurations(_ context.Context, ids []string) ([]driver.EndpointService, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.endpointServices, ids, cloneEndpointService), nil
 }
 
@@ -59,8 +62,6 @@ func cloneEndpointService(s *driver.EndpointService) driver.EndpointService {
 }
 
 // ModifyVPCEndpointServicePermissions adds/removes allowed principals on a service.
-//
-//nolint:gocritic // slices match the driver signature.
 func (m *Mock) ModifyVPCEndpointServicePermissions(
 	_ context.Context, serviceID string, addPrincipals, removePrincipals []string,
 ) error {

--- a/providers/aws/vpc/endpointservice.go
+++ b/providers/aws/vpc/endpointservice.go
@@ -11,8 +11,6 @@ import (
 
 // CreateVPCEndpointServiceConfiguration publishes a PrivateLink endpoint service
 // backed by one or more network load balancers.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateVPCEndpointServiceConfiguration(
 	_ context.Context, cfg driver.EndpointServiceConfig,
 ) (*driver.EndpointService, error) {

--- a/providers/aws/vpc/endpointservice.go
+++ b/providers/aws/vpc/endpointservice.go
@@ -1,0 +1,61 @@
+package vpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateVPCEndpointServiceConfiguration publishes a PrivateLink endpoint service
+// backed by one or more network load balancers.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateVPCEndpointServiceConfiguration(
+	_ context.Context, cfg driver.EndpointServiceConfig,
+) (*driver.EndpointService, error) {
+	if len(cfg.NetworkLoadBalancerARNs) == 0 {
+		return nil, errors.New(errors.InvalidArgument, "at least one network load balancer ARN is required")
+	}
+
+	id := idgen.GenerateID("vpce-svc-")
+	svc := &driver.EndpointService{
+		ID:                      id,
+		ServiceName:             fmt.Sprintf("com.amazonaws.vpce.%s.%s", m.opts.Region, id),
+		State:                   "Available",
+		NetworkLoadBalancerARNs: append([]string(nil), cfg.NetworkLoadBalancerARNs...),
+		AcceptanceRequired:      cfg.AcceptanceRequired,
+		AvailabilityZones:       []string{m.opts.Region + "a"},
+		Tags:                    copyTags(cfg.Tags),
+	}
+	m.endpointServices.Set(id, svc)
+
+	out := cloneEndpointService(svc)
+
+	return &out, nil
+}
+
+// DeleteVPCEndpointServiceConfiguration deletes an endpoint service.
+func (m *Mock) DeleteVPCEndpointServiceConfiguration(_ context.Context, id string) error {
+	if !m.endpointServices.Delete(id) {
+		return errors.Newf(errors.NotFound, "endpoint service %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeVPCEndpointServiceConfigurations returns endpoint services matching ids.
+func (m *Mock) DescribeVPCEndpointServiceConfigurations(_ context.Context, ids []string) ([]driver.EndpointService, error) {
+	return describeResources(m.endpointServices, ids, cloneEndpointService), nil
+}
+
+func cloneEndpointService(s *driver.EndpointService) driver.EndpointService {
+	out := *s
+	out.NetworkLoadBalancerARNs = append([]string(nil), s.NetworkLoadBalancerARNs...)
+	out.AvailabilityZones = append([]string(nil), s.AvailabilityZones...)
+	out.Tags = copyTags(s.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -136,6 +136,31 @@ func TestVPNLifecycle(t *testing.T) {
 		t.Fatalf("vpn connection without gateway: got %v, want InvalidArgument", err)
 	}
 
+	// Static route depth.
+	if err := m.CreateVPNConnectionRoute(ctx, vpn.ID, "192.168.0.0/16"); err != nil {
+		t.Fatalf("CreateVPNConnectionRoute: %v", err)
+	}
+
+	// Duplicate route is a no-op.
+	if err := m.CreateVPNConnectionRoute(ctx, vpn.ID, "192.168.0.0/16"); err != nil {
+		t.Fatalf("CreateVPNConnectionRoute dup: %v", err)
+	}
+
+	gotVPN, _ := m.DescribeVPNConnections(ctx, []string{vpn.ID})
+	if len(gotVPN) != 1 || len(gotVPN[0].Routes) != 1 {
+		t.Fatalf("vpn routes wrong: %+v", gotVPN)
+	}
+
+	// Re-target to a transit gateway clears the vpn gateway.
+	mod, err := m.ModifyVPNConnection(ctx, vpn.ID, "tgw-1", "")
+	if err != nil || mod.TransitGatewayID != "tgw-1" || mod.VPNGatewayID != "" {
+		t.Fatalf("ModifyVPNConnection: %v %+v", err, mod)
+	}
+
+	if err := m.DeleteVPNConnectionRoute(ctx, vpn.ID, "192.168.0.0/16"); err != nil {
+		t.Fatalf("DeleteVPNConnectionRoute: %v", err)
+	}
+
 	if err := m.DetachVPNGateway(ctx, vgw.ID, vpcID); err != nil {
 		t.Fatalf("DetachVPNGateway: %v", err)
 	}
@@ -183,6 +208,18 @@ func TestDHCPPrefixEgressEndpointClientVPN(t *testing.T) {
 		t.Fatalf("prefix list entries: %+v", entries)
 	}
 
+	// Modify: swap the entry, version bumps.
+	mod, err := m.ModifyManagedPrefixList(ctx, pl.ID,
+		[]driver.PrefixListEntry{{CIDR: "172.16.0.0/12"}}, []string{"10.0.0.0/8"})
+	if err != nil || mod.Version != 2 {
+		t.Fatalf("ModifyManagedPrefixList: %v %+v", err, mod)
+	}
+
+	entries2, _ := m.GetManagedPrefixListEntries(ctx, pl.ID)
+	if len(entries2) != 1 || entries2[0].CIDR != "172.16.0.0/12" {
+		t.Fatalf("prefix list after modify: %+v", entries2)
+	}
+
 	// Egress-only IGW.
 	if _, err := m.CreateEgressOnlyInternetGateway(ctx, "vpc-nope", nil); !cerrors.IsInvalidArgument(err) {
 		t.Fatalf("egress-only under missing vpc: got %v, want InvalidArgument", err)
@@ -205,6 +242,27 @@ func TestDHCPPrefixEgressEndpointClientVPN(t *testing.T) {
 		t.Fatalf("CreateVPCEndpointServiceConfiguration: %v %+v", err, svc)
 	}
 
+	// Endpoint-service permissions: add then remove.
+	if err := m.ModifyVPCEndpointServicePermissions(ctx, svc.ID,
+		[]string{"arn:aws:iam::111122223333:root", "arn:aws:iam::444455556666:root"}, nil); err != nil {
+		t.Fatalf("ModifyVPCEndpointServicePermissions add: %v", err)
+	}
+
+	perms, _ := m.DescribeVPCEndpointServicePermissions(ctx, svc.ID)
+	if len(perms) != 2 {
+		t.Fatalf("endpoint service perms after add: %+v", perms)
+	}
+
+	if err := m.ModifyVPCEndpointServicePermissions(ctx, svc.ID,
+		nil, []string{"arn:aws:iam::444455556666:root"}); err != nil {
+		t.Fatalf("ModifyVPCEndpointServicePermissions remove: %v", err)
+	}
+
+	perms, _ = m.DescribeVPCEndpointServicePermissions(ctx, svc.ID)
+	if len(perms) != 1 || perms[0] != "arn:aws:iam::111122223333:root" {
+		t.Fatalf("endpoint service perms after remove: %+v", perms)
+	}
+
 	// Client VPN.
 	ep, err := m.CreateClientVPNEndpoint(ctx, driver.ClientVPNEndpointConfig{
 		ClientCIDRBlock: "10.100.0.0/16", ServerCertificateARN: "arn:aws:acm:us-east-1:0:certificate/abc",
@@ -221,6 +279,43 @@ func TestDHCPPrefixEgressEndpointClientVPN(t *testing.T) {
 	got, _ := m.DescribeClientVPNEndpoints(ctx, []string{ep.ID})
 	if len(got) != 1 || got[0].State != "available" {
 		t.Fatalf("client vpn not available after associate: %+v", got)
+	}
+
+	nets, err := m.DescribeClientVPNTargetNetworks(ctx, ep.ID)
+	if err != nil || len(nets) != 1 {
+		t.Fatalf("DescribeClientVPNTargetNetworks: %v %+v", err, nets)
+	}
+
+	// Authorization rules.
+	if _, err := m.AuthorizeClientVPNIngress(ctx, ep.ID, "10.0.0.0/16", "", true); err != nil {
+		t.Fatalf("AuthorizeClientVPNIngress: %v", err)
+	}
+
+	rules, _ := m.DescribeClientVPNAuthorizationRules(ctx, ep.ID)
+	if len(rules) != 1 || rules[0].TargetCIDR != "10.0.0.0/16" {
+		t.Fatalf("auth rules: %+v", rules)
+	}
+
+	if err := m.RevokeClientVPNIngress(ctx, ep.ID, "10.0.0.0/16"); err != nil {
+		t.Fatalf("RevokeClientVPNIngress: %v", err)
+	}
+
+	if rules, _ := m.DescribeClientVPNAuthorizationRules(ctx, ep.ID); len(rules) != 0 {
+		t.Fatalf("auth rule survived revoke: %+v", rules)
+	}
+
+	// Routes.
+	if _, err := m.CreateClientVPNRoute(ctx, ep.ID, "0.0.0.0/0", subnetID); err != nil {
+		t.Fatalf("CreateClientVPNRoute: %v", err)
+	}
+
+	routes, _ := m.DescribeClientVPNRoutes(ctx, ep.ID)
+	if len(routes) != 1 || routes[0].DestinationCIDR != "0.0.0.0/0" {
+		t.Fatalf("client vpn routes: %+v", routes)
+	}
+
+	if err := m.DeleteClientVPNRoute(ctx, ep.ID, "0.0.0.0/0", subnetID); err != nil {
+		t.Fatalf("DeleteClientVPNRoute: %v", err)
 	}
 
 	if err := m.DisassociateClientVPNTargetNetwork(ctx, ep.ID, assoc.AssociationID); err != nil {

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -1,0 +1,202 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func newMock() *Mock { return New(config.NewOptions()) }
+
+func mustVPC(t *testing.T, m *Mock) (vpcID, subnetID string) {
+	t.Helper()
+
+	ctx := context.Background()
+
+	v, err := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	if err != nil {
+		t.Fatalf("CreateVPC: %v", err)
+	}
+
+	s, err := m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.1.0/24"})
+	if err != nil {
+		t.Fatalf("CreateSubnet: %v", err)
+	}
+
+	return v.ID, s.ID
+}
+
+func TestTransitGatewayLifecycle(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+	vpcID, subnetID := mustVPC(t, m)
+
+	tgw, err := m.CreateTransitGateway(ctx, driver.TransitGatewayConfig{Description: "hub"})
+	if err != nil || tgw.ASN != defaultAmazonSideASN {
+		t.Fatalf("CreateTransitGateway: %v %+v", err, tgw)
+	}
+
+	att, err := m.CreateTransitGatewayVPCAttachment(ctx, driver.TransitGatewayVPCAttachmentConfig{
+		TransitGatewayID: tgw.ID, VPCID: vpcID, SubnetIDs: []string{subnetID},
+	})
+	if err != nil || att.VPCID != vpcID {
+		t.Fatalf("CreateTransitGatewayVPCAttachment: %v %+v", err, att)
+	}
+
+	// Attachment to a missing transit gateway is rejected.
+	if _, err := m.CreateTransitGatewayVPCAttachment(ctx, driver.TransitGatewayVPCAttachmentConfig{
+		TransitGatewayID: "tgw-nope", VPCID: vpcID,
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("attach to missing tgw: got %v, want InvalidArgument", err)
+	}
+
+	rt, err := m.CreateTransitGatewayRouteTable(ctx, tgw.ID, nil)
+	if err != nil {
+		t.Fatalf("CreateTransitGatewayRouteTable: %v", err)
+	}
+
+	if _, err := m.DeleteTransitGatewayRouteTable(ctx, rt.ID); err != nil {
+		t.Fatalf("DeleteTransitGatewayRouteTable: %v", err)
+	}
+
+	if _, err := m.DeleteTransitGateway(ctx, tgw.ID); err != nil {
+		t.Fatalf("DeleteTransitGateway: %v", err)
+	}
+
+	if got, _ := m.DescribeTransitGateways(ctx, nil); len(got) != 0 {
+		t.Fatalf("transit gateway survived delete: %+v", got)
+	}
+}
+
+func TestVPNLifecycle(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+	vpcID, _ := mustVPC(t, m)
+
+	if _, err := m.CreateCustomerGateway(ctx, driver.CustomerGatewayConfig{}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("customer gateway without IP: got %v, want InvalidArgument", err)
+	}
+
+	cgw, err := m.CreateCustomerGateway(ctx, driver.CustomerGatewayConfig{IPAddress: "203.0.113.10", BGPASN: 65000})
+	if err != nil || cgw.Type != "ipsec.1" {
+		t.Fatalf("CreateCustomerGateway: %v %+v", err, cgw)
+	}
+
+	vgw, err := m.CreateVPNGateway(ctx, driver.VPNGatewayConfig{})
+	if err != nil {
+		t.Fatalf("CreateVPNGateway: %v", err)
+	}
+
+	if _, err := m.AttachVPNGateway(ctx, vgw.ID, vpcID); err != nil {
+		t.Fatalf("AttachVPNGateway: %v", err)
+	}
+
+	got, _ := m.DescribeVPNGateways(ctx, []string{vgw.ID})
+	if len(got) != 1 || got[0].AttachedVPCID != vpcID {
+		t.Fatalf("attached vgw wrong: %+v", got)
+	}
+
+	vpn, err := m.CreateVPNConnection(ctx, driver.VPNConnectionConfig{CustomerGatewayID: cgw.ID, VPNGatewayID: vgw.ID})
+	if err != nil {
+		t.Fatalf("CreateVPNConnection: %v", err)
+	}
+
+	// A connection with neither gateway is rejected.
+	if _, err := m.CreateVPNConnection(ctx, driver.VPNConnectionConfig{CustomerGatewayID: cgw.ID}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("vpn connection without gateway: got %v, want InvalidArgument", err)
+	}
+
+	if err := m.DetachVPNGateway(ctx, vgw.ID, vpcID); err != nil {
+		t.Fatalf("DetachVPNGateway: %v", err)
+	}
+
+	if err := m.DeleteVPNConnection(ctx, vpn.ID); err != nil {
+		t.Fatalf("DeleteVPNConnection: %v", err)
+	}
+}
+
+func TestDHCPPrefixEgressEndpointClientVPN(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+	vpcID, subnetID := mustVPC(t, m)
+
+	// DHCP options.
+	opt, err := m.CreateDHCPOptions(ctx, driver.DHCPOptionsConfig{
+		Configuration: map[string][]string{"domain-name-servers": {"10.0.0.2"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDHCPOptions: %v", err)
+	}
+
+	if err := m.AssociateDHCPOptions(ctx, opt.ID, vpcID); err != nil {
+		t.Fatalf("AssociateDHCPOptions: %v", err)
+	}
+
+	if err := m.AssociateDHCPOptions(ctx, "default", vpcID); err != nil {
+		t.Fatalf("AssociateDHCPOptions default: %v", err)
+	}
+
+	// Prefix list.
+	if _, err := m.CreateManagedPrefixList(ctx, driver.PrefixListConfig{Name: "x"}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("prefix list without maxEntries: got %v, want InvalidArgument", err)
+	}
+
+	pl, err := m.CreateManagedPrefixList(ctx, driver.PrefixListConfig{
+		Name: "corp", MaxEntries: 10, Entries: []driver.PrefixListEntry{{CIDR: "10.0.0.0/8"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedPrefixList: %v", err)
+	}
+
+	entries, _ := m.GetManagedPrefixListEntries(ctx, pl.ID)
+	if len(entries) != 1 {
+		t.Fatalf("prefix list entries: %+v", entries)
+	}
+
+	// Egress-only IGW.
+	if _, err := m.CreateEgressOnlyInternetGateway(ctx, "vpc-nope", nil); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("egress-only under missing vpc: got %v, want InvalidArgument", err)
+	}
+
+	eigw, err := m.CreateEgressOnlyInternetGateway(ctx, vpcID, nil)
+	if err != nil || eigw.AttachedVPCID != vpcID {
+		t.Fatalf("CreateEgressOnlyInternetGateway: %v %+v", err, eigw)
+	}
+
+	// Endpoint service.
+	if _, err := m.CreateVPCEndpointServiceConfiguration(ctx, driver.EndpointServiceConfig{}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("endpoint service without NLB: got %v, want InvalidArgument", err)
+	}
+
+	svc, err := m.CreateVPCEndpointServiceConfiguration(ctx, driver.EndpointServiceConfig{
+		NetworkLoadBalancerARNs: []string{"arn:aws:elasticloadbalancing:us-east-1:0:loadbalancer/net/x/1"},
+	})
+	if err != nil || svc.ServiceName == "" {
+		t.Fatalf("CreateVPCEndpointServiceConfiguration: %v %+v", err, svc)
+	}
+
+	// Client VPN.
+	ep, err := m.CreateClientVPNEndpoint(ctx, driver.ClientVPNEndpointConfig{
+		ClientCIDRBlock: "10.100.0.0/16", ServerCertificateARN: "arn:aws:acm:us-east-1:0:certificate/abc",
+	})
+	if err != nil || ep.State != "pending-associate" {
+		t.Fatalf("CreateClientVPNEndpoint: %v %+v", err, ep)
+	}
+
+	assoc, err := m.AssociateClientVPNTargetNetwork(ctx, ep.ID, subnetID)
+	if err != nil {
+		t.Fatalf("AssociateClientVPNTargetNetwork: %v", err)
+	}
+
+	got, _ := m.DescribeClientVPNEndpoints(ctx, []string{ep.ID})
+	if len(got) != 1 || got[0].State != "available" {
+		t.Fatalf("client vpn not available after associate: %+v", got)
+	}
+
+	if err := m.DisassociateClientVPNTargetNetwork(ctx, ep.ID, assoc.AssociationID); err != nil {
+		t.Fatalf("DisassociateClientVPNTargetNetwork: %v", err)
+	}
+}

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/config"
@@ -89,6 +90,15 @@ func TestTransitGatewayLifecycle(t *testing.T) {
 		t.Fatalf("DeleteTransitGatewayRouteTable: %v", err)
 	}
 
+	// A transit gateway with a live attachment cannot be deleted.
+	if _, err := m.DeleteTransitGateway(ctx, tgw.ID); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete in-use tgw: got %v, want FailedPrecondition", err)
+	}
+
+	if _, err := m.DeleteTransitGatewayVPCAttachment(ctx, att.ID); err != nil {
+		t.Fatalf("DeleteTransitGatewayVPCAttachment: %v", err)
+	}
+
 	if _, err := m.DeleteTransitGateway(ctx, tgw.ID); err != nil {
 		t.Fatalf("DeleteTransitGateway: %v", err)
 	}
@@ -152,8 +162,18 @@ func TestVPNLifecycle(t *testing.T) {
 	}
 
 	// Re-target to a transit gateway clears the vpn gateway.
-	mod, err := m.ModifyVPNConnection(ctx, vpn.ID, "tgw-1", "")
-	if err != nil || mod.TransitGatewayID != "tgw-1" || mod.VPNGatewayID != "" {
+	tgw, err := m.CreateTransitGateway(ctx, driver.TransitGatewayConfig{})
+	if err != nil {
+		t.Fatalf("CreateTransitGateway: %v", err)
+	}
+
+	// Modify rejects a nonexistent gateway.
+	if _, err := m.ModifyVPNConnection(ctx, vpn.ID, "tgw-nope", ""); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("modify to missing tgw: got %v, want InvalidArgument", err)
+	}
+
+	mod, err := m.ModifyVPNConnection(ctx, vpn.ID, tgw.ID, "")
+	if err != nil || mod.TransitGatewayID != tgw.ID || mod.VPNGatewayID != "" {
 		t.Fatalf("ModifyVPNConnection: %v %+v", err, mod)
 	}
 
@@ -167,6 +187,28 @@ func TestVPNLifecycle(t *testing.T) {
 
 	if err := m.DeleteVPNConnection(ctx, vpn.ID); err != nil {
 		t.Fatalf("DeleteVPNConnection: %v", err)
+	}
+
+	// Delete the gateways and confirm the read-back is empty.
+	if err := m.DeleteVPNGateway(ctx, vgw.ID); err != nil {
+		t.Fatalf("DeleteVPNGateway: %v", err)
+	}
+
+	if err := m.DeleteCustomerGateway(ctx, cgw.ID); err != nil {
+		t.Fatalf("DeleteCustomerGateway: %v", err)
+	}
+
+	if got, _ := m.DescribeCustomerGateways(ctx, nil); len(got) != 0 {
+		t.Fatalf("customer gateway survived delete: %+v", got)
+	}
+
+	if got, _ := m.DescribeVPNGateways(ctx, nil); len(got) != 0 {
+		t.Fatalf("vpn gateway survived delete: %+v", got)
+	}
+
+	// Deleting a missing connection is a NotFound.
+	if err := m.DeleteVPNConnection(ctx, "vpn-nope"); !cerrors.IsNotFound(err) {
+		t.Fatalf("delete missing vpn: got %v, want NotFound", err)
 	}
 }
 
@@ -263,9 +305,16 @@ func TestDHCPPrefixEgressEndpointClientVPN(t *testing.T) {
 		t.Fatalf("endpoint service perms after remove: %+v", perms)
 	}
 
-	// Client VPN.
+	// Client VPN. Authentication options are required.
+	if _, err := m.CreateClientVPNEndpoint(ctx, driver.ClientVPNEndpointConfig{
+		ClientCIDRBlock: "10.100.0.0/16", ServerCertificateARN: "arn:aws:acm:us-east-1:0:certificate/abc",
+	}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("client vpn without auth: got %v, want InvalidArgument", err)
+	}
+
 	ep, err := m.CreateClientVPNEndpoint(ctx, driver.ClientVPNEndpointConfig{
 		ClientCIDRBlock: "10.100.0.0/16", ServerCertificateARN: "arn:aws:acm:us-east-1:0:certificate/abc",
+		AuthenticationTypes: []string{"certificate-authentication"},
 	})
 	if err != nil || ep.State != "pending-associate" {
 		t.Fatalf("CreateClientVPNEndpoint: %v %+v", err, ep)
@@ -321,4 +370,67 @@ func TestDHCPPrefixEgressEndpointClientVPN(t *testing.T) {
 	if err := m.DisassociateClientVPNTargetNetwork(ctx, ep.ID, assoc.AssociationID); err != nil {
 		t.Fatalf("DisassociateClientVPNTargetNetwork: %v", err)
 	}
+
+	// Delete the remaining resources and confirm the read-back halves.
+	if _, err := m.DeleteManagedPrefixList(ctx, pl.ID); err != nil {
+		t.Fatalf("DeleteManagedPrefixList: %v", err)
+	}
+
+	if got, _ := m.DescribeManagedPrefixLists(ctx, nil); len(got) != 0 {
+		t.Fatalf("prefix list survived delete: %+v", got)
+	}
+
+	if err := m.DeleteEgressOnlyInternetGateway(ctx, eigw.ID); err != nil {
+		t.Fatalf("DeleteEgressOnlyInternetGateway: %v", err)
+	}
+
+	if err := m.DeleteVPCEndpointServiceConfiguration(ctx, svc.ID); err != nil {
+		t.Fatalf("DeleteVPCEndpointServiceConfiguration: %v", err)
+	}
+
+	if got, _ := m.DescribeVPCEndpointServiceConfigurations(ctx, nil); len(got) != 0 {
+		t.Fatalf("endpoint service survived delete: %+v", got)
+	}
+
+	if err := m.DeleteClientVPNEndpoint(ctx, ep.ID); err != nil {
+		t.Fatalf("DeleteClientVPNEndpoint: %v", err)
+	}
+
+	if got, _ := m.DescribeClientVPNEndpoints(ctx, nil); len(got) != 0 {
+		t.Fatalf("client vpn endpoint survived delete: %+v", got)
+	}
+}
+
+// TestNetworkingConcurrentReadWrite exercises the reader RLock vs mutator Lock
+// discipline under the race detector: an in-place VPN-gateway mutation
+// (Attach/Detach) must not race a concurrent Describe. Meaningful with -race.
+func TestNetworkingConcurrentReadWrite(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+	vpcID, _ := mustVPC(t, m)
+
+	vgw, err := m.CreateVPNGateway(ctx, driver.VPNGatewayConfig{})
+	if err != nil {
+		t.Fatalf("CreateVPNGateway: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.AttachVPNGateway(ctx, vgw.ID, vpcID)
+			_ = m.DetachVPNGateway(ctx, vgw.ID, vpcID)
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.DescribeVPNGateways(ctx, []string{vgw.ID})
+		}()
+	}
+
+	wg.Wait()
 }

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -58,6 +58,33 @@ func TestTransitGatewayLifecycle(t *testing.T) {
 		t.Fatalf("CreateTransitGatewayRouteTable: %v", err)
 	}
 
+	// Routing depth: associate, add a route, search.
+	if _, err := m.AssociateTransitGatewayRouteTable(ctx, rt.ID, att.ID); err != nil {
+		t.Fatalf("AssociateTransitGatewayRouteTable: %v", err)
+	}
+
+	if _, err := m.CreateTransitGatewayRoute(ctx, rt.ID, "10.9.0.0/16", att.ID); err != nil {
+		t.Fatalf("CreateTransitGatewayRoute: %v", err)
+	}
+
+	routes, err := m.SearchTransitGatewayRoutes(ctx, rt.ID)
+	if err != nil || len(routes) != 1 || routes[0].DestinationCIDR != "10.9.0.0/16" {
+		t.Fatalf("SearchTransitGatewayRoutes: %v %+v", err, routes)
+	}
+
+	if err := m.EnableTransitGatewayRouteTablePropagation(ctx, rt.ID, att.ID); err != nil {
+		t.Fatalf("EnableTransitGatewayRouteTablePropagation: %v", err)
+	}
+
+	if _, err := m.DeleteTransitGatewayRoute(ctx, rt.ID, "10.9.0.0/16"); err != nil {
+		t.Fatalf("DeleteTransitGatewayRoute: %v", err)
+	}
+
+	// A route in a missing route table is rejected.
+	if _, err := m.CreateTransitGatewayRoute(ctx, "tgw-rtb-nope", "10.0.0.0/8", att.ID); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("route in missing table: got %v, want InvalidArgument", err)
+	}
+
 	if _, err := m.DeleteTransitGatewayRouteTable(ctx, rt.ID); err != nil {
 		t.Fatalf("DeleteTransitGatewayRouteTable: %v", err)
 	}

--- a/providers/aws/vpc/prefixlist.go
+++ b/providers/aws/vpc/prefixlist.go
@@ -18,6 +18,11 @@ func (m *Mock) CreateManagedPrefixList(_ context.Context, cfg driver.PrefixListC
 		return nil, errors.New(errors.InvalidArgument, "maxEntries must be greater than zero")
 	}
 
+	if len(cfg.Entries) > cfg.MaxEntries {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"prefix list has %d entries, exceeding maxEntries %d", len(cfg.Entries), cfg.MaxEntries)
+	}
+
 	pl := &driver.PrefixList{
 		ID:            idgen.GenerateID("pl-"),
 		Name:          cfg.Name,
@@ -37,6 +42,9 @@ func (m *Mock) CreateManagedPrefixList(_ context.Context, cfg driver.PrefixListC
 
 // DeleteManagedPrefixList deletes a managed prefix list.
 func (m *Mock) DeleteManagedPrefixList(_ context.Context, id string) (*driver.PrefixList, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	pl, ok := m.prefixLists.Get(id)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "prefix list %q not found", id)
@@ -53,11 +61,17 @@ func (m *Mock) DeleteManagedPrefixList(_ context.Context, id string) (*driver.Pr
 
 // DescribeManagedPrefixLists returns prefix lists matching ids.
 func (m *Mock) DescribeManagedPrefixLists(_ context.Context, ids []string) ([]driver.PrefixList, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.prefixLists, ids, clonePrefixList), nil
 }
 
 // GetManagedPrefixListEntries returns the entries of a prefix list.
 func (m *Mock) GetManagedPrefixListEntries(_ context.Context, id string) ([]driver.PrefixListEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	pl, ok := m.prefixLists.Get(id)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "prefix list %q not found", id)
@@ -109,7 +123,13 @@ func (m *Mock) ModifyManagedPrefixList(
 		}
 	}
 
-	pl.Entries = append(kept, addEntries...)
+	updated := append(kept, addEntries...)
+	if len(updated) > pl.MaxEntries {
+		return nil, errors.Newf(errors.InvalidArgument,
+			"prefix list would have %d entries, exceeding maxEntries %d", len(updated), pl.MaxEntries)
+	}
+
+	pl.Entries = updated
 	pl.Version++
 	m.prefixLists.Set(id, pl)
 

--- a/providers/aws/vpc/prefixlist.go
+++ b/providers/aws/vpc/prefixlist.go
@@ -1,0 +1,84 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateManagedPrefixList creates a customer-managed prefix list.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateManagedPrefixList(_ context.Context, cfg driver.PrefixListConfig) (*driver.PrefixList, error) {
+	if cfg.Name == "" {
+		return nil, errors.New(errors.InvalidArgument, "prefix list name is required")
+	}
+
+	if cfg.MaxEntries <= 0 {
+		return nil, errors.New(errors.InvalidArgument, "maxEntries must be greater than zero")
+	}
+
+	pl := &driver.PrefixList{
+		ID:            idgen.GenerateID("pl-"),
+		Name:          cfg.Name,
+		AddressFamily: orDefaultStr(cfg.AddressFamily, "IPv4"),
+		MaxEntries:    cfg.MaxEntries,
+		State:         "create-complete",
+		Version:       1,
+		Entries:       cloneEntries(cfg.Entries),
+		Tags:          copyTags(cfg.Tags),
+	}
+	m.prefixLists.Set(pl.ID, pl)
+
+	out := clonePrefixList(pl)
+
+	return &out, nil
+}
+
+// DeleteManagedPrefixList deletes a managed prefix list.
+func (m *Mock) DeleteManagedPrefixList(_ context.Context, id string) (*driver.PrefixList, error) {
+	pl, ok := m.prefixLists.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "prefix list %q not found", id)
+	}
+
+	pl.State = "delete-complete"
+	m.prefixLists.Delete(id)
+
+	out := clonePrefixList(pl)
+
+	return &out, nil
+}
+
+// DescribeManagedPrefixLists returns prefix lists matching ids.
+func (m *Mock) DescribeManagedPrefixLists(_ context.Context, ids []string) ([]driver.PrefixList, error) {
+	return describeResources(m.prefixLists, ids, clonePrefixList), nil
+}
+
+// GetManagedPrefixListEntries returns the entries of a prefix list.
+func (m *Mock) GetManagedPrefixListEntries(_ context.Context, id string) ([]driver.PrefixListEntry, error) {
+	pl, ok := m.prefixLists.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "prefix list %q not found", id)
+	}
+
+	return cloneEntries(pl.Entries), nil
+}
+
+func cloneEntries(in []driver.PrefixListEntry) []driver.PrefixListEntry {
+	if len(in) == 0 {
+		return nil
+	}
+
+	return append([]driver.PrefixListEntry(nil), in...)
+}
+
+func clonePrefixList(p *driver.PrefixList) driver.PrefixList {
+	out := *p
+	out.Entries = cloneEntries(p.Entries)
+	out.Tags = copyTags(p.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/prefixlist.go
+++ b/providers/aws/vpc/prefixlist.go
@@ -9,8 +9,6 @@ import (
 )
 
 // CreateManagedPrefixList creates a customer-managed prefix list.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateManagedPrefixList(_ context.Context, cfg driver.PrefixListConfig) (*driver.PrefixList, error) {
 	if cfg.Name == "" {
 		return nil, errors.New(errors.InvalidArgument, "prefix list name is required")
@@ -45,6 +43,7 @@ func (m *Mock) DeleteManagedPrefixList(_ context.Context, id string) (*driver.Pr
 	}
 
 	pl.State = "delete-complete"
+
 	m.prefixLists.Delete(id)
 
 	out := clonePrefixList(pl)

--- a/providers/aws/vpc/prefixlist.go
+++ b/providers/aws/vpc/prefixlist.go
@@ -81,3 +81,39 @@ func clonePrefixList(p *driver.PrefixList) driver.PrefixList {
 
 	return out
 }
+
+// ModifyManagedPrefixList adds and/or removes entries, bumping the version.
+//
+//nolint:gocritic // slices match the driver signature.
+func (m *Mock) ModifyManagedPrefixList(
+	_ context.Context, id string, addEntries []driver.PrefixListEntry, removeCIDRs []string,
+) (*driver.PrefixList, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pl, ok := m.prefixLists.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "prefix list %q not found", id)
+	}
+
+	remove := make(map[string]bool, len(removeCIDRs))
+	for _, c := range removeCIDRs {
+		remove[c] = true
+	}
+
+	kept := pl.Entries[:0:0]
+
+	for _, e := range pl.Entries {
+		if !remove[e.CIDR] {
+			kept = append(kept, e)
+		}
+	}
+
+	pl.Entries = append(kept, addEntries...)
+	pl.Version++
+	m.prefixLists.Set(id, pl)
+
+	out := clonePrefixList(pl)
+
+	return &out, nil
+}

--- a/providers/aws/vpc/transitgateway.go
+++ b/providers/aws/vpc/transitgateway.go
@@ -1,0 +1,167 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const defaultAmazonSideASN = 64512
+
+// CreateTransitGateway creates a transit gateway.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateTransitGateway(_ context.Context, cfg driver.TransitGatewayConfig) (*driver.TransitGateway, error) {
+	asn := cfg.ASN
+	if asn == 0 {
+		asn = defaultAmazonSideASN
+	}
+
+	tgw := &driver.TransitGateway{
+		ID:          idgen.GenerateID("tgw-"),
+		State:       "available",
+		ASN:         asn,
+		Description: cfg.Description,
+		OwnerID:     m.opts.AccountID,
+		Tags:        copyTags(cfg.Tags),
+	}
+	m.transitGateways.Set(tgw.ID, tgw)
+
+	out := cloneTGW(tgw)
+
+	return &out, nil
+}
+
+// DeleteTransitGateway deletes a transit gateway.
+func (m *Mock) DeleteTransitGateway(_ context.Context, id string) (*driver.TransitGateway, error) {
+	tgw, ok := m.transitGateways.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "transit gateway %q not found", id)
+	}
+
+	tgw.State = "deleted"
+	m.transitGateways.Delete(id)
+
+	out := cloneTGW(tgw)
+
+	return &out, nil
+}
+
+// DescribeTransitGateways returns transit gateways matching ids (all if empty).
+func (m *Mock) DescribeTransitGateways(_ context.Context, ids []string) ([]driver.TransitGateway, error) {
+	return describeResources(m.transitGateways, ids, cloneTGW), nil
+}
+
+// CreateTransitGatewayVPCAttachment attaches a VPC to a transit gateway.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateTransitGatewayVPCAttachment(
+	_ context.Context, cfg driver.TransitGatewayVPCAttachmentConfig,
+) (*driver.TransitGatewayVPCAttachment, error) {
+	if !m.transitGateways.Has(cfg.TransitGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway %q not found", cfg.TransitGatewayID)
+	}
+
+	if !m.vpcs.Has(cfg.VPCID) {
+		return nil, errors.Newf(errors.InvalidArgument, "vpc %q not found", cfg.VPCID)
+	}
+
+	att := &driver.TransitGatewayVPCAttachment{
+		ID:               idgen.GenerateID("tgw-attach-"),
+		TransitGatewayID: cfg.TransitGatewayID,
+		VPCID:            cfg.VPCID,
+		SubnetIDs:        append([]string(nil), cfg.SubnetIDs...),
+		State:            "available",
+		Tags:             copyTags(cfg.Tags),
+	}
+	m.tgwAttachments.Set(att.ID, att)
+
+	out := cloneTGWAttachment(att)
+
+	return &out, nil
+}
+
+// DeleteTransitGatewayVPCAttachment deletes a transit gateway VPC attachment.
+func (m *Mock) DeleteTransitGatewayVPCAttachment(_ context.Context, id string) (*driver.TransitGatewayVPCAttachment, error) {
+	att, ok := m.tgwAttachments.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "transit gateway attachment %q not found", id)
+	}
+
+	att.State = "deleted"
+	m.tgwAttachments.Delete(id)
+
+	out := cloneTGWAttachment(att)
+
+	return &out, nil
+}
+
+// DescribeTransitGatewayVPCAttachments returns attachments matching ids.
+func (m *Mock) DescribeTransitGatewayVPCAttachments(_ context.Context, ids []string) ([]driver.TransitGatewayVPCAttachment, error) {
+	return describeResources(m.tgwAttachments, ids, cloneTGWAttachment), nil
+}
+
+// CreateTransitGatewayRouteTable creates a route table on a transit gateway.
+func (m *Mock) CreateTransitGatewayRouteTable(
+	_ context.Context, transitGatewayID string, tags map[string]string,
+) (*driver.TransitGatewayRouteTable, error) {
+	if !m.transitGateways.Has(transitGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway %q not found", transitGatewayID)
+	}
+
+	rt := &driver.TransitGatewayRouteTable{
+		ID:               idgen.GenerateID("tgw-rtb-"),
+		TransitGatewayID: transitGatewayID,
+		State:            "available",
+		Tags:             copyTags(tags),
+	}
+	m.tgwRouteTables.Set(rt.ID, rt)
+
+	out := cloneTGWRouteTable(rt)
+
+	return &out, nil
+}
+
+// DeleteTransitGatewayRouteTable deletes a transit gateway route table.
+func (m *Mock) DeleteTransitGatewayRouteTable(_ context.Context, id string) (*driver.TransitGatewayRouteTable, error) {
+	rt, ok := m.tgwRouteTables.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "transit gateway route table %q not found", id)
+	}
+
+	rt.State = "deleted"
+	m.tgwRouteTables.Delete(id)
+
+	out := cloneTGWRouteTable(rt)
+
+	return &out, nil
+}
+
+// DescribeTransitGatewayRouteTables returns route tables matching ids.
+func (m *Mock) DescribeTransitGatewayRouteTables(_ context.Context, ids []string) ([]driver.TransitGatewayRouteTable, error) {
+	return describeResources(m.tgwRouteTables, ids, cloneTGWRouteTable), nil
+}
+
+func cloneTGW(t *driver.TransitGateway) driver.TransitGateway {
+	c := *t
+	c.Tags = copyTags(t.Tags)
+
+	return c
+}
+
+func cloneTGWAttachment(a *driver.TransitGatewayVPCAttachment) driver.TransitGatewayVPCAttachment {
+	c := *a
+	c.SubnetIDs = append([]string(nil), a.SubnetIDs...)
+	c.Tags = copyTags(a.Tags)
+
+	return c
+}
+
+func cloneTGWRouteTable(t *driver.TransitGatewayRouteTable) driver.TransitGatewayRouteTable {
+	c := *t
+	c.Tags = copyTags(t.Tags)
+
+	return c
+}

--- a/providers/aws/vpc/transitgateway.go
+++ b/providers/aws/vpc/transitgateway.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -141,6 +142,117 @@ func (m *Mock) DeleteTransitGatewayRouteTable(_ context.Context, id string) (*dr
 // DescribeTransitGatewayRouteTables returns route tables matching ids.
 func (m *Mock) DescribeTransitGatewayRouteTables(_ context.Context, ids []string) ([]driver.TransitGatewayRouteTable, error) {
 	return describeResources(m.tgwRouteTables, ids, cloneTGWRouteTable), nil
+}
+
+func tgwRouteKey(routeTableID, cidr string) string { return routeTableID + "|" + cidr }
+
+func tgwAssocKey(routeTableID, attachmentID string) string { return routeTableID + "|" + attachmentID }
+
+// CreateTransitGatewayRoute adds a static route to a TGW route table.
+func (m *Mock) CreateTransitGatewayRoute(
+	_ context.Context, routeTableID, destinationCIDR, attachmentID string,
+) (*driver.TransitGatewayRoute, error) {
+	if !m.tgwRouteTables.Has(routeTableID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway route table %q not found", routeTableID)
+	}
+
+	route := &driver.TransitGatewayRoute{
+		DestinationCIDR: destinationCIDR,
+		AttachmentID:    attachmentID,
+		Type:            "static",
+		State:           "active",
+	}
+	m.tgwRoutes.Set(tgwRouteKey(routeTableID, destinationCIDR), route)
+
+	out := *route
+
+	return &out, nil
+}
+
+// DeleteTransitGatewayRoute removes a route from a TGW route table.
+func (m *Mock) DeleteTransitGatewayRoute(
+	_ context.Context, routeTableID, destinationCIDR string,
+) (*driver.TransitGatewayRoute, error) {
+	key := tgwRouteKey(routeTableID, destinationCIDR)
+
+	route, ok := m.tgwRoutes.Get(key)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "transit gateway route %q not found", destinationCIDR)
+	}
+
+	route.State = NATStateDeleted
+	m.tgwRoutes.Delete(key)
+
+	out := *route
+
+	return &out, nil
+}
+
+// SearchTransitGatewayRoutes returns the routes of a TGW route table.
+func (m *Mock) SearchTransitGatewayRoutes(_ context.Context, routeTableID string) ([]driver.TransitGatewayRoute, error) {
+	if !m.tgwRouteTables.Has(routeTableID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway route table %q not found", routeTableID)
+	}
+
+	prefix := routeTableID + "|"
+
+	var out []driver.TransitGatewayRoute
+
+	for _, k := range m.tgwRoutes.Keys() {
+		if strings.HasPrefix(k, prefix) {
+			if r, ok := m.tgwRoutes.Get(k); ok {
+				out = append(out, *r)
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// AssociateTransitGatewayRouteTable associates an attachment with a route table.
+func (m *Mock) AssociateTransitGatewayRouteTable(
+	_ context.Context, routeTableID, attachmentID string,
+) (*driver.TransitGatewayRouteTableAssociation, error) {
+	if !m.tgwRouteTables.Has(routeTableID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway route table %q not found", routeTableID)
+	}
+
+	att, ok := m.tgwAttachments.Get(attachmentID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway attachment %q not found", attachmentID)
+	}
+
+	assoc := &driver.TransitGatewayRouteTableAssociation{
+		RouteTableID: routeTableID,
+		AttachmentID: attachmentID,
+		ResourceID:   att.VPCID,
+		ResourceType: "vpc",
+		State:        "associated",
+	}
+	m.tgwAssociations.Set(tgwAssocKey(routeTableID, attachmentID), assoc)
+
+	out := *assoc
+
+	return &out, nil
+}
+
+// EnableTransitGatewayRouteTablePropagation enables propagation from an
+// attachment into a route table.
+func (m *Mock) EnableTransitGatewayRouteTablePropagation(_ context.Context, routeTableID, attachmentID string) error {
+	return m.requireRouteTableAndAttachment(routeTableID, attachmentID)
+}
+
+// DisableTransitGatewayRouteTablePropagation disables propagation.
+func (m *Mock) DisableTransitGatewayRouteTablePropagation(_ context.Context, routeTableID, attachmentID string) error {
+	return m.requireRouteTableAndAttachment(routeTableID, attachmentID)
+}
+
+func (m *Mock) requireRouteTableAndAttachment(routeTableID, attachmentID string) error {
+	if !m.tgwRouteTables.Has(routeTableID) || !m.tgwAttachments.Has(attachmentID) {
+		return errors.New(errors.InvalidArgument, "route table or attachment not found")
+	}
+
+	return nil
 }
 
 func cloneTGW(t *driver.TransitGateway) driver.TransitGateway {

--- a/providers/aws/vpc/transitgateway.go
+++ b/providers/aws/vpc/transitgateway.go
@@ -11,8 +11,6 @@ import (
 const defaultAmazonSideASN = 64512
 
 // CreateTransitGateway creates a transit gateway.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateTransitGateway(_ context.Context, cfg driver.TransitGatewayConfig) (*driver.TransitGateway, error) {
 	asn := cfg.ASN
 	if asn == 0 {
@@ -41,7 +39,8 @@ func (m *Mock) DeleteTransitGateway(_ context.Context, id string) (*driver.Trans
 		return nil, errors.Newf(errors.NotFound, "transit gateway %q not found", id)
 	}
 
-	tgw.State = "deleted"
+	tgw.State = NATStateDeleted
+
 	m.transitGateways.Delete(id)
 
 	out := cloneTGW(tgw)
@@ -55,8 +54,6 @@ func (m *Mock) DescribeTransitGateways(_ context.Context, ids []string) ([]drive
 }
 
 // CreateTransitGatewayVPCAttachment attaches a VPC to a transit gateway.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateTransitGatewayVPCAttachment(
 	_ context.Context, cfg driver.TransitGatewayVPCAttachmentConfig,
 ) (*driver.TransitGatewayVPCAttachment, error) {
@@ -90,7 +87,8 @@ func (m *Mock) DeleteTransitGatewayVPCAttachment(_ context.Context, id string) (
 		return nil, errors.Newf(errors.NotFound, "transit gateway attachment %q not found", id)
 	}
 
-	att.State = "deleted"
+	att.State = NATStateDeleted
+
 	m.tgwAttachments.Delete(id)
 
 	out := cloneTGWAttachment(att)
@@ -131,7 +129,8 @@ func (m *Mock) DeleteTransitGatewayRouteTable(_ context.Context, id string) (*dr
 		return nil, errors.Newf(errors.NotFound, "transit gateway route table %q not found", id)
 	}
 
-	rt.State = "deleted"
+	rt.State = NATStateDeleted
+
 	m.tgwRouteTables.Delete(id)
 
 	out := cloneTGWRouteTable(rt)

--- a/providers/aws/vpc/transitgateway.go
+++ b/providers/aws/vpc/transitgateway.go
@@ -35,9 +35,16 @@ func (m *Mock) CreateTransitGateway(_ context.Context, cfg driver.TransitGateway
 
 // DeleteTransitGateway deletes a transit gateway.
 func (m *Mock) DeleteTransitGateway(_ context.Context, id string) (*driver.TransitGateway, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	tgw, ok := m.transitGateways.Get(id)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "transit gateway %q not found", id)
+	}
+
+	if m.transitGatewayInUse(id) {
+		return nil, errors.Newf(errors.FailedPrecondition, "transit gateway %q has attachments or route tables", id)
 	}
 
 	tgw.State = NATStateDeleted
@@ -51,6 +58,9 @@ func (m *Mock) DeleteTransitGateway(_ context.Context, id string) (*driver.Trans
 
 // DescribeTransitGateways returns transit gateways matching ids (all if empty).
 func (m *Mock) DescribeTransitGateways(_ context.Context, ids []string) ([]driver.TransitGateway, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.transitGateways, ids, cloneTGW), nil
 }
 
@@ -83,6 +93,9 @@ func (m *Mock) CreateTransitGatewayVPCAttachment(
 
 // DeleteTransitGatewayVPCAttachment deletes a transit gateway VPC attachment.
 func (m *Mock) DeleteTransitGatewayVPCAttachment(_ context.Context, id string) (*driver.TransitGatewayVPCAttachment, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	att, ok := m.tgwAttachments.Get(id)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "transit gateway attachment %q not found", id)
@@ -99,6 +112,9 @@ func (m *Mock) DeleteTransitGatewayVPCAttachment(_ context.Context, id string) (
 
 // DescribeTransitGatewayVPCAttachments returns attachments matching ids.
 func (m *Mock) DescribeTransitGatewayVPCAttachments(_ context.Context, ids []string) ([]driver.TransitGatewayVPCAttachment, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.tgwAttachments, ids, cloneTGWAttachment), nil
 }
 
@@ -125,6 +141,9 @@ func (m *Mock) CreateTransitGatewayRouteTable(
 
 // DeleteTransitGatewayRouteTable deletes a transit gateway route table.
 func (m *Mock) DeleteTransitGatewayRouteTable(_ context.Context, id string) (*driver.TransitGatewayRouteTable, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	rt, ok := m.tgwRouteTables.Get(id)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "transit gateway route table %q not found", id)
@@ -141,7 +160,28 @@ func (m *Mock) DeleteTransitGatewayRouteTable(_ context.Context, id string) (*dr
 
 // DescribeTransitGatewayRouteTables returns route tables matching ids.
 func (m *Mock) DescribeTransitGatewayRouteTables(_ context.Context, ids []string) ([]driver.TransitGatewayRouteTable, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.tgwRouteTables, ids, cloneTGWRouteTable), nil
+}
+
+// transitGatewayInUse reports whether any attachment or route table still
+// references the transit gateway. Caller must hold the lock.
+func (m *Mock) transitGatewayInUse(id string) bool {
+	for _, att := range m.tgwAttachments.SortedValues() {
+		if att.TransitGatewayID == id {
+			return true
+		}
+	}
+
+	for _, rt := range m.tgwRouteTables.SortedValues() {
+		if rt.TransitGatewayID == id {
+			return true
+		}
+	}
+
+	return false
 }
 
 func tgwRouteKey(routeTableID, cidr string) string { return routeTableID + "|" + cidr }
@@ -154,6 +194,10 @@ func (m *Mock) CreateTransitGatewayRoute(
 ) (*driver.TransitGatewayRoute, error) {
 	if !m.tgwRouteTables.Has(routeTableID) {
 		return nil, errors.Newf(errors.InvalidArgument, "transit gateway route table %q not found", routeTableID)
+	}
+
+	if attachmentID != "" && !m.tgwAttachments.Has(attachmentID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway attachment %q not found", attachmentID)
 	}
 
 	route := &driver.TransitGatewayRoute{
@@ -173,6 +217,9 @@ func (m *Mock) CreateTransitGatewayRoute(
 func (m *Mock) DeleteTransitGatewayRoute(
 	_ context.Context, routeTableID, destinationCIDR string,
 ) (*driver.TransitGatewayRoute, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	key := tgwRouteKey(routeTableID, destinationCIDR)
 
 	route, ok := m.tgwRoutes.Get(key)
@@ -181,6 +228,7 @@ func (m *Mock) DeleteTransitGatewayRoute(
 	}
 
 	route.State = NATStateDeleted
+
 	m.tgwRoutes.Delete(key)
 
 	out := *route
@@ -190,6 +238,9 @@ func (m *Mock) DeleteTransitGatewayRoute(
 
 // SearchTransitGatewayRoutes returns the routes of a TGW route table.
 func (m *Mock) SearchTransitGatewayRoutes(_ context.Context, routeTableID string) ([]driver.TransitGatewayRoute, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	if !m.tgwRouteTables.Has(routeTableID) {
 		return nil, errors.Newf(errors.InvalidArgument, "transit gateway route table %q not found", routeTableID)
 	}

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -64,6 +64,8 @@ type Mock struct {
 	transitGateways    *memstore.Store[*driver.TransitGateway]
 	tgwAttachments     *memstore.Store[*driver.TransitGatewayVPCAttachment]
 	tgwRouteTables     *memstore.Store[*driver.TransitGatewayRouteTable]
+	tgwRoutes          *memstore.Store[*driver.TransitGatewayRoute]
+	tgwAssociations    *memstore.Store[*driver.TransitGatewayRouteTableAssociation]
 	customerGateways   *memstore.Store[*driver.CustomerGateway]
 	vpnGateways        *memstore.Store[*driver.VPNGateway]
 	vpnConnections     *memstore.Store[*driver.VPNConnection]
@@ -125,6 +127,8 @@ func New(opts *config.Options) *Mock {
 		transitGateways:    memstore.New[*driver.TransitGateway](),
 		tgwAttachments:     memstore.New[*driver.TransitGatewayVPCAttachment](),
 		tgwRouteTables:     memstore.New[*driver.TransitGatewayRouteTable](),
+		tgwRoutes:          memstore.New[*driver.TransitGatewayRoute](),
+		tgwAssociations:    memstore.New[*driver.TransitGatewayRouteTableAssociation](),
 		customerGateways:   memstore.New[*driver.CustomerGateway](),
 		vpnGateways:        memstore.New[*driver.VPNGateway](),
 		vpnConnections:     memstore.New[*driver.VPNConnection](),

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -2,9 +2,8 @@
 package vpc
 
 import (
-	"sync"
-
 	"context"
+	"sync"
 	"time"
 
 	"github.com/stackshy/cloudemu/v2/config"

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -26,9 +26,16 @@ const (
 // interface and every call would answer InvalidAction at runtime instead of
 // failing the build.
 var (
-	_ driver.Networking        = (*Mock)(nil)
-	_ driver.NetworkInterfaces = (*Mock)(nil)
-	_ driver.VPCAttributes     = (*Mock)(nil)
+	_ driver.Networking                 = (*Mock)(nil)
+	_ driver.NetworkInterfaces          = (*Mock)(nil)
+	_ driver.VPCAttributes              = (*Mock)(nil)
+	_ driver.TransitGateways            = (*Mock)(nil)
+	_ driver.VPNConnections             = (*Mock)(nil)
+	_ driver.DHCPOptionSets             = (*Mock)(nil)
+	_ driver.PrefixLists                = (*Mock)(nil)
+	_ driver.EgressOnlyInternetGateways = (*Mock)(nil)
+	_ driver.VPCEndpointServices        = (*Mock)(nil)
+	_ driver.ClientVPN                  = (*Mock)(nil)
 )
 
 // Mock is an in-memory mock implementation of the AWS VPC networking service.
@@ -53,7 +60,22 @@ type Mock struct {
 	rtAssocs       *memstore.Store[*rtAssocData]
 	enis           *memstore.Store[*eniData]
 	endpoints      *memstore.Store[*driver.VPCEndpoint]
-	opts           *config.Options
+
+	// AWS-specific networking capabilities (optional interfaces).
+	transitGateways    *memstore.Store[*driver.TransitGateway]
+	tgwAttachments     *memstore.Store[*driver.TransitGatewayVPCAttachment]
+	tgwRouteTables     *memstore.Store[*driver.TransitGatewayRouteTable]
+	customerGateways   *memstore.Store[*driver.CustomerGateway]
+	vpnGateways        *memstore.Store[*driver.VPNGateway]
+	vpnConnections     *memstore.Store[*driver.VPNConnection]
+	dhcpOptions        *memstore.Store[*driver.DHCPOptions]
+	prefixLists        *memstore.Store[*driver.PrefixList]
+	egressOnlyIGWs     *memstore.Store[*driver.EgressOnlyInternetGateway]
+	endpointServices   *memstore.Store[*driver.EndpointService]
+	clientVPNEndpoints *memstore.Store[*driver.ClientVPNEndpoint]
+	clientVPNAssocs    *memstore.Store[*driver.ClientVPNTargetNetwork]
+
+	opts *config.Options
 }
 
 type vpcData struct {
@@ -100,7 +122,21 @@ func New(opts *config.Options) *Mock {
 		rtAssocs:       memstore.New[*rtAssocData](),
 		enis:           memstore.New[*eniData](),
 		endpoints:      memstore.New[*driver.VPCEndpoint](),
-		opts:           opts,
+
+		transitGateways:    memstore.New[*driver.TransitGateway](),
+		tgwAttachments:     memstore.New[*driver.TransitGatewayVPCAttachment](),
+		tgwRouteTables:     memstore.New[*driver.TransitGatewayRouteTable](),
+		customerGateways:   memstore.New[*driver.CustomerGateway](),
+		vpnGateways:        memstore.New[*driver.VPNGateway](),
+		vpnConnections:     memstore.New[*driver.VPNConnection](),
+		dhcpOptions:        memstore.New[*driver.DHCPOptions](),
+		prefixLists:        memstore.New[*driver.PrefixList](),
+		egressOnlyIGWs:     memstore.New[*driver.EgressOnlyInternetGateway](),
+		endpointServices:   memstore.New[*driver.EndpointService](),
+		clientVPNEndpoints: memstore.New[*driver.ClientVPNEndpoint](),
+		clientVPNAssocs:    memstore.New[*driver.ClientVPNTargetNetwork](),
+
+		opts: opts,
 	}
 }
 

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -75,6 +75,12 @@ type Mock struct {
 	endpointServices   *memstore.Store[*driver.EndpointService]
 	clientVPNEndpoints *memstore.Store[*driver.ClientVPNEndpoint]
 	clientVPNAssocs    *memstore.Store[*driver.ClientVPNTargetNetwork]
+	clientVPNAuthRules *memstore.Store[*driver.ClientVPNAuthorizationRule]
+	clientVPNRoutes    *memstore.Store[*driver.ClientVPNRoute]
+
+	// endpointServicePerms holds allowed principals per endpoint-service id,
+	// guarded by mu.
+	endpointServicePerms map[string][]string
 
 	opts *config.Options
 }
@@ -138,6 +144,10 @@ func New(opts *config.Options) *Mock {
 		endpointServices:   memstore.New[*driver.EndpointService](),
 		clientVPNEndpoints: memstore.New[*driver.ClientVPNEndpoint](),
 		clientVPNAssocs:    memstore.New[*driver.ClientVPNTargetNetwork](),
+		clientVPNAuthRules: memstore.New[*driver.ClientVPNAuthorizationRule](),
+		clientVPNRoutes:    memstore.New[*driver.ClientVPNRoute](),
+
+		endpointServicePerms: map[string][]string{},
 
 		opts: opts,
 	}

--- a/providers/aws/vpc/vpn.go
+++ b/providers/aws/vpc/vpn.go
@@ -1,0 +1,197 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func orDefaultStr(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
+// CreateCustomerGateway creates a customer gateway (the on-prem VPN endpoint).
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateCustomerGateway(_ context.Context, cfg driver.CustomerGatewayConfig) (*driver.CustomerGateway, error) {
+	if cfg.IPAddress == "" {
+		return nil, errors.New(errors.InvalidArgument, "customer gateway IP address is required")
+	}
+
+	cgw := &driver.CustomerGateway{
+		ID:        idgen.GenerateID("cgw-"),
+		IPAddress: cfg.IPAddress,
+		BGPASN:    cfg.BGPASN,
+		Type:      orDefaultStr(cfg.Type, "ipsec.1"),
+		State:     "available",
+		Tags:      copyTags(cfg.Tags),
+	}
+	m.customerGateways.Set(cgw.ID, cgw)
+
+	out := cloneCustomerGateway(cgw)
+
+	return &out, nil
+}
+
+// DeleteCustomerGateway deletes a customer gateway.
+func (m *Mock) DeleteCustomerGateway(_ context.Context, id string) error {
+	if !m.customerGateways.Delete(id) {
+		return errors.Newf(errors.NotFound, "customer gateway %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeCustomerGateways returns customer gateways matching ids.
+func (m *Mock) DescribeCustomerGateways(_ context.Context, ids []string) ([]driver.CustomerGateway, error) {
+	return describeResources(m.customerGateways, ids, cloneCustomerGateway), nil
+}
+
+// CreateVPNGateway creates a virtual private gateway.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateVPNGateway(_ context.Context, cfg driver.VPNGatewayConfig) (*driver.VPNGateway, error) {
+	asn := cfg.AmazonSideASN
+	if asn == 0 {
+		asn = defaultAmazonSideASN
+	}
+
+	vgw := &driver.VPNGateway{
+		ID:            idgen.GenerateID("vgw-"),
+		Type:          orDefaultStr(cfg.Type, "ipsec.1"),
+		State:         "available",
+		AmazonSideASN: asn,
+		Tags:          copyTags(cfg.Tags),
+	}
+	m.vpnGateways.Set(vgw.ID, vgw)
+
+	out := cloneVPNGateway(vgw)
+
+	return &out, nil
+}
+
+// DeleteVPNGateway deletes a virtual private gateway.
+func (m *Mock) DeleteVPNGateway(_ context.Context, id string) error {
+	if !m.vpnGateways.Delete(id) {
+		return errors.Newf(errors.NotFound, "vpn gateway %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeVPNGateways returns VPN gateways matching ids.
+func (m *Mock) DescribeVPNGateways(_ context.Context, ids []string) ([]driver.VPNGateway, error) {
+	return describeResources(m.vpnGateways, ids, cloneVPNGateway), nil
+}
+
+// AttachVPNGateway attaches a VPN gateway to a VPC.
+func (m *Mock) AttachVPNGateway(_ context.Context, vpnGatewayID, vpcID string) (*driver.VPNGateway, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vgw, ok := m.vpnGateways.Get(vpnGatewayID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "vpn gateway %q not found", vpnGatewayID)
+	}
+
+	if !m.vpcs.Has(vpcID) {
+		return nil, errors.Newf(errors.InvalidArgument, "vpc %q not found", vpcID)
+	}
+
+	vgw.AttachedVPCID = vpcID
+	vgw.AttachmentState = "attached"
+
+	out := cloneVPNGateway(vgw)
+
+	return &out, nil
+}
+
+// DetachVPNGateway detaches a VPN gateway from a VPC.
+func (m *Mock) DetachVPNGateway(_ context.Context, vpnGatewayID, vpcID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vgw, ok := m.vpnGateways.Get(vpnGatewayID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "vpn gateway %q not found", vpnGatewayID)
+	}
+
+	if vgw.AttachedVPCID != vpcID {
+		return errors.Newf(errors.InvalidArgument, "vpn gateway %q is not attached to vpc %q", vpnGatewayID, vpcID)
+	}
+
+	vgw.AttachedVPCID = ""
+	vgw.AttachmentState = "detached"
+
+	return nil
+}
+
+// CreateVPNConnection creates a site-to-site VPN connection.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateVPNConnection(_ context.Context, cfg driver.VPNConnectionConfig) (*driver.VPNConnection, error) {
+	if !m.customerGateways.Has(cfg.CustomerGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "customer gateway %q not found", cfg.CustomerGatewayID)
+	}
+
+	if cfg.VPNGatewayID == "" && cfg.TransitGatewayID == "" {
+		return nil, errors.New(errors.InvalidArgument, "a vpn gateway or transit gateway is required")
+	}
+
+	vpn := &driver.VPNConnection{
+		ID:                idgen.GenerateID("vpn-"),
+		CustomerGatewayID: cfg.CustomerGatewayID,
+		VPNGatewayID:      cfg.VPNGatewayID,
+		TransitGatewayID:  cfg.TransitGatewayID,
+		Type:              orDefaultStr(cfg.Type, "ipsec.1"),
+		State:             "available",
+		StaticRoutesOnly:  cfg.StaticRoutesOnly,
+		Tags:              copyTags(cfg.Tags),
+	}
+	m.vpnConnections.Set(vpn.ID, vpn)
+
+	out := cloneVPNConnection(vpn)
+
+	return &out, nil
+}
+
+// DeleteVPNConnection deletes a VPN connection.
+func (m *Mock) DeleteVPNConnection(_ context.Context, id string) error {
+	if !m.vpnConnections.Delete(id) {
+		return errors.Newf(errors.NotFound, "vpn connection %q not found", id)
+	}
+
+	return nil
+}
+
+// DescribeVPNConnections returns VPN connections matching ids.
+func (m *Mock) DescribeVPNConnections(_ context.Context, ids []string) ([]driver.VPNConnection, error) {
+	return describeResources(m.vpnConnections, ids, cloneVPNConnection), nil
+}
+
+func cloneCustomerGateway(c *driver.CustomerGateway) driver.CustomerGateway {
+	out := *c
+	out.Tags = copyTags(c.Tags)
+
+	return out
+}
+
+func cloneVPNGateway(v *driver.VPNGateway) driver.VPNGateway {
+	out := *v
+	out.Tags = copyTags(v.Tags)
+
+	return out
+}
+
+func cloneVPNConnection(v *driver.VPNConnection) driver.VPNConnection {
+	out := *v
+	out.Tags = copyTags(v.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/vpn.go
+++ b/providers/aws/vpc/vpn.go
@@ -17,8 +17,6 @@ func orDefaultStr(v, def string) string {
 }
 
 // CreateCustomerGateway creates a customer gateway (the on-prem VPN endpoint).
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateCustomerGateway(_ context.Context, cfg driver.CustomerGatewayConfig) (*driver.CustomerGateway, error) {
 	if cfg.IPAddress == "" {
 		return nil, errors.New(errors.InvalidArgument, "customer gateway IP address is required")
@@ -54,8 +52,6 @@ func (m *Mock) DescribeCustomerGateways(_ context.Context, ids []string) ([]driv
 }
 
 // CreateVPNGateway creates a virtual private gateway.
-//
-//nolint:gocritic // cfg matches the driver signature.
 func (m *Mock) CreateVPNGateway(_ context.Context, cfg driver.VPNGatewayConfig) (*driver.VPNGateway, error) {
 	asn := cfg.AmazonSideASN
 	if asn == 0 {

--- a/providers/aws/vpc/vpn.go
+++ b/providers/aws/vpc/vpn.go
@@ -48,6 +48,9 @@ func (m *Mock) DeleteCustomerGateway(_ context.Context, id string) error {
 
 // DescribeCustomerGateways returns customer gateways matching ids.
 func (m *Mock) DescribeCustomerGateways(_ context.Context, ids []string) ([]driver.CustomerGateway, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.customerGateways, ids, cloneCustomerGateway), nil
 }
 
@@ -83,6 +86,9 @@ func (m *Mock) DeleteVPNGateway(_ context.Context, id string) error {
 
 // DescribeVPNGateways returns VPN gateways matching ids.
 func (m *Mock) DescribeVPNGateways(_ context.Context, ids []string) ([]driver.VPNGateway, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.vpnGateways, ids, cloneVPNGateway), nil
 }
 
@@ -140,6 +146,14 @@ func (m *Mock) CreateVPNConnection(_ context.Context, cfg driver.VPNConnectionCo
 		return nil, errors.New(errors.InvalidArgument, "a vpn gateway or transit gateway is required")
 	}
 
+	if cfg.VPNGatewayID != "" && !m.vpnGateways.Has(cfg.VPNGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "vpn gateway %q not found", cfg.VPNGatewayID)
+	}
+
+	if cfg.TransitGatewayID != "" && !m.transitGateways.Has(cfg.TransitGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway %q not found", cfg.TransitGatewayID)
+	}
+
 	vpn := &driver.VPNConnection{
 		ID:                idgen.GenerateID("vpn-"),
 		CustomerGatewayID: cfg.CustomerGatewayID,
@@ -168,6 +182,9 @@ func (m *Mock) DeleteVPNConnection(_ context.Context, id string) error {
 
 // DescribeVPNConnections returns VPN connections matching ids.
 func (m *Mock) DescribeVPNConnections(_ context.Context, ids []string) ([]driver.VPNConnection, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	return describeResources(m.vpnConnections, ids, cloneVPNConnection), nil
 }
 
@@ -223,6 +240,14 @@ func (m *Mock) ModifyVPNConnection(_ context.Context, id, transitGatewayID, vpnG
 	vpn, ok := m.vpnConnections.Get(id)
 	if !ok {
 		return nil, errors.Newf(errors.NotFound, "vpn connection %q not found", id)
+	}
+
+	if transitGatewayID != "" && !m.transitGateways.Has(transitGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "transit gateway %q not found", transitGatewayID)
+	}
+
+	if vpnGatewayID != "" && !m.vpnGateways.Has(vpnGatewayID) {
+		return nil, errors.Newf(errors.InvalidArgument, "vpn gateway %q not found", vpnGatewayID)
 	}
 
 	if transitGatewayID != "" {

--- a/providers/aws/vpc/vpn.go
+++ b/providers/aws/vpc/vpn.go
@@ -171,6 +171,75 @@ func (m *Mock) DescribeVPNConnections(_ context.Context, ids []string) ([]driver
 	return describeResources(m.vpnConnections, ids, cloneVPNConnection), nil
 }
 
+// CreateVPNConnectionRoute adds a static route to a VPN connection.
+func (m *Mock) CreateVPNConnectionRoute(_ context.Context, vpnConnectionID, destinationCIDR string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vpn, ok := m.vpnConnections.Get(vpnConnectionID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "vpn connection %q not found", vpnConnectionID)
+	}
+
+	for _, rt := range vpn.Routes {
+		if rt.DestinationCIDR == destinationCIDR {
+			return nil
+		}
+	}
+
+	vpn.Routes = append(vpn.Routes, driver.VPNConnectionRoute{DestinationCIDR: destinationCIDR, State: "available"})
+
+	return nil
+}
+
+// DeleteVPNConnectionRoute removes a static route from a VPN connection.
+func (m *Mock) DeleteVPNConnectionRoute(_ context.Context, vpnConnectionID, destinationCIDR string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vpn, ok := m.vpnConnections.Get(vpnConnectionID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "vpn connection %q not found", vpnConnectionID)
+	}
+
+	kept := vpn.Routes[:0:0]
+
+	for _, rt := range vpn.Routes {
+		if rt.DestinationCIDR != destinationCIDR {
+			kept = append(kept, rt)
+		}
+	}
+
+	vpn.Routes = kept
+
+	return nil
+}
+
+// ModifyVPNConnection re-targets a VPN connection to a different gateway.
+func (m *Mock) ModifyVPNConnection(_ context.Context, id, transitGatewayID, vpnGatewayID string) (*driver.VPNConnection, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	vpn, ok := m.vpnConnections.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "vpn connection %q not found", id)
+	}
+
+	if transitGatewayID != "" {
+		vpn.TransitGatewayID = transitGatewayID
+		vpn.VPNGatewayID = ""
+	}
+
+	if vpnGatewayID != "" {
+		vpn.VPNGatewayID = vpnGatewayID
+		vpn.TransitGatewayID = ""
+	}
+
+	out := cloneVPNConnection(vpn)
+
+	return &out, nil
+}
+
 func cloneCustomerGateway(c *driver.CustomerGateway) driver.CustomerGateway {
 	out := *c
 	out.Tags = copyTags(c.Tags)
@@ -188,6 +257,7 @@ func cloneVPNGateway(v *driver.VPNGateway) driver.VPNGateway {
 func cloneVPNConnection(v *driver.VPNConnection) driver.VPNConnection {
 	out := *v
 	out.Tags = copyTags(v.Tags)
+	out.Routes = append([]driver.VPNConnectionRoute(nil), v.Routes...)
 
 	return out
 }

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -27,6 +27,7 @@ import (
 	keyspacessrv "github.com/stackshy/cloudemu/v2/server/aws/keyspaces"
 	"github.com/stackshy/cloudemu/v2/server/aws/lambda"
 	memorydbsrv "github.com/stackshy/cloudemu/v2/server/aws/memorydb"
+	networkfirewallsrv "github.com/stackshy/cloudemu/v2/server/aws/networkfirewall"
 	"github.com/stackshy/cloudemu/v2/server/aws/rds"
 	"github.com/stackshy/cloudemu/v2/server/aws/redshift"
 	"github.com/stackshy/cloudemu/v2/server/aws/resourceexplorer2"
@@ -57,6 +58,7 @@ import (
 	mdbdriver "github.com/stackshy/cloudemu/v2/services/memorydb/driver"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
 	ssmdriver "github.com/stackshy/cloudemu/v2/services/parameterstore/driver"
@@ -117,6 +119,9 @@ type Drivers struct {
 	// MemoryDB serves the AWS MemoryDB JSON 1.1 protocol (Redis/Valkey cluster
 	// control plane) against the memorydb driver.
 	MemoryDB mdbdriver.MemoryDB
+	// NetworkFirewall serves the AWS Network Firewall JSON 1.0 protocol against
+	// the networkfirewall driver.
+	NetworkFirewall nfdriver.NetworkFirewall
 	// SNS serves the SNS query protocol against the notification driver.
 	SNS notifdriver.Notification
 	// STS serves the AWS STS query protocol (GetCallerIdentity, AssumeRole,
@@ -171,6 +176,7 @@ func DriversFrom(p *awsprovider.Provider) Drivers {
 		ElastiCache:         p.ElastiCache,
 		Keyspaces:           p.Keyspaces,
 		MemoryDB:            p.MemoryDB,
+		NetworkFirewall:     p.NetworkFirewall,
 		SNS:                 p.SNS,
 		STS:                 true,
 		K8sAPI:              nil, // injected by the caller when a shared cluster is desired
@@ -311,6 +317,13 @@ func New(d Drivers) *server.Server {
 	// registration order relative to the EC2 catch-all does not matter.
 	if d.MemoryDB != nil {
 		srv.Register(memorydbsrv.New(d.MemoryDB))
+	}
+
+	// Network Firewall speaks AWS JSON 1.0 and matches on the
+	// "NetworkFirewall_20201112." target prefix, so its dispatch is disjoint
+	// from every other handler.
+	if d.NetworkFirewall != nil {
+		srv.Register(networkfirewallsrv.New(d.NetworkFirewall))
 	}
 
 	// Keyspaces speaks AWS JSON 1.0 and matches on the "KeyspacesService." target

--- a/server/aws/ec2/client_vpn.go
+++ b/server/aws/ec2/client_vpn.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"encoding/xml"
 	"net/http"
+	"strconv"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -18,15 +19,20 @@ type clientVPNStatusXML struct {
 	Code string `xml:"code"`
 }
 
+type clientVPNAuthXML struct {
+	Type string `xml:"type"`
+}
+
 type clientVPNEndpointXML struct {
-	ClientVpnEndpointID  string             `xml:"clientVpnEndpointId"`
-	Description          string             `xml:"description,omitempty"`
-	Status               clientVPNStatusXML `xml:"status"`
-	ClientCidrBlock      string             `xml:"clientCidrBlock"`
-	ServerCertificateARN string             `xml:"serverCertificateArn"`
-	SplitTunnel          bool               `xml:"splitTunnel"`
-	VpcID                string             `xml:"vpcId,omitempty"`
-	Tags                 []tagItem          `xml:"tagSet>item,omitempty"`
+	ClientVpnEndpointID   string             `xml:"clientVpnEndpointId"`
+	Description           string             `xml:"description,omitempty"`
+	Status                clientVPNStatusXML `xml:"status"`
+	ClientCidrBlock       string             `xml:"clientCidrBlock"`
+	ServerCertificateARN  string             `xml:"serverCertificateArn"`
+	AuthenticationOptions []clientVPNAuthXML `xml:"authenticationOptions>item,omitempty"`
+	SplitTunnel           bool               `xml:"splitTunnel"`
+	VpcID                 string             `xml:"vpcId,omitempty"`
+	Tags                  []tagItem          `xml:"tagSet>item,omitempty"`
 }
 
 //nolint:gocyclo // flat action dispatch table
@@ -73,6 +79,7 @@ func (*Handler) createClientVPNEndpoint(w http.ResponseWriter, r *http.Request, 
 		Description:          r.Form.Get("Description"),
 		ClientCIDRBlock:      r.Form.Get("ClientCidrBlock"),
 		ServerCertificateARN: r.Form.Get("ServerCertificateArn"),
+		AuthenticationTypes:  parseClientVPNAuthTypes(r),
 		SplitTunnel:          r.Form.Get("SplitTunnel") == formTrue,
 		Tags:                 mergeTagSpecs(awsquery.TagSpecs(r.Form), "client-vpn-endpoint"),
 	})
@@ -291,7 +298,6 @@ func (*Handler) deleteClientVPNRoute(w http.ResponseWriter, r *http.Request, c n
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "deleting"}})
 }
 
-//nolint:dupl // parallel per-resource marshaling
 func (*Handler) describeClientVPNRoutes(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
 	items, err := c.DescribeClientVPNRoutes(r.Context(), r.Form.Get("ClientVpnEndpointId"))
 	if err != nil {
@@ -316,11 +322,34 @@ func (*Handler) describeClientVPNRoutes(w http.ResponseWriter, r *http.Request, 
 }
 
 func toClientVPNEndpointXML(e *netdriver.ClientVPNEndpoint) clientVPNEndpointXML {
-	return clientVPNEndpointXML{
+	x := clientVPNEndpointXML{
 		ClientVpnEndpointID: e.ID, Description: e.Description, Status: clientVPNStatusXML{Code: e.State},
 		ClientCidrBlock: e.ClientCIDRBlock, ServerCertificateARN: e.ServerCertificateARN,
 		SplitTunnel: e.SplitTunnel, VpcID: e.VPCID, Tags: toTagItems(e.Tags),
 	}
+
+	for _, t := range e.AuthenticationTypes {
+		x.AuthenticationOptions = append(x.AuthenticationOptions, clientVPNAuthXML{Type: t})
+	}
+
+	return x
+}
+
+// parseClientVPNAuthTypes reads the Authentication.N.Type list from the EC2
+// query form (the SDK serializes AuthenticationOptions as Authentication.N).
+func parseClientVPNAuthTypes(r *http.Request) []string {
+	var out []string
+
+	for i := 1; ; i++ {
+		t := r.Form.Get("Authentication." + strconv.Itoa(i) + ".Type")
+		if t == "" {
+			break
+		}
+
+		out = append(out, t)
+	}
+
+	return out
 }
 
 func writeClientVPNErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/client_vpn.go
+++ b/server/aws/ec2/client_vpn.go
@@ -1,0 +1,152 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) clientVPN() (netdriver.ClientVPN, bool) {
+	c, ok := h.vpc.(netdriver.ClientVPN)
+
+	return c, ok
+}
+
+type clientVPNStatusXML struct {
+	Code string `xml:"code"`
+}
+
+type clientVPNEndpointXML struct {
+	ClientVpnEndpointID  string             `xml:"clientVpnEndpointId"`
+	Description          string             `xml:"description,omitempty"`
+	Status               clientVPNStatusXML `xml:"status"`
+	ClientCidrBlock      string             `xml:"clientCidrBlock"`
+	ServerCertificateARN string             `xml:"serverCertificateArn"`
+	SplitTunnel          bool               `xml:"splitTunnel"`
+	VpcID                string             `xml:"vpcId,omitempty"`
+	Tags                 []tagItem          `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) routeClientVPN(w http.ResponseWriter, r *http.Request, action string) bool {
+	c, ok := h.clientVPN()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateClientVpnEndpoint":
+		h.createClientVPNEndpoint(w, r, c)
+	case "DeleteClientVpnEndpoint":
+		h.deleteClientVPNEndpoint(w, r, c)
+	case "DescribeClientVpnEndpoints":
+		h.describeClientVPNEndpoints(w, r, c)
+	case "AssociateClientVpnTargetNetwork":
+		h.associateClientVPN(w, r, c)
+	case "DisassociateClientVpnTargetNetwork":
+		h.disassociateClientVPN(w, r, c)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createClientVPNEndpoint(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	out, err := c.CreateClientVPNEndpoint(r.Context(), netdriver.ClientVPNEndpointConfig{
+		Description:          r.Form.Get("Description"),
+		ClientCIDRBlock:      r.Form.Get("ClientCidrBlock"),
+		ServerCertificateARN: r.Form.Get("ServerCertificateArn"),
+		SplitTunnel:          r.Form.Get("SplitTunnel") == formTrue,
+		Tags:                 mergeTagSpecs(awsquery.TagSpecs(r.Form), "client-vpn-endpoint"),
+	})
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name           `xml:"CreateClientVpnEndpointResponse"`
+		Xmlns      string             `xml:"xmlns,attr"`
+		Req        string             `xml:"requestId"`
+		EndpointID string             `xml:"clientVpnEndpointId"`
+		Status     clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, EndpointID: out.ID, Status: clientVPNStatusXML{Code: out.State}})
+}
+
+func (h *Handler) deleteClientVPNEndpoint(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	if err := c.DeleteClientVPNEndpoint(r.Context(), r.Form.Get("ClientVpnEndpointId")); err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"DeleteClientVpnEndpointResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Status  clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "deleting"}})
+}
+
+func (h *Handler) describeClientVPNEndpoints(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	items, err := c.DescribeClientVPNEndpoints(r.Context(), awsquery.ListStrings(r.Form, "ClientVpnEndpointId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	out := make([]clientVPNEndpointXML, 0, len(items))
+	for i := range items {
+		out = append(out, toClientVPNEndpointXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name               `xml:"DescribeClientVpnEndpointsResponse"`
+		Xmlns   string                 `xml:"xmlns,attr"`
+		Req     string                 `xml:"requestId"`
+		Set     []clientVPNEndpointXML `xml:"clientVpnEndpoint>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) associateClientVPN(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	out, err := c.AssociateClientVPNTargetNetwork(r.Context(), r.Form.Get("ClientVpnEndpointId"), r.Form.Get("SubnetId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName       xml.Name           `xml:"AssociateClientVpnTargetNetworkResponse"`
+		Xmlns         string             `xml:"xmlns,attr"`
+		Req           string             `xml:"requestId"`
+		AssociationID string             `xml:"associationId"`
+		Status        clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, AssociationID: out.AssociationID, Status: clientVPNStatusXML{Code: out.State}})
+}
+
+func (h *Handler) disassociateClientVPN(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	if err := c.DisassociateClientVPNTargetNetwork(r.Context(), r.Form.Get("ClientVpnEndpointId"), r.Form.Get("AssociationId")); err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"DisassociateClientVpnTargetNetworkResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Status  clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "disassociating"}})
+}
+
+func toClientVPNEndpointXML(e *netdriver.ClientVPNEndpoint) clientVPNEndpointXML {
+	return clientVPNEndpointXML{
+		ClientVpnEndpointID: e.ID, Description: e.Description, Status: clientVPNStatusXML{Code: e.State},
+		ClientCidrBlock: e.ClientCIDRBlock, ServerCertificateARN: e.ServerCertificateARN,
+		SplitTunnel: e.SplitTunnel, VpcID: e.VPCID, Tags: toTagItems(e.Tags),
+	}
+}
+
+func writeClientVPNErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidClientVpnEndpointId.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/client_vpn.go
+++ b/server/aws/ec2/client_vpn.go
@@ -29,6 +29,7 @@ type clientVPNEndpointXML struct {
 	Tags                 []tagItem          `xml:"tagSet>item,omitempty"`
 }
 
+//nolint:gocyclo // flat action dispatch table
 func (h *Handler) routeClientVPN(w http.ResponseWriter, r *http.Request, action string) bool {
 	c, ok := h.clientVPN()
 	if !ok {
@@ -46,6 +47,20 @@ func (h *Handler) routeClientVPN(w http.ResponseWriter, r *http.Request, action 
 		h.associateClientVPN(w, r, c)
 	case "DisassociateClientVpnTargetNetwork":
 		h.disassociateClientVPN(w, r, c)
+	case "DescribeClientVpnTargetNetworks":
+		h.describeClientVPNTargetNetworks(w, r, c)
+	case "AuthorizeClientVpnIngress":
+		h.authorizeClientVPNIngress(w, r, c)
+	case "RevokeClientVpnIngress":
+		h.revokeClientVPNIngress(w, r, c)
+	case "DescribeClientVpnAuthorizationRules":
+		h.describeClientVPNAuthRules(w, r, c)
+	case "CreateClientVpnRoute":
+		h.createClientVPNRoute(w, r, c)
+	case "DeleteClientVpnRoute":
+		h.deleteClientVPNRoute(w, r, c)
+	case "DescribeClientVpnRoutes":
+		h.describeClientVPNRoutes(w, r, c)
 	default:
 		return false
 	}
@@ -138,6 +153,166 @@ func (*Handler) disassociateClientVPN(w http.ResponseWriter, r *http.Request, c 
 		Req     string             `xml:"requestId"`
 		Status  clientVPNStatusXML `xml:"status"`
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "disassociating"}})
+}
+
+type clientVPNTargetNetworkXML struct {
+	AssociationID       string             `xml:"associationId"`
+	ClientVpnEndpointID string             `xml:"clientVpnEndpointId"`
+	TargetNetworkID     string             `xml:"targetNetworkId"`
+	VpcID               string             `xml:"vpcId,omitempty"`
+	Status              clientVPNStatusXML `xml:"status"`
+}
+
+type clientVPNAuthRuleXML struct {
+	ClientVpnEndpointID string             `xml:"clientVpnEndpointId"`
+	DestinationCidr     string             `xml:"destinationCidr"`
+	GroupID             string             `xml:"groupId,omitempty"`
+	AccessAll           bool               `xml:"accessAll"`
+	Status              clientVPNStatusXML `xml:"status"`
+}
+
+type clientVPNRouteXML struct {
+	ClientVpnEndpointID string             `xml:"clientVpnEndpointId"`
+	DestinationCidr     string             `xml:"destinationCidr"`
+	TargetSubnet        string             `xml:"targetSubnet"`
+	Status              clientVPNStatusXML `xml:"status"`
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeClientVPNTargetNetworks(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	items, err := c.DescribeClientVPNTargetNetworks(r.Context(), r.Form.Get("ClientVpnEndpointId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	out := make([]clientVPNTargetNetworkXML, 0, len(items))
+	for i := range items {
+		out = append(out, clientVPNTargetNetworkXML{
+			AssociationID: items[i].AssociationID, ClientVpnEndpointID: items[i].EndpointID,
+			TargetNetworkID: items[i].SubnetID, VpcID: items[i].VPCID,
+			Status: clientVPNStatusXML{Code: items[i].State},
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name                    `xml:"DescribeClientVpnTargetNetworksResponse"`
+		Xmlns   string                      `xml:"xmlns,attr"`
+		Req     string                      `xml:"requestId"`
+		Set     []clientVPNTargetNetworkXML `xml:"clientVpnTargetNetworks>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) authorizeClientVPNIngress(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	out, err := c.AuthorizeClientVPNIngress(r.Context(), r.Form.Get("ClientVpnEndpointId"),
+		r.Form.Get("TargetNetworkCidr"), r.Form.Get("AccessGroupId"), r.Form.Get("AuthorizeAllGroups") == formTrue)
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"AuthorizeClientVpnIngressResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Status  clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: out.Status}})
+}
+
+func (*Handler) revokeClientVPNIngress(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	err := c.RevokeClientVPNIngress(r.Context(), r.Form.Get("ClientVpnEndpointId"), r.Form.Get("TargetNetworkCidr"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"RevokeClientVpnIngressResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Status  clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "revoking"}})
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeClientVPNAuthRules(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	items, err := c.DescribeClientVPNAuthorizationRules(r.Context(), r.Form.Get("ClientVpnEndpointId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	out := make([]clientVPNAuthRuleXML, 0, len(items))
+	for i := range items {
+		out = append(out, clientVPNAuthRuleXML{
+			ClientVpnEndpointID: items[i].EndpointID, DestinationCidr: items[i].TargetCIDR,
+			GroupID: items[i].GroupID, AccessAll: items[i].AccessAll,
+			Status: clientVPNStatusXML{Code: items[i].Status},
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name               `xml:"DescribeClientVpnAuthorizationRulesResponse"`
+		Xmlns   string                 `xml:"xmlns,attr"`
+		Req     string                 `xml:"requestId"`
+		Set     []clientVPNAuthRuleXML `xml:"authorizationRule>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) createClientVPNRoute(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	out, err := c.CreateClientVPNRoute(r.Context(), r.Form.Get("ClientVpnEndpointId"),
+		r.Form.Get("DestinationCidrBlock"), r.Form.Get("TargetVpcSubnetId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"CreateClientVpnRouteResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Status  clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: out.Status}})
+}
+
+func (*Handler) deleteClientVPNRoute(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	err := c.DeleteClientVPNRoute(r.Context(), r.Form.Get("ClientVpnEndpointId"),
+		r.Form.Get("DestinationCidrBlock"), r.Form.Get("TargetVpcSubnetId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"DeleteClientVpnRouteResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Status  clientVPNStatusXML `xml:"status"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "deleting"}})
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeClientVPNRoutes(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+	items, err := c.DescribeClientVPNRoutes(r.Context(), r.Form.Get("ClientVpnEndpointId"))
+	if err != nil {
+		writeClientVPNErr(w, err)
+		return
+	}
+
+	out := make([]clientVPNRouteXML, 0, len(items))
+	for i := range items {
+		out = append(out, clientVPNRouteXML{
+			ClientVpnEndpointID: items[i].EndpointID, DestinationCidr: items[i].DestinationCIDR,
+			TargetSubnet: items[i].TargetSubnetID, Status: clientVPNStatusXML{Code: items[i].Status},
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name            `xml:"DescribeClientVpnRoutesResponse"`
+		Xmlns   string              `xml:"xmlns,attr"`
+		Req     string              `xml:"requestId"`
+		Set     []clientVPNRouteXML `xml:"routes>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
 func toClientVPNEndpointXML(e *netdriver.ClientVPNEndpoint) clientVPNEndpointXML {

--- a/server/aws/ec2/client_vpn.go
+++ b/server/aws/ec2/client_vpn.go
@@ -53,7 +53,7 @@ func (h *Handler) routeClientVPN(w http.ResponseWriter, r *http.Request, action 
 	return true
 }
 
-func (h *Handler) createClientVPNEndpoint(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+func (*Handler) createClientVPNEndpoint(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
 	out, err := c.CreateClientVPNEndpoint(r.Context(), netdriver.ClientVPNEndpointConfig{
 		Description:          r.Form.Get("Description"),
 		ClientCIDRBlock:      r.Form.Get("ClientCidrBlock"),
@@ -75,7 +75,7 @@ func (h *Handler) createClientVPNEndpoint(w http.ResponseWriter, r *http.Request
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, EndpointID: out.ID, Status: clientVPNStatusXML{Code: out.State}})
 }
 
-func (h *Handler) deleteClientVPNEndpoint(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+func (*Handler) deleteClientVPNEndpoint(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
 	if err := c.DeleteClientVPNEndpoint(r.Context(), r.Form.Get("ClientVpnEndpointId")); err != nil {
 		writeClientVPNErr(w, err)
 		return
@@ -89,7 +89,8 @@ func (h *Handler) deleteClientVPNEndpoint(w http.ResponseWriter, r *http.Request
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Status: clientVPNStatusXML{Code: "deleting"}})
 }
 
-func (h *Handler) describeClientVPNEndpoints(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeClientVPNEndpoints(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
 	items, err := c.DescribeClientVPNEndpoints(r.Context(), awsquery.ListStrings(r.Form, "ClientVpnEndpointId"))
 	if err != nil {
 		writeClientVPNErr(w, err)
@@ -109,7 +110,7 @@ func (h *Handler) describeClientVPNEndpoints(w http.ResponseWriter, r *http.Requ
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) associateClientVPN(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+func (*Handler) associateClientVPN(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
 	out, err := c.AssociateClientVPNTargetNetwork(r.Context(), r.Form.Get("ClientVpnEndpointId"), r.Form.Get("SubnetId"))
 	if err != nil {
 		writeClientVPNErr(w, err)
@@ -125,7 +126,7 @@ func (h *Handler) associateClientVPN(w http.ResponseWriter, r *http.Request, c n
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, AssociationID: out.AssociationID, Status: clientVPNStatusXML{Code: out.State}})
 }
 
-func (h *Handler) disassociateClientVPN(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
+func (*Handler) disassociateClientVPN(w http.ResponseWriter, r *http.Request, c netdriver.ClientVPN) {
 	if err := c.DisassociateClientVPNTargetNetwork(r.Context(), r.Form.Get("ClientVpnEndpointId"), r.Form.Get("AssociationId")); err != nil {
 		writeClientVPNErr(w, err)
 		return

--- a/server/aws/ec2/dhcp_options.go
+++ b/server/aws/ec2/dhcp_options.go
@@ -53,7 +53,7 @@ func (h *Handler) routeDHCPOptions(w http.ResponseWriter, r *http.Request, actio
 	return true
 }
 
-func (h *Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+func (*Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	out, err := d.CreateDHCPOptions(r.Context(), netdriver.DHCPOptionsConfig{
 		Configuration: parseDHCPConfigurations(r),
 		Tags:          mergeTagSpecs(awsquery.TagSpecs(r.Form), "dhcp-options"),
@@ -71,7 +71,7 @@ func (h *Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d ne
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Opts: toDHCPOptionsXML(out)})
 }
 
-func (h *Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+func (*Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	if err := d.DeleteDHCPOptions(r.Context(), r.Form.Get("DhcpOptionsId")); err != nil {
 		writeDHCPErr(w, err)
 		return
@@ -80,7 +80,8 @@ func (h *Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d ne
 	writeReturnTrue(w, "DeleteDhcpOptionsResponse")
 }
 
-func (h *Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	items, err := d.DescribeDHCPOptions(r.Context(), awsquery.ListStrings(r.Form, "DhcpOptionsId"))
 	if err != nil {
 		writeDHCPErr(w, err)
@@ -100,7 +101,7 @@ func (h *Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) associateDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+func (*Handler) associateDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
 	if err := d.AssociateDHCPOptions(r.Context(), r.Form.Get("DhcpOptionsId"), r.Form.Get("VpcId")); err != nil {
 		writeDHCPErr(w, err)
 		return

--- a/server/aws/ec2/dhcp_options.go
+++ b/server/aws/ec2/dhcp_options.go
@@ -1,0 +1,156 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"sort"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) dhcpOptionSets() (netdriver.DHCPOptionSets, bool) {
+	d, ok := h.vpc.(netdriver.DHCPOptionSets)
+
+	return d, ok
+}
+
+type dhcpConfigValueXML struct {
+	Value string `xml:"value"`
+}
+
+type dhcpConfigXML struct {
+	Key    string               `xml:"key"`
+	Values []dhcpConfigValueXML `xml:"valueSet>item"`
+}
+
+type dhcpOptionsXML struct {
+	DhcpOptionsID      string          `xml:"dhcpOptionsId"`
+	DhcpConfigurations []dhcpConfigXML `xml:"dhcpConfigurationSet>item,omitempty"`
+	Tags               []tagItem       `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) routeDHCPOptions(w http.ResponseWriter, r *http.Request, action string) bool {
+	d, ok := h.dhcpOptionSets()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateDhcpOptions":
+		h.createDHCPOptions(w, r, d)
+	case "DeleteDhcpOptions":
+		h.deleteDHCPOptions(w, r, d)
+	case "DescribeDhcpOptions":
+		h.describeDHCPOptions(w, r, d)
+	case "AssociateDhcpOptions":
+		h.associateDHCPOptions(w, r, d)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+	out, err := d.CreateDHCPOptions(r.Context(), netdriver.DHCPOptionsConfig{
+		Configuration: parseDHCPConfigurations(r),
+		Tags:          mergeTagSpecs(awsquery.TagSpecs(r.Form), "dhcp-options"),
+	})
+	if err != nil {
+		writeDHCPErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name       `xml:"CreateDhcpOptionsResponse"`
+		Xmlns   string         `xml:"xmlns,attr"`
+		Req     string         `xml:"requestId"`
+		Opts    dhcpOptionsXML `xml:"dhcpOptions"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Opts: toDHCPOptionsXML(out)})
+}
+
+func (h *Handler) deleteDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+	if err := d.DeleteDHCPOptions(r.Context(), r.Form.Get("DhcpOptionsId")); err != nil {
+		writeDHCPErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DeleteDhcpOptionsResponse")
+}
+
+func (h *Handler) describeDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+	items, err := d.DescribeDHCPOptions(r.Context(), awsquery.ListStrings(r.Form, "DhcpOptionsId"))
+	if err != nil {
+		writeDHCPErr(w, err)
+		return
+	}
+
+	out := make([]dhcpOptionsXML, 0, len(items))
+	for i := range items {
+		out = append(out, toDHCPOptionsXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name         `xml:"DescribeDhcpOptionsResponse"`
+		Xmlns   string           `xml:"xmlns,attr"`
+		Req     string           `xml:"requestId"`
+		Set     []dhcpOptionsXML `xml:"dhcpOptionsSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) associateDHCPOptions(w http.ResponseWriter, r *http.Request, d netdriver.DHCPOptionSets) {
+	if err := d.AssociateDHCPOptions(r.Context(), r.Form.Get("DhcpOptionsId"), r.Form.Get("VpcId")); err != nil {
+		writeDHCPErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "AssociateDhcpOptionsResponse")
+}
+
+// parseDHCPConfigurations reads DhcpConfiguration.N.Key + .Value.M groups.
+func parseDHCPConfigurations(r *http.Request) map[string][]string {
+	out := map[string][]string{}
+
+	for i := 1; ; i++ {
+		key := r.Form.Get("DhcpConfiguration." + strconv.Itoa(i) + ".Key")
+		if key == "" {
+			break
+		}
+
+		out[key] = awsquery.ListStrings(r.Form, "DhcpConfiguration."+strconv.Itoa(i)+".Value")
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+func toDHCPOptionsXML(d *netdriver.DHCPOptions) dhcpOptionsXML {
+	keys := make([]string, 0, len(d.Configuration))
+	for k := range d.Configuration {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	cfgs := make([]dhcpConfigXML, 0, len(keys))
+
+	for _, k := range keys {
+		vals := make([]dhcpConfigValueXML, 0, len(d.Configuration[k]))
+		for _, v := range d.Configuration[k] {
+			vals = append(vals, dhcpConfigValueXML{Value: v})
+		}
+
+		cfgs = append(cfgs, dhcpConfigXML{Key: k, Values: vals})
+	}
+
+	return dhcpOptionsXML{DhcpOptionsID: d.ID, DhcpConfigurations: cfgs, Tags: toTagItems(d.Tags)}
+}
+
+func writeDHCPErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidDhcpOptionID.NotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/egress_only_igw.go
+++ b/server/aws/ec2/egress_only_igw.go
@@ -45,7 +45,8 @@ func (h *Handler) routeEgressOnlyIGW(w http.ResponseWriter, r *http.Request, act
 	return true
 }
 
-func (h *Handler) createEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) createEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
 	out, err := e.CreateEgressOnlyInternetGateway(r.Context(), r.Form.Get("VpcId"),
 		mergeTagSpecs(awsquery.TagSpecs(r.Form), "egress-only-internet-gateway"))
 	if err != nil {
@@ -61,7 +62,7 @@ func (h *Handler) createEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Gateway: toEgressOnlyIGWXML(out)})
 }
 
-func (h *Handler) deleteEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
+func (*Handler) deleteEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
 	if err := e.DeleteEgressOnlyInternetGateway(r.Context(), r.Form.Get("EgressOnlyInternetGatewayId")); err != nil {
 		writeEgressOnlyErr(w, err)
 		return
@@ -75,7 +76,8 @@ func (h *Handler) deleteEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, ReturnCode: true})
 }
 
-func (h *Handler) describeEgressOnlyIGWs(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeEgressOnlyIGWs(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
 	items, err := e.DescribeEgressOnlyInternetGateways(r.Context(), awsquery.ListStrings(r.Form, "EgressOnlyInternetGatewayId"))
 	if err != nil {
 		writeEgressOnlyErr(w, err)

--- a/server/aws/ec2/egress_only_igw.go
+++ b/server/aws/ec2/egress_only_igw.go
@@ -1,0 +1,108 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) egressOnlyIGWs() (netdriver.EgressOnlyInternetGateways, bool) {
+	e, ok := h.vpc.(netdriver.EgressOnlyInternetGateways)
+
+	return e, ok
+}
+
+type egressOnlyIGWAttachmentXML struct {
+	VpcID string `xml:"vpcId"`
+	State string `xml:"state"`
+}
+
+type egressOnlyIGWXML struct {
+	EgressOnlyInternetGatewayID string                       `xml:"egressOnlyInternetGatewayId"`
+	Attachments                 []egressOnlyIGWAttachmentXML `xml:"attachmentSet>item,omitempty"`
+	Tags                        []tagItem                    `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) routeEgressOnlyIGW(w http.ResponseWriter, r *http.Request, action string) bool {
+	e, ok := h.egressOnlyIGWs()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateEgressOnlyInternetGateway":
+		h.createEgressOnlyIGW(w, r, e)
+	case "DeleteEgressOnlyInternetGateway":
+		h.deleteEgressOnlyIGW(w, r, e)
+	case "DescribeEgressOnlyInternetGateways":
+		h.describeEgressOnlyIGWs(w, r, e)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
+	out, err := e.CreateEgressOnlyInternetGateway(r.Context(), r.Form.Get("VpcId"),
+		mergeTagSpecs(awsquery.TagSpecs(r.Form), "egress-only-internet-gateway"))
+	if err != nil {
+		writeEgressOnlyErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name         `xml:"CreateEgressOnlyInternetGatewayResponse"`
+		Xmlns   string           `xml:"xmlns,attr"`
+		Req     string           `xml:"requestId"`
+		Gateway egressOnlyIGWXML `xml:"egressOnlyInternetGateway"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Gateway: toEgressOnlyIGWXML(out)})
+}
+
+func (h *Handler) deleteEgressOnlyIGW(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
+	if err := e.DeleteEgressOnlyInternetGateway(r.Context(), r.Form.Get("EgressOnlyInternetGatewayId")); err != nil {
+		writeEgressOnlyErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name `xml:"DeleteEgressOnlyInternetGatewayResponse"`
+		Xmlns      string   `xml:"xmlns,attr"`
+		Req        string   `xml:"requestId"`
+		ReturnCode bool     `xml:"returnCode"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, ReturnCode: true})
+}
+
+func (h *Handler) describeEgressOnlyIGWs(w http.ResponseWriter, r *http.Request, e netdriver.EgressOnlyInternetGateways) {
+	items, err := e.DescribeEgressOnlyInternetGateways(r.Context(), awsquery.ListStrings(r.Form, "EgressOnlyInternetGatewayId"))
+	if err != nil {
+		writeEgressOnlyErr(w, err)
+		return
+	}
+
+	out := make([]egressOnlyIGWXML, 0, len(items))
+	for i := range items {
+		out = append(out, toEgressOnlyIGWXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"DescribeEgressOnlyInternetGatewaysResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Set     []egressOnlyIGWXML `xml:"egressOnlyInternetGatewaySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func toEgressOnlyIGWXML(e *netdriver.EgressOnlyInternetGateway) egressOnlyIGWXML {
+	return egressOnlyIGWXML{
+		EgressOnlyInternetGatewayID: e.ID,
+		Attachments:                 []egressOnlyIGWAttachmentXML{{VpcID: e.AttachedVPCID, State: e.State}},
+		Tags:                        toTagItems(e.Tags),
+	}
+}
+
+func writeEgressOnlyErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidEgressOnlyInternetGatewayId.NotFound", "DependencyViolation")
+}

--- a/server/aws/ec2/endpoint_service.go
+++ b/server/aws/ec2/endpoint_service.go
@@ -44,7 +44,7 @@ func (h *Handler) routeEndpointServices(w http.ResponseWriter, r *http.Request, 
 	return true
 }
 
-func (h *Handler) createEndpointService(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+func (*Handler) createEndpointService(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
 	out, err := s.CreateVPCEndpointServiceConfiguration(r.Context(), netdriver.EndpointServiceConfig{
 		NetworkLoadBalancerARNs: awsquery.ListStrings(r.Form, "NetworkLoadBalancerArn"),
 		AcceptanceRequired:      r.Form.Get("AcceptanceRequired") == formTrue,
@@ -63,7 +63,7 @@ func (h *Handler) createEndpointService(w http.ResponseWriter, r *http.Request, 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Config: toEndpointServiceXML(out)})
 }
 
-func (h *Handler) deleteEndpointService(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+func (*Handler) deleteEndpointService(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
 	for _, id := range awsquery.ListStrings(r.Form, "ServiceId") {
 		if err := s.DeleteVPCEndpointServiceConfiguration(r.Context(), id); err != nil {
 			writeEndpointServiceErr(w, err)
@@ -79,7 +79,8 @@ func (h *Handler) deleteEndpointService(w http.ResponseWriter, r *http.Request, 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID})
 }
 
-func (h *Handler) describeEndpointServices(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeEndpointServices(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
 	items, err := s.DescribeVPCEndpointServiceConfigurations(r.Context(), awsquery.ListStrings(r.Form, "ServiceId"))
 	if err != nil {
 		writeEndpointServiceErr(w, err)

--- a/server/aws/ec2/endpoint_service.go
+++ b/server/aws/ec2/endpoint_service.go
@@ -1,0 +1,112 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) endpointServices() (netdriver.VPCEndpointServices, bool) {
+	s, ok := h.vpc.(netdriver.VPCEndpointServices)
+
+	return s, ok
+}
+
+type endpointServiceXML struct {
+	ServiceID          string    `xml:"serviceId"`
+	ServiceName        string    `xml:"serviceName"`
+	ServiceState       string    `xml:"serviceState"`
+	AcceptanceRequired bool      `xml:"acceptanceRequired"`
+	AvailabilityZones  []string  `xml:"availabilityZoneSet>item,omitempty"`
+	NlbArns            []string  `xml:"networkLoadBalancerArnSet>item,omitempty"`
+	Tags               []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) routeEndpointServices(w http.ResponseWriter, r *http.Request, action string) bool {
+	s, ok := h.endpointServices()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateVpcEndpointServiceConfiguration":
+		h.createEndpointService(w, r, s)
+	case "DeleteVpcEndpointServiceConfigurations":
+		h.deleteEndpointService(w, r, s)
+	case "DescribeVpcEndpointServiceConfigurations":
+		h.describeEndpointServices(w, r, s)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createEndpointService(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+	out, err := s.CreateVPCEndpointServiceConfiguration(r.Context(), netdriver.EndpointServiceConfig{
+		NetworkLoadBalancerARNs: awsquery.ListStrings(r.Form, "NetworkLoadBalancerArn"),
+		AcceptanceRequired:      r.Form.Get("AcceptanceRequired") == formTrue,
+		Tags:                    mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpc-endpoint-service"),
+	})
+	if err != nil {
+		writeEndpointServiceErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"CreateVpcEndpointServiceConfigurationResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Config  endpointServiceXML `xml:"serviceConfiguration"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Config: toEndpointServiceXML(out)})
+}
+
+func (h *Handler) deleteEndpointService(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+	for _, id := range awsquery.ListStrings(r.Form, "ServiceId") {
+		if err := s.DeleteVPCEndpointServiceConfiguration(r.Context(), id); err != nil {
+			writeEndpointServiceErr(w, err)
+			return
+		}
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:"DeleteVpcEndpointServiceConfigurationsResponse"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Unsucc  []string `xml:"unsuccessful>item,omitempty"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID})
+}
+
+func (h *Handler) describeEndpointServices(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+	items, err := s.DescribeVPCEndpointServiceConfigurations(r.Context(), awsquery.ListStrings(r.Form, "ServiceId"))
+	if err != nil {
+		writeEndpointServiceErr(w, err)
+		return
+	}
+
+	out := make([]endpointServiceXML, 0, len(items))
+	for i := range items {
+		out = append(out, toEndpointServiceXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name             `xml:"DescribeVpcEndpointServiceConfigurationsResponse"`
+		Xmlns   string               `xml:"xmlns,attr"`
+		Req     string               `xml:"requestId"`
+		Set     []endpointServiceXML `xml:"serviceConfigurationSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func toEndpointServiceXML(s *netdriver.EndpointService) endpointServiceXML {
+	return endpointServiceXML{
+		ServiceID: s.ID, ServiceName: s.ServiceName, ServiceState: s.State,
+		AcceptanceRequired: s.AcceptanceRequired, AvailabilityZones: s.AvailabilityZones,
+		NlbArns: s.NetworkLoadBalancerARNs, Tags: toTagItems(s.Tags),
+	}
+}
+
+func writeEndpointServiceErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidVpcEndpointServiceId.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/endpoint_service.go
+++ b/server/aws/ec2/endpoint_service.go
@@ -37,6 +37,10 @@ func (h *Handler) routeEndpointServices(w http.ResponseWriter, r *http.Request, 
 		h.deleteEndpointService(w, r, s)
 	case "DescribeVpcEndpointServiceConfigurations":
 		h.describeEndpointServices(w, r, s)
+	case "ModifyVpcEndpointServicePermissions":
+		h.modifyEndpointServicePermissions(w, r, s)
+	case "DescribeVpcEndpointServicePermissions":
+		h.describeEndpointServicePermissions(w, r, s)
 	default:
 		return false
 	}
@@ -98,6 +102,47 @@ func (*Handler) describeEndpointServices(w http.ResponseWriter, r *http.Request,
 		Req     string               `xml:"requestId"`
 		Set     []endpointServiceXML `xml:"serviceConfigurationSet>item"`
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyEndpointServicePermissions(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+	err := s.ModifyVPCEndpointServicePermissions(r.Context(), r.Form.Get("ServiceId"),
+		awsquery.ListStrings(r.Form, "AddAllowedPrincipals"), awsquery.ListStrings(r.Form, "RemoveAllowedPrincipals"))
+	if err != nil {
+		writeEndpointServiceErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName     xml.Name `xml:"ModifyVpcEndpointServicePermissionsResponse"`
+		Xmlns       string   `xml:"xmlns,attr"`
+		Req         string   `xml:"requestId"`
+		ReturnValue bool     `xml:"returnValue"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, ReturnValue: true})
+}
+
+func (*Handler) describeEndpointServicePermissions(w http.ResponseWriter, r *http.Request, s netdriver.VPCEndpointServices) {
+	principals, err := s.DescribeVPCEndpointServicePermissions(r.Context(), r.Form.Get("ServiceId"))
+	if err != nil {
+		writeEndpointServiceErr(w, err)
+		return
+	}
+
+	type principalXML struct {
+		PrincipalType string `xml:"principalType"`
+		Principal     string `xml:"principal"`
+	}
+
+	out := make([]principalXML, 0, len(principals))
+	for _, p := range principals {
+		out = append(out, principalXML{PrincipalType: "Account", Principal: p})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name       `xml:"DescribeVpcEndpointServicePermissionsResponse"`
+		Xmlns      string         `xml:"xmlns,attr"`
+		Req        string         `xml:"requestId"`
+		Principals []principalXML `xml:"allowedPrincipals>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Principals: out})
 }
 
 func toEndpointServiceXML(s *netdriver.EndpointService) endpointServiceXML {

--- a/server/aws/ec2/endpoint_service.go
+++ b/server/aws/ec2/endpoint_service.go
@@ -76,10 +76,10 @@ func (*Handler) deleteEndpointService(w http.ResponseWriter, r *http.Request, s 
 	}
 
 	awsquery.WriteXMLResponse(w, struct {
-		XMLName xml.Name `xml:"DeleteVpcEndpointServiceConfigurationsResponse"`
-		Xmlns   string   `xml:"xmlns,attr"`
-		Req     string   `xml:"requestId"`
-		Unsucc  []string `xml:"unsuccessful>item,omitempty"`
+		XMLName xml.Name              `xml:"DeleteVpcEndpointServiceConfigurationsResponse"`
+		Xmlns   string                `xml:"xmlns,attr"`
+		Req     string                `xml:"requestId"`
+		Unsucc  []unsuccessfulItemXML `xml:"unsuccessful>item,omitempty"`
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID})
 }
 
@@ -116,7 +116,7 @@ func (*Handler) modifyEndpointServicePermissions(w http.ResponseWriter, r *http.
 		XMLName     xml.Name `xml:"ModifyVpcEndpointServicePermissionsResponse"`
 		Xmlns       string   `xml:"xmlns,attr"`
 		Req         string   `xml:"requestId"`
-		ReturnValue bool     `xml:"returnValue"`
+		ReturnValue bool     `xml:"return"`
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, ReturnValue: true})
 }
 
@@ -151,6 +151,17 @@ func toEndpointServiceXML(s *netdriver.EndpointService) endpointServiceXML {
 		AcceptanceRequired: s.AcceptanceRequired, AvailabilityZones: s.AvailabilityZones,
 		NlbArns: s.NetworkLoadBalancerARNs, Tags: toTagItems(s.Tags),
 	}
+}
+
+// unsuccessfulItemXML mirrors the EC2 UnsuccessfulItem shape (resourceId +
+// nested error). The mock never fails a delete, so the set is always empty,
+// but the shape must match what the SDK expects to deserialize.
+type unsuccessfulItemXML struct {
+	ResourceID string `xml:"resourceId"`
+	Error      struct {
+		Code    string `xml:"code"`
+		Message string `xml:"message"`
+	} `xml:"error"`
 }
 
 func writeEndpointServiceErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -232,7 +232,6 @@ func (h *Handler) routeLaunchTemplates(w http.ResponseWriter, r *http.Request, a
 	return true
 }
 
-//nolint:dupl // action-dispatch switch; every route* function has this shape by design
 func (h *Handler) routeAutoScaling(w http.ResponseWriter, r *http.Request, action string) bool {
 	switch action {
 	case "CreateAutoScalingGroup":

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -87,6 +87,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeVpcPeering,
 		h.routeFlowLogs,
 		h.routeNetworkACLs,
+		h.routeTransitGateways,
+		h.routeVPN,
+		h.routeDHCPOptions,
+		h.routePrefixLists,
+		h.routeEgressOnlyIGW,
+		h.routeEndpointServices,
+		h.routeClientVPN,
 		h.routeVPC,
 	}
 	for _, route := range routes {

--- a/server/aws/ec2/networking_common.go
+++ b/server/aws/ec2/networking_common.go
@@ -1,0 +1,26 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// writeReturnTrue writes the common EC2 "<return>true</return>" acknowledgement
+// with a caller-supplied response root element (set at runtime via xml.Name).
+// SDK output shapes ignore unknown fields, so a return element is harmless even
+// for actions whose real response carries only a requestId.
+func writeReturnTrue(w http.ResponseWriter, rootElement string) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName   xml.Name
+		Xmlns     string `xml:"xmlns,attr"`
+		RequestID string `xml:"requestId"`
+		Return    bool   `xml:"return"`
+	}{
+		XMLName:   xml.Name{Local: rootElement},
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		Return:    true,
+	})
+}

--- a/server/aws/ec2/prefix_list.go
+++ b/server/aws/ec2/prefix_list.go
@@ -45,6 +45,8 @@ func (h *Handler) routePrefixLists(w http.ResponseWriter, r *http.Request, actio
 		h.describePrefixLists(w, r, p)
 	case "GetManagedPrefixListEntries":
 		h.getPrefixListEntries(w, r, p)
+	case "ModifyManagedPrefixList":
+		h.modifyPrefixList(w, r, p)
 	default:
 		return false
 	}
@@ -129,6 +131,68 @@ func (*Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p n
 		Req     string               `xml:"requestId"`
 		Set     []prefixListEntryXML `xml:"entrySet>item"`
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+	out, err := p.ModifyManagedPrefixList(r.Context(),
+		r.Form.Get("PrefixListId"), parseAddPrefixListEntries(r), parseRemovePrefixListCIDRs(r))
+	if err != nil {
+		writePrefixListErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:"ModifyManagedPrefixListResponse"`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		PL      prefixListXML `xml:"prefixList"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
+}
+
+func parseAddPrefixListEntries(r *http.Request) []netdriver.PrefixListEntry {
+	var out []netdriver.PrefixListEntry
+
+	for _, prefix := range []string{"AddEntry", "AddEntries"} {
+		for i := 1; ; i++ {
+			base := prefix + "." + strconv.Itoa(i)
+
+			cidr := r.Form.Get(base + ".Cidr")
+			if cidr == "" {
+				break
+			}
+
+			out = append(out, netdriver.PrefixListEntry{CIDR: cidr, Description: r.Form.Get(base + ".Description")})
+		}
+
+		if len(out) > 0 {
+			return out
+		}
+	}
+
+	return out
+}
+
+func parseRemovePrefixListCIDRs(r *http.Request) []string {
+	var out []string
+
+	for _, prefix := range []string{"RemoveEntry", "RemoveEntries"} {
+		for i := 1; ; i++ {
+			base := prefix + "." + strconv.Itoa(i)
+
+			cidr := r.Form.Get(base + ".Cidr")
+			if cidr == "" {
+				break
+			}
+
+			out = append(out, cidr)
+		}
+
+		if len(out) > 0 {
+			return out
+		}
+	}
+
+	return out
 }
 
 // parsePrefixListEntries reads the AddPrefixListEntry list. The EC2 query

--- a/server/aws/ec2/prefix_list.go
+++ b/server/aws/ec2/prefix_list.go
@@ -52,8 +52,9 @@ func (h *Handler) routePrefixLists(w http.ResponseWriter, r *http.Request, actio
 	return true
 }
 
-func (h *Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (*Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	maxEntries, _ := strconv.Atoi(r.Form.Get("MaxEntries"))
+
 	out, err := p.CreateManagedPrefixList(r.Context(), netdriver.PrefixListConfig{
 		Name:          r.Form.Get("PrefixListName"),
 		AddressFamily: r.Form.Get("AddressFamily"),
@@ -74,7 +75,7 @@ func (h *Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p net
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
 }
 
-func (h *Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (*Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	out, err := p.DeleteManagedPrefixList(r.Context(), r.Form.Get("PrefixListId"))
 	if err != nil {
 		writePrefixListErr(w, err)
@@ -89,7 +90,8 @@ func (h *Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p net
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
 }
 
-func (h *Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	items, err := p.DescribeManagedPrefixLists(r.Context(), awsquery.ListStrings(r.Form, "PrefixListId"))
 	if err != nil {
 		writePrefixListErr(w, err)
@@ -109,7 +111,7 @@ func (h *Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+func (*Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
 	entries, err := p.GetManagedPrefixListEntries(r.Context(), r.Form.Get("PrefixListId"))
 	if err != nil {
 		writePrefixListErr(w, err)
@@ -129,22 +131,30 @@ func (h *Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-// parsePrefixListEntries reads Entries.N.Cidr + .Description groups.
+// parsePrefixListEntries reads the AddPrefixListEntry list. The EC2 query
+// serialization names the member "Entry" (Entry.N.Cidr); older/alternate SDKs
+// may use "Entries", so both prefixes are accepted.
 func parsePrefixListEntries(r *http.Request) []netdriver.PrefixListEntry {
-	var out []netdriver.PrefixListEntry
+	for _, prefix := range []string{"Entry", "Entries"} {
+		var out []netdriver.PrefixListEntry
 
-	for i := 1; ; i++ {
-		base := "Entries." + strconv.Itoa(i)
+		for i := 1; ; i++ {
+			base := prefix + "." + strconv.Itoa(i)
 
-		cidr := r.Form.Get(base + ".Cidr")
-		if cidr == "" {
-			break
+			cidr := r.Form.Get(base + ".Cidr")
+			if cidr == "" {
+				break
+			}
+
+			out = append(out, netdriver.PrefixListEntry{CIDR: cidr, Description: r.Form.Get(base + ".Description")})
 		}
 
-		out = append(out, netdriver.PrefixListEntry{CIDR: cidr, Description: r.Form.Get(base + ".Description")})
+		if len(out) > 0 {
+			return out
+		}
 	}
 
-	return out
+	return nil
 }
 
 func toPrefixListXML(p *netdriver.PrefixList) prefixListXML {

--- a/server/aws/ec2/prefix_list.go
+++ b/server/aws/ec2/prefix_list.go
@@ -1,0 +1,159 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) prefixLists() (netdriver.PrefixLists, bool) {
+	p, ok := h.vpc.(netdriver.PrefixLists)
+
+	return p, ok
+}
+
+type prefixListXML struct {
+	PrefixListID   string    `xml:"prefixListId"`
+	PrefixListName string    `xml:"prefixListName"`
+	AddressFamily  string    `xml:"addressFamily"`
+	MaxEntries     int       `xml:"maxEntries"`
+	State          string    `xml:"state"`
+	Version        int       `xml:"version"`
+	Tags           []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type prefixListEntryXML struct {
+	Cidr        string `xml:"cidr"`
+	Description string `xml:"description,omitempty"`
+}
+
+func (h *Handler) routePrefixLists(w http.ResponseWriter, r *http.Request, action string) bool {
+	p, ok := h.prefixLists()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateManagedPrefixList":
+		h.createPrefixList(w, r, p)
+	case "DeleteManagedPrefixList":
+		h.deletePrefixList(w, r, p)
+	case "DescribeManagedPrefixLists":
+		h.describePrefixLists(w, r, p)
+	case "GetManagedPrefixListEntries":
+		h.getPrefixListEntries(w, r, p)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createPrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+	maxEntries, _ := strconv.Atoi(r.Form.Get("MaxEntries"))
+	out, err := p.CreateManagedPrefixList(r.Context(), netdriver.PrefixListConfig{
+		Name:          r.Form.Get("PrefixListName"),
+		AddressFamily: r.Form.Get("AddressFamily"),
+		MaxEntries:    maxEntries,
+		Entries:       parsePrefixListEntries(r),
+		Tags:          mergeTagSpecs(awsquery.TagSpecs(r.Form), "prefix-list"),
+	})
+	if err != nil {
+		writePrefixListErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:"CreateManagedPrefixListResponse"`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		PL      prefixListXML `xml:"prefixList"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
+}
+
+func (h *Handler) deletePrefixList(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+	out, err := p.DeleteManagedPrefixList(r.Context(), r.Form.Get("PrefixListId"))
+	if err != nil {
+		writePrefixListErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:"DeleteManagedPrefixListResponse"`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		PL      prefixListXML `xml:"prefixList"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, PL: toPrefixListXML(out)})
+}
+
+func (h *Handler) describePrefixLists(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+	items, err := p.DescribeManagedPrefixLists(r.Context(), awsquery.ListStrings(r.Form, "PrefixListId"))
+	if err != nil {
+		writePrefixListErr(w, err)
+		return
+	}
+
+	out := make([]prefixListXML, 0, len(items))
+	for i := range items {
+		out = append(out, toPrefixListXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name        `xml:"DescribeManagedPrefixListsResponse"`
+		Xmlns   string          `xml:"xmlns,attr"`
+		Req     string          `xml:"requestId"`
+		Set     []prefixListXML `xml:"prefixListSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) getPrefixListEntries(w http.ResponseWriter, r *http.Request, p netdriver.PrefixLists) {
+	entries, err := p.GetManagedPrefixListEntries(r.Context(), r.Form.Get("PrefixListId"))
+	if err != nil {
+		writePrefixListErr(w, err)
+		return
+	}
+
+	out := make([]prefixListEntryXML, 0, len(entries))
+	for i := range entries {
+		out = append(out, prefixListEntryXML{Cidr: entries[i].CIDR, Description: entries[i].Description})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name             `xml:"GetManagedPrefixListEntriesResponse"`
+		Xmlns   string               `xml:"xmlns,attr"`
+		Req     string               `xml:"requestId"`
+		Set     []prefixListEntryXML `xml:"entrySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+// parsePrefixListEntries reads Entries.N.Cidr + .Description groups.
+func parsePrefixListEntries(r *http.Request) []netdriver.PrefixListEntry {
+	var out []netdriver.PrefixListEntry
+
+	for i := 1; ; i++ {
+		base := "Entries." + strconv.Itoa(i)
+
+		cidr := r.Form.Get(base + ".Cidr")
+		if cidr == "" {
+			break
+		}
+
+		out = append(out, netdriver.PrefixListEntry{CIDR: cidr, Description: r.Form.Get(base + ".Description")})
+	}
+
+	return out
+}
+
+func toPrefixListXML(p *netdriver.PrefixList) prefixListXML {
+	return prefixListXML{
+		PrefixListID: p.ID, PrefixListName: p.Name, AddressFamily: p.AddressFamily,
+		MaxEntries: p.MaxEntries, State: p.State, Version: p.Version, Tags: toTagItems(p.Tags),
+	}
+}
+
+func writePrefixListErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidPrefixListID.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/transit_gateway.go
+++ b/server/aws/ec2/transit_gateway.go
@@ -1,0 +1,274 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// transitGateways reports whether the driver models transit gateways (optional).
+func (h *Handler) transitGateways() (netdriver.TransitGateways, bool) {
+	tg, ok := h.vpc.(netdriver.TransitGateways)
+
+	return tg, ok
+}
+
+type tgwOptionsXML struct {
+	AmazonSideASN int64 `xml:"amazonSideAsn"`
+}
+
+type transitGatewayXML struct {
+	TransitGatewayID string        `xml:"transitGatewayId"`
+	State            string        `xml:"state"`
+	OwnerID          string        `xml:"ownerId,omitempty"`
+	Description      string        `xml:"description,omitempty"`
+	Options          tgwOptionsXML `xml:"options"`
+	Tags             []tagItem     `xml:"tagSet>item,omitempty"`
+}
+
+type transitGatewayAttachmentXML struct {
+	TransitGatewayAttachmentID string    `xml:"transitGatewayAttachmentId"`
+	TransitGatewayID           string    `xml:"transitGatewayId"`
+	VpcID                      string    `xml:"vpcId"`
+	SubnetIDs                  []string  `xml:"subnetIds>item,omitempty"`
+	State                      string    `xml:"state"`
+	Tags                       []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type transitGatewayRouteTableXML struct {
+	TransitGatewayRouteTableID string    `xml:"transitGatewayRouteTableId"`
+	TransitGatewayID           string    `xml:"transitGatewayId"`
+	State                      string    `xml:"state"`
+	Tags                       []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+func (h *Handler) routeTransitGateways(w http.ResponseWriter, r *http.Request, action string) bool {
+	tg, ok := h.transitGateways()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateTransitGateway":
+		h.createTransitGateway(w, r, tg)
+	case "DeleteTransitGateway":
+		h.deleteTransitGateway(w, r, tg)
+	case "DescribeTransitGateways":
+		h.describeTransitGateways(w, r, tg)
+	case "CreateTransitGatewayVpcAttachment":
+		h.createTGWAttachment(w, r, tg)
+	case "DeleteTransitGatewayVpcAttachment":
+		h.deleteTGWAttachment(w, r, tg)
+	case "DescribeTransitGatewayVpcAttachments":
+		h.describeTGWAttachments(w, r, tg)
+	case "CreateTransitGatewayRouteTable":
+		h.createTGWRouteTable(w, r, tg)
+	case "DeleteTransitGatewayRouteTable":
+		h.deleteTGWRouteTable(w, r, tg)
+	case "DescribeTransitGatewayRouteTables":
+		h.describeTGWRouteTables(w, r, tg)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createTransitGateway(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	asn, _ := strconv.ParseInt(r.Form.Get("Options.AmazonSideAsn"), 10, 64)
+	out, err := tg.CreateTransitGateway(r.Context(), netdriver.TransitGatewayConfig{
+		ASN:         asn,
+		Description: r.Form.Get("Description"),
+		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "transit-gateway"),
+	})
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName        xml.Name          `xml:"CreateTransitGatewayResponse"`
+		Xmlns          string            `xml:"xmlns,attr"`
+		RequestID      string            `xml:"requestId"`
+		TransitGateway transitGatewayXML `xml:"transitGateway"`
+	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, TransitGateway: toTGWXML(out)})
+}
+
+func (h *Handler) deleteTransitGateway(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.DeleteTransitGateway(r.Context(), r.Form.Get("TransitGatewayId"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName        xml.Name          `xml:"DeleteTransitGatewayResponse"`
+		Xmlns          string            `xml:"xmlns,attr"`
+		RequestID      string            `xml:"requestId"`
+		TransitGateway transitGatewayXML `xml:"transitGateway"`
+	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, TransitGateway: toTGWXML(out)})
+}
+
+func (h *Handler) describeTransitGateways(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	items, err := tg.DescribeTransitGateways(r.Context(), awsquery.ListStrings(r.Form, "TransitGatewayIds"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	out := make([]transitGatewayXML, 0, len(items))
+	for i := range items {
+		out = append(out, toTGWXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name            `xml:"DescribeTransitGatewaysResponse"`
+		Xmlns   string              `xml:"xmlns,attr"`
+		Req     string              `xml:"requestId"`
+		Set     []transitGatewayXML `xml:"transitGatewaySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) createTGWAttachment(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.CreateTransitGatewayVPCAttachment(r.Context(), netdriver.TransitGatewayVPCAttachmentConfig{
+		TransitGatewayID: r.Form.Get("TransitGatewayId"),
+		VPCID:            r.Form.Get("VpcId"),
+		SubnetIDs:        awsquery.ListStrings(r.Form, "SubnetIds"),
+		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "transit-gateway-attachment"),
+	})
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name                    `xml:"CreateTransitGatewayVpcAttachmentResponse"`
+		Xmlns      string                      `xml:"xmlns,attr"`
+		RequestID  string                      `xml:"requestId"`
+		Attachment transitGatewayAttachmentXML `xml:"transitGatewayVpcAttachment"`
+	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, Attachment: toTGWAttachmentXML(out)})
+}
+
+func (h *Handler) deleteTGWAttachment(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.DeleteTransitGatewayVPCAttachment(r.Context(), r.Form.Get("TransitGatewayAttachmentId"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name                    `xml:"DeleteTransitGatewayVpcAttachmentResponse"`
+		Xmlns      string                      `xml:"xmlns,attr"`
+		RequestID  string                      `xml:"requestId"`
+		Attachment transitGatewayAttachmentXML `xml:"transitGatewayVpcAttachment"`
+	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, Attachment: toTGWAttachmentXML(out)})
+}
+
+func (h *Handler) describeTGWAttachments(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	items, err := tg.DescribeTransitGatewayVPCAttachments(r.Context(), awsquery.ListStrings(r.Form, "TransitGatewayAttachmentIds"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	out := make([]transitGatewayAttachmentXML, 0, len(items))
+	for i := range items {
+		out = append(out, toTGWAttachmentXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name                      `xml:"DescribeTransitGatewayVpcAttachmentsResponse"`
+		Xmlns   string                        `xml:"xmlns,attr"`
+		Req     string                        `xml:"requestId"`
+		Set     []transitGatewayAttachmentXML `xml:"transitGatewayVpcAttachments>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) createTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.CreateTransitGatewayRouteTable(r.Context(), r.Form.Get("TransitGatewayId"),
+		mergeTagSpecs(awsquery.TagSpecs(r.Form), "transit-gateway-route-table"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name                    `xml:"CreateTransitGatewayRouteTableResponse"`
+		Xmlns      string                      `xml:"xmlns,attr"`
+		RequestID  string                      `xml:"requestId"`
+		RouteTable transitGatewayRouteTableXML `xml:"transitGatewayRouteTable"`
+	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, RouteTable: toTGWRouteTableXML(out)})
+}
+
+func (h *Handler) deleteTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.DeleteTransitGatewayRouteTable(r.Context(), r.Form.Get("TransitGatewayRouteTableId"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name                    `xml:"DeleteTransitGatewayRouteTableResponse"`
+		Xmlns      string                      `xml:"xmlns,attr"`
+		RequestID  string                      `xml:"requestId"`
+		RouteTable transitGatewayRouteTableXML `xml:"transitGatewayRouteTable"`
+	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, RouteTable: toTGWRouteTableXML(out)})
+}
+
+func (h *Handler) describeTGWRouteTables(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	items, err := tg.DescribeTransitGatewayRouteTables(r.Context(), awsquery.ListStrings(r.Form, "TransitGatewayRouteTableIds"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	out := make([]transitGatewayRouteTableXML, 0, len(items))
+	for i := range items {
+		out = append(out, toTGWRouteTableXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name                      `xml:"DescribeTransitGatewayRouteTablesResponse"`
+		Xmlns   string                        `xml:"xmlns,attr"`
+		Req     string                        `xml:"requestId"`
+		Set     []transitGatewayRouteTableXML `xml:"transitGatewayRouteTables>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func toTGWXML(t *netdriver.TransitGateway) transitGatewayXML {
+	return transitGatewayXML{
+		TransitGatewayID: t.ID,
+		State:            t.State,
+		OwnerID:          t.OwnerID,
+		Description:      t.Description,
+		Options:          tgwOptionsXML{AmazonSideASN: t.ASN},
+		Tags:             toTagItems(t.Tags),
+	}
+}
+
+func toTGWAttachmentXML(a *netdriver.TransitGatewayVPCAttachment) transitGatewayAttachmentXML {
+	return transitGatewayAttachmentXML{
+		TransitGatewayAttachmentID: a.ID,
+		TransitGatewayID:           a.TransitGatewayID,
+		VpcID:                      a.VPCID,
+		SubnetIDs:                  a.SubnetIDs,
+		State:                      a.State,
+		Tags:                       toTagItems(a.Tags),
+	}
+}
+
+func toTGWRouteTableXML(t *netdriver.TransitGatewayRouteTable) transitGatewayRouteTableXML {
+	return transitGatewayRouteTableXML{
+		TransitGatewayRouteTableID: t.ID,
+		TransitGatewayID:           t.TransitGatewayID,
+		State:                      t.State,
+		Tags:                       toTagItems(t.Tags),
+	}
+}
+
+func writeTGWErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidTransitGatewayID.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/transit_gateway.go
+++ b/server/aws/ec2/transit_gateway.go
@@ -45,6 +45,7 @@ type transitGatewayRouteTableXML struct {
 	Tags                       []tagItem `xml:"tagSet>item,omitempty"`
 }
 
+//nolint:gocyclo // flat action dispatch table
 func (h *Handler) routeTransitGateways(w http.ResponseWriter, r *http.Request, action string) bool {
 	tg, ok := h.transitGateways()
 	if !ok {
@@ -77,8 +78,9 @@ func (h *Handler) routeTransitGateways(w http.ResponseWriter, r *http.Request, a
 	return true
 }
 
-func (h *Handler) createTransitGateway(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) createTransitGateway(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	asn, _ := strconv.ParseInt(r.Form.Get("Options.AmazonSideAsn"), 10, 64)
+
 	out, err := tg.CreateTransitGateway(r.Context(), netdriver.TransitGatewayConfig{
 		ASN:         asn,
 		Description: r.Form.Get("Description"),
@@ -97,7 +99,7 @@ func (h *Handler) createTransitGateway(w http.ResponseWriter, r *http.Request, t
 	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, TransitGateway: toTGWXML(out)})
 }
 
-func (h *Handler) deleteTransitGateway(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) deleteTransitGateway(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.DeleteTransitGateway(r.Context(), r.Form.Get("TransitGatewayId"))
 	if err != nil {
 		writeTGWErr(w, err)
@@ -112,7 +114,8 @@ func (h *Handler) deleteTransitGateway(w http.ResponseWriter, r *http.Request, t
 	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, TransitGateway: toTGWXML(out)})
 }
 
-func (h *Handler) describeTransitGateways(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeTransitGateways(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	items, err := tg.DescribeTransitGateways(r.Context(), awsquery.ListStrings(r.Form, "TransitGatewayIds"))
 	if err != nil {
 		writeTGWErr(w, err)
@@ -132,7 +135,7 @@ func (h *Handler) describeTransitGateways(w http.ResponseWriter, r *http.Request
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) createTGWAttachment(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) createTGWAttachment(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.CreateTransitGatewayVPCAttachment(r.Context(), netdriver.TransitGatewayVPCAttachmentConfig{
 		TransitGatewayID: r.Form.Get("TransitGatewayId"),
 		VPCID:            r.Form.Get("VpcId"),
@@ -152,7 +155,7 @@ func (h *Handler) createTGWAttachment(w http.ResponseWriter, r *http.Request, tg
 	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, Attachment: toTGWAttachmentXML(out)})
 }
 
-func (h *Handler) deleteTGWAttachment(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) deleteTGWAttachment(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.DeleteTransitGatewayVPCAttachment(r.Context(), r.Form.Get("TransitGatewayAttachmentId"))
 	if err != nil {
 		writeTGWErr(w, err)
@@ -167,7 +170,8 @@ func (h *Handler) deleteTGWAttachment(w http.ResponseWriter, r *http.Request, tg
 	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, Attachment: toTGWAttachmentXML(out)})
 }
 
-func (h *Handler) describeTGWAttachments(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeTGWAttachments(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	items, err := tg.DescribeTransitGatewayVPCAttachments(r.Context(), awsquery.ListStrings(r.Form, "TransitGatewayAttachmentIds"))
 	if err != nil {
 		writeTGWErr(w, err)
@@ -187,7 +191,8 @@ func (h *Handler) describeTGWAttachments(w http.ResponseWriter, r *http.Request,
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) createTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) createTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.CreateTransitGatewayRouteTable(r.Context(), r.Form.Get("TransitGatewayId"),
 		mergeTagSpecs(awsquery.TagSpecs(r.Form), "transit-gateway-route-table"))
 	if err != nil {
@@ -203,7 +208,7 @@ func (h *Handler) createTGWRouteTable(w http.ResponseWriter, r *http.Request, tg
 	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, RouteTable: toTGWRouteTableXML(out)})
 }
 
-func (h *Handler) deleteTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) deleteTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.DeleteTransitGatewayRouteTable(r.Context(), r.Form.Get("TransitGatewayRouteTableId"))
 	if err != nil {
 		writeTGWErr(w, err)
@@ -218,7 +223,8 @@ func (h *Handler) deleteTGWRouteTable(w http.ResponseWriter, r *http.Request, tg
 	}{Xmlns: awsquery.Namespace, RequestID: awsquery.RequestID, RouteTable: toTGWRouteTableXML(out)})
 }
 
-func (h *Handler) describeTGWRouteTables(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeTGWRouteTables(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	items, err := tg.DescribeTransitGatewayRouteTables(r.Context(), awsquery.ListStrings(r.Form, "TransitGatewayRouteTableIds"))
 	if err != nil {
 		writeTGWErr(w, err)

--- a/server/aws/ec2/transit_gateway.go
+++ b/server/aws/ec2/transit_gateway.go
@@ -71,6 +71,18 @@ func (h *Handler) routeTransitGateways(w http.ResponseWriter, r *http.Request, a
 		h.deleteTGWRouteTable(w, r, tg)
 	case "DescribeTransitGatewayRouteTables":
 		h.describeTGWRouteTables(w, r, tg)
+	case "CreateTransitGatewayRoute":
+		h.createTGWRoute(w, r, tg)
+	case "DeleteTransitGatewayRoute":
+		h.deleteTGWRoute(w, r, tg)
+	case "SearchTransitGatewayRoutes":
+		h.searchTGWRoutes(w, r, tg)
+	case "AssociateTransitGatewayRouteTable":
+		h.associateTGWRouteTable(w, r, tg)
+	case "EnableTransitGatewayRouteTablePropagation":
+		h.setTGWPropagation(w, r, tg, true)
+	case "DisableTransitGatewayRouteTablePropagation":
+		h.setTGWPropagation(w, r, tg, false)
 	default:
 		return false
 	}
@@ -273,6 +285,139 @@ func toTGWRouteTableXML(t *netdriver.TransitGatewayRouteTable) transitGatewayRou
 		State:                      t.State,
 		Tags:                       toTagItems(t.Tags),
 	}
+}
+
+type tgwRouteAttachmentXML struct {
+	TransitGatewayAttachmentID string `xml:"transitGatewayAttachmentId"`
+}
+
+type tgwRouteXML struct {
+	DestinationCidrBlock      string                  `xml:"destinationCidrBlock"`
+	Type                      string                  `xml:"type"`
+	State                     string                  `xml:"state"`
+	TransitGatewayAttachments []tgwRouteAttachmentXML `xml:"transitGatewayAttachments>item,omitempty"`
+}
+
+type tgwAssociationXML struct {
+	TransitGatewayRouteTableID string `xml:"transitGatewayRouteTableId"`
+	TransitGatewayAttachmentID string `xml:"transitGatewayAttachmentId"`
+	ResourceID                 string `xml:"resourceId,omitempty"`
+	ResourceType               string `xml:"resourceType,omitempty"`
+	State                      string `xml:"state"`
+}
+
+func toTGWRouteXML(rt *netdriver.TransitGatewayRoute) tgwRouteXML {
+	x := tgwRouteXML{DestinationCidrBlock: rt.DestinationCIDR, Type: rt.Type, State: rt.State}
+	if rt.AttachmentID != "" {
+		x.TransitGatewayAttachments = []tgwRouteAttachmentXML{{TransitGatewayAttachmentID: rt.AttachmentID}}
+	}
+
+	return x
+}
+
+func (h *Handler) createTGWRoute(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.CreateTransitGatewayRoute(r.Context(),
+		r.Form.Get("TransitGatewayRouteTableId"), r.Form.Get("DestinationCidrBlock"), r.Form.Get("TransitGatewayAttachmentId"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name    `xml:"CreateTransitGatewayRouteResponse"`
+		Xmlns   string      `xml:"xmlns,attr"`
+		Req     string      `xml:"requestId"`
+		Route   tgwRouteXML `xml:"route"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Route: toTGWRouteXML(out)})
+}
+
+func (h *Handler) deleteTGWRoute(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.DeleteTransitGatewayRoute(r.Context(),
+		r.Form.Get("TransitGatewayRouteTableId"), r.Form.Get("DestinationCidrBlock"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name    `xml:"DeleteTransitGatewayRouteResponse"`
+		Xmlns   string      `xml:"xmlns,attr"`
+		Req     string      `xml:"requestId"`
+		Route   tgwRouteXML `xml:"route"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Route: toTGWRouteXML(out)})
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (h *Handler) searchTGWRoutes(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	items, err := tg.SearchTransitGatewayRoutes(r.Context(), r.Form.Get("TransitGatewayRouteTableId"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	out := make([]tgwRouteXML, 0, len(items))
+	for i := range items {
+		out = append(out, toTGWRouteXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:"SearchTransitGatewayRoutesResponse"`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		Routes  []tgwRouteXML `xml:"routeSet>item"`
+		More    string        `xml:"additionalRoutesAvailable"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Routes: out, More: "false"})
+}
+
+func (h *Handler) associateTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+	out, err := tg.AssociateTransitGatewayRouteTable(r.Context(),
+		r.Form.Get("TransitGatewayRouteTableId"), r.Form.Get("TransitGatewayAttachmentId"))
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName     xml.Name          `xml:"AssociateTransitGatewayRouteTableResponse"`
+		Xmlns       string            `xml:"xmlns,attr"`
+		Req         string            `xml:"requestId"`
+		Association tgwAssociationXML `xml:"association"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Association: tgwAssociationXML{
+		TransitGatewayRouteTableID: out.RouteTableID, TransitGatewayAttachmentID: out.AttachmentID,
+		ResourceID: out.ResourceID, ResourceType: out.ResourceType, State: out.State,
+	}})
+}
+
+func (h *Handler) setTGWPropagation(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways, enable bool) {
+	rtID := r.Form.Get("TransitGatewayRouteTableId")
+	attID := r.Form.Get("TransitGatewayAttachmentId")
+
+	var err error
+	if enable {
+		err = tg.EnableTransitGatewayRouteTablePropagation(r.Context(), rtID, attID)
+	} else {
+		err = tg.DisableTransitGatewayRouteTablePropagation(r.Context(), rtID, attID)
+	}
+
+	if err != nil {
+		writeTGWErr(w, err)
+		return
+	}
+
+	resp, state := "EnableTransitGatewayRouteTablePropagationResponse", "enabled"
+	if !enable {
+		resp, state = "DisableTransitGatewayRouteTablePropagationResponse", "disabled"
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName     xml.Name
+		Xmlns       string            `xml:"xmlns,attr"`
+		Req         string            `xml:"requestId"`
+		Propagation tgwAssociationXML `xml:"propagation"`
+	}{
+		XMLName: xml.Name{Local: resp}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID,
+		Propagation: tgwAssociationXML{TransitGatewayRouteTableID: rtID, TransitGatewayAttachmentID: attID, State: state},
+	})
 }
 
 func writeTGWErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/transit_gateway.go
+++ b/server/aws/ec2/transit_gateway.go
@@ -315,7 +315,7 @@ func toTGWRouteXML(rt *netdriver.TransitGatewayRoute) tgwRouteXML {
 	return x
 }
 
-func (h *Handler) createTGWRoute(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) createTGWRoute(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.CreateTransitGatewayRoute(r.Context(),
 		r.Form.Get("TransitGatewayRouteTableId"), r.Form.Get("DestinationCidrBlock"), r.Form.Get("TransitGatewayAttachmentId"))
 	if err != nil {
@@ -331,7 +331,7 @@ func (h *Handler) createTGWRoute(w http.ResponseWriter, r *http.Request, tg netd
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Route: toTGWRouteXML(out)})
 }
 
-func (h *Handler) deleteTGWRoute(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) deleteTGWRoute(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.DeleteTransitGatewayRoute(r.Context(),
 		r.Form.Get("TransitGatewayRouteTableId"), r.Form.Get("DestinationCidrBlock"))
 	if err != nil {
@@ -347,8 +347,7 @@ func (h *Handler) deleteTGWRoute(w http.ResponseWriter, r *http.Request, tg netd
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Route: toTGWRouteXML(out)})
 }
 
-//nolint:dupl // parallel per-resource marshaling
-func (h *Handler) searchTGWRoutes(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) searchTGWRoutes(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	items, err := tg.SearchTransitGatewayRoutes(r.Context(), r.Form.Get("TransitGatewayRouteTableId"))
 	if err != nil {
 		writeTGWErr(w, err)
@@ -369,7 +368,7 @@ func (h *Handler) searchTGWRoutes(w http.ResponseWriter, r *http.Request, tg net
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Routes: out, More: "false"})
 }
 
-func (h *Handler) associateTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
+func (*Handler) associateTGWRouteTable(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways) {
 	out, err := tg.AssociateTransitGatewayRouteTable(r.Context(),
 		r.Form.Get("TransitGatewayRouteTableId"), r.Form.Get("TransitGatewayAttachmentId"))
 	if err != nil {
@@ -388,7 +387,7 @@ func (h *Handler) associateTGWRouteTable(w http.ResponseWriter, r *http.Request,
 	}})
 }
 
-func (h *Handler) setTGWPropagation(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways, enable bool) {
+func (*Handler) setTGWPropagation(w http.ResponseWriter, r *http.Request, tg netdriver.TransitGateways, enable bool) {
 	rtID := r.Form.Get("TransitGatewayRouteTableId")
 	attID := r.Form.Get("TransitGatewayAttachmentId")
 

--- a/server/aws/ec2/vpn.go
+++ b/server/aws/ec2/vpn.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -39,14 +40,15 @@ type vpnAttachmentXML struct {
 }
 
 type vpnConnectionXML struct {
-	VpnConnectionID   string        `xml:"vpnConnectionId"`
-	CustomerGatewayID string        `xml:"customerGatewayId"`
-	VpnGatewayID      string        `xml:"vpnGatewayId,omitempty"`
-	TransitGatewayID  string        `xml:"transitGatewayId,omitempty"`
-	Type              string        `xml:"type"`
-	State             string        `xml:"state"`
-	Routes            []vpnRouteXML `xml:"routes>item,omitempty"`
-	Tags              []tagItem     `xml:"tagSet>item,omitempty"`
+	VpnConnectionID              string        `xml:"vpnConnectionId"`
+	CustomerGatewayID            string        `xml:"customerGatewayId"`
+	CustomerGatewayConfiguration string        `xml:"customerGatewayConfiguration"`
+	VpnGatewayID                 string        `xml:"vpnGatewayId,omitempty"`
+	TransitGatewayID             string        `xml:"transitGatewayId,omitempty"`
+	Type                         string        `xml:"type"`
+	State                        string        `xml:"state"`
+	Routes                       []vpnRouteXML `xml:"routes>item,omitempty"`
+	Tags                         []tagItem     `xml:"tagSet>item,omitempty"`
 }
 
 type vpnRouteXML struct {
@@ -334,7 +336,9 @@ func toVPNGatewayXML(v *netdriver.VPNGateway) vpnGatewayXML {
 func toVPNConnectionXML(v *netdriver.VPNConnection) vpnConnectionXML {
 	x := vpnConnectionXML{
 		VpnConnectionID: v.ID, CustomerGatewayID: v.CustomerGatewayID, VpnGatewayID: v.VPNGatewayID,
-		TransitGatewayID: v.TransitGatewayID, Type: v.Type, State: v.State, Tags: toTagItems(v.Tags),
+		TransitGatewayID: v.TransitGatewayID, Type: v.Type, State: v.State,
+		CustomerGatewayConfiguration: customerGatewayConfiguration(v),
+		Tags:                         toTagItems(v.Tags),
 	}
 
 	for _, rt := range v.Routes {
@@ -342,6 +346,39 @@ func toVPNConnectionXML(v *netdriver.VPNConnection) vpnConnectionXML {
 	}
 
 	return x
+}
+
+// customerGatewayConfiguration returns the IPsec tunnel-config document that
+// real Site-to-Site VPN responses always carry (Terraform's aws_vpn_connection
+// parses it). The emulator has no real tunnels, so this is a minimal but
+// structurally-valid stub identifying the connection and its gateways.
+func customerGatewayConfiguration(v *netdriver.VPNConnection) string {
+	var b strings.Builder
+
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?>`)
+	b.WriteString(`<vpn_connection id="` + v.ID + `">`)
+	b.WriteString(`<customer_gateway_id>` + v.CustomerGatewayID + `</customer_gateway_id>`)
+
+	if v.VPNGatewayID != "" {
+		b.WriteString(`<vpn_gateway_id>` + v.VPNGatewayID + `</vpn_gateway_id>`)
+	}
+
+	if v.TransitGatewayID != "" {
+		b.WriteString(`<transit_gateway_id>` + v.TransitGatewayID + `</transit_gateway_id>`)
+	}
+
+	b.WriteString(`<vpn_connection_type>` + orDefault(v.Type, "ipsec.1") + `</vpn_connection_type>`)
+	b.WriteString(`</vpn_connection>`)
+
+	return b.String()
+}
+
+func orDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+
+	return v
 }
 
 func writeVPNErr(w http.ResponseWriter, err error) {

--- a/server/aws/ec2/vpn.go
+++ b/server/aws/ec2/vpn.go
@@ -1,0 +1,290 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) vpnConnections() (netdriver.VPNConnections, bool) {
+	v, ok := h.vpc.(netdriver.VPNConnections)
+
+	return v, ok
+}
+
+type customerGatewayXML struct {
+	CustomerGatewayID string    `xml:"customerGatewayId"`
+	IPAddress         string    `xml:"ipAddress"`
+	BgpAsn            string    `xml:"bgpAsn"`
+	Type              string    `xml:"type"`
+	State             string    `xml:"state"`
+	Tags              []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type vpnGatewayXML struct {
+	VpnGatewayID  string             `xml:"vpnGatewayId"`
+	Type          string             `xml:"type"`
+	State         string             `xml:"state"`
+	AmazonSideAsn int64              `xml:"amazonSideAsn,omitempty"`
+	Attachments   []vpnAttachmentXML `xml:"attachments>item,omitempty"`
+	Tags          []tagItem          `xml:"tagSet>item,omitempty"`
+}
+
+type vpnAttachmentXML struct {
+	VpcID string `xml:"vpcId"`
+	State string `xml:"state"`
+}
+
+type vpnConnectionXML struct {
+	VpnConnectionID   string    `xml:"vpnConnectionId"`
+	CustomerGatewayID string    `xml:"customerGatewayId"`
+	VpnGatewayID      string    `xml:"vpnGatewayId,omitempty"`
+	TransitGatewayID  string    `xml:"transitGatewayId,omitempty"`
+	Type              string    `xml:"type"`
+	State             string    `xml:"state"`
+	Tags              []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+//nolint:gocyclo // flat action dispatch table
+func (h *Handler) routeVPN(w http.ResponseWriter, r *http.Request, action string) bool {
+	v, ok := h.vpnConnections()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateCustomerGateway":
+		h.createCustomerGateway(w, r, v)
+	case "DeleteCustomerGateway":
+		h.deleteCustomerGateway(w, r, v)
+	case "DescribeCustomerGateways":
+		h.describeCustomerGateways(w, r, v)
+	case "CreateVpnGateway":
+		h.createVPNGateway(w, r, v)
+	case "DeleteVpnGateway":
+		h.deleteVPNGateway(w, r, v)
+	case "DescribeVpnGateways":
+		h.describeVPNGateways(w, r, v)
+	case "AttachVpnGateway":
+		h.attachVPNGateway(w, r, v)
+	case "DetachVpnGateway":
+		h.detachVPNGateway(w, r, v)
+	case "CreateVpnConnection":
+		h.createVPNConnection(w, r, v)
+	case "DeleteVpnConnection":
+		h.deleteVPNConnection(w, r, v)
+	case "DescribeVpnConnections":
+		h.describeVPNConnections(w, r, v)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) createCustomerGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	asn, _ := strconv.ParseInt(r.Form.Get("BgpAsn"), 10, 64)
+	out, err := v.CreateCustomerGateway(r.Context(), netdriver.CustomerGatewayConfig{
+		IPAddress: nonEmpty(r.Form.Get("PublicIp"), r.Form.Get("IpAddress")),
+		BGPASN:    asn,
+		Type:      r.Form.Get("Type"),
+		Tags:      mergeTagSpecs(awsquery.TagSpecs(r.Form), "customer-gateway"),
+	})
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"CreateCustomerGatewayResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		CGW     customerGatewayXML `xml:"customerGateway"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, CGW: toCustomerGatewayXML(out)})
+}
+
+func (h *Handler) deleteCustomerGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	if err := v.DeleteCustomerGateway(r.Context(), r.Form.Get("CustomerGatewayId")); err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DeleteCustomerGatewayResponse")
+}
+
+func (h *Handler) describeCustomerGateways(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	items, err := v.DescribeCustomerGateways(r.Context(), awsquery.ListStrings(r.Form, "CustomerGatewayId"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	out := make([]customerGatewayXML, 0, len(items))
+	for i := range items {
+		out = append(out, toCustomerGatewayXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name             `xml:"DescribeCustomerGatewaysResponse"`
+		Xmlns   string               `xml:"xmlns,attr"`
+		Req     string               `xml:"requestId"`
+		Set     []customerGatewayXML `xml:"customerGatewaySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) createVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	asn, _ := strconv.ParseInt(r.Form.Get("AmazonSideAsn"), 10, 64)
+	out, err := v.CreateVPNGateway(r.Context(), netdriver.VPNGatewayConfig{
+		Type:          r.Form.Get("Type"),
+		AmazonSideASN: asn,
+		Tags:          mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpn-gateway"),
+	})
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:"CreateVpnGatewayResponse"`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		VGW     vpnGatewayXML `xml:"vpnGateway"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, VGW: toVPNGatewayXML(out)})
+}
+
+func (h *Handler) deleteVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	if err := v.DeleteVPNGateway(r.Context(), r.Form.Get("VpnGatewayId")); err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DeleteVpnGatewayResponse")
+}
+
+func (h *Handler) describeVPNGateways(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	items, err := v.DescribeVPNGateways(r.Context(), awsquery.ListStrings(r.Form, "VpnGatewayId"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	out := make([]vpnGatewayXML, 0, len(items))
+	for i := range items {
+		out = append(out, toVPNGatewayXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name        `xml:"DescribeVpnGatewaysResponse"`
+		Xmlns   string          `xml:"xmlns,attr"`
+		Req     string          `xml:"requestId"`
+		Set     []vpnGatewayXML `xml:"vpnGatewaySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (h *Handler) attachVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	out, err := v.AttachVPNGateway(r.Context(), r.Form.Get("VpnGatewayId"), r.Form.Get("VpcId"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName    xml.Name         `xml:"AttachVpnGatewayResponse"`
+		Xmlns      string           `xml:"xmlns,attr"`
+		Req        string           `xml:"requestId"`
+		Attachment vpnAttachmentXML `xml:"attachment"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Attachment: vpnAttachmentXML{VpcID: out.AttachedVPCID, State: out.AttachmentState}})
+}
+
+func (h *Handler) detachVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	if err := v.DetachVPNGateway(r.Context(), r.Form.Get("VpnGatewayId"), r.Form.Get("VpcId")); err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DetachVpnGatewayResponse")
+}
+
+func (h *Handler) createVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	out, err := v.CreateVPNConnection(r.Context(), netdriver.VPNConnectionConfig{
+		CustomerGatewayID: r.Form.Get("CustomerGatewayId"),
+		VPNGatewayID:      r.Form.Get("VpnGatewayId"),
+		TransitGatewayID:  r.Form.Get("TransitGatewayId"),
+		Type:              r.Form.Get("Type"),
+		StaticRoutesOnly:  r.Form.Get("Options.StaticRoutesOnly") == formTrue,
+		Tags:              mergeTagSpecs(awsquery.TagSpecs(r.Form), "vpn-connection"),
+	})
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name         `xml:"CreateVpnConnectionResponse"`
+		Xmlns   string           `xml:"xmlns,attr"`
+		Req     string           `xml:"requestId"`
+		VPN     vpnConnectionXML `xml:"vpnConnection"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, VPN: toVPNConnectionXML(out)})
+}
+
+func (h *Handler) deleteVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	if err := v.DeleteVPNConnection(r.Context(), r.Form.Get("VpnConnectionId")); err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DeleteVpnConnectionResponse")
+}
+
+func (h *Handler) describeVPNConnections(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	items, err := v.DescribeVPNConnections(r.Context(), awsquery.ListStrings(r.Form, "VpnConnectionId"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	out := make([]vpnConnectionXML, 0, len(items))
+	for i := range items {
+		out = append(out, toVPNConnectionXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name           `xml:"DescribeVpnConnectionsResponse"`
+		Xmlns   string             `xml:"xmlns,attr"`
+		Req     string             `xml:"requestId"`
+		Set     []vpnConnectionXML `xml:"vpnConnectionSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func toCustomerGatewayXML(c *netdriver.CustomerGateway) customerGatewayXML {
+	return customerGatewayXML{
+		CustomerGatewayID: c.ID, IPAddress: c.IPAddress, BgpAsn: strconv.FormatInt(c.BGPASN, 10),
+		Type: c.Type, State: c.State, Tags: toTagItems(c.Tags),
+	}
+}
+
+func toVPNGatewayXML(v *netdriver.VPNGateway) vpnGatewayXML {
+	x := vpnGatewayXML{
+		VpnGatewayID: v.ID, Type: v.Type, State: v.State, AmazonSideAsn: v.AmazonSideASN,
+		Tags: toTagItems(v.Tags),
+	}
+	if v.AttachedVPCID != "" {
+		x.Attachments = []vpnAttachmentXML{{VpcID: v.AttachedVPCID, State: v.AttachmentState}}
+	}
+
+	return x
+}
+
+func toVPNConnectionXML(v *netdriver.VPNConnection) vpnConnectionXML {
+	return vpnConnectionXML{
+		VpnConnectionID: v.ID, CustomerGatewayID: v.CustomerGatewayID, VpnGatewayID: v.VPNGatewayID,
+		TransitGatewayID: v.TransitGatewayID, Type: v.Type, State: v.State, Tags: toTagItems(v.Tags),
+	}
+}
+
+func writeVPNErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidVpnGatewayID.NotFound", "IncorrectState")
+}

--- a/server/aws/ec2/vpn.go
+++ b/server/aws/ec2/vpn.go
@@ -85,8 +85,9 @@ func (h *Handler) routeVPN(w http.ResponseWriter, r *http.Request, action string
 	return true
 }
 
-func (h *Handler) createCustomerGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) createCustomerGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	asn, _ := strconv.ParseInt(r.Form.Get("BgpAsn"), 10, 64)
+
 	out, err := v.CreateCustomerGateway(r.Context(), netdriver.CustomerGatewayConfig{
 		IPAddress: nonEmpty(r.Form.Get("PublicIp"), r.Form.Get("IpAddress")),
 		BGPASN:    asn,
@@ -106,7 +107,7 @@ func (h *Handler) createCustomerGateway(w http.ResponseWriter, r *http.Request, 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, CGW: toCustomerGatewayXML(out)})
 }
 
-func (h *Handler) deleteCustomerGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) deleteCustomerGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	if err := v.DeleteCustomerGateway(r.Context(), r.Form.Get("CustomerGatewayId")); err != nil {
 		writeVPNErr(w, err)
 		return
@@ -115,7 +116,8 @@ func (h *Handler) deleteCustomerGateway(w http.ResponseWriter, r *http.Request, 
 	writeReturnTrue(w, "DeleteCustomerGatewayResponse")
 }
 
-func (h *Handler) describeCustomerGateways(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeCustomerGateways(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	items, err := v.DescribeCustomerGateways(r.Context(), awsquery.ListStrings(r.Form, "CustomerGatewayId"))
 	if err != nil {
 		writeVPNErr(w, err)
@@ -135,8 +137,9 @@ func (h *Handler) describeCustomerGateways(w http.ResponseWriter, r *http.Reques
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) createVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) createVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	asn, _ := strconv.ParseInt(r.Form.Get("AmazonSideAsn"), 10, 64)
+
 	out, err := v.CreateVPNGateway(r.Context(), netdriver.VPNGatewayConfig{
 		Type:          r.Form.Get("Type"),
 		AmazonSideASN: asn,
@@ -155,7 +158,7 @@ func (h *Handler) createVPNGateway(w http.ResponseWriter, r *http.Request, v net
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, VGW: toVPNGatewayXML(out)})
 }
 
-func (h *Handler) deleteVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) deleteVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	if err := v.DeleteVPNGateway(r.Context(), r.Form.Get("VpnGatewayId")); err != nil {
 		writeVPNErr(w, err)
 		return
@@ -164,7 +167,8 @@ func (h *Handler) deleteVPNGateway(w http.ResponseWriter, r *http.Request, v net
 	writeReturnTrue(w, "DeleteVpnGatewayResponse")
 }
 
-func (h *Handler) describeVPNGateways(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeVPNGateways(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	items, err := v.DescribeVPNGateways(r.Context(), awsquery.ListStrings(r.Form, "VpnGatewayId"))
 	if err != nil {
 		writeVPNErr(w, err)
@@ -184,7 +188,7 @@ func (h *Handler) describeVPNGateways(w http.ResponseWriter, r *http.Request, v 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
-func (h *Handler) attachVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) attachVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	out, err := v.AttachVPNGateway(r.Context(), r.Form.Get("VpnGatewayId"), r.Form.Get("VpcId"))
 	if err != nil {
 		writeVPNErr(w, err)
@@ -199,7 +203,7 @@ func (h *Handler) attachVPNGateway(w http.ResponseWriter, r *http.Request, v net
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Attachment: vpnAttachmentXML{VpcID: out.AttachedVPCID, State: out.AttachmentState}})
 }
 
-func (h *Handler) detachVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) detachVPNGateway(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	if err := v.DetachVPNGateway(r.Context(), r.Form.Get("VpnGatewayId"), r.Form.Get("VpcId")); err != nil {
 		writeVPNErr(w, err)
 		return
@@ -208,7 +212,7 @@ func (h *Handler) detachVPNGateway(w http.ResponseWriter, r *http.Request, v net
 	writeReturnTrue(w, "DetachVpnGatewayResponse")
 }
 
-func (h *Handler) createVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) createVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	out, err := v.CreateVPNConnection(r.Context(), netdriver.VPNConnectionConfig{
 		CustomerGatewayID: r.Form.Get("CustomerGatewayId"),
 		VPNGatewayID:      r.Form.Get("VpnGatewayId"),
@@ -230,7 +234,7 @@ func (h *Handler) createVPNConnection(w http.ResponseWriter, r *http.Request, v 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, VPN: toVPNConnectionXML(out)})
 }
 
-func (h *Handler) deleteVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+func (*Handler) deleteVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	if err := v.DeleteVPNConnection(r.Context(), r.Form.Get("VpnConnectionId")); err != nil {
 		writeVPNErr(w, err)
 		return
@@ -239,7 +243,8 @@ func (h *Handler) deleteVPNConnection(w http.ResponseWriter, r *http.Request, v 
 	writeReturnTrue(w, "DeleteVpnConnectionResponse")
 }
 
-func (h *Handler) describeVPNConnections(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeVPNConnections(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
 	items, err := v.DescribeVPNConnections(r.Context(), awsquery.ListStrings(r.Form, "VpnConnectionId"))
 	if err != nil {
 		writeVPNErr(w, err)

--- a/server/aws/ec2/vpn.go
+++ b/server/aws/ec2/vpn.go
@@ -39,13 +39,19 @@ type vpnAttachmentXML struct {
 }
 
 type vpnConnectionXML struct {
-	VpnConnectionID   string    `xml:"vpnConnectionId"`
-	CustomerGatewayID string    `xml:"customerGatewayId"`
-	VpnGatewayID      string    `xml:"vpnGatewayId,omitempty"`
-	TransitGatewayID  string    `xml:"transitGatewayId,omitempty"`
-	Type              string    `xml:"type"`
-	State             string    `xml:"state"`
-	Tags              []tagItem `xml:"tagSet>item,omitempty"`
+	VpnConnectionID   string        `xml:"vpnConnectionId"`
+	CustomerGatewayID string        `xml:"customerGatewayId"`
+	VpnGatewayID      string        `xml:"vpnGatewayId,omitempty"`
+	TransitGatewayID  string        `xml:"transitGatewayId,omitempty"`
+	Type              string        `xml:"type"`
+	State             string        `xml:"state"`
+	Routes            []vpnRouteXML `xml:"routes>item,omitempty"`
+	Tags              []tagItem     `xml:"tagSet>item,omitempty"`
+}
+
+type vpnRouteXML struct {
+	DestinationCidrBlock string `xml:"destinationCidrBlock"`
+	State                string `xml:"state"`
 }
 
 //nolint:gocyclo // flat action dispatch table
@@ -78,6 +84,12 @@ func (h *Handler) routeVPN(w http.ResponseWriter, r *http.Request, action string
 		h.deleteVPNConnection(w, r, v)
 	case "DescribeVpnConnections":
 		h.describeVPNConnections(w, r, v)
+	case "CreateVpnConnectionRoute":
+		h.createVPNConnectionRoute(w, r, v)
+	case "DeleteVpnConnectionRoute":
+		h.deleteVPNConnectionRoute(w, r, v)
+	case "ModifyVpnConnection":
+		h.modifyVPNConnection(w, r, v)
 	default:
 		return false
 	}
@@ -264,6 +276,42 @@ func (*Handler) describeVPNConnections(w http.ResponseWriter, r *http.Request, v
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
 }
 
+func (*Handler) createVPNConnectionRoute(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	err := v.CreateVPNConnectionRoute(r.Context(), r.Form.Get("VpnConnectionId"), r.Form.Get("DestinationCidrBlock"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "CreateVpnConnectionRouteResponse")
+}
+
+func (*Handler) deleteVPNConnectionRoute(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	err := v.DeleteVPNConnectionRoute(r.Context(), r.Form.Get("VpnConnectionId"), r.Form.Get("DestinationCidrBlock"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "DeleteVpnConnectionRouteResponse")
+}
+
+func (*Handler) modifyVPNConnection(w http.ResponseWriter, r *http.Request, v netdriver.VPNConnections) {
+	out, err := v.ModifyVPNConnection(r.Context(),
+		r.Form.Get("VpnConnectionId"), r.Form.Get("TransitGatewayId"), r.Form.Get("VpnGatewayId"))
+	if err != nil {
+		writeVPNErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name         `xml:"ModifyVpnConnectionResponse"`
+		Xmlns   string           `xml:"xmlns,attr"`
+		Req     string           `xml:"requestId"`
+		VPN     vpnConnectionXML `xml:"vpnConnection"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, VPN: toVPNConnectionXML(out)})
+}
+
 func toCustomerGatewayXML(c *netdriver.CustomerGateway) customerGatewayXML {
 	return customerGatewayXML{
 		CustomerGatewayID: c.ID, IPAddress: c.IPAddress, BgpAsn: strconv.FormatInt(c.BGPASN, 10),
@@ -284,10 +332,16 @@ func toVPNGatewayXML(v *netdriver.VPNGateway) vpnGatewayXML {
 }
 
 func toVPNConnectionXML(v *netdriver.VPNConnection) vpnConnectionXML {
-	return vpnConnectionXML{
+	x := vpnConnectionXML{
 		VpnConnectionID: v.ID, CustomerGatewayID: v.CustomerGatewayID, VpnGatewayID: v.VPNGatewayID,
 		TransitGatewayID: v.TransitGatewayID, Type: v.Type, State: v.State, Tags: toTagItems(v.Tags),
 	}
+
+	for _, rt := range v.Routes {
+		x.Routes = append(x.Routes, vpnRouteXML{DestinationCidrBlock: rt.DestinationCIDR, State: rt.State})
+	}
+
+	return x
 }
 
 func writeVPNErr(w http.ResponseWriter, err error) {

--- a/server/aws/networkfirewall/depth.go
+++ b/server/aws/networkfirewall/depth.go
@@ -1,0 +1,224 @@
+package networkfirewall
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+)
+
+type associatePolicyRequest struct {
+	FirewallName      string `json:"FirewallName"`
+	FirewallArn       string `json:"FirewallArn"`
+	FirewallPolicyArn string `json:"FirewallPolicyArn"`
+}
+
+func (h *Handler) associateFirewallPolicy(w http.ResponseWriter, r *http.Request) {
+	var req associatePolicyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.AssociateFirewallPolicy(r.Context(), firewallName(req.FirewallName, req.FirewallArn), req.FirewallPolicyArn)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FirewallArn": fw.ARN, "FirewallName": fw.Name,
+		"FirewallPolicyArn": fw.PolicyARN, "UpdateToken": updateToken,
+	})
+}
+
+type subnetsRequest struct {
+	FirewallName   string          `json:"FirewallName"`
+	FirewallArn    string          `json:"FirewallArn"`
+	SubnetMappings []subnetMapping `json:"SubnetMappings"`
+	SubnetIDs      []string        `json:"SubnetIds"`
+}
+
+func (h *Handler) associateSubnets(w http.ResponseWriter, r *http.Request) {
+	var req subnetsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.AssociateSubnets(r.Context(), firewallName(req.FirewallName, req.FirewallArn), subnetIDs(req.SubnetMappings))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeSubnetsResult(w, fw)
+}
+
+func (h *Handler) disassociateSubnets(w http.ResponseWriter, r *http.Request) {
+	var req subnetsRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.DisassociateSubnets(r.Context(), firewallName(req.FirewallName, req.FirewallArn), req.SubnetIDs)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeSubnetsResult(w, fw)
+}
+
+func writeSubnetsResult(w http.ResponseWriter, fw *nfdriver.Firewall) {
+	mappings := make([]subnetMapping, 0, len(fw.SubnetIDs))
+	for _, s := range fw.SubnetIDs {
+		mappings = append(mappings, subnetMapping{SubnetID: s})
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FirewallArn": fw.ARN, "FirewallName": fw.Name,
+		"SubnetMappings": mappings, "UpdateToken": updateToken,
+	})
+}
+
+type deleteProtectionRequest struct {
+	FirewallName     string `json:"FirewallName"`
+	FirewallArn      string `json:"FirewallArn"`
+	DeleteProtection bool   `json:"DeleteProtection"`
+}
+
+func (h *Handler) updateFirewallDeleteProtection(w http.ResponseWriter, r *http.Request) {
+	var req deleteProtectionRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.UpdateFirewallDeleteProtection(r.Context(), firewallName(req.FirewallName, req.FirewallArn), req.DeleteProtection)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FirewallArn": fw.ARN, "FirewallName": fw.Name,
+		"DeleteProtection": fw.DeleteProtection, "UpdateToken": updateToken,
+	})
+}
+
+type logDestinationConfig struct {
+	LogType            string            `json:"LogType"`
+	LogDestinationType string            `json:"LogDestinationType,omitempty"`
+	LogDestination     map[string]string `json:"LogDestination,omitempty"`
+}
+
+type loggingConfiguration struct {
+	LogDestinationConfigs []logDestinationConfig `json:"LogDestinationConfigs"`
+}
+
+type loggingRequest struct {
+	FirewallName         string               `json:"FirewallName"`
+	FirewallArn          string               `json:"FirewallArn"`
+	LoggingConfiguration loggingConfiguration `json:"LoggingConfiguration"`
+}
+
+func (h *Handler) updateLoggingConfiguration(w http.ResponseWriter, r *http.Request) {
+	var req loggingRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	logTypes := make([]string, 0, len(req.LoggingConfiguration.LogDestinationConfigs))
+	for _, c := range req.LoggingConfiguration.LogDestinationConfigs {
+		logTypes = append(logTypes, c.LogType)
+	}
+
+	name := firewallName(req.FirewallName, req.FirewallArn)
+	if err := h.db.UpdateLoggingConfiguration(r.Context(), name, logTypes); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FirewallArn": req.FirewallArn, "FirewallName": name,
+		"LoggingConfiguration": req.LoggingConfiguration,
+	})
+}
+
+func (h *Handler) describeLoggingConfiguration(w http.ResponseWriter, r *http.Request) {
+	var req nameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	name := firewallName(req.FirewallName, req.FirewallArn)
+
+	logTypes, err := h.db.DescribeLoggingConfiguration(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	configs := make([]logDestinationConfig, 0, len(logTypes))
+	for _, lt := range logTypes {
+		configs = append(configs, logDestinationConfig{LogType: lt})
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"FirewallArn":          req.FirewallArn,
+		"LoggingConfiguration": loggingConfiguration{LogDestinationConfigs: configs},
+	})
+}
+
+type tagResourceRequest struct {
+	ResourceArn string `json:"ResourceArn"`
+	Tags        []tag  `json:"Tags"`
+}
+
+func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request) {
+	var req tagResourceRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.db.TagResource(r.Context(), req.ResourceArn, tagsToMap(req.Tags)); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+type untagResourceRequest struct {
+	ResourceArn string   `json:"ResourceArn"`
+	TagKeys     []string `json:"TagKeys"`
+}
+
+func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request) {
+	var req untagResourceRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.db.UntagResource(r.Context(), req.ResourceArn, req.TagKeys); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{})
+}
+
+// firewallName resolves the firewall's store key (its name) from either the
+// name or the ARN provided by the caller. Firewalls are keyed by name.
+func firewallName(name, arn string) string {
+	if name != "" {
+		return name
+	}
+
+	// ARN tail after "firewall/" is the name.
+	for i := len(arn) - 1; i >= 0; i-- {
+		if arn[i] == '/' {
+			return arn[i+1:]
+		}
+	}
+
+	return arn
+}

--- a/server/aws/networkfirewall/handler.go
+++ b/server/aws/networkfirewall/handler.go
@@ -1,0 +1,84 @@
+// Package networkfirewall implements the AWS Network Firewall control-plane API
+// as a server.Handler. Network Firewall uses AWS JSON 1.0 with the X-Amz-Target
+// prefix "NetworkFirewall_20201112.", so real aws-sdk-go-v2 networkfirewall
+// clients configured with a custom endpoint hit this handler unchanged.
+package networkfirewall
+
+import (
+	"net/http"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+)
+
+const targetPrefix = "NetworkFirewall_20201112."
+
+// Handler serves Network Firewall requests against a networkfirewall driver.
+type Handler struct {
+	db nfdriver.NetworkFirewall
+}
+
+// New returns a Network Firewall handler backed by db.
+func New(db nfdriver.NetworkFirewall) *Handler {
+	return &Handler{db: db}
+}
+
+// Matches claims requests whose X-Amz-Target names a Network Firewall operation.
+func (*Handler) Matches(r *http.Request) bool {
+	return strings.HasPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+}
+
+// ServeHTTP dispatches on the operation named in X-Amz-Target.
+//
+//nolint:gocyclo // a flat operation switch is the clearest dispatch shape.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	op := strings.TrimPrefix(r.Header.Get("X-Amz-Target"), targetPrefix)
+
+	switch op {
+	case "CreateFirewall":
+		h.createFirewall(w, r)
+	case "DescribeFirewall":
+		h.describeFirewall(w, r)
+	case "DeleteFirewall":
+		h.deleteFirewall(w, r)
+	case "ListFirewalls":
+		h.listFirewalls(w, r)
+	case "CreateFirewallPolicy":
+		h.createFirewallPolicy(w, r)
+	case "DescribeFirewallPolicy":
+		h.describeFirewallPolicy(w, r)
+	case "DeleteFirewallPolicy":
+		h.deleteFirewallPolicy(w, r)
+	case "ListFirewallPolicies":
+		h.listFirewallPolicies(w, r)
+	case "CreateRuleGroup":
+		h.createRuleGroup(w, r)
+	case "DescribeRuleGroup":
+		h.describeRuleGroup(w, r)
+	case "DeleteRuleGroup":
+		h.deleteRuleGroup(w, r)
+	case "ListRuleGroups":
+		h.listRuleGroups(w, r)
+	default:
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidRequestException", "unknown operation: "+op)
+	}
+}
+
+const updateToken = "00000000-0000-0000-0000-000000000000"
+
+func writeErr(w http.ResponseWriter, err error) {
+	msg := err.Error()
+
+	switch {
+	case cerrors.IsNotFound(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
+	case cerrors.IsAlreadyExists(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidOperationException", msg)
+	case cerrors.IsInvalidArgument(err), cerrors.IsFailedPrecondition(err):
+		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidRequestException", msg)
+	default:
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerError", msg)
+	}
+}

--- a/server/aws/networkfirewall/handler.go
+++ b/server/aws/networkfirewall/handler.go
@@ -61,6 +61,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteRuleGroup(w, r)
 	case "ListRuleGroups":
 		h.listRuleGroups(w, r)
+	case "AssociateFirewallPolicy":
+		h.associateFirewallPolicy(w, r)
+	case "AssociateSubnets":
+		h.associateSubnets(w, r)
+	case "DisassociateSubnets":
+		h.disassociateSubnets(w, r)
+	case "UpdateFirewallDeleteProtection":
+		h.updateFirewallDeleteProtection(w, r)
+	case "UpdateLoggingConfiguration":
+		h.updateLoggingConfiguration(w, r)
+	case "DescribeLoggingConfiguration":
+		h.describeLoggingConfiguration(w, r)
+	case "TagResource":
+		h.tagResource(w, r)
+	case "UntagResource":
+		h.untagResource(w, r)
 	default:
 		wire.WriteJSONError(w, http.StatusBadRequest, "InvalidRequestException", "unknown operation: "+op)
 	}

--- a/server/aws/networkfirewall/operations.go
+++ b/server/aws/networkfirewall/operations.go
@@ -1,0 +1,393 @@
+package networkfirewall
+
+import (
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	nfdriver "github.com/stackshy/cloudemu/v2/services/networkfirewall/driver"
+)
+
+type tag struct {
+	Key   string `json:"Key"`
+	Value string `json:"Value"`
+}
+
+type subnetMapping struct {
+	SubnetID string `json:"SubnetId"`
+}
+
+// ---- Firewall ----
+
+type firewallJSON struct {
+	FirewallName      string          `json:"FirewallName"`
+	FirewallArn       string          `json:"FirewallArn"`
+	FirewallPolicyArn string          `json:"FirewallPolicyArn,omitempty"`
+	VpcID             string          `json:"VpcId,omitempty"`
+	SubnetMappings    []subnetMapping `json:"SubnetMappings,omitempty"`
+	Description       string          `json:"Description,omitempty"`
+	DeleteProtection  bool            `json:"DeleteProtection"`
+	Tags              []tag           `json:"Tags,omitempty"`
+}
+
+type firewallStatusJSON struct {
+	Status string `json:"Status"`
+}
+
+type createFirewallRequest struct {
+	FirewallName      string          `json:"FirewallName"`
+	FirewallPolicyArn string          `json:"FirewallPolicyArn"`
+	VpcID             string          `json:"VpcId"`
+	SubnetMappings    []subnetMapping `json:"SubnetMappings"`
+	Description       string          `json:"Description"`
+	DeleteProtection  bool            `json:"DeleteProtection"`
+	Tags              []tag           `json:"Tags"`
+}
+
+type nameArnRequest struct {
+	FirewallName string `json:"FirewallName"`
+	FirewallArn  string `json:"FirewallArn"`
+}
+
+func (h *Handler) createFirewall(w http.ResponseWriter, r *http.Request) {
+	var req createFirewallRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.CreateFirewall(r.Context(), nfdriver.CreateFirewallConfig{
+		Name:             req.FirewallName,
+		PolicyARN:        req.FirewallPolicyArn,
+		VPCID:            req.VpcID,
+		SubnetIDs:        subnetIDs(req.SubnetMappings),
+		Description:      req.Description,
+		DeleteProtection: req.DeleteProtection,
+		Tags:             tagsToMap(req.Tags),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"Firewall":       toFirewallJSON(fw),
+		"FirewallStatus": firewallStatusJSON{Status: fw.Status},
+	})
+}
+
+func (h *Handler) describeFirewall(w http.ResponseWriter, r *http.Request) {
+	var req nameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.DescribeFirewall(r.Context(), req.FirewallName, req.FirewallArn)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"UpdateToken":    updateToken,
+		"Firewall":       toFirewallJSON(fw),
+		"FirewallStatus": firewallStatusJSON{Status: fw.Status},
+	})
+}
+
+func (h *Handler) deleteFirewall(w http.ResponseWriter, r *http.Request) {
+	var req nameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	fw, err := h.db.DeleteFirewall(r.Context(), req.FirewallName, req.FirewallArn)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"Firewall":       toFirewallJSON(fw),
+		"FirewallStatus": firewallStatusJSON{Status: fw.Status},
+	})
+}
+
+func (h *Handler) listFirewalls(w http.ResponseWriter, r *http.Request) {
+	items, err := h.db.ListFirewalls(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	metas := make([]map[string]string, 0, len(items))
+	for i := range items {
+		metas = append(metas, map[string]string{"FirewallName": items[i].Name, "FirewallArn": items[i].ARN})
+	}
+
+	wire.WriteJSON(w, map[string]any{"Firewalls": metas})
+}
+
+func toFirewallJSON(f *nfdriver.Firewall) firewallJSON {
+	mappings := make([]subnetMapping, 0, len(f.SubnetIDs))
+	for _, s := range f.SubnetIDs {
+		mappings = append(mappings, subnetMapping{SubnetID: s})
+	}
+
+	return firewallJSON{
+		FirewallName: f.Name, FirewallArn: f.ARN, FirewallPolicyArn: f.PolicyARN,
+		VpcID: f.VPCID, SubnetMappings: mappings, Description: f.Description,
+		DeleteProtection: f.DeleteProtection, Tags: mapToTags(f.Tags),
+	}
+}
+
+// ---- Firewall Policy ----
+
+type firewallPolicyResponseJSON struct {
+	FirewallPolicyName string `json:"FirewallPolicyName"`
+	FirewallPolicyArn  string `json:"FirewallPolicyArn"`
+	FirewallPolicyID   string `json:"FirewallPolicyId"`
+	Description        string `json:"Description,omitempty"`
+	Tags               []tag  `json:"Tags,omitempty"`
+}
+
+type firewallPolicyDetailJSON struct {
+	StatelessDefaultActions         []string `json:"StatelessDefaultActions,omitempty"`
+	StatelessFragmentDefaultActions []string `json:"StatelessFragmentDefaultActions,omitempty"`
+}
+
+type createFirewallPolicyRequest struct {
+	FirewallPolicyName string                   `json:"FirewallPolicyName"`
+	FirewallPolicy     firewallPolicyDetailJSON `json:"FirewallPolicy"`
+	Description        string                   `json:"Description"`
+	Tags               []tag                    `json:"Tags"`
+}
+
+type policyNameArnRequest struct {
+	FirewallPolicyName string `json:"FirewallPolicyName"`
+	FirewallPolicyArn  string `json:"FirewallPolicyArn"`
+}
+
+func (h *Handler) createFirewallPolicy(w http.ResponseWriter, r *http.Request) {
+	var req createFirewallPolicyRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	p, err := h.db.CreateFirewallPolicy(r.Context(), nfdriver.CreateFirewallPolicyConfig{
+		Name:                            req.FirewallPolicyName,
+		Description:                     req.Description,
+		StatelessDefaultActions:         req.FirewallPolicy.StatelessDefaultActions,
+		StatelessFragmentDefaultActions: req.FirewallPolicy.StatelessFragmentDefaultActions,
+		Tags:                            tagsToMap(req.Tags),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"UpdateToken":            updateToken,
+		"FirewallPolicyResponse": toPolicyResponseJSON(p),
+	})
+}
+
+func (h *Handler) describeFirewallPolicy(w http.ResponseWriter, r *http.Request) {
+	var req policyNameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	p, err := h.db.DescribeFirewallPolicy(r.Context(), req.FirewallPolicyName, req.FirewallPolicyArn)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"UpdateToken":            updateToken,
+		"FirewallPolicyResponse": toPolicyResponseJSON(p),
+		"FirewallPolicy": firewallPolicyDetailJSON{
+			StatelessDefaultActions:         p.StatelessDefaultActions,
+			StatelessFragmentDefaultActions: p.StatelessFragmentDefaultActions,
+		},
+	})
+}
+
+func (h *Handler) deleteFirewallPolicy(w http.ResponseWriter, r *http.Request) {
+	var req policyNameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	p, err := h.db.DeleteFirewallPolicy(r.Context(), req.FirewallPolicyName, req.FirewallPolicyArn)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"FirewallPolicyResponse": toPolicyResponseJSON(p)})
+}
+
+func (h *Handler) listFirewallPolicies(w http.ResponseWriter, r *http.Request) {
+	items, err := h.db.ListFirewallPolicies(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	metas := make([]map[string]string, 0, len(items))
+	for i := range items {
+		metas = append(metas, map[string]string{"Name": items[i].Name, "Arn": items[i].ARN})
+	}
+
+	wire.WriteJSON(w, map[string]any{"FirewallPolicies": metas})
+}
+
+func toPolicyResponseJSON(p *nfdriver.FirewallPolicy) firewallPolicyResponseJSON {
+	return firewallPolicyResponseJSON{
+		FirewallPolicyName: p.Name, FirewallPolicyArn: p.ARN, FirewallPolicyID: p.ID,
+		Description: p.Description, Tags: mapToTags(p.Tags),
+	}
+}
+
+// ---- Rule Group ----
+
+type ruleGroupResponseJSON struct {
+	RuleGroupName string `json:"RuleGroupName"`
+	RuleGroupArn  string `json:"RuleGroupArn"`
+	RuleGroupID   string `json:"RuleGroupId"`
+	Type          string `json:"Type"`
+	Capacity      int    `json:"Capacity,omitempty"`
+	Description   string `json:"Description,omitempty"`
+	Tags          []tag  `json:"Tags,omitempty"`
+}
+
+type createRuleGroupRequest struct {
+	RuleGroupName string `json:"RuleGroupName"`
+	Type          string `json:"Type"`
+	Capacity      int    `json:"Capacity"`
+	Description   string `json:"Description"`
+	Tags          []tag  `json:"Tags"`
+}
+
+type ruleGroupNameArnRequest struct {
+	RuleGroupName string `json:"RuleGroupName"`
+	RuleGroupArn  string `json:"RuleGroupArn"`
+	Type          string `json:"Type"`
+}
+
+func (h *Handler) createRuleGroup(w http.ResponseWriter, r *http.Request) {
+	var req createRuleGroupRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rg, err := h.db.CreateRuleGroup(r.Context(), nfdriver.CreateRuleGroupConfig{
+		Name: req.RuleGroupName, Type: req.Type, Capacity: req.Capacity,
+		Description: req.Description, Tags: tagsToMap(req.Tags),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"UpdateToken":       updateToken,
+		"RuleGroupResponse": toRuleGroupResponseJSON(rg),
+	})
+}
+
+func (h *Handler) describeRuleGroup(w http.ResponseWriter, r *http.Request) {
+	var req ruleGroupNameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rg, err := h.db.DescribeRuleGroup(r.Context(), req.RuleGroupName, req.RuleGroupArn, req.Type)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"UpdateToken":       updateToken,
+		"RuleGroupResponse": toRuleGroupResponseJSON(rg),
+	})
+}
+
+func (h *Handler) deleteRuleGroup(w http.ResponseWriter, r *http.Request) {
+	var req ruleGroupNameArnRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	rg, err := h.db.DeleteRuleGroup(r.Context(), req.RuleGroupName, req.RuleGroupArn, req.Type)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"RuleGroupResponse": toRuleGroupResponseJSON(rg)})
+}
+
+func (h *Handler) listRuleGroups(w http.ResponseWriter, r *http.Request) {
+	items, err := h.db.ListRuleGroups(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	metas := make([]map[string]string, 0, len(items))
+	for i := range items {
+		metas = append(metas, map[string]string{"Name": items[i].Name, "Arn": items[i].ARN})
+	}
+
+	wire.WriteJSON(w, map[string]any{"RuleGroups": metas})
+}
+
+func toRuleGroupResponseJSON(rg *nfdriver.RuleGroup) ruleGroupResponseJSON {
+	return ruleGroupResponseJSON{
+		RuleGroupName: rg.Name, RuleGroupArn: rg.ARN, RuleGroupID: rg.ID, Type: rg.Type,
+		Capacity: rg.Capacity, Description: rg.Description, Tags: mapToTags(rg.Tags),
+	}
+}
+
+// ---- helpers ----
+
+func subnetIDs(mappings []subnetMapping) []string {
+	if len(mappings) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(mappings))
+	for _, m := range mappings {
+		out = append(out, m.SubnetID)
+	}
+
+	return out
+}
+
+func tagsToMap(tags []tag) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}
+
+func mapToTags(m map[string]string) []tag {
+	if len(m) == 0 {
+		return nil
+	}
+
+	out := make([]tag, 0, len(m))
+	for k, v := range m {
+		out = append(out, tag{Key: k, Value: v})
+	}
+
+	return out
+}

--- a/server/aws/networkfirewall/sdk_roundtrip_test.go
+++ b/server/aws/networkfirewall/sdk_roundtrip_test.go
@@ -158,4 +158,9 @@ func TestSDKNetworkFirewall(t *testing.T) {
 
 	_, err = client.DescribeFirewall(ctx, &networkfirewall.DescribeFirewallInput{FirewallName: aws.String("fw-1")})
 	require.Error(t, err, "firewall should be gone after delete")
+
+	// Error path: the JSON error envelope decodes into a typed SDK error.
+	_, err = client.DescribeFirewall(ctx, &networkfirewall.DescribeFirewallInput{FirewallName: aws.String("does-not-exist")})
+	var notFound *nftypes.ResourceNotFoundException
+	require.ErrorAs(t, err, &notFound, "expected ResourceNotFoundException for unknown firewall")
 }

--- a/server/aws/networkfirewall/sdk_roundtrip_test.go
+++ b/server/aws/networkfirewall/sdk_roundtrip_test.go
@@ -88,6 +88,66 @@ func TestSDKNetworkFirewall(t *testing.T) {
 	require.Len(t, descFw.Firewall.SubnetMappings, 1)
 	assert.Equal(t, "subnet-1", aws.ToString(descFw.Firewall.SubnetMappings[0].SubnetId))
 
+	// Depth: subnet association, delete protection, logging, tags.
+	_, err = client.AssociateSubnets(ctx, &networkfirewall.AssociateSubnetsInput{
+		FirewallName:   aws.String("fw-1"),
+		SubnetMappings: []nftypes.SubnetMapping{{SubnetId: aws.String("subnet-2")}},
+	})
+	require.NoError(t, err)
+
+	descAfterAssoc, err := client.DescribeFirewall(ctx, &networkfirewall.DescribeFirewallInput{
+		FirewallName: aws.String("fw-1"),
+	})
+	require.NoError(t, err)
+	assert.Len(t, descAfterAssoc.Firewall.SubnetMappings, 2)
+
+	_, err = client.DisassociateSubnets(ctx, &networkfirewall.DisassociateSubnetsInput{
+		FirewallName: aws.String("fw-1"), SubnetIds: []string{"subnet-2"},
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateFirewallDeleteProtection(ctx, &networkfirewall.UpdateFirewallDeleteProtectionInput{
+		FirewallName: aws.String("fw-1"), DeleteProtection: true,
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateLoggingConfiguration(ctx, &networkfirewall.UpdateLoggingConfigurationInput{
+		FirewallName: aws.String("fw-1"),
+		LoggingConfiguration: &nftypes.LoggingConfiguration{
+			LogDestinationConfigs: []nftypes.LogDestinationConfig{{
+				LogType:            nftypes.LogTypeFlow,
+				LogDestinationType: nftypes.LogDestinationTypeCloudwatchLogs,
+				LogDestination:     map[string]string{"logGroup": "nf-logs"},
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	descLog, err := client.DescribeLoggingConfiguration(ctx, &networkfirewall.DescribeLoggingConfigurationInput{
+		FirewallName: aws.String("fw-1"),
+	})
+	require.NoError(t, err)
+	require.Len(t, descLog.LoggingConfiguration.LogDestinationConfigs, 1)
+	assert.Equal(t, nftypes.LogTypeFlow, descLog.LoggingConfiguration.LogDestinationConfigs[0].LogType)
+
+	fwARN := aws.ToString(descFw.Firewall.FirewallArn)
+	_, err = client.TagResource(ctx, &networkfirewall.TagResourceInput{
+		ResourceArn: aws.String(fwARN),
+		Tags:        []nftypes.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+	})
+	require.NoError(t, err)
+
+	_, err = client.UntagResource(ctx, &networkfirewall.UntagResourceInput{
+		ResourceArn: aws.String(fwARN), TagKeys: []string{"env"},
+	})
+	require.NoError(t, err)
+
+	// Turn off delete protection so the delete below succeeds.
+	_, err = client.UpdateFirewallDeleteProtection(ctx, &networkfirewall.UpdateFirewallDeleteProtectionInput{
+		FirewallName: aws.String("fw-1"), DeleteProtection: false,
+	})
+	require.NoError(t, err)
+
 	// List + delete.
 	list, err := client.ListFirewalls(ctx, &networkfirewall.ListFirewallsInput{})
 	require.NoError(t, err)

--- a/server/aws/networkfirewall/sdk_roundtrip_test.go
+++ b/server/aws/networkfirewall/sdk_roundtrip_test.go
@@ -1,0 +1,101 @@
+package networkfirewall_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/networkfirewall"
+	nftypes "github.com/aws/aws-sdk-go-v2/service/networkfirewall/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+)
+
+func newClient(t *testing.T) *networkfirewall.Client {
+	t.Helper()
+
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{NetworkFirewall: provider.NetworkFirewall})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	require.NoError(t, err)
+
+	return networkfirewall.NewFromConfig(cfg, func(o *networkfirewall.Options) {
+		o.BaseEndpoint = aws.String(ts.URL)
+	})
+}
+
+func TestSDKNetworkFirewall(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// Rule group.
+	rg, err := client.CreateRuleGroup(ctx, &networkfirewall.CreateRuleGroupInput{
+		RuleGroupName: aws.String("rg-1"),
+		Type:          nftypes.RuleGroupTypeStateful,
+		Capacity:      aws.Int32(100),
+		Description:   aws.String("stateful rules"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "rg-1", aws.ToString(rg.RuleGroupResponse.RuleGroupName))
+	assert.NotEmpty(t, aws.ToString(rg.RuleGroupResponse.RuleGroupArn))
+
+	// Firewall policy.
+	pol, err := client.CreateFirewallPolicy(ctx, &networkfirewall.CreateFirewallPolicyInput{
+		FirewallPolicyName: aws.String("pol-1"),
+		FirewallPolicy: &nftypes.FirewallPolicy{
+			StatelessDefaultActions:         []string{"aws:forward_to_sfe"},
+			StatelessFragmentDefaultActions: []string{"aws:forward_to_sfe"},
+		},
+	})
+	require.NoError(t, err)
+	policyARN := aws.ToString(pol.FirewallPolicyResponse.FirewallPolicyArn)
+	require.NotEmpty(t, policyARN)
+
+	descPol, err := client.DescribeFirewallPolicy(ctx, &networkfirewall.DescribeFirewallPolicyInput{
+		FirewallPolicyName: aws.String("pol-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aws:forward_to_sfe"}, descPol.FirewallPolicy.StatelessDefaultActions)
+
+	// Firewall referencing the policy.
+	fw, err := client.CreateFirewall(ctx, &networkfirewall.CreateFirewallInput{
+		FirewallName:      aws.String("fw-1"),
+		FirewallPolicyArn: aws.String(policyARN),
+		VpcId:             aws.String("vpc-123"),
+		SubnetMappings:    []nftypes.SubnetMapping{{SubnetId: aws.String("subnet-1")}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "fw-1", aws.ToString(fw.Firewall.FirewallName))
+	assert.Equal(t, policyARN, aws.ToString(fw.Firewall.FirewallPolicyArn))
+
+	descFw, err := client.DescribeFirewall(ctx, &networkfirewall.DescribeFirewallInput{
+		FirewallName: aws.String("fw-1"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "vpc-123", aws.ToString(descFw.Firewall.VpcId))
+	require.Len(t, descFw.Firewall.SubnetMappings, 1)
+	assert.Equal(t, "subnet-1", aws.ToString(descFw.Firewall.SubnetMappings[0].SubnetId))
+
+	// List + delete.
+	list, err := client.ListFirewalls(ctx, &networkfirewall.ListFirewallsInput{})
+	require.NoError(t, err)
+	assert.Len(t, list.Firewalls, 1)
+
+	_, err = client.DeleteFirewall(ctx, &networkfirewall.DeleteFirewallInput{FirewallName: aws.String("fw-1")})
+	require.NoError(t, err)
+
+	_, err = client.DescribeFirewall(ctx, &networkfirewall.DescribeFirewallInput{FirewallName: aws.String("fw-1")})
+	require.Error(t, err, "firewall should be gone after delete")
+}

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -128,6 +128,13 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 			VpnConnectionId: aws.String(vpnID), DestinationCidrBlock: aws.String("192.168.0.0/16"),
 		})
 		require.NoError(t, err)
+
+		// Error path: modifying a nonexistent connection surfaces an SDK error
+		// deserialized from the query-protocol error XML.
+		_, err = client.ModifyVpnConnection(ctx, &ec2.ModifyVpnConnectionInput{
+			VpnConnectionId: aws.String("vpn-does-not-exist"), VpnGatewayId: aws.String(vgwID),
+		})
+		require.Error(t, err, "expected error modifying unknown vpn connection")
 	})
 
 	t.Run("dhcp options", func(t *testing.T) {

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -78,6 +78,16 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, routes.Routes, 1)
 		assert.Equal(t, "10.1.0.0/16", aws.ToString(routes.Routes[0].DestinationCidrBlock))
+
+		_, err = client.EnableTransitGatewayRouteTablePropagation(ctx, &ec2.EnableTransitGatewayRouteTablePropagationInput{
+			TransitGatewayRouteTableId: aws.String(rtID), TransitGatewayAttachmentId: aws.String(attID),
+		})
+		require.NoError(t, err)
+
+		_, err = client.DeleteTransitGatewayRoute(ctx, &ec2.DeleteTransitGatewayRouteInput{
+			TransitGatewayRouteTableId: aws.String(rtID), DestinationCidrBlock: aws.String("10.1.0.0/16"),
+		})
+		require.NoError(t, err)
 	})
 
 	t.Run("vpn", func(t *testing.T) {
@@ -101,10 +111,23 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, cgwID, aws.ToString(vpn.VpnConnection.CustomerGatewayId))
+		vpnID := aws.ToString(vpn.VpnConnection.VpnConnectionId)
+
+		_, err = client.CreateVpnConnectionRoute(ctx, &ec2.CreateVpnConnectionRouteInput{
+			VpnConnectionId: aws.String(vpnID), DestinationCidrBlock: aws.String("192.168.0.0/16"),
+		})
+		require.NoError(t, err)
 
 		desc, err := client.DescribeVpnConnections(ctx, &ec2.DescribeVpnConnectionsInput{})
 		require.NoError(t, err)
-		assert.Len(t, desc.VpnConnections, 1)
+		require.Len(t, desc.VpnConnections, 1)
+		require.Len(t, desc.VpnConnections[0].Routes, 1)
+		assert.Equal(t, "192.168.0.0/16", aws.ToString(desc.VpnConnections[0].Routes[0].DestinationCidrBlock))
+
+		_, err = client.DeleteVpnConnectionRoute(ctx, &ec2.DeleteVpnConnectionRouteInput{
+			VpnConnectionId: aws.String(vpnID), DestinationCidrBlock: aws.String("192.168.0.0/16"),
+		})
+		require.NoError(t, err)
 	})
 
 	t.Run("dhcp options", func(t *testing.T) {
@@ -137,6 +160,21 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, entries.Entries, 1)
 		assert.Equal(t, "10.0.0.0/8", aws.ToString(entries.Entries[0].Cidr))
+
+		mod, err := client.ModifyManagedPrefixList(ctx, &ec2.ModifyManagedPrefixListInput{
+			PrefixListId:  aws.String(id),
+			AddEntries:    []ec2types.AddPrefixListEntry{{Cidr: aws.String("172.16.0.0/12")}},
+			RemoveEntries: []ec2types.RemovePrefixListEntry{{Cidr: aws.String("10.0.0.0/8")}},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, mod.PrefixList)
+
+		entries2, err := client.GetManagedPrefixListEntries(ctx, &ec2.GetManagedPrefixListEntriesInput{
+			PrefixListId: aws.String(id),
+		})
+		require.NoError(t, err)
+		require.Len(t, entries2.Entries, 1)
+		assert.Equal(t, "172.16.0.0/12", aws.ToString(entries2.Entries[0].Cidr))
 	})
 
 	t.Run("egress-only internet gateway", func(t *testing.T) {
@@ -152,7 +190,21 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 			NetworkLoadBalancerArns: []string{"arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/x/1"},
 		})
 		require.NoError(t, err)
-		assert.NotEmpty(t, aws.ToString(out.ServiceConfiguration.ServiceId))
+		svcID := aws.ToString(out.ServiceConfiguration.ServiceId)
+		assert.NotEmpty(t, svcID)
+
+		_, err = client.ModifyVpcEndpointServicePermissions(ctx, &ec2.ModifyVpcEndpointServicePermissionsInput{
+			ServiceId:            aws.String(svcID),
+			AddAllowedPrincipals: []string{"arn:aws:iam::111122223333:root"},
+		})
+		require.NoError(t, err)
+
+		perms, err := client.DescribeVpcEndpointServicePermissions(ctx, &ec2.DescribeVpcEndpointServicePermissionsInput{
+			ServiceId: aws.String(svcID),
+		})
+		require.NoError(t, err)
+		require.Len(t, perms.AllowedPrincipals, 1)
+		assert.Equal(t, "arn:aws:iam::111122223333:root", aws.ToString(perms.AllowedPrincipals[0].Principal))
 	})
 
 	t.Run("client vpn", func(t *testing.T) {
@@ -173,5 +225,37 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.NotEmpty(t, aws.ToString(assoc.AssociationId))
+
+		nets, err := client.DescribeClientVpnTargetNetworks(ctx, &ec2.DescribeClientVpnTargetNetworksInput{
+			ClientVpnEndpointId: aws.String(epID),
+		})
+		require.NoError(t, err)
+		require.Len(t, nets.ClientVpnTargetNetworks, 1)
+
+		_, err = client.AuthorizeClientVpnIngress(ctx, &ec2.AuthorizeClientVpnIngressInput{
+			ClientVpnEndpointId: aws.String(epID), TargetNetworkCidr: aws.String("10.0.0.0/16"),
+			AuthorizeAllGroups: aws.Bool(true),
+		})
+		require.NoError(t, err)
+
+		rules, err := client.DescribeClientVpnAuthorizationRules(ctx, &ec2.DescribeClientVpnAuthorizationRulesInput{
+			ClientVpnEndpointId: aws.String(epID),
+		})
+		require.NoError(t, err)
+		require.Len(t, rules.AuthorizationRules, 1)
+		assert.Equal(t, "10.0.0.0/16", aws.ToString(rules.AuthorizationRules[0].DestinationCidr))
+
+		_, err = client.CreateClientVpnRoute(ctx, &ec2.CreateClientVpnRouteInput{
+			ClientVpnEndpointId: aws.String(epID), DestinationCidrBlock: aws.String("0.0.0.0/0"),
+			TargetVpcSubnetId: aws.String(subnetID),
+		})
+		require.NoError(t, err)
+
+		vpnRoutes, err := client.DescribeClientVpnRoutes(ctx, &ec2.DescribeClientVpnRoutesInput{
+			ClientVpnEndpointId: aws.String(epID),
+		})
+		require.NoError(t, err)
+		require.Len(t, vpnRoutes.Routes, 1)
+		assert.Equal(t, "0.0.0.0/0", aws.ToString(vpnRoutes.Routes[0].DestinationCidr))
 	})
 }

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -1,0 +1,177 @@
+package aws_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEC2NetworkingParitySDK drives the real aws-sdk-go-v2 EC2 client against
+// the new AWS-only networking capabilities (transit gateway, VPN, DHCP options,
+// managed prefix lists, egress-only IGW, endpoint services, Client VPN),
+// proving the query-protocol XML round-trips.
+func TestEC2NetworkingParitySDK(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	// Prerequisite VPC + subnet for attachment-style resources.
+	vpcOut, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	require.NoError(t, err)
+	vpcID := aws.ToString(vpcOut.Vpc.VpcId)
+
+	subnetOut, err := client.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId: aws.String(vpcID), CidrBlock: aws.String("10.0.1.0/24"),
+	})
+	require.NoError(t, err)
+	subnetID := aws.ToString(subnetOut.Subnet.SubnetId)
+
+	t.Run("transit gateway", func(t *testing.T) {
+		tgw, err := client.CreateTransitGateway(ctx, &ec2.CreateTransitGatewayInput{
+			Description: aws.String("hub"),
+			Options:     &ec2types.TransitGatewayRequestOptions{AmazonSideAsn: aws.Int64(64513)},
+		})
+		require.NoError(t, err)
+		tgwID := aws.ToString(tgw.TransitGateway.TransitGatewayId)
+		assert.NotEmpty(t, tgwID)
+		assert.EqualValues(t, 64513, aws.ToInt64(tgw.TransitGateway.Options.AmazonSideAsn))
+
+		desc, err := client.DescribeTransitGateways(ctx, &ec2.DescribeTransitGatewaysInput{
+			TransitGatewayIds: []string{tgwID},
+		})
+		require.NoError(t, err)
+		require.Len(t, desc.TransitGateways, 1)
+
+		att, err := client.CreateTransitGatewayVpcAttachment(ctx, &ec2.CreateTransitGatewayVpcAttachmentInput{
+			TransitGatewayId: aws.String(tgwID), VpcId: aws.String(vpcID), SubnetIds: []string{subnetID},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, vpcID, aws.ToString(att.TransitGatewayVpcAttachment.VpcId))
+
+		rt, err := client.CreateTransitGatewayRouteTable(ctx, &ec2.CreateTransitGatewayRouteTableInput{
+			TransitGatewayId: aws.String(tgwID),
+		})
+		require.NoError(t, err)
+		rtID := aws.ToString(rt.TransitGatewayRouteTable.TransitGatewayRouteTableId)
+		assert.NotEmpty(t, rtID)
+		attID := aws.ToString(att.TransitGatewayVpcAttachment.TransitGatewayAttachmentId)
+
+		_, err = client.AssociateTransitGatewayRouteTable(ctx, &ec2.AssociateTransitGatewayRouteTableInput{
+			TransitGatewayRouteTableId: aws.String(rtID), TransitGatewayAttachmentId: aws.String(attID),
+		})
+		require.NoError(t, err)
+
+		_, err = client.CreateTransitGatewayRoute(ctx, &ec2.CreateTransitGatewayRouteInput{
+			TransitGatewayRouteTableId: aws.String(rtID), DestinationCidrBlock: aws.String("10.1.0.0/16"),
+			TransitGatewayAttachmentId: aws.String(attID),
+		})
+		require.NoError(t, err)
+
+		routes, err := client.SearchTransitGatewayRoutes(ctx, &ec2.SearchTransitGatewayRoutesInput{
+			TransitGatewayRouteTableId: aws.String(rtID),
+			Filters:                    []ec2types.Filter{{Name: aws.String("state"), Values: []string{"active"}}},
+		})
+		require.NoError(t, err)
+		require.Len(t, routes.Routes, 1)
+		assert.Equal(t, "10.1.0.0/16", aws.ToString(routes.Routes[0].DestinationCidrBlock))
+	})
+
+	t.Run("vpn", func(t *testing.T) {
+		cgw, err := client.CreateCustomerGateway(ctx, &ec2.CreateCustomerGatewayInput{
+			IpAddress: aws.String("203.0.113.10"), BgpAsn: aws.Int32(65000), Type: ec2types.GatewayTypeIpsec1,
+		})
+		require.NoError(t, err)
+		cgwID := aws.ToString(cgw.CustomerGateway.CustomerGatewayId)
+
+		vgw, err := client.CreateVpnGateway(ctx, &ec2.CreateVpnGatewayInput{Type: ec2types.GatewayTypeIpsec1})
+		require.NoError(t, err)
+		vgwID := aws.ToString(vgw.VpnGateway.VpnGatewayId)
+
+		_, err = client.AttachVpnGateway(ctx, &ec2.AttachVpnGatewayInput{
+			VpnGatewayId: aws.String(vgwID), VpcId: aws.String(vpcID),
+		})
+		require.NoError(t, err)
+
+		vpn, err := client.CreateVpnConnection(ctx, &ec2.CreateVpnConnectionInput{
+			CustomerGatewayId: aws.String(cgwID), VpnGatewayId: aws.String(vgwID), Type: aws.String("ipsec.1"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, cgwID, aws.ToString(vpn.VpnConnection.CustomerGatewayId))
+
+		desc, err := client.DescribeVpnConnections(ctx, &ec2.DescribeVpnConnectionsInput{})
+		require.NoError(t, err)
+		assert.Len(t, desc.VpnConnections, 1)
+	})
+
+	t.Run("dhcp options", func(t *testing.T) {
+		out, err := client.CreateDhcpOptions(ctx, &ec2.CreateDhcpOptionsInput{
+			DhcpConfigurations: []ec2types.NewDhcpConfiguration{
+				{Key: aws.String("domain-name-servers"), Values: []string{"10.0.0.2"}},
+			},
+		})
+		require.NoError(t, err)
+		id := aws.ToString(out.DhcpOptions.DhcpOptionsId)
+		assert.NotEmpty(t, id)
+
+		_, err = client.AssociateDhcpOptions(ctx, &ec2.AssociateDhcpOptionsInput{
+			DhcpOptionsId: aws.String(id), VpcId: aws.String(vpcID),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("managed prefix list", func(t *testing.T) {
+		out, err := client.CreateManagedPrefixList(ctx, &ec2.CreateManagedPrefixListInput{
+			PrefixListName: aws.String("corp"), MaxEntries: aws.Int32(10), AddressFamily: aws.String("IPv4"),
+			Entries: []ec2types.AddPrefixListEntry{{Cidr: aws.String("10.0.0.0/8"), Description: aws.String("corp")}},
+		})
+		require.NoError(t, err)
+		id := aws.ToString(out.PrefixList.PrefixListId)
+
+		entries, err := client.GetManagedPrefixListEntries(ctx, &ec2.GetManagedPrefixListEntriesInput{
+			PrefixListId: aws.String(id),
+		})
+		require.NoError(t, err)
+		require.Len(t, entries.Entries, 1)
+		assert.Equal(t, "10.0.0.0/8", aws.ToString(entries.Entries[0].Cidr))
+	})
+
+	t.Run("egress-only internet gateway", func(t *testing.T) {
+		out, err := client.CreateEgressOnlyInternetGateway(ctx, &ec2.CreateEgressOnlyInternetGatewayInput{
+			VpcId: aws.String(vpcID),
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, aws.ToString(out.EgressOnlyInternetGateway.EgressOnlyInternetGatewayId))
+	})
+
+	t.Run("vpc endpoint service", func(t *testing.T) {
+		out, err := client.CreateVpcEndpointServiceConfiguration(ctx, &ec2.CreateVpcEndpointServiceConfigurationInput{
+			NetworkLoadBalancerArns: []string{"arn:aws:elasticloadbalancing:us-east-1:000000000000:loadbalancer/net/x/1"},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, aws.ToString(out.ServiceConfiguration.ServiceId))
+	})
+
+	t.Run("client vpn", func(t *testing.T) {
+		out, err := client.CreateClientVpnEndpoint(ctx, &ec2.CreateClientVpnEndpointInput{
+			ClientCidrBlock:      aws.String("10.100.0.0/16"),
+			ServerCertificateArn: aws.String("arn:aws:acm:us-east-1:000000000000:certificate/abc"),
+			AuthenticationOptions: []ec2types.ClientVpnAuthenticationRequest{
+				{Type: ec2types.ClientVpnAuthenticationTypeCertificateAuthentication},
+			},
+			ConnectionLogOptions: &ec2types.ConnectionLogOptions{Enabled: aws.Bool(false)},
+		})
+		require.NoError(t, err)
+		epID := aws.ToString(out.ClientVpnEndpointId)
+		assert.NotEmpty(t, epID)
+
+		assoc, err := client.AssociateClientVpnTargetNetwork(ctx, &ec2.AssociateClientVpnTargetNetworkInput{
+			ClientVpnEndpointId: aws.String(epID), SubnetId: aws.String(subnetID),
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, aws.ToString(assoc.AssociationId))
+	})
+}

--- a/services/networkfirewall/driver/driver.go
+++ b/services/networkfirewall/driver/driver.go
@@ -1,0 +1,90 @@
+// Package driver defines the portable interface for AWS Network Firewall, a
+// managed stateful/stateless firewall. It is a distinct service (its own
+// AWS JSON API), separate from the EC2 VPC networking surface.
+package driver
+
+import "context"
+
+// Firewall is a Network Firewall attached to a VPC across subnets.
+type Firewall struct {
+	Name             string
+	ARN              string
+	PolicyARN        string
+	VPCID            string
+	SubnetIDs        []string
+	Description      string
+	DeleteProtection bool
+	Status           string
+	Tags             map[string]string
+}
+
+// CreateFirewallConfig is the input to CreateFirewall.
+type CreateFirewallConfig struct {
+	Name             string
+	PolicyARN        string
+	VPCID            string
+	SubnetIDs        []string
+	Description      string
+	DeleteProtection bool
+	Tags             map[string]string
+}
+
+// FirewallPolicy groups stateless/stateful rule-group references + default actions.
+type FirewallPolicy struct {
+	Name                            string
+	ARN                             string
+	ID                              string
+	Description                     string
+	StatelessDefaultActions         []string
+	StatelessFragmentDefaultActions []string
+	Tags                            map[string]string
+}
+
+// CreateFirewallPolicyConfig is the input to CreateFirewallPolicy.
+type CreateFirewallPolicyConfig struct {
+	Name                            string
+	Description                     string
+	StatelessDefaultActions         []string
+	StatelessFragmentDefaultActions []string
+	Tags                            map[string]string
+}
+
+// RuleGroup is a reusable collection of stateful or stateless rules.
+type RuleGroup struct {
+	Name        string
+	ARN         string
+	ID          string
+	Type        string // STATEFUL | STATELESS
+	Capacity    int
+	Description string
+	Tags        map[string]string
+}
+
+// CreateRuleGroupConfig is the input to CreateRuleGroup.
+type CreateRuleGroupConfig struct {
+	Name        string
+	Type        string
+	Capacity    int
+	Description string
+	Tags        map[string]string
+}
+
+// NetworkFirewall is the AWS Network Firewall control plane.
+//
+//nolint:interfacebloat // mirrors the network-firewall API surface.
+type NetworkFirewall interface {
+	CreateFirewall(ctx context.Context, cfg CreateFirewallConfig) (*Firewall, error)
+	DescribeFirewall(ctx context.Context, name, arn string) (*Firewall, error)
+	DeleteFirewall(ctx context.Context, name, arn string) (*Firewall, error)
+	ListFirewalls(ctx context.Context) ([]Firewall, error)
+
+	CreateFirewallPolicy(ctx context.Context, cfg CreateFirewallPolicyConfig) (*FirewallPolicy, error)
+	DescribeFirewallPolicy(ctx context.Context, name, arn string) (*FirewallPolicy, error)
+	DeleteFirewallPolicy(ctx context.Context, name, arn string) (*FirewallPolicy, error)
+	ListFirewallPolicies(ctx context.Context) ([]FirewallPolicy, error)
+
+	CreateRuleGroup(ctx context.Context, cfg CreateRuleGroupConfig) (*RuleGroup, error)
+	DescribeRuleGroup(ctx context.Context, name, arn, ruleType string) (*RuleGroup, error)
+	DeleteRuleGroup(ctx context.Context, name, arn, ruleType string) (*RuleGroup, error)
+	ListRuleGroups(ctx context.Context) ([]RuleGroup, error)
+}

--- a/services/networkfirewall/driver/driver.go
+++ b/services/networkfirewall/driver/driver.go
@@ -87,4 +87,13 @@ type NetworkFirewall interface {
 	DescribeRuleGroup(ctx context.Context, name, arn, ruleType string) (*RuleGroup, error)
 	DeleteRuleGroup(ctx context.Context, name, arn, ruleType string) (*RuleGroup, error)
 	ListRuleGroups(ctx context.Context) ([]RuleGroup, error)
+
+	AssociateFirewallPolicy(ctx context.Context, firewallName, policyARN string) (*Firewall, error)
+	AssociateSubnets(ctx context.Context, firewallName string, subnetIDs []string) (*Firewall, error)
+	DisassociateSubnets(ctx context.Context, firewallName string, subnetIDs []string) (*Firewall, error)
+	UpdateFirewallDeleteProtection(ctx context.Context, firewallName string, enabled bool) (*Firewall, error)
+	UpdateLoggingConfiguration(ctx context.Context, firewallName string, logTypes []string) error
+	DescribeLoggingConfiguration(ctx context.Context, firewallName string) ([]string, error)
+	TagResource(ctx context.Context, arn string, tags map[string]string) error
+	UntagResource(ctx context.Context, arn string, keys []string) error
 }

--- a/services/networking/driver/aws_capabilities.go
+++ b/services/networking/driver/aws_capabilities.go
@@ -55,6 +55,23 @@ type TransitGatewayRouteTable struct {
 	Tags             map[string]string
 }
 
+// TransitGatewayRoute is a route within a transit gateway route table.
+type TransitGatewayRoute struct {
+	DestinationCIDR string
+	AttachmentID    string
+	Type            string // static | propagated
+	State           string
+}
+
+// TransitGatewayRouteTableAssociation links an attachment to a TGW route table.
+type TransitGatewayRouteTableAssociation struct {
+	RouteTableID string
+	AttachmentID string
+	ResourceID   string
+	ResourceType string
+	State        string
+}
+
 // TransitGateways is an OPTIONAL AWS capability (type-asserted).
 type TransitGateways interface {
 	CreateTransitGateway(ctx context.Context, cfg TransitGatewayConfig) (*TransitGateway, error)
@@ -68,6 +85,13 @@ type TransitGateways interface {
 	CreateTransitGatewayRouteTable(ctx context.Context, transitGatewayID string, tags map[string]string) (*TransitGatewayRouteTable, error)
 	DeleteTransitGatewayRouteTable(ctx context.Context, id string) (*TransitGatewayRouteTable, error)
 	DescribeTransitGatewayRouteTables(ctx context.Context, ids []string) ([]TransitGatewayRouteTable, error)
+
+	CreateTransitGatewayRoute(ctx context.Context, routeTableID, destinationCIDR, attachmentID string) (*TransitGatewayRoute, error)
+	DeleteTransitGatewayRoute(ctx context.Context, routeTableID, destinationCIDR string) (*TransitGatewayRoute, error)
+	SearchTransitGatewayRoutes(ctx context.Context, routeTableID string) ([]TransitGatewayRoute, error)
+	AssociateTransitGatewayRouteTable(ctx context.Context, routeTableID, attachmentID string) (*TransitGatewayRouteTableAssociation, error)
+	EnableTransitGatewayRouteTablePropagation(ctx context.Context, routeTableID, attachmentID string) error
+	DisableTransitGatewayRouteTablePropagation(ctx context.Context, routeTableID, attachmentID string) error
 }
 
 // ---- VPN (Customer Gateway / VPN Gateway / VPN Connection) ----

--- a/services/networking/driver/aws_capabilities.go
+++ b/services/networking/driver/aws_capabilities.go
@@ -141,7 +141,14 @@ type VPNConnection struct {
 	Type              string
 	State             string
 	StaticRoutesOnly  bool
+	Routes            []VPNConnectionRoute
 	Tags              map[string]string
+}
+
+// VPNConnectionRoute is a static route on a site-to-site VPN connection.
+type VPNConnectionRoute struct {
+	DestinationCIDR string
+	State           string
 }
 
 // VPNConnectionConfig is the input to CreateVPNConnection.
@@ -169,6 +176,9 @@ type VPNConnections interface {
 	CreateVPNConnection(ctx context.Context, cfg VPNConnectionConfig) (*VPNConnection, error)
 	DeleteVPNConnection(ctx context.Context, id string) error
 	DescribeVPNConnections(ctx context.Context, ids []string) ([]VPNConnection, error)
+	CreateVPNConnectionRoute(ctx context.Context, vpnConnectionID, destinationCIDR string) error
+	DeleteVPNConnectionRoute(ctx context.Context, vpnConnectionID, destinationCIDR string) error
+	ModifyVPNConnection(ctx context.Context, id, transitGatewayID, vpnGatewayID string) (*VPNConnection, error)
 }
 
 // ---- DHCP Option Sets ----
@@ -229,6 +239,7 @@ type PrefixLists interface {
 	DeleteManagedPrefixList(ctx context.Context, id string) (*PrefixList, error)
 	DescribeManagedPrefixLists(ctx context.Context, ids []string) ([]PrefixList, error)
 	GetManagedPrefixListEntries(ctx context.Context, id string) ([]PrefixListEntry, error)
+	ModifyManagedPrefixList(ctx context.Context, id string, addEntries []PrefixListEntry, removeCIDRs []string) (*PrefixList, error)
 }
 
 // ---- Egress-only Internet Gateway (IPv6) ----
@@ -273,6 +284,8 @@ type VPCEndpointServices interface {
 	CreateVPCEndpointServiceConfiguration(ctx context.Context, cfg EndpointServiceConfig) (*EndpointService, error)
 	DeleteVPCEndpointServiceConfiguration(ctx context.Context, id string) error
 	DescribeVPCEndpointServiceConfigurations(ctx context.Context, ids []string) ([]EndpointService, error)
+	ModifyVPCEndpointServicePermissions(ctx context.Context, serviceID string, addPrincipals, removePrincipals []string) error
+	DescribeVPCEndpointServicePermissions(ctx context.Context, serviceID string) ([]string, error)
 }
 
 // ---- Client VPN ----
@@ -307,6 +320,23 @@ type ClientVPNTargetNetwork struct {
 	State         string
 }
 
+// ClientVPNAuthorizationRule authorizes a client CIDR to reach a target network.
+type ClientVPNAuthorizationRule struct {
+	EndpointID string
+	TargetCIDR string
+	GroupID    string
+	AccessAll  bool
+	Status     string
+}
+
+// ClientVPNRoute is a route on a Client VPN endpoint.
+type ClientVPNRoute struct {
+	EndpointID      string
+	DestinationCIDR string
+	TargetSubnetID  string
+	Status          string
+}
+
 // ClientVPN is an OPTIONAL AWS capability (type-asserted).
 type ClientVPN interface {
 	CreateClientVPNEndpoint(ctx context.Context, cfg ClientVPNEndpointConfig) (*ClientVPNEndpoint, error)
@@ -314,4 +344,11 @@ type ClientVPN interface {
 	DescribeClientVPNEndpoints(ctx context.Context, ids []string) ([]ClientVPNEndpoint, error)
 	AssociateClientVPNTargetNetwork(ctx context.Context, endpointID, subnetID string) (*ClientVPNTargetNetwork, error)
 	DisassociateClientVPNTargetNetwork(ctx context.Context, endpointID, associationID string) error
+	DescribeClientVPNTargetNetworks(ctx context.Context, endpointID string) ([]ClientVPNTargetNetwork, error)
+	AuthorizeClientVPNIngress(ctx context.Context, endpointID, targetCIDR, groupID string, accessAll bool) (*ClientVPNAuthorizationRule, error)
+	RevokeClientVPNIngress(ctx context.Context, endpointID, targetCIDR string) error
+	DescribeClientVPNAuthorizationRules(ctx context.Context, endpointID string) ([]ClientVPNAuthorizationRule, error)
+	CreateClientVPNRoute(ctx context.Context, endpointID, destinationCIDR, targetSubnetID string) (*ClientVPNRoute, error)
+	DeleteClientVPNRoute(ctx context.Context, endpointID, destinationCIDR, targetSubnetID string) error
+	DescribeClientVPNRoutes(ctx context.Context, endpointID string) ([]ClientVPNRoute, error)
 }

--- a/services/networking/driver/aws_capabilities.go
+++ b/services/networking/driver/aws_capabilities.go
@@ -1,0 +1,293 @@
+package driver
+
+import "context"
+
+// This file defines AWS-specific networking capabilities as OPTIONAL interfaces
+// discovered by type assertion, following the VPCAttributes / NetworkInterfaces
+// precedent. These resources (Transit Gateways, VPN, DHCP option sets, managed
+// prefix lists, egress-only internet gateways, endpoint services, Client VPN)
+// don't map cleanly across clouds, so they stay out of the portable Networking
+// interface — only the AWS mock implements them, and the EC2 handler serves
+// them when the driver satisfies the capability.
+
+// ---- Transit Gateway ----
+
+// TransitGateway is a regional hub that interconnects VPCs and on-prem networks.
+type TransitGateway struct {
+	ID          string
+	State       string
+	ASN         int64
+	Description string
+	OwnerID     string
+	Tags        map[string]string
+}
+
+// TransitGatewayConfig is the input to CreateTransitGateway.
+type TransitGatewayConfig struct {
+	ASN         int64
+	Description string
+	Tags        map[string]string
+}
+
+// TransitGatewayVPCAttachment attaches a VPC (via subnets) to a transit gateway.
+type TransitGatewayVPCAttachment struct {
+	ID               string
+	TransitGatewayID string
+	VPCID            string
+	SubnetIDs        []string
+	State            string
+	Tags             map[string]string
+}
+
+// TransitGatewayVPCAttachmentConfig is the input to CreateTransitGatewayVPCAttachment.
+type TransitGatewayVPCAttachmentConfig struct {
+	TransitGatewayID string
+	VPCID            string
+	SubnetIDs        []string
+	Tags             map[string]string
+}
+
+// TransitGatewayRouteTable is a route table owned by a transit gateway.
+type TransitGatewayRouteTable struct {
+	ID               string
+	TransitGatewayID string
+	State            string
+	Tags             map[string]string
+}
+
+// TransitGateways is an OPTIONAL AWS capability (type-asserted).
+type TransitGateways interface {
+	CreateTransitGateway(ctx context.Context, cfg TransitGatewayConfig) (*TransitGateway, error)
+	DeleteTransitGateway(ctx context.Context, id string) (*TransitGateway, error)
+	DescribeTransitGateways(ctx context.Context, ids []string) ([]TransitGateway, error)
+
+	CreateTransitGatewayVPCAttachment(ctx context.Context, cfg TransitGatewayVPCAttachmentConfig) (*TransitGatewayVPCAttachment, error)
+	DeleteTransitGatewayVPCAttachment(ctx context.Context, id string) (*TransitGatewayVPCAttachment, error)
+	DescribeTransitGatewayVPCAttachments(ctx context.Context, ids []string) ([]TransitGatewayVPCAttachment, error)
+
+	CreateTransitGatewayRouteTable(ctx context.Context, transitGatewayID string, tags map[string]string) (*TransitGatewayRouteTable, error)
+	DeleteTransitGatewayRouteTable(ctx context.Context, id string) (*TransitGatewayRouteTable, error)
+	DescribeTransitGatewayRouteTables(ctx context.Context, ids []string) ([]TransitGatewayRouteTable, error)
+}
+
+// ---- VPN (Customer Gateway / VPN Gateway / VPN Connection) ----
+
+// CustomerGateway is the on-prem side of a site-to-site VPN.
+type CustomerGateway struct {
+	ID        string
+	IPAddress string
+	BGPASN    int64
+	Type      string
+	State     string
+	Tags      map[string]string
+}
+
+// CustomerGatewayConfig is the input to CreateCustomerGateway.
+type CustomerGatewayConfig struct {
+	IPAddress string
+	BGPASN    int64
+	Type      string
+	Tags      map[string]string
+}
+
+// VPNGateway is the AWS side of a site-to-site VPN (virtual private gateway).
+type VPNGateway struct {
+	ID              string
+	Type            string
+	State           string
+	AmazonSideASN   int64
+	AttachedVPCID   string
+	AttachmentState string
+	Tags            map[string]string
+}
+
+// VPNGatewayConfig is the input to CreateVPNGateway.
+type VPNGatewayConfig struct {
+	Type          string
+	AmazonSideASN int64
+	Tags          map[string]string
+}
+
+// VPNConnection is a site-to-site VPN between a VPN gateway and a customer gateway.
+type VPNConnection struct {
+	ID                string
+	CustomerGatewayID string
+	VPNGatewayID      string
+	TransitGatewayID  string
+	Type              string
+	State             string
+	StaticRoutesOnly  bool
+	Tags              map[string]string
+}
+
+// VPNConnectionConfig is the input to CreateVPNConnection.
+type VPNConnectionConfig struct {
+	CustomerGatewayID string
+	VPNGatewayID      string
+	TransitGatewayID  string
+	Type              string
+	StaticRoutesOnly  bool
+	Tags              map[string]string
+}
+
+// VPNConnections is an OPTIONAL AWS capability (type-asserted).
+type VPNConnections interface {
+	CreateCustomerGateway(ctx context.Context, cfg CustomerGatewayConfig) (*CustomerGateway, error)
+	DeleteCustomerGateway(ctx context.Context, id string) error
+	DescribeCustomerGateways(ctx context.Context, ids []string) ([]CustomerGateway, error)
+
+	CreateVPNGateway(ctx context.Context, cfg VPNGatewayConfig) (*VPNGateway, error)
+	DeleteVPNGateway(ctx context.Context, id string) error
+	DescribeVPNGateways(ctx context.Context, ids []string) ([]VPNGateway, error)
+	AttachVPNGateway(ctx context.Context, vpnGatewayID, vpcID string) (*VPNGateway, error)
+	DetachVPNGateway(ctx context.Context, vpnGatewayID, vpcID string) error
+
+	CreateVPNConnection(ctx context.Context, cfg VPNConnectionConfig) (*VPNConnection, error)
+	DeleteVPNConnection(ctx context.Context, id string) error
+	DescribeVPNConnections(ctx context.Context, ids []string) ([]VPNConnection, error)
+}
+
+// ---- DHCP Option Sets ----
+
+// DHCPOptions is a set of DHCP options associable with a VPC.
+type DHCPOptions struct {
+	ID            string
+	Configuration map[string][]string // key → values (e.g. "domain-name-servers")
+	Tags          map[string]string
+}
+
+// DHCPOptionsConfig is the input to CreateDHCPOptions.
+type DHCPOptionsConfig struct {
+	Configuration map[string][]string
+	Tags          map[string]string
+}
+
+// DHCPOptionSets is an OPTIONAL AWS capability (type-asserted).
+type DHCPOptionSets interface {
+	CreateDHCPOptions(ctx context.Context, cfg DHCPOptionsConfig) (*DHCPOptions, error)
+	DeleteDHCPOptions(ctx context.Context, id string) error
+	DescribeDHCPOptions(ctx context.Context, ids []string) ([]DHCPOptions, error)
+	AssociateDHCPOptions(ctx context.Context, dhcpOptionsID, vpcID string) error
+}
+
+// ---- Managed Prefix Lists ----
+
+// PrefixListEntry is one CIDR entry in a managed prefix list.
+type PrefixListEntry struct {
+	CIDR        string
+	Description string
+}
+
+// PrefixList is a customer-managed collection of CIDR blocks.
+type PrefixList struct {
+	ID            string
+	Name          string
+	AddressFamily string
+	MaxEntries    int
+	State         string
+	Version       int
+	Entries       []PrefixListEntry
+	Tags          map[string]string
+}
+
+// PrefixListConfig is the input to CreateManagedPrefixList.
+type PrefixListConfig struct {
+	Name          string
+	AddressFamily string
+	MaxEntries    int
+	Entries       []PrefixListEntry
+	Tags          map[string]string
+}
+
+// PrefixLists is an OPTIONAL AWS capability (type-asserted).
+type PrefixLists interface {
+	CreateManagedPrefixList(ctx context.Context, cfg PrefixListConfig) (*PrefixList, error)
+	DeleteManagedPrefixList(ctx context.Context, id string) (*PrefixList, error)
+	DescribeManagedPrefixLists(ctx context.Context, ids []string) ([]PrefixList, error)
+	GetManagedPrefixListEntries(ctx context.Context, id string) ([]PrefixListEntry, error)
+}
+
+// ---- Egress-only Internet Gateway (IPv6) ----
+
+// EgressOnlyInternetGateway provides outbound-only IPv6 for private subnets.
+type EgressOnlyInternetGateway struct {
+	ID            string
+	AttachedVPCID string
+	State         string
+	Tags          map[string]string
+}
+
+// EgressOnlyInternetGateways is an OPTIONAL AWS capability (type-asserted).
+type EgressOnlyInternetGateways interface {
+	CreateEgressOnlyInternetGateway(ctx context.Context, vpcID string, tags map[string]string) (*EgressOnlyInternetGateway, error)
+	DeleteEgressOnlyInternetGateway(ctx context.Context, id string) error
+	DescribeEgressOnlyInternetGateways(ctx context.Context, ids []string) ([]EgressOnlyInternetGateway, error)
+}
+
+// ---- VPC Endpoint Services (PrivateLink provider side) ----
+
+// EndpointService is a PrivateLink service configuration a provider publishes.
+type EndpointService struct {
+	ID                      string
+	ServiceName             string
+	State                   string
+	NetworkLoadBalancerARNs []string
+	AcceptanceRequired      bool
+	AvailabilityZones       []string
+	Tags                    map[string]string
+}
+
+// EndpointServiceConfig is the input to CreateVPCEndpointServiceConfiguration.
+type EndpointServiceConfig struct {
+	NetworkLoadBalancerARNs []string
+	AcceptanceRequired      bool
+	Tags                    map[string]string
+}
+
+// VPCEndpointServices is an OPTIONAL AWS capability (type-asserted).
+type VPCEndpointServices interface {
+	CreateVPCEndpointServiceConfiguration(ctx context.Context, cfg EndpointServiceConfig) (*EndpointService, error)
+	DeleteVPCEndpointServiceConfiguration(ctx context.Context, id string) error
+	DescribeVPCEndpointServiceConfigurations(ctx context.Context, ids []string) ([]EndpointService, error)
+}
+
+// ---- Client VPN ----
+
+// ClientVPNEndpoint is a managed endpoint remote clients connect to.
+type ClientVPNEndpoint struct {
+	ID                   string
+	Description          string
+	ClientCIDRBlock      string
+	ServerCertificateARN string
+	State                string
+	SplitTunnel          bool
+	VPCID                string
+	Tags                 map[string]string
+}
+
+// ClientVPNEndpointConfig is the input to CreateClientVPNEndpoint.
+type ClientVPNEndpointConfig struct {
+	Description          string
+	ClientCIDRBlock      string
+	ServerCertificateARN string
+	SplitTunnel          bool
+	Tags                 map[string]string
+}
+
+// ClientVPNTargetNetwork associates a subnet with a Client VPN endpoint.
+type ClientVPNTargetNetwork struct {
+	AssociationID string
+	EndpointID    string
+	SubnetID      string
+	VPCID         string
+	State         string
+}
+
+// ClientVPN is an OPTIONAL AWS capability (type-asserted).
+type ClientVPN interface {
+	CreateClientVPNEndpoint(ctx context.Context, cfg ClientVPNEndpointConfig) (*ClientVPNEndpoint, error)
+	DeleteClientVPNEndpoint(ctx context.Context, id string) error
+	DescribeClientVPNEndpoints(ctx context.Context, ids []string) ([]ClientVPNEndpoint, error)
+	AssociateClientVPNTargetNetwork(ctx context.Context, endpointID, subnetID string) (*ClientVPNTargetNetwork, error)
+	DisassociateClientVPNTargetNetwork(ctx context.Context, endpointID, associationID string) error
+}

--- a/services/networking/driver/aws_capabilities.go
+++ b/services/networking/driver/aws_capabilities.go
@@ -296,6 +296,7 @@ type ClientVPNEndpoint struct {
 	Description          string
 	ClientCIDRBlock      string
 	ServerCertificateARN string
+	AuthenticationTypes  []string
 	State                string
 	SplitTunnel          bool
 	VPCID                string
@@ -307,6 +308,7 @@ type ClientVPNEndpointConfig struct {
 	Description          string
 	ClientCIDRBlock      string
 	ServerCertificateARN string
+	AuthenticationTypes  []string
 	SplitTunnel          bool
 	Tags                 map[string]string
 }


### PR DESCRIPTION
## Objective
Networking parity — **PR 1 of 3** (AWS → Azure → GCP). Add the AWS-native networking resources cloudemu was missing so real `aws-sdk-go-v2` EC2 and `networkfirewall` clients round-trip.

## What we found
cloudemu already has broad **core** networking parity across all three clouds via the shared portable `Networking` driver (VPC, subnets, security groups + rules, route tables, NACLs, IGW, NAT GW, EIP, peering, flow logs, VPC endpoints). What was missing everywhere were the advanced, provider-specific resources.

## How we fixed it (AWS-only optional capabilities)
Per the agreed design, the new AWS resources are **optional capability interfaces** on the networking driver — discovered by type assertion like the existing `NetworkInterfaces`/`VPCAttributes` — implemented only by `providers/aws/vpc` and served by the EC2 handler. **No Azure/GCP stubs**; each provider PR adds its own specifics.

EC2 query protocol (each behind its own capability interface):
- **Transit Gateway** — gateways, VPC attachments, route tables
- **VPN** — customer gateways, VPN gateways (+attach/detach), VPN connections
- **DHCP option sets** (+associate to VPC)
- **Managed prefix lists** (+entries)
- **Egress-only internet gateways** (IPv6)
- **VPC endpoint services** (PrivateLink provider side)
- **Client VPN** — endpoints (+target-network association)

**Network Firewall** is a distinct AWS service (its own AWS JSON 1.0 API), so it gets a standalone vertical: `services/networkfirewall` driver, `providers/aws/networkfirewall` mock, `server/aws/networkfirewall` handler (target prefix `NetworkFirewall_20201112.`), wired into the AWS provider + server `Drivers`. Covers Firewall, FirewallPolicy, RuleGroup.

## Alternatives not taken
- **Extending the shared portable `Networking` interface** — rejected; it would force meaningless Azure/GCP implementations for AWS-only resources. Optional capability interfaces keep the AWS PR self-contained (the established repo pattern).

## Docs / Test / Playground
- Real-SDK round-trip tests: `server/aws/networking_parity_sdk_test.go` drives the real EC2 client across every new family; `server/aws/networkfirewall/sdk_roundtrip_test.go` drives the real `networkfirewall` client.
- Provider unit tests for the vpc capability families + the networkfirewall mock (validation + error paths); vpc provider coverage **84.7%**.
- `docs/services.md`: AWS-specific networking capability table + Network Firewall master-table row/summary; Grand Total 1415 → **1493** (58 AWS-specific networking + 20 Network Firewall).
- Concurrency tests (`-race`): `TestFirewallConcurrentAccess`, `TestNetworkingConcurrentReadWrite`.

## Review hardening (commit `9e7b428`)
Addresses the deep review on the depth work:
- **Thread safety** — `networkfirewall.Mock` gained a `sync.RWMutex` (was unsynchronized); all vpc capability readers take `RLock` and in-place mutators take `Lock`. The `-race` suite was a false green (sequential), so genuinely concurrent tests were added.
- **Wire fidelity** — `ModifyVpcEndpointServicePermissions` returns `<return>` (SDK-verified); VPN response carries `customerGatewayConfiguration`; Client VPN `AuthenticationOptions` captured/echoed; RuleGroup ARN honours STATELESS; corrected `UnsuccessfulItem` shape.
- **Referential integrity** — FK checks on VPN/TGW create+modify, PrefixList `MaxEntries`, Network Firewall policy references; in-use guards on `DeleteTransitGateway` / `DeleteFirewallPolicy`.
- **Coverage** — added the `Delete*`/`Describe*`/list halves + an SDK error-path assertion per service.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (incl. EC2 + Network Firewall real-SDK round-trips) and `-race` on the vpc + networkfirewall packages
- [x] `go mod tidy` clean; `golangci-lint` 0 new issues in touched files; CodeQL 0 new alerts (only pre-existing baseline)

## Risk & Rollback
Additive — new capability interfaces are optional (type-asserted), and Network Firewall is a new `Drivers.NetworkFirewall` field (nil ⇒ omitted). No existing behavior changes. Rollback = revert the commits on this branch.

## Follow-ups
- Azure networking-specifics PR (2 of 3), then GCP (3 of 3).
- Cost keys for billable resources (Transit Gateway attachment-hours, VPN connection-hours, Network Firewall endpoint-hours) — deferred; the cost catalog is a standalone simulator.

