### PR TITLE
ci(release): prebuilt binaries + checksums via GoReleaser (PR-A of #444)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,10 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Build timestamp
+        id: date
+        run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -44,7 +48,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: VERSION=${{ github.ref_name }}
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            COMMIT=${{ github.sha }}
+            DATE=${{ steps.date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+# On a version tag, build cross-platform binaries + checksums and publish a
+# GitHub Release via GoReleaser. Runs alongside docker.yml (which also fires on
+# v* tags to publish the image) as an independent job — they share no state.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # create the Release and upload assets
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags — required for the changelog and version
+          fetch-tags: true
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,69 @@
+# GoReleaser v2 — builds the cloudemu CLI for every OS/arch and publishes a
+# GitHub Release with checksums on each `v*` tag. Test locally with:
+#   go run github.com/goreleaser/goreleaser/v2@latest check
+#   go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish
+version: 2
+
+project_name: cloudemu
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: cloudemu
+    main: ./cmd/cloudemu
+    binary: cloudemu
+    env:
+      - CGO_ENABLED=0 # pure-Go → static, portable binaries
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.CommitDate}} # CommitDate → reproducible across re-runs
+      - -X main.builtBy=goreleaser
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: cloudemu
+    ids:
+      - cloudemu
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - README.md
+      - LICENSE*
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  draft: false
+  prerelease: auto # a pre-release tag (v1.2.0-rc1) is marked pre-release

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,12 @@ COPY . .
 
 # Static binary so it runs on a distroless/scratch base with no libc.
 ARG VERSION=docker
+ARG COMMIT=none
+ARG DATE=unknown
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" \
+    CGO_ENABLED=0 go build -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE} -X main.builtBy=docker" \
     -o /out/cloudemu ./cmd/cloudemu
 
 # --- runtime stage -----------------------------------------------------------

--- a/cmd/cloudemu/main.go
+++ b/cmd/cloudemu/main.go
@@ -46,9 +46,14 @@ const (
 	cmdEnv      = "env"
 )
 
-// version is overridable at build time with
-// -ldflags "-X main.version=vX.Y.Z".
-var version = "dev"
+// Build metadata, overridden at release time by GoReleaser ldflags
+// (-X main.version=... etc.); the defaults apply to `go run` and dev builds.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+	builtBy = "unknown"
+)
 
 func main() {
 	if len(os.Args) < 2 {
@@ -88,7 +93,7 @@ func main() {
 			os.Exit(1)
 		}
 	case "version", "-v", "--version":
-		fmt.Println("cloudemu", version)
+		fmt.Printf("cloudemu %s (commit %s, built %s by %s)\n", version, commit, date, builtBy)
 	case "help", "-h", "--help":
 		fmt.Print(usage)
 	default:

--- a/docs/compat/README.md
+++ b/docs/compat/README.md
@@ -30,6 +30,22 @@ Legend: ✅ verified via Go SDK · `·` supported but not yet compat-tested · `
 
 **cache verified via Go SDK:** AWS 5/17 · Azure 5/17 · GCP 5/17.
 
+## cloudformation
+
+| Operation | AWS (CloudFormation) |
+|---|---|
+| CreateStack | ✅ |
+| DeleteStack | ✅ |
+| DescribeStackEvents | ✅ |
+| DescribeStackResources | ✅ |
+| DescribeStacks | ✅ |
+| GetTemplate | ✅ |
+| ListStackResources | ✅ |
+| ListStacks | ✅ |
+| UpdateStack | ✅ |
+
+**cloudformation verified via Go SDK:** AWS 9/9.
+
 ## compute
 
 | Operation | AWS (EC2) | Azure (VirtualMachines) | GCP (GCE) |

--- a/docs/compat/compat.json
+++ b/docs/compat/compat.json
@@ -287,6 +287,105 @@
     "status": "green"
   },
   {
+    "service": "cloudformation",
+    "operation": "CreateStack",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "DeleteStack",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "DescribeStackEvents",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "DescribeStackResources",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "DescribeStacks",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "GetTemplate",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "ListStackResources",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "ListStacks",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
+    "service": "cloudformation",
+    "operation": "UpdateStack",
+    "providers": {
+      "aws": {
+        "native": "CloudFormation",
+        "sdkGo": "pass"
+      }
+    },
+    "status": "green"
+  },
+  {
     "service": "compute",
     "operation": "AttachVolume",
     "providers": {


### PR DESCRIPTION
## Summary

First of three PRs closing #444 (install without a Go toolchain). On any `v*` tag, GoReleaser now builds cross-platform `cloudemu` binaries and publishes them on the GitHub Release with checksums.

## What's added
- **`.goreleaser.yaml`** (v2 schema) — builds `./cmd/cloudemu` for **linux · darwin · windows × amd64 · arm64**: `CGO_ENABLED=0`, `-trimpath`, reproducible (`{{.CommitDate}}` + `mod_timestamp`), tar.gz on unix / zip on Windows, `checksums.txt`, GitHub changelog. Version/commit/date stamped via `-X main.*` ldflags.
- **`.github/workflows/release.yml`** — `on: push tags: v*`, `permissions: contents: write`, `fetch-depth: 0`, `goreleaser-action@v6` `version: "~> v2"` `args: release --clean`. Coexists with `docker.yml` (both fire on `v*` as independent jobs; different outputs, no shared state).
- **`cmd/cloudemu/main.go`** — `version` was already ldflags-wired; added `commit`/`date`/`builtBy` siblings and `cloudemu version` now prints them.

## Verified locally
- `goreleaser check` — config valid, **zero v2 deprecation warnings** (current schema: `formats`, `version_template`, `ids` — not the stale v1 names).
- `goreleaser release --snapshot --clean --skip=publish` — **all six targets build**, archives + `checksums.txt` produced, `release succeeded`.
- Ran the built darwin/arm64 binary: `cloudemu 1.3.1-next (commit 656aa50…, built … by goreleaser)` — ldflags land. A real tag stamps the tag version.

## Not in this PR
- **Homebrew** (PR-B) — uses the current `homebrew_casks:` block (`brews:` is deprecated in v2); needs a `stackshy/homebrew-tap` repo + `HOMEBREW_TAP_TOKEN` secret.
- **`install.sh`** one-line installer (PR-C).