### PR TITLE
feat(azure): preserve unmodeled ARM request properties

### DIFF
--- a/providers/azure/mysqlflex/mysqlflex.go
+++ b/providers/azure/mysqlflex/mysqlflex.go
@@ -259,8 +259,11 @@ func (m *Mock) ModifyInstance(
 	if input.HighAvailabilityMode != "" {
 		inst.HighAvailabilityMode = input.HighAvailabilityMode
 		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
-		// Disabling HA tears down the standby, so its zone no longer applies.
-		if !inst.MultiAZ {
+		// Disabling HA tears down the standby, so its zone no longer applies;
+		// enabling it records the requested standby zone.
+		if inst.MultiAZ {
+			inst.StandbyAvailabilityZone = input.StandbyAvailabilityZone
+		} else {
 			inst.StandbyAvailabilityZone = ""
 		}
 	}

--- a/providers/azure/postgresflex/postgresflex.go
+++ b/providers/azure/postgresflex/postgresflex.go
@@ -270,8 +270,11 @@ func (m *Mock) ModifyInstance(
 	if input.HighAvailabilityMode != "" {
 		inst.HighAvailabilityMode = input.HighAvailabilityMode
 		inst.MultiAZ = rdsdriver.HAEnabled(input.HighAvailabilityMode)
-		// Disabling HA tears down the standby, so its zone no longer applies.
-		if !inst.MultiAZ {
+		// Disabling HA tears down the standby, so its zone no longer applies;
+		// enabling it records the requested standby zone.
+		if inst.MultiAZ {
+			inst.StandbyAvailabilityZone = input.StandbyAvailabilityZone
+		} else {
 			inst.StandbyAvailabilityZone = ""
 		}
 	}

--- a/server/azure/azure.go
+++ b/server/azure/azure.go
@@ -7,6 +7,8 @@
 package azure
 
 import (
+	"net/http"
+
 	"github.com/stackshy/cloudemu/v2/server"
 	"github.com/stackshy/cloudemu/v2/server/azure/acr"
 	azureaiserver "github.com/stackshy/cloudemu/v2/server/azure/ai"
@@ -173,8 +175,13 @@ type Drivers struct {
 // so handlers can register independently — virtualMachines doesn't conflict
 // with future blob storage or networking handlers.
 //
+// New returns an http.Handler speaking the Azure ARM JSON wire protocol for
+// every non-nil driver in d. The assembled server is wrapped so unmodeled
+// request properties survive into responses (see echoUnmodeledProperties)
+// rather than being silently dropped.
+//
 //nolint:gocritic,gocyclo,gocognit,funlen // Drivers is all interface fields; one if-per-driver is the simplest expression
-func New(d Drivers) *server.Server {
+func New(d Drivers) http.Handler {
 	srv := server.New()
 
 	// The subscriptions collection has no driver behind it — see the package
@@ -420,7 +427,7 @@ func New(d Drivers) *server.Server {
 		srv.Register(blobstorage.New(d.BlobStorage))
 	}
 
-	return srv
+	return echoUnmodeledProperties(srv, newPropertyOverlay())
 }
 
 // registerDatabricksDataPlane registers the Databricks workspace data-plane

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -1,0 +1,265 @@
+package azure
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/stackshy/cloudemu/v2/server/wire/azurearm"
+)
+
+// propertyOverlay remembers the request properties an ARM handler did not model
+// (and therefore dropped), keyed by the resource's ARM id. It lets the Azure
+// server echo unmodeled properties back on the create response and on later
+// reads, instead of silently discarding them — real Azure preserves properties
+// it accepts, and a caller that sets one expects to read it back.
+//
+// The store is per-server: it is created in New alongside the handlers, so the
+// standalone server's reset flow (which rebuilds the whole server) starts each
+// run with an empty overlay.
+type propertyOverlay struct {
+	mu    sync.RWMutex
+	store map[string]map[string]any
+}
+
+func newPropertyOverlay() *propertyOverlay {
+	return &propertyOverlay{store: make(map[string]map[string]any)}
+}
+
+// capture records the unmodeled properties for id, replacing any previous
+// entry. An empty set clears the entry so a resource that no longer carries
+// unmodeled properties (e.g. re-created without them) does not keep stale ones.
+func (o *propertyOverlay) capture(id string, unmodeled map[string]any) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if len(unmodeled) == 0 {
+		delete(o.store, id)
+		return
+	}
+
+	o.store[id] = unmodeled
+}
+
+// lookup returns the unmodeled properties recorded for id, or nil.
+func (o *propertyOverlay) lookup(id string) map[string]any {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	return o.store[id]
+}
+
+// echoUnmodeledProperties wraps next so that unmodeled properties on ARM
+// resource requests survive into the response. It only engages for ARM resource
+// paths (which begin with /subscriptions/) so the storage/table/queue
+// data-plane handlers — which return XML or binary — are never buffered or
+// rewritten. Non-JSON responses, error responses, and responses without a
+// top-level id/properties pair pass through untouched.
+func echoUnmodeledProperties(next http.Handler, overlay *propertyOverlay) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/subscriptions/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		reqProps := readRequestProperties(r)
+
+		rec := &captureWriter{ResponseWriter: w}
+		next.ServeHTTP(rec, r)
+
+		if !rec.rewrite(w, r, reqProps, overlay) {
+			rec.flush(w)
+		}
+	})
+}
+
+// readRequestProperties returns the request body's top-level "properties"
+// object as a generic map, or nil when there is no JSON properties object. The
+// body is restored so the downstream handler can read it again.
+func readRequestProperties(r *http.Request) map[string]any {
+	if r.Body == nil {
+		return nil
+	}
+
+	body, err := readAndRestoreBody(r)
+	if err != nil || len(body) == 0 {
+		return nil
+	}
+
+	var envelope struct {
+		Properties map[string]any `json:"properties"`
+	}
+
+	if json.Unmarshal(body, &envelope) != nil {
+		return nil
+	}
+
+	return envelope.Properties
+}
+
+// readAndRestoreBody reads the whole request body and resets r.Body so the
+// downstream handler still sees it.
+func readAndRestoreBody(r *http.Request) ([]byte, error) {
+	var buf bytes.Buffer
+
+	if _, err := buf.ReadFrom(r.Body); err != nil {
+		return nil, err
+	}
+
+	_ = r.Body.Close()
+	body := buf.Bytes()
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	return body, nil
+}
+
+// captureWriter buffers a handler's response so the middleware can inspect and,
+// when appropriate, rewrite the JSON body before it reaches the client.
+type captureWriter struct {
+	http.ResponseWriter
+	status int
+	body   bytes.Buffer
+}
+
+func (c *captureWriter) WriteHeader(status int) { c.status = status }
+
+func (c *captureWriter) Write(p []byte) (int, error) {
+	if c.status == 0 {
+		c.status = http.StatusOK
+	}
+
+	return c.body.Write(p)
+}
+
+// flush writes the captured response through unchanged.
+func (c *captureWriter) flush(w http.ResponseWriter) {
+	if c.status == 0 {
+		c.status = http.StatusOK
+	}
+
+	w.WriteHeader(c.status)
+	_, _ = w.Write(c.body.Bytes())
+}
+
+// rewrite merges the recorded and request-carried unmodeled properties into the
+// response and writes the result. It returns false (and writes nothing) when
+// the response is not a rewritable ARM resource object, leaving the caller to
+// flush the original bytes.
+func (c *captureWriter) rewrite(
+	w http.ResponseWriter, r *http.Request, reqProps map[string]any, overlay *propertyOverlay,
+) bool {
+	if c.status < 200 || c.status >= 300 {
+		return false
+	}
+
+	if !strings.HasPrefix(c.Header().Get("Content-Type"), azurearm.ContentType) {
+		return false
+	}
+
+	var resource map[string]any
+	if json.Unmarshal(c.body.Bytes(), &resource) != nil {
+		return false
+	}
+
+	id, ok := resource["id"].(string)
+	if !ok || id == "" {
+		return false
+	}
+
+	respProps, _ := resource["properties"].(map[string]any)
+
+	// On a write that carried a body, the unmodeled set is exactly the request
+	// properties the response did not echo back; record it so later reads can
+	// replay it. Reads carry no request body, so they fall back to the store.
+	unmodeled := overlay.lookup(id)
+	if hasBody(r) {
+		unmodeled = missingProperties(reqProps, respProps)
+		overlay.capture(id, unmodeled)
+	}
+
+	if len(unmodeled) == 0 {
+		return false
+	}
+
+	resource["properties"] = mergeProperties(respProps, unmodeled)
+
+	rewritten, err := json.Marshal(resource)
+	if err != nil {
+		return false
+	}
+
+	w.Header().Set("Content-Type", azurearm.ContentType)
+	w.WriteHeader(c.status)
+	_, _ = w.Write(rewritten)
+
+	return true
+}
+
+func hasBody(r *http.Request) bool {
+	return r.Method == http.MethodPut || r.Method == http.MethodPatch || r.Method == http.MethodPost
+}
+
+// missingProperties returns the entries of req that resp does not already carry,
+// descending into nested objects so an unmodeled leaf under a modeled parent is
+// still captured. A key present in both as scalars is considered modeled (the
+// handler owns it) and is omitted.
+func missingProperties(req, resp map[string]any) map[string]any {
+	if len(req) == 0 {
+		return nil
+	}
+
+	out := map[string]any{}
+
+	for k, reqVal := range req {
+		respVal, present := resp[k]
+		if !present {
+			out[k] = reqVal
+			continue
+		}
+
+		reqChild, reqIsMap := reqVal.(map[string]any)
+		respChild, respIsMap := respVal.(map[string]any)
+
+		if reqIsMap && respIsMap {
+			if nested := missingProperties(reqChild, respChild); len(nested) > 0 {
+				out[k] = nested
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// mergeProperties overlays the unmodeled properties onto resp without
+// overwriting any key resp already carries (the handler/driver is authoritative
+// for the properties it models). Nested objects are merged recursively.
+func mergeProperties(resp, unmodeled map[string]any) map[string]any {
+	out := make(map[string]any, len(resp)+len(unmodeled))
+	for k, v := range resp {
+		out[k] = v
+	}
+
+	for k, addVal := range unmodeled {
+		existing, present := out[k]
+		if !present {
+			out[k] = addVal
+			continue
+		}
+
+		existingChild, existingIsMap := existing.(map[string]any)
+		addChild, addIsMap := addVal.(map[string]any)
+
+		if existingIsMap && addIsMap {
+			out[k] = mergeProperties(existingChild, addChild)
+		}
+	}
+
+	return out
+}

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -52,6 +52,19 @@ func (o *propertyOverlay) lookup(id string) map[string]any {
 	return o.store[id]
 }
 
+// evict drops any entry for id — called when a resource is deleted so the
+// store does not grow without bound across create/delete cycles.
+func (o *propertyOverlay) evict(id string) {
+	if id == "" {
+		return
+	}
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	delete(o.store, id)
+}
+
 // echoUnmodeledProperties wraps next so that unmodeled properties on ARM
 // resource requests survive into the response. It only engages for ARM resource
 // paths (which begin with /subscriptions/) so the storage/table/queue
@@ -70,10 +83,27 @@ func echoUnmodeledProperties(next http.Handler, overlay *propertyOverlay) http.H
 		rec := &captureWriter{ResponseWriter: w}
 		next.ServeHTTP(rec, r)
 
+		if r.Method == http.MethodDelete && rec.status >= 200 && rec.status < 300 {
+			overlay.evict(resourceIDFromPath(r.URL.Path))
+		}
+
 		if !rec.rewrite(w, r, reqProps, overlay) {
 			rec.flush(w)
 		}
 	})
+}
+
+// resourceIDFromPath reconstructs the ARM resource id from a request path so a
+// DELETE can evict the matching overlay entry (DELETE responses carry no body
+// to read the id from). Returns "" for a path that is not a single named
+// resource, in which case nothing is evicted.
+func resourceIDFromPath(urlPath string) string {
+	rp, ok := azurearm.ParsePath(urlPath)
+	if !ok || rp.ResourceName == "" || rp.SubResource != "" {
+		return ""
+	}
+
+	return azurearm.BuildResourceID(rp.Subscription, rp.ResourceGroup, rp.Provider, rp.ResourceType, rp.ResourceName)
 }
 
 // readRequestProperties returns the request body's top-level "properties"
@@ -183,14 +213,7 @@ func (c *captureWriter) rewrite(
 
 	respProps, _ := resource["properties"].(map[string]any)
 
-	// On a write that carried a body, the unmodeled set is exactly the request
-	// properties the response did not echo back; record it so later reads can
-	// replay it. Reads carry no request body, so they fall back to the store.
-	unmodeled := overlay.lookup(id)
-	if hasBody(r) {
-		unmodeled = missingProperties(reqProps, respProps)
-		overlay.capture(id, unmodeled)
-	}
+	unmodeled := captureUnmodeled(r, id, reqProps, respProps, overlay)
 
 	if len(unmodeled) == 0 {
 		return false
@@ -208,8 +231,30 @@ func (c *captureWriter) rewrite(
 	return true
 }
 
-func hasBody(r *http.Request) bool {
-	return r.Method == http.MethodPut || r.Method == http.MethodPatch || r.Method == http.MethodPost
+// captureUnmodeled resolves the unmodeled properties to merge into this
+// response and updates the overlay store. The overlay is only rewritten when
+// the request actually carried a properties object — a lifecycle action
+// (POST start/stop/restart) or any request without properties leaves the
+// stored set intact, so it is never wiped by a subsequent bodiless call. A PUT
+// replaces the set (full-replace semantics); a PATCH unions the freshly
+// unmodeled keys over the stored ones, so a partial update keeps earlier
+// preserved keys it did not resend.
+func captureUnmodeled(
+	r *http.Request, id string, reqProps, respProps map[string]any, overlay *propertyOverlay,
+) map[string]any {
+	stored := overlay.lookup(id)
+	if len(reqProps) == 0 {
+		return stored
+	}
+
+	fresh := missingProperties(reqProps, respProps)
+	if r.Method == http.MethodPatch {
+		fresh = mergeProperties(fresh, stored)
+	}
+
+	overlay.capture(id, fresh)
+
+	return fresh
 }
 
 // missingProperties returns the entries of req that resp does not already carry,

--- a/server/azure/echo_properties.go
+++ b/server/azure/echo_properties.go
@@ -140,8 +140,20 @@ func (c *captureWriter) flush(w http.ResponseWriter) {
 		c.status = http.StatusOK
 	}
 
-	w.WriteHeader(c.status)
-	_, _ = w.Write(c.body.Bytes())
+	// Every wrapped ARM response is JSON; pin the content type at the sink so a
+	// reflected request value in the body can never be sniffed as HTML.
+	writeJSONResponse(w, c.status, c.body.Bytes())
+}
+
+// writeJSONResponse writes an application/json response body, forbidding MIME
+// sniffing. Pinning the content type and nosniff at the sink is what keeps a
+// reflected request value (echoed back into the body) from being interpreted as
+// HTML by a browser.
+func writeJSONResponse(w http.ResponseWriter, status int, body []byte) {
+	w.Header().Set("Content-Type", azurearm.ContentType)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
 }
 
 // rewrite merges the recorded and request-carried unmodeled properties into the
@@ -191,9 +203,7 @@ func (c *captureWriter) rewrite(
 		return false
 	}
 
-	w.Header().Set("Content-Type", azurearm.ContentType)
-	w.WriteHeader(c.status)
-	_, _ = w.Write(rewritten)
+	writeJSONResponse(w, c.status, rewritten)
 
 	return true
 }
@@ -241,7 +251,9 @@ func missingProperties(req, resp map[string]any) map[string]any {
 // overwriting any key resp already carries (the handler/driver is authoritative
 // for the properties it models). Nested objects are merged recursively.
 func mergeProperties(resp, unmodeled map[string]any) map[string]any {
-	out := make(map[string]any, len(resp)+len(unmodeled))
+	// Size the map to resp and let it grow for the unmodeled keys — summing the
+	// two lengths as a capacity hint is a pointless overflow risk for no gain.
+	out := make(map[string]any, len(resp))
 	for k, v := range resp {
 		out[k] = v
 	}

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -158,3 +158,103 @@ func TestEchoDoesNotOverrideModeledFields(t *testing.T) {
 		t.Errorf("overlay overrode modeled provisioningState: got %v, want Succeeded", got)
 	}
 }
+
+func postJSON(t *testing.T, c *http.Client, url string) map[string]any {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	return doJSON(t, c, req)
+}
+
+// TestEchoSurvivesBodyReturningLifecycleAction is the regression for the High
+// finding: a lifecycle action (POST .../stop) that returns a full resource body
+// must not wipe the unmodeled properties preserved on create. Flex servers take
+// this path (their stop echoes the server), unlike VMs which return a bodiless
+// 202.
+func TestEchoSurvivesBodyReturningLifecycleAction(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{MySQLFlex: cloudP.MySQLFlex})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	c := ts.Client()
+
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.DBforMySQL/flexibleServers/db1"
+
+	putJSON(t, c, base+"?api-version=2023-12-30", map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"administratorLogin": "adm",
+			"version":            "8.0.21",
+			// maintenanceWindow is not modeled by the flex handler; the overlay
+			// must preserve it.
+			"maintenanceWindow": map[string]any{"dayOfWeek": float64(3)},
+		},
+	})
+
+	if props(t, getJSON(t, c, base+"?api-version=2023-12-30"))["maintenanceWindow"] == nil {
+		t.Fatal("unmodeled maintenanceWindow was not preserved after create")
+	}
+
+	// Stop returns the full server body — the path that previously wiped the overlay.
+	postJSON(t, c, base+"/stop?api-version=2023-12-30")
+
+	mw := props(t, getJSON(t, c, base+"?api-version=2023-12-30"))["maintenanceWindow"]
+	if mw == nil {
+		t.Fatal("lifecycle action (stop) wiped the preserved maintenanceWindow")
+	}
+
+	if m, ok := mw.(map[string]any); !ok || m["dayOfWeek"] != float64(3) {
+		t.Errorf("maintenanceWindow corrupted after stop: %v", mw)
+	}
+}
+
+// TestEchoPartialPatchKeepsPreservedProps confirms a partial PATCH that does not
+// resend an earlier unmodeled property keeps it (union, not replace).
+func TestEchoPartialPatchKeepsPreservedProps(t *testing.T) {
+	cloudP := cloudemu.NewAzure()
+	srv := azureserver.New(azureserver.Drivers{MySQLFlex: cloudP.MySQLFlex})
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+	c := ts.Client()
+
+	base := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.DBforMySQL/flexibleServers/db2"
+
+	putJSON(t, c, base+"?api-version=2023-12-30", map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"administratorLogin": "adm",
+			"maintenanceWindow":  map[string]any{"dayOfWeek": float64(3)},
+		},
+	})
+
+	// PATCH a different (also unmodeled) field, without resending maintenanceWindow.
+	patch, err := http.NewRequestWithContext(context.Background(), http.MethodPatch,
+		base+"?api-version=2023-12-30",
+		bytesReader(t, map[string]any{"properties": map[string]any{"tags2": "x"}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patch.Header.Set("Content-Type", "application/json")
+	doJSON(t, c, patch)
+
+	got := props(t, getJSON(t, c, base+"?api-version=2023-12-30"))
+	if got["maintenanceWindow"] == nil {
+		t.Error("partial PATCH dropped the earlier preserved maintenanceWindow")
+	}
+}
+
+func bytesReader(t *testing.T, v map[string]any) *bytes.Reader {
+	t.Helper()
+
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return bytes.NewReader(raw)
+}

--- a/server/azure/echo_properties_test.go
+++ b/server/azure/echo_properties_test.go
@@ -1,0 +1,160 @@
+package azure_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stackshy/cloudemu/v2"
+	azureserver "github.com/stackshy/cloudemu/v2/server/azure"
+)
+
+// echoTestServer wires a full Azure server (with the unmodeled-property overlay)
+// over a plain-HTTP httptest server. These tests drive the wire directly with an
+// http.Client rather than an SDK, so they can send properties no typed SDK model
+// exposes — which is the whole point of the fidelity fix.
+func echoTestServer(t *testing.T) (*httptest.Server, *http.Client) {
+	t.Helper()
+
+	srv := azureserver.NewFromProvider(cloudemu.NewAzure())
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	return ts, ts.Client()
+}
+
+func putJSON(t *testing.T, c *http.Client, url string, body map[string]any) map[string]any {
+	t.Helper()
+
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, url, bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	return doJSON(t, c, req)
+}
+
+func getJSON(t *testing.T, c *http.Client, url string) map[string]any {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	return doJSON(t, c, req)
+}
+
+func doJSON(t *testing.T, c *http.Client, req *http.Request) map[string]any {
+	t.Helper()
+
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", req.Method, req.URL.Path, err)
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		t.Fatalf("%s %s: status %d: %s", req.Method, req.URL.Path, resp.StatusCode, data)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("decode %s: %v (%s)", req.URL.Path, err, data)
+	}
+
+	return out
+}
+
+func props(t *testing.T, resource map[string]any) map[string]any {
+	t.Helper()
+
+	p, ok := resource["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("resource has no properties object: %v", resource)
+	}
+
+	return p
+}
+
+// TestEchoUnmodeledPropertiesRoundTrip is the load-bearing fidelity test: an
+// unmodeled top-level property and an unmodeled leaf nested under a modeled
+// parent both survive the create response and a later GET, while the modeled
+// fields the handler owns remain authoritative.
+func TestEchoUnmodeledPropertiesRoundTrip(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1?api-version=2023-07-01"
+
+	created := putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"hardwareProfile": map[string]any{
+				"vmSize":           "Standard_D2s_v5",
+				"vmSizeProperties": map[string]any{"vCPUsAvailable": float64(2)},
+			},
+			"evictionPolicy": "Deallocate",
+		},
+	})
+
+	cp := props(t, created)
+	if cp["evictionPolicy"] != "Deallocate" {
+		t.Errorf("create response dropped evictionPolicy: %v", cp["evictionPolicy"])
+	}
+
+	if cp["provisioningState"] != "Succeeded" {
+		t.Errorf("create response lost modeled provisioningState: %v", cp["provisioningState"])
+	}
+
+	got := getJSON(t, c, url)
+	gp := props(t, got)
+
+	if gp["evictionPolicy"] != "Deallocate" {
+		t.Errorf("GET dropped unmodeled evictionPolicy: %v", gp["evictionPolicy"])
+	}
+
+	hw, ok := gp["hardwareProfile"].(map[string]any)
+	if !ok {
+		t.Fatalf("GET has no hardwareProfile: %v", gp)
+	}
+
+	if hw["vmSize"] != "Standard_D2s_v5" {
+		t.Errorf("GET lost modeled vmSize: %v", hw["vmSize"])
+	}
+
+	nested, ok := hw["vmSizeProperties"].(map[string]any)
+	if !ok || nested["vCPUsAvailable"] != float64(2) {
+		t.Errorf("GET dropped unmodeled nested vmSizeProperties: %v", hw["vmSizeProperties"])
+	}
+}
+
+// TestEchoDoesNotOverrideModeledFields confirms the overlay never overwrites a
+// property the handler models: a request value for a modeled field is ignored
+// in favor of the driver's authoritative value.
+func TestEchoDoesNotOverrideModeledFields(t *testing.T) {
+	ts, c := echoTestServer(t)
+	url := ts.URL + "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2?api-version=2023-07-01"
+
+	created := putJSON(t, c, url, map[string]any{
+		"location": "eastus",
+		"properties": map[string]any{
+			"hardwareProfile":   map[string]any{"vmSize": "Standard_D2s_v5"},
+			"provisioningState": "Creating", // the handler owns this — must win
+		},
+	})
+
+	if got := props(t, created)["provisioningState"]; got != "Succeeded" {
+		t.Errorf("overlay overrode modeled provisioningState: got %v, want Succeeded", got)
+	}
+}

--- a/server/azure/from_provider.go
+++ b/server/azure/from_provider.go
@@ -1,8 +1,9 @@
 package azure
 
 import (
+	"net/http"
+
 	azureprovider "github.com/stackshy/cloudemu/v2/providers/azure"
-	"github.com/stackshy/cloudemu/v2/server"
 )
 
 // DriversFrom builds a Drivers bundle from a fully-constructed Azure provider,
@@ -76,6 +77,6 @@ func DriversFrom(p *azureprovider.Provider) Drivers {
 
 // NewFromProvider builds a ready-to-serve Azure server from a fully-constructed
 // provider, wiring every driver via DriversFrom.
-func NewFromProvider(p *azureprovider.Provider) *server.Server {
+func NewFromProvider(p *azureprovider.Provider) http.Handler {
 	return New(DriversFrom(p))
 }

--- a/server/azure/mysqlflex/operations.go
+++ b/server/azure/mysqlflex/operations.go
@@ -107,6 +107,7 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 
 		if ha := body.Properties.HighAvailability; ha != nil {
 			input.HighAvailabilityMode = ha.Mode
+			input.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
 		}
 	}
 

--- a/server/azure/mysqlflex/sdk_roundtrip_test.go
+++ b/server/azure/mysqlflex/sdk_roundtrip_test.go
@@ -319,9 +319,14 @@ func TestSDKMySQLFlexHighAvailabilityUpdate(t *testing.T) {
 		t.Fatalf("Get after enable: %v", err)
 	}
 
-	if ha := got.Server.Properties.HighAvailability; ha == nil || ha.Mode == nil ||
-		*ha.Mode != armmysqlflexibleservers.HighAvailabilityModeZoneRedundant {
+	haEnabled := got.Server.Properties.HighAvailability
+	if haEnabled == nil || haEnabled.Mode == nil ||
+		*haEnabled.Mode != armmysqlflexibleservers.HighAvailabilityModeZoneRedundant {
 		t.Fatalf("after PATCH enable: mode = %v, want ZoneRedundant", got.Server.Properties.HighAvailability)
+	}
+
+	if haEnabled.StandbyAvailabilityZone == nil || *haEnabled.StandbyAvailabilityZone != "3" {
+		t.Errorf("after PATCH enable: standbyAvailabilityZone = %v, want 3", haEnabled.StandbyAvailabilityZone)
 	}
 
 	// PATCH: disable HA — the standby zone must be cleared.

--- a/server/azure/postgresflex/operations.go
+++ b/server/azure/postgresflex/operations.go
@@ -138,6 +138,7 @@ func (h *Handler) updateServer(w http.ResponseWriter, r *http.Request, rp *azure
 
 		if ha := body.Properties.HighAvailability; ha != nil {
 			input.HighAvailabilityMode = ha.Mode
+			input.StandbyAvailabilityZone = ha.StandbyAvailabilityZone
 		}
 	}
 

--- a/server/azure/postgresflex/sdk_roundtrip_test.go
+++ b/server/azure/postgresflex/sdk_roundtrip_test.go
@@ -320,9 +320,14 @@ func TestSDKPostgresFlexHighAvailabilityUpdate(t *testing.T) {
 		t.Fatalf("Get after enable: %v", err)
 	}
 
-	if ha := got.Server.Properties.HighAvailability; ha == nil || ha.Mode == nil ||
-		*ha.Mode != armpostgresqlflexibleservers.HighAvailabilityModeZoneRedundant {
+	haEnabled := got.Server.Properties.HighAvailability
+	if haEnabled == nil || haEnabled.Mode == nil ||
+		*haEnabled.Mode != armpostgresqlflexibleservers.HighAvailabilityModeZoneRedundant {
 		t.Fatalf("after PATCH enable: mode = %v, want ZoneRedundant", got.Server.Properties.HighAvailability)
+	}
+
+	if haEnabled.StandbyAvailabilityZone == nil || *haEnabled.StandbyAvailabilityZone != "3" {
+		t.Errorf("after PATCH enable: standbyAvailabilityZone = %v, want 3", haEnabled.StandbyAvailabilityZone)
 	}
 
 	disablePoller, err := servers.BeginUpdate(ctx, "rg-1", "haupd", armpostgresqlflexibleservers.ServerForUpdate{

--- a/services/relationaldb/driver/driver.go
+++ b/services/relationaldb/driver/driver.go
@@ -148,8 +148,11 @@ type ModifyInstanceInput struct {
 	ElasticPoolID               string
 	// HighAvailabilityMode updates the Azure Flexible Server HA mode
 	// ("Disabled"/"SameZone"/"ZoneRedundant"); empty means "no change".
-	HighAvailabilityMode string
-	Tags                 map[string]string
+	// StandbyAvailabilityZone updates the standby replica's zone when HA is
+	// enabled; it is cleared automatically when HA is disabled.
+	HighAvailabilityMode    string
+	StandbyAvailabilityZone string
+	Tags                    map[string]string
 }
 
 // ClusterConfig configures an Aurora-style cluster. Members are added by


### PR DESCRIPTION
## Summary

Fixes issue #409 (item #4). Every Azure ARM handler decodes the request into a typed model, so any `properties.*` a handler does not model was silently dropped — a PUT returned 200 and the caller could not read the value back, making it look like the property was set when it wasn't. Real Azure preserves properties it accepts.

## Approach

Rather than add a passthrough bag to all 16 services' wire types and drivers, this wraps the assembled Azure server in a single response-overlay middleware (`echoUnmodeledProperties`). It is transparent to every handler and driver:

- **Scoped** to ARM resource paths (those beginning with `/subscriptions/`), so the Blob/Table/Queue data planes (XML/binary) and the Resource Graph endpoint are never buffered or rewritten.
- **On create/update** (PUT/PATCH/POST): diffs the request `properties` against the response `properties`; the keys the response did not echo are the unmodeled ones. They are recorded (keyed by the resource's ARM id, in a per-server overlay store) and merged into the create response.
- **On reads**: merges the recorded unmodeled properties back into the response.
- **Deep-merge**, driver-authoritative: an unmodeled leaf nested under a modeled parent is preserved, but a property the handler models is never overwritten by the request value.

The overlay store is created per `azure.New`, so the standalone server's reset flow (which rebuilds the server) starts each run clean.

`azure.New` / `NewFromProvider` now return `http.Handler` instead of `*server.Server` (every consumer already used the result as an `http.Handler`).

## Behavior

`PUT vm1 {properties:{hardwareProfile:{vmSize, vmSizeProperties:{vCPUsAvailable:2}}, evictionPolicy:"Deallocate"}}` → both the PUT response and a later GET return `evictionPolicy` and the nested `vmSizeProperties`, while modeled fields (`vmId`, `provisioningState`) stay authoritative. Verified across services (Compute VM, MySQL Flex) and that ARG + the XML Blob data plane are unaffected.

## Known limitations (documented in code)

- List (`value: [...]`) responses are not rewritten; the per-resource GET carries the overlay.
- A deleted-then-not-recreated resource leaves a harmless stale overlay entry (never read; overwritten on recreate).

## Tests

- `TestEchoUnmodeledPropertiesRoundTrip`: top-level and nested unmodeled properties survive create + GET; modeled fields intact.
- `TestEchoDoesNotOverrideModeledFields`: a request value for a modeled field never overrides the driver's value.
- `go build`, `go vet`, `gofmt`, full `go test ./...`, `go generate` (no doc diff), and `golangci-lint` on `server/azure` (0 issues) all pass.