### PR TITLE
feat(dynamodb): faithful FilterExpression + ConditionExpression (in-memory)

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -13,6 +13,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/memstore"
 	"github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
 
@@ -277,7 +278,10 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
-	matched := m.matchQueryItems(td, pkField, skField, &input)
+	matched, err := m.matchQueryItems(td, pkField, skField, &input)
+	if err != nil {
+		return nil, err
+	}
 
 	limit := input.Limit
 	if limit <= 0 {
@@ -323,7 +327,12 @@ func resolveKeyFields(td *tableData, indexName string) (pkField, skField string,
 
 func (m *Mock) matchQueryItems(
 	td *tableData, pkField, skField string, input *driver.QueryInput,
-) []map[string]any {
+) ([]map[string]any, error) {
+	node, err := compileFilter(input.FilterExpression, input.ExprNames, input.ExprValues)
+	if err != nil {
+		return nil, err
+	}
+
 	allItems := td.items.All()
 
 	var matched []map[string]any
@@ -333,32 +342,65 @@ func (m *Mock) matchQueryItems(
 			continue
 		}
 
-		pkVal := fmt.Sprintf("%v", item[pkField])
-		if pkVal != fmt.Sprintf("%v", input.KeyCondition.PartitionVal) {
+		if !matchesKeyCondition(item, pkField, skField, input) {
 			continue
-		}
-
-		if input.KeyCondition.SortOp != "" && skField != "" {
-			skVal := fmt.Sprintf("%v", item[skField])
-			condSK := fmt.Sprintf("%v", input.KeyCondition.SortVal)
-
-			if !applySortCondition(skVal, input.KeyCondition.SortOp, condSK, input.KeyCondition.SortValEnd) {
-				continue
-			}
 		}
 
 		// Apply the FilterExpression (post key-condition), matching real
 		// DynamoDB: Query filters the key-matched set the same way Scan does.
-		if !matchesFilters(item, input.Filters) {
-			continue
+		ok, ferr := passesFilter(node, input.Filters, item)
+		if ferr != nil {
+			return nil, ferr
 		}
 
-		matched = append(matched, item)
+		if ok {
+			matched = append(matched, item)
+		}
 	}
 
-	return matched
+	return matched, nil
 }
 
+func matchesKeyCondition(item map[string]any, pkField, skField string, input *driver.QueryInput) bool {
+	pkVal := fmt.Sprintf("%v", item[pkField])
+	if pkVal != fmt.Sprintf("%v", input.KeyCondition.PartitionVal) {
+		return false
+	}
+
+	if input.KeyCondition.SortOp != "" && skField != "" {
+		skVal := fmt.Sprintf("%v", item[skField])
+		condSK := fmt.Sprintf("%v", input.KeyCondition.SortVal)
+
+		if !applySortCondition(skVal, input.KeyCondition.SortOp, condSK, input.KeyCondition.SortValEnd) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// compileFilter parses a raw FilterExpression once per request. An empty
+// expression yields a nil node, selecting the legacy Filters path.
+func compileFilter(filterExpr string, names map[string]string, values map[string]any) (expr.Node, error) {
+	if strings.TrimSpace(filterExpr) == "" {
+		return nil, nil
+	}
+
+	return expr.ParseCondition(filterExpr, names, values)
+}
+
+// passesFilter applies the parsed FilterExpression when present, else falls
+// back to the legacy flat ScanFilter matching (back-compat for direct driver
+// callers that populate Filters instead of FilterExpression).
+func passesFilter(node expr.Node, legacy []driver.ScanFilter, item map[string]any) (bool, error) {
+	if node != nil {
+		return expr.Eval(node, item)
+	}
+
+	return matchesFilters(item, legacy), nil
+}
+
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryResult, error) {
 	m.mu.RLock()
 	td, exists := m.tables[input.Table]
@@ -368,6 +410,11 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 		return nil, cerrors.Newf(cerrors.NotFound, "table %s not found", input.Table)
 	}
 
+	node, err := compileFilter(input.FilterExpression, input.ExprNames, input.ExprValues)
+	if err != nil {
+		return nil, err
+	}
+
 	allItems := td.items.All()
 
 	var matched []map[string]any
@@ -377,7 +424,12 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 			continue
 		}
 
-		if matchesFilters(item, input.Filters) {
+		ok, ferr := passesFilter(node, input.Filters, item)
+		if ferr != nil {
+			return nil, ferr
+		}
+
+		if ok {
 			matched = append(matched, item)
 		}
 	}

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -19,6 +19,7 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		TableName                 string            `json:"TableName"`
 		Key                       map[string]any    `json:"Key"`
 		UpdateExpression          string            `json:"UpdateExpression"`
+		ConditionExpression       string            `json:"ConditionExpression"`
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		ReturnValues              string            `json:"ReturnValues"`
@@ -28,13 +29,21 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actions := parseUpdateExpression(req.UpdateExpression,
-		fromWireItem(req.ExpressionAttributeValues), req.ExpressionAttributeNames)
+	key := fromWireItem(req.Key)
+	vals := fromWireItem(req.ExpressionAttributeValues)
+
+	// ExpressionAttributeValues serve both the UpdateExpression and the
+	// ConditionExpression, matching real DynamoDB. Gate the mutation on the
+	// condition (evaluated against the current item) before applying actions.
+	if !h.gateCondition(r.Context(), w, req.TableName, key,
+		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
+		return
+	}
 
 	input := dbdriver.UpdateItemInput{
 		Table:   req.TableName,
-		Key:     fromWireItem(req.Key),
-		Actions: actions,
+		Key:     key,
+		Actions: parseUpdateExpression(req.UpdateExpression, vals, req.ExpressionAttributeNames),
 	}
 
 	updated, err := h.db.UpdateItem(r.Context(), input)
@@ -229,11 +238,14 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vals := fromWireItem(req.ExpressionAttributeValues)
-	filters := parseFilterExpression(req.FilterExpression, vals, req.ExpressionAttributeNames)
 
+	// Flow the raw FilterExpression to the driver, which parses and evaluates
+	// it with full grammar fidelity.
 	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
 		Table:             req.TableName,
-		Filters:           filters,
+		FilterExpression:  req.FilterExpression,
+		ExprNames:         req.ExpressionAttributeNames,
+		ExprValues:        vals,
 		Limit:             req.Limit,
 		ExclusiveStartKey: fromWireItem(req.ExclusiveStartKey),
 	})
@@ -257,57 +269,6 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, resp)
-}
-
-// parseFilterExpression turns "a = :v AND b > :w" into driver ScanFilters.
-// Supports a single clause or AND-joined clauses.
-func parseFilterExpression(expr string, vals map[string]any, names map[string]string) []dbdriver.ScanFilter {
-	expr = strings.TrimSpace(expr)
-	if expr == "" {
-		return nil
-	}
-
-	var filters []dbdriver.ScanFilter
-
-	// A valid filter clause has exactly 3 tokens: field, op, value placeholder.
-	const filterTokens = 3
-
-	for _, clause := range splitByUpper(expr, " AND ") {
-		parts := strings.Fields(clause)
-		if len(parts) < filterTokens {
-			continue
-		}
-
-		filters = append(filters, dbdriver.ScanFilter{
-			Field: resolveAttrName(parts[0], names),
-			Op:    parts[1],
-			Value: resolveExprVal(parts[2], vals),
-		})
-	}
-
-	return filters
-}
-
-// splitByUpper splits s by sep, matching sep case-insensitively. The upstream
-// splitter in the query handler already has the same trick for KeyCondition;
-// we duplicate it locally to keep advanced.go self-contained.
-func splitByUpper(s, sep string) []string {
-	upper := strings.ToUpper(s)
-
-	var parts []string
-
-	start := 0
-
-	for {
-		i := strings.Index(upper[start:], strings.ToUpper(sep))
-		if i < 0 {
-			parts = append(parts, strings.TrimSpace(s[start:]))
-			return parts
-		}
-
-		parts = append(parts, strings.TrimSpace(s[start:start+i]))
-		start += i + len(sep)
-	}
 }
 
 // batchWriteItem handles BatchWriteItem (puts/deletes across one or more

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -508,8 +508,8 @@ func TestDDBQueryEdges(t *testing.T) {
 	require.ErrorAs(t, err, &rnf, "Query with unknown IndexName")
 }
 
-// TestDDBScanWithFilters: AND-combined scan filters with =, !=,
-// numeric >, <= and the emulator's infix CONTAINS dialect.
+// TestDDBScanWithFilters: AND-combined scan filters with =, <>,
+// numeric >, <= and the real contains() function form.
 func TestDDBScanWithFilters(t *testing.T) {
 	client, _ := newSuiteDDBEnv(t)
 	ctx := context.Background()
@@ -552,7 +552,7 @@ func TestDDBScanWithFilters(t *testing.T) {
 	assert.Equal(t, int32(3), scan("category = :c",
 		map[string]ddbtypes.AttributeValue{":c": sAttr("electronics")}).Count)
 
-	assert.Equal(t, int32(2), scan("category != :c",
+	assert.Equal(t, int32(2), scan("category <> :c",
 		map[string]ddbtypes.AttributeValue{":c": sAttr("electronics")}).Count)
 
 	// Numeric comparison: both sides parse as float64.
@@ -564,8 +564,8 @@ func TestDDBScanWithFilters(t *testing.T) {
 	assert.Equal(t, int32(2), scan("price <= :p",
 		map[string]ddbtypes.AttributeValue{":p": nAttr("35")}).Count)
 
-	// Emulator dialect: infix CONTAINS (real DynamoDB uses contains(name, :s)).
-	assert.Equal(t, int32(3), scan("name CONTAINS :s",
+	// Real DynamoDB contains(path, operand) function form.
+	assert.Equal(t, int32(3), scan("contains(name, :s)",
 		map[string]ddbtypes.AttributeValue{":s": sAttr("Widget")}).Count)
 }
 
@@ -899,10 +899,6 @@ func TestDDBTypedErrors(t *testing.T) {
 // TestDDBConditionalWrites: a conditional put succeeds when the
 // item is absent, and violating the condition must yield
 // ConditionalCheckFailedException like real DynamoDB.
-//
-// NOTE: the emulator does not parse ConditionExpression at all (PutItem is a
-// blind upsert with no ConditionalCheckFailedException path), so the
-// violation subtest is expected to surface that divergence.
 func TestDDBConditionalWrites(t *testing.T) {
 	client, _ := newSuiteDDBEnv(t)
 	ctx := context.Background()
@@ -1123,4 +1119,203 @@ func TestDDBQueryGSI(t *testing.T) {
 	}
 
 	assert.True(t, ids["u1"] && ids["u2"], "GSI query returns both matching users")
+}
+
+// lAttr builds a DynamoDB list AttributeValue from element AttributeValues.
+func lAttr(elems ...ddbtypes.AttributeValue) ddbtypes.AttributeValue {
+	return &ddbtypes.AttributeValueMemberL{Value: elems}
+}
+
+// TestDDBScanFilterExpressionGrammar drives the full FilterExpression grammar
+// through a real-SDK Scan: functions (attribute_exists/_not_exists, contains,
+// size), boolean operators (OR, NOT), IN, BETWEEN, and type-aware equality
+// (a numeric literal must not match a value stored as a string).
+func TestDDBScanFilterExpressionGrammar(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "people", "id", "")
+
+	suiteDDBPut(t, client, "people", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("p1"), "email": sAttr("a@x.com"), "name": sAttr("Alice"),
+		"tags": lAttr(sAttr("red"), sAttr("blue")), "n": nAttr("10"), "status": sAttr("active"),
+	})
+	suiteDDBPut(t, client, "people", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("p2"), "email": sAttr("b@x.com"), "name": sAttr("Bob"),
+		"tags": lAttr(sAttr("green")), "n": nAttr("20"), "status": sAttr("inactive"),
+	})
+	suiteDDBPut(t, client, "people", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("p3"), "name": sAttr("Carol"), // no email
+		"tags": lAttr(sAttr("red")), "n": nAttr("30"), "status": sAttr("pending"),
+	})
+	suiteDDBPut(t, client, "people", map[string]ddbtypes.AttributeValue{
+		"id": sAttr("p4"), "email": sAttr("d@x.com"), "name": sAttr("Dave"),
+		"n": sAttr("25"), "status": sAttr("active"), // n stored as a STRING
+	})
+
+	scanF := func(filter string, names map[string]string, vals map[string]ddbtypes.AttributeValue) int32 {
+		in := &dynamodb.ScanInput{
+			TableName:                 aws.String("people"),
+			FilterExpression:          aws.String(filter),
+			ExpressionAttributeValues: vals,
+			ExpressionAttributeNames:  names,
+		}
+
+		out, err := client.Scan(ctx, in)
+		require.NoError(t, err, "Scan filter=%q", filter)
+
+		return out.Count
+	}
+
+	assert.Equal(t, int32(3), scanF("attribute_exists(email)", nil, nil),
+		"attribute_exists selects rows that have the attribute")
+	assert.Equal(t, int32(4), scanF("attribute_not_exists(x)", nil, nil),
+		"attribute_not_exists(x) matches every row (x is never present)")
+	assert.Equal(t, int32(2), scanF("contains(tags, :t)", nil,
+		map[string]ddbtypes.AttributeValue{":t": sAttr("red")}),
+		"contains() tests list membership")
+	assert.Equal(t, int32(2), scanF("size(#nm) > :len",
+		map[string]string{"#nm": "name"},
+		map[string]ddbtypes.AttributeValue{":len": nAttr("4")}),
+		"size() of a string attribute compared numerically")
+	assert.Equal(t, int32(3), scanF("status = :s1 OR n = :n1", nil,
+		map[string]ddbtypes.AttributeValue{":s1": sAttr("active"), ":n1": nAttr("30")}),
+		"OR unions two single-attribute comparisons")
+	assert.Equal(t, int32(2), scanF("NOT status = :s", nil,
+		map[string]ddbtypes.AttributeValue{":s": sAttr("active")}),
+		"NOT negates the inner comparison")
+	assert.Equal(t, int32(3), scanF("status IN (:s1, :s2)", nil,
+		map[string]ddbtypes.AttributeValue{":s1": sAttr("active"), ":s2": sAttr("pending")}),
+		"IN matches any listed value")
+	assert.Equal(t, int32(2), scanF("n BETWEEN :lo AND :hi", nil,
+		map[string]ddbtypes.AttributeValue{":lo": nAttr("15"), ":hi": nAttr("30")}),
+		"BETWEEN is inclusive and numeric (the string-typed n is excluded)")
+
+	// Type-aware equality: :numeric (N 25) must NOT match p4's n stored as the
+	// string "25", but a numeric equality on a numerically-stored value does.
+	assert.Equal(t, int32(0), scanF("n = :numeric", nil,
+		map[string]ddbtypes.AttributeValue{":numeric": nAttr("25")}),
+		"a number literal must not equal a string-typed attribute")
+	assert.Equal(t, int32(1), scanF("n = :ten", nil,
+		map[string]ddbtypes.AttributeValue{":ten": nAttr("10")}),
+		"numeric equality still matches a numerically-stored value")
+}
+
+// TestDDBQueryFilterBeginsWith proves begins_with() works as a Query
+// FilterExpression (post key-condition), distinct from the KeyCondition path.
+func TestDDBQueryFilterBeginsWith(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "logs", "app", "ts")
+
+	for _, ts := range []string{"2023-12-01", "2024-01-01", "2024-02-01"} {
+		suiteDDBPut(t, client, "logs", map[string]ddbtypes.AttributeValue{
+			"app": sAttr("web"), "ts": sAttr(ts),
+		})
+	}
+
+	// The sort key (ts) is filtered with begins_with in the FilterExpression —
+	// distinct from the KeyConditionExpression, which only matches the
+	// partition key here.
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String("logs"),
+		KeyConditionExpression: aws.String("app = :a"),
+		FilterExpression:       aws.String("begins_with(ts, :p)"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+			":a": sAttr("web"), ":p": sAttr("2024"),
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(2), out.Count, "begins_with filter keeps only the 2024 rows")
+	for _, item := range out.Items {
+		assert.True(t, strings.HasPrefix(attrS(t, item, "ts"), "2024"))
+	}
+}
+
+// TestDDBConditionExpressionGrammar covers ConditionExpression on PutItem
+// (compound attribute_not_exists + size), UpdateItem and DeleteItem
+// (attribute_exists guards), asserting ConditionalCheckFailedException on
+// violation and success when the condition holds.
+func TestDDBConditionExpressionGrammar(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "cond2", "pk", "")
+
+	var ccf *ddbtypes.ConditionalCheckFailedException
+
+	// Seed an item so the guards below have something to evaluate against.
+	suiteDDBPut(t, client, "cond2", map[string]ddbtypes.AttributeValue{
+		"pk": sAttr("X"), "name": sAttr("hi"),
+	})
+
+	t.Run("PutItem compound condition fails on an existing item", func(t *testing.T) {
+		_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName:                aws.String("cond2"),
+			Item:                     map[string]ddbtypes.AttributeValue{"pk": sAttr("X"), "name": sAttr("new")},
+			ConditionExpression:      aws.String("attribute_not_exists(pk) AND size(#n) < :m"),
+			ExpressionAttributeNames: map[string]string{"#n": "name"},
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":m": nAttr("10"),
+			},
+		})
+		require.ErrorAs(t, err, &ccf, "attribute_not_exists(pk) must fail when pk exists")
+	})
+
+	t.Run("PutItem compound condition passes when it holds", func(t *testing.T) {
+		_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName:                aws.String("cond2"),
+			Item:                     map[string]ddbtypes.AttributeValue{"pk": sAttr("X"), "name": sAttr("hey")},
+			ConditionExpression:      aws.String("attribute_exists(pk) AND size(#n) < :m"),
+			ExpressionAttributeNames: map[string]string{"#n": "name"},
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":m": nAttr("10"),
+			},
+		})
+		require.NoError(t, err, "attribute_exists(pk) AND size(name) < 10 holds")
+
+		got := suiteDDBGet(t, client, "cond2", map[string]ddbtypes.AttributeValue{"pk": sAttr("X")})
+		require.NotNil(t, got.Item)
+		assert.Equal(t, "hey", attrS(t, got.Item, "name"))
+	})
+
+	t.Run("UpdateItem guarded by attribute_exists", func(t *testing.T) {
+		_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                 aws.String("cond2"),
+			Key:                       map[string]ddbtypes.AttributeValue{"pk": sAttr("X")},
+			UpdateExpression:          aws.String("SET v = :v"),
+			ConditionExpression:       aws.String("attribute_exists(pk)"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":v": nAttr("1")},
+		})
+		require.NoError(t, err, "guard holds on the existing item")
+
+		_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                 aws.String("cond2"),
+			Key:                       map[string]ddbtypes.AttributeValue{"pk": sAttr("missing")},
+			UpdateExpression:          aws.String("SET v = :v"),
+			ConditionExpression:       aws.String("attribute_exists(pk)"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":v": nAttr("1")},
+		})
+		require.ErrorAs(t, err, &ccf, "attribute_exists guard fails on a missing item")
+	})
+
+	t.Run("DeleteItem guarded by attribute_exists", func(t *testing.T) {
+		_, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName:           aws.String("cond2"),
+			Key:                 map[string]ddbtypes.AttributeValue{"pk": sAttr("missing")},
+			ConditionExpression: aws.String("attribute_exists(pk)"),
+		})
+		require.ErrorAs(t, err, &ccf, "delete guard fails on a missing item")
+
+		_, err = client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName:           aws.String("cond2"),
+			Key:                 map[string]ddbtypes.AttributeValue{"pk": sAttr("X")},
+			ConditionExpression: aws.String("attribute_exists(pk)"),
+		})
+		require.NoError(t, err, "delete guard holds on the existing item")
+
+		got := suiteDDBGet(t, client, "cond2", map[string]ddbtypes.AttributeValue{"pk": sAttr("X")})
+		assert.Nil(t, got.Item)
+	})
 }

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -12,6 +12,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
 const targetPrefix = "DynamoDB_20120810."
@@ -209,12 +210,14 @@ func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // mirrors deleteItem's condition-gated write path over Item, not Key.
 func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		TableName                string            `json:"TableName"`
-		Item                     map[string]any    `json:"Item"`
-		ConditionExpression      string            `json:"ConditionExpression"`
-		ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames"`
+		TableName                 string            `json:"TableName"`
+		Item                      map[string]any    `json:"Item"`
+		ConditionExpression       string            `json:"ConditionExpression"`
+		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
+		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -222,13 +225,10 @@ func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	item := fromWireItem(req.Item)
+	vals := fromWireItem(req.ExpressionAttributeValues)
 
-	if ok, err := h.checkCondition(r.Context(), req.TableName, item, req.ConditionExpression, req.ExpressionAttributeNames); err != nil {
-		writeErr(w, err)
-		return
-	} else if !ok {
-		wire.WriteJSONError(w, http.StatusBadRequest,
-			"ConditionalCheckFailedException", "The conditional request failed")
+	if !h.gateCondition(r.Context(), w, req.TableName, item,
+		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
 		return
 	}
 
@@ -240,55 +240,62 @@ func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{})
 }
 
-// checkCondition evaluates the supported ConditionExpression forms —
-// attribute_not_exists(field) and attribute_exists(field) — against the
-// current stored item, keyed by the incoming item's key attributes.
-// Real DynamoDB users lean on attribute_not_exists(pk) for create-if-absent.
+// gateCondition evaluates a ConditionExpression and, on failure, writes the
+// matching DynamoDB error response. It returns true when the caller should
+// proceed with the mutation. Shared by PutItem, UpdateItem and DeleteItem.
+func (h *Handler) gateCondition(
+	ctx context.Context,
+	w http.ResponseWriter,
+	table string,
+	keySource map[string]any,
+	condExpr string,
+	names map[string]string,
+	values map[string]any,
+) bool {
+	ok, err := h.checkCondition(ctx, table, keySource, condExpr, names, values)
+	if err != nil {
+		writeErr(w, err)
+		return false
+	}
+
+	if !ok {
+		wire.WriteJSONError(w, http.StatusBadRequest,
+			"ConditionalCheckFailedException", "The conditional request failed")
+		return false
+	}
+
+	return true
+}
+
+// checkCondition evaluates a DynamoDB ConditionExpression against the current
+// stored item, using the full expression grammar (functions, boolean
+// operators, IN/BETWEEN, size(), type-aware comparisons). keySource carries
+// the item's key attributes (the full item for PutItem, the Key map for
+// Update/Delete). A missing item is evaluated against an empty item, so
+// attribute_not_exists is true and attribute_exists is false — matching real
+// DynamoDB create-if-absent semantics. A malformed expression is a
+// cerrors.InvalidArgument; a well-formed but unmet condition returns false.
 func (h *Handler) checkCondition(
 	ctx context.Context,
 	table string,
-	item map[string]any,
-	expr string,
+	keySource map[string]any,
+	condExpr string,
 	names map[string]string,
+	values map[string]any,
 ) (bool, error) {
-	expr = strings.TrimSpace(expr)
-	if expr == "" {
+	condExpr = strings.TrimSpace(condExpr)
+	if condExpr == "" {
 		return true, nil
 	}
-
-	var (
-		rest       string
-		wantAbsent bool
-	)
-	switch {
-	case strings.HasPrefix(expr, "attribute_not_exists("):
-		rest = strings.TrimPrefix(expr, "attribute_not_exists(")
-		wantAbsent = true
-	case strings.HasPrefix(expr, "attribute_exists("):
-		rest = strings.TrimPrefix(expr, "attribute_exists(")
-	default:
-		return false, cerrors.Newf(cerrors.InvalidArgument,
-			"unsupported ConditionExpression: %s", expr)
-	}
-
-	rest, ok := strings.CutSuffix(rest, ")")
-	field := strings.TrimSpace(rest)
-	// Reject compound expressions and malformed input rather than
-	// mis-evaluating them (only the single-function forms are supported).
-	if !ok || field == "" || strings.ContainsAny(field, " ()") {
-		return false, cerrors.Newf(cerrors.InvalidArgument,
-			"unsupported ConditionExpression: %s", expr)
-	}
-	field = resolveAttrName(field, names)
 
 	cfg, err := h.db.DescribeTable(ctx, table)
 	if err != nil {
 		return false, err
 	}
 
-	key := map[string]any{cfg.PartitionKey: item[cfg.PartitionKey]}
+	key := map[string]any{cfg.PartitionKey: keySource[cfg.PartitionKey]}
 	if cfg.SortKey != "" {
-		key[cfg.SortKey] = item[cfg.SortKey]
+		key[cfg.SortKey] = keySource[cfg.SortKey]
 	}
 
 	existing, err := h.db.GetItem(ctx, table, key)
@@ -296,15 +303,16 @@ func (h *Handler) checkCondition(
 		return false, err
 	}
 
-	var hasAttr bool
-	if existing != nil {
-		_, hasAttr = existing[field]
+	node, err := expr.ParseCondition(condExpr, names, values)
+	if err != nil {
+		return false, err
 	}
 
-	if wantAbsent {
-		return !hasAttr, nil
+	if existing == nil {
+		existing = map[string]any{}
 	}
-	return hasAttr, nil
+
+	return expr.Eval(node, existing)
 }
 
 func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
@@ -340,10 +348,14 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, resp)
 }
 
+//nolint:dupl // mirrors putItem's condition-gated write path over Key, not Item.
 func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		TableName string         `json:"TableName"`
-		Key       map[string]any `json:"Key"`
+		TableName                 string            `json:"TableName"`
+		Key                       map[string]any    `json:"Key"`
+		ConditionExpression       string            `json:"ConditionExpression"`
+		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
+		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -351,6 +363,12 @@ func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	key := fromWireItem(req.Key)
+	vals := fromWireItem(req.ExpressionAttributeValues)
+
+	if !h.gateCondition(r.Context(), w, req.TableName, key,
+		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
+		return
+	}
 
 	if err := h.db.DeleteItem(r.Context(), req.TableName, key); err != nil {
 		writeErr(w, err)
@@ -379,18 +397,22 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 
 	vals := fromWireItem(req.ExpressionAttributeValues)
 	kc := parseKeyCondition(req.KeyConditionExpression, vals, req.ExpressionAttributeNames)
-	filters := parseFilterExpression(req.FilterExpression, vals, req.ExpressionAttributeNames)
 
 	forward := true
 	if req.ScanIndexForward != nil {
 		forward = *req.ScanIndexForward
 	}
 
+	// Flow the raw FilterExpression (post key-condition) to the driver, which
+	// parses and evaluates it with full grammar fidelity. The KeyCondition
+	// path is unchanged.
 	result, err := h.db.Query(r.Context(), dbdriver.QueryInput{
 		Table:             req.TableName,
 		IndexName:         req.IndexName,
 		KeyCondition:      kc,
-		Filters:           filters,
+		FilterExpression:  req.FilterExpression,
+		ExprNames:         req.ExpressionAttributeNames,
+		ExprValues:        vals,
 		Limit:             req.Limit,
 		SortDescending:    !forward,
 		ExclusiveStartKey: fromWireItem(req.ExclusiveStartKey),
@@ -419,22 +441,22 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 // parseKeyCondition extracts a KeyCondition from a simple expression.
 // Supports: "pk = :v" and "pk = :v AND sk op :v2".
 func parseKeyCondition(
-	expr string,
+	keyExpr string,
 	vals map[string]any,
 	names map[string]string,
 ) dbdriver.KeyCondition {
 	kc := dbdriver.KeyCondition{}
-	expr = strings.TrimSpace(expr)
+	keyExpr = strings.TrimSpace(keyExpr)
 
 	const andSep = " AND "
 
-	andIdx := findCaseInsensitive(expr, andSep)
-	pkExpr := strings.TrimSpace(expr)
+	andIdx := findCaseInsensitive(keyExpr, andSep)
+	pkExpr := strings.TrimSpace(keyExpr)
 	skExpr := ""
 
 	if andIdx >= 0 {
-		pkExpr = strings.TrimSpace(expr[:andIdx])
-		skExpr = strings.TrimSpace(expr[andIdx+len(andSep):])
+		pkExpr = strings.TrimSpace(keyExpr[:andIdx])
+		skExpr = strings.TrimSpace(keyExpr[andIdx+len(andSep):])
 	}
 
 	// Expression fields: [0]=field, [1]=operator, [2]=value placeholder.

--- a/services/database/database.go
+++ b/services/database/database.go
@@ -169,6 +169,7 @@ func (db *Database) Query(ctx context.Context, input driver.QueryInput) (*driver
 	return out.(*driver.QueryResult), nil
 }
 
+//nolint:gocritic // input passed by value to match driver.Database interface pattern
 func (db *Database) Scan(ctx context.Context, input driver.ScanInput) (*driver.QueryResult, error) {
 	out, err := db.do(ctx, "Scan", input, func() (any, error) { return db.driver.Scan(ctx, input) })
 	if err != nil {

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -94,9 +94,21 @@ type QueryInput struct {
 	Table        string
 	IndexName    string
 	KeyCondition KeyCondition
-	// Filters is the post-key-condition FilterExpression, applied to items
-	// that already match the key condition (same semantics as Scan.Filters).
-	Filters   []ScanFilter
+	// Filters is the legacy pre-simplified post-key-condition filter, applied
+	// to items that already match the key condition (same semantics as
+	// Scan.Filters). Retained for back-compat; ignored when FilterExpression
+	// is set.
+	Filters []ScanFilter
+
+	// FilterExpression is the raw DynamoDB FilterExpression. When non-empty it
+	// is parsed and evaluated with full grammar fidelity (functions, boolean
+	// operators, IN/BETWEEN, type-aware comparisons), taking precedence over
+	// the legacy Filters. ExprNames/ExprValues resolve #alias and :placeholder
+	// tokens (values already decoded to native Go).
+	FilterExpression string
+	ExprNames        map[string]string
+	ExprValues       map[string]any
+
 	Limit     int
 	PageToken string
 
@@ -116,8 +128,17 @@ type QueryInput struct {
 
 // ScanInput configures a scan operation.
 type ScanInput struct {
-	Table     string
-	Filters   []ScanFilter
+	Table string
+	// Filters is the legacy pre-simplified filter; ignored when
+	// FilterExpression is set. Retained for back-compat.
+	Filters []ScanFilter
+
+	// FilterExpression is the raw DynamoDB FilterExpression, evaluated with
+	// full grammar fidelity when non-empty (see QueryInput.FilterExpression).
+	FilterExpression string
+	ExprNames        map[string]string
+	ExprValues       map[string]any
+
 	Limit     int
 	PageToken string
 

--- a/services/database/driver/expr/ast.go
+++ b/services/database/driver/expr/ast.go
@@ -1,0 +1,126 @@
+// Package expr parses and evaluates DynamoDB condition and filter
+// expressions against native Go items (map[string]any), matching real
+// DynamoDB type-aware semantics. It is a pure library: it depends only on
+// the standard library and the module's canonical errors package, and is
+// shared by the AWS DynamoDB, Azure Cosmos and GCP Firestore providers.
+package expr
+
+// Node is a boolean expression AST node produced by ParseCondition and
+// evaluated by Eval.
+type Node interface {
+	isNode()
+}
+
+// And is a logical conjunction of two boolean sub-expressions.
+type And struct {
+	Left  Node
+	Right Node
+}
+
+// Or is a logical disjunction of two boolean sub-expressions.
+type Or struct {
+	Left  Node
+	Right Node
+}
+
+// Not negates a boolean sub-expression.
+type Not struct {
+	Child Node
+}
+
+// Comparison compares two operands with one of = <> < <= > >=.
+type Comparison struct {
+	Op    string
+	Left  Operand
+	Right Operand
+}
+
+// Between tests lo <= operand <= hi (type-aware, inclusive).
+type Between struct {
+	Operand Operand
+	Lo      Operand
+	Hi      Operand
+}
+
+// In tests whether Operand equals any member of List.
+type In struct {
+	Operand Operand
+	List    []Operand
+}
+
+// AttrExists is attribute_exists(path): true when the path resolves.
+type AttrExists struct {
+	Path *PathOperand
+}
+
+// AttrNotExists is attribute_not_exists(path): true when the path is absent.
+type AttrNotExists struct {
+	Path *PathOperand
+}
+
+// AttrType is attribute_type(path, :t): true when the path value's DynamoDB
+// type code equals the (string) type operand.
+type AttrType struct {
+	Path *PathOperand
+	Type Operand
+}
+
+// BeginsWith is begins_with(path, operand) on strings or binary.
+type BeginsWith struct {
+	Path   *PathOperand
+	Prefix Operand
+}
+
+// Contains is contains(path, operand): substring on strings, membership on
+// lists and sets.
+type Contains struct {
+	Path    *PathOperand
+	Operand Operand
+}
+
+func (*And) isNode()           {}
+func (*Or) isNode()            {}
+func (*Not) isNode()           {}
+func (*Comparison) isNode()    {}
+func (*Between) isNode()       {}
+func (*In) isNode()            {}
+func (*AttrExists) isNode()    {}
+func (*AttrNotExists) isNode() {}
+func (*AttrType) isNode()      {}
+func (*BeginsWith) isNode()    {}
+func (*Contains) isNode()      {}
+
+// Operand is a value-producing leaf: an attribute path, a resolved :value
+// placeholder, or a size(path) count.
+type Operand interface {
+	isOperand()
+}
+
+// PathPart is one step of a document path: either a named attribute
+// (Name, IsIndex false) or a list index (Index, IsIndex true).
+type PathPart struct {
+	Name    string
+	Index   int
+	IsIndex bool
+}
+
+// PathOperand is a document path such as a, a.b or a[0].c, with any #alias
+// steps already resolved to concrete names.
+type PathOperand struct {
+	Parts []PathPart
+}
+
+// ValueOperand is a :placeholder already resolved to its native value.
+type ValueOperand struct {
+	Value any
+}
+
+// SizeOperand is size(path): the length of the path value as a number,
+// usable on either side of a comparison.
+type SizeOperand struct {
+	Path *PathOperand
+}
+
+func (*PathOperand) isOperand()  {}
+func (*ValueOperand) isOperand() {}
+func (*SizeOperand) isOperand()  {}

--- a/services/database/driver/expr/eval.go
+++ b/services/database/driver/expr/eval.go
@@ -1,0 +1,363 @@
+package expr
+
+import (
+	"bytes"
+	"cmp"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Eval evaluates a parsed condition against a native DynamoDB item and
+// returns whether it matches. Comparisons are type-aware: numbers compare
+// numerically, strings lexically, binary bytewise; values of different
+// types are never equal and never ordered (any comparison yields false), and
+// any operand that resolves to a missing path makes its condition false —
+// matching real DynamoDB semantics.
+func Eval(node Node, item map[string]any) (bool, error) {
+	switch n := node.(type) {
+	case *And:
+		return evalAnd(n, item)
+	case *Or:
+		return evalOr(n, item)
+	case *Not:
+		v, err := Eval(n.Child, item)
+		return !v, err
+	case *Comparison:
+		return evalComparison(n, item)
+	case *Between:
+		return evalBetween(n, item)
+	case *In:
+		return evalIn(n, item)
+	default:
+		return evalFunctionNode(node, item)
+	}
+}
+
+// evalFunctionNode handles the function-condition nodes, keeping the primary
+// Eval dispatch within the cyclomatic-complexity budget.
+func evalFunctionNode(node Node, item map[string]any) (bool, error) {
+	switch n := node.(type) {
+	case *AttrExists:
+		_, ok := resolvePath(n.Path.Parts, item)
+		return ok, nil
+	case *AttrNotExists:
+		_, ok := resolvePath(n.Path.Parts, item)
+		return !ok, nil
+	case *AttrType:
+		return evalAttrType(n, item), nil
+	case *BeginsWith:
+		return evalBeginsWith(n, item), nil
+	case *Contains:
+		return evalContains(n, item), nil
+	default:
+		return false, cerrors.New(cerrors.InvalidArgument, "unsupported condition node")
+	}
+}
+
+func evalAnd(n *And, item map[string]any) (bool, error) {
+	left, err := Eval(n.Left, item)
+	if err != nil || !left {
+		return false, err
+	}
+
+	return Eval(n.Right, item)
+}
+
+func evalOr(n *Or, item map[string]any) (bool, error) {
+	left, err := Eval(n.Left, item)
+	if err != nil || left {
+		return left, err
+	}
+
+	return Eval(n.Right, item)
+}
+
+func evalComparison(n *Comparison, item map[string]any) (bool, error) {
+	lv, lok := resolveOperand(n.Left, item)
+	rv, rok := resolveOperand(n.Right, item)
+
+	if !lok || !rok {
+		return false, nil
+	}
+
+	return compareOp(n.Op, lv, rv), nil
+}
+
+func evalBetween(n *Between, item map[string]any) (bool, error) {
+	v, ok := resolveOperand(n.Operand, item)
+	lo, lok := resolveOperand(n.Lo, item)
+	hi, hok := resolveOperand(n.Hi, item)
+
+	if !ok || !lok || !hok {
+		return false, nil
+	}
+
+	cLo, ok1 := orderedCompare(v, lo)
+	cHi, ok2 := orderedCompare(v, hi)
+
+	if !ok1 || !ok2 {
+		return false, nil
+	}
+
+	return cLo >= 0 && cHi <= 0, nil
+}
+
+func evalIn(n *In, item map[string]any) (bool, error) {
+	v, ok := resolveOperand(n.Operand, item)
+	if !ok {
+		return false, nil
+	}
+
+	for _, opnd := range n.List {
+		iv, iok := resolveOperand(opnd, item)
+		if iok && valuesEqual(v, iv) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func evalAttrType(n *AttrType, item map[string]any) bool {
+	v, ok := resolvePath(n.Path.Parts, item)
+	if !ok {
+		return false
+	}
+
+	tv, tok := resolveOperand(n.Type, item)
+	if !tok {
+		return false
+	}
+
+	ts, isStr := tv.(string)
+
+	return isStr && dynamoType(v) == ts
+}
+
+func evalBeginsWith(n *BeginsWith, item map[string]any) bool {
+	v, ok := resolvePath(n.Path.Parts, item)
+	if !ok {
+		return false
+	}
+
+	pv, pok := resolveOperand(n.Prefix, item)
+	if !pok {
+		return false
+	}
+
+	switch s := v.(type) {
+	case string:
+		p, isStr := pv.(string)
+		return isStr && strings.HasPrefix(s, p)
+	case []byte:
+		p, isBytes := pv.([]byte)
+		return isBytes && bytes.HasPrefix(s, p)
+	}
+
+	return false
+}
+
+func evalContains(n *Contains, item map[string]any) bool {
+	v, ok := resolvePath(n.Path.Parts, item)
+	if !ok {
+		return false
+	}
+
+	target, tok := resolveOperand(n.Operand, item)
+	if !tok {
+		return false
+	}
+
+	switch s := v.(type) {
+	case string:
+		t, isStr := target.(string)
+		return isStr && strings.Contains(s, t)
+	case []any:
+		return sliceContains(s, target)
+	}
+
+	return false
+}
+
+func sliceContains(s []any, target any) bool {
+	for _, e := range s {
+		if valuesEqual(e, target) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveOperand yields an operand's native value and whether it is present.
+// A missing path (or a size() over a missing/non-sizable path) reports
+// present=false so its enclosing condition evaluates to false.
+func resolveOperand(op Operand, item map[string]any) (any, bool) {
+	switch o := op.(type) {
+	case *ValueOperand:
+		return o.Value, true
+	case *PathOperand:
+		return resolvePath(o.Parts, item)
+	case *SizeOperand:
+		v, ok := resolvePath(o.Path.Parts, item)
+		if !ok {
+			return nil, false
+		}
+
+		return sizeOf(v)
+	}
+
+	return nil, false
+}
+
+// resolvePath walks a document path over nested maps and slices. A key that
+// is present with a nil value counts as present (DynamoDB NULL).
+func resolvePath(parts []PathPart, item map[string]any) (any, bool) {
+	var cur any = item
+
+	for _, part := range parts {
+		if part.IsIndex {
+			arr, ok := cur.([]any)
+			if !ok || part.Index < 0 || part.Index >= len(arr) {
+				return nil, false
+			}
+
+			cur = arr[part.Index]
+
+			continue
+		}
+
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		v, ok := m[part.Name]
+		if !ok {
+			return nil, false
+		}
+
+		cur = v
+	}
+
+	return cur, true
+}
+
+func compareOp(op string, a, b any) bool {
+	switch op {
+	case "=":
+		return valuesEqual(a, b)
+	case "<>":
+		return !valuesEqual(a, b)
+	}
+
+	c, ok := orderedCompare(a, b)
+	if !ok {
+		return false
+	}
+
+	switch op {
+	case "<":
+		return c < 0
+	case "<=":
+		return c <= 0
+	case ">":
+		return c > 0
+	case ">=":
+		return c >= 0
+	}
+
+	return false
+}
+
+// valuesEqual reports type-aware equality: only same-typed values can be
+// equal, so a number never equals a string.
+func valuesEqual(a, b any) bool {
+	switch av := a.(type) {
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case []byte:
+		bv, ok := b.([]byte)
+		return ok && bytes.Equal(av, bv)
+	case nil:
+		return b == nil
+	}
+
+	return false
+}
+
+// orderedCompare returns -1/0/1 for orderable, same-typed values (numbers,
+// strings, binary). Mixed or non-orderable types report ok=false.
+func orderedCompare(a, b any) (int, bool) {
+	switch av := a.(type) {
+	case float64:
+		bv, ok := b.(float64)
+		if !ok {
+			return 0, false
+		}
+
+		return cmp.Compare(av, bv), true
+	case string:
+		bv, ok := b.(string)
+		if !ok {
+			return 0, false
+		}
+
+		return cmp.Compare(av, bv), true
+	case []byte:
+		bv, ok := b.([]byte)
+		if !ok {
+			return 0, false
+		}
+
+		return bytes.Compare(av, bv), true
+	}
+
+	return 0, false
+}
+
+func sizeOf(v any) (any, bool) {
+	switch x := v.(type) {
+	case string:
+		return float64(len(x)), true
+	case []byte:
+		return float64(len(x)), true
+	case []any:
+		return float64(len(x)), true
+	case map[string]any:
+		return float64(len(x)), true
+	}
+
+	return nil, false
+}
+
+// dynamoType returns the DynamoDB attribute type code for a native value.
+// Sets are indistinguishable from lists in the native model and report "L".
+func dynamoType(v any) string {
+	switch v.(type) {
+	case string:
+		return "S"
+	case float64:
+		return "N"
+	case bool:
+		return "BOOL"
+	case []byte:
+		return "B"
+	case nil:
+		return "NULL"
+	case []any:
+		return "L"
+	case map[string]any:
+		return "M"
+	}
+
+	return ""
+}

--- a/services/database/driver/expr/expr_test.go
+++ b/services/database/driver/expr/expr_test.go
@@ -1,0 +1,342 @@
+package expr
+
+import (
+	"testing"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sampleItem is a representative native DynamoDB item used across tests.
+func sampleItem() map[string]any {
+	return map[string]any{
+		"pk":       "user#1",
+		"age":      float64(30),
+		"score":    float64(75),
+		"name":     "Alice",
+		"active":   true,
+		"nickname": nil,
+		"blob":     []byte("hello"),
+		"tags":     []any{"red", "green", "blue"},
+		"nums":     []any{float64(1), float64(2), float64(3)},
+		"address": map[string]any{
+			"city": "Seattle",
+			"zip":  "98101",
+		},
+		"matrix": []any{
+			map[string]any{"k": "v0"},
+			map[string]any{"k": "v1"},
+		},
+	}
+}
+
+// evalRaw parses then evaluates raw against item, requiring no error.
+func evalRaw(t *testing.T, raw string, names map[string]string, values map[string]any) bool {
+	t.Helper()
+	node, err := ParseCondition(raw, names, values)
+	require.NoError(t, err)
+	got, err := Eval(node, sampleItem())
+	require.NoError(t, err)
+	return got
+}
+
+func TestComparators(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		values map[string]any
+		want   bool
+	}{
+		{"num eq", "age = :v", map[string]any{":v": float64(30)}, true},
+		{"num eq false", "age = :v", map[string]any{":v": float64(31)}, false},
+		{"num ne", "age <> :v", map[string]any{":v": float64(31)}, true},
+		{"num lt", "age < :v", map[string]any{":v": float64(40)}, true},
+		{"num le eq", "age <= :v", map[string]any{":v": float64(30)}, true},
+		{"num gt", "age > :v", map[string]any{":v": float64(10)}, true},
+		{"num ge", "age >= :v", map[string]any{":v": float64(30)}, true},
+		{"str eq", "name = :v", map[string]any{":v": "Alice"}, true},
+		{"str lt", "name < :v", map[string]any{":v": "Bob"}, true},
+		{"bool eq", "active = :v", map[string]any{":v": true}, true},
+		{"bool ne", "active <> :v", map[string]any{":v": false}, true},
+		// Cross-type: number 30 is not equal to string "30", and not orderable.
+		{"num not equal str", "age = :v", map[string]any{":v": "30"}, false},
+		{"num ne str is true", "age <> :v", map[string]any{":v": "30"}, true},
+		{"num lt str is false", "age < :v", map[string]any{":v": "30"}, false},
+		{"num gt str is false", "age > :v", map[string]any{":v": "30"}, false},
+		// Bytes compare bytewise.
+		{"bytes eq", "blob = :v", map[string]any{":v": []byte("hello")}, true},
+		{"bytes lt", "blob < :v", map[string]any{":v": []byte("world")}, true},
+		// Missing path → comparison false.
+		{"missing path", "missing = :v", map[string]any{":v": "x"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evalRaw(t, tt.raw, nil, tt.values))
+		})
+	}
+}
+
+func TestNumberNotEqualStringLiteralCase(t *testing.T) {
+	// The headline invariant: 25 != "25".
+	assert.False(t, evalRaw(t, "score = :v", nil, map[string]any{":v": "75"}))
+	assert.True(t, evalRaw(t, "score = :v", nil, map[string]any{":v": float64(75)}))
+}
+
+func TestBooleanLogicAndPrecedence(t *testing.T) {
+	v := map[string]any{
+		":a":     float64(30),
+		":score": float64(75),
+		":lo":    float64(70),
+		":hi":    float64(80),
+		":n":     "Alice",
+	}
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{"and true", "age = :a AND name = :n", true},
+		{"and false", "age = :a AND name = :hi", false},
+		{"or true", "age = :hi OR name = :n", true},
+		{"not", "NOT age = :hi", true},
+		{"not paren", "NOT (age = :a)", false},
+		// NOT binds tighter than AND: NOT age=:hi AND name=:n → (NOT age=:hi) AND (name=:n).
+		{"not before and", "NOT age = :hi AND name = :n", true},
+		// AND binds tighter than OR: false OR (true AND true).
+		{"and before or", "name = :hi OR age = :a AND score = :score", true},
+		// Same shape, but the AND clause is false → whole thing false.
+		{"and before or false", "name = :hi OR age = :a AND score = :lo", false},
+		// Parens override precedence: (false OR true) AND false.
+		{"paren override", "(name = :hi OR age = :a) AND score = :hi", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evalRaw(t, tt.raw, nil, v))
+		})
+	}
+}
+
+func TestInAndBetween(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		values map[string]any
+		want   bool
+	}{
+		{"in match", "name IN (:a, :b, :c)", map[string]any{":a": "Bob", ":b": "Alice", ":c": "Eve"}, true},
+		{"in no match", "name IN (:a, :b)", map[string]any{":a": "Bob", ":b": "Eve"}, false},
+		{"in numeric", "age IN (:a, :b)", map[string]any{":a": float64(30), ":b": float64(40)}, true},
+		{"between inside", "age BETWEEN :lo AND :hi", map[string]any{":lo": float64(20), ":hi": float64(40)}, true},
+		{"between edge lo", "age BETWEEN :lo AND :hi", map[string]any{":lo": float64(30), ":hi": float64(40)}, true},
+		{"between outside", "age BETWEEN :lo AND :hi", map[string]any{":lo": float64(31), ":hi": float64(40)}, false},
+		{"between string", "name BETWEEN :lo AND :hi", map[string]any{":lo": "A", ":hi": "B"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evalRaw(t, tt.raw, nil, tt.values))
+		})
+	}
+}
+
+func TestFunctions(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		values map[string]any
+		want   bool
+	}{
+		{"exists", "attribute_exists(name)", nil, true},
+		{"exists missing", "attribute_exists(missing)", nil, false},
+		// A key present with a nil value still counts as existing.
+		{"exists nil value", "attribute_exists(nickname)", nil, true},
+		{"not_exists true", "attribute_not_exists(missing)", nil, true},
+		{"not_exists false", "attribute_not_exists(name)", nil, false},
+		{"type S", "attribute_type(name, :t)", map[string]any{":t": "S"}, true},
+		{"type N", "attribute_type(age, :t)", map[string]any{":t": "N"}, true},
+		{"type BOOL", "attribute_type(active, :t)", map[string]any{":t": "BOOL"}, true},
+		{"type B", "attribute_type(blob, :t)", map[string]any{":t": "B"}, true},
+		{"type NULL", "attribute_type(nickname, :t)", map[string]any{":t": "NULL"}, true},
+		{"type L", "attribute_type(tags, :t)", map[string]any{":t": "L"}, true},
+		{"type M", "attribute_type(address, :t)", map[string]any{":t": "M"}, true},
+		{"type mismatch", "attribute_type(age, :t)", map[string]any{":t": "S"}, false},
+		{"begins_with", "begins_with(name, :p)", map[string]any{":p": "Al"}, true},
+		{"begins_with false", "begins_with(name, :p)", map[string]any{":p": "Xy"}, false},
+		{"begins_with bytes", "begins_with(blob, :p)", map[string]any{":p": []byte("he")}, true},
+		{"contains substr", "contains(name, :s)", map[string]any{":s": "lic"}, true},
+		{"contains substr false", "contains(name, :s)", map[string]any{":s": "zzz"}, false},
+		{"contains list member", "contains(tags, :s)", map[string]any{":s": "green"}, true},
+		{"contains list absent", "contains(tags, :s)", map[string]any{":s": "pink"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evalRaw(t, tt.raw, nil, tt.values))
+		})
+	}
+}
+
+func TestSizeInComparison(t *testing.T) {
+	// size(tags) == 3
+	assert.True(t, evalRaw(t, "size(tags) > :n", nil, map[string]any{":n": float64(2)}))
+	assert.False(t, evalRaw(t, "size(tags) > :n", nil, map[string]any{":n": float64(3)}))
+	assert.True(t, evalRaw(t, "size(tags) = :n", nil, map[string]any{":n": float64(3)}))
+	// size of a string is its byte length; "Alice" == 5.
+	assert.True(t, evalRaw(t, "size(name) = :n", nil, map[string]any{":n": float64(5)}))
+	// size of a map is its entry count; address has 2 entries.
+	assert.True(t, evalRaw(t, "size(address) = :n", nil, map[string]any{":n": float64(2)}))
+	// size over a missing path → comparison false.
+	assert.False(t, evalRaw(t, "size(missing) > :n", nil, map[string]any{":n": float64(0)}))
+	// size on the right-hand side of a comparison also works.
+	assert.True(t, evalRaw(t, ":n < size(tags)", nil, map[string]any{":n": float64(2)}))
+}
+
+func TestDocumentPaths(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		values map[string]any
+		want   bool
+	}{
+		{"nested map", "address.city = :v", map[string]any{":v": "Seattle"}, true},
+		{"nested map miss", "address.city = :v", map[string]any{":v": "Boston"}, false},
+		{"list index", "tags[0] = :v", map[string]any{":v": "red"}, true},
+		{"list index 2", "tags[2] = :v", map[string]any{":v": "blue"}, true},
+		{"list index oob", "tags[9] = :v", map[string]any{":v": "red"}, false},
+		{"nested list of maps", "matrix[1].k = :v", map[string]any{":v": "v1"}, true},
+		{"path exists", "attribute_exists(address.zip)", nil, true},
+		{"path missing exists", "attribute_exists(address.country)", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evalRaw(t, tt.raw, nil, tt.values))
+		})
+	}
+}
+
+func TestAliasAndValueSubstitution(t *testing.T) {
+	names := map[string]string{
+		"#n":   "name",
+		"#a":   "address",
+		"#c":   "city",
+		"#age": "age",
+	}
+	values := map[string]any{":v": "Alice", ":city": "Seattle", ":min": float64(18)}
+
+	assert.True(t, evalRaw(t, "#n = :v", names, values))
+	assert.True(t, evalRaw(t, "#a.#c = :city", names, values))
+	assert.True(t, evalRaw(t, "#age >= :min", names, values))
+	assert.True(t, evalRaw(t, "attribute_exists(#n)", names, values))
+}
+
+func TestMalformedExpressions(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		names  map[string]string
+		values map[string]any
+	}{
+		{"empty", "", nil, nil},
+		{"dangling operator", "age =", nil, nil},
+		{"unclosed paren", "(age = :v", nil, map[string]any{":v": float64(1)}},
+		{"missing operator", "age name", nil, nil},
+		{"unknown alias", "#x = :v", nil, map[string]any{":v": float64(1)}},
+		{"unknown value", "age = :missing", nil, nil},
+		{"empty ref", "age = :", nil, nil},
+		{"bad index", "tags[x] = :v", nil, map[string]any{":v": "red"}},
+		{"trailing token", "age = :v :v", nil, map[string]any{":v": float64(1)}},
+		{"bad char", "age ~ :v", nil, map[string]any{":v": float64(1)}},
+		{"size as condition", "size(tags)", nil, nil},
+		{"in missing rparen", "name IN (:a", nil, map[string]any{":a": "x"}},
+		{"between missing and", "age BETWEEN :lo :hi", nil, map[string]any{":lo": float64(1), ":hi": float64(2)}},
+		{"func no args", "attribute_exists()", nil, nil},
+		{"operand func misuse", "contains(tags) = :v", nil, map[string]any{":v": "x"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCondition(tt.raw, tt.names, tt.values)
+			require.Error(t, err)
+			assert.True(t, cerrors.IsInvalidArgument(err), "expected InvalidArgument, got %v", err)
+		})
+	}
+}
+
+func TestCaseInsensitiveKeywordsAndFunctions(t *testing.T) {
+	v := map[string]any{":a": float64(30), ":n": "Alice"}
+	assert.True(t, evalRaw(t, "age = :a and name = :n", nil, v))
+	assert.True(t, evalRaw(t, "age = :a Or name = :n", nil, v))
+	assert.True(t, evalRaw(t, "Attribute_Exists(name)", nil, nil))
+	assert.True(t, evalRaw(t, "BEGINS_WITH(name, :p)", nil, map[string]any{":p": "Al"}))
+}
+
+func TestTypeAndContainerEdges(t *testing.T) {
+	tests := []struct {
+		name   string
+		raw    string
+		values map[string]any
+		want   bool
+	}{
+		// Descending into a scalar as if it were a map fails → false.
+		{"scalar as map", "name.foo = :v", map[string]any{":v": "x"}, false},
+		// Descending into a scalar as if it were a list fails → false.
+		{"scalar as list", "name[0] = :v", map[string]any{":v": "x"}, false},
+		// begins_with with a non-string prefix against a string value → false.
+		{"begins_with type mismatch", "begins_with(name, :p)", map[string]any{":p": float64(1)}, false},
+		// begins_with over a non-string, non-binary value → false.
+		{"begins_with wrong target", "begins_with(age, :p)", map[string]any{":p": "3"}, false},
+		// contains over a non-string, non-list value → false.
+		{"contains wrong target", "contains(age, :s)", map[string]any{":s": "3"}, false},
+		// contains substring where the value operand isn't a string → false.
+		{"contains type mismatch", "contains(name, :s)", map[string]any{":s": float64(1)}, false},
+		// Ordering a binary value against a number → not orderable → false.
+		{"bytes vs num", "blob < :v", map[string]any{":v": float64(5)}, false},
+		// bool inequality with a non-bool operand.
+		{"bool vs string", "active = :v", map[string]any{":v": "true"}, false},
+		// nil equality: nickname (NULL) equals a NULL value operand.
+		{"nil eq nil", "nickname = :v", map[string]any{":v": nil}, true},
+		{"nil ne value", "nickname = :v", map[string]any{":v": "x"}, false},
+		// size() over a scalar number is not sizable → comparison false.
+		{"size of number", "size(age) > :n", map[string]any{":n": float64(0)}, false},
+		// contains membership over a numeric list.
+		{"contains numeric list", "contains(nums, :s)", map[string]any{":s": float64(2)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evalRaw(t, tt.raw, nil, tt.values))
+		})
+	}
+}
+
+func TestMoreMalformed(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"size missing rparen", "size(tags = :v"},
+		{"binary func missing comma", "begins_with(name :p)"},
+		{"between operand error", "age BETWEEN AND :hi"},
+		{"path dot no name", "address. = :v"},
+		{"index no rbracket", "tags[0 = :v"},
+		{"leading operator", "= :v"},
+		{"not nothing", "NOT"},
+		{"binary func bad arg", "attribute_type(name, )"},
+		{"binary func missing value", "begins_with(name, :nope)"},
+		{"size bad alias", "size(#bad) = :v"},
+		{"binary func missing rparen", "contains(name, :v"},
+		{"in bad member", "name IN (:nope)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCondition(tt.raw, nil, map[string]any{":v": "x", ":p": "x", ":hi": float64(1)})
+			require.Error(t, err)
+			assert.True(t, cerrors.IsInvalidArgument(err), "expected InvalidArgument, got %v", err)
+		})
+	}
+}
+
+func TestEvalUnsupportedNode(t *testing.T) {
+	// Guards the defensive branch in Eval for an unknown node type.
+	type bogus struct{ Node }
+	_, err := Eval(bogus{}, sampleItem())
+	require.Error(t, err)
+	assert.True(t, cerrors.IsInvalidArgument(err))
+}

--- a/services/database/driver/expr/lex.go
+++ b/services/database/driver/expr/lex.go
@@ -1,0 +1,209 @@
+package expr
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+type tokenKind int
+
+const (
+	tEOF tokenKind = iota
+	tIdent
+	tAlias
+	tValue
+	tNumber
+	tOp
+	tAnd
+	tOr
+	tNot
+	tIn
+	tBetween
+	tFunc
+	tLParen
+	tRParen
+	tComma
+	tDot
+	tLBracket
+	tRBracket
+)
+
+// twoByteOp is the length of a two-character relational operator (<= <> >=).
+const twoByteOp = 2
+
+type token struct {
+	kind tokenKind
+	text string
+}
+
+//nolint:gochecknoglobals // static keyword lookup table.
+var keywords = map[string]tokenKind{
+	"and":     tAnd,
+	"or":      tOr,
+	"not":     tNot,
+	"in":      tIn,
+	"between": tBetween,
+}
+
+//nolint:gochecknoglobals // static set of recognized DynamoDB functions.
+var functions = map[string]bool{
+	fnAttrExists:           true,
+	"attribute_not_exists": true,
+	"attribute_type":       true,
+	"begins_with":          true,
+	"contains":             true,
+	fnSize:                 true,
+}
+
+// lex tokenizes a DynamoDB condition/filter expression. Keywords and
+// function names are case-insensitive; attribute names are case-sensitive.
+func lex(s string) ([]token, error) {
+	toks := []token{}
+	i := 0
+
+	for i < len(s) {
+		if isSpace(s[i]) {
+			i++
+
+			continue
+		}
+
+		tok, next, err := lexToken(s, i)
+		if err != nil {
+			return nil, err
+		}
+
+		toks = append(toks, tok)
+		i = next
+	}
+
+	return append(toks, token{kind: tEOF}), nil
+}
+
+// lexToken scans the single token starting at s[i], which is known not to be
+// whitespace.
+func lexToken(s string, i int) (tok token, next int, err error) {
+	c := s[i]
+
+	switch {
+	case isWordStart(c):
+		tok, next = lexWord(s, i)
+		return tok, next, nil
+	case c == '#' || c == ':':
+		return lexRef(s, i)
+	case isDigit(c):
+		tok, next = lexNumber(s, i)
+		return tok, next, nil
+	default:
+		return lexSymbol(s, i)
+	}
+}
+
+func lexWord(s string, i int) (tok token, next int) {
+	start := i
+
+	for i < len(s) && isWordChar(s[i]) {
+		i++
+	}
+
+	word := s[start:i]
+	lower := strings.ToLower(word)
+
+	if k, ok := keywords[lower]; ok {
+		return token{kind: k, text: lower}, i
+	}
+
+	if functions[lower] {
+		return token{kind: tFunc, text: lower}, i
+	}
+
+	return token{kind: tIdent, text: word}, i
+}
+
+func lexRef(s string, i int) (tok token, next int, err error) {
+	prefix := s[i]
+	start := i
+	i++
+
+	for i < len(s) && isWordChar(s[i]) {
+		i++
+	}
+
+	if i == start+1 {
+		return token{}, 0, cerrors.Newf(cerrors.InvalidArgument, "empty %c reference at position %d", prefix, start)
+	}
+
+	kind := tAlias
+	if prefix == ':' {
+		kind = tValue
+	}
+
+	return token{kind: kind, text: s[start:i]}, i, nil
+}
+
+func lexNumber(s string, i int) (tok token, next int) {
+	start := i
+
+	for i < len(s) && isDigit(s[i]) {
+		i++
+	}
+
+	return token{kind: tNumber, text: s[start:i]}, i
+}
+
+func lexSymbol(s string, i int) (tok token, next int, err error) {
+	switch s[i] {
+	case '(':
+		return token{kind: tLParen}, i + 1, nil
+	case ')':
+		return token{kind: tRParen}, i + 1, nil
+	case ',':
+		return token{kind: tComma}, i + 1, nil
+	case '.':
+		return token{kind: tDot}, i + 1, nil
+	case '[':
+		return token{kind: tLBracket}, i + 1, nil
+	case ']':
+		return token{kind: tRBracket}, i + 1, nil
+	case '=':
+		return token{kind: tOp, text: "="}, i + 1, nil
+	case '<', '>':
+		return lexRelational(s, i)
+	}
+
+	return token{}, 0, cerrors.Newf(cerrors.InvalidArgument, "unexpected character %q at position %d", string(s[i]), i)
+}
+
+func lexRelational(s string, i int) (tok token, next int, err error) {
+	c := s[i]
+
+	if i+1 < len(s) {
+		switch {
+		case c == '<' && s[i+1] == '=':
+			return token{kind: tOp, text: "<="}, i + twoByteOp, nil
+		case c == '<' && s[i+1] == '>':
+			return token{kind: tOp, text: "<>"}, i + twoByteOp, nil
+		case c == '>' && s[i+1] == '=':
+			return token{kind: tOp, text: ">="}, i + twoByteOp, nil
+		}
+	}
+
+	return token{kind: tOp, text: string(c)}, i + 1, nil
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+func isWordStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isWordChar(c byte) bool {
+	return isWordStart(c) || isDigit(c)
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}

--- a/services/database/driver/expr/parse.go
+++ b/services/database/driver/expr/parse.go
@@ -1,0 +1,411 @@
+package expr
+
+import (
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Function name literals shared by the lexer and parser.
+const (
+	fnSize       = "size"
+	fnAttrExists = "attribute_exists"
+)
+
+// ParseCondition parses a DynamoDB condition/filter expression into an AST.
+// names resolves #alias steps (ExpressionAttributeNames) and values resolves
+// :placeholder operands (ExpressionAttributeValues, already native). It
+// returns a cerrors.InvalidArgument error on any malformed input.
+func ParseCondition(raw string, names map[string]string, values map[string]any) (Node, error) {
+	toks, err := lex(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &parser{toks: toks, names: names, values: values}
+	if p.peek().kind == tEOF {
+		return nil, cerrors.New(cerrors.InvalidArgument, "empty expression")
+	}
+
+	node, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.peek().kind != tEOF {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unexpected trailing token %q", p.peek().text)
+	}
+
+	return node, nil
+}
+
+type parser struct {
+	toks   []token
+	pos    int
+	names  map[string]string
+	values map[string]any
+}
+
+func (p *parser) peek() token { return p.toks[p.pos] }
+
+func (p *parser) next() token {
+	t := p.toks[p.pos]
+
+	if p.pos < len(p.toks)-1 {
+		p.pos++
+	}
+
+	return t
+}
+
+func (p *parser) expect(kind tokenKind, what string) error {
+	if p.peek().kind != kind {
+		return cerrors.Newf(cerrors.InvalidArgument, "expected %s but found %q", what, p.peek().text)
+	}
+
+	p.next()
+
+	return nil
+}
+
+// parseExpr → OR (lowest precedence).
+func (p *parser) parseExpr() (Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tOr {
+		p.next()
+
+		right, rerr := p.parseAnd()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		left = &Or{Left: left, Right: right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseAnd() (Node, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tAnd {
+		p.next()
+
+		right, rerr := p.parseNot()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		left = &And{Left: left, Right: right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseNot() (Node, error) {
+	if p.peek().kind == tNot {
+		p.next()
+
+		child, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+
+		return &Not{Child: child}, nil
+	}
+
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (Node, error) {
+	if p.peek().kind == tLParen {
+		p.next()
+
+		node, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+
+		if perr := p.expect(tRParen, "')'"); perr != nil {
+			return nil, perr
+		}
+
+		return node, nil
+	}
+
+	return p.parseCondition()
+}
+
+func (p *parser) parseCondition() (Node, error) {
+	if p.peek().kind == tFunc && p.peek().text != fnSize {
+		return p.parseBooleanFunc()
+	}
+
+	left, err := p.parseOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	//nolint:exhaustive // remaining token kinds fall through to the error default.
+	switch p.peek().kind {
+	case tBetween:
+		return p.parseBetween(left)
+	case tIn:
+		return p.parseIn(left)
+	case tOp:
+		op := p.next().text
+
+		right, rerr := p.parseOperand()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		return &Comparison{Op: op, Left: left, Right: right}, nil
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected an operator but found %q", p.peek().text)
+	}
+}
+
+func (p *parser) parseBetween(left Operand) (Node, error) {
+	p.next()
+
+	lo, err := p.parseOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	if aerr := p.expect(tAnd, "'AND'"); aerr != nil {
+		return nil, aerr
+	}
+
+	hi, herr := p.parseOperand()
+	if herr != nil {
+		return nil, herr
+	}
+
+	return &Between{Operand: left, Lo: lo, Hi: hi}, nil
+}
+
+func (p *parser) parseIn(left Operand) (Node, error) {
+	p.next()
+
+	if err := p.expect(tLParen, "'('"); err != nil {
+		return nil, err
+	}
+
+	list := []Operand{}
+
+	for {
+		op, err := p.parseOperand()
+		if err != nil {
+			return nil, err
+		}
+
+		list = append(list, op)
+
+		if p.peek().kind != tComma {
+			break
+		}
+
+		p.next()
+	}
+
+	if err := p.expect(tRParen, "')'"); err != nil {
+		return nil, err
+	}
+
+	return &In{Operand: left, List: list}, nil
+}
+
+func (p *parser) parseBooleanFunc() (Node, error) {
+	fn := p.next().text
+
+	if err := p.expect(tLParen, "'('"); err != nil {
+		return nil, err
+	}
+
+	if fn == fnAttrExists || fn == "attribute_not_exists" {
+		return p.finishUnaryFunc(fn)
+	}
+
+	return p.finishBinaryFunc(fn)
+}
+
+func (p *parser) finishUnaryFunc(fn string) (Node, error) {
+	path, err := p.parsePath()
+	if err != nil {
+		return nil, err
+	}
+
+	if rerr := p.expect(tRParen, "')'"); rerr != nil {
+		return nil, rerr
+	}
+
+	if fn == fnAttrExists {
+		return &AttrExists{Path: path}, nil
+	}
+
+	return &AttrNotExists{Path: path}, nil
+}
+
+func (p *parser) finishBinaryFunc(fn string) (Node, error) {
+	path, err := p.parsePath()
+	if err != nil {
+		return nil, err
+	}
+
+	if cerr := p.expect(tComma, "','"); cerr != nil {
+		return nil, cerr
+	}
+
+	arg, aerr := p.parseOperand()
+	if aerr != nil {
+		return nil, aerr
+	}
+
+	if rerr := p.expect(tRParen, "')'"); rerr != nil {
+		return nil, rerr
+	}
+
+	switch fn {
+	case "attribute_type":
+		return &AttrType{Path: path, Type: arg}, nil
+	case "begins_with":
+		return &BeginsWith{Path: path, Prefix: arg}, nil
+	default:
+		return &Contains{Path: path, Operand: arg}, nil
+	}
+}
+
+func (p *parser) parseOperand() (Operand, error) {
+	//nolint:exhaustive // remaining token kinds fall through to the error default.
+	switch p.peek().kind {
+	case tValue:
+		return p.parseValue()
+	case tFunc:
+		if p.peek().text != fnSize {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "function %q cannot be used as an operand", p.peek().text)
+		}
+
+		return p.parseSize()
+	case tIdent, tAlias:
+		return p.parsePath()
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected an operand but found %q", p.peek().text)
+	}
+}
+
+func (p *parser) parseValue() (Operand, error) {
+	name := p.next().text
+
+	v, ok := p.values[name]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "no value supplied for placeholder %q", name)
+	}
+
+	return &ValueOperand{Value: v}, nil
+}
+
+func (p *parser) parseSize() (Operand, error) {
+	p.next()
+
+	if err := p.expect(tLParen, "'('"); err != nil {
+		return nil, err
+	}
+
+	path, err := p.parsePath()
+	if err != nil {
+		return nil, err
+	}
+
+	if rerr := p.expect(tRParen, "')'"); rerr != nil {
+		return nil, rerr
+	}
+
+	return &SizeOperand{Path: path}, nil
+}
+
+func (p *parser) parsePath() (*PathOperand, error) {
+	name, err := p.parseName()
+	if err != nil {
+		return nil, err
+	}
+
+	parts := []PathPart{{Name: name}}
+
+	for {
+		//nolint:exhaustive // only '.' and '[' continue a path; anything else ends it.
+		switch p.peek().kind {
+		case tDot:
+			p.next()
+
+			next, nerr := p.parseName()
+			if nerr != nil {
+				return nil, nerr
+			}
+
+			parts = append(parts, PathPart{Name: next})
+		case tLBracket:
+			idx, ierr := p.parseIndex()
+			if ierr != nil {
+				return nil, ierr
+			}
+
+			parts = append(parts, PathPart{Index: idx, IsIndex: true})
+		default:
+			return &PathOperand{Parts: parts}, nil
+		}
+	}
+}
+
+func (p *parser) parseName() (string, error) {
+	tok := p.peek()
+
+	//nolint:exhaustive // only identifiers and aliases name attributes.
+	switch tok.kind {
+	case tIdent:
+		p.next()
+
+		return tok.text, nil
+	case tAlias:
+		p.next()
+
+		resolved, ok := p.names[tok.text]
+		if !ok {
+			return "", cerrors.Newf(cerrors.InvalidArgument, "no name supplied for alias %q", tok.text)
+		}
+
+		return resolved, nil
+	default:
+		return "", cerrors.Newf(cerrors.InvalidArgument, "expected an attribute name but found %q", tok.text)
+	}
+}
+
+func (p *parser) parseIndex() (int, error) {
+	p.next()
+
+	tok := p.peek()
+	if tok.kind != tNumber {
+		return 0, cerrors.Newf(cerrors.InvalidArgument, "expected a list index but found %q", tok.text)
+	}
+
+	p.next()
+
+	idx, err := strconv.Atoi(tok.text)
+	if err != nil {
+		return 0, cerrors.Newf(cerrors.InvalidArgument, "invalid list index %q", tok.text)
+	}
+
+	if rerr := p.expect(tRBracket, "']'"); rerr != nil {
+		return 0, rerr
+	}
+
+	return idx, nil
+}


### PR DESCRIPTION
## DynamoDB expression fidelity (real query semantics, in-memory)

Make cloudemu's **in-memory** DynamoDB actually understand the query language — no real backing, no Docker. Real apps use expressions the emulator silently dropped or got wrong; now they behave like DynamoDB.

### Before → after

Previously the emulator only honored ` AND ` between simple `field op value` clauses and compared everything as strings (`25` matched the string `"25"`). Everything else — `OR`, `NOT`, parentheses, `IN`, `BETWEEN`, `attribute_exists`, `contains()`, `size()`, document paths — was **dropped or rejected**. Now:

```
FilterExpression: "attribute_exists(email) AND status IN (:a, :b) AND size(#tags) > :n"
                  "begins_with(sk, :p) OR NOT (n BETWEEN :lo AND :hi)"
ConditionExpression (Put/Update/Delete): "attribute_not_exists(pk) AND size(#n) < :m"
```
all evaluate faithfully, with **type-aware** comparison (`25` ≠ `"25"`).

### How

- New **`services/database/driver/expr`** — a real tokenizer → recursive-descent parser → AST → type-aware evaluator over the native `map[string]any` item model (93% covered). Precedence `NOT > AND > OR`; parentheses; `IN`/`BETWEEN`; functions `attribute_exists`/`attribute_not_exists`/`attribute_type`/`begins_with`/`contains`/`size`; `#name`/`:value` substitution; document paths (`a.b[0]`). A shared library — reusable by other NoSQL providers later.
- **Filters** (Query/Scan): the raw `FilterExpression` + name/value maps flow to the driver via new `QueryInput`/`ScanInput` struct fields (no interface-method change → **no docs regeneration**) and evaluate per item through `expr`, replacing the flat AND-only path. Paging/Limit/Count/ScannedCount/ordering unchanged.
- **Conditions** (Put/Update/Delete): evaluated with the full grammar against the pre-write item; **extended to UpdateItem and DeleteItem** (was PutItem-only), returning `ConditionalCheckFailedException` on failure.
- The **no-expression path is byte-for-byte behavior-identical** (legacy `Filters` retained for direct driver callers).

### Validation

Real `aws-sdk-go-v2/service/dynamodb` e2es against the wire server assert every new grammar form (functions, `IN`, `OR`/`NOT`, `BETWEEN`, `size`, `contains`, `begins_with`, typed `25` ≠ `"25"`, and Put/Update/Delete conditions). Full suite + `-race` green, no docs drift, 0 new lint.

### Scope
DynamoDB only. Cosmos SQL and Firestore structured queries are different grammars → separate follow-ups. KeyCondition `begins_with`/`BETWEEN`, UpdateExpression `ADD`/`DELETE`/arithmetic, and ProjectionExpression are follow-up slices.
