### PR TITLE
fix(rgt): tag EC2 instances + Lambda/Secrets/SNS/SQS via Resource Groups Tagging API

### DIFF
--- a/server/aws/resourcegroupstaggingapi/sdk_test.go
+++ b/server/aws/resourcegroupstaggingapi/sdk_test.go
@@ -19,8 +19,14 @@ import (
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
+	serverlessdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 )
 
 func TestSDKResourceGroupsTagging(t *testing.T) {
@@ -127,13 +133,97 @@ func TestSDKResourceGroupsTagging(t *testing.T) {
 		assert.False(t, has, "env tag should be gone after UntagResources")
 	})
 
-	t.Run("TagResources reports failures for unsupported ARNs", func(t *testing.T) {
+	t.Run("TagResources across compute, lambda, sns, sqs and secrets", func(t *testing.T) {
+		// Seed one resource of each newly-taggable service.
+		insts, err := cloud.EC2.RunInstances(ctx, computedriver.InstanceConfig{
+			ImageID: "ami-1", InstanceType: "t3.micro",
+		}, 1)
+		require.NoError(t, err)
+		instanceID := insts[0].ID
+
+		_, err = cloud.Lambda.CreateFunction(ctx, serverlessdriver.FunctionConfig{
+			Name: "proc", Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30,
+		})
+		require.NoError(t, err)
+
+		_, err = cloud.SNS.CreateTopic(ctx, notifdriver.TopicConfig{Name: "events"})
+		require.NoError(t, err)
+
+		_, err = cloud.SQS.CreateQueue(ctx, mqdriver.QueueConfig{Name: "tasks"})
+		require.NoError(t, err)
+
+		_, err = cloud.SecretsManager.CreateSecret(ctx, secretsdriver.SecretConfig{Name: "api-key"}, []byte("v"))
+		require.NoError(t, err)
+
+		arns := []string{
+			"arn:aws:ec2:us-east-1:123456789012:instance/" + instanceID,
+			"arn:aws:lambda:us-east-1:123456789012:function:proc",
+			"arn:aws:sns:us-east-1:123456789012:events",
+			"arn:aws:sqs:us-east-1:123456789012:tasks",
+			"arn:aws:secretsmanager:us-east-1:123456789012:secret:api-key",
+		}
+
 		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
-			ResourceARNList: []string{"arn:aws:lambda:us-east-1:111:function:nope"},
+			ResourceARNList: arns,
+			Tags:            map[string]string{"Environment": "prod"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, out.FailedResourcesMap, "all five resource types should tag cleanly")
+
+		// Verify each tag landed on its backing store.
+		gotInst, err := cloud.EC2.DescribeInstances(ctx, []string{instanceID}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "prod", gotInst[0].Tags["Environment"])
+
+		gotFn, err := cloud.Lambda.GetFunction(ctx, "proc")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", gotFn.Tags["Environment"])
+
+		topics, err := cloud.SNS.ListTopics(ctx, scope.Scope{})
+		require.NoError(t, err)
+		snsTags := map[string]string{}
+		for i := range topics {
+			if topics[i].Name == "events" {
+				snsTags = topics[i].Tags
+			}
+		}
+		assert.Equal(t, "prod", snsTags["Environment"], "sns topic tag should be set")
+
+		queues, err := cloud.SQS.ListQueues(ctx, "")
+		require.NoError(t, err)
+		sqsTags := map[string]string{}
+		for i := range queues {
+			if queues[i].Name == "tasks" {
+				sqsTags = queues[i].Tags
+			}
+		}
+		assert.Equal(t, "prod", sqsTags["Environment"], "sqs queue tag should be set")
+
+		gotSecret, err := cloud.SecretsManager.GetSecret(ctx, "api-key")
+		require.NoError(t, err)
+		assert.Equal(t, "prod", gotSecret.Tags["Environment"])
+
+		// UntagResources reaches the same stores.
+		_, err = client.UntagResources(ctx, &rgta.UntagResourcesInput{
+			ResourceARNList: []string{arns[0]},
+			TagKeys:         []string{"Environment"},
+		})
+		require.NoError(t, err)
+		gotInst, err = cloud.EC2.DescribeInstances(ctx, []string{instanceID}, nil)
+		require.NoError(t, err)
+		_, has := gotInst[0].Tags["Environment"]
+		assert.False(t, has)
+	})
+
+	t.Run("TagResources reports failures for a service without a tag store", func(t *testing.T) {
+		out, err := client.TagResources(ctx, &rgta.TagResourcesInput{
+			ResourceARNList: []string{"arn:aws:kms:us-east-1:123456789012:key/abc"},
 			Tags:            map[string]string{"k": "v"},
 		})
 		require.NoError(t, err)
-		assert.Len(t, out.FailedResourcesMap, 1)
+		require.Len(t, out.FailedResourcesMap, 1)
+		fail := out.FailedResourcesMap["arn:aws:kms:us-east-1:123456789012:key/abc"]
+		assert.Equal(t, "InvalidParameterException", string(fail.ErrorCode))
 	})
 }
 

--- a/services/resourcediscovery/engine_test.go
+++ b/services/resourcediscovery/engine_test.go
@@ -13,10 +13,16 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/ec2"
 	"github.com/stackshy/cloudemu/v2/providers/aws/lambda"
 	"github.com/stackshy/cloudemu/v2/providers/aws/s3"
+	"github.com/stackshy/cloudemu/v2/providers/aws/secretsmanager"
+	"github.com/stackshy/cloudemu/v2/providers/aws/sns"
+	"github.com/stackshy/cloudemu/v2/providers/aws/sqs"
 	"github.com/stackshy/cloudemu/v2/providers/aws/vpc"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+	secretsdriver "github.com/stackshy/cloudemu/v2/services/secrets/driver"
 	serverlessdriver "github.com/stackshy/cloudemu/v2/services/serverless/driver"
 	storagedriver "github.com/stackshy/cloudemu/v2/services/storage/driver"
 	"github.com/stretchr/testify/assert"
@@ -24,12 +30,15 @@ import (
 )
 
 type fixture struct {
-	engine *Engine
-	ec2    *ec2.Mock
-	vpc    *vpc.Mock
-	s3     *s3.Mock
-	ddb    *dynamodb.Mock
-	lambda *lambda.Mock
+	engine  *Engine
+	ec2     *ec2.Mock
+	vpc     *vpc.Mock
+	s3      *s3.Mock
+	ddb     *dynamodb.Mock
+	lambda  *lambda.Mock
+	secrets *secretsmanager.Mock
+	sns     *sns.Mock
+	sqs     *sqs.Mock
 }
 
 func newAWSFixture(t *testing.T) *fixture {
@@ -43,22 +52,31 @@ func newAWSFixture(t *testing.T) *fixture {
 	s3Mock := s3.New(opts)
 	ddbMock := dynamodb.New(opts)
 	lambdaMock := lambda.New(opts)
+	secretsMock := secretsmanager.New(opts)
+	snsMock := sns.New(opts)
+	sqsMock := sqs.New(opts)
 
 	eng := New(ProviderAWS, "123456789012", "us-east-1", &Drivers{
-		Compute:    ec2Mock,
-		Networking: vpcMock,
-		Storage:    s3Mock,
-		Database:   ddbMock,
-		Serverless: lambdaMock,
+		Compute:      ec2Mock,
+		Networking:   vpcMock,
+		Storage:      s3Mock,
+		Database:     ddbMock,
+		Serverless:   lambdaMock,
+		Secrets:      secretsMock,
+		Notification: snsMock,
+		MessageQueue: sqsMock,
 	})
 
 	return &fixture{
-		engine: eng,
-		ec2:    ec2Mock,
-		vpc:    vpcMock,
-		s3:     s3Mock,
-		ddb:    ddbMock,
-		lambda: lambdaMock,
+		engine:  eng,
+		ec2:     ec2Mock,
+		vpc:     vpcMock,
+		s3:      s3Mock,
+		ddb:     ddbMock,
+		lambda:  lambdaMock,
+		secrets: secretsMock,
+		sns:     snsMock,
+		sqs:     sqsMock,
 	}
 }
 
@@ -311,6 +329,25 @@ func seedLambda(t *testing.T, f *fixture, name string, tags map[string]string) {
 	_, err := f.lambda.CreateFunction(context.Background(), serverlessdriver.FunctionConfig{
 		Name: name, Runtime: "go1.x", Handler: "main", Memory: 128, Timeout: 30, Tags: tags,
 	})
+	require.NoError(t, err)
+}
+
+func seedSecret(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	_, err := f.secrets.CreateSecret(context.Background(),
+		secretsdriver.SecretConfig{Name: name, Tags: tags}, []byte("value"))
+	require.NoError(t, err)
+}
+
+func seedSNS(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	_, err := f.sns.CreateTopic(context.Background(), notifdriver.TopicConfig{Name: name, Tags: tags})
+	require.NoError(t, err)
+}
+
+func seedSQS(t *testing.T, f *fixture, name string, tags map[string]string) {
+	t.Helper()
+	_, err := f.sqs.CreateQueue(context.Background(), mqdriver.QueueConfig{Name: name, Tags: tags})
 	require.NoError(t, err)
 }
 

--- a/services/resourcediscovery/tagging.go
+++ b/services/resourcediscovery/tagging.go
@@ -194,8 +194,8 @@ func parseSecretsARN(arn, resource string) (parsedARN, error) {
 }
 
 // parseSNSARN accepts arn:aws:sns:region:account:topic-name. Subscription ARNs
-// (…:topic:subscription-id, which contain a '/') are rejected — they are not a
-// taggable resource.
+// (whose resource segment is "subscription/<id>", containing a '/') are
+// rejected — a subscription is not a taggable resource.
 func parseSNSARN(arn, resource string) (parsedARN, error) {
 	if resource == "" || strings.ContainsRune(resource, '/') {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected SNS topic ARN, got %q", arn)
@@ -465,7 +465,8 @@ func (e *Engine) resolveQueueURL(ctx context.Context, name string) (string, erro
 func driverAs[T any](driver any, name string) (T, error) {
 	var zero T
 
-	// A nil interface value, or a typed-nil driver, both mean "not configured".
+	// An unconfigured driver is stored as a nil interface field (the engine
+	// never wraps a typed-nil pointer), so this catches the "not wired" case.
 	if driver == nil {
 		return zero, cerrors.Newf(cerrors.FailedPrecondition, "%s driver not configured on engine", name)
 	}

--- a/services/resourcediscovery/tagging.go
+++ b/services/resourcediscovery/tagging.go
@@ -13,10 +13,29 @@ const (
 	awsServiceS3       = "s3"
 	awsServiceDynamoDB = "dynamodb"
 	awsServiceEC2      = "ec2"
+	awsServiceLambda   = "lambda"
+	awsServiceSecrets  = "secretsmanager"
+	awsServiceSNS      = "sns"
+	awsServiceSQS      = "sqs"
 )
 
-// DynamoDB resource type within an EC2 ARN.
+// DynamoDB resource type within a DynamoDB ARN.
 const awsTypeTable = "table"
+
+// EC2 compute resource types that route to the compute driver's tag store
+// (the networking sub-types below route to the networking driver instead).
+const (
+	ec2TypeInstance = "instance"
+	ec2TypeVolume   = "volume"
+	ec2TypeSnapshot = "snapshot"
+	ec2TypeImage    = "image"
+)
+
+// Lambda / Secrets Manager resource-type prefixes within their ARNs.
+const (
+	lambdaTypeFunction = "function"
+	secretsTypeSecret  = "secret"
+)
 
 // arnParts is the number of colon-separated segments in a fully-qualified
 // AWS ARN: arn:partition:service:region:account:resource.
@@ -24,15 +43,21 @@ const arnParts = 6
 
 // TagResourceByARN merges tags into the resource identified by arn. The arn
 // is parsed to determine the underlying service and resource type, then
-// dispatched to the matching driver's tag-mutation method.
+// dispatched to the matching driver's tag-mutation method. Tagging is
+// additive: existing tags are preserved and overlapping keys are overwritten.
 //
-// Supported in Phase 2:
-//   - AWS S3 bucket: arn:aws:s3:::name
-//   - AWS DynamoDB table: arn:aws:dynamodb:region:account:table/name
-//   - AWS VPC/Subnet/SecurityGroup: arn:aws:ec2:region:account:{vpc,subnet,security-group}/id
+// Supported AWS resources:
+//   - S3 bucket:            arn:aws:s3:::name
+//   - DynamoDB table:       arn:aws:dynamodb:region:account:table/name
+//   - EC2 compute:          arn:aws:ec2:region:account:{instance,volume,snapshot,image}/id
+//   - EC2 networking:       arn:aws:ec2:region:account:{vpc,subnet,security-group}/id
+//   - Lambda function:      arn:aws:lambda:region:account:function:name
+//   - Secrets Manager:      arn:aws:secretsmanager:region:account:secret:name
+//   - SNS topic:            arn:aws:sns:region:account:name
+//   - SQS queue:            arn:aws:sqs:region:account:name
 //
-// Returns InvalidArgument for unsupported services (lambda, ec2 instance, etc.)
-// or unparseable ARNs.
+// Returns InvalidArgument for services/resource types without a tag store
+// (e.g. CloudWatch alarms, IAM, RDS) or for unparseable ARNs.
 func (e *Engine) TagResourceByARN(ctx context.Context, arn string, tags map[string]string) error {
 	res, err := parseSupportedARN(arn)
 	if err != nil {
@@ -55,14 +80,14 @@ func (e *Engine) UntagResourceByARN(ctx context.Context, arn string, keys []stri
 
 // parsedARN holds the fragments TagResourceByARN needs to route a call.
 type parsedARN struct {
-	service      string // "s3", "dynamodb", "ec2"
-	resourceType string // "table", "vpc", "subnet", "security-group", or "" for s3 bucket
-	id           string // bucket name, table name, vpc-id, subnet-id, sg-id
+	service      string // "s3", "dynamodb", "ec2", "lambda", "secretsmanager", "sns", "sqs"
+	resourceType string // "table"/"instance"/"vpc"/"function"/… or "" for s3/sns/sqs
+	id           string // bucket, table, vpc-id, instance-id, function/secret/topic/queue name
 }
 
 func parseSupportedARN(arn string) (parsedARN, error) {
 	// AWS ARN format: arn:partition:service:region:account:resource
-	// resource is either "name" (S3), "type/id", or "type:id".
+	// resource is either "name" (S3/SNS/SQS), "type/id", or "type:id".
 	if !strings.HasPrefix(arn, "arn:aws:") {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "only AWS ARNs are supported, got %q", arn)
 	}
@@ -82,9 +107,17 @@ func parseSupportedARN(arn string) (parsedARN, error) {
 		return parseDynamoDBARN(arn, resource)
 	case awsServiceEC2:
 		return parseEC2ARN(arn, resource)
+	case awsServiceLambda:
+		return parseLambdaARN(arn, resource)
+	case awsServiceSecrets:
+		return parseSecretsARN(arn, resource)
+	case awsServiceSNS:
+		return parseSNSARN(arn, resource)
+	case awsServiceSQS:
+		return parseSQSARN(arn, resource)
 	default:
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
-			"tagging service %q is not yet supported (Phase 2 covers s3, dynamodb, ec2 networking)", service)
+			"tagging service %q is not yet supported", service)
 	}
 }
 
@@ -95,11 +128,10 @@ func parseS3ARN(arn, resource string) (parsedARN, error) {
 
 	// arn:aws:s3:::bucket-name → resource = "bucket-name" (taggable).
 	// arn:aws:s3:::bucket-name/object-key → resource = "bucket-name/object-key".
-	// Object-level tagging requires PutObjectTagging, not PutBucketTagging;
-	// reject until Phase 2.x adds object support.
+	// Object-level tagging requires PutObjectTagging, not PutBucketTagging.
 	if strings.ContainsRune(resource, '/') {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
-			"S3 object ARNs are not yet supported (Phase 2 covers buckets only): %q", arn)
+			"S3 object ARNs are not supported (bucket tagging only): %q", arn)
 	}
 
 	return parsedARN{service: awsServiceS3, id: resource}, nil
@@ -121,12 +153,64 @@ func parseEC2ARN(arn, resource string) (parsedARN, error) {
 	}
 
 	switch rt {
-	case netKindVPC, netKindSubnet, netKindSecurityGroup:
+	case ec2TypeInstance, ec2TypeVolume, ec2TypeSnapshot, ec2TypeImage,
+		netKindVPC, netKindSubnet, netKindSecurityGroup:
 		return parsedARN{service: awsServiceEC2, resourceType: rt, id: id}, nil
 	default:
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument,
-			"tagging EC2 resource type %q is not yet supported (Phase 2 covers vpc, subnet, security-group)", rt)
+			"tagging EC2 resource type %q is not supported", rt)
 	}
+}
+
+// parseLambdaARN accepts arn:aws:lambda:region:account:function:name — and the
+// versioned/aliased form (…:function:name:1) — resolving both to the function
+// name, since a Lambda's tags are shared across its versions and aliases.
+func parseLambdaARN(arn, resource string) (parsedARN, error) {
+	rt, rest, ok := splitTypeID(resource, ':')
+	if !ok || rt != lambdaTypeFunction {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected Lambda function ARN, got %q", arn)
+	}
+
+	name := rest
+	if i := strings.IndexByte(rest, ':'); i >= 0 {
+		name = rest[:i] // strip a trailing :version or :alias qualifier
+	}
+
+	if name == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "Lambda ARN missing function name: %q", arn)
+	}
+
+	return parsedARN{service: awsServiceLambda, resourceType: lambdaTypeFunction, id: name}, nil
+}
+
+// parseSecretsARN accepts arn:aws:secretsmanager:region:account:secret:name.
+func parseSecretsARN(arn, resource string) (parsedARN, error) {
+	rt, id, ok := splitTypeID(resource, ':')
+	if !ok || rt != secretsTypeSecret || id == "" {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected Secrets Manager secret ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceSecrets, resourceType: secretsTypeSecret, id: id}, nil
+}
+
+// parseSNSARN accepts arn:aws:sns:region:account:topic-name. Subscription ARNs
+// (…:topic:subscription-id, which contain a '/') are rejected — they are not a
+// taggable resource.
+func parseSNSARN(arn, resource string) (parsedARN, error) {
+	if resource == "" || strings.ContainsRune(resource, '/') {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected SNS topic ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceSNS, id: resource}, nil
+}
+
+// parseSQSARN accepts arn:aws:sqs:region:account:queue-name.
+func parseSQSARN(arn, resource string) (parsedARN, error) {
+	if resource == "" || strings.ContainsRune(resource, '/') {
+		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected SQS queue ARN, got %q", arn)
+	}
+
+	return parsedARN{service: awsServiceSQS, id: resource}, nil
 }
 
 func splitTypeID(s string, sep rune) (rt, id string, ok bool) {
@@ -139,17 +223,72 @@ func splitTypeID(s string, sep rune) (rt, id string, ok bool) {
 	return "", "", false
 }
 
+func isEC2ComputeType(rt string) bool {
+	switch rt {
+	case ec2TypeInstance, ec2TypeVolume, ec2TypeSnapshot, ec2TypeImage:
+		return true
+	default:
+		return false
+	}
+}
+
 func (e *Engine) dispatchTag(ctx context.Context, res parsedARN, tags map[string]string, set bool, keys []string) error {
-	switch {
-	case res.service == awsServiceS3:
+	switch res.service {
+	case awsServiceS3:
 		return e.tagS3(ctx, res.id, tags, set, keys)
-	case res.service == awsServiceDynamoDB && res.resourceType == awsTypeTable:
+	case awsServiceDynamoDB:
 		return e.tagDynamoDB(ctx, res.id, tags, set, keys)
-	case res.service == awsServiceEC2:
+	case awsServiceEC2:
+		if isEC2ComputeType(res.resourceType) {
+			return e.tagEC2Compute(ctx, res.id, tags, set, keys)
+		}
+
 		return e.tagEC2Network(ctx, res.resourceType, res.id, tags, set, keys)
+	case awsServiceLambda:
+		return e.tagLambda(ctx, res.id, tags, set, keys)
+	case awsServiceSecrets:
+		return e.tagSecret(ctx, res.id, tags, set, keys)
+	case awsServiceSNS:
+		return e.tagTopic(ctx, res.id, tags, set, keys)
+	case awsServiceSQS:
+		return e.tagQueue(ctx, res.id, tags, set, keys)
 	default:
 		return cerrors.Newf(cerrors.InvalidArgument, "internal: unrouted parsedARN %+v", res)
 	}
+}
+
+// The tag-mutation methods below are provider-specific: only the AWS mocks
+// implement them, and the AWS Resource Groups Tagging API is the only surface
+// that reaches this dispatcher. Rather than widen every shared services/*/driver
+// interface (which would force Azure/GCP to implement AWS-only tag plumbing),
+// we type-assert the driver to a narrow capability interface — the same pattern
+// resourcediscovery already uses for KubernetesClusters/ScaleSets/RelationalDatabases.
+
+// computeTagger is implemented by the AWS EC2 mock; it tags instances, volumes,
+// snapshots, and images by their prefixed id (i-/vol-/snap-/ami-).
+type computeTagger interface {
+	TagResource(ctx context.Context, id string, tags map[string]string) error
+	UntagResource(ctx context.Context, id string, keys []string) error
+}
+
+type functionTagger interface {
+	TagFunction(ctx context.Context, name string, tags map[string]string) error
+	UntagFunction(ctx context.Context, name string, keys []string) error
+}
+
+type secretTagger interface {
+	TagSecret(ctx context.Context, name string, tags map[string]string) error
+	UntagSecret(ctx context.Context, name string, keys []string) error
+}
+
+type topicTagger interface {
+	TagTopic(ctx context.Context, name string, tags map[string]string) error
+	UntagTopic(ctx context.Context, name string, keys []string) error
+}
+
+type queueTagger interface {
+	TagQueue(ctx context.Context, queueURL string, tags map[string]string) error
+	UntagQueue(ctx context.Context, queueURL string, keys []string) error
 }
 
 func (e *Engine) tagS3(ctx context.Context, bucket string, tags map[string]string, set bool, keys []string) error {
@@ -201,6 +340,19 @@ func (e *Engine) tagDynamoDB(ctx context.Context, table string, tags map[string]
 	return e.drivers.Database.UntagResource(ctx, table, keys)
 }
 
+func (e *Engine) tagEC2Compute(ctx context.Context, id string, tags map[string]string, set bool, keys []string) error {
+	ct, err := driverAs[computeTagger](e.drivers.Compute, "compute")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return ct.TagResource(ctx, id, tags)
+	}
+
+	return ct.UntagResource(ctx, id, keys)
+}
+
 func (e *Engine) tagEC2Network(ctx context.Context, resourceType, id string,
 	tags map[string]string, set bool, keys []string,
 ) error {
@@ -230,4 +382,98 @@ func (e *Engine) tagEC2Network(ctx context.Context, resourceType, id string,
 	default:
 		return cerrors.Newf(cerrors.InvalidArgument, "unsupported EC2 resource type %q", resourceType)
 	}
+}
+
+func (e *Engine) tagLambda(ctx context.Context, name string, tags map[string]string, set bool, keys []string) error {
+	ft, err := driverAs[functionTagger](e.drivers.Serverless, "serverless")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return ft.TagFunction(ctx, name, tags)
+	}
+
+	return ft.UntagFunction(ctx, name, keys)
+}
+
+func (e *Engine) tagSecret(ctx context.Context, name string, tags map[string]string, set bool, keys []string) error {
+	st, err := driverAs[secretTagger](e.drivers.Secrets, "secrets")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return st.TagSecret(ctx, name, tags)
+	}
+
+	return st.UntagSecret(ctx, name, keys)
+}
+
+func (e *Engine) tagTopic(ctx context.Context, name string, tags map[string]string, set bool, keys []string) error {
+	tt, err := driverAs[topicTagger](e.drivers.Notification, "notification")
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return tt.TagTopic(ctx, name, tags)
+	}
+
+	return tt.UntagTopic(ctx, name, keys)
+}
+
+// tagQueue resolves the queue name (from the SQS ARN) to the queue URL that the
+// SQS tag store is keyed by, then applies the tag mutation.
+func (e *Engine) tagQueue(ctx context.Context, name string, tags map[string]string, set bool, keys []string) error {
+	qt, err := driverAs[queueTagger](e.drivers.MessageQueue, "message queue")
+	if err != nil {
+		return err
+	}
+
+	url, err := e.resolveQueueURL(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if set {
+		return qt.TagQueue(ctx, url, tags)
+	}
+
+	return qt.UntagQueue(ctx, url, keys)
+}
+
+func (e *Engine) resolveQueueURL(ctx context.Context, name string) (string, error) {
+	queues, err := e.drivers.MessageQueue.ListQueues(ctx, "")
+	if err != nil {
+		return "", fmt.Errorf("resolveQueueURL: %w", err)
+	}
+
+	for i := range queues {
+		if queues[i].Name == name {
+			return queues[i].URL, nil
+		}
+	}
+
+	return "", cerrors.Newf(cerrors.NotFound, "queue %q not found", name)
+}
+
+// driverAs returns the driver typed as the capability interface T. It returns
+// FailedPrecondition when the driver is unconfigured (nil) or does not
+// implement the tag capability (e.g. a non-AWS provider), which the RGT handler
+// surfaces as an InternalServiceException.
+func driverAs[T any](driver any, name string) (T, error) {
+	var zero T
+
+	// A nil interface value, or a typed-nil driver, both mean "not configured".
+	if driver == nil {
+		return zero, cerrors.Newf(cerrors.FailedPrecondition, "%s driver not configured on engine", name)
+	}
+
+	tagger, ok := driver.(T)
+	if !ok {
+		return zero, cerrors.Newf(cerrors.FailedPrecondition, "%s driver does not support tagging", name)
+	}
+
+	return tagger, nil
 }

--- a/services/resourcediscovery/tagging.go
+++ b/services/resourcediscovery/tagging.go
@@ -193,11 +193,12 @@ func parseSecretsARN(arn, resource string) (parsedARN, error) {
 	return parsedARN{service: awsServiceSecrets, resourceType: secretsTypeSecret, id: id}, nil
 }
 
-// parseSNSARN accepts arn:aws:sns:region:account:topic-name. Subscription ARNs
-// (whose resource segment is "subscription/<id>", containing a '/') are
-// rejected — a subscription is not a taggable resource.
+// parseSNSARN accepts arn:aws:sns:region:account:topic-name. A topic name is
+// alphanumeric plus '-'/'_', so a resource segment carrying a ':' or '/' is a
+// subscription (real AWS uses "MyTopic:<uuid>"; the mock uses
+// "subscription/<uuid>") — rejected, since a subscription is not taggable.
 func parseSNSARN(arn, resource string) (parsedARN, error) {
-	if resource == "" || strings.ContainsRune(resource, '/') {
+	if resource == "" || strings.ContainsAny(resource, ":/") {
 		return parsedARN{}, cerrors.Newf(cerrors.InvalidArgument, "expected SNS topic ARN, got %q", arn)
 	}
 

--- a/services/resourcediscovery/tagging_test.go
+++ b/services/resourcediscovery/tagging_test.go
@@ -38,7 +38,8 @@ func TestParseSupportedARN(t *testing.T) {
 		{name: "sns topic", arn: "arn:aws:sns:us-east-1:111:my-topic", wantSvc: "sns", wantID: "my-topic"},
 		{name: "sqs queue", arn: "arn:aws:sqs:us-east-1:111:my-queue", wantSvc: "sqs", wantID: "my-queue"},
 		{name: "ec2 unsupported type", arn: "arn:aws:ec2:us-east-1:111:natgateway/nat-abc", wantErr: true, errSubstr: "is not supported"},
-		{name: "sns subscription rejected", arn: "arn:aws:sns:us-east-1:111:subscription/uuid", wantErr: true, errSubstr: "expected SNS topic"},
+		{name: "sns subscription rejected (real colon shape)", arn: "arn:aws:sns:us-east-1:111:MyTopic:8a21-uuid", wantErr: true, errSubstr: "expected SNS topic"},
+		{name: "sns subscription rejected (mock slash shape)", arn: "arn:aws:sns:us-east-1:111:subscription/uuid", wantErr: true, errSubstr: "expected SNS topic"},
 		{name: "kms unsupported service", arn: "arn:aws:kms:us-east-1:111:key/abc", wantErr: true, errSubstr: "not yet supported"},
 		{name: "non-aws partition", arn: "arn:azure:s3:::x", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "malformed", arn: "not-an-arn", wantErr: true, errSubstr: "only AWS ARNs"},
@@ -250,6 +251,39 @@ func TestTagResourceByARN_EC2Snapshot(t *testing.T) {
 	got, err := f.ec2.DescribeSnapshots(ctx, []string{snap.ID})
 	require.NoError(t, err)
 	assert.Equal(t, "30d", got[0].Tags["keep"])
+}
+
+func TestTagResourceByARN_EC2Image(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	insts, err := f.ec2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-1", InstanceType: "t3.micro",
+	}, 1)
+	require.NoError(t, err)
+	img, err := f.ec2.CreateImage(ctx, computedriver.ImageConfig{InstanceID: insts[0].ID, Name: "golden"})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:image/" + img.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"release": "v1", "team": "core"}))
+
+	got, err := f.ec2.DescribeImages(ctx, []string{img.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "v1", got[0].Tags["release"])
+
+	// Additive merge, then key removal — same contract as instance/volume/snapshot.
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"release": "v2"}))
+	got, err = f.ec2.DescribeImages(ctx, []string{img.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", got[0].Tags["release"])
+	assert.Equal(t, "core", got[0].Tags["team"], "non-overlapping key should survive merge")
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"release"}))
+	got, err = f.ec2.DescribeImages(ctx, []string{img.ID})
+	require.NoError(t, err)
+	_, has := got[0].Tags["release"]
+	assert.False(t, has)
+	assert.Equal(t, "core", got[0].Tags["team"])
 }
 
 func TestTagResourceByARN_Lambda(t *testing.T) {

--- a/services/resourcediscovery/tagging_test.go
+++ b/services/resourcediscovery/tagging_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	netdriver "github.com/stackshy/cloudemu/v2/services/networking/driver"
+	"github.com/stackshy/cloudemu/v2/services/scope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,15 +25,25 @@ func TestParseSupportedARN(t *testing.T) {
 	}{
 		{name: "s3 bucket", arn: "arn:aws:s3:::my-bucket", wantSvc: "s3", wantID: "my-bucket"},
 		{name: "dynamodb table", arn: "arn:aws:dynamodb:us-east-1:111:table/MyTable", wantSvc: "dynamodb", wantType: "table", wantID: "MyTable"},
+		{name: "ec2 instance", arn: "arn:aws:ec2:us-east-1:111:instance/i-abc", wantSvc: "ec2", wantType: "instance", wantID: "i-abc"},
+		{name: "ec2 volume", arn: "arn:aws:ec2:us-east-1:111:volume/vol-abc", wantSvc: "ec2", wantType: "volume", wantID: "vol-abc"},
+		{name: "ec2 snapshot", arn: "arn:aws:ec2:us-east-1:111:snapshot/snap-abc", wantSvc: "ec2", wantType: "snapshot", wantID: "snap-abc"},
+		{name: "ec2 image", arn: "arn:aws:ec2:us-east-1:111:image/ami-abc", wantSvc: "ec2", wantType: "image", wantID: "ami-abc"},
 		{name: "vpc", arn: "arn:aws:ec2:us-east-1:111:vpc/vpc-abc", wantSvc: "ec2", wantType: "vpc", wantID: "vpc-abc"},
 		{name: "subnet", arn: "arn:aws:ec2:us-east-1:111:subnet/subnet-abc", wantSvc: "ec2", wantType: "subnet", wantID: "subnet-abc"},
 		{name: "security-group", arn: "arn:aws:ec2:us-east-1:111:security-group/sg-abc", wantSvc: "ec2", wantType: "security-group", wantID: "sg-abc"},
-		{name: "instance unsupported", arn: "arn:aws:ec2:us-east-1:111:instance/i-abc", wantErr: true, errSubstr: "not yet supported"},
-		{name: "lambda unsupported", arn: "arn:aws:lambda:us-east-1:111:function:fn", wantErr: true, errSubstr: "not yet supported"},
+		{name: "lambda function", arn: "arn:aws:lambda:us-east-1:111:function:fn", wantSvc: "lambda", wantType: "function", wantID: "fn"},
+		{name: "lambda function versioned", arn: "arn:aws:lambda:us-east-1:111:function:fn:2", wantSvc: "lambda", wantType: "function", wantID: "fn"},
+		{name: "secrets manager", arn: "arn:aws:secretsmanager:us-east-1:111:secret:db-pw", wantSvc: "secretsmanager", wantType: "secret", wantID: "db-pw"},
+		{name: "sns topic", arn: "arn:aws:sns:us-east-1:111:my-topic", wantSvc: "sns", wantID: "my-topic"},
+		{name: "sqs queue", arn: "arn:aws:sqs:us-east-1:111:my-queue", wantSvc: "sqs", wantID: "my-queue"},
+		{name: "ec2 unsupported type", arn: "arn:aws:ec2:us-east-1:111:natgateway/nat-abc", wantErr: true, errSubstr: "is not supported"},
+		{name: "sns subscription rejected", arn: "arn:aws:sns:us-east-1:111:subscription/uuid", wantErr: true, errSubstr: "expected SNS topic"},
+		{name: "kms unsupported service", arn: "arn:aws:kms:us-east-1:111:key/abc", wantErr: true, errSubstr: "not yet supported"},
 		{name: "non-aws partition", arn: "arn:azure:s3:::x", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "malformed", arn: "not-an-arn", wantErr: true, errSubstr: "only AWS ARNs"},
 		{name: "missing parts", arn: "arn:aws:s3", wantErr: true, errSubstr: "malformed ARN"},
-		{name: "s3 object rejected", arn: "arn:aws:s3:::bkt/obj.txt", wantErr: true, errSubstr: "object ARNs are not yet supported"},
+		{name: "s3 object rejected", arn: "arn:aws:s3:::bkt/obj.txt", wantErr: true, errSubstr: "object ARNs are not supported"},
 	}
 
 	for _, tt := range tests {
@@ -160,11 +172,211 @@ func TestTagResourceByARN_UnsupportedReturnsInvalidArgument(t *testing.T) {
 	ctx := context.Background()
 	f := newAWSFixture(t)
 
-	err := f.engine.TagResourceByARN(ctx, "arn:aws:lambda:us-east-1:111:function:fn",
+	// KMS has no tag store wired through the RGT dispatcher.
+	err := f.engine.TagResourceByARN(ctx, "arn:aws:kms:us-east-1:111:key/abc",
 		map[string]string{"k": "v"})
 	require.Error(t, err)
 	assert.Equal(t, cerrors.InvalidArgument, cerrors.GetCode(err))
 	assert.Contains(t, err.Error(), "not yet supported")
+}
+
+func TestTagResourceByARN_EC2Instance(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	insts, err := f.ec2.RunInstances(ctx, computedriver.InstanceConfig{
+		ImageID: "ami-1", InstanceType: "t3.micro",
+	}, 1)
+	require.NoError(t, err)
+	id := insts[0].ID
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:instance/" + id
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"Environment": "prod", "team": "core"}))
+
+	got, err := f.ec2.DescribeInstances(ctx, []string{id}, nil, computedriver.DescribeInstancesOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got[0].Tags["Environment"])
+	assert.Equal(t, "core", got[0].Tags["team"])
+
+	// Merge is additive: a second tag call keeps the earlier keys.
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"Environment": "stage", "new": "x"}))
+	got, err = f.ec2.DescribeInstances(ctx, []string{id}, nil, computedriver.DescribeInstancesOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "stage", got[0].Tags["Environment"])
+	assert.Equal(t, "core", got[0].Tags["team"], "non-overlapping key should survive merge")
+	assert.Equal(t, "x", got[0].Tags["new"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"Environment", "missing"}))
+	got, err = f.ec2.DescribeInstances(ctx, []string{id}, nil, computedriver.DescribeInstancesOptions{})
+	require.NoError(t, err)
+	_, has := got[0].Tags["Environment"]
+	assert.False(t, has)
+	assert.Equal(t, "core", got[0].Tags["team"])
+}
+
+func TestTagResourceByARN_EC2Volume(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	vol, err := f.ec2.CreateVolume(ctx, computedriver.VolumeConfig{Size: 8, VolumeType: "gp3", AvailabilityZone: "us-east-1a"})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:volume/" + vol.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"backup": "daily"}))
+
+	got, err := f.ec2.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "daily", got[0].Tags["backup"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"backup"}))
+	got, err = f.ec2.DescribeVolumes(ctx, []string{vol.ID})
+	require.NoError(t, err)
+	_, has := got[0].Tags["backup"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_EC2Snapshot(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	vol, err := f.ec2.CreateVolume(ctx, computedriver.VolumeConfig{Size: 8, VolumeType: "gp3", AvailabilityZone: "us-east-1a"})
+	require.NoError(t, err)
+	snap, err := f.ec2.CreateSnapshot(ctx, computedriver.SnapshotConfig{VolumeID: vol.ID})
+	require.NoError(t, err)
+
+	arn := "arn:aws:ec2:us-east-1:123456789012:snapshot/" + snap.ID
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"keep": "30d"}))
+
+	got, err := f.ec2.DescribeSnapshots(ctx, []string{snap.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "30d", got[0].Tags["keep"])
+}
+
+func TestTagResourceByARN_Lambda(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedLambda(t, f, "handler", nil)
+
+	arn := "arn:aws:lambda:us-east-1:123456789012:function:handler"
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"env": "prod"}))
+
+	got, err := f.lambda.GetFunction(ctx, "handler")
+	require.NoError(t, err)
+	assert.Equal(t, "prod", got.Tags["env"])
+
+	// A version-qualified ARN resolves to the same function's tags.
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn+":3", map[string]string{"team": "data"}))
+	got, err = f.lambda.GetFunction(ctx, "handler")
+	require.NoError(t, err)
+	assert.Equal(t, "data", got.Tags["team"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"env"}))
+	got, err = f.lambda.GetFunction(ctx, "handler")
+	require.NoError(t, err)
+	_, has := got.Tags["env"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_Secret(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedSecret(t, f, "db-password", nil)
+
+	arn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:db-password"
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"rotation": "30d"}))
+
+	got, err := f.secrets.GetSecret(ctx, "db-password")
+	require.NoError(t, err)
+	assert.Equal(t, "30d", got.Tags["rotation"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"rotation"}))
+	got, err = f.secrets.GetSecret(ctx, "db-password")
+	require.NoError(t, err)
+	_, has := got.Tags["rotation"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_SNSTopic(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedSNS(t, f, "alerts", nil)
+
+	arn := "arn:aws:sns:us-east-1:123456789012:alerts"
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"severity": "high"}))
+
+	assert.Equal(t, "high", snsTopicTags(t, f, "alerts")["severity"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"severity"}))
+	_, has := snsTopicTags(t, f, "alerts")["severity"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_SQSQueue(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	seedSQS(t, f, "jobs", nil)
+
+	arn := "arn:aws:sqs:us-east-1:123456789012:jobs"
+	require.NoError(t, f.engine.TagResourceByARN(ctx, arn, map[string]string{"pipeline": "etl"}))
+
+	assert.Equal(t, "etl", sqsQueueTags(t, f, "jobs")["pipeline"])
+
+	require.NoError(t, f.engine.UntagResourceByARN(ctx, arn, []string{"pipeline"}))
+	_, has := sqsQueueTags(t, f, "jobs")["pipeline"]
+	assert.False(t, has)
+}
+
+func TestTagResourceByARN_NotFound(t *testing.T) {
+	ctx := context.Background()
+	f := newAWSFixture(t)
+
+	cases := map[string]string{
+		"instance": "arn:aws:ec2:us-east-1:123456789012:instance/i-missing",
+		"lambda":   "arn:aws:lambda:us-east-1:123456789012:function:ghost",
+		"secret":   "arn:aws:secretsmanager:us-east-1:123456789012:secret:ghost",
+		"sns":      "arn:aws:sns:us-east-1:123456789012:ghost",
+		"sqs":      "arn:aws:sqs:us-east-1:123456789012:ghost",
+	}
+
+	for name, arn := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := f.engine.TagResourceByARN(ctx, arn, map[string]string{"k": "v"})
+			require.Error(t, err)
+			assert.Equal(t, cerrors.NotFound, cerrors.GetCode(err), "expected NotFound for %s", arn)
+		})
+	}
+}
+
+// snsTopicTags reads a topic's tags back through the SNS list surface.
+func snsTopicTags(t *testing.T, f *fixture, name string) map[string]string {
+	t.Helper()
+	topics, err := f.sns.ListTopics(context.Background(), scope.Scope{})
+	require.NoError(t, err)
+	for i := range topics {
+		if topics[i].Name == name {
+			return topics[i].Tags
+		}
+	}
+	t.Fatalf("topic %q not found", name)
+	return nil
+}
+
+// sqsQueueTags reads a queue's tags back through the SQS list surface.
+func sqsQueueTags(t *testing.T, f *fixture, name string) map[string]string {
+	t.Helper()
+	queues, err := f.sqs.ListQueues(context.Background(), "")
+	require.NoError(t, err)
+	for i := range queues {
+		if queues[i].Name == name {
+			return queues[i].Tags
+		}
+	}
+	t.Fatalf("queue %q not found", name)
+	return nil
 }
 
 func TestTagResourceByARN_MissingDriverReturnsFailedPrecondition(t *testing.T) {


### PR DESCRIPTION
Fixes #395.

## Problem

The AWS Resource Groups Tagging API (`TagResources` / `UntagResources`) routes through `resourcediscovery.Engine.TagResourceByARN`, but the ARN parser + dispatcher only handled **S3, DynamoDB, and EC2 networking** (vpc/subnet/security-group). Tagging an **EC2 instance** ARN failed with `InvalidParameterException` — and instances are one of the most commonly tagged resources. The same gap applied to every other discoverable service that has an AWS tag store.

## Fix

Extends `TagResourceByARN` / `UntagResourceByARN` to also cover:

| Service | Resource types | Notes |
|---|---|---|
| EC2 compute | instance, volume, snapshot, image | `ec2.Mock.TagResource` (by prefixed id) |
| Lambda | function | version/alias qualifiers resolve to the base function |
| Secrets Manager | secret | |
| SNS | topic | subscription ARNs rejected |
| SQS | queue | ARN name resolved to the queue URL via `ListQueues` |

Tagging is additive (existing tags preserved, overlapping keys overwritten), matching the existing S3/DynamoDB/VPC behavior and real AWS.

### Design

These tag methods live on the AWS provider mocks, **not** the shared `services/*/driver` interfaces, and RGT is AWS-only. Rather than widen five interfaces (forcing Azure/GCP to implement AWS-only tag plumbing), the dispatcher **type-asserts each driver to a narrow capability interface** — the same pattern `resourcediscovery` already uses for `KubernetesClusters` / `ScaleSets` / `RelationalDatabases`. No provider changes were needed: the AWS provider already wires all these drivers into its `ResourceDiscovery` engine, so it works end-to-end.

Error mapping is unchanged: unknown ids → `NotFound` → `InvalidParameterException`; unconfigured/incapable driver → `FailedPrecondition` → `InternalServiceException`.

### Deferred (called out honestly)

- **ECR** and **Route53** — discovery currently emits a non-ARN identifier (an ECR registry URI; a bare `zone-<id>`), so `TagResources` can't round-trip the value `GetResources` returns. Needs a discovery-side change first.
- **No tag store at all** — CloudWatch Logs/alarms, ElastiCache, ELB, IAM, RDS, and networking sub-types beyond vpc/subnet/sg. These return a clear unsupported error.

## Tests

- Engine-level: tag / untag / additive-merge / not-found for **every** newly-supported type, plus a parser table covering all ARN shapes (including the versioned Lambda ARN and rejected SNS subscription / KMS / S3-object cases).
- **Real `aws-sdk-go-v2` RGT round-trip**: seeds an instance, function, topic, queue, and secret, tags all five through the live in-memory handler, asserts `FailedResourcesMap` is empty, and verifies each tag landed on its backing store; a KMS ARN still fails with `InvalidParameterException`.

`go build ./...`, `go vet`, and the full `go test ./...` suite pass. Lint adds zero new issues (the 6 pre-existing gocyclo/dupl/goconst/prealloc findings are unchanged from `development` and live in files this PR doesn't touch).
