### PR TITLE
feat(firestore+cosmos): complete query fidelity — Firestore orderBy/cursors/select + Cosmos SQL

### DIFF
--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -5,7 +5,8 @@
 //
 // The Cosmos HTTP surface (server/azure/cosmos/handler.go) covers: account
 // probe, virtual databases, container create/list/read/delete, document
-// create/list/read/replace/delete, and query (SQL body ignored — full scan).
+// create/list/read/replace/delete, and query (SQL WHERE / ORDER BY /
+// projection / aggregates evaluated).
 // TTL and the change feed are driver-level only (no HTTP endpoint), so those
 // journeys mix SDK writes with direct driver calls on the same provider, per
 // the suite SDK-test-setup notes.
@@ -15,9 +16,10 @@
 //   - CreateItem with a duplicate id succeeds (blind upsert; real Cosmos: 409).
 //   - ReplaceItem ignores IfMatchEtag (real Cosmos: 412 on stale etag).
 //   - DeleteItem on a missing document returns 204 (real Cosmos: 404).
-//   - Queries ignore the SQL text and the partition key (full scan).
-//   - Item identity is the partition-key value only, so two docs with the
-//     same pk but different ids collide (real Cosmos keys on (pk, id)).
+//   - Queries evaluate the SQL WHERE/ORDER BY/projection but treat the
+//     partition key as advisory (cross-partition), since item identity is the
+//     partition-key value only, so two docs with the same pk but different ids
+//     collide (real Cosmos keys on (pk, id)).
 //   - PATCH (PatchItem) is not routed at all (405 MethodNotAllowed).
 package cosmosdb_test
 
@@ -417,10 +419,12 @@ func TestCosmosWriteDivergences(t *testing.T) {
 	}
 }
 
-// TestCosmosQueryAndPagination drives the SDK query pager: empty
-// container first, then 30 documents across two partitions. The emulator
-// ignores the SQL text and the partition key (full scan, DIVERGENCE) and
-// never emits a continuation token, so everything arrives in one page.
+// TestCosmosQueryAndPagination drives the SDK query pager: empty container
+// first, then 30 documents across two partitions. The WHERE clause is
+// evaluated faithfully, so `c.part = 'part-a'` returns exactly the 15 part-a
+// documents. The partition-key header is advisory in the emulator (its item
+// model conflates partition and document identity), so cross-partition WHERE
+// does the filtering.
 func TestCosmosQueryAndPagination(t *testing.T) {
 	ctx := context.Background()
 	env := newCosmosEnv(t)
@@ -456,8 +460,9 @@ func TestCosmosQueryAndPagination(t *testing.T) {
 		t.Errorf("query on empty container returned %d items, want 0", n)
 	}
 
-	// Insert 30 documents: 15 in part-a, 15 in part-b.
-	seen := map[string]bool{}
+	// Insert 30 documents: 15 in part-a, 15 in part-b. Track the part-a ids —
+	// only those should match the WHERE clause below.
+	expected := map[string]bool{}
 
 	for i := 0; i < 30; i++ {
 		part := "part-a"
@@ -466,12 +471,14 @@ func TestCosmosQueryAndPagination(t *testing.T) {
 		}
 
 		id := "evt-" + string(rune('a'+i/10)) + string(rune('0'+i%10)) // evt-a0..evt-c9, unique ids
-		seen[id] = false
+		if part == "part-a" {
+			expected[id] = false
+		}
+
 		createDoc(ctx, t, cc, part, map[string]any{"id": id, "pk": id, "part": part, "n": i})
 	}
 
-	// DIVERGENCE: the WHERE clause and the partition key are both ignored —
-	// all 30 documents come back regardless.
+	// The WHERE clause is honored: exactly the 15 part-a documents come back.
 	pager := cc.NewQueryItemsPager("SELECT * FROM c WHERE c.part = 'part-a'", pkA, nil)
 	total := 0
 
@@ -489,9 +496,9 @@ func TestCosmosQueryAndPagination(t *testing.T) {
 
 			id, _ := doc["id"].(string)
 
-			was, known := seen[id]
+			was, known := expected[id]
 			if !known {
-				t.Errorf("query returned unknown id %q", id)
+				t.Errorf("query returned non-part-a id %q", id)
 				continue
 			}
 
@@ -499,18 +506,18 @@ func TestCosmosQueryAndPagination(t *testing.T) {
 				t.Errorf("query returned id %q twice", id)
 			}
 
-			seen[id] = true
-			total += 1
+			expected[id] = true
+			total++
 		}
 	}
 
-	if total != 30 {
-		t.Errorf("query returned %d items, want all 30 (SQL is ignored → full scan)", total)
+	if total != 15 {
+		t.Errorf("query returned %d items, want the 15 part-a documents", total)
 	}
 
-	for id, ok := range seen {
+	for id, ok := range expected {
 		if !ok {
-			t.Errorf("query never returned id %q", id)
+			t.Errorf("query never returned part-a id %q", id)
 		}
 	}
 }
@@ -747,4 +754,124 @@ func TestCosmosChangeFeed(t *testing.T) {
 	if len(page2.Records) != 1 || page2.Records[0].EventType != "REMOVE" || page2.NextToken != "" {
 		t.Fatalf("page2 records=%+v next=%q want single REMOVE, empty token", page2.Records, page2.NextToken)
 	}
+}
+
+// TestCosmosQueryFidelity drives the SDK query pager through the SQL surface:
+// parameters, ORDER BY, OFFSET/LIMIT, field/aliased/VALUE projection, an
+// aggregate, and the STARTSWITH / BETWEEN / ARRAY_CONTAINS predicates.
+func TestCosmosQueryFidelity(t *testing.T) {
+	ctx := context.Background()
+	env := newCosmosEnv(t)
+	cc := env.container(ctx, t, "shopdb", "products")
+
+	for _, d := range []map[string]any{
+		{"id": "p1", "pk": "p1", "name": "apple", "price": 30, "tags": []any{"fruit", "red"}},
+		{"id": "p2", "pk": "p2", "name": "banana", "price": 10, "tags": []any{"fruit"}},
+		{"id": "p3", "pk": "p3", "name": "almond", "price": 20, "tags": []any{"nut"}},
+	} {
+		createDoc(ctx, t, cc, d["pk"].(string), d)
+	}
+
+	pk := azcosmos.NewPartitionKeyString("p1") // advisory in the emulator
+
+	rawItems := func(sql string, opts *azcosmos.QueryOptions) [][]byte {
+		t.Helper()
+
+		var items [][]byte
+
+		pager := cc.NewQueryItemsPager(sql, pk, opts)
+		for pager.More() {
+			page, err := pager.NextPage(ctx)
+			if err != nil {
+				t.Fatalf("NextPage %q: %v", sql, err)
+			}
+
+			items = append(items, page.Items...)
+		}
+
+		return items
+	}
+
+	scalars := func(sql string) []any {
+		t.Helper()
+
+		var out []any
+		for _, raw := range rawItems(sql, nil) {
+			var v any
+			if err := json.Unmarshal(raw, &v); err != nil {
+				t.Fatalf("unmarshal %q: %v", sql, err)
+			}
+
+			out = append(out, v)
+		}
+
+		return out
+	}
+
+	// Parameterized WHERE.
+	priced := rawItems("SELECT * FROM c WHERE c.price >= @min",
+		&azcosmos.QueryOptions{QueryParameters: []azcosmos.QueryParameter{{Name: "@min", Value: 20}}})
+	if len(priced) != 2 {
+		t.Errorf("price>=20 returned %d items, want 2", len(priced))
+	}
+
+	// ORDER BY price DESC → first item is the most expensive.
+	desc := scalars("SELECT VALUE c.price FROM c ORDER BY c.price DESC")
+	if len(desc) != 3 || desc[0] != float64(30) {
+		t.Errorf("order by price desc = %v, want [30 20 10]", desc)
+	}
+
+	// VALUE projection + ORDER BY name → sorted bare strings.
+	names := scalars("SELECT VALUE c.name FROM c ORDER BY c.name")
+	if want := []any{"almond", "apple", "banana"}; !equalAny(names, want) {
+		t.Errorf("value name ordered = %v, want %v", names, want)
+	}
+
+	// Aliased field projection.
+	aliased := rawItems("SELECT c.name AS n FROM c WHERE c.id = 'p1'", nil)
+	if len(aliased) != 1 {
+		t.Fatalf("aliased projection returned %d items, want 1", len(aliased))
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(aliased[0], &obj); err != nil {
+		t.Fatalf("unmarshal aliased: %v", err)
+	}
+
+	if obj["n"] != "apple" || len(obj) != 1 {
+		t.Errorf("aliased projection = %v, want {n: apple}", obj)
+	}
+
+	// Aggregate.
+	if cnt := scalars("SELECT VALUE COUNT(1) FROM c"); len(cnt) != 1 || cnt[0] != float64(3) {
+		t.Errorf("count = %v, want [3]", cnt)
+	}
+
+	// Predicate functions.
+	checks := map[string]int{
+		"SELECT * FROM c WHERE STARTSWITH(c.name, 'a')":         2,
+		"SELECT * FROM c WHERE c.price BETWEEN 15 AND 35":       2,
+		"SELECT * FROM c WHERE ARRAY_CONTAINS(c.tags, 'fruit')": 2,
+		"SELECT * FROM c WHERE c.name IN ('apple', 'banana')":   2,
+		"SELECT * FROM c OFFSET 1 LIMIT 1":                      1,
+	}
+	for sql, want := range checks {
+		if got := len(rawItems(sql, nil)); got != want {
+			t.Errorf("%q returned %d items, want %d", sql, got, want)
+		}
+	}
+}
+
+func equalAny(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/server/azure/cosmosdb/cosmos_lifecycle_test.go
+++ b/server/azure/cosmosdb/cosmos_lifecycle_test.go
@@ -21,6 +21,9 @@
 //     partition-key value only, so two docs with the same pk but different ids
 //     collide (real Cosmos keys on (pk, id)).
 //   - PATCH (PatchItem) is not routed at all (405 MethodNotAllowed).
+//   - NOT over a composite predicate (AND/OR of several fields) uses two-valued
+//     logic, so an absent field is not excluded; NOT over a single-field
+//     predicate is guarded and matches real Cosmos three-valued behavior.
 package cosmosdb_test
 
 import (
@@ -845,6 +848,15 @@ func TestCosmosQueryFidelity(t *testing.T) {
 	// Aggregate.
 	if cnt := scalars("SELECT VALUE COUNT(1) FROM c"); len(cnt) != 1 || cnt[0] != float64(3) {
 		t.Errorf("count = %v, want [3]", cnt)
+	}
+
+	// Aggregate over no matches: COUNT is 0, but MAX is undefined (empty result).
+	if cnt := scalars("SELECT VALUE COUNT(1) FROM c WHERE c.id = 'nope'"); len(cnt) != 1 || cnt[0] != float64(0) {
+		t.Errorf("count over empty = %v, want [0]", cnt)
+	}
+
+	if mx := rawItems("SELECT VALUE MAX(c.price) FROM c WHERE c.id = 'nope'", nil); len(mx) != 0 {
+		t.Errorf("MAX over empty returned %d rows, want 0", len(mx))
 	}
 
 	// Predicate functions.

--- a/server/azure/cosmosdb/handler.go
+++ b/server/azure/cosmosdb/handler.go
@@ -19,7 +19,6 @@ package cosmosdb
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -27,6 +26,7 @@ import (
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
 	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/cosmossql"
 )
 
 const (
@@ -325,8 +325,11 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll str
 		return
 	}
 
+	docs := make([]any, 0, len(result.Items))
+
 	for i := range result.Items {
 		addSystemProps(result.Items[i])
+		docs = append(docs, result.Items[i])
 	}
 
 	if result.NextPageToken != "" {
@@ -335,52 +338,45 @@ func (h *Handler) listDocuments(w http.ResponseWriter, r *http.Request, coll str
 
 	writeJSON(w, http.StatusOK, documentsList{
 		RID:       "cloudemu",
-		Documents: result.Items,
+		Documents: docs,
 		Count:     result.Count,
 	})
 }
 
 func (h *Handler) queryDocuments(w http.ResponseWriter, r *http.Request, coll string) {
-	// We accept the query body but ignore it — return all items via Scan.
-	// This is sufficient for SDK round-trip validation; full SQL parsing is
-	// out of scope.
-	body, _ := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
-	_ = body
-
-	// Honor Cosmos paging: x-ms-max-item-count is the page size and
-	// x-ms-continuation carries the driver page token between requests.
-	// Default page size matches real Cosmos (and the driver default);
-	// callers page onward via the x-ms-continuation round-trip below.
-	limit := 100
-	if v := r.Header.Get("X-Ms-Max-Item-Count"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			limit = n
-		}
+	body, ok := decodeQueryBody(w, r)
+	if !ok {
+		return
 	}
 
-	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{
-		Table:     coll,
-		Limit:     limit,
-		PageToken: r.Header.Get("X-Ms-Continuation"),
-	})
+	stmt, perr := cosmossql.Parse(body.Query, body.paramMap())
+	if perr != nil {
+		writeErr(w, perr)
+		return
+	}
+
+	// Fetch the whole container and evaluate the query here with full fidelity.
+	result, err := h.db.Scan(r.Context(), dbdriver.ScanInput{Table: coll, Limit: allResults})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	for i := range result.Items {
-		addSystemProps(result.Items[i])
+	matched, ferr := cosmosFilter(result.Items, stmt.Where)
+	if ferr != nil {
+		writeErr(w, ferr)
+		return
 	}
 
-	if result.NextPageToken != "" {
-		w.Header().Set("X-Ms-Continuation", result.NextPageToken)
+	docs := shapeCosmos(matched, stmt)
+
+	// Page the logical result set with the x-ms-continuation offset contract.
+	page, next := pageDocs(docs, continuationOffset(r.Header.Get("X-Ms-Continuation")), maxItemCount(r))
+	if next > 0 {
+		w.Header().Set("X-Ms-Continuation", strconv.Itoa(next))
 	}
 
-	writeJSON(w, http.StatusOK, documentsList{
-		RID:       "cloudemu",
-		Documents: result.Items,
-		Count:     result.Count,
-	})
+	writeJSON(w, http.StatusOK, documentsList{RID: "cloudemu", Documents: page, Count: len(page)})
 }
 
 func (h *Handler) documentResource(w http.ResponseWriter, r *http.Request, _, coll, id string) {

--- a/server/azure/cosmosdb/query.go
+++ b/server/azure/cosmosdb/query.go
@@ -1,0 +1,378 @@
+package cosmosdb
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/cosmossql"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// allResults fetches the whole container so the SQL query is evaluated with
+// full fidelity in the handler.
+const (
+	allResults      = 1 << 30
+	defaultPageSize = 100
+)
+
+type queryBody struct {
+	Query      string `json:"query"`
+	Parameters []struct {
+		Name  string `json:"name"`
+		Value any    `json:"value"`
+	} `json:"parameters"`
+}
+
+func (q queryBody) paramMap() map[string]any {
+	m := make(map[string]any, len(q.Parameters))
+	for _, p := range q.Parameters {
+		m[p.Name] = p.Value
+	}
+
+	return m
+}
+
+func decodeQueryBody(w http.ResponseWriter, r *http.Request) (queryBody, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+
+	var q queryBody
+	if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
+		writeError(w, http.StatusBadRequest, "BadRequest", "invalid query JSON: "+err.Error())
+		return queryBody{}, false
+	}
+
+	return q, true
+}
+
+// cosmosFilter keeps the items matching node (a nil node matches all).
+func cosmosFilter(items []map[string]any, node expr.Node) ([]map[string]any, error) {
+	if node == nil {
+		return items, nil
+	}
+
+	out := make([]map[string]any, 0, len(items))
+
+	for _, item := range items {
+		ok, err := expr.Eval(node, item)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			out = append(out, item)
+		}
+	}
+
+	return out, nil
+}
+
+// shapeCosmos applies ORDER BY, projection, DISTINCT and the SQL TOP/OFFSET/
+// LIMIT to the matched documents, returning the logical result set (full docs,
+// projected objects, or bare scalars for SELECT VALUE / aggregates).
+func shapeCosmos(matched []map[string]any, stmt *cosmossql.Statement) []any {
+	if stmt.Proj.Kind == cosmossql.ProjAggregate {
+		return aggregateResult(matched, stmt.Proj)
+	}
+
+	if len(stmt.OrderBy) > 0 {
+		sortCosmos(matched, stmt.OrderBy)
+	}
+
+	rows := projectCosmos(matched, stmt.Proj)
+
+	if stmt.Distinct {
+		rows = distinctRows(rows)
+	}
+
+	return sqlPage(rows, stmt)
+}
+
+func sqlPage(rows []any, stmt *cosmossql.Statement) []any {
+	if stmt.Offset > 0 {
+		if stmt.Offset >= len(rows) {
+			return nil
+		}
+
+		rows = rows[stmt.Offset:]
+	}
+
+	limit := -1
+	if stmt.Top > 0 {
+		limit = stmt.Top
+	}
+
+	if stmt.Limit >= 0 {
+		limit = stmt.Limit
+	}
+
+	if limit >= 0 && limit < len(rows) {
+		rows = rows[:limit]
+	}
+
+	return rows
+}
+
+func projectCosmos(items []map[string]any, proj cosmossql.Projection) []any {
+	out := make([]any, 0, len(items))
+
+	for _, item := range items {
+		switch proj.Kind {
+		case cosmossql.ProjStar:
+			addSystemProps(item)
+			out = append(out, item)
+		case cosmossql.ProjFields:
+			out = append(out, projectFields(item, proj.Fields))
+		case cosmossql.ProjValue:
+			if v, ok := resolveDocValue(item, proj.ValuePath); ok {
+				out = append(out, v)
+			}
+		case cosmossql.ProjAggregate:
+		}
+	}
+
+	return out
+}
+
+func projectFields(item map[string]any, fields []cosmossql.ProjField) map[string]any {
+	obj := map[string]any{}
+
+	for _, f := range fields {
+		if v, ok := resolveDocValue(item, f.Path); ok {
+			obj[fieldKey(f)] = v
+		}
+	}
+
+	return obj
+}
+
+func fieldKey(f cosmossql.ProjField) string {
+	switch {
+	case f.Alias != "":
+		return f.Alias
+	case len(f.Path) > 0:
+		return f.Path[len(f.Path)-1]
+	default:
+		return "$1"
+	}
+}
+
+// resolveDocValue walks a name path over nested maps. An empty path (a bare
+// alias) is the whole document.
+func resolveDocValue(item map[string]any, segs []string) (any, bool) {
+	if len(segs) == 0 {
+		return item, true
+	}
+
+	var cur any = item
+
+	for _, s := range segs {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		v, ok := m[s]
+		if !ok {
+			return nil, false
+		}
+
+		cur = v
+	}
+
+	return cur, true
+}
+
+func sortCosmos(items []map[string]any, order []cosmossql.OrderTerm) {
+	sort.SliceStable(items, func(i, j int) bool {
+		for _, t := range order {
+			av, _ := resolveDocValue(items[i], t.Path)
+			bv, _ := resolveDocValue(items[j], t.Path)
+
+			c := dbdriver.CompareValues(av, bv)
+			if t.Desc {
+				c = -c
+			}
+
+			if c != 0 {
+				return c < 0
+			}
+		}
+
+		return false
+	})
+}
+
+func distinctRows(rows []any) []any {
+	seen := make(map[string]bool, len(rows))
+	out := make([]any, 0, len(rows))
+
+	for _, row := range rows {
+		key := distinctKey(row)
+		if seen[key] {
+			continue
+		}
+
+		seen[key] = true
+
+		out = append(out, row)
+	}
+
+	return out
+}
+
+func distinctKey(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+func aggregateResult(matched []map[string]any, proj cosmossql.Projection) []any {
+	val := computeAggregate(matched, proj.Aggregate)
+
+	if proj.Bare {
+		return []any{map[string]any{"$1": val}}
+	}
+
+	return []any{val}
+}
+
+func computeAggregate(matched []map[string]any, agg *cosmossql.Aggregate) any {
+	if agg.Func == "COUNT" {
+		return float64(countDefined(matched, agg.Path))
+	}
+
+	return numericAggregate(matched, agg.Func, agg.Path)
+}
+
+func countDefined(matched []map[string]any, path []string) int {
+	if len(path) == 0 {
+		return len(matched)
+	}
+
+	n := 0
+
+	for _, item := range matched {
+		if _, ok := resolveDocValue(item, path); ok {
+			n++
+		}
+	}
+
+	return n
+}
+
+func numericAggregate(matched []map[string]any, fn string, path []string) any {
+	nums := collectNumbers(matched, path)
+
+	if len(nums) == 0 {
+		if fn == "SUM" {
+			return float64(0)
+		}
+
+		return nil
+	}
+
+	return reduceNumbers(fn, nums)
+}
+
+func collectNumbers(matched []map[string]any, path []string) []float64 {
+	var nums []float64
+
+	for _, item := range matched {
+		v, ok := resolveDocValue(item, path)
+		if !ok {
+			continue
+		}
+
+		if f, ok := numericValue(v); ok {
+			nums = append(nums, f)
+		}
+	}
+
+	return nums
+}
+
+func reduceNumbers(fn string, nums []float64) any {
+	switch fn {
+	case "MIN":
+		acc := nums[0]
+		for _, n := range nums[1:] {
+			acc = min(acc, n)
+		}
+
+		return acc
+	case "MAX":
+		acc := nums[0]
+		for _, n := range nums[1:] {
+			acc = max(acc, n)
+		}
+
+		return acc
+	default: // SUM, AVG
+		sum := 0.0
+		for _, n := range nums {
+			sum += n
+		}
+
+		if fn == "AVG" {
+			return sum / float64(len(nums))
+		}
+
+		return sum
+	}
+}
+
+func numericValue(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int64:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+func maxItemCount(r *http.Request) int {
+	v := r.Header.Get("X-Ms-Max-Item-Count")
+	if v == "" {
+		return defaultPageSize
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil || n == 0 {
+		return defaultPageSize
+	}
+
+	if n < 0 {
+		return allResults
+	}
+
+	return n
+}
+
+func continuationOffset(tok string) int {
+	if n, err := strconv.Atoi(tok); err == nil && n > 0 {
+		return n
+	}
+
+	return 0
+}
+
+// pageDocs returns the page starting at start and the next continuation offset
+// (0 when the page is the last).
+func pageDocs(docs []any, start, pageSize int) (page []any, next int) {
+	if start >= len(docs) {
+		return nil, 0
+	}
+
+	end := start + pageSize
+	if end >= len(docs) {
+		return docs[start:], 0
+	}
+
+	return docs[start:end], end
+}

--- a/server/azure/cosmosdb/query.go
+++ b/server/azure/cosmosdb/query.go
@@ -229,7 +229,11 @@ func distinctKey(v any) string {
 }
 
 func aggregateResult(matched []map[string]any, proj cosmossql.Projection) []any {
-	val := computeAggregate(matched, proj.Aggregate)
+	val, ok := computeAggregate(matched, proj.Aggregate)
+	if !ok {
+		// An aggregate over no values is undefined; Cosmos returns no row.
+		return []any{}
+	}
 
 	if proj.Bare {
 		return []any{map[string]any{"$1": val}}
@@ -238,12 +242,17 @@ func aggregateResult(matched []map[string]any, proj cosmossql.Projection) []any 
 	return []any{val}
 }
 
-func computeAggregate(matched []map[string]any, agg *cosmossql.Aggregate) any {
+func computeAggregate(matched []map[string]any, agg *cosmossql.Aggregate) (any, bool) {
 	if agg.Func == "COUNT" {
-		return float64(countDefined(matched, agg.Path))
+		return float64(countDefined(matched, agg.Path)), true
 	}
 
-	return numericAggregate(matched, agg.Func, agg.Path)
+	nums := collectNumbers(matched, agg.Path)
+	if len(nums) == 0 {
+		return nil, false
+	}
+
+	return reduceNumbers(agg.Func, nums), true
 }
 
 func countDefined(matched []map[string]any, path []string) int {
@@ -260,20 +269,6 @@ func countDefined(matched []map[string]any, path []string) int {
 	}
 
 	return n
-}
-
-func numericAggregate(matched []map[string]any, fn string, path []string) any {
-	nums := collectNumbers(matched, path)
-
-	if len(nums) == 0 {
-		if fn == "SUM" {
-			return float64(0)
-		}
-
-		return nil
-	}
-
-	return reduceNumbers(fn, nums)
 }
 
 func collectNumbers(matched []map[string]any, path []string) []float64 {

--- a/server/azure/cosmosdb/types.go
+++ b/server/azure/cosmosdb/types.go
@@ -50,9 +50,11 @@ type containersList struct {
 }
 
 type documentsList struct {
-	RID       string           `json:"_rid"`
-	Documents []map[string]any `json:"Documents"`
-	Count     int              `json:"_count"`
+	RID string `json:"_rid"`
+	// Documents holds full documents (SELECT *), projected objects, or bare
+	// scalars (SELECT VALUE / aggregates), so it is []any rather than a doc list.
+	Documents []any `json:"Documents"`
+	Count     int   `json:"_count"`
 }
 
 type errorEnvelope struct {

--- a/server/gcp/firestore/firestore_lifecycle_test.go
+++ b/server/gcp/firestore/firestore_lifecycle_test.go
@@ -856,3 +856,65 @@ func TestDatabaseQueryOperators(t *testing.T) {
 	}}
 	count("OR", coll.WhereEntity(or), 2)
 }
+
+func collectDBOrderedIDs(t *testing.T, it *gcpfirestore.DocumentIterator) []string {
+	t.Helper()
+
+	var ids []string
+
+	for {
+		snap, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("iterator.Next: %v", err)
+		}
+
+		ids = append(ids, snap.Ref.ID)
+	}
+
+	return ids
+}
+
+// TestDatabaseQueryOrderingAndPaging drives the real Firestore REST client
+// through orderBy (asc/desc), startAfter/endBefore cursors, offset, limit, and
+// a select projection.
+func TestDatabaseQueryOrderingAndPaging(t *testing.T) {
+	ctx, client, _ := newDBClient(t, "scores")
+	coll := client.Collection("scores")
+
+	for _, d := range []struct {
+		id    string
+		score int
+	}{{"a", 30}, {"b", 10}, {"c", 20}} {
+		if _, err := coll.Doc(d.id).Set(ctx, map[string]any{"score": d.score, "extra": "x"}); err != nil {
+			t.Fatalf("Set %s: %v", d.id, err)
+		}
+	}
+
+	order := func(name string, q gcpfirestore.Query, want string) {
+		got := strings.Join(collectDBOrderedIDs(t, q.Documents(ctx)), ",")
+		if got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+
+	order("orderBy asc", coll.OrderBy("score", gcpfirestore.Asc), "b,c,a")
+	order("orderBy desc", coll.OrderBy("score", gcpfirestore.Desc), "a,c,b")
+	order("startAfter+limit", coll.OrderBy("score", gcpfirestore.Asc).StartAfter(10).Limit(1), "c")
+	order("offset", coll.OrderBy("score", gcpfirestore.Asc).Offset(1), "c,a")
+	order("endBefore", coll.OrderBy("score", gcpfirestore.Asc).EndBefore(20), "b")
+
+	// select projects to just 'score' (plus the document name); 'extra' is dropped.
+	for id, data := range dbCollectAll(t, coll.Select("score").Documents(ctx)) {
+		if _, hasExtra := data["extra"]; hasExtra {
+			t.Errorf("select score: doc %s still carries 'extra': %v", id, data)
+		}
+
+		if _, hasScore := data["score"]; !hasScore {
+			t.Errorf("select score: doc %s missing 'score': %v", id, data)
+		}
+	}
+}

--- a/server/gcp/firestore/handler.go
+++ b/server/gcp/firestore/handler.go
@@ -317,13 +317,61 @@ func (h *Handler) batchGet(w http.ResponseWriter, r *http.Request, _ string) {
 const allResults = 1 << 30
 
 type runQueryRequest struct {
-	StructuredQuery struct {
-		From []struct {
-			CollectionID string `json:"collectionId"`
-		} `json:"from"`
-		Where *queryFilter `json:"where"`
-		Limit int          `json:"limit"`
-	} `json:"structuredQuery"`
+	StructuredQuery structuredQuery `json:"structuredQuery"`
+}
+
+type structuredQuery struct {
+	From []struct {
+		CollectionID string `json:"collectionId"`
+	} `json:"from"`
+	Where   *queryFilter    `json:"where"`
+	OrderBy []orderByClause `json:"orderBy"`
+	Limit   int             `json:"limit"`
+	Offset  int             `json:"offset"`
+	StartAt *queryCursor    `json:"startAt"`
+	EndAt   *queryCursor    `json:"endAt"`
+	Select  *selectClause   `json:"select"`
+}
+
+type orderByClause struct {
+	Field     fieldRef  `json:"field"`
+	Direction direction `json:"direction"` // ASCENDING (default) or DESCENDING
+}
+
+// direction decodes an ORDER BY direction sent as its enum name ("DESCENDING")
+// or its protobuf number (ASCENDING=1, DESCENDING=2).
+type direction string
+
+//nolint:gochecknoglobals // static lookup table
+var directionNames = map[int]direction{1: "ASCENDING", 2: "DESCENDING"}
+
+func (d *direction) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*d = direction(v)
+		return nil
+	}
+
+	var n int
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*d = directionNames[n]
+	return nil
+}
+
+// queryCursor is a startAt/endAt boundary: values align positionally to the
+// orderBy fields, and before selects the inclusive/exclusive side.
+type queryCursor struct {
+	Values []value `json:"values"`
+	Before bool    `json:"before"`
+}
+
+type selectClause struct {
+	Fields []fieldRef `json:"fields"`
 }
 
 // queryFilter mirrors StructuredQuery.Filter: a single fieldFilter, a
@@ -481,36 +529,35 @@ func (h *Handler) runQuery(w http.ResponseWriter, r *http.Request, base string) 
 		return
 	}
 
-	matched, merr := filterDocuments(result.Items, node, req.StructuredQuery.Limit)
+	matched, merr := filterDocuments(result.Items, node)
 	if merr != nil {
 		writeErr(w, merr)
 		return
 	}
 
+	// Shape the matched set: order by, cursors, offset/limit, then select.
+	matched = shapeResults(matched, &req.StructuredQuery)
+
 	streamQueryResults(w, matched, p)
 }
 
-// filterDocuments keeps the items matching node (nil node matches all) up to
-// limit (limit<=0 means no limit).
-func filterDocuments(items []map[string]any, node expr.Node, limit int) ([]map[string]any, error) {
+// filterDocuments keeps the items matching node (a nil node matches all).
+func filterDocuments(items []map[string]any, node expr.Node) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(items))
 
 	for _, item := range items {
-		if node != nil {
-			ok, err := expr.Eval(node, item)
-			if err != nil {
-				return nil, err
-			}
-
-			if !ok {
-				continue
-			}
+		if node == nil {
+			out = append(out, item)
+			continue
 		}
 
-		out = append(out, item)
+		ok, err := expr.Eval(node, item)
+		if err != nil {
+			return nil, err
+		}
 
-		if limit > 0 && len(out) >= limit {
-			break
+		if ok {
+			out = append(out, item)
 		}
 	}
 

--- a/server/gcp/firestore/queryshape.go
+++ b/server/gcp/firestore/queryshape.go
@@ -1,0 +1,225 @@
+package firestore
+
+import (
+	"sort"
+	"strings"
+
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+// docName is the field carrying the document id, addressable in a query as the
+// special __name__ path.
+const (
+	docName    = "id"
+	fieldName  = "__name__"
+	descending = "DESCENDING"
+)
+
+// sortKey is one resolved ORDER BY term.
+type sortKey struct {
+	path string
+	desc bool
+}
+
+// shapeResults applies the non-WHERE parts of a StructuredQuery to the matched
+// documents in order: ORDER BY, startAt/endAt cursors, offset, limit, then the
+// select projection.
+func shapeResults(items []map[string]any, q *structuredQuery) []map[string]any {
+	keys := effectiveSortKeys(q.OrderBy)
+
+	applyOrderBy(items, keys)
+
+	items = applyCursor(items, keys, q.StartAt, true)
+	items = applyCursor(items, keys, q.EndAt, false)
+	items = applyOffsetLimit(items, q.Offset, q.Limit)
+
+	return applySelect(items, q.Select)
+}
+
+// effectiveSortKeys returns the ORDER BY terms plus the implicit __name__
+// tiebreaker Firestore appends (inheriting the last term's direction). When no
+// ORDER BY is given the result is a single ascending __name__ key, which
+// matches the store's default document-id order.
+func effectiveSortKeys(orderBy []orderByClause) []sortKey {
+	keys := make([]sortKey, 0, len(orderBy)+1)
+	hasName := false
+
+	for _, ob := range orderBy {
+		keys = append(keys, sortKey{path: ob.Field.FieldPath, desc: isDescending(ob.Direction)})
+
+		if ob.Field.FieldPath == fieldName {
+			hasName = true
+		}
+	}
+
+	if !hasName {
+		desc := false
+		if len(orderBy) > 0 {
+			desc = isDescending(orderBy[len(orderBy)-1].Direction)
+		}
+
+		keys = append(keys, sortKey{path: fieldName, desc: desc})
+	}
+
+	return keys
+}
+
+func isDescending(dir direction) bool { return strings.EqualFold(string(dir), descending) }
+
+func applyOrderBy(items []map[string]any, keys []sortKey) {
+	sort.SliceStable(items, func(i, j int) bool {
+		return compareByKeys(items[i], items[j], keys) < 0
+	})
+}
+
+func compareByKeys(a, b map[string]any, keys []sortKey) int {
+	for _, k := range keys {
+		c := dbdriver.CompareValues(resolveField(a, k.path), resolveField(b, k.path))
+		if k.desc {
+			c = -c
+		}
+
+		if c != 0 {
+			return c
+		}
+	}
+
+	return 0
+}
+
+// applyCursor keeps the documents on the requested side of a startAt/endAt
+// boundary. isStart distinguishes startAt (lower bound) from endAt (upper).
+func applyCursor(items []map[string]any, keys []sortKey, cur *queryCursor, isStart bool) []map[string]any {
+	if cur == nil {
+		return items
+	}
+
+	vals := make([]any, len(cur.Values))
+	for i, v := range cur.Values {
+		vals[i] = firestoreValueToGo(v)
+	}
+
+	out := make([]map[string]any, 0, len(items))
+
+	for _, item := range items {
+		if cursorKeeps(compareToCursor(item, keys, vals), cur.Before, isStart) {
+			out = append(out, item)
+		}
+	}
+
+	return out
+}
+
+// compareToCursor compares a document's sort tuple against the cursor values,
+// over as many positions as the cursor supplies.
+func compareToCursor(item map[string]any, keys []sortKey, vals []any) int {
+	n := min(len(keys), len(vals))
+
+	for i := range n {
+		c := dbdriver.CompareValues(resolveField(item, keys[i].path), vals[i])
+		if keys[i].desc {
+			c = -c
+		}
+
+		if c != 0 {
+			return c
+		}
+	}
+
+	return 0
+}
+
+// cursorKeeps applies the four boundary cases: startAt/before=true keeps k>=c
+// (StartAt), startAt/before=false keeps k>c (StartAfter), endAt/before=true
+// keeps k<c (EndBefore), endAt/before=false keeps k<=c (EndAt).
+func cursorKeeps(c int, before, isStart bool) bool {
+	switch {
+	case isStart && before:
+		return c >= 0
+	case isStart:
+		return c > 0
+	case before:
+		return c < 0
+	default:
+		return c <= 0
+	}
+}
+
+func applyOffsetLimit(items []map[string]any, offset, limit int) []map[string]any {
+	if offset > 0 {
+		if offset >= len(items) {
+			return nil
+		}
+
+		items = items[offset:]
+	}
+
+	if limit > 0 && limit < len(items) {
+		items = items[:limit]
+	}
+
+	return items
+}
+
+// applySelect projects each document to the selected field paths, always
+// retaining the document id (its name). An absent or empty select returns the
+// documents unchanged.
+func applySelect(items []map[string]any, sel *selectClause) []map[string]any {
+	if sel == nil || len(sel.Fields) == 0 {
+		return items
+	}
+
+	paths := make([]*expr.PathOperand, 0, len(sel.Fields))
+
+	for _, f := range sel.Fields {
+		if f.FieldPath == fieldName {
+			continue // the name is always retained below
+		}
+
+		paths = append(paths, fieldPathToOperand(f.FieldPath))
+	}
+
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, selectDoc(item, paths))
+	}
+
+	return out
+}
+
+func selectDoc(item map[string]any, paths []*expr.PathOperand) map[string]any {
+	var projected map[string]any
+	if len(paths) == 0 {
+		projected = map[string]any{}
+	} else {
+		projected = expr.Project(item, paths)
+	}
+
+	if id, ok := item[docName]; ok {
+		projected[docName] = id
+	}
+
+	return projected
+}
+
+// resolveField resolves a document field path (including the special __name__)
+// to its value, walking nested maps. A missing path yields nil.
+func resolveField(item map[string]any, path string) any {
+	if path == fieldName {
+		return item[docName]
+	}
+
+	var cur any = item
+
+	for _, seg := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+
+		cur = m[seg]
+	}
+
+	return cur
+}

--- a/services/database/driver/cosmossql/ast.go
+++ b/services/database/driver/cosmossql/ast.go
@@ -1,0 +1,62 @@
+// Package cosmossql parses the faithful subset of the Cosmos DB SQL (core
+// NoSQL) query language used by the emulator, producing a Statement whose WHERE
+// clause is a shared expr AST evaluated over native map[string]any documents.
+package cosmossql
+
+import "github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+
+// ProjKind is the shape of a SELECT projection.
+type ProjKind int
+
+const (
+	// ProjStar is SELECT * — the whole document.
+	ProjStar ProjKind = iota
+	// ProjFields is SELECT c.a, c.b AS x — an object of the named fields.
+	ProjFields
+	// ProjValue is SELECT VALUE c.a — the bare value of one path per document.
+	ProjValue
+	// ProjAggregate is SELECT VALUE COUNT(1) / SUM(c.x) — a single scalar over
+	// the whole result set.
+	ProjAggregate
+)
+
+// Statement is a parsed Cosmos SQL query.
+type Statement struct {
+	Distinct bool
+	Top      int // 0 = no TOP
+	Proj     Projection
+	Where    expr.Node // nil = match all
+	OrderBy  []OrderTerm
+	Offset   int
+	Limit    int // -1 = no LIMIT
+}
+
+// Projection describes what SELECT returns.
+type Projection struct {
+	Kind      ProjKind
+	Fields    []ProjField // ProjFields
+	ValuePath []string    // ProjValue (nil for ProjStar/ProjAggregate)
+	Aggregate *Aggregate  // ProjAggregate
+	// Bare reports a projection written without SELECT VALUE. For an aggregate
+	// this wraps the scalar in {"$1": v}; ignored otherwise.
+	Bare bool
+}
+
+// ProjField is one item of a field projection: a path and its output alias.
+type ProjField struct {
+	Path  []string
+	Alias string
+}
+
+// Aggregate is a COUNT/SUM/AVG/MIN/MAX over the matched documents. Path is nil
+// for COUNT(1)/COUNT(*).
+type Aggregate struct {
+	Func string
+	Path []string
+}
+
+// OrderTerm is one ORDER BY key.
+type OrderTerm struct {
+	Path []string
+	Desc bool
+}

--- a/services/database/driver/cosmossql/lex.go
+++ b/services/database/driver/cosmossql/lex.go
@@ -1,0 +1,188 @@
+package cosmossql
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+type tokKind int
+
+const (
+	tEOF tokKind = iota
+	tIdent
+	tString
+	tNumber
+	tParam
+	tStar
+	tOp
+	tLParen
+	tRParen
+	tComma
+	tDot
+	tLBracket
+	tRBracket
+)
+
+type token struct {
+	kind tokKind
+	text string
+}
+
+// lex tokenizes a Cosmos SQL query. Keywords and function names stay as tIdent
+// (the parser matches them case-insensitively); string literals are unquoted.
+func lex(s string) ([]token, error) {
+	toks := []token{}
+	i := 0
+
+	for i < len(s) {
+		if isSpace(s[i]) {
+			i++
+			continue
+		}
+
+		tok, next, err := lexOne(s, i)
+		if err != nil {
+			return nil, err
+		}
+
+		toks = append(toks, tok)
+		i = next
+	}
+
+	return append(toks, token{kind: tEOF}), nil
+}
+
+func lexOne(s string, i int) (tok token, next int, err error) {
+	c := s[i]
+
+	switch {
+	case isWordStart(c):
+		tok, next = lexWord(s, i)
+		return tok, next, nil
+	case c == '@':
+		return lexParam(s, i)
+	case c == '\'' || c == '"':
+		return lexString(s, i)
+	case isDigit(c) || (c == '-' && i+1 < len(s) && isDigit(s[i+1])):
+		tok, next = lexNumber(s, i)
+		return tok, next, nil
+	default:
+		return lexSymbol(s, i)
+	}
+}
+
+func lexWord(s string, i int) (tok token, next int) {
+	start := i
+
+	for i < len(s) && isWordChar(s[i]) {
+		i++
+	}
+
+	return token{kind: tIdent, text: s[start:i]}, i
+}
+
+func lexParam(s string, i int) (tok token, next int, err error) {
+	start := i
+	i++ // consume '@'
+
+	for i < len(s) && isWordChar(s[i]) {
+		i++
+	}
+
+	if i == start+1 {
+		return token{}, 0, cerrors.Newf(cerrors.InvalidArgument, "empty parameter at position %d", start)
+	}
+
+	return token{kind: tParam, text: s[start:i]}, i, nil
+}
+
+func lexString(s string, i int) (tok token, next int, err error) {
+	quote := s[i]
+	i++ // opening quote
+
+	var b strings.Builder
+
+	for i < len(s) {
+		c := s[i]
+
+		switch {
+		case c == '\\' && i+1 < len(s):
+			b.WriteByte(s[i+1])
+			i += 2
+		case c == quote:
+			return token{kind: tString, text: b.String()}, i + 1, nil
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+
+	return token{}, 0, cerrors.New(cerrors.InvalidArgument, "unterminated string literal")
+}
+
+func lexNumber(s string, i int) (tok token, next int) {
+	start := i
+
+	if s[i] == '-' {
+		i++
+	}
+
+	for i < len(s) && (isDigit(s[i]) || s[i] == '.') {
+		i++
+	}
+
+	return token{kind: tNumber, text: s[start:i]}, i
+}
+
+func lexSymbol(s string, i int) (tok token, next int, err error) {
+	switch s[i] {
+	case '*':
+		return token{kind: tStar, text: "*"}, i + 1, nil
+	case '(':
+		return token{kind: tLParen}, i + 1, nil
+	case ')':
+		return token{kind: tRParen}, i + 1, nil
+	case ',':
+		return token{kind: tComma}, i + 1, nil
+	case '.':
+		return token{kind: tDot}, i + 1, nil
+	case '[':
+		return token{kind: tLBracket}, i + 1, nil
+	case ']':
+		return token{kind: tRBracket}, i + 1, nil
+	case '=':
+		return token{kind: tOp, text: "="}, i + 1, nil
+	case '!', '<', '>':
+		return lexRelational(s, i)
+	}
+
+	return token{}, 0, cerrors.Newf(cerrors.InvalidArgument, "unexpected character %q at position %d", string(s[i]), i)
+}
+
+func lexRelational(s string, i int) (tok token, next int, err error) {
+	const twoByte = 2
+
+	if i+1 < len(s) {
+		switch s[i : i+twoByte] {
+		case "!=", "<>", "<=", ">=":
+			return token{kind: tOp, text: s[i : i+twoByte]}, i + twoByte, nil
+		}
+	}
+
+	if s[i] == '!' {
+		return token{}, 0, cerrors.Newf(cerrors.InvalidArgument, "unexpected '!' at position %d", i)
+	}
+
+	return token{kind: tOp, text: string(s[i])}, i + 1, nil
+}
+
+func isSpace(c byte) bool { return c == ' ' || c == '\t' || c == '\n' || c == '\r' }
+
+func isWordStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isWordChar(c byte) bool { return isWordStart(c) || isDigit(c) }
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }

--- a/services/database/driver/cosmossql/parse.go
+++ b/services/database/driver/cosmossql/parse.go
@@ -1,0 +1,244 @@
+package cosmossql
+
+import (
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// Parse parses a Cosmos SQL query. params resolves @name placeholders (already
+// native values). It returns a cerrors.InvalidArgument error on malformed or
+// unsupported input.
+func Parse(query string, params map[string]any) (*Statement, error) {
+	toks, err := lex(query)
+	if err != nil {
+		return nil, err
+	}
+
+	p := &parser{toks: toks, params: params}
+
+	stmt, err := p.parseStatement()
+	if err != nil {
+		return nil, err
+	}
+
+	if p.peek().kind != tEOF {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "unexpected trailing token %q", p.peek().text)
+	}
+
+	return stmt, nil
+}
+
+type parser struct {
+	toks   []token
+	pos    int
+	params map[string]any
+	alias  string
+}
+
+func (p *parser) peek() token { return p.toks[p.pos] }
+
+func (p *parser) next() token {
+	t := p.toks[p.pos]
+	if p.pos < len(p.toks)-1 {
+		p.pos++
+	}
+
+	return t
+}
+
+// keyword reports whether the current token is the identifier kw (case-insensitive).
+func (p *parser) keyword(kw string) bool {
+	t := p.peek()
+	return t.kind == tIdent && strings.EqualFold(t.text, kw)
+}
+
+// accept consumes the current token when it is the keyword kw.
+func (p *parser) accept(kw string) bool {
+	if p.keyword(kw) {
+		p.next()
+		return true
+	}
+
+	return false
+}
+
+func (p *parser) expectKind(k tokKind, what string) error {
+	if p.peek().kind != k {
+		return cerrors.Newf(cerrors.InvalidArgument, "expected %s but found %q", what, p.peek().text)
+	}
+
+	p.next()
+
+	return nil
+}
+
+func (p *parser) parseStatement() (*Statement, error) {
+	if !p.accept("SELECT") {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected SELECT but found %q", p.peek().text)
+	}
+
+	stmt := &Statement{Limit: -1}
+	stmt.Distinct = p.accept("DISTINCT")
+
+	if p.accept("TOP") {
+		n, err := p.parseIntToken()
+		if err != nil {
+			return nil, err
+		}
+
+		stmt.Top = n
+	}
+
+	proj, err := p.parseProjection()
+	if err != nil {
+		return nil, err
+	}
+
+	if aerr := p.parseFrom(); aerr != nil {
+		return nil, aerr
+	}
+
+	if werr := p.parseTail(stmt); werr != nil {
+		return nil, werr
+	}
+
+	stmt.Proj = p.stripProjection(proj)
+
+	return stmt, nil
+}
+
+// parseTail parses the optional WHERE, ORDER BY and OFFSET/LIMIT clauses.
+func (p *parser) parseTail(stmt *Statement) error {
+	if p.accept("WHERE") {
+		node, err := p.parsePredicate()
+		if err != nil {
+			return err
+		}
+
+		stmt.Where = node
+	}
+
+	if p.accept("ORDER") {
+		if err := p.parseOrderBy(stmt); err != nil {
+			return err
+		}
+	}
+
+	return p.parseOffsetLimit(stmt)
+}
+
+func (p *parser) parseFrom() error {
+	if !p.accept("FROM") {
+		return cerrors.Newf(cerrors.InvalidArgument, "expected FROM but found %q", p.peek().text)
+	}
+
+	if p.peek().kind != tIdent {
+		return cerrors.Newf(cerrors.InvalidArgument, "expected a container alias but found %q", p.peek().text)
+	}
+
+	p.alias = p.next().text
+
+	return nil
+}
+
+func (p *parser) parseOrderBy(stmt *Statement) error {
+	if !p.accept("BY") {
+		return cerrors.Newf(cerrors.InvalidArgument, "expected BY after ORDER but found %q", p.peek().text)
+	}
+
+	for {
+		segs, err := p.parseSegments()
+		if err != nil {
+			return err
+		}
+
+		term := OrderTerm{Path: p.strip(segs)}
+
+		if p.accept("DESC") {
+			term.Desc = true
+		} else {
+			p.accept("ASC")
+		}
+
+		stmt.OrderBy = append(stmt.OrderBy, term)
+
+		if p.peek().kind != tComma {
+			return nil
+		}
+
+		p.next()
+	}
+}
+
+func (p *parser) parseOffsetLimit(stmt *Statement) error {
+	if !p.accept("OFFSET") {
+		return nil
+	}
+
+	off, err := p.parseIntToken()
+	if err != nil {
+		return err
+	}
+
+	stmt.Offset = off
+
+	if !p.accept("LIMIT") {
+		return cerrors.New(cerrors.InvalidArgument, "OFFSET must be followed by LIMIT")
+	}
+
+	lim, err := p.parseIntToken()
+	if err != nil {
+		return err
+	}
+
+	stmt.Limit = lim
+
+	return nil
+}
+
+func (p *parser) parseIntToken() (int, error) {
+	if p.peek().kind != tNumber {
+		return 0, cerrors.Newf(cerrors.InvalidArgument, "expected a number but found %q", p.peek().text)
+	}
+
+	n, err := strconv.Atoi(p.next().text)
+	if err != nil {
+		return 0, cerrors.Newf(cerrors.InvalidArgument, "invalid integer %q", err)
+	}
+
+	return n, nil
+}
+
+// parseSegments parses a dotted path (alias.a.b) into its raw name segments.
+// Aliases are stripped later once FROM is known.
+func (p *parser) parseSegments() ([]string, error) {
+	if p.peek().kind != tIdent {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected a property path but found %q", p.peek().text)
+	}
+
+	segs := []string{p.next().text}
+
+	for p.peek().kind == tDot {
+		p.next()
+
+		if p.peek().kind != tIdent {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "expected a property name but found %q", p.peek().text)
+		}
+
+		segs = append(segs, p.next().text)
+	}
+
+	return segs, nil
+}
+
+// strip removes the FROM alias head from a path (alias.a → a). A lone alias
+// (the whole document) becomes an empty path.
+func (p *parser) strip(segs []string) []string {
+	if len(segs) > 0 && segs[0] == p.alias {
+		return segs[1:]
+	}
+
+	return segs
+}

--- a/services/database/driver/cosmossql/parse.go
+++ b/services/database/driver/cosmossql/parse.go
@@ -203,9 +203,15 @@ func (p *parser) parseIntToken() (int, error) {
 		return 0, cerrors.Newf(cerrors.InvalidArgument, "expected a number but found %q", p.peek().text)
 	}
 
-	n, err := strconv.Atoi(p.next().text)
+	tok := p.next().text
+
+	n, err := strconv.Atoi(tok)
 	if err != nil {
-		return 0, cerrors.Newf(cerrors.InvalidArgument, "invalid integer %q", err)
+		return 0, cerrors.Newf(cerrors.InvalidArgument, "invalid integer %q", tok)
+	}
+
+	if n < 0 {
+		return 0, cerrors.Newf(cerrors.InvalidArgument, "expected a non-negative number but found %q", tok)
 	}
 
 	return n, nil

--- a/services/database/driver/cosmossql/parse_proj.go
+++ b/services/database/driver/cosmossql/parse_proj.go
@@ -1,0 +1,217 @@
+package cosmossql
+
+import (
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+func (p *parser) parseProjection() (Projection, error) {
+	if p.peek().kind == tStar {
+		p.next()
+		return Projection{Kind: ProjStar}, nil
+	}
+
+	value := p.accept("VALUE")
+
+	agg, isAgg, err := p.tryAggregate()
+	if err != nil {
+		return Projection{}, err
+	}
+
+	if isAgg {
+		return Projection{Kind: ProjAggregate, Aggregate: agg, Bare: !value}, nil
+	}
+
+	if value {
+		segs, verr := p.parseSegments()
+		if verr != nil {
+			return Projection{}, verr
+		}
+
+		return Projection{Kind: ProjValue, ValuePath: segs}, nil
+	}
+
+	fields, ferr := p.parseFieldList()
+	if ferr != nil {
+		return Projection{}, ferr
+	}
+
+	return Projection{Kind: ProjFields, Fields: fields}, nil
+}
+
+func (p *parser) parseFieldList() ([]ProjField, error) {
+	var fields []ProjField
+
+	for {
+		segs, err := p.parseSegments()
+		if err != nil {
+			return nil, err
+		}
+
+		field := ProjField{Path: segs}
+
+		if p.accept("AS") {
+			if p.peek().kind != tIdent {
+				return nil, cerrors.Newf(cerrors.InvalidArgument, "expected an alias but found %q", p.peek().text)
+			}
+
+			field.Alias = p.next().text
+		}
+
+		fields = append(fields, field)
+
+		if p.peek().kind != tComma {
+			return fields, nil
+		}
+
+		p.next()
+	}
+}
+
+// tryAggregate parses an aggregate call (COUNT/SUM/AVG/MIN/MAX) when the cursor
+// is on one; ok is false (without consuming) otherwise.
+func (p *parser) tryAggregate() (*Aggregate, bool, error) {
+	t := p.peek()
+	if t.kind != tIdent || !isAggregate(t.text) || p.toks[p.pos+1].kind != tLParen {
+		return nil, false, nil
+	}
+
+	fn := strings.ToUpper(p.next().text)
+	p.next() // '('
+
+	agg := &Aggregate{Func: fn}
+
+	// COUNT(1) / COUNT(*) take no path; the others aggregate a property.
+	if fn == "COUNT" && (p.peek().kind == tStar || p.peek().kind == tNumber) {
+		p.next()
+	} else {
+		segs, err := p.parseSegments()
+		if err != nil {
+			return nil, false, err
+		}
+
+		agg.Path = segs
+	}
+
+	if err := p.expectKind(tRParen, "')'"); err != nil {
+		return nil, false, err
+	}
+
+	return agg, true, nil
+}
+
+func (p *parser) stripProjection(proj Projection) Projection {
+	switch proj.Kind {
+	case ProjFields:
+		for i := range proj.Fields {
+			proj.Fields[i].Path = p.strip(proj.Fields[i].Path)
+		}
+	case ProjValue:
+		proj.ValuePath = p.strip(proj.ValuePath)
+	case ProjAggregate:
+		if proj.Aggregate.Path != nil {
+			proj.Aggregate.Path = p.strip(proj.Aggregate.Path)
+		}
+	case ProjStar:
+	}
+
+	return proj
+}
+
+// tryBoolFunc parses a boolean SQL function (STARTSWITH/CONTAINS/IS_DEFINED/
+// IS_NULL/ARRAY_CONTAINS) into a node; ok is false (without consuming) when the
+// cursor is not on such a call.
+func (p *parser) tryBoolFunc() (expr.Node, bool, error) {
+	t := p.peek()
+	if t.kind != tIdent || !isBoolFunc(t.text) || p.toks[p.pos+1].kind != tLParen {
+		return nil, false, nil
+	}
+
+	fn := strings.ToUpper(p.next().text)
+	p.next() // '('
+
+	node, err := p.finishBoolFunc(fn)
+
+	return node, true, err
+}
+
+const fnIsDefined = "IS_DEFINED"
+
+func (p *parser) finishBoolFunc(fn string) (expr.Node, error) {
+	if fn == fnIsDefined || fn == "IS_NULL" {
+		return p.finishUnaryFunc(fn)
+	}
+
+	path, arg, err := p.parsePathAndArg()
+	if err != nil {
+		return nil, err
+	}
+
+	switch fn {
+	case "STARTSWITH":
+		return &expr.BeginsWith{Path: path, Prefix: arg}, nil
+	case "CONTAINS":
+		return &expr.Contains{Path: path, Operand: arg}, nil
+	default: // ARRAY_CONTAINS — gate on the field being an array (see isArray).
+		return &expr.And{Left: isArray(path), Right: &expr.Contains{Path: path, Operand: arg}}, nil
+	}
+}
+
+func (p *parser) finishUnaryFunc(fn string) (expr.Node, error) {
+	path, err := p.parsePathOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	if rerr := p.expectKind(tRParen, "')'"); rerr != nil {
+		return nil, rerr
+	}
+
+	if fn == fnIsDefined {
+		return &expr.AttrExists{Path: path}, nil
+	}
+
+	return &expr.Comparison{Op: "=", Left: path, Right: &expr.ValueOperand{Value: nil}}, nil
+}
+
+func (p *parser) parsePathAndArg() (*expr.PathOperand, expr.Operand, error) {
+	path, err := p.parsePathOperand()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if cerr := p.expectKind(tComma, "','"); cerr != nil {
+		return nil, nil, cerr
+	}
+
+	arg, aerr := p.parseOperand()
+	if aerr != nil {
+		return nil, nil, aerr
+	}
+
+	if rerr := p.expectKind(tRParen, "')'"); rerr != nil {
+		return nil, nil, rerr
+	}
+
+	return path, arg, nil
+}
+
+// isArray is true when path resolves to a list ("L" is expr.dynamoType's code
+// for a native []any), gating ARRAY_CONTAINS off the substring match that the
+// shared Contains node does on strings.
+func isArray(path *expr.PathOperand) expr.Node {
+	return &expr.AttrType{Path: path, Type: &expr.ValueOperand{Value: "L"}}
+}
+
+//nolint:gochecknoglobals // static keyword sets
+var (
+	aggregateFuncs = map[string]bool{"COUNT": true, "SUM": true, "AVG": true, "MIN": true, "MAX": true}
+	boolFuncs      = map[string]bool{
+		"STARTSWITH": true, "CONTAINS": true, "IS_DEFINED": true, "IS_NULL": true, "ARRAY_CONTAINS": true,
+	}
+)
+
+func isAggregate(name string) bool { return aggregateFuncs[strings.ToUpper(name)] }
+func isBoolFunc(name string) bool  { return boolFuncs[strings.ToUpper(name)] }

--- a/services/database/driver/cosmossql/parse_test.go
+++ b/services/database/driver/cosmossql/parse_test.go
@@ -1,0 +1,130 @@
+package cosmossql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+func TestParseSelectStar(t *testing.T) {
+	s, err := Parse("SELECT * FROM c", nil)
+	require.NoError(t, err)
+	assert.Equal(t, ProjStar, s.Proj.Kind)
+	assert.Nil(t, s.Where)
+	assert.Equal(t, -1, s.Limit)
+}
+
+func TestParseWhereEval(t *testing.T) {
+	s, err := Parse("SELECT * FROM c WHERE c.age >= @min AND c.status = 'active'",
+		map[string]any{"@min": float64(18)})
+	require.NoError(t, err)
+	require.NotNil(t, s.Where)
+
+	match, err := expr.Eval(s.Where, map[string]any{"age": float64(20), "status": "active"})
+	require.NoError(t, err)
+	assert.True(t, match)
+
+	match, _ = expr.Eval(s.Where, map[string]any{"age": float64(10), "status": "active"})
+	assert.False(t, match, "age below @min")
+
+	match, _ = expr.Eval(s.Where, map[string]any{"age": float64(20), "status": "archived"})
+	assert.False(t, match, "wrong status")
+}
+
+func TestParseInBetweenOrNot(t *testing.T) {
+	s, err := Parse("SELECT * FROM c WHERE c.n BETWEEN 1 AND 10 AND c.t IN ('a','b') AND NOT c.hidden = true", nil)
+	require.NoError(t, err)
+
+	match, _ := expr.Eval(s.Where, map[string]any{"n": float64(5), "t": "a", "hidden": false})
+	assert.True(t, match)
+
+	match, _ = expr.Eval(s.Where, map[string]any{"n": float64(50), "t": "a", "hidden": false})
+	assert.False(t, match, "n out of BETWEEN range")
+
+	match, _ = expr.Eval(s.Where, map[string]any{"n": float64(5), "t": "z", "hidden": false})
+	assert.False(t, match, "t not IN list")
+
+	match, _ = expr.Eval(s.Where, map[string]any{"n": float64(5), "t": "a", "hidden": true})
+	assert.False(t, match, "NOT hidden=true")
+}
+
+func TestParseFunctions(t *testing.T) {
+	item := map[string]any{
+		"name": "hello",
+		"tags": []any{"x", "y"},
+		"opt":  nil,
+	}
+
+	cases := map[string]bool{
+		"SELECT * FROM c WHERE STARTSWITH(c.name, 'he')":    true,
+		"SELECT * FROM c WHERE STARTSWITH(c.name, 'zz')":    false,
+		"SELECT * FROM c WHERE CONTAINS(c.name, 'ell')":     true,
+		"SELECT * FROM c WHERE ARRAY_CONTAINS(c.tags, 'x')": true,
+		"SELECT * FROM c WHERE ARRAY_CONTAINS(c.name, 'e')": false, // scalar, not array
+		"SELECT * FROM c WHERE IS_DEFINED(c.name)":          true,
+		"SELECT * FROM c WHERE IS_DEFINED(c.missing)":       false,
+		"SELECT * FROM c WHERE IS_NULL(c.opt)":              true,
+		"SELECT * FROM c WHERE NOT IS_DEFINED(c.missing)":   true,
+	}
+
+	for q, want := range cases {
+		s, err := Parse(q, nil)
+		require.NoError(t, err, q)
+
+		got, err := expr.Eval(s.Where, item)
+		require.NoError(t, err, q)
+		assert.Equal(t, want, got, q)
+	}
+}
+
+func TestParseOrderByPaging(t *testing.T) {
+	s, err := Parse("SELECT * FROM c WHERE c.a = 1 ORDER BY c.age DESC OFFSET 2 LIMIT 5", nil)
+	require.NoError(t, err)
+
+	require.Len(t, s.OrderBy, 1)
+	assert.Equal(t, []string{"age"}, s.OrderBy[0].Path)
+	assert.True(t, s.OrderBy[0].Desc)
+	assert.Equal(t, 2, s.Offset)
+	assert.Equal(t, 5, s.Limit)
+}
+
+func TestParseProjectionFields(t *testing.T) {
+	s, err := Parse("SELECT c.a, c.b AS x FROM c", nil)
+	require.NoError(t, err)
+	require.Equal(t, ProjFields, s.Proj.Kind)
+	require.Len(t, s.Proj.Fields, 2)
+	assert.Equal(t, []string{"a"}, s.Proj.Fields[0].Path)
+	assert.Equal(t, "x", s.Proj.Fields[1].Alias)
+}
+
+func TestParseValueAndAggregate(t *testing.T) {
+	s, err := Parse("SELECT VALUE c.name FROM c", nil)
+	require.NoError(t, err)
+	assert.Equal(t, ProjValue, s.Proj.Kind)
+	assert.Equal(t, []string{"name"}, s.Proj.ValuePath)
+
+	s, err = Parse("SELECT VALUE COUNT(1) FROM c", nil)
+	require.NoError(t, err)
+	require.Equal(t, ProjAggregate, s.Proj.Kind)
+	assert.Equal(t, "COUNT", s.Proj.Aggregate.Func)
+	assert.False(t, s.Proj.Bare)
+
+	s, err = Parse("SELECT DISTINCT TOP 3 c.city FROM c", nil)
+	require.NoError(t, err)
+	assert.True(t, s.Distinct)
+	assert.Equal(t, 3, s.Top)
+}
+
+func TestParseErrors(t *testing.T) {
+	for _, q := range []string{
+		"", "SELECT c.a", "SELECT * FROM", "SELECT * FROM c WHERE",
+		"SELECT * FROM c WHERE c.a", "SELECT * FROM c ORDER c.a",
+		"SELECT * FROM c OFFSET 2", "SELECT * FROM c WHERE c.a = @p",
+	} {
+		_, err := Parse(q, nil)
+		assert.Error(t, err, "%q should fail to parse", q)
+	}
+}

--- a/services/database/driver/cosmossql/parse_test.go
+++ b/services/database/driver/cosmossql/parse_test.go
@@ -128,3 +128,39 @@ func TestParseErrors(t *testing.T) {
 		assert.Error(t, err, "%q should fail to parse", q)
 	}
 }
+
+func TestParseGuardedNot(t *testing.T) {
+	// NOT over a single-field predicate excludes documents missing that field
+	// (Cosmos three-valued logic; the two-valued evaluator is guarded).
+	cases := []string{
+		"SELECT * FROM c WHERE NOT (c.status = 'deleted')",
+		"SELECT * FROM c WHERE NOT STARTSWITH(c.name, 'x')",
+		"SELECT * FROM c WHERE NOT ARRAY_CONTAINS(c.tags, 'x')",
+		"SELECT * FROM c WHERE NOT c.n IN (1, 2)",
+	}
+
+	present := map[string]any{"status": "active", "name": "apple", "tags": []any{"a"}, "n": float64(9)}
+
+	for _, q := range cases {
+		s, err := Parse(q, nil)
+		require.NoError(t, err, q)
+
+		got, err := expr.Eval(s.Where, present)
+		require.NoError(t, err, q)
+		assert.True(t, got, "present field should match: %s", q)
+
+		got, err = expr.Eval(s.Where, map[string]any{})
+		require.NoError(t, err, q)
+		assert.False(t, got, "absent field must be excluded: %s", q)
+	}
+
+	// NOT IS_DEFINED is intentionally NOT guarded: it matches absent fields.
+	s, err := Parse("SELECT * FROM c WHERE NOT IS_DEFINED(c.x)", nil)
+	require.NoError(t, err)
+
+	got, _ := expr.Eval(s.Where, map[string]any{})
+	assert.True(t, got, "NOT IS_DEFINED matches an absent field")
+
+	got, _ = expr.Eval(s.Where, map[string]any{"x": float64(1)})
+	assert.False(t, got, "NOT IS_DEFINED excludes a present field")
+}

--- a/services/database/driver/cosmossql/parse_where.go
+++ b/services/database/driver/cosmossql/parse_where.go
@@ -53,10 +53,69 @@ func (p *parser) parseNot() (expr.Node, error) {
 			return nil, err
 		}
 
-		return &expr.Not{Child: child}, nil
+		return guardedNot(child), nil
 	}
 
 	return p.parsePrimaryPred()
+}
+
+// guardedNot negates child. Cosmos uses three-valued logic: negating a
+// predicate over an absent field yields undefined (the row is excluded), not
+// true. The shared evaluator is two-valued, so for a NOT over a single-field
+// predicate we require that field to exist. NOT over a composite predicate
+// (AND/OR of several fields) keeps the two-valued behavior — a documented
+// limitation. NOT IS_DEFINED is left unguarded so it still matches absent
+// fields.
+func guardedNot(child expr.Node) expr.Node {
+	path := negationPath(child)
+	if path == nil {
+		return &expr.Not{Child: child}
+	}
+
+	return &expr.And{Left: &expr.AttrExists{Path: path}, Right: &expr.Not{Child: child}}
+}
+
+// negationPath returns the single field path a predicate references, or nil for
+// existence checks and composite predicates (which are not guarded).
+func negationPath(n expr.Node) *expr.PathOperand {
+	switch t := n.(type) {
+	case *expr.Comparison:
+		return operandPath(t.Left)
+	case *expr.BeginsWith:
+		return t.Path
+	case *expr.Contains:
+		return t.Path
+	case *expr.Between:
+		return operandPath(t.Operand)
+	case *expr.In:
+		return operandPath(t.Operand)
+	case *expr.And:
+		return arrayGatePath(t)
+	default:
+		return nil
+	}
+}
+
+// arrayGatePath recognizes the And{AttrType, Contains} shape that ARRAY_CONTAINS
+// compiles to and returns its path, so NOT ARRAY_CONTAINS is guarded too.
+func arrayGatePath(a *expr.And) *expr.PathOperand {
+	if _, ok := a.Left.(*expr.AttrType); !ok {
+		return nil
+	}
+
+	if c, ok := a.Right.(*expr.Contains); ok {
+		return c.Path
+	}
+
+	return nil
+}
+
+func operandPath(o expr.Operand) *expr.PathOperand {
+	if p, ok := o.(*expr.PathOperand); ok {
+		return p
+	}
+
+	return nil
 }
 
 func (p *parser) parsePrimaryPred() (expr.Node, error) {
@@ -189,7 +248,10 @@ func (p *parser) parseOperand() (expr.Operand, error) {
 	case tNumber:
 		p.next()
 
-		f, _ := strconv.ParseFloat(t.text, 64)
+		f, err := strconv.ParseFloat(t.text, 64)
+		if err != nil {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "invalid number literal %q", t.text)
+		}
 
 		return &expr.ValueOperand{Value: f}, nil
 	case tIdent:

--- a/services/database/driver/cosmossql/parse_where.go
+++ b/services/database/driver/cosmossql/parse_where.go
@@ -1,0 +1,296 @@
+package cosmossql
+
+import (
+	"strconv"
+	"strings"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/database/driver/expr"
+)
+
+func (p *parser) parsePredicate() (expr.Node, error) { return p.parseOr() }
+
+func (p *parser) parseOr() (expr.Node, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.accept("OR") {
+		right, rerr := p.parseAnd()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		left = &expr.Or{Left: left, Right: right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseAnd() (expr.Node, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+
+	for p.accept("AND") {
+		right, rerr := p.parseNot()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		left = &expr.And{Left: left, Right: right}
+	}
+
+	return left, nil
+}
+
+func (p *parser) parseNot() (expr.Node, error) {
+	if p.accept("NOT") {
+		child, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+
+		return &expr.Not{Child: child}, nil
+	}
+
+	return p.parsePrimaryPred()
+}
+
+func (p *parser) parsePrimaryPred() (expr.Node, error) {
+	if p.peek().kind == tLParen {
+		p.next()
+
+		node, err := p.parsePredicate()
+		if err != nil {
+			return nil, err
+		}
+
+		if perr := p.expectKind(tRParen, "')'"); perr != nil {
+			return nil, perr
+		}
+
+		return node, nil
+	}
+
+	if node, ok, err := p.tryBoolFunc(); err != nil {
+		return nil, err
+	} else if ok {
+		return node, nil
+	}
+
+	return p.parseComparison()
+}
+
+func (p *parser) parseComparison() (expr.Node, error) {
+	left, err := p.parseOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case p.accept("IN"):
+		return p.parseIn(left)
+	case p.accept("BETWEEN"):
+		return p.parseBetween(left)
+	case p.peek().kind == tOp:
+		op := normalizeOp(p.next().text)
+
+		right, rerr := p.parseOperand()
+		if rerr != nil {
+			return nil, rerr
+		}
+
+		return &expr.Comparison{Op: op, Left: left, Right: right}, nil
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected an operator but found %q", p.peek().text)
+	}
+}
+
+const (
+	opBangEqual = "!="
+	opNotEqual  = "<>"
+)
+
+func normalizeOp(op string) string {
+	if op == opBangEqual {
+		return opNotEqual
+	}
+
+	return op
+}
+
+func (p *parser) parseIn(left expr.Operand) (expr.Node, error) {
+	if err := p.expectKind(tLParen, "'('"); err != nil {
+		return nil, err
+	}
+
+	var list []expr.Operand
+
+	for {
+		op, err := p.parseOperand()
+		if err != nil {
+			return nil, err
+		}
+
+		list = append(list, op)
+
+		if p.peek().kind != tComma {
+			break
+		}
+
+		p.next()
+	}
+
+	if err := p.expectKind(tRParen, "')'"); err != nil {
+		return nil, err
+	}
+
+	return &expr.In{Operand: left, List: list}, nil
+}
+
+func (p *parser) parseBetween(left expr.Operand) (expr.Node, error) {
+	lo, err := p.parseOperand()
+	if err != nil {
+		return nil, err
+	}
+
+	if !p.accept("AND") {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected AND in BETWEEN but found %q", p.peek().text)
+	}
+
+	hi, herr := p.parseOperand()
+	if herr != nil {
+		return nil, herr
+	}
+
+	return &expr.Between{Operand: left, Lo: lo, Hi: hi}, nil
+}
+
+func (p *parser) parseOperand() (expr.Operand, error) {
+	t := p.peek()
+
+	//nolint:exhaustive // the default case handles the remaining token kinds.
+	switch t.kind {
+	case tParam:
+		p.next()
+
+		v, ok := p.params[t.text]
+		if !ok {
+			return nil, cerrors.Newf(cerrors.InvalidArgument, "no value supplied for parameter %q", t.text)
+		}
+
+		return &expr.ValueOperand{Value: v}, nil
+	case tString:
+		p.next()
+		return &expr.ValueOperand{Value: t.text}, nil
+	case tNumber:
+		p.next()
+
+		f, _ := strconv.ParseFloat(t.text, 64)
+
+		return &expr.ValueOperand{Value: f}, nil
+	case tIdent:
+		return p.parseIdentOperand()
+	default:
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected an operand but found %q", t.text)
+	}
+}
+
+func (p *parser) parseIdentOperand() (expr.Operand, error) {
+	switch strings.ToUpper(p.peek().text) {
+	case "TRUE":
+		p.next()
+		return &expr.ValueOperand{Value: true}, nil
+	case "FALSE":
+		p.next()
+		return &expr.ValueOperand{Value: false}, nil
+	case "NULL":
+		p.next()
+		return &expr.ValueOperand{Value: nil}, nil
+	default:
+		return p.parsePathOperand()
+	}
+}
+
+func (p *parser) parsePathOperand() (*expr.PathOperand, error) {
+	parts, err := p.parsePathParts()
+	if err != nil {
+		return nil, err
+	}
+
+	return &expr.PathOperand{Parts: p.stripParts(parts)}, nil
+}
+
+func (p *parser) parsePathParts() ([]expr.PathPart, error) {
+	if p.peek().kind != tIdent {
+		return nil, cerrors.Newf(cerrors.InvalidArgument, "expected a property path but found %q", p.peek().text)
+	}
+
+	parts := []expr.PathPart{{Name: p.next().text}}
+
+	for {
+		//nolint:exhaustive // only '.' and '[' continue a path.
+		switch p.peek().kind {
+		case tDot:
+			p.next()
+
+			if p.peek().kind != tIdent {
+				return nil, cerrors.Newf(cerrors.InvalidArgument, "expected a property name but found %q", p.peek().text)
+			}
+
+			parts = append(parts, expr.PathPart{Name: p.next().text})
+		case tLBracket:
+			part, err := p.parseBracket()
+			if err != nil {
+				return nil, err
+			}
+
+			parts = append(parts, part)
+		default:
+			return parts, nil
+		}
+	}
+}
+
+func (p *parser) parseBracket() (expr.PathPart, error) {
+	p.next() // '['
+
+	t := p.peek()
+
+	var part expr.PathPart
+
+	//nolint:exhaustive // the default case handles the remaining token kinds.
+	switch t.kind {
+	case tString:
+		p.next()
+		part = expr.PathPart{Name: t.text}
+	case tNumber:
+		p.next()
+
+		idx, err := strconv.Atoi(t.text)
+		if err != nil {
+			return part, cerrors.Newf(cerrors.InvalidArgument, "invalid array index %q", t.text)
+		}
+
+		part = expr.PathPart{Index: idx, IsIndex: true}
+	default:
+		return part, cerrors.Newf(cerrors.InvalidArgument, "expected a property or index but found %q", t.text)
+	}
+
+	if err := p.expectKind(tRBracket, "']'"); err != nil {
+		return part, err
+	}
+
+	return part, nil
+}
+
+func (p *parser) stripParts(parts []expr.PathPart) []expr.PathPart {
+	if len(parts) > 0 && !parts[0].IsIndex && parts[0].Name == p.alias {
+		return parts[1:]
+	}
+
+	return parts
+}


### PR DESCRIPTION
## Summary

The final PR of the query-fidelity initiative, closing out both remaining tracks. All handler-side, reusing the shared `expr` evaluator; no `Database` interface change (no docs regeneration).

### Firestore — structured-query completion
Building on the WHERE fidelity from #437:
- **ORDER BY** — multi-key, direction-aware, with the implicit `__name__` tiebreaker Firestore appends.
- **offset**, **limit**, and **startAt / StartAfter / endAt / EndBefore** cursors (positional comparison over the order-by tuple).
- **select** — field projection (retaining the document name).

### Cosmos DB — real SQL queries
New `services/database/driver/cosmossql` package (lexer + recursive-descent parser) compiles a Cosmos SQL query into a shared `expr` WHERE AST plus a projection / order-by / paging plan; the handler evaluates it instead of discarding the SQL and returning everything.
- **WHERE**: `= != <> < <= > >=`, `AND`/`OR`/`NOT`, `IN`, `BETWEEN`, `STARTSWITH`, `CONTAINS`, `ARRAY_CONTAINS` (array-gated so it never substring-matches a string field), `IS_DEFINED`, `IS_NULL`, `@parameters`, dotted/indexed paths (FROM alias stripped).
- **SELECT**: `*`, field list with `AS` aliases, `SELECT VALUE`, `DISTINCT`, `TOP n`.
- **ORDER BY** (ASC/DESC), **OFFSET/LIMIT**, and **COUNT/SUM/AVG/MIN/MAX** aggregates.
- Offset-based `x-ms-continuation` paging over the logical result set; the response envelope widened to carry bare scalars (`SELECT VALUE` / aggregates).
- The partition-key header is advisory (cross-partition), matching the emulator's pk-only item identity.

## Why
Real apps and IaC drive `orderBy`/cursors on Firestore and `SELECT … WHERE … ORDER BY` on Cosmos constantly; the emulator previously dropped Firestore ordering/paging and ignored Cosmos SQL entirely (full scan). Both now behave faithfully, all in-memory — no external Firestore/Cosmos.

## Tests
- `cosmossql`: parser unit tests (WHERE eval, IN/BETWEEN/NOT, functions incl. array-gated ARRAY_CONTAINS, projection/VALUE/aggregate, ORDER BY/OFFSET/LIMIT, DISTINCT/TOP, error cases).
- Real `cloud.google.com/go/firestore` SDK: `TestDatabaseQueryOrderingAndPaging` (orderBy asc/desc, StartAfter+limit, offset, EndBefore, select).
- Real `azcosmos` SDK: `TestCosmosQueryFidelity` (parameters, ORDER BY, VALUE, aliased projection, COUNT, STARTSWITH/BETWEEN/ARRAY_CONTAINS/IN/OFFSET-LIMIT); the divergence test rewritten to assert faithful WHERE (15 of 30 docs).
- build, vet, gofmt, tidy, zero docs drift, `-race`, full suite — all green.