### PR TITLE
docs: refresh the hand-written guides — real engines, topology/chaos API fixes, query grammar

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # CloudEmu Documentation
 
-CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, and GCP cloud APIs. Run it as a standalone server (`cloudemu serve` or the `ghcr.io/stackshy/cloudemu` Docker image) and point any app in any language at a local endpoint, or use it in-process from Go via the SDK-compat HTTP server or the typed mock API -- for testing and development without real cloud accounts, network, or bill.
+CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, GCP, OCI, and Kubernetes cloud APIs. Run it as a standalone server (`cloudemu serve` or the `ghcr.io/stackshy/cloudemu` Docker image) and point any app in any language at a local endpoint, or use it in-process from Go via the SDK-compat HTTP server or the typed mock API -- for testing and development without real cloud accounts, network, or bill. Drivers are in-memory by default and can be backed by opt-in [real engines](features.md#11-real-data-plane-engines-opt-in) (real SQL/Redis/function code) when you need real workloads.
 
 ## Table of Contents
 
@@ -12,6 +12,7 @@ CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, and GCP cloud AP
 - [Standalone Server](standalone-server.md) -- Run CloudEmu as a local dev cloud (`cloudemu serve` / Docker), point any language at it
 - [Integration](integration.md) -- Wire CloudEmu into your real app and tests (not a throwaway demo)
 - [Topology](topology.md) -- Network topology simulation engine
+- [Chaos](chaos.md) -- Fault, latency, and throttling injection across the service layer
 - [Getting Started](getting-started.md) -- Installation, provider creation, basic examples, configuration
 - [OCI Conventions](oci-conventions.md) -- The contract every OCI service implementation follows
 
@@ -26,5 +27,6 @@ CloudEmu is a zero-cost, in-memory emulation of the AWS, Azure, and GCP cloud AP
 | Auto-metric generation | [Features](features.md#1-auto-metric-generation) |
 | Error injection and rate limiting | [Features](features.md#8-portable-api-cross-cutting-concerns) |
 | Cost tracking | [Features](features.md#7-cost-tracking) |
+| Real data-plane engines | [Features](features.md#11-real-data-plane-engines-opt-in) |
 | Configuration options | [Getting Started](getting-started.md#configuration-options) |
 | Package structure | [Architecture](architecture.md#package-structure-overview) |

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -25,6 +25,21 @@ server/<cloud>/<service>/        # SDK-compat wire handler for one cloud
   may have no cross-cloud `services/` abstraction, and some services have no wire
   handler yet. That is fine; the naming rules below still apply to whichever layers exist.
 
+### Sibling modules under `contrib/`
+
+Heavyweight, opt-in add-ons live in their own Go modules under `contrib/` so their
+dependencies stay out of the core `cloudemu` module:
+
+```
+contrib/realengine/       # opt-in real engines, no Docker (embedded-postgres, miniredis, subprocess)
+contrib/dockerengine/     # opt-in real engines, Docker required (mysql, compute, containers, azure functions)
+contrib/server/           # the batteries-included `cloudemu-server` binary (engines wired onto the wire servers)
+contrib/testcontainers/   # a Testcontainers Go module
+```
+
+A real-engine implementation goes in the matching `contrib/<realengine|dockerengine>/<capability>/`
+subpackage and satisfies the `config.<X>Engine` interface from `config/engine.go`.
+
 ---
 
 ## 2. Naming (the rule)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,6 +104,17 @@ aws.EC2.RunInstances(ctx, instanceConfig, 1)
 aws.DynamoDB.CreateTable(ctx, tableConfig)
 ```
 
+### Optional real data-plane engines
+
+The same options can carry opt-in **real engines** (`config.With<X>Engine`).
+When set, a driver routes its data path through the engine — real Postgres/MySQL,
+Redis, function runtimes, Docker compute/containers, or filesystem-backed object
+bytes — instead of `memstore`; when unset (the default) everything stays
+in-memory. The engine implementations live in sibling modules `contrib/realengine`
+(no Docker) and `contrib/dockerengine` (Docker). Because engines can hold real
+resources, `Provider.Close()` calls `Options.EngineClosers()` to tear every wired
+engine down. See [features.md — Real Data-Plane Engines](features.md#11-real-data-plane-engines-opt-in).
+
 ## Package Structure Overview
 
 | Package | Purpose |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,266 +2,122 @@
 
 ## Overview
 
-CloudEmu follows a three-layer architecture that separates portable API concerns, driver interfaces, and provider-specific implementations. This design allows each cloud provider to implement the same driver interface while the portable API layer adds cross-cutting concerns such as recording, metrics collection, rate limiting, error injection, and latency simulation. AWS, Azure, and GCP are fully implemented; OCI is an in-progress fourth provider whose foundation is in place and whose services arrive incrementally, with the generated [capability coverage](coverage/README.md) as the source of truth for which exist (see [Fourth provider: OCI](#fourth-provider-oci-in-progress)).
+CloudEmu separates **what** a cloud service does from **which** cloud does it, in three layers: a provider-agnostic **portable API**, a minimal **driver interface** per service, and an in-memory **provider mock** per cloud. Every provider implements the same driver interface, so one set of cross-cutting behaviors (recording, metrics, rate limiting, error injection, latency) and one set of wire servers work uniformly across clouds.
 
-## Three-Layer Architecture
+AWS, Azure, and GCP are fully implemented; **OCI** is an in-progress fourth provider (see [below](#fourth-provider-oci-in-progress)). The generated [capability coverage](coverage/README.md) is the source of truth for which services exist.
 
-```
-┌─────────────────────────────────────────────────────┐
-│         Portable API Layer                          │
-│   (storage/, compute/, database/, etc.)             │
-│   Recording, Metrics, Rate Limiting, Error Inject   │
-├─────────────────────────────────────────────────────┤
-│                      ↓                              │
-├─────────────────────────────────────────────────────┤
-│         Driver Interfaces                           │
-│   (*/driver/driver.go)                              │
-│   Minimal Go interfaces per service                 │
-├─────────────────────────────────────────────────────┤
-│                      ↓                              │
-├─────────────────────────────────────────────────────┤
-│         Provider Implementations                    │
-│   (providers/aws/, providers/azure/, providers/gcp/)│
-│   In-memory backends using memstore.Store[V]        │
-├─────────────────────────────────────────────────────┤
-│                      ↓                              │
-├─────────────────────────────────────────────────────┤
-│         In-Memory State                             │
-│   (internal/memstore) Generic Store[V]              │
-└─────────────────────────────────────────────────────┘
+## The three layers
+
+```mermaid
+flowchart TB
+    L1["<b>Layer 1 · Portable API</b> — services/&lt;svc&gt;<br/>optional wrapper: recording · metrics · rate limiting · error injection · latency<br/>provider-agnostic (the same wrapper works over S3, Blob, or GCS)"]
+    L2{{"<b>Layer 2 · Driver interface</b> — services/&lt;svc&gt;/driver<br/>a minimal Go contract per service · no cloud SDK types"}}
+    L3["<b>Layer 3 · Provider mock</b> — providers/&lt;cloud&gt;/&lt;service&gt;<br/>an in-memory backend, one per cloud (aws · azure · gcp · oci)"]
+    S[("State — internal/memstore Store&lt;V&gt;<br/>or an opt-in real engine")]
+
+    L1 -->|delegates to| L2
+    L3 -. implements .-> L2
+    L3 -->|reads / writes| S
 ```
 
-### Layer 1: Portable API
+- **Layer 1 — Portable API** (`services/storage`, `services/compute`, `services/database`, …). Each portable type wraps a driver and adds the cross-cutting concerns above to every call. It is provider-agnostic and **optional**: you wrap a driver with it when you want those behaviors. For example `storage.Bucket` wraps any `driver.Bucket` — S3, Blob, or GCS.
+- **Layer 2 — Driver interface** (`services/<svc>/driver/driver.go`). The hinge of the whole design: a minimal Go interface listing the operations every provider must implement (`CreateBucket`, `PutObject`, …), using plain Go types. Everything that reaches state goes through a driver.
+- **Layer 3 — Provider mock** (`providers/{aws,azure,gcp,oci}/<service>`). The concrete implementation for one cloud. It implements the driver interface and stores state in `internal/memstore.Store[V]` — a generic, thread-safe in-memory store — or, when opted in, a [real engine](#real-data-plane-engines).
 
-The top layer lives in service-specific packages (`services/storage/`, `services/compute/`, `services/database/`, etc.). Each portable API type wraps a driver with cross-cutting concerns. For example, `storage.Bucket` wraps `driver.Bucket` and adds call recording, metrics collection, rate limiting, error injection, and simulated latency to every operation. This layer is provider-agnostic -- the same `storage.Bucket` works with S3, Blob Storage, or GCS.
+## How a call reaches state
 
-### Layer 2: Driver Interfaces
+There are **two ways in**, and both converge on the driver interface:
 
-Each service defines a minimal Go interface in `<service>/driver/driver.go`. These interfaces specify the operations that every provider must implement. For example, `services/storage/driver/driver.go` defines the `Bucket` interface with methods like `CreateBucket`, `PutObject`, `GetObject`, etc. Driver interfaces use plain Go types (no cloud SDK dependencies).
+```mermaid
+flowchart LR
+    SDK["Real SDK / CLI / IaC<br/>(any language)"] -->|"HTTP · native protocol"| WH["Wire handler<br/>server/&lt;cloud&gt;/&lt;service&gt;"]
+    Go["Go code / tests"] -->|typed call| PW["Portable wrapper<br/>services/&lt;svc&gt; · optional"]
+    Go -.->|or straight to the mock| DRV
+    WH --> DRV{{"Driver<br/>interface"}}
+    PW --> DRV
+    DRV -. implemented by .-> MOCK["Provider mock<br/>providers/&lt;cloud&gt;/…"]
+    MOCK -->|default| MEM[("memstore")]
+    MOCK -.->|"opt-in With&lt;X&gt;Engine"| ENG[("real engine")]
+```
 
-### Layer 3: Provider Implementations
+- **Standalone / SDK path** — a real `aws-sdk-go-v2`, `azure-sdk-for-go`, or `cloud.google.com/go` client (or a CLI, or IaC) sends an HTTP request in the cloud's native wire format. The matching **wire handler** decodes it and calls the driver. Point the client at the endpoint; nothing else changes. See [sdk-server.md](sdk-server.md) and [standalone-server.md](standalone-server.md).
+- **Typed Go path** — `cloudemu.NewAWS().S3.CreateBucket(...)` calls a provider mock (a driver implementation) directly. Wrap it in the portable API first (`storage.New(mock, …)`) when you want recording/metrics/rate-limiting/injection/latency on those calls.
 
-The bottom layer contains the actual mock implementations for each cloud provider. These live in `providers/aws/`, `providers/azure/`, `providers/gcp/`, and — for the services built so far — `providers/oci/`. Each implementation uses `internal/memstore.Store[V]` as its backing data structure -- a generic, thread-safe in-memory store. All state lives in process memory with no external dependencies.
+Either way the request lands on the **driver interface**, the provider mock services it, and state lives in `memstore` — unless a real engine is wired in.
 
-### Fourth provider: OCI (in progress)
+## Real data-plane engines
 
-A fourth provider, OCI, lives in `providers/oci/`. Its foundation is staged on `development` (identity options, OCID generation in `internal/idgen/ocid.go`, the shared `services/scope` compartment scoping, the `server/wire/ocirest` wire format, and the `server/oci/workrequest` async envelope), and its services land one PR at a time — see [oci-conventions.md](oci-conventions.md). Each one that lands follows the same three-layer shape as the others: a `providers/oci/<service>/` package with a `memstore`-backed mock implementing the shared `services/<service>/driver` interface, plus a `server/oci/<service>/` wire handler.
+The provider mock's data path is normally `memstore`. Passing a `config.With<X>Engine` option routes that path through an **opt-in real engine** instead — real Postgres/MySQL, Redis, function runtimes, Docker compute/containers, or filesystem-backed object bytes — so clients run real workloads against the emulator. Unset (the default) keeps everything in-memory. Engine code lives in sibling modules `contrib/realengine` (no Docker) and `contrib/dockerengine` (Docker); `Provider.Close()` tears every wired engine down via `Options.EngineClosers()`. Full catalog: [features.md — Real Data-Plane Engines](features.md#11-real-data-plane-engines-opt-in).
 
-Until every service has landed, OCI diverges from the pattern above in two documented ways:
+## Cross-service engines
 
-- **A partially populated provider.** `providers/oci.Provider` declares each service as a bare driver interface rather than a concrete mock, so a service that has not landed yet reads as `nil` instead of failing to compile. The generated [capability coverage](coverage/README.md) is the source of truth for which OCI services exist and what each one implements — read it rather than any list in prose.
-- **Resource discovery has no OCI branch.** The per-resource ARN/ID formatters in `services/resourcediscovery` switch on AWS/Azure/GCP and fall through to a default for OCI, so OCI resources do not yet get native OCIDs from discovery. This must be filled in alongside the services that produce discoverable resources.
+Some features need to read **several** drivers at once, so they sit beside the portable API and consume Layer 2 interfaces directly (never concrete provider types), which is why they work uniformly across clouds:
 
-## Cross-Service Engines
+```mermaid
+flowchart LR
+    subgraph drivers["Driver interfaces (Layer 2)"]
+        C["compute"]
+        N["networking"]
+        D["dns"]
+        R["all service drivers"]
+    end
+    T["features/topology<br/>CanConnect · TraceRoute · Resolve"]
+    RD["services/resourcediscovery<br/>one unified inventory view"]
+    SV["server/<br/>SDK-compat wire handlers"]
 
-Sitting above Layer 2 (driver interfaces) are **cross-service engines** that consume driver interfaces directly without going through the portable API. They're peers of each other, not layers in the three-layer stack. Two exist today:
+    C --> T
+    N --> T
+    D --> T
+    R --> RD
+    R --> SV
+```
 
-- `features/topology/` -- reads from compute, networking, and DNS drivers to simulate real network connectivity (`CanConnect`, `TraceRoute`, `Resolve`, security-group and NACL evaluation). See [topology.md](topology.md).
-- `server/` -- exposes driver interfaces over HTTP in each cloud's native SDK wire format, so real `aws-sdk-go-v2`, `azure-sdk-for-go`, and `cloud.google.com/go` clients work against CloudEmu by only changing the endpoint. Covers storage, compute, relational and NoSQL databases (incl. Redis/MemoryDB and Cassandra — Keyspaces and Azure Managed Cassandra), networking, monitoring/logging, serverless, containers (registry + ECS + Kubernetes), messaging, streaming (Kinesis Data Streams and MSK / managed Kafka), secrets, key management (KMS), certificate management (ACM), web application firewall (WAFv2), workflow orchestration (Step Functions), search/analytics (OpenSearch), audit logging (CloudTrail), configuration management (AWS Config), data integration / ETL and the Data Catalog (Glue), threat detection (GuardDuty), file systems (EFS), email (SES v2), IAM, resource discovery, and AI/ML (Bedrock, SageMaker, Azure AI, Vertex AI) across all 3 providers. Uses a pluggable `Handler` registry so new services drop in as self-contained packages without touching the core. See [sdk-server.md](sdk-server.md) and the full catalog in [services.md](services.md).
+- **`features/topology`** — reads compute, networking, and DNS drivers to evaluate real network reachability. See [topology.md](topology.md).
+- **`services/resourcediscovery`** — walks every driver a provider holds and returns one normalized inventory (backs AWS Resource Explorer, Azure Resource Graph, GCP Cloud Asset). See [features.md](features.md#10-cross-service-resource-discovery).
+- **`server/`** — exposes drivers over HTTP in each cloud's native SDK wire format, via a pluggable `Handler` registry so new services drop in as self-contained packages. See [sdk-server.md](sdk-server.md).
 
-Both engines depend only on Layer 2 interfaces -- never on concrete provider types -- so they work uniformly across AWS, Azure, and GCP backends.
+## Provider factory & cross-service wiring
 
-## Cross-Service Wiring
-
-Provider factories automatically wire cross-service dependencies using `SetMonitoring()`. When a compute instance is launched, the compute mock pushes metrics directly into the monitoring service. This wiring is established at provider creation time.
+Each provider has a factory (`New()` in `providers/aws/aws.go`, etc.) that reads `config.Option` values, instantiates every service mock with the shared options, **wires cross-service dependencies**, and returns a `Provider` struct whose services are public fields.
 
 ```go
-// In providers/aws/aws.go
-p.EC2.SetMonitoring(p.CloudWatch)        // EC2 pushes metrics to CloudWatch
-p.S3.SetMonitoring(p.CloudWatch)         // S3 pushes metrics to CloudWatch
-p.DynamoDB.SetMonitoring(p.CloudWatch)   // DynamoDB pushes metrics to CloudWatch
+aws := cloudemu.NewAWS(config.WithRegion("us-west-2"))
+defer aws.Close()                       // tears down any wired real engines
 
-// In providers/azure/azure.go
-p.VirtualMachines.SetMonitoring(p.Monitor) // VMs push metrics to Azure Monitor
-p.BlobStorage.SetMonitoring(p.Monitor)     // Blob Storage pushes metrics
-
-// In providers/gcp/gcp.go
-p.GCE.SetMonitoring(p.CloudMonitoring)    // GCE pushes metrics to Cloud Monitoring
-p.GCS.SetMonitoring(p.CloudMonitoring)    // GCS pushes metrics
-```
-
-Currently, 10 services per provider are wired to push auto-metrics to their respective monitoring service: Compute, Storage, Database, Serverless, Message Queue, Cache, Logging, Notification, Container Registry, and Event Bus.
-
-## Provider Factory Pattern
-
-Each provider has a factory function (`New()`) in its top-level package (`providers/aws/aws.go`, `providers/azure/azure.go`, `providers/gcp/gcp.go`). The factory:
-
-1. Accepts functional `config.Option` values for configuration (clock, region, account ID, etc.)
-2. Creates `config.Options` from the functional options
-3. Instantiates every service mock, passing the shared options to each
-4. Wires cross-service dependencies (e.g., compute to monitoring)
-5. Returns the `Provider` struct with all services accessible as public fields
-
-```go
-aws := cloudemu.NewAWS(
-    config.WithRegion("us-west-2"),
-    config.WithAccountID("123456789012"),
-)
-
-// All services are ready to use
 aws.S3.CreateBucket(ctx, "my-bucket")
 aws.EC2.RunInstances(ctx, instanceConfig, 1)
-aws.DynamoDB.CreateTable(ctx, tableConfig)
 ```
 
-### Optional real data-plane engines
+The key wiring is auto-metrics: `SetMonitoring()` connects a service to its monitoring backend at construction, so a launched VM pushes metrics straight into CloudWatch / Azure Monitor / Cloud Monitoring.
 
-The same options can carry opt-in **real engines** (`config.With<X>Engine`).
-When set, a driver routes its data path through the engine — real Postgres/MySQL,
-Redis, function runtimes, Docker compute/containers, or filesystem-backed object
-bytes — instead of `memstore`; when unset (the default) everything stays
-in-memory. The engine implementations live in sibling modules `contrib/realengine`
-(no Docker) and `contrib/dockerengine` (Docker). Because engines can hold real
-resources, `Provider.Close()` calls `Options.EngineClosers()` to tear every wired
-engine down. See [features.md — Real Data-Plane Engines](features.md#11-real-data-plane-engines-opt-in).
+```go
+p.EC2.SetMonitoring(p.CloudWatch)          // AWS
+p.VirtualMachines.SetMonitoring(p.Monitor) // Azure
+p.GCE.SetMonitoring(p.CloudMonitoring)     // GCP
+```
 
-## Package Structure Overview
+10 services per provider push auto-metrics this way: Compute, Storage, Database, Serverless, Message Queue, Cache, Logging, Notification, Container Registry, and Event Bus.
+
+## Package map
 
 | Package | Purpose |
 |---------|---------|
-| `config` | Functional options (`WithClock`, `WithRegion`, `WithAccountID`, `WithProjectID`, `WithLatency`), `Clock` interface, `RealClock`, `FakeClock` for deterministic time |
-| `errors` | Canonical error codes: `NotFound`, `AlreadyExists`, `InvalidArgument`, `FailedPrecondition`, `PermissionDenied`, `Throttled`, `Internal`, `Unimplemented`, `ResourceExhausted`, `Unavailable` |
-| `internal/memstore` | Generic thread-safe `Store[V]` -- the backing data structure for all mock implementations |
-| `internal/idgen` | ID generators: AWS ARNs, Azure resource IDs, GCP self-links |
-| `statemachine` | Generic finite state machine for VM lifecycle transitions (pending, running, stopping, stopped, terminated) with callback support |
-| `pagination` | Generic `Paginate[T]` with base64 page tokens for list operations |
-| `recorder` | Call recording for test assertions -- captures service, operation, input, output, error, and duration |
-| `metrics` | In-memory metrics collector with Counter, Gauge, and Histogram types |
-| `ratelimit` | Token bucket rate limiter that returns `Throttled` errors |
-| `inject` | Error injection with policies: `Always`, `NthCall`, `Probabilistic`, `Countdown` |
-| `cost` | Simulated cost tracking with per-operation pricing rates |
+| `config` | Functional options (`WithClock`/`WithRegion`/`WithAccountID`/`WithProjectID`/`WithLatency`, the `With<X>Engine` engine options), the `Clock` interface, and `FakeClock` for deterministic time |
+| `errors` | Canonical error codes: `NotFound`, `AlreadyExists`, `InvalidArgument`, `FailedPrecondition`, `PermissionDenied`, `Throttled`, `Internal`, … |
+| `internal/memstore` | Generic thread-safe `Store[V]` — the backing store for every mock |
+| `internal/idgen` | ID generators: AWS ARNs, Azure resource IDs, GCP self-links, OCIDs |
+| `statemachine` | Generic FSM for VM lifecycle transitions (pending → running → stopping → …) |
+| `pagination` | Generic `Paginate[T]` with base64 page tokens |
+| `features/{recorder,metrics,ratelimit,inject,chaos,topology}` | The cross-cutting behaviors and cross-service engines |
+| `cost` | Simulated per-operation cost tracking |
 
-## File Structure
+The source tree mirrors the layers — `services/<svc>/` (portable API + `driver/`), `providers/<cloud>/<service>/` (mocks), `server/<cloud>/<service>/` (wire handlers) — plus the `contrib/*` sibling modules. See [STRUCTURE.md](STRUCTURE.md) for the full layout, naming rules, and where new code goes.
 
-```
-cloudemu.go                           # Entry point: NewAWS(), NewAzure(), NewGCP()
-cloudemu_test.go                      # All tests
-doc.go                                # Package documentation
-go.mod                                # Module: github.com/stackshy/cloudemu/v2
-config/
-    options.go                        # Options, WithClock, WithRegion, etc.
-    clock.go                          # Clock, RealClock, FakeClock
-errors/
-    errors.go                         # Canonical error codes and helpers
-internal/
-    memstore/                         # Generic Store[V]
-    idgen/                            # ID generators (ARNs, Azure IDs, GCP IDs)
-    statemachine/                     # Generic FSM
-    pagination/                       # Generic Paginate[T]
-services/                             # emulated cloud services (portable API + driver interface)
-    storage/
-        storage.go                    # Portable storage API
-        driver/driver.go              # Bucket interface
-    compute/  database/  relationaldb/  serverless/  networking/  monitoring/
-    iam/  dns/  loadbalancer/  messagequeue/  cache/  secrets/  logging/
-    notification/  eventbus/  containerregistry/  kubernetes/  resourcediscovery/
-    bedrock/  sagemaker/  vertexai/  databricks/  ai/  search/
-    memorydb/  keyspaces/  managedcassandra/  ecs/
-    parameterstore/  tablestorage/  cost/
-                                      # each: <name>.go (portable API) + driver/ (interface)
-features/                             # cross-cutting capabilities you wrap drivers with
-    chaos/                            # fault / latency / throttle injection
-    recorder/                         # call recording for assertions
-    metrics/                          # in-memory metrics collection
-    ratelimit/                        # token-bucket rate limiter
-    inject/                           # error injection (policies + injector)
-    topology/                         # network reachability (CanConnect / TraceRoute / Resolve)
-providers/
-    aws/
-        aws.go                        # AWS factory (wires all services)
-        s3/                           # S3 mock
-        ec2/                          # EC2 mock
-        dynamodb/                     # DynamoDB mock
-        lambda/                       # Lambda mock
-        vpc/                          # VPC mock
-        cloudwatch/                   # CloudWatch mock
-        iam/                       # IAM mock
-        route53/                      # Route 53 mock
-        elb/                          # ELB mock
-        sqs/                          # SQS mock
-        elasticache/                  # ElastiCache mock
-        memorydb/                     # MemoryDB mock (Redis/Valkey control plane)
-        keyspaces/                    # Keyspaces mock (Cassandra control plane)
-        secretsmanager/               # Secrets Manager mock
-        cloudwatchlogs/               # CloudWatch Logs mock
-        sns/                          # SNS mock
-        ecr/                          # ECR mock
-        eventbridge/                  # EventBridge mock
-        rds/                          # RDS mock (Aurora + Neptune + DocumentDB engines)
-        redshift/                     # Redshift mock
-        eks/                          # EKS control-plane mock (clusters, node groups,
-                                      # Fargate profiles, addons)
-    azure/
-        azure.go                      # Azure factory (wires all services)
-        blobstorage/                  # Blob Storage mock
-        virtualmachines/              # Virtual Machines mock
-        cosmosdb/                     # Cosmos DB mock
-        managedcassandra/             # Managed Instance for Apache Cassandra mock
-        functions/                    # Azure Functions mock
-        vnet/                         # VNet mock
-        monitor/                 # Azure Monitor mock
-        iam/                     # Azure IAM mock
-        dns/                     # Azure DNS mock
-        loadbalancer/                      # Azure LB mock
-        servicebus/                   # Service Bus mock
-        cache/                   # Azure Cache mock
-        keyvault/                     # Key Vault mock
-        loganalytics/                 # Log Analytics mock
-        notificationhubs/             # Notification Hubs mock
-        acr/                          # ACR mock
-        eventgrid/                    # Event Grid mock
-        sql/                     # Azure SQL Database mock
-        postgresflex/                 # Azure PostgreSQL Flexible Server mock
-        mysqlflex/                    # Azure MySQL Flexible Server mock
-        aks/                          # AKS control-plane mock (managed clusters,
-                                      # agent pools, maintenance configs)
-    gcp/
-        gcp.go                        # GCP factory (wires all services)
-        gcs/                          # GCS mock
-        compute/                          # GCE mock
-        firestore/                    # Firestore mock
-        cloudfunctions/               # Cloud Functions mock
-        vpc/                       # GCP VPC mock
-        monitoring/              # Cloud Monitoring mock
-        iam/                       # GCP IAM mock
-        clouddns/                     # Cloud DNS mock
-        loadbalancer/                        # GCP LB mock
-        pubsub/                       # Pub/Sub mock
-        memorystore/                  # Memorystore mock
-        secretmanager/                # Secret Manager mock
-        cloudlogging/                 # Cloud Logging mock
-        fcm/                          # FCM mock
-        artifactregistry/             # Artifact Registry mock
-        eventarc/                     # Eventarc mock
-        cloudsql/                     # Cloud SQL mock
-        gke/                          # GKE control-plane mock (clusters, node pools,
-                                      # operations)
-server/                               # SDK-compat HTTP servers (real cloud SDKs work against this)
-    server.go                         # core: Handler interface + dispatcher
-    wire/
-        wire.go                       # shared XML/JSON helpers
-        awsquery/                     # AWS query-protocol helpers
-        azurearm/                     # ARM URL parser + JSON envelope
-        gcprest/                      # GCP REST URL parser + LRO Operation helpers
-    aws/
-        aws.go                        # awsserver.New(Drivers{...})
-        s3/  ec2/  dynamodb/          # S3 REST+XML, EC2 query, DynamoDB JSON-RPC
-        cloudwatch/                   # Smithy rpc-v2-cbor
-        lambda/  sqs/                 # REST + JSON-RPC handlers
-        rds/  redshift/               # query-protocol relational DB handlers
-        memorydb/  keyspaces/         # JSON 1.1 / JSON 1.0 NoSQL DB handlers
-        eks/                          # REST EKS control-plane handler
-    azure/
-        azure.go                      # azureserver.New(Drivers{...})
-        virtualmachines/  disks/  snapshots/  images/  sshpublickeys/
-        blob/  cosmos/  network/  monitor/  functions/  servicebus/
-        sql/  postgresflex/  mysqlflex/   # ARM relational DB handlers
-        managedcassandra/             # ARM Managed Cassandra handler
-        aks/                          # ARM AKS control-plane handler
-    gcp/
-        gcp.go                        # gcpserver.New(Drivers{...})
-        compute/  networks/  gcs/  firestore/  monitoring/
-        cloudfunctions/  pubsub/
-        cloudsql/                     # REST Cloud SQL handler
-        gke/                          # REST GKE control-plane handler
-```
+## Fourth provider: OCI (in progress)
+
+OCI (`providers/oci/`) follows the same three-layer shape: a `memstore`-backed mock per service implementing the shared driver, plus a `server/oci/<service>/` handler. Its foundation is in place (identity options, OCID generation in `internal/idgen/ocid.go`, `services/scope` compartment scoping, the `server/wire/ocirest` format, and the `server/oci/workrequest` async envelope); services land one PR at a time — see [oci-conventions.md](oci-conventions.md).
+
+Until every service has landed, OCI diverges in two documented ways:
+
+- **Partially populated provider** — `providers/oci.Provider` declares each service as a bare driver interface, so a service that hasn't landed reads as `nil` rather than failing to compile. The generated [capability coverage](coverage/README.md) is the source of truth for what exists.
+- **No OCI branch in resource discovery** — the ARN/ID formatters in `services/resourcediscovery` fall through to a default for OCI, so its resources don't yet get native OCIDs from discovery. This fills in alongside the services that produce discoverable resources.

--- a/docs/chaos.md
+++ b/docs/chaos.md
@@ -44,7 +44,17 @@ Each call to `engine.Apply` returns an `*Active` handle with `.Stop()` to cancel
 
 ## What's wrapped today
 
-`WrapBucket` (S3), `WrapCompute` (EC2), `WrapDatabase` (DynamoDB). Phase 2 will wire the remaining 13 services.
+Chaos wrapping spans the portable service layer — 20 `Wrap*` helpers cover
+storage, compute, database, cache, DNS, IAM, container registry, logging, event
+bus, load balancer, message queue, monitoring, networking, notification,
+secrets, serverless, and the ML/GenAI surfaces (SageMaker, Vertex AI, Azure AI,
+Azure Search):
+
+`WrapBucket`, `WrapCompute`, `WrapDatabase`, `WrapCache`, `WrapDNS`, `WrapIAM`,
+`WrapContainerRegistry`, `WrapLogging`, `WrapEventBus`, `WrapLoadBalancer`,
+`WrapMessageQueue`, `WrapMonitoring`, `WrapNetworking`, `WrapNotification`,
+`WrapSecrets`, `WrapServerless`, `WrapSageMaker`, `WrapVertexAI`, `WrapAzureAI`,
+`WrapAzureSearch`.
 
 ## Inspecting what happened
 
@@ -53,9 +63,8 @@ events := engine.Recorded()  // every Effect that was applied
 engine.Reset()               // clear the buffer between test phases
 ```
 
-## Coming next (Phase 2 / 3)
+## Coming next
 
-- Wire chaos into the remaining 13 portable services
 - `SlowDegradation` (latency ramps up over a window)
 - `BurstFailure` (N consecutive failures)
 - `NetworkPartition` (cross-service: A → B fails, B → A is fine)

--- a/docs/features.md
+++ b/docs/features.md
@@ -166,11 +166,29 @@ Tables support creating GSIs with a different partition key and optional sort ke
 
 The `compareValues(a, b string)` helper in each database mock tries `strconv.ParseFloat` on both values. If both parse as numbers, it performs numeric comparison. Otherwise it falls back to string comparison. This is used by all comparison operators in scan filters and query sort conditions.
 
-### Full Scan Operators
+### Query & Expression Grammar
 
-Scan filters support: `=`, `!=`, `<`, `>`, `<=`, `>=`, `CONTAINS`, `BEGINS_WITH`
+The database drivers evaluate the real expression grammars, not a reduced
+subset — the raw expression strings a client sends are tokenized, parsed and
+evaluated with type-aware semantics:
 
-Query sort key conditions support: `=`, `<`, `>`, `<=`, `>=`, `BEGINS_WITH`, `BETWEEN`
+- **DynamoDB**: full `KeyConditionExpression` (`=`/`<`/`<=`/`>`/`>=`, `BETWEEN`,
+  `begins_with`), `FilterExpression`/`ConditionExpression` (boolean operators,
+  `IN`, `BETWEEN`, `attribute_exists`/`attribute_type`/`begins_with`/`contains`/
+  `size`), `ProjectionExpression`, and `UpdateExpression` (`SET` with arithmetic,
+  `if_not_exists`, `list_append`; `REMOVE`; `ADD`; `DELETE`) — including the real
+  `SS`/`NS`/`BS` set types.
+- **Firestore**: structured queries with all field operators (`IN`/`NOT_IN`/
+  `ARRAY_CONTAINS`/`ARRAY_CONTAINS_ANY`), `AND`/`OR` composite filters, unary
+  `IS_NULL`/`IS_NOT_NULL`, `orderBy`, `offset`, `startAt`/`endAt` cursors, and
+  field projection.
+- **Cosmos DB**: Cosmos SQL (`SELECT`/`WHERE`/`ORDER BY`/`OFFSET`-`LIMIT`,
+  `DISTINCT`, `TOP`, projections incl. `SELECT VALUE`, and `COUNT`/`SUM`/`AVG`/
+  `MIN`/`MAX` aggregates).
+
+The legacy driver-level `ScanFilter`/`SortOp` operators (`=`, `!=`, `<`, `>`,
+`<=`, `>=`, `CONTAINS`, `BEGINS_WITH`, `BETWEEN`) remain for direct Go-API
+callers.
 
 ### TTL (Time To Live)
 
@@ -430,3 +448,59 @@ The engine drives three handlers, each registered on its provider's SDK-compat s
 | GCP | `server/gcp/cloudasset` | `cloudasset.SearchAllResources`, `assets.List`, `ExportAssets`, Feeds CRUD, `Operations.Get` |
 
 See [services.md — Resource Discovery](services.md#19-resource-discovery) for the full per-handler operation list and [sdk-server.md](sdk-server.md) for the wire protocols.
+
+## 11. Real Data-Plane Engines (opt-in)
+
+By default CloudEmu is a pure in-memory emulator — every driver stores state in
+`memstore` and returns synthetic responses, with no external processes. For the
+cases where you want clients to run **real workloads** (real SQL, real Redis
+commands, real function code) against the emulator, drivers can be backed by an
+opt-in **real engine**. The in-memory default is unchanged; engines are strictly
+opt-in and nil means "stay in-memory".
+
+### Capability → engine
+
+Six engine seams are defined in `config` (`config/engine.go`), each wired with a
+`config.With<X>Engine(...)` option:
+
+| Capability | Option | Backed by |
+|-----------|--------|-----------|
+| Relational database | `WithDatabaseEngine` | real Postgres / MySQL |
+| Cache | `WithCacheEngine` | real Redis |
+| Functions | `WithFunctionEngine` | real code execution (subprocess / Docker) |
+| Compute | `WithComputeEngine` | Docker containers as VMs |
+| Containers | `WithContainerEngine` | Docker containers |
+| Object storage | `WithStorageEngine` | filesystem-backed object bytes |
+
+### Two backing modules
+
+The engine implementations live in separate Go modules so their heavyweight
+dependencies stay out of the core `cloudemu` module:
+
+- **`contrib/realengine`** — *no Docker*. Real Postgres via `embedded-postgres`,
+  real Redis via `miniredis`, real function execution via the host's
+  `python3`/`node`, filesystem-backed object storage.
+- **`contrib/dockerengine`** — *Docker required*. MySQL, Docker-backed compute
+  and containers, and Azure Functions. Tests skip cleanly when Docker is absent.
+
+### Wiring engines (Go)
+
+```go
+import (
+    cloudemu "github.com/stackshy/cloudemu/v2"
+    "github.com/stackshy/cloudemu/v2/config"
+    "github.com/stackshy/cloudemu/v2/contrib/realengine/postgres"
+)
+
+pg, _ := postgres.New()                 // starts a real Postgres
+aws := cloudemu.NewAWS(config.WithDatabaseEngine(pg))
+defer aws.Close()                        // Provider.Close() tears down every wired engine
+```
+
+`Provider.Close()` calls `Options.EngineClosers()`, so every engine that
+implements `io.Closer` is shut down when the provider is closed.
+
+For the standalone server, the batteries-included `cloudemu-server` binary
+(`contrib/server`) turns engines on with flags (`--db`, `--cache`, `--functions`,
+`--compute`, `--containers`, `--all-real`) — see
+[standalone-server.md — Real engines](standalone-server.md#real-engines).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -267,6 +267,29 @@ aws = cloudemu.NewAWS(
 | `WithProjectID(id)` | `"mock-project"` | GCP project ID |
 | `WithLatency(d)` | `0` | Simulated latency added to all operations |
 
+### Real-engine options (opt-in)
+
+By default every driver is in-memory. To back a capability with a **real
+engine** (real SQL/Redis/function code), pass one of the `With<X>Engine` options
+— `nil`/unset keeps the in-memory default:
+
+| Option | Backs |
+|--------|-------|
+| `WithDatabaseEngine(e)` | relational database → real Postgres/MySQL |
+| `WithCacheEngine(e)` | cache → real Redis |
+| `WithFunctionEngine(e)` | functions → real code execution |
+| `WithComputeEngine(e)` | compute → Docker containers as VMs |
+| `WithContainerEngine(e)` | containers → Docker |
+| `WithStorageEngine(e)` | object storage → filesystem-backed bytes |
+
+```go
+pg, _ := postgres.New()                          // contrib/realengine/postgres
+aws := cloudemu.NewAWS(config.WithDatabaseEngine(pg))
+defer aws.Close()                                 // tears down every wired engine
+```
+
+See [features.md — Real Data-Plane Engines](features.md#11-real-data-plane-engines-opt-in) for the engine catalog and the `cloudemu-server` binary.
+
 ## Error Handling
 
 CloudEmu uses canonical error codes from the `errors` package. Use the helper functions to check error types.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -4,6 +4,8 @@ The mistake to avoid: **don't write a new `main.go` that just calls CloudEmu and
 
 Do this instead — point your app's *existing* cloud client at CloudEmu in your *existing* tests. Your real code runs against an in-memory cloud, no mocks.
 
+> Need a test to exercise real SQL, Redis or function code rather than the in-memory backend? Back the relevant driver with a [real engine](features.md#11-real-data-plane-engines-opt-in) — the wiring is a `config.With<X>Engine` option, everything below stays the same.
+
 ## The trick
 
 Make the endpoint injectable, then point it at CloudEmu in tests. An env var is the easy default (shown below) — but it's your call: a config field or setting it directly in the test works just as well. Production uses the real cloud; your code doesn't change.

--- a/docs/sdk-server.md
+++ b/docs/sdk-server.md
@@ -4,6 +4,8 @@ CloudEmu includes an HTTP server that speaks the real cloud SDK wire protocols a
 
 Nothing to mock. No Docker. No accounts. The same SDK calls you'd run against real AWS / Azure / GCP hit a local `httptest.NewServer` and get back SDK-decodable responses.
 
+The backend is in-memory by default; the same drivers can be backed by opt-in [real engines](features.md#11-real-data-plane-engines-opt-in) (real SQL/Redis/function code) when you need real workloads behind the wire protocol.
+
 ## Why
 
 CloudEmu's Go API is great for new code you write for testing. But most real apps already use the official cloud SDKs directly. Rewriting those call sites just to test against an emulator is friction. The SDK-compat server removes that friction — change the endpoint, done.
@@ -160,7 +162,7 @@ Region, credentials, and tokens can be any dummy values — the server doesn't v
 | Service | Operations |
 |---------|-----------|
 | **S3** | CreateBucket, DeleteBucket, ListBuckets, PutObject, GetObject, HeadObject, DeleteObject, ListObjectsV2 (prefix, delimiter, common prefixes, continuation token), CopyObject |
-| **DynamoDB** | CreateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, UpdateItem (SET/REMOVE), Query, Scan (with FilterExpression), BatchWriteItem, BatchGetItem, TransactWriteItems |
+| **DynamoDB** | CreateTable, DeleteTable, DescribeTable, ListTables, PutItem, GetItem, DeleteItem, UpdateItem (SET/REMOVE/ADD/DELETE + arithmetic/`if_not_exists`/`list_append`), Query/Scan (full KeyCondition/Filter/Projection expressions), BatchWriteItem, BatchGetItem, TransactWriteItems (ConditionExpression, real `SS`/`NS`/`BS` sets) |
 | **EC2** | RunInstances, DescribeInstances (filters: `instance-id`, `instance-type`, `instance-state-name`, `tag:*`), Start/Stop/Reboot/TerminateInstances, ModifyInstanceAttribute |
 | **EC2 — VPC + Networking** | VPCs, Subnets, Security Groups + ingress/egress rules, Internet Gateways, Route Tables + Routes, NAT Gateways, VPC Peering, Flow Logs, Network ACLs |
 | **EC2 — EBS + Key Pairs** | Volumes (Create/Delete/Describe/Attach/Detach), Key Pairs |
@@ -364,7 +366,7 @@ The `Handler` interface is the only contract — no registration is needed in co
 - **No signature validation.** CloudEmu is a local development tool, not a security boundary. Requests are accepted regardless of AWS SigV4 / Azure AAD / GCP OAuth signatures.
 - **No AMQP for Azure Service Bus.** The modern `azservicebus` SDK uses AMQP exclusively for data plane. ARM control plane is fully supported via `armservicebus`; tests that need send/receive can use the raw-HTTP REST data plane.
 - **GCS direct-media downloads** assume path-style URLs.
-- **DynamoDB / Cosmos / Firestore filters and queries** support common patterns but are not full DSL parsers.
+- **DynamoDB / Cosmos / Firestore queries** parse the real grammars — DynamoDB expressions (KeyCondition/Filter/Condition/Projection/Update), Firestore structured queries (composite filters, `orderBy`, cursors, `select`), and Cosmos SQL (`SELECT`/`WHERE`/`ORDER BY`/`OFFSET`-`LIMIT`/aggregates). A few advanced constructs are deliberately out of scope (e.g. Cosmos `JOIN`/spatial/UDFs); `NOT` over a composite predicate stays two-valued.
 - **Pagination tokens** are honored where present in the SDK contract; some list operations short-circuit to a single page.
 - **Resource Graph `resourceGroup`.** Rows expose `resourceGroup` derived from the resource's ARM id. Where a mock doesn't model a per-resource resource group, the id (and thus `resourceGroup`) falls back to `default`, so all such resources share one resource group — fine for SKU/tier/size-sensitive discovery and cost tests, but consumers that key on distinct resource groups should be aware. Event Hubs (`microsoft.eventhub/namespaces`) is not yet modeled, so its `sku.tier` isn't surfaced.
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -2,6 +2,8 @@
 
 This document lists every service and operation available in CloudEmu across all three cloud providers.
 
+> Every operation here is served from an in-memory backend by default. Selected data-plane services (relational database, cache, functions, compute, containers, object storage) can additionally be backed by opt-in [real engines](features.md#11-real-data-plane-engines-opt-in) for real SQL/Redis/function execution.
+
 ## Master Table
 
 | # | Service Category | AWS | Azure | GCP |

--- a/docs/standalone-server.md
+++ b/docs/standalone-server.md
@@ -259,6 +259,16 @@ default `127.0.0.1` keeps it local-only).
 
 ## Pointing SDKs at it
 
+For CLIs and any-language SDKs that read endpoint/credential env vars, the
+`cloudemu env` subcommand prints the `export` lines to point them at a running
+server:
+
+```bash
+eval "$(cloudemu env)"   # exports AWS_ENDPOINT_URL, AWS_ACCESS_KEY_ID=test, ... (ports default 4566/4568/4569)
+```
+
+The Go examples below set the endpoint on the client directly.
+
 ### AWS (`aws-sdk-go-v2`)
 
 ```go
@@ -421,9 +431,36 @@ f, _ := seed.LoadFS(fixtures, "testdata/fixtures.json")
 seed.Apply(ctx, f, seed.Target{Storage: aws.S3, Database: aws.DynamoDB})
 ```
 
+## Real engines
+
+`cloudemu serve` is pure in-memory. To point clients at **real** SQL, Redis,
+function runtimes or containers, use the batteries-included **`cloudemu-server`**
+binary (the `contrib/server` module), which wires the opt-in
+[real engines](features.md#11-real-data-plane-engines-opt-in) onto the same wire
+servers. Engines are turned on with flags (or the matching `CLOUDEMU_*` env
+vars):
+
+```bash
+cloudemu-server --db=postgres --cache=redis --functions=subprocess
+# or turn everything on:
+cloudemu-server --all-real
+```
+
+| Flag | Env | Values |
+|------|-----|--------|
+| `--db` | `CLOUDEMU_DB` | `off` \| `postgres` \| `mysql` \| `both` |
+| `--cache` | `CLOUDEMU_CACHE` | `off` \| `redis` |
+| `--functions` | `CLOUDEMU_FUNCTIONS` | `off` \| `subprocess` |
+| `--compute` | `CLOUDEMU_COMPUTE` | `off` \| `docker` |
+| `--containers` | `CLOUDEMU_CONTAINERS` | `off` \| `docker` |
+| `--all-real` | — | shorthand: postgres + redis + subprocess + docker compute + docker containers |
+
+`--db`/`--cache`/`--functions` need no Docker (`contrib/realengine`);
+`--compute`/`--containers` require a Docker daemon (`contrib/dockerengine`). The
+server calls `Provider.Close()` on shutdown, tearing every engine down.
+
 ## Not yet included
 
 **Persistence** covers object storage and NoSQL tables today (see "Persistence
 across restarts" above); the remaining services and full **snapshot/restore**
-fidelity are tracked in #107. Docker packaging (#247) and a Testcontainers
-module (#248) build directly on this binary.
+fidelity are tracked in #107.

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -68,30 +68,26 @@ The topology engine does not store its own state. It reads from the existing moc
 Checks whether traffic can flow from source to destination on a given protocol and port.
 
 ```go
-result, err := engine.CanConnect(ctx, CanConnectInput{
-    SourceInstanceID: "i-abc123",
-    DestInstanceID:   "i-def456",
-    Protocol:         "tcp",
-    Port:             443,
+result, err := engine.CanConnect(ctx, topology.ConnectivityQuery{
+    SrcInstanceID: "i-abc123",
+    DstInstanceID: "i-def456",
+    Protocol:      "tcp", // "tcp", "udp", "icmp", or "-1" for all
+    Port:          443,
 })
-// result.Allowed  -- bool
-// result.Reason   -- string explaining why allowed/denied
-// result.DeniedBy -- which component denied (e.g., "security-group", "network-acl", "no-route")
+// result.Allowed    -- bool
+// result.Reason     -- string explaining why allowed/denied
+// result.Path       -- []RouteHop, the network path that was walked
+// result.SGVerdict  -- TrafficVerdict from the security-group evaluation
+// result.ACLVerdict -- *ACLVerdict from the network-ACL evaluation (nil if not reached)
 ```
 
 ### TraceRoute
 
-Produces a hop-by-hop path between two endpoints.
+Produces a hop-by-hop path from a source instance to a destination IP.
 
 ```go
-trace, err := engine.TraceRoute(ctx, TraceRouteInput{
-    SourceInstanceID: "i-abc123",
-    DestInstanceID:   "i-def456",
-    Protocol:         "tcp",
-    Port:             80,
-})
-// trace.Hops -- []Hop with Type, ID, and description
-// trace.Reachable -- bool
+hops, err := engine.TraceRoute(ctx, "i-abc123", "10.0.2.50")
+// hops -- []RouteHop with Type, ResourceID, and Detail
 ```
 
 ### Resolve
@@ -105,55 +101,64 @@ ips, err := engine.Resolve(ctx, "api.example.com")
 
 ### EvaluateSecurityGroups
 
-Evaluates whether a set of security groups allows traffic on a given protocol, port, and source CIDR.
+Evaluates whether traffic is allowed between a source and destination security
+group on a given port and protocol.
 
 ```go
-allowed, err := engine.EvaluateSecurityGroups(ctx, EvaluateSGInput{
-    SecurityGroupIDs: []string{"sg-abc123"},
-    Direction:        "inbound",  // or "outbound"
-    Protocol:         "tcp",
-    Port:             443,
-    CIDR:             "10.0.0.0/16",
-})
-// allowed -- bool
+verdict, err := engine.EvaluateSecurityGroups(ctx, "sg-src", "sg-dst", 443, "tcp")
+// verdict.Allowed      -- bool
+// verdict.IngressMatch -- *RuleMatch (the destination-group rule that matched)
+// verdict.EgressMatch  -- *RuleMatch (the source-group rule that matched)
+// verdict.Reason       -- string
 ```
 
 ### EvaluateNetworkACL
 
-Evaluates a network ACL against a specific traffic pattern.
+Evaluates a network ACL against a specific traffic pattern. Rules are evaluated
+in order, first match wins.
 
 ```go
-allowed, err := engine.EvaluateNetworkACL(ctx, EvaluateACLInput{
-    NetworkACLID: "acl-abc123",
-    Egress:       false,
-    Protocol:     "tcp",
-    Port:         443,
-    CIDR:         "10.0.1.0/24",
-})
-// allowed -- bool
+verdict, err := engine.EvaluateNetworkACL(ctx, "acl-abc123", "10.0.1.5", "10.0.2.9", 443, "tcp", true /* ingress */)
+// verdict.Allowed    -- bool
+// verdict.RuleNumber -- int, the ACL rule that decided
+// verdict.Action     -- "allow" or "deny"
+// verdict.Reason     -- string
 ```
 
 ## Result Types
 
-### CanConnectResult
+### ConnectivityResult (from `CanConnect`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `Allowed` | `bool` | Whether the connection is permitted |
 | `Reason` | `string` | Human-readable explanation |
-| `DeniedBy` | `string` | Component that denied traffic (empty if allowed): `"security-group"`, `"network-acl"`, `"no-route"`, `"no-peering"` |
+| `Path` | `[]RouteHop` | Ordered network path that was walked |
+| `SGVerdict` | `TrafficVerdict` | Security-group evaluation result |
+| `ACLVerdict` | `*ACLVerdict` | Network-ACL evaluation result (nil when not reached) |
 
-### TraceRouteResult
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `Hops` | `[]Hop` | Ordered list of network hops |
-| `Reachable` | `bool` | Whether the destination was reached |
-
-### Hop
+### RouteHop (path element, also returned by `TraceRoute`)
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `Type` | `string` | Hop type: `"subnet"`, `"nat-gateway"`, `"internet-gateway"`, `"peering"`, `"destination"` |
-| `ID` | `string` | Resource ID of the hop |
-| `Description` | `string` | Human-readable label |
+| `Type` | `string` | `"instance"`, `"subnet"`, `"route-table"`, `"gateway"`, `"nat-gateway"`, `"peering"`, `"local"` |
+| `ResourceID` | `string` | Resource ID of the hop |
+| `Detail` | `string` | Human-readable label |
+
+### TrafficVerdict (from `EvaluateSecurityGroups`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Allowed` | `bool` | Whether the security groups permit the traffic |
+| `IngressMatch` | `*RuleMatch` | Destination-group rule that matched (nil if none) |
+| `EgressMatch` | `*RuleMatch` | Source-group rule that matched (nil if none) |
+| `Reason` | `string` | Human-readable explanation |
+
+### ACLVerdict (from `EvaluateNetworkACL`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Allowed` | `bool` | Whether the ACL permits the traffic |
+| `RuleNumber` | `int` | The ACL rule number that decided |
+| `Action` | `string` | `"allow"` or `"deny"` |
+| `Reason` | `string` | Human-readable explanation |


### PR DESCRIPTION
## Summary

Brings the **hand-written** guides in `docs/` up to date with the code. The generated docs (`docs/coverage/**`, `docs/compat/**`) are untouched and remain zero-drift (`go generate` verified). One file per commit.

### Fixed factually-wrong guides
- **topology.md** — the entire API reference was uncompilable (`CanConnectInput`, `DeniedBy`, `Hop{ID,Description}` don't exist). Rewritten against `features/topology/types.go`: `ConnectivityQuery`, `ConnectivityResult`, `RouteHop`, `TrafficVerdict`, `ACLVerdict`, and the real method signatures.
- **chaos.md** — replaced "3 wrappers, Phase 2 will wire the remaining 13" with the actual **20** `Wrap*` helpers; dropped the completed pending items.
- **sdk-server.md** — the "filters/queries… not full DSL parsers" note was false; corrected to describe the real DynamoDB/Firestore/Cosmos grammars, and fixed the DynamoDB op list (UpdateItem ADD/DELETE/arithmetic, full expressions, real sets).
- **standalone-server.md** — removed the "Not yet included: Docker packaging #247 / Testcontainers #248" block (both shipped).

### Documented the real data-plane engine program (was entirely absent)
The opt-in engines (`config.With<X>Engine`), the `contrib/realengine` (no-Docker) and `contrib/dockerengine` (Docker) modules, the `cloudemu-server` binary with its `--db/--cache/--all-real` flags, `cloudemu env`, and `Provider.Close()` teardown are now covered — a primary section in **features.md** (§11) with short cross-links from **getting-started.md**, **architecture.md**, **standalone-server.md**, **sdk-server.md**, **services.md**, **integration.md**, and **README.md** (which also gains the missing chaos.md link and OCI/Kubernetes scope).

## Notes
- All new internal links verified to resolve (file + anchor).
- Two lines — Firestore ordering/paging and Cosmos SQL — correspond to #438; merge that first for `development` to match those lines exactly. Everything else reflects already-merged work.