### PR TITLE
feat(azure): model Flexible Server high availability

### DIFF
--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -430,9 +430,20 @@ func appendFlexServers(
 	out []resourcediscovery.DiscoveredDatabase, insts []rdsdriver.Instance, typ string,
 ) []resourcediscovery.DiscoveredDatabase {
 	for i := range insts {
-		ha := "Disabled"
-		if insts[i].MultiAZ {
-			ha = "ZoneRedundant"
+		// Prefer the explicit HA mode the ARM API recorded (which can be
+		// SameZone, not just ZoneRedundant); fall back to MultiAZ for instances
+		// created through the portable API, which has no HA-mode input.
+		ha := insts[i].HighAvailabilityMode
+		if ha == "" {
+			ha = rdsdriver.HAModeDisabled
+			if insts[i].MultiAZ {
+				ha = rdsdriver.HAModeZoneRedundant
+			}
+		}
+
+		haProps := map[string]any{"mode": ha}
+		if insts[i].StandbyAvailabilityZone != "" {
+			haProps["standbyAvailabilityZone"] = insts[i].StandbyAvailabilityZone
 		}
 
 		out = append(out, resourcediscovery.DiscoveredDatabase{
@@ -443,7 +454,7 @@ func appendFlexServers(
 				SKUTier: flexTier(insts[i].InstanceClass),
 				Properties: nonEmptyProps(map[string]any{
 					"storage":          map[string]any{"storageSizeGB": insts[i].AllocatedStorage},
-					"highAvailability": map[string]any{"mode": ha},
+					"highAvailability": haProps,
 					"version":          insts[i].EngineVersion,
 				}),
 			},

--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -259,6 +259,10 @@ func (m *Mock) ModifyInstance(
 	if input.HighAvailabilityMode != "" {
 		inst.HighAvailabilityMode = input.HighAvailabilityMode
 		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
+		// Disabling HA tears down the standby, so its zone no longer applies.
+		if !inst.MultiAZ {
+			inst.StandbyAvailabilityZone = ""
+		}
 	}
 
 	if input.Tags != nil {

--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -163,25 +163,27 @@ func (m *Mock) CreateInstance(_ context.Context, cfg rdsdriver.InstanceConfig) (
 	}
 
 	inst := rdsdriver.Instance{
-		ID:                 cfg.ID,
-		ARN:                m.armResourceID(cfg.ID),
-		Engine:             engine,
-		EngineVersion:      cfg.EngineVersion,
-		InstanceClass:      tier,
-		AllocatedStorage:   storage,
-		StorageType:        storageType,
-		MasterUsername:     cfg.MasterUsername,
-		DBName:             cfg.DBName,
-		Endpoint:           cfg.ID + endpointSuffix,
-		Port:               port,
-		State:              rdsdriver.StateAvailable,
-		MultiAZ:            cfg.MultiAZ,
-		PubliclyAccessible: cfg.PubliclyAccessible,
-		VPCSecurityGroups:  append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:    cfg.SubnetGroupName,
-		AvailabilityZone:   region,
-		CreatedAt:          m.opts.Clock.Now().UTC(),
-		Tags:               copyTags(cfg.Tags),
+		ID:                      cfg.ID,
+		ARN:                     m.armResourceID(cfg.ID),
+		Engine:                  engine,
+		EngineVersion:           cfg.EngineVersion,
+		InstanceClass:           tier,
+		AllocatedStorage:        storage,
+		StorageType:             storageType,
+		MasterUsername:          cfg.MasterUsername,
+		DBName:                  cfg.DBName,
+		Endpoint:                cfg.ID + endpointSuffix,
+		Port:                    port,
+		State:                   rdsdriver.StateAvailable,
+		MultiAZ:                 cfg.MultiAZ || rdsdriver.HAEnabled(cfg.HighAvailabilityMode),
+		PubliclyAccessible:      cfg.PubliclyAccessible,
+		VPCSecurityGroups:       append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:         cfg.SubnetGroupName,
+		AvailabilityZone:        region,
+		HighAvailabilityMode:    cfg.HighAvailabilityMode,
+		StandbyAvailabilityZone: cfg.StandbyAvailabilityZone,
+		CreatedAt:               m.opts.Clock.Now().UTC(),
+		Tags:                    copyTags(cfg.Tags),
 	}
 
 	m.instances.Set(cfg.ID, inst)
@@ -252,6 +254,11 @@ func (m *Mock) ModifyInstance(
 
 	if input.MultiAZ != nil {
 		inst.MultiAZ = *input.MultiAZ
+	}
+
+	if input.HighAvailabilityMode != "" {
+		inst.HighAvailabilityMode = input.HighAvailabilityMode
+		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
 	}
 
 	if input.Tags != nil {

--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -174,25 +174,27 @@ func (m *Mock) CreateInstance(_ context.Context, cfg rdsdriver.InstanceConfig) (
 	}
 
 	inst := rdsdriver.Instance{
-		ID:                 cfg.ID,
-		ARN:                flexibleServerResourceID(region, cfg.ID),
-		Engine:             engine,
-		EngineVersion:      cfg.EngineVersion,
-		InstanceClass:      sku,
-		AllocatedStorage:   storage,
-		StorageType:        storageType,
-		MasterUsername:     cfg.MasterUsername,
-		DBName:             cfg.DBName,
-		Endpoint:           flexibleServerEndpoint(cfg.ID),
-		Port:               port,
-		State:              rdsdriver.StateAvailable,
-		MultiAZ:            cfg.MultiAZ,
-		PubliclyAccessible: cfg.PubliclyAccessible,
-		VPCSecurityGroups:  append([]string(nil), cfg.VPCSecurityGroups...),
-		SubnetGroupName:    cfg.SubnetGroupName,
-		AvailabilityZone:   region,
-		CreatedAt:          m.opts.Clock.Now().UTC(),
-		Tags:               copyTags(cfg.Tags),
+		ID:                      cfg.ID,
+		ARN:                     flexibleServerResourceID(region, cfg.ID),
+		Engine:                  engine,
+		EngineVersion:           cfg.EngineVersion,
+		InstanceClass:           sku,
+		AllocatedStorage:        storage,
+		StorageType:             storageType,
+		MasterUsername:          cfg.MasterUsername,
+		DBName:                  cfg.DBName,
+		Endpoint:                flexibleServerEndpoint(cfg.ID),
+		Port:                    port,
+		State:                   rdsdriver.StateAvailable,
+		MultiAZ:                 cfg.MultiAZ || rdsdriver.HAEnabled(cfg.HighAvailabilityMode),
+		PubliclyAccessible:      cfg.PubliclyAccessible,
+		VPCSecurityGroups:       append([]string(nil), cfg.VPCSecurityGroups...),
+		SubnetGroupName:         cfg.SubnetGroupName,
+		AvailabilityZone:        region,
+		HighAvailabilityMode:    cfg.HighAvailabilityMode,
+		StandbyAvailabilityZone: cfg.StandbyAvailabilityZone,
+		CreatedAt:               m.opts.Clock.Now().UTC(),
+		Tags:                    copyTags(cfg.Tags),
 	}
 
 	m.instances.Set(cfg.ID, inst)
@@ -263,6 +265,11 @@ func (m *Mock) ModifyInstance(
 
 	if input.MultiAZ != nil {
 		inst.MultiAZ = *input.MultiAZ
+	}
+
+	if input.HighAvailabilityMode != "" {
+		inst.HighAvailabilityMode = input.HighAvailabilityMode
+		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
 	}
 
 	if input.Tags != nil {

--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -270,6 +270,10 @@ func (m *Mock) ModifyInstance(
 	if input.HighAvailabilityMode != "" {
 		inst.HighAvailabilityMode = input.HighAvailabilityMode
 		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
+		// Disabling HA tears down the standby, so its zone no longer applies.
+		if !inst.MultiAZ {
+			inst.StandbyAvailabilityZone = ""
+		}
 	}
 
 	if input.Tags != nil {

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -9,9 +9,32 @@ import (
 
 // ---- Server lifecycle ----
 
+// rejectInvalidHAMode writes a 400 and returns true when the body carries a
+// highAvailability.mode that is not a recognized enum value — real Azure
+// rejects a bogus mode rather than storing it.
+func rejectInvalidHAMode(w http.ResponseWriter, body *armServer) bool {
+	if body.Properties == nil || body.Properties.HighAvailability == nil {
+		return false
+	}
+
+	mode := body.Properties.HighAvailability.Mode
+	if rdsdriver.ValidHAMode(mode) {
+		return false
+	}
+
+	azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameterValue",
+		"invalid highAvailability.mode: "+mode)
+
+	return true
+}
+
 func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armServer
 	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if rejectInvalidHAMode(w, &body) {
 		return
 	}
 
@@ -60,6 +83,10 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armServer
 	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if rejectInvalidHAMode(w, &body) {
 		return
 	}
 

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -35,6 +35,11 @@ func (h *Handler) createServer(w http.ResponseWriter, r *http.Request, rp *azure
 			cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
 			cfg.StorageType = body.Properties.Storage.StorageSKU
 		}
+
+		if ha := body.Properties.HighAvailability; ha != nil {
+			cfg.HighAvailabilityMode = ha.Mode
+			cfg.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
+		}
 	}
 
 	inst, err := h.db.CreateInstance(r.Context(), cfg)
@@ -71,6 +76,10 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			input.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		}
+
+		if ha := body.Properties.HighAvailability; ha != nil {
+			input.HighAvailabilityMode = ha.Mode
 		}
 	}
 

--- a/server/azure/mysqlflex/sdk_roundtrip_test.go
+++ b/server/azure/mysqlflex/sdk_roundtrip_test.go
@@ -277,3 +277,105 @@ func TestSDKMySQLFlexHighAvailability(t *testing.T) {
 		t.Fatalf("state = %v, want Healthy", ha.State)
 	}
 }
+
+// TestSDKMySQLFlexHighAvailabilityUpdate covers the PATCH path: a server created
+// with HA disabled is switched to ZoneRedundant via BeginUpdate, and disabling
+// it again clears the standby zone.
+func TestSDKMySQLFlexHighAvailabilityUpdate(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	createPoller, err := servers.BeginCreate(ctx, "rg-1", "haupd", armmysqlflexibleservers.Server{
+		Location:   to.Ptr("eastus"),
+		Properties: &armmysqlflexibleservers.ServerProperties{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	// PATCH: enable ZoneRedundant HA.
+	patchPoller, err := servers.BeginUpdate(ctx, "rg-1", "haupd", armmysqlflexibleservers.ServerForUpdate{
+		Properties: &armmysqlflexibleservers.ServerPropertiesForUpdate{
+			HighAvailability: &armmysqlflexibleservers.HighAvailability{
+				Mode:                    to.Ptr(armmysqlflexibleservers.HighAvailabilityModeZoneRedundant),
+				StandbyAvailabilityZone: to.Ptr("3"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate(enable): %v", err)
+	}
+
+	if _, err := patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update(enable) PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "haupd", nil)
+	if err != nil {
+		t.Fatalf("Get after enable: %v", err)
+	}
+
+	if ha := got.Server.Properties.HighAvailability; ha == nil || ha.Mode == nil ||
+		*ha.Mode != armmysqlflexibleservers.HighAvailabilityModeZoneRedundant {
+		t.Fatalf("after PATCH enable: mode = %v, want ZoneRedundant", got.Server.Properties.HighAvailability)
+	}
+
+	// PATCH: disable HA — the standby zone must be cleared.
+	disablePoller, err := servers.BeginUpdate(ctx, "rg-1", "haupd", armmysqlflexibleservers.ServerForUpdate{
+		Properties: &armmysqlflexibleservers.ServerPropertiesForUpdate{
+			HighAvailability: &armmysqlflexibleservers.HighAvailability{
+				Mode: to.Ptr(armmysqlflexibleservers.HighAvailabilityModeDisabled),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate(disable): %v", err)
+	}
+
+	if _, err := disablePoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update(disable) PollUntilDone: %v", err)
+	}
+
+	got, err = servers.Get(ctx, "rg-1", "haupd", nil)
+	if err != nil {
+		t.Fatalf("Get after disable: %v", err)
+	}
+
+	ha := got.Server.Properties.HighAvailability
+	if ha == nil || ha.Mode == nil || *ha.Mode != armmysqlflexibleservers.HighAvailabilityModeDisabled {
+		t.Fatalf("after PATCH disable: mode = %v, want Disabled", ha)
+	}
+
+	if ha.StandbyAvailabilityZone != nil && *ha.StandbyAvailabilityZone != "" {
+		t.Errorf("disabling HA left a stale standbyAvailabilityZone: %v", *ha.StandbyAvailabilityZone)
+	}
+}
+
+// TestSDKMySQLFlexRejectsInvalidHAMode confirms a bogus highAvailability.mode is
+// rejected (real Azure returns 400) rather than stored and echoed.
+func TestSDKMySQLFlexRejectsInvalidHAMode(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	poller, err := servers.BeginCreate(ctx, "rg-1", "bogus", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			HighAvailability: &armmysqlflexibleservers.HighAvailability{
+				Mode: to.Ptr(armmysqlflexibleservers.HighAvailabilityMode("Bogus")),
+			},
+		},
+	}, nil)
+
+	// The error may surface at BeginCreate or when the poller runs.
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("expected an error for invalid highAvailability.mode, got nil")
+	}
+}

--- a/server/azure/mysqlflex/sdk_roundtrip_test.go
+++ b/server/azure/mysqlflex/sdk_roundtrip_test.go
@@ -233,3 +233,47 @@ func TestSDKMySQLFlexStartStopRestart(t *testing.T) {
 		t.Fatalf("expected state Ready after restart, got %v", got.Server.Properties.State)
 	}
 }
+
+func TestSDKMySQLFlexHighAvailability(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	createPoller, err := servers.BeginCreate(ctx, "rg-1", "ha1", armmysqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armmysqlflexibleservers.ServerProperties{
+			HighAvailability: &armmysqlflexibleservers.HighAvailability{
+				Mode:                    to.Ptr(armmysqlflexibleservers.HighAvailabilityModeZoneRedundant),
+				StandbyAvailabilityZone: to.Ptr("2"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "ha1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	ha := got.Server.Properties.HighAvailability
+	if ha == nil || ha.Mode == nil {
+		t.Fatal("expected highAvailability to round-trip, got nil")
+	}
+
+	if *ha.Mode != armmysqlflexibleservers.HighAvailabilityModeZoneRedundant {
+		t.Fatalf("mode = %v, want ZoneRedundant", *ha.Mode)
+	}
+
+	if ha.StandbyAvailabilityZone == nil || *ha.StandbyAvailabilityZone != "2" {
+		t.Fatalf("standbyAvailabilityZone = %v, want 2", ha.StandbyAvailabilityZone)
+	}
+
+	if ha.State == nil || *ha.State != armmysqlflexibleservers.HighAvailabilityStateHealthy {
+		t.Fatalf("state = %v, want Healthy", ha.State)
+	}
+}

--- a/server/azure/mysqlflex/types.go
+++ b/server/azure/mysqlflex/types.go
@@ -32,13 +32,23 @@ type armSKU struct {
 }
 
 type armServerProps struct {
-	AdministratorLogin         string      `json:"administratorLogin,omitempty"`
-	AdministratorLoginPassword string      `json:"administratorLoginPassword,omitempty"`
-	Version                    string      `json:"version,omitempty"`
-	State                      string      `json:"state,omitempty"`
-	FullyQualifiedDomainName   string      `json:"fullyQualifiedDomainName,omitempty"`
-	Storage                    *armStorage `json:"storage,omitempty"`
-	AvailabilityZone           string      `json:"availabilityZone,omitempty"`
+	AdministratorLogin         string               `json:"administratorLogin,omitempty"`
+	AdministratorLoginPassword string               `json:"administratorLoginPassword,omitempty"`
+	Version                    string               `json:"version,omitempty"`
+	State                      string               `json:"state,omitempty"`
+	FullyQualifiedDomainName   string               `json:"fullyQualifiedDomainName,omitempty"`
+	Storage                    *armStorage          `json:"storage,omitempty"`
+	AvailabilityZone           string               `json:"availabilityZone,omitempty"`
+	HighAvailability           *armHighAvailability `json:"highAvailability,omitempty"`
+}
+
+// armHighAvailability mirrors properties.highAvailability on a MySQL Flexible
+// Server. Mode is Disabled/SameZone/ZoneRedundant; State is computed by the
+// service (Healthy when a standby is running, NotEnabled otherwise).
+type armHighAvailability struct {
+	Mode                    string `json:"mode,omitempty"`
+	StandbyAvailabilityZone string `json:"standbyAvailabilityZone,omitempty"`
+	State                   string `json:"state,omitempty"`
 }
 
 type armStorage struct {
@@ -71,11 +81,34 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 			State:                    serverState(inst.State),
 			FullyQualifiedDomainName: inst.Endpoint,
 			AvailabilityZone:         inst.AvailabilityZone,
+			HighAvailability:         highAvailability(inst),
 			Storage: &armStorage{
 				StorageSizeGB: inst.AllocatedStorage,
 				StorageSKU:    inst.StorageType,
 			},
 		},
+	}
+}
+
+// highAvailability renders the server's HA configuration for an ARM response.
+// The mode defaults to Disabled so GET always reports HA faithfully; State is
+// Healthy while a standby is active (the mock provisions synchronously) and
+// NotEnabled otherwise.
+func highAvailability(inst *rdsdriver.Instance) *armHighAvailability {
+	mode := inst.HighAvailabilityMode
+	if mode == "" {
+		mode = rdsdriver.HAModeDisabled
+	}
+
+	state := "NotEnabled"
+	if rdsdriver.HAEnabled(mode) {
+		state = "Healthy"
+	}
+
+	return &armHighAvailability{
+		Mode:                    mode,
+		StandbyAvailabilityZone: inst.StandbyAvailabilityZone,
+		State:                   state,
 	}
 }
 

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -28,6 +28,11 @@ func instanceFromBody(body *armServer) rdsdriver.InstanceConfig {
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			cfg.AllocatedStorage = body.Properties.Storage.StorageSizeGB
 		}
+
+		if ha := body.Properties.HighAvailability; ha != nil {
+			cfg.HighAvailabilityMode = ha.Mode
+			cfg.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
+		}
 	}
 
 	return cfg

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -7,6 +7,25 @@ import (
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
+// rejectInvalidHAMode writes a 400 and returns true when the body carries a
+// highAvailability.mode that is not a recognized enum value — real Azure
+// rejects a bogus mode rather than storing it.
+func rejectInvalidHAMode(w http.ResponseWriter, body *armServer) bool {
+	if body.Properties == nil || body.Properties.HighAvailability == nil {
+		return false
+	}
+
+	mode := body.Properties.HighAvailability.Mode
+	if rdsdriver.ValidHAMode(mode) {
+		return false
+	}
+
+	azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameterValue",
+		"invalid highAvailability.mode: "+mode)
+
+	return true
+}
+
 // instanceFromBody decodes a Postgres Flex create/update body and converts it
 // to the portable driver shape.
 func instanceFromBody(body *armServer) rdsdriver.InstanceConfig {
@@ -41,6 +60,10 @@ func instanceFromBody(body *armServer) rdsdriver.InstanceConfig {
 func (h *Handler) createOrUpdateServer(w http.ResponseWriter, r *http.Request, rp *azurearm.ResourcePath) {
 	var body armServer
 	if !azurearm.DecodeJSON(w, r, &body) {
+		return
+	}
+
+	if rejectInvalidHAMode(w, &body) {
 		return
 	}
 
@@ -94,6 +117,10 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 		return
 	}
 
+	if rejectInvalidHAMode(w, &body) {
+		return
+	}
+
 	input := rdsdriver.ModifyInstanceInput{
 		Tags: body.Tags,
 	}
@@ -107,6 +134,10 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 
 		if body.Properties.Storage != nil && body.Properties.Storage.StorageSizeGB > 0 {
 			input.AllocatedStorage = body.Properties.Storage.StorageSizeGB
+		}
+
+		if ha := body.Properties.HighAvailability; ha != nil {
+			input.HighAvailabilityMode = ha.Mode
 		}
 	}
 

--- a/server/azure/postgresflex/sdk_roundtrip_test.go
+++ b/server/azure/postgresflex/sdk_roundtrip_test.go
@@ -278,3 +278,79 @@ func TestSDKPostgresFlexHighAvailability(t *testing.T) {
 		t.Fatalf("standbyAvailabilityZone = %v, want 2", ha.StandbyAvailabilityZone)
 	}
 }
+
+// TestSDKPostgresFlexHighAvailabilityUpdate covers the PATCH path — the case
+// that previously silently dropped highAvailability on PostgreSQL. A server
+// created with HA disabled is switched to ZoneRedundant via BeginUpdate, then
+// disabled again, clearing the standby zone.
+func TestSDKPostgresFlexHighAvailabilityUpdate(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	createPoller, err := servers.BeginCreate(ctx, "rg-1", "haupd", armpostgresqlflexibleservers.Server{
+		Location:   to.Ptr("eastus"),
+		Properties: &armpostgresqlflexibleservers.ServerProperties{},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	patchPoller, err := servers.BeginUpdate(ctx, "rg-1", "haupd", armpostgresqlflexibleservers.ServerForUpdate{
+		Properties: &armpostgresqlflexibleservers.ServerPropertiesForUpdate{
+			HighAvailability: &armpostgresqlflexibleservers.HighAvailability{
+				Mode:                    to.Ptr(armpostgresqlflexibleservers.HighAvailabilityModeZoneRedundant),
+				StandbyAvailabilityZone: to.Ptr("3"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate(enable): %v", err)
+	}
+
+	if _, err := patchPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update(enable) PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "haupd", nil)
+	if err != nil {
+		t.Fatalf("Get after enable: %v", err)
+	}
+
+	if ha := got.Server.Properties.HighAvailability; ha == nil || ha.Mode == nil ||
+		*ha.Mode != armpostgresqlflexibleservers.HighAvailabilityModeZoneRedundant {
+		t.Fatalf("after PATCH enable: mode = %v, want ZoneRedundant", got.Server.Properties.HighAvailability)
+	}
+
+	disablePoller, err := servers.BeginUpdate(ctx, "rg-1", "haupd", armpostgresqlflexibleservers.ServerForUpdate{
+		Properties: &armpostgresqlflexibleservers.ServerPropertiesForUpdate{
+			HighAvailability: &armpostgresqlflexibleservers.HighAvailability{
+				Mode: to.Ptr(armpostgresqlflexibleservers.HighAvailabilityModeDisabled),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginUpdate(disable): %v", err)
+	}
+
+	if _, err := disablePoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Update(disable) PollUntilDone: %v", err)
+	}
+
+	got, err = servers.Get(ctx, "rg-1", "haupd", nil)
+	if err != nil {
+		t.Fatalf("Get after disable: %v", err)
+	}
+
+	ha := got.Server.Properties.HighAvailability
+	if ha == nil || ha.Mode == nil || *ha.Mode != armpostgresqlflexibleservers.HighAvailabilityModeDisabled {
+		t.Fatalf("after PATCH disable: mode = %v, want Disabled", ha)
+	}
+
+	if ha.StandbyAvailabilityZone != nil && *ha.StandbyAvailabilityZone != "" {
+		t.Errorf("disabling HA left a stale standbyAvailabilityZone: %v", *ha.StandbyAvailabilityZone)
+	}
+}

--- a/server/azure/postgresflex/sdk_roundtrip_test.go
+++ b/server/azure/postgresflex/sdk_roundtrip_test.go
@@ -238,3 +238,43 @@ func TestSDKPostgresFlexUpdateAndLifecycle(t *testing.T) {
 		t.Fatalf("expected state Ready after restart, got %v", got.Server.Properties.State)
 	}
 }
+
+func TestSDKPostgresFlexHighAvailability(t *testing.T) {
+	servers := newSDKClient(t)
+	ctx := context.Background()
+
+	createPoller, err := servers.BeginCreate(ctx, "rg-1", "ha1", armpostgresqlflexibleservers.Server{
+		Location: to.Ptr("eastus"),
+		Properties: &armpostgresqlflexibleservers.ServerProperties{
+			HighAvailability: &armpostgresqlflexibleservers.HighAvailability{
+				Mode:                    to.Ptr(armpostgresqlflexibleservers.HighAvailabilityModeZoneRedundant),
+				StandbyAvailabilityZone: to.Ptr("2"),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := createPoller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("Create PollUntilDone: %v", err)
+	}
+
+	got, err := servers.Get(ctx, "rg-1", "ha1", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	ha := got.Server.Properties.HighAvailability
+	if ha == nil || ha.Mode == nil {
+		t.Fatal("expected highAvailability to round-trip, got nil")
+	}
+
+	if *ha.Mode != armpostgresqlflexibleservers.HighAvailabilityModeZoneRedundant {
+		t.Fatalf("mode = %v, want ZoneRedundant", *ha.Mode)
+	}
+
+	if ha.StandbyAvailabilityZone == nil || *ha.StandbyAvailabilityZone != "2" {
+		t.Fatalf("standbyAvailabilityZone = %v, want 2", ha.StandbyAvailabilityZone)
+	}
+}

--- a/server/azure/postgresflex/types.go
+++ b/server/azure/postgresflex/types.go
@@ -35,15 +35,25 @@ type armSKU struct {
 }
 
 type armServerProps struct {
-	AdministratorLogin         string      `json:"administratorLogin,omitempty"`
-	AdministratorLoginPassword string      `json:"administratorLoginPassword,omitempty"`
-	Version                    string      `json:"version,omitempty"`
-	State                      string      `json:"state,omitempty"`
-	FullyQualifiedDomainName   string      `json:"fullyQualifiedDomainName,omitempty"`
-	Storage                    *armStorage `json:"storage,omitempty"`
-	AvailabilityZone           string      `json:"availabilityZone,omitempty"`
-	CreateMode                 string      `json:"createMode,omitempty"`
-	SourceServerResourceID     string      `json:"sourceServerResourceId,omitempty"`
+	AdministratorLogin         string               `json:"administratorLogin,omitempty"`
+	AdministratorLoginPassword string               `json:"administratorLoginPassword,omitempty"`
+	Version                    string               `json:"version,omitempty"`
+	State                      string               `json:"state,omitempty"`
+	FullyQualifiedDomainName   string               `json:"fullyQualifiedDomainName,omitempty"`
+	Storage                    *armStorage          `json:"storage,omitempty"`
+	AvailabilityZone           string               `json:"availabilityZone,omitempty"`
+	HighAvailability           *armHighAvailability `json:"highAvailability,omitempty"`
+	CreateMode                 string               `json:"createMode,omitempty"`
+	SourceServerResourceID     string               `json:"sourceServerResourceId,omitempty"`
+}
+
+// armHighAvailability mirrors properties.highAvailability on a PostgreSQL
+// Flexible Server. Mode is Disabled/SameZone/ZoneRedundant; State is computed
+// by the service (Healthy when a standby is running, NotEnabled otherwise).
+type armHighAvailability struct {
+	Mode                    string `json:"mode,omitempty"`
+	StandbyAvailabilityZone string `json:"standbyAvailabilityZone,omitempty"`
+	State                   string `json:"state,omitempty"`
 }
 
 type armStorage struct {
@@ -64,6 +74,7 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 		State:                    serverState(inst.State),
 		FullyQualifiedDomainName: inst.Endpoint,
 		AvailabilityZone:         inst.AvailabilityZone,
+		HighAvailability:         highAvailability(inst),
 	}
 
 	if inst.AllocatedStorage > 0 {
@@ -80,6 +91,28 @@ func toARMServer(inst *rdsdriver.Instance, subscription, resourceGroup string) a
 			Name: inst.InstanceClass,
 		},
 		Properties: props,
+	}
+}
+
+// highAvailability renders the server's HA configuration for an ARM response.
+// The mode defaults to Disabled so GET always reports HA faithfully; State is
+// Healthy while a standby is active (the mock provisions synchronously) and
+// NotEnabled otherwise.
+func highAvailability(inst *rdsdriver.Instance) *armHighAvailability {
+	mode := inst.HighAvailabilityMode
+	if mode == "" {
+		mode = rdsdriver.HAModeDisabled
+	}
+
+	state := "NotEnabled"
+	if rdsdriver.HAEnabled(mode) {
+		state = "Healthy"
+	}
+
+	return &armHighAvailability{
+		Mode:                    mode,
+		StandbyAvailabilityZone: inst.StandbyAvailabilityZone,
+		State:                   state,
 	}
 }
 

--- a/server/azure/resourcegraph/arg_cost_fields_test.go
+++ b/server/azure/resourcegraph/arg_cost_fields_test.go
@@ -280,6 +280,29 @@ func TestARGCostFields_MySQLFlex(t *testing.T) {
 	assert.Equal(t, "ZoneRedundant", rowObj(t, props, "highAvailability")["mode"])
 }
 
+// TestARGCostFields_MySQLFlex_ExplicitHAMode pins the HA fidelity that MultiAZ
+// alone cannot express: an explicit SameZone mode (distinct from ZoneRedundant)
+// and the standby zone must survive into the ARG projection verbatim.
+func TestARGCostFields_MySQLFlex_ExplicitHAMode(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.MySQLFlex.CreateInstance(ctx, rdsdriver.InstanceConfig{
+		ID:                      "mysql-ha",
+		InstanceClass:           "Standard_D2ds_v4",
+		HighAvailabilityMode:    rdsdriver.HAModeSameZone,
+		StandbyAvailabilityZone: "3",
+	})
+	require.NoError(t, err)
+
+	client := argCostClient(t, cloudP)
+
+	row := queryOne(t, client, "microsoft.dbformysql/flexibleservers")
+	ha := rowObj(t, rowProps(t, row), "highAvailability")
+	assert.Equal(t, "SameZone", ha["mode"])
+	assert.Equal(t, "3", ha["standbyAvailabilityZone"])
+}
+
 // TestARGCostFields_PostgresFlex mirrors TestARGCostFields_MySQLFlex for the
 // PostgreSQL Flexible Server family: both flavors share the same
 // appendFlexServers discovery path, so the derived tier, engine version,

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -46,6 +46,19 @@ func HAEnabled(mode string) bool {
 	return mode == HAModeSameZone || mode == HAModeZoneRedundant
 }
 
+// ValidHAMode reports whether mode is an accepted highAvailability.mode value.
+// The empty string is valid — it means "not specified" (no HA change on an
+// update, HA disabled on a create). Any other non-enum value is rejected, so a
+// caller sending a bogus mode gets the same 400 real Azure returns.
+func ValidHAMode(mode string) bool {
+	switch mode {
+	case "", HAModeDisabled, HAModeSameZone, HAModeZoneRedundant:
+		return true
+	default:
+		return false
+	}
+}
+
 // InstanceConfig configures a managed database instance.
 type InstanceConfig struct {
 	ID                   string

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -31,6 +31,21 @@ const (
 	SnapshotAvailable = "available"
 )
 
+// Azure Flexible Server high-availability modes. These map directly onto the
+// Azure MySQL/PostgreSQL Flexible Server properties.highAvailability.mode enum.
+const (
+	HAModeDisabled      = "Disabled"
+	HAModeSameZone      = "SameZone"
+	HAModeZoneRedundant = "ZoneRedundant"
+)
+
+// HAEnabled reports whether an HA mode designates an active standby replica
+// (SameZone or ZoneRedundant). It is the single source of truth for deriving
+// MultiAZ and the HA (2x) cost signal from a mode string.
+func HAEnabled(mode string) bool {
+	return mode == HAModeSameZone || mode == HAModeZoneRedundant
+}
+
 // InstanceConfig configures a managed database instance.
 type InstanceConfig struct {
 	ID                   string
@@ -51,6 +66,12 @@ type InstanceConfig struct {
 	OptionGroupName      string
 	ClusterID            string // empty for standalone, set for Aurora cluster members
 	AvailabilityZone     string
+	// HighAvailabilityMode is the Azure Flexible Server HA mode
+	// ("Disabled"/"SameZone"/"ZoneRedundant"); empty for engines with no such
+	// concept. StandbyAvailabilityZone is the zone the standby replica runs in
+	// when HA is enabled. Both drive the HA (2x) cost a discoverer prices on.
+	HighAvailabilityMode    string
+	StandbyAvailabilityZone string
 	// ElasticPoolID is the Azure SQL elastic pool a database belongs to (the
 	// pool's ARM resource ID); empty for standalone databases and non-Azure
 	// engines.
@@ -84,9 +105,13 @@ type Instance struct {
 	OptionGroupName      string
 	ClusterID            string
 	AvailabilityZone     string
-	ElasticPoolID        string
-	CreatedAt            time.Time
-	Tags                 map[string]string
+	// HighAvailabilityMode / StandbyAvailabilityZone echo the Azure Flexible
+	// Server HA configuration on read; empty for engines with no HA concept.
+	HighAvailabilityMode    string
+	StandbyAvailabilityZone string
+	ElasticPoolID           string
+	CreatedAt               time.Time
+	Tags                    map[string]string
 	// ReadReplicaSource is the identifier of the primary this instance
 	// replicates from; empty for a primary. ReadReplicaTargets lists the
 	// replica identifiers reading from this instance.
@@ -108,7 +133,10 @@ type ModifyInstanceInput struct {
 	OptionGroupName             string
 	DBClusterParameterGroupName string
 	ElasticPoolID               string
-	Tags                        map[string]string
+	// HighAvailabilityMode updates the Azure Flexible Server HA mode
+	// ("Disabled"/"SameZone"/"ZoneRedundant"); empty means "no change".
+	HighAvailabilityMode string
+	Tags                 map[string]string
 }
 
 // ClusterConfig configures an Aurora-style cluster. Members are added by


### PR DESCRIPTION
## Summary

Fixes issue #409 (item #2). Azure MySQL/PostgreSQL Flexible Server PUTs that include `properties.highAvailability` were accepted with a 200 but the field was silently dropped — HA configuration (which drives the HA 2× cost a discovery/cost tool prices on) could not be represented.

## What changed

- **relationaldb driver**: added `HighAvailabilityMode` + `StandbyAvailabilityZone` to `InstanceConfig`/`Instance` and `HighAvailabilityMode` to `ModifyInstanceInput`, plus `HAMode*` constants and an `HAEnabled(mode)` helper (single source of truth for deriving `MultiAZ`).
- **mysqlflex / postgresflex mocks**: store and echo the HA fields; `MultiAZ` is derived from the mode so existing consumers stay consistent.
- **ARM wire (mysqlflex + postgresflex)**: added the `highAvailability{mode,standbyAvailabilityZone,state}` shape; map it in on create/update and echo it on GET. `state` is computed (`Healthy` when a standby is active, `NotEnabled` otherwise).
- **Resource Graph projection**: surfaces the recorded mode verbatim — so `SameZone` is now representable, not just `Disabled`/`ZoneRedundant` derived from `MultiAZ`.

## Tests

- SDK round-trip HA tests for both MySQL and PostgreSQL Flexible Server (`armmysqlflexibleservers` / `armpostgresqlflexibleservers`).
- ARG cost-field test asserting an explicit `SameZone` mode + standby zone reach the Resource Graph projection.
- `go build`, `go vet`, `gofmt`, full `go test ./...`, and `go generate` (no doc diff) all pass.