### PR TITLE
fix(azure): carry VM location and resource group into Resource Graph

### DIFF
--- a/features/chaos/wrappers_test.go
+++ b/features/chaos/wrappers_test.go
@@ -425,6 +425,8 @@ type computeConfigCompat = struct {
 	Priority       string
 	LicenseType    string
 	Zones          []string
+	Region         string
+	ResourceGroup  string
 }
 
 // computeInstanceConfig reproduces the helper used elsewhere in the package

--- a/providers/azure/virtualmachines/vm.go
+++ b/providers/azure/virtualmachines/vm.go
@@ -79,6 +79,8 @@ type instanceData struct {
 	Priority       string
 	LicenseType    string
 	Zones          []string
+	Region         string
+	ResourceGroup  string
 }
 
 type asgData struct {
@@ -203,7 +205,8 @@ func toInstance(d *instanceData) driver.Instance {
 		PrivateIP: d.PrivateIP, PublicIP: d.PublicIP, SubnetID: d.SubnetID, VPCID: d.VPCID,
 		SecurityGroups: sg, Tags: tags, LaunchTime: d.LaunchTime,
 		OSType: d.OSType, Priority: d.Priority, LicenseType: d.LicenseType,
-		Zones: append([]string(nil), d.Zones...),
+		Zones:  append([]string(nil), d.Zones...),
+		Region: d.Region, ResourceGroup: d.ResourceGroup,
 	}
 }
 
@@ -242,11 +245,13 @@ func (m *Mock) RunInstances(ctx context.Context, cfg driver.InstanceConfig, coun
 			ID: id, ImageID: cfg.ImageID, InstanceType: cfg.InstanceType,
 			State: compute.StatePending, PrivateIP: m.nextIP(), SubnetID: cfg.SubnetID,
 			SecurityGroups: sg, Tags: tags,
-			LaunchTime:  m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
-			OSType:      cfg.OSType,
-			Priority:    cfg.Priority,
-			LicenseType: cfg.LicenseType,
-			Zones:       zones,
+			LaunchTime:    m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05Z"),
+			OSType:        cfg.OSType,
+			Priority:      cfg.Priority,
+			LicenseType:   cfg.LicenseType,
+			Zones:         zones,
+			Region:        cfg.Region,
+			ResourceGroup: cfg.ResourceGroup,
 		}
 		m.instances.Set(id, inst)
 		m.sm.SetState(id, compute.StatePending)

--- a/server/azure/resourcegraph/arg_cost_fields_test.go
+++ b/server/azure/resourcegraph/arg_cost_fields_test.go
@@ -253,6 +253,28 @@ func TestARGCostFields_ManagedInstance(t *testing.T) {
 // TestARGCostFields_MySQLFlex proves the MySQL Flexible Server projects its
 // compute SKU (with a derived Burstable tier), engine version, storage size and
 // HA mode through the same generic sku/properties slots.
+// TestARGVMLocationResourceGroup pins the fidelity fix for issue #409 item #1:
+// a VM created with an explicit region and resource group must surface both in
+// the ARG row (and in the resource id) rather than falling back to the engine
+// default region and a "default" resource group.
+func TestARGVMLocationResourceGroup(t *testing.T) {
+	ctx := context.Background()
+	cloudP := cloudemu.NewAzure()
+
+	_, err := cloudP.VirtualMachines.RunInstances(ctx, computedriver.InstanceConfig{
+		InstanceType:  "Standard_D2s_v5",
+		Region:        "westeurope",
+		ResourceGroup: "rg-prod",
+	}, 1)
+	require.NoError(t, err)
+
+	row := queryOne(t, argCostClient(t, cloudP), "microsoft.compute/virtualmachines")
+
+	assert.Equal(t, "westeurope", row["location"])
+	assert.Equal(t, "rg-prod", row["resourceGroup"])
+	assert.Contains(t, row["id"], "/resourceGroups/rg-prod/")
+}
+
 func TestARGCostFields_MySQLFlex(t *testing.T) {
 	ctx := context.Background()
 	cloudP := cloudemu.NewAzure()

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -41,15 +41,17 @@ func (h *Handler) createOrUpdate(w http.ResponseWriter, r *http.Request, rp azur
 	}
 
 	cfg := computedriver.InstanceConfig{
-		ImageID:      imageRefToID(req.Properties.StorageProfile),
-		InstanceType: hardwareSize(req.Properties.HardwareProfile),
-		SubnetID:     firstNicID(req.Properties.NetworkProfile),
-		KeyName:      computerName(req.Properties.OSProfile),
-		Tags:         mergeTags(req.Tags, rp.ResourceName),
-		Priority:     req.Properties.Priority,
-		LicenseType:  req.Properties.LicenseType,
-		OSType:       osTypeFromStorage(req.Properties.StorageProfile),
-		Zones:        req.Zones,
+		ImageID:       imageRefToID(req.Properties.StorageProfile),
+		InstanceType:  hardwareSize(req.Properties.HardwareProfile),
+		SubnetID:      firstNicID(req.Properties.NetworkProfile),
+		KeyName:       computerName(req.Properties.OSProfile),
+		Tags:          mergeTags(req.Tags, rp.ResourceName),
+		Priority:      req.Properties.Priority,
+		LicenseType:   req.Properties.LicenseType,
+		OSType:        osTypeFromStorage(req.Properties.StorageProfile),
+		Zones:         req.Zones,
+		Region:        req.Location,
+		ResourceGroup: rp.ResourceGroup,
 	}
 
 	instances, err := h.compute.RunInstances(r.Context(), cfg, 1)

--- a/server/azure/virtualmachines/instances.go
+++ b/server/azure/virtualmachines/instances.go
@@ -279,10 +279,13 @@ func toVMResponse(inst *computedriver.Instance, rp azurearm.ResourcePath, req vm
 	name := tagOr(inst.Tags, armNameTag, rp.ResourceName)
 
 	return vmResponse{
-		ID:       azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
-		Name:     name,
-		Type:     providerName + "/" + resourceType,
-		Location: defaultIfEmpty(req.Location, "eastus"),
+		ID:   azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, providerName, resourceType, name),
+		Name: name,
+		Type: providerName + "/" + resourceType,
+		// Prefer the instance's recorded region so GET/LIST report where the VM
+		// was actually created; the request location (create path) and the
+		// "eastus" default are fallbacks for instances that carry no region.
+		Location: defaultIfEmpty(inst.Region, defaultIfEmpty(req.Location, "eastus")),
 		Tags:     stripInternalTags(inst.Tags),
 		Zones:    inst.Zones,
 		Properties: vmResponseProps{

--- a/server/azure/virtualmachines/sdk_roundtrip_test.go
+++ b/server/azure/virtualmachines/sdk_roundtrip_test.go
@@ -247,4 +247,15 @@ func TestSDKVMRecordsLocationAndResourceGroup(t *testing.T) {
 	if insts[0].ResourceGroup != "rg-prod" {
 		t.Errorf("ResourceGroup=%q, want rg-prod", insts[0].ResourceGroup)
 	}
+
+	// The ARM read path (GET) must report the created region, not the "eastus"
+	// default — this is what an `az vm show` / armcompute Get client reads.
+	got, err := client.Get(ctx, "rg-prod", "vm-loc", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Location == nil || *got.Location != "westeurope" {
+		t.Errorf("Get location=%v, want westeurope", got.Location)
+	}
 }

--- a/server/azure/virtualmachines/sdk_roundtrip_test.go
+++ b/server/azure/virtualmachines/sdk_roundtrip_test.go
@@ -199,3 +199,52 @@ func pollUntilDone(ctx context.Context,
 
 	return resp.VirtualMachine, nil
 }
+
+// TestSDKVMRecordsLocationAndResourceGroup verifies the ARM create path carries
+// the request's location and resource group onto the compute driver instance,
+// so cross-service discovery (Resource Graph) can report where the VM actually
+// lives instead of the emulator defaults (issue #409 item #1).
+func TestSDKVMRecordsLocationAndResourceGroup(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{VirtualMachines: cloudP.VirtualMachines})
+
+	ts := httptest.NewTLSServer(srv)
+	t.Cleanup(ts.Close)
+
+	client := newSDKClient(t, ts)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreateOrUpdate(ctx, "rg-prod", "vm-loc",
+		armcompute.VirtualMachine{
+			Location: to.Ptr("westeurope"),
+			Properties: &armcompute.VirtualMachineProperties{
+				HardwareProfile: &armcompute.HardwareProfile{
+					VMSize: to.Ptr(armcompute.VirtualMachineSizeTypesStandardD2SV3),
+				},
+			},
+		}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreateOrUpdate: %v", err)
+	}
+
+	if _, err := pollUntilDone(ctx, poller); err != nil {
+		t.Fatalf("CreateOrUpdate poll: %v", err)
+	}
+
+	insts, err := cloudP.VirtualMachines.DescribeInstances(ctx, nil, nil)
+	if err != nil {
+		t.Fatalf("DescribeInstances: %v", err)
+	}
+
+	if len(insts) != 1 {
+		t.Fatalf("got %d instances, want 1", len(insts))
+	}
+
+	if insts[0].Region != "westeurope" {
+		t.Errorf("Region=%q, want westeurope", insts[0].Region)
+	}
+
+	if insts[0].ResourceGroup != "rg-prod" {
+		t.Errorf("ResourceGroup=%q, want rg-prod", insts[0].ResourceGroup)
+	}
+}

--- a/services/compute/driver/driver.go
+++ b/services/compute/driver/driver.go
@@ -24,6 +24,14 @@ type InstanceConfig struct {
 	Priority    string
 	LicenseType string
 	Zones       []string
+	// Region is the location the instance is launched in (Azure location, e.g.
+	// "eastus"); empty falls back to the emulator's default region. ResourceGroup
+	// is the Azure resource group the instance belongs to; empty for providers
+	// with no such concept. Both are carried through so cross-service discovery
+	// (Resource Graph) reports the instance's real location and resource group
+	// rather than the emulator defaults.
+	Region        string
+	ResourceGroup string
 }
 
 // Instance describes a running virtual machine.
@@ -49,6 +57,10 @@ type Instance struct {
 	LicenseType string
 	// Zones are the availability zones the instance occupies, when known.
 	Zones []string
+	// Region / ResourceGroup echo where the instance lives (Azure location and
+	// resource group), when known; empty falls back to the emulator defaults.
+	Region        string
+	ResourceGroup string
 	// Operator carries service-provider managed-resource metadata. It is nil
 	// for ordinary (unmanaged) instances.
 	Operator *OperatorInfo

--- a/services/resourcediscovery/arn.go
+++ b/services/resourcediscovery/arn.go
@@ -27,12 +27,17 @@ const (
 	netKindRouteTable    = "route-table"
 )
 
-func (e *Engine) computeInstanceARN(id string) string {
+// computeInstanceARN builds the canonical identifier for a compute instance.
+// resourceGroup is the Azure resource group the instance belongs to; empty
+// falls back to the default group (and it is ignored by the AWS/GCP branches,
+// which have no such concept).
+func (e *Engine) computeInstanceARN(id, resourceGroup string) string {
 	switch e.provider {
 	case ProviderAWS:
 		return idgen.AWSARN("ec2", e.region, e.accountID, "instance/"+id)
 	case ProviderAzure:
-		return idgen.AzureID(e.accountID, azureDefaultResourceGroup, "Microsoft.Compute", "virtualMachines", id)
+		return idgen.AzureID(e.accountID, azureResourceGroupOrDefault(resourceGroup),
+			"Microsoft.Compute", "virtualMachines", id)
 	case ProviderGCP:
 		return id
 	default:

--- a/services/resourcediscovery/engine_test.go
+++ b/services/resourcediscovery/engine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stackshy/cloudemu/v2/providers/aws/sns"
 	"github.com/stackshy/cloudemu/v2/providers/aws/sqs"
 	"github.com/stackshy/cloudemu/v2/providers/aws/vpc"
+	azurevm "github.com/stackshy/cloudemu/v2/providers/azure/virtualmachines"
 	computedriver "github.com/stackshy/cloudemu/v2/services/compute/driver"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
 	mqdriver "github.com/stackshy/cloudemu/v2/services/messagequeue/driver"
@@ -460,4 +461,45 @@ func TestWalkerErrorPropagation(t *testing.T) {
 		assert.ErrorIs(t, err, sentinel)
 		assert.Contains(t, err.Error(), `"bkt"`)
 	})
+}
+
+// TestVolumeManagedByUsesInstanceResourceGroup verifies an attached volume's
+// managedBy back-reference is built with the owning VM's real resource group,
+// so it matches the RG-aware id the VM itself carries (an ARM-created Azure VM
+// records its resource group; the disk must point at the same id, not a
+// "default" one that would not exist in the inventory).
+func TestVolumeManagedByUsesInstanceResourceGroup(t *testing.T) {
+	ctx := context.Background()
+	fc := config.NewFakeClock(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	vm := azurevm.New(config.NewOptions(config.WithClock(fc), config.WithAccountID("sub-1")))
+
+	insts, err := vm.RunInstances(ctx, computedriver.InstanceConfig{
+		InstanceType: "Standard_D2s_v3", ResourceGroup: "rg-app", Region: "westeurope",
+	}, 1)
+	require.NoError(t, err)
+	require.Len(t, insts, 1)
+
+	vol, err := vm.CreateVolume(ctx, computedriver.VolumeConfig{Size: 32})
+	require.NoError(t, err)
+	require.NoError(t, vm.AttachVolume(ctx, vol.ID, insts[0].ID, "/dev/sdb"))
+
+	engine := New(ProviderAzure, "sub-1", "westeurope", &Drivers{Compute: vm})
+
+	out, err := engine.ListAll(ctx)
+	require.NoError(t, err)
+
+	var vmARN, volManagedBy string
+	for i := range out {
+		switch out[i].Type {
+		case TypeInstance:
+			vmARN = out[i].ARN
+		case TypeVolume:
+			volManagedBy = out[i].ManagedBy
+		}
+	}
+
+	require.NotEmpty(t, vmARN)
+	require.NotEmpty(t, volManagedBy)
+	assert.Contains(t, vmARN, "/resourceGroups/rg-app/")
+	assert.Equal(t, vmARN, volManagedBy, "volume managedBy must match the owning VM's id")
 }

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -137,13 +137,22 @@ func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
 			props["storageProfile"] = map[string]any{"osDisk": map[string]any{"osType": inst.OSType}}
 		}
 
+		// Prefer the instance's own location/resource group (recorded by the ARM
+		// create path) so ARG reports where the resource actually lives; fall
+		// back to the engine default region for portable-API creations that
+		// carry neither.
+		region := inst.Region
+		if region == "" {
+			region = e.region
+		}
+
 		out = append(out, Resource{
 			Provider:   e.provider,
 			Service:    ServiceCompute,
 			Type:       TypeInstance,
 			ID:         inst.ID,
-			ARN:        e.computeInstanceARN(inst.ID),
-			Region:     e.region,
+			ARN:        e.computeInstanceARN(inst.ID, inst.ResourceGroup),
+			Region:     region,
 			Tags:       copyTags(inst.Tags),
 			SKU:        inst.InstanceType,
 			Zones:      cloneStrings(inst.Zones),
@@ -202,7 +211,7 @@ func (e *Engine) walkVolumes(ctx context.Context) ([]Resource, error) {
 
 		managedBy := ""
 		if v.AttachedTo != "" {
-			managedBy = e.computeInstanceARN(v.AttachedTo)
+			managedBy = e.computeInstanceARN(v.AttachedTo, "")
 		}
 
 		out = append(out, Resource{

--- a/services/resourcediscovery/walkers.go
+++ b/services/resourcediscovery/walkers.go
@@ -124,6 +124,14 @@ func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
 
 	out := make([]Resource, 0, len(instances))
 
+	// Map each instance to its resource group so an attached volume's managedBy
+	// back-reference resolves to the same id the VM carries (both RG-aware),
+	// instead of a "default" id that would not exist in the inventory.
+	rgByInstance := make(map[string]string, len(instances))
+	for i := range instances {
+		rgByInstance[instances[i].ID] = instances[i].ResourceGroup
+	}
+
 	for i := range instances {
 		inst := &instances[i]
 
@@ -160,7 +168,7 @@ func (e *Engine) walkCompute(ctx context.Context) ([]Resource, error) {
 		})
 	}
 
-	vols, err := e.walkVolumes(ctx)
+	vols, err := e.walkVolumes(ctx, rgByInstance)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +200,7 @@ func (e *Engine) walkSnapshots(ctx context.Context) ([]Resource, error) {
 // walkVolumes surfaces block volumes (EBS / Azure managed disks / GCE PDs) as
 // first-class resources, so a discoverer sees them the way the real cloud APIs
 // do. ManagedBy links the volume to its owning instance.
-func (e *Engine) walkVolumes(ctx context.Context) ([]Resource, error) {
+func (e *Engine) walkVolumes(ctx context.Context, rgByInstance map[string]string) ([]Resource, error) {
 	vols, err := e.drivers.Compute.DescribeVolumes(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("walkCompute volumes: %w", err)
@@ -211,7 +219,7 @@ func (e *Engine) walkVolumes(ctx context.Context) ([]Resource, error) {
 
 		managedBy := ""
 		if v.AttachedTo != "" {
-			managedBy = e.computeInstanceARN(v.AttachedTo, "")
+			managedBy = e.computeInstanceARN(v.AttachedTo, rgByInstance[v.AttachedTo])
 		}
 
 		out = append(out, Resource{


### PR DESCRIPTION
## Summary

Fixes issue #409 (item #1, residual). A VM created through the ARM API (`PUT .../virtualMachines/{name}`) recorded neither its `location` nor its resource group on the compute driver. Resource Graph then fell back to the engine's default region and a `default` resource group, so every discovered VM reported the wrong location/RG (and a `default` resource id) regardless of where it was created.

> The primary ARG↔ARM decoupling from the issue was already fixed in a prior release; this closes the remaining fidelity gap that ARG rows still carried.

## What changed

- **compute driver**: added `Region` + `ResourceGroup` to `InstanceConfig` and `Instance`.
- **Azure VM mock**: stores and echoes both fields on `RunInstances` / `DescribeInstances`.
- **ARM VM handler**: populates `Region` from the request body's `location` and `ResourceGroup` from the request path.
- **discovery walker + ARN builder**: `walkCompute` uses the instance's own region, and `computeInstanceARN` builds the id with the instance's resource group (falling back to `default` when unset, preserving portable-API behavior).

## Behavior

`PUT rg1/.../vm1 {location: eastus}` → ARG now returns `resourceGroup: "rg1"`, `location: "eastus"`, and an id under `/resourceGroups/rg1/` (previously `default` / `us-east-1`).

## Tests

- `TestSDKVMRecordsLocationAndResourceGroup`: real `armcompute` SDK create → asserts the driver recorded location + RG.
- `TestARGVMLocationResourceGroup`: end-to-end ARG query asserts location, resourceGroup, and the id path.
- `go build`, `go vet`, `gofmt`, full `go test ./...`, and `go generate` (no doc diff) all pass. The shared compute-driver struct change was mirrored where needed (chaos test compat struct); AWS/GCP compute suites remain green.