### PR TITLE
fix(k8s): server-side apply, apply-create, and finalizers for typed core kinds (#330)

### DIFF
--- a/services/kubernetes/configmap.go
+++ b/services/kubernetes/configmap.go
@@ -100,13 +100,23 @@ func (s *ClusterState) serveConfigMapItem(w http.ResponseWriter, r *http.Request
 	}
 }
 
-//nolint:dupl // namespaced-create CRUD pattern; copy-paste is clearer than a generic helper.
 func (s *ClusterState) createConfigMap(w http.ResponseWriter, r *http.Request, namespace string) {
 	var in corev1.ConfigMap
 	if !readJSON(w, r, &in) {
 		return
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.createConfigMapLocked(w, r, namespace, &in)
+}
+
+// createConfigMapLocked persists a new ConfigMap. The caller holds s.mu. It is
+// shared by the POST create path and server-side apply-create (an apply to a
+// name that doesn't exist yet), which passes an object already carrying its
+// Apply managedFields entry.
+func (s *ClusterState) createConfigMapLocked(w http.ResponseWriter, r *http.Request, namespace string, in *corev1.ConfigMap) {
 	if in.Name == "" {
 		writeBadRequest(w, "k8s api: configmap: metadata.name is required")
 
@@ -118,9 +128,6 @@ func (s *ClusterState) createConfigMap(w http.ResponseWriter, r *http.Request, n
 
 	key := configMapKey(namespace, in.Name)
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if _, ok := s.configMaps[key]; ok {
 		writeAlreadyExists(w, "k8s api: configmap already exists: "+key)
 
@@ -131,12 +138,12 @@ func (s *ClusterState) createConfigMap(w http.ResponseWriter, r *http.Request, n
 	in.TypeMeta = metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"}
 
 	if isDryRun(r) {
-		writeJSON(w, http.StatusCreated, &in)
+		writeJSON(w, http.StatusCreated, in)
 
 		return
 	}
 
-	cm := in
+	cm := *in
 	s.configMaps[key] = &cm
 	s.wConfigMaps.publish(EventAdded, namespace, *cm.DeepCopy())
 	writeJSON(w, http.StatusCreated, &cm)
@@ -266,12 +273,25 @@ func (s *ClusterState) patchConfigMap(w http.ResponseWriter, r *http.Request, na
 
 	cur, ok := s.configMaps[key]
 	if !ok {
+		// Server-side apply to a missing object creates it (upstream SSA).
+		if r.Header.Get("Content-Type") == contentTypeApplyPatch {
+			in, aok := serverSideApplyTyped(s, w, r, apiVersionV1, &corev1.ConfigMap{})
+			if !aok {
+				return
+			}
+
+			in.Name = name
+			s.createConfigMapLocked(w, r, namespace, in)
+
+			return
+		}
+
 		writeNotFound(w, "k8s api: configmap not found: "+key)
 
 		return
 	}
 
-	patched, ok := applyJSONPatch(w, r, cur)
+	patched, ok := applyOrPatchTyped(s, w, r, apiVersionV1, cur)
 	if !ok {
 		return
 	}
@@ -279,6 +299,16 @@ func (s *ClusterState) patchConfigMap(w http.ResponseWriter, r *http.Request, na
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, patched)
+
+		return
+	}
+
+	// A patch that drops the last finalizer from a Terminating object completes
+	// the delete (the patch was merged onto cur, so it inherits deletionTimestamp).
+	if finalizersDrained(&patched.ObjectMeta) {
+		delete(s.configMaps, key)
+		s.wConfigMaps.publish(EventDeleted, namespace, *patched.DeepCopy())
 		writeJSON(w, http.StatusOK, patched)
 
 		return
@@ -303,6 +333,16 @@ func (s *ClusterState) deleteConfigMap(w http.ResponseWriter, r *http.Request, n
 	}
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, cm.DeepCopy())
+
+		return
+	}
+
+	// Finalizer-gated deletion: a ConfigMap with finalizers goes Terminating and
+	// is removed only when the last finalizer is dropped via update/patch.
+	if s.markForDeletion(&cm.ObjectMeta) {
+		cm.ResourceVersion = bumpResourceVersion(cm.ResourceVersion)
+		s.wConfigMaps.publish(EventModified, namespace, *cm.DeepCopy())
 		writeJSON(w, http.StatusOK, cm.DeepCopy())
 
 		return

--- a/services/kubernetes/deployment.go
+++ b/services/kubernetes/deployment.go
@@ -15,6 +15,9 @@ import (
 // live under: /apis/apps/v1/...
 const apiGroupApps = "apps"
 
+// apiVersionAppsV1 is the group/version Deployments report in managedFields.
+const apiVersionAppsV1 = apiGroupApps + "/" + apiVersionV1
+
 // resourceDeployments is the plural resource segment for Deployments.
 const resourceDeployments = "deployments"
 
@@ -112,6 +115,15 @@ func (s *ClusterState) createDeployment(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.createDeploymentLocked(w, r, namespace, &in)
+}
+
+// createDeploymentLocked persists a new Deployment and reconciles it. The caller
+// holds s.mu. Shared by the POST create path and server-side apply-create.
+func (s *ClusterState) createDeploymentLocked(w http.ResponseWriter, r *http.Request, namespace string, in *appsv1.Deployment) {
 	if in.Name == "" {
 		writeBadRequest(w, "k8s api: deployment: metadata.name is required")
 
@@ -121,9 +133,6 @@ func (s *ClusterState) createDeployment(w http.ResponseWriter, r *http.Request, 
 	in.Namespace = namespace
 
 	key := deploymentKey(namespace, in.Name)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if _, ok := s.deployments[key]; ok {
 		writeAlreadyExists(w, "k8s api: deployment already exists: "+key)
@@ -135,17 +144,17 @@ func (s *ClusterState) createDeployment(w http.ResponseWriter, r *http.Request, 
 	in.TypeMeta = metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}
 	in.Generation = 1
 
-	if handled := s.admit(w, opCreate, gvrDeployments(), &in); handled {
+	if handled := s.admit(w, opCreate, gvrDeployments(), in); handled {
 		return
 	}
 
 	if isDryRun(r) {
-		writeJSON(w, http.StatusCreated, &in)
+		writeJSON(w, http.StatusCreated, in)
 
 		return
 	}
 
-	dep := in
+	dep := *in
 	s.deployments[key] = &dep
 	// Reconcile: materialize Running Pods and populate status + Service
 	// endpoints so the deployment is actually "up", not just stored.
@@ -271,12 +280,25 @@ func (s *ClusterState) patchDeployment(w http.ResponseWriter, r *http.Request, n
 
 	cur, ok := s.deployments[key]
 	if !ok {
+		// Server-side apply to a missing object creates it (upstream SSA).
+		if r.Header.Get("Content-Type") == contentTypeApplyPatch {
+			in, aok := serverSideApplyTyped(s, w, r, apiVersionAppsV1, &appsv1.Deployment{})
+			if !aok {
+				return
+			}
+
+			in.Name = name
+			s.createDeploymentLocked(w, r, namespace, in)
+
+			return
+		}
+
 		writeNotFound(w, "k8s api: deployment not found: "+key)
 
 		return
 	}
 
-	patched, ok := applyJSONPatch(w, r, cur)
+	patched, ok := applyOrPatchTyped(s, w, r, apiVersionAppsV1, cur)
 	if !ok {
 		return
 	}
@@ -285,6 +307,17 @@ func (s *ClusterState) patchDeployment(w http.ResponseWriter, r *http.Request, n
 	patched.Generation = generationFor(cur.Generation, &patched.Spec, &cur.Spec)
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, patched)
+
+		return
+	}
+
+	// A patch that drops the last finalizer from a Terminating object completes
+	// the delete (the patch was merged onto cur, so it inherits deletionTimestamp).
+	if finalizersDrained(&patched.ObjectMeta) {
+		delete(s.deployments, key)
+		s.garbageCollectLocked(patched.UID)
+		s.wDeployments.publish(EventDeleted, namespace, *patched.DeepCopy())
 		writeJSON(w, http.StatusOK, patched)
 
 		return
@@ -321,6 +354,16 @@ func (s *ClusterState) deleteDeployment(w http.ResponseWriter, r *http.Request, 
 	}
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, dep.DeepCopy())
+
+		return
+	}
+
+	// Finalizer-gated deletion: a Deployment with finalizers goes Terminating and
+	// is removed only when the last finalizer is dropped via update/patch.
+	if s.markForDeletion(&dep.ObjectMeta) {
+		dep.ResourceVersion = bumpResourceVersion(dep.ResourceVersion)
+		s.wDeployments.publish(EventModified, namespace, *dep.DeepCopy())
 		writeJSON(w, http.StatusOK, dep.DeepCopy())
 
 		return

--- a/services/kubernetes/kubectl_smoke_test.go
+++ b/services/kubernetes/kubectl_smoke_test.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stackshy/cloudemu/v2/services/kubernetes"
@@ -140,4 +141,122 @@ func runKubectl(t *testing.T, kubectlPath, kubeconfig string, args ...string) {
 	if err != nil {
 		t.Fatalf("kubectl %v: %v\n%s", args, err, out)
 	}
+}
+
+// TestKubectlServerSideApply drives real kubectl through server-side apply
+// against a temporary in-memory cluster: apply-create on a fresh cluster, a
+// field-ownership conflict resolved with --force-conflicts, and a
+// finalizer-gated delete that completes when the finalizer is dropped.
+func TestKubectlServerSideApply(t *testing.T) {
+	kubectlPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		t.Skip("kubectl not found on PATH; skipping kubectl e2e")
+	}
+
+	api := kubernetes.NewAPIServer()
+	ts := httptest.NewServer(api)
+	t.Cleanup(ts.Close)
+	api.SetBaseURL(ts.URL)
+
+	uid, _ := api.RegisterCluster()
+	kc := writeSmokeKubeconfig(t, ts.URL, uid)
+
+	// 1. Server-side apply-create: apply a ConfigMap that does not exist yet.
+	settingsBlue := writeManifest(t, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  color: blue
+`)
+	runKubectl(t, kubectlPath, kc, "apply", "--server-side", "--field-manager=alice", "-f", settingsBlue)
+
+	if got := kubectlOut(t, kubectlPath, kc, "get", "configmap", "settings",
+		"-o", "jsonpath={.data.color}"); got != "blue" {
+		t.Fatalf("apply-create: data.color=%q, want blue", got)
+	}
+
+	// 2. Field ownership + conflict: bob changing alice's owned field must fail,
+	//    and --force-conflicts must win.
+	settingsRed := writeManifest(t, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: settings
+  namespace: default
+data:
+  color: red
+`)
+	if _, err := kubectlRaw(kubectlPath, kc, "apply", "--server-side",
+		"--field-manager=bob", "-f", settingsRed); err == nil {
+		t.Fatal("expected bob's conflicting server-side apply to fail, but it succeeded")
+	}
+
+	runKubectl(t, kubectlPath, kc, "apply", "--server-side",
+		"--field-manager=bob", "--force-conflicts", "-f", settingsRed)
+
+	if got := kubectlOut(t, kubectlPath, kc, "get", "configmap", "settings",
+		"-o", "jsonpath={.data.color}"); got != "red" {
+		t.Fatalf("forced apply: data.color=%q, want red", got)
+	}
+
+	// 3. Finalizers: a ConfigMap with a finalizer must go Terminating on delete
+	//    (not hard-deleted), and dropping the finalizer completes the delete.
+	guarded := writeManifest(t, `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: guarded
+  namespace: default
+  finalizers:
+  - cloudemu.dev/hold
+data:
+  k: v
+`)
+	runKubectl(t, kubectlPath, kc, "apply", "--server-side", "--field-manager=alice", "-f", guarded)
+	runKubectl(t, kubectlPath, kc, "delete", "configmap", "guarded", "--wait=false")
+
+	if got := kubectlOut(t, kubectlPath, kc, "get", "configmap", "guarded",
+		"-o", "jsonpath={.metadata.deletionTimestamp}"); got == "" {
+		t.Fatal("finalizer-gated delete: deletionTimestamp is empty; object was hard-deleted")
+	}
+
+	runKubectl(t, kubectlPath, kc, "patch", "configmap", "guarded",
+		"--type=merge", "-p", `{"metadata":{"finalizers":[]}}`)
+
+	if _, err := kubectlRaw(kubectlPath, kc, "get", "configmap", "guarded"); err == nil {
+		t.Fatal("expected NotFound after draining the finalizer, but the object still exists")
+	}
+}
+
+// writeManifest writes a manifest to a temp file and returns its path.
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "manifest.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	return path
+}
+
+// kubectlOut runs kubectl and returns trimmed combined output, failing on error.
+func kubectlOut(t *testing.T, kubectlPath, kubeconfig string, args ...string) string {
+	t.Helper()
+
+	out, err := kubectlRaw(kubectlPath, kubeconfig, args...)
+	if err != nil {
+		t.Fatalf("kubectl %v: %v\n%s", args, err, out)
+	}
+
+	return strings.TrimSpace(out)
+}
+
+// kubectlRaw runs kubectl with the kubeconfig and returns combined output and
+// error without failing the test — for cases that expect a non-zero exit.
+func kubectlRaw(kubectlPath, kubeconfig string, args ...string) (string, error) {
+	cmdArgs := append([]string{"--kubeconfig=" + kubeconfig}, args...)
+	out, err := exec.Command(kubectlPath, cmdArgs...).CombinedOutput()
+
+	return string(out), err
 }

--- a/services/kubernetes/registry.go
+++ b/services/kubernetes/registry.go
@@ -471,7 +471,7 @@ func (s *ClusterState) registryPatch(w http.ResponseWriter, r *http.Request, st 
 
 	cur, ok := st.items[objKey(namespace, name)]
 	if !ok {
-		writeNotFound(w, "k8s api: "+st.def.kind+" not found: "+objKey(namespace, name))
+		s.registryPatchOnMissingLocked(w, r, st, namespace, name)
 
 		return
 	}
@@ -488,7 +488,7 @@ func (s *ClusterState) registryPatch(w http.ResponseWriter, r *http.Request, st 
 	var patched *unstructured.Unstructured
 
 	if r.Header.Get("Content-Type") == contentTypeApplyPatch {
-		patched, ok = s.serverSideApply(w, r, st, cur)
+		patched, ok = s.serverSideApply(w, r, st.def.apiVersion(), cur)
 	} else {
 		patched, ok = s.applyUnstructuredPatch(w, r, cur)
 	}
@@ -545,6 +545,85 @@ func (s *ClusterState) registryPatch(w http.ResponseWriter, r *http.Request, st 
 
 	st.watch.publish(EventModified, patched.GetNamespace(), *patched.DeepCopy())
 	writeJSON(w, http.StatusOK, patched)
+}
+
+// registryPatchOnMissingLocked handles a patch whose target does not exist: a
+// server-side apply creates it (upstream SSA semantics), any other patch 404s.
+// The caller holds s.mu.
+func (s *ClusterState) registryPatchOnMissingLocked(
+	w http.ResponseWriter, r *http.Request, st *registryStore, namespace, name string,
+) {
+	if r.Header.Get("Content-Type") == contentTypeApplyPatch {
+		s.registryApplyCreateLocked(w, r, st, namespace, name)
+
+		return
+	}
+
+	writeNotFound(w, "k8s api: "+st.def.kind+" not found: "+objKey(namespace, name))
+}
+
+// registryApplyCreateLocked creates a registry object from a server-side apply
+// body whose target name doesn't exist yet (upstream SSA creates on apply). It
+// records an Apply managedFields entry and runs the same admission, quota,
+// reconcile, and watch path as a POST create. The caller holds s.mu.
+func (s *ClusterState) registryApplyCreateLocked(
+	w http.ResponseWriter, r *http.Request, st *registryStore, namespace, name string,
+) {
+	base := &unstructured.Unstructured{Object: map[string]any{}}
+	base.SetAPIVersion(st.def.apiVersion())
+	base.SetKind(st.def.kind)
+	base.SetName(name)
+
+	if st.def.namespaced {
+		base.SetNamespace(namespace)
+	}
+
+	obj, ok := s.serverSideApply(w, r, st.def.apiVersion(), base)
+	if !ok {
+		return
+	}
+
+	// URL identity and server-owned fields win over anything the apply body set.
+	obj.SetName(name)
+	obj.SetNamespace(base.GetNamespace())
+	obj.SetAPIVersion(st.def.apiVersion())
+	obj.SetKind(st.def.kind)
+	obj.SetUID(types.UID(newUID()))
+	obj.SetCreationTimestamp(s.now())
+	obj.SetGeneration(1)
+
+	if handled := s.admit(w, opCreate, st.def.gvr(), obj); handled {
+		return
+	}
+
+	if isDryRun(r) {
+		if status := s.checkQuotaLocked(namespace, st.def.kind, st.def.plural); status != nil {
+			writeJSON(w, int(status.Code), status)
+
+			return
+		}
+
+		obj.SetResourceVersion(strconv.Itoa(st.rv + 1))
+		writeJSON(w, http.StatusCreated, obj)
+
+		return
+	}
+
+	if status := s.checkAndReserveQuota(namespace, st.def.kind, st.def.plural); status != nil {
+		writeJSON(w, int(status.Code), status)
+
+		return
+	}
+
+	st.stampRVLocked(obj)
+	st.items[objKey(obj.GetNamespace(), name)] = obj
+
+	if st.def.reconcile != nil {
+		st.def.reconcile(s, obj)
+	}
+
+	st.watch.publish(EventAdded, obj.GetNamespace(), *obj.DeepCopy())
+	writeJSON(w, http.StatusCreated, obj)
 }
 
 func (s *ClusterState) registryDelete(w http.ResponseWriter, r *http.Request, st *registryStore, namespace, name string) {

--- a/services/kubernetes/secret.go
+++ b/services/kubernetes/secret.go
@@ -103,6 +103,15 @@ func (s *ClusterState) createSecret(w http.ResponseWriter, r *http.Request, name
 		return
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.createSecretLocked(w, r, namespace, &in)
+}
+
+// createSecretLocked persists a new Secret. The caller holds s.mu. Shared by the
+// POST create path and server-side apply-create.
+func (s *ClusterState) createSecretLocked(w http.ResponseWriter, r *http.Request, namespace string, in *corev1.Secret) {
 	if in.Name == "" {
 		writeBadRequest(w, "k8s api: secret: metadata.name is required")
 
@@ -111,12 +120,9 @@ func (s *ClusterState) createSecret(w http.ResponseWriter, r *http.Request, name
 
 	in.Namespace = namespace
 
-	mergeStringData(&in)
+	mergeStringData(in)
 
 	key := secretKey(namespace, in.Name)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if _, ok := s.secrets[key]; ok {
 		writeAlreadyExists(w, "k8s api: secret already exists: "+key)
@@ -132,12 +138,12 @@ func (s *ClusterState) createSecret(w http.ResponseWriter, r *http.Request, name
 	}
 
 	if isDryRun(r) {
-		writeJSON(w, http.StatusCreated, &in)
+		writeJSON(w, http.StatusCreated, in)
 
 		return
 	}
 
-	sec := in
+	sec := *in
 	s.secrets[key] = &sec
 	s.wSecrets.publish(EventAdded, namespace, *sec.DeepCopy())
 	writeJSON(w, http.StatusCreated, &sec)
@@ -268,12 +274,25 @@ func (s *ClusterState) patchSecret(w http.ResponseWriter, r *http.Request, names
 
 	cur, ok := s.secrets[key]
 	if !ok {
+		// Server-side apply to a missing object creates it (upstream SSA).
+		if r.Header.Get("Content-Type") == contentTypeApplyPatch {
+			in, aok := serverSideApplyTyped(s, w, r, apiVersionV1, &corev1.Secret{})
+			if !aok {
+				return
+			}
+
+			in.Name = name
+			s.createSecretLocked(w, r, namespace, in)
+
+			return
+		}
+
 		writeNotFound(w, "k8s api: secret not found: "+key)
 
 		return
 	}
 
-	patched, ok := applyJSONPatch(w, r, cur)
+	patched, ok := applyOrPatchTyped(s, w, r, apiVersionV1, cur)
 	if !ok {
 		return
 	}
@@ -281,6 +300,16 @@ func (s *ClusterState) patchSecret(w http.ResponseWriter, r *http.Request, names
 	patched.ResourceVersion = bumpResourceVersion(cur.ResourceVersion)
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, patched)
+
+		return
+	}
+
+	// A patch that drops the last finalizer from a Terminating object completes
+	// the delete (the patch was merged onto cur, so it inherits deletionTimestamp).
+	if finalizersDrained(&patched.ObjectMeta) {
+		delete(s.secrets, key)
+		s.wSecrets.publish(EventDeleted, namespace, *patched.DeepCopy())
 		writeJSON(w, http.StatusOK, patched)
 
 		return
@@ -305,6 +334,16 @@ func (s *ClusterState) deleteSecret(w http.ResponseWriter, r *http.Request, name
 	}
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, sec.DeepCopy())
+
+		return
+	}
+
+	// Finalizer-gated deletion: a Secret with finalizers goes Terminating and is
+	// removed only when the last finalizer is dropped via update/patch.
+	if s.markForDeletion(&sec.ObjectMeta) {
+		sec.ResourceVersion = bumpResourceVersion(sec.ResourceVersion)
+		s.wSecrets.publish(EventModified, namespace, *sec.DeepCopy())
 		writeJSON(w, http.StatusOK, sec.DeepCopy())
 
 		return

--- a/services/kubernetes/service.go
+++ b/services/kubernetes/service.go
@@ -109,6 +109,15 @@ func (s *ClusterState) createService(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.createServiceLocked(w, r, namespace, &in)
+}
+
+// createServiceLocked persists a new Service (ClusterIP allocation + paired
+// Endpoints). The caller holds s.mu. Shared by POST create and apply-create.
+func (s *ClusterState) createServiceLocked(w http.ResponseWriter, r *http.Request, namespace string, in *corev1.Service) {
 	if in.Name == "" {
 		writeBadRequest(w, "k8s api: service: metadata.name is required")
 
@@ -118,9 +127,6 @@ func (s *ClusterState) createService(w http.ResponseWriter, r *http.Request, nam
 	in.Namespace = namespace
 
 	key := serviceKey(namespace, in.Name)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	if _, ok := s.services[key]; ok {
 		writeAlreadyExists(w, "k8s api: service already exists: "+key)
@@ -148,12 +154,12 @@ func (s *ClusterState) createService(w http.ResponseWriter, r *http.Request, nam
 	}
 
 	if isDryRun(r) {
-		writeJSON(w, http.StatusCreated, &in)
+		writeJSON(w, http.StatusCreated, in)
 
 		return
 	}
 
-	svc := in
+	svc := *in
 	s.services[key] = &svc
 
 	// Auto-create the Endpoints object, then let the endpoints controller fill
@@ -295,12 +301,25 @@ func (s *ClusterState) patchService(w http.ResponseWriter, r *http.Request, name
 
 	cur, ok := s.services[key]
 	if !ok {
+		// Server-side apply to a missing object creates it (upstream SSA).
+		if r.Header.Get("Content-Type") == contentTypeApplyPatch {
+			in, aok := serverSideApplyTyped(s, w, r, apiVersionV1, &corev1.Service{})
+			if !aok {
+				return
+			}
+
+			in.Name = name
+			s.createServiceLocked(w, r, namespace, in)
+
+			return
+		}
+
 		writeNotFound(w, "k8s api: service not found: "+key)
 
 		return
 	}
 
-	patched, ok := applyJSONPatch(w, r, cur)
+	patched, ok := applyOrPatchTyped(s, w, r, apiVersionV1, cur)
 	if !ok {
 		return
 	}
@@ -311,6 +330,16 @@ func (s *ClusterState) patchService(w http.ResponseWriter, r *http.Request, name
 	patched.Spec.ClusterIPs = cur.Spec.ClusterIPs
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, patched)
+
+		return
+	}
+
+	// A patch that drops the last finalizer from a Terminating object completes
+	// the delete (the patch was merged onto cur, so it inherits deletionTimestamp).
+	if finalizersDrained(&patched.ObjectMeta) {
+		delete(s.services, key)
+		s.wServices.publish(EventDeleted, namespace, *patched.DeepCopy())
 		writeJSON(w, http.StatusOK, patched)
 
 		return
@@ -335,6 +364,16 @@ func (s *ClusterState) deleteService(w http.ResponseWriter, r *http.Request, nam
 	}
 
 	if isDryRun(r) {
+		writeJSON(w, http.StatusOK, svc.DeepCopy())
+
+		return
+	}
+
+	// Finalizer-gated deletion: a Service with finalizers goes Terminating and is
+	// removed only when the last finalizer is dropped via update/patch.
+	if s.markForDeletion(&svc.ObjectMeta) {
+		svc.ResourceVersion = bumpResourceVersion(svc.ResourceVersion)
+		s.wServices.publish(EventModified, namespace, *svc.DeepCopy())
 		writeJSON(w, http.StatusOK, svc.DeepCopy())
 
 		return

--- a/services/kubernetes/serviceaccount.go
+++ b/services/kubernetes/serviceaccount.go
@@ -99,7 +99,6 @@ func (s *ClusterState) serveServiceAccountItem(w http.ResponseWriter, r *http.Re
 	}
 }
 
-//nolint:dupl // namespaced-create CRUD pattern; copy-paste is clearer than a generic helper.
 func (s *ClusterState) createServiceAccount(w http.ResponseWriter, r *http.Request, namespace string) {
 	var in corev1.ServiceAccount
 	if !readJSON(w, r, &in) {
@@ -249,8 +248,6 @@ func (s *ClusterState) updateServiceAccount(w http.ResponseWriter, r *http.Reque
 
 // Patch flow is identical across namespaced resources; sharing would force a
 // runtime type-switch and obscure the resource-specific store access.
-//
-//nolint:dupl // see comment above.
 func (s *ClusterState) patchServiceAccount(w http.ResponseWriter, r *http.Request, namespace, name string) {
 	key := serviceAccountKey(namespace, name)
 

--- a/services/kubernetes/ssa.go
+++ b/services/kubernetes/ssa.go
@@ -58,7 +58,7 @@ var ssaSkipMeta = map[string]bool{
 // (merged, true) on success; on conflict or wire error it has already written
 // the response and returns (nil, false).
 func (s *ClusterState) serverSideApply(
-	w http.ResponseWriter, r *http.Request, st *registryStore, cur *unstructured.Unstructured,
+	w http.ResponseWriter, r *http.Request, apiVersion string, cur *unstructured.Unstructured,
 ) (*unstructured.Unstructured, bool) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -95,7 +95,7 @@ func (s *ClusterState) serverSideApply(
 		return nil, false
 	}
 
-	setManagedFields(merged, updateManagedFields(cur, manager, appliedLeaves, st.def.apiVersion(), s.now()))
+	setManagedFields(merged, updateManagedFields(cur, manager, appliedLeaves, apiVersion, s.now()))
 	// Upstream apply removes fields this manager previously owned but now omits,
 	// unless another manager still owns them.
 	removeDroppedLeaves(merged, diffLeaves(prevLeaves, appliedLeaves))
@@ -449,6 +449,63 @@ func objectMap(v any) map[string]any {
 	}
 
 	return m
+}
+
+// applyOrPatchTyped dispatches a typed PATCH: an `application/apply-patch+yaml`
+// body runs through the server-side-apply engine (field ownership + conflicts),
+// every other content type is a plain merge/strategic/JSONPatch. apiVersion
+// labels the managedFields entry SSA records. This mirrors registryPatch's
+// content-type branch for the typed core kinds.
+func applyOrPatchTyped[T any](
+	s *ClusterState, w http.ResponseWriter, r *http.Request, apiVersion string, cur *T,
+) (*T, bool) {
+	if r.Header.Get("Content-Type") == contentTypeApplyPatch {
+		return serverSideApplyTyped(s, w, r, apiVersion, cur)
+	}
+
+	return applyJSONPatch(w, r, cur)
+}
+
+// serverSideApplyTyped runs server-side apply for a typed core kind by
+// round-tripping the current object through the unstructured SSA engine, which
+// carries all the field-ownership and conflict logic. It returns the merged
+// typed object (managedFields set), or (nil, false) after the engine has
+// already written a 409/400 response.
+func serverSideApplyTyped[T any](
+	s *ClusterState, w http.ResponseWriter, r *http.Request, apiVersion string, cur *T,
+) (*T, bool) {
+	curMap := objectMap(cur)
+	if curMap == nil {
+		writeBadRequest(w, "k8s api: encode current object for apply")
+
+		return nil, false
+	}
+
+	merged, ok := s.serverSideApply(w, r, apiVersion, &unstructured.Unstructured{Object: curMap})
+	if !ok {
+		return nil, false
+	}
+
+	return typedFromUnstructured[T](w, merged)
+}
+
+// typedFromUnstructured decodes an unstructured object back into a typed T.
+func typedFromUnstructured[T any](w http.ResponseWriter, u *unstructured.Unstructured) (*T, bool) {
+	b, err := json.Marshal(u.Object)
+	if err != nil {
+		writeBadRequest(w, "k8s api: marshal merged object: "+err.Error())
+
+		return nil, false
+	}
+
+	out := new(T)
+	if err := json.Unmarshal(b, out); err != nil {
+		writeBadRequest(w, "k8s api: decode merged typed object: "+err.Error())
+
+		return nil, false
+	}
+
+	return out, true
 }
 
 // typedEntryLeaves returns the leaf set recorded in a typed managedFields entry.

--- a/services/kubernetes/ssa.go
+++ b/services/kubernetes/ssa.go
@@ -11,6 +11,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Server-side apply with field ownership. Each apply request carries a
@@ -74,6 +75,13 @@ func (s *ClusterState) serverSideApply(
 		return nil, false
 	}
 
+	// Snapshot server-owned identity BEFORE the merge — mergeRFC7396 mutates
+	// cur.Object in place, so reading these after the merge would see the
+	// applied body's values (e.g. the `creationTimestamp: null` kubectl sends).
+	prevUID := cur.GetUID()
+	prevCreation := cur.GetCreationTimestamp()
+	prevDeletion := cur.GetDeletionTimestamp()
+
 	manager := r.URL.Query().Get("fieldManager")
 	if manager == "" {
 		manager = defaultFieldManager
@@ -94,6 +102,16 @@ func (s *ClusterState) serverSideApply(
 	if !mok {
 		return nil, false
 	}
+
+	// Server-owned identity metadata is never settable by an apply. Re-assert the
+	// pre-merge snapshot here — the one place every apply path (typed and
+	// registry) flows through — so an applied body carrying `creationTimestamp:
+	// null` (kubectl always sends it) or omitting uid/deletionTimestamp cannot
+	// blank or re-identify the object via the RFC-7396 merge. ssaSkipMeta already
+	// keeps these out of ownership tracking; this protects the values.
+	merged.SetUID(prevUID)
+	merged.SetCreationTimestamp(prevCreation)
+	merged.SetDeletionTimestamp(prevDeletion)
 
 	setManagedFields(merged, updateManagedFields(cur, manager, appliedLeaves, apiVersion, s.now()))
 	// Upstream apply removes fields this manager previously owned but now omits,
@@ -436,15 +454,12 @@ func managedFieldsOf(obj *unstructured.Unstructured) []any {
 	return entries
 }
 
-// objectMap marshals a typed object to a generic JSON map for leaf computation.
+// objectMap converts a typed object to a generic map via the canonical
+// typed↔unstructured converter (not a json round-trip, which silently drops
+// unknown fields and doesn't surface shape mismatches).
 func objectMap(v any) map[string]any {
-	b, err := json.Marshal(v)
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(v)
 	if err != nil {
-		return nil
-	}
-
-	m := map[string]any{}
-	if json.Unmarshal(b, &m) != nil {
 		return nil
 	}
 
@@ -489,17 +504,12 @@ func serverSideApplyTyped[T any](
 	return typedFromUnstructured[T](w, merged)
 }
 
-// typedFromUnstructured decodes an unstructured object back into a typed T.
+// typedFromUnstructured decodes an unstructured object back into a typed T via
+// the canonical converter, which errors on a shape mismatch rather than
+// silently dropping fields a json round-trip would.
 func typedFromUnstructured[T any](w http.ResponseWriter, u *unstructured.Unstructured) (*T, bool) {
-	b, err := json.Marshal(u.Object)
-	if err != nil {
-		writeBadRequest(w, "k8s api: marshal merged object: "+err.Error())
-
-		return nil, false
-	}
-
 	out := new(T)
-	if err := json.Unmarshal(b, out); err != nil {
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, out); err != nil {
 		writeBadRequest(w, "k8s api: decode merged typed object: "+err.Error())
 
 		return nil, false

--- a/services/kubernetes/typed_ssa_test.go
+++ b/services/kubernetes/typed_ssa_test.go
@@ -1,0 +1,247 @@
+// Server-side apply, apply-create, and finalizers for the typed core kinds
+// (ConfigMap/Secret/Service/Deployment) — they must behave the way registry-
+// backed kinds already do.
+package kubernetes_test
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+// managedFieldsOf pulls metadata.managedFields out of a decoded object.
+func managedFieldsOfObj(t *testing.T, obj map[string]any) []any {
+	t.Helper()
+
+	meta, _ := obj["metadata"].(map[string]any)
+	mf, _ := meta["managedFields"].([]any)
+
+	return mf
+}
+
+// hasApplyEntry reports whether managedFields carries an Apply entry for manager.
+func hasApplyEntry(mf []any, manager string) bool {
+	for _, e := range mf {
+		em, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		if em["manager"] == manager && em["operation"] == "Apply" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestTypedServerSideApply_OwnershipAndConflict: applying to a typed ConfigMap
+// must record managedFields and a second manager changing an owned field must
+// 409 (unless force). Today the typed PATCH path treats apply-patch as a plain
+// merge, so no ownership is recorded and the conflicting apply silently wins.
+func TestTypedServerSideApply_OwnershipAndConflict(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	collURL := base + "/api/v1/namespaces/default/configmaps"
+	cmURL := collURL + "/owned"
+
+	// Seed the object first so this isolates ownership/conflict on an existing
+	// object (apply-create is covered by TestServerSideApplyCreate).
+	seed := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "owned"},
+	})
+	if c := do(t, http.MethodPost, collURL, seed); c.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(c.Body)
+		c.Body.Close()
+		t.Fatalf("seed ConfigMap: got %d, want 201 (%s)", c.StatusCode, body)
+	} else {
+		c.Body.Close()
+	}
+
+	alice := apply(t, cmURL, "alice", false, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "owned"},
+		"data":     map[string]any{"foo": "1"},
+	})
+	if alice.StatusCode != http.StatusOK && alice.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(alice.Body)
+		alice.Body.Close()
+		t.Fatalf("alice apply: got %d, want 200/201 (%s)", alice.StatusCode, body)
+	}
+
+	obj := decodeMap(t, alice.Body)
+	alice.Body.Close()
+
+	if mf := managedFieldsOfObj(t, obj); !hasApplyEntry(mf, "alice") {
+		t.Fatalf("typed apply did not record an Apply managedFields entry for alice: %v", mf)
+	}
+
+	// bob changes alice's owned field without force -> conflict 409.
+	bob := apply(t, cmURL, "bob", false, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "owned"},
+		"data":     map[string]any{"foo": "2"},
+	})
+	bobStatus := bob.StatusCode
+	bob.Body.Close()
+
+	if bobStatus != http.StatusConflict {
+		t.Fatalf("bob apply over alice's field: got %d, want 409 Conflict", bobStatus)
+	}
+
+	// bob with force -> ownership transfers, 200.
+	bobF := apply(t, cmURL, "bob", true, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "owned"},
+		"data":     map[string]any{"foo": "2"},
+	})
+	bobFStatus := bobF.StatusCode
+	bobF.Body.Close()
+
+	if bobFStatus != http.StatusOK {
+		t.Fatalf("bob apply with force: got %d, want 200", bobFStatus)
+	}
+}
+
+// TestServerSideApplyCreate: apply-patch to a non-existent object must create it,
+// for both a typed kind and a registry kind. Today both return 404.
+func TestServerSideApplyCreate(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	// Typed: apply to a ConfigMap that does not exist yet.
+	cmURL := base + "/api/v1/namespaces/default/configmaps/fresh"
+	tr := apply(t, cmURL, "kubectl", false, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "fresh"},
+		"data":     map[string]any{"k": "v"},
+	})
+	trStatus := tr.StatusCode
+	tr.Body.Close()
+
+	if trStatus != http.StatusOK && trStatus != http.StatusCreated {
+		t.Fatalf("apply-create typed ConfigMap: got %d, want 200/201 (create-on-apply)", trStatus)
+	}
+
+	g := do(t, http.MethodGet, cmURL, nil)
+	if g.StatusCode != http.StatusOK {
+		g.Body.Close()
+		t.Fatalf("GET after apply-create ConfigMap: got %d, want 200", g.StatusCode)
+	}
+
+	got := decodeMap(t, g.Body)
+	g.Body.Close()
+
+	if mf := managedFieldsOfObj(t, got); !hasApplyEntry(mf, "kubectl") {
+		t.Fatalf("apply-created ConfigMap has no Apply managedFields entry for kubectl: %v", mf)
+	}
+
+	// Typed workload: apply-create a Deployment (the headline `kubectl apply
+	// --server-side -f deployment.yaml` path) — must create and reconcile.
+	depURL := base + "/apis/apps/v1/namespaces/default/deployments/web"
+	dr := apply(t, depURL, "kubectl", false, map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{"name": "web"},
+		"spec": map[string]any{
+			"replicas": 1,
+			"selector": map[string]any{"matchLabels": map[string]any{"app": "web"}},
+			"template": map[string]any{
+				"metadata": map[string]any{"labels": map[string]any{"app": "web"}},
+				"spec": map[string]any{
+					"containers": []any{map[string]any{"name": "c", "image": "nginx"}},
+				},
+			},
+		},
+	})
+	drStatus := dr.StatusCode
+	dr.Body.Close()
+
+	if drStatus != http.StatusOK && drStatus != http.StatusCreated {
+		t.Fatalf("apply-create Deployment: got %d, want 200/201", drStatus)
+	}
+
+	if gd := do(t, http.MethodGet, depURL, nil); gd.StatusCode != http.StatusOK {
+		gd.Body.Close()
+		t.Fatalf("GET after apply-create Deployment: got %d, want 200", gd.StatusCode)
+	} else {
+		gd.Body.Close()
+	}
+
+	// Registry: apply to a NetworkPolicy that does not exist yet.
+	npURL := base + "/apis/networking.k8s.io/v1/namespaces/default/networkpolicies/freshnp"
+	rr := apply(t, npURL, "kubectl", false, map[string]any{
+		"apiVersion": "networking.k8s.io/v1", "kind": "NetworkPolicy",
+		"metadata": map[string]any{"name": "freshnp"},
+		"spec":     map[string]any{"podSelector": map[string]any{}},
+	})
+	rrStatus := rr.StatusCode
+	rr.Body.Close()
+
+	if rrStatus != http.StatusOK && rrStatus != http.StatusCreated {
+		t.Fatalf("apply-create registry NetworkPolicy: got %d, want 200/201 (create-on-apply)", rrStatus)
+	}
+}
+
+// TestTypedFinalizerGatedDelete: deleting a typed ConfigMap that carries a
+// finalizer must leave it Terminating (deletionTimestamp set), not hard-delete
+// it; removing the finalizer then completes the delete. Today it is hard-deleted.
+func TestTypedFinalizerGatedDelete(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	collURL := base + "/api/v1/namespaces/default/configmaps"
+	itemURL := collURL + "/guarded"
+
+	create := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{
+			"name":       "guarded",
+			"finalizers": []any{"cloudemu.dev/hold"},
+		},
+		"data": map[string]any{"k": "v"},
+	})
+	if c := do(t, http.MethodPost, collURL, create); c.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(c.Body)
+		c.Body.Close()
+		t.Fatalf("create guarded ConfigMap: got %d, want 201 (%s)", c.StatusCode, body)
+	} else {
+		c.Body.Close()
+	}
+
+	// DELETE must not remove it — it should go Terminating.
+	del := do(t, http.MethodDelete, itemURL, nil)
+	del.Body.Close()
+
+	g := do(t, http.MethodGet, itemURL, nil)
+	if g.StatusCode != http.StatusOK {
+		g.Body.Close()
+		t.Fatalf("GET after finalizer-gated delete: got %d, want 200 (object should be Terminating)", g.StatusCode)
+	}
+
+	obj := decodeMap(t, g.Body)
+	g.Body.Close()
+
+	meta, _ := obj["metadata"].(map[string]any)
+	if meta["deletionTimestamp"] == nil {
+		t.Fatalf("finalizer-gated delete did not set deletionTimestamp; object was hard-deleted")
+	}
+
+	// Remove the finalizer -> delete completes.
+	clear := mustJSON(t, map[string]any{"metadata": map[string]any{"finalizers": []any{}}})
+	if p := patchReq(t, itemURL, "application/merge-patch+json", clear); p.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(p.Body)
+		p.Body.Close()
+		t.Fatalf("remove finalizer: got %d, want 200 (%s)", p.StatusCode, body)
+	} else {
+		p.Body.Close()
+	}
+
+	if g2 := do(t, http.MethodGet, itemURL, nil); g2.StatusCode != http.StatusNotFound {
+		g2.Body.Close()
+		t.Fatalf("GET after draining finalizer: got %d, want 404 (object should be gone)", g2.StatusCode)
+	} else {
+		g2.Body.Close()
+	}
+}

--- a/services/kubernetes/typed_ssa_test.go
+++ b/services/kubernetes/typed_ssa_test.go
@@ -184,6 +184,132 @@ func TestServerSideApplyCreate(t *testing.T) {
 	}
 }
 
+// identityOf pulls the server-owned uid + creationTimestamp out of an object.
+func identityOf(t *testing.T, obj map[string]any) (uid, creation string) {
+	t.Helper()
+
+	meta, _ := obj["metadata"].(map[string]any)
+	uid, _ = meta["uid"].(string)
+	creation, _ = meta["creationTimestamp"].(string)
+
+	return uid, creation
+}
+
+// TestTypedApply_PreservesServerMetadata: an apply body that carries
+// `creationTimestamp: null` (kubectl always sends it) or omits `uid` must NOT
+// blank the server-owned identity metadata. This re-GETs after the apply — the
+// exact check that catches the metadata-drop the apply path used to have. Run
+// across two typed kinds so it isn't ConfigMap-specific.
+func TestTypedApply_PreservesServerMetadata(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	for _, tc := range []struct {
+		name, kind, coll string
+	}{
+		{"configmap", "ConfigMap", "/api/v1/namespaces/default/configmaps"},
+		{"secret", "Secret", "/api/v1/namespaces/default/secrets"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			collURL := base + tc.coll
+			itemURL := collURL + "/meta"
+
+			// Create it and capture the server-assigned identity.
+			create := mustJSON(t, map[string]any{
+				"apiVersion": "v1", "kind": tc.kind,
+				"metadata": map[string]any{"name": "meta"},
+			})
+			c := do(t, http.MethodPost, collURL, create)
+			if c.StatusCode != http.StatusCreated {
+				b, _ := io.ReadAll(c.Body)
+				c.Body.Close()
+				t.Fatalf("create %s: got %d, want 201 (%s)", tc.kind, c.StatusCode, b)
+			}
+			uid, creation := identityOf(t, decodeMap(t, c.Body))
+			c.Body.Close()
+
+			if uid == "" || creation == "" {
+				t.Fatalf("created %s missing uid/creationTimestamp: uid=%q creation=%q", tc.kind, uid, creation)
+			}
+
+			// Apply with an explicit creationTimestamp:null (kubectl's behavior)
+			// plus a real change.
+			r := apply(t, itemURL, "kubectl", false, map[string]any{
+				"apiVersion": "v1", "kind": tc.kind,
+				"metadata": map[string]any{
+					"name":              "meta",
+					"creationTimestamp": nil,
+					"labels":            map[string]any{"applied": "yes"},
+				},
+			})
+			if r.StatusCode != http.StatusOK && r.StatusCode != http.StatusCreated {
+				b, _ := io.ReadAll(r.Body)
+				r.Body.Close()
+				t.Fatalf("apply %s: got %d, want 200/201 (%s)", tc.kind, r.StatusCode, b)
+			}
+			r.Body.Close()
+
+			// Re-GET: identity must be exactly what create assigned.
+			g := do(t, http.MethodGet, itemURL, nil)
+			got := decodeMap(t, g.Body)
+			g.Body.Close()
+
+			gUID, gCreation := identityOf(t, got)
+			if gUID != uid {
+				t.Fatalf("%s uid changed across apply: %q -> %q", tc.kind, uid, gUID)
+			}
+			if gCreation != creation {
+				t.Fatalf("%s creationTimestamp blanked/changed across apply: %q -> %q", tc.kind, creation, gCreation)
+			}
+		})
+	}
+}
+
+// TestTypedApply_TwoManagerRetention: the core SSA property — two managers each
+// owning a different field both survive. alice applies data.x, bob applies
+// data.y (disjoint, so no conflict); a re-GET must show both.
+func TestTypedApply_TwoManagerRetention(t *testing.T) {
+	base, done := newFixture(t)
+	defer done()
+
+	collURL := base + "/api/v1/namespaces/default/configmaps"
+	itemURL := collURL + "/shared"
+
+	seed := mustJSON(t, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "shared"},
+	})
+	do(t, http.MethodPost, collURL, seed).Body.Close()
+
+	a := apply(t, itemURL, "alice", false, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "shared"},
+		"data":     map[string]any{"x": "1"},
+	})
+	a.Body.Close()
+
+	b := apply(t, itemURL, "bob", false, map[string]any{
+		"apiVersion": "v1", "kind": "ConfigMap",
+		"metadata": map[string]any{"name": "shared"},
+		"data":     map[string]any{"y": "2"},
+	})
+	if b.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(b.Body)
+		b.Body.Close()
+		t.Fatalf("bob apply (disjoint field): got %d, want 200 (%s)", b.StatusCode, body)
+	}
+	b.Body.Close()
+
+	g := do(t, http.MethodGet, itemURL, nil)
+	got := decodeMap(t, g.Body)
+	g.Body.Close()
+
+	data, _ := got["data"].(map[string]any)
+	if data["x"] != "1" || data["y"] != "2" {
+		t.Fatalf("two-manager retention failed: both fields should survive, got data=%v", data)
+	}
+}
+
 // TestTypedFinalizerGatedDelete: deleting a typed ConfigMap that carries a
 // finalizer must leave it Terminating (deletionTimestamp set), not hard-delete
 // it; removing the finalizer then completes the delete. Today it is hard-deleted.

--- a/services/kubernetes/typed_ssa_test.go
+++ b/services/kubernetes/typed_ssa_test.go
@@ -169,6 +169,18 @@ func TestServerSideApplyCreate(t *testing.T) {
 		gd.Body.Close()
 	}
 
+	// The headline of apply-create is that it preserves per-kind reconcile — the
+	// Deployment must materialize its Pods, not just store the object. Assert the
+	// child Pod count == spec.replicas so a future change to the apply-create
+	// path can't silently stop reconciling while this test stays green.
+	pl := do(t, http.MethodGet, base+"/api/v1/namespaces/default/pods?labelSelector=app%3Dweb", nil)
+	pods := decodeMap(t, pl.Body)
+	pl.Body.Close()
+
+	if items, _ := pods["items"].([]any); len(items) != 1 {
+		t.Fatalf("apply-create Deployment materialized %d Pods, want 1 (spec.replicas)", len(items))
+	}
+
 	// Registry: apply to a NetworkPolicy that does not exist yet.
 	npURL := base + "/apis/networking.k8s.io/v1/namespaces/default/networkpolicies/freshnp"
 	rr := apply(t, npURL, "kubectl", false, map[string]any{


### PR DESCRIPTION
Fixes #330.

## Problem

`kubectl apply --server-side` and finalizer-gated deletes worked for registry-backed kinds but not for the typed core kinds (ConfigMap, Secret, Service, Deployment):

- **apply-patch was a dumb merge** — the typed handlers ran `application/apply-patch+yaml` through a plain RFC-7396 merge, so no field ownership (`managedFields`) and no conflict detection.
- **apply to a missing object 404'd** instead of creating it, so `kubectl apply --server-side -f x.yaml` failed on a fresh cluster.
- **typed deletes ignored finalizers** — an object with `metadata.finalizers` was hard-deleted instead of going Terminating.

## Solution

The machinery already existed for registry kinds; this routes the typed handlers into it.

- **Server-side apply.** `serverSideApply` is decoupled from `registryStore` (takes an `apiVersion` string); a `serverSideApplyTyped` bridge round-trips a typed struct through it. The four typed PATCH handlers now branch on content-type exactly like `registryPatch` — apply-patch → real SSA (ownership + 409 conflicts), everything else → the existing merge.
- **Apply-create.** Apply to a missing object now creates it — typed kinds via a shared `createXLocked` core (so per-kind defaulting/reconcile is preserved, e.g. a Deployment materializes Pods), registry kinds via `registryApplyCreateLocked`.
- **Finalizers.** The four typed delete handlers call the existing `markForDeletion` (object goes Terminating), and a patch that drains the last finalizer completes the delete — matching Pod / Namespace / registry.

No new abstractions and no changes outside `services/kubernetes/`.

## Verification

**Unit** — repro-first tests for all three gaps; full `services/kubernetes` package green, including under `-race`. Full module builds; the EKS/AKS/GKE server layers and provider tests pass.

**Real-user e2e** — a `kubectl`-tagged test drives **real kubectl v1.35.4** against a temporary in-memory cluster. Live run output:

```
# apply-create on a fresh cluster
$ kubectl apply --server-side --field-manager=alice -f cm.yaml
configmap/settings serverside-applied

# conflict when another manager changes an owned field
$ kubectl apply --server-side --field-manager=bob -f cm-red.yaml
error: Apply failed with conflicts: fields managed by another manager: data.color (owned by alice)
$ kubectl apply --server-side --field-manager=bob --force-conflicts -f cm-red.yaml
configmap/settings serverside-applied

# finalizer-gated delete stays Terminating, then completes on removal
$ kubectl delete configmap guarded --wait=false
configmap "guarded" deleted from default namespace
$ kubectl get cm guarded -o jsonpath='{.metadata.deletionTimestamp}'
2026-08-11T06:58:09Z
$ kubectl patch configmap guarded --type=merge -p '{"metadata":{"finalizers":[]}}'
$ kubectl get cm guarded
Error from server (NotFound): configmap not found: default/guarded
```

## Not included

Pod's apply path was already recording update ownership and is out of this issue's scope; unchanged.
