### PR TITLE
fix(serve): advertise a routable Kubernetes endpoint under Docker (--host 0.0.0.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=build /out/cloudemu /usr/local/bin/cloudemu
 
-# AWS (LocalStack-compatible), Azure (HTTPS), GCP, Kubernetes data-plane.
-EXPOSE 4566 4568 4569 4570
+# AWS (LocalStack-compatible), Azure (HTTPS), GCP, Kubernetes data-plane, OCI.
+# OCI (4571) is opt-in (--providers …,oci) so it isn't published by default, but
+# the port is declared here for when it is enabled.
+EXPOSE 4566 4568 4569 4570 4571
 
 # Bind all interfaces so the container is reachable from the host / other
 # containers. The control plane (/_cloudemu/reset) is on by default — see the

--- a/cmd/cloudemu/advertise_test.go
+++ b/cmd/cloudemu/advertise_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The Kubernetes data plane self-advertises an endpoint (EKS/AKS/GKE
+// DescribeCluster returns it). It must never advertise a bind-all address like
+// 0.0.0.0 — that isn't connectable, so a kubeconfig pointing at it can't be
+// dialed or TLS-verified. Under Docker (`--host 0.0.0.0`) it must fall back to a
+// routable loopback.
+func TestAdvertiseHostFor(t *testing.T) {
+	cases := []struct {
+		name, advertise, bind, want string
+	}{
+		{"docker all-interfaces -> loopback", "", "0.0.0.0", "127.0.0.1"},
+		{"empty bind -> loopback", "", "", "127.0.0.1"},
+		{"ipv6 unspecified -> loopback", "", "::", "127.0.0.1"},
+		{"loopback bind kept", "", "127.0.0.1", "127.0.0.1"},
+		{"specific ip kept", "", "192.168.1.5", "192.168.1.5"},
+		{"explicit advertise wins over bind-all", "k8s.local", "0.0.0.0", "k8s.local"},
+		{"explicit advertise wins over specific bind", "k8s.local", "10.0.0.2", "k8s.local"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := advertiseHostFor(tc.advertise, tc.bind); got != tc.want {
+				t.Fatalf("advertiseHostFor(%q, %q) = %q, want %q", tc.advertise, tc.bind, got, tc.want)
+			}
+		})
+	}
+}
+
+// k8sCertHosts must certify the advertised host + loopback names + extra
+// --tls-host SANs, with no duplicates (so TLS verifies against whatever the
+// endpoint advertises).
+func TestK8sCertHosts(t *testing.T) {
+	if got := k8sCertHosts("127.0.0.1", nil); !reflect.DeepEqual(got, []string{"127.0.0.1", "localhost"}) {
+		t.Fatalf("loopback advertise: got %v, want [127.0.0.1 localhost] (deduped)", got)
+	}
+
+	got := k8sCertHosts("k8s.local", stringList{"192.168.1.5", "k8s.local"})
+	want := []string{"k8s.local", "localhost", "127.0.0.1", "192.168.1.5"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("custom advertise + extras: got %v, want %v", got, want)
+	}
+}

--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -46,6 +46,7 @@ var errUnsupportedSnapshot = errors.New("unsupported snapshot schema version")
 type serveConfig struct {
 	providers       string
 	host            string
+	advertiseHost   string
 	awsPort         string
 	azurePort       string
 	gcpPort         string
@@ -85,6 +86,9 @@ func runServe(args []string) error {
 	// so the default set never binds a port that serves nothing.
 	fs.StringVar(&c.providers, "providers", "aws,azure,gcp", "comma-separated providers to start: aws,azure,gcp,oci")
 	fs.StringVar(&c.host, "host", "127.0.0.1", "host/interface to bind (use 0.0.0.0 to expose on the network)")
+	fs.StringVar(&c.advertiseHost, "advertise-host", "",
+		"host/IP the Kubernetes data-plane endpoint is advertised at in kubeconfigs and its TLS cert "+
+			"(default: --host, or 127.0.0.1 when binding all interfaces such as 0.0.0.0 under Docker)")
 	fs.StringVar(&c.awsPort, "aws-port", "4566", "port for the AWS endpoint (HTTP)")
 	fs.StringVar(&c.azurePort, "azure-port", "4568", "port for the Azure endpoint (HTTPS)")
 	fs.StringVar(&c.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
@@ -120,6 +124,13 @@ func runServe(args []string) error {
 	if c.persist && c.stateFile == "" {
 		return errStateFileRequired
 	}
+
+	// Resolve the host the Kubernetes data plane advertises to clients. The bind
+	// host isn't always reachable: under Docker the container binds 0.0.0.0 (all
+	// interfaces), but 0.0.0.0 is not a connectable address — a kubeconfig
+	// advertising https://0.0.0.0:4570 with a 0.0.0.0-only cert SAN can't be
+	// dialed or TLS-verified from the host. Advertise a routable host instead.
+	advertiseHost := advertiseHostFor(c.advertiseHost, c.host)
 
 	sel, err := parseProviders(c.providers)
 	if err != nil {
@@ -187,7 +198,7 @@ func runServe(args []string) error {
 			// rest.Config from Endpoint plus CertificateAuthority can then
 			// validate what it dials; over plain HTTP that CA certifies
 			// nothing and the handshake fails.
-			k8s.SetBaseURL("https://" + net.JoinHostPort(c.host, c.k8sPort))
+			k8s.SetBaseURL("https://" + net.JoinHostPort(advertiseHost, c.k8sPort))
 		}
 		fresh := make(map[string]http.Handler, len(sel))
 		freshTargets := make(map[string]seed.Target, len(sel))
@@ -415,7 +426,9 @@ func runServe(args []string) error {
 	if k8sBackend != nil {
 		addr := net.JoinHostPort(c.host, c.k8sPort)
 
-		k8sTLS, err := eksprov.ServingTLSConfig([]string{c.host, "localhost", "127.0.0.1"})
+		// The cert must certify the advertised host (what clients dial), plus the
+		// loopback names, plus any extra --tls-host SANs.
+		k8sTLS, err := eksprov.ServingTLSConfig(k8sCertHosts(advertiseHost, c.tlsHosts))
 		if err != nil {
 			return fmt.Errorf("kubernetes data-plane TLS: %w", err)
 		}
@@ -425,7 +438,9 @@ func runServe(args []string) error {
 			srv:  &http.Server{Addr: addr, Handler: handlerFor(k8sBackend, nil), TLSConfig: k8sTLS},
 			tls:  true,
 		})
-		eps.Kubernetes = fmt.Sprintf("https://%s", addr)
+		// Show the reachable (advertised) endpoint, not the bind address — the
+		// listener binds `addr` (may be 0.0.0.0) but clients dial advertiseHost.
+		eps.Kubernetes = fmt.Sprintf("https://%s", net.JoinHostPort(advertiseHost, c.k8sPort))
 	}
 
 	// Bind every listener before serving so a port clash fails fast, before
@@ -742,6 +757,62 @@ type namedServer struct {
 }
 
 // isLoopbackHost reports whether binding to h keeps the server local-only.
+// loopbackIPv4 is advertised for the Kubernetes data plane when the server binds
+// all interfaces (a published -p 4570:4570 maps to it from the host).
+const loopbackIPv4 = "127.0.0.1"
+
+// advertiseHostFor resolves the host the Kubernetes data plane advertises to
+// clients: an explicit --advertise-host wins; otherwise the bind host, unless
+// that binds all interfaces (0.0.0.0 / :: / empty — e.g. Docker), in which case
+// loopback.
+func advertiseHostFor(advertiseHost, bindHost string) string {
+	if advertiseHost != "" {
+		return advertiseHost
+	}
+
+	if isAllInterfaces(bindHost) {
+		return loopbackIPv4
+	}
+
+	return bindHost
+}
+
+// isAllInterfaces reports whether h is a bind-all address (not connectable).
+func isAllInterfaces(h string) bool {
+	switch h {
+	case "", "0.0.0.0", "::", "[::]":
+		return true
+	}
+
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsUnspecified()
+	}
+
+	return false
+}
+
+// k8sCertHosts is the SAN set for the Kubernetes serving cert: the advertised
+// host (what clients dial and verify), the loopback names, and any extra
+// --tls-host entries, de-duplicated.
+func k8sCertHosts(advertiseHost string, extra stringList) []string {
+	base := []string{advertiseHost, "localhost", loopbackIPv4}
+
+	seen := map[string]bool{}
+	out := make([]string, 0, len(base)+len(extra))
+
+	for _, h := range append(base, extra...) {
+		if h == "" || seen[h] {
+			continue
+		}
+
+		seen[h] = true
+
+		out = append(out, h)
+	}
+
+	return out
+}
+
 func isLoopbackHost(h string) bool {
 	switch h {
 	case "127.0.0.1", "::1", "localhost":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,5 @@ services:
       - "4568:4568" # Azure (HTTPS, self-signed)
       - "4569:4569" # GCP
       - "4570:4570" # Kubernetes data-plane
+      # - "4571:4571" # OCI — only served with: command: ["serve","--host","0.0.0.0","--providers","aws,azure,gcp,oci"]
     # command: ["serve", "--host", "0.0.0.0", "--admin=false"]  # disable the control plane

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -27,8 +27,14 @@ go run ./cmd/cloudemu serve
 No Go toolchain needed — pull the published image (it runs `serve --host 0.0.0.0`):
 
 ```sh
-docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 ghcr.io/stackshy/cloudemu:latest
+docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 -p 4570:4570 ghcr.io/stackshy/cloudemu:latest
 ```
+
+The container binds `0.0.0.0`, but the Kubernetes data plane advertises a
+routable endpoint (defaults to `127.0.0.1`, not the bind address), so an
+EKS/AKS/GKE kubeconfig from the container works with `kubectl` on the host. To
+reach it from another machine, pass `--advertise-host <name-or-ip>` (also added
+to the serving cert's SANs).
 
 Or bring up the whole emulated cloud with the example compose file:
 
@@ -312,7 +318,8 @@ cloudemu serve --tls-host myhost.local --tls-host 192.168.1.10
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `--providers` | `aws,azure,gcp` | which providers to start |
-| `--host` | `127.0.0.1` | bind interface |
+| `--host` | `127.0.0.1` | bind interface (`0.0.0.0` to expose on the network) |
+| `--advertise-host` | (derived) | host/IP the Kubernetes endpoint is advertised at + its cert SAN; defaults to `--host`, or `127.0.0.1` when binding all interfaces |
 | `--aws-port` / `--azure-port` / `--gcp-port` / `--k8s-port` | `4566`/`4568`/`4569`/`4570` | listen ports (empty `--k8s-port` disables Kubernetes) |
 | `--account-id` | `000000000000` | AWS account ID / Azure subscription ID |
 | `--region` | `us-east-1` | default region |

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -313,6 +313,27 @@ cloudemu serve --tls-cert cert.pem --tls-key key.pem
 cloudemu serve --tls-host myhost.local --tls-host 192.168.1.10
 ```
 
+### Trusting the Azure self-signed cert (any language)
+
+AWS (`:4566`) and GCP (`:4569`) are plain HTTP — no TLS step. Only **Azure**
+(`:4568`) is HTTPS with a self-signed cert, so a non-Go client must either skip
+verification or trust the cert (the same one-liner you'd use against any local
+HTTPS emulator). The cert already covers `localhost`, `127.0.0.1`, and `::1`, so
+dial it at `https://localhost:4568` / `https://127.0.0.1:4568`.
+
+| Client | How to accept the cert (local dev) |
+|--------|-------------------------------------|
+| `curl` | `curl -k https://localhost:4568/...` |
+| Node.js | `NODE_TLS_REJECT_UNAUTHORIZED=0` (env var) |
+| Python (`requests` / azure-sdk) | `verify=False` / `connection_verify=False` |
+| Go | `http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}` |
+| .NET | `HttpClientHandler.ServerCertificateCustomValidationCallback = (_,_,_,_) => true` |
+
+To verify **properly** instead of skipping, supply a cert your OS/language
+already trusts with `--tls-cert/--tls-key`, or add your hostname to the
+generated cert's SANs with `--tls-host <name>` and import/trust that cert in
+your client.
+
 ## Flags
 
 | Flag | Default | Purpose |
@@ -320,7 +341,7 @@ cloudemu serve --tls-host myhost.local --tls-host 192.168.1.10
 | `--providers` | `aws,azure,gcp` | which providers to start |
 | `--host` | `127.0.0.1` | bind interface (`0.0.0.0` to expose on the network) |
 | `--advertise-host` | (derived) | host/IP the Kubernetes endpoint is advertised at + its cert SAN; defaults to `--host`, or `127.0.0.1` when binding all interfaces |
-| `--aws-port` / `--azure-port` / `--gcp-port` / `--k8s-port` | `4566`/`4568`/`4569`/`4570` | listen ports (empty `--k8s-port` disables Kubernetes) |
+| `--aws-port` / `--azure-port` / `--gcp-port` / `--k8s-port` / `--oci-port` | `4566`/`4568`/`4569`/`4570`/`4571` | listen ports (empty `--k8s-port` disables Kubernetes; OCI only served when `oci` is in `--providers`) |
 | `--account-id` | `000000000000` | AWS account ID / Azure subscription ID |
 | `--region` | `us-east-1` | default region |
 | `--project-id` | `cloudemu-local` | GCP project ID |


### PR DESCRIPTION
## Problem

Running the standalone server in Docker (the `ghcr.io/stackshy/cloudemu` image runs `serve --host 0.0.0.0`) left the **Kubernetes data plane unreachable from the host**. `0.0.0.0` is a *bind-all* address, not a *connectable* one — but the k8s data plane **self-advertises** it: `EKS/AKS/GKE DescribeCluster` returned `https://0.0.0.0:4570/k8s/<uid>` with a `0.0.0.0`-only cert SAN, so `kubectl`/`client-go` on the host could neither dial nor TLS-verify the cluster.

(AWS/Azure/GCP endpoints are unaffected — callers pass their own endpoint; only the Kubernetes data plane self-advertises via `SetBaseURL`.)

## Fix

- **Advertise a routable host, not the bind address.** When `--host` binds all interfaces (`0.0.0.0` / `::` / empty), advertise `127.0.0.1` (a published `-p 4570:4570` maps there from the host). A specific `--host` is kept as-is.
- **`--advertise-host <name-or-ip>`** to override — for pointing `kubectl` at the cluster from *another* machine (its LAN IP/hostname); it's also added to the serving cert's SANs.
- The k8s serving cert now certifies **advertised host + loopback + any `--tls-host` extras** (was `[host, localhost, 127.0.0.1]`, which produced a useless `0.0.0.0` SAN under Docker).
- Startup banner shows the reachable endpoint, not the bind address.
- **docs:** the `docker run` example now publishes **`-p 4570:4570`** (it was missing, so kubectl couldn't reach the cluster regardless) and documents the advertise behavior + `--advertise-host`.

## Verification

- Unit tests for `advertiseHostFor` / `k8sCertHosts`.
- End-to-end: `serve --host 0.0.0.0` → EKS `DescribeCluster` advertises `https://127.0.0.1:4570/k8s/<uid>` (not `0.0.0.0`) → `kubectl get ns` connects and TLS-verifies. ✅
- Build + full `cmd/cloudemu` tests green; no new lint (package baseline unchanged).

Independent of #390 (touches only `cmd/cloudemu/serve.go` + docs). Both can ride the same `v2.5.0` release.
