### PR TITLE
fix(iam): wire fidelity — group membership, role/user updates, delete conflicts, policy metadata

### DIFF
--- a/providers/aws/iam/accesskey_update.go
+++ b/providers/aws/iam/accesskey_update.go
@@ -1,0 +1,37 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// accessKeyStatusActive and accessKeyStatusInactive are the only two states an
+// access key can be in (IAM statusType).
+const (
+	accessKeyStatusActive   = "Active"
+	accessKeyStatusInactive = "Inactive"
+)
+
+// UpdateAccessKey changes the status of an access key to Active or Inactive
+// (IAM UpdateAccessKey). It exists for the wire layer and is not part of the
+// portable driver.
+func (m *Mock) UpdateAccessKey(_ context.Context, userName, accessKeyID, status string) error {
+	if status != accessKeyStatusActive && status != accessKeyStatusInactive {
+		return errors.Newf(errors.InvalidArgument,
+			"status %q is not one of %q or %q", status, accessKeyStatusActive, accessKeyStatusInactive)
+	}
+
+	ak, ok := m.accessKeys.Get(accessKeyID)
+	if !ok || ak.UserName != userName {
+		return errors.Newf(errors.NotFound, "access key %q not found for user %q", accessKeyID, userName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	ak.Status = status
+	m.accessKeys.Set(accessKeyID, ak)
+
+	return nil
+}

--- a/providers/aws/iam/iam.go
+++ b/providers/aws/iam/iam.go
@@ -83,6 +83,7 @@ type policyVersionData struct {
 
 type groupData struct {
 	Name      string
+	ID        string
 	ARN       string
 	Path      string
 	CreatedAt string
@@ -146,15 +147,39 @@ func (m *Mock) CreateUser(_ context.Context, cfg driver.UserConfig) (*driver.Use
 	return &info, nil
 }
 
-// DeleteUser deletes the IAM user with the given name.
+// DeleteUser deletes the IAM user with the given name. Like real IAM it refuses
+// (DeleteConflict) while managed policies are still attached, access keys still
+// exist, or the user is still a member of a group — the caller must remove
+// those first.
 func (m *Mock) DeleteUser(_ context.Context, name string) error {
-	if !m.users.Delete(name) {
+	if !m.users.Has(name) {
 		return errors.Newf(errors.NotFound, "user %q not found", name)
 	}
 
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.userPolicies[name]) > 0 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete user %q: managed policies are still attached (detach them first)", name)
+	}
+
+	for _, members := range m.groupUsers {
+		if members[name] {
+			return errors.Newf(errors.FailedPrecondition,
+				"cannot delete user %q: still a member of a group (remove it first)", name)
+		}
+	}
+
+	for _, ak := range m.accessKeys.All() {
+		if ak.UserName == name {
+			return errors.Newf(errors.FailedPrecondition,
+				"cannot delete user %q: access keys still exist (delete them first)", name)
+		}
+	}
+
+	m.users.Delete(name)
 	delete(m.userPolicies, name)
-	m.mu.Unlock()
 
 	return nil
 }
@@ -313,13 +338,55 @@ func (m *Mock) CreatePolicy(_ context.Context, cfg driver.PolicyConfig) (*driver
 	return &info, nil
 }
 
-// DeletePolicy deletes the IAM policy with the given ARN.
+// DeletePolicy deletes the IAM policy with the given ARN. Like real IAM it
+// refuses (DeleteConflict) while the policy is still attached to any user or
+// role — the caller must detach it everywhere first.
 func (m *Mock) DeletePolicy(_ context.Context, arn string) error {
-	if !m.policies.Delete(arn) {
+	if !m.policies.Has(arn) {
 		return errors.Newf(errors.NotFound, "policy %q not found", arn)
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.policyAttachmentCountLocked(arn) > 0 {
+		return errors.Newf(errors.FailedPrecondition,
+			"cannot delete policy %q: still attached to one or more users or roles (detach it first)", arn)
+	}
+
+	m.policies.Delete(arn)
+
 	return nil
+}
+
+// policyAttachmentCountLocked returns how many users and roles currently have
+// the given policy ARN attached. The caller must hold m.mu.
+func (m *Mock) policyAttachmentCountLocked(arn string) int {
+	count := 0
+
+	for _, arns := range m.userPolicies {
+		if arns[arn] {
+			count++
+		}
+	}
+
+	for _, arns := range m.rolePolicies {
+		if arns[arn] {
+			count++
+		}
+	}
+
+	return count
+}
+
+// PolicyAttachmentCount returns how many principals have the given managed
+// policy attached. It exists for the wire layer to populate AttachmentCount and
+// to honor ListPolicies OnlyAttached; it is not part of the portable driver.
+func (m *Mock) PolicyAttachmentCount(_ context.Context, arn string) (int, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return m.policyAttachmentCountLocked(arn), nil
 }
 
 // GetPolicy returns the IAM policy with the given ARN.
@@ -817,6 +884,7 @@ func (m *Mock) CreateGroup(
 
 	g := &groupData{
 		Name:      cfg.Name,
+		ID:        idgen.GenerateID("AGPA"),
 		ARN:       arn,
 		Path:      path,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
@@ -868,6 +936,32 @@ func (m *Mock) ListGroups(
 
 	for _, g := range all {
 		result = append(result, toGroupInfo(g))
+	}
+
+	return result, nil
+}
+
+// ListGroupMembers returns the users that belong to the given group. It exists
+// for the wire layer to populate GetGroup's Users list; it is not part of the
+// portable driver.
+func (m *Mock) ListGroupMembers(_ context.Context, groupName string) ([]driver.UserInfo, error) {
+	if !m.groups.Has(groupName) {
+		return nil, errors.Newf(errors.NotFound, "group %q not found", groupName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	members := m.groupUsers[groupName]
+	result := make([]driver.UserInfo, 0, len(members))
+
+	for userName := range members {
+		u, ok := m.users.Get(userName)
+		if !ok {
+			continue
+		}
+
+		result = append(result, toUserInfo(u))
 	}
 
 	return result, nil
@@ -1064,9 +1158,15 @@ func (m *Mock) CreateInstanceProfile(
 		"instance-profile/"+cfg.Name,
 	)
 
+	path := cfg.Path
+	if path == "" {
+		path = "/"
+	}
+
 	info := &driver.InstanceProfileInfo{
 		ID:        id,
 		Name:      cfg.Name,
+		Path:      path,
 		RoleName:  cfg.RoleName,
 		ARN:       arn,
 		CreatedAt: m.opts.Clock.Now().UTC().Format(timeFormat),
@@ -1182,6 +1282,7 @@ func copyProfileInfo(p *driver.InstanceProfileInfo) *driver.InstanceProfileInfo 
 	return &driver.InstanceProfileInfo{
 		ID:        p.ID,
 		Name:      p.Name,
+		Path:      p.Path,
 		RoleName:  p.RoleName,
 		ARN:       p.ARN,
 		CreatedAt: p.CreatedAt,
@@ -1242,6 +1343,7 @@ func toPolicyInfo(p *policyData) driver.PolicyInfo {
 func toGroupInfo(g *groupData) driver.GroupInfo {
 	return driver.GroupInfo{
 		Name:      g.Name,
+		ID:        g.ID,
 		Path:      g.Path,
 		ARN:       g.ARN,
 		CreatedAt: g.CreatedAt,

--- a/providers/aws/iam/role_update.go
+++ b/providers/aws/iam/role_update.go
@@ -1,0 +1,51 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// UpdateRole updates a role's Description and/or MaxSessionDuration in place
+// (IAM UpdateRole). Nil pointers leave the corresponding field unchanged, which
+// matches how the SDK omits unset optional parameters. It exists for the wire
+// layer's UpdateRole action and is not part of the portable driver.
+func (m *Mock) UpdateRole(_ context.Context, roleName string, description *string, maxSessionDuration *int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.roles.Get(roleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "role %q not found", roleName)
+	}
+
+	if description != nil {
+		rd.Description = *description
+	}
+
+	if maxSessionDuration != nil {
+		rd.MaxSessionDuration = *maxSessionDuration
+	}
+
+	m.roles.Set(roleName, rd)
+
+	return nil
+}
+
+// UpdateAssumeRolePolicy replaces a role's trust policy document (IAM
+// UpdateAssumeRolePolicy). It exists for the wire layer and is not part of the
+// portable driver.
+func (m *Mock) UpdateAssumeRolePolicy(_ context.Context, roleName, policyDocument string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	rd, ok := m.roles.Get(roleName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "role %q not found", roleName)
+	}
+
+	rd.AssumeRolePolicyDoc = policyDocument
+	m.roles.Set(roleName, rd)
+
+	return nil
+}

--- a/providers/aws/iam/usertags.go
+++ b/providers/aws/iam/usertags.go
@@ -1,0 +1,66 @@
+package iam
+
+import (
+	"context"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+)
+
+// TagUser adds or overwrites tags on a user (IAM TagUser). It exists for the
+// wire layer and is not part of the portable driver.
+func (m *Mock) TagUser(_ context.Context, userName string, tags map[string]string) error {
+	u, ok := m.users.Get(userName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if u.Tags == nil {
+		u.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		u.Tags[k] = v
+	}
+
+	return nil
+}
+
+// UntagUser removes tags by key from a user (IAM UntagUser). It exists for the
+// wire layer and is not part of the portable driver.
+func (m *Mock) UntagUser(_ context.Context, userName string, keys []string) error {
+	u, ok := m.users.Get(userName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, k := range keys {
+		delete(u.Tags, k)
+	}
+
+	return nil
+}
+
+// ListUserTags returns a user's tags (IAM ListUserTags). It exists for the wire
+// layer and is not part of the portable driver.
+func (m *Mock) ListUserTags(_ context.Context, userName string) (map[string]string, error) {
+	u, ok := m.users.Get(userName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "user %q not found", userName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	out := make(map[string]string, len(u.Tags))
+	for k, v := range u.Tags {
+		out[k] = v
+	}
+
+	return out, nil
+}

--- a/server/aws/iam/accesskey_update.go
+++ b/server/aws/iam/accesskey_update.go
@@ -1,0 +1,41 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// accessKeyUpdater is the AWS-specific surface for changing an access key's
+// status (UpdateAccessKey). It's not part of the portable driver, so the
+// handler type-asserts for it.
+type accessKeyUpdater interface {
+	UpdateAccessKey(ctx context.Context, userName, accessKeyID, status string) error
+}
+
+type updateAccessKeyResponse struct {
+	XMLName  xml.Name         `xml:"UpdateAccessKeyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) updateAccessKey(w http.ResponseWriter, r *http.Request) {
+	upd, ok := h.iam.(accessKeyUpdater)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "access key updates not supported"))
+		return
+	}
+
+	if err := upd.UpdateAccessKey(r.Context(),
+		r.Form.Get("UserName"), r.Form.Get("AccessKeyId"), r.Form.Get("Status")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, updateAccessKeyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/accesskey_update_test.go
+++ b/server/aws/iam/accesskey_update_test.go
@@ -1,0 +1,50 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKUpdateAccessKeyStatus proves UpdateAccessKey can deactivate a key and
+// the new status is reflected in ListAccessKeys (previously undispatched →
+// InvalidAction).
+func TestSDKUpdateAccessKeyStatus(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("keyed")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	created, err := client.CreateAccessKey(ctx, &iam.CreateAccessKeyInput{UserName: aws.String("keyed")})
+	if err != nil {
+		t.Fatalf("CreateAccessKey: %v", err)
+	}
+
+	keyID := aws.ToString(created.AccessKey.AccessKeyId)
+
+	if _, err := client.UpdateAccessKey(ctx, &iam.UpdateAccessKeyInput{
+		UserName:    aws.String("keyed"),
+		AccessKeyId: aws.String(keyID),
+		Status:      iamtypes.StatusTypeInactive,
+	}); err != nil {
+		t.Fatalf("UpdateAccessKey: %v", err)
+	}
+
+	listed, err := client.ListAccessKeys(ctx, &iam.ListAccessKeysInput{UserName: aws.String("keyed")})
+	if err != nil {
+		t.Fatalf("ListAccessKeys: %v", err)
+	}
+
+	if len(listed.AccessKeyMetadata) != 1 {
+		t.Fatalf("ListAccessKeys = %d keys, want 1", len(listed.AccessKeyMetadata))
+	}
+
+	if status := listed.AccessKeyMetadata[0].Status; status != iamtypes.StatusTypeInactive {
+		t.Fatalf("access key status = %q, want Inactive", status)
+	}
+}

--- a/server/aws/iam/entities_test.go
+++ b/server/aws/iam/entities_test.go
@@ -81,6 +81,97 @@ func TestSDKDeleteRoleConflictWhenPolicyAttached(t *testing.T) {
 	}
 }
 
+// TestSDKDeleteUserConflictWhenPolicyAttached proves DeleteUser is refused with
+// DeleteConflictException while a managed policy is still attached, and succeeds
+// once detached.
+func TestSDKDeleteUserConflictWhenPolicyAttached(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("busy-user")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	policy, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("user-pol"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	arn := aws.ToString(policy.Policy.Arn)
+	if _, err := client.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
+		UserName: aws.String("busy-user"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	_, err = client.DeleteUser(ctx, &iam.DeleteUserInput{UserName: aws.String("busy-user")})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeleteUser while attached: want DeleteConflictException, got %v", err)
+	}
+
+	if _, err := client.DetachUserPolicy(ctx, &iam.DetachUserPolicyInput{
+		UserName: aws.String("busy-user"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("DetachUserPolicy: %v", err)
+	}
+
+	if _, err := client.DeleteUser(ctx, &iam.DeleteUserInput{UserName: aws.String("busy-user")}); err != nil {
+		t.Fatalf("DeleteUser after detach: %v", err)
+	}
+}
+
+// TestSDKDeletePolicyConflictWhenAttached proves DeletePolicy is refused with
+// DeleteConflictException while it is still attached to a role, and succeeds
+// once detached.
+func TestSDKDeletePolicyConflictWhenAttached(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("holder-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	policy, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("held-pol"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	arn := aws.ToString(policy.Policy.Arn)
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName: aws.String("holder-role"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	_, err = client.DeletePolicy(ctx, &iam.DeletePolicyInput{PolicyArn: aws.String(arn)})
+
+	var conflict *iamtypes.DeleteConflictException
+	if !errors.As(err, &conflict) {
+		t.Fatalf("DeletePolicy while attached: want DeleteConflictException, got %v", err)
+	}
+
+	if _, err := client.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
+		RoleName: aws.String("holder-role"), PolicyArn: aws.String(arn),
+	}); err != nil {
+		t.Fatalf("DetachRolePolicy: %v", err)
+	}
+
+	if _, err := client.DeletePolicy(ctx, &iam.DeletePolicyInput{PolicyArn: aws.String(arn)}); err != nil {
+		t.Fatalf("DeletePolicy after detach: %v", err)
+	}
+}
+
 // TestSDKGetUserNoUserNameReturnsCaller proves GetUser with no UserName returns
 // the calling principal's own user record instead of NoSuchEntity.
 func TestSDKGetUserNoUserNameReturnsCaller(t *testing.T) {

--- a/server/aws/iam/group_members_test.go
+++ b/server/aws/iam/group_members_test.go
@@ -1,0 +1,75 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// TestSDKGetGroupReturnsMembers proves GetGroup lists the users added via
+// AddUserToGroup (previously the membership was hardcoded empty).
+func TestSDKGetGroupReturnsMembers(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("devs")}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	for _, name := range []string{"ann", "bob"} {
+		if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String(name)}); err != nil {
+			t.Fatalf("CreateUser %s: %v", name, err)
+		}
+
+		if _, err := client.AddUserToGroup(ctx, &iam.AddUserToGroupInput{
+			GroupName: aws.String("devs"), UserName: aws.String(name),
+		}); err != nil {
+			t.Fatalf("AddUserToGroup %s: %v", name, err)
+		}
+	}
+
+	got, err := client.GetGroup(ctx, &iam.GetGroupInput{GroupName: aws.String("devs")})
+	if err != nil {
+		t.Fatalf("GetGroup: %v", err)
+	}
+
+	if len(got.Users) != 2 {
+		t.Fatalf("GetGroup Users = %d, want 2", len(got.Users))
+	}
+
+	names := map[string]bool{}
+	for _, u := range got.Users {
+		names[aws.ToString(u.UserName)] = true
+	}
+
+	if !names["ann"] || !names["bob"] {
+		t.Fatalf("GetGroup Users = %v, want ann and bob", names)
+	}
+}
+
+// TestSDKGroupIDIsPopulated proves group responses carry a non-empty GroupId
+// (previously always empty).
+func TestSDKGroupIDIsPopulated(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateGroup(ctx, &iam.CreateGroupInput{GroupName: aws.String("admins")})
+	if err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	if id := aws.ToString(created.Group.GroupId); id == "" {
+		t.Fatal("CreateGroup GroupId is empty")
+	}
+
+	got, err := client.GetGroup(ctx, &iam.GetGroupInput{GroupName: aws.String("admins")})
+	if err != nil {
+		t.Fatalf("GetGroup: %v", err)
+	}
+
+	if id := aws.ToString(got.Group.GroupId); id == "" {
+		t.Fatal("GetGroup GroupId is empty")
+	}
+}

--- a/server/aws/iam/handler.go
+++ b/server/aws/iam/handler.go
@@ -41,6 +41,8 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DeleteRole":                    {},
 	"GetRole":                       {},
 	"ListRoles":                     {},
+	"UpdateRole":                    {},
+	"UpdateAssumeRolePolicy":        {},
 	"CreatePolicy":                  {},
 	"DeletePolicy":                  {},
 	"GetPolicy":                     {},
@@ -66,6 +68,7 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"CreateAccessKey":               {},
 	"DeleteAccessKey":               {},
 	"ListAccessKeys":                {},
+	"UpdateAccessKey":               {},
 	"CreateInstanceProfile":         {},
 	"DeleteInstanceProfile":         {},
 	"GetInstanceProfile":            {},
@@ -80,6 +83,9 @@ var iamActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"TagRole":                       {},
 	"UntagRole":                     {},
 	"ListRoleTags":                  {},
+	"TagUser":                       {},
+	"UntagUser":                     {},
+	"ListUserTags":                  {},
 }
 
 // roleTagManager is the AWS-specific role-tagging surface, asserted against the
@@ -167,6 +173,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.getRole(w, r)
 	case "ListRoles":
 		h.listRoles(w, r)
+	case "UpdateRole":
+		h.updateRole(w, r)
+	case "UpdateAssumeRolePolicy":
+		h.updateAssumeRolePolicy(w, r)
 	case "CreatePolicy":
 		h.createPolicy(w, r)
 	case "DeletePolicy":
@@ -217,6 +227,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteAccessKey(w, r)
 	case "ListAccessKeys":
 		h.listAccessKeys(w, r)
+	case "UpdateAccessKey":
+		h.updateAccessKey(w, r)
 	case "CreateInstanceProfile":
 		h.createInstanceProfile(w, r)
 	case "DeleteInstanceProfile":
@@ -245,6 +257,12 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.untagRole(w, r)
 	case "ListRoleTags":
 		h.listRoleTags(w, r)
+	case "TagUser":
+		h.tagUser(w, r)
+	case "UntagUser":
+		h.untagUser(w, r)
+	case "ListUserTags":
+		h.listUserTags(w, r)
 	default:
 		awsquery.WriteXMLError(w, http.StatusBadRequest,
 			"InvalidAction", "unknown IAM action: "+r.Form.Get("Action"))

--- a/server/aws/iam/instance_profile_test.go
+++ b/server/aws/iam/instance_profile_test.go
@@ -1,0 +1,74 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+// TestSDKInstanceProfilePath proves the instance profile Path is populated
+// (previously empty).
+func TestSDKInstanceProfilePath(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String("web-profile"),
+	}); err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+
+	got, err := client.GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{
+		InstanceProfileName: aws.String("web-profile"),
+	})
+	if err != nil {
+		t.Fatalf("GetInstanceProfile: %v", err)
+	}
+
+	if path := aws.ToString(got.InstanceProfile.Path); path != "/" {
+		t.Fatalf("InstanceProfile.Path = %q, want %q", path, "/")
+	}
+}
+
+// TestSDKListInstanceProfilesForRole proves the operation returns the profiles
+// that reference the role (previously always empty).
+func TestSDKListInstanceProfilesForRole(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("app-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.CreateInstanceProfile(ctx, &iam.CreateInstanceProfileInput{
+		InstanceProfileName: aws.String("app-profile"),
+	}); err != nil {
+		t.Fatalf("CreateInstanceProfile: %v", err)
+	}
+
+	if _, err := client.AddRoleToInstanceProfile(ctx, &iam.AddRoleToInstanceProfileInput{
+		InstanceProfileName: aws.String("app-profile"), RoleName: aws.String("app-role"),
+	}); err != nil {
+		t.Fatalf("AddRoleToInstanceProfile: %v", err)
+	}
+
+	got, err := client.ListInstanceProfilesForRole(ctx, &iam.ListInstanceProfilesForRoleInput{
+		RoleName: aws.String("app-role"),
+	})
+	if err != nil {
+		t.Fatalf("ListInstanceProfilesForRole: %v", err)
+	}
+
+	if len(got.InstanceProfiles) != 1 {
+		t.Fatalf("ListInstanceProfilesForRole = %d, want 1", len(got.InstanceProfiles))
+	}
+
+	if name := aws.ToString(got.InstanceProfiles[0].InstanceProfileName); name != "app-profile" {
+		t.Fatalf("returned profile %q, want app-profile", name)
+	}
+}

--- a/server/aws/iam/operations.go
+++ b/server/aws/iam/operations.go
@@ -2,17 +2,44 @@ package iam
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
 	iamdriver "github.com/stackshy/cloudemu/v2/services/iam/driver"
 )
 
+// codeMalformedPolicy is the error code IAM returns when a supplied policy or
+// trust-policy document is not a valid JSON object.
+const codeMalformedPolicy = "MalformedPolicyDocument"
+
+// validPolicyDocument reports whether doc is acceptable as an IAM policy or
+// trust-policy document. An empty document is left to the driver's required-field
+// checks; a non-empty one must parse as a JSON object.
+func validPolicyDocument(doc string) bool {
+	if doc == "" {
+		return true
+	}
+
+	var obj map[string]any
+
+	return json.Unmarshal([]byte(doc), &obj) == nil
+}
+
+// writeMalformedPolicy emits the IAM MalformedPolicyDocument error (HTTP 400).
+func writeMalformedPolicy(w http.ResponseWriter, message string) {
+	awsquery.WriteXMLError(w, http.StatusBadRequest, codeMalformedPolicy, message)
+}
+
 // defaultPolicyVersionID is the version a freshly created policy starts with.
 const defaultPolicyVersionID = "v1"
+
+// formValueTrue is the string a boolean query-protocol parameter carries when set.
+const formValueTrue = "true"
 
 // callerUserName is the synthetic IAM user name reported for the calling
 // principal (GetUser with no UserName). Matches STS GetCallerIdentity.
@@ -140,11 +167,17 @@ func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
 // --- Roles ---
 
 func (h *Handler) createRole(w http.ResponseWriter, r *http.Request) {
+	assumeRolePolicy := r.Form.Get("AssumeRolePolicyDocument")
+	if !validPolicyDocument(assumeRolePolicy) {
+		writeMalformedPolicy(w, "The trust policy is not a valid JSON document")
+		return
+	}
+
 	cfg := iamdriver.RoleConfig{
 		Name:                r.Form.Get("RoleName"),
 		Path:                r.Form.Get("Path"),
 		Description:         r.Form.Get("Description"),
-		AssumeRolePolicyDoc: r.Form.Get("AssumeRolePolicyDocument"),
+		AssumeRolePolicyDoc: assumeRolePolicy,
 		Tags:                parseIAMTags(r.Form),
 	}
 
@@ -219,6 +252,11 @@ func (h *Handler) listRoles(w http.ResponseWriter, r *http.Request) {
 // --- Policies ---
 
 func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request) {
+	if !validPolicyDocument(r.Form.Get("PolicyDocument")) {
+		writeMalformedPolicy(w, "Syntax errors in policy")
+		return
+	}
+
 	cfg := iamdriver.PolicyConfig{
 		Name:           r.Form.Get("PolicyName"),
 		Path:           r.Form.Get("Path"),
@@ -234,7 +272,7 @@ func (h *Handler) createPolicy(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, createPolicyResponse{
 		Xmlns:    Namespace,
-		Result:   createPolicyResult{Policy: toPolicyXML(p, defaultPolicyVersionID)},
+		Result:   createPolicyResult{Policy: toPolicyXML(p, h.policyMetaFor(r.Context(), p.ARN))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -260,7 +298,7 @@ func (h *Handler) getPolicy(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, getPolicyResponse{
 		Xmlns:    Namespace,
-		Result:   getPolicyResult{Policy: toPolicyXML(p, h.defaultVersionID(r.Context(), p.ARN))},
+		Result:   getPolicyResult{Policy: toPolicyXML(p, h.policyMetaFor(r.Context(), p.ARN))},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -272,6 +310,8 @@ func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	policies = h.filterPolicies(r, policies)
+
 	sort.Slice(policies, func(i, j int) bool { return policies[i].ARN < policies[j].ARN })
 
 	start, end, marker, truncated := pageWindow(len(policies), r.Form)
@@ -279,7 +319,7 @@ func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 
 	out := policiesListXML{Member: make([]policyXML, 0, len(page))}
 	for i := range page {
-		out.Member = append(out.Member, toPolicyXML(&page[i], h.defaultVersionID(r.Context(), page[i].ARN)))
+		out.Member = append(out.Member, toPolicyXML(&page[i], h.policyMetaFor(r.Context(), page[i].ARN)))
 	}
 
 	awsquery.WriteXMLResponse(w, listPoliciesResponse{
@@ -289,28 +329,105 @@ func (h *Handler) listPolicies(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// defaultVersionID returns the version ID currently marked default for the
-// policy, falling back to "v1" if the versions cannot be read.
-func (h *Handler) defaultVersionID(ctx context.Context, policyARN string) string {
+// awsManagedPolicyPrefix is the ARN prefix AWS-published (managed) policies
+// carry. Everything else is a customer-managed (Local) policy.
+const awsManagedPolicyPrefix = "arn:aws:iam::aws:policy/"
+
+// filterPolicies applies the ListPolicies Scope, PathPrefix, and OnlyAttached
+// filters. Real IAM defaults Scope to All and OnlyAttached to false.
+func (h *Handler) filterPolicies(r *http.Request, policies []iamdriver.PolicyInfo) []iamdriver.PolicyInfo {
+	scope := r.Form.Get("Scope")
+	pathPrefix := r.Form.Get("PathPrefix")
+	onlyAttached := r.Form.Get("OnlyAttached") == formValueTrue
+
+	out := policies[:0]
+
+	for i := range policies {
+		p := policies[i]
+
+		isAWS := strings.HasPrefix(p.ARN, awsManagedPolicyPrefix)
+		if scope == "AWS" && !isAWS {
+			continue
+		}
+
+		if scope == "Local" && isAWS {
+			continue
+		}
+
+		if pathPrefix != "" && !strings.HasPrefix(p.Path, pathPrefix) {
+			continue
+		}
+
+		if onlyAttached && h.attachmentCount(r.Context(), p.ARN) == 0 {
+			continue
+		}
+
+		out = append(out, p)
+	}
+
+	return out
+}
+
+// policyMetaFor derives the wire-only policy fields (default version, its
+// create/update timestamps, and the live attachment count) for a policy ARN.
+// It falls back to sensible defaults when the version list cannot be read.
+func (h *Handler) policyMetaFor(ctx context.Context, policyARN string) policyMeta {
+	meta := policyMeta{
+		defaultVersionID: defaultPolicyVersionID,
+		attachmentCount:  h.attachmentCount(ctx, policyARN),
+	}
+
 	versions, err := h.iam.ListPolicyVersions(ctx, policyARN)
 	if err != nil {
-		return defaultPolicyVersionID
+		return meta
 	}
 
 	for i := range versions {
+		if versions[i].VersionID == defaultPolicyVersionID {
+			meta.createDate = versions[i].CreatedAt
+		}
+
 		if versions[i].IsDefaultVersion {
-			return versions[i].VersionID
+			meta.defaultVersionID = versions[i].VersionID
+			meta.updateDate = versions[i].CreatedAt
 		}
 	}
 
-	return defaultPolicyVersionID
+	if meta.updateDate == "" {
+		meta.updateDate = meta.createDate
+	}
+
+	return meta
+}
+
+// policyAttachmentCounter is the AWS-specific surface for the live count of
+// principals a managed policy is attached to. It's not part of the portable
+// driver, so the handler type-asserts for it.
+type policyAttachmentCounter interface {
+	PolicyAttachmentCount(ctx context.Context, policyARN string) (int, error)
+}
+
+// attachmentCount returns the live attachment count, or 0 when the driver does
+// not expose the counter.
+func (h *Handler) attachmentCount(ctx context.Context, policyARN string) int {
+	counter, ok := h.iam.(policyAttachmentCounter)
+	if !ok {
+		return 0
+	}
+
+	n, err := counter.PolicyAttachmentCount(ctx, policyARN)
+	if err != nil {
+		return 0
+	}
+
+	return n
 }
 
 func (h *Handler) createPolicyVersion(w http.ResponseWriter, r *http.Request) {
 	cfg := iamdriver.PolicyVersionConfig{
 		PolicyARN:      r.Form.Get("PolicyArn"),
 		PolicyDocument: r.Form.Get("PolicyDocument"),
-		SetAsDefault:   r.Form.Get("SetAsDefault") == "true",
+		SetAsDefault:   r.Form.Get("SetAsDefault") == formValueTrue,
 	}
 
 	v, err := h.iam.CreatePolicyVersion(r.Context(), cfg)
@@ -539,11 +656,40 @@ func (h *Handler) getGroup(w http.ResponseWriter, r *http.Request) {
 		Xmlns: Namespace,
 		Result: getGroupResult{
 			Group:       toGroupXML(g),
-			Users:       usersListXML{},
+			Users:       h.groupMembersXML(r.Context(), g.Name),
 			IsTruncated: false,
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// groupMemberLister is the AWS-specific surface for a group's membership. It's
+// not part of the portable driver, so the handler type-asserts for it.
+type groupMemberLister interface {
+	ListGroupMembers(ctx context.Context, groupName string) ([]iamdriver.UserInfo, error)
+}
+
+// groupMembersXML returns the users in a group as the wire shape GetGroup
+// expects, or an empty list when the driver does not track membership.
+func (h *Handler) groupMembersXML(ctx context.Context, groupName string) usersListXML {
+	lister, ok := h.iam.(groupMemberLister)
+	if !ok {
+		return usersListXML{}
+	}
+
+	users, err := lister.ListGroupMembers(ctx, groupName)
+	if err != nil {
+		return usersListXML{}
+	}
+
+	sort.Slice(users, func(i, j int) bool { return users[i].Name < users[j].Name })
+
+	out := usersListXML{Member: make([]userXML, 0, len(users))}
+	for i := range users {
+		out.Member = append(out.Member, toUserXML(&users[i]))
+	}
+
+	return out
 }
 
 //nolint:dupl // list handlers share shape but operate on different driver types and response envelopes.
@@ -677,6 +823,7 @@ func (h *Handler) listAccessKeys(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) createInstanceProfile(w http.ResponseWriter, r *http.Request) {
 	cfg := iamdriver.InstanceProfileConfig{
 		Name: r.Form.Get("InstanceProfileName"),
+		Path: r.Form.Get("Path"),
 		Tags: parseIAMTags(r.Form),
 	}
 
@@ -785,14 +932,32 @@ func (h *Handler) lookupRole(r *http.Request, name string) *iamdriver.RoleInfo {
 	return role
 }
 
-// listInstanceProfilesForRole returns an empty list. CloudEmu does not track
-// role→instance-profile membership; this exists so `terraform destroy` (which
-// lists a role's instance profiles before deleting it) succeeds.
-func (*Handler) listInstanceProfilesForRole(w http.ResponseWriter, _ *http.Request) {
+// listInstanceProfilesForRole returns the instance profiles that reference the
+// given role. It filters the full profile list by RoleName, which is how the
+// association is stored (AddRoleToInstanceProfile sets the profile's role).
+func (h *Handler) listInstanceProfilesForRole(w http.ResponseWriter, r *http.Request) {
+	roleName := r.Form.Get("RoleName")
+
+	profiles, err := h.iam.ListInstanceProfiles(r.Context())
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := instanceProfilesListXML{Member: []instanceProfileXML{}}
+
+	for i := range profiles {
+		if profiles[i].RoleName != roleName {
+			continue
+		}
+
+		out.Member = append(out.Member, toInstanceProfileXML(&profiles[i], h.lookupRole(r, profiles[i].RoleName)))
+	}
+
 	awsquery.WriteXMLResponse(w, listInstanceProfilesForRoleResponse{
 		Xmlns: Namespace,
 		Result: listInstanceProfilesForRoleResult{
-			InstanceProfiles: instanceProfilesListXML{Member: []instanceProfileXML{}},
+			InstanceProfiles: out,
 		},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})

--- a/server/aws/iam/policy_metadata_test.go
+++ b/server/aws/iam/policy_metadata_test.go
@@ -1,0 +1,150 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKPolicyDatesArePopulated proves CreatePolicy/GetPolicy return non-nil
+// CreateDate and UpdateDate (previously both nil).
+func TestSDKPolicyDatesArePopulated(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("dated-pol"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	if created.Policy.CreateDate == nil {
+		t.Fatal("CreatePolicy CreateDate is nil")
+	}
+
+	if created.Policy.UpdateDate == nil {
+		t.Fatal("CreatePolicy UpdateDate is nil")
+	}
+
+	got, err := client.GetPolicy(ctx, &iam.GetPolicyInput{PolicyArn: created.Policy.Arn})
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	if got.Policy.CreateDate == nil {
+		t.Fatal("GetPolicy CreateDate is nil")
+	}
+}
+
+// TestSDKPolicyAttachmentCount proves GetPolicy reflects the live attachment
+// count (previously hardcoded 0).
+func TestSDKPolicyAttachmentCount(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("counted-pol"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	arn := created.Policy.Arn
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("attach-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName: aws.String("attach-role"), PolicyArn: arn,
+	}); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	got, err := client.GetPolicy(ctx, &iam.GetPolicyInput{PolicyArn: arn})
+	if err != nil {
+		t.Fatalf("GetPolicy: %v", err)
+	}
+
+	if c := aws.ToInt32(got.Policy.AttachmentCount); c != 1 {
+		t.Fatalf("AttachmentCount = %d, want 1", c)
+	}
+}
+
+// TestSDKListPoliciesOnlyAttached proves the OnlyAttached filter returns only
+// policies with a live attachment (previously ignored).
+func TestSDKListPoliciesOnlyAttached(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	attached, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("is-attached"),
+		PolicyDocument: aws.String(samplePolicy),
+	})
+	if err != nil {
+		t.Fatalf("CreatePolicy attached: %v", err)
+	}
+
+	if _, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("not-attached"),
+		PolicyDocument: aws.String(samplePolicy),
+	}); err != nil {
+		t.Fatalf("CreatePolicy unattached: %v", err)
+	}
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("filter-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName: aws.String("filter-role"), PolicyArn: attached.Policy.Arn,
+	}); err != nil {
+		t.Fatalf("AttachRolePolicy: %v", err)
+	}
+
+	listed, err := client.ListPolicies(ctx, &iam.ListPoliciesInput{
+		OnlyAttached: true,
+		Scope:        iamtypes.PolicyScopeTypeLocal,
+	})
+	if err != nil {
+		t.Fatalf("ListPolicies: %v", err)
+	}
+
+	if len(listed.Policies) != 1 {
+		t.Fatalf("OnlyAttached returned %d policies, want 1", len(listed.Policies))
+	}
+
+	if name := aws.ToString(listed.Policies[0].PolicyName); name != "is-attached" {
+		t.Fatalf("OnlyAttached returned %q, want is-attached", name)
+	}
+}
+
+// TestSDKCreatePolicyRejectsMalformed proves an unparseable PolicyDocument is
+// rejected with MalformedPolicyDocumentException (previously accepted).
+func TestSDKCreatePolicyRejectsMalformed(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	_, err := client.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     aws.String("bad-pol"),
+		PolicyDocument: aws.String("}{ not json"),
+	})
+
+	var malformed *iamtypes.MalformedPolicyDocumentException
+	if !errors.As(err, &malformed) {
+		t.Fatalf("CreatePolicy with bad JSON: want MalformedPolicyDocumentException, got %v", err)
+	}
+}

--- a/server/aws/iam/role_update.go
+++ b/server/aws/iam/role_update.go
@@ -1,0 +1,110 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// roleUpdater is the AWS-specific surface for in-place role mutation
+// (UpdateRole / UpdateAssumeRolePolicy). It's not part of the portable driver,
+// so the handler type-asserts for it.
+type roleUpdater interface {
+	UpdateRole(ctx context.Context, roleName string, description *string, maxSessionDuration *int) error
+	UpdateAssumeRolePolicy(ctx context.Context, roleName, policyDocument string) error
+}
+
+type updateRoleResponse struct {
+	XMLName  xml.Name         `xml:"UpdateRoleResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Result   struct{}         `xml:"UpdateRoleResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type updateAssumeRolePolicyResponse struct {
+	XMLName  xml.Name         `xml:"UpdateAssumeRolePolicyResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) roleUpdates() (roleUpdater, bool) {
+	u, ok := h.iam.(roleUpdater)
+
+	return u, ok
+}
+
+func (h *Handler) updateRole(w http.ResponseWriter, r *http.Request) {
+	upd, ok := h.roleUpdates()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "role updates not supported"))
+		return
+	}
+
+	description := optionalFormString(r, "Description")
+	maxSession := optionalFormInt(r, "MaxSessionDuration")
+
+	if err := upd.UpdateRole(r.Context(), r.Form.Get("RoleName"), description, maxSession); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, updateRoleResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// optionalFormString returns a pointer to the form value when the key is
+// present, or nil when it is absent — so an omitted parameter leaves the target
+// field unchanged.
+func optionalFormString(r *http.Request, key string) *string {
+	if !r.Form.Has(key) {
+		return nil
+	}
+
+	v := r.Form.Get(key)
+
+	return &v
+}
+
+// optionalFormInt returns a pointer to the parsed integer form value, or nil
+// when the key is absent or unparseable.
+func optionalFormInt(r *http.Request, key string) *int {
+	v := r.Form.Get(key)
+	if v == "" {
+		return nil
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return nil
+	}
+
+	return &n
+}
+
+func (h *Handler) updateAssumeRolePolicy(w http.ResponseWriter, r *http.Request) {
+	upd, ok := h.roleUpdates()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "role updates not supported"))
+		return
+	}
+
+	policyDocument := r.Form.Get("PolicyDocument")
+	if !validPolicyDocument(policyDocument) {
+		writeMalformedPolicy(w, "The trust policy is not a valid JSON document")
+		return
+	}
+
+	if err := upd.UpdateAssumeRolePolicy(r.Context(), r.Form.Get("RoleName"), policyDocument); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, updateAssumeRolePolicyResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/role_update_test.go
+++ b/server/aws/iam/role_update_test.go
@@ -1,0 +1,105 @@
+package iam_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKUpdateRole proves UpdateRole mutates Description and MaxSessionDuration
+// in place (previously undispatched → InvalidAction).
+func TestSDKUpdateRole(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("editable"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+		Description:              aws.String("original"),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	if _, err := client.UpdateRole(ctx, &iam.UpdateRoleInput{
+		RoleName:           aws.String("editable"),
+		Description:        aws.String("updated"),
+		MaxSessionDuration: aws.Int32(7200),
+	}); err != nil {
+		t.Fatalf("UpdateRole: %v", err)
+	}
+
+	got, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("editable")})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	if desc := aws.ToString(got.Role.Description); desc != "updated" {
+		t.Fatalf("Role.Description = %q, want %q", desc, "updated")
+	}
+
+	if d := aws.ToInt32(got.Role.MaxSessionDuration); d != 7200 {
+		t.Fatalf("Role.MaxSessionDuration = %d, want 7200", d)
+	}
+}
+
+// TestSDKUpdateAssumeRolePolicy proves the trust policy is replaced in place
+// (previously undispatched → InvalidAction).
+func TestSDKUpdateAssumeRolePolicy(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("trust-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	const newTrust = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}`
+
+	if _, err := client.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String("trust-role"),
+		PolicyDocument: aws.String(newTrust),
+	}); err != nil {
+		t.Fatalf("UpdateAssumeRolePolicy: %v", err)
+	}
+
+	got, err := client.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String("trust-role")})
+	if err != nil {
+		t.Fatalf("GetRole: %v", err)
+	}
+
+	// The SDK URL-decodes AssumeRolePolicyDocument; assert the new principal made it through.
+	if doc := aws.ToString(got.Role.AssumeRolePolicyDocument); !strings.Contains(doc, "lambda.amazonaws.com") {
+		t.Fatalf("trust policy = %q, want it to mention lambda.amazonaws.com", doc)
+	}
+}
+
+// TestSDKUpdateAssumeRolePolicyRejectsMalformed proves a non-JSON trust policy
+// is rejected with MalformedPolicyDocumentException.
+func TestSDKUpdateAssumeRolePolicyRejectsMalformed(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String("mal-role"),
+		AssumeRolePolicyDocument: aws.String(trustPolicy),
+	}); err != nil {
+		t.Fatalf("CreateRole: %v", err)
+	}
+
+	_, err := client.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String("mal-role"),
+		PolicyDocument: aws.String("not json"),
+	})
+
+	var malformed *iamtypes.MalformedPolicyDocumentException
+	if !errors.As(err, &malformed) {
+		t.Fatalf("UpdateAssumeRolePolicy with bad JSON: want MalformedPolicyDocumentException, got %v", err)
+	}
+}

--- a/server/aws/iam/usertags.go
+++ b/server/aws/iam/usertags.go
@@ -1,0 +1,110 @@
+package iam
+
+import (
+	"context"
+	"encoding/xml"
+	"net/http"
+	"sort"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+)
+
+// userTagManager is the AWS-specific user-tagging surface, asserted against the
+// provider (not part of the portable IAM driver).
+type userTagManager interface {
+	TagUser(ctx context.Context, userName string, tags map[string]string) error
+	UntagUser(ctx context.Context, userName string, keys []string) error
+	ListUserTags(ctx context.Context, userName string) (map[string]string, error)
+}
+
+type tagUserResponse struct {
+	XMLName  xml.Name         `xml:"TagUserResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type untagUserResponse struct {
+	XMLName  xml.Name         `xml:"UntagUserResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type listUserTagsResponse struct {
+	XMLName  xml.Name         `xml:"ListUserTagsResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Tags     []tagMemberXML   `xml:"ListUserTagsResult>Tags>member"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+func (h *Handler) userTags() (userTagManager, bool) {
+	m, ok := h.iam.(userTagManager)
+
+	return m, ok
+}
+
+//nolint:dupl // tag handlers share shape but operate on distinct actions and response envelopes.
+func (h *Handler) tagUser(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.userTags()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "user tagging not supported"))
+		return
+	}
+
+	if err := mgr.TagUser(r.Context(), r.Form.Get("UserName"), awsquery.FlatTags(r.Form, "Tags.member")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, tagUserResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+//nolint:dupl // tag handlers share shape but operate on distinct actions and response envelopes.
+func (h *Handler) untagUser(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.userTags()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "user tagging not supported"))
+		return
+	}
+
+	if err := mgr.UntagUser(r.Context(), r.Form.Get("UserName"), awsquery.ListStrings(r.Form, "TagKeys.member")); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, untagUserResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) listUserTags(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.userTags()
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "user tagging not supported"))
+		return
+	}
+
+	tags, err := mgr.ListUserTags(r.Context(), r.Form.Get("UserName"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	members := make([]tagMemberXML, 0, len(keys))
+	for _, k := range keys {
+		members = append(members, tagMemberXML{Key: k, Value: tags[k]})
+	}
+
+	awsquery.WriteXMLResponse(w, listUserTagsResponse{
+		Xmlns: Namespace, Tags: members, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}

--- a/server/aws/iam/usertags_test.go
+++ b/server/aws/iam/usertags_test.go
@@ -1,0 +1,60 @@
+package iam_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// TestSDKUserTagging proves TagUser/ListUserTags/UntagUser round-trip
+// (previously undispatched → InvalidAction).
+func TestSDKUserTagging(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateUser(ctx, &iam.CreateUserInput{UserName: aws.String("tagged")}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	if _, err := client.TagUser(ctx, &iam.TagUserInput{
+		UserName: aws.String("tagged"),
+		Tags: []iamtypes.Tag{
+			{Key: aws.String("team"), Value: aws.String("platform")},
+			{Key: aws.String("env"), Value: aws.String("dev")},
+		},
+	}); err != nil {
+		t.Fatalf("TagUser: %v", err)
+	}
+
+	listed, err := client.ListUserTags(ctx, &iam.ListUserTagsInput{UserName: aws.String("tagged")})
+	if err != nil {
+		t.Fatalf("ListUserTags: %v", err)
+	}
+
+	got := map[string]string{}
+	for _, tg := range listed.Tags {
+		got[aws.ToString(tg.Key)] = aws.ToString(tg.Value)
+	}
+
+	if got["team"] != "platform" || got["env"] != "dev" {
+		t.Fatalf("ListUserTags = %v, want team=platform env=dev", got)
+	}
+
+	if _, err := client.UntagUser(ctx, &iam.UntagUserInput{
+		UserName: aws.String("tagged"), TagKeys: []string{"env"},
+	}); err != nil {
+		t.Fatalf("UntagUser: %v", err)
+	}
+
+	after, err := client.ListUserTags(ctx, &iam.ListUserTagsInput{UserName: aws.String("tagged")})
+	if err != nil {
+		t.Fatalf("ListUserTags after untag: %v", err)
+	}
+
+	if len(after.Tags) != 1 || aws.ToString(after.Tags[0].Key) != "team" {
+		t.Fatalf("after untag = %v, want only team", after.Tags)
+	}
+}

--- a/server/aws/iam/xml.go
+++ b/server/aws/iam/xml.go
@@ -92,28 +92,35 @@ type policyXML struct {
 	AttachmentCount  int    `xml:"AttachmentCount"`
 	IsAttachable     bool   `xml:"IsAttachable"`
 	Description      string `xml:"Description,omitempty"`
+	CreateDate       string `xml:"CreateDate,omitempty"`
+	UpdateDate       string `xml:"UpdateDate,omitempty"`
 }
 
-// toPolicyXML emits the wire shape the SDK expects. Two fields are fixed
-// constants rather than driver-derived because the in-memory PolicyInfo
-// doesn't carry them:
-//
-//   - AttachmentCount is always 0. The driver does not track the live
-//     count, and recomputing it would mean walking every user/role on
-//     every read. The SDK accepts the field at zero.
-//   - IsAttachable is always true. Real AWS distinguishes
-//     customer-managed (attachable) from AWS-managed policies; we only
-//     emit customer-managed, so true is correct.
-func toPolicyXML(p *iamdriver.PolicyInfo, defaultVersionID string) policyXML {
+// policyMeta carries the per-policy fields the driver's PolicyInfo doesn't hold
+// directly: the current default version, its create/update timestamps (derived
+// from the policy's version list), and the live attachment count.
+type policyMeta struct {
+	defaultVersionID string
+	createDate       string
+	updateDate       string
+	attachmentCount  int
+}
+
+// toPolicyXML emits the wire shape the SDK expects. IsAttachable is always true:
+// real AWS distinguishes customer-managed (attachable) from AWS-managed
+// policies, and both kinds this emulator serves are attachable.
+func toPolicyXML(p *iamdriver.PolicyInfo, meta policyMeta) policyXML {
 	return policyXML{
 		PolicyName:       p.Name,
 		PolicyID:         p.ID,
 		Arn:              p.ARN,
 		Path:             p.Path,
-		DefaultVersionID: defaultVersionID,
-		AttachmentCount:  0,
+		DefaultVersionID: meta.defaultVersionID,
+		AttachmentCount:  meta.attachmentCount,
 		IsAttachable:     true,
 		Description:      p.Description,
+		CreateDate:       meta.createDate,
+		UpdateDate:       meta.updateDate,
 	}
 }
 
@@ -153,12 +160,11 @@ type groupXML struct {
 	CreateDate string `xml:"CreateDate,omitempty"`
 }
 
-// toGroupXML emits the wire shape the SDK expects. GroupId is omitted
-// because the driver's GroupInfo doesn't carry one; the SDK tolerates the
-// missing field (it's modeled as optional on the response).
+// toGroupXML emits the wire shape the SDK expects.
 func toGroupXML(g *iamdriver.GroupInfo) groupXML {
 	return groupXML{
 		GroupName:  g.Name,
+		GroupID:    g.ID,
 		Arn:        g.ARN,
 		Path:       g.Path,
 		CreateDate: g.CreatedAt,
@@ -218,6 +224,7 @@ func toInstanceProfileXML(p *iamdriver.InstanceProfileInfo, role *iamdriver.Role
 		InstanceProfileName: p.Name,
 		InstanceProfileID:   p.ID,
 		Arn:                 p.ARN,
+		Path:                p.Path,
 		CreateDate:          p.CreatedAt,
 		Tags:                toTagsXML(p.Tags),
 	}

--- a/services/iam/driver/driver.go
+++ b/services/iam/driver/driver.go
@@ -85,6 +85,7 @@ type GroupConfig struct {
 // GroupInfo describes an IAM group.
 type GroupInfo struct {
 	Name      string
+	ID        string
 	Path      string
 	ARN       string
 	CreatedAt string
@@ -107,6 +108,7 @@ type AccessKeyInfo struct {
 // InstanceProfileConfig describes an instance profile to create.
 type InstanceProfileConfig struct {
 	Name     string
+	Path     string
 	RoleName string
 	Tags     map[string]string
 }
@@ -115,6 +117,7 @@ type InstanceProfileConfig struct {
 type InstanceProfileInfo struct {
 	ID        string
 	Name      string
+	Path      string
 	RoleName  string
 	ARN       string
 	CreatedAt string


### PR DESCRIPTION
Closes remaining IAM audit findings, wire-layer where possible.

- GetGroup populates Users; ListInstanceProfilesForRole filters by role
- UpdateRole / UpdateAssumeRolePolicy dispatched; DeleteUser/DeletePolicy return DeleteConflict when still in use
- ListPolicies honors Scope/OnlyAttached/PathPrefix; AttachmentCount + Create/UpdateDate emitted; GroupId + InstanceProfile Path populated
- TagUser/UntagUser/ListUserTags/UpdateAccessKey dispatched; MalformedPolicyDocument for unparseable JSON

Additive driver struct fields only (GroupInfo.ID, InstanceProfileInfo/Config.Path) — Azure/GCP/OCI compile unchanged, compat docs clean. SDK round-trip tests per feature.