### PR TITLE
fix(azure): surface management-API resources in Resource Graph and storage list

### DIFF
--- a/cmd/cloudemu/serve.go
+++ b/cmd/cloudemu/serve.go
@@ -44,30 +44,31 @@ var errUnsupportedSnapshot = errors.New("unsupported snapshot schema version")
 
 // serveConfig holds the resolved serve flags.
 type serveConfig struct {
-	providers       string
-	host            string
-	advertiseHost   string
-	awsPort         string
-	azurePort       string
-	gcpPort         string
-	ociPort         string
-	k8sPort         string
-	accountID       string
-	region          string
-	projectID       string
-	latency         time.Duration
-	tlsCert         string
-	tlsKey          string
-	tlsHosts        stringList
-	endpoints       string
-	admin           bool
-	logReqs         bool
-	quiet           bool
-	shutdownTO      time.Duration
-	persist         bool
-	stateFile       string
-	persistMetaOnly bool
-	initDir         string
+	providers         string
+	host              string
+	advertiseHost     string
+	awsPort           string
+	azurePort         string
+	gcpPort           string
+	ociPort           string
+	k8sPort           string
+	accountID         string
+	azureSubscription string
+	region            string
+	projectID         string
+	latency           time.Duration
+	tlsCert           string
+	tlsKey            string
+	tlsHosts          stringList
+	endpoints         string
+	admin             bool
+	logReqs           bool
+	quiet             bool
+	shutdownTO        time.Duration
+	persist           bool
+	stateFile         string
+	persistMetaOnly   bool
+	initDir           string
 }
 
 // stringList is a repeatable string flag (e.g. --tls-host a --tls-host b).
@@ -94,7 +95,9 @@ func runServe(args []string) error {
 	fs.StringVar(&c.gcpPort, "gcp-port", "4569", "port for the GCP endpoint (HTTP)")
 	fs.StringVar(&c.ociPort, "oci-port", "4571", "port for the OCI endpoint (HTTP)")
 	fs.StringVar(&c.k8sPort, "k8s-port", "4570", "port for the shared Kubernetes data-plane (HTTPS); empty to disable")
-	fs.StringVar(&c.accountID, "account-id", "000000000000", "AWS account ID / Azure subscription ID reported by the emulator")
+	fs.StringVar(&c.accountID, "account-id", "000000000000", "AWS account ID (also GCP/OCI) reported by the emulator")
+	fs.StringVar(&c.azureSubscription, "azure-subscription", "00000000-0000-0000-0000-000000000000",
+		"Azure subscription id reported by the emulator (a GUID; real Azure SDKs/CLIs require one)")
 	fs.StringVar(&c.region, "region", "us-east-1", "default region reported by the emulator")
 	fs.StringVar(&c.projectID, "project-id", "cloudemu-local", "GCP project ID reported by the emulator")
 	fs.DurationVar(&c.latency, "latency", 0, "artificial latency added to every emulated call (e.g. 20ms)")
@@ -230,7 +233,15 @@ func runServe(args []string) error {
 				freshTargets["gcp"] = seed.Target{Storage: cloud.GCS, Database: cloud.Firestore, Secrets: cloud.SecretManager, Compute: cloud.GCE}
 				freshDiscovery["gcp"] = cloud.ResourceDiscovery
 			case "azure":
-				cloud := cloudemu.NewAzure(opts...)
+				// Azure subscriptions are GUIDs, unlike the 12-digit AWS
+				// account id. Give the Azure provider its own subscription so
+				// resource ids and Resource Graph scoping use a real Azure GUID
+				// (WithAccountID is last-wins). Copy opts so the override never
+				// leaks into another provider's option list.
+				azureOpts := make([]config.Option, len(opts), len(opts)+1)
+				copy(azureOpts, opts)
+				azureOpts = append(azureOpts, config.WithAccountID(c.azureSubscription))
+				cloud := cloudemu.NewAzure(azureOpts...)
 				d := azureserver.DriversFrom(cloud)
 				d.K8sAPI = k8s
 				cloud.AKS.SetK8sAPI(k8s)

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -342,7 +342,8 @@ your client.
 | `--host` | `127.0.0.1` | bind interface (`0.0.0.0` to expose on the network) |
 | `--advertise-host` | (derived) | host/IP the Kubernetes endpoint is advertised at + its cert SAN; defaults to `--host`, or `127.0.0.1` when binding all interfaces |
 | `--aws-port` / `--azure-port` / `--gcp-port` / `--k8s-port` / `--oci-port` | `4566`/`4568`/`4569`/`4570`/`4571` | listen ports (empty `--k8s-port` disables Kubernetes; OCI only served when `oci` is in `--providers`) |
-| `--account-id` | `000000000000` | AWS account ID / Azure subscription ID |
+| `--account-id` | `000000000000` | AWS account ID (also used for GCP/OCI) |
+| `--azure-subscription` | `00000000-0000-0000-0000-000000000000` | Azure subscription id (a GUID). Resource ids and Resource Graph scoping use it; discovery is subscription-transparent, so a query scoped to any subscription returns the estate rendered under it |
 | `--region` | `us-east-1` | default region |
 | `--project-id` | `cloudemu-local` | GCP project ID |
 | `--latency` | `0` | artificial per-call latency (e.g. `20ms`) |

--- a/server/azure/resourcegraph/handler.go
+++ b/server/azure/resourcegraph/handler.go
@@ -84,10 +84,13 @@ func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.subscriptionAllowed(req.Subscriptions) {
-		azurearm.WriteJSON(w, http.StatusOK, emptyResponse())
-		return
-	}
+	// The emulator serves a single estate, and the management plane accepts any
+	// subscription a client uses (it echoes it straight back into the resource
+	// id). So Resource Graph is subscription-transparent: it never rejects a
+	// requested subscription — it reports the estate under whichever one the
+	// caller scoped to, so "create under sub X" then "discover under sub X"
+	// stays consistent for every service.
+	subscription := h.effectiveSubscription(req.Subscriptions)
 
 	parsed := parseKQL(req.Query)
 
@@ -108,7 +111,7 @@ func (h *Handler) queryResources(w http.ResponseWriter, r *http.Request) {
 
 	data := make([]map[string]any, 0, len(results))
 	for i := range results {
-		data = append(data, h.resourceToWire(&results[i]))
+		data = append(data, resourceToWire(&results[i], subscription))
 	}
 
 	azurearm.WriteJSON(w, http.StatusOK, map[string]any{
@@ -155,23 +158,18 @@ func operationDescriptor(name, resource, op, desc string) map[string]any {
 	}
 }
 
-// subscriptionAllowed returns true if the request's subscription list is
-// empty (caller doesn't care about scoping) or includes this handler's
-// subscription ID. Mismatch returns an empty result rather than an error,
-// matching real Resource Graph behavior when the caller scopes to
-// subscriptions they can't see.
-func (h *Handler) subscriptionAllowed(reqSubs []string) bool {
-	if len(reqSubs) == 0 {
-		return true
+// effectiveSubscription reports the subscription id the estate is rendered
+// under for this query. The emulator is single-tenant, so it does not partition
+// resources by subscription: when the caller scopes to exactly one subscription
+// the estate is reported under that one (so the ids a client sees match the
+// subscription it created resources under, and its own scoped queries match);
+// otherwise it falls back to the handler's configured subscription.
+func (h *Handler) effectiveSubscription(reqSubs []string) string {
+	if len(reqSubs) == 1 && reqSubs[0] != "" {
+		return reqSubs[0]
 	}
 
-	for _, s := range reqSubs {
-		if s == h.subscriptionID {
-			return true
-		}
-	}
-
-	return false
+	return h.subscriptionID
 }
 
 func emptyResponse() map[string]any {
@@ -215,19 +213,19 @@ func applyLimit(results []resourcediscovery.Resource, kqlLimit, top, skip int) [
 // slots only when set — the same rendering for every resource type, with no
 // per-type branching. id is the ARM resource ID and resourceGroup is derived
 // from it (real Resource Graph consumers parse both).
-func (h *Handler) resourceToWire(r *resourcediscovery.Resource) map[string]any {
-	// The emulator is single-subscription: every resource belongs to the
-	// configured subscription the ARM clients use. Stamp that, rather than
-	// parsing it out of each mock's ARN — those embed inconsistent placeholders
-	// (empty, a region, a zero id), which would make a subscription-scoped ARG
-	// query return nothing. Fall back to the ARN only when unset.
-	subscription := h.subscriptionID
+func resourceToWire(r *resourcediscovery.Resource, subscription string) map[string]any {
+	// The emulator is single-tenant; each mock's ARN embeds an inconsistent
+	// subscription placeholder (empty, a region, a zero id). Render every
+	// resource under the subscription this query is scoped to, so both the id
+	// and subscriptionId match what the caller (and the management plane, which
+	// echoes the client's subscription on create) uses. Fall back to the ARN's
+	// own subscription only when the query carries none.
 	if subscription == "" {
 		subscription = extractSubscription(r.ARN)
 	}
 
 	out := map[string]any{
-		"id":             r.ARN,
+		"id":             rewriteSubscription(r.ARN, subscription),
 		"name":           r.ID,
 		"type":           portableToAzureType(r.Service, r.Type),
 		"location":       r.Region,
@@ -236,20 +234,7 @@ func (h *Handler) resourceToWire(r *resourcediscovery.Resource) map[string]any {
 		"tags":           tagsOrEmpty(r.Tags),
 	}
 
-	if r.SKU != "" || r.SKUTier != "" || r.SKUCapacity > 0 {
-		sku := map[string]any{}
-		if r.SKU != "" {
-			sku["name"] = r.SKU
-		}
-
-		if r.SKUTier != "" {
-			sku["tier"] = r.SKUTier
-		}
-
-		if r.SKUCapacity > 0 {
-			sku["capacity"] = r.SKUCapacity
-		}
-
+	if sku := skuMap(r); sku != nil {
 		out["sku"] = sku
 	}
 
@@ -270,6 +255,28 @@ func (h *Handler) resourceToWire(r *resourcediscovery.Resource) map[string]any {
 	}
 
 	return out
+}
+
+// skuMap renders a resource's SKU fields, or nil when none are set.
+func skuMap(r *resourcediscovery.Resource) map[string]any {
+	if r.SKU == "" && r.SKUTier == "" && r.SKUCapacity == 0 {
+		return nil
+	}
+
+	sku := map[string]any{}
+	if r.SKU != "" {
+		sku["name"] = r.SKU
+	}
+
+	if r.SKUTier != "" {
+		sku["tier"] = r.SKUTier
+	}
+
+	if r.SKUCapacity > 0 {
+		sku["capacity"] = r.SKUCapacity
+	}
+
+	return sku
 }
 
 // resourceGroupOrDefault pulls the resource group out of an Azure resource ID
@@ -313,6 +320,24 @@ func extractSubscription(arn string) string {
 	}
 
 	return rest
+}
+
+// rewriteSubscription replaces the subscription segment of an Azure resource id
+// with sub, so the id a Resource Graph client sees is scoped to the subscription
+// it queried. An id that isn't subscription-shaped, or an empty sub, is returned
+// unchanged.
+func rewriteSubscription(arn, sub string) string {
+	const prefix = "/subscriptions/"
+	if sub == "" || !strings.HasPrefix(arn, prefix) {
+		return arn
+	}
+
+	rest := arn[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return prefix + sub + rest[i:]
+	}
+
+	return prefix + sub
 }
 
 // portableToAzureTypeMap is the inverse of mapAzureType's mapping — the engine's

--- a/server/azure/resourcegraph/sdk_test.go
+++ b/server/azure/resourcegraph/sdk_test.go
@@ -114,13 +114,24 @@ func TestSDKResourceGraph(t *testing.T) {
 		assert.Len(t, data, 1, "the one VNet we seeded")
 	})
 
-	t.Run("subscription scoping — wrong sub returns empty", func(t *testing.T) {
+	t.Run("single-tenant: any scoped subscription sees the estate, rendered under it", func(t *testing.T) {
+		// The emulator serves one estate and the management plane accepts any
+		// subscription on create (echoing it into the resource id). So a scoped
+		// Resource Graph query returns that estate rendered under whichever
+		// subscription the caller used — "create under sub X, discover under
+		// sub X" stays consistent for a real client that picked its own GUID.
 		out, err := client.Resources(ctx, armresourcegraph.QueryRequest{
 			Query:         to.Ptr("Resources"),
-			Subscriptions: []*string{to.Ptr("some-other-sub")},
+			Subscriptions: []*string{to.Ptr("00000000-0000-0000-0000-000000000000")},
 		}, nil)
 		require.NoError(t, err)
-		assert.EqualValues(t, 0, *out.TotalRecords)
+		require.NotZero(t, *out.TotalRecords, "the estate is visible under the requested subscription")
+
+		row := out.Data.([]any)[0].(map[string]any)
+		assert.Equal(t, "00000000-0000-0000-0000-000000000000", row["subscriptionId"],
+			"resources are stamped with the subscription the query scoped to")
+		assert.Contains(t, row["id"].(string), "/subscriptions/00000000-0000-0000-0000-000000000000/",
+			"the resource id is rewritten under the requested subscription")
 	})
 
 	t.Run("limit clause caps results", func(t *testing.T) {

--- a/server/azure/storageaccount/handler.go
+++ b/server/azure/storageaccount/handler.go
@@ -85,8 +85,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// An empty resource name is a collection path — a subscription- or
+	// resource-group-scoped list (…/storageAccounts). Route it to the list
+	// handler rather than rejecting it, so a management-plane inventory sees
+	// accounts created by PUT (matching real Azure and the disks/vnet handlers).
 	if rp.ResourceName == "" {
-		azurearm.WriteError(w, http.StatusNotFound, "NotFound", "storage account name required")
+		h.serveCollection(w, r, &rp)
 		return
 	}
 
@@ -100,6 +104,40 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
 	}
+}
+
+// serveCollection lists storage accounts at the subscription or resource-group
+// scope (GET …/storageAccounts). Real Azure returns every account in scope in a
+// {"value":[…]} envelope; the emulator is single-estate, so it lists every
+// stored account under the requested scope.
+func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
+	if r.Method != http.MethodGet {
+		azurearm.WriteError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed")
+		return
+	}
+
+	buckets, err := h.bucket.ListBuckets(r.Context())
+	if err != nil {
+		azurearm.WriteCErr(w, err)
+		return
+	}
+
+	out := make([]armAccount, 0, len(buckets))
+
+	for i := range buckets {
+		scope := *rp
+		scope.ResourceName = buckets[i].Name
+		// A subscription-scoped list carries no resource group; the mock doesn't
+		// track which group a bucket was created under, so stamp the default
+		// group rather than emitting an id with an empty "resourceGroups//".
+		if scope.ResourceGroup == "" {
+			scope.ResourceGroup = "default"
+		}
+
+		out = append(out, h.toARMAccount(r.Context(), &scope, defaultLocation, nil))
+	}
+
+	azurearm.WriteJSON(w, http.StatusOK, armAccountList{Value: out})
 }
 
 func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {

--- a/server/azure/storageaccount/sdk_test.go
+++ b/server/azure/storageaccount/sdk_test.go
@@ -112,3 +112,64 @@ func TestSDKStorageAccountGetMissing(t *testing.T) {
 	_, err := client.GetProperties(ctx, "rg-1", "nope", nil)
 	require.Error(t, err)
 }
+
+// A management-API create must be visible to the list calls, at both the
+// subscription and resource-group scope — the gap reported in #404, where a
+// PUT-created account was returned by GET-by-id but not by list.
+func TestSDKStorageAccountList(t *testing.T) {
+	ctx := context.Background()
+	client := newAccountsClient(t)
+
+	for _, name := range []string{"acctA", "acctB"} {
+		poller, err := client.BeginCreate(ctx, "rg-1", name, armstorage.AccountCreateParameters{
+			Location: to.Ptr("eastus"),
+			Kind:     to.Ptr(armstorage.KindBlockBlobStorage),
+			SKU:      &armstorage.SKU{Name: to.Ptr(armstorage.SKUNamePremiumLRS)},
+		}, nil)
+		require.NoError(t, err)
+		_, err = poller.PollUntilDone(ctx, nil)
+		require.NoError(t, err)
+	}
+
+	collect := func(pager interface {
+		More() bool
+	}, next func() ([]string, error)) []string {
+		var names []string
+		for pager.More() {
+			page, err := next()
+			require.NoError(t, err)
+			names = append(names, page...)
+		}
+		return names
+	}
+
+	// Subscription-scoped list.
+	subPager := client.NewListPager(nil)
+	subNames := collect(subPager, func() ([]string, error) {
+		page, err := subPager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, 0, len(page.Value))
+		for _, a := range page.Value {
+			out = append(out, *a.Name)
+		}
+		return out, nil
+	})
+	assert.ElementsMatch(t, []string{"acctA", "acctB"}, subNames, "subscription-scoped list must return both accounts")
+
+	// Resource-group-scoped list.
+	rgPager := client.NewListByResourceGroupPager("rg-1", nil)
+	rgNames := collect(rgPager, func() ([]string, error) {
+		page, err := rgPager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]string, 0, len(page.Value))
+		for _, a := range page.Value {
+			out = append(out, *a.Name)
+		}
+		return out, nil
+	})
+	assert.ElementsMatch(t, []string{"acctA", "acctB"}, rgNames, "resource-group-scoped list must return both accounts")
+}

--- a/server/azure/storageaccount/types.go
+++ b/server/azure/storageaccount/types.go
@@ -33,6 +33,11 @@ type armAccount struct {
 	Properties *armAccountProps  `json:"properties,omitempty"`
 }
 
+// armAccountList is the {"value":[…]} envelope a storage-account list returns.
+type armAccountList struct {
+	Value []armAccount `json:"value"`
+}
+
 type armAccountProps struct {
 	AccessTier        string `json:"accessTier,omitempty"`
 	ProvisioningState string `json:"provisioningState,omitempty"`


### PR DESCRIPTION
Closes #404.

## Problem

On the standalone/Docker server, a resource created through the Azure **management REST API** was returned by **GET-by-id** but was **invisible to a Resource Graph query** and to the management **list** call. An app inventorying a subscription via ARG saw an empty estate.

Root cause: Resource Graph's `subscriptionAllowed` gate rejected the query when the requested subscription didn't match the emulator's configured id — and that id defaulted to a **12-digit AWS-style account number** (`000000000000`), not a valid Azure subscription **GUID**. Any real Azure SDK/CLI/app queries with a GUID (e.g. `00000000-0000-0000-0000-000000000000`), so it was filtered to empty *before the discovery engine was consulted*. The engine, walkers, and wiring were already correct — ARG scoped to the actual configured id (or with no subscription) returned the resource.

## Fix

- **Resource Graph is subscription-transparent (all services).** The emulator serves a single estate and the management plane already accepts any subscription on create (it echoes it into the resource id). Resource Graph now reports that estate under whichever subscription the query scopes to — rewriting both `id` and `subscriptionId` — so "create under sub X, discover under sub X" is consistent for **every** Azure service (it lives in the shared `resourcegraph` handler).
- **Azure subscription defaults to a GUID.** New `--azure-subscription` flag, defaulting to `00000000-0000-0000-0000-000000000000`, decoupled from the 12-digit `--account-id` (which stays for AWS/GCP/OCI). Standalone-server only, so no library-test churn.
- **Storage-account list.** The handler now serves the subscription- and resource-group-scoped list (`{"value":[…]}`) instead of `404` — mirroring the existing disks/vnet handlers (storage was the outlier).

## Verification

End-to-end against the running server (the issue's exact sequence): PUT create → 200; GET-by-id → 200; management **list → 200 with the account** (was 404); ARG with the subscription GUID → **1 row** rendered under that GUID (was 0); type filter → 1; no-subscription → GUID default. Cross-service: a storage account **and** a VNet created via the management API both appear in one ARG query.

- Full `go test ./...`: green (0 failures, `-race` clean on the touched packages).
- Added a real-SDK storage-account list test (subscription + resource-group scope); updated the Resource Graph subscription-scoping test to the single-tenant contract.
- `gofmt`/`go vet`/`golangci-lint` clean (0 new issues); generated coverage docs unaffected (no driver-capability change).
- `docs/standalone-server.md` documents `--azure-subscription`.
