### PR TITLE
feat(dynamodb): UpdateExpression grammar (ADD/DELETE/arithmetic/if_not_exists/list_append) + real set types

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -194,6 +194,8 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 }
 
 // UpdateItem applies partial updates to an existing item.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[string]any, error) {
 	m.mu.Lock()
 
@@ -212,18 +214,11 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	}
 
 	oldItem := copyItem(item)
-	updated := copyItem(item)
 
-	for _, action := range input.Actions {
-		switch action.Action {
-		case "SET":
-			updated[action.Field] = action.Value
-		case "REMOVE":
-			delete(updated, action.Field)
-		default:
-			m.mu.Unlock()
-			return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported action: %s", action.Action)
-		}
+	updated, err := driver.ApplyUpdate(copyItem(item), input)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
 	}
 
 	td.items.Set(k, updated)

--- a/providers/azure/cosmosdb/cosmosdb.go
+++ b/providers/azure/cosmosdb/cosmosdb.go
@@ -252,6 +252,8 @@ func (m *Mock) GetItem(_ context.Context, table string, key map[string]any) (map
 }
 
 // UpdateItem applies partial updates to an existing document in a container.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[string]any, error) {
 	m.mu.Lock()
 
@@ -270,18 +272,11 @@ func (m *Mock) UpdateItem(_ context.Context, input driver.UpdateItemInput) (map[
 	}
 
 	oldItem := copyItem(item)
-	updated := copyItem(item)
 
-	for _, action := range input.Actions {
-		switch action.Action {
-		case "SET":
-			updated[action.Field] = action.Value
-		case "REMOVE":
-			delete(updated, action.Field)
-		default:
-			m.mu.Unlock()
-			return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported action: %s", action.Action)
-		}
+	updated, err := driver.ApplyUpdate(copyItem(item), input)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
 	}
 
 	td.items.Set(k, updated)

--- a/providers/azure/cosmosdb/cosmosdb_lifecycle_test.go
+++ b/providers/azure/cosmosdb/cosmosdb_lifecycle_test.go
@@ -160,7 +160,7 @@ func TestLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "shipped", got["status"])
 
-	// Unsupported update action is rejected with InvalidArgument.
+	// Unsupported legacy update action is rejected with InvalidArgument.
 	_, err = m.UpdateItem(ctx, driver.UpdateItemInput{
 		Table:   "orders",
 		Key:     map[string]any{"pk": "cust#1", "sk": "order#002"},
@@ -168,6 +168,18 @@ func TestLifecycle(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.True(t, cerrors.IsInvalidArgument(err))
+
+	// The raw UpdateExpression path runs the full shared grammar (here SET plus
+	// ADD), which the legacy Actions form cannot express.
+	rich, err := m.UpdateItem(ctx, driver.UpdateItemInput{
+		Table:            "orders",
+		Key:              map[string]any{"pk": "cust#1", "sk": "order#002"},
+		UpdateExpression: "SET status = :s ADD hits :h",
+		ExprValues:       map[string]any{":s": "done", ":h": float64(2)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "done", rich["status"])
+	assert.Equal(t, float64(2), rich["hits"])
 
 	// Conditional-write semantics in this driver: UpdateItem is the
 	// "must already exist" path — it fails with NotFound on a missing item

--- a/providers/gcp/firestore/firestore.go
+++ b/providers/gcp/firestore/firestore.go
@@ -197,6 +197,8 @@ func (m *Mock) GetItem(ctx context.Context, table string, key map[string]any) (m
 }
 
 // UpdateItem applies partial updates to an existing document in a collection.
+//
+//nolint:gocritic // hugeParam: interface method signature cannot be changed.
 func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (map[string]any, error) {
 	m.mu.Lock()
 
@@ -215,18 +217,11 @@ func (m *Mock) UpdateItem(ctx context.Context, input driver.UpdateItemInput) (ma
 	}
 
 	oldItem := copyItem(item)
-	updated := copyItem(item)
 
-	for _, action := range input.Actions {
-		switch action.Action {
-		case "SET":
-			updated[action.Field] = action.Value
-		case "REMOVE":
-			delete(updated, action.Field)
-		default:
-			m.mu.Unlock()
-			return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported action: %s", action.Action)
-		}
+	updated, err := driver.ApplyUpdate(copyItem(item), input)
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
 	}
 
 	cd.items.Set(k, updated)

--- a/providers/gcp/firestore/firestore_lifecycle_test.go
+++ b/providers/gcp/firestore/firestore_lifecycle_test.go
@@ -173,7 +173,7 @@ func TestLifecycle(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, cerrors.IsNotFound(err))
 
-	// Unsupported update action → InvalidArgument.
+	// Unsupported legacy update action → InvalidArgument.
 	_, err = db.UpdateItem(ctx, driver.UpdateItemInput{
 		Table:   coll,
 		Key:     map[string]any{"customerId": "cust-1", "orderId": "2026-001"},
@@ -181,6 +181,18 @@ func TestLifecycle(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.True(t, cerrors.IsInvalidArgument(err))
+
+	// The raw UpdateExpression path runs the full shared grammar (SET plus ADD),
+	// which the legacy Actions form cannot express.
+	rich, err := db.UpdateItem(ctx, driver.UpdateItemInput{
+		Table:            coll,
+		Key:              map[string]any{"customerId": "cust-1", "orderId": "2026-001"},
+		UpdateExpression: "SET paid = :p ADD hits :c",
+		ExprValues:       map[string]any{":p": true, ":c": float64(3)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, rich["paid"])
+	assert.Equal(t, float64(3), rich["hits"])
 
 	// Batch put + batch get.
 	batch := []map[string]any{

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -41,10 +41,15 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The raw UpdateExpression flows to the driver, which parses and evaluates
+	// the full grammar (SET arithmetic, if_not_exists, list_append, ADD, DELETE)
+	// against the stored item.
 	input := dbdriver.UpdateItemInput{
-		Table:   req.TableName,
-		Key:     key,
-		Actions: parseUpdateExpression(req.UpdateExpression, vals, req.ExpressionAttributeNames),
+		Table:            req.TableName,
+		Key:              key,
+		UpdateExpression: req.UpdateExpression,
+		ExprNames:        req.ExpressionAttributeNames,
+		ExprValues:       vals,
 	}
 
 	updated, err := h.db.UpdateItem(r.Context(), input)
@@ -59,168 +64,6 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	wire.WriteJSON(w, resp)
-}
-
-// parseUpdateExpression parses a DynamoDB UpdateExpression into driver actions.
-// Supports "SET a = :v, b = :w" and "REMOVE c, d" clauses combined.
-func parseUpdateExpression(updateExpr string, vals map[string]any, names map[string]string) []dbdriver.UpdateAction {
-	updateExpr = strings.TrimSpace(updateExpr)
-	if updateExpr == "" {
-		return nil
-	}
-
-	var actions []dbdriver.UpdateAction
-
-	for _, clause := range splitClauses(updateExpr) {
-		verb, rest := splitVerb(clause)
-
-		switch strings.ToUpper(verb) {
-		case "SET":
-			actions = append(actions, parseSet(rest, vals, names)...)
-		case "REMOVE":
-			actions = append(actions, parseRemove(rest, names)...)
-		}
-	}
-
-	return actions
-}
-
-// splitClauses splits an UpdateExpression by keyword boundaries (SET, REMOVE,
-// ADD, DELETE). Returns one string per clause.
-func splitClauses(updateExpr string) []string {
-	upper := strings.ToUpper(updateExpr)
-
-	keywords := []string{"SET", "REMOVE", "ADD", "DELETE"}
-
-	starts := make([]int, 0, len(keywords))
-	for _, kw := range keywords {
-		starts = append(starts, findKeywordStarts(upper, kw)...)
-	}
-
-	if len(starts) == 0 {
-		return []string{updateExpr}
-	}
-
-	sortInts(starts)
-
-	clauses := make([]string, 0, len(starts))
-
-	for i, s := range starts {
-		end := len(updateExpr)
-		if i+1 < len(starts) {
-			end = starts[i+1]
-		}
-
-		clauses = append(clauses, strings.TrimSpace(updateExpr[s:end]))
-	}
-
-	return clauses
-}
-
-// findKeywordStarts returns every offset in upper where kw appears as a
-// standalone word (preceded by a non-ident char, followed by a space).
-func findKeywordStarts(upper, kw string) []int {
-	var starts []int
-
-	i := 0
-	for i < len(upper) {
-		j := strings.Index(upper[i:], kw)
-		if j < 0 {
-			return starts
-		}
-
-		abs := i + j
-		if isWordStart(upper, abs) && hasSpaceAfter(upper, abs, len(kw)) {
-			starts = append(starts, abs)
-		}
-
-		i = abs + len(kw)
-	}
-
-	return starts
-}
-
-func isWordStart(s string, i int) bool {
-	return i == 0 || !isIdentByte(s[i-1])
-}
-
-func hasSpaceAfter(s string, i, kwLen int) bool {
-	return i+kwLen < len(s) && s[i+kwLen] == ' '
-}
-
-func sortInts(a []int) {
-	for i := 1; i < len(a); i++ {
-		for j := i; j > 0 && a[j] < a[j-1]; j-- {
-			a[j], a[j-1] = a[j-1], a[j]
-		}
-	}
-}
-
-func isIdentByte(b byte) bool {
-	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') ||
-		(b >= '0' && b <= '9') || b == '_'
-}
-
-// splitVerb splits "SET a = :b, c = :d" → ("SET", "a = :b, c = :d").
-func splitVerb(clause string) (verb, rest string) {
-	const pair = 2
-
-	parts := strings.SplitN(strings.TrimSpace(clause), " ", pair)
-	if len(parts) < pair {
-		return parts[0], ""
-	}
-
-	return parts[0], parts[1]
-}
-
-// parseSet parses "a = :val, b = :other" into SET actions.
-func parseSet(rest string, vals map[string]any, names map[string]string) []dbdriver.UpdateAction {
-	const pair = 2
-
-	var actions []dbdriver.UpdateAction
-
-	for _, assign := range splitTopLevel(rest, ',') {
-		parts := strings.SplitN(assign, "=", pair)
-		if len(parts) != pair {
-			continue
-		}
-
-		field := resolveAttrName(strings.TrimSpace(parts[0]), names)
-		valExpr := strings.TrimSpace(parts[1])
-		actions = append(actions, dbdriver.UpdateAction{
-			Action: "SET",
-			Field:  field,
-			Value:  resolveExprVal(valExpr, vals),
-		})
-	}
-
-	return actions
-}
-
-// parseRemove parses "a, b, c" into REMOVE actions.
-func parseRemove(rest string, names map[string]string) []dbdriver.UpdateAction {
-	var actions []dbdriver.UpdateAction
-
-	for _, f := range splitTopLevel(rest, ',') {
-		f = strings.TrimSpace(f)
-		if f == "" {
-			continue
-		}
-
-		actions = append(actions, dbdriver.UpdateAction{
-			Action: "REMOVE",
-			Field:  resolveAttrName(f, names),
-		})
-	}
-
-	return actions
-}
-
-// splitTopLevel splits by sep at the top level (we don't have nesting here,
-// so it's just strings.Split — kept as a separate function in case we add
-// list/map value literals later).
-func splitTopLevel(s string, sep byte) []string {
-	return strings.Split(s, string(sep))
 }
 
 // scan handles Scan (full-table read with optional filters).

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -1551,6 +1551,18 @@ func TestDDBUpdateExpressionGrammar(t *testing.T) {
 		_, has := attrs["tags"]
 		assert.False(t, has, "an emptied set attribute is removed")
 	})
+
+	t.Run("ADD with a mismatched type is rejected", func(t *testing.T) {
+		_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:        aws.String("acct"),
+			Key:              map[string]ddbtypes.AttributeValue{"id": sAttr("a1")},
+			UpdateExpression: aws.String("ADD balance :s"), // balance is a number
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":s": &ddbtypes.AttributeValueMemberSS{Value: []string{"x"}},
+			},
+		})
+		require.Error(t, err, "ADD a set to a numeric attribute must be a ValidationException")
+	})
 }
 
 // TestDDBSetTypesRoundTrip proves the wire codec decodes and re-encodes all

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -417,6 +417,12 @@ func TestDDBQueryPartitionAndSort(t *testing.T) {
 		":c": sAttr("alice"), ":p": sAttr("2024"),
 	}, nil)
 	assert.Equal(t, int32(3), out.Count)
+
+	// The parser tolerates missing spaces around the operators.
+	out = query("customer=:c AND orderDate>:d", map[string]ddbtypes.AttributeValue{
+		":c": sAttr("alice"), ":d": sAttr("2024-01-31"),
+	}, nil)
+	assert.Equal(t, int32(2), out.Count, "space-less operators parse correctly")
 }
 
 // TestDDBTimeToLive is a regression guard for issue #319:
@@ -1461,4 +1467,123 @@ func TestDDBProjectionExpression(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int32(0), out.Count, "a non-matching filter yields nothing to project")
 	})
+
+	t.Run("overlapping projected paths are rejected", func(t *testing.T) {
+		_, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName:            aws.String("profiles"),
+			Key:                  map[string]ddbtypes.AttributeValue{"id": sAttr("u1")},
+			ProjectionExpression: aws.String("address, address.city"),
+		})
+		require.Error(t, err, "overlapping document paths must be a ValidationException")
+	})
+}
+
+// TestDDBUpdateExpressionGrammar drives the real SDK through the rich
+// UpdateExpression grammar: SET arithmetic, if_not_exists and list_append, ADD
+// on a number and on a set (union), and DELETE on a set (difference, then
+// emptying removes the attribute). Results are asserted via ReturnValues=ALL_NEW.
+func TestDDBUpdateExpressionGrammar(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "acct", "id", "")
+	suiteDDBPut(t, client, "acct", map[string]ddbtypes.AttributeValue{
+		"id":      sAttr("a1"),
+		"balance": nAttr("100"),
+		"items":   &ddbtypes.AttributeValueMemberL{Value: []ddbtypes.AttributeValue{sAttr("x")}},
+		"tags":    &ddbtypes.AttributeValueMemberSS{Value: []string{"red", "blue"}},
+	})
+
+	update := func(exprStr string, vals map[string]ddbtypes.AttributeValue) map[string]ddbtypes.AttributeValue {
+		out, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                 aws.String("acct"),
+			Key:                       map[string]ddbtypes.AttributeValue{"id": sAttr("a1")},
+			UpdateExpression:          aws.String(exprStr),
+			ExpressionAttributeValues: vals,
+			ReturnValues:              ddbtypes.ReturnValueAllNew,
+		})
+		require.NoError(t, err, "UpdateItem %q", exprStr)
+
+		return out.Attributes
+	}
+
+	t.Run("SET arithmetic, if_not_exists, list_append and ADD number", func(t *testing.T) {
+		attrs := update(
+			"SET balance = balance + :d, nickname = if_not_exists(nickname, :nn), "+
+				"items = list_append(items, :more) ADD visits :one",
+			map[string]ddbtypes.AttributeValue{
+				":d":    nAttr("50"),
+				":nn":   sAttr("ace"),
+				":more": &ddbtypes.AttributeValueMemberL{Value: []ddbtypes.AttributeValue{sAttr("y")}},
+				":one":  nAttr("1"),
+			})
+
+		assert.Equal(t, "150", attrN(t, attrs, "balance"), "balance + 50")
+		assert.Equal(t, "ace", attrS(t, attrs, "nickname"), "if_not_exists set the default")
+		assert.Equal(t, "1", attrN(t, attrs, "visits"), "ADD created and incremented from zero")
+
+		l, ok := attrs["items"].(*ddbtypes.AttributeValueMemberL)
+		require.True(t, ok)
+		require.Len(t, l.Value, 2, "list_append grew the list")
+	})
+
+	t.Run("ADD unions a string set", func(t *testing.T) {
+		attrs := update("ADD tags :t", map[string]ddbtypes.AttributeValue{
+			":t": &ddbtypes.AttributeValueMemberSS{Value: []string{"green", "blue"}},
+		})
+
+		ss, ok := attrs["tags"].(*ddbtypes.AttributeValueMemberSS)
+		require.True(t, ok, "tags should be a string set, got %T", attrs["tags"])
+		assert.ElementsMatch(t, []string{"red", "blue", "green"}, ss.Value, "union, deduplicated")
+	})
+
+	t.Run("DELETE removes set members then empties the attribute", func(t *testing.T) {
+		attrs := update("DELETE tags :t", map[string]ddbtypes.AttributeValue{
+			":t": &ddbtypes.AttributeValueMemberSS{Value: []string{"red"}},
+		})
+		ss, ok := attrs["tags"].(*ddbtypes.AttributeValueMemberSS)
+		require.True(t, ok)
+		assert.ElementsMatch(t, []string{"blue", "green"}, ss.Value)
+
+		attrs = update("DELETE tags :t", map[string]ddbtypes.AttributeValue{
+			":t": &ddbtypes.AttributeValueMemberSS{Value: []string{"blue", "green"}},
+		})
+		_, has := attrs["tags"]
+		assert.False(t, has, "an emptied set attribute is removed")
+	})
+}
+
+// TestDDBSetTypesRoundTrip proves the wire codec decodes and re-encodes all
+// three DynamoDB set types (SS/NS/BS) plus the binary scalar (B) through the
+// real SDK.
+func TestDDBSetTypesRoundTrip(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+
+	suiteDDBCreateTable(t, client, "sets", "id", "")
+	suiteDDBPut(t, client, "sets", map[string]ddbtypes.AttributeValue{
+		"id":  sAttr("s1"),
+		"ss":  &ddbtypes.AttributeValueMemberSS{Value: []string{"a", "b"}},
+		"ns":  &ddbtypes.AttributeValueMemberNS{Value: []string{"1", "2"}},
+		"bs":  &ddbtypes.AttributeValueMemberBS{Value: [][]byte{{0x01, 0x02}, {0x03}}},
+		"bin": &ddbtypes.AttributeValueMemberB{Value: []byte{0xDE, 0xAD}},
+	})
+
+	out := suiteDDBGet(t, client, "sets", map[string]ddbtypes.AttributeValue{"id": sAttr("s1")})
+	require.NotNil(t, out.Item)
+
+	ss, ok := out.Item["ss"].(*ddbtypes.AttributeValueMemberSS)
+	require.True(t, ok, "ss should round-trip as SS, got %T", out.Item["ss"])
+	assert.ElementsMatch(t, []string{"a", "b"}, ss.Value)
+
+	ns, ok := out.Item["ns"].(*ddbtypes.AttributeValueMemberNS)
+	require.True(t, ok, "ns should round-trip as NS, got %T", out.Item["ns"])
+	assert.ElementsMatch(t, []string{"1", "2"}, ns.Value)
+
+	bs, ok := out.Item["bs"].(*ddbtypes.AttributeValueMemberBS)
+	require.True(t, ok, "bs should round-trip as BS, got %T", out.Item["bs"])
+	require.Len(t, bs.Value, 2)
+
+	bin, ok := out.Item["bin"].(*ddbtypes.AttributeValueMemberB)
+	require.True(t, ok, "binary scalar should round-trip as B, got %T", out.Item["bin"])
+	assert.Equal(t, []byte{0xDE, 0xAD}, bin.Value)
 }

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -408,7 +408,12 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	}
 
 	vals := fromWireItem(req.ExpressionAttributeValues)
-	kc := parseKeyCondition(req.KeyConditionExpression, vals, req.ExpressionAttributeNames)
+
+	kc, err := parseKeyCondition(req.KeyConditionExpression, vals, req.ExpressionAttributeNames)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
 
 	forward := true
 	if req.ScanIndexForward != nil {
@@ -459,134 +464,29 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 // Sort-key operators emitted for the function/keyword forms of a
 // KeyConditionExpression. Relational operators (= < <= > >=) flow through as
 // their literal token.
-const (
-	sortOpBetween    = "BETWEEN"
-	sortOpBeginsWith = "BEGINS_WITH"
-)
-
-// parseKeyCondition extracts a KeyCondition from a KeyConditionExpression.
-// The partition key must use equality ("pk = :v"); the optional sort-key
-// condition may be a relational comparison ("sk op :v"), "sk BETWEEN :lo AND
-// :hi", or "begins_with(sk, :v)".
+// parseKeyCondition parses a KeyConditionExpression into a driver KeyCondition.
+// It delegates to the shared expr parser, which uses the real lexer (so it is
+// tolerant of spacing) and enforces the restricted key grammar: equality on the
+// partition key and one optional sort-key condition (relational, BETWEEN or
+// begins_with). The sort-key attribute name is derived by the provider from the
+// table's key schema, so it is not carried on the returned condition.
 func parseKeyCondition(
 	keyExpr string,
 	vals map[string]any,
 	names map[string]string,
-) dbdriver.KeyCondition {
-	kc := dbdriver.KeyCondition{}
-	keyExpr = strings.TrimSpace(keyExpr)
-
-	const andSep = " AND "
-
-	// Split on the FIRST " AND " only: it separates the partition-key equality
-	// from the sort-key condition. A BETWEEN sort condition carries its own
-	// internal " AND ", which stays with the sort clause.
-	andIdx := findCaseInsensitive(keyExpr, andSep)
-	pkExpr := keyExpr
-	skExpr := ""
-
-	if andIdx >= 0 {
-		pkExpr = strings.TrimSpace(keyExpr[:andIdx])
-		skExpr = strings.TrimSpace(keyExpr[andIdx+len(andSep):])
+) (dbdriver.KeyCondition, error) {
+	kc, err := expr.ParseKeyCondition(keyExpr, names, vals)
+	if err != nil {
+		return dbdriver.KeyCondition{}, err
 	}
 
-	// Partition key: [0]=field, [1]="=", [2]=value placeholder.
-	const valueIdx = 2
-
-	pkParts := strings.Fields(pkExpr)
-	if len(pkParts) > valueIdx {
-		kc.PartitionKey = resolveAttrName(pkParts[0], names)
-		kc.PartitionVal = resolveExprVal(pkParts[valueIdx], vals)
-	}
-
-	if skExpr != "" {
-		parseSortCondition(&kc, skExpr, vals)
-	}
-
-	return kc
-}
-
-// parseSortCondition fills kc's sort-key fields from the sort portion of a
-// KeyConditionExpression. The sort key's attribute name is resolved by the
-// provider from the table's key schema, so only the operator and value
-// placeholders are extracted here.
-func parseSortCondition(kc *dbdriver.KeyCondition, skExpr string, vals map[string]any) {
-	if val, ok := parseBeginsWith(skExpr, vals); ok {
-		kc.SortOp = sortOpBeginsWith
-		kc.SortVal = val
-
-		return
-	}
-
-	fields := strings.Fields(skExpr)
-
-	// "sk BETWEEN :lo AND :hi" → [sk BETWEEN :lo AND :hi].
-	const (
-		betweenLen = 5
-		loIdx      = 2
-		hiIdx      = 4
-	)
-
-	if len(fields) >= betweenLen && strings.EqualFold(fields[1], sortOpBetween) {
-		kc.SortOp = sortOpBetween
-		kc.SortVal = resolveExprVal(fields[loIdx], vals)
-		kc.SortValEnd = resolveExprVal(fields[hiIdx], vals)
-
-		return
-	}
-
-	// "sk op :v" → [sk op :v].
-	const opLen = 3
-	if len(fields) >= opLen {
-		kc.SortOp = fields[1]
-		kc.SortVal = resolveExprVal(fields[loIdx], vals)
-	}
-}
-
-// parseBeginsWith recognizes a "begins_with(sk, :v)" sort-key condition and
-// returns its resolved value. ok is false when skExpr is not a begins_with
-// call.
-func parseBeginsWith(skExpr string, vals map[string]any) (val any, ok bool) {
-	const fnBeginsWith = "begins_with"
-	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(skExpr)), fnBeginsWith) {
-		return nil, false
-	}
-
-	openIdx := strings.Index(skExpr, "(")
-	closeIdx := strings.LastIndex(skExpr, ")")
-
-	if openIdx < 0 || closeIdx < openIdx {
-		return nil, false
-	}
-
-	const argCount = 2
-
-	args := strings.Split(skExpr[openIdx+1:closeIdx], ",")
-	if len(args) != argCount {
-		return nil, false
-	}
-
-	return resolveExprVal(strings.TrimSpace(args[1]), vals), true
-}
-
-func findCaseInsensitive(s, substr string) int {
-	return strings.Index(strings.ToUpper(s), strings.ToUpper(substr))
-}
-
-func resolveAttrName(token string, names map[string]string) string {
-	if v, ok := names[token]; ok {
-		return v
-	}
-
-	return token
-}
-
-func resolveExprVal(token string, vals map[string]any) any {
-	if v, ok := vals[token]; ok {
-		return v
-	}
-
-	return token
+	return dbdriver.KeyCondition{
+		PartitionKey: kc.PartitionKey,
+		PartitionVal: kc.PartitionVal,
+		SortOp:       kc.SortOp,
+		SortVal:      kc.SortVal,
+		SortValEnd:   kc.SortValEnd,
+	}, nil
 }
 
 // writeErr maps CloudEmu errors to DynamoDB HTTP error responses.

--- a/server/aws/dynamodb/types.go
+++ b/server/aws/dynamodb/types.go
@@ -1,8 +1,11 @@
 package dynamodb
 
 import (
+	"encoding/base64"
 	"fmt"
 	"strconv"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
 // fromWireItem converts a DynamoDB wire-format item to a plain map.
@@ -73,7 +76,99 @@ func fromAttributeValue(v any) any {
 		return fromMap(m)
 	}
 
+	return fromBinaryOrSet(av, v)
+}
+
+// fromBinaryOrSet decodes the binary scalar (B) and the set types (SS/NS/BS),
+// which the SDK sends as base64 (B/BS) or numeric strings (NS). An unknown
+// shape returns the original value untouched.
+func fromBinaryOrSet(av map[string]any, v any) any {
+	if b, ok := av["B"]; ok {
+		return decodeBinary(b)
+	}
+
+	if ss, ok := av["SS"]; ok {
+		return decodeStringSet(ss)
+	}
+
+	if ns, ok := av["NS"]; ok {
+		return decodeNumberSet(ns)
+	}
+
+	if bs, ok := av["BS"]; ok {
+		return decodeBinarySet(bs)
+	}
+
 	return v
+}
+
+func decodeBinary(v any) any {
+	s, ok := v.(string)
+	if !ok {
+		return v
+	}
+
+	data, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return v
+	}
+
+	return data
+}
+
+func decodeStringSet(v any) any {
+	list, ok := v.([]any)
+	if !ok {
+		return v
+	}
+
+	out := make(expr.StringSet, 0, len(list))
+
+	for _, e := range list {
+		if s, ok := e.(string); ok {
+			out = append(out, s)
+		}
+	}
+
+	return out
+}
+
+func decodeNumberSet(v any) any {
+	list, ok := v.([]any)
+	if !ok {
+		return v
+	}
+
+	out := make(expr.NumberSet, 0, len(list))
+
+	for _, e := range list {
+		if s, ok := e.(string); ok {
+			if f, err := strconv.ParseFloat(s, 64); err == nil {
+				out = append(out, f)
+			}
+		}
+	}
+
+	return out
+}
+
+func decodeBinarySet(v any) any {
+	list, ok := v.([]any)
+	if !ok {
+		return v
+	}
+
+	out := make(expr.BinarySet, 0, len(list))
+
+	for _, e := range list {
+		if s, ok := e.(string); ok {
+			if data, err := base64.StdEncoding.DecodeString(s); err == nil {
+				out = append(out, data)
+			}
+		}
+	}
+
+	return out
 }
 
 func fromList(v any) []any {
@@ -102,6 +197,10 @@ func fromMap(v any) map[string]any {
 
 // toAttributeValue wraps a plain value into DynamoDB wire format.
 func toAttributeValue(v any) map[string]any {
+	if av, ok := toBinaryOrSetValue(v); ok {
+		return av
+	}
+
 	switch val := v.(type) {
 	case string:
 		return map[string]any{"S": val}
@@ -122,6 +221,41 @@ func toAttributeValue(v any) map[string]any {
 	default:
 		return map[string]any{"S": fmt.Sprintf("%v", val)}
 	}
+}
+
+// toBinaryOrSetValue encodes the binary scalar (B) and the set types (SS/NS/BS),
+// keeping toAttributeValue's own type switch within the complexity budget.
+func toBinaryOrSetValue(v any) (map[string]any, bool) {
+	switch val := v.(type) {
+	case []byte:
+		return map[string]any{"B": base64.StdEncoding.EncodeToString(val)}, true
+	case expr.StringSet:
+		return map[string]any{"SS": []string(val)}, true
+	case expr.NumberSet:
+		return map[string]any{"NS": formatNumberSet(val)}, true
+	case expr.BinarySet:
+		return map[string]any{"BS": formatBinarySet(val)}, true
+	default:
+		return nil, false
+	}
+}
+
+func formatNumberSet(ns expr.NumberSet) []string {
+	out := make([]string, 0, len(ns))
+	for _, f := range ns {
+		out = append(out, strconv.FormatFloat(f, 'f', -1, 64))
+	}
+
+	return out
+}
+
+func formatBinarySet(bs expr.BinarySet) []string {
+	out := make([]string, 0, len(bs))
+	for _, b := range bs {
+		out = append(out, base64.StdEncoding.EncodeToString(b))
+	}
+
+	return out
 }
 
 func toListValue(list []any) map[string]any {

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -11,6 +11,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/pagination"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
 // TTLConfig configures TTL for a table.
@@ -59,18 +60,57 @@ type GSIConfig struct {
 	SortKey      string
 }
 
-// UpdateAction represents a single field-level update action.
+// UpdateAction represents a single field-level update action. It is the legacy,
+// pre-expression update form; the wire handler uses UpdateExpression instead.
 type UpdateAction struct {
 	Action string // "SET" or "REMOVE"
 	Field  string
 	Value  any // ignored for REMOVE
 }
 
-// UpdateItemInput describes an update operation on an existing item.
+// UpdateItemInput describes an update operation on an existing item. When
+// UpdateExpression is set it takes precedence and is evaluated with full
+// DynamoDB grammar (SET arithmetic, if_not_exists, list_append, ADD, DELETE);
+// otherwise the legacy Actions are applied. ExprNames/ExprValues resolve the
+// expression's #aliases and :placeholders.
 type UpdateItemInput struct {
-	Table   string
-	Key     map[string]any
-	Actions []UpdateAction
+	Table            string
+	Key              map[string]any
+	Actions          []UpdateAction
+	UpdateExpression string
+	ExprNames        map[string]string
+	ExprValues       map[string]any
+}
+
+// ApplyUpdate applies input's update to a caller-owned copy of item, mutating
+// it in place and returning it. It runs the full UpdateExpression grammar when
+// input.UpdateExpression is set, otherwise the legacy SET/REMOVE Actions. It is
+// shared by every database provider so update semantics stay identical across
+// clouds.
+//
+//nolint:gocritic // hugeParam: input mirrors the driver's UpdateItem signature.
+func ApplyUpdate(item map[string]any, input UpdateItemInput) (map[string]any, error) {
+	if input.UpdateExpression != "" {
+		prog, err := expr.ParseUpdate(input.UpdateExpression, input.ExprNames, input.ExprValues)
+		if err != nil {
+			return nil, err
+		}
+
+		return expr.ApplyUpdate(item, prog)
+	}
+
+	for _, action := range input.Actions {
+		switch action.Action {
+		case "SET":
+			item[action.Field] = action.Value
+		case "REMOVE":
+			delete(item, action.Field)
+		default:
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported action: %s", action.Action)
+		}
+	}
+
+	return item, nil
 }
 
 // KeyCondition defines a key condition for queries.

--- a/services/database/driver/expr/eval.go
+++ b/services/database/driver/expr/eval.go
@@ -175,6 +175,23 @@ func evalContains(n *Contains, item map[string]any) bool {
 		return isStr && strings.Contains(s, t)
 	case []any:
 		return sliceContains(s, target)
+	default:
+		return setContains(v, target)
+	}
+}
+
+// setContains reports set membership for the SS/NS/BS types.
+func setContains(v, target any) bool {
+	switch s := v.(type) {
+	case StringSet:
+		t, ok := target.(string)
+		return ok && stringSetHas(s, t)
+	case NumberSet:
+		t, ok := target.(float64)
+		return ok && numberSetHas(s, t)
+	case BinarySet:
+		t, ok := target.([]byte)
+		return ok && binarySetHas(s, t)
 	}
 
 	return false
@@ -244,6 +261,13 @@ func resolvePath(parts []PathPart, item map[string]any) (any, bool) {
 	return cur, true
 }
 
+// Two-character relational operators, shared so the same literal is not
+// repeated across the comparison and key-condition code.
+const (
+	opLTE = "<="
+	opGTE = ">="
+)
+
 func compareOp(op string, a, b any) bool {
 	switch op {
 	case "=":
@@ -260,11 +284,11 @@ func compareOp(op string, a, b any) bool {
 	switch op {
 	case "<":
 		return c < 0
-	case "<=":
+	case opLTE:
 		return c <= 0
 	case ">":
 		return c > 0
-	case ">=":
+	case opGTE:
 		return c >= 0
 	}
 
@@ -291,7 +315,9 @@ func valuesEqual(a, b any) bool {
 		return b == nil
 	}
 
-	return false
+	// Set types (SS/NS/BS) compare order-independently; non-set values that
+	// reach here are unequal, which setsEqual also reports.
+	return setsEqual(a, b)
 }
 
 // orderedCompare returns -1/0/1 for orderable, same-typed values (numbers,
@@ -339,8 +365,8 @@ func sizeOf(v any) (any, bool) {
 	return nil, false
 }
 
-// dynamoType returns the DynamoDB attribute type code for a native value.
-// Sets are indistinguishable from lists in the native model and report "L".
+// dynamoType returns the DynamoDB attribute type code for a native value,
+// including the set types SS/NS/BS, which are modeled distinctly from a List.
 func dynamoType(v any) string {
 	switch v.(type) {
 	case string:
@@ -357,6 +383,20 @@ func dynamoType(v any) string {
 		return "L"
 	case map[string]any:
 		return "M"
+	}
+
+	return setType(v)
+}
+
+// setType returns the DynamoDB type code for the set types, or "" otherwise.
+func setType(v any) string {
+	switch v.(type) {
+	case StringSet:
+		return "SS"
+	case NumberSet:
+		return "NS"
+	case BinarySet:
+		return "BS"
 	}
 
 	return ""

--- a/services/database/driver/expr/keycond.go
+++ b/services/database/driver/expr/keycond.go
@@ -1,0 +1,202 @@
+package expr
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// KeyCond is a parsed DynamoDB KeyConditionExpression: an equality on the
+// partition key and an optional sort-key condition. SortOp is "" when no sort
+// condition is present, otherwise one of = < <= > >= BETWEEN BEGINS_WITH.
+type KeyCond struct {
+	PartitionKey string
+	PartitionVal any
+	SortKey      string
+	SortOp       string
+	SortVal      any
+	SortValEnd   any // for BETWEEN
+}
+
+// ParseKeyCondition parses a KeyConditionExpression using the shared lexer, so
+// it is tolerant of spacing (e.g. "sk>:v") and enforces the restricted key
+// grammar: equality on the partition key and one optional sort-key condition.
+func ParseKeyCondition(raw string, names map[string]string, values map[string]any) (KeyCond, error) {
+	toks, err := lex(strings.TrimSpace(raw))
+	if err != nil {
+		return KeyCond{}, err
+	}
+
+	p := &parser{toks: toks, names: names, values: values}
+
+	kc, perr := p.parseKeyCond()
+	if perr != nil {
+		return KeyCond{}, perr
+	}
+
+	if p.peek().kind != tEOF {
+		return KeyCond{}, cerrors.Newf(cerrors.InvalidArgument,
+			"unexpected token %q in key condition", p.peek().text)
+	}
+
+	return kc, nil
+}
+
+func (p *parser) parseKeyCond() (KeyCond, error) {
+	name, err := p.keyName()
+	if err != nil {
+		return KeyCond{}, err
+	}
+
+	if eq := p.next(); eq.kind != tOp || eq.text != "=" {
+		return KeyCond{}, cerrors.Newf(cerrors.InvalidArgument,
+			"partition key must use '=' but found %q", eq.text)
+	}
+
+	val, verr := p.keyValue()
+	if verr != nil {
+		return KeyCond{}, verr
+	}
+
+	kc := KeyCond{PartitionKey: name, PartitionVal: val}
+
+	if p.peek().kind == tAnd {
+		p.next()
+
+		if serr := p.parseSortCond(&kc); serr != nil {
+			return KeyCond{}, serr
+		}
+	}
+
+	return kc, nil
+}
+
+func (p *parser) parseSortCond(kc *KeyCond) error {
+	if p.peek().kind == tFunc {
+		return p.parseBeginsWithCond(kc)
+	}
+
+	name, err := p.keyName()
+	if err != nil {
+		return err
+	}
+
+	kc.SortKey = name
+
+	if p.peek().kind == tBetween {
+		return p.parseBetweenCond(kc)
+	}
+
+	op := p.next()
+	if op.kind != tOp || !isKeyOp(op.text) {
+		return cerrors.Newf(cerrors.InvalidArgument, "invalid sort key operator %q", op.text)
+	}
+
+	val, verr := p.keyValue()
+	if verr != nil {
+		return verr
+	}
+
+	kc.SortOp = op.text
+	kc.SortVal = val
+
+	return nil
+}
+
+func (p *parser) parseBeginsWithCond(kc *KeyCond) error {
+	fn := p.next().text
+	if !strings.EqualFold(fn, "begins_with") {
+		return cerrors.Newf(cerrors.InvalidArgument, "unsupported function %q in key condition", fn)
+	}
+
+	if err := p.expect(tLParen, "'('"); err != nil {
+		return err
+	}
+
+	name, nerr := p.keyName()
+	if nerr != nil {
+		return nerr
+	}
+
+	if cerr := p.expect(tComma, "','"); cerr != nil {
+		return cerr
+	}
+
+	val, verr := p.keyValue()
+	if verr != nil {
+		return verr
+	}
+
+	if rerr := p.expect(tRParen, "')'"); rerr != nil {
+		return rerr
+	}
+
+	kc.SortKey = name
+	kc.SortOp = "BEGINS_WITH"
+	kc.SortVal = val
+
+	return nil
+}
+
+func (p *parser) parseBetweenCond(kc *KeyCond) error {
+	p.next() // consume BETWEEN
+
+	lo, lerr := p.keyValue()
+	if lerr != nil {
+		return lerr
+	}
+
+	if aerr := p.expect(tAnd, "'AND'"); aerr != nil {
+		return aerr
+	}
+
+	hi, herr := p.keyValue()
+	if herr != nil {
+		return herr
+	}
+
+	kc.SortOp = "BETWEEN"
+	kc.SortVal = lo
+	kc.SortValEnd = hi
+
+	return nil
+}
+
+// keyName parses a single attribute name (resolving a #alias). Key attributes
+// are simple top-level names — nested paths and indexes are rejected.
+func (p *parser) keyName() (string, error) {
+	path, err := p.parsePath()
+	if err != nil {
+		return "", err
+	}
+
+	if len(path.Parts) != 1 || path.Parts[0].IsIndex {
+		return "", cerrors.New(cerrors.InvalidArgument, "key condition attributes must be simple names")
+	}
+
+	return path.Parts[0].Name, nil
+}
+
+// keyValue parses a :placeholder and returns its resolved native value.
+func (p *parser) keyValue() (any, error) {
+	op, err := p.parseValue()
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := op.(*ValueOperand)
+	if !ok {
+		return nil, cerrors.New(cerrors.InvalidArgument, "key condition expects a value placeholder")
+	}
+
+	return v.Value, nil
+}
+
+func isKeyOp(op string) bool {
+	switch op {
+	case "=", "<", opLTE, ">", opGTE:
+		return true
+	default:
+		return false
+	}
+}

--- a/services/database/driver/expr/keycond_test.go
+++ b/services/database/driver/expr/keycond_test.go
@@ -1,0 +1,76 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseKeyConditionPartitionOnly(t *testing.T) {
+	kc, err := ParseKeyCondition("id = :i", nil, map[string]any{":i": "u1"})
+	require.NoError(t, err)
+	assert.Equal(t, "id", kc.PartitionKey)
+	assert.Equal(t, "u1", kc.PartitionVal)
+	assert.Empty(t, kc.SortOp)
+}
+
+func TestParseKeyConditionSpacingTolerant(t *testing.T) {
+	// No spaces around '=' or the sort operator — the lexer handles it.
+	kc, err := ParseKeyCondition("id=:i AND sk>:s", nil, map[string]any{":i": "u1", ":s": float64(5)})
+	require.NoError(t, err)
+	assert.Equal(t, "id", kc.PartitionKey)
+	assert.Equal(t, ">", kc.SortOp)
+	assert.Equal(t, float64(5), kc.SortVal)
+}
+
+func TestParseKeyConditionRelational(t *testing.T) {
+	for _, op := range []string{"=", "<", "<=", ">", ">="} {
+		kc, err := ParseKeyCondition("pk = :p AND sk "+op+" :s", nil,
+			map[string]any{":p": "x", ":s": "y"})
+		require.NoError(t, err, "op %q", op)
+		assert.Equal(t, op, kc.SortOp)
+	}
+}
+
+func TestParseKeyConditionBetween(t *testing.T) {
+	kc, err := ParseKeyCondition("pk = :p AND sk BETWEEN :lo AND :hi", nil,
+		map[string]any{":p": "x", ":lo": "a", ":hi": "z"})
+	require.NoError(t, err)
+	assert.Equal(t, "BETWEEN", kc.SortOp)
+	assert.Equal(t, "a", kc.SortVal)
+	assert.Equal(t, "z", kc.SortValEnd)
+}
+
+func TestParseKeyConditionBeginsWith(t *testing.T) {
+	kc, err := ParseKeyCondition("pk = :p AND begins_with(sk, :pre)", nil,
+		map[string]any{":p": "x", ":pre": "2024"})
+	require.NoError(t, err)
+	assert.Equal(t, "BEGINS_WITH", kc.SortOp)
+	assert.Equal(t, "2024", kc.SortVal)
+}
+
+func TestParseKeyConditionAlias(t *testing.T) {
+	kc, err := ParseKeyCondition("#c = :c", map[string]string{"#c": "customer"},
+		map[string]any{":c": "bob"})
+	require.NoError(t, err)
+	assert.Equal(t, "customer", kc.PartitionKey)
+}
+
+func TestParseKeyConditionErrors(t *testing.T) {
+	cases := map[string]string{
+		"pk not equality":    "pk > :p",
+		"invalid sort op <>": "pk = :p AND sk <> :s",
+		"unsupported func":   "pk = :p AND contains(sk, :s)",
+		"empty":              "",
+		"trailing tokens":    "pk = :p AND sk = :s AND x = :y",
+		"nested key attr":    "pk.a = :p",
+	}
+
+	vals := map[string]any{":p": "x", ":s": "y", ":c": "z", ":y": "w"}
+
+	for name, raw := range cases {
+		_, err := ParseKeyCondition(raw, nil, vals)
+		assert.Error(t, err, "%s: %q should fail", name, raw)
+	}
+}

--- a/services/database/driver/expr/lex.go
+++ b/services/database/driver/expr/lex.go
@@ -153,26 +153,38 @@ func lexNumber(s string, i int) (tok token, next int) {
 }
 
 func lexSymbol(s string, i int) (tok token, next int, err error) {
+	if kind, ok := punctToken(s[i]); ok {
+		return token{kind: kind}, i + 1, nil
+	}
+
 	switch s[i] {
-	case '(':
-		return token{kind: tLParen}, i + 1, nil
-	case ')':
-		return token{kind: tRParen}, i + 1, nil
-	case ',':
-		return token{kind: tComma}, i + 1, nil
-	case '.':
-		return token{kind: tDot}, i + 1, nil
-	case '[':
-		return token{kind: tLBracket}, i + 1, nil
-	case ']':
-		return token{kind: tRBracket}, i + 1, nil
-	case '=':
-		return token{kind: tOp, text: "="}, i + 1, nil
+	case '=', '+', '-':
+		return token{kind: tOp, text: string(s[i])}, i + 1, nil
 	case '<', '>':
 		return lexRelational(s, i)
 	}
 
 	return token{}, 0, cerrors.Newf(cerrors.InvalidArgument, "unexpected character %q at position %d", string(s[i]), i)
+}
+
+// punctToken maps a single-character punctuation byte to its token kind.
+func punctToken(c byte) (tokenKind, bool) {
+	switch c {
+	case '(':
+		return tLParen, true
+	case ')':
+		return tRParen, true
+	case ',':
+		return tComma, true
+	case '.':
+		return tDot, true
+	case '[':
+		return tLBracket, true
+	case ']':
+		return tRBracket, true
+	}
+
+	return tEOF, false
 }
 
 func lexRelational(s string, i int) (tok token, next int, err error) {

--- a/services/database/driver/expr/project.go
+++ b/services/database/driver/expr/project.go
@@ -53,7 +53,48 @@ func parseProjectionPaths(p *parser) ([]*PathOperand, error) {
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "unexpected token %q in projection", p.peek().text)
 	}
 
+	if err := checkNoOverlap(paths); err != nil {
+		return nil, err
+	}
+
 	return paths, nil
+}
+
+// checkNoOverlap rejects a projection where one path is a prefix of another (or
+// a duplicate), which DynamoDB reports as overlapping document paths.
+func checkNoOverlap(paths []*PathOperand) error {
+	for i := range paths {
+		for j := i + 1; j < len(paths); j++ {
+			if pathsOverlap(paths[i].Parts, paths[j].Parts) {
+				return cerrors.New(cerrors.InvalidArgument, "two document paths overlap")
+			}
+		}
+	}
+
+	return nil
+}
+
+func pathsOverlap(a, b []PathPart) bool {
+	n := min(len(a), len(b))
+	for i := range n {
+		if !partsEqual(a[i], b[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func partsEqual(a, b PathPart) bool {
+	if a.IsIndex != b.IsIndex {
+		return false
+	}
+
+	if a.IsIndex {
+		return a.Index == b.Index
+	}
+
+	return a.Name == b.Name
 }
 
 // Project returns a deep copy of item containing only the given paths,

--- a/services/database/driver/expr/sets.go
+++ b/services/database/driver/expr/sets.go
@@ -11,7 +11,9 @@ import "bytes"
 type StringSet []string
 
 // NumberSet is a DynamoDB Number Set (NS). Elements are numeric values, kept as
-// float64 to match how scalar numbers (N) are modeled.
+// float64 to match how scalar numbers (N) are modeled; like scalar N, this does
+// not preserve DynamoDB's full decimal precision for very large or high-precision
+// numbers.
 type NumberSet []float64
 
 // BinarySet is a DynamoDB Binary Set (BS).

--- a/services/database/driver/expr/sets.go
+++ b/services/database/driver/expr/sets.go
@@ -1,0 +1,240 @@
+package expr
+
+import "bytes"
+
+// DynamoDB set types (SS/NS/BS) are distinct from a List (L) in the value
+// model: their elements are unique and unordered. They are represented
+// natively as these named slice types so the type-aware evaluator and the wire
+// codec can tell a set apart from a list.
+
+// StringSet is a DynamoDB String Set (SS).
+type StringSet []string
+
+// NumberSet is a DynamoDB Number Set (NS). Elements are numeric values, kept as
+// float64 to match how scalar numbers (N) are modeled.
+type NumberSet []float64
+
+// BinarySet is a DynamoDB Binary Set (BS).
+type BinarySet [][]byte
+
+// stringSetHas reports whether s contains v.
+func stringSetHas(s StringSet, v string) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+
+	return false
+}
+
+// numberSetHas reports whether s contains v.
+func numberSetHas(s NumberSet, v float64) bool {
+	for _, e := range s {
+		if e == v {
+			return true
+		}
+	}
+
+	return false
+}
+
+// binarySetHas reports whether s contains v.
+func binarySetHas(s BinarySet, v []byte) bool {
+	for _, e := range s {
+		if bytes.Equal(e, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// setsEqual reports whether two same-typed sets hold the same elements,
+// ignoring order.
+func setsEqual(a, b any) bool {
+	switch av := a.(type) {
+	case StringSet:
+		bv, ok := b.(StringSet)
+		return ok && len(av) == len(bv) && stringSetSubset(av, bv)
+	case NumberSet:
+		bv, ok := b.(NumberSet)
+		return ok && len(av) == len(bv) && numberSetSubset(av, bv)
+	case BinarySet:
+		bv, ok := b.(BinarySet)
+		return ok && len(av) == len(bv) && binarySetSubset(av, bv)
+	}
+
+	return false
+}
+
+func stringSetSubset(a, b StringSet) bool {
+	for _, e := range a {
+		if !stringSetHas(b, e) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func numberSetSubset(a, b NumberSet) bool {
+	for _, e := range a {
+		if !numberSetHas(b, e) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func binarySetSubset(a, b BinarySet) bool {
+	for _, e := range a {
+		if !binarySetHas(b, e) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// UnionSets returns the set union of dst and add for ADD on a set attribute.
+// dst may be nil (ADD creates the attribute). The two must be the same set
+// type; a mismatch returns dst unchanged and ok=false.
+func UnionSets(dst, add any) (result any, ok bool) {
+	switch a := add.(type) {
+	case StringSet:
+		return unionString(dst, a)
+	case NumberSet:
+		return unionNumber(dst, a)
+	case BinarySet:
+		return unionBinary(dst, a)
+	}
+
+	return dst, false
+}
+
+func unionString(dst any, add StringSet) (any, bool) {
+	base, _ := dst.(StringSet)
+	out := append(StringSet{}, base...)
+
+	for _, e := range add {
+		if !stringSetHas(out, e) {
+			out = append(out, e)
+		}
+	}
+
+	return out, dst == nil || isStringSet(dst)
+}
+
+func unionNumber(dst any, add NumberSet) (any, bool) {
+	base, _ := dst.(NumberSet)
+	out := append(NumberSet{}, base...)
+
+	for _, e := range add {
+		if !numberSetHas(out, e) {
+			out = append(out, e)
+		}
+	}
+
+	return out, dst == nil || isNumberSet(dst)
+}
+
+func unionBinary(dst any, add BinarySet) (any, bool) {
+	base, _ := dst.(BinarySet)
+	out := append(BinarySet{}, base...)
+
+	for _, e := range add {
+		if !binarySetHas(out, e) {
+			out = append(out, e)
+		}
+	}
+
+	return out, dst == nil || isBinarySet(dst)
+}
+
+// DifferenceSets returns dst with rm's elements removed, for DELETE on a set
+// attribute. When the result is empty the attribute should be removed, which
+// the caller detects via SetIsEmpty. ok is false on a type mismatch.
+func DifferenceSets(dst, rm any) (result any, ok bool) {
+	switch r := rm.(type) {
+	case StringSet:
+		return diffString(dst, r)
+	case NumberSet:
+		return diffNumber(dst, r)
+	case BinarySet:
+		return diffBinary(dst, r)
+	}
+
+	return dst, false
+}
+
+func diffString(dst any, rm StringSet) (any, bool) {
+	base, ok := dst.(StringSet)
+	if !ok {
+		return dst, false
+	}
+
+	out := StringSet{}
+
+	for _, e := range base {
+		if !stringSetHas(rm, e) {
+			out = append(out, e)
+		}
+	}
+
+	return out, true
+}
+
+func diffNumber(dst any, rm NumberSet) (any, bool) {
+	base, ok := dst.(NumberSet)
+	if !ok {
+		return dst, false
+	}
+
+	out := NumberSet{}
+
+	for _, e := range base {
+		if !numberSetHas(rm, e) {
+			out = append(out, e)
+		}
+	}
+
+	return out, true
+}
+
+func diffBinary(dst any, rm BinarySet) (any, bool) {
+	base, ok := dst.(BinarySet)
+	if !ok {
+		return dst, false
+	}
+
+	out := BinarySet{}
+
+	for _, e := range base {
+		if !binarySetHas(rm, e) {
+			out = append(out, e)
+		}
+	}
+
+	return out, true
+}
+
+// SetIsEmpty reports whether v is a set type with no elements. DynamoDB removes
+// an attribute whose set becomes empty after a DELETE.
+func SetIsEmpty(v any) bool {
+	switch s := v.(type) {
+	case StringSet:
+		return len(s) == 0
+	case NumberSet:
+		return len(s) == 0
+	case BinarySet:
+		return len(s) == 0
+	}
+
+	return false
+}
+
+func isStringSet(v any) bool { _, ok := v.(StringSet); return ok }
+func isNumberSet(v any) bool { _, ok := v.(NumberSet); return ok }
+func isBinarySet(v any) bool { _, ok := v.(BinarySet); return ok }

--- a/services/database/driver/expr/sets_test.go
+++ b/services/database/driver/expr/sets_test.go
@@ -1,0 +1,79 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamoTypeSets(t *testing.T) {
+	assert.Equal(t, "SS", dynamoType(StringSet{"a"}))
+	assert.Equal(t, "NS", dynamoType(NumberSet{1}))
+	assert.Equal(t, "BS", dynamoType(BinarySet{{0x1}}))
+}
+
+func TestContainsOnSets(t *testing.T) {
+	item := map[string]any{
+		"ss": StringSet{"red", "blue"},
+		"ns": NumberSet{1, 2},
+		"bs": BinarySet{{0x1}, {0x2}},
+	}
+
+	// contains(ss, :v)
+	node, err := ParseCondition("contains(ss, :v)", nil, map[string]any{":v": "blue"})
+	require.NoError(t, err)
+	ok, err := Eval(node, item)
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	node, _ = ParseCondition("contains(ns, :v)", nil, map[string]any{":v": float64(2)})
+	ok, _ = Eval(node, item)
+	assert.True(t, ok, "number set membership")
+
+	node, _ = ParseCondition("contains(ss, :v)", nil, map[string]any{":v": "green"})
+	ok, _ = Eval(node, item)
+	assert.False(t, ok, "absent member")
+}
+
+func TestAttributeTypeSet(t *testing.T) {
+	node, err := ParseCondition("attribute_type(ss, :t)", nil, map[string]any{":t": "SS"})
+	require.NoError(t, err)
+	ok, err := Eval(node, map[string]any{"ss": StringSet{"a"}})
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestSetsEqual(t *testing.T) {
+	assert.True(t, setsEqual(StringSet{"a", "b"}, StringSet{"b", "a"}), "order-independent")
+	assert.False(t, setsEqual(StringSet{"a"}, StringSet{"a", "b"}))
+	assert.False(t, setsEqual(StringSet{"a"}, NumberSet{1}), "different set types")
+}
+
+func TestUnionAndDifference(t *testing.T) {
+	u, ok := UnionSets(StringSet{"a"}, StringSet{"a", "b"})
+	require.True(t, ok)
+	assert.ElementsMatch(t, StringSet{"a", "b"}, u)
+
+	// type mismatch
+	_, ok = UnionSets(StringSet{"a"}, NumberSet{1})
+	assert.False(t, ok)
+
+	d, ok := DifferenceSets(NumberSet{1, 2, 3}, NumberSet{2})
+	require.True(t, ok)
+	assert.ElementsMatch(t, NumberSet{1, 3}, d)
+
+	assert.True(t, SetIsEmpty(StringSet{}))
+	assert.False(t, SetIsEmpty(StringSet{"a"}))
+}
+
+func TestProjectionOverlapRejected(t *testing.T) {
+	for _, raw := range []string{"a, a.b", "a.b, a", "a, a", "tags[0], tags"} {
+		_, err := ParseProjection(raw, nil)
+		assert.Error(t, err, "%q overlaps and must be rejected", raw)
+	}
+
+	// Non-overlapping siblings are fine.
+	_, err := ParseProjection("a.b, a.c", nil)
+	assert.NoError(t, err)
+}

--- a/services/database/driver/expr/update.go
+++ b/services/database/driver/expr/update.go
@@ -1,0 +1,316 @@
+package expr
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// UpdateProgram is a parsed DynamoDB UpdateExpression: the actions of its
+// SET / REMOVE / ADD / DELETE clauses.
+type UpdateProgram struct {
+	sets    []setItem
+	removes []*PathOperand
+	adds    []pathValue
+	deletes []pathValue
+}
+
+type setItem struct {
+	path *PathOperand
+	rhs  updOperand
+}
+
+type pathValue struct {
+	path  *PathOperand
+	value *ValueOperand
+}
+
+// updOperand is a SET right-hand-side operand: a leaf (value or path),
+// arithmetic (+/-), if_not_exists, or list_append.
+type updOperand interface{ isUpdOperand() }
+
+type updLeaf struct{ operand Operand }
+
+type updArith struct {
+	op    string
+	left  updOperand
+	right updOperand
+}
+
+type updIfNotExists struct {
+	path *PathOperand
+	def  updOperand
+}
+
+type updListAppend struct {
+	left  updOperand
+	right updOperand
+}
+
+func (*updLeaf) isUpdOperand()        {}
+func (*updArith) isUpdOperand()       {}
+func (*updIfNotExists) isUpdOperand() {}
+func (*updListAppend) isUpdOperand()  {}
+
+// ParseUpdate parses a DynamoDB UpdateExpression. names resolves #alias steps
+// and values resolves :placeholder operands (already native). It returns a
+// cerrors.InvalidArgument error on malformed input.
+func ParseUpdate(raw string, names map[string]string, values map[string]any) (*UpdateProgram, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, cerrors.New(cerrors.InvalidArgument, "empty update expression")
+	}
+
+	toks, err := lex(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &parser{toks: toks, names: names, values: values}
+	prog := &UpdateProgram{}
+
+	for p.peek().kind != tEOF {
+		if cerr := p.parseClause(prog); cerr != nil {
+			return nil, cerr
+		}
+	}
+
+	return prog, nil
+}
+
+func (p *parser) parseClause(prog *UpdateProgram) error {
+	kw := p.peek()
+	if kw.kind != tIdent {
+		return cerrors.Newf(cerrors.InvalidArgument, "expected an update clause keyword but found %q", kw.text)
+	}
+
+	p.next()
+
+	switch strings.ToUpper(kw.text) {
+	case "SET":
+		return p.parseSetClause(prog)
+	case "REMOVE":
+		return p.parseRemoveClause(prog)
+	case "ADD":
+		return p.parseAddClause(prog)
+	case "DELETE":
+		return p.parseDeleteClause(prog)
+	default:
+		return cerrors.Newf(cerrors.InvalidArgument, "unknown update clause keyword %q", kw.text)
+	}
+}
+
+func (p *parser) parseSetClause(prog *UpdateProgram) error {
+	for {
+		path, err := p.parsePath()
+		if err != nil {
+			return err
+		}
+
+		if eq := p.next(); eq.kind != tOp || eq.text != "=" {
+			return cerrors.Newf(cerrors.InvalidArgument, "expected '=' in SET but found %q", eq.text)
+		}
+
+		rhs, rerr := p.parseSetOperand()
+		if rerr != nil {
+			return rerr
+		}
+
+		prog.sets = append(prog.sets, setItem{path: path, rhs: rhs})
+
+		if p.peek().kind != tComma {
+			return nil
+		}
+
+		p.next()
+	}
+}
+
+func (p *parser) parseRemoveClause(prog *UpdateProgram) error {
+	for {
+		path, err := p.parsePath()
+		if err != nil {
+			return err
+		}
+
+		prog.removes = append(prog.removes, path)
+
+		if p.peek().kind != tComma {
+			return nil
+		}
+
+		p.next()
+	}
+}
+
+func (p *parser) parseAddClause(prog *UpdateProgram) error {
+	items, err := p.parsePathValueList()
+	if err != nil {
+		return err
+	}
+
+	prog.adds = append(prog.adds, items...)
+
+	return nil
+}
+
+func (p *parser) parseDeleteClause(prog *UpdateProgram) error {
+	items, err := p.parsePathValueList()
+	if err != nil {
+		return err
+	}
+
+	prog.deletes = append(prog.deletes, items...)
+
+	return nil
+}
+
+// parsePathValueList parses the "path value[, path value]" form shared by ADD
+// and DELETE.
+func (p *parser) parsePathValueList() ([]pathValue, error) {
+	var out []pathValue
+
+	for {
+		path, err := p.parsePath()
+		if err != nil {
+			return nil, err
+		}
+
+		if p.peek().kind != tValue {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "expected a value but found %q", p.peek().text)
+		}
+
+		v, verr := p.parseValue()
+		if verr != nil {
+			return nil, verr
+		}
+
+		out = append(out, pathValue{path: path, value: v.(*ValueOperand)})
+
+		if p.peek().kind != tComma {
+			return out, nil
+		}
+
+		p.next()
+	}
+}
+
+// parseSetOperand parses a SET right-hand side: term (('+' | '-') term)*.
+func (p *parser) parseSetOperand() (updOperand, error) {
+	left, err := p.parseTerm()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.peek().kind == tOp && (p.peek().text == "+" || p.peek().text == "-") {
+		op := p.next().text
+
+		right, rerr := p.parseTerm()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		left = &updArith{op: op, left: left, right: right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseTerm() (updOperand, error) {
+	tok := p.peek()
+
+	//nolint:exhaustive // only values, paths and the two update functions are terms.
+	switch tok.kind {
+	case tValue:
+		v, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+
+		return &updLeaf{operand: v}, nil
+	case tIdent, tAlias:
+		if p.isUpdateFunc(tok) {
+			return p.parseUpdateFunc(tok.text)
+		}
+
+		path, err := p.parsePath()
+		if err != nil {
+			return nil, err
+		}
+
+		return &updLeaf{operand: path}, nil
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unexpected token %q in SET operand", tok.text)
+	}
+}
+
+func (p *parser) isUpdateFunc(tok token) bool {
+	if tok.kind != tIdent {
+		return false
+	}
+
+	name := strings.ToLower(tok.text)
+	if name != "if_not_exists" && name != "list_append" {
+		return false
+	}
+
+	return p.toks[p.pos+1].kind == tLParen
+}
+
+func (p *parser) parseUpdateFunc(name string) (updOperand, error) {
+	p.next() // consume the function name
+
+	if err := p.expect(tLParen, "'('"); err != nil {
+		return nil, err
+	}
+
+	if strings.EqualFold(name, "if_not_exists") {
+		return p.parseIfNotExists()
+	}
+
+	return p.parseListAppend()
+}
+
+func (p *parser) parseIfNotExists() (updOperand, error) {
+	path, err := p.parsePath()
+	if err != nil {
+		return nil, err
+	}
+
+	if cerr := p.expect(tComma, "','"); cerr != nil {
+		return nil, cerr
+	}
+
+	def, derr := p.parseSetOperand()
+	if derr != nil {
+		return nil, derr
+	}
+
+	if rerr := p.expect(tRParen, "')'"); rerr != nil {
+		return nil, rerr
+	}
+
+	return &updIfNotExists{path: path, def: def}, nil
+}
+
+func (p *parser) parseListAppend() (updOperand, error) {
+	left, err := p.parseSetOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	if cerr := p.expect(tComma, "','"); cerr != nil {
+		return nil, cerr
+	}
+
+	right, rerr := p.parseSetOperand()
+	if rerr != nil {
+		return nil, rerr
+	}
+
+	if rerr := p.expect(tRParen, "')'"); rerr != nil {
+		return nil, rerr
+	}
+
+	return &updListAppend{left: left, right: right}, nil
+}

--- a/services/database/driver/expr/update_eval.go
+++ b/services/database/driver/expr/update_eval.go
@@ -1,0 +1,301 @@
+package expr
+
+import cerrors "github.com/stackshy/cloudemu/v2/errors"
+
+// ApplyUpdate applies a parsed UpdateProgram to item, mutating it in place and
+// returning it. item is expected to be a caller-owned copy. Clauses apply in
+// SET, REMOVE, ADD, DELETE order. A SET operand that resolves to a missing
+// attribute, or an ADD/DELETE type mismatch, is a cerrors.InvalidArgument.
+func ApplyUpdate(item map[string]any, prog *UpdateProgram) (map[string]any, error) {
+	for _, s := range prog.sets {
+		if err := applySet(item, s); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, p := range prog.removes {
+		removePath(item, p.Parts)
+	}
+
+	for _, a := range prog.adds {
+		if err := applyAdd(item, a); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, d := range prog.deletes {
+		if err := applyDelete(item, d); err != nil {
+			return nil, err
+		}
+	}
+
+	return item, nil
+}
+
+func applySet(item map[string]any, s setItem) error {
+	val, ok := evalUpdOperand(s.rhs, item)
+	if !ok {
+		return cerrors.New(cerrors.InvalidArgument, "SET operand refers to a missing attribute")
+	}
+
+	assignPath(item, s.path.Parts, val)
+
+	return nil
+}
+
+func applyAdd(item map[string]any, a pathValue) error {
+	cur, exists := resolvePath(a.path.Parts, item)
+
+	newVal, err := addValue(cur, exists, a.value.Value)
+	if err != nil {
+		return err
+	}
+
+	assignPath(item, a.path.Parts, newVal)
+
+	return nil
+}
+
+// addValue computes the result of ADD: numeric addition (creating the
+// attribute at the value when absent), or set union.
+func addValue(cur any, exists bool, val any) (any, error) {
+	switch v := val.(type) {
+	case float64:
+		if !exists {
+			return v, nil
+		}
+
+		base, ok := cur.(float64)
+		if !ok {
+			return nil, cerrors.New(cerrors.InvalidArgument, "ADD to a non-numeric attribute")
+		}
+
+		return base + v, nil
+	case StringSet, NumberSet, BinarySet:
+		if !exists {
+			return val, nil
+		}
+
+		res, ok := UnionSets(cur, val)
+		if !ok {
+			return nil, cerrors.New(cerrors.InvalidArgument, "ADD set type does not match the attribute")
+		}
+
+		return res, nil
+	default:
+		return nil, cerrors.New(cerrors.InvalidArgument, "ADD supports only Number and Set attributes")
+	}
+}
+
+func applyDelete(item map[string]any, d pathValue) error {
+	cur, exists := resolvePath(d.path.Parts, item)
+	if !exists {
+		return nil
+	}
+
+	res, ok := DifferenceSets(cur, d.value.Value)
+	if !ok {
+		return cerrors.New(cerrors.InvalidArgument, "DELETE requires a set attribute and a matching set value")
+	}
+
+	if SetIsEmpty(res) {
+		removePath(item, d.path.Parts)
+		return nil
+	}
+
+	assignPath(item, d.path.Parts, res)
+
+	return nil
+}
+
+func evalUpdOperand(op updOperand, item map[string]any) (any, bool) {
+	switch o := op.(type) {
+	case *updLeaf:
+		return resolveOperand(o.operand, item)
+	case *updArith:
+		return evalArith(o, item)
+	case *updIfNotExists:
+		return evalIfNotExists(o, item)
+	case *updListAppend:
+		return evalListAppend(o, item)
+	default:
+		return nil, false
+	}
+}
+
+func evalArith(o *updArith, item map[string]any) (any, bool) {
+	lv, lok := evalUpdOperand(o.left, item)
+	rv, rok := evalUpdOperand(o.right, item)
+
+	if !lok || !rok {
+		return nil, false
+	}
+
+	lf, ok1 := lv.(float64)
+	rf, ok2 := rv.(float64)
+
+	if !ok1 || !ok2 {
+		return nil, false
+	}
+
+	if o.op == "+" {
+		return lf + rf, true
+	}
+
+	return lf - rf, true
+}
+
+func evalIfNotExists(o *updIfNotExists, item map[string]any) (any, bool) {
+	if v, ok := resolvePath(o.path.Parts, item); ok {
+		return v, true
+	}
+
+	return evalUpdOperand(o.def, item)
+}
+
+func evalListAppend(o *updListAppend, item map[string]any) (any, bool) {
+	lv, lok := evalUpdOperand(o.left, item)
+	rv, rok := evalUpdOperand(o.right, item)
+
+	if !lok || !rok {
+		return nil, false
+	}
+
+	ll, ok1 := lv.([]any)
+	rl, ok2 := rv.([]any)
+
+	if !ok1 || !ok2 {
+		return nil, false
+	}
+
+	out := make([]any, 0, len(ll)+len(rl))
+	out = append(out, ll...)
+	out = append(out, rl...)
+
+	return out, true
+}
+
+// assignPath places value at parts within item. The top-level map is the
+// caller-owned copy and is mutated in place; nested containers are cloned
+// copy-on-write so structure shared with the stored item is never mutated. A
+// list index at or beyond the slice length appends, matching DynamoDB.
+func assignPath(item map[string]any, parts []PathPart, value any) {
+	head := parts[0]
+
+	if len(parts) == 1 {
+		item[head.Name] = value
+		return
+	}
+
+	item[head.Name] = mergeAssign(item[head.Name], parts[1:], value)
+}
+
+func mergeAssign(cur any, parts []PathPart, value any) any {
+	part := parts[0]
+	last := len(parts) == 1
+
+	if part.IsIndex {
+		arr := cloneSlice(cur)
+
+		if last {
+			return setListElem(arr, part.Index, value)
+		}
+
+		if part.Index >= 0 && part.Index < len(arr) {
+			arr[part.Index] = mergeAssign(arr[part.Index], parts[1:], value)
+		}
+
+		return arr
+	}
+
+	m := cloneMap(cur)
+
+	if last {
+		m[part.Name] = value
+	} else {
+		m[part.Name] = mergeAssign(m[part.Name], parts[1:], value)
+	}
+
+	return m
+}
+
+func setListElem(arr []any, idx int, value any) []any {
+	if idx >= 0 && idx < len(arr) {
+		arr[idx] = value
+		return arr
+	}
+
+	return append(arr, value)
+}
+
+// removePath deletes the value at parts within item, mutating the owned top map
+// in place and cloning nested containers copy-on-write. A list index shifts
+// later elements down; missing paths are a no-op.
+func removePath(item map[string]any, parts []PathPart) {
+	head := parts[0]
+
+	if len(parts) == 1 {
+		delete(item, head.Name)
+		return
+	}
+
+	if child, ok := item[head.Name]; ok {
+		item[head.Name] = mergeRemove(child, parts[1:])
+	}
+}
+
+func mergeRemove(cur any, parts []PathPart) any {
+	part := parts[0]
+	last := len(parts) == 1
+
+	if part.IsIndex {
+		return removeListElem(cur, part.Index, parts, last)
+	}
+
+	m := cloneMap(cur)
+
+	if last {
+		delete(m, part.Name)
+	} else if child, present := m[part.Name]; present {
+		m[part.Name] = mergeRemove(child, parts[1:])
+	}
+
+	return m
+}
+
+func removeListElem(cur any, idx int, parts []PathPart, last bool) any {
+	arr := cloneSlice(cur)
+	if idx < 0 || idx >= len(arr) {
+		return arr
+	}
+
+	if last {
+		return append(arr[:idx:idx], arr[idx+1:]...)
+	}
+
+	arr[idx] = mergeRemove(arr[idx], parts[1:])
+
+	return arr
+}
+
+func cloneMap(v any) map[string]any {
+	src, ok := v.(map[string]any)
+	if !ok {
+		return map[string]any{}
+	}
+
+	out := make(map[string]any, len(src))
+	for k, e := range src {
+		out[k] = e
+	}
+
+	return out
+}
+
+func cloneSlice(v any) []any {
+	src, _ := v.([]any)
+	out := make([]any, len(src))
+	copy(out, src)
+
+	return out
+}

--- a/services/database/driver/expr/update_eval.go
+++ b/services/database/driver/expr/update_eval.go
@@ -4,27 +4,35 @@ import cerrors "github.com/stackshy/cloudemu/v2/errors"
 
 // ApplyUpdate applies a parsed UpdateProgram to item, mutating it in place and
 // returning it. item is expected to be a caller-owned copy. Clauses apply in
-// SET, REMOVE, ADD, DELETE order. A SET operand that resolves to a missing
-// attribute, or an ADD/DELETE type mismatch, is a cerrors.InvalidArgument.
+// SET, REMOVE, ADD, DELETE order, and every operand is resolved against the
+// pre-update image of the item — DynamoDB evaluates all clauses against the
+// item as it was before the update. Because writes are copy-on-write, a shallow
+// snapshot stays pristine as item mutates. A SET operand that resolves to a
+// missing attribute, an ADD/DELETE type mismatch, or an invalid document path
+// is a cerrors.InvalidArgument.
 func ApplyUpdate(item map[string]any, prog *UpdateProgram) (map[string]any, error) {
+	orig := cloneMap(item)
+
 	for _, s := range prog.sets {
-		if err := applySet(item, s); err != nil {
+		if err := applySet(item, orig, s); err != nil {
 			return nil, err
 		}
 	}
 
 	for _, p := range prog.removes {
-		removePath(item, p.Parts)
+		if err := removePath(item, p.Parts); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, a := range prog.adds {
-		if err := applyAdd(item, a); err != nil {
+		if err := applyAdd(item, orig, a); err != nil {
 			return nil, err
 		}
 	}
 
 	for _, d := range prog.deletes {
-		if err := applyDelete(item, d); err != nil {
+		if err := applyDelete(item, orig, d); err != nil {
 			return nil, err
 		}
 	}
@@ -32,28 +40,24 @@ func ApplyUpdate(item map[string]any, prog *UpdateProgram) (map[string]any, erro
 	return item, nil
 }
 
-func applySet(item map[string]any, s setItem) error {
-	val, ok := evalUpdOperand(s.rhs, item)
+func applySet(item, orig map[string]any, s setItem) error {
+	val, ok := evalUpdOperand(s.rhs, orig)
 	if !ok {
 		return cerrors.New(cerrors.InvalidArgument, "SET operand refers to a missing attribute")
 	}
 
-	assignPath(item, s.path.Parts, val)
-
-	return nil
+	return assignPath(item, s.path.Parts, val)
 }
 
-func applyAdd(item map[string]any, a pathValue) error {
-	cur, exists := resolvePath(a.path.Parts, item)
+func applyAdd(item, orig map[string]any, a pathValue) error {
+	cur, exists := resolvePath(a.path.Parts, orig)
 
 	newVal, err := addValue(cur, exists, a.value.Value)
 	if err != nil {
 		return err
 	}
 
-	assignPath(item, a.path.Parts, newVal)
-
-	return nil
+	return assignPath(item, a.path.Parts, newVal)
 }
 
 // addValue computes the result of ADD: numeric addition (creating the
@@ -87,8 +91,8 @@ func addValue(cur any, exists bool, val any) (any, error) {
 	}
 }
 
-func applyDelete(item map[string]any, d pathValue) error {
-	cur, exists := resolvePath(d.path.Parts, item)
+func applyDelete(item, orig map[string]any, d pathValue) error {
+	cur, exists := resolvePath(d.path.Parts, orig)
 	if !exists {
 		return nil
 	}
@@ -99,13 +103,10 @@ func applyDelete(item map[string]any, d pathValue) error {
 	}
 
 	if SetIsEmpty(res) {
-		removePath(item, d.path.Parts)
-		return nil
+		return removePath(item, d.path.Parts)
 	}
 
-	assignPath(item, d.path.Parts, res)
-
-	return nil
+	return assignPath(item, d.path.Parts, res)
 }
 
 func evalUpdOperand(op updOperand, item map[string]any) (any, bool) {
@@ -178,47 +179,84 @@ func evalListAppend(o *updListAppend, item map[string]any) (any, bool) {
 // assignPath places value at parts within item. The top-level map is the
 // caller-owned copy and is mutated in place; nested containers are cloned
 // copy-on-write so structure shared with the stored item is never mutated. A
-// list index at or beyond the slice length appends, matching DynamoDB.
-func assignPath(item map[string]any, parts []PathPart, value any) {
+// document path that traverses an attribute of the wrong container type (e.g.
+// SET a.b where a is a scalar) is rejected, matching DynamoDB.
+func assignPath(item map[string]any, parts []PathPart, value any) error {
 	head := parts[0]
 
 	if len(parts) == 1 {
 		item[head.Name] = value
-		return
+		return nil
 	}
 
-	item[head.Name] = mergeAssign(item[head.Name], parts[1:], value)
+	child, err := mergeAssign(item[head.Name], parts[1:], value)
+	if err != nil {
+		return err
+	}
+
+	item[head.Name] = child
+
+	return nil
 }
 
-func mergeAssign(cur any, parts []PathPart, value any) any {
+func mergeAssign(cur any, parts []PathPart, value any) (any, error) {
 	part := parts[0]
 	last := len(parts) == 1
 
 	if part.IsIndex {
-		arr := cloneSlice(cur)
-
-		if last {
-			return setListElem(arr, part.Index, value)
-		}
-
-		if part.Index >= 0 && part.Index < len(arr) {
-			arr[part.Index] = mergeAssign(arr[part.Index], parts[1:], value)
-		}
-
-		return arr
+		return assignIndex(cur, part.Index, parts, last, value)
 	}
 
-	m := cloneMap(cur)
+	m, ok := cur.(map[string]any)
+	if !ok {
+		return nil, invalidPath()
+	}
+
+	m = cloneMap(m)
 
 	if last {
 		m[part.Name] = value
-	} else {
-		m[part.Name] = mergeAssign(m[part.Name], parts[1:], value)
+		return m, nil
 	}
 
-	return m
+	child, err := mergeAssign(m[part.Name], parts[1:], value)
+	if err != nil {
+		return nil, err
+	}
+
+	m[part.Name] = child
+
+	return m, nil
 }
 
+func assignIndex(cur any, idx int, parts []PathPart, last bool, value any) (any, error) {
+	arr, ok := cur.([]any)
+	if !ok {
+		return nil, invalidPath()
+	}
+
+	arr = cloneSlice(arr)
+
+	if last {
+		return setListElem(arr, idx, value), nil
+	}
+
+	if idx < 0 || idx >= len(arr) {
+		return nil, invalidPath()
+	}
+
+	child, err := mergeAssign(arr[idx], parts[1:], value)
+	if err != nil {
+		return nil, err
+	}
+
+	arr[idx] = child
+
+	return arr, nil
+}
+
+// setListElem sets arr[idx] = value, appending when idx is at or beyond the
+// slice length (DynamoDB appends rather than creating gaps).
 func setListElem(arr []any, idx int, value any) []any {
 	if idx >= 0 && idx < len(arr) {
 		arr[idx] = value
@@ -230,60 +268,97 @@ func setListElem(arr []any, idx int, value any) []any {
 
 // removePath deletes the value at parts within item, mutating the owned top map
 // in place and cloning nested containers copy-on-write. A list index shifts
-// later elements down; missing paths are a no-op.
-func removePath(item map[string]any, parts []PathPart) {
+// later elements down. A missing path is a no-op; a path that traverses the
+// wrong container type is rejected.
+func removePath(item map[string]any, parts []PathPart) error {
 	head := parts[0]
 
 	if len(parts) == 1 {
 		delete(item, head.Name)
-		return
+		return nil
 	}
 
-	if child, ok := item[head.Name]; ok {
-		item[head.Name] = mergeRemove(child, parts[1:])
+	child, ok := item[head.Name]
+	if !ok {
+		return nil
 	}
+
+	newChild, err := mergeRemove(child, parts[1:])
+	if err != nil {
+		return err
+	}
+
+	item[head.Name] = newChild
+
+	return nil
 }
 
-func mergeRemove(cur any, parts []PathPart) any {
+func mergeRemove(cur any, parts []PathPart) (any, error) {
 	part := parts[0]
 	last := len(parts) == 1
 
 	if part.IsIndex {
-		return removeListElem(cur, part.Index, parts, last)
+		return removeIndex(cur, part.Index, parts, last)
 	}
 
-	m := cloneMap(cur)
+	m, ok := cur.(map[string]any)
+	if !ok {
+		return nil, invalidPath()
+	}
+
+	m = cloneMap(m)
 
 	if last {
 		delete(m, part.Name)
-	} else if child, present := m[part.Name]; present {
-		m[part.Name] = mergeRemove(child, parts[1:])
+		return m, nil
 	}
 
-	return m
+	child, present := m[part.Name]
+	if !present {
+		return m, nil
+	}
+
+	nc, err := mergeRemove(child, parts[1:])
+	if err != nil {
+		return nil, err
+	}
+
+	m[part.Name] = nc
+
+	return m, nil
 }
 
-func removeListElem(cur any, idx int, parts []PathPart, last bool) any {
-	arr := cloneSlice(cur)
+func removeIndex(cur any, idx int, parts []PathPart, last bool) (any, error) {
+	arr, ok := cur.([]any)
+	if !ok {
+		return nil, invalidPath()
+	}
+
+	arr = cloneSlice(arr)
+
 	if idx < 0 || idx >= len(arr) {
-		return arr
+		return arr, nil
 	}
 
 	if last {
-		return append(arr[:idx:idx], arr[idx+1:]...)
+		return append(arr[:idx:idx], arr[idx+1:]...), nil
 	}
 
-	arr[idx] = mergeRemove(arr[idx], parts[1:])
+	child, err := mergeRemove(arr[idx], parts[1:])
+	if err != nil {
+		return nil, err
+	}
 
-	return arr
+	arr[idx] = child
+
+	return arr, nil
 }
 
-func cloneMap(v any) map[string]any {
-	src, ok := v.(map[string]any)
-	if !ok {
-		return map[string]any{}
-	}
+func invalidPath() error {
+	return cerrors.New(cerrors.InvalidArgument, "invalid document path for update")
+}
 
+func cloneMap(src map[string]any) map[string]any {
 	out := make(map[string]any, len(src))
 	for k, e := range src {
 		out[k] = e
@@ -292,8 +367,7 @@ func cloneMap(v any) map[string]any {
 	return out
 }
 
-func cloneSlice(v any) []any {
-	src, _ := v.([]any)
+func cloneSlice(src []any) []any {
 	out := make([]any, len(src))
 	copy(out, src)
 

--- a/services/database/driver/expr/update_test.go
+++ b/services/database/driver/expr/update_test.go
@@ -1,0 +1,157 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustUpdate(t *testing.T, item map[string]any, raw string, values map[string]any) map[string]any {
+	t.Helper()
+
+	prog, err := ParseUpdate(raw, nil, values)
+	require.NoError(t, err, "parse %q", raw)
+
+	out, err := ApplyUpdate(item, prog)
+	require.NoError(t, err, "apply %q", raw)
+
+	return out
+}
+
+func TestUpdateSetLiteralAndArithmetic(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"a": float64(10)}, "SET a = a + :n, b = :b",
+		map[string]any{":n": float64(5), ":b": "new"})
+
+	assert.Equal(t, float64(15), out["a"], "a + :n")
+	assert.Equal(t, "new", out["b"])
+
+	out = mustUpdate(t, map[string]any{"a": float64(10)}, "SET a = a - :n", map[string]any{":n": float64(3)})
+	assert.Equal(t, float64(7), out["a"], "a - :n")
+}
+
+func TestUpdateIfNotExists(t *testing.T) {
+	out := mustUpdate(t, map[string]any{}, "SET a = if_not_exists(a, :d)", map[string]any{":d": float64(1)})
+	assert.Equal(t, float64(1), out["a"], "absent → default")
+
+	out = mustUpdate(t, map[string]any{"a": float64(9)}, "SET a = if_not_exists(a, :d)", map[string]any{":d": float64(1)})
+	assert.Equal(t, float64(9), out["a"], "present → keeps existing")
+}
+
+func TestUpdateListAppend(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"l": []any{"a", "b"}}, "SET l = list_append(l, :new)",
+		map[string]any{":new": []any{"c"}})
+	assert.Equal(t, []any{"a", "b", "c"}, out["l"])
+}
+
+func TestUpdateRemove(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"a": 1, "b": 2, "l": []any{"x", "y", "z"}}, "REMOVE a, l[1]", nil)
+
+	_, hasA := out["a"]
+	assert.False(t, hasA, "a removed")
+	assert.Equal(t, []any{"x", "z"}, out["l"], "list element removed and shifted")
+}
+
+func TestUpdateAddNumber(t *testing.T) {
+	out := mustUpdate(t, map[string]any{}, "ADD n :inc", map[string]any{":inc": float64(3)})
+	assert.Equal(t, float64(3), out["n"], "ADD creates the attribute at the value")
+
+	out = mustUpdate(t, map[string]any{"n": float64(10)}, "ADD n :inc", map[string]any{":inc": float64(3)})
+	assert.Equal(t, float64(13), out["n"], "ADD increments")
+}
+
+func TestUpdateAddSet(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"colors": StringSet{"red", "blue"}}, "ADD colors :c",
+		map[string]any{":c": StringSet{"blue", "green"}})
+
+	cs, ok := out["colors"].(StringSet)
+	require.True(t, ok)
+	assert.ElementsMatch(t, StringSet{"red", "blue", "green"}, cs, "union, deduplicated")
+
+	out = mustUpdate(t, map[string]any{}, "ADD colors :c", map[string]any{":c": StringSet{"red"}})
+	assert.Equal(t, StringSet{"red"}, out["colors"], "ADD creates the set")
+}
+
+func TestUpdateAddNumberSet(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"nums": NumberSet{1, 2}}, "ADD nums :n",
+		map[string]any{":n": NumberSet{2, 3}})
+
+	ns, ok := out["nums"].(NumberSet)
+	require.True(t, ok)
+	assert.ElementsMatch(t, NumberSet{1, 2, 3}, ns)
+}
+
+func TestUpdateDeleteSet(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"colors": StringSet{"red", "blue", "green"}}, "DELETE colors :c",
+		map[string]any{":c": StringSet{"blue"}})
+
+	assert.ElementsMatch(t, StringSet{"red", "green"}, out["colors"].(StringSet))
+}
+
+func TestUpdateDeleteSetEmptiesRemovesAttr(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"colors": StringSet{"red"}}, "DELETE colors :c",
+		map[string]any{":c": StringSet{"red"}})
+
+	_, has := out["colors"]
+	assert.False(t, has, "an emptied set attribute is removed")
+}
+
+func TestUpdateNestedSet(t *testing.T) {
+	out := mustUpdate(t, map[string]any{"addr": map[string]any{"city": "Paris"}}, "SET addr.city = :c",
+		map[string]any{":c": "London"})
+
+	addr, ok := out["addr"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "London", addr["city"])
+}
+
+func TestUpdateCopyOnWriteDoesNotMutateSource(t *testing.T) {
+	inner := map[string]any{"city": "Paris"}
+	// A shallow item copy (as the providers make) shares the nested map.
+	shallowCopy := map[string]any{"addr": inner}
+
+	_ = mustUpdate(t, shallowCopy, "SET addr.city = :c", map[string]any{":c": "London"})
+	assert.Equal(t, "Paris", inner["city"], "the shared nested map must not be mutated")
+}
+
+func TestUpdateMultiClause(t *testing.T) {
+	item := map[string]any{"a": float64(1), "old": "x", "tags": StringSet{"t1"}}
+	out := mustUpdate(t, item, "SET b = :b REMOVE old ADD a :n DELETE tags :t",
+		map[string]any{":b": "y", ":n": float64(4), ":t": StringSet{"t1"}})
+
+	assert.Equal(t, "y", out["b"])
+	assert.Equal(t, float64(5), out["a"])
+
+	_, hasOld := out["old"]
+	assert.False(t, hasOld)
+
+	_, hasTags := out["tags"]
+	assert.False(t, hasTags, "tags emptied by DELETE")
+}
+
+func TestUpdateApplyErrors(t *testing.T) {
+	cases := []struct {
+		raw    string
+		item   map[string]any
+		values map[string]any
+	}{
+		{"SET a = b", map[string]any{}, nil},                                             // operand path missing
+		{"ADD s :n", map[string]any{"s": "hi"}, map[string]any{":n": float64(1)}},        // ADD to non-number
+		{"DELETE s :c", map[string]any{"s": "hi"}, map[string]any{":c": StringSet{"x"}}}, // DELETE on non-set
+	}
+
+	for _, c := range cases {
+		prog, err := ParseUpdate(c.raw, nil, c.values)
+		require.NoError(t, err, "parse %q", c.raw)
+
+		_, aerr := ApplyUpdate(c.item, prog)
+		assert.Error(t, aerr, "apply %q should error", c.raw)
+	}
+}
+
+func TestUpdateParseErrors(t *testing.T) {
+	for _, raw := range []string{"", "SET", "SET a", "SET a =", "FOO a = :v", "ADD a", "SET a > :v"} {
+		_, err := ParseUpdate(raw, nil, map[string]any{":v": float64(1)})
+		assert.Error(t, err, "%q should fail to parse", raw)
+	}
+}

--- a/services/database/driver/expr/update_test.go
+++ b/services/database/driver/expr/update_test.go
@@ -155,3 +155,55 @@ func TestUpdateParseErrors(t *testing.T) {
 		assert.Error(t, err, "%q should fail to parse", raw)
 	}
 }
+
+func TestUpdateInvalidDocumentPath(t *testing.T) {
+	one := map[string]any{":v": float64(1)}
+
+	cases := []struct {
+		raw  string
+		item map[string]any
+	}{
+		{"SET a.b = :v", map[string]any{"a": "scalar"}},                // descend into a scalar
+		{"SET a.b = :v", map[string]any{}},                             // parent missing
+		{"REMOVE a[0]", map[string]any{"a": map[string]any{"x": 1.0}}}, // index into a map
+	}
+
+	for _, c := range cases {
+		prog, err := ParseUpdate(c.raw, nil, one)
+		require.NoError(t, err)
+
+		_, aerr := ApplyUpdate(c.item, prog)
+		assert.Error(t, aerr, "%q on %v should be an invalid document path", c.raw, c.item)
+	}
+}
+
+func TestUpdatePreUpdateImage(t *testing.T) {
+	// b reads the pre-update value of a, even though a is SET in the same
+	// expression (DynamoDB evaluates operands against the pre-update image).
+	out := mustUpdate(t, map[string]any{"a": float64(0)}, "SET a = :one, b = a",
+		map[string]any{":one": float64(1)})
+
+	assert.Equal(t, float64(1), out["a"])
+	assert.Equal(t, float64(0), out["b"], "b reads the pre-update value of a")
+}
+
+func TestUpdateListAppendDoesNotMutateSource(t *testing.T) {
+	src := []any{"x"}
+	out := mustUpdate(t, map[string]any{"l": src}, "SET l2 = list_append(l, :new)",
+		map[string]any{":new": []any{"y"}})
+
+	assert.Equal(t, []any{"x", "y"}, out["l2"])
+	assert.Equal(t, []any{"x"}, src, "list_append does not mutate the source list")
+}
+
+func TestUpdateNestedRemoveCopyOnWrite(t *testing.T) {
+	inner := map[string]any{"x": float64(1), "y": float64(2)}
+	out := mustUpdate(t, map[string]any{"m": inner}, "REMOVE m.x", nil)
+
+	m, ok := out["m"].(map[string]any)
+	require.True(t, ok)
+
+	_, hasX := m["x"]
+	assert.False(t, hasX, "m.x removed")
+	assert.Equal(t, float64(1), inner["x"], "the shared source map is not mutated")
+}


### PR DESCRIPTION
## Summary

Completes the DynamoDB expression surface begun in #434/#435, all through the shared \`services/database/driver/expr\` engine and with no \`Database\` interface change (so no docs regeneration).

### UpdateExpression — full grammar
A new parser + evaluator in \`expr\` handles the forms the wire handler previously dropped:
- **SET** operands: \`a = a + :n\`, \`a = a - :n\` (number-only), \`if_not_exists(path, :v)\`, \`list_append(a, b)\`, plus literals/paths and **nested / list-indexed** targets.
- **REMOVE** including \`path[i]\` (shifts later elements down).
- **ADD**: number (atomic increment, creates the attribute when absent) and **set union**.
- **DELETE**: **set difference**; an emptied set removes the attribute.

The raw expression flows via new \`UpdateItemInput\` fields (\`UpdateExpression\`/\`ExprNames\`/\`ExprValues\`); the legacy \`Actions\` form is retained for direct-API callers. A single shared \`driver.ApplyUpdate\` routes **all three providers** (DynamoDB, Cosmos, Firestore) through the same evaluator, replacing three identical SET/REMOVE loops. Path mutation is **copy-on-write**, so a shallow item copy never aliases the stored item.

### Real set types (SS / NS / BS)
Previously sets were indistinguishable from lists. The wire codec now decodes/encodes \`SS\`/\`NS\`/\`BS\` (and the \`B\` binary scalar), modeled as distinct native types (\`expr.StringSet\`/\`NumberSet\`/\`BinarySet\`) that the evaluator understands for \`attribute_type\`, \`contains\`, equality, and ADD/DELETE set algebra.

### Edge fixes (from the #435 review)
- **KeyConditionExpression** now parses through the shared lexer, so it is spacing-tolerant (e.g. \`sk>:v\`), and enforces the restricted key grammar.
- **ProjectionExpression** rejects overlapping document paths (\`a, a.b\`).
- Known limitation: \`begins_with\` on a numeric sort key isn't rejected — the emulator doesn't model attribute types, so schema-based validation isn't available (separate change).

## Why
Real apps and IaC drive counters, sets, and conditional list edits through UpdateExpression constantly; without the grammar and real set types these operations failed or silently misbehaved. All in-memory — no Docker.

## Tests
- \`expr\`: unit coverage for the update parser/evaluator (arithmetic, if_not_exists, list_append, ADD/DELETE number+set, nested paths, copy-on-write, error cases), set algebra, and the key-condition parser (spacing-tolerant, BETWEEN, begins_with, aliases, rejections).
- Real aws-sdk-go-v2 e2e: \`TestDDBUpdateExpressionGrammar\` (SET/ADD/DELETE incl. set union/difference) and \`TestDDBSetTypesRoundTrip\` (SS/NS/BS/B). Cosmos + Firestore provider tests exercise the shared raw-expression path.
- build, vet, gofmt, tidy, \`-race\`, full suite — all green.