### PR TITLE
feat(terraform): networking IaC compatibility (VPC/subnet/SG/route-table)

### DIFF
--- a/contrib/terraform/README.md
+++ b/contrib/terraform/README.md
@@ -57,8 +57,11 @@ needs it:
   DescribeTable → a GSI fixture would show a perpetual diff.
 - **Networking** — `aws_vpc`, `aws_subnet`, `aws_security_group`,
   `aws_route_table` and `aws_route_table_association` round-trip. A new security
-  group is seeded with the real allow-all egress default; `Revoke*` is idempotent
-  (Terraform strips IPv4 and IPv6 defaults, and a v4-only VPC has no IPv6 one).
+  group is seeded with the real allow-all egress default (AWS only — Azure/GCP/OCI
+  network groups keep their own defaults); `Revoke*` is idempotent (Terraform
+  strips IPv4 and IPv6 defaults, and a v4-only VPC has no IPv6 one). ENIs don't
+  yet model security-group membership, so `DeleteSecurityGroup` has no in-use
+  dependency check — fine until instances/ENIs enter a fixture.
 - **S3** — the base `aws_s3_bucket` round-trips. The standalone config resources
   (`aws_s3_bucket_policy`, `_public_access_block`, `_cors_configuration`,
   `_server_side_encryption_configuration`, `_lifecycle_configuration`) are **not**

--- a/contrib/terraform/README.md
+++ b/contrib/terraform/README.md
@@ -55,6 +55,10 @@ needs it:
 - **DynamoDB** — `PAY_PER_REQUEST` and `PROVISIONED` (with `read/write_capacity`)
   round-trip. `global_secondary_index` blocks are **not** yet echoed by
   DescribeTable → a GSI fixture would show a perpetual diff.
+- **Networking** — `aws_vpc`, `aws_subnet`, `aws_security_group`,
+  `aws_route_table` and `aws_route_table_association` round-trip. A new security
+  group is seeded with the real allow-all egress default; `Revoke*` is idempotent
+  (Terraform strips IPv4 and IPv6 defaults, and a v4-only VPC has no IPv6 one).
 - **S3** — the base `aws_s3_bucket` round-trips. The standalone config resources
   (`aws_s3_bucket_policy`, `_public_access_block`, `_cors_configuration`,
   `_server_side_encryption_configuration`, `_lifecycle_configuration`) are **not**

--- a/contrib/terraform/fixtures/networking/main.tf
+++ b/contrib/terraform/fixtures/networking/main.tf
@@ -1,0 +1,52 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "cloudemu-tf-net"
+  }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "us-east-1a"
+
+  tags = {
+    Name = "cloudemu-tf-net-public"
+  }
+}
+
+resource "aws_security_group" "web" {
+  name        = "cloudemu-tf-net-web"
+  description = "web tier"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "cloudemu-tf-net-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}

--- a/contrib/terraform/fixtures/networking/provider.tf
+++ b/contrib/terraform/fixtures/networking/provider.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "endpoint" {
+  type        = string
+  description = "CloudEmu AWS endpoint URL"
+}
+
+provider "aws" {
+  access_key = "test"
+  secret_key = "test"
+  region     = "us-east-1"
+
+  # Point every service at CloudEmu and suppress the real-AWS preflight.
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ec2 = var.endpoint
+    sts = var.endpoint
+  }
+}

--- a/contrib/terraform/terraform_test.go
+++ b/contrib/terraform/terraform_test.go
@@ -25,14 +25,28 @@ import (
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
 
-func TestTerraformBasicApplyIsIdempotent(t *testing.T) {
+// TestTerraformApplyIsIdempotent runs each fixture through the full
+// init → apply → plan → destroy loop against a fresh in-process AWS server and
+// asserts the post-apply plan is empty. Each fixture is one scenario (a family
+// of resources); add a directory under fixtures/ and a name here to cover more.
+func TestTerraformApplyIsIdempotent(t *testing.T) {
 	bin := tfBinary(t)
+
+	for _, fixture := range []string{"basic", "networking"} {
+		t.Run(fixture, func(t *testing.T) {
+			applyFixture(t, fixture, bin)
+		})
+	}
+}
+
+func applyFixture(t *testing.T, fixture, bin string) {
+	t.Helper()
 
 	// In-process AWS wire server — no subprocess, no Docker.
 	srv := httptest.NewServer(awsserver.NewFromProvider(cloudemu.NewAWS()))
 	defer srv.Close()
 
-	tf := newTerraform(t, "basic", bin)
+	tf := newTerraform(t, fixture, bin)
 	ctx := context.Background()
 	endpoint := tfexec.Var("endpoint=" + srv.URL)
 

--- a/providers/aws/vpc/vpc.go
+++ b/providers/aws/vpc/vpc.go
@@ -415,6 +415,12 @@ func (m *Mock) DescribeSubnets(_ context.Context, ids []string) ([]driver.Subnet
 }
 
 // CreateSecurityGroup creates a new security group with the given configuration.
+// defaultEgressRule is the allow-all outbound rule real EC2 attaches to every
+// new security group (protocol -1, 0.0.0.0/0, all ports).
+//
+//nolint:gochecknoglobals // static default, mirrors real EC2
+var defaultEgressRule = driver.SecurityRule{Protocol: allTrafficProtocol, CIDR: allTrafficCIDR}
+
 func (m *Mock) CreateSecurityGroup(_ context.Context, cfg driver.SecurityGroupConfig) (*driver.SecurityGroupInfo, error) {
 	if cfg.Name == "" {
 		return nil, errors.Newf(errors.InvalidArgument, "security group name is required")
@@ -437,8 +443,12 @@ func (m *Mock) CreateSecurityGroup(_ context.Context, cfg driver.SecurityGroupCo
 		Description:  cfg.Description,
 		VPCID:        cfg.VPCID,
 		IngressRules: []driver.SecurityRule{},
-		EgressRules:  []driver.SecurityRule{},
-		Tags:         tags,
+		// Real EC2 seeds every new security group with an allow-all egress rule
+		// (no ingress). IaC tools rely on it — Terraform revokes this default
+		// before applying the egress blocks in the config — and the topology
+		// engine otherwise reports a fresh SG as denying all outbound traffic.
+		EgressRules: []driver.SecurityRule{defaultEgressRule},
+		Tags:        tags,
 	}
 	m.securityGroups.Set(id, sg)
 

--- a/providers/aws/vpc/vpc_test.go
+++ b/providers/aws/vpc/vpc_test.go
@@ -236,6 +236,13 @@ func TestAddAndRemoveSecurityGroupRules(t *testing.T) {
 	ingressRule := driver.SecurityRule{Protocol: "tcp", FromPort: 80, ToPort: 80, CIDR: "0.0.0.0/0"}
 	egressRule := driver.SecurityRule{Protocol: "tcp", FromPort: 443, ToPort: 443, CIDR: "0.0.0.0/0"}
 
+	t.Run("default egress rule on create", func(t *testing.T) {
+		// Real EC2 seeds a new SG with an allow-all egress rule and no ingress.
+		sgs, _ := m.DescribeSecurityGroups(ctx, []string{sg.ID})
+		assertEqual(t, 0, len(sgs[0].IngressRules))
+		assertEqual(t, 1, len(sgs[0].EgressRules))
+	})
+
 	t.Run("add ingress rule", func(t *testing.T) {
 		err := m.AddIngressRule(ctx, sg.ID, ingressRule)
 		requireNoError(t, err)
@@ -250,7 +257,8 @@ func TestAddAndRemoveSecurityGroupRules(t *testing.T) {
 		requireNoError(t, err)
 
 		sgs, _ := m.DescribeSecurityGroups(ctx, []string{sg.ID})
-		assertEqual(t, 1, len(sgs[0].EgressRules))
+		// The default allow-all rule plus the one just added.
+		assertEqual(t, 2, len(sgs[0].EgressRules))
 	})
 
 	t.Run("remove ingress rule", func(t *testing.T) {
@@ -266,7 +274,8 @@ func TestAddAndRemoveSecurityGroupRules(t *testing.T) {
 		requireNoError(t, err)
 
 		sgs, _ := m.DescribeSecurityGroups(ctx, []string{sg.ID})
-		assertEqual(t, 0, len(sgs[0].EgressRules))
+		// The seeded default allow-all egress rule remains.
+		assertEqual(t, 1, len(sgs[0].EgressRules))
 	})
 
 	t.Run("remove nonexistent ingress rule", func(t *testing.T) {

--- a/server/aws/ec2/handler.go
+++ b/server/aws/ec2/handler.go
@@ -365,6 +365,8 @@ func (h *Handler) routeVPCResource(w http.ResponseWriter, r *http.Request, actio
 		h.deleteVpc(w, r)
 	case "ModifyVpcAttribute":
 		h.modifyVpcAttribute(w, r)
+	case "DescribeVpcAttribute":
+		h.describeVpcAttribute(w, r)
 	case "DescribeVpcs":
 		h.describeVpcs(w, r)
 	case "DescribeAvailabilityZones":

--- a/server/aws/ec2/network_interface.go
+++ b/server/aws/ec2/network_interface.go
@@ -107,6 +107,12 @@ func eniFilterField(eni *netdriver.NetworkInterface, name string) (string, bool)
 		return eni.ID, true
 	case "description":
 		return eni.Description, true
+	case "group-id":
+		// ENIs don't model security-group membership, so this filter is
+		// recognized but matches no interface. That is what the SG-delete
+		// preflight (Terraform lists group-id ENIs before dropping a group)
+		// needs: no interface uses the group, so the delete proceeds.
+		return "", true
 	default:
 		return "", false
 	}

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -24,11 +24,16 @@ type routeXML struct {
 	State                string `xml:"state"`
 }
 
+type rtAssociationStateXML struct {
+	State string `xml:"state"`
+}
+
 type rtAssociationXML struct {
-	AssociationID string `xml:"routeTableAssociationId"`
-	RouteTableID  string `xml:"routeTableId"`
-	SubnetID      string `xml:"subnetId,omitempty"`
-	Main          bool   `xml:"main"`
+	AssociationID    string                `xml:"routeTableAssociationId"`
+	RouteTableID     string                `xml:"routeTableId"`
+	SubnetID         string                `xml:"subnetId,omitempty"`
+	Main             bool                  `xml:"main"`
+	AssociationState rtAssociationStateXML `xml:"associationState"`
 }
 
 type routeTableXML struct {
@@ -107,7 +112,6 @@ func (h *Handler) createRouteTable(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // per-resource describe pattern; siblings in vpc/subnet/sg/igw
 func (h *Handler) describeRouteTables(w http.ResponseWriter, r *http.Request) {
 	ids := awsquery.ListStrings(r.Form, "RouteTableId")
 
@@ -117,8 +121,14 @@ func (h *Handler) describeRouteTables(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	filters := awsquery.Filters(r.Form)
+
 	out := make([]routeTableXML, 0, len(rts))
 	for i := range rts {
+		if !routeTableMatchesFilters(&rts[i], filters) {
+			continue
+		}
+
 		out = append(out, toRouteTableXML(&rts[i]))
 	}
 
@@ -231,6 +241,52 @@ func resolveRouteTarget(r *http.Request) (target, targetType string) {
 	return "", ""
 }
 
+// routeTableMatchesFilters reports whether a route table satisfies every
+// DescribeRouteTables filter. Terraform's route-table-association waiter filters
+// by association.route-table-association-id and expects exactly one table back;
+// without honoring the filter the handler returns every table and the provider's
+// single-result assertion fails, hanging the association until it times out.
+func routeTableMatchesFilters(rt *netdriver.RouteTable, filters []awsquery.Filter) bool {
+	for _, f := range filters {
+		if !routeTableMatchesFilter(rt, f) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func routeTableMatchesFilter(rt *netdriver.RouteTable, f awsquery.Filter) bool {
+	switch f.Name {
+	case "route-table-id":
+		return containsString(f.Values, rt.ID)
+	case "vpc-id":
+		return containsString(f.Values, rt.VPCID)
+	case "association.route-table-association-id":
+		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool { return containsString(f.Values, a.ID) })
+	case "association.route-table-id":
+		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool {
+			return containsString(f.Values, nonEmpty(a.RouteTableID, rt.ID))
+		})
+	case "association.subnet-id":
+		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool { return containsString(f.Values, a.SubnetID) })
+	default:
+		// Unknown filter: match nothing rather than hand back tables the caller
+		// did not ask for.
+		return false
+	}
+}
+
+func anyAssoc(rt *netdriver.RouteTable, pred func(netdriver.RouteTableAssociation) bool) bool {
+	for _, a := range rt.Associations {
+		if pred(a) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
 	x := routeTableXML{
 		RouteTableID: rt.ID,
@@ -240,10 +296,11 @@ func toRouteTableXML(rt *netdriver.RouteTable) routeTableXML {
 
 	for _, a := range rt.Associations {
 		x.Associations = append(x.Associations, rtAssociationXML{
-			AssociationID: a.ID,
-			RouteTableID:  nonEmpty(a.RouteTableID, rt.ID),
-			SubnetID:      a.SubnetID,
-			Main:          a.Main,
+			AssociationID:    a.ID,
+			RouteTableID:     nonEmpty(a.RouteTableID, rt.ID),
+			SubnetID:         a.SubnetID,
+			Main:             a.Main,
+			AssociationState: rtAssociationStateXML{State: "associated"},
 		})
 	}
 

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -262,6 +262,9 @@ func validateRouteTableFilters(filters []awsquery.Filter) error {
 	return nil
 }
 
+// routeTableFilterKnown lists the filters routeTableMatchesFilter implements:
+// keep the two in sync, or a "known" filter would validate and then silently
+// match nothing.
 func routeTableFilterKnown(name string) bool {
 	switch name {
 	case "route-table-id", "vpc-id",

--- a/server/aws/ec2/route_table.go
+++ b/server/aws/ec2/route_table.go
@@ -80,10 +80,11 @@ type deleteRouteTableResponseXML struct {
 }
 
 type associateRouteTableResponseXML struct {
-	XMLName       xml.Name `xml:"AssociateRouteTableResponse"`
-	Xmlns         string   `xml:"xmlns,attr"`
-	RequestID     string   `xml:"requestId"`
-	AssociationID string   `xml:"associationId"`
+	XMLName          xml.Name              `xml:"AssociateRouteTableResponse"`
+	Xmlns            string                `xml:"xmlns,attr"`
+	RequestID        string                `xml:"requestId"`
+	AssociationID    string                `xml:"associationId"`
+	AssociationState rtAssociationStateXML `xml:"associationState"`
 }
 
 type disassociateRouteTableResponseXML struct {
@@ -122,6 +123,10 @@ func (h *Handler) describeRouteTables(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filters := awsquery.Filters(r.Form)
+	if err := validateRouteTableFilters(filters); err != nil {
+		writeRouteTableErr(w, err)
+		return
+	}
 
 	out := make([]routeTableXML, 0, len(rts))
 	for i := range rts {
@@ -203,9 +208,10 @@ func (h *Handler) associateRouteTable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	awsquery.WriteXMLResponse(w, associateRouteTableResponseXML{
-		Xmlns:         awsquery.Namespace,
-		RequestID:     awsquery.RequestID,
-		AssociationID: assoc.ID,
+		Xmlns:            awsquery.Namespace,
+		RequestID:        awsquery.RequestID,
+		AssociationID:    assoc.ID,
+		AssociationState: rtAssociationStateXML{State: "associated"},
 	})
 }
 
@@ -241,11 +247,38 @@ func resolveRouteTarget(r *http.Request) (target, targetType string) {
 	return "", ""
 }
 
+// validateRouteTableFilters rejects filter names this emulator does not model.
+// Like validateENIFilters, an explicit InvalidParameterValue is safer than
+// silently matching nothing: an unrecognized filter that returned an empty set
+// could tell a caller a route table is already gone and let it proceed to a VPC
+// delete that then fails with DependencyViolation.
+func validateRouteTableFilters(filters []awsquery.Filter) error {
+	for _, f := range filters {
+		if !routeTableFilterKnown(f.Name) {
+			return newInvalidParameterErr("The filter '" + f.Name + "' is invalid")
+		}
+	}
+
+	return nil
+}
+
+func routeTableFilterKnown(name string) bool {
+	switch name {
+	case "route-table-id", "vpc-id",
+		"association.route-table-association-id", "association.route-table-id",
+		"association.subnet-id", "association.main":
+		return true
+	default:
+		return false
+	}
+}
+
 // routeTableMatchesFilters reports whether a route table satisfies every
 // DescribeRouteTables filter. Terraform's route-table-association waiter filters
 // by association.route-table-association-id and expects exactly one table back;
 // without honoring the filter the handler returns every table and the provider's
 // single-result assertion fails, hanging the association until it times out.
+// Filter names are validated up front, so an unknown name never reaches here.
 func routeTableMatchesFilters(rt *netdriver.RouteTable, filters []awsquery.Filter) bool {
 	for _, f := range filters {
 		if !routeTableMatchesFilter(rt, f) {
@@ -270,11 +303,23 @@ func routeTableMatchesFilter(rt *netdriver.RouteTable, f awsquery.Filter) bool {
 		})
 	case "association.subnet-id":
 		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool { return containsString(f.Values, a.SubnetID) })
+	case "association.main":
+		return anyAssoc(rt, func(a netdriver.RouteTableAssociation) bool {
+			return containsString(f.Values, boolFilterValue(a.Main))
+		})
 	default:
 		// Unknown filter: match nothing rather than hand back tables the caller
 		// did not ask for.
 		return false
 	}
+}
+
+func boolFilterValue(b bool) string {
+	if b {
+		return "true"
+	}
+
+	return "false"
 }
 
 func anyAssoc(rt *netdriver.RouteTable, pred func(netdriver.RouteTableAssociation) bool) bool {

--- a/server/aws/ec2/route_table_lifecycle_test.go
+++ b/server/aws/ec2/route_table_lifecycle_test.go
@@ -118,6 +118,52 @@ func TestRouteTableAssociationRoundTrip(t *testing.T) {
 	}
 }
 
+// TestDescribeRouteTablesByAssociationFilter guards the IaC waiter path:
+// Terraform polls DescribeRouteTables filtered by the association id and expects
+// exactly the one owning table, reporting associationState=associated.
+func TestDescribeRouteTablesByAssociationFilter(t *testing.T) {
+	h := newFullHandler()
+	vpcID, subnetID := mkVPCAndSubnet(t, h)
+	rtID := mkRouteTable(t, h, vpcID)
+
+	assocResp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action": {"AssociateRouteTable"}, "RouteTableId": {rtID}, "SubnetId": {subnetID},
+	})
+	assocID := between(assocResp.Body.String(), "<associationId>", "</associationId>")
+
+	resp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":        {"DescribeRouteTables"},
+		"Filter.1.Name": {"association.route-table-association-id"}, "Filter.1.Value.1": {assocID},
+	})
+	if resp.Code != http.StatusOK {
+		t.Fatalf("DescribeRouteTables (filtered) = %d: %s", resp.Code, resp.Body.String())
+	}
+
+	body := resp.Body.String()
+	if got := between(body, "<routeTableId>", "</routeTableId>"); got != rtID {
+		t.Errorf("filtered describe returned routeTableId %q, want %q\nbody: %s", got, rtID, body)
+	}
+
+	if !strings.Contains(body, "<state>associated</state>") {
+		t.Errorf("association should report state=associated\nbody: %s", body)
+	}
+}
+
+// TestDescribeRouteTablesRejectsUnknownFilter guards against silently returning
+// an empty set for a filter we do not model — an empty result could tell a
+// caller a route table is gone and let it delete the VPC (DependencyViolation).
+func TestDescribeRouteTablesRejectsUnknownFilter(t *testing.T) {
+	h := newFullHandler()
+
+	resp := do(t, h, http.MethodPost, "/", url.Values{
+		"Action":        {"DescribeRouteTables"},
+		"Filter.1.Name": {"transit-gateway-id"}, "Filter.1.Value.1": {"tgw-x"},
+	})
+	if resp.Code == http.StatusOK {
+		t.Errorf("an unrecognized filter should error, got 200: %s", resp.Body.String())
+	}
+}
+
 func TestDisassociateUnknownAssociationIsNotFound(t *testing.T) {
 	h := newFullHandler()
 

--- a/server/aws/ec2/security_group.go
+++ b/server/aws/ec2/security_group.go
@@ -134,11 +134,25 @@ func (h *Handler) authorizeSecurityGroupEgress(w http.ResponseWriter, r *http.Re
 }
 
 func (h *Handler) revokeSecurityGroupIngress(w http.ResponseWriter, r *http.Request) {
-	h.applyRules(w, r, h.vpc.RemoveIngressRule, "RevokeSecurityGroupIngressResponse")
+	h.applyRules(w, r, tolerateMissingRule(h.vpc.RemoveIngressRule), "RevokeSecurityGroupIngressResponse")
 }
 
 func (h *Handler) revokeSecurityGroupEgress(w http.ResponseWriter, r *http.Request) {
-	h.applyRules(w, r, h.vpc.RemoveEgressRule, "RevokeSecurityGroupEgressResponse")
+	h.applyRules(w, r, tolerateMissingRule(h.vpc.RemoveEgressRule), "RevokeSecurityGroupEgressResponse")
+}
+
+// tolerateMissingRule makes a Revoke idempotent: real EC2 does not fail when a
+// revoked rule is absent, and IaC tools depend on it — Terraform strips the
+// default egress rules (IPv4 and IPv6) from a new group, but a v4-only VPC has
+// no IPv6 default to remove.
+func tolerateMissingRule(remove ruleFunc) ruleFunc {
+	return func(ctx context.Context, groupID string, rule netdriver.SecurityRule) error {
+		if err := remove(ctx, groupID, rule); err != nil && !cerrors.IsNotFound(err) {
+			return err
+		}
+
+		return nil
+	}
 }
 
 // ruleFunc is the common signature of AddIngressRule / AddEgressRule /

--- a/server/aws/ec2/vpc_attribute.go
+++ b/server/aws/ec2/vpc_attribute.go
@@ -55,7 +55,15 @@ func (h *Handler) describeVpcAttribute(w http.ResponseWriter, r *http.Request) {
 		VpcID:     id,
 	}
 
-	switch r.Form.Get("Attribute") {
+	attr := r.Form.Get("Attribute")
+	if attr == "" {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "MissingParameter",
+			"The request must contain the parameter Attribute")
+
+		return
+	}
+
+	switch attr {
 	case "enableDnsSupport":
 		resp.EnableDNSSupport = &vpcAttributeBoolXML{Value: vpcs[0].EnableDNSSupport}
 	case "enableDnsHostnames":

--- a/server/aws/ec2/vpc_attribute.go
+++ b/server/aws/ec2/vpc_attribute.go
@@ -15,6 +15,64 @@ type modifyVpcAttributeResponseXML struct {
 	Return    bool     `xml:"return"`
 }
 
+type vpcAttributeBoolXML struct {
+	Value bool `xml:"value"`
+}
+
+type describeVpcAttributeResponseXML struct {
+	XMLName                          xml.Name             `xml:"DescribeVpcAttributeResponse"`
+	Xmlns                            string               `xml:"xmlns,attr"`
+	RequestID                        string               `xml:"requestId"`
+	VpcID                            string               `xml:"vpcId"`
+	EnableDNSSupport                 *vpcAttributeBoolXML `xml:"enableDnsSupport,omitempty"`
+	EnableDNSHostnames               *vpcAttributeBoolXML `xml:"enableDnsHostnames,omitempty"`
+	EnableNetworkAddressUsageMetrics *vpcAttributeBoolXML `xml:"enableNetworkAddressUsageMetrics,omitempty"`
+}
+
+// describeVpcAttribute returns one DNS attribute of a VPC. Like the real API it
+// answers exactly the requested Attribute (enableDnsSupport or
+// enableDnsHostnames); the aws_vpc resource reads both back after create, so an
+// absent handler makes VPC creation fail outright.
+func (h *Handler) describeVpcAttribute(w http.ResponseWriter, r *http.Request) {
+	id := r.Form.Get("VpcId")
+
+	vpcs, err := h.vpc.DescribeVPCs(r.Context(), []string{id})
+	if err != nil {
+		writeVPCErr(w, err)
+		return
+	}
+
+	if len(vpcs) == 0 {
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidVpcID.NotFound",
+			"The vpc ID '"+id+"' does not exist")
+
+		return
+	}
+
+	resp := describeVpcAttributeResponseXML{
+		Xmlns:     awsquery.Namespace,
+		RequestID: awsquery.RequestID,
+		VpcID:     id,
+	}
+
+	switch r.Form.Get("Attribute") {
+	case "enableDnsSupport":
+		resp.EnableDNSSupport = &vpcAttributeBoolXML{Value: vpcs[0].EnableDNSSupport}
+	case "enableDnsHostnames":
+		resp.EnableDNSHostnames = &vpcAttributeBoolXML{Value: vpcs[0].EnableDNSHostnames}
+	case "enableNetworkAddressUsageMetrics":
+		// Not modeled; the resource default is off.
+		resp.EnableNetworkAddressUsageMetrics = &vpcAttributeBoolXML{Value: false}
+	default:
+		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue",
+			"Invalid value for VPC attribute")
+
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, resp)
+}
+
 // modifyVpcAttribute sets one DNS attribute of a VPC.
 //
 // The real API accepts exactly one attribute per call and leaves the other


### PR DESCRIPTION
## Summary

PR-2 of the Terraform track. Extends the IaC compatibility suite to the **core networking stack** and closes the EC2 wire-server read-path gaps that a real `terraform apply → plan → destroy` surfaced. A new `networking` fixture drives `aws_vpc` + `aws_subnet` + `aws_security_group` + `aws_route_table` + `aws_route_table_association`, and the suite is now fixture-table-driven (`basic` + `networking`), each asserting the post-apply plan is empty.

## Read-path fixes (each surfaced empirically by driving OpenTofu)

- **`DescribeVpcAttribute`** — implemented (`enableDnsSupport`, `enableDnsHostnames`, `enableNetworkAddressUsageMetrics`). `aws_vpc` creation *failed outright* without it (the provider reads the DNS attributes right after create).
- **Security-group egress default** — a new SG is now seeded with the real allow-all egress rule, and `Revoke{Ingress,Egress}` is **idempotent** (matches real EC2). Terraform strips the default IPv4 *and* IPv6 egress on create; a v4-only VPC has no IPv6 default, so the revoke must tolerate a missing rule. This also makes the topology engine correct: a fresh SG now allows egress instead of denying all.
- **Route-table association** — associations report `associationState = associated`, and `DescribeRouteTables` now honors the `association.route-table-association-id` / `route-table-id` / `vpc-id` / `association.subnet-id` filters. The provider's association waiter filters by association id and asserts a single table; returning all tables hung it until a 5-minute timeout.
- **`DescribeNetworkInterfaces` `group-id` filter** — recognized (the SG-delete preflight lists ENIs by `group-id`); no ENI models SG membership, so it matches nothing, which is correct — nothing uses the SG, so `destroy` proceeds.

## Blast radius

Seeding the default egress rule is a deliberate behavior change (real EC2 does this). One provider test updated to expect it; the **entire** test suite is otherwise green, including the topology engine (which now reports fresh SGs as egress-allowed — more accurate).

## Tests
- `basic` and `networking` fixtures both pass `apply → plan(no-diff) → destroy` against real Terraform (local; CI uses OpenTofu).
- Full `go test ./...` green; build/vet clean; introduced lint cleared.

## Next
PR-3: a `tflocal`-equivalent drop-in wrapper + `docs/terraform.md`.