### PR TITLE
fix(s3): DeleteObjects batch + ?acl routing (data-loss + blocker)

### DIFF
--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -4,6 +4,7 @@
 package s3
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/xml"
 	"errors"
@@ -152,6 +153,17 @@ func (h *Handler) bucketOp(w http.ResponseWriter, r *http.Request, bucket string
 			return
 		}
 		writeError(w, http.StatusMethodNotAllowed, "MethodNotAllowed", "method not allowed on ?versions")
+		return
+	case q.Has("delete"):
+		// POST /{bucket}?delete => DeleteObjects (batch delete). Without this the
+		// request falls through to the method switch and 405s, breaking
+		// `aws s3 rm --recursive`, SDK batch delete, and Terraform force_destroy.
+		h.deleteObjects(w, r, bucket)
+		return
+	case q.Has("acl"):
+		// GET returns a canned ACL; a PUT is a no-op so it does NOT fall through
+		// to createBucket (which 409s) — see aclOp.
+		h.aclOp(w, r)
 		return
 	}
 
@@ -353,6 +365,11 @@ func (h *Handler) objectOp(w http.ResponseWriter, r *http.Request, bucket, key s
 	case q.Has("uploadId"):
 		h.multipartUploadOp(w, r, bucket, key, q.Get("uploadId"))
 		return
+	case q.Has("acl"):
+		// GET returns a canned ACL; a PUT/DELETE is a no-op so it does NOT fall
+		// through to putObject and overwrite the object with the ACL body.
+		h.aclOp(w, r)
+		return
 	}
 
 	switch r.Method {
@@ -501,6 +518,140 @@ func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, k
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// maxDeleteBody caps a DeleteObjects request body. Real S3 allows up to 1000
+// keys per call; this is a generous ceiling on the XML that carries them.
+const maxDeleteBody = 2 << 20
+
+type deleteObjectsRequest struct {
+	XMLName xml.Name `xml:"Delete"`
+	Quiet   bool     `xml:"Quiet"`
+	Objects []struct {
+		Key       string `xml:"Key"`
+		VersionID string `xml:"VersionId"`
+	} `xml:"Object"`
+}
+
+type deletedObjectXML struct {
+	Key          string `xml:"Key"`
+	VersionID    string `xml:"VersionId,omitempty"`
+	DeleteMarker bool   `xml:"DeleteMarker,omitempty"`
+}
+
+type deleteErrorXML struct {
+	Key     string `xml:"Key"`
+	Code    string `xml:"Code"`
+	Message string `xml:"Message"`
+}
+
+type deleteResultXML struct {
+	XMLName xml.Name           `xml:"DeleteResult"`
+	Xmlns   string             `xml:"xmlns,attr"`
+	Deleted []deletedObjectXML `xml:"Deleted"`
+	Errors  []deleteErrorXML   `xml:"Error"`
+}
+
+// deleteObjects implements POST /{bucket}?delete (DeleteObjects). Per-key delete
+// is idempotent (a missing key still reports Deleted, matching real S3); a
+// missing bucket fails the whole request with NoSuchBucket.
+func (h *Handler) deleteObjects(w http.ResponseWriter, r *http.Request, bucket string) {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxDeleteBody))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "could not read request body")
+		return
+	}
+
+	var req deleteObjectsRequest
+	if err := xml.Unmarshal(body, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "malformed Delete request")
+		return
+	}
+
+	result := deleteResultXML{Xmlns: xmlns}
+
+	for _, obj := range req.Objects {
+		vid, marker, derr := h.deleteOneObject(r.Context(), bucket, obj.Key, obj.VersionID)
+		switch {
+		case derr != nil && bucketMissing(derr):
+			// A missing bucket aborts the whole batch, as in real S3.
+			writeErr(w, derr)
+			return
+		case derr != nil:
+			result.Errors = append(result.Errors, deleteErrorXML{
+				Key: obj.Key, Code: "InternalError", Message: derr.Error(),
+			})
+		case !req.Quiet:
+			result.Deleted = append(result.Deleted, deletedObjectXML{
+				Key: obj.Key, VersionID: vid, DeleteMarker: marker,
+			})
+		}
+	}
+
+	wire.WriteXML(w, http.StatusOK, result)
+}
+
+// cannedOwnerID is the fixed S3 canonical user id cloudemu reports as the owner
+// of every bucket/object (no per-account ACLs are modeled).
+const cannedOwnerID = "cloudemu00000000000000000000000000000000000000000000000000000000"
+
+type aclOwnerXML struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName"`
+}
+
+type aclGranteeXML struct {
+	ID          string `xml:"ID"`
+	DisplayName string `xml:"DisplayName"`
+}
+
+type aclGrantXML struct {
+	Grantee    aclGranteeXML `xml:"Grantee"`
+	Permission string        `xml:"Permission"`
+}
+
+type accessControlPolicyXML struct {
+	XMLName xml.Name      `xml:"AccessControlPolicy"`
+	Xmlns   string        `xml:"xmlns,attr"`
+	Owner   aclOwnerXML   `xml:"Owner"`
+	Grants  []aclGrantXML `xml:"AccessControlList>Grant"`
+}
+
+// aclOp answers ?acl on a bucket or object. GET returns a canned
+// full-control-to-owner ACL; any write is accepted as a no-op. The point is to
+// stop a PUT ?acl from falling through and overwriting the object/bucket, and a
+// GET ?acl from returning object bytes instead of an ACL document.
+func (h *Handler) aclOp(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	owner := aclOwnerXML{ID: cannedOwnerID, DisplayName: "cloudemu"}
+	wire.WriteXML(w, http.StatusOK, accessControlPolicyXML{
+		Xmlns: xmlns,
+		Owner: owner,
+		Grants: []aclGrantXML{{
+			Grantee:    aclGranteeXML{ID: cannedOwnerID, DisplayName: "cloudemu"},
+			Permission: "FULL_CONTROL",
+		}},
+	})
+}
+
+// deleteOneObject deletes a single key for the batch path, honoring versioning
+// and treating a missing key as success (idempotent).
+func (h *Handler) deleteOneObject(ctx context.Context, bucket, key, versionID string) (vid string, marker bool, err error) {
+	if h.versioned != nil {
+		vid, marker, err = h.versioned.DeleteObjectVersion(ctx, bucket, key, versionID)
+	} else {
+		err = h.bucket.DeleteObject(ctx, bucket, key)
+	}
+
+	if err != nil && cerrors.IsNotFound(err) && !bucketMissing(err) {
+		err = nil // missing key is a successful (idempotent) delete
+	}
+
+	return vid, marker, err
 }
 
 func (h *Handler) copyObject(w http.ResponseWriter, r *http.Request, bucket, key string) {

--- a/server/aws/s3/sdk_roundtrip_test.go
+++ b/server/aws/s3/sdk_roundtrip_test.go
@@ -400,3 +400,83 @@ func TestSDKBucketVersioning(t *testing.T) {
 		t.Fatalf("expected versioning Enabled, got %q", got.Status)
 	}
 }
+
+// TestSDKDeleteObjects covers the batch-delete blocker: POST /{bucket}?delete
+// used by `aws s3 rm --recursive`, the SDK batch deleter, and TF force_destroy.
+func TestSDKDeleteObjects(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	mustCreateBucket(t, client, "batch")
+
+	for _, k := range []string{"a", "b", "c"} {
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String("batch"), Key: aws.String(k), Body: bytes.NewReader([]byte("x")),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", k, err)
+		}
+	}
+
+	out, err := client.DeleteObjects(ctx, &awss3.DeleteObjectsInput{
+		Bucket: aws.String("batch"),
+		Delete: &types.Delete{Objects: []types.ObjectIdentifier{
+			{Key: aws.String("a")}, {Key: aws.String("b")}, {Key: aws.String("missing")},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("DeleteObjects: %v", err)
+	}
+
+	// a, b, and the idempotent missing key all report Deleted; no Errors.
+	if len(out.Deleted) != 3 {
+		t.Fatalf("Deleted = %d, want 3", len(out.Deleted))
+	}
+	if len(out.Errors) != 0 {
+		t.Fatalf("Errors = %+v, want none", out.Errors)
+	}
+
+	list, err := client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{Bucket: aws.String("batch")})
+	if err != nil {
+		t.Fatalf("ListObjectsV2: %v", err)
+	}
+	if len(list.Contents) != 1 || aws.ToString(list.Contents[0].Key) != "c" {
+		t.Fatalf("remaining = %+v, want just [c]", list.Contents)
+	}
+}
+
+// TestSDKObjectAclNoDataLoss covers the data-loss bug: PutObjectAcl must NOT
+// overwrite the object, and GetObjectAcl must return an ACL doc (not the bytes).
+func TestSDKObjectAclNoDataLoss(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+	mustCreateBucket(t, client, "acl")
+
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String("acl"), Key: aws.String("k"), Body: bytes.NewReader([]byte("payload")),
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	if _, err := client.PutObjectAcl(ctx, &awss3.PutObjectAclInput{
+		Bucket: aws.String("acl"), Key: aws.String("k"), ACL: types.ObjectCannedACLPrivate,
+	}); err != nil {
+		t.Fatalf("PutObjectAcl: %v", err)
+	}
+
+	// The object content must be intact (not overwritten by the ACL request).
+	got, err := client.GetObject(ctx, &awss3.GetObjectInput{Bucket: aws.String("acl"), Key: aws.String("k")})
+	if err != nil {
+		t.Fatalf("GetObject: %v", err)
+	}
+	body, _ := io.ReadAll(got.Body)
+	if string(body) != "payload" {
+		t.Fatalf("object body = %q, want 'payload' (PutObjectAcl overwrote it)", string(body))
+	}
+
+	acl, err := client.GetObjectAcl(ctx, &awss3.GetObjectAclInput{Bucket: aws.String("acl"), Key: aws.String("k")})
+	if err != nil {
+		t.Fatalf("GetObjectAcl: %v", err)
+	}
+	if acl.Owner == nil || len(acl.Grants) == 0 {
+		t.Fatalf("GetObjectAcl returned no owner/grants: %+v", acl)
+	}
+}


### PR DESCRIPTION
First batch of the AWS audit fixes (see AUDIT_AWS.md). Two high-priority S3 items:

- **`DeleteObjects` (blocker)** — `POST /{bucket}?delete` was a 405; now does a batch delete (idempotent per key, missing bucket → `NoSuchBucket`). Fixes `aws s3 rm --recursive`, the SDK batch deleter, and Terraform `force_destroy`.
- **`?acl` routing (data-loss)** — `PUT /{key}?acl` fell through to `putObject` and **overwrote the object with the ACL body**; `GET ?acl` served the object bytes; `PUT /{bucket}?acl` 409'd. Now `?acl` on a bucket or object is handled: GET returns a canned `AccessControlPolicy` (owner + FULL_CONTROL), writes are a no-op. No more data loss.

Resolves AUDIT_AWS.md findings: s3.DeleteObjects, s3.PutObjectAcl, s3.PutBucketAcl, s3.GetBucketAcl/GetObjectAcl.

## Tests
Two SDK-level tests (`TestSDKDeleteObjects`, `TestSDKObjectAclNoDataLoss`) drive the real aws-sdk-go-v2 client; full S3 suite + build green.