### PR TITLE
feat(firestore): faithful structured-query WHERE (OR / IN / array-contains / unary) + expr numeric coercion

### DIFF
--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -824,6 +824,7 @@ func TestDatabaseQueryOperators(t *testing.T) {
 		"p0": {"status": "active", "tags": []string{"red", "new"}, "score": 10},
 		"p1": {"status": "pending", "tags": []string{"blue"}, "score": 20},
 		"p2": {"status": "archived", "tags": []string{"red", "old"}, "score": 30, "owner": nil},
+		"p3": {"score": 5}, // no status/tags/owner — must be excluded from not-in / !=
 	}
 	for id, fields := range docs {
 		if _, err := coll.Doc(id).Set(ctx, fields); err != nil {
@@ -839,11 +840,14 @@ func TestDatabaseQueryOperators(t *testing.T) {
 	}
 
 	count("in", coll.Where("status", "in", []string{"active", "pending"}), 2)
+	// not-in and != exclude p2 (archived) AND p3 (field absent).
 	count("not-in", coll.Where("status", "not-in", []string{"archived"}), 2)
+	count("!=", coll.Where("status", "!=", "active"), 2)
 	count("array-contains", coll.Where("tags", "array-contains", "red"), 2)
 	count("array-contains-any", coll.Where("tags", "array-contains-any", []string{"blue", "old"}), 2)
+	// array-contains on a scalar (string) field matches nothing — no substring fallback.
+	count("array-contains on scalar", coll.Where("status", "array-contains", "arch"), 0)
 	count("numeric >", coll.Where("score", ">", 15), 2)
-	count("!=", coll.Where("status", "!=", "active"), 2)
 	count("is-null", coll.Where("owner", "==", nil), 1)
 
 	or := gcpfirestore.OrFilter{Filters: []gcpfirestore.EntityFilter{

--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -811,3 +811,44 @@ func TestDatabaseStreams(t *testing.T) {
 		t.Error("stream iterator should carry a shard id")
 	}
 }
+
+// TestDatabaseQueryOperators drives the real Firestore REST client through the
+// StructuredQuery operators added for faithful querying: IN / NOT_IN,
+// ARRAY_CONTAINS / ARRAY_CONTAINS_ANY, a composite OR, a unary IS_NULL, and a
+// numeric range over int-valued fields.
+func TestDatabaseQueryOperators(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "products")
+	coll := client.Collection("products")
+
+	docs := map[string]map[string]any{
+		"p0": {"status": "active", "tags": []string{"red", "new"}, "score": 10},
+		"p1": {"status": "pending", "tags": []string{"blue"}, "score": 20},
+		"p2": {"status": "archived", "tags": []string{"red", "old"}, "score": 30, "owner": nil},
+	}
+	for id, fields := range docs {
+		if _, err := coll.Doc(id).Set(ctx, fields); err != nil {
+			t.Fatalf("Set %s: %v", id, err)
+		}
+	}
+
+	count := func(name string, q gcpfirestore.Query, want int) {
+		got := dbCollectAll(t, q.Documents(ctx))
+		if len(got) != want {
+			t.Errorf("%s: got %d docs (%v), want %d", name, len(got), keysOfDB(got), want)
+		}
+	}
+
+	count("in", coll.Where("status", "in", []string{"active", "pending"}), 2)
+	count("not-in", coll.Where("status", "not-in", []string{"archived"}), 2)
+	count("array-contains", coll.Where("tags", "array-contains", "red"), 2)
+	count("array-contains-any", coll.Where("tags", "array-contains-any", []string{"blue", "old"}), 2)
+	count("numeric >", coll.Where("score", ">", 15), 2)
+	count("!=", coll.Where("status", "!=", "active"), 2)
+	count("is-null", coll.Where("owner", "==", nil), 1)
+
+	or := gcpfirestore.OrFilter{Filters: []gcpfirestore.EntityFilter{
+		gcpfirestore.PropertyFilter{Path: "status", Operator: "==", Value: "active"},
+		gcpfirestore.PropertyFilter{Path: "score", Operator: "==", Value: 30},
+	}}
+	count("OR", coll.WhereEntity(or), 2)
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -23,6 +23,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
 )
 
 // Path-segment values used in Firestore REST URLs.
@@ -325,33 +326,50 @@ type runQueryRequest struct {
 	} `json:"structuredQuery"`
 }
 
-// queryFilter mirrors StructuredQuery.Filter: either a single fieldFilter
-// or a compositeFilter AND of nested filters.
+// queryFilter mirrors StructuredQuery.Filter: a single fieldFilter, a
+// compositeFilter (AND/OR) of nested filters, or a unaryFilter.
 type queryFilter struct {
-	FieldFilter *struct {
-		Field struct {
-			FieldPath string `json:"fieldPath"`
-		} `json:"field"`
-		Op    fieldOp `json:"op"`
-		Value value   `json:"value"`
-	} `json:"fieldFilter"`
-	CompositeFilter *struct {
-		Op      compositeOp   `json:"op"`
-		Filters []queryFilter `json:"filters"`
-	} `json:"compositeFilter"`
+	FieldFilter     *fieldFilter     `json:"fieldFilter"`
+	CompositeFilter *compositeFilter `json:"compositeFilter"`
+	UnaryFilter     *unaryFilter     `json:"unaryFilter"`
+}
+
+type fieldRef struct {
+	FieldPath string `json:"fieldPath"`
+}
+
+type fieldFilter struct {
+	Field fieldRef `json:"field"`
+	Op    fieldOp  `json:"op"`
+	Value value    `json:"value"`
+}
+
+type compositeFilter struct {
+	Op      compositeOp   `json:"op"`
+	Filters []queryFilter `json:"filters"`
+}
+
+type unaryFilter struct {
+	Op    unaryOp  `json:"op"`
+	Field fieldRef `json:"field"`
 }
 
 // fieldOp decodes a FieldFilter operator sent either as its enum name
 // ("EQUAL") or its protobuf number (5), as the REST client does.
 type fieldOp string
 
+//nolint:gochecknoglobals // static lookup table
 var fieldOpNames = map[int]fieldOp{
-	1: "LESS_THAN",
-	2: "LESS_THAN_OR_EQUAL",
-	3: "GREATER_THAN",
-	4: "GREATER_THAN_OR_EQUAL",
-	5: "EQUAL",
-	6: "NOT_EQUAL",
+	1:  "LESS_THAN",
+	2:  "LESS_THAN_OR_EQUAL",
+	3:  "GREATER_THAN",
+	4:  "GREATER_THAN_OR_EQUAL",
+	5:  "EQUAL",
+	6:  "NOT_EQUAL",
+	7:  "ARRAY_CONTAINS",
+	8:  "IN",
+	9:  "ARRAY_CONTAINS_ANY",
+	10: "NOT_IN",
 }
 
 func (o *fieldOp) UnmarshalJSON(b []byte) error {
@@ -372,8 +390,16 @@ func (o *fieldOp) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// compositeOp decodes a CompositeFilter operator name or number (AND=1).
+// compositeOp decodes a CompositeFilter operator name or number (AND=1, OR=2).
 type compositeOp string
+
+const (
+	compositeAnd compositeOp = "AND"
+	compositeOr  compositeOp = "OR"
+)
+
+//nolint:gochecknoglobals // static lookup table
+var compositeOpNames = map[int]compositeOp{1: compositeAnd, 2: compositeOr}
 
 func (o *compositeOp) UnmarshalJSON(b []byte) error {
 	if len(b) > 0 && b[0] == '"' {
@@ -389,58 +415,33 @@ func (o *compositeOp) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &n); err != nil {
 		return err
 	}
-	if n == 1 {
-		*o = "AND"
-	}
+	*o = compositeOpNames[n] // unknown numbers stay "" and fail downstream
 	return nil
 }
 
-// firestoreOps maps StructuredQuery operators onto driver scan filter ops.
-var firestoreOps = map[string]string{
-	"EQUAL":                 "=",
-	"NOT_EQUAL":             "!=",
-	"LESS_THAN":             "<",
-	"LESS_THAN_OR_EQUAL":    "<=",
-	"GREATER_THAN":          ">",
-	"GREATER_THAN_OR_EQUAL": ">=",
-}
+// unaryOp decodes a UnaryFilter operator name or number (IS_NAN=2, IS_NULL=3,
+// IS_NOT_NAN=4, IS_NOT_NULL=5).
+type unaryOp string
 
-// filtersFromQuery flattens a where clause into driver scan filters.
-// Only AND composites are supported; anything else is an error so queries
-// are never silently answered with the wrong result set.
-func filtersFromQuery(f *queryFilter) ([]dbdriver.ScanFilter, error) {
-	if f == nil {
-		return nil, nil
+//nolint:gochecknoglobals // static lookup table
+var unaryOpNames = map[int]unaryOp{2: "IS_NAN", 3: "IS_NULL", 4: "IS_NOT_NAN", 5: "IS_NOT_NULL"}
+
+func (o *unaryOp) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*o = unaryOp(v)
+		return nil
 	}
 
-	if f.FieldFilter != nil {
-		op, ok := firestoreOps[string(f.FieldFilter.Op)]
-		if !ok {
-			return nil, fmt.Errorf("unsupported filter op %q", f.FieldFilter.Op)
-		}
-		return []dbdriver.ScanFilter{{
-			Field: f.FieldFilter.Field.FieldPath,
-			Op:    op,
-			Value: firestoreValueToGo(f.FieldFilter.Value),
-		}}, nil
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
 	}
-
-	if f.CompositeFilter != nil {
-		if f.CompositeFilter.Op != "AND" {
-			return nil, fmt.Errorf("unsupported composite op %q", f.CompositeFilter.Op)
-		}
-		var out []dbdriver.ScanFilter
-		for i := range f.CompositeFilter.Filters {
-			sub, err := filtersFromQuery(&f.CompositeFilter.Filters[i])
-			if err != nil {
-				return nil, err
-			}
-			out = append(out, sub...)
-		}
-		return out, nil
-	}
-
-	return nil, nil
+	*o = unaryOpNames[n]
+	return nil
 }
 
 type runQueryResponseEntry struct {
@@ -466,37 +467,64 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 	p, _ := parseFirestorePath(base)
 	p.collection = collection
 
-	filters, ferr := filtersFromQuery(req.StructuredQuery.Where)
+	node, ferr := buildFilterNode(req.StructuredQuery.Where)
 	if ferr != nil {
 		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", ferr.Error())
 		return
 	}
 
-	// runQuery is not paged: honor an explicit limit, otherwise stream the
-	// full result set (the driver treats limit<=0 as a 100-item default).
-	limit := req.StructuredQuery.Limit
-	if limit <= 0 {
-		limit = allResults
-	}
-
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
-		Table:   collection,
-		Filters: filters,
-		Limit:   limit,
-	})
+	// Fetch the full collection and evaluate the where clause here with full
+	// grammar fidelity (type-aware, AND/OR/NOT, IN/array-contains, unary).
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: collection, Limit: allResults})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
+	matched, merr := filterDocuments(result.Items, node, req.StructuredQuery.Limit)
+	if merr != nil {
+		writeErr(w, merr)
+		return
+	}
+
+	streamQueryResults(w, matched, p)
+}
+
+// filterDocuments keeps the items matching node (nil node matches all) up to
+// limit (limit<=0 means no limit).
+func filterDocuments(items []map[string]any, node expr.Node, limit int) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(items))
+
+	for _, item := range items {
+		if node != nil {
+			ok, err := expr.Eval(node, item)
+			if err != nil {
+				return nil, err
+			}
+
+			if !ok {
+				continue
+			}
+		}
+
+		out = append(out, item)
+
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+
+	return out, nil
+}
+
+func streamQueryResults(w http.ResponseWriter, items []map[string]any, p firestorePath) {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
 
-	// Stream JSON array of entries.
 	w.Header().Set("Content-Type", contentTypeJSON)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("[")) //nolint:errcheck // best-effort streaming response
 
-	for i, item := range result.Items {
+	for i, item := range items {
 		if i > 0 {
 			w.Write([]byte(",")) //nolint:errcheck // best-effort
 		}

--- a/server/gcp/firestore/query.go
+++ b/server/gcp/firestore/query.go
@@ -48,7 +48,7 @@ func fieldFilterNode(ff *fieldFilter) (expr.Node, error) {
 	}
 
 	if ff.Op == "ARRAY_CONTAINS" {
-		return &expr.Contains{Path: path, Operand: valueOperand(ff.Value)}, nil
+		return arrayContainsNode(path, &expr.Contains{Path: path, Operand: valueOperand(ff.Value)}), nil
 	}
 
 	return listFilterNode(ff)
@@ -68,12 +68,33 @@ func listFilterNode(ff *fieldFilter) (expr.Node, error) {
 	case "IN":
 		return inNode(path, members), nil
 	case "NOT_IN":
-		return &expr.Not{Child: inNode(path, members)}, nil
+		return notInNode(path, members), nil
 	case "ARRAY_CONTAINS_ANY":
-		return arrayContainsAnyNode(path, members), nil
+		return arrayContainsNode(path, orContains(path, members)), nil
 	default:
 		return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported filter op %q", ff.Op)
 	}
+}
+
+// notInNode matches documents whose field is present, non-null, and not equal
+// to any member — Firestore excludes absent and null fields from not-in (a bare
+// negation would wrongly include them).
+func notInNode(path *expr.PathOperand, members []any) expr.Node {
+	presentAndNotNull := &expr.Comparison{Op: "<>", Left: path, Right: &expr.ValueOperand{Value: nil}}
+	return &expr.And{Left: presentAndNotNull, Right: &expr.Not{Child: inNode(path, members)}}
+}
+
+// arrayContainsNode gates an array-membership test on the field actually being
+// an array, so it never falls back to the substring match that the shared
+// Contains node performs on string fields.
+func arrayContainsNode(path *expr.PathOperand, membership expr.Node) expr.Node {
+	return &expr.And{Left: isArray(path), Right: membership}
+}
+
+// isArray is true when path resolves to a list ("L" is the type code
+// expr.dynamoType reports for a native []any).
+func isArray(path *expr.PathOperand) expr.Node {
+	return &expr.AttrType{Path: path, Type: &expr.ValueOperand{Value: "L"}}
 }
 
 func compositeFilterNode(cf *compositeFilter) (expr.Node, error) {
@@ -90,6 +111,12 @@ func compositeFilterNode(cf *compositeFilter) (expr.Node, error) {
 		}
 
 		if child == nil {
+			// A match-all sub-filter absorbs an OR (always true) but is a no-op
+			// in an AND.
+			if cf.Op == compositeOr {
+				return nil, nil
+			}
+
 			continue
 		}
 
@@ -135,9 +162,9 @@ func inNode(path *expr.PathOperand, members []any) expr.Node {
 	return &expr.In{Operand: path, List: list}
 }
 
-// arrayContainsAnyNode matches when the document's array field intersects any
-// member of the query array — an OR of ARRAY_CONTAINS over each member.
-func arrayContainsAnyNode(path *expr.PathOperand, members []any) expr.Node {
+// orContains builds an OR of ARRAY_CONTAINS over each member, for
+// ARRAY_CONTAINS_ANY. members is non-empty (validated by arrayMembers).
+func orContains(path *expr.PathOperand, members []any) expr.Node {
 	var node expr.Node
 
 	for _, m := range members {

--- a/server/gcp/firestore/query.go
+++ b/server/gcp/firestore/query.go
@@ -1,0 +1,189 @@
+package firestore
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// buildFilterNode translates a Firestore StructuredQuery where clause into an
+// expr AST, reusing the shared type-aware evaluator. A nil filter (or an empty
+// composite) yields a nil node, meaning "match every document".
+func buildFilterNode(f *queryFilter) (expr.Node, error) {
+	if f == nil {
+		return nil, nil
+	}
+
+	switch {
+	case f.FieldFilter != nil:
+		return fieldFilterNode(f.FieldFilter)
+	case f.CompositeFilter != nil:
+		return compositeFilterNode(f.CompositeFilter)
+	case f.UnaryFilter != nil:
+		return unaryFilterNode(f.UnaryFilter)
+	default:
+		return nil, nil
+	}
+}
+
+// firestoreCompareOps maps the relational Firestore operators onto expr
+// comparison operators.
+//
+//nolint:gochecknoglobals // static lookup table
+var firestoreCompareOps = map[fieldOp]string{
+	"EQUAL":                 "=",
+	"NOT_EQUAL":             "<>",
+	"LESS_THAN":             "<",
+	"LESS_THAN_OR_EQUAL":    "<=",
+	"GREATER_THAN":          ">",
+	"GREATER_THAN_OR_EQUAL": ">=",
+}
+
+func fieldFilterNode(ff *fieldFilter) (expr.Node, error) {
+	path := fieldPathToOperand(ff.Field.FieldPath)
+
+	if op, ok := firestoreCompareOps[ff.Op]; ok {
+		return &expr.Comparison{Op: op, Left: path, Right: valueOperand(ff.Value)}, nil
+	}
+
+	if ff.Op == "ARRAY_CONTAINS" {
+		return &expr.Contains{Path: path, Operand: valueOperand(ff.Value)}, nil
+	}
+
+	return listFilterNode(ff)
+}
+
+// listFilterNode handles the array-operand operators IN, NOT_IN and
+// ARRAY_CONTAINS_ANY, whose value is a (non-empty) array.
+func listFilterNode(ff *fieldFilter) (expr.Node, error) {
+	path := fieldPathToOperand(ff.Field.FieldPath)
+
+	members, err := arrayMembers(ff.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	switch ff.Op {
+	case "IN":
+		return inNode(path, members), nil
+	case "NOT_IN":
+		return &expr.Not{Child: inNode(path, members)}, nil
+	case "ARRAY_CONTAINS_ANY":
+		return arrayContainsAnyNode(path, members), nil
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported filter op %q", ff.Op)
+	}
+}
+
+func compositeFilterNode(cf *compositeFilter) (expr.Node, error) {
+	if cf.Op != compositeAnd && cf.Op != compositeOr {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unsupported composite op %q", cf.Op)
+	}
+
+	var node expr.Node
+
+	for i := range cf.Filters {
+		child, err := buildFilterNode(&cf.Filters[i])
+		if err != nil {
+			return nil, err
+		}
+
+		if child == nil {
+			continue
+		}
+
+		if node == nil {
+			node = child
+			continue
+		}
+
+		node = combine(cf.Op, node, child)
+	}
+
+	return node, nil
+}
+
+func combine(op compositeOp, left, right expr.Node) expr.Node {
+	if op == compositeOr {
+		return &expr.Or{Left: left, Right: right}
+	}
+
+	return &expr.And{Left: left, Right: right}
+}
+
+func unaryFilterNode(uf *unaryFilter) (expr.Node, error) {
+	path := fieldPathToOperand(uf.Field.FieldPath)
+
+	switch uf.Op {
+	case "IS_NULL":
+		return &expr.Comparison{Op: "=", Left: path, Right: &expr.ValueOperand{Value: nil}}, nil
+	case "IS_NOT_NULL":
+		return &expr.Comparison{Op: "<>", Left: path, Right: &expr.ValueOperand{Value: nil}}, nil
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument,
+			"unsupported unary op %q (IS_NAN/IS_NOT_NAN are not modeled)", uf.Op)
+	}
+}
+
+func inNode(path *expr.PathOperand, members []any) expr.Node {
+	list := make([]expr.Operand, len(members))
+	for i, m := range members {
+		list[i] = &expr.ValueOperand{Value: m}
+	}
+
+	return &expr.In{Operand: path, List: list}
+}
+
+// arrayContainsAnyNode matches when the document's array field intersects any
+// member of the query array — an OR of ARRAY_CONTAINS over each member.
+func arrayContainsAnyNode(path *expr.PathOperand, members []any) expr.Node {
+	var node expr.Node
+
+	for _, m := range members {
+		c := &expr.Contains{Path: path, Operand: &expr.ValueOperand{Value: m}}
+		if node == nil {
+			node = c
+			continue
+		}
+
+		node = &expr.Or{Left: node, Right: c}
+	}
+
+	return node
+}
+
+// arrayMembers returns the native values of an array-valued query operand,
+// rejecting a non-array or empty array (Firestore requires a non-empty array
+// for IN / NOT_IN / ARRAY_CONTAINS_ANY).
+//
+//nolint:gocritic // hugeParam: value is the wire field type
+func arrayMembers(v value) ([]any, error) {
+	if v.ArrayValue == nil || len(v.ArrayValue.Values) == 0 {
+		return nil, cerrors.New(cerrors.InvalidArgument,
+			"IN / NOT_IN / ARRAY_CONTAINS_ANY require a non-empty array value")
+	}
+
+	out := make([]any, len(v.ArrayValue.Values))
+	for i, el := range v.ArrayValue.Values {
+		out[i] = firestoreValueToGo(el)
+	}
+
+	return out, nil
+}
+
+func fieldPathToOperand(path string) *expr.PathOperand {
+	segments := strings.Split(path, ".")
+
+	parts := make([]expr.PathPart, 0, len(segments))
+	for _, name := range segments {
+		parts = append(parts, expr.PathPart{Name: name})
+	}
+
+	return &expr.PathOperand{Parts: parts}
+}
+
+//nolint:gocritic // hugeParam: value is the wire field type
+func valueOperand(v value) *expr.ValueOperand {
+	return &expr.ValueOperand{Value: firestoreValueToGo(v)}
+}

--- a/services/database/driver/expr/eval.go
+++ b/services/database/driver/expr/eval.go
@@ -296,12 +296,16 @@ func compareOp(op string, a, b any) bool {
 }
 
 // valuesEqual reports type-aware equality: only same-typed values can be
-// equal, so a number never equals a string.
+// equal, so a number never equals a string. Numeric values coerce to float64
+// first, so the int64 that Firestore produces and the float64 that DynamoDB
+// produces compare across types (2 == 2.0).
 func valuesEqual(a, b any) bool {
+	if af, ok := toFloat(a); ok {
+		bf, bok := toFloat(b)
+		return bok && af == bf
+	}
+
 	switch av := a.(type) {
-	case float64:
-		bv, ok := b.(float64)
-		return ok && av == bv
 	case string:
 		bv, ok := b.(string)
 		return ok && av == bv
@@ -323,14 +327,16 @@ func valuesEqual(a, b any) bool {
 // orderedCompare returns -1/0/1 for orderable, same-typed values (numbers,
 // strings, binary). Mixed or non-orderable types report ok=false.
 func orderedCompare(a, b any) (int, bool) {
-	switch av := a.(type) {
-	case float64:
-		bv, ok := b.(float64)
-		if !ok {
+	if af, ok := toFloat(a); ok {
+		bf, bok := toFloat(b)
+		if !bok {
 			return 0, false
 		}
 
-		return cmp.Compare(av, bv), true
+		return cmp.Compare(af, bf), true
+	}
+
+	switch av := a.(type) {
 	case string:
 		bv, ok := b.(string)
 		if !ok {
@@ -345,6 +351,22 @@ func orderedCompare(a, b any) (int, bool) {
 		}
 
 		return bytes.Compare(av, bv), true
+	}
+
+	return 0, false
+}
+
+// toFloat coerces the numeric types the drivers produce to float64: DynamoDB
+// decodes numbers as float64, Firestore decodes integers as int64. Non-numeric
+// values report ok=false so they stay type-segregated.
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int64:
+		return float64(n), true
+	case int:
+		return float64(n), true
 	}
 
 	return 0, false

--- a/services/database/driver/expr/numeric_test.go
+++ b/services/database/driver/expr/numeric_test.go
@@ -1,0 +1,29 @@
+package expr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNumericCoercionAcrossTypes covers the int64/float64 coercion that lets
+// the Firestore int64 model and the DynamoDB float64 model share the evaluator.
+func TestNumericCoercionAcrossTypes(t *testing.T) {
+	eval := func(raw string, val, itemVal any) bool {
+		node, err := ParseCondition(raw, nil, map[string]any{":v": val})
+		require.NoError(t, err)
+
+		ok, err := Eval(node, map[string]any{"n": itemVal})
+		require.NoError(t, err)
+
+		return ok
+	}
+
+	assert.True(t, eval("n = :v", int64(5), int64(5)), "int64 equals int64")
+	assert.True(t, eval("n = :v", float64(2), int64(2)), "float64 equals int64 numerically")
+	assert.True(t, eval("n = :v", int64(2), float64(2)), "int64 equals float64 numerically")
+	assert.True(t, eval("n > :v", float64(1.5), int64(2)), "int64 orders against float64")
+	assert.True(t, eval("n <= :v", int64(3), float64(3.0)), "mixed-type ordering is numeric")
+	assert.False(t, eval("n = :v", "5", int64(5)), "a number never equals a string")
+}


### PR DESCRIPTION
## Summary

Makes in-memory Firestore queries faithful by translating the StructuredQuery `where` clause into the shared `expr` AST and evaluating it in the handler, replacing the previous stringly flat-filter path (which only did AND of six relational ops with `fmt.Sprintf` comparisons).

### WHERE fidelity
- **fieldFilter**: all operators — `EQUAL`/`NOT_EQUAL`/`<`/`<=`/`>`/`>=`, plus `ARRAY_CONTAINS`, `IN`, `NOT_IN`, `ARRAY_CONTAINS_ANY`.
- **compositeFilter**: `OR` as well as `AND` (previously OR was rejected).
- **unaryFilter**: `IS_NULL` / `IS_NOT_NULL`.
- Type-aware throughout (a number never equals a string; missing fields don't match).

Evaluation moved handler-side: the full collection is fetched and each document is matched with `expr.Eval`, so nested composites and the array/list operators are honored exactly.

### expr numeric coercion (shared prerequisite)
Firestore decodes integers as `int64`; DynamoDB decodes numbers as `float64`. The evaluator now coerces `int64`/`int`→`float64` in equality and ordering, so cross-type numeric comparisons work (`2 == 2.0`). Guarded so DynamoDB behavior is byte-identical (its values are already float64).

## Scope / next
This is the WHERE slice. `orderBy` (direction-aware multi-key), `offset`, `startAt`/`endAt` cursors, and `select` projection are the next Firestore PR. `IS_NAN`/`IS_NOT_NAN` are documented as unmodeled (no expr primitive; rare).

## Why
Real apps and the Firestore SDK drive OR, `in`, and `array-contains` constantly; the emulator previously rejected OR and silently mishandled the array operators. All in-memory — no external Firestore.

## Tests
- `expr`: `TestNumericCoercionAcrossTypes` (int64/float64 equality + ordering, number≠string).
- Real `cloud.google.com/go/firestore` REST SDK: `TestDatabaseQueryOperators` drives `in`, `not-in`, `array-contains`, `array-contains-any`, numeric range over int fields, `!=`, `IS_NULL`, and a composite `OR`.
- build, vet, gofmt, tidy, zero docs drift, `-race`, full suite — all green.