### PR TITLE
feat(azure): model Redis clustering and real SKU family/capacity

### DIFF
--- a/providers/azure/cache/cache.go
+++ b/providers/azure/cache/cache.go
@@ -103,14 +103,18 @@ func (m *Mock) CreateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 	}
 
 	info := driver.CacheInfo{
-		Name:      cfg.Name,
-		Scope:     cfg.Scope,
-		NodeType:  nodeType,
-		Engine:    engine,
-		Status:    "Running",
-		Endpoint:  endpoint,
-		CreatedAt: m.opts.Clock.Now().UTC().Format(time.RFC3339),
-		Tags:      tags,
+		Name:               cfg.Name,
+		Scope:              cfg.Scope,
+		NodeType:           nodeType,
+		Engine:             engine,
+		Status:             "Running",
+		Endpoint:           endpoint,
+		CreatedAt:          m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		Tags:               tags,
+		SKUFamily:          cfg.SKUFamily,
+		SKUCapacity:        cfg.SKUCapacity,
+		ShardCount:         cfg.ShardCount,
+		ReplicasPerPrimary: cfg.ReplicasPerPrimary,
 	}
 
 	cd := &cacheData{
@@ -172,6 +176,18 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 
 	if cfg.NodeType != "" {
 		cd.info.NodeType = cfg.NodeType
+	}
+	if cfg.SKUFamily != "" {
+		cd.info.SKUFamily = cfg.SKUFamily
+	}
+	if cfg.SKUCapacity > 0 {
+		cd.info.SKUCapacity = cfg.SKUCapacity
+	}
+	if cfg.ShardCount > 0 {
+		cd.info.ShardCount = cfg.ShardCount
+	}
+	if cfg.ReplicasPerPrimary > 0 {
+		cd.info.ReplicasPerPrimary = cfg.ReplicasPerPrimary
 	}
 	if cfg.Tags != nil {
 		cd.info.Tags = maps.Clone(cfg.Tags)

--- a/providers/azure/cache/cache.go
+++ b/providers/azure/cache/cache.go
@@ -177,21 +177,27 @@ func (m *Mock) UpdateCache(_ context.Context, cfg driver.CacheConfig) (*driver.C
 	if cfg.NodeType != "" {
 		cd.info.NodeType = cfg.NodeType
 	}
+
 	if cfg.SKUFamily != "" {
 		cd.info.SKUFamily = cfg.SKUFamily
 	}
+
 	if cfg.SKUCapacity > 0 {
 		cd.info.SKUCapacity = cfg.SKUCapacity
 	}
+
 	if cfg.ShardCount > 0 {
 		cd.info.ShardCount = cfg.ShardCount
 	}
+
 	if cfg.ReplicasPerPrimary > 0 {
 		cd.info.ReplicasPerPrimary = cfg.ReplicasPerPrimary
 	}
+
 	if cfg.Tags != nil {
 		cd.info.Tags = maps.Clone(cfg.Tags)
 	}
+
 	if !cfg.Scope.IsZero() {
 		cd.info.Scope = cfg.Scope
 	}

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -20,6 +20,10 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		return
 	}
 
+	if rejectClusteringOnNonPremium(w, &body) {
+		return
+	}
+
 	cfg := cachedriver.CacheConfig{
 		Name:     rp.ResourceName,
 		Engine:   "redis",
@@ -46,6 +50,34 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	azurearm.WriteJSON(w, http.StatusCreated, toRedisJSON(rp, info))
+}
+
+// skuNamePremium is the Redis SKU tier that supports clustering (shardCount /
+// replicasPerPrimary). Real Azure rejects those fields on Basic/Standard.
+const skuNamePremium = "Premium"
+
+// rejectClusteringOnNonPremium writes a 400 and returns true when the body sets
+// shardCount or replicasPerPrimary on a non-Premium SKU — clustering and
+// replicas are Premium-only features, and real Azure rejects them otherwise.
+func rejectClusteringOnNonPremium(w http.ResponseWriter, body *redisJSON) bool {
+	if body.Properties == nil {
+		return false
+	}
+
+	clustered := body.Properties.ShardCount > 0 ||
+		body.Properties.ReplicasPerPrimary > 0 || body.Properties.ReplicasPerMaster > 0
+	if !clustered {
+		return false
+	}
+
+	if body.Properties.SKU != nil && body.Properties.SKU.Name == skuNamePremium {
+		return false
+	}
+
+	azurearm.WriteError(w, http.StatusBadRequest, "InvalidParameterValue",
+		"shardCount/replicasPerPrimary require a Premium SKU")
+
+	return true
 }
 
 // applySKUAndClustering copies the request's SKU family/capacity and the

--- a/server/azure/cache/operations.go
+++ b/server/azure/cache/operations.go
@@ -27,6 +27,7 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 		Tags:     body.Tags,
 		Scope:    scope.Scope{Subscription: rp.Subscription, ResourceGroup: rp.ResourceGroup},
 	}
+	applySKUAndClustering(&cfg, &body)
 
 	if _, err := h.cache.GetCache(r.Context(), rp.ResourceName); err == nil {
 		info, uerr := h.cache.UpdateCache(r.Context(), cfg)
@@ -45,6 +46,28 @@ func (h *Handler) createOrUpdateCache(w http.ResponseWriter, r *http.Request, rp
 	}
 
 	azurearm.WriteJSON(w, http.StatusCreated, toRedisJSON(rp, info))
+}
+
+// applySKUAndClustering copies the request's SKU family/capacity and the
+// Premium clustering fields (shardCount, replicasPerPrimary — replicasPerMaster
+// is accepted as the legacy alias) onto the driver config, so a clustered
+// Premium cache round-trips instead of collapsing to a stub SKU.
+func applySKUAndClustering(cfg *cachedriver.CacheConfig, body *redisJSON) {
+	if body.Properties == nil {
+		return
+	}
+
+	if sku := body.Properties.SKU; sku != nil {
+		cfg.SKUFamily = sku.Family
+		cfg.SKUCapacity = sku.Capacity
+	}
+
+	cfg.ShardCount = body.Properties.ShardCount
+
+	cfg.ReplicasPerPrimary = body.Properties.ReplicasPerPrimary
+	if cfg.ReplicasPerPrimary == 0 {
+		cfg.ReplicasPerPrimary = body.Properties.ReplicasPerMaster
+	}
 }
 
 // nodeTypeFromBody derives the driver's node-type string from the request SKU.

--- a/server/azure/cache/sdk_roundtrip_test.go
+++ b/server/azure/cache/sdk_roundtrip_test.go
@@ -214,3 +214,74 @@ func TestSDKAzureCachePremiumClustering(t *testing.T) {
 		t.Errorf("replicasPerPrimary = %v, want 2", props.ReplicasPerPrimary)
 	}
 }
+
+// TestSDKAzureCacheClusteringUpdate covers the mutation path: a second PUT on an
+// existing Premium cache updates its clustering values (shardCount, capacity),
+// which the initial create-only tests did not exercise.
+func TestSDKAzureCacheClusteringUpdate(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	create := func(shards, capacity int32) {
+		poller, err := client.BeginCreate(ctx, testRG, "clu", armredis.CreateParameters{
+			Location: to.Ptr("eastus"),
+			Properties: &armredis.CreateProperties{
+				SKU: &armredis.SKU{
+					Name:     to.Ptr(armredis.SKUNamePremium),
+					Family:   to.Ptr(armredis.SKUFamilyP),
+					Capacity: to.Ptr(capacity),
+				},
+				ShardCount: to.Ptr(shards),
+			},
+		}, nil)
+		if err != nil {
+			t.Fatalf("BeginCreate(shards=%d): %v", shards, err)
+		}
+
+		if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+			t.Fatalf("PollUntilDone(shards=%d): %v", shards, err)
+		}
+	}
+
+	create(3, 2)
+	create(5, 3) // second PUT on the existing cache
+
+	got, err := client.Get(ctx, testRG, "clu", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Properties.ShardCount == nil || *got.Properties.ShardCount != 5 {
+		t.Errorf("shardCount = %v, want 5 after update", got.Properties.ShardCount)
+	}
+
+	if got.Properties.SKU == nil || got.Properties.SKU.Capacity == nil || *got.Properties.SKU.Capacity != 3 {
+		t.Errorf("capacity = %v, want 3 after update", got.Properties.SKU)
+	}
+}
+
+// TestSDKAzureCacheRejectsClusteringOnStandard confirms clustering is rejected
+// on a non-Premium SKU (real Azure returns 400).
+func TestSDKAzureCacheRejectsClusteringOnStandard(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "bad", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNameStandard),
+				Family:   to.Ptr(armredis.SKUFamilyC),
+				Capacity: to.Ptr(int32(1)),
+			},
+			ShardCount: to.Ptr(int32(2)),
+		},
+	}, nil)
+	if err == nil {
+		_, err = poller.PollUntilDone(ctx, nil)
+	}
+
+	if err == nil {
+		t.Fatal("expected an error for clustering on a Standard SKU, got nil")
+	}
+}

--- a/server/azure/cache/sdk_roundtrip_test.go
+++ b/server/azure/cache/sdk_roundtrip_test.go
@@ -155,3 +155,62 @@ func TestSDKAzureCacheNotFound(t *testing.T) {
 		t.Fatalf("Get(missing): got %v, want 404", err)
 	}
 }
+
+// TestSDKAzureCachePremiumClustering verifies a Premium clustered cache
+// round-trips its real SKU (family P, capacity) plus shardCount and
+// replicasPerPrimary through the ARM API — the fields that drive node-count
+// cost and could not be represented when Family/Capacity were stubbed.
+func TestSDKAzureCachePremiumClustering(t *testing.T) {
+	client := newRedisClient(t)
+	ctx := context.Background()
+
+	poller, err := client.BeginCreate(ctx, testRG, "premium-cache", armredis.CreateParameters{
+		Location: to.Ptr("eastus"),
+		Properties: &armredis.CreateProperties{
+			SKU: &armredis.SKU{
+				Name:     to.Ptr(armredis.SKUNamePremium),
+				Family:   to.Ptr(armredis.SKUFamilyP),
+				Capacity: to.Ptr(int32(2)),
+			},
+			ShardCount:         to.Ptr(int32(3)),
+			ReplicasPerPrimary: to.Ptr(int32(2)),
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BeginCreate: %v", err)
+	}
+
+	if _, err := poller.PollUntilDone(ctx, nil); err != nil {
+		t.Fatalf("PollUntilDone: %v", err)
+	}
+
+	got, err := client.Get(ctx, testRG, "premium-cache", nil)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	props := got.Properties
+	if props == nil || props.SKU == nil {
+		t.Fatal("expected SKU on response")
+	}
+
+	if props.SKU.Name == nil || *props.SKU.Name != armredis.SKUNamePremium {
+		t.Errorf("sku.name = %v, want Premium", props.SKU.Name)
+	}
+
+	if props.SKU.Family == nil || *props.SKU.Family != armredis.SKUFamilyP {
+		t.Errorf("sku.family = %v, want P", props.SKU.Family)
+	}
+
+	if props.SKU.Capacity == nil || *props.SKU.Capacity != 2 {
+		t.Errorf("sku.capacity = %v, want 2", props.SKU.Capacity)
+	}
+
+	if props.ShardCount == nil || *props.ShardCount != 3 {
+		t.Errorf("shardCount = %v, want 3", props.ShardCount)
+	}
+
+	if props.ReplicasPerPrimary == nil || *props.ReplicasPerPrimary != 2 {
+		t.Errorf("replicasPerPrimary = %v, want 2", props.ReplicasPerPrimary)
+	}
+}

--- a/server/azure/cache/types.go
+++ b/server/azure/cache/types.go
@@ -19,9 +19,9 @@ const (
 	defaultRedisVersion        = "6.0"
 )
 
-// skuJSON mirrors the armredis SKU. The cache driver only tracks a node-type
-// string, which maps onto SKU.Name (Basic/Standard/Premium); Family and
-// Capacity carry stub defaults so the SDK round-trips a well-formed SKU.
+// skuJSON mirrors the armredis SKU. Name is the tier (Basic/Standard/Premium),
+// Family is C (Basic/Standard) or P (Premium), and Capacity is the size unit —
+// all recorded on the driver so the SDK round-trips the exact SKU it sent.
 type skuJSON struct {
 	Name     string `json:"name,omitempty"`
 	Family   string `json:"family,omitempty"`
@@ -29,14 +29,21 @@ type skuJSON struct {
 }
 
 // redisProperties mirrors the subset of armredis Properties the cache driver
-// can populate.
+// can populate. ShardCount and ReplicasPerPrimary describe a Premium clustered
+// cache; both are omitted when unset (a non-clustered cache).
 type redisProperties struct {
-	ProvisioningState string   `json:"provisioningState,omitempty"`
-	RedisVersion      string   `json:"redisVersion,omitempty"`
-	SKU               *skuJSON `json:"sku,omitempty"`
-	HostName          string   `json:"hostName,omitempty"`
-	SSLPort           int      `json:"sslPort,omitempty"`
-	Port              int      `json:"port,omitempty"`
+	ProvisioningState  string   `json:"provisioningState,omitempty"`
+	RedisVersion       string   `json:"redisVersion,omitempty"`
+	SKU                *skuJSON `json:"sku,omitempty"`
+	HostName           string   `json:"hostName,omitempty"`
+	SSLPort            int      `json:"sslPort,omitempty"`
+	Port               int      `json:"port,omitempty"`
+	ShardCount         int      `json:"shardCount,omitempty"`
+	ReplicasPerPrimary int      `json:"replicasPerPrimary,omitempty"`
+	// ReplicasPerMaster is the legacy alias for ReplicasPerPrimary. It is
+	// accepted on input (older SDKs still send it) but not emitted — the
+	// response carries the current replicasPerPrimary field.
+	ReplicasPerMaster int `json:"replicasPerMaster,omitempty"`
 }
 
 // redisJSON mirrors the armredis ResourceInfo / CreateParameters resource.
@@ -111,11 +118,35 @@ func toRedisJSON(rp *azurearm.ResourcePath, info *cachedriver.CacheInfo) redisJS
 		Location: defaultLocation,
 		Tags:     info.Tags,
 		Properties: &redisProperties{
-			ProvisioningState: provisioningStateSucceeded,
-			RedisVersion:      defaultRedisVersion,
-			SKU:               &skuJSON{Name: skuNameFromNodeType(info.NodeType), Family: "C", Capacity: 1},
-			HostName:          host,
-			SSLPort:           sslPort,
+			ProvisioningState:  provisioningStateSucceeded,
+			RedisVersion:       defaultRedisVersion,
+			SKU:                skuFromInfo(info),
+			HostName:           host,
+			SSLPort:            sslPort,
+			ShardCount:         info.ShardCount,
+			ReplicasPerPrimary: info.ReplicasPerPrimary,
 		},
+	}
+}
+
+// skuFromInfo builds the ARM SKU from the recorded driver fields. Family
+// defaults to "C" (Basic/Standard) and capacity to 1 only when the driver has
+// no recorded value — e.g. a cache created through the portable API, which
+// carries a node type but no SKU family/capacity.
+func skuFromInfo(info *cachedriver.CacheInfo) *skuJSON {
+	family := info.SKUFamily
+	if family == "" {
+		family = "C"
+	}
+
+	capacity := info.SKUCapacity
+	if capacity == 0 {
+		capacity = 1
+	}
+
+	return &skuJSON{
+		Name:     skuNameFromNodeType(info.NodeType),
+		Family:   family,
+		Capacity: capacity,
 	}
 }

--- a/services/cache/driver/driver.go
+++ b/services/cache/driver/driver.go
@@ -26,6 +26,16 @@ type CacheInfo struct {
 	CreatedAt string
 	Tags      map[string]string
 	Scope     scope.Scope
+
+	// SKUFamily / SKUCapacity are the Azure Redis SKU family ("C" for
+	// Basic/Standard, "P" for Premium) and capacity unit; empty/zero for
+	// providers with no such concept. ShardCount and ReplicasPerPrimary model
+	// a Premium clustered cache (both drive node-count cost); zero when
+	// clustering is not configured.
+	SKUFamily          string
+	SKUCapacity        int
+	ShardCount         int
+	ReplicasPerPrimary int
 }
 
 // CacheConfig describes a cache instance to create.
@@ -38,6 +48,14 @@ type CacheConfig struct {
 	// Scope records where the resource lives (Azure subscription/resource
 	// group, GCP project). Zero for AWS and unscoped portable callers.
 	Scope scope.Scope
+
+	// SKUFamily / SKUCapacity carry the Azure Redis SKU family ("C"/"P") and
+	// capacity unit. ShardCount / ReplicasPerPrimary configure a Premium
+	// clustered cache. All are optional and left zero by non-Azure callers.
+	SKUFamily          string
+	SKUCapacity        int
+	ShardCount         int
+	ReplicasPerPrimary int
 }
 
 // Cache is the interface that cache provider implementations must satisfy.


### PR DESCRIPTION
## Summary

Fixes issue #409 (item #3). Azure Cache for Redis (`Microsoft.Cache/redis`) emitted a stubbed SKU (`Family: "C"`, `Capacity: 1`) regardless of the request, and had no `shardCount` / `replicasPerPrimary` — so a Premium clustered cache (the fields that drive node-count cost) could not be represented. Values sent on a PUT were silently dropped.

## What changed

- **cache driver**: added `SKUFamily`, `SKUCapacity`, `ShardCount`, `ReplicasPerPrimary` to `CacheConfig` and `CacheInfo` (optional; non-Azure providers leave them zero).
- **Azure cache mock**: stores the fields on create and updates them on ARM CreateOrUpdate-on-existing.
- **ARM wire**: `redisProperties` gains `shardCount` + `replicasPerPrimary` (and accepts the legacy `replicasPerMaster` alias on input); the SKU is now emitted from the recorded family/capacity instead of a stub, defaulting to `C`/`1` only for portable-API creations that carry no SKU.

## Behavior

`PUT` a Premium cache with `sku:{name:Premium,family:P,capacity:2}`, `shardCount:3`, `replicasPerPrimary:2` → GET returns exactly those values (verified against the real `armredis/v3` SDK). `replicasPerMaster` maps to `replicasPerPrimary`.

## Tests

- `TestSDKAzureCachePremiumClustering`: real `armredis/v3` SDK create → get asserting SKU family/capacity + shardCount + replicasPerPrimary.
- `go build`, `go vet`, `gofmt`, full `go test ./...`, and `go generate` (no doc diff) all pass; AWS ElastiCache/MemoryDB and GCP Memorystore suites remain green.