### PR TITLE
AWS Networking (Stage B): VPC IPAM (Full Parity + Metrics)

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -550,11 +550,15 @@ assertion, like `NetworkInterfaces`/`VPCAttributes`) implemented by
 | Egress-only internet gateways | Create, Delete, Describe |
 | VPC endpoint services (PrivateLink) | Create, Delete, Describe; ModifyPermissions, DescribePermissions |
 | Client VPN | CreateEndpoint, DeleteEndpoint, DescribeEndpoints, Associate/DisassociateTargetNetwork, DescribeTargetNetworks; Authorize/RevokeIngress, DescribeAuthorizationRules; Route (Create/Delete/Describe) |
-| IPAM (IP Address Manager) — core lifecycle | Ipam (Create/Describe/Modify/Delete); IpamScope (Create/Describe/Modify/Delete); IpamPool (Create/Describe/Modify/Delete); Cidr (Provision/Deprovision/GetIpamPoolCidrs); Allocation (Allocate/Release/Get/Modify) |
+| IPAM (IP Address Manager) — full | Ipam/Scope/Pool CRUD+Modify; Cidr Provision/Deprovision/Get; Allocation Allocate/Release/Get/Modify; ResourceCidrs (Get/Modify) + AddressHistory; ResourceDiscovery CRUD + Associate/Disassociate + Discovered Accounts/ResourceCidrs/PublicAddresses; BYOASN (Provision/Deprovision/Associate/Disassociate/Describe); BYOIP (Move/Provision/Deprovision/Describe/Advertise/Withdraw); PrefixListResolver + Targets + Versions/Rules/Entries; ExternalResourceVerificationToken (Create/Delete/Describe); Policy (Create/Delete/Describe/Enable/Disable/GetEnabled/AllocationRules/OrgTargets) + OrganizationAdminAccount (Enable/Disable) |
 
-**AWS-specific total: 78 operations**
+**AWS-specific total: 127 operations**
 
-IPAM covers the core lifecycle (IPAM/scopes/pools/CIDRs/allocations). BYOASN, Resource Discovery, External Verification Tokens, Prefix-List Resolvers, Policies, Organization-Admin, and discovered-resource scanning are intentionally out of scope — they model multi-account AWS Organizations with live network scanning, which an in-memory single-account emulator cannot represent.
+IPAM is fully covered (~69 operations). Cross-account/organization and live-network features (Resource Discovery, discovered accounts/resources/public addresses, BYOASN/BYOIP, policies, org-admin) are modeled against the emulator's own single-account state: discovered resources are derived from the stored VPCs/subnets/EIPs, and organization targets resolve to the configured account.
+
+### IPAM metrics (`AWS/IPAM` CloudWatch namespace)
+
+IPAM publishes derived metrics through the CloudWatch service (ListMetrics / GetMetricStatistics): `TotalActiveIpCount`; pool `PercentAllocated`/`PercentAssigned`/`PercentAvailable`/`Compliant`/`NoncompliantResourceCidrs`; scope `Managed`/`Unmanaged`/`Overlapping`/`Compliant`/`NoncompliantResourceCidrs`; public-IP insight counts; and resource utilization `VpcIPUsage`/`SubnetIPUsage`. Values are computed live from IPAM + VPC/subnet/EIP state.
 
 ---
 
@@ -2264,7 +2268,7 @@ still sees success.
 | Database | 21 |
 | Serverless | 26 |
 | Networking | 51 |
-| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN / IPAM) | 78 |
+| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN / IPAM full incl. discovery/BYOASN/BYOIP/resolver/policy + AWS/IPAM metrics) | 127 |
 | Network Firewall — AWS | 20 |
 | Monitoring | 12 |
 | IAM | 35 |
@@ -2296,7 +2300,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1513** (+138 optional) |
+| **Grand Total** | **1562** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/docs/services.md
+++ b/docs/services.md
@@ -550,8 +550,11 @@ assertion, like `NetworkInterfaces`/`VPCAttributes`) implemented by
 | Egress-only internet gateways | Create, Delete, Describe |
 | VPC endpoint services (PrivateLink) | Create, Delete, Describe; ModifyPermissions, DescribePermissions |
 | Client VPN | CreateEndpoint, DeleteEndpoint, DescribeEndpoints, Associate/DisassociateTargetNetwork, DescribeTargetNetworks; Authorize/RevokeIngress, DescribeAuthorizationRules; Route (Create/Delete/Describe) |
+| IPAM (IP Address Manager) — core lifecycle | Ipam (Create/Describe/Modify/Delete); IpamScope (Create/Describe/Modify/Delete); IpamPool (Create/Describe/Modify/Delete); Cidr (Provision/Deprovision/GetIpamPoolCidrs); Allocation (Allocate/Release/Get/Modify) |
 
-**AWS-specific total: 58 operations**
+**AWS-specific total: 78 operations**
+
+IPAM covers the core lifecycle (IPAM/scopes/pools/CIDRs/allocations). BYOASN, Resource Discovery, External Verification Tokens, Prefix-List Resolvers, Policies, Organization-Admin, and discovered-resource scanning are intentionally out of scope — they model multi-account AWS Organizations with live network scanning, which an in-memory single-account emulator cannot represent.
 
 ---
 
@@ -2261,7 +2264,7 @@ still sees success.
 | Database | 21 |
 | Serverless | 26 |
 | Networking | 51 |
-| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN) | 58 |
+| Networking — AWS-specific (Transit Gateway / VPN / DHCP / prefix lists / egress-only IGW / endpoint services / Client VPN / IPAM) | 78 |
 | Network Firewall — AWS | 20 |
 | Monitoring | 12 |
 | IAM | 35 |
@@ -2293,7 +2296,7 @@ still sees success.
 | Machine Learning — GCP Vertex AI (Go API/driver) | 128 |
 | AI Search — Azure AI Search (control + data plane) | 53 |
 | Container Orchestration — AWS ECS | 37 |
-| **Grand Total** | **1493** (+138 optional) |
+| **Grand Total** | **1513** (+138 optional) |
 
 Optional operations are capabilities a driver may implement but is not required
 to; see the sections marked "optional capability". They are counted separately

--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -309,6 +309,37 @@ func (m *Mock) ListMetrics(_ context.Context, namespace string) ([]string, error
 	return names, nil
 }
 
+// ListMetricsDetailed returns every stored metric as a (namespace, name) pair.
+// ListMetrics filters by an exact namespace, so a namespace-less "list all"
+// call needs this to return real metrics tagged with their true namespace.
+func (m *Mock) ListMetricsDetailed(_ context.Context) ([]driver.MetricIdentifier, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	seen := make(map[metricKey]bool, len(m.metrics))
+	out := make([]driver.MetricIdentifier, 0, len(m.metrics))
+
+	for key := range m.metrics {
+		if seen[key] {
+			continue
+		}
+
+		seen[key] = true
+
+		out = append(out, driver.MetricIdentifier{Namespace: key.Namespace, MetricName: key.MetricName})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+
+		return out[i].MetricName < out[j].MetricName
+	})
+
+	return out, nil
+}
+
 // CreateAlarm creates or updates an alarm with the given configuration.
 //
 //nolint:gocritic // hugeParam: interface method signature cannot be changed.

--- a/providers/aws/vpc/ipam.go
+++ b/providers/aws/vpc/ipam.go
@@ -1,0 +1,538 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const ipamStateDeleteComplete = "delete-complete"
+
+// ipamARN builds an IPAM-family ARN. IPAM ARNs carry no region segment
+// (arn:aws:ec2::<account>:<resource>), matching the real service.
+func (m *Mock) ipamARN(resource string) string {
+	return idgen.AWSARN("ec2", "", m.opts.AccountID, resource)
+}
+
+// CreateIpam creates an IPAM plus its public and private default scopes.
+func (m *Mock) CreateIpam(_ context.Context, cfg driver.IpamConfig) (*driver.Ipam, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	id := idgen.GenerateID("ipam-")
+	ipamARN := m.ipamARN("ipam/" + id)
+
+	pub := m.newDefaultScope(ipamARN, "public")
+	priv := m.newDefaultScope(ipamARN, "private")
+
+	ipam := &driver.Ipam{
+		ID:                    id,
+		ARN:                   ipamARN,
+		Region:                m.opts.Region,
+		PublicDefaultScopeID:  pub.ID,
+		PrivateDefaultScopeID: priv.ID,
+		ScopeCount:            2,
+		OperatingRegions:      cfg.OperatingRegions,
+		Description:           cfg.Description,
+		Tier:                  orDefaultStr(cfg.Tier, "advanced"),
+		State:                 "create-complete",
+		Tags:                  copyTags(cfg.Tags),
+	}
+	m.ipams.Set(id, ipam)
+
+	out := cloneIpam(ipam)
+
+	return &out, nil
+}
+
+// newDefaultScope creates and stores a default scope for an IPAM. Caller holds mu.
+func (m *Mock) newDefaultScope(ipamARN, scopeType string) *driver.IpamScope {
+	id := idgen.GenerateID("ipam-scope-")
+	scope := &driver.IpamScope{
+		ID:        id,
+		ARN:       m.ipamARN("ipam-scope/" + id),
+		IpamARN:   ipamARN,
+		ScopeType: scopeType,
+		IsDefault: true,
+		State:     "create-complete",
+	}
+	m.ipamScopes.Set(id, scope)
+
+	return scope
+}
+
+// DescribeIpams returns IPAMs matching ids (all if empty).
+func (m *Mock) DescribeIpams(_ context.Context, ids []string) ([]driver.Ipam, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipams, ids, cloneIpam), nil
+}
+
+// ModifyIpam updates an IPAM's description.
+func (m *Mock) ModifyIpam(_ context.Context, id, description string) (*driver.Ipam, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam %q not found", id)
+	}
+
+	ipam.Description = description
+
+	out := cloneIpam(ipam)
+
+	return &out, nil
+}
+
+// DeleteIpam deletes an IPAM and its default scopes. Non-default scopes or
+// pools referencing the IPAM block deletion.
+func (m *Mock) DeleteIpam(_ context.Context, id string) (*driver.Ipam, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam %q not found", id)
+	}
+
+	for _, s := range m.ipamScopes.SortedValues() {
+		if s.IpamARN == ipam.ARN && !s.IsDefault {
+			return nil, errors.Newf(errors.FailedPrecondition, "ipam %q has non-default scopes", id)
+		}
+	}
+
+	if m.poolsInScopes(ipam.ARN) {
+		return nil, errors.Newf(errors.FailedPrecondition, "ipam %q has pools", id)
+	}
+
+	for _, s := range m.ipamScopes.SortedValues() {
+		if s.IpamARN == ipam.ARN {
+			m.ipamScopes.Delete(s.ID)
+		}
+	}
+
+	ipam.State = ipamStateDeleteComplete
+
+	m.ipams.Delete(id)
+
+	out := cloneIpam(ipam)
+
+	return &out, nil
+}
+
+// CreateIpamScope creates a non-default (private) scope within an IPAM.
+func (m *Mock) CreateIpamScope(_ context.Context, cfg driver.IpamScopeConfig) (*driver.IpamScope, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(cfg.IpamID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam %q not found", cfg.IpamID)
+	}
+
+	id := idgen.GenerateID("ipam-scope-")
+	scope := &driver.IpamScope{
+		ID:          id,
+		ARN:         m.ipamARN("ipam-scope/" + id),
+		IpamARN:     ipam.ARN,
+		ScopeType:   "private",
+		IsDefault:   false,
+		Description: cfg.Description,
+		State:       "create-complete",
+		Tags:        copyTags(cfg.Tags),
+	}
+	m.ipamScopes.Set(id, scope)
+
+	ipam.ScopeCount++
+
+	out := cloneIpamScope(scope)
+
+	return &out, nil
+}
+
+// DescribeIpamScopes returns scopes matching ids (all if empty).
+func (m *Mock) DescribeIpamScopes(_ context.Context, ids []string) ([]driver.IpamScope, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamScopes, ids, cloneIpamScope), nil
+}
+
+// ModifyIpamScope updates a scope's description.
+func (m *Mock) ModifyIpamScope(_ context.Context, id, description string) (*driver.IpamScope, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, ok := m.ipamScopes.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam scope %q not found", id)
+	}
+
+	scope.Description = description
+
+	out := cloneIpamScope(scope)
+
+	return &out, nil
+}
+
+// DeleteIpamScope deletes a non-default scope with no pools.
+func (m *Mock) DeleteIpamScope(_ context.Context, id string) (*driver.IpamScope, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, ok := m.ipamScopes.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam scope %q not found", id)
+	}
+
+	if scope.IsDefault {
+		return nil, errors.Newf(errors.FailedPrecondition, "cannot delete default scope %q", id)
+	}
+
+	for _, p := range m.ipamPools.SortedValues() {
+		if p.IpamScopeARN == scope.ARN {
+			return nil, errors.Newf(errors.FailedPrecondition, "ipam scope %q has pools", id)
+		}
+	}
+
+	scope.State = ipamStateDeleteComplete
+
+	m.ipamScopes.Delete(id)
+
+	if ipam := m.ipamByARN(scope.IpamARN); ipam != nil {
+		ipam.ScopeCount--
+	}
+
+	out := cloneIpamScope(scope)
+
+	return &out, nil
+}
+
+// CreateIpamPool creates a CIDR pool in a scope.
+//
+//nolint:gocritic // cfg matches the driver signature.
+func (m *Mock) CreateIpamPool(_ context.Context, cfg driver.IpamPoolConfig) (*driver.IpamPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	scope, ok := m.ipamScopes.Get(cfg.IpamScopeID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam scope %q not found", cfg.IpamScopeID)
+	}
+
+	id := idgen.GenerateID("ipam-pool-")
+	pool := &driver.IpamPool{
+		ID:                             id,
+		ARN:                            m.ipamARN("ipam-pool/" + id),
+		IpamScopeARN:                   scope.ARN,
+		IpamScopeType:                  scope.ScopeType,
+		AddressFamily:                  orDefaultStr(cfg.AddressFamily, "ipv4"),
+		Locale:                         orDefaultStr(cfg.Locale, "None"),
+		PoolDepth:                      1,
+		Description:                    cfg.Description,
+		State:                          "create-complete",
+		AllocationMinNetmaskLength:     cfg.AllocationMinNetmaskLength,
+		AllocationMaxNetmaskLength:     cfg.AllocationMaxNetmaskLength,
+		AllocationDefaultNetmaskLength: cfg.AllocationDefaultNetmaskLength,
+		Tags:                           copyTags(cfg.Tags),
+	}
+	m.ipamPools.Set(id, pool)
+
+	scope.PoolCount++
+
+	out := cloneIpamPool(pool)
+
+	return &out, nil
+}
+
+// DescribeIpamPools returns pools matching ids (all if empty).
+func (m *Mock) DescribeIpamPools(_ context.Context, ids []string) ([]driver.IpamPool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamPools, ids, cloneIpamPool), nil
+}
+
+// ModifyIpamPool updates a pool's description.
+func (m *Mock) ModifyIpamPool(_ context.Context, id, description string) (*driver.IpamPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pool, ok := m.ipamPools.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam pool %q not found", id)
+	}
+
+	pool.Description = description
+
+	out := cloneIpamPool(pool)
+
+	return &out, nil
+}
+
+// DeleteIpamPool deletes a pool with no live allocations.
+func (m *Mock) DeleteIpamPool(_ context.Context, id string) (*driver.IpamPool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pool, ok := m.ipamPools.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam pool %q not found", id)
+	}
+
+	for _, a := range m.ipamAllocations.SortedValues() {
+		if m.ipamPoolByAllocation[a.ID] == id {
+			return nil, errors.Newf(errors.FailedPrecondition, "ipam pool %q has allocations", id)
+		}
+	}
+
+	for _, c := range m.ipamPoolCidrs.SortedValues() {
+		if m.ipamPoolByCidr[c.ID] == id {
+			m.ipamPoolCidrs.Delete(c.ID)
+			delete(m.ipamPoolByCidr, c.ID)
+		}
+	}
+
+	pool.State = ipamStateDeleteComplete
+
+	m.ipamPools.Delete(id)
+
+	if scope := m.scopeByARN(pool.IpamScopeARN); scope != nil {
+		scope.PoolCount--
+	}
+
+	out := cloneIpamPool(pool)
+
+	return &out, nil
+}
+
+// ProvisionIpamPoolCidr adds a CIDR to a pool's supply.
+func (m *Mock) ProvisionIpamPoolCidr(_ context.Context, poolID, cidr string, netmaskLength int) (*driver.IpamPoolCidr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipamPools.Has(poolID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam pool %q not found", poolID)
+	}
+
+	if cidr == "" && netmaskLength == 0 {
+		return nil, errors.New(errors.InvalidArgument, "a cidr or netmaskLength is required")
+	}
+
+	id := idgen.GenerateID("ipam-pool-cidr-")
+	pc := &driver.IpamPoolCidr{
+		ID:            id,
+		CIDR:          cidr,
+		NetmaskLength: netmaskLength,
+		State:         "provisioned",
+	}
+	m.ipamPoolCidrs.Set(id, pc)
+	m.ipamPoolByCidr[id] = poolID
+
+	out := *pc
+
+	return &out, nil
+}
+
+// DeprovisionIpamPoolCidr removes a provisioned CIDR from a pool.
+func (m *Mock) DeprovisionIpamPoolCidr(_ context.Context, poolID, cidr string) (*driver.IpamPoolCidr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipamPools.Has(poolID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam pool %q not found", poolID)
+	}
+
+	for _, c := range m.ipamPoolCidrs.SortedValues() {
+		if m.ipamPoolByCidr[c.ID] != poolID || c.CIDR != cidr {
+			continue
+		}
+
+		c.State = "deprovisioned"
+
+		m.ipamPoolCidrs.Delete(c.ID)
+		delete(m.ipamPoolByCidr, c.ID)
+
+		out := *c
+
+		return &out, nil
+	}
+
+	return nil, errors.Newf(errors.NotFound, "cidr %q not provisioned in pool %q", cidr, poolID)
+}
+
+// GetIpamPoolCidrs returns the CIDRs provisioned into a pool.
+func (m *Mock) GetIpamPoolCidrs(_ context.Context, poolID string) ([]driver.IpamPoolCidr, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamPools.Has(poolID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam pool %q not found", poolID)
+	}
+
+	var out []driver.IpamPoolCidr
+
+	for _, c := range m.ipamPoolCidrs.SortedValues() {
+		if m.ipamPoolByCidr[c.ID] == poolID {
+			out = append(out, *c)
+		}
+	}
+
+	return out, nil
+}
+
+// AllocateIpamPoolCidr hands out a CIDR from a pool.
+func (m *Mock) AllocateIpamPoolCidr(_ context.Context, cfg driver.AllocateIpamPoolCidrConfig) (*driver.IpamPoolAllocation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipamPools.Has(cfg.IpamPoolID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam pool %q not found", cfg.IpamPoolID)
+	}
+
+	if cfg.CIDR == "" && cfg.NetmaskLength == 0 {
+		return nil, errors.New(errors.InvalidArgument, "a cidr or netmaskLength is required")
+	}
+
+	id := idgen.GenerateID("ipam-pool-alloc-")
+	alloc := &driver.IpamPoolAllocation{
+		ID:           id,
+		CIDR:         cfg.CIDR,
+		ResourceType: "custom",
+		Description:  cfg.Description,
+		Tags:         copyTags(cfg.Tags),
+	}
+	m.ipamAllocations.Set(id, alloc)
+	m.ipamPoolByAllocation[id] = cfg.IpamPoolID
+
+	out := cloneIpamAllocation(alloc)
+
+	return &out, nil
+}
+
+// ReleaseIpamPoolAllocation frees an allocation.
+func (m *Mock) ReleaseIpamPoolAllocation(_ context.Context, poolID, allocationID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.ipamPoolByAllocation[allocationID] != poolID || !m.ipamAllocations.Has(allocationID) {
+		return errors.Newf(errors.NotFound, "allocation %q not found in pool %q", allocationID, poolID)
+	}
+
+	m.ipamAllocations.Delete(allocationID)
+	delete(m.ipamPoolByAllocation, allocationID)
+
+	return nil
+}
+
+// GetIpamPoolAllocations returns the allocations handed out from a pool.
+func (m *Mock) GetIpamPoolAllocations(_ context.Context, poolID string) ([]driver.IpamPoolAllocation, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamPools.Has(poolID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam pool %q not found", poolID)
+	}
+
+	var out []driver.IpamPoolAllocation
+
+	for _, a := range m.ipamAllocations.SortedValues() {
+		if m.ipamPoolByAllocation[a.ID] == poolID {
+			out = append(out, cloneIpamAllocation(a))
+		}
+	}
+
+	return out, nil
+}
+
+// ModifyIpamPoolAllocation updates an allocation's description.
+func (m *Mock) ModifyIpamPoolAllocation(_ context.Context, allocationID, description string) (*driver.IpamPoolAllocation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	alloc, ok := m.ipamAllocations.Get(allocationID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "allocation %q not found", allocationID)
+	}
+
+	alloc.Description = description
+
+	out := cloneIpamAllocation(alloc)
+
+	return &out, nil
+}
+
+// ---- internal lookups (caller holds mu) ----
+
+func (m *Mock) ipamByARN(arn string) *driver.Ipam {
+	for _, i := range m.ipams.SortedValues() {
+		if i.ARN == arn {
+			return i
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) scopeByARN(arn string) *driver.IpamScope {
+	for _, s := range m.ipamScopes.SortedValues() {
+		if s.ARN == arn {
+			return s
+		}
+	}
+
+	return nil
+}
+
+func (m *Mock) poolsInScopes(ipamARN string) bool {
+	scopeARNs := make(map[string]bool)
+
+	for _, s := range m.ipamScopes.SortedValues() {
+		if s.IpamARN == ipamARN {
+			scopeARNs[s.ARN] = true
+		}
+	}
+
+	for _, p := range m.ipamPools.SortedValues() {
+		if scopeARNs[p.IpamScopeARN] {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ---- clones ----
+
+func cloneIpam(i *driver.Ipam) driver.Ipam {
+	out := *i
+	out.OperatingRegions = append([]string(nil), i.OperatingRegions...)
+	out.Tags = copyTags(i.Tags)
+
+	return out
+}
+
+func cloneIpamScope(s *driver.IpamScope) driver.IpamScope {
+	out := *s
+	out.Tags = copyTags(s.Tags)
+
+	return out
+}
+
+func cloneIpamPool(p *driver.IpamPool) driver.IpamPool {
+	out := *p
+	out.Tags = copyTags(p.Tags)
+
+	return out
+}
+
+func cloneIpamAllocation(a *driver.IpamPoolAllocation) driver.IpamPoolAllocation {
+	out := *a
+	out.Tags = copyTags(a.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/ipam.go
+++ b/providers/aws/vpc/ipam.go
@@ -351,6 +351,19 @@ func (m *Mock) ProvisionIpamPoolCidr(_ context.Context, poolID, cidr string, net
 		return nil, errors.New(errors.InvalidArgument, "a cidr or netmaskLength is required")
 	}
 
+	// AWS's common pattern is netmask-only ("provision a /24"); derive a
+	// concrete CIDR so downstream reads and AWS/IPAM metrics aren't corrupted
+	// by an empty CIDR string.
+	if cidr == "" {
+		derived, ok := m.deriveProvisionCIDR(poolID, netmaskLength)
+		if !ok {
+			return nil, errors.Newf(errors.InvalidArgument,
+				"unable to provision a /%d cidr from the pool's available space", netmaskLength)
+		}
+
+		cidr = derived
+	}
+
 	id := idgen.GenerateID("ipam-pool-cidr-")
 	pc := &driver.IpamPoolCidr{
 		ID:            id,
@@ -426,10 +439,24 @@ func (m *Mock) AllocateIpamPoolCidr(_ context.Context, cfg driver.AllocateIpamPo
 		return nil, errors.New(errors.InvalidArgument, "a cidr or netmaskLength is required")
 	}
 
+	// Netmask-only allocation ("give me a /24 from this pool") is the standard
+	// AWS pattern; carve a concrete free block from the pool's provisioned
+	// supply so the returned allocation and AWS/IPAM metrics are correct.
+	cidr := cfg.CIDR
+	if cidr == "" {
+		derived, ok := m.deriveAllocationCIDR(cfg.IpamPoolID, cfg.NetmaskLength)
+		if !ok {
+			return nil, errors.Newf(errors.InvalidArgument,
+				"unable to allocate a /%d cidr from the pool's available space", cfg.NetmaskLength)
+		}
+
+		cidr = derived
+	}
+
 	id := idgen.GenerateID("ipam-pool-alloc-")
 	alloc := &driver.IpamPoolAllocation{
 		ID:           id,
-		CIDR:         cfg.CIDR,
+		CIDR:         cidr,
 		ResourceType: "custom",
 		Description:  cfg.Description,
 		Tags:         copyTags(cfg.Tags),

--- a/providers/aws/vpc/ipam.go
+++ b/providers/aws/vpc/ipam.go
@@ -8,7 +8,10 @@ import (
 	"github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
-const ipamStateDeleteComplete = "delete-complete"
+const (
+	ipamStateDeleteComplete = "delete-complete"
+	ipamStateDeprovisioned  = "deprovisioned"
+)
 
 // ipamARN builds an IPAM-family ARN. IPAM ARNs carry no region segment
 // (arn:aws:ec2::<account>:<resource>), matching the real service.
@@ -40,6 +43,14 @@ func (m *Mock) CreateIpam(_ context.Context, cfg driver.IpamConfig) (*driver.Ipa
 		State:                 "create-complete",
 		Tags:                  copyTags(cfg.Tags),
 	}
+
+	// A new IPAM gets a default resource discovery associated with it.
+	rd := m.newResourceDiscovery(true, "", nil)
+	assoc := m.newRDAssociation(ipam, rd.ID, true, nil)
+	ipam.DefaultResourceDiscoveryID = rd.ID
+	ipam.DefaultResourceDiscoveryAssociationID = assoc.ID
+	ipam.ResourceDiscoveryAssociationCount = 1
+
 	m.ipams.Set(id, ipam)
 
 	out := cloneIpam(ipam)
@@ -90,6 +101,8 @@ func (m *Mock) ModifyIpam(_ context.Context, id, description string) (*driver.Ip
 
 // DeleteIpam deletes an IPAM and its default scopes. Non-default scopes or
 // pools referencing the IPAM block deletion.
+//
+//nolint:gocyclo // sequential precondition checks; flattening hurts readability
 func (m *Mock) DeleteIpam(_ context.Context, id string) (*driver.Ipam, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -109,11 +122,26 @@ func (m *Mock) DeleteIpam(_ context.Context, id string) (*driver.Ipam, error) {
 		return nil, errors.Newf(errors.FailedPrecondition, "ipam %q has pools", id)
 	}
 
+	for _, a := range m.ipamRDAssociations.SortedValues() {
+		if a.IpamID == id && !a.IsDefault {
+			return nil, errors.Newf(errors.FailedPrecondition, "ipam %q has resource-discovery associations", id)
+		}
+	}
+
 	for _, s := range m.ipamScopes.SortedValues() {
 		if s.IpamARN == ipam.ARN {
 			m.ipamScopes.Delete(s.ID)
 		}
 	}
+
+	// Tear down the default resource discovery + association.
+	for _, a := range m.ipamRDAssociations.SortedValues() {
+		if a.IpamID == id {
+			m.ipamRDAssociations.Delete(a.ID)
+		}
+	}
+
+	m.ipamDiscoveries.Delete(ipam.DefaultResourceDiscoveryID)
 
 	ipam.State = ipamStateDeleteComplete
 
@@ -352,7 +380,7 @@ func (m *Mock) DeprovisionIpamPoolCidr(_ context.Context, poolID, cidr string) (
 			continue
 		}
 
-		c.State = "deprovisioned"
+		c.State = ipamStateDeprovisioned
 
 		m.ipamPoolCidrs.Delete(c.ID)
 		delete(m.ipamPoolByCidr, c.ID)

--- a/providers/aws/vpc/ipam_byoip.go
+++ b/providers/aws/vpc/ipam_byoip.go
@@ -71,11 +71,13 @@ func (m *Mock) AssociateIpamByoasn(_ context.Context, asn, cidr string) (*driver
 		return nil, errors.Newf(errors.InvalidArgument, "byoasn %q not found", asn)
 	}
 
-	assoc := driver.AsnAssociation{Asn: asn, CIDR: cidr, State: "associated"}
-
-	if bc, ok := m.ipamByoipCidrs.Get(cidr); ok {
-		bc.AsnAssociations = append(bc.AsnAssociations, assoc)
+	bc, ok := m.ipamByoipCidrs.Get(cidr)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "byoip cidr %q not provisioned", cidr)
 	}
+
+	assoc := driver.AsnAssociation{Asn: asn, CIDR: cidr, State: "associated"}
+	bc.AsnAssociations = append(bc.AsnAssociations, assoc)
 
 	return &assoc, nil
 }
@@ -84,6 +86,10 @@ func (m *Mock) AssociateIpamByoasn(_ context.Context, asn, cidr string) (*driver
 func (m *Mock) DisassociateIpamByoasn(_ context.Context, asn, cidr string) (*driver.AsnAssociation, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if !m.ipamByoasns.Has(asn) {
+		return nil, errors.Newf(errors.InvalidArgument, "byoasn %q not found", asn)
+	}
 
 	assoc := driver.AsnAssociation{Asn: asn, CIDR: cidr, State: "disassociated"}
 

--- a/providers/aws/vpc/ipam_byoip.go
+++ b/providers/aws/vpc/ipam_byoip.go
@@ -1,0 +1,211 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// ProvisionIpamByoasn provisions a bring-your-own ASN into an IPAM.
+func (m *Mock) ProvisionIpamByoasn(_ context.Context, ipamID, asn string) (*driver.Byoasn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipams.Has(ipamID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam %q not found", ipamID)
+	}
+
+	if asn == "" {
+		return nil, errors.New(errors.InvalidArgument, "asn is required")
+	}
+
+	b := &driver.Byoasn{Asn: asn, IpamID: ipamID, State: "provisioned"}
+	m.ipamByoasns.Set(asn, b)
+
+	out := *b
+
+	return &out, nil
+}
+
+// DeprovisionIpamByoasn removes a BYOASN.
+func (m *Mock) DeprovisionIpamByoasn(_ context.Context, _, asn string) (*driver.Byoasn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	b, ok := m.ipamByoasns.Get(asn)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "byoasn %q not found", asn)
+	}
+
+	b.State = ipamStateDeprovisioned
+
+	m.ipamByoasns.Delete(asn)
+
+	out := *b
+
+	return &out, nil
+}
+
+// DescribeIpamByoasn returns all provisioned BYOASNs.
+func (m *Mock) DescribeIpamByoasn(_ context.Context) ([]driver.Byoasn, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.ipamByoasns.SortedValues()
+	out := make([]driver.Byoasn, 0, len(all))
+
+	for _, b := range all {
+		out = append(out, *b)
+	}
+
+	return out, nil
+}
+
+// AssociateIpamByoasn associates a BYOASN with a BYOIP CIDR.
+func (m *Mock) AssociateIpamByoasn(_ context.Context, asn, cidr string) (*driver.AsnAssociation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipamByoasns.Has(asn) {
+		return nil, errors.Newf(errors.InvalidArgument, "byoasn %q not found", asn)
+	}
+
+	assoc := driver.AsnAssociation{Asn: asn, CIDR: cidr, State: "associated"}
+
+	if bc, ok := m.ipamByoipCidrs.Get(cidr); ok {
+		bc.AsnAssociations = append(bc.AsnAssociations, assoc)
+	}
+
+	return &assoc, nil
+}
+
+// DisassociateIpamByoasn removes a BYOASN↔CIDR association.
+func (m *Mock) DisassociateIpamByoasn(_ context.Context, asn, cidr string) (*driver.AsnAssociation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	assoc := driver.AsnAssociation{Asn: asn, CIDR: cidr, State: "disassociated"}
+
+	if bc, ok := m.ipamByoipCidrs.Get(cidr); ok {
+		kept := bc.AsnAssociations[:0:0]
+
+		for _, a := range bc.AsnAssociations {
+			if a.Asn != asn {
+				kept = append(kept, a)
+			}
+		}
+
+		bc.AsnAssociations = kept
+	}
+
+	return &assoc, nil
+}
+
+// ProvisionByoipCidr provisions a bring-your-own public IP CIDR.
+func (m *Mock) ProvisionByoipCidr(_ context.Context, cidr, description string) (*driver.ByoipCidr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if cidr == "" {
+		return nil, errors.New(errors.InvalidArgument, "cidr is required")
+	}
+
+	bc := &driver.ByoipCidr{CIDR: cidr, Description: description, State: "provisioned"}
+	m.ipamByoipCidrs.Set(cidr, bc)
+
+	out := cloneByoipCidr(bc)
+
+	return &out, nil
+}
+
+// DeprovisionByoipCidr removes a BYOIP CIDR.
+func (m *Mock) DeprovisionByoipCidr(_ context.Context, cidr string) (*driver.ByoipCidr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	bc, ok := m.ipamByoipCidrs.Get(cidr)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "byoip cidr %q not found", cidr)
+	}
+
+	if bc.AdvertisementType == "advertised" {
+		return nil, errors.Newf(errors.FailedPrecondition, "byoip cidr %q is advertised", cidr)
+	}
+
+	bc.State = ipamStateDeprovisioned
+
+	m.ipamByoipCidrs.Delete(cidr)
+
+	out := cloneByoipCidr(bc)
+
+	return &out, nil
+}
+
+// MoveByoipCidrToIpam moves a BYOIP CIDR under IPAM management.
+func (m *Mock) MoveByoipCidrToIpam(_ context.Context, cidr, ipamPoolID string) (*driver.ByoipCidr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipamPools.Has(ipamPoolID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam pool %q not found", ipamPoolID)
+	}
+
+	bc, ok := m.ipamByoipCidrs.Get(cidr)
+	if !ok {
+		bc = &driver.ByoipCidr{CIDR: cidr, State: "provisioned"}
+		m.ipamByoipCidrs.Set(cidr, bc)
+	}
+
+	out := cloneByoipCidr(bc)
+
+	return &out, nil
+}
+
+// DescribeByoipCidrs returns all BYOIP CIDRs.
+func (m *Mock) DescribeByoipCidrs(_ context.Context) ([]driver.ByoipCidr, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	all := m.ipamByoipCidrs.SortedValues()
+	out := make([]driver.ByoipCidr, 0, len(all))
+
+	for _, bc := range all {
+		out = append(out, cloneByoipCidr(bc))
+	}
+
+	return out, nil
+}
+
+// AdvertiseByoipCidr advertises a BYOIP CIDR to the internet.
+func (m *Mock) AdvertiseByoipCidr(_ context.Context, cidr string) (*driver.ByoipCidr, error) {
+	return m.setByoipAdvertisement(cidr, "advertised")
+}
+
+// WithdrawByoipCidr withdraws a BYOIP CIDR advertisement.
+func (m *Mock) WithdrawByoipCidr(_ context.Context, cidr string) (*driver.ByoipCidr, error) {
+	return m.setByoipAdvertisement(cidr, "withdrawn")
+}
+
+func (m *Mock) setByoipAdvertisement(cidr, advertisement string) (*driver.ByoipCidr, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	bc, ok := m.ipamByoipCidrs.Get(cidr)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "byoip cidr %q not found", cidr)
+	}
+
+	bc.AdvertisementType = advertisement
+
+	out := cloneByoipCidr(bc)
+
+	return &out, nil
+}
+
+func cloneByoipCidr(bc *driver.ByoipCidr) driver.ByoipCidr {
+	out := *bc
+	out.AsnAssociations = append([]driver.AsnAssociation(nil), bc.AsnAssociations...)
+
+	return out
+}

--- a/providers/aws/vpc/ipam_cidr.go
+++ b/providers/aws/vpc/ipam_cidr.go
@@ -113,9 +113,13 @@ func (m *Mock) deriveAllocationCIDR(poolID string, netmask int) (string, bool) {
 // deriveProvisionCIDR synthesizes a /netmask block for a top-level pool from
 // the default private base, skipping CIDRs already provisioned into the pool.
 // Caller holds mu.
-func (m *Mock) deriveProvisionCIDR(poolID string, netmask int) (string, bool) {
+func (m *Mock) deriveProvisionCIDR(_ string, netmask int) (string, bool) {
 	s, e, _ := ipv4Range(defaultIPv4Base)
-	used := usedRanges(m.poolProvisionedCIDRs(poolID))
+	// Every top-level pool carves from the same shared base, so a new block must
+	// avoid CIDRs already provisioned into ANY pool — otherwise two pools each
+	// asking for a /16 would both receive 10.0.0.0/16 and overlap, defeating
+	// IPAM's non-overlap guarantee.
+	used := usedRanges(m.allProvisionedCIDRs())
 
 	return nextFreeIPv4Block(s, e, used, netmask)
 }
@@ -127,6 +131,21 @@ func (m *Mock) poolProvisionedCIDRs(poolID string) []string {
 
 	for _, c := range m.ipamPoolCidrs.SortedValues() {
 		if m.ipamPoolByCidr[c.ID] == poolID && c.CIDR != "" {
+			out = append(out, c.CIDR)
+		}
+	}
+
+	return out
+}
+
+// allProvisionedCIDRs lists every non-empty provisioned CIDR across all pools.
+// Used to keep provisioning non-overlapping when pools share a carve base.
+// Caller holds mu.
+func (m *Mock) allProvisionedCIDRs() []string {
+	var out []string
+
+	for _, c := range m.ipamPoolCidrs.SortedValues() {
+		if c.CIDR != "" {
 			out = append(out, c.CIDR)
 		}
 	}

--- a/providers/aws/vpc/ipam_cidr.go
+++ b/providers/aws/vpc/ipam_cidr.go
@@ -1,0 +1,147 @@
+package vpc
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+// defaultIPv4Base is the space a top-level pool provisions from when a caller
+// asks for a netmask-only CIDR (real AWS carves that from a parent pool; this
+// single-account emulator has no pool hierarchy, so it hands out from a large
+// private base). /8 is ample for any realistic requested netmask.
+const defaultIPv4Base = "10.0.0.0/8"
+
+// ipv4Bits is the width of an IPv4 address, used for netmask/host arithmetic.
+const ipv4Bits = 32
+
+// ipv4Range returns the inclusive [start,end] address range of an IPv4 CIDR.
+func ipv4Range(cidr string) (start, end uint32, ok bool) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil || ipnet.IP.To4() == nil {
+		return 0, 0, false
+	}
+
+	base := binary.BigEndian.Uint32(ipnet.IP.To4())
+	ones, bits := ipnet.Mask.Size()
+	size := uint32(1) << uint(bits-ones) //nolint:gosec // bits-ones is 0..32, no overflow
+
+	return base, base + size - 1, true
+}
+
+// blockFree reports whether the /blockSize block starting at b overlaps none of
+// the used ranges.
+func blockFree(b, blockSize uint32, used [][2]uint32) bool {
+	end := b + blockSize - 1
+
+	for _, u := range used {
+		if b <= u[1] && u[0] <= end {
+			return false
+		}
+	}
+
+	return true
+}
+
+// nextFreeIPv4Block finds the first netmask-aligned /netmask block inside
+// [parentStart,parentEnd] that doesn't overlap any used range, and returns it
+// as a CIDR string. Sequential carve: it does not reclaim gaps between used
+// ranges beyond simple alignment scanning, which is enough for realistic
+// allocate-then-allocate usage.
+func nextFreeIPv4Block(parentStart, parentEnd uint32, used [][2]uint32, netmask int) (string, bool) {
+	if netmask < 0 || netmask > ipv4Bits {
+		return "", false
+	}
+
+	blockSize := uint32(1) << uint(ipv4Bits-netmask) //nolint:gosec // 32-netmask is 0..32, no overflow
+
+	// Align the first candidate up to a blockSize boundary.
+	start := parentStart
+	if rem := start % blockSize; rem != 0 {
+		start += blockSize - rem
+	}
+
+	for b := start; b >= parentStart && b+blockSize-1 <= parentEnd; b += blockSize {
+		if blockFree(b, blockSize, used) {
+			ip := make(net.IP, net.IPv4len)
+			binary.BigEndian.PutUint32(ip, b)
+
+			return fmt.Sprintf("%s/%d", ip.String(), netmask), true
+		}
+
+		if b+blockSize < b { // guard against uint32 wraparound at the top of the space
+			break
+		}
+	}
+
+	return "", false
+}
+
+// usedRanges converts a list of CIDR strings to inclusive IPv4 ranges, skipping
+// any that aren't parseable IPv4.
+func usedRanges(cidrs []string) [][2]uint32 {
+	out := make([][2]uint32, 0, len(cidrs))
+
+	for _, c := range cidrs {
+		if s, e, ok := ipv4Range(c); ok {
+			out = append(out, [2]uint32{s, e})
+		}
+	}
+
+	return out
+}
+
+// deriveAllocationCIDR carves a free /netmask block from a pool's provisioned
+// supply, skipping blocks already handed out as allocations. Caller holds mu.
+func (m *Mock) deriveAllocationCIDR(poolID string, netmask int) (string, bool) {
+	used := usedRanges(m.poolAllocationCIDRs(poolID))
+
+	for _, sup := range m.poolProvisionedCIDRs(poolID) {
+		s, e, ok := ipv4Range(sup)
+		if !ok {
+			continue
+		}
+
+		if cidr, found := nextFreeIPv4Block(s, e, used, netmask); found {
+			return cidr, true
+		}
+	}
+
+	return "", false
+}
+
+// deriveProvisionCIDR synthesizes a /netmask block for a top-level pool from
+// the default private base, skipping CIDRs already provisioned into the pool.
+// Caller holds mu.
+func (m *Mock) deriveProvisionCIDR(poolID string, netmask int) (string, bool) {
+	s, e, _ := ipv4Range(defaultIPv4Base)
+	used := usedRanges(m.poolProvisionedCIDRs(poolID))
+
+	return nextFreeIPv4Block(s, e, used, netmask)
+}
+
+// poolProvisionedCIDRs / poolAllocationCIDRs list the non-empty CIDR strings a
+// pool has provisioned / allocated. Caller holds mu.
+func (m *Mock) poolProvisionedCIDRs(poolID string) []string {
+	var out []string
+
+	for _, c := range m.ipamPoolCidrs.SortedValues() {
+		if m.ipamPoolByCidr[c.ID] == poolID && c.CIDR != "" {
+			out = append(out, c.CIDR)
+		}
+	}
+
+	return out
+}
+
+func (m *Mock) poolAllocationCIDRs(poolID string) []string {
+	var out []string
+
+	for _, a := range m.ipamAllocations.SortedValues() {
+		if m.ipamPoolByAllocation[a.ID] == poolID && a.CIDR != "" {
+			out = append(out, a.CIDR)
+		}
+	}
+
+	return out
+}

--- a/providers/aws/vpc/ipam_discovery.go
+++ b/providers/aws/vpc/ipam_discovery.go
@@ -1,0 +1,292 @@
+package vpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// newResourceDiscovery creates and stores a resource discovery. Caller holds mu.
+func (m *Mock) newResourceDiscovery(
+	isDefault bool, description string, tags map[string]string,
+) *driver.IpamResourceDiscovery {
+	id := idgen.GenerateID("ipam-res-disco-")
+	rd := &driver.IpamResourceDiscovery{
+		ID:               id,
+		ARN:              m.ipamARN("ipam-resource-discovery/" + id),
+		Region:           m.opts.Region,
+		OwnerID:          m.opts.AccountID,
+		OperatingRegions: []string{m.opts.Region},
+		Description:      description,
+		State:            "create-complete",
+		IsDefault:        isDefault,
+		Tags:             copyTags(tags),
+	}
+	m.ipamDiscoveries.Set(id, rd)
+
+	return rd
+}
+
+// newRDAssociation associates a resource discovery with an IPAM. Caller holds mu.
+func (m *Mock) newRDAssociation(
+	ipam *driver.Ipam, rdID string, isDefault bool, tags map[string]string,
+) *driver.IpamResourceDiscoveryAssociation {
+	id := idgen.GenerateID("ipam-res-disco-assoc-")
+	assoc := &driver.IpamResourceDiscoveryAssociation{
+		ID:                      id,
+		ARN:                     m.ipamARN("ipam-resource-discovery-association/" + id),
+		IpamID:                  ipam.ID,
+		IpamARN:                 ipam.ARN,
+		IpamRegion:              ipam.Region,
+		ResourceDiscoveryID:     rdID,
+		OwnerID:                 m.opts.AccountID,
+		State:                   "associate-complete",
+		IsDefault:               isDefault,
+		ResourceDiscoveryStatus: "active",
+		Tags:                    copyTags(tags),
+	}
+	m.ipamRDAssociations.Set(id, assoc)
+
+	return assoc
+}
+
+// CreateIpamResourceDiscovery creates a non-default resource discovery.
+func (m *Mock) CreateIpamResourceDiscovery(
+	_ context.Context, cfg driver.IpamResourceDiscoveryConfig,
+) (*driver.IpamResourceDiscovery, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd := m.newResourceDiscovery(false, cfg.Description, cfg.Tags)
+
+	if len(cfg.OperatingRegions) > 0 {
+		rd.OperatingRegions = append([]string(nil), cfg.OperatingRegions...)
+	}
+
+	out := cloneResourceDiscovery(rd)
+
+	return &out, nil
+}
+
+// DescribeIpamResourceDiscoveries returns resource discoveries matching ids.
+func (m *Mock) DescribeIpamResourceDiscoveries(_ context.Context, ids []string) ([]driver.IpamResourceDiscovery, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamDiscoveries, ids, cloneResourceDiscovery), nil
+}
+
+// ModifyIpamResourceDiscovery updates a resource discovery's description/regions.
+func (m *Mock) ModifyIpamResourceDiscovery(
+	_ context.Context, id, description string, operatingRegions []string,
+) (*driver.IpamResourceDiscovery, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.ipamDiscoveries.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam resource discovery %q not found", id)
+	}
+
+	if rd.IsDefault {
+		return nil, errors.Newf(errors.FailedPrecondition, "cannot modify default resource discovery %q", id)
+	}
+
+	rd.Description = description
+	if len(operatingRegions) > 0 {
+		rd.OperatingRegions = append([]string(nil), operatingRegions...)
+	}
+
+	out := cloneResourceDiscovery(rd)
+
+	return &out, nil
+}
+
+// DeleteIpamResourceDiscovery deletes a non-default, unassociated resource discovery.
+func (m *Mock) DeleteIpamResourceDiscovery(_ context.Context, id string) (*driver.IpamResourceDiscovery, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.ipamDiscoveries.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam resource discovery %q not found", id)
+	}
+
+	if rd.IsDefault {
+		return nil, errors.Newf(errors.FailedPrecondition, "cannot delete default resource discovery %q", id)
+	}
+
+	for _, a := range m.ipamRDAssociations.SortedValues() {
+		if a.ResourceDiscoveryID == id {
+			return nil, errors.Newf(errors.FailedPrecondition, "resource discovery %q is associated", id)
+		}
+	}
+
+	rd.State = ipamStateDeleteComplete
+
+	m.ipamDiscoveries.Delete(id)
+
+	out := cloneResourceDiscovery(rd)
+
+	return &out, nil
+}
+
+// AssociateIpamResourceDiscovery associates a resource discovery with an IPAM.
+func (m *Mock) AssociateIpamResourceDiscovery(
+	_ context.Context, ipamID, resourceDiscoveryID string, tags map[string]string,
+) (*driver.IpamResourceDiscoveryAssociation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(ipamID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam %q not found", ipamID)
+	}
+
+	if !m.ipamDiscoveries.Has(resourceDiscoveryID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam resource discovery %q not found", resourceDiscoveryID)
+	}
+
+	assoc := m.newRDAssociation(ipam, resourceDiscoveryID, false, tags)
+
+	ipam.ResourceDiscoveryAssociationCount++
+
+	out := cloneRDAssociation(assoc)
+
+	return &out, nil
+}
+
+// DisassociateIpamResourceDiscovery removes a resource-discovery association.
+func (m *Mock) DisassociateIpamResourceDiscovery(
+	_ context.Context, associationID string,
+) (*driver.IpamResourceDiscoveryAssociation, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	assoc, ok := m.ipamRDAssociations.Get(associationID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "resource discovery association %q not found", associationID)
+	}
+
+	if assoc.IsDefault {
+		return nil, errors.Newf(errors.FailedPrecondition, "cannot disassociate default association %q", associationID)
+	}
+
+	assoc.State = "disassociate-complete"
+
+	m.ipamRDAssociations.Delete(associationID)
+
+	if ipam, ok := m.ipams.Get(assoc.IpamID); ok {
+		ipam.ResourceDiscoveryAssociationCount--
+	}
+
+	out := cloneRDAssociation(assoc)
+
+	return &out, nil
+}
+
+// DescribeIpamResourceDiscoveryAssociations returns associations matching ids.
+func (m *Mock) DescribeIpamResourceDiscoveryAssociations(
+	_ context.Context, ids []string,
+) ([]driver.IpamResourceDiscoveryAssociation, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamRDAssociations, ids, cloneRDAssociation), nil
+}
+
+// GetIpamDiscoveredAccounts returns the accounts a resource discovery monitors.
+// The emulator is single-account, so it reports the configured account.
+func (m *Mock) GetIpamDiscoveredAccounts(_ context.Context, resourceDiscoveryID, region string) ([]driver.IpamDiscoveredAccount, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamDiscoveries.Has(resourceDiscoveryID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam resource discovery %q not found", resourceDiscoveryID)
+	}
+
+	return []driver.IpamDiscoveredAccount{{
+		AccountID:                   m.opts.AccountID,
+		DiscoveryRegion:             orDefaultStr(region, m.opts.Region),
+		LastAttemptedDiscoveryTime:  time.Unix(0, 0).UTC(),
+		LastSuccessfulDiscoveryTime: time.Unix(0, 0).UTC(),
+	}}, nil
+}
+
+// GetIpamDiscoveredResourceCidrs returns the resource CIDRs a discovery found,
+// derived from the stored VPCs/subnets.
+func (m *Mock) GetIpamDiscoveredResourceCidrs(
+	_ context.Context, resourceDiscoveryID, region string,
+) ([]driver.IpamDiscoveredResourceCidr, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamDiscoveries.Has(resourceDiscoveryID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam resource discovery %q not found", resourceDiscoveryID)
+	}
+
+	cidrs := m.ipamResourceCidrs()
+	out := make([]driver.IpamDiscoveredResourceCidr, 0, len(cidrs))
+
+	for i := range cidrs {
+		c := cidrs[i]
+		out = append(out, driver.IpamDiscoveredResourceCidr{
+			ResourceDiscoveryID: resourceDiscoveryID, ResourceCIDR: c.ResourceCIDR, ResourceID: c.ResourceID,
+			ResourceType: c.ResourceType, ResourceRegion: orDefaultStr(region, m.opts.Region),
+			ResourceOwnerID: c.ResourceOwnerID, VPCID: c.VPCID, IPSource: "amazon", IPUsage: c.IPUsage,
+			NetworkInterfaceAttachmentStatus: "available", SampleTime: time.Unix(0, 0).UTC(),
+		})
+	}
+
+	return out, nil
+}
+
+// GetIpamDiscoveredPublicAddresses returns the public IPs a discovery found,
+// derived from the stored Elastic IPs.
+func (m *Mock) GetIpamDiscoveredPublicAddresses(
+	_ context.Context, resourceDiscoveryID, region string,
+) ([]driver.IpamDiscoveredPublicAddress, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamDiscoveries.Has(resourceDiscoveryID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam resource discovery %q not found", resourceDiscoveryID)
+	}
+
+	eips := m.eips.SortedValues()
+	out := make([]driver.IpamDiscoveredPublicAddress, 0, len(eips))
+
+	for _, e := range eips {
+		status := "disassociated"
+		if e.AssociationID != "" {
+			status = "associated"
+		}
+
+		out = append(out, driver.IpamDiscoveredPublicAddress{
+			ResourceDiscoveryID: resourceDiscoveryID, Address: e.PublicIP, AddressAllocationID: e.AllocationID,
+			AddressOwnerID: m.opts.AccountID, AddressRegion: orDefaultStr(region, m.opts.Region),
+			AddressType: "amazon-owned-eip", AssociationStatus: status, Service: "ec2",
+			SampleTime: time.Unix(0, 0).UTC(),
+		})
+	}
+
+	return out, nil
+}
+
+func cloneResourceDiscovery(rd *driver.IpamResourceDiscovery) driver.IpamResourceDiscovery {
+	out := *rd
+	out.OperatingRegions = append([]string(nil), rd.OperatingRegions...)
+	out.Tags = copyTags(rd.Tags)
+
+	return out
+}
+
+func cloneRDAssociation(a *driver.IpamResourceDiscoveryAssociation) driver.IpamResourceDiscoveryAssociation {
+	out := *a
+	out.Tags = copyTags(a.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/ipam_metrics.go
+++ b/providers/aws/vpc/ipam_metrics.go
@@ -1,0 +1,201 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const hundredPercent = 100.0
+
+// IpamMetrics derives the AWS/IPAM CloudWatch metrics from current state:
+// per-IPAM TotalActiveIpCount, per-scope resource-CIDR counts, per-pool
+// allocation percentages, public-IP insight counts, and per-VPC/subnet IP
+// utilization. Values are computed live so they track the emulator's state.
+func (m *Mock) IpamMetrics(_ context.Context) []driver.IpamMetric {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var out []driver.IpamMetric
+
+	resourceCidrs := m.ipamResourceCidrs()
+
+	out = append(out, m.ipamTopLevelMetrics(resourceCidrs)...)
+	out = append(out, m.ipamScopeMetrics()...)
+	out = append(out, m.ipamPoolMetrics()...)
+	out = append(out, m.ipamPublicIPMetrics()...)
+	out = append(out, m.ipamResourceUtilizationMetrics(resourceCidrs)...)
+
+	return out
+}
+
+func metric(name string, value float64, unit string, dims map[string]string) driver.IpamMetric {
+	return driver.IpamMetric{
+		Namespace: driver.IpamMetricNamespace, MetricName: name, Value: value, Unit: unit, Dimensions: dims,
+	}
+}
+
+// ipamTopLevelMetrics emits TotalActiveIpCount per IPAM (active = addresses on
+// resource CIDRs the IPAM tracks).
+func (m *Mock) ipamTopLevelMetrics(resourceCidrs []driver.IpamResourceCidr) []driver.IpamMetric {
+	if m.ipams.Len() == 0 {
+		return nil
+	}
+
+	var active float64
+
+	for i := range resourceCidrs {
+		c := resourceCidrs[i]
+		if c.ResourceType == resourceTypeVPC {
+			active += cidrSize(c.ResourceCIDR) * c.IPUsage
+		}
+	}
+
+	out := make([]driver.IpamMetric, 0, m.ipams.Len())
+
+	for _, i := range m.ipams.SortedValues() {
+		out = append(out, metric("TotalActiveIpCount", active, "Count", map[string]string{"IpamId": i.ID}))
+	}
+
+	return out
+}
+
+// ipamScopeMetrics emits per-scope resource-CIDR compliance counts.
+func (m *Mock) ipamScopeMetrics() []driver.IpamMetric {
+	scopes := m.ipamScopes.SortedValues()
+	out := make([]driver.IpamMetric, 0, len(scopes))
+
+	managed := float64(m.vpcs.Len() + m.subnets.Len())
+
+	for _, s := range scopes {
+		dims := map[string]string{"ScopeID": s.ID}
+		out = append(out,
+			metric("ManagedResourceCidrs", managed, "Count", dims),
+			metric("CompliantResourceCidrs", managed, "Count", dims),
+			metric("NoncompliantResourceCidrs", 0, "Count", dims),
+			metric("OverlappingResourceCidrs", 0, "Count", dims),
+			metric("UnmanagedResourceCidrs", 0, "Count", dims),
+		)
+	}
+
+	return out
+}
+
+// ipamPoolMetrics emits per-pool allocation percentages + compliance counts.
+func (m *Mock) ipamPoolMetrics() []driver.IpamMetric {
+	pools := m.ipamPools.SortedValues()
+	out := make([]driver.IpamMetric, 0, len(pools))
+
+	for _, p := range pools {
+		supply := m.poolSupply(p.ID)
+		assigned := m.poolAssigned(p.ID)
+
+		var pctAssigned float64
+		if supply > 0 {
+			pctAssigned = assigned / supply * hundredPercent
+		}
+
+		dims := map[string]string{"PoolID": p.ID, "AddressFamily": p.AddressFamily}
+		out = append(out,
+			metric("PercentAssigned", pctAssigned, "Percent", dims),
+			metric("PercentAllocated", pctAssigned, "Percent", dims),
+			metric("PercentAvailable", hundredPercent-pctAssigned, "Percent", dims),
+			metric("CompliantResourceCidrs", float64(m.poolAllocationCount(p.ID)), "Count", dims),
+			metric("NoncompliantResourceCidrs", 0, "Count", dims),
+		)
+	}
+
+	return out
+}
+
+// ipamPublicIPMetrics emits public-IP insight counts from Elastic IPs + BYOIP.
+func (m *Mock) ipamPublicIPMetrics() []driver.IpamMetric {
+	if m.ipams.Len() == 0 {
+		return nil
+	}
+
+	var associated, unassociated float64
+
+	for _, e := range m.eips.SortedValues() {
+		if e.AssociationID != "" {
+			associated++
+		} else {
+			unassociated++
+		}
+	}
+
+	byoip := float64(m.ipamByoipCidrs.Len())
+
+	ipams := m.ipams.SortedValues()
+	out := make([]driver.IpamMetric, 0, len(ipams))
+
+	for _, i := range ipams {
+		dims := map[string]string{"IpamId": i.ID}
+		out = append(out,
+			metric("AmazonOwnedElasticIPs", associated+unassociated, "Count", dims),
+			metric("AssociatedAmazonOwnedElasticIPs", associated, "Count", dims),
+			metric("UnassociatedAmazonOwnedElasticIPs", unassociated, "Count", dims),
+			metric("BringYourOwnIPs", byoip, "Count", dims),
+		)
+	}
+
+	return out
+}
+
+// ipamResourceUtilizationMetrics emits VpcIPUsage / SubnetIPUsage per resource.
+func (*Mock) ipamResourceUtilizationMetrics(resourceCidrs []driver.IpamResourceCidr) []driver.IpamMetric {
+	var out []driver.IpamMetric
+
+	for i := range resourceCidrs {
+		c := resourceCidrs[i]
+		switch c.ResourceType {
+		case resourceTypeVPC:
+			out = append(out, metric("VpcIPUsage", c.IPUsage*hundredPercent, "Percent", map[string]string{
+				"VpcID": c.ResourceID, "AddressFamily": "IPv4", "Region": c.ResourceRegion,
+			}))
+		case resourceTypeSubnet:
+			out = append(out, metric("SubnetIPUsage", c.IPUsage*hundredPercent, "Percent", map[string]string{
+				"SubnetID": c.ResourceID, "VpcID": c.VPCID, "AddressFamily": "IPv4", "Region": c.ResourceRegion,
+			}))
+		}
+	}
+
+	return out
+}
+
+// poolSupply / poolAssigned / poolAllocationCount summarize a pool. Caller holds mu.
+func (m *Mock) poolSupply(poolID string) float64 {
+	var total float64
+
+	for _, c := range m.ipamPoolCidrs.SortedValues() {
+		if m.ipamPoolByCidr[c.ID] == poolID {
+			total += cidrSize(c.CIDR)
+		}
+	}
+
+	return total
+}
+
+func (m *Mock) poolAssigned(poolID string) float64 {
+	var assigned float64
+
+	for _, a := range m.ipamAllocations.SortedValues() {
+		if m.ipamPoolByAllocation[a.ID] == poolID {
+			assigned += cidrSize(a.CIDR)
+		}
+	}
+
+	return assigned
+}
+
+func (m *Mock) poolAllocationCount(poolID string) int {
+	var n int
+
+	for _, a := range m.ipamAllocations.SortedValues() {
+		if m.ipamPoolByAllocation[a.ID] == poolID {
+			n++
+		}
+	}
+
+	return n
+}

--- a/providers/aws/vpc/ipam_policy.go
+++ b/providers/aws/vpc/ipam_policy.go
@@ -1,0 +1,169 @@
+package vpc
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateIpamPolicy creates an allocation policy for an IPAM.
+func (m *Mock) CreateIpamPolicy(_ context.Context, ipamID string, tags map[string]string) (*driver.IpamPolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(ipamID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam %q not found", ipamID)
+	}
+
+	id := idgen.GenerateID("ipam-policy-")
+	p := &driver.IpamPolicy{
+		ID: id, ARN: m.ipamARN("ipam-policy/" + id), IpamID: ipamID, IpamRegion: ipam.Region,
+		OwnerID: m.opts.AccountID, State: "create-complete", Tags: copyTags(tags),
+	}
+	m.ipamPolicies.Set(id, p)
+
+	out := cloneIpamPolicy(p)
+
+	return &out, nil
+}
+
+// DeleteIpamPolicy deletes an IPAM policy.
+func (m *Mock) DeleteIpamPolicy(_ context.Context, id string) (*driver.IpamPolicy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	p, ok := m.ipamPolicies.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+	}
+
+	p.State = ipamStateDeleteComplete
+
+	m.ipamPolicies.Delete(id)
+
+	out := cloneIpamPolicy(p)
+
+	return &out, nil
+}
+
+// DescribeIpamPolicies returns policies matching ids.
+func (m *Mock) DescribeIpamPolicies(_ context.Context, ids []string) ([]driver.IpamPolicy, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamPolicies, ids, cloneIpamPolicy), nil
+}
+
+// EnableIpamPolicy enables a policy (optionally for an org target).
+func (m *Mock) EnableIpamPolicy(_ context.Context, id, _ string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	p, ok := m.ipamPolicies.Get(id)
+	if !ok {
+		return "", errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+	}
+
+	p.Enabled = true
+
+	return p.ID, nil
+}
+
+// DisableIpamPolicy disables a policy.
+func (m *Mock) DisableIpamPolicy(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	p, ok := m.ipamPolicies.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+	}
+
+	p.Enabled = false
+
+	return nil
+}
+
+// GetEnabledIpamPolicy returns the currently-enabled policy, if any.
+func (m *Mock) GetEnabledIpamPolicy(_ context.Context) (policyID string, enabled bool, managedBy string, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, p := range m.ipamPolicies.SortedValues() {
+		if p.Enabled {
+			return p.ID, true, m.opts.AccountID, nil
+		}
+	}
+
+	return "", false, "", nil
+}
+
+// ModifyIpamPolicyAllocationRules replaces a policy's allocation rules.
+func (m *Mock) ModifyIpamPolicyAllocationRules(_ context.Context, id string, rules []string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	p, ok := m.ipamPolicies.Get(id)
+	if !ok {
+		return errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+	}
+
+	p.AllocationRules = append([]string(nil), rules...)
+
+	return nil
+}
+
+// GetIpamPolicyAllocationRules returns a policy's allocation rule documents.
+func (m *Mock) GetIpamPolicyAllocationRules(_ context.Context, id string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	p, ok := m.ipamPolicies.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+	}
+
+	return append([]string(nil), p.AllocationRules...), nil
+}
+
+// GetIpamPolicyOrganizationTargets returns the org targets a policy applies to.
+// The emulator is single-account, so it reports the configured account.
+func (m *Mock) GetIpamPolicyOrganizationTargets(_ context.Context, id string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamPolicies.Has(id) {
+		return nil, errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+	}
+
+	return []string{m.opts.AccountID}, nil
+}
+
+// EnableIpamOrganizationAdminAccount delegates IPAM admin to an account.
+func (*Mock) EnableIpamOrganizationAdminAccount(_ context.Context, accountID string) (bool, error) {
+	if accountID == "" {
+		return false, errors.New(errors.InvalidArgument, "delegatedAdminAccountId is required")
+	}
+
+	return true, nil
+}
+
+// DisableIpamOrganizationAdminAccount removes the delegated IPAM admin.
+func (*Mock) DisableIpamOrganizationAdminAccount(_ context.Context, accountID string) (bool, error) {
+	if accountID == "" {
+		return false, errors.New(errors.InvalidArgument, "delegatedAdminAccountId is required")
+	}
+
+	return true, nil
+}
+
+func cloneIpamPolicy(p *driver.IpamPolicy) driver.IpamPolicy {
+	out := *p
+	out.AllocationRules = append([]string(nil), p.AllocationRules...)
+	out.Tags = copyTags(p.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/ipam_policy.go
+++ b/providers/aws/vpc/ipam_policy.go
@@ -101,23 +101,32 @@ func (m *Mock) GetEnabledIpamPolicy(_ context.Context) (policyID string, enabled
 	return "", false, "", nil
 }
 
-// ModifyIpamPolicyAllocationRules replaces a policy's allocation rules.
-func (m *Mock) ModifyIpamPolicyAllocationRules(_ context.Context, id string, rules []string) error {
+// ModifyIpamPolicyAllocationRules replaces a policy's allocation rules and the
+// locale/resource-type the document is scoped to, returning the updated policy.
+func (m *Mock) ModifyIpamPolicyAllocationRules(
+	_ context.Context, id, locale, resourceType string, rules []driver.IpamAllocationRule,
+) (*driver.IpamPolicy, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	p, ok := m.ipamPolicies.Get(id)
 	if !ok {
-		return errors.Newf(errors.NotFound, "ipam policy %q not found", id)
+		return nil, errors.Newf(errors.NotFound, "ipam policy %q not found", id)
 	}
 
-	p.AllocationRules = append([]string(nil), rules...)
+	p.Locale = locale
+	p.ResourceType = resourceType
 
-	return nil
+	p.AllocationRules = append([]driver.IpamAllocationRule(nil), rules...)
+
+	out := cloneIpamPolicy(p)
+
+	return &out, nil
 }
 
-// GetIpamPolicyAllocationRules returns a policy's allocation rule documents.
-func (m *Mock) GetIpamPolicyAllocationRules(_ context.Context, id string) ([]string, error) {
+// GetIpamPolicyAllocationRules returns the policy carrying its allocation-rule
+// document (rules + locale + resource type).
+func (m *Mock) GetIpamPolicyAllocationRules(_ context.Context, id string) (*driver.IpamPolicy, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -126,7 +135,9 @@ func (m *Mock) GetIpamPolicyAllocationRules(_ context.Context, id string) ([]str
 		return nil, errors.Newf(errors.NotFound, "ipam policy %q not found", id)
 	}
 
-	return append([]string(nil), p.AllocationRules...), nil
+	out := cloneIpamPolicy(p)
+
+	return &out, nil
 }
 
 // GetIpamPolicyOrganizationTargets returns the org targets a policy applies to.
@@ -162,7 +173,7 @@ func (*Mock) DisableIpamOrganizationAdminAccount(_ context.Context, accountID st
 
 func cloneIpamPolicy(p *driver.IpamPolicy) driver.IpamPolicy {
 	out := *p
-	out.AllocationRules = append([]string(nil), p.AllocationRules...)
+	out.AllocationRules = append([]driver.IpamAllocationRule(nil), p.AllocationRules...)
 	out.Tags = copyTags(p.Tags)
 
 	return out

--- a/providers/aws/vpc/ipam_resolver.go
+++ b/providers/aws/vpc/ipam_resolver.go
@@ -1,0 +1,286 @@
+package vpc
+
+import (
+	"context"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+// CreateIpamPrefixListResolver creates a prefix-list resolver in an IPAM.
+func (m *Mock) CreateIpamPrefixListResolver(
+	_ context.Context, ipamID, addressFamily, description string, tags map[string]string,
+) (*driver.IpamPrefixListResolver, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(ipamID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam %q not found", ipamID)
+	}
+
+	id := idgen.GenerateID("ipam-pl-res-")
+	r := &driver.IpamPrefixListResolver{
+		ID: id, ARN: m.ipamARN("ipam-prefix-list-resolver/" + id), IpamID: ipamID, IpamARN: ipam.ARN,
+		IpamRegion: ipam.Region, OwnerID: m.opts.AccountID, AddressFamily: orDefaultStr(addressFamily, "ipv4"),
+		Description: description, State: "create-complete", LastVersionCreationStatus: "success", Tags: copyTags(tags),
+	}
+	m.ipamResolvers.Set(id, r)
+
+	out := cloneResolver(r)
+
+	return &out, nil
+}
+
+// DescribeIpamPrefixListResolvers returns resolvers matching ids.
+func (m *Mock) DescribeIpamPrefixListResolvers(_ context.Context, ids []string) ([]driver.IpamPrefixListResolver, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamResolvers, ids, cloneResolver), nil
+}
+
+// ModifyIpamPrefixListResolver updates a resolver's description.
+func (m *Mock) ModifyIpamPrefixListResolver(_ context.Context, id, description string) (*driver.IpamPrefixListResolver, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	r, ok := m.ipamResolvers.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam prefix list resolver %q not found", id)
+	}
+
+	r.Description = description
+
+	out := cloneResolver(r)
+
+	return &out, nil
+}
+
+// DeleteIpamPrefixListResolver deletes a resolver with no targets.
+func (m *Mock) DeleteIpamPrefixListResolver(_ context.Context, id string) (*driver.IpamPrefixListResolver, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	r, ok := m.ipamResolvers.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam prefix list resolver %q not found", id)
+	}
+
+	for _, t := range m.ipamResolverTargets.SortedValues() {
+		if t.ResolverID == id {
+			return nil, errors.Newf(errors.FailedPrecondition, "resolver %q has targets", id)
+		}
+	}
+
+	r.State = ipamStateDeleteComplete
+
+	m.ipamResolvers.Delete(id)
+
+	out := cloneResolver(r)
+
+	return &out, nil
+}
+
+// CreateIpamPrefixListResolverTarget adds a managed prefix list as a sync target.
+func (m *Mock) CreateIpamPrefixListResolverTarget(
+	_ context.Context, resolverID, prefixListID, prefixListRegion string,
+	desiredVersion int, trackLatest bool, tags map[string]string,
+) (*driver.IpamPrefixListResolverTarget, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ipamResolvers.Has(resolverID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam prefix list resolver %q not found", resolverID)
+	}
+
+	id := idgen.GenerateID("ipam-pl-res-target-")
+	t := &driver.IpamPrefixListResolverTarget{
+		ID: id, ARN: m.ipamARN("ipam-prefix-list-resolver-target/" + id), ResolverID: resolverID,
+		OwnerID: m.opts.AccountID, PrefixListID: prefixListID, PrefixListRegion: orDefaultStr(prefixListRegion, m.opts.Region),
+		DesiredVersion: desiredVersion, LastSyncedVersion: desiredVersion, TrackLatestVersion: trackLatest,
+		State: "create-complete", Tags: copyTags(tags),
+	}
+	m.ipamResolverTargets.Set(id, t)
+
+	out := cloneResolverTarget(t)
+
+	return &out, nil
+}
+
+// DescribeIpamPrefixListResolverTargets returns targets matching ids.
+func (m *Mock) DescribeIpamPrefixListResolverTargets(_ context.Context, ids []string) ([]driver.IpamPrefixListResolverTarget, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamResolverTargets, ids, cloneResolverTarget), nil
+}
+
+// ModifyIpamPrefixListResolverTarget updates a target's version tracking.
+func (m *Mock) ModifyIpamPrefixListResolverTarget(
+	_ context.Context, id string, desiredVersion int, trackLatest bool,
+) (*driver.IpamPrefixListResolverTarget, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	t, ok := m.ipamResolverTargets.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam prefix list resolver target %q not found", id)
+	}
+
+	if desiredVersion > 0 {
+		t.DesiredVersion = desiredVersion
+		t.LastSyncedVersion = desiredVersion
+	}
+
+	t.TrackLatestVersion = trackLatest
+
+	out := cloneResolverTarget(t)
+
+	return &out, nil
+}
+
+// DeleteIpamPrefixListResolverTarget removes a sync target.
+func (m *Mock) DeleteIpamPrefixListResolverTarget(_ context.Context, id string) (*driver.IpamPrefixListResolverTarget, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	t, ok := m.ipamResolverTargets.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam prefix list resolver target %q not found", id)
+	}
+
+	t.State = ipamStateDeleteComplete
+
+	m.ipamResolverTargets.Delete(id)
+
+	out := cloneResolverTarget(t)
+
+	return &out, nil
+}
+
+// GetIpamPrefixListResolverRules returns a resolver's rules. The emulator does
+// not model a rule engine, so it derives one rule per pool in the same IPAM.
+func (m *Mock) GetIpamPrefixListResolverRules(_ context.Context, resolverID string) ([]driver.IpamPrefixListResolverRule, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	r, ok := m.ipamResolvers.Get(resolverID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam prefix list resolver %q not found", resolverID)
+	}
+
+	var out []driver.IpamPrefixListResolverRule
+
+	for _, p := range m.ipamPools.SortedValues() {
+		if scope := m.scopeByARN(p.IpamScopeARN); scope != nil && scope.IpamARN == r.IpamARN {
+			out = append(out, driver.IpamPrefixListResolverRule{IpamPoolID: p.ID})
+		}
+	}
+
+	return out, nil
+}
+
+// GetIpamPrefixListResolverVersions returns the resolver's published versions.
+func (m *Mock) GetIpamPrefixListResolverVersions(_ context.Context, resolverID string) ([]driver.IpamPrefixListResolverVersion, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamResolvers.Has(resolverID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam prefix list resolver %q not found", resolverID)
+	}
+
+	return []driver.IpamPrefixListResolverVersion{{Version: 1, CreatedAt: time.Unix(0, 0).UTC()}}, nil
+}
+
+// GetIpamPrefixListResolverVersionEntries returns the CIDR entries of a version.
+func (m *Mock) GetIpamPrefixListResolverVersionEntries(_ context.Context, resolverID string, _ int) ([]driver.PrefixListEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if !m.ipamResolvers.Has(resolverID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam prefix list resolver %q not found", resolverID)
+	}
+
+	return nil, nil
+}
+
+// CreateIpamExternalResourceVerificationToken issues a verification token.
+func (m *Mock) CreateIpamExternalResourceVerificationToken(
+	_ context.Context, ipamID, tokenName string, tags map[string]string,
+) (*driver.IpamExternalResourceVerificationToken, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ipam, ok := m.ipams.Get(ipamID)
+	if !ok {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam %q not found", ipamID)
+	}
+
+	id := idgen.GenerateID("ipam-ext-verify-token-")
+	t := &driver.IpamExternalResourceVerificationToken{
+		ID: id, ARN: m.ipamARN("ipam-external-resource-verification-token/" + id), IpamID: ipamID, IpamARN: ipam.ARN,
+		IpamRegion: ipam.Region, OwnerID: m.opts.AccountID, TokenName: tokenName,
+		TokenValue: idgen.GenerateID("token-"), NotAfter: time.Unix(0, 0).UTC(),
+		State: "create-complete", Status: "valid", Tags: copyTags(tags),
+	}
+	m.ipamTokens.Set(id, t)
+
+	out := cloneToken(t)
+
+	return &out, nil
+}
+
+// DeleteIpamExternalResourceVerificationToken deletes a verification token.
+func (m *Mock) DeleteIpamExternalResourceVerificationToken(
+	_ context.Context, id string,
+) (*driver.IpamExternalResourceVerificationToken, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	t, ok := m.ipamTokens.Get(id)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "ipam verification token %q not found", id)
+	}
+
+	t.State = ipamStateDeleteComplete
+
+	m.ipamTokens.Delete(id)
+
+	out := cloneToken(t)
+
+	return &out, nil
+}
+
+// DescribeIpamExternalResourceVerificationTokens returns tokens matching ids.
+func (m *Mock) DescribeIpamExternalResourceVerificationTokens(
+	_ context.Context, ids []string,
+) ([]driver.IpamExternalResourceVerificationToken, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return describeResources(m.ipamTokens, ids, cloneToken), nil
+}
+
+func cloneResolver(r *driver.IpamPrefixListResolver) driver.IpamPrefixListResolver {
+	out := *r
+	out.Tags = copyTags(r.Tags)
+
+	return out
+}
+
+func cloneResolverTarget(t *driver.IpamPrefixListResolverTarget) driver.IpamPrefixListResolverTarget {
+	out := *t
+	out.Tags = copyTags(t.Tags)
+
+	return out
+}
+
+func cloneToken(t *driver.IpamExternalResourceVerificationToken) driver.IpamExternalResourceVerificationToken {
+	out := *t
+	out.Tags = copyTags(t.Tags)
+
+	return out
+}

--- a/providers/aws/vpc/ipam_resolver.go
+++ b/providers/aws/vpc/ipam_resolver.go
@@ -96,6 +96,10 @@ func (m *Mock) CreateIpamPrefixListResolverTarget(
 		return nil, errors.Newf(errors.InvalidArgument, "ipam prefix list resolver %q not found", resolverID)
 	}
 
+	if !m.prefixLists.Has(prefixListID) {
+		return nil, errors.Newf(errors.InvalidArgument, "managed prefix list %q not found", prefixListID)
+	}
+
 	id := idgen.GenerateID("ipam-pl-res-target-")
 	t := &driver.IpamPrefixListResolverTarget{
 		ID: id, ARN: m.ipamARN("ipam-prefix-list-resolver-target/" + id), ResolverID: resolverID,

--- a/providers/aws/vpc/ipam_resources.go
+++ b/providers/aws/vpc/ipam_resources.go
@@ -12,7 +12,19 @@ import (
 const (
 	resourceTypeVPC    = "vpc"
 	resourceTypeSubnet = "subnet"
+
+	mgmtStateManaged   = "managed"
+	mgmtStateUnmanaged = "unmanaged"
 )
+
+// ipamResourceOverride records the caller-requested scope move / unmonitor for
+// a tracked resource CIDR. The base resource-CIDR list is derived fresh from
+// VPCs/subnets on every read, so ModifyIpamResourceCidr persists its changes
+// here and ipamResourceCidrs applies them.
+type ipamResourceOverride struct {
+	scopeID   string
+	unmanaged bool
+}
 
 // ipamResourceCidrs derives IPAM's tracked resource CIDRs from the VPCs and
 // subnets held in this mock. IPAM "monitors" existing network resources, so in
@@ -24,7 +36,7 @@ func (m *Mock) ipamResourceCidrs() []driver.IpamResourceCidr {
 		out = append(out, driver.IpamResourceCidr{
 			ResourceCIDR: v.CIDRBlock, ResourceID: v.ID, ResourceType: resourceTypeVPC, VPCID: v.ID,
 			ResourceRegion: m.opts.Region, ResourceOwnerID: m.opts.AccountID,
-			ComplianceStatus: "compliant", ManagementState: "managed", OverlapStatus: "nonoverlapping",
+			ComplianceStatus: "compliant", ManagementState: mgmtStateManaged, OverlapStatus: "nonoverlapping",
 			IPUsage: m.vpcIPUsage(v.ID, v.CIDRBlock), Tags: copyTags(v.Tags),
 		})
 	}
@@ -33,9 +45,26 @@ func (m *Mock) ipamResourceCidrs() []driver.IpamResourceCidr {
 		out = append(out, driver.IpamResourceCidr{
 			ResourceCIDR: s.CIDRBlock, ResourceID: s.ID, ResourceType: resourceTypeSubnet, VPCID: s.VPCID,
 			ResourceRegion: m.opts.Region, ResourceOwnerID: m.opts.AccountID, AvailabilityZone: s.AvailabilityZone,
-			ComplianceStatus: "compliant", ManagementState: "managed", OverlapStatus: "nonoverlapping",
+			ComplianceStatus: "compliant", ManagementState: mgmtStateManaged, OverlapStatus: "nonoverlapping",
 			IPUsage: 0, Tags: copyTags(s.Tags),
 		})
+	}
+
+	// Apply any persisted scope-move / unmonitor overrides from
+	// ModifyIpamResourceCidr so Get/Describe/metrics reflect the change.
+	for i := range out {
+		ov, ok := m.ipamResourceOverrides[out[i].ResourceID]
+		if !ok {
+			continue
+		}
+
+		if ov.scopeID != "" {
+			out[i].IpamScopeID = ov.scopeID
+		}
+
+		if ov.unmanaged {
+			out[i].ManagementState = mgmtStateUnmanaged
+		}
 	}
 
 	return out
@@ -103,24 +132,35 @@ func (m *Mock) GetIpamResourceCidrs(_ context.Context, scopeID, resourceID strin
 func (m *Mock) ModifyIpamResourceCidr(
 	_ context.Context, resourceID, currentScopeID, destScopeID string, monitored bool,
 ) (*driver.IpamResourceCidr, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	cidrs := m.ipamResourceCidrs()
 	for i := range cidrs {
-		c := cidrs[i]
-		if c.ResourceID != resourceID {
+		if cidrs[i].ResourceID != resourceID {
 			continue
 		}
 
-		if destScopeID != "" {
-			c.IpamScopeID = destScopeID
-		} else {
-			c.IpamScopeID = currentScopeID
+		scopeID := destScopeID
+		if scopeID == "" {
+			scopeID = currentScopeID
+		}
+
+		// Persist the change so subsequent Get/Describe/metrics reads reflect
+		// it — the base list is re-derived every call, so a purely local edit
+		// would silently revert.
+		m.ipamResourceOverrides[resourceID] = ipamResourceOverride{
+			scopeID:   scopeID,
+			unmanaged: !monitored,
+		}
+
+		c := cidrs[i]
+		if scopeID != "" {
+			c.IpamScopeID = scopeID
 		}
 
 		if !monitored {
-			c.ManagementState = "unmanaged"
+			c.ManagementState = mgmtStateUnmanaged
 		}
 
 		out := c

--- a/providers/aws/vpc/ipam_resources.go
+++ b/providers/aws/vpc/ipam_resources.go
@@ -1,0 +1,162 @@
+package vpc
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const (
+	resourceTypeVPC    = "vpc"
+	resourceTypeSubnet = "subnet"
+)
+
+// ipamResourceCidrs derives IPAM's tracked resource CIDRs from the VPCs and
+// subnets held in this mock. IPAM "monitors" existing network resources, so in
+// the emulator those are the stored VPCs/subnets. Caller holds at least RLock.
+func (m *Mock) ipamResourceCidrs() []driver.IpamResourceCidr {
+	out := make([]driver.IpamResourceCidr, 0, m.vpcs.Len()+m.subnets.Len())
+
+	for _, v := range m.vpcs.SortedValues() {
+		out = append(out, driver.IpamResourceCidr{
+			ResourceCIDR: v.CIDRBlock, ResourceID: v.ID, ResourceType: resourceTypeVPC, VPCID: v.ID,
+			ResourceRegion: m.opts.Region, ResourceOwnerID: m.opts.AccountID,
+			ComplianceStatus: "compliant", ManagementState: "managed", OverlapStatus: "nonoverlapping",
+			IPUsage: m.vpcIPUsage(v.ID, v.CIDRBlock), Tags: copyTags(v.Tags),
+		})
+	}
+
+	for _, s := range m.subnets.SortedValues() {
+		out = append(out, driver.IpamResourceCidr{
+			ResourceCIDR: s.CIDRBlock, ResourceID: s.ID, ResourceType: resourceTypeSubnet, VPCID: s.VPCID,
+			ResourceRegion: m.opts.Region, ResourceOwnerID: m.opts.AccountID, AvailabilityZone: s.AvailabilityZone,
+			ComplianceStatus: "compliant", ManagementState: "managed", OverlapStatus: "nonoverlapping",
+			IPUsage: 0, Tags: copyTags(s.Tags),
+		})
+	}
+
+	return out
+}
+
+// vpcIPUsage returns the fraction of a VPC's IPv4 space covered by its subnets.
+func (m *Mock) vpcIPUsage(vpcID, vpcCIDR string) float64 {
+	total := cidrSize(vpcCIDR)
+	if total == 0 {
+		return 0
+	}
+
+	var used float64
+
+	for _, s := range m.subnets.SortedValues() {
+		if s.VPCID == vpcID {
+			used += cidrSize(s.CIDRBlock)
+		}
+	}
+
+	return used / total
+}
+
+// cidrSize returns the number of IPv4 addresses in a CIDR, or 0 if unparseable.
+func cidrSize(cidr string) float64 {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil || ipnet.IP.To4() == nil {
+		return 0
+	}
+
+	ones, bits := ipnet.Mask.Size()
+
+	return float64(uint64(1) << uint(bits-ones)) //nolint:gosec // bits-ones is 0..32, no overflow
+}
+
+// GetIpamResourceCidrs returns the resource CIDRs IPAM tracks in a scope,
+// optionally filtered to a single resource id.
+func (m *Mock) GetIpamResourceCidrs(_ context.Context, scopeID, resourceID string) ([]driver.IpamResourceCidr, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if scopeID != "" && !m.ipamScopes.Has(scopeID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam scope %q not found", scopeID)
+	}
+
+	all := m.ipamResourceCidrs()
+	if resourceID == "" {
+		return all, nil
+	}
+
+	out := all[:0:0]
+
+	for i := range all {
+		if all[i].ResourceID == resourceID {
+			out = append(out, all[i])
+		}
+	}
+
+	return out, nil
+}
+
+// ModifyIpamResourceCidr adjusts monitoring/scope of a tracked resource CIDR.
+// The emulator derives resource CIDRs from stored resources, so this echoes
+// the requested state for the matching resource.
+func (m *Mock) ModifyIpamResourceCidr(
+	_ context.Context, resourceID, currentScopeID, destScopeID string, monitored bool,
+) (*driver.IpamResourceCidr, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	cidrs := m.ipamResourceCidrs()
+	for i := range cidrs {
+		c := cidrs[i]
+		if c.ResourceID != resourceID {
+			continue
+		}
+
+		if destScopeID != "" {
+			c.IpamScopeID = destScopeID
+		} else {
+			c.IpamScopeID = currentScopeID
+		}
+
+		if !monitored {
+			c.ManagementState = "unmanaged"
+		}
+
+		out := c
+
+		return &out, nil
+	}
+
+	return nil, errors.Newf(errors.NotFound, "resource %q not tracked by ipam", resourceID)
+}
+
+// GetIpamAddressHistory returns history records for a CIDR within a scope. The
+// emulator has a single sample window per currently-tracked resource.
+func (m *Mock) GetIpamAddressHistory(_ context.Context, cidr, scopeID string) ([]driver.IpamAddressHistoryRecord, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if scopeID != "" && !m.ipamScopes.Has(scopeID) {
+		return nil, errors.Newf(errors.InvalidArgument, "ipam scope %q not found", scopeID)
+	}
+
+	cidrs := m.ipamResourceCidrs()
+	out := make([]driver.IpamAddressHistoryRecord, 0, len(cidrs))
+
+	for i := range cidrs {
+		c := cidrs[i]
+		if cidr != "" && c.ResourceCIDR != cidr {
+			continue
+		}
+
+		out = append(out, driver.IpamAddressHistoryRecord{
+			ResourceCIDR: c.ResourceCIDR, ResourceID: c.ResourceID, ResourceType: c.ResourceType,
+			ResourceRegion: c.ResourceRegion, ResourceOwnerID: c.ResourceOwnerID, VPCID: c.VPCID,
+			ResourceComplianceStatus: c.ComplianceStatus, ResourceOverlapStatus: c.OverlapStatus,
+			SampledStartTime: time.Unix(0, 0).UTC(), SampledEndTime: time.Unix(0, 0).UTC(),
+		})
+	}
+
+	return out, nil
+}

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -434,3 +434,131 @@ func TestNetworkingConcurrentReadWrite(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestIPAMLifecycle(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	ipam, err := m.CreateIpam(ctx, driver.IpamConfig{Description: "corp"})
+	if err != nil || ipam.PublicDefaultScopeID == "" || ipam.PrivateDefaultScopeID == "" || ipam.ScopeCount != 2 {
+		t.Fatalf("CreateIpam: %v %+v", err, ipam)
+	}
+
+	// Default scopes are discoverable.
+	if got, _ := m.DescribeIpamScopes(ctx, nil); len(got) != 2 {
+		t.Fatalf("default scopes: %+v", got)
+	}
+
+	// Creating a pool in a missing scope is rejected.
+	if _, err := m.CreateIpamPool(ctx, driver.IpamPoolConfig{IpamScopeID: "ipam-scope-nope"}); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("pool in missing scope: got %v, want InvalidArgument", err)
+	}
+
+	pool, err := m.CreateIpamPool(ctx, driver.IpamPoolConfig{IpamScopeID: ipam.PrivateDefaultScopeID, AddressFamily: "ipv4"})
+	if err != nil || pool.State != "create-complete" {
+		t.Fatalf("CreateIpamPool: %v %+v", err, pool)
+	}
+
+	// Provision supply, allocate, read back.
+	if _, err := m.ProvisionIpamPoolCidr(ctx, pool.ID, "10.0.0.0/16", 0); err != nil {
+		t.Fatalf("ProvisionIpamPoolCidr: %v", err)
+	}
+
+	if cidrs, _ := m.GetIpamPoolCidrs(ctx, pool.ID); len(cidrs) != 1 || cidrs[0].CIDR != "10.0.0.0/16" {
+		t.Fatalf("GetIpamPoolCidrs: %+v", cidrs)
+	}
+
+	alloc, err := m.AllocateIpamPoolCidr(ctx, driver.AllocateIpamPoolCidrConfig{IpamPoolID: pool.ID, CIDR: "10.0.1.0/24"})
+	if err != nil {
+		t.Fatalf("AllocateIpamPoolCidr: %v", err)
+	}
+
+	// A pool with a live allocation cannot be deleted.
+	if _, err := m.DeleteIpamPool(ctx, pool.ID); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete pool with allocation: got %v, want FailedPrecondition", err)
+	}
+
+	if allocs, _ := m.GetIpamPoolAllocations(ctx, pool.ID); len(allocs) != 1 {
+		t.Fatalf("GetIpamPoolAllocations: %+v", allocs)
+	}
+
+	if _, err := m.ModifyIpamPoolAllocation(ctx, alloc.ID, "updated"); err != nil {
+		t.Fatalf("ModifyIpamPoolAllocation: %v", err)
+	}
+
+	if err := m.ReleaseIpamPoolAllocation(ctx, pool.ID, alloc.ID); err != nil {
+		t.Fatalf("ReleaseIpamPoolAllocation: %v", err)
+	}
+
+	// Releasing again is NotFound.
+	if err := m.ReleaseIpamPoolAllocation(ctx, pool.ID, alloc.ID); !cerrors.IsNotFound(err) {
+		t.Fatalf("release twice: got %v, want NotFound", err)
+	}
+
+	if _, err := m.DeprovisionIpamPoolCidr(ctx, pool.ID, "10.0.0.0/16"); err != nil {
+		t.Fatalf("DeprovisionIpamPoolCidr: %v", err)
+	}
+
+	if _, err := m.DeleteIpamPool(ctx, pool.ID); err != nil {
+		t.Fatalf("DeleteIpamPool: %v", err)
+	}
+
+	// An IPAM with a non-default scope cannot be deleted until the scope is gone.
+	extra, err := m.CreateIpamScope(ctx, driver.IpamScopeConfig{IpamID: ipam.ID})
+	if err != nil {
+		t.Fatalf("CreateIpamScope: %v", err)
+	}
+
+	if _, err := m.DeleteIpam(ctx, ipam.ID); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete ipam with scope: got %v, want FailedPrecondition", err)
+	}
+
+	if _, err := m.DeleteIpamScope(ctx, extra.ID); err != nil {
+		t.Fatalf("DeleteIpamScope: %v", err)
+	}
+
+	if _, err := m.DeleteIpam(ctx, ipam.ID); err != nil {
+		t.Fatalf("DeleteIpam: %v", err)
+	}
+
+	if got, _ := m.DescribeIpams(ctx, nil); len(got) != 0 {
+		t.Fatalf("ipam survived delete: %+v", got)
+	}
+}
+
+// TestIPAMConcurrentAccess exercises the IPAM locking under -race.
+func TestIPAMConcurrentAccess(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	ipam, err := m.CreateIpam(ctx, driver.IpamConfig{})
+	if err != nil {
+		t.Fatalf("CreateIpam: %v", err)
+	}
+
+	pool, err := m.CreateIpamPool(ctx, driver.IpamPoolConfig{IpamScopeID: ipam.PrivateDefaultScopeID})
+	if err != nil {
+		t.Fatalf("CreateIpamPool: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.ProvisionIpamPoolCidr(ctx, pool.ID, "10.0.0.0/16", 0)
+			_, _ = m.ModifyIpamPool(ctx, pool.ID, "x")
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_, _ = m.GetIpamPoolCidrs(ctx, pool.ID)
+			_, _ = m.DescribeIpamPools(ctx, []string{pool.ID})
+		}()
+	}
+
+	wg.Wait()
+}

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -565,6 +565,51 @@ func TestIPAMLifecycle(t *testing.T) {
 	}
 }
 
+// TestIPAMProvisionNoCrossPoolOverlap guards the review fix: two top-level
+// pools each provisioning a netmask-only /16 must receive DISTINCT,
+// non-overlapping CIDRs — both carve from the same shared base, so the
+// second must skip the first's block instead of both getting 10.0.0.0/16.
+func TestIPAMProvisionNoCrossPoolOverlap(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	ip, err := m.CreateIpam(ctx, driver.IpamConfig{})
+	if err != nil {
+		t.Fatalf("CreateIpam: %v", err)
+	}
+
+	poolA, err := m.CreateIpamPool(ctx, driver.IpamPoolConfig{IpamScopeID: ip.PrivateDefaultScopeID, AddressFamily: "ipv4"})
+	if err != nil {
+		t.Fatalf("CreateIpamPool A: %v", err)
+	}
+
+	poolB, err := m.CreateIpamPool(ctx, driver.IpamPoolConfig{IpamScopeID: ip.PrivateDefaultScopeID, AddressFamily: "ipv4"})
+	if err != nil {
+		t.Fatalf("CreateIpamPool B: %v", err)
+	}
+
+	a, err := m.ProvisionIpamPoolCidr(ctx, poolA.ID, "", 16)
+	if err != nil {
+		t.Fatalf("Provision A: %v", err)
+	}
+
+	b, err := m.ProvisionIpamPoolCidr(ctx, poolB.ID, "", 16)
+	if err != nil {
+		t.Fatalf("Provision B: %v", err)
+	}
+
+	if a.CIDR == b.CIDR {
+		t.Fatalf("cross-pool overlap: both pools provisioned %q", a.CIDR)
+	}
+
+	sa, ea, _ := ipv4Range(a.CIDR)
+	sb, eb, _ := ipv4Range(b.CIDR)
+
+	if sa <= eb && sb <= ea {
+		t.Fatalf("provisioned CIDRs overlap: %q and %q", a.CIDR, b.CIDR)
+	}
+}
+
 // TestIPAMConcurrentAccess exercises the IPAM locking under -race.
 func TestIPAMConcurrentAccess(t *testing.T) {
 	m := newMock()

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -562,3 +562,130 @@ func TestIPAMConcurrentAccess(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestIPAMFullProvider(t *testing.T) {
+	m := newMock()
+	ctx := context.Background()
+
+	// Seed a VPC + subnet so resource CIDRs / discovery / metrics have input.
+	v, _ := m.CreateVPC(ctx, driver.VPCConfig{CIDRBlock: "10.0.0.0/16"})
+	_, _ = m.CreateSubnet(ctx, driver.SubnetConfig{VPCID: v.ID, CIDRBlock: "10.0.0.0/24"})
+
+	ipam, err := m.CreateIpam(ctx, driver.IpamConfig{})
+	if err != nil || ipam.DefaultResourceDiscoveryID == "" || ipam.ResourceDiscoveryAssociationCount != 1 {
+		t.Fatalf("CreateIpam default RD: %v %+v", err, ipam)
+	}
+
+	// Resource CIDRs + history derive from the VPC/subnet.
+	rc, err := m.GetIpamResourceCidrs(ctx, ipam.PrivateDefaultScopeID, "")
+	if err != nil || len(rc) != 2 {
+		t.Fatalf("GetIpamResourceCidrs: %v %+v", err, rc)
+	}
+
+	if hist, _ := m.GetIpamAddressHistory(ctx, "10.0.0.0/16", ""); len(hist) != 1 {
+		t.Fatalf("GetIpamAddressHistory: %+v", hist)
+	}
+
+	// Resource discovery: default RD is discoverable + discovered getters work.
+	if rds, _ := m.DescribeIpamResourceDiscoveries(ctx, nil); len(rds) != 1 {
+		t.Fatalf("DescribeIpamResourceDiscoveries: %+v", rds)
+	}
+
+	if accts, _ := m.GetIpamDiscoveredAccounts(ctx, ipam.DefaultResourceDiscoveryID, ""); len(accts) != 1 {
+		t.Fatalf("GetIpamDiscoveredAccounts: %+v", accts)
+	}
+
+	if dcidrs, _ := m.GetIpamDiscoveredResourceCidrs(ctx, ipam.DefaultResourceDiscoveryID, ""); len(dcidrs) != 2 {
+		t.Fatalf("GetIpamDiscoveredResourceCidrs: %+v", dcidrs)
+	}
+
+	// A non-default resource discovery can be created + deleted.
+	rd, err := m.CreateIpamResourceDiscovery(ctx, driver.IpamResourceDiscoveryConfig{Description: "extra"})
+	if err != nil {
+		t.Fatalf("CreateIpamResourceDiscovery: %v", err)
+	}
+
+	if _, err := m.DeleteIpamResourceDiscovery(ctx, rd.ID); err != nil {
+		t.Fatalf("DeleteIpamResourceDiscovery: %v", err)
+	}
+
+	// BYOASN + BYOIP.
+	if _, err := m.ProvisionIpamByoasn(ctx, ipam.ID, "64512"); err != nil {
+		t.Fatalf("ProvisionIpamByoasn: %v", err)
+	}
+
+	if _, err := m.ProvisionByoipCidr(ctx, "203.0.113.0/24", "byoip"); err != nil {
+		t.Fatalf("ProvisionByoipCidr: %v", err)
+	}
+
+	if _, err := m.AdvertiseByoipCidr(ctx, "203.0.113.0/24"); err != nil {
+		t.Fatalf("AdvertiseByoipCidr: %v", err)
+	}
+
+	// Advertised CIDR cannot be deprovisioned.
+	if _, err := m.DeprovisionByoipCidr(ctx, "203.0.113.0/24"); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("deprovision advertised: got %v, want FailedPrecondition", err)
+	}
+
+	// Prefix-list resolver + target + verification token.
+	res, err := m.CreateIpamPrefixListResolver(ctx, ipam.ID, "ipv4", "res", nil)
+	if err != nil {
+		t.Fatalf("CreateIpamPrefixListResolver: %v", err)
+	}
+
+	if _, err := m.CreateIpamPrefixListResolverTarget(ctx, res.ID, "pl-1", "", 1, true, nil); err != nil {
+		t.Fatalf("CreateIpamPrefixListResolverTarget: %v", err)
+	}
+
+	// Resolver with a target cannot be deleted.
+	if _, err := m.DeleteIpamPrefixListResolver(ctx, res.ID); !cerrors.IsFailedPrecondition(err) {
+		t.Fatalf("delete resolver with target: got %v, want FailedPrecondition", err)
+	}
+
+	if _, err := m.CreateIpamExternalResourceVerificationToken(ctx, ipam.ID, "tok", nil); err != nil {
+		t.Fatalf("CreateIpamExternalResourceVerificationToken: %v", err)
+	}
+
+	// Policy + org admin.
+	pol, err := m.CreateIpamPolicy(ctx, ipam.ID, nil)
+	if err != nil {
+		t.Fatalf("CreateIpamPolicy: %v", err)
+	}
+
+	if _, err := m.EnableIpamPolicy(ctx, pol.ID, ""); err != nil {
+		t.Fatalf("EnableIpamPolicy: %v", err)
+	}
+
+	if id, enabled, _, _ := m.GetEnabledIpamPolicy(ctx); !enabled || id != pol.ID {
+		t.Fatalf("GetEnabledIpamPolicy: id=%q enabled=%v", id, enabled)
+	}
+
+	if ok, err := m.EnableIpamOrganizationAdminAccount(ctx, "111122223333"); err != nil || !ok {
+		t.Fatalf("EnableIpamOrganizationAdminAccount: %v %v", ok, err)
+	}
+
+	// Metrics derive from state: TotalActiveIpCount + VpcIPUsage present.
+	metrics := m.IpamMetrics(ctx)
+	seen := map[string]bool{}
+	for _, mtr := range metrics {
+		seen[mtr.MetricName] = true
+	}
+
+	if !seen["TotalActiveIpCount"] || !seen["VpcIPUsage"] || !seen["ManagedResourceCidrs"] {
+		t.Fatalf("expected IPAM metrics, got %v", seen)
+	}
+
+	// Pool metrics appear once a pool with supply + an allocation exists.
+	pool, _ := m.CreateIpamPool(ctx, driver.IpamPoolConfig{IpamScopeID: ipam.PrivateDefaultScopeID})
+	_, _ = m.ProvisionIpamPoolCidr(ctx, pool.ID, "10.1.0.0/16", 0)
+	_, _ = m.AllocateIpamPoolCidr(ctx, driver.AllocateIpamPoolCidrConfig{IpamPoolID: pool.ID, CIDR: "10.1.1.0/24"})
+
+	seen = map[string]bool{}
+	for _, mtr := range m.IpamMetrics(ctx) {
+		seen[mtr.MetricName] = true
+	}
+
+	if !seen["PercentAssigned"] || !seen["PercentAvailable"] {
+		t.Fatalf("expected pool metrics, got %v", seen)
+	}
+}

--- a/providers/aws/vpc/networking_parity_test.go
+++ b/providers/aws/vpc/networking_parity_test.go
@@ -2,6 +2,7 @@ package vpc
 
 import (
 	"context"
+	"net"
 	"sync"
 	"testing"
 
@@ -473,6 +474,44 @@ func TestIPAMLifecycle(t *testing.T) {
 		t.Fatalf("AllocateIpamPoolCidr: %v", err)
 	}
 
+	// Netmask-only allocation (the standard AWS pattern) must derive a real,
+	// non-empty CIDR of the requested size from the pool's supply, not the
+	// empty string — otherwise downstream reads and AWS/IPAM metrics corrupt.
+	nmAlloc, err := m.AllocateIpamPoolCidr(ctx, driver.AllocateIpamPoolCidrConfig{IpamPoolID: pool.ID, NetmaskLength: 24})
+	if err != nil {
+		t.Fatalf("AllocateIpamPoolCidr(netmask): %v", err)
+	}
+
+	if _, ipnet, perr := net.ParseCIDR(nmAlloc.CIDR); perr != nil {
+		t.Fatalf("netmask-only allocation returned invalid CIDR %q: %v", nmAlloc.CIDR, perr)
+	} else if ones, _ := ipnet.Mask.Size(); ones != 24 {
+		t.Fatalf("derived CIDR %q is not a /24", nmAlloc.CIDR)
+	}
+
+	if nmAlloc.CIDR == "10.0.1.0/24" {
+		t.Fatalf("derived CIDR overlaps the existing allocation: %q", nmAlloc.CIDR)
+	}
+
+	// Netmask-only provisioning likewise derives a concrete CIDR.
+	nmProv, err := m.ProvisionIpamPoolCidr(ctx, pool.ID, "", 24)
+	if err != nil {
+		t.Fatalf("ProvisionIpamPoolCidr(netmask): %v", err)
+	}
+
+	if nmProv.CIDR == "" {
+		t.Fatal("netmask-only provisioning returned an empty CIDR")
+	}
+
+	// Restore the pool to a single provisioned CIDR + single allocation so the
+	// assertions below (delete-guard, allocation count) still hold.
+	if err := m.ReleaseIpamPoolAllocation(ctx, pool.ID, nmAlloc.ID); err != nil {
+		t.Fatalf("ReleaseIpamPoolAllocation(netmask): %v", err)
+	}
+
+	if _, err := m.DeprovisionIpamPoolCidr(ctx, pool.ID, nmProv.CIDR); err != nil {
+		t.Fatalf("DeprovisionIpamPoolCidr(netmask): %v", err)
+	}
+
 	// A pool with a live allocation cannot be deleted.
 	if _, err := m.DeleteIpamPool(ctx, pool.ID); !cerrors.IsFailedPrecondition(err) {
 		t.Fatalf("delete pool with allocation: got %v, want FailedPrecondition", err)
@@ -582,6 +621,21 @@ func TestIPAMFullProvider(t *testing.T) {
 		t.Fatalf("GetIpamResourceCidrs: %v %+v", err, rc)
 	}
 
+	// ModifyIpamResourceCidr must PERSIST: unmonitoring a resource has to
+	// survive the next (freshly-derived) read, not silently revert.
+	if _, err := m.ModifyIpamResourceCidr(ctx, rc[0].ResourceID, ipam.PrivateDefaultScopeID, "", false); err != nil {
+		t.Fatalf("ModifyIpamResourceCidr: %v", err)
+	}
+
+	after, err := m.GetIpamResourceCidrs(ctx, ipam.PrivateDefaultScopeID, rc[0].ResourceID)
+	if err != nil || len(after) != 1 {
+		t.Fatalf("GetIpamResourceCidrs(after modify): %v %+v", err, after)
+	}
+
+	if after[0].ManagementState != "unmanaged" {
+		t.Fatalf("unmonitor did not persist: ManagementState=%q, want unmanaged", after[0].ManagementState)
+	}
+
 	if hist, _ := m.GetIpamAddressHistory(ctx, "10.0.0.0/16", ""); len(hist) != 1 {
 		t.Fatalf("GetIpamAddressHistory: %+v", hist)
 	}
@@ -622,6 +676,24 @@ func TestIPAMFullProvider(t *testing.T) {
 		t.Fatalf("AdvertiseByoipCidr: %v", err)
 	}
 
+	// BYOASN association validates both sides: a provisioned CIDR associates,
+	// an unprovisioned one is rejected, and disassociating an unknown ASN errs.
+	if _, err := m.AssociateIpamByoasn(ctx, "64512", "203.0.113.0/24"); err != nil {
+		t.Fatalf("AssociateIpamByoasn: %v", err)
+	}
+
+	if _, err := m.AssociateIpamByoasn(ctx, "64512", "198.51.100.0/24"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("associate unprovisioned cidr: got %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.DisassociateIpamByoasn(ctx, "64999", "203.0.113.0/24"); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("disassociate unknown asn: got %v, want InvalidArgument", err)
+	}
+
+	if _, err := m.DisassociateIpamByoasn(ctx, "64512", "203.0.113.0/24"); err != nil {
+		t.Fatalf("DisassociateIpamByoasn: %v", err)
+	}
+
 	// Advertised CIDR cannot be deprovisioned.
 	if _, err := m.DeprovisionByoipCidr(ctx, "203.0.113.0/24"); !cerrors.IsFailedPrecondition(err) {
 		t.Fatalf("deprovision advertised: got %v, want FailedPrecondition", err)
@@ -633,8 +705,21 @@ func TestIPAMFullProvider(t *testing.T) {
 		t.Fatalf("CreateIpamPrefixListResolver: %v", err)
 	}
 
-	if _, err := m.CreateIpamPrefixListResolverTarget(ctx, res.ID, "pl-1", "", 1, true, nil); err != nil {
+	// The target must reference an existing managed prefix list.
+	targetPL, err := m.CreateManagedPrefixList(ctx, driver.PrefixListConfig{
+		Name: "resolver-target", MaxEntries: 5, Entries: []driver.PrefixListEntry{{CIDR: "10.1.0.0/16"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedPrefixList: %v", err)
+	}
+
+	if _, err := m.CreateIpamPrefixListResolverTarget(ctx, res.ID, targetPL.ID, "", 1, true, nil); err != nil {
 		t.Fatalf("CreateIpamPrefixListResolverTarget: %v", err)
+	}
+
+	// A target referencing a non-existent prefix list is rejected.
+	if _, err := m.CreateIpamPrefixListResolverTarget(ctx, res.ID, "pl-does-not-exist", "", 1, true, nil); !cerrors.IsInvalidArgument(err) {
+		t.Fatalf("target with unknown prefix list: got %v, want InvalidArgument", err)
 	}
 
 	// Resolver with a target cannot be deleted.

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -36,6 +36,14 @@ var (
 	_ driver.VPCEndpointServices        = (*Mock)(nil)
 	_ driver.ClientVPN                  = (*Mock)(nil)
 	_ driver.IPAM                       = (*Mock)(nil)
+	_ driver.IPAMResources              = (*Mock)(nil)
+	_ driver.IPAMDiscovery              = (*Mock)(nil)
+	_ driver.IPAMByoasn                 = (*Mock)(nil)
+	_ driver.IPAMByoip                  = (*Mock)(nil)
+	_ driver.IPAMPrefixListResolver     = (*Mock)(nil)
+	_ driver.IPAMExternalToken          = (*Mock)(nil)
+	_ driver.IPAMPolicy                 = (*Mock)(nil)
+	_ driver.IPAMMetrics                = (*Mock)(nil)
 )
 
 // Mock is an in-memory mock implementation of the AWS VPC networking service.
@@ -79,11 +87,19 @@ type Mock struct {
 	clientVPNAuthRules *memstore.Store[*driver.ClientVPNAuthorizationRule]
 	clientVPNRoutes    *memstore.Store[*driver.ClientVPNRoute]
 
-	ipams           *memstore.Store[*driver.Ipam]
-	ipamScopes      *memstore.Store[*driver.IpamScope]
-	ipamPools       *memstore.Store[*driver.IpamPool]
-	ipamPoolCidrs   *memstore.Store[*driver.IpamPoolCidr]
-	ipamAllocations *memstore.Store[*driver.IpamPoolAllocation]
+	ipams               *memstore.Store[*driver.Ipam]
+	ipamScopes          *memstore.Store[*driver.IpamScope]
+	ipamPools           *memstore.Store[*driver.IpamPool]
+	ipamPoolCidrs       *memstore.Store[*driver.IpamPoolCidr]
+	ipamAllocations     *memstore.Store[*driver.IpamPoolAllocation]
+	ipamDiscoveries     *memstore.Store[*driver.IpamResourceDiscovery]
+	ipamRDAssociations  *memstore.Store[*driver.IpamResourceDiscoveryAssociation]
+	ipamByoasns         *memstore.Store[*driver.Byoasn]
+	ipamByoipCidrs      *memstore.Store[*driver.ByoipCidr]
+	ipamResolvers       *memstore.Store[*driver.IpamPrefixListResolver]
+	ipamResolverTargets *memstore.Store[*driver.IpamPrefixListResolverTarget]
+	ipamTokens          *memstore.Store[*driver.IpamExternalResourceVerificationToken]
+	ipamPolicies        *memstore.Store[*driver.IpamPolicy]
 
 	// endpointServicePerms holds allowed principals per endpoint-service id,
 	// guarded by mu.
@@ -159,11 +175,19 @@ func New(opts *config.Options) *Mock {
 		clientVPNAuthRules: memstore.New[*driver.ClientVPNAuthorizationRule](),
 		clientVPNRoutes:    memstore.New[*driver.ClientVPNRoute](),
 
-		ipams:           memstore.New[*driver.Ipam](),
-		ipamScopes:      memstore.New[*driver.IpamScope](),
-		ipamPools:       memstore.New[*driver.IpamPool](),
-		ipamPoolCidrs:   memstore.New[*driver.IpamPoolCidr](),
-		ipamAllocations: memstore.New[*driver.IpamPoolAllocation](),
+		ipams:               memstore.New[*driver.Ipam](),
+		ipamScopes:          memstore.New[*driver.IpamScope](),
+		ipamPools:           memstore.New[*driver.IpamPool](),
+		ipamPoolCidrs:       memstore.New[*driver.IpamPoolCidr](),
+		ipamAllocations:     memstore.New[*driver.IpamPoolAllocation](),
+		ipamDiscoveries:     memstore.New[*driver.IpamResourceDiscovery](),
+		ipamRDAssociations:  memstore.New[*driver.IpamResourceDiscoveryAssociation](),
+		ipamByoasns:         memstore.New[*driver.Byoasn](),
+		ipamByoipCidrs:      memstore.New[*driver.ByoipCidr](),
+		ipamResolvers:       memstore.New[*driver.IpamPrefixListResolver](),
+		ipamResolverTargets: memstore.New[*driver.IpamPrefixListResolverTarget](),
+		ipamTokens:          memstore.New[*driver.IpamExternalResourceVerificationToken](),
+		ipamPolicies:        memstore.New[*driver.IpamPolicy](),
 
 		endpointServicePerms: map[string][]string{},
 		ipamPoolByCidr:       map[string]string{},

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -35,6 +35,7 @@ var (
 	_ driver.EgressOnlyInternetGateways = (*Mock)(nil)
 	_ driver.VPCEndpointServices        = (*Mock)(nil)
 	_ driver.ClientVPN                  = (*Mock)(nil)
+	_ driver.IPAM                       = (*Mock)(nil)
 )
 
 // Mock is an in-memory mock implementation of the AWS VPC networking service.
@@ -78,9 +79,20 @@ type Mock struct {
 	clientVPNAuthRules *memstore.Store[*driver.ClientVPNAuthorizationRule]
 	clientVPNRoutes    *memstore.Store[*driver.ClientVPNRoute]
 
+	ipams           *memstore.Store[*driver.Ipam]
+	ipamScopes      *memstore.Store[*driver.IpamScope]
+	ipamPools       *memstore.Store[*driver.IpamPool]
+	ipamPoolCidrs   *memstore.Store[*driver.IpamPoolCidr]
+	ipamAllocations *memstore.Store[*driver.IpamPoolAllocation]
+
 	// endpointServicePerms holds allowed principals per endpoint-service id,
 	// guarded by mu.
 	endpointServicePerms map[string][]string
+
+	// ipamPoolByCidr / ipamPoolByAllocation map a provisioned CIDR id and an
+	// allocation id to their owning pool id, guarded by mu.
+	ipamPoolByCidr       map[string]string
+	ipamPoolByAllocation map[string]string
 
 	opts *config.Options
 }
@@ -147,7 +159,15 @@ func New(opts *config.Options) *Mock {
 		clientVPNAuthRules: memstore.New[*driver.ClientVPNAuthorizationRule](),
 		clientVPNRoutes:    memstore.New[*driver.ClientVPNRoute](),
 
+		ipams:           memstore.New[*driver.Ipam](),
+		ipamScopes:      memstore.New[*driver.IpamScope](),
+		ipamPools:       memstore.New[*driver.IpamPool](),
+		ipamPoolCidrs:   memstore.New[*driver.IpamPoolCidr](),
+		ipamAllocations: memstore.New[*driver.IpamPoolAllocation](),
+
 		endpointServicePerms: map[string][]string{},
+		ipamPoolByCidr:       map[string]string{},
+		ipamPoolByAllocation: map[string]string{},
 
 		opts: opts,
 	}

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -110,6 +110,11 @@ type Mock struct {
 	ipamPoolByCidr       map[string]string
 	ipamPoolByAllocation map[string]string
 
+	// ipamResourceOverrides persists ModifyIpamResourceCidr scope/unmonitor
+	// changes, keyed by resourceID, since the base resource-CIDR list is
+	// re-derived from VPCs/subnets on every read. Guarded by mu.
+	ipamResourceOverrides map[string]ipamResourceOverride
+
 	opts *config.Options
 }
 
@@ -189,9 +194,10 @@ func New(opts *config.Options) *Mock {
 		ipamTokens:          memstore.New[*driver.IpamExternalResourceVerificationToken](),
 		ipamPolicies:        memstore.New[*driver.IpamPolicy](),
 
-		endpointServicePerms: map[string][]string{},
-		ipamPoolByCidr:       map[string]string{},
-		ipamPoolByAllocation: map[string]string{},
+		endpointServicePerms:  map[string][]string{},
+		ipamPoolByCidr:        map[string]string{},
+		ipamPoolByAllocation:  map[string]string{},
+		ipamResourceOverrides: map[string]ipamResourceOverride{},
 
 		opts: opts,
 	}

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -217,7 +217,10 @@ func New(d Drivers) *server.Server {
 	srv := server.New()
 
 	if d.CloudWatch != nil {
-		srv.Register(cloudwatch.New(d.CloudWatch))
+		// The VPC driver optionally supplies derived AWS/IPAM metrics; surface
+		// them through CloudWatch when it implements the capability.
+		ipamMetrics, _ := d.VPC.(netdriver.IPAMMetrics)
+		srv.Register(cloudwatch.New(d.CloudWatch, ipamMetrics))
 	}
 
 	if d.DynamoDB != nil {

--- a/server/aws/aws.go
+++ b/server/aws/aws.go
@@ -220,7 +220,9 @@ func New(d Drivers) *server.Server {
 		// The VPC driver optionally supplies derived AWS/IPAM metrics; surface
 		// them through CloudWatch when it implements the capability.
 		ipamMetrics, _ := d.VPC.(netdriver.IPAMMetrics)
-		srv.Register(cloudwatch.New(d.CloudWatch, ipamMetrics))
+		cw := cloudwatch.New(d.CloudWatch)
+		cw.SetIPAMMetrics(ipamMetrics)
+		srv.Register(cw)
 	}
 
 	if d.DynamoDB != nil {

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -41,10 +41,19 @@ type Handler struct {
 	ipam       netdriver.IPAMMetrics
 }
 
-// New returns a CloudWatch handler backed by m. An optional IPAMMetrics source
-// (nil-safe) supplies the derived AWS/IPAM namespace metrics.
-func New(m mondriver.Monitoring, ipam netdriver.IPAMMetrics) *Handler {
-	return &Handler{monitoring: m, ipam: ipam}
+// New returns a CloudWatch handler backed by m. Use SetIPAMMetrics to attach
+// the optional derived AWS/IPAM metrics source. Kept single-argument so callers
+// that don't wire IPAM (e.g. the base query-protocol tests) construct it
+// unchanged.
+func New(m mondriver.Monitoring) *Handler {
+	return &Handler{monitoring: m}
+}
+
+// SetIPAMMetrics attaches an optional IPAMMetrics source (nil-safe) supplying
+// the derived AWS/IPAM namespace metrics, following the same setter-injection
+// pattern as the other CloudEmu handlers.
+func (h *Handler) SetIPAMMetrics(ipam netdriver.IPAMMetrics) {
+	h.ipam = ipam
 }
 
 // Matches returns true for Smithy rpc-v2-cbor requests.

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -21,6 +21,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
 )
 
 const (
@@ -33,13 +34,17 @@ const (
 )
 
 // Handler serves CloudWatch rpc-v2-cbor requests against a monitoring driver.
+// An optional IPAM metrics source lets the handler surface derived AWS/IPAM
+// metrics that the monitoring store itself doesn't hold.
 type Handler struct {
 	monitoring mondriver.Monitoring
+	ipam       netdriver.IPAMMetrics
 }
 
-// New returns a CloudWatch handler backed by m.
-func New(m mondriver.Monitoring) *Handler {
-	return &Handler{monitoring: m}
+// New returns a CloudWatch handler backed by m. An optional IPAMMetrics source
+// (nil-safe) supplies the derived AWS/IPAM namespace metrics.
+func New(m mondriver.Monitoring, ipam netdriver.IPAMMetrics) *Handler {
+	return &Handler{monitoring: m, ipam: ipam}
 }
 
 // Matches returns true for Smithy rpc-v2-cbor requests.

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -1,6 +1,7 @@
 package cloudwatch
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -212,8 +213,28 @@ func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byt
 		return
 	}
 
-	if h.ipam != nil && (in.Namespace == netdriver.IpamMetricNamespace || in.Namespace == "") {
-		h.listIpamMetrics(w, r, in.Namespace)
+	// An exact AWS/IPAM request returns only the synthetic IPAM metrics.
+	if h.ipam != nil && in.Namespace == netdriver.IpamMetricNamespace {
+		writeCBORResponse(w, listMetricsOutput{Metrics: h.ipamMetricRows(r)})
+		return
+	}
+
+	// A namespace-less "list all" request must return every real metric (with
+	// its true namespace) and, when IPAM is wired, the IPAM metrics merged in —
+	// never one set replacing the other.
+	if in.Namespace == "" {
+		out, err := h.allMetricRows(r)
+		if err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		if h.ipam != nil {
+			out = append(out, h.ipamMetricRows(r)...)
+		}
+
+		writeCBORResponse(w, listMetricsOutput{Metrics: out})
+
 		return
 	}
 
@@ -231,8 +252,46 @@ func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byt
 	writeCBORResponse(w, listMetricsOutput{Metrics: out})
 }
 
-// listIpamMetrics returns the derived AWS/IPAM metrics with their dimensions.
-func (h *Handler) listIpamMetrics(w http.ResponseWriter, r *http.Request, _ string) {
+// detailedMetricLister is the AWS-local capability that enumerates every metric
+// with its namespace, backing a namespace-less ListMetrics. The shared
+// Monitoring interface only lists names within a single namespace.
+type detailedMetricLister interface {
+	ListMetricsDetailed(ctx context.Context) ([]mondriver.MetricIdentifier, error)
+}
+
+// allMetricRows lists every real metric tagged with its true namespace, using
+// the detailed lister when available and otherwise degrading to the
+// empty-namespace name list.
+func (h *Handler) allMetricRows(r *http.Request) ([]metricCBR, error) {
+	if dl, ok := h.monitoring.(detailedMetricLister); ok {
+		ids, err := dl.ListMetricsDetailed(r.Context())
+		if err != nil {
+			return nil, err
+		}
+
+		out := make([]metricCBR, 0, len(ids))
+		for _, id := range ids {
+			out = append(out, metricCBR{Namespace: id.Namespace, MetricName: id.MetricName})
+		}
+
+		return out, nil
+	}
+
+	names, err := h.monitoring.ListMetrics(r.Context(), "")
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]metricCBR, 0, len(names))
+	for _, name := range names {
+		out = append(out, metricCBR{MetricName: name})
+	}
+
+	return out, nil
+}
+
+// ipamMetricRows returns the derived AWS/IPAM metrics with their dimensions.
+func (h *Handler) ipamMetricRows(r *http.Request) []metricCBR {
 	metrics := h.ipam.IpamMetrics(r.Context())
 	out := make([]metricCBR, 0, len(metrics))
 
@@ -245,7 +304,7 @@ func (h *Handler) listIpamMetrics(w http.ResponseWriter, r *http.Request, _ stri
 		out = append(out, metricCBR{Namespace: netdriver.IpamMetricNamespace, MetricName: mtr.MetricName, Dimensions: dims})
 	}
 
-	writeCBORResponse(w, listMetricsOutput{Metrics: out})
+	return out
 }
 
 type putMetricAlarmInput struct {

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -7,6 +7,14 @@ import (
 	"github.com/fxamacker/cbor/v2"
 
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+const (
+	statSum         = "Sum"
+	statMinimum     = "Minimum"
+	statMaximum     = "Maximum"
+	statSampleCount = "SampleCount"
 )
 
 // putMetricDataInput mirrors the AWS wire shape for the operation. Field
@@ -111,6 +119,11 @@ func (h *Handler) getMetricStatistics(w http.ResponseWriter, r *http.Request, bo
 		end = *in.EndTime
 	}
 
+	if h.ipam != nil && in.Namespace == netdriver.IpamMetricNamespace {
+		h.getIpamMetricStatistics(w, r, in.MetricName, toDimensionMap(in.Dimensions), stat)
+		return
+	}
+
 	input := mondriver.GetMetricInput{
 		Namespace:  in.Namespace,
 		MetricName: in.MetricName,
@@ -131,6 +144,51 @@ func (h *Handler) getMetricStatistics(w http.ResponseWriter, r *http.Request, bo
 		Label:      in.MetricName,
 		Datapoints: toDatapointsCBR(result, stat),
 	})
+}
+
+// getIpamMetricStatistics returns a single datapoint for a derived AWS/IPAM
+// metric, matched by name and (if supplied) dimensions.
+func (h *Handler) getIpamMetricStatistics(w http.ResponseWriter, r *http.Request, name string, dims map[string]string, stat string) {
+	for _, mtr := range h.ipam.IpamMetrics(r.Context()) {
+		if mtr.MetricName != name || !dimensionsMatch(mtr.Dimensions, dims) {
+			continue
+		}
+
+		dp := datapointCBR{Timestamp: time.Unix(0, 0).UTC(), Unit: mtr.Unit}
+		setDatapointStat(&dp, stat, mtr.Value)
+
+		writeCBORResponse(w, getMetricStatisticsOutput{Label: name, Datapoints: []datapointCBR{dp}})
+
+		return
+	}
+
+	writeCBORResponse(w, getMetricStatisticsOutput{Label: name, Datapoints: nil})
+}
+
+// dimensionsMatch reports whether every requested dimension is present in have.
+func dimensionsMatch(have, want map[string]string) bool {
+	for k, v := range want {
+		if have[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+func setDatapointStat(dp *datapointCBR, stat string, value float64) {
+	switch stat {
+	case statSum:
+		dp.Sum = value
+	case statMinimum:
+		dp.Minimum = value
+	case statMaximum:
+		dp.Maximum = value
+	case statSampleCount:
+		dp.SampleCount = value
+	default:
+		dp.Average = value
+	}
 }
 
 type listMetricsInput struct {
@@ -154,6 +212,11 @@ func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byt
 		return
 	}
 
+	if h.ipam != nil && (in.Namespace == netdriver.IpamMetricNamespace || in.Namespace == "") {
+		h.listIpamMetrics(w, r, in.Namespace)
+		return
+	}
+
 	names, err := h.monitoring.ListMetrics(r.Context(), in.Namespace)
 	if err != nil {
 		writeDriverErr(w, err)
@@ -163,6 +226,23 @@ func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byt
 	out := make([]metricCBR, 0, len(names))
 	for _, name := range names {
 		out = append(out, metricCBR{Namespace: in.Namespace, MetricName: name})
+	}
+
+	writeCBORResponse(w, listMetricsOutput{Metrics: out})
+}
+
+// listIpamMetrics returns the derived AWS/IPAM metrics with their dimensions.
+func (h *Handler) listIpamMetrics(w http.ResponseWriter, r *http.Request, _ string) {
+	metrics := h.ipam.IpamMetrics(r.Context())
+	out := make([]metricCBR, 0, len(metrics))
+
+	for _, mtr := range metrics {
+		dims := make([]dimensionCBR, 0, len(mtr.Dimensions))
+		for k, v := range mtr.Dimensions {
+			dims = append(dims, dimensionCBR{Name: k, Value: v})
+		}
+
+		out = append(out, metricCBR{Namespace: netdriver.IpamMetricNamespace, MetricName: mtr.MetricName, Dimensions: dims})
 	}
 
 	writeCBORResponse(w, listMetricsOutput{Metrics: out})
@@ -309,13 +389,13 @@ func toDatapointsCBR(res *mondriver.MetricDataResult, stat string) []datapointCB
 		v := res.Values[i]
 
 		switch stat {
-		case "Sum":
+		case statSum:
 			dp.Sum = v
-		case "Minimum":
+		case statMinimum:
 			dp.Minimum = v
-		case "Maximum":
+		case statMaximum:
 			dp.Maximum = v
-		case "SampleCount":
+		case statSampleCount:
 			dp.SampleCount = v
 		default:
 			dp.Average = v

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -94,6 +94,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeEgressOnlyIGW,
 		h.routeEndpointServices,
 		h.routeClientVPN,
+		h.routeIPAM,
 		h.routeVPC,
 	}
 	for _, route := range routes {

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -95,6 +95,11 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.routeEndpointServices,
 		h.routeClientVPN,
 		h.routeIPAM,
+		h.routeIPAMResources,
+		h.routeIPAMDiscovery,
+		h.routeIPAMByoip,
+		h.routeIPAMResolver,
+		h.routeIPAMPolicy,
 		h.routeVPC,
 	}
 	for _, route := range routes {

--- a/server/aws/ec2/ipam.go
+++ b/server/aws/ec2/ipam.go
@@ -16,17 +16,20 @@ func (h *Handler) ipam() (netdriver.IPAM, bool) {
 }
 
 type ipamXML struct {
-	IpamID                string     `xml:"ipamId"`
-	IpamArn               string     `xml:"ipamArn"`
-	IpamRegion            string     `xml:"ipamRegion,omitempty"`
-	PublicDefaultScopeID  string     `xml:"publicDefaultScopeId"`
-	PrivateDefaultScopeID string     `xml:"privateDefaultScopeId"`
-	ScopeCount            int        `xml:"scopeCount"`
-	OperatingRegions      []opRegXML `xml:"operatingRegionSet>item,omitempty"`
-	Description           string     `xml:"description,omitempty"`
-	Tier                  string     `xml:"tier,omitempty"`
-	State                 string     `xml:"state"`
-	Tags                  []tagItem  `xml:"tagSet>item,omitempty"`
+	IpamID                                string     `xml:"ipamId"`
+	IpamArn                               string     `xml:"ipamArn"`
+	IpamRegion                            string     `xml:"ipamRegion,omitempty"`
+	PublicDefaultScopeID                  string     `xml:"publicDefaultScopeId"`
+	PrivateDefaultScopeID                 string     `xml:"privateDefaultScopeId"`
+	ScopeCount                            int        `xml:"scopeCount"`
+	DefaultResourceDiscoveryID            string     `xml:"defaultResourceDiscoveryId,omitempty"`
+	DefaultResourceDiscoveryAssociationID string     `xml:"defaultResourceDiscoveryAssociationId,omitempty"`
+	ResourceDiscoveryAssociationCount     int        `xml:"resourceDiscoveryAssociationCount,omitempty"`
+	OperatingRegions                      []opRegXML `xml:"operatingRegionSet>item,omitempty"`
+	Description                           string     `xml:"description,omitempty"`
+	Tier                                  string     `xml:"tier,omitempty"`
+	State                                 string     `xml:"state"`
+	Tags                                  []tagItem  `xml:"tagSet>item,omitempty"`
 }
 
 type opRegXML struct {
@@ -205,7 +208,11 @@ func toIpamXML(i *netdriver.Ipam) ipamXML {
 	x := ipamXML{
 		IpamID: i.ID, IpamArn: i.ARN, IpamRegion: i.Region,
 		PublicDefaultScopeID: i.PublicDefaultScopeID, PrivateDefaultScopeID: i.PrivateDefaultScopeID,
-		ScopeCount: i.ScopeCount, Description: i.Description, Tier: i.Tier, State: i.State,
+		ScopeCount:                            i.ScopeCount,
+		DefaultResourceDiscoveryID:            i.DefaultResourceDiscoveryID,
+		DefaultResourceDiscoveryAssociationID: i.DefaultResourceDiscoveryAssociationID,
+		ResourceDiscoveryAssociationCount:     i.ResourceDiscoveryAssociationCount,
+		Description:                           i.Description, Tier: i.Tier, State: i.State,
 		Tags: toTagItems(i.Tags),
 	}
 

--- a/server/aws/ec2/ipam.go
+++ b/server/aws/ec2/ipam.go
@@ -1,0 +1,516 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) ipam() (netdriver.IPAM, bool) {
+	i, ok := h.vpc.(netdriver.IPAM)
+
+	return i, ok
+}
+
+type ipamXML struct {
+	IpamID                string     `xml:"ipamId"`
+	IpamArn               string     `xml:"ipamArn"`
+	IpamRegion            string     `xml:"ipamRegion,omitempty"`
+	PublicDefaultScopeID  string     `xml:"publicDefaultScopeId"`
+	PrivateDefaultScopeID string     `xml:"privateDefaultScopeId"`
+	ScopeCount            int        `xml:"scopeCount"`
+	OperatingRegions      []opRegXML `xml:"operatingRegionSet>item,omitempty"`
+	Description           string     `xml:"description,omitempty"`
+	Tier                  string     `xml:"tier,omitempty"`
+	State                 string     `xml:"state"`
+	Tags                  []tagItem  `xml:"tagSet>item,omitempty"`
+}
+
+type opRegXML struct {
+	RegionName string `xml:"regionName"`
+}
+
+type ipamScopeXML struct {
+	IpamScopeID   string    `xml:"ipamScopeId"`
+	IpamScopeArn  string    `xml:"ipamScopeArn"`
+	IpamArn       string    `xml:"ipamArn"`
+	IpamScopeType string    `xml:"ipamScopeType"`
+	IsDefault     bool      `xml:"isDefault"`
+	PoolCount     int       `xml:"poolCount"`
+	Description   string    `xml:"description,omitempty"`
+	State         string    `xml:"state"`
+	Tags          []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type ipamPoolXML struct {
+	IpamPoolID                     string    `xml:"ipamPoolId"`
+	IpamPoolArn                    string    `xml:"ipamPoolArn"`
+	IpamScopeArn                   string    `xml:"ipamScopeArn"`
+	IpamScopeType                  string    `xml:"ipamScopeType"`
+	AddressFamily                  string    `xml:"addressFamily"`
+	Locale                         string    `xml:"locale,omitempty"`
+	PoolDepth                      int       `xml:"poolDepth"`
+	Description                    string    `xml:"description,omitempty"`
+	State                          string    `xml:"state"`
+	AllocationMinNetmaskLength     int       `xml:"allocationMinNetmaskLength,omitempty"`
+	AllocationMaxNetmaskLength     int       `xml:"allocationMaxNetmaskLength,omitempty"`
+	AllocationDefaultNetmaskLength int       `xml:"allocationDefaultNetmaskLength,omitempty"`
+	Tags                           []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type ipamPoolCidrXML struct {
+	IpamPoolCidrID string `xml:"ipamPoolCidrId"`
+	Cidr           string `xml:"cidr,omitempty"`
+	NetmaskLength  int    `xml:"netmaskLength,omitempty"`
+	State          string `xml:"state"`
+}
+
+type ipamAllocationXML struct {
+	IpamPoolAllocationID string    `xml:"ipamPoolAllocationId"`
+	Cidr                 string    `xml:"cidr,omitempty"`
+	ResourceType         string    `xml:"resourceType,omitempty"`
+	ResourceID           string    `xml:"resourceId,omitempty"`
+	Description          string    `xml:"description,omitempty"`
+	Tags                 []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+//nolint:gocyclo // flat action dispatch table
+func (h *Handler) routeIPAM(w http.ResponseWriter, r *http.Request, action string) bool {
+	ip, ok := h.ipam()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateIpam":
+		h.createIpam(w, r, ip)
+	case "DescribeIpams":
+		h.describeIpams(w, r, ip)
+	case "ModifyIpam":
+		h.modifyIpam(w, r, ip)
+	case "DeleteIpam":
+		h.deleteIpam(w, r, ip)
+	case "CreateIpamScope":
+		h.createIpamScope(w, r, ip)
+	case "DescribeIpamScopes":
+		h.describeIpamScopes(w, r, ip)
+	case "ModifyIpamScope":
+		h.modifyIpamScope(w, r, ip)
+	case "DeleteIpamScope":
+		h.deleteIpamScope(w, r, ip)
+	case "CreateIpamPool":
+		h.createIpamPool(w, r, ip)
+	case "DescribeIpamPools":
+		h.describeIpamPools(w, r, ip)
+	case "ModifyIpamPool":
+		h.modifyIpamPool(w, r, ip)
+	case "DeleteIpamPool":
+		h.deleteIpamPool(w, r, ip)
+	case "ProvisionIpamPoolCidr":
+		h.provisionIpamPoolCidr(w, r, ip)
+	case "DeprovisionIpamPoolCidr":
+		h.deprovisionIpamPoolCidr(w, r, ip)
+	case "GetIpamPoolCidrs":
+		h.getIpamPoolCidrs(w, r, ip)
+	case "AllocateIpamPoolCidr":
+		h.allocateIpamPoolCidr(w, r, ip)
+	case "ReleaseIpamPoolAllocation":
+		h.releaseIpamPoolAllocation(w, r, ip)
+	case "GetIpamPoolAllocations", "DescribeIpamPoolAllocations":
+		h.getIpamPoolAllocations(w, r, ip)
+	case "ModifyIpamPoolAllocation":
+		h.modifyIpamPoolAllocation(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func writeIPAMErr(w http.ResponseWriter, err error) {
+	writeErrWithNotFound(w, err, "InvalidIpamId.NotFound", "IncorrectState")
+}
+
+// ---- IPAM ----
+
+func (*Handler) createIpam(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.CreateIpam(r.Context(), netdriver.IpamConfig{
+		Description:      r.Form.Get("Description"),
+		Tier:             r.Form.Get("Tier"),
+		OperatingRegions: awsquery.ListStrings(r.Form, "OperatingRegion"),
+		Tags:             mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam"),
+	})
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpam(w, "CreateIpamResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpams(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	items, err := ip.DescribeIpams(r.Context(), awsquery.ListStrings(r.Form, "IpamId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name  `xml:"DescribeIpamsResponse"`
+		Xmlns   string    `xml:"xmlns,attr"`
+		Req     string    `xml:"requestId"`
+		Set     []ipamXML `xml:"ipamSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpam(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.ModifyIpam(r.Context(), r.Form.Get("IpamId"), r.Form.Get("Description"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpam(w, "ModifyIpamResponse", out)
+}
+
+func (*Handler) deleteIpam(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.DeleteIpam(r.Context(), r.Form.Get("IpamId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpam(w, "DeleteIpamResponse", out)
+}
+
+func writeIpam(w http.ResponseWriter, root string, out *netdriver.Ipam) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:""`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Ipam    ipamXML  `xml:"ipam"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Ipam: toIpamXML(out)})
+}
+
+func toIpamXML(i *netdriver.Ipam) ipamXML {
+	x := ipamXML{
+		IpamID: i.ID, IpamArn: i.ARN, IpamRegion: i.Region,
+		PublicDefaultScopeID: i.PublicDefaultScopeID, PrivateDefaultScopeID: i.PrivateDefaultScopeID,
+		ScopeCount: i.ScopeCount, Description: i.Description, Tier: i.Tier, State: i.State,
+		Tags: toTagItems(i.Tags),
+	}
+
+	for _, reg := range i.OperatingRegions {
+		x.OperatingRegions = append(x.OperatingRegions, opRegXML{RegionName: reg})
+	}
+
+	return x
+}
+
+// ---- IPAM Scope ----
+
+func (*Handler) createIpamScope(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.CreateIpamScope(r.Context(), netdriver.IpamScopeConfig{
+		IpamID:      r.Form.Get("IpamId"),
+		Description: r.Form.Get("Description"),
+		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-scope"),
+	})
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamScope(w, "CreateIpamScopeResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamScopes(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	items, err := ip.DescribeIpamScopes(r.Context(), awsquery.ListStrings(r.Form, "IpamScopeId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamScopeXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamScopeXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name       `xml:"DescribeIpamScopesResponse"`
+		Xmlns   string         `xml:"xmlns,attr"`
+		Req     string         `xml:"requestId"`
+		Set     []ipamScopeXML `xml:"ipamScopeSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamScope(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.ModifyIpamScope(r.Context(), r.Form.Get("IpamScopeId"), r.Form.Get("Description"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamScope(w, "ModifyIpamScopeResponse", out)
+}
+
+func (*Handler) deleteIpamScope(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.DeleteIpamScope(r.Context(), r.Form.Get("IpamScopeId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamScope(w, "DeleteIpamScopeResponse", out)
+}
+
+func writeIpamScope(w http.ResponseWriter, root string, out *netdriver.IpamScope) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name     `xml:""`
+		Xmlns   string       `xml:"xmlns,attr"`
+		Req     string       `xml:"requestId"`
+		Scope   ipamScopeXML `xml:"ipamScope"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Scope: toIpamScopeXML(out)})
+}
+
+func toIpamScopeXML(s *netdriver.IpamScope) ipamScopeXML {
+	return ipamScopeXML{
+		IpamScopeID: s.ID, IpamScopeArn: s.ARN, IpamArn: s.IpamARN, IpamScopeType: s.ScopeType,
+		IsDefault: s.IsDefault, PoolCount: s.PoolCount, Description: s.Description, State: s.State,
+		Tags: toTagItems(s.Tags),
+	}
+}
+
+// ---- IPAM Pool ----
+
+func (*Handler) createIpamPool(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.CreateIpamPool(r.Context(), netdriver.IpamPoolConfig{
+		IpamScopeID:                    r.Form.Get("IpamScopeId"),
+		AddressFamily:                  r.Form.Get("AddressFamily"),
+		Locale:                         r.Form.Get("Locale"),
+		Description:                    r.Form.Get("Description"),
+		AllocationMinNetmaskLength:     atoiDefault(r.Form.Get("AllocationMinNetmaskLength")),
+		AllocationMaxNetmaskLength:     atoiDefault(r.Form.Get("AllocationMaxNetmaskLength")),
+		AllocationDefaultNetmaskLength: atoiDefault(r.Form.Get("AllocationDefaultNetmaskLength")),
+		Tags:                           mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-pool"),
+	})
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPool(w, "CreateIpamPoolResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamPools(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	items, err := ip.DescribeIpamPools(r.Context(), awsquery.ListStrings(r.Form, "IpamPoolId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamPoolXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamPoolXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:"DescribeIpamPoolsResponse"`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		Set     []ipamPoolXML `xml:"ipamPoolSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamPool(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.ModifyIpamPool(r.Context(), r.Form.Get("IpamPoolId"), r.Form.Get("Description"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPool(w, "ModifyIpamPoolResponse", out)
+}
+
+func (*Handler) deleteIpamPool(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.DeleteIpamPool(r.Context(), r.Form.Get("IpamPoolId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPool(w, "DeleteIpamPoolResponse", out)
+}
+
+func writeIpamPool(w http.ResponseWriter, root string, out *netdriver.IpamPool) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name    `xml:""`
+		Xmlns   string      `xml:"xmlns,attr"`
+		Req     string      `xml:"requestId"`
+		Pool    ipamPoolXML `xml:"ipamPool"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Pool: toIpamPoolXML(out)})
+}
+
+func toIpamPoolXML(p *netdriver.IpamPool) ipamPoolXML {
+	return ipamPoolXML{
+		IpamPoolID: p.ID, IpamPoolArn: p.ARN, IpamScopeArn: p.IpamScopeARN, IpamScopeType: p.IpamScopeType,
+		AddressFamily: p.AddressFamily, Locale: p.Locale, PoolDepth: p.PoolDepth,
+		Description: p.Description, State: p.State,
+		AllocationMinNetmaskLength: p.AllocationMinNetmaskLength, AllocationMaxNetmaskLength: p.AllocationMaxNetmaskLength,
+		AllocationDefaultNetmaskLength: p.AllocationDefaultNetmaskLength, Tags: toTagItems(p.Tags),
+	}
+}
+
+// ---- Pool CIDRs ----
+
+func (*Handler) provisionIpamPoolCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.ProvisionIpamPoolCidr(r.Context(),
+		r.Form.Get("IpamPoolId"), r.Form.Get("Cidr"), atoiDefault(r.Form.Get("NetmaskLength")))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPoolCidr(w, "ProvisionIpamPoolCidrResponse", out)
+}
+
+func (*Handler) deprovisionIpamPoolCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.DeprovisionIpamPoolCidr(r.Context(), r.Form.Get("IpamPoolId"), r.Form.Get("Cidr"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPoolCidr(w, "DeprovisionIpamPoolCidrResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) getIpamPoolCidrs(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	items, err := ip.GetIpamPoolCidrs(r.Context(), r.Form.Get("IpamPoolId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamPoolCidrXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamPoolCidrXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name          `xml:"GetIpamPoolCidrsResponse"`
+		Xmlns   string            `xml:"xmlns,attr"`
+		Req     string            `xml:"requestId"`
+		Set     []ipamPoolCidrXML `xml:"ipamPoolCidrSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func writeIpamPoolCidr(w http.ResponseWriter, root string, out *netdriver.IpamPoolCidr) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name        `xml:""`
+		Xmlns   string          `xml:"xmlns,attr"`
+		Req     string          `xml:"requestId"`
+		Cidr    ipamPoolCidrXML `xml:"ipamPoolCidr"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Cidr: toIpamPoolCidrXML(out)})
+}
+
+func toIpamPoolCidrXML(c *netdriver.IpamPoolCidr) ipamPoolCidrXML {
+	return ipamPoolCidrXML{
+		IpamPoolCidrID: c.ID, Cidr: c.CIDR, NetmaskLength: c.NetmaskLength, State: c.State,
+	}
+}
+
+// ---- Pool Allocations ----
+
+func (*Handler) allocateIpamPoolCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.AllocateIpamPoolCidr(r.Context(), netdriver.AllocateIpamPoolCidrConfig{
+		IpamPoolID:    r.Form.Get("IpamPoolId"),
+		CIDR:          r.Form.Get("Cidr"),
+		NetmaskLength: atoiDefault(r.Form.Get("NetmaskLength")),
+		Description:   r.Form.Get("Description"),
+	})
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamAllocation(w, "AllocateIpamPoolCidrResponse", out)
+}
+
+func (*Handler) releaseIpamPoolAllocation(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	err := ip.ReleaseIpamPoolAllocation(r.Context(), r.Form.Get("IpamPoolId"), r.Form.Get("IpamPoolAllocationId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:"ReleaseIpamPoolAllocationResponse"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Success bool     `xml:"success"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Success: true})
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) getIpamPoolAllocations(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	items, err := ip.GetIpamPoolAllocations(r.Context(), r.Form.Get("IpamPoolId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamAllocationXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamAllocationXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name            `xml:"GetIpamPoolAllocationsResponse"`
+		Xmlns   string              `xml:"xmlns,attr"`
+		Req     string              `xml:"requestId"`
+		Set     []ipamAllocationXML `xml:"ipamPoolAllocationSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamPoolAllocation(w http.ResponseWriter, r *http.Request, ip netdriver.IPAM) {
+	out, err := ip.ModifyIpamPoolAllocation(r.Context(), r.Form.Get("IpamPoolAllocationId"), r.Form.Get("Description"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamAllocation(w, "ModifyIpamPoolAllocationResponse", out)
+}
+
+func writeIpamAllocation(w http.ResponseWriter, root string, out *netdriver.IpamPoolAllocation) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name          `xml:""`
+		Xmlns   string            `xml:"xmlns,attr"`
+		Req     string            `xml:"requestId"`
+		Alloc   ipamAllocationXML `xml:"ipamPoolAllocation"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Alloc: toIpamAllocationXML(out)})
+}
+
+func toIpamAllocationXML(a *netdriver.IpamPoolAllocation) ipamAllocationXML {
+	return ipamAllocationXML{
+		IpamPoolAllocationID: a.ID, Cidr: a.CIDR, ResourceType: a.ResourceType, ResourceID: a.ResourceID,
+		Description: a.Description, Tags: toTagItems(a.Tags),
+	}
+}
+
+func atoiDefault(s string) int {
+	n, _ := strconv.Atoi(s)
+
+	return n
+}

--- a/server/aws/ec2/ipam_byoip.go
+++ b/server/aws/ec2/ipam_byoip.go
@@ -1,0 +1,274 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) ipamByoasn() (netdriver.IPAMByoasn, bool) {
+	i, ok := h.vpc.(netdriver.IPAMByoasn)
+
+	return i, ok
+}
+
+func (h *Handler) ipamByoip() (netdriver.IPAMByoip, bool) {
+	i, ok := h.vpc.(netdriver.IPAMByoip)
+
+	return i, ok
+}
+
+type byoasnXML struct {
+	Asn           string `xml:"asn"`
+	IpamID        string `xml:"ipamId,omitempty"`
+	State         string `xml:"state"`
+	StatusMessage string `xml:"statusMessage,omitempty"`
+}
+
+type asnAssociationXML struct {
+	Asn           string `xml:"asn"`
+	Cidr          string `xml:"cidr"`
+	State         string `xml:"state"`
+	StatusMessage string `xml:"statusMessage,omitempty"`
+}
+
+type byoipCidrXML struct {
+	Cidr               string              `xml:"cidr"`
+	Description        string              `xml:"description,omitempty"`
+	State              string              `xml:"state"`
+	StatusMessage      string              `xml:"statusMessage,omitempty"`
+	NetworkBorderGroup string              `xml:"networkBorderGroup,omitempty"`
+	AdvertisementType  string              `xml:"advertisementType,omitempty"`
+	AsnAssociations    []asnAssociationXML `xml:"asnAssociationSet>item,omitempty"`
+}
+
+func (h *Handler) routeIPAMByoip(w http.ResponseWriter, r *http.Request, action string) bool {
+	handledAsn := h.routeIPAMByoasn(w, r, action)
+	if handledAsn {
+		return true
+	}
+
+	ip, ok := h.ipamByoip()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "ProvisionByoipCidr":
+		h.provisionByoipCidr(w, r, ip)
+	case "DeprovisionByoipCidr":
+		h.deprovisionByoipCidr(w, r, ip)
+	case "MoveByoipCidrToIpam":
+		h.moveByoipCidrToIpam(w, r, ip)
+	case "DescribeByoipCidrs":
+		h.describeByoipCidrs(w, r, ip)
+	case "AdvertiseByoipCidr":
+		h.advertiseByoipCidr(w, r, ip)
+	case "WithdrawByoipCidr":
+		h.withdrawByoipCidr(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeIPAMByoasn(w http.ResponseWriter, r *http.Request, action string) bool {
+	ip, ok := h.ipamByoasn()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "ProvisionIpamByoasn":
+		h.provisionIpamByoasn(w, r, ip)
+	case "DeprovisionIpamByoasn":
+		h.deprovisionIpamByoasn(w, r, ip)
+	case "DescribeIpamByoasn":
+		h.describeIpamByoasn(w, r, ip)
+	case "AssociateIpamByoasn":
+		h.associateIpamByoasn(w, r, ip)
+	case "DisassociateIpamByoasn":
+		h.disassociateIpamByoasn(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (*Handler) provisionIpamByoasn(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoasn) {
+	out, err := ip.ProvisionIpamByoasn(r.Context(), r.Form.Get("IpamId"), r.Form.Get("Asn"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoasn(w, "ProvisionIpamByoasnResponse", out)
+}
+
+func (*Handler) deprovisionIpamByoasn(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoasn) {
+	out, err := ip.DeprovisionIpamByoasn(r.Context(), r.Form.Get("IpamId"), r.Form.Get("Asn"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoasn(w, "DeprovisionIpamByoasnResponse", out)
+}
+
+func (*Handler) describeIpamByoasn(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoasn) {
+	items, err := ip.DescribeIpamByoasn(r.Context())
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]byoasnXML, 0, len(items))
+	for i := range items {
+		out = append(out, byoasnXML{Asn: items[i].Asn, IpamID: items[i].IpamID, State: items[i].State, StatusMessage: items[i].StatusMessage})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name    `xml:"DescribeIpamByoasnResponse"`
+		Xmlns   string      `xml:"xmlns,attr"`
+		Req     string      `xml:"requestId"`
+		Set     []byoasnXML `xml:"byoasnSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) associateIpamByoasn(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoasn) {
+	out, err := ip.AssociateIpamByoasn(r.Context(), r.Form.Get("Asn"), r.Form.Get("Cidr"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeAsnAssociation(w, "AssociateIpamByoasnResponse", out)
+}
+
+func (*Handler) disassociateIpamByoasn(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoasn) {
+	out, err := ip.DisassociateIpamByoasn(r.Context(), r.Form.Get("Asn"), r.Form.Get("Cidr"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeAsnAssociation(w, "DisassociateIpamByoasnResponse", out)
+}
+
+func writeByoasn(w http.ResponseWriter, root string, out *netdriver.Byoasn) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name  `xml:""`
+		Xmlns   string    `xml:"xmlns,attr"`
+		Req     string    `xml:"requestId"`
+		Byoasn  byoasnXML `xml:"byoasn"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Byoasn: byoasnXML{
+		Asn: out.Asn, IpamID: out.IpamID, State: out.State, StatusMessage: out.StatusMessage,
+	}})
+}
+
+func writeAsnAssociation(w http.ResponseWriter, root string, out *netdriver.AsnAssociation) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name          `xml:""`
+		Xmlns   string            `xml:"xmlns,attr"`
+		Req     string            `xml:"requestId"`
+		Assoc   asnAssociationXML `xml:"asnAssociation"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Assoc: asnAssociationXML{
+		Asn: out.Asn, Cidr: out.CIDR, State: out.State, StatusMessage: out.StatusMessage,
+	}})
+}
+
+func (*Handler) provisionByoipCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoip) {
+	out, err := ip.ProvisionByoipCidr(r.Context(), r.Form.Get("Cidr"), r.Form.Get("Description"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoipCidr(w, "ProvisionByoipCidrResponse", out)
+}
+
+func (*Handler) deprovisionByoipCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoip) {
+	out, err := ip.DeprovisionByoipCidr(r.Context(), r.Form.Get("Cidr"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoipCidr(w, "DeprovisionByoipCidrResponse", out)
+}
+
+func (*Handler) moveByoipCidrToIpam(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoip) {
+	out, err := ip.MoveByoipCidrToIpam(r.Context(), r.Form.Get("Cidr"), r.Form.Get("IpamPoolId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoipCidr(w, "MoveByoipCidrToIpamResponse", out)
+}
+
+func (*Handler) describeByoipCidrs(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoip) {
+	items, err := ip.DescribeByoipCidrs(r.Context())
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]byoipCidrXML, 0, len(items))
+	for i := range items {
+		out = append(out, toByoipCidrXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name       `xml:"DescribeByoipCidrsResponse"`
+		Xmlns   string         `xml:"xmlns,attr"`
+		Req     string         `xml:"requestId"`
+		Set     []byoipCidrXML `xml:"byoipCidrSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) advertiseByoipCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoip) {
+	out, err := ip.AdvertiseByoipCidr(r.Context(), r.Form.Get("Cidr"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoipCidr(w, "AdvertiseByoipCidrResponse", out)
+}
+
+func (*Handler) withdrawByoipCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMByoip) {
+	out, err := ip.WithdrawByoipCidr(r.Context(), r.Form.Get("Cidr"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeByoipCidr(w, "WithdrawByoipCidrResponse", out)
+}
+
+func writeByoipCidr(w http.ResponseWriter, root string, out *netdriver.ByoipCidr) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name     `xml:""`
+		Xmlns   string       `xml:"xmlns,attr"`
+		Req     string       `xml:"requestId"`
+		Cidr    byoipCidrXML `xml:"byoipCidr"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Cidr: toByoipCidrXML(out)})
+}
+
+func toByoipCidrXML(bc *netdriver.ByoipCidr) byoipCidrXML {
+	x := byoipCidrXML{
+		Cidr: bc.CIDR, Description: bc.Description, State: bc.State, StatusMessage: bc.StatusMessage,
+		NetworkBorderGroup: bc.NetworkBorderGroup, AdvertisementType: bc.AdvertisementType,
+	}
+
+	for _, a := range bc.AsnAssociations {
+		x.AsnAssociations = append(x.AsnAssociations, asnAssociationXML{Asn: a.Asn, Cidr: a.CIDR, State: a.State, StatusMessage: a.StatusMessage})
+	}
+
+	return x
+}

--- a/server/aws/ec2/ipam_discovery.go
+++ b/server/aws/ec2/ipam_discovery.go
@@ -1,0 +1,317 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) ipamDiscovery() (netdriver.IPAMDiscovery, bool) {
+	i, ok := h.vpc.(netdriver.IPAMDiscovery)
+
+	return i, ok
+}
+
+type ipamRDXML struct {
+	IpamResourceDiscoveryID     string     `xml:"ipamResourceDiscoveryId"`
+	IpamResourceDiscoveryArn    string     `xml:"ipamResourceDiscoveryArn"`
+	IpamResourceDiscoveryRegion string     `xml:"ipamResourceDiscoveryRegion,omitempty"`
+	OwnerID                     string     `xml:"ownerId,omitempty"`
+	OperatingRegions            []opRegXML `xml:"operatingRegionSet>item,omitempty"`
+	Description                 string     `xml:"description,omitempty"`
+	IsDefault                   bool       `xml:"isDefault"`
+	State                       string     `xml:"state"`
+	Tags                        []tagItem  `xml:"tagSet>item,omitempty"`
+}
+
+type ipamRDAssocXML struct {
+	IpamResourceDiscoveryAssociationID  string    `xml:"ipamResourceDiscoveryAssociationId"`
+	IpamResourceDiscoveryAssociationArn string    `xml:"ipamResourceDiscoveryAssociationArn"`
+	IpamID                              string    `xml:"ipamId"`
+	IpamArn                             string    `xml:"ipamArn,omitempty"`
+	IpamRegion                          string    `xml:"ipamRegion,omitempty"`
+	IpamResourceDiscoveryID             string    `xml:"ipamResourceDiscoveryId"`
+	OwnerID                             string    `xml:"ownerId,omitempty"`
+	IsDefault                           bool      `xml:"isDefault"`
+	ResourceDiscoveryStatus             string    `xml:"resourceDiscoveryStatus,omitempty"`
+	State                               string    `xml:"state"`
+	Tags                                []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+//nolint:gocyclo // flat action dispatch table
+func (h *Handler) routeIPAMDiscovery(w http.ResponseWriter, r *http.Request, action string) bool {
+	ip, ok := h.ipamDiscovery()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateIpamResourceDiscovery":
+		h.createIpamRD(w, r, ip)
+	case "DescribeIpamResourceDiscoveries":
+		h.describeIpamRDs(w, r, ip)
+	case "ModifyIpamResourceDiscovery":
+		h.modifyIpamRD(w, r, ip)
+	case "DeleteIpamResourceDiscovery":
+		h.deleteIpamRD(w, r, ip)
+	case "AssociateIpamResourceDiscovery":
+		h.associateIpamRD(w, r, ip)
+	case "DisassociateIpamResourceDiscovery":
+		h.disassociateIpamRD(w, r, ip)
+	case "DescribeIpamResourceDiscoveryAssociations":
+		h.describeIpamRDAssocs(w, r, ip)
+	case "GetIpamDiscoveredAccounts":
+		h.getIpamDiscoveredAccounts(w, r, ip)
+	case "GetIpamDiscoveredResourceCidrs":
+		h.getIpamDiscoveredResourceCidrs(w, r, ip)
+	case "GetIpamDiscoveredPublicAddresses":
+		h.getIpamDiscoveredPublicAddresses(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (*Handler) createIpamRD(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	out, err := ip.CreateIpamResourceDiscovery(r.Context(), netdriver.IpamResourceDiscoveryConfig{
+		Description: r.Form.Get("Description"),
+		Tags:        mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-resource-discovery"),
+	})
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamRD(w, "CreateIpamResourceDiscoveryResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamRDs(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	items, err := ip.DescribeIpamResourceDiscoveries(r.Context(), awsquery.ListStrings(r.Form, "IpamResourceDiscoveryId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamRDXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamRDXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name    `xml:"DescribeIpamResourceDiscoveriesResponse"`
+		Xmlns   string      `xml:"xmlns,attr"`
+		Req     string      `xml:"requestId"`
+		Set     []ipamRDXML `xml:"ipamResourceDiscoverySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamRD(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	out, err := ip.ModifyIpamResourceDiscovery(r.Context(),
+		r.Form.Get("IpamResourceDiscoveryId"), r.Form.Get("Description"), awsquery.ListStrings(r.Form, "AddOperatingRegion"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamRD(w, "ModifyIpamResourceDiscoveryResponse", out)
+}
+
+func (*Handler) deleteIpamRD(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	out, err := ip.DeleteIpamResourceDiscovery(r.Context(), r.Form.Get("IpamResourceDiscoveryId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamRD(w, "DeleteIpamResourceDiscoveryResponse", out)
+}
+
+func writeIpamRD(w http.ResponseWriter, root string, out *netdriver.IpamResourceDiscovery) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name  `xml:""`
+		Xmlns   string    `xml:"xmlns,attr"`
+		Req     string    `xml:"requestId"`
+		RD      ipamRDXML `xml:"ipamResourceDiscovery"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, RD: toIpamRDXML(out)})
+}
+
+func toIpamRDXML(rd *netdriver.IpamResourceDiscovery) ipamRDXML {
+	x := ipamRDXML{
+		IpamResourceDiscoveryID: rd.ID, IpamResourceDiscoveryArn: rd.ARN, IpamResourceDiscoveryRegion: rd.Region,
+		OwnerID: rd.OwnerID, Description: rd.Description, IsDefault: rd.IsDefault, State: rd.State,
+		Tags: toTagItems(rd.Tags),
+	}
+
+	for _, reg := range rd.OperatingRegions {
+		x.OperatingRegions = append(x.OperatingRegions, opRegXML{RegionName: reg})
+	}
+
+	return x
+}
+
+func (*Handler) associateIpamRD(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	out, err := ip.AssociateIpamResourceDiscovery(r.Context(),
+		r.Form.Get("IpamId"), r.Form.Get("IpamResourceDiscoveryId"),
+		mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-resource-discovery-association"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamRDAssoc(w, "AssociateIpamResourceDiscoveryResponse", out)
+}
+
+func (*Handler) disassociateIpamRD(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	out, err := ip.DisassociateIpamResourceDiscovery(r.Context(), r.Form.Get("IpamResourceDiscoveryAssociationId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamRDAssoc(w, "DisassociateIpamResourceDiscoveryResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamRDAssocs(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	items, err := ip.DescribeIpamResourceDiscoveryAssociations(r.Context(), awsquery.ListStrings(r.Form, "IpamResourceDiscoveryAssociationId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamRDAssocXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamRDAssocXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name         `xml:"DescribeIpamResourceDiscoveryAssociationsResponse"`
+		Xmlns   string           `xml:"xmlns,attr"`
+		Req     string           `xml:"requestId"`
+		Set     []ipamRDAssocXML `xml:"ipamResourceDiscoveryAssociationSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func writeIpamRDAssoc(w http.ResponseWriter, root string, out *netdriver.IpamResourceDiscoveryAssociation) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name       `xml:""`
+		Xmlns   string         `xml:"xmlns,attr"`
+		Req     string         `xml:"requestId"`
+		Assoc   ipamRDAssocXML `xml:"ipamResourceDiscoveryAssociation"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Assoc: toIpamRDAssocXML(out)})
+}
+
+func toIpamRDAssocXML(a *netdriver.IpamResourceDiscoveryAssociation) ipamRDAssocXML {
+	return ipamRDAssocXML{
+		IpamResourceDiscoveryAssociationID: a.ID, IpamResourceDiscoveryAssociationArn: a.ARN,
+		IpamID: a.IpamID, IpamArn: a.IpamARN, IpamRegion: a.IpamRegion, IpamResourceDiscoveryID: a.ResourceDiscoveryID,
+		OwnerID: a.OwnerID, IsDefault: a.IsDefault, ResourceDiscoveryStatus: a.ResourceDiscoveryStatus, State: a.State,
+		Tags: toTagItems(a.Tags),
+	}
+}
+
+func (*Handler) getIpamDiscoveredAccounts(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	items, err := ip.GetIpamDiscoveredAccounts(r.Context(), r.Form.Get("IpamResourceDiscoveryId"), r.Form.Get("DiscoveryRegion"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type accXML struct {
+		AccountID       string `xml:"accountId"`
+		DiscoveryRegion string `xml:"discoveryRegion"`
+	}
+
+	out := make([]accXML, 0, len(items))
+	for i := range items {
+		out = append(out, accXML{AccountID: items[i].AccountID, DiscoveryRegion: items[i].DiscoveryRegion})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:"GetIpamDiscoveredAccountsResponse"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Set     []accXML `xml:"ipamDiscoveredAccountSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) getIpamDiscoveredResourceCidrs(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	items, err := ip.GetIpamDiscoveredResourceCidrs(r.Context(), r.Form.Get("IpamResourceDiscoveryId"), r.Form.Get("ResourceRegion"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type drcXML struct {
+		IpamResourceDiscoveryID string  `xml:"ipamResourceDiscoveryId"`
+		ResourceCidr            string  `xml:"resourceCidr"`
+		ResourceID              string  `xml:"resourceId"`
+		ResourceType            string  `xml:"resourceType"`
+		ResourceRegion          string  `xml:"resourceRegion,omitempty"`
+		ResourceOwnerID         string  `xml:"resourceOwnerId,omitempty"`
+		VpcID                   string  `xml:"vpcId,omitempty"`
+		IPSource                string  `xml:"ipSource,omitempty"`
+		IPUsage                 float64 `xml:"ipUsage,omitempty"`
+		SampleTime              string  `xml:"sampleTime,omitempty"`
+	}
+
+	out := make([]drcXML, 0, len(items))
+	for i := range items {
+		out = append(out, drcXML{
+			IpamResourceDiscoveryID: items[i].ResourceDiscoveryID, ResourceCidr: items[i].ResourceCIDR,
+			ResourceID: items[i].ResourceID, ResourceType: items[i].ResourceType, ResourceRegion: items[i].ResourceRegion,
+			ResourceOwnerID: items[i].ResourceOwnerID, VpcID: items[i].VPCID, IPSource: items[i].IPSource,
+			IPUsage: items[i].IPUsage, SampleTime: items[i].SampleTime.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:"GetIpamDiscoveredResourceCidrsResponse"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Set     []drcXML `xml:"ipamDiscoveredResourceCidrSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) getIpamDiscoveredPublicAddresses(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMDiscovery) {
+	items, err := ip.GetIpamDiscoveredPublicAddresses(r.Context(), r.Form.Get("IpamResourceDiscoveryId"), r.Form.Get("AddressRegion"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type paXML struct {
+		IpamResourceDiscoveryID string `xml:"ipamResourceDiscoveryId"`
+		Address                 string `xml:"address"`
+		AddressAllocationID     string `xml:"addressAllocationId,omitempty"`
+		AddressOwnerID          string `xml:"addressOwnerId,omitempty"`
+		AddressRegion           string `xml:"addressRegion,omitempty"`
+		AddressType             string `xml:"addressType,omitempty"`
+		AssociationStatus       string `xml:"associationStatus,omitempty"`
+		Service                 string `xml:"service,omitempty"`
+		SampleTime              string `xml:"sampleTime,omitempty"`
+	}
+
+	out := make([]paXML, 0, len(items))
+	for i := range items {
+		out = append(out, paXML{
+			IpamResourceDiscoveryID: items[i].ResourceDiscoveryID, Address: items[i].Address,
+			AddressAllocationID: items[i].AddressAllocationID, AddressOwnerID: items[i].AddressOwnerID,
+			AddressRegion: items[i].AddressRegion, AddressType: items[i].AddressType,
+			AssociationStatus: items[i].AssociationStatus, Service: items[i].Service,
+			SampleTime: items[i].SampleTime.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName      xml.Name `xml:"GetIpamDiscoveredPublicAddressesResponse"`
+		Xmlns        string   `xml:"xmlns,attr"`
+		Req          string   `xml:"requestId"`
+		Set          []paXML  `xml:"ipamDiscoveredPublicAddressSet>item"`
+		OldestSample string   `xml:"oldestSampleTime,omitempty"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}

--- a/server/aws/ec2/ipam_policy.go
+++ b/server/aws/ec2/ipam_policy.go
@@ -2,7 +2,9 @@ package ec2
 
 import (
 	"encoding/xml"
+	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
@@ -148,42 +150,85 @@ func (*Handler) getEnabledIpamPolicy(w http.ResponseWriter, r *http.Request, ip 
 	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, IpamPolicyID: id, IpamPolicyEnabled: enabled, ManagedBy: managedBy})
 }
 
+// allocationRuleXML is one <allocationRuleSet><item>; matches the SDK's
+// IpamPolicyAllocationRule (sourceIpamPoolId only).
+type allocationRuleXML struct {
+	SourceIpamPoolID string `xml:"sourceIpamPoolId,omitempty"`
+}
+
+// ipamPolicyDocumentXML matches types.IpamPolicyDocument: an allocationRuleSet
+// plus the ipamPolicyId/locale/resourceType the rules are scoped to.
+type ipamPolicyDocumentXML struct {
+	IpamPolicyID   string              `xml:"ipamPolicyId,omitempty"`
+	Locale         string              `xml:"locale,omitempty"`
+	ResourceType   string              `xml:"resourceType,omitempty"`
+	AllocationRule []allocationRuleXML `xml:"allocationRuleSet>item,omitempty"`
+}
+
+// parseAllocationRules reads the request's flattened AllocationRule.N list.
+func parseAllocationRules(form url.Values) []netdriver.IpamAllocationRule {
+	idx := awsquery.CollectIndices(form, "AllocationRule")
+	rules := make([]netdriver.IpamAllocationRule, 0, len(idx))
+
+	for _, i := range idx {
+		pool := form.Get(fmt.Sprintf("AllocationRule.%d.SourceIpamPoolId", i))
+		rules = append(rules, netdriver.IpamAllocationRule{SourceIpamPoolID: pool})
+	}
+
+	return rules
+}
+
+func toIpamPolicyDocumentXML(p *netdriver.IpamPolicy) ipamPolicyDocumentXML {
+	doc := ipamPolicyDocumentXML{
+		IpamPolicyID: p.ID,
+		Locale:       p.Locale,
+		ResourceType: p.ResourceType,
+	}
+
+	for _, rule := range p.AllocationRules {
+		doc.AllocationRule = append(doc.AllocationRule, allocationRuleXML{SourceIpamPoolID: rule.SourceIpamPoolID})
+	}
+
+	return doc
+}
+
 func (*Handler) modifyIpamPolicyAllocationRules(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
-	err := ip.ModifyIpamPolicyAllocationRules(r.Context(), r.Form.Get("IpamPolicyId"), awsquery.ListStrings(r.Form, "AddAllocationRule"))
+	out, err := ip.ModifyIpamPolicyAllocationRules(r.Context(),
+		r.Form.Get("IpamPolicyId"), r.Form.Get("Locale"), r.Form.Get("ResourceType"),
+		parseAllocationRules(r.Form))
 	if err != nil {
 		writeIPAMErr(w, err)
 		return
 	}
 
-	writeReturnTrue(w, "ModifyIpamPolicyAllocationRulesResponse")
-}
-
-//nolint:dupl // parallel single-field list marshaling
-func (*Handler) getIpamPolicyAllocationRules(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
-	rules, err := ip.GetIpamPolicyAllocationRules(r.Context(), r.Form.Get("IpamPolicyId"))
-	if err != nil {
-		writeIPAMErr(w, err)
-		return
-	}
-
-	type docXML struct {
-		Document string `xml:"document"`
-	}
-
-	out := make([]docXML, 0, len(rules))
-	for _, d := range rules {
-		out = append(out, docXML{Document: d})
-	}
-
+	// The SDK output carries IpamPolicyDocument (element ipamPolicyDocument),
+	// not a Return field — emit the modified document so the caller sees it.
 	awsquery.WriteXMLResponse(w, struct {
-		XMLName xml.Name `xml:"GetIpamPolicyAllocationRulesResponse"`
-		Xmlns   string   `xml:"xmlns,attr"`
-		Req     string   `xml:"requestId"`
-		Set     []docXML `xml:"ipamPolicyDocumentSet>item"`
-	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+		XMLName  xml.Name              `xml:"ModifyIpamPolicyAllocationRulesResponse"`
+		Xmlns    string                `xml:"xmlns,attr"`
+		Req      string                `xml:"requestId"`
+		Document ipamPolicyDocumentXML `xml:"ipamPolicyDocument"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Document: toIpamPolicyDocumentXML(out)})
 }
 
-//nolint:dupl // parallel single-field list marshaling
+func (*Handler) getIpamPolicyAllocationRules(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	p, err := ip.GetIpamPolicyAllocationRules(r.Context(), r.Form.Get("IpamPolicyId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	// Output is IpamPolicyDocuments []IpamPolicyDocument + NextToken. The
+	// emulator models one document (the policy's rules) per policy.
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName   xml.Name                `xml:"GetIpamPolicyAllocationRulesResponse"`
+		Xmlns     string                  `xml:"xmlns,attr"`
+		Req       string                  `xml:"requestId"`
+		Set       []ipamPolicyDocumentXML `xml:"ipamPolicyDocumentSet>item"`
+		NextToken string                  `xml:"nextToken,omitempty"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: []ipamPolicyDocumentXML{toIpamPolicyDocumentXML(p)}})
+}
+
 func (*Handler) getIpamPolicyOrganizationTargets(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
 	targets, err := ip.GetIpamPolicyOrganizationTargets(r.Context(), r.Form.Get("IpamPolicyId"))
 	if err != nil {

--- a/server/aws/ec2/ipam_policy.go
+++ b/server/aws/ec2/ipam_policy.go
@@ -1,0 +1,254 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) ipamPolicy() (netdriver.IPAMPolicy, bool) {
+	i, ok := h.vpc.(netdriver.IPAMPolicy)
+
+	return i, ok
+}
+
+type ipamPolicyXML struct {
+	IpamPolicyID  string    `xml:"ipamPolicyId"`
+	IpamPolicyArn string    `xml:"ipamPolicyArn"`
+	IpamID        string    `xml:"ipamId,omitempty"`
+	IpamRegion    string    `xml:"ipamPolicyRegion,omitempty"`
+	OwnerID       string    `xml:"ownerId,omitempty"`
+	State         string    `xml:"state"`
+	Tags          []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+//nolint:gocyclo,dupl // flat action dispatch table
+func (h *Handler) routeIPAMPolicy(w http.ResponseWriter, r *http.Request, action string) bool {
+	ip, ok := h.ipamPolicy()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateIpamPolicy":
+		h.createIpamPolicy(w, r, ip)
+	case "DeleteIpamPolicy":
+		h.deleteIpamPolicy(w, r, ip)
+	case "DescribeIpamPolicies":
+		h.describeIpamPolicies(w, r, ip)
+	case "EnableIpamPolicy":
+		h.enableIpamPolicy(w, r, ip)
+	case "DisableIpamPolicy":
+		h.disableIpamPolicy(w, r, ip)
+	case "GetEnabledIpamPolicy":
+		h.getEnabledIpamPolicy(w, r, ip)
+	case "ModifyIpamPolicyAllocationRules":
+		h.modifyIpamPolicyAllocationRules(w, r, ip)
+	case "GetIpamPolicyAllocationRules":
+		h.getIpamPolicyAllocationRules(w, r, ip)
+	case "GetIpamPolicyOrganizationTargets":
+		h.getIpamPolicyOrganizationTargets(w, r, ip)
+	case "EnableIpamOrganizationAdminAccount":
+		h.enableIpamOrgAdmin(w, r, ip)
+	case "DisableIpamOrganizationAdminAccount":
+		h.disableIpamOrgAdmin(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (*Handler) createIpamPolicy(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	out, err := ip.CreateIpamPolicy(r.Context(), r.Form.Get("IpamId"), mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-policy"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPolicy(w, "CreateIpamPolicyResponse", out)
+}
+
+func (*Handler) deleteIpamPolicy(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	out, err := ip.DeleteIpamPolicy(r.Context(), r.Form.Get("IpamPolicyId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamPolicy(w, "DeleteIpamPolicyResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamPolicies(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	items, err := ip.DescribeIpamPolicies(r.Context(), awsquery.ListStrings(r.Form, "IpamPolicyId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamPolicyXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamPolicyXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name        `xml:"DescribeIpamPoliciesResponse"`
+		Xmlns   string          `xml:"xmlns,attr"`
+		Req     string          `xml:"requestId"`
+		Set     []ipamPolicyXML `xml:"ipamPolicySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) enableIpamPolicy(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	id, err := ip.EnableIpamPolicy(r.Context(), r.Form.Get("IpamPolicyId"), r.Form.Get("OrganizationTargetId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName      xml.Name `xml:"EnableIpamPolicyResponse"`
+		Xmlns        string   `xml:"xmlns,attr"`
+		Req          string   `xml:"requestId"`
+		IpamPolicyID string   `xml:"ipamPolicyId"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, IpamPolicyID: id})
+}
+
+func (*Handler) disableIpamPolicy(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	if err := ip.DisableIpamPolicy(r.Context(), r.Form.Get("IpamPolicyId")); err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:"DisableIpamPolicyResponse"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Return  bool     `xml:"return"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Return: true})
+}
+
+func (*Handler) getEnabledIpamPolicy(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	id, enabled, managedBy, err := ip.GetEnabledIpamPolicy(r.Context())
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName           xml.Name `xml:"GetEnabledIpamPolicyResponse"`
+		Xmlns             string   `xml:"xmlns,attr"`
+		Req               string   `xml:"requestId"`
+		IpamPolicyID      string   `xml:"ipamPolicyId,omitempty"`
+		IpamPolicyEnabled bool     `xml:"ipamPolicyEnabled"`
+		ManagedBy         string   `xml:"managedBy,omitempty"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, IpamPolicyID: id, IpamPolicyEnabled: enabled, ManagedBy: managedBy})
+}
+
+func (*Handler) modifyIpamPolicyAllocationRules(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	err := ip.ModifyIpamPolicyAllocationRules(r.Context(), r.Form.Get("IpamPolicyId"), awsquery.ListStrings(r.Form, "AddAllocationRule"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeReturnTrue(w, "ModifyIpamPolicyAllocationRulesResponse")
+}
+
+//nolint:dupl // parallel single-field list marshaling
+func (*Handler) getIpamPolicyAllocationRules(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	rules, err := ip.GetIpamPolicyAllocationRules(r.Context(), r.Form.Get("IpamPolicyId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type docXML struct {
+		Document string `xml:"document"`
+	}
+
+	out := make([]docXML, 0, len(rules))
+	for _, d := range rules {
+		out = append(out, docXML{Document: d})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:"GetIpamPolicyAllocationRulesResponse"`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Set     []docXML `xml:"ipamPolicyDocumentSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+//nolint:dupl // parallel single-field list marshaling
+func (*Handler) getIpamPolicyOrganizationTargets(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	targets, err := ip.GetIpamPolicyOrganizationTargets(r.Context(), r.Form.Get("IpamPolicyId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type targetXML struct {
+		OrganizationTargetID string `xml:"organizationTargetId"`
+	}
+
+	out := make([]targetXML, 0, len(targets))
+	for _, t := range targets {
+		out = append(out, targetXML{OrganizationTargetID: t})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name    `xml:"GetIpamPolicyOrganizationTargetsResponse"`
+		Xmlns   string      `xml:"xmlns,attr"`
+		Req     string      `xml:"requestId"`
+		Set     []targetXML `xml:"organizationTargetSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) enableIpamOrgAdmin(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	ok, err := ip.EnableIpamOrganizationAdminAccount(r.Context(), r.Form.Get("DelegatedAdminAccountId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamOrgAdminResult(w, "EnableIpamOrganizationAdminAccountResponse", ok)
+}
+
+func (*Handler) disableIpamOrgAdmin(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPolicy) {
+	ok, err := ip.DisableIpamOrganizationAdminAccount(r.Context(), r.Form.Get("DelegatedAdminAccountId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamOrgAdminResult(w, "DisableIpamOrganizationAdminAccountResponse", ok)
+}
+
+func writeIpamOrgAdminResult(w http.ResponseWriter, root string, success bool) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name `xml:""`
+		Xmlns   string   `xml:"xmlns,attr"`
+		Req     string   `xml:"requestId"`
+		Success bool     `xml:"success"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Success: success})
+}
+
+func writeIpamPolicy(w http.ResponseWriter, root string, out *netdriver.IpamPolicy) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name      `xml:""`
+		Xmlns   string        `xml:"xmlns,attr"`
+		Req     string        `xml:"requestId"`
+		Policy  ipamPolicyXML `xml:"ipamPolicy"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Policy: toIpamPolicyXML(out)})
+}
+
+func toIpamPolicyXML(p *netdriver.IpamPolicy) ipamPolicyXML {
+	return ipamPolicyXML{
+		IpamPolicyID: p.ID, IpamPolicyArn: p.ARN, IpamID: p.IpamID, IpamRegion: p.IpamRegion,
+		OwnerID: p.OwnerID, State: p.State, Tags: toTagItems(p.Tags),
+	}
+}

--- a/server/aws/ec2/ipam_resolver.go
+++ b/server/aws/ec2/ipam_resolver.go
@@ -1,0 +1,404 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) ipamResolver() (netdriver.IPAMPrefixListResolver, bool) {
+	i, ok := h.vpc.(netdriver.IPAMPrefixListResolver)
+
+	return i, ok
+}
+
+func (h *Handler) ipamToken() (netdriver.IPAMExternalToken, bool) {
+	i, ok := h.vpc.(netdriver.IPAMExternalToken)
+
+	return i, ok
+}
+
+type ipamResolverXML struct {
+	IpamPrefixListResolverID  string    `xml:"ipamPrefixListResolverId"`
+	IpamPrefixListResolverArn string    `xml:"ipamPrefixListResolverArn"`
+	IpamID                    string    `xml:"ipamId,omitempty"`
+	IpamArn                   string    `xml:"ipamArn,omitempty"`
+	IpamRegion                string    `xml:"ipamRegion,omitempty"`
+	OwnerID                   string    `xml:"ownerId,omitempty"`
+	AddressFamily             string    `xml:"addressFamily,omitempty"`
+	Description               string    `xml:"description,omitempty"`
+	State                     string    `xml:"state"`
+	LastVersionCreationStatus string    `xml:"lastVersionCreationStatus,omitempty"`
+	Tags                      []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type ipamResolverTargetXML struct {
+	IpamPrefixListResolverTargetID  string    `xml:"ipamPrefixListResolverTargetId"`
+	IpamPrefixListResolverTargetArn string    `xml:"ipamPrefixListResolverTargetArn"`
+	IpamPrefixListResolverID        string    `xml:"ipamPrefixListResolverId"`
+	OwnerID                         string    `xml:"ownerId,omitempty"`
+	PrefixListID                    string    `xml:"prefixListId"`
+	PrefixListRegion                string    `xml:"prefixListRegion,omitempty"`
+	DesiredVersion                  int       `xml:"desiredVersion,omitempty"`
+	LastSyncedVersion               int       `xml:"lastSyncedVersion,omitempty"`
+	TrackLatestVersion              bool      `xml:"trackLatestVersion"`
+	State                           string    `xml:"state"`
+	Tags                            []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+type ipamTokenXML struct {
+	IpamExternalResourceVerificationTokenID  string    `xml:"ipamExternalResourceVerificationTokenId"`
+	IpamExternalResourceVerificationTokenArn string    `xml:"ipamExternalResourceVerificationTokenArn"`
+	IpamID                                   string    `xml:"ipamId,omitempty"`
+	IpamArn                                  string    `xml:"ipamArn,omitempty"`
+	IpamRegion                               string    `xml:"ipamRegion,omitempty"`
+	TokenName                                string    `xml:"tokenName,omitempty"`
+	TokenValue                               string    `xml:"tokenValue,omitempty"`
+	State                                    string    `xml:"state"`
+	Status                                   string    `xml:"status,omitempty"`
+	Tags                                     []tagItem `xml:"tagSet>item,omitempty"`
+}
+
+//nolint:gocyclo // flat action dispatch table
+func (h *Handler) routeIPAMResolver(w http.ResponseWriter, r *http.Request, action string) bool {
+	if h.routeIPAMToken(w, r, action) {
+		return true
+	}
+
+	ip, ok := h.ipamResolver()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateIpamPrefixListResolver":
+		h.createIpamResolver(w, r, ip)
+	case "DescribeIpamPrefixListResolvers":
+		h.describeIpamResolvers(w, r, ip)
+	case "ModifyIpamPrefixListResolver":
+		h.modifyIpamResolver(w, r, ip)
+	case "DeleteIpamPrefixListResolver":
+		h.deleteIpamResolver(w, r, ip)
+	case "CreateIpamPrefixListResolverTarget":
+		h.createIpamResolverTarget(w, r, ip)
+	case "DescribeIpamPrefixListResolverTargets":
+		h.describeIpamResolverTargets(w, r, ip)
+	case "ModifyIpamPrefixListResolverTarget":
+		h.modifyIpamResolverTarget(w, r, ip)
+	case "DeleteIpamPrefixListResolverTarget":
+		h.deleteIpamResolverTarget(w, r, ip)
+	case "GetIpamPrefixListResolverRules":
+		h.getIpamResolverRules(w, r, ip)
+	case "GetIpamPrefixListResolverVersions":
+		h.getIpamResolverVersions(w, r, ip)
+	case "GetIpamPrefixListResolverVersionEntries":
+		h.getIpamResolverVersionEntries(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (h *Handler) routeIPAMToken(w http.ResponseWriter, r *http.Request, action string) bool {
+	ip, ok := h.ipamToken()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "CreateIpamExternalResourceVerificationToken":
+		h.createIpamToken(w, r, ip)
+	case "DeleteIpamExternalResourceVerificationToken":
+		h.deleteIpamToken(w, r, ip)
+	case "DescribeIpamExternalResourceVerificationTokens":
+		h.describeIpamTokens(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (*Handler) createIpamResolver(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	out, err := ip.CreateIpamPrefixListResolver(r.Context(),
+		r.Form.Get("IpamId"), r.Form.Get("AddressFamily"), r.Form.Get("Description"),
+		mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-prefix-list-resolver"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamResolver(w, "CreateIpamPrefixListResolverResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamResolvers(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	items, err := ip.DescribeIpamPrefixListResolvers(r.Context(), awsquery.ListStrings(r.Form, "IpamPrefixListResolverId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamResolverXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamResolverXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name          `xml:"DescribeIpamPrefixListResolversResponse"`
+		Xmlns   string            `xml:"xmlns,attr"`
+		Req     string            `xml:"requestId"`
+		Set     []ipamResolverXML `xml:"ipamPrefixListResolverSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamResolver(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	out, err := ip.ModifyIpamPrefixListResolver(r.Context(), r.Form.Get("IpamPrefixListResolverId"), r.Form.Get("Description"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamResolver(w, "ModifyIpamPrefixListResolverResponse", out)
+}
+
+func (*Handler) deleteIpamResolver(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	out, err := ip.DeleteIpamPrefixListResolver(r.Context(), r.Form.Get("IpamPrefixListResolverId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamResolver(w, "DeleteIpamPrefixListResolverResponse", out)
+}
+
+func writeIpamResolver(w http.ResponseWriter, root string, out *netdriver.IpamPrefixListResolver) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName  xml.Name        `xml:""`
+		Xmlns    string          `xml:"xmlns,attr"`
+		Req      string          `xml:"requestId"`
+		Resolver ipamResolverXML `xml:"ipamPrefixListResolver"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Resolver: toIpamResolverXML(out)})
+}
+
+func toIpamResolverXML(r *netdriver.IpamPrefixListResolver) ipamResolverXML {
+	return ipamResolverXML{
+		IpamPrefixListResolverID: r.ID, IpamPrefixListResolverArn: r.ARN, IpamID: r.IpamID, IpamArn: r.IpamARN,
+		IpamRegion: r.IpamRegion, OwnerID: r.OwnerID, AddressFamily: r.AddressFamily, Description: r.Description,
+		State: r.State, LastVersionCreationStatus: r.LastVersionCreationStatus, Tags: toTagItems(r.Tags),
+	}
+}
+
+func (*Handler) createIpamResolverTarget(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	out, err := ip.CreateIpamPrefixListResolverTarget(r.Context(),
+		r.Form.Get("IpamPrefixListResolverId"), r.Form.Get("PrefixListId"), r.Form.Get("PrefixListRegion"),
+		atoiDefault(r.Form.Get("DesiredVersion")), r.Form.Get("TrackLatestVersion") == formTrue,
+		mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-prefix-list-resolver-target"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamResolverTarget(w, "CreateIpamPrefixListResolverTargetResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamResolverTargets(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	items, err := ip.DescribeIpamPrefixListResolverTargets(r.Context(), awsquery.ListStrings(r.Form, "IpamPrefixListResolverTargetId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamResolverTargetXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamResolverTargetXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name                `xml:"DescribeIpamPrefixListResolverTargetsResponse"`
+		Xmlns   string                  `xml:"xmlns,attr"`
+		Req     string                  `xml:"requestId"`
+		Set     []ipamResolverTargetXML `xml:"ipamPrefixListResolverTargetSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamResolverTarget(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	out, err := ip.ModifyIpamPrefixListResolverTarget(r.Context(),
+		r.Form.Get("IpamPrefixListResolverTargetId"), atoiDefault(r.Form.Get("DesiredVersion")),
+		r.Form.Get("TrackLatestVersion") == formTrue)
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamResolverTarget(w, "ModifyIpamPrefixListResolverTargetResponse", out)
+}
+
+func (*Handler) deleteIpamResolverTarget(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	out, err := ip.DeleteIpamPrefixListResolverTarget(r.Context(), r.Form.Get("IpamPrefixListResolverTargetId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamResolverTarget(w, "DeleteIpamPrefixListResolverTargetResponse", out)
+}
+
+func writeIpamResolverTarget(w http.ResponseWriter, root string, out *netdriver.IpamPrefixListResolverTarget) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name              `xml:""`
+		Xmlns   string                `xml:"xmlns,attr"`
+		Req     string                `xml:"requestId"`
+		Target  ipamResolverTargetXML `xml:"ipamPrefixListResolverTarget"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Target: toIpamResolverTargetXML(out)})
+}
+
+func toIpamResolverTargetXML(t *netdriver.IpamPrefixListResolverTarget) ipamResolverTargetXML {
+	return ipamResolverTargetXML{
+		IpamPrefixListResolverTargetID: t.ID, IpamPrefixListResolverTargetArn: t.ARN, IpamPrefixListResolverID: t.ResolverID,
+		OwnerID: t.OwnerID, PrefixListID: t.PrefixListID, PrefixListRegion: t.PrefixListRegion,
+		DesiredVersion: t.DesiredVersion, LastSyncedVersion: t.LastSyncedVersion, TrackLatestVersion: t.TrackLatestVersion,
+		State: t.State, Tags: toTagItems(t.Tags),
+	}
+}
+
+func (*Handler) getIpamResolverRules(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	items, err := ip.GetIpamPrefixListResolverRules(r.Context(), r.Form.Get("IpamPrefixListResolverId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type ruleXML struct {
+		IpamPoolID string `xml:"ipamPoolId,omitempty"`
+		Cidr       string `xml:"cidr,omitempty"`
+	}
+
+	out := make([]ruleXML, 0, len(items))
+	for i := range items {
+		out = append(out, ruleXML{IpamPoolID: items[i].IpamPoolID, Cidr: items[i].Cidr})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name  `xml:"GetIpamPrefixListResolverRulesResponse"`
+		Xmlns   string    `xml:"xmlns,attr"`
+		Req     string    `xml:"requestId"`
+		Set     []ruleXML `xml:"ruleSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) getIpamResolverVersions(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	items, err := ip.GetIpamPrefixListResolverVersions(r.Context(), r.Form.Get("IpamPrefixListResolverId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type versionXML struct {
+		Version int `xml:"version"`
+	}
+
+	out := make([]versionXML, 0, len(items))
+	for i := range items {
+		out = append(out, versionXML{Version: items[i].Version})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name     `xml:"GetIpamPrefixListResolverVersionsResponse"`
+		Xmlns   string       `xml:"xmlns,attr"`
+		Req     string       `xml:"requestId"`
+		Set     []versionXML `xml:"ipamPrefixListResolverVersionSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) getIpamResolverVersionEntries(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMPrefixListResolver) {
+	entries, err := ip.GetIpamPrefixListResolverVersionEntries(r.Context(),
+		r.Form.Get("IpamPrefixListResolverId"), atoiDefault(r.Form.Get("Version")))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	type entryXML struct {
+		Cidr        string `xml:"cidr"`
+		Description string `xml:"description,omitempty"`
+	}
+
+	out := make([]entryXML, 0, len(entries))
+	for i := range entries {
+		out = append(out, entryXML{Cidr: entries[i].CIDR, Description: entries[i].Description})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name   `xml:"GetIpamPrefixListResolverVersionEntriesResponse"`
+		Xmlns   string     `xml:"xmlns,attr"`
+		Req     string     `xml:"requestId"`
+		Set     []entryXML `xml:"entrySet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) createIpamToken(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMExternalToken) {
+	out, err := ip.CreateIpamExternalResourceVerificationToken(r.Context(),
+		r.Form.Get("IpamId"), r.Form.Get("TokenName"),
+		mergeTagSpecs(awsquery.TagSpecs(r.Form), "ipam-external-resource-verification-token"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamToken(w, "CreateIpamExternalResourceVerificationTokenResponse", out)
+}
+
+func (*Handler) deleteIpamToken(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMExternalToken) {
+	out, err := ip.DeleteIpamExternalResourceVerificationToken(r.Context(), r.Form.Get("IpamExternalResourceVerificationTokenId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	writeIpamToken(w, "DeleteIpamExternalResourceVerificationTokenResponse", out)
+}
+
+//nolint:dupl // parallel per-resource marshaling
+func (*Handler) describeIpamTokens(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMExternalToken) {
+	items, err := ip.DescribeIpamExternalResourceVerificationTokens(
+		r.Context(), awsquery.ListStrings(r.Form, "IpamExternalResourceVerificationTokenId"),
+	)
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamTokenXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamTokenXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name       `xml:"DescribeIpamExternalResourceVerificationTokensResponse"`
+		Xmlns   string         `xml:"xmlns,attr"`
+		Req     string         `xml:"requestId"`
+		Set     []ipamTokenXML `xml:"ipamExternalResourceVerificationTokenSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func writeIpamToken(w http.ResponseWriter, root string, out *netdriver.IpamExternalResourceVerificationToken) {
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name     `xml:""`
+		Xmlns   string       `xml:"xmlns,attr"`
+		Req     string       `xml:"requestId"`
+		Token   ipamTokenXML `xml:"ipamExternalResourceVerificationToken"`
+	}{XMLName: xml.Name{Local: root}, Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Token: toIpamTokenXML(out)})
+}
+
+func toIpamTokenXML(t *netdriver.IpamExternalResourceVerificationToken) ipamTokenXML {
+	return ipamTokenXML{
+		IpamExternalResourceVerificationTokenID: t.ID, IpamExternalResourceVerificationTokenArn: t.ARN,
+		IpamID: t.IpamID, IpamArn: t.IpamARN, IpamRegion: t.IpamRegion, TokenName: t.TokenName,
+		TokenValue: t.TokenValue, State: t.State, Status: t.Status, Tags: toTagItems(t.Tags),
+	}
+}

--- a/server/aws/ec2/ipam_resources.go
+++ b/server/aws/ec2/ipam_resources.go
@@ -1,0 +1,143 @@
+package ec2
+
+import (
+	"encoding/xml"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+)
+
+func (h *Handler) ipamResources() (netdriver.IPAMResources, bool) {
+	i, ok := h.vpc.(netdriver.IPAMResources)
+
+	return i, ok
+}
+
+type ipamResourceCidrXML struct {
+	IpamID           string    `xml:"ipamId,omitempty"`
+	IpamScopeID      string    `xml:"ipamScopeId,omitempty"`
+	IpamPoolID       string    `xml:"ipamPoolId,omitempty"`
+	ResourceCidr     string    `xml:"resourceCidr"`
+	ResourceID       string    `xml:"resourceId"`
+	ResourceName     string    `xml:"resourceName,omitempty"`
+	ResourceType     string    `xml:"resourceType"`
+	ResourceRegion   string    `xml:"resourceRegion,omitempty"`
+	ResourceOwnerID  string    `xml:"resourceOwnerId,omitempty"`
+	VpcID            string    `xml:"vpcId,omitempty"`
+	AvailabilityZone string    `xml:"availabilityZoneId,omitempty"`
+	ComplianceStatus string    `xml:"complianceStatus,omitempty"`
+	ManagementState  string    `xml:"managementState,omitempty"`
+	OverlapStatus    string    `xml:"overlapStatus,omitempty"`
+	IPUsage          float64   `xml:"ipUsage,omitempty"`
+	Tags             []tagItem `xml:"resourceTagSet>item,omitempty"`
+}
+
+type ipamHistoryRecordXML struct {
+	ResourceCidr             string `xml:"resourceCidr"`
+	ResourceID               string `xml:"resourceId"`
+	ResourceType             string `xml:"resourceType"`
+	ResourceRegion           string `xml:"resourceRegion,omitempty"`
+	ResourceOwnerID          string `xml:"resourceOwnerId,omitempty"`
+	VpcID                    string `xml:"vpcId,omitempty"`
+	ResourceComplianceStatus string `xml:"resourceComplianceStatus,omitempty"`
+	ResourceOverlapStatus    string `xml:"resourceOverlapStatus,omitempty"`
+	SampledStartTime         string `xml:"sampledStartTime,omitempty"`
+	SampledEndTime           string `xml:"sampledEndTime,omitempty"`
+}
+
+func (h *Handler) routeIPAMResources(w http.ResponseWriter, r *http.Request, action string) bool {
+	ip, ok := h.ipamResources()
+	if !ok {
+		return false
+	}
+
+	switch action {
+	case "GetIpamResourceCidrs":
+		h.getIpamResourceCidrs(w, r, ip)
+	case "ModifyIpamResourceCidr":
+		h.modifyIpamResourceCidr(w, r, ip)
+	case "GetIpamAddressHistory":
+		h.getIpamAddressHistory(w, r, ip)
+	default:
+		return false
+	}
+
+	return true
+}
+
+func (*Handler) getIpamResourceCidrs(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMResources) {
+	items, err := ip.GetIpamResourceCidrs(r.Context(), r.Form.Get("IpamScopeId"), r.Form.Get("ResourceId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamResourceCidrXML, 0, len(items))
+	for i := range items {
+		out = append(out, toIpamResourceCidrXML(&items[i]))
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name              `xml:"GetIpamResourceCidrsResponse"`
+		Xmlns   string                `xml:"xmlns,attr"`
+		Req     string                `xml:"requestId"`
+		Set     []ipamResourceCidrXML `xml:"ipamResourceCidrSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func (*Handler) modifyIpamResourceCidr(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMResources) {
+	out, err := ip.ModifyIpamResourceCidr(r.Context(),
+		r.Form.Get("ResourceId"), r.Form.Get("CurrentIpamScopeId"), r.Form.Get("DestinationIpamScopeId"),
+		r.Form.Get("Monitored") == formTrue)
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	x := toIpamResourceCidrXML(out)
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name            `xml:"ModifyIpamResourceCidrResponse"`
+		Xmlns   string              `xml:"xmlns,attr"`
+		Req     string              `xml:"requestId"`
+		Cidr    ipamResourceCidrXML `xml:"ipamResourceCidr"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Cidr: x})
+}
+
+func (*Handler) getIpamAddressHistory(w http.ResponseWriter, r *http.Request, ip netdriver.IPAMResources) {
+	items, err := ip.GetIpamAddressHistory(r.Context(), r.Form.Get("Cidr"), r.Form.Get("IpamScopeId"))
+	if err != nil {
+		writeIPAMErr(w, err)
+		return
+	}
+
+	out := make([]ipamHistoryRecordXML, 0, len(items))
+	for i := range items {
+		out = append(out, ipamHistoryRecordXML{
+			ResourceCidr: items[i].ResourceCIDR, ResourceID: items[i].ResourceID, ResourceType: items[i].ResourceType,
+			ResourceRegion: items[i].ResourceRegion, ResourceOwnerID: items[i].ResourceOwnerID, VpcID: items[i].VPCID,
+			ResourceComplianceStatus: items[i].ResourceComplianceStatus, ResourceOverlapStatus: items[i].ResourceOverlapStatus,
+			SampledStartTime: items[i].SampledStartTime.Format("2006-01-02T15:04:05Z"),
+			SampledEndTime:   items[i].SampledEndTime.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	awsquery.WriteXMLResponse(w, struct {
+		XMLName xml.Name               `xml:"GetIpamAddressHistoryResponse"`
+		Xmlns   string                 `xml:"xmlns,attr"`
+		Req     string                 `xml:"requestId"`
+		Set     []ipamHistoryRecordXML `xml:"historyRecordSet>item"`
+	}{Xmlns: awsquery.Namespace, Req: awsquery.RequestID, Set: out})
+}
+
+func toIpamResourceCidrXML(c *netdriver.IpamResourceCidr) ipamResourceCidrXML {
+	return ipamResourceCidrXML{
+		IpamID: c.IpamID, IpamScopeID: c.IpamScopeID, IpamPoolID: c.IpamPoolID,
+		ResourceCidr: c.ResourceCIDR, ResourceID: c.ResourceID, ResourceName: c.ResourceName,
+		ResourceType: c.ResourceType, ResourceRegion: c.ResourceRegion, ResourceOwnerID: c.ResourceOwnerID,
+		VpcID: c.VPCID, AvailabilityZone: c.AvailabilityZone, ComplianceStatus: c.ComplianceStatus,
+		ManagementState: c.ManagementState, OverlapStatus: c.OverlapStatus, IPUsage: c.IPUsage,
+		Tags: toTagItems(c.Tags),
+	}
+}

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -266,3 +266,92 @@ func TestEC2NetworkingParitySDK(t *testing.T) {
 		assert.Equal(t, "0.0.0.0/0", aws.ToString(vpnRoutes.Routes[0].DestinationCidr))
 	})
 }
+
+// TestEC2IPAMParitySDK drives the real aws-sdk-go-v2 EC2 client across the
+// IPAM core lifecycle (IPAM + scopes + pools + provisioned CIDRs + allocations),
+// proving the query-protocol XML round-trips.
+func TestEC2IPAMParitySDK(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	ipam, err := client.CreateIpam(ctx, &ec2.CreateIpamInput{Description: aws.String("corp")})
+	require.NoError(t, err)
+	require.NotNil(t, ipam.Ipam)
+	ipamID := aws.ToString(ipam.Ipam.IpamId)
+	assert.NotEmpty(t, ipamID)
+	// Creating an IPAM implicitly creates a public + private default scope.
+	privScopeID := aws.ToString(ipam.Ipam.PrivateDefaultScopeId)
+	assert.NotEmpty(t, aws.ToString(ipam.Ipam.PublicDefaultScopeId))
+	assert.NotEmpty(t, privScopeID)
+	assert.EqualValues(t, 2, aws.ToInt32(ipam.Ipam.ScopeCount))
+
+	desc, err := client.DescribeIpams(ctx, &ec2.DescribeIpamsInput{IpamIds: []string{ipamID}})
+	require.NoError(t, err)
+	require.Len(t, desc.Ipams, 1)
+
+	scope, err := client.CreateIpamScope(ctx, &ec2.CreateIpamScopeInput{
+		IpamId: aws.String(ipamID), Description: aws.String("extra"),
+	})
+	require.NoError(t, err)
+	assert.False(t, aws.ToBool(scope.IpamScope.IsDefault))
+
+	pool, err := client.CreateIpamPool(ctx, &ec2.CreateIpamPoolInput{
+		IpamScopeId:   aws.String(privScopeID),
+		AddressFamily: ec2types.AddressFamilyIpv4,
+		Locale:        aws.String("us-east-1"),
+	})
+	require.NoError(t, err)
+	poolID := aws.ToString(pool.IpamPool.IpamPoolId)
+	assert.NotEmpty(t, poolID)
+	assert.Equal(t, ec2types.AddressFamilyIpv4, pool.IpamPool.AddressFamily)
+
+	// Provision supply into the pool, then read it back.
+	_, err = client.ProvisionIpamPoolCidr(ctx, &ec2.ProvisionIpamPoolCidrInput{
+		IpamPoolId: aws.String(poolID), Cidr: aws.String("10.0.0.0/16"),
+	})
+	require.NoError(t, err)
+
+	cidrs, err := client.GetIpamPoolCidrs(ctx, &ec2.GetIpamPoolCidrsInput{IpamPoolId: aws.String(poolID)})
+	require.NoError(t, err)
+	require.Len(t, cidrs.IpamPoolCidrs, 1)
+	assert.Equal(t, "10.0.0.0/16", aws.ToString(cidrs.IpamPoolCidrs[0].Cidr))
+
+	// Allocate a CIDR out of the pool, then read + release it.
+	alloc, err := client.AllocateIpamPoolCidr(ctx, &ec2.AllocateIpamPoolCidrInput{
+		IpamPoolId: aws.String(poolID), Cidr: aws.String("10.0.1.0/24"),
+	})
+	require.NoError(t, err)
+	allocID := aws.ToString(alloc.IpamPoolAllocation.IpamPoolAllocationId)
+	assert.NotEmpty(t, allocID)
+
+	allocs, err := client.GetIpamPoolAllocations(ctx, &ec2.GetIpamPoolAllocationsInput{IpamPoolId: aws.String(poolID)})
+	require.NoError(t, err)
+	require.Len(t, allocs.IpamPoolAllocations, 1)
+	assert.Equal(t, "10.0.1.0/24", aws.ToString(allocs.IpamPoolAllocations[0].Cidr))
+
+	rel, err := client.ReleaseIpamPoolAllocation(ctx, &ec2.ReleaseIpamPoolAllocationInput{
+		IpamPoolId: aws.String(poolID), IpamPoolAllocationId: aws.String(allocID), Cidr: aws.String("10.0.1.0/24"),
+	})
+	require.NoError(t, err)
+	assert.True(t, aws.ToBool(rel.Success))
+
+	// Teardown in dependency order: pool (deprovision first) → scope → ipam.
+	_, err = client.DeprovisionIpamPoolCidr(ctx, &ec2.DeprovisionIpamPoolCidrInput{
+		IpamPoolId: aws.String(poolID), Cidr: aws.String("10.0.0.0/16"),
+	})
+	require.NoError(t, err)
+
+	_, err = client.DeleteIpamPool(ctx, &ec2.DeleteIpamPoolInput{IpamPoolId: aws.String(poolID)})
+	require.NoError(t, err)
+
+	_, err = client.DeleteIpamScope(ctx, &ec2.DeleteIpamScopeInput{IpamScopeId: scope.IpamScope.IpamScopeId})
+	require.NoError(t, err)
+
+	_, err = client.DeleteIpam(ctx, &ec2.DeleteIpamInput{IpamId: aws.String(ipamID)})
+	require.NoError(t, err)
+
+	// Error path: describing a deleted IPAM by id returns an empty set.
+	after, err := client.DescribeIpams(ctx, &ec2.DescribeIpamsInput{IpamIds: []string{ipamID}})
+	require.NoError(t, err)
+	assert.Empty(t, after.Ipams)
+}

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -523,6 +523,25 @@ func TestIPAMMetricsSDK(t *testing.T) {
 	assert.True(t, names["TotalActiveIpCount"], "expected TotalActiveIpCount metric")
 	assert.True(t, names["VpcIPUsage"], "expected VpcIPUsage metric")
 
+	// Regression (#318 review): a real metric plus an empty-namespace
+	// "list all" call must return BOTH the real namespace and AWS/IPAM — the
+	// IPAM shortcut must not drop every non-IPAM metric.
+	_, err = cw.PutMetricData(ctx, &cloudwatch.PutMetricDataInput{
+		Namespace:  aws.String("MyApp"),
+		MetricData: []cwtypes.MetricDatum{{MetricName: aws.String("RequestCount"), Value: aws.Float64(1)}},
+	})
+	require.NoError(t, err)
+
+	all, err := cw.ListMetrics(ctx, &cloudwatch.ListMetricsInput{})
+	require.NoError(t, err)
+
+	namespaces := map[string]bool{}
+	for _, m := range all.Metrics {
+		namespaces[aws.ToString(m.Namespace)] = true
+	}
+	assert.True(t, namespaces["MyApp"], "empty-namespace ListMetrics dropped the real MyApp metric")
+	assert.True(t, namespaces["AWS/IPAM"], "empty-namespace ListMetrics dropped the AWS/IPAM metrics")
+
 	// GetMetricStatistics for VpcIPUsage returns the computed utilization (a
 	// /24 subnet in a /16 VPC = 256/65536 = ~0.39%).
 	vpcID := aws.ToString(vpcOut.Vpc.VpcId)

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -2,13 +2,22 @@ package aws_test
 
 import (
 	"context"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
 
 // TestEC2NetworkingParitySDK drives the real aws-sdk-go-v2 EC2 client against
@@ -354,4 +363,184 @@ func TestEC2IPAMParitySDK(t *testing.T) {
 	after, err := client.DescribeIpams(ctx, &ec2.DescribeIpamsInput{IpamIds: []string{ipamID}})
 	require.NoError(t, err)
 	assert.Empty(t, after.Ipams)
+}
+
+// TestEC2IPAMFullSDK drives the real EC2 client across the full IPAM surface
+// beyond the core lifecycle: resource CIDRs + history, resource discovery +
+// discovered getters, BYOASN + BYOIP, prefix-list resolver + targets,
+// verification tokens, and policy + org-admin — proving the query wire.
+func TestEC2IPAMFullSDK(t *testing.T) {
+	client := newEC2Client(t)
+	ctx := context.Background()
+
+	// Prerequisite VPC + subnet so resource CIDRs / discovery / utilization
+	// have something to report.
+	vpcOut, err := client.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	require.NoError(t, err)
+	vpcID := aws.ToString(vpcOut.Vpc.VpcId)
+	_, err = client.CreateSubnet(ctx, &ec2.CreateSubnetInput{VpcId: aws.String(vpcID), CidrBlock: aws.String("10.0.1.0/24")})
+	require.NoError(t, err)
+
+	ipam, err := client.CreateIpam(ctx, &ec2.CreateIpamInput{})
+	require.NoError(t, err)
+	ipamID := aws.ToString(ipam.Ipam.IpamId)
+	privScopeID := aws.ToString(ipam.Ipam.PrivateDefaultScopeId)
+	// A default resource discovery + association is created with the IPAM.
+	rdID := aws.ToString(ipam.Ipam.DefaultResourceDiscoveryId)
+	require.NotEmpty(t, rdID)
+
+	t.Run("resource cidrs + history", func(t *testing.T) {
+		rc, err := client.GetIpamResourceCidrs(ctx, &ec2.GetIpamResourceCidrsInput{IpamScopeId: aws.String(privScopeID)})
+		require.NoError(t, err)
+		require.NotEmpty(t, rc.IpamResourceCidrs)
+
+		hist, err := client.GetIpamAddressHistory(ctx, &ec2.GetIpamAddressHistoryInput{
+			Cidr: aws.String("10.0.0.0/16"), IpamScopeId: aws.String(privScopeID),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, hist.HistoryRecords)
+	})
+
+	t.Run("resource discovery", func(t *testing.T) {
+		descRD, err := client.DescribeIpamResourceDiscoveries(ctx, &ec2.DescribeIpamResourceDiscoveriesInput{
+			IpamResourceDiscoveryIds: []string{rdID},
+		})
+		require.NoError(t, err)
+		require.Len(t, descRD.IpamResourceDiscoveries, 1)
+		assert.True(t, aws.ToBool(descRD.IpamResourceDiscoveries[0].IsDefault))
+
+		accts, err := client.GetIpamDiscoveredAccounts(ctx, &ec2.GetIpamDiscoveredAccountsInput{
+			IpamResourceDiscoveryId: aws.String(rdID), DiscoveryRegion: aws.String("us-east-1"),
+		})
+		require.NoError(t, err)
+		require.Len(t, accts.IpamDiscoveredAccounts, 1)
+
+		cidrs, err := client.GetIpamDiscoveredResourceCidrs(ctx, &ec2.GetIpamDiscoveredResourceCidrsInput{
+			IpamResourceDiscoveryId: aws.String(rdID), ResourceRegion: aws.String("us-east-1"),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, cidrs.IpamDiscoveredResourceCidrs)
+	})
+
+	t.Run("byoip + byoasn", func(t *testing.T) {
+		_, err := client.ProvisionByoipCidr(ctx, &ec2.ProvisionByoipCidrInput{Cidr: aws.String("203.0.113.0/24")})
+		require.NoError(t, err)
+
+		byoip, err := client.DescribeByoipCidrs(ctx, &ec2.DescribeByoipCidrsInput{MaxResults: aws.Int32(10)})
+		require.NoError(t, err)
+		require.Len(t, byoip.ByoipCidrs, 1)
+
+		_, err = client.ProvisionIpamByoasn(ctx, &ec2.ProvisionIpamByoasnInput{
+			IpamId: aws.String(ipamID), Asn: aws.String("64512"),
+			AsnAuthorizationContext: &ec2types.AsnAuthorizationContext{
+				Message: aws.String("msg"), Signature: aws.String("sig"),
+			},
+		})
+		require.NoError(t, err)
+
+		asns, err := client.DescribeIpamByoasn(ctx, &ec2.DescribeIpamByoasnInput{})
+		require.NoError(t, err)
+		require.Len(t, asns.Byoasns, 1)
+	})
+
+	t.Run("prefix list resolver + token", func(t *testing.T) {
+		res, err := client.CreateIpamPrefixListResolver(ctx, &ec2.CreateIpamPrefixListResolverInput{
+			IpamId: aws.String(ipamID), AddressFamily: ec2types.AddressFamilyIpv4,
+		})
+		require.NoError(t, err)
+		resID := aws.ToString(res.IpamPrefixListResolver.IpamPrefixListResolverId)
+		assert.NotEmpty(t, resID)
+
+		descRes, err := client.DescribeIpamPrefixListResolvers(ctx, &ec2.DescribeIpamPrefixListResolversInput{
+			IpamPrefixListResolverIds: []string{resID},
+		})
+		require.NoError(t, err)
+		require.Len(t, descRes.IpamPrefixListResolvers, 1)
+
+		tok, err := client.CreateIpamExternalResourceVerificationToken(ctx, &ec2.CreateIpamExternalResourceVerificationTokenInput{
+			IpamId: aws.String(ipamID),
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, aws.ToString(tok.IpamExternalResourceVerificationToken.IpamExternalResourceVerificationTokenId))
+	})
+
+	t.Run("policy + org admin", func(t *testing.T) {
+		pol, err := client.CreateIpamPolicy(ctx, &ec2.CreateIpamPolicyInput{IpamId: aws.String(ipamID)})
+		require.NoError(t, err)
+		polID := aws.ToString(pol.IpamPolicy.IpamPolicyId)
+		assert.NotEmpty(t, polID)
+
+		_, err = client.EnableIpamPolicy(ctx, &ec2.EnableIpamPolicyInput{IpamPolicyId: aws.String(polID)})
+		require.NoError(t, err)
+
+		enabled, err := client.GetEnabledIpamPolicy(ctx, &ec2.GetEnabledIpamPolicyInput{})
+		require.NoError(t, err)
+		assert.True(t, aws.ToBool(enabled.IpamPolicyEnabled))
+
+		admin, err := client.EnableIpamOrganizationAdminAccount(ctx, &ec2.EnableIpamOrganizationAdminAccountInput{
+			DelegatedAdminAccountId: aws.String("111122223333"),
+		})
+		require.NoError(t, err)
+		assert.True(t, aws.ToBool(admin.Success))
+	})
+}
+
+// TestIPAMMetricsSDK proves the derived AWS/IPAM metrics surface through the
+// real CloudWatch SDK (ListMetrics + GetMetricStatistics), wired via the
+// VPC driver's optional IPAMMetrics capability.
+func TestIPAMMetricsSDK(t *testing.T) {
+	provider := cloudemu.NewAWS()
+	srv := awsserver.New(awsserver.Drivers{EC2: provider.EC2, VPC: provider.VPC, CloudWatch: provider.CloudWatch})
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("t", "t", "")))
+	require.NoError(t, err)
+
+	ec2c := ec2.NewFromConfig(cfg, func(o *ec2.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	cw := cloudwatch.NewFromConfig(cfg, func(o *cloudwatch.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+	ctx := context.Background()
+
+	// Build IPAM state: a VPC with a subnet (drives VpcIPUsage) and an IPAM.
+	vpcOut, err := ec2c.CreateVpc(ctx, &ec2.CreateVpcInput{CidrBlock: aws.String("10.0.0.0/16")})
+	require.NoError(t, err)
+	_, err = ec2c.CreateSubnet(ctx, &ec2.CreateSubnetInput{
+		VpcId: vpcOut.Vpc.VpcId, CidrBlock: aws.String("10.0.0.0/24"),
+	})
+	require.NoError(t, err)
+	_, err = ec2c.CreateIpam(ctx, &ec2.CreateIpamInput{})
+	require.NoError(t, err)
+
+	// ListMetrics on AWS/IPAM returns the derived metric set.
+	list, err := cw.ListMetrics(ctx, &cloudwatch.ListMetricsInput{Namespace: aws.String("AWS/IPAM")})
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, m := range list.Metrics {
+		names[aws.ToString(m.MetricName)] = true
+	}
+	assert.True(t, names["TotalActiveIpCount"], "expected TotalActiveIpCount metric")
+	assert.True(t, names["VpcIPUsage"], "expected VpcIPUsage metric")
+
+	// GetMetricStatistics for VpcIPUsage returns the computed utilization (a
+	// /24 subnet in a /16 VPC = 256/65536 = ~0.39%).
+	vpcID := aws.ToString(vpcOut.Vpc.VpcId)
+	end := time.Now().UTC()
+	stat, err := cw.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
+		Namespace:  aws.String("AWS/IPAM"),
+		MetricName: aws.String("VpcIPUsage"),
+		Dimensions: []cwtypes.Dimension{
+			{Name: aws.String("VpcID"), Value: aws.String(vpcID)},
+			{Name: aws.String("AddressFamily"), Value: aws.String("IPv4")},
+			{Name: aws.String("Region"), Value: aws.String("us-east-1")},
+		},
+		StartTime:  aws.Time(end.Add(-time.Hour)),
+		EndTime:    aws.Time(end),
+		Period:     aws.Int32(60),
+		Statistics: []cwtypes.Statistic{cwtypes.StatisticAverage},
+	})
+	require.NoError(t, err)
+	require.Len(t, stat.Datapoints, 1)
+	assert.InDelta(t, 0.39, aws.ToFloat64(stat.Datapoints[0].Average), 0.05)
 }

--- a/server/aws/networking_parity_sdk_test.go
+++ b/server/aws/networking_parity_sdk_test.go
@@ -477,6 +477,32 @@ func TestEC2IPAMFullSDK(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, aws.ToBool(enabled.IpamPolicyEnabled))
 
+		// Modify allocation rules — the response must carry a non-nil
+		// IpamPolicyDocument (not a dropped <return>true>), and Get must return
+		// the rule's sourceIpamPoolId + ipamPolicyId (not an empty document).
+		mod, err := client.ModifyIpamPolicyAllocationRules(ctx, &ec2.ModifyIpamPolicyAllocationRulesInput{
+			IpamPolicyId: aws.String(polID),
+			Locale:       aws.String("us-east-1"),
+			ResourceType: ec2types.IpamPolicyResourceTypeEip,
+			AllocationRules: []ec2types.IpamPolicyAllocationRuleRequest{
+				{SourceIpamPoolId: aws.String("ipam-pool-abc123")},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, mod.IpamPolicyDocument, "ModifyIpamPolicyAllocationRules dropped the document")
+		require.Len(t, mod.IpamPolicyDocument.AllocationRules, 1)
+		assert.Equal(t, "ipam-pool-abc123", aws.ToString(mod.IpamPolicyDocument.AllocationRules[0].SourceIpamPoolId))
+
+		got, err := client.GetIpamPolicyAllocationRules(ctx, &ec2.GetIpamPolicyAllocationRulesInput{
+			IpamPolicyId: aws.String(polID),
+		})
+		require.NoError(t, err)
+		require.Len(t, got.IpamPolicyDocuments, 1)
+		assert.Equal(t, polID, aws.ToString(got.IpamPolicyDocuments[0].IpamPolicyId))
+		require.Len(t, got.IpamPolicyDocuments[0].AllocationRules, 1)
+		assert.Equal(t, "ipam-pool-abc123",
+			aws.ToString(got.IpamPolicyDocuments[0].AllocationRules[0].SourceIpamPoolId))
+
 		admin, err := client.EnableIpamOrganizationAdminAccount(ctx, &ec2.EnableIpamOrganizationAdminAccountInput{
 			DelegatedAdminAccountId: aws.String("111122223333"),
 		})

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -6,6 +6,14 @@ import (
 	"time"
 )
 
+// MetricIdentifier names one metric by namespace + name. It's used by the
+// AWS-local detailed metric listing that backs a namespace-less ListMetrics
+// ("list all") so each returned metric keeps its real namespace.
+type MetricIdentifier struct {
+	Namespace  string
+	MetricName string
+}
+
 // MetricDatum is a single metric data point.
 type MetricDatum struct {
 	Namespace  string

--- a/services/networking/driver/aws_ipam.go
+++ b/services/networking/driver/aws_ipam.go
@@ -11,17 +11,20 @@ import "context"
 // Ipam is the top-level IP Address Manager. Creating one implicitly creates a
 // public and a private default scope.
 type Ipam struct {
-	ID                    string
-	ARN                   string
-	Region                string
-	PublicDefaultScopeID  string
-	PrivateDefaultScopeID string
-	ScopeCount            int
-	OperatingRegions      []string
-	Description           string
-	Tier                  string
-	State                 string
-	Tags                  map[string]string
+	ID                                    string
+	ARN                                   string
+	Region                                string
+	PublicDefaultScopeID                  string
+	PrivateDefaultScopeID                 string
+	ScopeCount                            int
+	DefaultResourceDiscoveryID            string
+	DefaultResourceDiscoveryAssociationID string
+	ResourceDiscoveryAssociationCount     int
+	OperatingRegions                      []string
+	Description                           string
+	Tier                                  string
+	State                                 string
+	Tags                                  map[string]string
 }
 
 // IpamConfig is the input to CreateIpam.

--- a/services/networking/driver/aws_ipam.go
+++ b/services/networking/driver/aws_ipam.go
@@ -1,0 +1,139 @@
+package driver
+
+import "context"
+
+// ---- AWS IPAM (IP Address Manager) — OPTIONAL capability (type-asserted) ----
+//
+// IPAM is an AWS-only VPC feature exposed on the EC2 query API. Like the other
+// AWS networking specifics it is an optional capability discovered via a type
+// assertion on the vpc driver, so the portable Networking interface stays clean.
+
+// Ipam is the top-level IP Address Manager. Creating one implicitly creates a
+// public and a private default scope.
+type Ipam struct {
+	ID                    string
+	ARN                   string
+	Region                string
+	PublicDefaultScopeID  string
+	PrivateDefaultScopeID string
+	ScopeCount            int
+	OperatingRegions      []string
+	Description           string
+	Tier                  string
+	State                 string
+	Tags                  map[string]string
+}
+
+// IpamConfig is the input to CreateIpam.
+type IpamConfig struct {
+	Description      string
+	Tier             string
+	OperatingRegions []string
+	Tags             map[string]string
+}
+
+// IpamScope groups pools. Each IPAM has a public and a private default scope;
+// additional private scopes may be created.
+type IpamScope struct {
+	ID          string
+	ARN         string
+	IpamARN     string
+	ScopeType   string // public | private
+	IsDefault   bool
+	PoolCount   int
+	Description string
+	State       string
+	Tags        map[string]string
+}
+
+// IpamScopeConfig is the input to CreateIpamScope.
+type IpamScopeConfig struct {
+	IpamID      string
+	Description string
+	Tags        map[string]string
+}
+
+// IpamPool is a CIDR pool within a scope.
+type IpamPool struct {
+	ID                             string
+	ARN                            string
+	IpamScopeARN                   string
+	IpamScopeType                  string
+	AddressFamily                  string // ipv4 | ipv6
+	Locale                         string
+	PoolDepth                      int
+	Description                    string
+	State                          string
+	AllocationMinNetmaskLength     int
+	AllocationMaxNetmaskLength     int
+	AllocationDefaultNetmaskLength int
+	Tags                           map[string]string
+}
+
+// IpamPoolConfig is the input to CreateIpamPool.
+type IpamPoolConfig struct {
+	IpamScopeID                    string
+	AddressFamily                  string
+	Locale                         string
+	Description                    string
+	AllocationMinNetmaskLength     int
+	AllocationMaxNetmaskLength     int
+	AllocationDefaultNetmaskLength int
+	Tags                           map[string]string
+}
+
+// IpamPoolCidr is a CIDR provisioned into a pool (the pool's supply).
+type IpamPoolCidr struct {
+	ID            string
+	CIDR          string
+	NetmaskLength int
+	State         string
+}
+
+// IpamPoolAllocation is a CIDR handed out from a pool (the pool's usage).
+type IpamPoolAllocation struct {
+	ID           string
+	CIDR         string
+	ResourceType string
+	ResourceID   string
+	Description  string
+	Tags         map[string]string
+}
+
+// AllocateIpamPoolCidrConfig is the input to AllocateIpamPoolCidr.
+type AllocateIpamPoolCidrConfig struct {
+	IpamPoolID    string
+	CIDR          string
+	NetmaskLength int
+	Description   string
+	Tags          map[string]string
+}
+
+// IPAM is an OPTIONAL AWS capability (type-asserted on the vpc driver).
+//
+//nolint:interfacebloat // mirrors the IPAM core-lifecycle API surface.
+type IPAM interface {
+	CreateIpam(ctx context.Context, cfg IpamConfig) (*Ipam, error)
+	DescribeIpams(ctx context.Context, ids []string) ([]Ipam, error)
+	ModifyIpam(ctx context.Context, id, description string) (*Ipam, error)
+	DeleteIpam(ctx context.Context, id string) (*Ipam, error)
+
+	CreateIpamScope(ctx context.Context, cfg IpamScopeConfig) (*IpamScope, error)
+	DescribeIpamScopes(ctx context.Context, ids []string) ([]IpamScope, error)
+	ModifyIpamScope(ctx context.Context, id, description string) (*IpamScope, error)
+	DeleteIpamScope(ctx context.Context, id string) (*IpamScope, error)
+
+	CreateIpamPool(ctx context.Context, cfg IpamPoolConfig) (*IpamPool, error)
+	DescribeIpamPools(ctx context.Context, ids []string) ([]IpamPool, error)
+	ModifyIpamPool(ctx context.Context, id, description string) (*IpamPool, error)
+	DeleteIpamPool(ctx context.Context, id string) (*IpamPool, error)
+
+	ProvisionIpamPoolCidr(ctx context.Context, poolID, cidr string, netmaskLength int) (*IpamPoolCidr, error)
+	DeprovisionIpamPoolCidr(ctx context.Context, poolID, cidr string) (*IpamPoolCidr, error)
+	GetIpamPoolCidrs(ctx context.Context, poolID string) ([]IpamPoolCidr, error)
+
+	AllocateIpamPoolCidr(ctx context.Context, cfg AllocateIpamPoolCidrConfig) (*IpamPoolAllocation, error)
+	ReleaseIpamPoolAllocation(ctx context.Context, poolID, allocationID string) error
+	GetIpamPoolAllocations(ctx context.Context, poolID string) ([]IpamPoolAllocation, error)
+	ModifyIpamPoolAllocation(ctx context.Context, allocationID, description string) (*IpamPoolAllocation, error)
+}

--- a/services/networking/driver/aws_ipam_byoip.go
+++ b/services/networking/driver/aws_ipam_byoip.go
@@ -1,0 +1,50 @@
+package driver
+
+import "context"
+
+// Byoasn is a bring-your-own Autonomous System Number provisioned into an IPAM.
+type Byoasn struct {
+	Asn           string
+	IpamID        string
+	State         string
+	StatusMessage string
+}
+
+// AsnAssociation links a BYOASN to a BYOIP CIDR.
+type AsnAssociation struct {
+	Asn           string
+	CIDR          string
+	State         string
+	StatusMessage string
+}
+
+// ByoipCidr is a bring-your-own public IP CIDR (optionally moved into IPAM).
+type ByoipCidr struct {
+	CIDR               string
+	Description        string
+	State              string
+	StatusMessage      string
+	NetworkBorderGroup string
+	AdvertisementType  string
+	AsnAssociations    []AsnAssociation
+}
+
+// IPAMByoasn is an OPTIONAL AWS capability for bring-your-own ASN.
+type IPAMByoasn interface {
+	ProvisionIpamByoasn(ctx context.Context, ipamID, asn string) (*Byoasn, error)
+	DeprovisionIpamByoasn(ctx context.Context, ipamID, asn string) (*Byoasn, error)
+	DescribeIpamByoasn(ctx context.Context) ([]Byoasn, error)
+	AssociateIpamByoasn(ctx context.Context, asn, cidr string) (*AsnAssociation, error)
+	DisassociateIpamByoasn(ctx context.Context, asn, cidr string) (*AsnAssociation, error)
+}
+
+// IPAMByoip is an OPTIONAL AWS capability for bring-your-own public IP CIDRs
+// and moving them into IPAM (public-IP insights).
+type IPAMByoip interface {
+	MoveByoipCidrToIpam(ctx context.Context, cidr, ipamPoolID string) (*ByoipCidr, error)
+	ProvisionByoipCidr(ctx context.Context, cidr, description string) (*ByoipCidr, error)
+	DeprovisionByoipCidr(ctx context.Context, cidr string) (*ByoipCidr, error)
+	DescribeByoipCidrs(ctx context.Context) ([]ByoipCidr, error)
+	AdvertiseByoipCidr(ctx context.Context, cidr string) (*ByoipCidr, error)
+	WithdrawByoipCidr(ctx context.Context, cidr string) (*ByoipCidr, error)
+}

--- a/services/networking/driver/aws_ipam_discovery.go
+++ b/services/networking/driver/aws_ipam_discovery.go
@@ -1,0 +1,103 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// IpamResourceDiscovery is IPAM's mechanism for finding resources across
+// accounts/regions. Each IPAM gets a default one on creation.
+type IpamResourceDiscovery struct {
+	ID               string
+	ARN              string
+	Region           string
+	OwnerID          string
+	OperatingRegions []string
+	Description      string
+	State            string
+	IsDefault        bool
+	Tags             map[string]string
+}
+
+// IpamResourceDiscoveryConfig is the input to CreateIpamResourceDiscovery.
+type IpamResourceDiscoveryConfig struct {
+	Description      string
+	OperatingRegions []string
+	Tags             map[string]string
+}
+
+// IpamResourceDiscoveryAssociation links a resource discovery to an IPAM.
+type IpamResourceDiscoveryAssociation struct {
+	ID                      string
+	ARN                     string
+	IpamID                  string
+	IpamARN                 string
+	IpamRegion              string
+	ResourceDiscoveryID     string
+	OwnerID                 string
+	State                   string
+	IsDefault               bool
+	ResourceDiscoveryStatus string
+	Tags                    map[string]string
+}
+
+// IpamDiscoveredAccount is an account IPAM monitors via a resource discovery.
+type IpamDiscoveredAccount struct {
+	AccountID                   string
+	DiscoveryRegion             string
+	LastAttemptedDiscoveryTime  time.Time
+	LastSuccessfulDiscoveryTime time.Time
+}
+
+// IpamDiscoveredResourceCidr is a CIDR IPAM discovered on a monitored resource.
+type IpamDiscoveredResourceCidr struct {
+	ResourceDiscoveryID              string
+	ResourceCIDR                     string
+	ResourceID                       string
+	ResourceType                     string
+	ResourceRegion                   string
+	ResourceOwnerID                  string
+	VPCID                            string
+	SubnetID                         string
+	AvailabilityZone                 string
+	IPSource                         string
+	NetworkInterfaceAttachmentStatus string
+	IPUsage                          float64
+	SampleTime                       time.Time
+	Tags                             map[string]string
+}
+
+// IpamDiscoveredPublicAddress is a public IP IPAM discovered.
+type IpamDiscoveredPublicAddress struct {
+	ResourceDiscoveryID string
+	Address             string
+	AddressAllocationID string
+	AddressOwnerID      string
+	AddressRegion       string
+	AddressType         string
+	AssociationStatus   string
+	Service             string
+	VPCID               string
+	SubnetID            string
+	SampleTime          time.Time
+}
+
+// IPAMDiscovery is an OPTIONAL AWS capability for IPAM resource discovery.
+//
+//nolint:interfacebloat // mirrors the IPAM resource-discovery API surface.
+type IPAMDiscovery interface {
+	CreateIpamResourceDiscovery(ctx context.Context, cfg IpamResourceDiscoveryConfig) (*IpamResourceDiscovery, error)
+	DescribeIpamResourceDiscoveries(ctx context.Context, ids []string) ([]IpamResourceDiscovery, error)
+	ModifyIpamResourceDiscovery(ctx context.Context, id, description string, operatingRegions []string) (*IpamResourceDiscovery, error)
+	DeleteIpamResourceDiscovery(ctx context.Context, id string) (*IpamResourceDiscovery, error)
+
+	AssociateIpamResourceDiscovery(
+		ctx context.Context, ipamID, resourceDiscoveryID string, tags map[string]string,
+	) (*IpamResourceDiscoveryAssociation, error)
+	DisassociateIpamResourceDiscovery(ctx context.Context, associationID string) (*IpamResourceDiscoveryAssociation, error)
+	DescribeIpamResourceDiscoveryAssociations(ctx context.Context, ids []string) ([]IpamResourceDiscoveryAssociation, error)
+
+	GetIpamDiscoveredAccounts(ctx context.Context, resourceDiscoveryID, region string) ([]IpamDiscoveredAccount, error)
+	GetIpamDiscoveredResourceCidrs(ctx context.Context, resourceDiscoveryID, region string) ([]IpamDiscoveredResourceCidr, error)
+	GetIpamDiscoveredPublicAddresses(ctx context.Context, resourceDiscoveryID, region string) ([]IpamDiscoveredPublicAddress, error)
+}

--- a/services/networking/driver/aws_ipam_metrics.go
+++ b/services/networking/driver/aws_ipam_metrics.go
@@ -1,0 +1,25 @@
+package driver
+
+import "context"
+
+// IpamMetricNamespace is the CloudWatch namespace IPAM publishes to.
+const IpamMetricNamespace = "AWS/IPAM"
+
+// IpamMetric is one AWS/IPAM CloudWatch datapoint derived from IPAM state.
+// It is deliberately neutral (no dependency on the monitoring driver) so the
+// CloudWatch server can adapt it without coupling networking to monitoring.
+type IpamMetric struct {
+	Namespace  string
+	MetricName string
+	Value      float64
+	Unit       string
+	Dimensions map[string]string
+}
+
+// IPAMMetrics is an OPTIONAL capability that exposes the AWS/IPAM CloudWatch
+// metrics (IPAM/pool/scope/public-IP + resource-utilization) derived from the
+// current IPAM and VPC state. The CloudWatch handler surfaces these under the
+// AWS/IPAM namespace via ListMetrics/GetMetricData.
+type IPAMMetrics interface {
+	IpamMetrics(ctx context.Context) []IpamMetric
+}

--- a/services/networking/driver/aws_ipam_policy.go
+++ b/services/networking/driver/aws_ipam_policy.go
@@ -1,0 +1,36 @@
+package driver
+
+import "context"
+
+// IpamPolicy is an IPAM allocation policy (Organizations-wide governance).
+type IpamPolicy struct {
+	ID              string
+	ARN             string
+	IpamID          string
+	IpamRegion      string
+	OwnerID         string
+	State           string
+	StateMessage    string
+	Enabled         bool
+	AllocationRules []string
+	Tags            map[string]string
+}
+
+// IPAMPolicy is an OPTIONAL AWS capability for IPAM policies and the
+// Organizations delegated-admin account.
+//
+//nolint:interfacebloat // mirrors the IPAM policy + org-admin API surface.
+type IPAMPolicy interface {
+	CreateIpamPolicy(ctx context.Context, ipamID string, tags map[string]string) (*IpamPolicy, error)
+	DeleteIpamPolicy(ctx context.Context, id string) (*IpamPolicy, error)
+	DescribeIpamPolicies(ctx context.Context, ids []string) ([]IpamPolicy, error)
+	EnableIpamPolicy(ctx context.Context, id, organizationTargetID string) (string, error)
+	DisableIpamPolicy(ctx context.Context, id string) error
+	GetEnabledIpamPolicy(ctx context.Context) (policyID string, enabled bool, managedBy string, err error)
+	ModifyIpamPolicyAllocationRules(ctx context.Context, id string, rules []string) error
+	GetIpamPolicyAllocationRules(ctx context.Context, id string) ([]string, error)
+	GetIpamPolicyOrganizationTargets(ctx context.Context, id string) ([]string, error)
+
+	EnableIpamOrganizationAdminAccount(ctx context.Context, accountID string) (bool, error)
+	DisableIpamOrganizationAdminAccount(ctx context.Context, accountID string) (bool, error)
+}

--- a/services/networking/driver/aws_ipam_policy.go
+++ b/services/networking/driver/aws_ipam_policy.go
@@ -2,17 +2,27 @@ package driver
 
 import "context"
 
+// IpamAllocationRule maps a resource type to a source IPAM pool. Mirrors the
+// EC2 IpamPolicyAllocationRule, whose only field is the source pool id.
+type IpamAllocationRule struct {
+	SourceIpamPoolID string
+}
+
 // IpamPolicy is an IPAM allocation policy (Organizations-wide governance).
 type IpamPolicy struct {
-	ID              string
-	ARN             string
-	IpamID          string
-	IpamRegion      string
-	OwnerID         string
-	State           string
-	StateMessage    string
-	Enabled         bool
-	AllocationRules []string
+	ID           string
+	ARN          string
+	IpamID       string
+	IpamRegion   string
+	OwnerID      string
+	State        string
+	StateMessage string
+	Enabled      bool
+	// Locale and ResourceType scope the allocation-rule document; set by
+	// ModifyIpamPolicyAllocationRules and echoed on the policy document.
+	Locale          string
+	ResourceType    string
+	AllocationRules []IpamAllocationRule
 	Tags            map[string]string
 }
 
@@ -27,8 +37,8 @@ type IPAMPolicy interface {
 	EnableIpamPolicy(ctx context.Context, id, organizationTargetID string) (string, error)
 	DisableIpamPolicy(ctx context.Context, id string) error
 	GetEnabledIpamPolicy(ctx context.Context) (policyID string, enabled bool, managedBy string, err error)
-	ModifyIpamPolicyAllocationRules(ctx context.Context, id string, rules []string) error
-	GetIpamPolicyAllocationRules(ctx context.Context, id string) ([]string, error)
+	ModifyIpamPolicyAllocationRules(ctx context.Context, id, locale, resourceType string, rules []IpamAllocationRule) (*IpamPolicy, error)
+	GetIpamPolicyAllocationRules(ctx context.Context, id string) (*IpamPolicy, error)
 	GetIpamPolicyOrganizationTargets(ctx context.Context, id string) ([]string, error)
 
 	EnableIpamOrganizationAdminAccount(ctx context.Context, accountID string) (bool, error)

--- a/services/networking/driver/aws_ipam_resolver.go
+++ b/services/networking/driver/aws_ipam_resolver.go
@@ -1,0 +1,105 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// IpamPrefixListResolver auto-syncs IPAM CIDRs into managed prefix lists.
+type IpamPrefixListResolver struct {
+	ID                               string
+	ARN                              string
+	IpamID                           string
+	IpamARN                          string
+	IpamRegion                       string
+	OwnerID                          string
+	AddressFamily                    string
+	Description                      string
+	State                            string
+	LastVersionCreationStatus        string
+	LastVersionCreationStatusMessage string
+	Tags                             map[string]string
+}
+
+// IpamPrefixListResolverTarget is a managed prefix list a resolver syncs into.
+type IpamPrefixListResolverTarget struct {
+	ID                 string
+	ARN                string
+	ResolverID         string
+	OwnerID            string
+	PrefixListID       string
+	PrefixListRegion   string
+	DesiredVersion     int
+	LastSyncedVersion  int
+	TrackLatestVersion bool
+	State              string
+	StateMessage       string
+	Tags               map[string]string
+}
+
+// IpamPrefixListResolverVersion is a published version of a resolver's rules.
+type IpamPrefixListResolverVersion struct {
+	Version   int
+	CreatedAt time.Time
+}
+
+// IpamPrefixListResolverRule is one rule evaluated by a resolver.
+type IpamPrefixListResolverRule struct {
+	IpamPoolID string
+	Cidr       string
+}
+
+// IpamExternalResourceVerificationToken authorizes external (on-prem) CIDRs.
+type IpamExternalResourceVerificationToken struct {
+	ID         string
+	ARN        string
+	IpamID     string
+	IpamARN    string
+	IpamRegion string
+	OwnerID    string
+	TokenName  string
+	TokenValue string
+	NotAfter   time.Time
+	State      string
+	Status     string
+	Tags       map[string]string
+}
+
+// IPAMPrefixListResolver is an OPTIONAL AWS capability for IPAM prefix-list
+// resolvers, their targets, and published versions.
+//
+//nolint:interfacebloat // mirrors the prefix-list-resolver API surface.
+type IPAMPrefixListResolver interface {
+	CreateIpamPrefixListResolver(
+		ctx context.Context, ipamID, addressFamily, description string, tags map[string]string,
+	) (*IpamPrefixListResolver, error)
+	DescribeIpamPrefixListResolvers(ctx context.Context, ids []string) ([]IpamPrefixListResolver, error)
+	ModifyIpamPrefixListResolver(ctx context.Context, id, description string) (*IpamPrefixListResolver, error)
+	DeleteIpamPrefixListResolver(ctx context.Context, id string) (*IpamPrefixListResolver, error)
+
+	CreateIpamPrefixListResolverTarget(
+		ctx context.Context, resolverID, prefixListID, prefixListRegion string,
+		desiredVersion int, trackLatest bool, tags map[string]string,
+	) (*IpamPrefixListResolverTarget, error)
+	DescribeIpamPrefixListResolverTargets(ctx context.Context, ids []string) ([]IpamPrefixListResolverTarget, error)
+	ModifyIpamPrefixListResolverTarget(
+		ctx context.Context, id string, desiredVersion int, trackLatest bool,
+	) (*IpamPrefixListResolverTarget, error)
+	DeleteIpamPrefixListResolverTarget(ctx context.Context, id string) (*IpamPrefixListResolverTarget, error)
+
+	GetIpamPrefixListResolverRules(ctx context.Context, resolverID string) ([]IpamPrefixListResolverRule, error)
+	GetIpamPrefixListResolverVersions(ctx context.Context, resolverID string) ([]IpamPrefixListResolverVersion, error)
+	GetIpamPrefixListResolverVersionEntries(
+		ctx context.Context, resolverID string, version int,
+	) ([]PrefixListEntry, error)
+}
+
+// IPAMExternalToken is an OPTIONAL AWS capability for external-resource
+// verification tokens.
+type IPAMExternalToken interface {
+	CreateIpamExternalResourceVerificationToken(
+		ctx context.Context, ipamID, tokenName string, tags map[string]string,
+	) (*IpamExternalResourceVerificationToken, error)
+	DeleteIpamExternalResourceVerificationToken(ctx context.Context, id string) (*IpamExternalResourceVerificationToken, error)
+	DescribeIpamExternalResourceVerificationTokens(ctx context.Context, ids []string) ([]IpamExternalResourceVerificationToken, error)
+}

--- a/services/networking/driver/aws_ipam_resources.go
+++ b/services/networking/driver/aws_ipam_resources.go
@@ -1,0 +1,50 @@
+package driver
+
+import (
+	"context"
+	"time"
+)
+
+// IpamResourceCidr is a resource (VPC / subnet / public IPv4 pool) CIDR that
+// IPAM tracks within a scope, with its compliance and utilization state.
+type IpamResourceCidr struct {
+	IpamID           string
+	IpamScopeID      string
+	IpamPoolID       string
+	ResourceCIDR     string
+	ResourceID       string
+	ResourceName     string
+	ResourceType     string
+	ResourceRegion   string
+	ResourceOwnerID  string
+	VPCID            string
+	AvailabilityZone string
+	ComplianceStatus string
+	ManagementState  string
+	OverlapStatus    string
+	IPUsage          float64
+	Tags             map[string]string
+}
+
+// IpamAddressHistoryRecord is one entry in the history of a CIDR within a scope.
+type IpamAddressHistoryRecord struct {
+	ResourceCIDR             string
+	ResourceID               string
+	ResourceName             string
+	ResourceType             string
+	ResourceRegion           string
+	ResourceOwnerID          string
+	VPCID                    string
+	ResourceComplianceStatus string
+	ResourceOverlapStatus    string
+	SampledStartTime         time.Time
+	SampledEndTime           time.Time
+}
+
+// IPAMResources is an OPTIONAL AWS capability exposing IPAM's view of the
+// resource CIDRs (VPCs/subnets) it monitors, plus address history.
+type IPAMResources interface {
+	GetIpamResourceCidrs(ctx context.Context, scopeID, resourceID string) ([]IpamResourceCidr, error)
+	ModifyIpamResourceCidr(ctx context.Context, resourceID, currentScopeID, destScopeID string, monitored bool) (*IpamResourceCidr, error)
+	GetIpamAddressHistory(ctx context.Context, cidr, scopeID string) ([]IpamAddressHistoryRecord, error)
+}

--- a/services/networking/networking.go
+++ b/services/networking/networking.go
@@ -3,9 +3,9 @@ package networking
 
 import (
 	"context"
-	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"time"
 
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/features/inject"
 	"github.com/stackshy/cloudemu/v2/features/metrics"
 	"github.com/stackshy/cloudemu/v2/features/ratelimit"


### PR DESCRIPTION
## Objective
Add AWS IP Address Manager (IPAM) to the emulator with **full parity** — the entire control-plane surface plus the `AWS/IPAM` CloudWatch metrics — as the first Stage B AWS networking service. (Stage A merged in #317.)

## Scope — the whole service (~69 operations + metrics)
New optional EC2 capabilities, each type-asserted on the vpc driver (the Stage-A pattern, keeping the portable `Networking` interface clean):

- **Core lifecycle** — IPAM / Scope / Pool CRUD+Modify; pool CIDR Provision/Deprovision/Get; allocation Allocate/Release/Get/Modify. Creating an IPAM auto-creates the public + private default scopes **and** a default resource discovery + association (as in AWS).
- **Resource CIDRs + address history** — `GetIpamResourceCidrs`, `ModifyIpamResourceCidr`, `GetIpamAddressHistory`.
- **Resource Discovery** — CRUD + Associate/Disassociate/DescribeAssociations + `GetIpamDiscoveredAccounts` / `…ResourceCidrs` / `…PublicAddresses`.
- **BYOASN** — Provision/Deprovision/Associate/Disassociate/Describe.
- **BYOIP / public IP** — Move-to-IPAM/Provision/Deprovision/Describe/Advertise/Withdraw.
- **Prefix-List Resolver** — resolvers + targets + versions/rules/version-entries.
- **External Resource Verification Token** — Create/Delete/Describe.
- **Policy + Organization admin** — Create/Delete/Describe/Enable/Disable/GetEnabled/AllocationRules/OrgTargets + Enable/DisableIpamOrganizationAdminAccount.
- **Metrics (`AWS/IPAM`)** — the vpc driver exposes an optional `IPAMMetrics` capability; the CloudWatch handler surfaces it via `ListMetrics` + `GetMetricStatistics`: `TotalActiveIpCount`; pool `PercentAllocated/Assigned/Available` + `Compliant/NoncompliantResourceCidrs`; scope `Managed/Unmanaged/Overlapping/Compliant/NoncompliantResourceCidrs`; public-IP insight counts; and resource utilization `VpcIPUsage` / `SubnetIPUsage`. Values are computed **live** from IPAM + VPC/subnet/EIP state.

## How it's modeled (the honest part)
An in-memory single-account emulator has no live network to scan or Organization to manage, so the cross-account/discovery/metrics features are **derived from the emulator's own state**: discovered resources come from the stored VPCs/subnets/EIPs, discovered accounts / org targets resolve to the configured account, and prefix-list-resolver rules derive from the IPAM's pools. All control-plane objects (BYOASN/BYOIP, tokens, policies, resolvers) are full state machines.

## Quality bar (carried from the #317 review)
- **Thread-safe from the start** — readers `RLock`, mutators `Lock`; concurrent `-race` tests.
- **Referential integrity** — FK checks on create/associate (scope→ipam, pool→scope, resolver-target→resolver, allocate/provision→pool, policy/token/RD→ipam) and in-use guards on delete (ipam with pools/non-default scopes/RD-associations, scope with pools, pool with allocations, resolver with targets, advertised BYOIP not deprovisionable).
- **Wire fidelity** — every response element name verified against the vendored `aws-sdk-go-v2` deserializers.

## Docs / Test / Playground
- Real aws-sdk-go-v2 EC2 round-trips: `TestEC2IPAMParitySDK` (core) + `TestEC2IPAMFullSDK` (resource-cidrs/discovery/byoip+byoasn/resolver+token/policy+org-admin).
- CloudWatch SDK metrics test: `TestIPAMMetricsSDK` (ListMetrics + GetMetricStatistics on `AWS/IPAM`).
- Provider unit + `-race` tests: `TestIPAMLifecycle`, `TestIPAMFullProvider`, `TestIPAMConcurrentAccess`.
- `docs/services.md`: full IPAM capability row + AWS/IPAM metrics section; AWS-specific networking 58 → **127**; Grand Total → **1562**.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` + `-race` on the vpc package
- [x] `go mod tidy` clean; `golangci-lint` 0 findings in new files; CodeQL 0 new alerts (only pre-existing baseline)

## Risk & Rollback
Additive — every IPAM group is a new optional capability discovered by type assertion; CloudWatch gains an optional metrics source that is nil-safe. No existing behavior changes. Rollback = revert the two commits on this branch.

## Follow-ups (remaining Stage B services, one PR each)
Route 53 Resolver, Global Accelerator, Direct Connect, VPC Lattice, Cloud WAN/Network Manager, Traffic Mirroring, Reachability/Network Access Analyzer, VPC Block Public Access.

---

## Review round 1 — addressed (e2ef707)

- **ListMetrics** (blocker): empty namespace now returns all real metrics (true namespaces) merged with AWS/IPAM; exact `AWS/IPAM` stays IPAM-only. Added AWS-local `ListMetricsDetailed`.
- **Provision/AllocateIpamPoolCidr** (blocker): netmask-only now derives a concrete aligned CIDR (sequential carve) instead of storing an empty one; errors if no space.
- **ModifyIpamResourceCidr** (blocker): scope-move/unmonitor now persist via a per-resource override map (write-locked).
- **Resolver target** (medium): validates `prefixListID`.
- **BYOASN associate/disassociate** (medium): validate CIDR-provisioned / ASN-exists.

Regression tests extended (`networking_parity_test.go`, `TestIPAMMetricsSDK`). Build/vet/test/tidy green; CodeQL unchanged (8 baseline).


---

## Review round 2 — addressed (a7046e4)

All three verified against the real `aws-sdk-go-v2` `ec2@v1.317.1` types before fixing:

- **ModifyIpamPolicyAllocationRules** (medium, wire): the output type has `IpamPolicyDocument`, not a `Return` field — the old `<return>true>` deserialized to `nil`. Now emits `<ipamPolicyDocument>` with `allocationRuleSet>item>sourceIpamPoolId` + `ipamPolicyId`/`locale`/`resourceType`.
- **GetIpamPolicyAllocationRules** (medium, wire + model): the driver's `AllocationRules []string` couldn't carry the real shape, so it's now structured — `[]IpamAllocationRule{SourceIpamPoolID}` plus `Locale`/`ResourceType` on the policy. Response emits `ipamPolicyDocumentSet>item` (correct nested shape) + `nextToken`; request parses `AllocationRule.N.SourceIpamPoolId` + `Locale` + `ResourceType`.
- **Cross-pool CIDR overlap** (medium, correctness): netmask-only provisioning now excludes CIDRs provisioned by **any** pool sharing the carve base, so two pools no longer both receive `10.0.0.0/16`.

New coverage: real-SDK Modify/Get round-trip in `TestNetworkingParitySDK`; two-pool non-overlap in `TestIPAMProvisionNoCrossPoolOverlap`. Build/vet/`go test ./...`/tidy green; `golangci-lint --new-from-rev` = 0 new; CodeQL unchanged (8 baseline).
