### PR TITLE
fix(lambda): GET GetFunctionConfiguration (waiter-hang blocker)

### DIFF
--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -356,9 +356,23 @@ func (h *Handler) serveRemovePermission(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// serveConfiguration handles PUT .../{name}/configuration
-// (UpdateFunctionConfiguration).
+// serveConfiguration handles .../{name}/configuration: GET is
+// GetFunctionConfiguration (the op FunctionActiveV2 / FunctionUpdatedV2 waiters
+// poll — a 405 here hangs every Terraform/SAM/CDK deploy), PUT is
+// UpdateFunctionConfiguration.
 func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, name string) {
+	if r.Method == http.MethodGet {
+		info, err := h.fn.GetFunction(r.Context(), name)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, toConfiguration(info))
+
+		return
+	}
+
 	if r.Method != http.MethodPut {
 		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
 		return

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -285,3 +285,31 @@ func TestSDKLambdaLayersRoundtrip(t *testing.T) {
 		t.Fatal("GetLayerVersion after delete returned nil error, want NotFound")
 	}
 }
+
+// TestSDKGetFunctionConfiguration covers the blocker: GET .../configuration
+// (the op FunctionActive/FunctionUpdated waiters poll) returned 405 and hung
+// every Terraform/SAM/CDK deploy.
+func TestSDKGetFunctionConfiguration(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("cfg"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("z")},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	out, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("cfg"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if aws.ToString(out.FunctionName) != "cfg" || aws.ToString(out.Handler) != "main" {
+		t.Fatalf("config = %+v, want FunctionName=cfg Handler=main", out)
+	}
+}


### PR DESCRIPTION
AWS audit blocker. `GET /2015-03-31/functions/{name}/configuration` was a 405 (the handler was PUT-only). That endpoint is exactly what the `FunctionActiveV2` / `FunctionUpdatedV2` waiters poll, so **every Terraform / SAM / CDK / serverless deploy hung** waiting for it. GET now returns the function configuration (same shape as UpdateFunctionConfiguration's response).

Resolves the `lambda.GetFunctionConfiguration` finding in AUDIT_AWS.md.

## Tests
`TestSDKGetFunctionConfiguration` (real SDK): CreateFunction → GetFunctionConfiguration returns the config. Full Lambda suite green.