### PR TITLE
docs: add Zopday deploy badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
   <a href="https://github.com/stackshy/cloudemu/blob/development/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/providers-AWS_|_Azure_|_GCP-orange" alt="Providers">
   <img src="https://img.shields.io/badge/cost-$0-brightgreen" alt="Zero Cost">
+</p>
+
+<p align="center">
   <a href="http://zop.dev/zopday/"><img src="https://zop.dev/deploytozopday-inkhard.svg" alt="Deploy to Zopday"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://github.com/stackshy/cloudemu/blob/development/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License"></a>
   <img src="https://img.shields.io/badge/providers-AWS_|_Azure_|_GCP-orange" alt="Providers">
   <img src="https://img.shields.io/badge/cost-$0-brightgreen" alt="Zero Cost">
+  <a href="http://zop.dev/zopday/"><img src="https://zop.dev/deploytozopday-inkhard.svg" alt="Deploy to Zopday"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Adds a "Deploy to Zopday" badge to the right of the existing badge row in the README, linking to http://zop.dev/zopday/

## Test plan
- Rendered README locally to confirm the badge displays inline with the existing Docker Image / Go Reference / Go Report Card / MIT License / Providers / Zero Cost badges and links out correctly