### PR TITLE
fix(dynamodb): wire fidelity — LSIs, streams spec, UpdateTable, TransactGetItems, ReturnValues, capacity

### DIFF
--- a/providers/aws/dynamodb/dynamodb.go
+++ b/providers/aws/dynamodb/dynamodb.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"maps"
 	"strconv"
@@ -51,6 +52,7 @@ type tableData struct {
 	streamRecords []driver.StreamRecord
 	seqCounter    atomic.Int64
 	tags          map[string]string
+	pitrEnabled   bool
 }
 
 // Mock is an in-memory mock implementation of DynamoDB.
@@ -101,10 +103,49 @@ func (m *Mock) CreateTable(_ context.Context, cfg driver.TableConfig) error {
 
 	cfg.TableArn = idgen.AWSARN("dynamodb", m.opts.Region, m.opts.AccountID, "table/"+cfg.Name)
 	cfg.CreatedAtUnix = float64(m.opts.Clock.Now().Unix())
+	cfg.TableID = uuidV4()
 
-	m.tables[cfg.Name] = &tableData{config: cfg, items: memstore.New[map[string]any]()}
+	td := &tableData{items: memstore.New[map[string]any]()}
+
+	if cfg.StreamEnabled {
+		viewType := cfg.StreamViewType
+		if viewType == "" {
+			viewType = ViewNewAndOld
+		}
+
+		cfg.StreamViewType = viewType
+		cfg.StreamLabel, cfg.StreamArn = m.newStreamIdentity(cfg.TableArn)
+		td.streamConfig = driver.StreamConfig{Enabled: true, ViewType: viewType}
+	}
+
+	td.config = cfg
+	m.tables[cfg.Name] = td
 
 	return nil
+}
+
+// newStreamIdentity builds the (label, ARN) pair a DynamoDB stream carries.
+// The label is an ISO-like timestamp and the ARN embeds it, matching the real
+// LatestStreamLabel/LatestStreamArn shape clients read back.
+func (m *Mock) newStreamIdentity(tableArn string) (label, arn string) {
+	label = m.opts.Clock.Now().UTC().Format("2006-01-02T15:04:05.000")
+	arn = tableArn + "/stream/" + label
+
+	return label, arn
+}
+
+// uuidV4 returns a random RFC-4122 v4 UUID, the format a real DynamoDB TableId
+// carries. A crypto/rand read failure is unrecoverable for the mock.
+func uuidV4() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("dynamodb: crypto/rand failed: " + err.Error())
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 func (m *Mock) DeleteTable(_ context.Context, name string) error {
@@ -277,7 +318,7 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
-	matched, err := m.matchQueryItems(td, pkField, skField, &input)
+	matched, scanned, err := m.matchQueryItems(td, pkField, skField, &input)
 	if err != nil {
 		return nil, err
 	}
@@ -300,6 +341,8 @@ func (m *Mock) Query(_ context.Context, input driver.QueryInput) (*driver.QueryR
 		return nil, err
 	}
 
+	result.ScannedCount = scanned
+
 	dims := map[string]string{"TableName": input.Table}
 	m.emitMetric("ConsumedReadCapacityUnits", float64(len(result.Items)), dims)
 	m.emitMetric("SuccessfulRequestCount", 1, dims)
@@ -321,20 +364,28 @@ func resolveKeyFields(td *tableData, indexName string) (pkField, skField string,
 		}
 	}
 
+	// An LSI shares the table partition key and defines an alternate sort key.
+	for _, lsi := range td.config.LSIs {
+		if lsi.Name == indexName {
+			return td.config.PartitionKey, lsi.SortKey, nil
+		}
+	}
+
 	return "", "", cerrors.Newf(cerrors.NotFound, "index %s not found", indexName)
 }
 
+// matchQueryItems returns the items matching the key condition and filter, plus
+// the pre-filter scanned count (items that matched the key condition before the
+// FilterExpression), which the response surfaces as ScannedCount.
 func (m *Mock) matchQueryItems(
 	td *tableData, pkField, skField string, input *driver.QueryInput,
-) ([]map[string]any, error) {
+) (matched []map[string]any, scanned int, err error) {
 	node, err := compileFilter(input.FilterExpression, input.ExprNames, input.ExprValues)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	allItems := td.items.All()
-
-	var matched []map[string]any
 
 	for _, item := range allItems {
 		if m.isItemExpired(td, item) {
@@ -345,11 +396,13 @@ func (m *Mock) matchQueryItems(
 			continue
 		}
 
+		scanned++
+
 		// Apply the FilterExpression (post key-condition), matching real
 		// DynamoDB: Query filters the key-matched set the same way Scan does.
 		ok, ferr := passesFilter(node, input.Filters, item)
 		if ferr != nil {
-			return nil, ferr
+			return nil, 0, ferr
 		}
 
 		if ok {
@@ -357,7 +410,7 @@ func (m *Mock) matchQueryItems(
 		}
 	}
 
-	return matched, nil
+	return matched, scanned, nil
 }
 
 func matchesKeyCondition(item map[string]any, pkField, skField string, input *driver.QueryInput) bool {
@@ -416,12 +469,17 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 
 	allItems := td.items.All()
 
-	var matched []map[string]any
+	var (
+		matched []map[string]any
+		scanned int
+	)
 
 	for _, item := range allItems {
 		if m.isItemExpired(td, item) {
 			continue
 		}
+
+		scanned++
 
 		ok, ferr := passesFilter(node, input.Filters, item)
 		if ferr != nil {
@@ -446,6 +504,8 @@ func (m *Mock) Scan(_ context.Context, input driver.ScanInput) (*driver.QueryRes
 	if err != nil {
 		return nil, err
 	}
+
+	result.ScannedCount = scanned
 
 	dims := map[string]string{"TableName": input.Table}
 	m.emitMetric("ConsumedReadCapacityUnits", float64(len(result.Items)), dims)
@@ -624,7 +684,78 @@ func (m *Mock) UpdateStreamConfig(_ context.Context, table string, cfg driver.St
 
 	td.streamConfig = cfg
 
+	// Mirror the stream state onto the table config so a describe reflects it as
+	// LatestStreamArn/Label. Enabling assigns a fresh stream identity; disabling
+	// clears it.
+	td.config.StreamEnabled = cfg.Enabled
+	td.config.StreamViewType = cfg.ViewType
+
+	if cfg.Enabled {
+		if td.config.StreamArn == "" {
+			td.config.StreamLabel, td.config.StreamArn = m.newStreamIdentity(td.config.TableArn)
+		}
+	} else {
+		td.config.StreamArn = ""
+		td.config.StreamLabel = ""
+	}
+
 	return nil
+}
+
+// UpdateThroughput changes a table's billing mode and provisioned throughput.
+// It is an AWS-specific capability (UpdateTable), discovered by the wire handler
+// via type assertion, so it is not part of the cross-cloud Database interface.
+func (m *Mock) UpdateThroughput(_ context.Context, table, billingMode string, rcu, wcu int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	if billingMode != "" {
+		td.config.BillingMode = billingMode
+	}
+
+	if rcu > 0 {
+		td.config.ReadCapacityUnits = rcu
+	}
+
+	if wcu > 0 {
+		td.config.WriteCapacityUnits = wcu
+	}
+
+	return nil
+}
+
+// SetPITR toggles point-in-time recovery for a table (UpdateContinuousBackups).
+// AWS-specific capability, discovered by type assertion.
+func (m *Mock) SetPITR(_ context.Context, table string, enabled bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	td.pitrEnabled = enabled
+
+	return nil
+}
+
+// GetPITR reports whether point-in-time recovery is enabled for a table.
+func (m *Mock) GetPITR(_ context.Context, table string) (bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	td, exists := m.tables[table]
+	if !exists {
+		return false, cerrors.Newf(cerrors.NotFound, "table %s not found", table)
+	}
+
+	return td.pitrEnabled, nil
 }
 
 // GetStreamRecords returns stream records after the given token.

--- a/server/aws/dynamodb/advanced.go
+++ b/server/aws/dynamodb/advanced.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -24,6 +25,7 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		ReturnValues              string            `json:"ReturnValues"`
+		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -40,6 +42,10 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 		req.ConditionExpression, req.ExpressionAttributeNames, vals) {
 		return
 	}
+
+	// Capture the pre-update image so ALL_OLD/UPDATED_OLD/UPDATED_NEW can report
+	// the changed attributes relative to it.
+	old := h.previousItem(r.Context(), req.TableName, key)
 
 	// The raw UpdateExpression flows to the driver, which parses and evaluates
 	// the full grammar (SET arithmetic, if_not_exists, list_append, ADD, DELETE)
@@ -59,11 +65,72 @@ func (h *Handler) updateItem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{}
-	if strings.EqualFold(req.ReturnValues, "ALL_NEW") && updated != nil {
-		resp["Attributes"] = toWireItem(updated)
+	if attrs := updateReturnValues(req.ReturnValues, old, updated); attrs != nil {
+		resp["Attributes"] = toWireItem(attrs)
 	}
 
+	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
 	wire.WriteJSON(w, resp)
+}
+
+// updateReturnValues resolves the UpdateItem ReturnValues mode into the
+// Attributes map DynamoDB returns: ALL_OLD/ALL_NEW echo the whole pre/post
+// image, while UPDATED_OLD/UPDATED_NEW return only the attributes the update
+// changed (their old / new values). NONE (or empty) returns nil.
+func updateReturnValues(mode string, old, updated map[string]any) map[string]any {
+	switch strings.ToUpper(mode) {
+	case "ALL_NEW":
+		return updated
+	case "ALL_OLD":
+		return old
+	case "UPDATED_NEW":
+		return changedAttributes(old, updated, false)
+	case "UPDATED_OLD":
+		return changedAttributes(old, updated, true)
+	default:
+		return nil
+	}
+}
+
+// changedAttributes returns the attributes that differ between old and updated.
+// When wantOld is set it returns their previous values (UPDATED_OLD), otherwise
+// their new values (UPDATED_NEW). A removed attribute contributes to UPDATED_OLD
+// only; an added one to UPDATED_NEW only.
+func changedAttributes(old, updated map[string]any, wantOld bool) map[string]any {
+	out := map[string]any{}
+
+	for k, nv := range updated {
+		if ov, ok := old[k]; !ok || !equalAttr(ov, nv) {
+			if wantOld {
+				if ov, ok := old[k]; ok {
+					out[k] = ov
+				}
+			} else {
+				out[k] = nv
+			}
+		}
+	}
+
+	if wantOld {
+		for k, ov := range old {
+			if _, ok := updated[k]; !ok {
+				out[k] = ov
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}
+
+// equalAttr compares two decoded attribute values for equality. It covers the
+// scalar and container shapes fromWireItem produces; a mismatch in shape counts
+// as unequal, which is safe for change detection.
+func equalAttr(a, b any) bool {
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }
 
 // scan handles Scan (full-table read with optional filters).
@@ -76,6 +143,7 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		Limit                     int               `json:"Limit"`
 		ExclusiveStartKey         map[string]any    `json:"ExclusiveStartKey"`
+		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -113,12 +181,13 @@ func (h *Handler) scan(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
 		"Items":        items,
 		"Count":        len(items),
-		"ScannedCount": len(items),
+		"ScannedCount": result.ScannedCount,
 	}
 	if result.LastEvaluatedKey != nil {
 		resp["LastEvaluatedKey"] = toWireItem(result.LastEvaluatedKey)
 	}
 
+	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
 	wire.WriteJSON(w, resp)
 }
 
@@ -207,6 +276,74 @@ func (h *Handler) batchGetItem(w http.ResponseWriter, r *http.Request) {
 		"Responses":       responses,
 		"UnprocessedKeys": map[string]any{},
 	})
+}
+
+// transactGetItems handles TransactGetItems: an ordered, cross-table batch of
+// gets. The Responses array mirrors the request order and length, each element
+// carrying an Item (or an empty object when that item is absent), exactly as
+// real DynamoDB returns.
+func (h *Handler) transactGetItems(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TransactItems []struct {
+			Get *struct {
+				TableName                string            `json:"TableName"`
+				Key                      map[string]any    `json:"Key"`
+				ProjectionExpression     string            `json:"ProjectionExpression"`
+				ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames"`
+			} `json:"Get,omitempty"`
+		} `json:"TransactItems"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	responses := make([]map[string]any, 0, len(req.TransactItems))
+
+	for _, t := range req.TransactItems {
+		if t.Get == nil {
+			responses = append(responses, map[string]any{})
+			continue
+		}
+
+		entry, err := h.transactGetOne(r, t.Get.TableName, t.Get.Key,
+			t.Get.ProjectionExpression, t.Get.ExpressionAttributeNames)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		responses = append(responses, entry)
+	}
+
+	wire.WriteJSON(w, map[string]any{"Responses": responses})
+}
+
+// transactGetOne resolves a single TransactGetItems Get into its response
+// entry: {"Item": ...} when present, {} when the item is missing. A missing
+// table is a real error and is propagated.
+func (h *Handler) transactGetOne(
+	r *http.Request, table string, wireKey map[string]any, projection string, names map[string]string,
+) (map[string]any, error) {
+	paths, perr := expr.ParseProjection(projection, names)
+	if perr != nil {
+		return nil, perr
+	}
+
+	if _, terr := h.db.DescribeTable(r.Context(), table); terr != nil {
+		return nil, terr
+	}
+
+	item, err := h.db.GetItem(r.Context(), table, fromWireItem(wireKey))
+	if err != nil {
+		if cerrors.IsNotFound(err) {
+			return map[string]any{}, nil
+		}
+
+		return nil, err
+	}
+
+	return map[string]any{"Item": toWireItem(expr.Project(item, paths))}, nil
 }
 
 // transactWriteItems handles TransactWriteItems (grouped puts/deletes).

--- a/server/aws/dynamodb/dynamodb_lifecycle_test.go
+++ b/server/aws/dynamodb/dynamodb_lifecycle_test.go
@@ -894,13 +894,22 @@ func TestDDBTypedErrors(t *testing.T) {
 		require.ErrorAs(t, err, &rnf)
 	})
 
-	t.Run("GetItem on missing table flattens to empty response", func(t *testing.T) {
-		// Documented emulator quirk: the handler converts ANY driver NotFound
-		// (missing item OR missing table) into an empty 200, so the SDK sees
-		// Item == nil instead of ResourceNotFoundException.
-		out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+	t.Run("GetItem on missing table is ResourceNotFoundException", func(t *testing.T) {
+		// A GetItem against a table that does not exist is a
+		// ResourceNotFoundException in real DynamoDB — distinct from a missing
+		// item (which returns an empty 200). The two must not conflate.
+		_, err := client.GetItem(ctx, &dynamodb.GetItemInput{
 			TableName: aws.String("ghost"),
 			Key:       map[string]ddbtypes.AttributeValue{"pk": sAttr("x")},
+		})
+		require.ErrorAs(t, err, &rnf)
+	})
+
+	t.Run("GetItem on missing item returns empty response", func(t *testing.T) {
+		// A missing item in an existing table is still an empty 200, not an error.
+		out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName: aws.String("errs"),
+			Key:       map[string]ddbtypes.AttributeValue{"pk": sAttr("nope")},
 		})
 		require.NoError(t, err)
 		assert.Nil(t, out.Item)
@@ -1639,4 +1648,393 @@ func TestGSIRoundTripAndQuery(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, q.Items, 1)
+}
+
+// TestDDBLocalSecondaryIndexRoundTrip covers finding: a LocalSecondaryIndex
+// declared at CreateTable must be echoed by DescribeTable (previously dropped).
+func TestDDBLocalSecondaryIndexRoundTrip(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("lsitab"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("sk"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("alt"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+			{AttributeName: aws.String("sk"), KeyType: ddbtypes.KeyTypeRange},
+		},
+		LocalSecondaryIndexes: []ddbtypes.LocalSecondaryIndex{{
+			IndexName: aws.String("by-alt"),
+			KeySchema: []ddbtypes.KeySchemaElement{
+				{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+				{AttributeName: aws.String("alt"), KeyType: ddbtypes.KeyTypeRange},
+			},
+			Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+		}},
+	})
+	require.NoError(t, err)
+
+	d, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("lsitab")})
+	require.NoError(t, err)
+	require.Len(t, d.Table.LocalSecondaryIndexes, 1)
+	lsi := d.Table.LocalSecondaryIndexes[0]
+	assert.Equal(t, "by-alt", aws.ToString(lsi.IndexName))
+	require.Len(t, lsi.KeySchema, 2)
+	assert.Equal(t, "alt", aws.ToString(lsi.KeySchema[1].AttributeName))
+}
+
+// TestDDBStreamSpecificationRoundTrip covers finding: a StreamSpecification set
+// at CreateTable must be echoed with a populated LatestStreamArn/Label.
+func TestDDBStreamSpecificationRoundTrip(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:            aws.String("streamtab"),
+		BillingMode:          ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS}},
+		KeySchema:            []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		StreamSpecification: &ddbtypes.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: ddbtypes.StreamViewTypeNewAndOldImages,
+		},
+	})
+	require.NoError(t, err)
+
+	d, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("streamtab")})
+	require.NoError(t, err)
+	require.NotNil(t, d.Table.StreamSpecification)
+	assert.True(t, aws.ToBool(d.Table.StreamSpecification.StreamEnabled))
+	assert.Equal(t, ddbtypes.StreamViewTypeNewAndOldImages, d.Table.StreamSpecification.StreamViewType)
+	assert.NotEmpty(t, aws.ToString(d.Table.LatestStreamArn))
+	assert.NotEmpty(t, aws.ToString(d.Table.LatestStreamLabel))
+}
+
+// TestDDBTagsAtCreate covers finding: Tags supplied at CreateTable must be
+// readable via ListTagsOfResource (previously dropped).
+func TestDDBTagsAtCreate(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	out, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:            aws.String("tagtab"),
+		BillingMode:          ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS}},
+		KeySchema:            []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+		Tags: []ddbtypes.Tag{
+			{Key: aws.String("env"), Value: aws.String("prod")},
+			{Key: aws.String("team"), Value: aws.String("core")},
+		},
+	})
+	require.NoError(t, err)
+
+	tags, err := client.ListTagsOfResource(ctx, &dynamodb.ListTagsOfResourceInput{
+		ResourceArn: out.TableDescription.TableArn,
+	})
+	require.NoError(t, err)
+	got := map[string]string{}
+	for _, tg := range tags.Tags {
+		got[aws.ToString(tg.Key)] = aws.ToString(tg.Value)
+	}
+	assert.Equal(t, map[string]string{"env": "prod", "team": "core"}, got)
+}
+
+// TestDDBTableIdAssigned covers finding: a table must carry a TableId (UUID).
+func TestDDBTableIdAssigned(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "idtab", "pk", "")
+	d, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("idtab")})
+	require.NoError(t, err)
+	id := aws.ToString(d.Table.TableId)
+	assert.Len(t, id, 36, "TableId should be a UUID: %q", id)
+}
+
+// TestDDBUpdateTable covers finding: UpdateTable must be dispatched and apply
+// throughput/billing and stream changes.
+func TestDDBUpdateTable(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("uptab"),
+		BillingMode: ddbtypes.BillingModeProvisioned,
+		ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{
+			ReadCapacityUnits: aws.Int64(1), WriteCapacityUnits: aws.Int64(1),
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS}},
+		KeySchema:            []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+	})
+	require.NoError(t, err)
+
+	upd, err := client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("uptab"),
+		ProvisionedThroughput: &ddbtypes.ProvisionedThroughput{
+			ReadCapacityUnits: aws.Int64(25), WriteCapacityUnits: aws.Int64(10),
+		},
+		StreamSpecification: &ddbtypes.StreamSpecification{
+			StreamEnabled:  aws.Bool(true),
+			StreamViewType: ddbtypes.StreamViewTypeNewImage,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, upd.TableDescription)
+
+	d, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("uptab")})
+	require.NoError(t, err)
+	require.NotNil(t, d.Table.ProvisionedThroughput)
+	assert.Equal(t, int64(25), aws.ToInt64(d.Table.ProvisionedThroughput.ReadCapacityUnits))
+	assert.Equal(t, int64(10), aws.ToInt64(d.Table.ProvisionedThroughput.WriteCapacityUnits))
+	require.NotNil(t, d.Table.StreamSpecification)
+	assert.True(t, aws.ToBool(d.Table.StreamSpecification.StreamEnabled))
+	assert.NotEmpty(t, aws.ToString(d.Table.LatestStreamArn))
+}
+
+// TestDDBUpdateTableAddGSI covers a GlobalSecondaryIndexUpdates.Create on
+// UpdateTable being applied and then queryable.
+func TestDDBUpdateTableAddGSI(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+		TableName:   aws.String("gsiadd"),
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("email"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		KeySchema: []ddbtypes.KeySchemaElement{{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash}},
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateTable(ctx, &dynamodb.UpdateTableInput{
+		TableName: aws.String("gsiadd"),
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("email"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{{
+			Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+				IndexName:  aws.String("by-email"),
+				KeySchema:  []ddbtypes.KeySchemaElement{{AttributeName: aws.String("email"), KeyType: ddbtypes.KeyTypeHash}},
+				Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+			},
+		}},
+	})
+	require.NoError(t, err)
+
+	d, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{TableName: aws.String("gsiadd")})
+	require.NoError(t, err)
+	require.Len(t, d.Table.GlobalSecondaryIndexes, 1)
+	assert.Equal(t, "by-email", aws.ToString(d.Table.GlobalSecondaryIndexes[0].IndexName))
+}
+
+// TestDDBTransactGetItems covers finding: TransactGetItems must be dispatched
+// (previously UnknownOperationException) and return items in request order.
+func TestDDBTransactGetItems(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "tg1", "pk", "")
+	suiteDDBCreateTable(t, client, "tg2", "pk", "")
+	suiteDDBPut(t, client, "tg1", map[string]ddbtypes.AttributeValue{"pk": sAttr("a"), "v": nAttr("1")})
+	suiteDDBPut(t, client, "tg2", map[string]ddbtypes.AttributeValue{"pk": sAttr("b"), "v": nAttr("2")})
+
+	out, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{
+		TransactItems: []ddbtypes.TransactGetItem{
+			{Get: &ddbtypes.Get{TableName: aws.String("tg1"), Key: map[string]ddbtypes.AttributeValue{"pk": sAttr("a")}}},
+			{Get: &ddbtypes.Get{TableName: aws.String("tg2"), Key: map[string]ddbtypes.AttributeValue{"pk": sAttr("b")}}},
+			{Get: &ddbtypes.Get{TableName: aws.String("tg1"), Key: map[string]ddbtypes.AttributeValue{"pk": sAttr("missing")}}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Responses, 3)
+
+	first, ok := out.Responses[0].Item["v"].(*ddbtypes.AttributeValueMemberN)
+	require.True(t, ok)
+	assert.Equal(t, "1", first.Value)
+	second := out.Responses[1].Item["v"].(*ddbtypes.AttributeValueMemberN)
+	assert.Equal(t, "2", second.Value)
+	assert.Nil(t, out.Responses[2].Item, "missing item yields an empty response entry")
+}
+
+// TestDDBReturnValues covers finding: Put/Delete ALL_OLD and Update
+// ALL_OLD/UPDATED_OLD/UPDATED_NEW must return the corresponding Attributes.
+func TestDDBReturnValues(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "rv", "pk", "")
+	suiteDDBPut(t, client, "rv", map[string]ddbtypes.AttributeValue{"pk": sAttr("k"), "n": nAttr("1"), "s": sAttr("old")})
+
+	t.Run("PutItem ALL_OLD returns prior image", func(t *testing.T) {
+		out, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName:    aws.String("rv"),
+			Item:         map[string]ddbtypes.AttributeValue{"pk": sAttr("k"), "n": nAttr("2")},
+			ReturnValues: ddbtypes.ReturnValueAllOld,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.Attributes)
+		assert.Equal(t, "old", out.Attributes["s"].(*ddbtypes.AttributeValueMemberS).Value)
+		assert.Equal(t, "1", out.Attributes["n"].(*ddbtypes.AttributeValueMemberN).Value)
+	})
+
+	t.Run("UpdateItem UPDATED_NEW returns only changed attrs", func(t *testing.T) {
+		out, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                 aws.String("rv"),
+			Key:                       map[string]ddbtypes.AttributeValue{"pk": sAttr("k")},
+			UpdateExpression:          aws.String("SET n = :n"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": nAttr("9")},
+			ReturnValues:              ddbtypes.ReturnValueUpdatedNew,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.Attributes)
+		assert.Equal(t, "9", out.Attributes["n"].(*ddbtypes.AttributeValueMemberN).Value)
+		_, hasPK := out.Attributes["pk"]
+		assert.False(t, hasPK, "UPDATED_NEW returns only changed attributes")
+	})
+
+	t.Run("UpdateItem UPDATED_OLD returns prior value of changed attrs", func(t *testing.T) {
+		out, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName:                 aws.String("rv"),
+			Key:                       map[string]ddbtypes.AttributeValue{"pk": sAttr("k")},
+			UpdateExpression:          aws.String("SET n = :n"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": nAttr("11")},
+			ReturnValues:              ddbtypes.ReturnValueUpdatedOld,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.Attributes)
+		assert.Equal(t, "9", out.Attributes["n"].(*ddbtypes.AttributeValueMemberN).Value)
+	})
+
+	t.Run("DeleteItem ALL_OLD returns deleted image", func(t *testing.T) {
+		out, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+			TableName:    aws.String("rv"),
+			Key:          map[string]ddbtypes.AttributeValue{"pk": sAttr("k")},
+			ReturnValues: ddbtypes.ReturnValueAllOld,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.Attributes)
+		assert.Equal(t, "k", out.Attributes["pk"].(*ddbtypes.AttributeValueMemberS).Value)
+	})
+}
+
+// TestDDBScannedCount covers finding: Query must report ScannedCount, and Scan's
+// ScannedCount must count items examined before the filter (not post-filter).
+func TestDDBScannedCount(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "sc", "pk", "sk")
+	for i, sk := range []string{"a", "b", "c"} {
+		suiteDDBPut(t, client, "sc", map[string]ddbtypes.AttributeValue{
+			"pk": sAttr("p"), "sk": sAttr(sk), "n": nAttr(fmt.Sprintf("%d", i)),
+		})
+	}
+
+	q, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                 aws.String("sc"),
+		KeyConditionExpression:    aws.String("pk = :p"),
+		FilterExpression:          aws.String("n > :z"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":p": sAttr("p"), ":z": nAttr("0")},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), q.Count, "n>0 keeps b,c")
+	assert.Equal(t, int32(3), q.ScannedCount, "all 3 key-matched items were scanned")
+
+	s, err := client.Scan(ctx, &dynamodb.ScanInput{
+		TableName:                 aws.String("sc"),
+		FilterExpression:          aws.String("n > :z"),
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":z": nAttr("0")},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), s.Count)
+	assert.Equal(t, int32(3), s.ScannedCount, "Scan examines all items before filtering")
+}
+
+// TestDDBDeleteTableDescription covers finding: DeleteTable must return the full
+// TableDescription (ARN + key schema), not a name-only stub.
+func TestDDBDeleteTableDescription(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "deltab", "pk", "sk")
+	out, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String("deltab")})
+	require.NoError(t, err)
+	require.NotNil(t, out.TableDescription)
+	assert.NotEmpty(t, aws.ToString(out.TableDescription.TableArn))
+	assert.Len(t, out.TableDescription.KeySchema, 2)
+	assert.Equal(t, ddbtypes.TableStatusDeleting, out.TableDescription.TableStatus)
+}
+
+// TestDDBContinuousBackups covers finding: UpdateContinuousBackups must enable
+// PITR and DescribeContinuousBackups must reflect it.
+func TestDDBContinuousBackups(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "pitr", "pk", "")
+
+	d0, err := client.DescribeContinuousBackups(ctx, &dynamodb.DescribeContinuousBackupsInput{TableName: aws.String("pitr")})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.PointInTimeRecoveryStatusDisabled,
+		d0.ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus)
+
+	_, err = client.UpdateContinuousBackups(ctx, &dynamodb.UpdateContinuousBackupsInput{
+		TableName: aws.String("pitr"),
+		PointInTimeRecoverySpecification: &ddbtypes.PointInTimeRecoverySpecification{
+			PointInTimeRecoveryEnabled: aws.Bool(true),
+		},
+	})
+	require.NoError(t, err)
+
+	d1, err := client.DescribeContinuousBackups(ctx, &dynamodb.DescribeContinuousBackupsInput{TableName: aws.String("pitr")})
+	require.NoError(t, err)
+	assert.Equal(t, ddbtypes.PointInTimeRecoveryStatusEnabled,
+		d1.ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus)
+}
+
+// TestDDBConsumedCapacity covers finding: ReturnConsumedCapacity=TOTAL must
+// populate ConsumedCapacity (previously always nil).
+func TestDDBConsumedCapacity(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	suiteDDBCreateTable(t, client, "cc", "pk", "")
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:              aws.String("cc"),
+		Item:                   map[string]ddbtypes.AttributeValue{"pk": sAttr("k")},
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+	})
+	require.NoError(t, err)
+
+	g, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:              aws.String("cc"),
+		Key:                    map[string]ddbtypes.AttributeValue{"pk": sAttr("k")},
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, g.ConsumedCapacity)
+	assert.Equal(t, "cc", aws.ToString(g.ConsumedCapacity.TableName))
+	assert.Positive(t, aws.ToFloat64(g.ConsumedCapacity.CapacityUnits))
+}
+
+// TestDDBErrorMessageNoInternalPrefix covers finding: error messages must not
+// leak the internal "NotFound: " code prefix.
+func TestDDBErrorMessageNoInternalPrefix(t *testing.T) {
+	client, _ := newSuiteDDBEnv(t)
+	ctx := context.Background()
+
+	_, err := client.DeleteTable(ctx, &dynamodb.DeleteTableInput{TableName: aws.String("ghost")})
+	require.Error(t, err)
+
+	var apiErr smithy.APIError
+	require.True(t, errors.As(err, &apiErr))
+	assert.NotContains(t, apiErr.ErrorMessage(), "NotFound:")
+	assert.Contains(t, apiErr.ErrorMessage(), "ghost")
 }

--- a/server/aws/dynamodb/handler.go
+++ b/server/aws/dynamodb/handler.go
@@ -6,6 +6,7 @@ package dynamodb
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -16,6 +17,15 @@ import (
 )
 
 const targetPrefix = "DynamoDB_20120810."
+
+const (
+	keyTypeHash        = "HASH"
+	keyTypeRange       = "RANGE"
+	projectionAll      = "ALL"
+	statusEnabled      = "ENABLED"
+	statusDisabled     = "DISABLED"
+	billingProvisioned = "PROVISIONED"
+)
 
 // Handler serves DynamoDB JSON-RPC requests against a database.Database driver.
 type Handler struct {
@@ -54,8 +64,12 @@ func (h *Handler) routeTables(w http.ResponseWriter, r *http.Request, op string)
 		h.deleteTable(w, r)
 	case "DescribeTable":
 		h.describeTable(w, r)
+	case "UpdateTable":
+		h.updateTable(w, r)
 	case "DescribeContinuousBackups":
 		h.describeContinuousBackups(w, r)
+	case "UpdateContinuousBackups":
+		h.updateContinuousBackups(w, r)
 	case "ListTables":
 		h.listTables(w, r)
 	default:
@@ -94,6 +108,8 @@ func (h *Handler) routeBatch(w http.ResponseWriter, r *http.Request, op string) 
 		h.batchGetItem(w, r)
 	case "TransactWriteItems":
 		h.transactWriteItems(w, r)
+	case "TransactGetItems":
+		h.transactGetItems(w, r)
 	default:
 		return false
 	}
@@ -101,75 +117,45 @@ func (h *Handler) routeBatch(w http.ResponseWriter, r *http.Request, op string) 
 	return true
 }
 
+// createTableRequest is the CreateTable wire input, decoded once and mapped to
+// a driver TableConfig by buildCreateConfig.
+type createTableRequest struct {
+	TableName string `json:"TableName"`
+	KeySchema []struct {
+		AttributeName string `json:"AttributeName"`
+		KeyType       string `json:"KeyType"`
+	} `json:"KeySchema"`
+	AttributeDefinitions []struct {
+		AttributeName string `json:"AttributeName"`
+		AttributeType string `json:"AttributeType"`
+	} `json:"AttributeDefinitions"`
+	BillingMode           string `json:"BillingMode"`
+	ProvisionedThroughput struct {
+		ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
+		WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
+	} `json:"ProvisionedThroughput"`
+	GlobalSecondaryIndexes []secondaryIndexJSON `json:"GlobalSecondaryIndexes"`
+	LocalSecondaryIndexes  []secondaryIndexJSON `json:"LocalSecondaryIndexes"`
+	StreamSpecification    *struct {
+		StreamEnabled  bool   `json:"StreamEnabled"`
+		StreamViewType string `json:"StreamViewType"`
+	} `json:"StreamSpecification"`
+	Tags []tagJSON `json:"Tags"`
+}
+
 func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		TableName string `json:"TableName"`
-		KeySchema []struct {
-			AttributeName string `json:"AttributeName"`
-			KeyType       string `json:"KeyType"`
-		} `json:"KeySchema"`
-		AttributeDefinitions []struct {
-			AttributeName string `json:"AttributeName"`
-			AttributeType string `json:"AttributeType"`
-		} `json:"AttributeDefinitions"`
-		BillingMode           string `json:"BillingMode"`
-		ProvisionedThroughput struct {
-			ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
-			WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
-		} `json:"ProvisionedThroughput"`
-		GlobalSecondaryIndexes []struct {
-			IndexName string `json:"IndexName"`
-			KeySchema []struct {
-				AttributeName string `json:"AttributeName"`
-				KeyType       string `json:"KeyType"`
-			} `json:"KeySchema"`
-			Projection struct {
-				ProjectionType string `json:"ProjectionType"`
-			} `json:"Projection"`
-		} `json:"GlobalSecondaryIndexes"`
-	}
+	var req createTableRequest
 
 	if !wire.DecodeJSON(w, r, &req) {
 		return
 	}
 
-	cfg := dbdriver.TableConfig{
-		Name:               req.TableName,
-		BillingMode:        req.BillingMode,
-		ReadCapacityUnits:  req.ProvisionedThroughput.ReadCapacityUnits,
-		WriteCapacityUnits: req.ProvisionedThroughput.WriteCapacityUnits,
-	}
-
-	for _, gsi := range req.GlobalSecondaryIndexes {
-		idx := dbdriver.GSIConfig{Name: gsi.IndexName, Projection: gsi.Projection.ProjectionType}
-		for _, ks := range gsi.KeySchema {
-			if ks.KeyType == "HASH" {
-				idx.PartitionKey = ks.AttributeName
-			}
-			if ks.KeyType == "RANGE" {
-				idx.SortKey = ks.AttributeName
-			}
-		}
-		cfg.GSIs = append(cfg.GSIs, idx)
-	}
-
-	for _, ks := range req.KeySchema {
-		if ks.KeyType == "HASH" {
-			cfg.PartitionKey = ks.AttributeName
-		}
-
-		if ks.KeyType == "RANGE" {
-			cfg.SortKey = ks.AttributeName
-		}
-	}
-
-	for _, ad := range req.AttributeDefinitions {
-		cfg.Attributes = append(cfg.Attributes,
-			dbdriver.AttributeDef{Name: ad.AttributeName, Type: ad.AttributeType})
-	}
-
-	if err := h.db.CreateTable(r.Context(), cfg); err != nil {
+	if err := h.db.CreateTable(r.Context(), buildCreateConfig(&req)); err != nil {
 		writeErr(w, err)
+		return
+	}
+
+	if !h.applyCreateTags(r, w, req.TableName, req.Tags) {
 		return
 	}
 
@@ -183,21 +169,120 @@ func (h *Handler) createTable(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"TableDescription": tableDescription(full)})
 }
 
+// buildCreateConfig maps a decoded CreateTable request onto a driver
+// TableConfig (keys, attributes, secondary indexes and the stream spec).
+func buildCreateConfig(req *createTableRequest) dbdriver.TableConfig {
+	cfg := dbdriver.TableConfig{
+		Name:               req.TableName,
+		BillingMode:        req.BillingMode,
+		ReadCapacityUnits:  req.ProvisionedThroughput.ReadCapacityUnits,
+		WriteCapacityUnits: req.ProvisionedThroughput.WriteCapacityUnits,
+	}
+
+	for _, gsi := range req.GlobalSecondaryIndexes {
+		pk, sk := indexKeys(gsi)
+		cfg.GSIs = append(cfg.GSIs,
+			dbdriver.GSIConfig{Name: gsi.IndexName, PartitionKey: pk, SortKey: sk, Projection: gsi.Projection.ProjectionType})
+	}
+
+	for _, lsi := range req.LocalSecondaryIndexes {
+		_, sk := indexKeys(lsi)
+		cfg.LSIs = append(cfg.LSIs,
+			dbdriver.LSIConfig{Name: lsi.IndexName, SortKey: sk, Projection: lsi.Projection.ProjectionType})
+	}
+
+	if req.StreamSpecification != nil && req.StreamSpecification.StreamEnabled {
+		cfg.StreamEnabled = true
+		cfg.StreamViewType = req.StreamSpecification.StreamViewType
+	}
+
+	cfg.PartitionKey, cfg.SortKey = keySchemaKeys(req)
+
+	for _, ad := range req.AttributeDefinitions {
+		cfg.Attributes = append(cfg.Attributes,
+			dbdriver.AttributeDef{Name: ad.AttributeName, Type: ad.AttributeType})
+	}
+
+	return cfg
+}
+
+// keySchemaKeys resolves the table's partition and sort key from the request
+// key schema.
+func keySchemaKeys(req *createTableRequest) (partitionKey, sortKey string) {
+	for _, ks := range req.KeySchema {
+		if ks.KeyType == keyTypeHash {
+			partitionKey = ks.AttributeName
+		}
+
+		if ks.KeyType == keyTypeRange {
+			sortKey = ks.AttributeName
+		}
+	}
+
+	return partitionKey, sortKey
+}
+
+// secondaryIndexJSON is the shared wire shape of a GSI or LSI on CreateTable.
+type secondaryIndexJSON struct {
+	IndexName string `json:"IndexName"`
+	KeySchema []struct {
+		AttributeName string `json:"AttributeName"`
+		KeyType       string `json:"KeyType"`
+	} `json:"KeySchema"`
+	Projection struct {
+		ProjectionType string `json:"ProjectionType"`
+	} `json:"Projection"`
+}
+
+// indexKeys extracts the HASH/RANGE attribute names from an index key schema.
+func indexKeys(idx secondaryIndexJSON) (partitionKey, sortKey string) {
+	for _, ks := range idx.KeySchema {
+		if ks.KeyType == keyTypeHash {
+			partitionKey = ks.AttributeName
+		}
+
+		if ks.KeyType == keyTypeRange {
+			sortKey = ks.AttributeName
+		}
+	}
+
+	return partitionKey, sortKey
+}
+
+// applyCreateTags applies tags supplied on CreateTable so ListTagsOfResource
+// returns them, matching real DynamoDB (which tags at create time). It writes
+// the error response and returns false on failure.
+func (h *Handler) applyCreateTags(r *http.Request, w http.ResponseWriter, table string, tags []tagJSON) bool {
+	if len(tags) == 0 {
+		return true
+	}
+
+	m := make(map[string]string, len(tags))
+	for _, t := range tags {
+		m[t.Key] = t.Value
+	}
+
+	if err := h.db.TagResource(r.Context(), table, m); err != nil {
+		writeErr(w, err)
+		return false
+	}
+
+	return true
+}
+
 // tableDescription builds the DynamoDB TableDescription wire shape that both
 // CreateTable and DescribeTable return, including the fields an IaC client reads
 // back (ARN, creation time, attribute definitions, billing mode).
 func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
-	keySchema := []map[string]string{{"AttributeName": cfg.PartitionKey, "KeyType": "HASH"}}
+	keySchema := []map[string]string{{"AttributeName": cfg.PartitionKey, "KeyType": keyTypeHash}}
 	if cfg.SortKey != "" {
-		keySchema = append(keySchema, map[string]string{"AttributeName": cfg.SortKey, "KeyType": "RANGE"})
+		keySchema = append(keySchema, map[string]string{"AttributeName": cfg.SortKey, "KeyType": keyTypeRange})
 	}
 
 	attrs := make([]map[string]string, 0, len(cfg.Attributes))
 	for _, a := range cfg.Attributes {
 		attrs = append(attrs, map[string]string{"AttributeName": a.Name, "AttributeType": a.Type})
 	}
-
-	const billingProvisioned = "PROVISIONED"
 
 	billing := cfg.BillingMode
 	if billing == "" {
@@ -208,6 +293,7 @@ func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
 		"TableName":            cfg.Name,
 		"TableStatus":          "ACTIVE",
 		"TableArn":             cfg.TableArn,
+		"TableId":              cfg.TableID,
 		"CreationDateTime":     cfg.CreatedAtUnix,
 		"KeySchema":            keySchema,
 		"AttributeDefinitions": attrs,
@@ -228,7 +314,50 @@ func tableDescription(cfg *dbdriver.TableConfig) map[string]any {
 		td["GlobalSecondaryIndexes"] = gsis
 	}
 
+	if lsis := lsiDescriptions(cfg); len(lsis) > 0 {
+		td["LocalSecondaryIndexes"] = lsis
+	}
+
+	if cfg.StreamEnabled {
+		td["StreamSpecification"] = map[string]any{
+			"StreamEnabled":  true,
+			"StreamViewType": cfg.StreamViewType,
+		}
+		td["LatestStreamArn"] = cfg.StreamArn
+		td["LatestStreamLabel"] = cfg.StreamLabel
+	}
+
 	return td
+}
+
+// lsiDescriptions builds the LocalSecondaryIndexes wire block echoed by
+// CreateTable/DescribeTable so an IaC-declared LSI round-trips. An LSI shares
+// the table partition key and adds its own sort key.
+func lsiDescriptions(cfg *dbdriver.TableConfig) []map[string]any {
+	out := make([]map[string]any, 0, len(cfg.LSIs))
+
+	for _, lsi := range cfg.LSIs {
+		keySchema := []map[string]string{
+			{"AttributeName": cfg.PartitionKey, "KeyType": keyTypeHash},
+			{"AttributeName": lsi.SortKey, "KeyType": keyTypeRange},
+		}
+
+		projection := lsi.Projection
+		if projection == "" {
+			projection = projectionAll
+		}
+
+		out = append(out, map[string]any{
+			"IndexName":      lsi.Name,
+			"KeySchema":      keySchema,
+			"Projection":     map[string]any{"ProjectionType": projection},
+			"IndexArn":       cfg.TableArn + "/index/" + lsi.Name,
+			"ItemCount":      0,
+			"IndexSizeBytes": 0,
+		})
+	}
+
+	return out
 }
 
 // gsiDescriptions builds the GlobalSecondaryIndexes wire block echoed by
@@ -238,14 +367,14 @@ func gsiDescriptions(cfg *dbdriver.TableConfig, billing string) []map[string]any
 	out := make([]map[string]any, 0, len(cfg.GSIs))
 
 	for _, gsi := range cfg.GSIs {
-		keySchema := []map[string]string{{"AttributeName": gsi.PartitionKey, "KeyType": "HASH"}}
+		keySchema := []map[string]string{{"AttributeName": gsi.PartitionKey, "KeyType": keyTypeHash}}
 		if gsi.SortKey != "" {
-			keySchema = append(keySchema, map[string]string{"AttributeName": gsi.SortKey, "KeyType": "RANGE"})
+			keySchema = append(keySchema, map[string]string{"AttributeName": gsi.SortKey, "KeyType": keyTypeRange})
 		}
 
 		projection := gsi.Projection
 		if projection == "" {
-			projection = "ALL"
+			projection = projectionAll
 		}
 
 		desc := map[string]any{
@@ -258,7 +387,7 @@ func gsiDescriptions(cfg *dbdriver.TableConfig, billing string) []map[string]any
 			"IndexSizeBytes": 0,
 		}
 
-		if billing == "PROVISIONED" {
+		if billing == billingProvisioned {
 			desc["ProvisionedThroughput"] = map[string]any{
 				"ReadCapacityUnits":      cfg.ReadCapacityUnits,
 				"WriteCapacityUnits":     cfg.WriteCapacityUnits,
@@ -281,17 +410,23 @@ func (h *Handler) deleteTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Describe before deleting so the response carries the real ARN, key schema
+	// and attribute definitions a client reads back — not a name-only stub.
+	full, err := h.db.DescribeTable(r.Context(), req.TableName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
 	if err := h.db.DeleteTable(r.Context(), req.TableName); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{
-		"TableDescription": map[string]any{
-			"TableName":   req.TableName,
-			"TableStatus": "DELETING",
-		},
-	})
+	desc := tableDescription(full)
+	desc["TableStatus"] = "DELETING"
+
+	wire.WriteJSON(w, map[string]any{"TableDescription": desc})
 }
 
 func (h *Handler) describeTable(w http.ResponseWriter, r *http.Request) {
@@ -312,8 +447,10 @@ func (h *Handler) describeTable(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, map[string]any{"Table": tableDescription(cfg)})
 }
 
-// describeContinuousBackups reports point-in-time recovery as disabled. IaC
-// clients read this on every table refresh; without it the read errors.
+// describeContinuousBackups reports the table's point-in-time recovery state.
+// IaC clients read this on every table refresh; without it the read errors.
+// ContinuousBackups is always enabled on a real table, so only the PITR sub-
+// status tracks the UpdateContinuousBackups toggle.
 func (h *Handler) describeContinuousBackups(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TableName string `json:"TableName"`
@@ -328,11 +465,16 @@ func (h *Handler) describeContinuousBackups(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	pitr := statusDisabled
+	if h.pitrEnabled(r.Context(), req.TableName) {
+		pitr = statusEnabled
+	}
+
 	wire.WriteJSON(w, map[string]any{
 		"ContinuousBackupsDescription": map[string]any{
-			"ContinuousBackupsStatus": "DISABLED",
+			"ContinuousBackupsStatus": statusEnabled,
 			"PointInTimeRecoveryDescription": map[string]any{
-				"PointInTimeRecoveryStatus": "DISABLED",
+				"PointInTimeRecoveryStatus": pitr,
 			},
 		},
 	})
@@ -350,7 +492,6 @@ func (h *Handler) listTables(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // mirrors deleteItem's condition-gated write path over Item, not Key.
 func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TableName                 string            `json:"TableName"`
@@ -358,6 +499,8 @@ func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 		ConditionExpression       string            `json:"ConditionExpression"`
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
+		ReturnValues              string            `json:"ReturnValues"`
+		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -372,12 +515,45 @@ func (h *Handler) putItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resp := map[string]any{}
+
+	// ReturnValues=ALL_OLD returns the item as it was before the overwrite, so
+	// read it before the mutation.
+	if strings.EqualFold(req.ReturnValues, "ALL_OLD") {
+		if old := h.previousItem(r.Context(), req.TableName, item); old != nil {
+			resp["Attributes"] = toWireItem(old)
+		}
+	}
+
 	if err := h.db.PutItem(r.Context(), req.TableName, item); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{})
+	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
+	wire.WriteJSON(w, resp)
+}
+
+// previousItem fetches the stored item identified by keySource's key attributes,
+// returning nil when the table or item is missing. Used to satisfy
+// ReturnValues=ALL_OLD on Put/Delete without surfacing a lookup error.
+func (h *Handler) previousItem(ctx context.Context, table string, keySource map[string]any) map[string]any {
+	cfg, err := h.db.DescribeTable(ctx, table)
+	if err != nil {
+		return nil
+	}
+
+	key := map[string]any{cfg.PartitionKey: keySource[cfg.PartitionKey]}
+	if cfg.SortKey != "" {
+		key[cfg.SortKey] = keySource[cfg.SortKey]
+	}
+
+	old, err := h.db.GetItem(ctx, table, key)
+	if err != nil {
+		return nil
+	}
+
+	return old
 }
 
 // gateCondition evaluates a ConditionExpression and, on failure, writes the
@@ -461,6 +637,7 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 		Key                      map[string]any    `json:"Key"`
 		ProjectionExpression     string            `json:"ProjectionExpression"`
 		ExpressionAttributeNames map[string]string `json:"ExpressionAttributeNames"`
+		ReturnConsumedCapacity   string            `json:"ReturnConsumedCapacity"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -478,11 +655,22 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A GetItem against a table that does not exist is a ResourceNotFoundException
+	// in real DynamoDB — distinct from a missing item, which returns an empty
+	// (200) response. Resolve the table first so the two cases don't conflate.
+	if _, terr := h.db.DescribeTable(r.Context(), req.TableName); terr != nil {
+		writeErr(w, terr)
+		return
+	}
+
+	resp := map[string]any{}
+	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
+
 	item, err := h.db.GetItem(r.Context(), req.TableName, key)
 	if err != nil {
 		// DynamoDB returns an empty response for missing items, not an error.
 		if cerrors.IsNotFound(err) {
-			wire.WriteJSON(w, map[string]any{})
+			wire.WriteJSON(w, resp)
 			return
 		}
 
@@ -491,7 +679,6 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := map[string]any{}
 	if item != nil {
 		resp["Item"] = toWireItem(expr.Project(item, paths))
 	}
@@ -499,7 +686,21 @@ func (h *Handler) getItem(w http.ResponseWriter, r *http.Request) {
 	wire.WriteJSON(w, resp)
 }
 
-//nolint:dupl // mirrors putItem's condition-gated write path over Key, not Item.
+// addConsumedCapacity adds a ConsumedCapacity block to resp when the request
+// asked for it (ReturnConsumedCapacity=TOTAL or INDEXES). The emulator charges a
+// nominal one capacity unit — enough for clients that assert the field is
+// present and non-nil, which real SDK cost-tracking code does.
+func addConsumedCapacity(resp map[string]any, returnConsumed, table string) {
+	if !strings.EqualFold(returnConsumed, "TOTAL") && !strings.EqualFold(returnConsumed, "INDEXES") {
+		return
+	}
+
+	resp["ConsumedCapacity"] = map[string]any{
+		"TableName":     table,
+		"CapacityUnits": 1.0,
+	}
+}
+
 func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TableName                 string            `json:"TableName"`
@@ -507,6 +708,8 @@ func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 		ConditionExpression       string            `json:"ConditionExpression"`
 		ExpressionAttributeNames  map[string]string `json:"ExpressionAttributeNames"`
 		ExpressionAttributeValues map[string]any    `json:"ExpressionAttributeValues"`
+		ReturnValues              string            `json:"ReturnValues"`
+		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -521,12 +724,22 @@ func (h *Handler) deleteItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resp := map[string]any{}
+
+	// ReturnValues=ALL_OLD returns the deleted item, so read it before removal.
+	if strings.EqualFold(req.ReturnValues, "ALL_OLD") {
+		if old := h.previousItem(r.Context(), req.TableName, key); old != nil {
+			resp["Attributes"] = toWireItem(old)
+		}
+	}
+
 	if err := h.db.DeleteItem(r.Context(), req.TableName, key); err != nil {
 		writeErr(w, err)
 		return
 	}
 
-	wire.WriteJSON(w, map[string]any{})
+	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
+	wire.WriteJSON(w, resp)
 }
 
 func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
@@ -541,6 +754,7 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 		ScanIndexForward          *bool             `json:"ScanIndexForward"`
 		IndexName                 string            `json:"IndexName"`
 		ExclusiveStartKey         map[string]any    `json:"ExclusiveStartKey"`
+		ReturnConsumedCapacity    string            `json:"ReturnConsumedCapacity"`
 	}
 
 	if !wire.DecodeJSON(w, r, &req) {
@@ -591,13 +805,15 @@ func (h *Handler) query(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]any{
-		"Items": items,
-		"Count": len(items),
+		"Items":        items,
+		"Count":        len(items),
+		"ScannedCount": result.ScannedCount,
 	}
 	if result.LastEvaluatedKey != nil {
 		resp["LastEvaluatedKey"] = toWireItem(result.LastEvaluatedKey)
 	}
 
+	addConsumedCapacity(resp, req.ReturnConsumedCapacity, req.TableName)
 	wire.WriteJSON(w, resp)
 }
 
@@ -631,14 +847,28 @@ func parseKeyCondition(
 
 // writeErr maps CloudEmu errors to DynamoDB HTTP error responses.
 func writeErr(w http.ResponseWriter, err error) {
+	msg := errMessage(err)
+
 	switch {
 	case cerrors.IsNotFound(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceNotFoundException", msg)
 	case cerrors.IsAlreadyExists(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUseException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ResourceInUseException", msg)
 	case cerrors.IsInvalidArgument(err):
-		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", err.Error())
+		wire.WriteJSONError(w, http.StatusBadRequest, "ValidationException", msg)
 	default:
-		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		wire.WriteJSONError(w, http.StatusInternalServerError, "InternalServerError", msg)
 	}
+}
+
+// errMessage returns the human-readable message for a cloudemu error without
+// the internal "Code: " prefix that Error() prepends. Real DynamoDB error
+// messages carry no such prefix, so surfacing it would leak an internal detail.
+func errMessage(err error) string {
+	var e *cerrors.Error
+	if errors.As(err, &e) {
+		return e.Message
+	}
+
+	return err.Error()
 }

--- a/server/aws/dynamodb/update_table.go
+++ b/server/aws/dynamodb/update_table.go
@@ -1,0 +1,192 @@
+package dynamodb
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/stackshy/cloudemu/v2/server/wire"
+	dbdriver "github.com/stackshy/cloudemu/v2/services/database/driver"
+)
+
+// throughputUpdater is the optional provider capability UpdateTable needs to
+// change a table's billing mode / provisioned throughput. Discovered by type
+// assertion so it stays off the cross-cloud Database interface (only the AWS
+// mock implements it).
+type throughputUpdater interface {
+	UpdateThroughput(ctx context.Context, table, billingMode string, rcu, wcu int64) error
+}
+
+// pitrController is the optional provider capability backing
+// UpdateContinuousBackups / DescribeContinuousBackups.
+type pitrController interface {
+	SetPITR(ctx context.Context, table string, enabled bool) error
+	GetPITR(ctx context.Context, table string) (bool, error)
+}
+
+// updateTable handles UpdateTable: billing/throughput changes, GSI create/delete
+// updates and stream enable/disable. It returns the refreshed TableDescription,
+// matching real DynamoDB. Without it the SDK sees UnknownOperationException and
+// every throughput/GSI/stream mutation fails.
+func (h *Handler) updateTable(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TableName             string `json:"TableName"`
+		BillingMode           string `json:"BillingMode"`
+		ProvisionedThroughput *struct {
+			ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
+			WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
+		} `json:"ProvisionedThroughput"`
+		GlobalSecondaryIndexUpdates []struct {
+			Create *secondaryIndexJSON `json:"Create,omitempty"`
+			Delete *struct {
+				IndexName string `json:"IndexName"`
+			} `json:"Delete,omitempty"`
+		} `json:"GlobalSecondaryIndexUpdates"`
+		StreamSpecification *struct {
+			StreamEnabled  bool   `json:"StreamEnabled"`
+			StreamViewType string `json:"StreamViewType"`
+		} `json:"StreamSpecification"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if err := h.applyThroughput(r.Context(), req.TableName, req.BillingMode, req.ProvisionedThroughput); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	for i := range req.GlobalSecondaryIndexUpdates {
+		if err := h.applyGSIUpdate(r.Context(), req.TableName,
+			req.GlobalSecondaryIndexUpdates[i].Create,
+			indexDeleteName(req.GlobalSecondaryIndexUpdates[i].Delete)); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	if req.StreamSpecification != nil {
+		cfg := dbdriver.StreamConfig{Enabled: req.StreamSpecification.StreamEnabled, ViewType: req.StreamSpecification.StreamViewType}
+		if err := h.db.UpdateStreamConfig(r.Context(), req.TableName, cfg); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	full, err := h.db.DescribeTable(r.Context(), req.TableName)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	wire.WriteJSON(w, map[string]any{"TableDescription": tableDescription(full)})
+}
+
+func indexDeleteName(del *struct {
+	IndexName string `json:"IndexName"`
+}) string {
+	if del == nil {
+		return ""
+	}
+
+	return del.IndexName
+}
+
+// applyThroughput applies a billing/throughput change when one was requested.
+// A provider that does not expose the capability is a no-op (the change simply
+// isn't modeled), so unrelated UpdateTable fields still succeed.
+func (h *Handler) applyThroughput(ctx context.Context, table, billingMode string, pt *struct {
+	ReadCapacityUnits  int64 `json:"ReadCapacityUnits"`
+	WriteCapacityUnits int64 `json:"WriteCapacityUnits"`
+}) error {
+	if billingMode == "" && pt == nil {
+		return nil
+	}
+
+	updater, ok := h.db.(throughputUpdater)
+	if !ok {
+		return nil
+	}
+
+	var rcu, wcu int64
+	if pt != nil {
+		rcu, wcu = pt.ReadCapacityUnits, pt.WriteCapacityUnits
+	}
+
+	return updater.UpdateThroughput(ctx, table, billingMode, rcu, wcu)
+}
+
+// applyGSIUpdate creates or deletes one GSI as part of an UpdateTable request.
+func (h *Handler) applyGSIUpdate(ctx context.Context, table string, create *secondaryIndexJSON, deleteName string) error {
+	if create != nil {
+		pk, sk := indexKeys(*create)
+		_, err := h.db.CreateIndex(ctx, table, dbdriver.GSIConfig{
+			Name: create.IndexName, PartitionKey: pk, SortKey: sk, Projection: create.Projection.ProjectionType,
+		})
+
+		return err
+	}
+
+	if deleteName != "" {
+		return h.db.DeleteIndex(ctx, table, deleteName)
+	}
+
+	return nil
+}
+
+// updateContinuousBackups handles UpdateContinuousBackups, toggling point-in-
+// time recovery. Without it PITR can never be enabled and
+// DescribeContinuousBackups always reports DISABLED.
+func (h *Handler) updateContinuousBackups(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		TableName                        string `json:"TableName"`
+		PointInTimeRecoverySpecification struct {
+			PointInTimeRecoveryEnabled bool `json:"PointInTimeRecoveryEnabled"`
+		} `json:"PointInTimeRecoverySpecification"`
+	}
+
+	if !wire.DecodeJSON(w, r, &req) {
+		return
+	}
+
+	if _, err := h.db.DescribeTable(r.Context(), req.TableName); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	enabled := req.PointInTimeRecoverySpecification.PointInTimeRecoveryEnabled
+
+	if ctrl, ok := h.db.(pitrController); ok {
+		if err := ctrl.SetPITR(r.Context(), req.TableName, enabled); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	pitr := statusDisabled
+	if enabled {
+		pitr = statusEnabled
+	}
+
+	wire.WriteJSON(w, map[string]any{
+		"ContinuousBackupsDescription": map[string]any{
+			"ContinuousBackupsStatus": statusEnabled,
+			"PointInTimeRecoveryDescription": map[string]any{
+				"PointInTimeRecoveryStatus": pitr,
+			},
+		},
+	})
+}
+
+// pitrEnabled reports whether point-in-time recovery is on for a table, via the
+// optional pitrController capability. A provider without it reports disabled.
+func (h *Handler) pitrEnabled(ctx context.Context, table string) bool {
+	ctrl, ok := h.db.(pitrController)
+	if !ok {
+		return false
+	}
+
+	on, err := ctrl.GetPITR(ctx, table)
+
+	return err == nil && on
+}

--- a/services/database/driver/driver.go
+++ b/services/database/driver/driver.go
@@ -51,6 +51,10 @@ type TableConfig struct {
 	PartitionKey string
 	SortKey      string
 	GSIs         []GSIConfig
+	// LSIs carries the Local Secondary Indexes declared at create time. Like
+	// GSIs they share the table's partition key but define an alternate sort
+	// key; a describe echoes them so an IaC-declared LSI round-trips.
+	LSIs []LSIConfig
 	// Attributes carries the attribute definitions (name + type) so a describe
 	// echoes them back — an IaC client compares them and otherwise sees a diff.
 	Attributes []AttributeDef
@@ -61,9 +65,18 @@ type TableConfig struct {
 	// IaC client sees a perpetual diff. Ignored for PAY_PER_REQUEST.
 	ReadCapacityUnits  int64
 	WriteCapacityUnits int64
-	// TableArn and CreatedAtUnix are populated by the provider on create.
+	// StreamEnabled/StreamViewType carry the requested StreamSpecification. When
+	// StreamEnabled is set the provider turns on the change stream and populates
+	// StreamArn/StreamLabel, which a describe surfaces as LatestStreamArn/Label.
+	StreamEnabled  bool
+	StreamViewType string
+	StreamArn      string
+	StreamLabel    string
+	// TableArn, CreatedAtUnix and TableID are populated by the provider on
+	// create. TableID is a UUID a real table carries and IaC clients read back.
 	TableArn      string
 	CreatedAtUnix float64
+	TableID       string
 }
 
 // AttributeDef is a DynamoDB attribute definition (name + scalar type S/N/B).
@@ -79,6 +92,15 @@ type GSIConfig struct {
 	SortKey      string
 	// Projection is the DynamoDB projection type (ALL, KEYS_ONLY, INCLUDE); a
 	// describe echoes it so an IaC client's declared index round-trips.
+	Projection string
+}
+
+// LSIConfig describes a Local Secondary Index. An LSI shares the table's
+// partition key and defines an alternate sort key. Projection is the DynamoDB
+// projection type (ALL, KEYS_ONLY, INCLUDE), echoed by a describe.
+type LSIConfig struct {
+	Name       string
+	SortKey    string
 	Projection string
 }
 
@@ -213,6 +235,12 @@ type QueryResult struct {
 	Items         []map[string]any
 	Count         int
 	NextPageToken string
+
+	// ScannedCount is the number of items examined before a FilterExpression
+	// was applied (items matching the key condition for Query, all items for
+	// Scan). Count is the post-filter count; the two differ when a filter drops
+	// items, exactly as real DynamoDB reports.
+	ScannedCount int
 
 	// LastEvaluatedKey holds the key attributes of the last returned item
 	// whenever more items remain, enabling DynamoDB-style continuation.


### PR DESCRIPTION
Closes the remaining DynamoDB audit findings, wire/provider only (no cross-cloud interface change).

- LocalSecondaryIndexes stored + echoed + queryable; StreamSpecification round-trips (+ LatestStreamArn/Label); tags at CreateTable persisted
- UpdateTable dispatched (throughput/GSI/stream); TransactGetItems; ReturnValues (ALL_OLD/ALL_NEW/UPDATED_*)
- GetItem on missing table → ResourceNotFoundException; ScannedCount + ConsumedCapacity + TableId emitted; DeleteTable returns full description; ContinuousBackups (PITR); error messages no longer leak internal code prefixes

DynamoDB Streams data-plane API deferred (separate large wire surface). SDK round-trip test per fix.