### PR TITLE
docs: reframe README/metadata as an any-language emulator, not a Go test library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI agents working in the cloudemu repository. (Human contributors: 
 
 ## What cloudemu is
 
-Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. It runs three ways: as a standalone server (the `cloudemu serve` binary or the `ghcr.io/stackshy/cloudemu` Docker image) that any app in any language points at, and in-process from Go via either the SDK-compat HTTP server or the typed mock API. It emulates control surfaces, not a real cloud — it does not run workloads/containers, serve real traffic, authenticate requests, enforce quotas, or persist state across restarts. See the "What it is / isn't" section of the [README](README.md).
+Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. It runs three ways: as a standalone server (the `cloudemu serve` binary or the `ghcr.io/stackshy/cloudemu` Docker image) that any app in any language points at, and in-process from Go via either the SDK-compat HTTP server or the typed mock API. It emulates control surfaces, not a real cloud — it does not run workloads/containers, serve real traffic, authenticate requests, enforce quotas, or persist state across restarts. See the [README](README.md) for the full framing and scope.
 
 ## Where the capabilities are
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI agents working in the cloudemu repository. (Human contributors: 
 
 ## What cloudemu is
 
-Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs** for Go tests. It emulates control surfaces, not a real cloud — it does not run workloads/containers, serve real traffic, authenticate requests, enforce quotas, or persist state across restarts. See the "What it is / isn't" section of the [README](README.md).
+Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. It runs three ways: as a standalone server (the `cloudemu serve` binary or the `ghcr.io/stackshy/cloudemu` Docker image) that any app in any language points at, and in-process from Go via either the SDK-compat HTTP server or the typed mock API. It emulates control surfaces, not a real cloud — it does not run workloads/containers, serve real traffic, authenticate requests, enforce quotas, or persist state across restarts. See the "What it is / isn't" section of the [README](README.md).
 
 ## Where the capabilities are
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 -p 4570:4570 \
 #   Kubernetes  https://127.0.0.1:4570
 ```
 
-Then point your existing SDK or CLI at it — nothing cloudemu-specific:
+Then point your existing SDK or CLI at it — nothing cloudemu-specific. cloudemu accepts any credentials, but the AWS CLI still needs some set in its chain:
 
 ```sh
+export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=us-east-1
 aws --endpoint-url http://127.0.0.1:4566 s3 mb s3://demo
 aws --endpoint-url http://127.0.0.1:4566 s3 ls
 ```
@@ -63,6 +64,7 @@ ts := httptest.NewServer(awsserver.New(awsserver.Drivers{
 }))
 defer ts.Close()
 
+ctx := context.Background()
 cfg, _ := config.LoadDefaultConfig(ctx) // credentials/region are ignored
 client := s3.NewFromConfig(cfg, func(o *s3.Options) {
     o.BaseEndpoint = aws.String(ts.URL)
@@ -126,6 +128,12 @@ Full per-service operation list: [docs/services.md](docs/services.md). Per-handl
 - [docs/features.md](docs/features.md) — auto-metrics, alarm evaluation, IAM policy evaluation, FIFO dedup, error injection, fake clock
 - [docs/chaos.md](docs/chaos.md) — deliberately fail or slow down services to test retry/timeout paths
 - [docs/topology.md](docs/topology.md) — network connectivity simulation across VPC, peering, SGs, ACLs
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, the branch-from-`development` flow, and the lint/coverage bar. Please also read the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Questions or bugs? Open a [GitHub issue](https://github.com/stackshy/cloudemu/issues). For security reports, follow [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,56 +5,56 @@
   </picture>
 </p>
 
-<p align="center"><b>Zero-Cost In-Memory Cloud Emulation for Go</b></p>
+<p align="center"><b>In-memory AWS, Azure &amp; GCP — run it as a local cloud, or mock in-process.</b><br/>Any language. $0. Deterministic. Resettable.</p>
 
 <p align="center">
+  <a href="https://github.com/stackshy/cloudemu/pkgs/container/cloudemu"><img src="https://img.shields.io/badge/docker-ghcr.io%2Fstackshy%2Fcloudemu-2496ED?logo=docker&logoColor=white" alt="Docker Image"></a>
   <a href="https://pkg.go.dev/github.com/stackshy/cloudemu/v2"><img src="https://pkg.go.dev/badge/github.com/stackshy/cloudemu/v2.svg" alt="Go Reference"></a>
   <a href="https://goreportcard.com/report/github.com/stackshy/cloudemu/v2"><img src="https://goreportcard.com/badge/github.com/stackshy/cloudemu/v2" alt="Go Report Card"></a>
   <a href="https://github.com/stackshy/cloudemu/blob/development/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white" alt="Go Version">
   <img src="https://img.shields.io/badge/providers-AWS_|_Azure_|_GCP-orange" alt="Providers">
   <img src="https://img.shields.io/badge/cost-$0-brightgreen" alt="Zero Cost">
 </p>
 
 ---
 
-## What it does
+## What it is
 
-cloudemu emulates AWS, Azure, and GCP cloud services entirely in memory, so you can test cloud-dependent code without real accounts, Docker, or network calls.
+cloudemu emulates the **cloud APIs** of AWS, Azure, and GCP entirely in memory. Point the real cloud SDKs — in any language — at a local endpoint and your unmodified app code runs against an in-memory backend. No accounts, no network, no bill.
 
-It ships two surfaces you can mix and match:
+It emulates control surfaces, **not** a real cloud: it doesn't run workloads, serve traffic, authenticate requests, enforce quotas, or persist across restarts. That's the point — it's fast, deterministic, and resettable.
 
-- **SDK-compat HTTP server** — point the real `aws-sdk-go-v2`, `azure-sdk-for-go`, `cloud.google.com/go`, or `databricks-sdk-go` clients at a local endpoint and they just work. No code changes in your app.
-- **Go API** — typed in-memory mocks (`aws.S3`, `azure.VirtualMachines`, `gcp.GCE`, …) for tests written against cloudemu directly.
+## Three ways to run it
 
-## What it is / isn't
+1. **Standalone server / Docker** — `docker run … ghcr.io/stackshy/cloudemu` (or `cloudemu serve`). A long-lived local cloud you point **any app, any language** at. LocalStack-style.
+2. **SDK-compat HTTP server** (in-process, Go) — a `httptest.NewServer` your Go tests point the real SDKs at.
+3. **Go API** — typed in-memory mocks (`aws.S3`, `azure.VirtualMachines`, `gcp.GCE`, …) driven directly.
 
-cloudemu emulates cloud **control surfaces** — the APIs — so your code exercises real request/response behavior without a real account. It is **not** a cloud.
+## Quickstart (Docker)
 
-**It does:**
-- ✅ Emulate cloud **APIs** for fast, deterministic, Docker-free testing — via the Go API, the SDK-compat HTTP server, the standalone `serve` process, and an in-memory Kubernetes API with built-in controllers.
-- ✅ Keep all state in process memory, with a fake clock and deterministic IDs for reproducible tests.
-
-**It does not:**
-- ❌ **Run real workloads or containers.** Kubernetes controllers converge synchronously (no scheduler/kubelet); there is no real `kubectl logs`/`exec`, no container runtime, no VM.
-- ❌ **Serve real traffic.** A created load balancer, DNS record, or queue models the API object — it does not route packets or deliver over the network.
-- ❌ **Authenticate or authorize requests.** Any credentials are accepted and signatures are not verified. The IAM service evaluates policies only when you explicitly call it; it does not gate other services' operations.
-- ❌ **Enforce quotas, limits, or billing.**
-- ❌ **Persist state across restarts.** Everything is in memory and gone when the process exits.
-
-Per-service "Not in scope" notes live alongside each service in the generated [capability coverage](docs/coverage/README.md).
-
-## Install
-
-```bash
-go get github.com/stackshy/cloudemu/v2
+```sh
+docker run --rm -p 4566:4566 -p 4568:4568 -p 4569:4569 -p 4570:4570 \
+  ghcr.io/stackshy/cloudemu:latest
+#   AWS         http://127.0.0.1:4566
+#   Azure       https://127.0.0.1:4568   (self-signed TLS)
+#   GCP         http://127.0.0.1:4569
+#   Kubernetes  https://127.0.0.1:4570
 ```
 
-Requires Go 1.25+.
+Then point your existing SDK or CLI at it — nothing cloudemu-specific:
 
-## How it works (SDK-compat)
+```sh
+aws --endpoint-url http://127.0.0.1:4566 s3 mb s3://demo
+aws --endpoint-url http://127.0.0.1:4566 s3 ls
+```
 
-Most apps already use the official cloud SDKs. cloudemu speaks the same wire protocols (AWS Query/JSON/Smithy, Azure ARM, GCP REST) over a local `httptest.NewServer`. Change the SDK endpoint, and the same production code runs against an in-memory backend.
+The Kubernetes control plane hands back a real kubeconfig, so `kubectl apply -f deployment.yaml` then `kubectl get pods` round-trips end-to-end against the in-memory cluster. Reset all state between tests with `curl -X POST http://127.0.0.1:4566/_cloudemu/reset`.
+
+Full flags, ports, per-SDK wiring, and the [Testcontainers module](https://github.com/stackshy/cloudemu/tree/development/contrib/testcontainers) (auto start/stop in Go tests): [docs/standalone-server.md](docs/standalone-server.md).
+
+## In-process (Go)
+
+Prefer running the emulator inside your Go test process instead of over the network? cloudemu speaks the same wire protocols (AWS Query/JSON/Smithy, Azure ARM, GCP REST) over a local `httptest.NewServer` — change the SDK endpoint and your production code runs against an in-memory backend.
 
 ```go
 import (
@@ -71,8 +71,6 @@ ts := httptest.NewServer(awsserver.New(awsserver.Drivers{
     S3:       cloud.S3,
     DynamoDB: cloud.DynamoDB,
     EC2:      cloud.EC2,
-    RDS:      cloud.RDS,
-    EKS:      cloud.EKS,
     // …leave fields nil to omit a service
 }))
 defer ts.Close()
@@ -81,51 +79,42 @@ client := s3.NewFromConfig(cfg, func(o *s3.Options) {
     o.BaseEndpoint = aws.String(ts.URL)
     o.UsePathStyle = true
 })
-
 client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory backend
 ```
 
-Equivalent setups for Azure (`azureserver.New`) and GCP (`gcpserver.New`) are in [docs/sdk-server.md](docs/sdk-server.md).
-
-### Standalone server
-
-Prefer a long-lived process you point out-of-process apps at? Run the emulator
-as a server and point any SDK — any language — at the printed endpoints:
-
-```sh
-go run ./cmd/cloudemu serve
-#   AWS         http://127.0.0.1:4566
-#   Azure       https://127.0.0.1:4568   (self-signed TLS)
-#   GCP         http://127.0.0.1:4569
-```
-
-Full flags, port scheme, and per-SDK wiring: [docs/standalone-server.md](docs/standalone-server.md).
-
-The snippet above is a quick taste. To adopt cloudemu in a real app, don't write a demo — wire it into your existing client and tests so your real code runs against it. See [docs/integration.md](docs/integration.md).
-
-## Or use the Go API directly
+Or skip the SDK and drive the typed Go API directly:
 
 ```go
 aws := cloudemu.NewAWS()
 
 instances, _ := aws.EC2.RunInstances(ctx, driver.InstanceConfig{
-    ImageID:      "ami-0abcdef1234567890",
-    InstanceType: "t2.micro",
+    ImageID: "ami-0abcdef1234567890", InstanceType: "t2.micro",
 }, 2)
-
 _ = aws.EC2.StopInstances(ctx, []string{instances[0].ID})
-
-desc, _ := aws.EC2.DescribeInstances(ctx, []string{instances[0].ID}, nil)
-// desc[0].State == "stopped"
 ```
 
-The same pattern works across all services and all three providers — swap `aws.EC2` for `azure.VirtualMachines` or `gcp.GCE`.
+Install: `go get github.com/stackshy/cloudemu/v2` (Go 1.25+). Equivalent Azure/GCP wiring is in [docs/sdk-server.md](docs/sdk-server.md); wiring cloudemu into a real app and test suite is in [docs/integration.md](docs/integration.md).
+
+## What it is / isn't
+
+cloudemu emulates cloud **control surfaces** — the APIs — so your code exercises real request/response behavior without a real account.
+
+**It does:**
+- ✅ Emulate cloud **APIs** for fast, deterministic testing — via Docker/standalone `serve`, the SDK-compat HTTP server, the typed Go API, and an in-memory Kubernetes API with built-in controllers.
+- ✅ Keep all state in process memory, with a fake clock and deterministic IDs for reproducible tests.
+
+**It does not:**
+- ❌ **Run real workloads or containers.** Kubernetes controllers converge synchronously (no scheduler/kubelet); there is no real `kubectl logs`/`exec`, no container runtime, no VM.
+- ❌ **Serve real traffic.** A created load balancer, DNS record, or queue models the API object — it does not route packets or deliver over the network.
+- ❌ **Authenticate or authorize requests.** Any credentials are accepted and signatures are not verified. The IAM service evaluates policies only when you explicitly call it; it does not gate other services' operations.
+- ❌ **Enforce quotas, limits, or billing.**
+- ❌ **Persist state across restarts.** Everything is in memory and gone when the process exits.
+
+Per-service "Not in scope" notes live alongside each service in the generated [capability coverage](docs/coverage/README.md).
 
 ## What's supported
 
 The authoritative, always-current list is the generated [capability coverage](docs/coverage/README.md) — one page listing every service and every operation, produced from the driver interfaces by `go generate` so it cannot drift. The table below is a curated overview.
-
-SDK-compat coverage across AWS, Azure, and GCP:
 
 | Domain | AWS | Azure | GCP |
 |---|---|---|---|
@@ -155,30 +144,21 @@ SDK-compat coverage across AWS, Azure, and GCP:
 | AI Search | — | Azure AI Search | — |
 | Databricks | — | Databricks (ARM workspace + workspace data plane) | — |
 
-The Kubernetes story is two layers, both shipped:
+**Kubernetes is two layers, both shipped:**
 
 - **Control plane** (EKS / AKS / GKE) — cluster, node-pool, addon / Fargate / maintenance-config lifecycle via the real cloud SDKs.
-- **Data plane** (in-memory Kubernetes API) — core, apps, batch, networking, rbac, storage, autoscaling, policy, discovery, **apiextensions** (CRDs) and **admissionregistration** kinds. Supports CRUD, all patch types + **server-side apply** (field ownership + conflicts), `?dryRun=All`, finalizers, `limit`/`continue` pagination, watch streaming with `resourceVersion` resume + BOOKMARK — so real `client-go` `Informer`/`Reflector` machinery works against a cloudemu-emulated cluster. Kubeconfigs returned by the control plane point at the in-memory data plane — `kubectl apply -f deployment.yaml` followed by `kubectl get pods` round-trips end-to-end.
+- **Data plane** (in-memory Kubernetes API) — core, apps, batch, networking, rbac, storage, autoscaling, policy, discovery, **apiextensions** (CRDs) and **admissionregistration** kinds. CRUD, all patch types + **server-side apply** (field ownership + conflicts), `?dryRun=All`, finalizers, `limit`/`continue` pagination, watch streaming with `resourceVersion` resume + BOOKMARK — so real `client-go` `Informer`/`Reflector` machinery works against a cloudemu cluster. There's no scheduler or kubelet, so controllers converge **synchronously** — a Deployment materializes Pods straight to Running, a Job to Succeeded, Services get Endpoints, on every write. It also serves **`metrics.k8s.io`** + **HPA** actuation, **ResourceQuota** / **LimitRange** / **PDB-gated eviction**, **RBAC** SubjectAccessReview + **NetworkPolicy** evaluation, and **opt-in admission webhooks**. See [docs/services.md](docs/services.md) §18.
 
-Emulation model: there is no scheduler or kubelet, so controllers converge **synchronously** — a Deployment interposes a ReplicaSet and materializes Pods straight to Running (a Job's straight to Succeeded), and Services get Endpoints, on every write. On top of the raw object store it also serves **CRDs** (dynamic servable kinds), **`metrics.k8s.io`** + **HPA** actuation, object-count **ResourceQuota** / **LimitRange** / **PDB-gated eviction** enforcement, **RBAC** SubjectAccessReview + **NetworkPolicy** evaluation, and **opt-in admission webhooks**. See [docs/services.md](docs/services.md) §18 for the authoritative capability list.
-
-Full per-service operation list: [docs/services.md](docs/services.md).
-Per-handler protocol details and limitations: [docs/sdk-server.md](docs/sdk-server.md).
+Full per-service operation list: [docs/services.md](docs/services.md). Per-handler protocol details: [docs/sdk-server.md](docs/sdk-server.md).
 
 ## More
 
 - [docs/getting-started.md](docs/getting-started.md) — set up a test in 5 minutes
+- [docs/standalone-server.md](docs/standalone-server.md) — run the local dev cloud (Docker, flags, ports)
 - [docs/architecture.md](docs/architecture.md) — three-layer design, factory wiring
 - [docs/features.md](docs/features.md) — auto-metrics, alarm evaluation, IAM policy evaluation, FIFO dedup, error injection, fake clock
 - [docs/chaos.md](docs/chaos.md) — deliberately fail or slow down services to test retry/timeout paths
 - [docs/topology.md](docs/topology.md) — network connectivity simulation across VPC, peering, SGs, ACLs
-
-## Tests
-
-```bash
-go build ./...
-go test ./...
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 cloudemu emulates the **cloud APIs** of AWS, Azure, and GCP entirely in memory. Point the real cloud SDKs — in any language — at a local endpoint and your unmodified app code runs against an in-memory backend. No accounts, no network, no bill.
 
-It emulates control surfaces, **not** a real cloud: it doesn't run workloads, serve traffic, authenticate requests, enforce quotas, or persist across restarts. That's the point — it's fast, deterministic, and resettable.
+It models the cloud **control surfaces** — the APIs your code actually calls — with real request/response behavior, so the same production code path runs against an in-memory backend. That's what makes it instant, deterministic, and resettable, at $0.
 
 ## Three ways to run it
 
@@ -54,27 +54,16 @@ Full flags, ports, per-SDK wiring, and the [Testcontainers module](https://githu
 
 ## In-process (Go)
 
-Prefer running the emulator inside your Go test process instead of over the network? cloudemu speaks the same wire protocols (AWS Query/JSON/Smithy, Azure ARM, GCP REST) over a local `httptest.NewServer` — change the SDK endpoint and your production code runs against an in-memory backend.
+For Go tests, run the emulator inside your process — no container. cloudemu speaks the same wire protocols over a local `httptest.NewServer`, so you just change the SDK endpoint:
 
 ```go
-import (
-    "net/http/httptest"
-
-    "github.com/aws/aws-sdk-go-v2/aws"
-    "github.com/aws/aws-sdk-go-v2/service/s3"
-    "github.com/stackshy/cloudemu/v2"
-    awsserver "github.com/stackshy/cloudemu/v2/server/aws"
-)
-
 cloud := cloudemu.NewAWS()
 ts := httptest.NewServer(awsserver.New(awsserver.Drivers{
-    S3:       cloud.S3,
-    DynamoDB: cloud.DynamoDB,
-    EC2:      cloud.EC2,
-    // …leave fields nil to omit a service
+    S3: cloud.S3, DynamoDB: cloud.DynamoDB, EC2: cloud.EC2, // nil fields omit a service
 }))
 defer ts.Close()
 
+cfg, _ := config.LoadDefaultConfig(ctx) // credentials/region are ignored
 client := s3.NewFromConfig(cfg, func(o *s3.Options) {
     o.BaseEndpoint = aws.String(ts.URL)
     o.UsePathStyle = true
@@ -82,35 +71,13 @@ client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 client.PutObject(ctx, &s3.PutObjectInput{ /* … */ }) // hits the in-memory backend
 ```
 
-Or skip the SDK and drive the typed Go API directly:
+Or skip the SDK and call the typed Go API directly — `cloud.EC2.RunInstances(ctx, …)`, `cloud.S3.PutObject(ctx, …)`.
 
-```go
-aws := cloudemu.NewAWS()
+Install: `go get github.com/stackshy/cloudemu/v2` (Go 1.25+). Azure/GCP wiring: [docs/sdk-server.md](docs/sdk-server.md) · adopting it in a real test suite: [docs/integration.md](docs/integration.md).
 
-instances, _ := aws.EC2.RunInstances(ctx, driver.InstanceConfig{
-    ImageID: "ami-0abcdef1234567890", InstanceType: "t2.micro",
-}, 2)
-_ = aws.EC2.StopInstances(ctx, []string{instances[0].ID})
-```
+## Why it's fast
 
-Install: `go get github.com/stackshy/cloudemu/v2` (Go 1.25+). Equivalent Azure/GCP wiring is in [docs/sdk-server.md](docs/sdk-server.md); wiring cloudemu into a real app and test suite is in [docs/integration.md](docs/integration.md).
-
-## What it is / isn't
-
-cloudemu emulates cloud **control surfaces** — the APIs — so your code exercises real request/response behavior without a real account.
-
-**It does:**
-- ✅ Emulate cloud **APIs** for fast, deterministic testing — via Docker/standalone `serve`, the SDK-compat HTTP server, the typed Go API, and an in-memory Kubernetes API with built-in controllers.
-- ✅ Keep all state in process memory, with a fake clock and deterministic IDs for reproducible tests.
-
-**It does not:**
-- ❌ **Run real workloads or containers.** Kubernetes controllers converge synchronously (no scheduler/kubelet); there is no real `kubectl logs`/`exec`, no container runtime, no VM.
-- ❌ **Serve real traffic.** A created load balancer, DNS record, or queue models the API object — it does not route packets or deliver over the network.
-- ❌ **Authenticate or authorize requests.** Any credentials are accepted and signatures are not verified. The IAM service evaluates policies only when you explicitly call it; it does not gate other services' operations.
-- ❌ **Enforce quotas, limits, or billing.**
-- ❌ **Persist state across restarts.** Everything is in memory and gone when the process exits.
-
-Per-service "Not in scope" notes live alongside each service in the generated [capability coverage](docs/coverage/README.md).
+cloudemu keeps all state in process memory, with a fake clock and deterministic IDs, so tests are reproducible and reset in microseconds. It emulates the API layer — the control surface — rather than provisioning real infrastructure, which is exactly what removes accounts, network, cost, and flakiness from the loop. The precise per-service scope (and the handful of things that are intentionally out of scope, like running real containers or serving live traffic) is documented alongside each service in the generated [capability coverage](docs/coverage/README.md).
 
 ## What's supported
 

--- a/doc.go
+++ b/doc.go
@@ -1,5 +1,8 @@
-// Package cloudemu provides zero-cost, in-memory cloud emulation of
-// AWS, Azure, and GCP cloud services for Go.
+// Package cloudemu provides zero-cost, in-memory emulation of the AWS, Azure,
+// and GCP cloud APIs. It runs three ways: as a standalone server (the
+// cloudemu serve binary or the ghcr.io/stackshy/cloudemu Docker image) that any
+// app in any language can point at, and in-process from Go via either the
+// SDK-compat HTTP server or the typed mock API.
 //
 // The repository is organized by role so new services and features slot into
 // predictable places:
@@ -13,12 +16,16 @@
 //   - server/{aws,azure,gcp}: SDK-compat HTTP servers that speak each cloud's
 //     real wire protocol, so unmodified SDK clients drive the backends.
 //
+//   - cmd/cloudemu: the standalone "cloudemu serve" binary (also shipped as a
+//     Docker image) that runs the SDK-compat servers as a long-lived process.
+//
 //   - features/<name>: cross-cutting capabilities you wrap drivers with —
 //     chaos, recorder, metrics, inject, ratelimit, and topology.
 //
 //   - config, errors: foundational options and the canonical error type.
 //
-// The three surfaces build on the same drivers: the SDK-compat server (the
-// primary entrypoint), the Portable API (services/<name>), and the cross-cutting
-// features, so a behavior implemented in a driver lights up across all of them.
+// Every surface builds on the same drivers — the SDK-compat server (in-process
+// or standalone via cmd/cloudemu), the Portable API (services/<name>), and the
+// cross-cutting features — so a behavior implemented in a driver lights up
+// across all of them.
 package cloudemu

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CloudEmu Documentation
 
-CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides mock implementations of cloud services across AWS, Azure, and GCP -- designed for testing and development without real cloud accounts, Docker, or network calls.
+CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, and GCP cloud APIs. Run it as a standalone server (`cloudemu serve` or the `ghcr.io/stackshy/cloudemu` Docker image) and point any app in any language at a local endpoint, or use it in-process from Go via the SDK-compat HTTP server or the typed mock API -- for testing and development without real cloud accounts, network, or bill.
 
 ## Table of Contents
 
@@ -9,6 +9,7 @@ CloudEmu is a zero-cost, in-memory cloud emulation library for Go. It provides m
 - [Services](services.md) -- Complete provider resource reference with all operations across every supported service
 - [Features](features.md) -- Cross-cutting features: auto-metrics, alarm evaluation, IAM policy checking, FIFO dedup, cost tracking, and more
 - [SDK Server](sdk-server.md) -- SDK-compatible HTTP server (use the real aws-sdk-go-v2 against CloudEmu)
+- [Standalone Server](standalone-server.md) -- Run CloudEmu as a local dev cloud (`cloudemu serve` / Docker), point any language at it
 - [Integration](integration.md) -- Wire CloudEmu into your real app and tests (not a throwaway demo)
 - [Topology](topology.md) -- Network topology simulation engine
 - [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -3,7 +3,7 @@
 `cloudemu serve` runs the emulator as a long-lived, out-of-process HTTP server.
 Point real AWS, Azure, and GCP SDK clients — in any language — at the printed
 endpoints and they talk to cloudemu over the network exactly as they would to
-the real cloud. No accounts, no Docker, no code changes.
+the real cloud. No accounts, no network, no code changes.
 
 This is the "local dev cloud" mode. The in-process test-double API
 (`cloudemu.NewAWS()`, `awsserver.New(Drivers{…})`) is unchanged and still the

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # cloudemu
 
-> Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs** for Go tests. Point the real cloud SDKs at a local endpoint, or use typed Go mocks directly — no accounts, Docker, or network calls. It emulates control surfaces, not a real cloud: it does not run workloads, serve traffic, authenticate requests, enforce quotas, or persist across restarts.
+> Zero-cost, in-memory emulation of AWS, Azure, and GCP cloud **APIs**. Run it as a standalone server (binary or the `ghcr.io/stackshy/cloudemu` Docker image) and point any app in any language at a local endpoint, or use it in-process from Go (SDK-compat HTTP server, or typed mocks driven directly) — no accounts, no network, no bill. It emulates control surfaces, not a real cloud: it does not run workloads, serve traffic, authenticate requests, enforce quotas, or persist across restarts.
 
 ## Capabilities (start here)
 
@@ -9,7 +9,8 @@
 
 ## Docs
 
-- [README](README.md): what cloudemu is / isn't, install, quickstarts for the SDK-compat server and the Go API.
+- [README](README.md): what cloudemu is / isn't, the three ways to run it (Docker/standalone, SDK-compat HTTP server, Go API), and quickstarts for each.
+- [Standalone server](docs/standalone-server.md): run cloudemu as a local dev cloud via `cloudemu serve` or the Docker image — the "point any app in any language at it" mode.
 - [Getting started](docs/getting-started.md): set up a test in five minutes.
 - [Architecture](docs/architecture.md): the three-layer design (portable API → driver interfaces → provider backends) and provider status (AWS/Azure/GCP implemented; OCI foundation only).
 - [SDK-compat server](docs/sdk-server.md): per-handler wire-protocol details and limitations.
@@ -21,4 +22,3 @@
 - [Features](docs/features.md): auto-metrics, alarm evaluation, IAM policy evaluation, FIFO dedup, error injection, fake clock.
 - [Chaos](docs/chaos.md): deliberately fail or slow services to test retry/timeout paths.
 - [Topology](docs/topology.md): network connectivity simulation across VPC, peering, security groups, ACLs.
-- [Standalone server](docs/standalone-server.md): run the emulator as a long-lived process for out-of-process apps.

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 
 ## Docs
 
-- [README](README.md): what cloudemu is / isn't, the three ways to run it (Docker/standalone, SDK-compat HTTP server, Go API), and quickstarts for each.
+- [README](README.md): what cloudemu is and its scope, the three ways to run it (Docker/standalone, SDK-compat HTTP server, Go API), and quickstarts for each.
 - [Standalone server](docs/standalone-server.md): run cloudemu as a local dev cloud via `cloudemu serve` or the Docker image — the "point any app in any language at it" mode.
 - [Getting started](docs/getting-started.md): set up a test in five minutes.
 - [Architecture](docs/architecture.md): the three-layer design (portable API → driver interfaces → provider backends) and provider status (AWS/Azure/GCP implemented; OCI foundation only).


### PR DESCRIPTION
## Why

The tagline (\`…for Go\`), the first code block (an in-process \`httptest\` snippet), and the opening sentence of \`llms.txt\` / \`AGENTS.md\` / \`doc.go\` (\`…cloud APIs for Go tests\`) all scoped cloudemu to Go testing. Meanwhile Docker showed up only as a negation (\`Docker-free\`, \`without … Docker\`) — which now contradicts the shipped, public \`ghcr.io/stackshy/cloudemu\` image. Net effect: humans and agents read cloudemu as a Go-test-only library and miss the standalone/Docker "point any app in any language at it" mode.

Approach cross-checked against how top local-emulator/dev-tool repos write their READMEs (LocalStack, MinIO, k3s; Zod, Bun, Ollama): lead sentence-one with the compatibility hook, make the first code block a single copy-paste \`docker run\`, then point the user's existing SDK/CLI at the printed endpoint.

## Changes (docs/text only — no code)

- **README.md** — broad one-liner (drops "for Go"); new **"Three ways to run it"** section; **\`docker run\` quickstart as the first code block** (endpoints + \`aws --endpoint-url …\` + \`kubectl\` round-trip + \`_cloudemu/reset\`); in-process Go snippets kept but demoted below it; added a Docker badge; \`Docker-free\` → honest "no Docker required for in-process modes". Capability table + two-layer Kubernetes writeup preserved.
- **llms.txt / AGENTS.md / doc.go** — opening sentence rewritten to the three-mode, any-language framing; standalone/Docker surface surfaced; de-duplicated the standalone-server link in llms.txt.
- **docs/README.md** — same reframe + links the standalone-server page.
- **docs/standalone-server.md** — "no Docker" → "no network" (Docker is a documented run option in that same file).

## Verification

- \`go build ./...\` passes.
- Confirmed \`/_cloudemu/reset\` is mounted per-provider port (\`serve.go\`), so \`http://127.0.0.1:4566/_cloudemu/reset\` in the README is accurate.
- Confirmed the \`docker run\` ports (4566/4568/4569/4570) match \`Dockerfile\` \`EXPOSE\` and \`docker-compose.yml\`.
- No residual \`for Go tests\` / \`Docker-free\` / \`two surfaces\` / \`library for Go\` strings remain in tracked files.