### PR TITLE
fix(dynamodb): expose GlobalSecondaryIndexes over the wire (GSI blocker)

### DIFF
--- a/contrib/terraform/README.md
+++ b/contrib/terraform/README.md
@@ -53,8 +53,7 @@ is idempotent is verified; everything else is a known gap, closed as a fixture
 needs it:
 
 - **DynamoDB** — `PAY_PER_REQUEST` and `PROVISIONED` (with `read/write_capacity`)
-  round-trip. `global_secondary_index` blocks are **not** yet echoed by
-  DescribeTable → a GSI fixture would show a perpetual diff.
+  and `global_secondary_index` blocks round-trip.
 - **Networking** — `aws_vpc`, `aws_subnet`, `aws_security_group`,
   `aws_route_table` and `aws_route_table_association` round-trip. A new security
   group is seeded with the real allow-all egress default (AWS only — Azure/GCP/OCI

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -1597,3 +1597,46 @@ func TestDDBSetTypesRoundTrip(t *testing.T) {
 	require.True(t, ok, "binary scalar should round-trip as B, got %T", out.Item["bin"])
 	assert.Equal(t, []byte{0xDE, 0xAD}, bin.Value)
 }
+
+// TestGSIRoundTripAndQuery covers the blocker: a GSI declared at CreateTable is
+// echoed by DescribeTable and is queryable via Query(IndexName=...).
+func TestGSIRoundTripAndQuery(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("gsitab"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("email"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		GlobalSecondaryIndexes: []ddbtypes.GlobalSecondaryIndex{{
+			IndexName:  aws.String("by-email"),
+			KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("email"), KeyType: ddbtypes.KeyTypeHash}},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+		}},
+	})
+	require.NoError(t, err)
+
+	d, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("gsitab")})
+	require.NoError(t, err)
+	require.Len(t, d.Table.GlobalSecondaryIndexes, 1)
+	require.Equal(t, "by-email", aws.ToString(d.Table.GlobalSecondaryIndexes[0].IndexName))
+
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{TableName: aws.String("gsitab"), Item: map[string]ddbtypes.AttributeValue{
+		"id":    &ddbtypes.AttributeValueMemberS{Value: "u1"},
+		"email": &ddbtypes.AttributeValueMemberS{Value: "a@x.com"},
+	}})
+	require.NoError(t, err)
+
+	q, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String("gsitab"),
+		IndexName:                 aws.String("by-email"),
+		KeyConditionExpression:    aws.String("email = :e"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":e": &ddbtypes.AttributeValueMemberS{Value: "a@x.com"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, q.Items, 1)
+}

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -117,6 +117,16 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 			ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
 			WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
 		} `json:"ProvisionedThroughput"`
+		GlobalSecondaryIndexes []struct {
+			IndexName string `json:"IndexName"`
+			KeySchema []struct {
+				AttributeName string `json:"AttributeName"`
+				KeyType       string `json:"KeyType"`
+			} `json:"KeySchema"`
+			Projection struct {
+				ProjectionType string `json:"ProjectionType"`
+			} `json:"Projection"`
+		} `json:"GlobalSecondaryIndexes"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -128,6 +138,19 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 		BillingMode:        req.BillingMode,
 		ReadCapacityUnits:  req.ProvisionedThroughput.ReadCapacityUnits,
 		WriteCapacityUnits: req.ProvisionedThroughput.WriteCapacityUnits,
+	}
+
+	for _, gsi := range req.GlobalSecondaryIndexes {
+		idx := dbdriver.GSIConfig{Name: gsi.IndexName, Projection: gsi.Projection.ProjectionType}
+		for _, ks := range gsi.KeySchema {
+			if ks.KeyType == "HASH" {
+				idx.PartitionKey = ks.AttributeName
+			}
+			if ks.KeyType == "RANGE" {
+				idx.SortKey = ks.AttributeName
+			}
+		}
+		cfg.GSIs = append(cfg.GSIs, idx)
 	}
 
 	for _, ks := range req.KeySchema {
@@ -181,9 +204,6 @@ func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
 		billing = billingProvisioned
 	}
 
-	// NOTE: GlobalSecondaryIndexes are not echoed here. A fixture that declares a
-	// global_secondary_index would therefore see a perpetual diff — GSIs are out
-	// of scope for the current fixtures (see contrib/terraform "Known limits").
 	td := map[string]any{
 		"TableName":            cfg.Name,
 		"TableStatus":          "ACTIVE",
@@ -204,7 +224,52 @@ func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
 		}
 	}
 
+	if gsis := gsiDescriptions(cfg, billing); len(gsis) > 0 {
+		td["GlobalSecondaryIndexes"] = gsis
+	}
+
 	return td
+}
+
+// gsiDescriptions builds the GlobalSecondaryIndexes wire block echoed by
+// CreateTable/DescribeTable so an IaC-declared index round-trips (and Query can
+// target it via IndexName).
+func gsiDescriptions(cfg *dbdriver.TableConfig, billing string) []map[string]any {
+	out := make([]map[string]any, 0, len(cfg.GSIs))
+
+	for _, gsi := range cfg.GSIs {
+		keySchema := []map[string]string{{"AttributeName": gsi.PartitionKey, "KeyType": "HASH"}}
+		if gsi.SortKey != "" {
+			keySchema = append(keySchema, map[string]string{"AttributeName": gsi.SortKey, "KeyType": "RANGE"})
+		}
+
+		projection := gsi.Projection
+		if projection == "" {
+			projection = "ALL"
+		}
+
+		desc := map[string]any{
+			"IndexName":      gsi.Name,
+			"IndexStatus":    "ACTIVE",
+			"KeySchema":      keySchema,
+			"Projection":     map[string]any{"ProjectionType": projection},
+			"IndexArn":       cfg.TableArn + "/index/" + gsi.Name,
+			"ItemCount":      0,
+			"IndexSizeBytes": 0,
+		}
+
+		if billing == "PROVISIONED" {
+			desc["ProvisionedThroughput"] = map[string]any{
+				"ReadCapacityUnits":      cfg.ReadCapacityUnits,
+				"WriteCapacityUnits":     cfg.WriteCapacityUnits,
+				"NumberOfDecreasesToday": 0,
+			}
+		}
+
+		out = append(out, desc)
+	}
+
+	return out
 }
 
 func (h *Handler) deleteTable(w http.ResponseWriter, r *http.Request) {

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -77,6 +77,9 @@ type GSIConfig struct {
 	Name         string
 	PartitionKey string
 	SortKey      string
+	// Projection is the DynamoDB projection type (ALL, KEYS_ONLY, INCLUDE); a
+	// describe echoes it so an IaC client's declared index round-trips.
+	Projection string
 }
 
 // UpdateAction represents a single field-level update action. It is the legacy,


### PR DESCRIPTION
AWS audit blocker (AUDIT_AWS.md). The DynamoDB provider already stores and queries GSIs, but the wire `CreateTable` never parsed `GlobalSecondaryIndexes` and `DescribeTable` never echoed them — so a declared GSI was silently dropped and `Query(IndexName=...)` returned `ResourceNotFoundException`.

- `createTable` now parses `GlobalSecondaryIndexes` (IndexName, KeySchema, Projection) into `TableConfig.GSIs`.
- `tableDescription` echoes the index block (KeySchema, Projection, IndexStatus=ACTIVE, IndexArn, throughput for PROVISIONED).
- `GSIConfig` gains a `Projection` field so the declared projection type round-trips (no perpetual Terraform diff).

Resolves the `dynamodb.CreateTable/DescribeTable/Query` GSI finding; updates the terraform README's "known limits" (GSIs now round-trip).

## Tests
`TestGSIRoundTripAndQuery` (real SDK): CreateTable w/ GSI → DescribeTable echoes it → PutItem → Query(IndexName) returns the item. Full DynamoDB + database suites green.