### PR TITLE
docs: update Zopday badge link to direct deploy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="http://zop.dev/zopday/"><img src="https://zop.dev/deploytozopday-inkhard.svg" alt="Deploy to Zopday"></a>
+  <a href="https://zop.dev/zopday/app/deploy?image=ghcr.io/stackshy/cloudemu:2.5&amp;port=8000"><img src="https://zop.dev/deploytozopday-inkhard.svg" alt="Deploy to Zopday"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Updates the "Deploy to Zopday" badge link (added in #406) from http://zop.dev/zopday/ to the direct deploy URL: https://zop.dev/zopday/app/deploy?image=ghcr.io/stackshy/cloudemu:2.5&port=8000, so clicking it pre-fills the image and port.

## Test plan
- Verified the README renders the same badge, only the href changed