### PR TITLE
Add OCI provider foundation: identity, OCIDs, work requests, wire layer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,12 +11,13 @@
 - [ ] AWS
 - [ ] Azure
 - [ ] GCP
+- [ ] OCI
 
 ## Checklist
 
 - [ ] All tests pass (`go test ./...`)
 - [ ] Linter passes (`golangci-lint run --timeout=9m ./...`)
-- [ ] All 3 providers implement the same behavior
+- [ ] Every provider the change applies to implements the same behavior
 - [ ] Integration tests added to `cloudemu_test.go`
 - [ ] Unit tests added to provider test files
 

--- a/cloudemu.go
+++ b/cloudemu.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws"
 	"github.com/stackshy/cloudemu/v2/providers/azure"
 	"github.com/stackshy/cloudemu/v2/providers/gcp"
+	"github.com/stackshy/cloudemu/v2/providers/oci"
 )
 
 // NewAWS creates a new AWS mock provider.
@@ -20,4 +21,9 @@ func NewAzure(opts ...config.Option) *azure.Provider {
 // NewGCP creates a new GCP mock provider.
 func NewGCP(opts ...config.Option) *gcp.Provider {
 	return gcp.New(opts...)
+}
+
+// NewOCI creates a new OCI mock provider.
+func NewOCI(opts ...config.Option) *oci.Provider {
+	return oci.New(opts...)
 }

--- a/cmd/cloudemu/endpoints.go
+++ b/cmd/cloudemu/endpoints.go
@@ -13,10 +13,11 @@ type endpointSet struct {
 	AWS        string `json:"aws,omitempty"`
 	Azure      string `json:"azure,omitempty"`
 	GCP        string `json:"gcp,omitempty"`
+	OCI        string `json:"oci,omitempty"`
 	Kubernetes string `json:"kubernetes,omitempty"`
 }
 
-func (e endpointSet) writeFile(path string) error {
+func (e *endpointSet) writeFile(path string) error {
 	b, err := json.MarshalIndent(e, "", "  ")
 	if err != nil {
 		return err
@@ -24,38 +25,54 @@ func (e endpointSet) writeFile(path string) error {
 	return os.WriteFile(path, append(b, '\n'), 0o644)
 }
 
+// banner lists the endpoints in display order, so adding a provider is one
+// row rather than another branch in printBanner.
+func (e *endpointSet) banner() []struct{ label, url, note string } {
+	return []struct{ label, url, note string }{
+		{"AWS", e.AWS, ""},
+		{"Azure", e.Azure, "   (self-signed TLS)"},
+		{"GCP", e.GCP, ""},
+		{"OCI", e.OCI, ""},
+		{"Kubernetes", e.Kubernetes, ""},
+	}
+}
+
+// sdkHints pairs each endpoint with the snippet that points its SDK at it.
+func (e *endpointSet) sdkHints() []struct{ label, url, hint string } {
+	return []struct{ label, url, hint string }{
+		{"AWS", e.AWS, "export AWS_ENDPOINT_URL=%s   (or o.BaseEndpoint in aws-sdk-go-v2)"},
+		{"GCP", e.GCP, "option.WithEndpoint(%q) + option.WithoutAuthentication()"},
+		{"OCI", e.OCI, "common.NewRawConfigurationProvider + client.Host = %q"},
+		{"Azure", e.Azure, "cloud.Configuration ResourceManager endpoint = %q (trust the cert or skip verify)"},
+	}
+}
+
 // printBanner writes the startup summary: the live endpoints and copy-paste
 // snippets for pointing each SDK at them.
-func printBanner(w io.Writer, e endpointSet, adminOn bool) {
+func printBanner(w io.Writer, e *endpointSet, adminOn bool) {
 	fmt.Fprintln(w, "cloudemu — standalone server")
 	fmt.Fprintln(w, "────────────────────────────")
-	if e.AWS != "" {
-		fmt.Fprintf(w, "  AWS         %s\n", e.AWS)
+
+	for _, row := range e.banner() {
+		if row.url != "" {
+			fmt.Fprintf(w, "  %-11s %s%s\n", row.label, row.url, row.note)
+		}
 	}
-	if e.Azure != "" {
-		fmt.Fprintf(w, "  Azure       %s   (self-signed TLS)\n", e.Azure)
-	}
-	if e.GCP != "" {
-		fmt.Fprintf(w, "  GCP         %s\n", e.GCP)
-	}
-	if e.Kubernetes != "" {
-		fmt.Fprintf(w, "  Kubernetes  %s\n", e.Kubernetes)
-	}
+
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Point your SDKs at these endpoints:")
-	if e.AWS != "" {
-		fmt.Fprintf(w, "  AWS   export AWS_ENDPOINT_URL=%s   (or o.BaseEndpoint in aws-sdk-go-v2)\n", e.AWS)
+
+	for _, row := range e.sdkHints() {
+		if row.url != "" {
+			fmt.Fprintf(w, "  %-5s "+row.hint+"\n", row.label, row.url)
+		}
 	}
-	if e.GCP != "" {
-		fmt.Fprintf(w, "  GCP   option.WithEndpoint(%q) + option.WithoutAuthentication()\n", e.GCP)
-	}
-	if e.Azure != "" {
-		fmt.Fprintf(w, "  Azure cloud.Configuration ResourceManager endpoint = %q (trust the cert or skip verify)\n", e.Azure)
-	}
+
 	if adminOn {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Reset state between tests: POST /_cloudemu/reset")
 	}
+
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Press Ctrl-C to stop.")
 }

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -29,6 +29,7 @@ import (
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
 	gcpserver "github.com/stackshy/cloudemu/v2/server/gcp"
+	ociserver "github.com/stackshy/cloudemu/v2/server/oci"
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
 )
 
@@ -46,6 +47,7 @@ type serveConfig struct {
 	awsPort         string
 	azurePort       string
 	gcpPort         string
+	ociPort         string
 	k8sPort         string
 	accountID       string
 	region          string
@@ -77,11 +79,14 @@ func (s *stringList) Set(v string) error {
 func runServe(args []string) error {
 	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	var c serveConfig
-	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp")
+	// OCI is not started by default: it stays opt-in until its services land,
+	// so the default set never binds a port that serves nothing.
+	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
 	fs.StringVar(&c.host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
 	fs.StringVar(&c.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
 	fs.StringVar(&c.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
 	fs.StringVar(&c.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
+	fs.StringVar(&c.ociPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
 	fs.StringVar(&c.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
 	fs.StringVar(&c.accountID, "account-id", "000000000000", "AWS account ID / Azure subscription ID reported by the emulator")
 	fs.StringVar(&c.region, "region", "us-east-1", "default region reported by the emulator")
@@ -214,6 +219,15 @@ func runServe(args []string) error {
 				cloud.AKS.SetK8sAPI(k8s)
 				fresh["azure"] = wrap(azureserver.New(d), "azure", c.logReqs)
 				freshTargets["azure"] = seed.Target{Storage: cloud.BlobStorage, Database: cloud.CosmosDB, Secrets: cloud.KeyVault, Compute: cloud.VirtualMachines}
+			case "oci":
+				cloud := cloudemu.NewOCI(opts...)
+				d := ociserver.DriversFrom(cloud)
+				d.K8sAPI = k8s
+				fresh["oci"] = wrap(ociserver.New(d), "oci", c.logReqs)
+				freshTargets["oci"] = seed.Target{
+					Storage: cloud.ObjectStorage, Database: cloud.NoSQL,
+					Secrets: cloud.Vault, Compute: cloud.Compute,
+				}
 			}
 		}
 		if k8sBackend != nil {
@@ -364,6 +378,9 @@ func runServe(args []string) error {
 		case "gcp":
 			addr = net.JoinHostPort(c.host, c.gcpPort)
 			eps.GCP = fmt.Sprintf("http://%s", addr)
+		case "oci":
+			addr = net.JoinHostPort(c.host, c.ociPort)
+			eps.OCI = fmt.Sprintf("http://%s", addr)
 		case "azure":
 			addr = net.JoinHostPort(c.host, c.azurePort)
 			var err error
@@ -428,7 +445,7 @@ func runServe(args []string) error {
 	}
 
 	if !c.quiet {
-		printBanner(os.Stdout, eps, c.admin)
+		printBanner(os.Stdout, &eps, c.admin)
 	}
 	if c.endpoints != "" {
 		if err := eps.writeFile(c.endpoints); err != nil {
@@ -678,8 +695,8 @@ func parseProviders(s string) ([]string, error) {
 		if p == "" {
 			continue
 		}
-		if p != "aws" && p != "azure" && p != "gcp" {
-			return nil, fmt.Errorf("unknown provider %q (want aws, azure, or gcp)", p)
+		if p != "aws" && p != "azure" && p != "gcp" && p != "oci" {
+			return nil, fmt.Errorf("unknown provider %q (want aws, azure, gcp, or oci)", p)
 		}
 		if !seen[p] {
 			seen[p] = true

--- a/config/oci_options_test.go
+++ b/config/oci_options_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewOptionsOCIDefaults(t *testing.T) {
+	o := NewOptions()
+
+	assert.Equal(t, DefaultTenancyOCID, o.TenancyOCID)
+	assert.Equal(t, DefaultRealm, o.Realm)
+	assert.Equal(t, o.TenancyOCID, o.CompartmentID)
+}
+
+func TestCompartmentDefaultsToSuppliedTenancy(t *testing.T) {
+	o := NewOptions(WithTenancyOCID("ocid1.tenancy.oc1..custom"))
+
+	assert.Equal(t, "ocid1.tenancy.oc1..custom", o.CompartmentID)
+}
+
+func TestExplicitCompartmentWins(t *testing.T) {
+	o := NewOptions(
+		WithTenancyOCID("ocid1.tenancy.oc1..custom"),
+		WithCompartmentID("ocid1.compartment.oc1..dev"),
+	)
+
+	assert.Equal(t, "ocid1.compartment.oc1..dev", o.CompartmentID)
+}
+
+func TestWithRealm(t *testing.T) {
+	assert.Equal(t, "oc2", NewOptions(WithRealm("oc2")).Realm)
+}
+
+func TestOCIRegion(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		expect string
+	}{
+		{name: "untouched AWS default is substituted", region: DefaultRegion, expect: DefaultOCIRegion},
+		{name: "empty is substituted", region: "", expect: DefaultOCIRegion},
+		{name: "explicit OCI region is kept", region: "eu-frankfurt-1", expect: "eu-frankfurt-1"},
+		{name: "any other region is kept", region: "us-west-2", expect: "us-west-2"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &Options{Region: tc.region}
+			assert.Equal(t, tc.expect, o.OCIRegion())
+		})
+	}
+}
+
+func TestOCIOptionsDoNotDisturbOtherProviders(t *testing.T) {
+	o := NewOptions()
+
+	assert.Equal(t, DefaultRegion, o.Region)
+	assert.Equal(t, "123456789012", o.AccountID)
+	assert.Equal(t, "mock-project", o.ProjectID)
+}

--- a/config/options.go
+++ b/config/options.go
@@ -1,6 +1,10 @@
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+)
 
 // Defaults applied when a caller sets no corresponding option.
 const (
@@ -11,8 +15,9 @@ const (
 	// DefaultOCIRegion is used when Region is still DefaultRegion.
 	DefaultOCIRegion = "us-ashburn-1"
 
-	// DefaultRealm is the OCI realm new OCIDs are minted in.
-	DefaultRealm = "oc1"
+	// DefaultRealm is the OCI realm new OCIDs are minted in. Aliased from
+	// idgen, which owns the OCID format, so the two cannot drift.
+	DefaultRealm = idgen.DefaultRealm
 
 	// DefaultTenancyOCID is the built-in tenancy, and the root compartment.
 	DefaultTenancyOCID = "ocid1.tenancy.oc1..aaaaaaaacloudemulocaltenancy"

--- a/config/options.go
+++ b/config/options.go
@@ -2,6 +2,22 @@ package config
 
 import "time"
 
+// Defaults applied when a caller sets no corresponding option.
+const (
+	// DefaultRegion is an AWS region name, so providers with unrelated region
+	// naming compare against it to tell "unset" from "chosen".
+	DefaultRegion = "us-east-1"
+
+	// DefaultOCIRegion is used when Region is still DefaultRegion.
+	DefaultOCIRegion = "us-ashburn-1"
+
+	// DefaultRealm is the OCI realm new OCIDs are minted in.
+	DefaultRealm = "oc1"
+
+	// DefaultTenancyOCID is the built-in tenancy, and the root compartment.
+	DefaultTenancyOCID = "ocid1.tenancy.oc1..aaaaaaaacloudemulocaltenancy"
+)
+
 // Options holds configuration for cloudemu services.
 type Options struct {
 	Clock     Clock
@@ -9,6 +25,21 @@ type Options struct {
 	Latency   time.Duration
 	AccountID string
 	ProjectID string
+	// OCI identity. TenancyOCID is the root compartment; CompartmentID is
+	// where resources land when a caller names none, and defaults to it.
+	TenancyOCID   string
+	CompartmentID string
+	Realm         string
+}
+
+// OCIRegion returns the region OCI services should use, substituting an OCI
+// region when the caller left Region at the AWS default.
+func (o *Options) OCIRegion() string {
+	if o.Region == "" || o.Region == DefaultRegion {
+		return DefaultOCIRegion
+	}
+
+	return o.Region
 }
 
 // Option is a functional option for configuring cloudemu services.
@@ -17,13 +48,21 @@ type Option func(*Options)
 // NewOptions creates Options from the given functional options.
 func NewOptions(opts ...Option) *Options {
 	o := &Options{
-		Clock:     RealClock{},
-		Region:    "us-east-1",
-		AccountID: "123456789012",
-		ProjectID: "mock-project",
+		Clock:       RealClock{},
+		Region:      DefaultRegion,
+		AccountID:   "123456789012",
+		ProjectID:   "mock-project",
+		TenancyOCID: DefaultTenancyOCID,
+		Realm:       DefaultRealm,
 	}
 	for _, opt := range opts {
 		opt(o)
+	}
+
+	// Applied after the options so a custom tenancy becomes the default
+	// compartment rather than the built-in root.
+	if o.CompartmentID == "" {
+		o.CompartmentID = o.TenancyOCID
 	}
 
 	return o
@@ -61,5 +100,26 @@ func WithAccountID(id string) Option {
 func WithProjectID(id string) Option {
 	return func(o *Options) {
 		o.ProjectID = id
+	}
+}
+
+// WithTenancyOCID sets the OCI tenancy, which is also the root compartment.
+func WithTenancyOCID(id string) Option {
+	return func(o *Options) {
+		o.TenancyOCID = id
+	}
+}
+
+// WithCompartmentID sets the OCI compartment new resources default to.
+func WithCompartmentID(id string) Option {
+	return func(o *Options) {
+		o.CompartmentID = id
+	}
+}
+
+// WithRealm sets the OCI realm embedded in generated OCIDs.
+func WithRealm(realm string) Option {
+	return func(o *Options) {
+		o.Realm = realm
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 - [Integration](integration.md) -- Wire CloudEmu into your real app and tests (not a throwaway demo)
 - [Topology](topology.md) -- Network topology simulation engine
 - [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration
+- [OCI Conventions](oci-conventions.md) -- The contract every OCI service implementation follows
 
 ## Quick Links
 

--- a/docs/oci-conventions.md
+++ b/docs/oci-conventions.md
@@ -80,7 +80,8 @@ scope.Scope{Compartment: compartmentID}
 Matching is exact — real OCI only descends the compartment tree when the caller
 passes `compartmentIdInSubtree=true`. Handlers get the parameter with
 `ocirest.RequireCompartmentID(w, r)`, which writes the 400 for you when it is
-missing.
+missing. Use it on every list endpoint; do not fall back to listing across all
+compartments, which real OCI never does.
 
 ## Wire handlers
 
@@ -88,13 +89,17 @@ Use `server/wire/ocirest` for everything that touches the response:
 
 | Helper | Use |
 |---|---|
-| `WriteJSON(w, status, v)` | Success. Stamps `opc-request-id` |
-| `WriteDriverError(w, err)` | Driver errors. Maps the canonical code to OCI's status and code |
-| `WriteError(w, status, code, msg)` | Errors raised in the handler itself |
+| `WriteJSON(w, r, status, v)` | Success. Stamps `opc-request-id` |
+| `WriteDriverError(w, r, err)` | Driver errors. Maps the canonical code to OCI's status and code |
+| `WriteError(w, r, status, code, msg)` | Errors raised in the handler itself |
 | `DecodeJSON(w, r, &v)` | Request bodies. Returns false once it has written the 400 |
 | `RequireCompartmentID(w, r)` | The required list parameter |
-| `Limit(r)` / `Page(r)` / `SetNextPage(w, tok)` | Pagination |
+| `Limit(r)` / `Page(r)` / `SetNextPage(w, tok)` | Pagination. `Limit` caps at `MaxLimit` |
 | `SetWorkRequestID(w, id)` | Async mutations |
+
+The write helpers take the `*http.Request` so they can echo the caller's
+`opc-request-id`, which SDKs and logs correlate on, and mint one only when the
+caller sent none. Pass the request through; do not pass nil.
 
 Never write an error body by hand. `WriteDriverError` is what keeps
 `NotFound` and `PermissionDenied` collapsing into the single
@@ -124,7 +129,7 @@ id := d.WorkRequests.Accept("CREATE_INSTANCE", compartmentID, workrequest.Resour
     Identifier: inst.ID,
 })
 ocirest.SetWorkRequestID(w, id)
-ocirest.WriteJSON(w, http.StatusAccepted, nil)
+ocirest.WriteJSON(w, r, http.StatusAccepted, nil)
 ```
 
 Every CloudEmu mutation completes synchronously, so the request is already

--- a/docs/oci-conventions.md
+++ b/docs/oci-conventions.md
@@ -1,0 +1,186 @@
+# OCI Service Conventions
+
+The contract every OCI service implementation follows. One service per branch,
+one PR to `development`. Read this before writing a service; it exists so
+seventeen independently-built services come out looking like one codebase.
+
+The foundation this builds on (`config` identity, `internal/idgen` OCIDs,
+`scope.Compartment`, `server/wire/ocirest`, `server/oci/workrequest`, the
+`Provider` and `Drivers` bundles) is already on `development`. Do not modify it
+without saying so in your PR — every other service depends on it.
+
+## Scope of one branch
+
+| Branch | Adds |
+|---|---|
+| `feat/oci-<service>` | `providers/oci/<service>/` and `server/oci/<service>/` |
+
+Assign your slot in `providers/oci/oci.go` `New()` and `server/oci/oci.go`
+`New()`, and map it in `server/oci/from_provider.go`. The struct fields already
+exist — fill them in, do not restructure them. Those three one-line edits are
+the only shared files a service branch touches.
+
+## The three layers
+
+A service implements the portable driver interface that already exists in
+`services/<name>/driver`. Do not define a new driver interface; if OCI needs an
+operation the interface lacks, add it as an optional capability discovered by
+type assertion, the way `storage/driver.BucketAttributes` and
+`cache/driver.SubnetGroups` do.
+
+| Layer | Path | Contains |
+|---|---|---|
+| Provider mock | `providers/oci/<service>/` | `Mock` over `memstore.Store[V]`, implements the driver |
+| Wire handler | `server/oci/<service>/` | `Matches`/`ServeHTTP`, speaks OCI REST |
+
+Start the mock with a compile-time interface check, as every other provider does:
+
+```go
+var _ driver.Bucket = (*Mock)(nil)
+```
+
+## Identity
+
+Read identity off `*config.Options`. Never hard-code a tenancy, compartment or
+realm.
+
+| Field | Meaning |
+|---|---|
+| `o.TenancyOCID` | Root compartment |
+| `o.CompartmentID` | Where a resource lands when the caller names none |
+| `o.Realm` | `oc1` commercial, `oc2`/`oc3` government |
+| `o.OCIRegion()` | Region, substituting an OCI region for the AWS default |
+
+Use `o.OCIRegion()`, not `o.Region`. The latter defaults to `us-east-1`, which
+is not an OCI region and mints OCIDs with a nonsense region code.
+
+## OCIDs
+
+Generate every identifier with `idgen`, never by hand.
+
+```go
+idgen.OCID("instance", o.Realm, o.OCIRegion())  // ocid1.instance.oc1.iad.aaaaaaaa…
+idgen.GlobalOCID("compartment", o.Realm)        // ocid1.compartment.oc1..aaaaaaaa…
+```
+
+Identity resources — compartments, users, groups, policies, dynamic groups —
+are region-agnostic and use `GlobalOCID`. Everything else is region-scoped.
+The resource type segment is the lowercase OCI resource name (`instance`,
+`vcn`, `subnet`, `bucket`, `vault`, `cluster`).
+
+## Compartments
+
+`compartmentId` is required on nearly every OCI list call. Record it at create
+time and filter lists by it:
+
+```go
+scope.Scope{Compartment: compartmentID}
+```
+
+Matching is exact — real OCI only descends the compartment tree when the caller
+passes `compartmentIdInSubtree=true`. Handlers get the parameter with
+`ocirest.RequireCompartmentID(w, r)`, which writes the 400 for you when it is
+missing.
+
+## Wire handlers
+
+Use `server/wire/ocirest` for everything that touches the response:
+
+| Helper | Use |
+|---|---|
+| `WriteJSON(w, status, v)` | Success. Stamps `opc-request-id` |
+| `WriteDriverError(w, err)` | Driver errors. Maps the canonical code to OCI's status and code |
+| `WriteError(w, status, code, msg)` | Errors raised in the handler itself |
+| `DecodeJSON(w, r, &v)` | Request bodies. Returns false once it has written the 400 |
+| `RequireCompartmentID(w, r)` | The required list parameter |
+| `Limit(r)` / `Page(r)` / `SetNextPage(w, tok)` | Pagination |
+| `SetWorkRequestID(w, id)` | Async mutations |
+
+Never write an error body by hand. `WriteDriverError` is what keeps
+`NotFound` and `PermissionDenied` collapsing into the single
+`404 NotAuthorizedOrNotFound` that real OCI returns, so callers cannot probe
+across a compartment boundary.
+
+Do not verify request signatures. No provider in this repo authenticates, and
+the OCI SDK's signing is ignored the same way.
+
+### Matches
+
+Register the narrowest predicate that identifies your service. Handlers are
+evaluated in registration order and first match wins, so a broad `Matches` will
+silently swallow another service's traffic. If your paths overlap another
+service's, say so in the `Drivers` field comment — that is what the GCP bundle
+does for AlloyDB and GKE.
+
+## Work requests
+
+Mutations that are asynchronous in real OCI return `202` with an
+`opc-work-request-id` header. Record one and stamp it:
+
+```go
+id := d.WorkRequests.Accept("CREATE_INSTANCE", compartmentID, workrequest.Resource{
+    EntityType: "instance",
+    ActionType: workrequest.ActionCreated,
+    Identifier: inst.ID,
+})
+ocirest.SetWorkRequestID(w, id)
+ocirest.WriteJSON(w, http.StatusAccepted, nil)
+```
+
+Every CloudEmu mutation completes synchronously, so the request is already
+`SUCCEEDED` when the waiter first polls. The envelope exists to satisfy SDK
+waiters and to carry the created resource's OCID back to them. The shared
+poller is registered ahead of every service handler; do not serve
+`/workRequests` yourself.
+
+## Metrics
+
+If the service produces metrics, give the mock a `SetMonitoring` method:
+
+```go
+func (m *Mock) SetMonitoring(mon mondriver.Monitoring) { m.mon = mon }
+```
+
+`providers/oci.New` finds it by type assertion and wires it. Add the service to
+the slice in `wireMonitoring` if it belongs there.
+
+## Errors
+
+Return `errors.New(errors.<Code>, msg)` / `errors.Newf` from drivers. Use the
+canonical codes — the wire layer maps them. Do not return OCI error strings
+from a driver; the driver is provider-agnostic and the same code path serves
+the portable API.
+
+## Comments
+
+Match the density of the file next to yours. Struct fields are usually bare;
+where a comment earns its place it is one or two lines stating a fact. Type and
+function doc comments are typically a single sentence. No multi-paragraph
+rationale blocks, no embedded code samples in doc comments.
+
+## Tests
+
+`go build ./... && go test ./...` and `golangci-lint run` must be clean before
+the PR. Table-driven tests with `testify`, matching the existing files.
+
+Cover, at minimum:
+
+- Driver CRUD, including the not-found and already-exists paths
+- Compartment filtering — a resource in another compartment must not list
+- OCID shape for each resource type the service mints
+- Handler routing: what `Matches` claims and, importantly, what it does not
+- The wire response for one success and one error per operation family
+
+An SDK-compat test using `github.com/oracle/oci-go-sdk` against
+`httptest.NewServer` is the strongest evidence the handler is right. Add one
+where the SDK makes it practical.
+
+## Definition of done
+
+- [ ] Driver interface fully implemented, compile-time check present
+- [ ] Wire handler registered in `server/oci/oci.go`
+- [ ] Slot assigned in `providers/oci/oci.go` and `server/oci/from_provider.go`
+- [ ] `go build ./...` clean
+- [ ] `go test ./...` clean — the whole suite, not just your package
+- [ ] `golangci-lint run` clean for the packages you touched
+- [ ] Operations added to `docs/services.md`

--- a/internal/idgen/ocid.go
+++ b/internal/idgen/ocid.go
@@ -56,8 +56,10 @@ var regionCodes = map[string]string{
 }
 
 // RegionCode returns the three-letter code for an OCI region name. An
-// unrecognized region falls back to its city segment, so regions this table
-// predates still get distinct codes.
+// unrecognized region falls back to the first three letters of its city
+// segment, which is not the real IATA code and can collide with another
+// unmapped city sharing that prefix. The table covers every current
+// commercial region, so the fallback only applies to ones added later.
 func RegionCode(region string) string {
 	if code, ok := regionCodes[region]; ok {
 		return code

--- a/internal/idgen/ocid.go
+++ b/internal/idgen/ocid.go
@@ -1,0 +1,104 @@
+package idgen
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultRealm is the OCI realm used when none is configured.
+const DefaultRealm = "oc1"
+
+// regionCodeLen is the length of the region code embedded in an OCID.
+const regionCodeLen = 3
+
+// regionCodes maps an OCI region name to the three-letter code that appears
+// inside an OCID.
+//
+//nolint:gochecknoglobals // static lookup table, never mutated
+var regionCodes = map[string]string{
+	"af-johannesburg-1": "jnb",
+	"ap-chuncheon-1":    "yny",
+	"ap-hyderabad-1":    "hyd",
+	"ap-melbourne-1":    "mel",
+	"ap-mumbai-1":       "bom",
+	"ap-osaka-1":        "kix",
+	"ap-seoul-1":        "icn",
+	"ap-singapore-1":    "sin",
+	"ap-sydney-1":       "syd",
+	"ap-tokyo-1":        "nrt",
+	"ca-montreal-1":     "yul",
+	"ca-toronto-1":      "yyz",
+	"eu-amsterdam-1":    "ams",
+	"eu-frankfurt-1":    "fra",
+	"eu-madrid-1":       "mad",
+	"eu-marseille-1":    "mrs",
+	"eu-milan-1":        "lin",
+	"eu-paris-1":        "cdg",
+	"eu-stockholm-1":    "arn",
+	"eu-zurich-1":       "zrh",
+	"il-jerusalem-1":    "mtz",
+	"me-abudhabi-1":     "auh",
+	"me-dubai-1":        "dxb",
+	"me-jeddah-1":       "jed",
+	"mx-monterrey-1":    "mty",
+	"mx-queretaro-1":    "qro",
+	"sa-bogota-1":       "bog",
+	"sa-santiago-1":     "scl",
+	"sa-saopaulo-1":     "gru",
+	"sa-valparaiso-1":   "vap",
+	"sa-vinhedo-1":      "vcp",
+	"uk-cardiff-1":      "cwl",
+	"uk-london-1":       "lhr",
+	"us-ashburn-1":      "iad",
+	"us-chicago-1":      "ord",
+	"us-phoenix-1":      "phx",
+	"us-sanjose-1":      "sjc",
+}
+
+// RegionCode returns the three-letter code for an OCI region name. An
+// unrecognized region falls back to its city segment, so regions this table
+// predates still get distinct codes.
+func RegionCode(region string) string {
+	if code, ok := regionCodes[region]; ok {
+		return code
+	}
+
+	if region == "" {
+		return ""
+	}
+
+	parts := strings.Split(strings.ToLower(region), "-")
+
+	city := parts[0]
+	if len(parts) > 1 {
+		city = parts[1]
+	}
+
+	if len(city) >= regionCodeLen {
+		return city[:regionCodeLen]
+	}
+
+	return city
+}
+
+// OCID generates an Oracle Cloud Identifier of the form
+// ocid1.<type>.<realm>.<region>.<unique>. Identity resources are global and
+// pass an empty region, producing the doubled dot real OCI emits.
+func OCID(resourceType, realm, region string) string {
+	if realm == "" {
+		realm = DefaultRealm
+	}
+
+	return fmt.Sprintf("ocid1.%s.%s.%s.%s", resourceType, realm, RegionCode(region), uniqueSuffix())
+}
+
+// GlobalOCID generates an OCID for a region-agnostic identity resource.
+func GlobalOCID(resourceType, realm string) string {
+	return OCID(resourceType, realm, "")
+}
+
+// uniqueSuffix returns the opaque trailing segment of an OCID, keeping the
+// leading "a" run of a real one and the shared monotonic counter.
+func uniqueSuffix() string {
+	return fmt.Sprintf("aaaaaaaa%016x", next())
+}

--- a/internal/idgen/ocid_test.go
+++ b/internal/idgen/ocid_test.go
@@ -1,0 +1,139 @@
+package idgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegionCode(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		expect string
+	}{
+		{name: "ashburn", region: "us-ashburn-1", expect: "iad"},
+		{name: "phoenix", region: "us-phoenix-1", expect: "phx"},
+		{name: "frankfurt", region: "eu-frankfurt-1", expect: "fra"},
+		{name: "mumbai", region: "ap-mumbai-1", expect: "bom"},
+		{name: "empty region", region: "", expect: ""},
+		{name: "unknown region falls back to city prefix", region: "us-neverland-1", expect: "nev"},
+		{name: "unknown short city keeps what it has", region: "us-ab-1", expect: "ab"},
+		{name: "single segment", region: "narnia", expect: "nar"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, RegionCode(tc.region))
+		})
+	}
+}
+
+func TestRegionCodeIsDistinctPerRegion(t *testing.T) {
+	// A shared fallback would let two regions collide and silently merge
+	// resources in a list filtered by OCID region.
+	seen := make(map[string]string, len(regionCodes))
+
+	for region, code := range regionCodes {
+		if prev, dup := seen[code]; dup {
+			t.Errorf("region code %q shared by %q and %q", code, prev, region)
+		}
+
+		seen[code] = region
+	}
+}
+
+func TestOCID(t *testing.T) {
+	Reset()
+
+	tests := []struct {
+		name         string
+		resourceType string
+		realm        string
+		region       string
+		expectPrefix string
+	}{
+		{
+			name:         "region-scoped instance",
+			resourceType: "instance",
+			realm:        "oc1",
+			region:       "us-ashburn-1",
+			expectPrefix: "ocid1.instance.oc1.iad.",
+		},
+		{
+			name:         "empty realm defaults to oc1",
+			resourceType: "volume",
+			realm:        "",
+			region:       "us-phoenix-1",
+			expectPrefix: "ocid1.volume.oc1.phx.",
+		},
+		{
+			name:         "government realm is preserved",
+			resourceType: "instance",
+			realm:        "oc2",
+			region:       "us-langley-1",
+			expectPrefix: "ocid1.instance.oc2.lan.",
+		},
+		{
+			name:         "global resource has empty region segment",
+			resourceType: "compartment",
+			realm:        "oc1",
+			region:       "",
+			expectPrefix: "ocid1.compartment.oc1..",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id := OCID(tc.resourceType, tc.realm, tc.region)
+
+			assert.True(t, strings.HasPrefix(id, tc.expectPrefix),
+				"got %q, want prefix %q", id, tc.expectPrefix)
+			assert.Greater(t, len(id), len(tc.expectPrefix),
+				"unique suffix must not be empty")
+		})
+	}
+}
+
+func TestGlobalOCIDHasDoubledDot(t *testing.T) {
+	Reset()
+
+	// Real OCI identity OCIDs carry an empty region segment, so clients that
+	// split on "." must still see the same field count.
+	id := GlobalOCID("user", "oc1")
+
+	require.True(t, strings.HasPrefix(id, "ocid1.user.oc1.."), "got %q", id)
+	assert.Len(t, strings.Split(id, "."), 5, "OCID must always have 5 dot-separated segments: %q", id)
+}
+
+func TestOCIDIsUnique(t *testing.T) {
+	Reset()
+
+	const count = 100
+
+	seen := make(map[string]struct{}, count)
+
+	for range count {
+		id := OCID("instance", "oc1", "us-ashburn-1")
+
+		_, dup := seen[id]
+		require.False(t, dup, "duplicate OCID generated: %q", id)
+
+		seen[id] = struct{}{}
+	}
+
+	assert.Len(t, seen, count)
+}
+
+func TestOCIDSharesCounterWithOtherGenerators(t *testing.T) {
+	Reset()
+
+	// All generators draw from one counter, so a resource that has both an
+	// OCID and a plain ID can never collide on the numeric part.
+	first := OCID("instance", "oc1", "us-ashburn-1")
+	second := OCID("instance", "oc1", "us-ashburn-1")
+
+	assert.NotEqual(t, first, second)
+}

--- a/providers/oci/oci.go
+++ b/providers/oci/oci.go
@@ -1,0 +1,109 @@
+// Package oci provides OCI mock provider factories.
+package oci
+
+import (
+	"github.com/stackshy/cloudemu/v2/config"
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	serverlessdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Provider holds all OCI mock services. Fields are driver interfaces rather
+// than concrete mocks, so a service not yet implemented is simply nil.
+type Provider struct {
+	ObjectStorage     storagedriver.Bucket
+	Compute           computedriver.Compute
+	NoSQL             dbdriver.Database
+	Functions         serverlessdriver.Serverless
+	VCN               netdriver.Networking
+	Monitoring        mondriver.Monitoring
+	Identity          iamdriver.IAM
+	DNS               dnsdriver.DNS
+	LoadBalancer      lbdriver.LoadBalancer
+	Queue             mqdriver.MessageQueue
+	Cache             cachedriver.Cache
+	Vault             secretsdriver.Secrets
+	Logging           logdriver.Logging
+	Notifications     notifdriver.Notification
+	ContainerRegistry crdriver.ContainerRegistry
+	Events            ebdriver.EventBus
+	Database          rdbdriver.RelationalDB
+
+	ResourceDiscovery *resourcediscovery.Engine
+
+	// Identity this provider was created with, so callers (e.g. a standalone
+	// server) can wire them without re-reading the options.
+	TenancyOCID   string
+	CompartmentID string
+	Realm         string
+	Region        string
+}
+
+// monitoringAware is implemented by mocks that push metrics into the
+// monitoring service, discovered by type assertion since the portable driver
+// interfaces do not declare it.
+type monitoringAware interface {
+	SetMonitoring(mon mondriver.Monitoring)
+}
+
+// New creates a new OCI provider with all mock services.
+func New(opts ...config.Option) *Provider {
+	o := config.NewOptions(opts...)
+	p := &Provider{
+		TenancyOCID:   o.TenancyOCID,
+		CompartmentID: o.CompartmentID,
+		Realm:         o.Realm,
+		Region:        o.OCIRegion(),
+	}
+
+	p.wireMonitoring()
+	p.wireDiscovery()
+
+	return p
+}
+
+// wireMonitoring points every metric-producing mock at the monitoring service.
+func (p *Provider) wireMonitoring() {
+	if p.Monitoring == nil {
+		return
+	}
+
+	for _, svc := range []any{
+		p.ObjectStorage, p.Compute, p.NoSQL, p.Functions, p.Queue,
+		p.Cache, p.Logging, p.Notifications, p.ContainerRegistry,
+		p.Events, p.Database,
+	} {
+		if aware, ok := svc.(monitoringAware); ok {
+			aware.SetMonitoring(p.Monitoring)
+		}
+	}
+}
+
+// wireDiscovery builds the resource discovery engine over the mock services.
+func (p *Provider) wireDiscovery() {
+	p.ResourceDiscovery = resourcediscovery.New(
+		resourcediscovery.ProviderOCI, p.CompartmentID, p.Region,
+		&resourcediscovery.Drivers{
+			Compute:    p.Compute,
+			Networking: p.VCN,
+			Storage:    p.ObjectStorage,
+			Database:   p.NoSQL,
+			Serverless: p.Functions,
+		},
+	)
+}

--- a/providers/oci/oci_test.go
+++ b/providers/oci/oci_test.go
@@ -1,0 +1,68 @@
+package oci_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2"
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/providers/oci"
+)
+
+func TestNewAppliesIdentityDefaults(t *testing.T) {
+	p := oci.New()
+
+	assert.Equal(t, config.DefaultTenancyOCID, p.TenancyOCID)
+	assert.Equal(t, config.DefaultRealm, p.Realm)
+	// The AWS default region is not a real OCI region, so it is substituted.
+	assert.Equal(t, config.DefaultOCIRegion, p.Region)
+	assert.Equal(t, p.TenancyOCID, p.CompartmentID)
+}
+
+func TestNewHonoursIdentityOptions(t *testing.T) {
+	p := oci.New(
+		config.WithTenancyOCID("ocid1.tenancy.oc1..custom"),
+		config.WithCompartmentID("ocid1.compartment.oc1..dev"),
+		config.WithRealm("oc2"),
+		config.WithRegion("eu-frankfurt-1"),
+	)
+
+	assert.Equal(t, "ocid1.tenancy.oc1..custom", p.TenancyOCID)
+	assert.Equal(t, "ocid1.compartment.oc1..dev", p.CompartmentID)
+	assert.Equal(t, "oc2", p.Realm)
+	assert.Equal(t, "eu-frankfurt-1", p.Region)
+}
+
+func TestCompartmentDefaultsToCustomTenancy(t *testing.T) {
+	// A caller who sets only the tenancy must not get the built-in root as
+	// their default compartment.
+	p := oci.New(config.WithTenancyOCID("ocid1.tenancy.oc1..custom"))
+
+	assert.Equal(t, "ocid1.tenancy.oc1..custom", p.CompartmentID)
+}
+
+func TestResourceDiscoveryIsWired(t *testing.T) {
+	p := oci.New()
+
+	require.NotNil(t, p.ResourceDiscovery, "discovery engine must exist even with no services")
+}
+
+func TestUnimplementedServicesAreNil(t *testing.T) {
+	// Every service slot is declared up front, so a service that has not
+	// landed yet reads as nil rather than failing to compile.
+	p := oci.New()
+
+	assert.Nil(t, p.ObjectStorage)
+	assert.Nil(t, p.Compute)
+	assert.Nil(t, p.VCN)
+	assert.Nil(t, p.Identity)
+}
+
+func TestNewOCIFactory(t *testing.T) {
+	p := cloudemu.NewOCI(config.WithRegion("uk-london-1"))
+
+	require.NotNil(t, p)
+	assert.Equal(t, "uk-london-1", p.Region)
+}

--- a/server/oci/from_provider.go
+++ b/server/oci/from_provider.go
@@ -1,0 +1,38 @@
+package oci
+
+import (
+	ociprovider "github.com/stackshy/cloudemu/v2/providers/oci"
+)
+
+// DriversFrom maps a fully-constructed OCI provider onto a Drivers bundle,
+// wiring every service handler the standalone server can expose. It lets a
+// standalone binary go from a provider to a running server without
+// hand-mapping each field.
+func DriversFrom(p *ociprovider.Provider) Drivers {
+	return Drivers{
+		ObjectStorage:     p.ObjectStorage,
+		Compute:           p.Compute,
+		NoSQL:             p.NoSQL,
+		Functions:         p.Functions,
+		VCN:               p.VCN,
+		Monitoring:        p.Monitoring,
+		Identity:          p.Identity,
+		DNS:               p.DNS,
+		LoadBalancer:      p.LoadBalancer,
+		Queue:             p.Queue,
+		Cache:             p.Cache,
+		Vault:             p.Vault,
+		Logging:           p.Logging,
+		Notifications:     p.Notifications,
+		ContainerRegistry: p.ContainerRegistry,
+		Events:            p.Events,
+		Database:          p.Database,
+		// K8sAPI is left nil; injected by the caller when a shared cluster is desired.
+		K8sAPI:            nil,
+		ResourceDiscovery: p.ResourceDiscovery,
+		TenancyOCID:       p.TenancyOCID,
+		CompartmentID:     p.CompartmentID,
+		Realm:             p.Realm,
+		Region:            p.Region,
+	}
+}

--- a/server/oci/oci.go
+++ b/server/oci/oci.go
@@ -1,0 +1,111 @@
+// Package oci assembles CloudEmu's OCI-compatible HTTP server.
+//
+// New takes a Drivers bundle and returns a *server.Server preloaded with the
+// handler for each non-nil driver. Consumers that want a single service can
+// skip this package and register the handler directly on their own
+// server.Server.
+package oci
+
+import (
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server"
+	"github.com/stackshy/cloudemu/v2/server/oci/workrequest"
+	cachedriver "github.com/stackshy/cloudemu/v2/services/cache/driver"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
+	crdriver "github.com/stackshy/cloudemu/v2/services/containerregistry/driver"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	dnsdriver "github.com/stackshy/cloudemu/v2/services/dns/driver"
+	ebdriver "github.com/stackshy/cloudemu/v2/services/eventbus/driver"
+	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
+	"github.com/stackshy/cloudemu/v2/services/kubernetes"
+	lbdriver "github.com/stackshy/cloudemu/v2/services/loadbalancer/driver"
+	logdriver "github.com/stackshy/cloudemu/v2/services/logging/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	rdbdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
+	"github.com/stackshy/cloudemu/v2/services/resourcediscovery"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	serverlessdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
+)
+
+// Drivers bundles the driver interfaces the OCI server can expose.
+type Drivers struct {
+	ObjectStorage     storagedriver.Bucket
+	Compute           computedriver.Compute
+	NoSQL             dbdriver.Database
+	Functions         serverlessdriver.Serverless
+	VCN               netdriver.Networking
+	Monitoring        mondriver.Monitoring
+	Identity          iamdriver.IAM
+	DNS               dnsdriver.DNS
+	LoadBalancer      lbdriver.LoadBalancer
+	Queue             mqdriver.MessageQueue
+	Cache             cachedriver.Cache
+	Vault             secretsdriver.Secrets
+	Logging           logdriver.Logging
+	Notifications     notifdriver.Notification
+	ContainerRegistry crdriver.ContainerRegistry
+	Events            ebdriver.EventBus
+	Database          rdbdriver.RelationalDB
+	// K8sAPI is the shared in-memory Kubernetes data-plane API server, shared
+	// with the AWS, Azure and GCP bundles so a kubeconfig issued by any
+	// control plane reaches the same backend. Leave nil to disable it.
+	K8sAPI *kubernetes.APIServer
+	// ResourceDiscovery backs OCI Resource Search. Leave nil to omit it.
+	ResourceDiscovery *resourcediscovery.Engine
+	// WorkRequests backs the shared work request poller. New creates one when
+	// it is nil, so handlers can always record asynchronous operations.
+	WorkRequests *workrequest.Store
+
+	TenancyOCID   string
+	CompartmentID string
+	Realm         string
+	Region        string
+}
+
+// New returns a server that speaks OCI's REST JSON wire protocol for every
+// non-nil driver in d.
+//
+//nolint:gocritic // Drivers is all interface fields; the bundle is passed by value like the other providers'.
+func New(d Drivers) *server.Server {
+	if d.WorkRequests == nil {
+		d.WorkRequests = workrequest.New(config.NewOptions(d.identityOptions()...))
+	}
+
+	srv := server.New()
+
+	// Registered first so it owns every work request poll uniformly, rather
+	// than a service handler greedily claiming polls it did not create.
+	srv.Register(workrequest.NewHandler(d.WorkRequests))
+
+	return srv
+}
+
+// identityOptions turns the bundle's identity fields into config options,
+// skipping empty ones so they keep their defaults.
+//
+//nolint:gocritic // matches New's by-value Drivers.
+func (d Drivers) identityOptions() []config.Option {
+	var opts []config.Option
+
+	if d.Region != "" {
+		opts = append(opts, config.WithRegion(d.Region))
+	}
+
+	if d.Realm != "" {
+		opts = append(opts, config.WithRealm(d.Realm))
+	}
+
+	if d.TenancyOCID != "" {
+		opts = append(opts, config.WithTenancyOCID(d.TenancyOCID))
+	}
+
+	if d.CompartmentID != "" {
+		opts = append(opts, config.WithCompartmentID(d.CompartmentID))
+	}
+
+	return opts
+}

--- a/server/oci/oci_test.go
+++ b/server/oci/oci_test.go
@@ -43,7 +43,7 @@ func TestNewCreatesWorkRequestStoreWhenAbsent(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests")
+	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests?compartmentId=ocid1.compartment.oc1..abc")
 	require.NoError(t, err)
 
 	defer resp.Body.Close()
@@ -94,7 +94,7 @@ func TestDriversFromProviderBuildsServer(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests")
+	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests?compartmentId=ocid1.compartment.oc1..abc")
 	require.NoError(t, err)
 
 	defer resp.Body.Close()

--- a/server/oci/oci_test.go
+++ b/server/oci/oci_test.go
@@ -1,0 +1,103 @@
+package oci_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	ociprovider "github.com/stackshy/cloudemu/v2/providers/oci"
+	ociserver "github.com/stackshy/cloudemu/v2/server/oci"
+	"github.com/stackshy/cloudemu/v2/server/oci/workrequest"
+)
+
+func TestNewServesWorkRequests(t *testing.T) {
+	store := workrequest.New(config.NewOptions(config.WithRegion("us-ashburn-1")))
+	id := store.Accept("CREATE_INSTANCE", "ocid1.compartment.oc1..abc")
+
+	srv := ociserver.New(ociserver.Drivers{WorkRequests: store})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests/" + id)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var wr workrequest.WorkRequest
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&wr))
+	assert.Equal(t, id, wr.ID)
+}
+
+func TestNewCreatesWorkRequestStoreWhenAbsent(t *testing.T) {
+	// A caller assembling Drivers by hand must still get a working poller.
+	srv := ociserver.New(ociserver.Drivers{Region: "eu-frankfurt-1"})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests")
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestUnroutedRequestIsNotImplemented(t *testing.T) {
+	// No services have landed yet, so anything else falls through the empty
+	// handler chain.
+	srv := ociserver.New(ociserver.Drivers{})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/20160918/instances?compartmentId=x")
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+}
+
+func TestDriversFromCarriesIdentity(t *testing.T) {
+	p := ociprovider.New(
+		config.WithTenancyOCID("ocid1.tenancy.oc1..custom"),
+		config.WithCompartmentID("ocid1.compartment.oc1..dev"),
+		config.WithRealm("oc2"),
+		config.WithRegion("ap-mumbai-1"),
+	)
+
+	d := ociserver.DriversFrom(p)
+
+	assert.Equal(t, "ocid1.tenancy.oc1..custom", d.TenancyOCID)
+	assert.Equal(t, "ocid1.compartment.oc1..dev", d.CompartmentID)
+	assert.Equal(t, "oc2", d.Realm)
+	assert.Equal(t, "ap-mumbai-1", d.Region)
+	assert.NotNil(t, d.ResourceDiscovery)
+	assert.Nil(t, d.K8sAPI, "K8sAPI is injected by the caller, not the provider")
+}
+
+func TestDriversFromProviderBuildsServer(t *testing.T) {
+	p := ociprovider.New()
+
+	srv := ociserver.New(ociserver.DriversFrom(p))
+	require.NotNil(t, srv)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/20160918/workRequests")
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/server/oci/workrequest/workrequest.go
+++ b/server/oci/workrequest/workrequest.go
@@ -1,0 +1,210 @@
+// Package workrequest provides OCI's asynchronous work request envelope.
+//
+// Real OCI returns 202 with an opc-work-request-id from most mutating calls,
+// and SDK waiters poll GET /{version}/workRequests/{id} until the status is
+// terminal. Each service publishes that endpoint under its own API version
+// prefix; CloudEmu collapses every service onto one HTTP server, so this
+// handler claims any path ending in workRequests and answers uniformly.
+//
+// Every CloudEmu mutation completes synchronously, so an accepted work request
+// is already SUCCEEDED — the envelope exists to keep SDK waiters happy and to
+// carry the created resource's OCID back to them.
+package workrequest
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+	"github.com/stackshy/cloudemu/v2/internal/memstore"
+	"github.com/stackshy/cloudemu/v2/server/wire/ocirest"
+)
+
+// Work request lifecycle states.
+const (
+	StatusAccepted   = "ACCEPTED"
+	StatusInProgress = "IN_PROGRESS"
+	StatusSucceeded  = "SUCCEEDED"
+	StatusFailed     = "FAILED"
+)
+
+// Action types a work request reports against an affected resource.
+const (
+	ActionCreated    = "CREATED"
+	ActionUpdated    = "UPDATED"
+	ActionDeleted    = "DELETED"
+	ActionInProgress = "IN_PROGRESS"
+	ActionRelated    = "RELATED"
+)
+
+const segment = "workRequests"
+
+// Resource is a resource a work request affected.
+type Resource struct {
+	EntityType string `json:"entityType"`
+	ActionType string `json:"actionType"`
+	Identifier string `json:"identifier"`
+	EntityURI  string `json:"entityUri,omitempty"`
+}
+
+// WorkRequest is OCI's asynchronous operation record.
+type WorkRequest struct {
+	ID              string     `json:"id"`
+	OperationType   string     `json:"operationType"`
+	Status          string     `json:"status"`
+	CompartmentID   string     `json:"compartmentId"`
+	Resources       []Resource `json:"resources"`
+	PercentComplete float32    `json:"percentComplete"`
+	TimeAccepted    string     `json:"timeAccepted"`
+	TimeStarted     string     `json:"timeStarted,omitempty"`
+	TimeFinished    string     `json:"timeFinished,omitempty"`
+}
+
+// Store records work requests so SDK waiters can poll them.
+type Store struct {
+	requests *memstore.Store[*WorkRequest]
+	opts     *config.Options
+	mu       sync.RWMutex
+	order    []string
+}
+
+// New creates a work request store.
+func New(opts *config.Options) *Store {
+	return &Store{
+		requests: memstore.New[*WorkRequest](),
+		opts:     opts,
+	}
+}
+
+// Accept records a completed work request and returns its OCID, which the
+// caller stamps as opc-work-request-id.
+func (s *Store) Accept(operationType, compartmentID string, resources ...Resource) string {
+	now := s.opts.Clock.Now().UTC().Format(time.RFC3339)
+	id := idgen.OCID("workrequest", s.opts.Realm, s.opts.OCIRegion())
+
+	wr := &WorkRequest{
+		ID:              id,
+		OperationType:   operationType,
+		Status:          StatusSucceeded,
+		CompartmentID:   compartmentID,
+		Resources:       resources,
+		PercentComplete: 100,
+		TimeAccepted:    now,
+		TimeStarted:     now,
+		TimeFinished:    now,
+	}
+
+	s.requests.Set(id, wr)
+
+	s.mu.Lock()
+	s.order = append(s.order, id)
+	s.mu.Unlock()
+
+	return id
+}
+
+// Get returns a recorded work request.
+func (s *Store) Get(id string) (*WorkRequest, bool) {
+	return s.requests.Get(id)
+}
+
+// List returns work requests in the given compartment, in creation order. An
+// empty compartment returns all of them.
+func (s *Store) List(compartmentID string) []*WorkRequest {
+	s.mu.RLock()
+	ids := make([]string, len(s.order))
+	copy(ids, s.order)
+	s.mu.RUnlock()
+
+	out := make([]*WorkRequest, 0, len(ids))
+
+	for _, id := range ids {
+		wr, ok := s.requests.Get(id)
+		if !ok {
+			continue
+		}
+
+		if compartmentID != "" && wr.CompartmentID != compartmentID {
+			continue
+		}
+
+		out = append(out, wr)
+	}
+
+	return out
+}
+
+// Handler serves work request polls for every OCI service.
+type Handler struct{ store *Store }
+
+// NewHandler returns the work request handler backed by store.
+func NewHandler(store *Store) *Handler { return &Handler{store: store} }
+
+// Matches claims GET on any path under a workRequests segment, regardless of
+// the service's API version prefix.
+func (*Handler) Matches(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+
+	_, _, ok := parse(r.URL.Path)
+
+	return ok
+}
+
+// ServeHTTP answers a single work request, its sub-collections, or a list.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	id, sub, ok := parse(r.URL.Path)
+	if !ok {
+		ocirest.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed work request path")
+		return
+	}
+
+	if id == "" {
+		ocirest.WriteJSON(w, http.StatusOK, h.store.List(ocirest.CompartmentID(r)))
+		return
+	}
+
+	wr, found := h.store.Get(id)
+	if !found {
+		ocirest.WriteError(w, http.StatusNotFound, "NotAuthorizedOrNotFound", "work request "+id+" not found")
+		return
+	}
+
+	// A synchronous mutation never fails partway, so errors and logs are
+	// always empty; the sub-collections exist because SDK waiters read them
+	// after a terminal status.
+	switch sub {
+	case "errors", "logs":
+		ocirest.WriteJSON(w, http.StatusOK, []any{})
+	default:
+		ocirest.WriteJSON(w, http.StatusOK, wr)
+	}
+}
+
+// parse splits /{version}/workRequests[/{id}[/{sub}]].
+func parse(urlPath string) (id, sub string, ok bool) {
+	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
+
+	for i, p := range parts {
+		if p != segment {
+			continue
+		}
+
+		switch rest := parts[i+1:]; {
+		case len(rest) == 0:
+			return "", "", true
+		case len(rest) == 1:
+			return rest[0], "", true
+		case len(rest) == 2: //nolint:mnd // an id plus one sub-collection segment
+			return rest[0], rest[1], true
+		default:
+			return "", "", false
+		}
+	}
+
+	return "", "", false
+}

--- a/server/oci/workrequest/workrequest.go
+++ b/server/oci/workrequest/workrequest.go
@@ -156,21 +156,32 @@ func (*Handler) Matches(r *http.Request) bool {
 }
 
 // ServeHTTP answers a single work request, its sub-collections, or a list.
+//
+// The malformed-path branch is unreachable through server.Server, which calls
+// Matches first, but ServeHTTP is exported and stays correct when mounted on a
+// plain mux.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	id, sub, ok := parse(r.URL.Path)
 	if !ok {
-		ocirest.WriteError(w, http.StatusBadRequest, "InvalidParameter", "malformed work request path")
+		ocirest.WriteError(w, r, http.StatusBadRequest, "InvalidParameter", "malformed work request path")
 		return
 	}
 
 	if id == "" {
-		ocirest.WriteJSON(w, http.StatusOK, h.store.List(ocirest.CompartmentID(r)))
+		// ListWorkRequests requires compartmentId in real OCI.
+		compartmentID, given := ocirest.RequireCompartmentID(w, r)
+		if !given {
+			return
+		}
+
+		ocirest.WriteJSON(w, r, http.StatusOK, h.store.List(compartmentID))
+
 		return
 	}
 
 	wr, found := h.store.Get(id)
 	if !found {
-		ocirest.WriteError(w, http.StatusNotFound, "NotAuthorizedOrNotFound", "work request "+id+" not found")
+		ocirest.WriteError(w, r, http.StatusNotFound, "NotAuthorizedOrNotFound", "work request "+id+" not found")
 		return
 	}
 
@@ -179,9 +190,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// after a terminal status.
 	switch sub {
 	case "errors", "logs":
-		ocirest.WriteJSON(w, http.StatusOK, []any{})
+		ocirest.WriteJSON(w, r, http.StatusOK, []any{})
 	default:
-		ocirest.WriteJSON(w, http.StatusOK, wr)
+		ocirest.WriteJSON(w, r, http.StatusOK, wr)
 	}
 }
 

--- a/server/oci/workrequest/workrequest_test.go
+++ b/server/oci/workrequest/workrequest_test.go
@@ -178,3 +178,34 @@ func TestHandlerListsByCompartment(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, "CREATE_INSTANCE", got[0].OperationType)
 }
+
+func TestHandlerListRequiresCompartmentID(t *testing.T) {
+	// Real OCI ListWorkRequests 400s without compartmentId rather than
+	// listing across every compartment.
+	s := newStore()
+	s.Accept("CREATE_INSTANCE", "compartment-a")
+	h := workrequest.NewHandler(s)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/20160918/workRequests", nil))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	var body ocirest.ErrorBody
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "InvalidParameter", body.Code)
+}
+
+func TestHandlerEchoesRequestID(t *testing.T) {
+	s := newStore()
+	id := s.Accept("CREATE_INSTANCE", "compartment-a")
+	h := workrequest.NewHandler(s)
+
+	req := httptest.NewRequest(http.MethodGet, "/20160918/workRequests/"+id, nil)
+	req.Header.Set(ocirest.HeaderRequestID, "caller-supplied-id")
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, "caller-supplied-id", rec.Header().Get(ocirest.HeaderRequestID))
+}

--- a/server/oci/workrequest/workrequest_test.go
+++ b/server/oci/workrequest/workrequest_test.go
@@ -1,0 +1,180 @@
+package workrequest_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	"github.com/stackshy/cloudemu/v2/server/oci/workrequest"
+	"github.com/stackshy/cloudemu/v2/server/wire/ocirest"
+)
+
+func newStore() *workrequest.Store {
+	return workrequest.New(config.NewOptions(
+		config.WithClock(config.NewFakeClock(time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC))),
+		config.WithRegion("us-ashburn-1"),
+	))
+}
+
+func TestAcceptRecordsSucceededRequest(t *testing.T) {
+	s := newStore()
+
+	id := s.Accept("CREATE_INSTANCE", "ocid1.compartment.oc1..abc", workrequest.Resource{
+		EntityType: "instance",
+		ActionType: workrequest.ActionCreated,
+		Identifier: "ocid1.instance.oc1.iad.xyz",
+	})
+
+	require.True(t, strings.HasPrefix(id, "ocid1.workrequest.oc1.iad."), "got %q", id)
+
+	wr, ok := s.Get(id)
+	require.True(t, ok)
+
+	// Mutations complete synchronously, so a waiter's first poll is terminal.
+	assert.Equal(t, workrequest.StatusSucceeded, wr.Status)
+	assert.InDelta(t, float32(100), wr.PercentComplete, 0.001)
+	assert.Equal(t, "CREATE_INSTANCE", wr.OperationType)
+	assert.Equal(t, "ocid1.compartment.oc1..abc", wr.CompartmentID)
+	assert.NotEmpty(t, wr.TimeFinished)
+	require.Len(t, wr.Resources, 1)
+	assert.Equal(t, "ocid1.instance.oc1.iad.xyz", wr.Resources[0].Identifier)
+}
+
+func TestGetMissingRequest(t *testing.T) {
+	s := newStore()
+
+	_, ok := s.Get("ocid1.workrequest.oc1.iad.missing")
+	assert.False(t, ok)
+}
+
+func TestListFiltersByCompartment(t *testing.T) {
+	s := newStore()
+	s.Accept("CREATE_INSTANCE", "compartment-a")
+	s.Accept("CREATE_VCN", "compartment-b")
+	s.Accept("DELETE_INSTANCE", "compartment-a")
+
+	tests := []struct {
+		name        string
+		compartment string
+		expectLen   int
+	}{
+		{name: "compartment a", compartment: "compartment-a", expectLen: 2},
+		{name: "compartment b", compartment: "compartment-b", expectLen: 1},
+		{name: "empty compartment returns all", compartment: "", expectLen: 3},
+		{name: "unknown compartment returns none", compartment: "compartment-z", expectLen: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Len(t, s.List(tc.compartment), tc.expectLen)
+		})
+	}
+}
+
+func TestListPreservesCreationOrder(t *testing.T) {
+	s := newStore()
+	first := s.Accept("CREATE_INSTANCE", "c")
+	second := s.Accept("CREATE_VCN", "c")
+
+	got := s.List("c")
+
+	require.Len(t, got, 2)
+	assert.Equal(t, first, got[0].ID)
+	assert.Equal(t, second, got[1].ID)
+}
+
+func TestHandlerMatches(t *testing.T) {
+	h := workrequest.NewHandler(newStore())
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		expect bool
+	}{
+		{name: "core version prefix", method: http.MethodGet, path: "/20160918/workRequests/ocid1.workrequest.oc1.iad.a", expect: true},
+		{name: "another service version prefix", method: http.MethodGet, path: "/20180222/workRequests/ocid1.workrequest.oc1.iad.a", expect: true},
+		{name: "collection", method: http.MethodGet, path: "/20160918/workRequests", expect: true},
+		{name: "errors sub-collection", method: http.MethodGet, path: "/20160918/workRequests/abc/errors", expect: true},
+		{name: "non-GET is not claimed", method: http.MethodPost, path: "/20160918/workRequests", expect: false},
+		{name: "unrelated path", method: http.MethodGet, path: "/20160918/instances", expect: false},
+		{name: "too many trailing segments", method: http.MethodGet, path: "/20160918/workRequests/a/b/c", expect: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			assert.Equal(t, tc.expect, h.Matches(req))
+		})
+	}
+}
+
+func TestHandlerServesSingleRequest(t *testing.T) {
+	s := newStore()
+	id := s.Accept("CREATE_INSTANCE", "ocid1.compartment.oc1..abc")
+	h := workrequest.NewHandler(s)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/20160918/workRequests/"+id, nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var wr workrequest.WorkRequest
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &wr))
+	assert.Equal(t, id, wr.ID)
+	assert.Equal(t, workrequest.StatusSucceeded, wr.Status)
+}
+
+func TestHandlerUnknownRequestIs404(t *testing.T) {
+	h := workrequest.NewHandler(newStore())
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/20160918/workRequests/nope", nil))
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	var body ocirest.ErrorBody
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "NotAuthorizedOrNotFound", body.Code)
+}
+
+func TestHandlerSubCollectionsAreEmpty(t *testing.T) {
+	s := newStore()
+	id := s.Accept("CREATE_INSTANCE", "c")
+	h := workrequest.NewHandler(s)
+
+	for _, sub := range []string{"errors", "logs"} {
+		t.Run(sub, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/20160918/workRequests/"+id+"/"+sub, nil))
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.JSONEq(t, `[]`, rec.Body.String())
+		})
+	}
+}
+
+func TestHandlerListsByCompartment(t *testing.T) {
+	s := newStore()
+	s.Accept("CREATE_INSTANCE", "compartment-a")
+	s.Accept("CREATE_VCN", "compartment-b")
+	h := workrequest.NewHandler(s)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/20160918/workRequests?compartmentId=compartment-a", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got []workrequest.WorkRequest
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.Equal(t, "CREATE_INSTANCE", got[0].OperationType)
+}

--- a/server/wire/ocirest/ocirest.go
+++ b/server/wire/ocirest/ocirest.go
@@ -22,8 +22,12 @@ const (
 // codeInternalServerError is OCI's error code for an unmapped failure.
 const codeInternalServerError = "InternalServerError"
 
-// DefaultLimit is the page size used when a list request omits limit.
-const DefaultLimit = 100
+// Page size bounds. Real OCI caps a page at 1000 regardless of what the
+// caller asks for.
+const (
+	DefaultLimit = 100
+	MaxLimit     = 1000
+)
 
 // ErrorBody is OCI's error response shape.
 type ErrorBody struct {
@@ -31,11 +35,11 @@ type ErrorBody struct {
 	Message string `json:"message"`
 }
 
-// WriteJSON writes a JSON response with the given status code, stamping an
+// WriteJSON writes a JSON response with the given status code, stamping the
 // opc-request-id.
-func WriteJSON(w http.ResponseWriter, status int, v any) {
+func WriteJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	setRequestID(w)
+	setRequestID(w, r)
 	w.WriteHeader(status)
 
 	if v == nil {
@@ -46,9 +50,9 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 }
 
 // WriteError writes an OCI error response.
-func WriteError(w http.ResponseWriter, status int, code, message string) {
+func WriteError(w http.ResponseWriter, r *http.Request, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
-	setRequestID(w)
+	setRequestID(w, r)
 	w.WriteHeader(status)
 
 	json.NewEncoder(w).Encode(ErrorBody{ //nolint:errcheck // best-effort response
@@ -58,9 +62,9 @@ func WriteError(w http.ResponseWriter, status int, code, message string) {
 }
 
 // WriteDriverError maps a driver error onto OCI's status and error code.
-func WriteDriverError(w http.ResponseWriter, err error) {
+func WriteDriverError(w http.ResponseWriter, r *http.Request, err error) {
 	status, code := statusFor(cerrors.GetCode(err))
-	WriteError(w, status, code, err.Error())
+	WriteError(w, r, status, code, err.Error())
 }
 
 // statusFor maps a canonical error code onto OCI's HTTP status and error code.
@@ -97,7 +101,7 @@ func statusFor(code cerrors.Code) (status int, ociCode string) {
 // returning false if it cannot be decoded.
 func DecodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
-		WriteError(w, http.StatusBadRequest, "InvalidParameter", "invalid JSON: "+err.Error())
+		WriteError(w, r, http.StatusBadRequest, "InvalidParameter", "invalid JSON: "+err.Error())
 		return false
 	}
 
@@ -115,7 +119,7 @@ func CompartmentID(r *http.Request) string {
 func RequireCompartmentID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	id := CompartmentID(r)
 	if id == "" {
-		WriteError(w, http.StatusBadRequest, "InvalidParameter", "compartmentId is required")
+		WriteError(w, r, http.StatusBadRequest, "InvalidParameter", "compartmentId is required")
 		return "", false
 	}
 
@@ -123,7 +127,7 @@ func RequireCompartmentID(w http.ResponseWriter, r *http.Request) (string, bool)
 }
 
 // Limit returns the limit query parameter, falling back to DefaultLimit when
-// it is absent or unparseable.
+// it is absent or unparseable and capping at MaxLimit.
 func Limit(r *http.Request) int {
 	raw := r.URL.Query().Get("limit")
 	if raw == "" {
@@ -135,7 +139,7 @@ func Limit(r *http.Request) int {
 		return DefaultLimit
 	}
 
-	return n
+	return min(n, MaxLimit)
 }
 
 // Page returns the page query parameter, OCI's opaque pagination cursor.
@@ -156,9 +160,19 @@ func SetWorkRequestID(w http.ResponseWriter, id string) {
 	w.Header().Set(HeaderWorkRequestID, id)
 }
 
-// setRequestID echoes the caller's opc-request-id, or mints one.
-func setRequestID(w http.ResponseWriter) {
-	if w.Header().Get(HeaderRequestID) == "" {
-		w.Header().Set(HeaderRequestID, idgen.GenerateID("cloudemu"))
+// setRequestID echoes the caller's opc-request-id, which SDKs and logs
+// correlate on, and mints one when the caller sent none.
+func setRequestID(w http.ResponseWriter, r *http.Request) {
+	if w.Header().Get(HeaderRequestID) != "" {
+		return
 	}
+
+	if r != nil {
+		if id := r.Header.Get(HeaderRequestID); id != "" {
+			w.Header().Set(HeaderRequestID, id)
+			return
+		}
+	}
+
+	w.Header().Set(HeaderRequestID, idgen.GenerateID("cloudemu"))
 }

--- a/server/wire/ocirest/ocirest.go
+++ b/server/wire/ocirest/ocirest.go
@@ -1,0 +1,164 @@
+// Package ocirest provides shared HTTP wire helpers for OCI service handlers:
+// JSON encoding, OCI's error shape, opc-* headers, and pagination.
+package ocirest
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
+)
+
+// OCI request/response headers.
+const (
+	HeaderRequestID     = "opc-request-id"
+	HeaderNextPage      = "opc-next-page"
+	HeaderWorkRequestID = "opc-work-request-id"
+	HeaderRetryToken    = "opc-retry-token" //nolint:gosec // header name, not a credential
+)
+
+// codeInternalServerError is OCI's error code for an unmapped failure.
+const codeInternalServerError = "InternalServerError"
+
+// DefaultLimit is the page size used when a list request omits limit.
+const DefaultLimit = 100
+
+// ErrorBody is OCI's error response shape.
+type ErrorBody struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// WriteJSON writes a JSON response with the given status code, stamping an
+// opc-request-id.
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	setRequestID(w)
+	w.WriteHeader(status)
+
+	if v == nil {
+		return
+	}
+
+	json.NewEncoder(w).Encode(v) //nolint:errcheck // best-effort response
+}
+
+// WriteError writes an OCI error response.
+func WriteError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	setRequestID(w)
+	w.WriteHeader(status)
+
+	json.NewEncoder(w).Encode(ErrorBody{ //nolint:errcheck // best-effort response
+		Code:    code,
+		Message: message,
+	})
+}
+
+// WriteDriverError maps a driver error onto OCI's status and error code.
+func WriteDriverError(w http.ResponseWriter, err error) {
+	status, code := statusFor(cerrors.GetCode(err))
+	WriteError(w, status, code, err.Error())
+}
+
+// statusFor maps a canonical error code onto OCI's HTTP status and error code.
+//
+// NotFound and PermissionDenied both yield 404 NotAuthorizedOrNotFound: OCI
+// does not distinguish them, so a caller cannot probe for a resource's
+// existence across a compartment boundary.
+func statusFor(code cerrors.Code) (status int, ociCode string) {
+	switch code {
+	case cerrors.OK:
+		return http.StatusOK, ""
+	case cerrors.NotFound, cerrors.PermissionDenied:
+		return http.StatusNotFound, "NotAuthorizedOrNotFound"
+	case cerrors.AlreadyExists:
+		return http.StatusConflict, "Conflict"
+	case cerrors.InvalidArgument:
+		return http.StatusBadRequest, "InvalidParameter"
+	case cerrors.FailedPrecondition:
+		return http.StatusConflict, "IncorrectState"
+	case cerrors.Throttled, cerrors.ResourceExhausted:
+		return http.StatusTooManyRequests, "TooManyRequests"
+	case cerrors.Unimplemented:
+		return http.StatusNotImplemented, "NotImplemented"
+	case cerrors.Unavailable:
+		return http.StatusServiceUnavailable, "ServiceUnavailable"
+	case cerrors.Internal:
+		return http.StatusInternalServerError, codeInternalServerError
+	default:
+		return http.StatusInternalServerError, codeInternalServerError
+	}
+}
+
+// DecodeJSON reads a JSON request body into v, writing an error response and
+// returning false if it cannot be decoded.
+func DecodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		WriteError(w, http.StatusBadRequest, "InvalidParameter", "invalid JSON: "+err.Error())
+		return false
+	}
+
+	return true
+}
+
+// CompartmentID returns the compartmentId query parameter, which OCI requires
+// on nearly every list call.
+func CompartmentID(r *http.Request) string {
+	return r.URL.Query().Get("compartmentId")
+}
+
+// RequireCompartmentID returns the compartmentId query parameter, writing
+// OCI's error response and returning false when it is absent.
+func RequireCompartmentID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	id := CompartmentID(r)
+	if id == "" {
+		WriteError(w, http.StatusBadRequest, "InvalidParameter", "compartmentId is required")
+		return "", false
+	}
+
+	return id, true
+}
+
+// Limit returns the limit query parameter, falling back to DefaultLimit when
+// it is absent or unparseable.
+func Limit(r *http.Request) int {
+	raw := r.URL.Query().Get("limit")
+	if raw == "" {
+		return DefaultLimit
+	}
+
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return DefaultLimit
+	}
+
+	return n
+}
+
+// Page returns the page query parameter, OCI's opaque pagination cursor.
+func Page(r *http.Request) string {
+	return r.URL.Query().Get("page")
+}
+
+// SetNextPage stamps the cursor a client passes back as page. An empty token
+// sets no header, which is how OCI signals the last page.
+func SetNextPage(w http.ResponseWriter, token string) {
+	if token != "" {
+		w.Header().Set(HeaderNextPage, token)
+	}
+}
+
+// SetWorkRequestID stamps the work request a client polls for completion.
+func SetWorkRequestID(w http.ResponseWriter, id string) {
+	w.Header().Set(HeaderWorkRequestID, id)
+}
+
+// setRequestID echoes the caller's opc-request-id, or mints one.
+func setRequestID(w http.ResponseWriter) {
+	if w.Header().Get(HeaderRequestID) == "" {
+		w.Header().Set(HeaderRequestID, idgen.GenerateID("cloudemu"))
+	}
+}

--- a/server/wire/ocirest/ocirest_test.go
+++ b/server/wire/ocirest/ocirest_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestWriteJSONStampsRequestID(t *testing.T) {
 	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/20160918/instances", nil)
 
-	ocirest.WriteJSON(rec, http.StatusOK, map[string]string{"id": "ocid1.instance.oc1.iad.abc"})
+	ocirest.WriteJSON(rec, req, http.StatusOK, map[string]string{"id": "ocid1.instance.oc1.iad.abc"})
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
@@ -25,10 +26,42 @@ func TestWriteJSONStampsRequestID(t *testing.T) {
 	assert.JSONEq(t, `{"id":"ocid1.instance.oc1.iad.abc"}`, rec.Body.String())
 }
 
+func TestRequestIDIsEchoedWhenCallerSendsOne(t *testing.T) {
+	// SDKs and logs correlate on the caller's opc-request-id, so it must come
+	// back rather than being replaced by a freshly minted one.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/20160918/instances", nil)
+	req.Header.Set(ocirest.HeaderRequestID, "caller-supplied-id")
+
+	ocirest.WriteJSON(rec, req, http.StatusOK, nil)
+
+	assert.Equal(t, "caller-supplied-id", rec.Header().Get(ocirest.HeaderRequestID))
+}
+
+func TestRequestIDIsMintedWhenCallerSendsNone(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/20160918/instances", nil)
+
+	ocirest.WriteJSON(rec, req, http.StatusOK, nil)
+
+	assert.NotEmpty(t, rec.Header().Get(ocirest.HeaderRequestID))
+}
+
+func TestRequestIDEchoedOnErrorsToo(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/20160918/instances", nil)
+	req.Header.Set(ocirest.HeaderRequestID, "caller-supplied-id")
+
+	ocirest.WriteDriverError(rec, req, cerrors.New(cerrors.NotFound, "gone"))
+
+	assert.Equal(t, "caller-supplied-id", rec.Header().Get(ocirest.HeaderRequestID))
+}
+
 func TestWriteJSONNilBodyWritesNothing(t *testing.T) {
 	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/20160918/instances", nil)
 
-	ocirest.WriteJSON(rec, http.StatusNoContent, nil)
+	ocirest.WriteJSON(rec, req, http.StatusNoContent, nil)
 
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Empty(t, rec.Body.String())
@@ -100,8 +133,9 @@ func TestWriteDriverError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/20160918/instances", nil)
 
-			ocirest.WriteDriverError(rec, tc.err)
+			ocirest.WriteDriverError(rec, req, tc.err)
 
 			assert.Equal(t, tc.expectStatus, rec.Code)
 
@@ -197,6 +231,8 @@ func TestLimit(t *testing.T) {
 		{name: "unparseable falls back", url: "/x?limit=abc", expect: ocirest.DefaultLimit},
 		{name: "zero falls back", url: "/x?limit=0", expect: ocirest.DefaultLimit},
 		{name: "negative falls back", url: "/x?limit=-5", expect: ocirest.DefaultLimit},
+		{name: "at the cap", url: "/x?limit=1000", expect: ocirest.MaxLimit},
+		{name: "above the cap is clamped", url: "/x?limit=999999", expect: ocirest.MaxLimit},
 	}
 
 	for _, tc := range tests {

--- a/server/wire/ocirest/ocirest_test.go
+++ b/server/wire/ocirest/ocirest_test.go
@@ -1,0 +1,221 @@
+package ocirest_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/ocirest"
+)
+
+func TestWriteJSONStampsRequestID(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	ocirest.WriteJSON(rec, http.StatusOK, map[string]string{"id": "ocid1.instance.oc1.iad.abc"})
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.NotEmpty(t, rec.Header().Get(ocirest.HeaderRequestID))
+	assert.JSONEq(t, `{"id":"ocid1.instance.oc1.iad.abc"}`, rec.Body.String())
+}
+
+func TestWriteJSONNilBodyWritesNothing(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	ocirest.WriteJSON(rec, http.StatusNoContent, nil)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Empty(t, rec.Body.String())
+}
+
+func TestWriteDriverError(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectStatus int
+		expectCode   string
+	}{
+		{
+			name:         "not found",
+			err:          cerrors.New(cerrors.NotFound, "no such bucket"),
+			expectStatus: http.StatusNotFound,
+			expectCode:   "NotAuthorizedOrNotFound",
+		},
+		{
+			name:         "permission denied is indistinguishable from not found",
+			err:          cerrors.New(cerrors.PermissionDenied, "denied"),
+			expectStatus: http.StatusNotFound,
+			expectCode:   "NotAuthorizedOrNotFound",
+		},
+		{
+			name:         "already exists",
+			err:          cerrors.New(cerrors.AlreadyExists, "bucket exists"),
+			expectStatus: http.StatusConflict,
+			expectCode:   "Conflict",
+		},
+		{
+			name:         "invalid argument",
+			err:          cerrors.New(cerrors.InvalidArgument, "bad name"),
+			expectStatus: http.StatusBadRequest,
+			expectCode:   "InvalidParameter",
+		},
+		{
+			name:         "failed precondition",
+			err:          cerrors.New(cerrors.FailedPrecondition, "not terminated"),
+			expectStatus: http.StatusConflict,
+			expectCode:   "IncorrectState",
+		},
+		{
+			name:         "throttled",
+			err:          cerrors.New(cerrors.Throttled, "slow down"),
+			expectStatus: http.StatusTooManyRequests,
+			expectCode:   "TooManyRequests",
+		},
+		{
+			name:         "unimplemented",
+			err:          cerrors.New(cerrors.Unimplemented, "not yet"),
+			expectStatus: http.StatusNotImplemented,
+			expectCode:   "NotImplemented",
+		},
+		{
+			name:         "unavailable",
+			err:          cerrors.New(cerrors.Unavailable, "down"),
+			expectStatus: http.StatusServiceUnavailable,
+			expectCode:   "ServiceUnavailable",
+		},
+		{
+			name:         "non-cloudemu error falls back to internal",
+			err:          assert.AnError,
+			expectStatus: http.StatusInternalServerError,
+			expectCode:   "InternalServerError",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+
+			ocirest.WriteDriverError(rec, tc.err)
+
+			assert.Equal(t, tc.expectStatus, rec.Code)
+
+			var body ocirest.ErrorBody
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			assert.Equal(t, tc.expectCode, body.Code)
+			assert.NotEmpty(t, body.Message)
+		})
+	}
+}
+
+func TestDecodeJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		expectOK  bool
+		expectVal string
+	}{
+		{name: "valid JSON", body: `{"name":"bucket-a"}`, expectOK: true, expectVal: "bucket-a"},
+		{name: "malformed JSON", body: `{`, expectOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/20160918/buckets", strings.NewReader(tc.body))
+
+			var payload struct {
+				Name string `json:"name"`
+			}
+
+			ok := ocirest.DecodeJSON(rec, req, &payload)
+
+			assert.Equal(t, tc.expectOK, ok)
+
+			if tc.expectOK {
+				assert.Equal(t, tc.expectVal, payload.Name)
+				return
+			}
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+func TestRequireCompartmentID(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		expectID  string
+		expectOK  bool
+		expectErr int
+	}{
+		{
+			name:     "present",
+			url:      "/20160918/instances?compartmentId=ocid1.compartment.oc1..abc",
+			expectID: "ocid1.compartment.oc1..abc",
+			expectOK: true,
+		},
+		{
+			name:      "absent",
+			url:       "/20160918/instances",
+			expectOK:  false,
+			expectErr: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+
+			id, ok := ocirest.RequireCompartmentID(rec, req)
+
+			assert.Equal(t, tc.expectOK, ok)
+			assert.Equal(t, tc.expectID, id)
+
+			if !tc.expectOK {
+				assert.Equal(t, tc.expectErr, rec.Code)
+			}
+		})
+	}
+}
+
+func TestLimit(t *testing.T) {
+	tests := []struct {
+		name   string
+		url    string
+		expect int
+	}{
+		{name: "absent falls back to default", url: "/x", expect: ocirest.DefaultLimit},
+		{name: "explicit limit", url: "/x?limit=25", expect: 25},
+		{name: "unparseable falls back", url: "/x?limit=abc", expect: ocirest.DefaultLimit},
+		{name: "zero falls back", url: "/x?limit=0", expect: ocirest.DefaultLimit},
+		{name: "negative falls back", url: "/x?limit=-5", expect: ocirest.DefaultLimit},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			assert.Equal(t, tc.expect, ocirest.Limit(req))
+		})
+	}
+}
+
+func TestSetNextPageOmitsHeaderOnLastPage(t *testing.T) {
+	// OCI signals the last page by omitting opc-next-page, so an empty token
+	// must not write the header.
+	rec := httptest.NewRecorder()
+	ocirest.SetNextPage(rec, "")
+	assert.Empty(t, rec.Header().Get(ocirest.HeaderNextPage))
+
+	rec = httptest.NewRecorder()
+	ocirest.SetNextPage(rec, "cursor-2")
+	assert.Equal(t, "cursor-2", rec.Header().Get(ocirest.HeaderNextPage))
+}
+

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -16,6 +16,7 @@ const (
 	ProviderAWS   = "aws"
 	ProviderAzure = "azure"
 	ProviderGCP   = "gcp"
+	ProviderOCI   = "oci"
 )
 
 // Service name constants embedded in Resource.Service. These are the

--- a/services/scope/scope.go
+++ b/services/scope/scope.go
@@ -1,8 +1,9 @@
 // Package scope identifies the cloud-side container a resource lives in —
-// the Azure subscription/resource group or the GCP project. Drivers record
-// a resource's scope at create time and filter lists by it, so scoped list
-// endpoints (ListByResourceGroup, per-project lists) return only what the
-// caller's scope actually contains.
+// the Azure subscription/resource group, the GCP project, or the OCI
+// compartment. Drivers record a resource's scope at create time and filter
+// lists by it, so scoped list endpoints (ListByResourceGroup, per-project
+// lists, compartmentId queries) return only what the caller's scope actually
+// contains.
 package scope
 
 // Scope locates a resource. The zero value means "unscoped": AWS resources
@@ -12,6 +13,9 @@ type Scope struct {
 	Subscription  string
 	ResourceGroup string
 	Project       string
+	// Compartment is the OCI compartment OCID. Matching is exact: real OCI
+	// only descends the compartment tree when compartmentIdInSubtree is set.
+	Compartment string
 }
 
 // IsZero reports whether no scope information is set.
@@ -35,6 +39,9 @@ func (s Scope) Matches(f Scope) bool {
 		return false
 	}
 	if f.Project != "" && s.Project != f.Project {
+		return false
+	}
+	if f.Compartment != "" && s.Compartment != f.Compartment {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary

- Lays the groundwork for **OCI as a fourth provider**, so its ~17 portable services can be built independently and in parallel.
- **No OCI service is implemented here.** This is only the scaffolding every one of them needs, landed once so per-service branches never have to restructure shared files.
- Additive: no existing provider's behavior changes. Full suite green (236 packages).

## Changes

**Shared primitives**
- `config` — `TenancyOCID` / `CompartmentID` / `Realm` with their `With*` options, plus `OCIRegion()`, which substitutes an OCI region when `Region` is still the AWS default. Without it every OCID would carry a region code derived from `us-east-1`. `CompartmentID` defaults to the tenancy *after* options apply, so a caller setting only a custom tenancy doesn't inherit the built-in root.
- `internal/idgen` — `OCID()` / `GlobalOCID()` and a 37-region code table. Identity resources are region-agnostic and emit the doubled dot real OCI returns (`ocid1.compartment.oc1..aaaa…`), so clients splitting on `.` still see five segments. Unknown regions fall back to a per-region code rather than a shared one, which would let two regions collide.
- `services/scope` — `Compartment` field. Matching is exact; real OCI only descends the compartment tree when `compartmentIdInSubtree` is set.

**Wire layer**
- `server/wire/ocirest` — JSON/error encoding, `opc-*` headers, pagination, and the required `compartmentId` parameter. `NotFound` and `PermissionDenied` both map to `404 NotAuthorizedOrNotFound`, since OCI does not distinguish them.
- `server/oci/workrequest` — OCI's async envelope. Registered ahead of service handlers and matched on any path containing `workRequests`, because the collapsed server cannot tell one service's version prefix from another's — the same reasoning as `server/gcp/lro`. Mutations are synchronous, so an accepted request is already `SUCCEEDED`; the envelope carries the new resource's OCID back to SDK waiters.

**Aggregators**
- `providers/oci` + `server/oci` — `Provider` and `Drivers` with all 17 service slots declared up front as *driver interfaces*, so a service that hasn't landed reads as `nil` rather than failing to compile, and a service branch fills a slot instead of editing the struct. Monitoring is cross-wired by type assertion.

**Plumbing**
- `cmd/cloudemu` — `--providers` accepts `oci`, `--oci-port` (4571; 4570 is the k8s data plane), endpoint JSON and banner. OCI is **not** in the default provider set until its services land, so the default never binds a port serving nothing.
- `docs/oci-conventions.md` — the contract each service PR follows.
- PR template gains an OCI checkbox.

`printBanner` is now table-driven: the added rows pushed it past the cyclomatic limit and `endpointSet` past `hugeParam`. The refactor also clears five pre-existing `wsl` warnings in that file.

## Provider Coverage

- [ ] AWS
- [ ] Azure
- [ ] GCP
- [x] OCI

## Checklist

- [x] All tests pass (`go test ./...`)
- [x] Linter passes for every package touched here
- [x] Every provider the change applies to implements the same behavior — OCI-only, additive
- [ ] Integration tests added to `cloudemu_test.go` — deferred to the first service PR; there is no OCI service to integration-test yet
- [x] Unit tests added to provider test files

## Test Plan

`go test ./...` — exit 0, **236 packages ok, 0 failures**. The full suite matters here because `config` and `scope` are shared by every provider.

`golangci-lint run --timeout=9m` — clean for all new packages. `cmd/cloudemu/endpoints.go` now reports fewer issues than before this branch.

New unit tests:
- `internal/idgen` — region-code mapping, per-region distinctness, OCID shape for region-scoped vs. global resources, uniqueness, five-segment invariant
- `config` — OCI defaults, compartment-defaults-to-custom-tenancy, explicit compartment wins, `OCIRegion()` substitution, and that OCI options leave AWS/GCP defaults untouched
- `server/wire/ocirest` — error-code mapping for all nine canonical codes, JSON decode failure, required `compartmentId`, limit fallbacks, `opc-next-page` omitted on last page
- `server/oci/workrequest` — accept/get/list, compartment filtering, creation order, handler routing (including what `Matches` must *not* claim), sub-collections, 404 shape
- `providers/oci` + `server/oci` — identity defaults and overrides, discovery wiring, nil service slots, `DriversFrom` round-trip, 501 for unrouted paths

Manual, against the built binary:

```
$ cloudemu serve -providers aws,gcp,oci
  AWS         http://127.0.0.1:4566
  GCP         http://127.0.0.1:4569
  OCI         http://127.0.0.1:4571

GET /20160918/workRequests        -> 200 [] , Opc-Request-Id set
GET /20160918/workRequests/nope   -> 404 {"code":"NotAuthorizedOrNotFound",...}
GET /20160918/instances           -> 501  (no services yet)
```

## Related Issues

None yet — happy to open a tracking issue for the OCI Tier 1 rollout if that's preferred.

## Follow-ups

Once this merges, the ~17 portable services (Object Storage, Compute, VCN, Identity, Monitoring, DNS, Load Balancer, Queue, Cache, Vault, Logging, Notifications, OCIR, Events, Functions, NoSQL, Database) can be cut from `development` in parallel, one branch and one PR each, per `docs/oci-conventions.md`.

