### PR TITLE
feat(terraform): core-services IaC coverage (SNS, Secrets Manager, KMS, SSM)

### DIFF
--- a/contrib/terraform/fixtures/core-services/main.tf
+++ b/contrib/terraform/fixtures/core-services/main.tf
@@ -1,0 +1,21 @@
+resource "aws_sns_topic" "t" {
+  name = "cloudemu-tf-core"
+
+  tags = {
+    env = "test"
+  }
+}
+
+resource "aws_secretsmanager_secret" "s" {
+  name = "cloudemu-tf-core"
+}
+
+resource "aws_kms_key" "k" {
+  description = "cloudemu-tf-core"
+}
+
+resource "aws_ssm_parameter" "p" {
+  name  = "/cloudemu/tf/core"
+  type  = "String"
+  value = "hello"
+}

--- a/contrib/terraform/fixtures/core-services/provider.tf
+++ b/contrib/terraform/fixtures/core-services/provider.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "endpoint" {
+  type        = string
+  description = "CloudEmu AWS endpoint URL"
+}
+
+provider "aws" {
+  access_key = "test"
+  secret_key = "test"
+  region     = "us-east-1"
+
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    sns            = var.endpoint
+    secretsmanager = var.endpoint
+    kms            = var.endpoint
+    ssm            = var.endpoint
+    sts            = var.endpoint
+  }
+}

--- a/contrib/terraform/terraform_test.go
+++ b/contrib/terraform/terraform_test.go
@@ -32,7 +32,7 @@ import (
 func TestTerraformApplyIsIdempotent(t *testing.T) {
 	bin := tfBinary(t)
 
-	for _, fixture := range []string{"basic", "networking"} {
+	for _, fixture := range []string{"basic", "networking", "core-services"} {
 		t.Run(fixture, func(t *testing.T) {
 			applyFixture(t, fixture, bin)
 		})

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
 )
 
@@ -36,28 +37,7 @@ func isQueryRequest(r *http.Request) bool {
 		return false
 	}
 
-	return sigV4ScopeService(r.Header.Get("Authorization")) == sigV4Service
-}
-
-// sigV4ScopeService extracts the service from a SigV4 Authorization header's
-// credential scope: "Credential=AKID/20260101/us-east-1/<service>/aws4_request".
-func sigV4ScopeService(auth string) string {
-	i := strings.Index(auth, "Credential=")
-	if i < 0 {
-		return ""
-	}
-
-	scope := auth[i+len("Credential="):]
-	if j := strings.IndexByte(scope, ','); j >= 0 {
-		scope = scope[:j]
-	}
-
-	parts := strings.Split(scope, "/")
-	if len(parts) < 5 {
-		return ""
-	}
-
-	return parts[3]
+	return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == sigV4Service
 }
 
 // serveQuery handles a CloudWatch query-protocol request.

--- a/server/aws/rds/handler.go
+++ b/server/aws/rds/handler.go
@@ -154,7 +154,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	// the SigV4 credential scope names "rds"; otherwise let them fall through
 	// to the owning handler.
 	if _, ambiguous := rdsAmbiguousTagActions[action]; ambiguous {
-		return sigV4ScopeService(r.Header.Get("Authorization")) == "rds"
+		return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == "rds"
 	}
 
 	return true
@@ -166,24 +166,6 @@ var rdsAmbiguousTagActions = map[string]struct{}{ //nolint:gochecknoglobals // s
 	"AddTagsToResource":      {},
 	"RemoveTagsFromResource": {},
 	"ListTagsForResource":    {},
-}
-
-// sigV4ScopeService extracts the service from a SigV4 Authorization credential
-// scope: "Credential=AKID/20260101/us-east-1/<service>/aws4_request".
-func sigV4ScopeService(auth string) string {
-	i := strings.Index(auth, "Credential=")
-	if i < 0 {
-		return ""
-	}
-
-	parts := strings.Split(auth[i+len("Credential="):], "/")
-
-	const serviceField = 3
-	if len(parts) <= serviceField {
-		return ""
-	}
-
-	return parts[serviceField]
 }
 
 // ServeHTTP dispatches on Action. The form has already been parsed by Matches.

--- a/server/aws/redshift/handler.go
+++ b/server/aws/redshift/handler.go
@@ -105,7 +105,7 @@ func (*Handler) Matches(r *http.Request) bool {
 	// claim these only when the SigV4 credential scope names "redshift";
 	// otherwise let them fall through to the owning handler.
 	if _, ambiguous := ambiguousTagActions[action]; ambiguous {
-		return sigV4ScopeService(r.Header.Get("Authorization")) == "redshift"
+		return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == "redshift"
 	}
 
 	return true
@@ -117,24 +117,6 @@ var ambiguousTagActions = map[string]struct{}{ //nolint:gochecknoglobals // stat
 	"CreateTags":   {},
 	"DeleteTags":   {},
 	"DescribeTags": {},
-}
-
-// sigV4ScopeService extracts the service from a SigV4 Authorization credential
-// scope: "Credential=AKID/20260101/us-east-1/<service>/aws4_request".
-func sigV4ScopeService(auth string) string {
-	i := strings.Index(auth, "Credential=")
-	if i < 0 {
-		return ""
-	}
-
-	parts := strings.Split(auth[i+len("Credential="):], "/")
-
-	const serviceField = 3
-	if len(parts) <= serviceField {
-		return ""
-	}
-
-	return parts[serviceField]
 }
 
 // ServeHTTP dispatches on Action. The form has already been parsed by Matches.

--- a/server/aws/secretsmanager/handler.go
+++ b/server/aws/secretsmanager/handler.go
@@ -54,6 +54,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteSecret(w, r)
 	case "DescribeSecret":
 		h.describeSecret(w, r)
+	case "GetResourcePolicy":
+		h.getResourcePolicy(w, r)
 	case "ListSecrets":
 		h.listSecrets(w, r)
 	case "GetSecretValue":

--- a/server/aws/secretsmanager/operations.go
+++ b/server/aws/secretsmanager/operations.go
@@ -72,6 +72,24 @@ func (h *Handler) describeSecret(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, toSecretListEntry(info))
 }
 
+// getResourcePolicy returns the secret's resource policy. None is modeled, so
+// ResourcePolicy is absent — which the aws_secretsmanager_secret resource reads
+// as "no policy". Without the operation the read fails outright.
+func (h *Handler) getResourcePolicy(w http.ResponseWriter, r *http.Request) {
+	var req secretIDRequest
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	info, err := h.secrets.GetSecret(r.Context(), resolveSecretID(req.SecretID))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"ARN": info.ResourceID, "Name": info.Name})
+}
+
 func (h *Handler) listSecrets(w http.ResponseWriter, r *http.Request) {
 	infos, err := h.secrets.ListSecrets(r.Context())
 	if err != nil {

--- a/server/aws/secretsmanager/sdk_roundtrip_test.go
+++ b/server/aws/secretsmanager/sdk_roundtrip_test.go
@@ -279,3 +279,38 @@ func TestSDKSecretErrors(t *testing.T) {
 		t.Fatalf("DeleteSecret(missing): got %v, want ResourceNotFoundException", err)
 	}
 }
+
+// TestSDKGetResourcePolicy guards the read path the aws_secretsmanager_secret
+// resource uses: GetResourcePolicy must return the secret's ARN/Name and no
+// ResourcePolicy (none is modeled), which the SDK reads as "no policy".
+func TestSDKGetResourcePolicy(t *testing.T) {
+	client := newSecretsClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateSecret(ctx, &awssm.CreateSecretInput{
+		Name:         aws.String("with-policy"),
+		SecretString: aws.String("s3cr3t"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+
+	out, err := client.GetResourcePolicy(ctx, &awssm.GetResourcePolicyInput{
+		SecretId: created.ARN,
+	})
+	if err != nil {
+		t.Fatalf("GetResourcePolicy: %v", err)
+	}
+
+	if aws.ToString(out.ARN) != aws.ToString(created.ARN) {
+		t.Errorf("ARN = %q, want %q", aws.ToString(out.ARN), aws.ToString(created.ARN))
+	}
+
+	if aws.ToString(out.Name) != "with-policy" {
+		t.Errorf("Name = %q, want with-policy", aws.ToString(out.Name))
+	}
+
+	if out.ResourcePolicy != nil {
+		t.Errorf("ResourcePolicy = %q, want nil (none modeled)", aws.ToString(out.ResourcePolicy))
+	}
+}

--- a/server/aws/sns/handler.go
+++ b/server/aws/sns/handler.go
@@ -115,9 +115,9 @@ func (*Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
-	// ListTagsForResource is a generic tag verb SNS shares with RDS/ElastiCache
-	// on the same wire (RDS registers first). Claim it only when the SigV4
-	// credential scope names "sns"; otherwise let it fall through.
+	// ListTagsForResource is a generic tag verb SNS shares with RDS on the same
+	// query wire (RDS registers first). Claim it only when the SigV4 credential
+	// scope names "sns"; otherwise let it fall through.
 	if action == actionListTagsForResource {
 		return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == "sns"
 	}
@@ -210,6 +210,6 @@ func defaultTopicPolicy(arn, owner string) string {
 		`"Sid":"__default_statement_ID","Effect":"Allow","Principal":{"AWS":"*"},` +
 		`"Action":["SNS:GetTopicAttributes","SNS:SetTopicAttributes","SNS:AddPermission",` +
 		`"SNS:RemovePermission","SNS:DeleteTopic","SNS:Subscribe","SNS:ListSubscriptionsByTopic",` +
-		`"SNS:Publish"],"Resource":"` + arn + `",` +
+		`"SNS:Publish","SNS:Receive"],"Resource":"` + arn + `",` +
 		`"Condition":{"StringEquals":{"AWS:SourceOwner":"` + owner + `"}}}]}`
 }

--- a/server/aws/sns/handler.go
+++ b/server/aws/sns/handler.go
@@ -57,16 +57,20 @@ var snsActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"Publish":                  {},
 	"TagResource":              {},
 	"UntagResource":            {},
+	actionListTagsForResource:  {},
 }
+
+// actionListTagsForResource is the generic tag-read verb SNS shares with other
+// query-protocol services; it's scope-gated in Matches.
+const actionListTagsForResource = "ListTagsForResource"
 
 // topicTagger is the AWS-specific topic-tagging surface. It's not part of the
 // portable Notification driver (Azure Notification Hubs and GCP FCM also
 // implement it), so the handler type-asserts for it.
 //
-// ListTagsForResource is intentionally omitted: that action name collides with
-// RDS in the shared query protocol (RDS registers first and claims it), and
-// disambiguating would require SigV4 credential-scope routing. SNS tag writes
-// (the flagged gap) work; tag read-back is a follow-up.
+// ListTagsForResource collides with RDS in the shared query protocol (RDS
+// registers first), so both handlers claim it only for their own SigV4
+// credential scope — see Matches.
 type topicTagger interface {
 	TagTopic(ctx context.Context, topicName string, tags map[string]string) error
 	UntagTopic(ctx context.Context, topicName string, keys []string) error
@@ -104,9 +108,21 @@ func (*Handler) Matches(r *http.Request) bool {
 		return false
 	}
 
-	_, ok := snsActions[r.Form.Get("Action")]
+	action := r.Form.Get("Action")
 
-	return ok
+	_, ok := snsActions[action]
+	if !ok {
+		return false
+	}
+
+	// ListTagsForResource is a generic tag verb SNS shares with RDS/ElastiCache
+	// on the same wire (RDS registers first). Claim it only when the SigV4
+	// credential scope names "sns"; otherwise let it fall through.
+	if action == actionListTagsForResource {
+		return awsquery.CredentialScopeService(r.Header.Get("Authorization")) == "sns"
+	}
+
+	return true
 }
 
 // ServeHTTP dispatches on Action. The form has already been parsed by Matches.
@@ -138,6 +154,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.tagResource(w, r)
 	case "UntagResource":
 		h.untagResource(w, r)
+	case actionListTagsForResource:
+		h.listTagsForResource(w, r)
 	default:
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			"InvalidAction", "unknown SNS action: "+action)
@@ -170,4 +188,28 @@ func topicNameFromARN(arn string) string {
 	}
 
 	return arn
+}
+
+// accountFromARN pulls the account id (field 4) out of an ARN
+// arn:aws:sns:region:account:name, or "" when the shape doesn't match.
+func accountFromARN(arn string) string {
+	const accountField = 4
+
+	parts := strings.Split(arn, ":")
+	if len(parts) > accountField {
+		return parts[accountField]
+	}
+
+	return ""
+}
+
+// defaultTopicPolicy mirrors the access policy real SNS attaches to a new topic,
+// so a client that reads Policy back gets valid JSON.
+func defaultTopicPolicy(arn, owner string) string {
+	return `{"Version":"2008-10-17","Id":"__default_policy_ID","Statement":[{` +
+		`"Sid":"__default_statement_ID","Effect":"Allow","Principal":{"AWS":"*"},` +
+		`"Action":["SNS:GetTopicAttributes","SNS:SetTopicAttributes","SNS:AddPermission",` +
+		`"SNS:RemovePermission","SNS:DeleteTopic","SNS:Subscribe","SNS:ListSubscriptionsByTopic",` +
+		`"SNS:Publish"],"Resource":"` + arn + `",` +
+		`"Condition":{"StringEquals":{"AWS:SourceOwner":"` + owner + `"}}}]}`
 }

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -127,12 +127,9 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request) {
 // getTopicAttributes maps GetTopicAttributes to Notification.GetTopic and
 // exposes the topic's ARN, display name, and subscription count as the standard
 // SNS attribute map.
-// setTopicAttributes maps SetTopicAttributes to Notification.UpdateTopic for
-// the DisplayName attribute. Other attribute names (Policy, DeliveryPolicy) are
-// accepted but not modeled — the emulator doesn't evaluate topic policies, so
-// storing them would have no observable effect.
-// setTopicAttributes persists only DisplayName today. A Policy write is accepted
-// but not stored, and GetTopicAttributes returns the synthesized default — so a
+// setTopicAttributes maps SetTopicAttributes to Notification.UpdateTopic, but
+// persists only DisplayName today. A Policy (or DeliveryPolicy) write is accepted
+// and dropped, and GetTopicAttributes returns the synthesized default — so a
 // topic that declares a custom `policy` would drift. Tracked as a follow-up;
 // topics without a policy (the common case) round-trip cleanly.
 func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -3,6 +3,7 @@ package sns
 import (
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -147,6 +148,30 @@ func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request) {
+	name := topicNameFromARN(r.Form.Get("ResourceArn"))
+
+	info, err := h.notif.GetTopic(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	members := make([]tagMember, 0, len(info.Tags))
+	for k, v := range info.Tags {
+		members = append(members, tagMember{Key: k, Value: v})
+	}
+	// Stable order: the store is a map, and a caller diffing tags on successive
+	// reads should not see phantom churn.
+	sort.Slice(members, func(i, j int) bool { return members[i].Key < members[j].Key })
+
+	awsquery.WriteXMLResponse(w, listTagsForResourceResponse{
+		Xmlns:    Namespace,
+		Result:   listTagsResult{Tags: members},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
 func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	name := topicNameFromARN(r.Form.Get("TopicArn"))
 
@@ -156,9 +181,16 @@ func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	owner := accountFromARN(info.ResourceID)
+
 	entries := []attributeEntry{
 		{Key: "TopicArn", Value: info.ResourceID},
 		{Key: "SubscriptionsConfirmed", Value: strconv.Itoa(info.SubscriptionCount)},
+		{Key: "Owner", Value: owner},
+		// Real SNS seeds a default access policy. The aws_sns_topic resource
+		// reads Policy back and parses it as JSON, so an absent value fails
+		// with "unexpected end of JSON input".
+		{Key: "Policy", Value: defaultTopicPolicy(info.ResourceID, owner)},
 	}
 	if info.DisplayName != "" {
 		entries = append(entries, attributeEntry{Key: "DisplayName", Value: info.DisplayName})

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -131,6 +131,10 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request) {
 // the DisplayName attribute. Other attribute names (Policy, DeliveryPolicy) are
 // accepted but not modeled — the emulator doesn't evaluate topic policies, so
 // storing them would have no observable effect.
+// setTopicAttributes persists only DisplayName today. A Policy write is accepted
+// but not stored, and GetTopicAttributes returns the synthesized default — so a
+// topic that declares a custom `policy` would drift. Tracked as a follow-up;
+// topics without a policy (the common case) round-trip cleanly.
 func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	name := topicNameFromARN(r.Form.Get("TopicArn"))
 

--- a/server/aws/sns/sdk_roundtrip_test.go
+++ b/server/aws/sns/sdk_roundtrip_test.go
@@ -2,6 +2,7 @@ package sns_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http/httptest"
 	"testing"
@@ -190,5 +191,47 @@ func TestSDKSNSErrors(t *testing.T) {
 		Message:  aws.String("x"),
 	}); !errors.As(err, &nfe) {
 		t.Fatalf("Publish(missing topic): got %v, want NotFoundException", err)
+	}
+}
+
+// TestSDKSNSListTagsAndPolicy guards the two IaC read-path fixes: ListTagsForResource
+// must be claimed by SNS (via its SigV4 scope, not RDS which registers first) and
+// echo the tag, and GetTopicAttributes must return a valid-JSON default Policy.
+func TestSDKSNSListTagsAndPolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+		Name: aws.String("tagged"),
+		Tags: []snstypes.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	arn := aws.ToString(created.TopicArn)
+
+	tags, err := client.ListTagsForResource(ctx, &awssns.ListTagsForResourceInput{ResourceArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+
+	if len(tags.Tags) != 1 || aws.ToString(tags.Tags[0].Key) != "env" || aws.ToString(tags.Tags[0].Value) != "prod" {
+		t.Fatalf("tags = %+v, want env=prod", tags.Tags)
+	}
+
+	attrs, err := client.GetTopicAttributes(ctx, &awssns.GetTopicAttributesInput{TopicArn: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("GetTopicAttributes: %v", err)
+	}
+
+	policy := attrs.Attributes["Policy"]
+	if policy == "" {
+		t.Fatal("Policy attribute is empty")
+	}
+
+	var js map[string]any
+	if err := json.Unmarshal([]byte(policy), &js); err != nil {
+		t.Fatalf("Policy is not valid JSON: %v\n%s", err, policy)
 	}
 }

--- a/server/aws/sns/sdk_roundtrip_test.go
+++ b/server/aws/sns/sdk_roundtrip_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
+	snspkg "github.com/stackshy/cloudemu/v2/server/aws/sns"
 )
 
 func newSDKClient(t *testing.T) *awssns.Client {
@@ -23,8 +26,10 @@ func newSDKClient(t *testing.T) *awssns.Client {
 	cloud := cloudemu.NewAWS()
 	srv := awsserver.New(awsserver.Drivers{
 		SNS: cloud.SNS,
-		// EC2 also wired so we exercise the dispatch precedence: a request
-		// for SNS must claim the body before EC2 sees it.
+		// RDS is wired (and registers before SNS) so the SNS-scoped
+		// ListTagsForResource genuinely competes with RDS on the shared query
+		// wire; EC2 is the query-protocol catch-all.
+		RDS: cloud.RDS,
 		EC2: cloud.EC2,
 	})
 
@@ -233,5 +238,35 @@ func TestSDKSNSListTagsAndPolicy(t *testing.T) {
 	var js map[string]any
 	if err := json.Unmarshal([]byte(policy), &js); err != nil {
 		t.Fatalf("Policy is not valid JSON: %v\n%s", err, policy)
+	}
+
+	// Owner must be the ARN's account id (also the policy's SourceOwner).
+	if want := strings.Split(arn, ":")[4]; attrs.Attributes["Owner"] != want {
+		t.Fatalf("Owner = %q, want %q", attrs.Attributes["Owner"], want)
+	}
+}
+
+// TestSNSMatchesScopeGatesListTags asserts the SigV4-scope gating both ways:
+// SNS claims ListTagsForResource only for an sns-signed request, and declines an
+// rds-signed one (which RDS, registered first on the shared query wire, owns).
+func TestSNSMatchesScopeGatesListTags(t *testing.T) {
+	h := snspkg.New(cloudemu.NewAWS().SNS)
+	body := "Action=ListTagsForResource&ResourceArn=arn:aws:sns:us-east-1:123456789012:t"
+
+	req := func(service string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("Authorization",
+			"AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/"+service+"/aws4_request, SignedHeaders=host, Signature=x")
+
+		return r
+	}
+
+	if !h.Matches(req("sns")) {
+		t.Error("sns-scoped ListTagsForResource should be claimed by SNS")
+	}
+
+	if h.Matches(req("rds")) {
+		t.Error("rds-scoped ListTagsForResource must NOT be claimed by SNS")
 	}
 }

--- a/server/aws/sns/types.go
+++ b/server/aws/sns/types.go
@@ -63,6 +63,24 @@ type untagResourceResponse struct {
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }
 
+// --- ListTagsForResource ---
+
+type listTagsForResourceResponse struct {
+	XMLName  xml.Name         `xml:"ListTagsForResourceResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   listTagsResult   `xml:"ListTagsForResourceResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type listTagsResult struct {
+	Tags []tagMember `xml:"Tags>member"`
+}
+
+type tagMember struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
 // --- GetTopicAttributes ---
 
 type attributeEntry struct {

--- a/server/wire/awsquery/awsquery.go
+++ b/server/wire/awsquery/awsquery.go
@@ -250,8 +250,10 @@ func CredentialScopeService(auth string) string {
 
 	parts := strings.Split(auth[i+len("Credential="):], "/")
 
-	const serviceField = 3
-	if len(parts) <= serviceField {
+	// A well-formed credential scope is AKID/DATE/REGION/SERVICE/aws4_request —
+	// require all five so a truncated scope yields "" rather than a stray field.
+	const serviceField, scopeFields = 3, 5
+	if len(parts) < scopeFields {
 		return ""
 	}
 

--- a/server/wire/awsquery/awsquery.go
+++ b/server/wire/awsquery/awsquery.go
@@ -236,3 +236,24 @@ func WriteXMLError(w http.ResponseWriter, status int, code, message string) {
 		RequestId: RequestID,
 	})
 }
+
+// CredentialScopeService extracts the service name from a SigV4 Authorization
+// header's credential scope: "Credential=AKID/20260101/us-east-1/<service>/aws4_request".
+// It returns "" when the header is absent or malformed. Handlers use it to
+// disambiguate generic action names (e.g. ListTagsForResource) that several
+// query-protocol services share on the same wire.
+func CredentialScopeService(auth string) string {
+	i := strings.Index(auth, "Credential=")
+	if i < 0 {
+		return ""
+	}
+
+	parts := strings.Split(auth[i+len("Credential="):], "/")
+
+	const serviceField = 3
+	if len(parts) <= serviceField {
+		return ""
+	}
+
+	return parts[serviceField]
+}

--- a/server/wire/awsquery/awsquery_test.go
+++ b/server/wire/awsquery/awsquery_test.go
@@ -231,3 +231,28 @@ func equalMaps(a, b map[string]string) bool {
 
 	return true
 }
+
+func TestCredentialScopeService(t *testing.T) {
+	const realHeader = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/sns/aws4_request, " +
+		"SignedHeaders=host;x-amz-date, Signature=abc123"
+
+	tests := map[string]struct {
+		auth string
+		want string
+	}{
+		"real sns header":    {realHeader, "sns"},
+		"rds scope":          {"AWS4-HMAC-SHA256 Credential=AKID/20260101/us-west-2/rds/aws4_request, Signature=x", "rds"},
+		"region independent": {"Credential=AKID/20260101/eu-central-1/monitoring/aws4_request", "monitoring"},
+		"missing credential": {"AWS4-HMAC-SHA256 SignedHeaders=host, Signature=x", ""},
+		"empty":              {"", ""},
+		"truncated scope":    {"Credential=AKID/20260101/us-east-1/sns", ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := awsquery.CredentialScopeService(tc.auth); got != tc.want {
+				t.Errorf("CredentialScopeService(%q) = %q, want %q", tc.auth, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Extends the Terraform/OpenTofu compatibility suite to four more AWS services real configs lean on. A new `core-services` fixture drives `aws_sns_topic` (with tags), `aws_secretsmanager_secret`, `aws_kms_key`, and `aws_ssm_parameter` through `apply → plan(no-diff) → destroy` against a real OpenTofu binary.

## Read-path fixes (each surfaced by the idempotency bar)

- **SNS** — `GetTopicAttributes` now returns a default access `Policy` (valid JSON) + `Owner`; without it the read failed with `unexpected end of JSON input`. **`ListTagsForResource`** is now served — it collides with RDS on the shared query wire (RDS registers first), so both handlers claim it only for their own **SigV4 credential scope**. The scope parser is shared as `awsquery.CredentialScopeService` (RDS now uses it too).
- **Secrets Manager** — `GetResourcePolicy` implemented (the `aws_secretsmanager_secret` read calls it).

KMS keys and SSM parameters already round-tripped.

## Tests
- `core-services` fixture passes `apply → plan(no-diff) → destroy` against real OpenTofu; a new SDK-level regression test (`TestSDKSNSListTagsAndPolicy`) locks in the SNS scope-gating + default policy.
- Full `go test ./...` green (incl. RDS, which shares the refactored scope helper); build/vet/lint clean.

## Deferred
- **SQS** — its create-time attribute-wait needs proper driver storage (`ReceiveMessageWaitTimeSeconds`, `SqsManagedSseEnabled`); its own PR.
- **Lambda** — needs a deployment package; follow-up.

## Next
Terraform breadth continues: SQS, then Lambda, then more.