### PR TITLE
feat(dynamodb): KeyCondition begins_with/BETWEEN + ProjectionExpression

### DIFF
--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -8,6 +8,7 @@ import (
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/server/wire"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
 // updateItem handles UpdateItem. Supports the common cases:
@@ -62,15 +63,15 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 
 // parseUpdateExpression parses a DynamoDB UpdateExpression into driver actions.
 // Supports "SET a = :v, b = :w" and "REMOVE c, d" clauses combined.
-func parseUpdateExpression(expr string, vals map[string]any, names map[string]string) []dbdriver.UpdateAction {
-	expr = strings.TrimSpace(expr)
-	if expr == "" {
+func parseUpdateExpression(updateExpr string, vals map[string]any, names map[string]string) []dbdriver.UpdateAction {
+	updateExpr = strings.TrimSpace(updateExpr)
+	if updateExpr == "" {
 		return nil
 	}
 
 	var actions []dbdriver.UpdateAction
 
-	for _, clause := range splitClauses(expr) {
+	for _, clause := range splitClauses(updateExpr) {
 		verb, rest := splitVerb(clause)
 
 		switch strings.ToUpper(verb) {
@@ -86,8 +87,8 @@ func parseUpdateExpression(expr string, vals map[string]any, names map[string]st
 
 // splitClauses splits an UpdateExpression by keyword boundaries (SET, REMOVE,
 // ADD, DELETE). Returns one string per clause.
-func splitClauses(expr string) []string {
-	upper := strings.ToUpper(expr)
+func splitClauses(updateExpr string) []string {
+	upper := strings.ToUpper(updateExpr)
 
 	keywords := []string{"SET", "REMOVE", "ADD", "DELETE"}
 
@@ -97,7 +98,7 @@ func splitClauses(expr string) []string {
 	}
 
 	if len(starts) == 0 {
-		return []string{expr}
+		return []string{updateExpr}
 	}
 
 	sortInts(starts)
@@ -105,12 +106,12 @@ func splitClauses(expr string) []string {
 	clauses := make([]string, 0, len(starts))
 
 	for i, s := range starts {
-		end := len(expr)
+		end := len(updateExpr)
 		if i+1 < len(starts) {
 			end = starts[i+1]
 		}
 
-		clauses = append(clauses, strings.TrimSpace(expr[s:end]))
+		clauses = append(clauses, strings.TrimSpace(updateExpr[s:end]))
 	}
 
 	return clauses
@@ -227,6 +228,7 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TableName                 string            `json:"TableName"`
 		FilterExpression          string            `json:"FilterExpression"`
+		ProjectionExpression      string            `json:"ProjectionExpression"`
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		Limit                     int               `json:"Limit"`
@@ -254,9 +256,15 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	paths, perr := expr.ParseProjection(req.ProjectionExpression, req.ExpressionAttributeNames)
+	if perr != nil {
+		writeErr(w, perr)
+		return
+	}
+
 	items := make([]map[string]any, 0, len(result.Items))
 	for _, item := range result.Items {
-		items = append(items, toWireItem(item))
+		items = append(items, toWireItem(expr.Project(item, paths)))
 	}
 
 	resp := map[string]any{

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -330,9 +330,8 @@ func TestDDBItemJourney(t *testing.T) {
 }
 
 // TestDDBQueryPartitionAndSort: query by partition key with sort
-// conditions =, >, <=, >= and an ExpressionAttributeNames alias. Note the
-// emulator wire parser only accepts token-form "pk = :v AND sk <op> :v2"
-// (no begins_with()/BETWEEN function syntax).
+// conditions =, >, <=, >=, BETWEEN and begins_with(), plus an
+// ExpressionAttributeNames alias.
 func TestDDBQueryPartitionAndSort(t *testing.T) {
 	client, _ := newSuiteDDBEnv(t)
 	ctx := context.Background()
@@ -399,6 +398,25 @@ func TestDDBQueryPartitionAndSort(t *testing.T) {
 		map[string]string{"#c": "customer"})
 	require.Equal(t, int32(1), out.Count)
 	assert.Equal(t, "99", attrN(t, out.Items[0], "total"))
+
+	// BETWEEN is inclusive on both bounds.
+	out = query("customer = :c AND orderDate BETWEEN :lo AND :hi", map[string]ddbtypes.AttributeValue{
+		":c": sAttr("alice"), ":lo": sAttr("2024-01-01"), ":hi": sAttr("2024-02-28"),
+	}, nil)
+	assert.Equal(t, int32(2), out.Count, "BETWEEN spans Jan 1 and Feb 15 inclusive, excludes Mar 10")
+
+	// begins_with matches the sort-key prefix.
+	out = query("customer = :c AND begins_with(orderDate, :p)", map[string]ddbtypes.AttributeValue{
+		":c": sAttr("alice"), ":p": sAttr("2024-02"),
+	}, nil)
+	require.Equal(t, int32(1), out.Count)
+	assert.Equal(t, "2024-02-15", attrS(t, out.Items[0], "orderDate"))
+
+	// A wider begins_with prefix matches every alice order.
+	out = query("customer = :c AND begins_with(orderDate, :p)", map[string]ddbtypes.AttributeValue{
+		":c": sAttr("alice"), ":p": sAttr("2024"),
+	}, nil)
+	assert.Equal(t, int32(3), out.Count)
 }
 
 // TestDDBTimeToLive is a regression guard for issue #319:
@@ -1317,5 +1335,90 @@ func TestDDBConditionExpressionGrammar(t *testing.T) {
 
 		got := suiteDDBGet(t, client, "cond2", map[string]ddbtypes.AttributeValue{"pk": sAttr("X")})
 		assert.Nil(t, got.Item)
+	})
+}
+
+// TestDDBProjectionExpression covers ProjectionExpression on GetItem, Query
+// and Scan: only the requested paths are returned, nested map sub-paths keep
+// their structure, #aliases resolve, and a projected-but-absent path is
+// omitted.
+func TestDDBProjectionExpression(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "profiles", "id", "")
+
+	suiteDDBPut(t, client, "profiles", map[string]ddbtypes.AttributeValue{
+		"id":   sAttr("u1"),
+		"name": sAttr("alice"),
+		"age":  nAttr("30"),
+		"address": &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
+			"city": sAttr("Paris"),
+			"zip":  sAttr("75001"),
+		}},
+	})
+
+	t.Run("GetItem projects a subset via #alias", func(t *testing.T) {
+		out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName:                aws.String("profiles"),
+			Key:                      map[string]ddbtypes.AttributeValue{"id": sAttr("u1")},
+			ProjectionExpression:     aws.String("id, #n"),
+			ExpressionAttributeNames: map[string]string{"#n": "name"},
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Item, 2, "only id and name are returned")
+		assert.Equal(t, "u1", attrS(t, out.Item, "id"))
+		assert.Equal(t, "alice", attrS(t, out.Item, "name"))
+	})
+
+	t.Run("GetItem projects a nested map path", func(t *testing.T) {
+		out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName:            aws.String("profiles"),
+			Key:                  map[string]ddbtypes.AttributeValue{"id": sAttr("u1")},
+			ProjectionExpression: aws.String("address.city"),
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Item, 1)
+
+		m, ok := out.Item["address"].(*ddbtypes.AttributeValueMemberM)
+		require.True(t, ok, "address should be a map, got %T", out.Item["address"])
+		require.Len(t, m.Value, 1, "only the projected sub-path survives, zip is dropped")
+		assert.Equal(t, "Paris", attrS(t, m.Value, "city"))
+	})
+
+	t.Run("GetItem omits an absent projected path", func(t *testing.T) {
+		out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName:            aws.String("profiles"),
+			Key:                  map[string]ddbtypes.AttributeValue{"id": sAttr("u1")},
+			ProjectionExpression: aws.String("id, missing"),
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Item, 1, "the absent attribute is silently omitted")
+		assert.Equal(t, "u1", attrS(t, out.Item, "id"))
+	})
+
+	t.Run("Query projects each item", func(t *testing.T) {
+		out, err := client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 aws.String("profiles"),
+			KeyConditionExpression:    aws.String("id = :i"),
+			ProjectionExpression:      aws.String("age"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":i": sAttr("u1")},
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(1), out.Count)
+		require.Len(t, out.Items[0], 1)
+		assert.Equal(t, "30", attrN(t, out.Items[0], "age"))
+	})
+
+	t.Run("Scan projects each item", func(t *testing.T) {
+		out, err := client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:            aws.String("profiles"),
+			ProjectionExpression: aws.String("id, age"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(1), out.Count)
+		require.Len(t, out.Items[0], 2)
+		assert.Equal(t, "u1", attrS(t, out.Items[0], "id"))
+		assert.Equal(t, "30", attrN(t, out.Items[0], "age"))
 	})
 }

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -1352,6 +1352,9 @@ func TestDDBProjectionExpression(t *testing.T) {
 		"id":   sAttr("u1"),
 		"name": sAttr("alice"),
 		"age":  nAttr("30"),
+		"tags": &ddbtypes.AttributeValueMemberL{Value: []ddbtypes.AttributeValue{
+			sAttr("x"), sAttr("y"), sAttr("z"),
+		}},
 		"address": &ddbtypes.AttributeValueMemberM{Value: map[string]ddbtypes.AttributeValue{
 			"city": sAttr("Paris"),
 			"zip":  sAttr("75001"),
@@ -1420,5 +1423,42 @@ func TestDDBProjectionExpression(t *testing.T) {
 		require.Len(t, out.Items[0], 2)
 		assert.Equal(t, "u1", attrS(t, out.Items[0], "id"))
 		assert.Equal(t, "30", attrN(t, out.Items[0], "age"))
+	})
+
+	t.Run("GetItem projects a list index, compacted", func(t *testing.T) {
+		out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName:            aws.String("profiles"),
+			Key:                  map[string]ddbtypes.AttributeValue{"id": sAttr("u1")},
+			ProjectionExpression: aws.String("tags[1]"),
+		})
+		require.NoError(t, err)
+		require.Len(t, out.Item, 1)
+
+		l, ok := out.Item["tags"].(*ddbtypes.AttributeValueMemberL)
+		require.True(t, ok, "tags should be a list, got %T", out.Item["tags"])
+		require.Len(t, l.Value, 1, "the projected index compacts to a one-element list")
+		assert.Equal(t, "y", attrS(t, map[string]ddbtypes.AttributeValue{"v": l.Value[0]}, "v"))
+	})
+
+	t.Run("Scan composes ProjectionExpression with FilterExpression", func(t *testing.T) {
+		out, err := client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:                 aws.String("profiles"),
+			FilterExpression:          aws.String("age = :a"),
+			ProjectionExpression:      aws.String("id"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":a": nAttr("30")},
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(1), out.Count, "the filter keeps the matching row")
+		require.Len(t, out.Items[0], 1, "projection trims it to id only")
+		assert.Equal(t, "u1", attrS(t, out.Items[0], "id"))
+
+		out, err = client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:                 aws.String("profiles"),
+			FilterExpression:          aws.String("age = :a"),
+			ProjectionExpression:      aws.String("id"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":a": nAttr("99")},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), out.Count, "a non-matching filter yields nothing to project")
 	})
 }

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -317,8 +317,10 @@ func (h *Handler) checkCondition(
 
 func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		TableName string         `json:"TableName"`
-		Key       map[string]any `json:"Key"`
+		TableName                string            `json:"TableName"`
+		Key                      map[string]any    `json:"Key"`
+		ProjectionExpression     string            `json:"ProjectionExpression"`
+		ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -341,8 +343,15 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{}
+
 	if item != nil {
-		resp["Item"] = toWireItem(item)
+		paths, perr := expr.ParseProjection(req.ProjectionExpression, req.ExpressionAttributeNames)
+		if perr != nil {
+			writeErr(w, perr)
+			return
+		}
+
+		resp["Item"] = toWireItem(expr.Project(item, paths))
 	}
 
 	wire.WriteJSON(w, resp)
@@ -383,6 +392,7 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 		TableName                 string            `json:"TableName"`
 		KeyConditionExpression    string            `json:"KeyConditionExpression"`
 		FilterExpression          string            `json:"FilterExpression"`
+		ProjectionExpression      string            `json:"ProjectionExpression"`
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		Limit                     int               `json:"Limit"`
@@ -422,9 +432,15 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	paths, perr := expr.ParseProjection(req.ProjectionExpression, req.ExpressionAttributeNames)
+	if perr != nil {
+		writeErr(w, perr)
+		return
+	}
+
 	items := make([]map[string]any, 0, len(result.Items))
 	for _, item := range result.Items {
-		items = append(items, toWireItem(item))
+		items = append(items, toWireItem(expr.Project(item, paths)))
 	}
 
 	resp := map[string]any{
@@ -438,8 +454,18 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, resp)
 }
 
-// parseKeyCondition extracts a KeyCondition from a simple expression.
-// Supports: "pk = :v" and "pk = :v AND sk op :v2".
+// Sort-key operators emitted for the function/keyword forms of a
+// KeyConditionExpression. Relational operators (= < <= > >=) flow through as
+// their literal token.
+const (
+	sortOpBetween    = "BETWEEN"
+	sortOpBeginsWith = "BEGINS_WITH"
+)
+
+// parseKeyCondition extracts a KeyCondition from a KeyConditionExpression.
+// The partition key must use equality ("pk = :v"); the optional sort-key
+// condition may be a relational comparison ("sk op :v"), "sk BETWEEN :lo AND
+// :hi", or "begins_with(sk, :v)".
 func parseKeyCondition(
 	keyExpr string,
 	vals map[string]any,
@@ -450,8 +476,11 @@ func parseKeyCondition(
 
 	const andSep = " AND "
 
+	// Split on the FIRST " AND " only: it separates the partition-key equality
+	// from the sort-key condition. A BETWEEN sort condition carries its own
+	// internal " AND ", which stays with the sort clause.
 	andIdx := findCaseInsensitive(keyExpr, andSep)
-	pkExpr := strings.TrimSpace(keyExpr)
+	pkExpr := keyExpr
 	skExpr := ""
 
 	if andIdx >= 0 {
@@ -459,7 +488,7 @@ func parseKeyCondition(
 		skExpr = strings.TrimSpace(keyExpr[andIdx+len(andSep):])
 	}
 
-	// Expression fields: [0]=field, [1]=operator, [2]=value placeholder.
+	// Partition key: [0]=field, [1]="=", [2]=value placeholder.
 	const valueIdx = 2
 
 	pkParts := strings.Fields(pkExpr)
@@ -469,14 +498,73 @@ func parseKeyCondition(
 	}
 
 	if skExpr != "" {
-		skParts := strings.Fields(skExpr)
-		if len(skParts) > valueIdx {
-			kc.SortOp = skParts[1]
-			kc.SortVal = resolveExprVal(skParts[valueIdx], vals)
-		}
+		parseSortCondition(&kc, skExpr, vals)
 	}
 
 	return kc
+}
+
+// parseSortCondition fills kc's sort-key fields from the sort portion of a
+// KeyConditionExpression. The sort key's attribute name is resolved by the
+// provider from the table's key schema, so only the operator and value
+// placeholders are extracted here.
+func parseSortCondition(kc *dbdriver.KeyCondition, skExpr string, vals map[string]any) {
+	if val, ok := parseBeginsWith(skExpr, vals); ok {
+		kc.SortOp = sortOpBeginsWith
+		kc.SortVal = val
+
+		return
+	}
+
+	fields := strings.Fields(skExpr)
+
+	// "sk BETWEEN :lo AND :hi" → [sk BETWEEN :lo AND :hi].
+	const (
+		betweenLen = 5
+		loIdx      = 2
+		hiIdx      = 4
+	)
+
+	if len(fields) >= betweenLen && strings.EqualFold(fields[1], sortOpBetween) {
+		kc.SortOp = sortOpBetween
+		kc.SortVal = resolveExprVal(fields[loIdx], vals)
+		kc.SortValEnd = resolveExprVal(fields[hiIdx], vals)
+
+		return
+	}
+
+	// "sk op :v" → [sk op :v].
+	const opLen = 3
+	if len(fields) >= opLen {
+		kc.SortOp = fields[1]
+		kc.SortVal = resolveExprVal(fields[loIdx], vals)
+	}
+}
+
+// parseBeginsWith recognizes a "begins_with(sk, :v)" sort-key condition and
+// returns its resolved value. ok is false when skExpr is not a begins_with
+// call.
+func parseBeginsWith(skExpr string, vals map[string]any) (val any, ok bool) {
+	const fnBeginsWith = "begins_with"
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(skExpr)), fnBeginsWith) {
+		return nil, false
+	}
+
+	openIdx := strings.Index(skExpr, "(")
+	closeIdx := strings.LastIndex(skExpr, ")")
+
+	if openIdx < 0 || closeIdx < openIdx {
+		return nil, false
+	}
+
+	const argCount = 2
+
+	args := strings.Split(skExpr[openIdx+1:closeIdx], ",")
+	if len(args) != argCount {
+		return nil, false
+	}
+
+	return resolveExprVal(strings.TrimSpace(args[1]), vals), true
 }
 
 func findCaseInsensitive(s, substr string) int {

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -329,6 +329,15 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 
 	key := fromWireItem(req.Key)
 
+	// Validate the projection before the lookup so a malformed expression is a
+	// ValidationException regardless of whether the item exists, matching real
+	// DynamoDB.
+	paths, perr := expr.ParseProjection(req.ProjectionExpression, req.ExpressionAttributeNames)
+	if perr != nil {
+		writeErr(w, perr)
+		return
+	}
+
 	item, err := h.db.GetItem(r.Context(), req.TableName, key)
 	if err != nil {
 		// DynamoDB returns an empty response for missing items, not an error.
@@ -343,14 +352,7 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{}
-
 	if item != nil {
-		paths, perr := expr.ParseProjection(req.ProjectionExpression, req.ExpressionAttributeNames)
-		if perr != nil {
-			writeErr(w, perr)
-			return
-		}
-
 		resp["Item"] = toWireItem(expr.Project(item, paths))
 	}
 

--- a/services/database/driver/expr/project.go
+++ b/services/database/driver/expr/project.go
@@ -1,0 +1,145 @@
+package expr
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// ParseProjection parses a DynamoDB ProjectionExpression — a comma-separated
+// list of document paths (top-level names, nested a.b, and a[n] indexes) —
+// into the paths to retain. names resolves #alias steps
+// (ExpressionAttributeNames). An empty expression yields a nil slice, which
+// callers treat as "return the whole item".
+func ParseProjection(raw string, names map[string]string) ([]*PathOperand, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	toks, err := lex(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &parser{toks: toks, names: names}
+	if p.peek().kind == tEOF {
+		return nil, cerrors.New(cerrors.InvalidArgument, "empty projection expression")
+	}
+
+	return parseProjectionPaths(p)
+}
+
+func parseProjectionPaths(p *parser) ([]*PathOperand, error) {
+	paths := []*PathOperand{}
+
+	for {
+		path, err := p.parsePath()
+		if err != nil {
+			return nil, err
+		}
+
+		paths = append(paths, path)
+
+		if p.peek().kind != tComma {
+			break
+		}
+
+		p.next()
+	}
+
+	if p.peek().kind != tEOF {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unexpected token %q in projection", p.peek().text)
+	}
+
+	return paths, nil
+}
+
+// Project returns a copy of item containing only the given paths, preserving
+// nested map and list structure. A path that is absent from item is skipped,
+// matching DynamoDB, which omits missing projected attributes. With no paths
+// it returns item unchanged.
+func Project(item map[string]any, paths []*PathOperand) map[string]any {
+	if len(paths) == 0 {
+		return item
+	}
+
+	out := map[string]any{}
+
+	for _, path := range paths {
+		v, ok := resolvePath(path.Parts, item)
+		if !ok {
+			continue
+		}
+
+		setProjectedPath(out, path.Parts, v)
+	}
+
+	return out
+}
+
+// setProjectedPath writes val into dst at parts, creating intermediate maps
+// (name steps) and slices (index steps) and merging with structure placed by
+// earlier projected paths. A path always begins with a name step. Index steps
+// only occur for indexes that exist in the source item, so slice growth is
+// bounded by the source document.
+func setProjectedPath(dst map[string]any, parts []PathPart, val any) {
+	head := parts[0]
+
+	if len(parts) == 1 {
+		dst[head.Name] = val
+		return
+	}
+
+	dst[head.Name] = mergeProjected(dst[head.Name], parts[1:], val)
+}
+
+func mergeProjected(existing any, parts []PathPart, val any) any {
+	part := parts[0]
+
+	if part.IsIndex {
+		arr := growSlice(asSlice(existing), part.Index)
+		arr[part.Index] = leafOrMerge(arr[part.Index], parts, val)
+
+		return arr
+	}
+
+	m := asMap(existing)
+	m[part.Name] = leafOrMerge(m[part.Name], parts, val)
+
+	return m
+}
+
+// leafOrMerge returns val when parts has a single remaining step, otherwise it
+// merges val deeper along parts[1:].
+func leafOrMerge(existing any, parts []PathPart, val any) any {
+	if len(parts) == 1 {
+		return val
+	}
+
+	return mergeProjected(existing, parts[1:], val)
+}
+
+func asSlice(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+func asMap(v any) map[string]any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+
+	return m
+}
+
+// growSlice returns s extended so index idx is addressable, filling new gaps
+// with nil.
+func growSlice(s []any, idx int) []any {
+	for len(s) <= idx {
+		s = append(s, nil)
+	}
+
+	return s
+}

--- a/services/database/driver/expr/project.go
+++ b/services/database/driver/expr/project.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"sort"
 	"strings"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -55,10 +56,12 @@ func parseProjectionPaths(p *parser) ([]*PathOperand, error) {
 	return paths, nil
 }
 
-// Project returns a copy of item containing only the given paths, preserving
-// nested map and list structure. A path that is absent from item is skipped,
-// matching DynamoDB, which omits missing projected attributes. With no paths
-// it returns item unchanged.
+// Project returns a deep copy of item containing only the given paths,
+// preserving nested map structure. A path that is absent from item is skipped,
+// matching DynamoDB, which omits missing projected attributes. Projected list
+// indexes are compacted into a list of just those elements in index order,
+// again matching DynamoDB. With no paths it returns item unchanged. The result
+// shares no mutable structure with item.
 func Project(item map[string]any, paths []*PathOperand) map[string]any {
 	if len(paths) == 0 {
 		return item
@@ -75,14 +78,12 @@ func Project(item map[string]any, paths []*PathOperand) map[string]any {
 		setProjectedPath(out, path.Parts, v)
 	}
 
-	return out
+	return finalizeMap(out)
 }
 
 // setProjectedPath writes val into dst at parts, creating intermediate maps
-// (name steps) and slices (index steps) and merging with structure placed by
-// earlier projected paths. A path always begins with a name step. Index steps
-// only occur for indexes that exist in the source item, so slice growth is
-// bounded by the source document.
+// (name steps) and sparse lists (index steps) and merging with structure
+// placed by earlier projected paths. A path always begins with a name step.
 func setProjectedPath(dst map[string]any, parts []PathPart, val any) {
 	head := parts[0]
 
@@ -98,10 +99,10 @@ func mergeProjected(existing any, parts []PathPart, val any) any {
 	part := parts[0]
 
 	if part.IsIndex {
-		arr := growSlice(asSlice(existing), part.Index)
-		arr[part.Index] = leafOrMerge(arr[part.Index], parts, val)
+		sl := asSparse(existing)
+		sl.byIndex[part.Index] = leafOrMerge(sl.byIndex[part.Index], parts, val)
 
-		return arr
+		return sl
 	}
 
 	m := asMap(existing)
@@ -120,9 +121,20 @@ func leafOrMerge(existing any, parts []PathPart, val any) any {
 	return mergeProjected(existing, parts[1:], val)
 }
 
-func asSlice(v any) []any {
-	s, _ := v.([]any)
-	return s
+// sparseList accumulates projected list elements by their source index while a
+// projection is being built. finalize converts it to a compacted list ordered
+// by index — DynamoDB returns only the projected elements, dropping the gaps
+// between them.
+type sparseList struct {
+	byIndex map[int]any
+}
+
+func asSparse(v any) *sparseList {
+	if sl, ok := v.(*sparseList); ok {
+		return sl
+	}
+
+	return &sparseList{byIndex: map[int]any{}}
 }
 
 func asMap(v any) map[string]any {
@@ -134,12 +146,52 @@ func asMap(v any) map[string]any {
 	return m
 }
 
-// growSlice returns s extended so index idx is addressable, filling new gaps
-// with nil.
-func growSlice(s []any, idx int) []any {
-	for len(s) <= idx {
-		s = append(s, nil)
+// finalize materializes the projection scaffold into plain values: sparse
+// lists become compacted slices, maps and slices are deep-copied so the result
+// shares no mutable structure with the source item, and scalars pass through.
+func finalize(v any) any {
+	switch x := v.(type) {
+	case *sparseList:
+		return finalizeSparse(x)
+	case map[string]any:
+		return finalizeMap(x)
+	case []any:
+		return finalizeSlice(x)
+	default:
+		return v
+	}
+}
+
+func finalizeMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, e := range m {
+		out[k] = finalize(e)
 	}
 
-	return s
+	return out
+}
+
+func finalizeSlice(s []any) []any {
+	out := make([]any, 0, len(s))
+	for _, e := range s {
+		out = append(out, finalize(e))
+	}
+
+	return out
+}
+
+func finalizeSparse(s *sparseList) []any {
+	idxs := make([]int, 0, len(s.byIndex))
+	for i := range s.byIndex {
+		idxs = append(idxs, i)
+	}
+
+	sort.Ints(idxs)
+
+	out := make([]any, 0, len(idxs))
+	for _, i := range idxs {
+		out = append(out, finalize(s.byIndex[i]))
+	}
+
+	return out
 }

--- a/services/database/driver/expr/project_test.go
+++ b/services/database/driver/expr/project_test.go
@@ -1,0 +1,96 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseProjectionEmpty(t *testing.T) {
+	paths, err := ParseProjection("", nil)
+	require.NoError(t, err)
+	assert.Nil(t, paths, "an empty projection yields no paths")
+
+	paths, err = ParseProjection("   ", nil)
+	require.NoError(t, err)
+	assert.Nil(t, paths)
+}
+
+func TestParseProjectionPaths(t *testing.T) {
+	paths, err := ParseProjection("a, b.c, d[0]", nil)
+	require.NoError(t, err)
+	require.Len(t, paths, 3)
+
+	assert.Equal(t, []PathPart{{Name: "a"}}, paths[0].Parts)
+	assert.Equal(t, []PathPart{{Name: "b"}, {Name: "c"}}, paths[1].Parts)
+	assert.Equal(t, []PathPart{{Name: "d"}, {Index: 0, IsIndex: true}}, paths[2].Parts)
+}
+
+func TestParseProjectionAlias(t *testing.T) {
+	paths, err := ParseProjection("#n, #a.city", map[string]string{"#n": "name", "#a": "address"})
+	require.NoError(t, err)
+	require.Len(t, paths, 2)
+
+	assert.Equal(t, "name", paths[0].Parts[0].Name)
+	assert.Equal(t, "address", paths[1].Parts[0].Name)
+	assert.Equal(t, "city", paths[1].Parts[1].Name)
+}
+
+func TestParseProjectionErrors(t *testing.T) {
+	for _, raw := range []string{",a", "a b", "a,", "#missing"} {
+		_, err := ParseProjection(raw, nil)
+		assert.Error(t, err, "projection %q should not parse", raw)
+	}
+}
+
+func TestProjectSubsetAndAbsent(t *testing.T) {
+	item := map[string]any{"id": "u1", "name": "alice", "age": float64(30)}
+
+	paths, err := ParseProjection("id, name, missing", nil)
+	require.NoError(t, err)
+
+	got := Project(item, paths)
+	assert.Equal(t, map[string]any{"id": "u1", "name": "alice"}, got,
+		"only present projected paths are kept; missing is omitted")
+}
+
+func TestProjectNestedMap(t *testing.T) {
+	item := map[string]any{
+		"id": "u1",
+		"address": map[string]any{
+			"city": "Paris",
+			"zip":  "75001",
+		},
+	}
+
+	paths, err := ParseProjection("address.city", nil)
+	require.NoError(t, err)
+
+	got := Project(item, paths)
+	assert.Equal(t, map[string]any{"address": map[string]any{"city": "Paris"}}, got,
+		"the nested structure is rebuilt with only the projected sub-path")
+}
+
+func TestProjectListIndex(t *testing.T) {
+	item := map[string]any{
+		"tags": []any{"a", "b", "c"},
+	}
+
+	paths, err := ParseProjection("tags[1]", nil)
+	require.NoError(t, err)
+
+	got := Project(item, paths)
+	require.Contains(t, got, "tags")
+
+	arr, ok := got["tags"].([]any)
+	require.True(t, ok)
+	require.Len(t, arr, 2, "the slice grows to reach the projected index; earlier gaps are nil")
+	assert.Nil(t, arr[0])
+	assert.Equal(t, "b", arr[1])
+}
+
+func TestProjectNoPathsReturnsWholeItem(t *testing.T) {
+	item := map[string]any{"a": 1, "b": 2}
+	assert.Equal(t, item, Project(item, nil))
+}

--- a/services/database/driver/expr/project_test.go
+++ b/services/database/driver/expr/project_test.go
@@ -81,13 +81,38 @@ func TestProjectListIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	got := Project(item, paths)
-	require.Contains(t, got, "tags")
+	assert.Equal(t, map[string]any{"tags": []any{"b"}}, got,
+		"a single projected index compacts to a one-element list, DynamoDB-style")
+}
 
-	arr, ok := got["tags"].([]any)
+func TestProjectMultipleListIndexesCompact(t *testing.T) {
+	item := map[string]any{
+		"tags": []any{"a", "b", "c", "d"},
+	}
+
+	// Projected out of order — the result is ordered by source index, gaps dropped.
+	paths, err := ParseProjection("tags[2], tags[0]", nil)
+	require.NoError(t, err)
+
+	got := Project(item, paths)
+	assert.Equal(t, map[string]any{"tags": []any{"a", "c"}}, got,
+		"projected indexes compact in index order, dropping the gap at index 1")
+}
+
+func TestProjectDoesNotAliasSource(t *testing.T) {
+	inner := map[string]any{"city": "Paris", "zip": "75001"}
+	item := map[string]any{"address": inner}
+
+	paths, err := ParseProjection("address", nil)
+	require.NoError(t, err)
+
+	got := Project(item, paths)
+	gotAddr, ok := got["address"].(map[string]any)
 	require.True(t, ok)
-	require.Len(t, arr, 2, "the slice grows to reach the projected index; earlier gaps are nil")
-	assert.Nil(t, arr[0])
-	assert.Equal(t, "b", arr[1])
+
+	// Mutating the projected copy must not touch the source item.
+	gotAddr["city"] = "London"
+	assert.Equal(t, "Paris", inner["city"], "the projection is a deep copy of the source")
 }
 
 func TestProjectNoPathsReturnsWholeItem(t *testing.T) {


### PR DESCRIPTION
## Summary

Completes DynamoDB expression fidelity begun in #434 by handling the two remaining query-shaping expressions, reusing the shared \`services/database/driver/expr\` package.

### KeyConditionExpression — \`begins_with\` and \`BETWEEN\`
The wire parser previously accepted only \`pk = :v\` and \`pk = :v AND sk <op> :v2\`. It now parses the full official sort-key grammar:
- \`sk = | < | <= | > | >= :v\` (unchanged)
- \`sk BETWEEN :lo AND :hi\` (inclusive)
- \`begins_with(sk, :v)\`

The driver \`KeyCondition\` struct and provider \`applySortCondition\` already supported \`BEGINS_WITH\`/\`BETWEEN\`, so this is a wire-parser-only change. The top-level split fires on the **first** \` AND \` so BETWEEN's internal \`AND\` stays with the sort clause.

### ProjectionExpression
GetItem, Query and Scan now honor \`ProjectionExpression\` — returning only the requested paths. Added exported \`expr.ParseProjection\` + \`expr.Project\` reusing the existing lexer and path resolver: supports top-level names, nested \`a.b\` (structure rebuilt), list indexes \`a[n]\`, \`#alias\` resolution, and silently omits absent paths. Applied post-driver over native items; parsed once per page.

## Why
Real apps and IaC drive DynamoDB with these expressions constantly; without them queries returned wrong key ranges and full items where a projection was requested. All in-memory — no Docker, helps every user.

## Notes
- No \`Database\` interface method change → no docs/coverage regeneration.
- Set-based expressions are unaffected (out of scope; tracked for the UpdateExpression PR).

## Tests
- \`expr/project_test.go\`: parse (empty/paths/alias/errors) + project (subset, nested map, list index, absent omitted, passthrough).
- Real aws-sdk-go-v2 e2e: BETWEEN + begins_with in \`TestDDBQueryPartitionAndSort\`; projection over GetItem (subset, nested, absent), Query and Scan in \`TestDDBProjectionExpression\`.
- build, vet, gofmt, 0 lint, \`-race\`, full suite — all green.