### PR TITLE
fix(cloudwatch): wire fidelity — GetMetricData, alarm metadata/history

### DIFF
--- a/providers/aws/cloudwatch/cloudwatch.go
+++ b/providers/aws/cloudwatch/cloudwatch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,9 +48,14 @@ type alarmData struct {
 	Stat                    string
 	State                   string
 	StateReason             string
+	StateUpdatedTimestamp   time.Time
 	AlarmActions            []string
 	OKActions               []string
 	InsufficientDataActions []string
+	AlarmDescription        string
+	ActionsEnabled          bool
+	AlarmArn                string
+	Tags                    map[string]string
 }
 
 // New creates a new CloudWatch mock with the given configuration options.
@@ -162,6 +168,8 @@ func (m *Mock) evaluateSingleAlarm(alarm *alarmData, namespace, metricName strin
 			Reason:    fmt.Sprintf("Transition from %s to %s: %s", alarm.State, newState, reason),
 		})
 		m.mu.Unlock()
+
+		alarm.StateUpdatedTimestamp = now
 	}
 
 	alarm.State = newState
@@ -249,6 +257,10 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 		return result
 	}
 
+	// Carry the stored unit so the wire layer can echo the real unit (e.g.
+	// "Percent" for CPUUtilization) instead of hardcoding "Count".
+	result.Unit = unitOf(filtered)
+
 	periodDur := time.Duration(period) * time.Second
 
 	// Walk through periods from StartTime to EndTime.
@@ -272,6 +284,18 @@ func buildMetricResult(filtered []driver.MetricDatum, startTime, endTime time.Ti
 	}
 
 	return result
+}
+
+// unitOf returns the first non-empty unit among the data points, or "" if none
+// carry a unit.
+func unitOf(data []driver.MetricDatum) string {
+	for _, d := range data {
+		if d.Unit != "" {
+			return d.Unit
+		}
+	}
+
+	return ""
 }
 
 func collectPeriodValues(filtered []driver.MetricDatum, periodStart, periodEnd time.Time) []float64 {
@@ -316,17 +340,26 @@ func (m *Mock) ListMetricsDetailed(_ context.Context) ([]driver.MetricIdentifier
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	seen := make(map[metricKey]bool, len(m.metrics))
+	// AWS lists one entry per unique (namespace, name, dimension-set), so walk
+	// every stored datum and dedupe on a canonical dimension signature.
+	seen := make(map[string]bool)
 	out := make([]driver.MetricIdentifier, 0, len(m.metrics))
 
-	for key := range m.metrics {
-		if seen[key] {
-			continue
+	for key, data := range m.metrics {
+		for i := range data {
+			sig := key.Namespace + "\x00" + key.MetricName + "\x00" + canonicalDims(data[i].Dimensions)
+			if seen[sig] {
+				continue
+			}
+
+			seen[sig] = true
+
+			out = append(out, driver.MetricIdentifier{
+				Namespace:  key.Namespace,
+				MetricName: key.MetricName,
+				Dimensions: copyDims(data[i].Dimensions),
+			})
 		}
-
-		seen[key] = true
-
-		out = append(out, driver.MetricIdentifier{Namespace: key.Namespace, MetricName: key.MetricName})
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -334,10 +367,51 @@ func (m *Mock) ListMetricsDetailed(_ context.Context) ([]driver.MetricIdentifier
 			return out[i].Namespace < out[j].Namespace
 		}
 
-		return out[i].MetricName < out[j].MetricName
+		if out[i].MetricName != out[j].MetricName {
+			return out[i].MetricName < out[j].MetricName
+		}
+
+		return canonicalDims(out[i].Dimensions) < canonicalDims(out[j].Dimensions)
 	})
 
 	return out, nil
+}
+
+// canonicalDims renders a dimension map as a stable, order-independent string.
+func canonicalDims(dims map[string]string) string {
+	if len(dims) == 0 {
+		return ""
+	}
+
+	keys := make([]string, 0, len(dims))
+	for k := range dims {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(dims[k])
+		b.WriteByte(';')
+	}
+
+	return b.String()
+}
+
+func copyDims(dims map[string]string) map[string]string {
+	if len(dims) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(dims))
+	for k, v := range dims {
+		out[k] = v
+	}
+
+	return out
 }
 
 // CreateAlarm creates or updates an alarm with the given configuration.
@@ -353,6 +427,16 @@ func (m *Mock) CreateAlarm(_ context.Context, cfg driver.AlarmConfig) error {
 		dims[k] = v
 	}
 
+	actionsEnabled := true
+	if cfg.ActionsEnabled != nil {
+		actionsEnabled = *cfg.ActionsEnabled
+	}
+
+	tags := make(map[string]string, len(cfg.Tags))
+	for k, v := range cfg.Tags {
+		tags[k] = v
+	}
+
 	alarm := &alarmData{
 		Name:                    cfg.Name,
 		Namespace:               cfg.Namespace,
@@ -364,9 +448,14 @@ func (m *Mock) CreateAlarm(_ context.Context, cfg driver.AlarmConfig) error {
 		EvaluationPeriods:       cfg.EvaluationPeriods,
 		Stat:                    cfg.Stat,
 		State:                   "INSUFFICIENT_DATA",
+		StateUpdatedTimestamp:   m.opts.Clock.Now(),
 		AlarmActions:            append([]string{}, cfg.AlarmActions...),
 		OKActions:               append([]string{}, cfg.OKActions...),
 		InsufficientDataActions: append([]string{}, cfg.InsufficientDataActions...),
+		AlarmDescription:        cfg.AlarmDescription,
+		ActionsEnabled:          actionsEnabled,
+		AlarmArn:                idgen.AWSARN("cloudwatch", m.opts.Region, m.opts.AccountID, "alarm:"+cfg.Name),
+		Tags:                    tags,
 	}
 
 	m.alarms.Set(cfg.Name, alarm)
@@ -419,6 +508,7 @@ func (m *Mock) SetAlarmState(_ context.Context, name, state, reason string) erro
 
 	a.State = state
 	a.StateReason = reason
+	a.StateUpdatedTimestamp = m.opts.Clock.Now()
 
 	return nil
 }
@@ -500,6 +590,74 @@ func (m *Mock) GetAlarmHistory(_ context.Context, alarmName string, limit int) (
 	return filtered, nil
 }
 
+// SetAlarmActionsEnabled toggles ActionsEnabled for the named alarms. It backs
+// the AWS-local EnableAlarmActions / DisableAlarmActions wire operations.
+func (m *Mock) SetAlarmActionsEnabled(_ context.Context, names []string, enabled bool) error {
+	for _, name := range names {
+		a, ok := m.alarms.Get(name)
+		if !ok {
+			return errors.Newf(errors.NotFound, "alarm %q not found", name)
+		}
+
+		a.ActionsEnabled = enabled
+	}
+
+	return nil
+}
+
+// AddAlarmTags merges tags onto the named alarm, backing TagResource.
+func (m *Mock) AddAlarmTags(_ context.Context, alarmName string, tags map[string]string) error {
+	a, ok := m.alarms.Get(alarmName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if a.Tags == nil {
+		a.Tags = make(map[string]string, len(tags))
+	}
+
+	for k, v := range tags {
+		a.Tags[k] = v
+	}
+
+	return nil
+}
+
+// RemoveAlarmTags deletes the given tag keys from the named alarm, backing
+// UntagResource.
+func (m *Mock) RemoveAlarmTags(_ context.Context, alarmName string, keys []string) error {
+	a, ok := m.alarms.Get(alarmName)
+	if !ok {
+		return errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, k := range keys {
+		delete(a.Tags, k)
+	}
+
+	return nil
+}
+
+// AlarmTags returns a copy of the named alarm's tags, backing
+// ListTagsForResource.
+func (m *Mock) AlarmTags(_ context.Context, alarmName string) (map[string]string, error) {
+	a, ok := m.alarms.Get(alarmName)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "alarm %q not found", alarmName)
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return copyDims(a.Tags), nil
+}
+
 // matchDimensions returns true if the data point dimensions contain all of the
 // requested filter dimensions.
 func matchDimensions(dataDims, filterDims map[string]string) bool {
@@ -567,12 +725,29 @@ func maxValue(values []float64) float64 {
 }
 
 func toAlarmInfo(a *alarmData) driver.AlarmInfo {
+	dims := make(map[string]string, len(a.Dimensions))
+	for k, v := range a.Dimensions {
+		dims[k] = v
+	}
+
 	return driver.AlarmInfo{
-		Name:               a.Name,
-		Namespace:          a.Namespace,
-		MetricName:         a.MetricName,
-		State:              a.State,
-		ComparisonOperator: a.ComparisonOperator,
-		Threshold:          a.Threshold,
+		Name:                    a.Name,
+		Namespace:               a.Namespace,
+		MetricName:              a.MetricName,
+		State:                   a.State,
+		ComparisonOperator:      a.ComparisonOperator,
+		Threshold:               a.Threshold,
+		StateReason:             a.StateReason,
+		StateUpdatedTimestamp:   a.StateUpdatedTimestamp,
+		Period:                  a.Period,
+		EvaluationPeriods:       a.EvaluationPeriods,
+		Statistic:               a.Stat,
+		ActionsEnabled:          a.ActionsEnabled,
+		AlarmActions:            append([]string{}, a.AlarmActions...),
+		OKActions:               append([]string{}, a.OKActions...),
+		InsufficientDataActions: append([]string{}, a.InsufficientDataActions...),
+		AlarmDescription:        a.AlarmDescription,
+		AlarmArn:                a.AlarmArn,
+		Dimensions:              dims,
 	}
 }

--- a/server/aws/cloudwatch/alarm_metadata_test.go
+++ b/server/aws/cloudwatch/alarm_metadata_test.go
@@ -1,0 +1,314 @@
+package cloudwatch_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+)
+
+// putAlarm creates a fully-specified alarm for the metadata tests.
+func putAlarm(t *testing.T, client *awscw.Client, name string) {
+	t.Helper()
+
+	_, err := client.PutMetricAlarm(t.Context(), &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String(name),
+		AlarmDescription:   aws.String("desc-" + name),
+		Namespace:          aws.String("MyApp"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(5),
+		EvaluationPeriods:  aws.Int32(3),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+		AlarmActions:       []string{"arn:aws:sns:us-east-1:123456789012:alerts"},
+		Dimensions: []cwtypes.Dimension{{
+			Name:  aws.String("Service"),
+			Value: aws.String("api"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("PutMetricAlarm(%s): %v", name, err)
+	}
+}
+
+// TestSDKDescribeAlarmsFields covers finding 2: DescribeAlarms must populate the
+// full MetricAlarm shape, not just six fields.
+func TestSDKDescribeAlarmsFields(t *testing.T) {
+	client, ctx := newCWClient(t)
+	putAlarm(t, client, "a1")
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"a1"}})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+
+	if len(out.MetricAlarms) != 1 {
+		t.Fatalf("alarms = %+v, want 1", out.MetricAlarms)
+	}
+
+	a := out.MetricAlarms[0]
+	if aws.ToString(a.AlarmArn) == "" {
+		t.Errorf("AlarmArn empty")
+	}
+	if aws.ToString(a.AlarmDescription) != "desc-a1" {
+		t.Errorf("AlarmDescription = %q, want desc-a1", aws.ToString(a.AlarmDescription))
+	}
+	if aws.ToInt32(a.Period) != 60 {
+		t.Errorf("Period = %d, want 60", aws.ToInt32(a.Period))
+	}
+	if aws.ToInt32(a.EvaluationPeriods) != 3 {
+		t.Errorf("EvaluationPeriods = %d, want 3", aws.ToInt32(a.EvaluationPeriods))
+	}
+	if a.Statistic != cwtypes.StatisticAverage {
+		t.Errorf("Statistic = %q, want Average", a.Statistic)
+	}
+	if !aws.ToBool(a.ActionsEnabled) {
+		t.Errorf("ActionsEnabled = false, want true (default)")
+	}
+	if len(a.AlarmActions) != 1 {
+		t.Errorf("AlarmActions = %+v, want 1", a.AlarmActions)
+	}
+	if a.StateUpdatedTimestamp == nil || a.StateUpdatedTimestamp.IsZero() {
+		t.Errorf("StateUpdatedTimestamp = %v, want non-zero", a.StateUpdatedTimestamp)
+	}
+	if len(a.Dimensions) != 1 || aws.ToString(a.Dimensions[0].Name) != "Service" {
+		t.Errorf("Dimensions = %+v, want Service=api", a.Dimensions)
+	}
+}
+
+// TestSDKDescribeAlarmsFilters covers finding 5: AlarmNamePrefix / StateValue /
+// MaxRecords must be honored server-side.
+func TestSDKDescribeAlarmsFilters(t *testing.T) {
+	client, ctx := newCWClient(t)
+	putAlarm(t, client, "prod-a")
+	putAlarm(t, client, "prod-b")
+	putAlarm(t, client, "dev-a")
+
+	byPrefix, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{
+		AlarmNamePrefix: aws.String("prod-"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarms prefix: %v", err)
+	}
+	if len(byPrefix.MetricAlarms) != 2 {
+		t.Fatalf("prefix filter = %d alarms, want 2", len(byPrefix.MetricAlarms))
+	}
+
+	// Force one alarm into ALARM and filter by state.
+	if _, err := client.SetAlarmState(ctx, &awscw.SetAlarmStateInput{
+		AlarmName:   aws.String("prod-a"),
+		StateValue:  cwtypes.StateValueAlarm,
+		StateReason: aws.String("test"),
+	}); err != nil {
+		t.Fatalf("SetAlarmState: %v", err)
+	}
+
+	byState, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{
+		StateValue: cwtypes.StateValueAlarm,
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarms state: %v", err)
+	}
+	if len(byState.MetricAlarms) != 1 || aws.ToString(byState.MetricAlarms[0].AlarmName) != "prod-a" {
+		t.Fatalf("state filter = %+v, want only prod-a", byState.MetricAlarms)
+	}
+
+	capped, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{MaxRecords: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("DescribeAlarms maxrecords: %v", err)
+	}
+	if len(capped.MetricAlarms) != 2 {
+		t.Fatalf("maxrecords = %d alarms, want 2", len(capped.MetricAlarms))
+	}
+}
+
+// TestSDKDescribeAlarmHistory covers finding 4: transition history recorded on
+// state changes must be readable via DescribeAlarmHistory.
+func TestSDKDescribeAlarmHistory(t *testing.T) {
+	client, ctx := newCWClient(t)
+	putAlarm(t, client, "h1")
+
+	if _, err := client.SetAlarmState(ctx, &awscw.SetAlarmStateInput{
+		AlarmName:   aws.String("h1"),
+		StateValue:  cwtypes.StateValueAlarm,
+		StateReason: aws.String("crossed"),
+	}); err != nil {
+		t.Fatalf("SetAlarmState: %v", err)
+	}
+
+	// A metric that keeps it in ALARM records a transition into history.
+	now := time.Now().UTC()
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("MyApp"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("Errors"),
+			Value:      aws.Float64(0),
+			Dimensions: []cwtypes.Dimension{{Name: aws.String("Service"), Value: aws.String("api")}},
+			Timestamp:  aws.Time(now),
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	out, err := client.DescribeAlarmHistory(ctx, &awscw.DescribeAlarmHistoryInput{
+		AlarmName: aws.String("h1"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmHistory: %v", err)
+	}
+
+	if len(out.AlarmHistoryItems) == 0 {
+		t.Fatalf("history empty, want at least one StateUpdate entry")
+	}
+	if out.AlarmHistoryItems[0].HistoryItemType != cwtypes.HistoryItemTypeStateUpdate {
+		t.Fatalf("history type = %q, want StateUpdate", out.AlarmHistoryItems[0].HistoryItemType)
+	}
+	if aws.ToString(out.AlarmHistoryItems[0].AlarmName) != "h1" {
+		t.Fatalf("history alarm = %q, want h1", aws.ToString(out.AlarmHistoryItems[0].AlarmName))
+	}
+}
+
+// TestSDKDescribeAlarmsForMetric covers finding 7: DescribeAlarmsForMetric must
+// be dispatched and filter by metric.
+func TestSDKDescribeAlarmsForMetric(t *testing.T) {
+	client, ctx := newCWClient(t)
+	putAlarm(t, client, "m1")
+
+	out, err := client.DescribeAlarmsForMetric(ctx, &awscw.DescribeAlarmsForMetricInput{
+		Namespace:  aws.String("MyApp"),
+		MetricName: aws.String("Errors"),
+		Dimensions: []cwtypes.Dimension{{Name: aws.String("Service"), Value: aws.String("api")}},
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmsForMetric: %v", err)
+	}
+
+	if len(out.MetricAlarms) != 1 || aws.ToString(out.MetricAlarms[0].AlarmName) != "m1" {
+		t.Fatalf("alarms = %+v, want only m1", out.MetricAlarms)
+	}
+
+	// A different metric returns nothing.
+	none, err := client.DescribeAlarmsForMetric(ctx, &awscw.DescribeAlarmsForMetricInput{
+		Namespace:  aws.String("MyApp"),
+		MetricName: aws.String("Other"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeAlarmsForMetric(Other): %v", err)
+	}
+	if len(none.MetricAlarms) != 0 {
+		t.Fatalf("alarms for Other = %+v, want none", none.MetricAlarms)
+	}
+}
+
+// TestSDKEnableDisableAlarmActions covers finding 7: EnableAlarmActions /
+// DisableAlarmActions must toggle ActionsEnabled.
+func TestSDKEnableDisableAlarmActions(t *testing.T) {
+	client, ctx := newCWClient(t)
+	putAlarm(t, client, "act")
+
+	if _, err := client.DisableAlarmActions(ctx, &awscw.DisableAlarmActionsInput{
+		AlarmNames: []string{"act"},
+	}); err != nil {
+		t.Fatalf("DisableAlarmActions: %v", err)
+	}
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"act"}})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+	if aws.ToBool(out.MetricAlarms[0].ActionsEnabled) {
+		t.Fatalf("ActionsEnabled = true after Disable, want false")
+	}
+
+	if _, err := client.EnableAlarmActions(ctx, &awscw.EnableAlarmActionsInput{
+		AlarmNames: []string{"act"},
+	}); err != nil {
+		t.Fatalf("EnableAlarmActions: %v", err)
+	}
+
+	out, err = client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"act"}})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+	if !aws.ToBool(out.MetricAlarms[0].ActionsEnabled) {
+		t.Fatalf("ActionsEnabled = false after Enable, want true")
+	}
+}
+
+// TestSDKAlarmTags covers finding 7: PutMetricAlarm Tags plus the
+// Tag/Untag/ListTags operations must round-trip.
+func TestSDKAlarmTags(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("tagged"),
+		Namespace:          aws.String("MyApp"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(1),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+		Tags: []cwtypes.Tag{{
+			Key:   aws.String("team"),
+			Value: aws.String("payments"),
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	da, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"tagged"}})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+	arn := aws.ToString(da.MetricAlarms[0].AlarmArn)
+	if arn == "" {
+		t.Fatalf("alarm has no ARN")
+	}
+
+	list, err := client.ListTagsForResource(ctx, &awscw.ListTagsForResourceInput{ResourceARN: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+	if !hasTag(list.Tags, "team", "payments") {
+		t.Fatalf("tags = %+v, want team=payments (dropped on PutMetricAlarm)", list.Tags)
+	}
+
+	if _, err := client.TagResource(ctx, &awscw.TagResourceInput{
+		ResourceARN: aws.String(arn),
+		Tags:        []cwtypes.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+	}); err != nil {
+		t.Fatalf("TagResource: %v", err)
+	}
+
+	if _, err := client.UntagResource(ctx, &awscw.UntagResourceInput{
+		ResourceARN: aws.String(arn),
+		TagKeys:     []string{"team"},
+	}); err != nil {
+		t.Fatalf("UntagResource: %v", err)
+	}
+
+	list, err = client.ListTagsForResource(ctx, &awscw.ListTagsForResourceInput{ResourceARN: aws.String(arn)})
+	if err != nil {
+		t.Fatalf("ListTagsForResource: %v", err)
+	}
+	if hasTag(list.Tags, "team", "payments") {
+		t.Fatalf("team tag still present after Untag: %+v", list.Tags)
+	}
+	if !hasTag(list.Tags, "env", "prod") {
+		t.Fatalf("env tag missing after Tag: %+v", list.Tags)
+	}
+}
+
+func hasTag(tags []cwtypes.Tag, key, value string) bool {
+	for _, tag := range tags {
+		if aws.ToString(tag.Key) == key && aws.ToString(tag.Value) == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/server/aws/cloudwatch/handler.go
+++ b/server/aws/cloudwatch/handler.go
@@ -33,6 +33,17 @@ const (
 	maxBodyBytes    = 1 << 20
 )
 
+// Operation names shared by the rpc-v2-cbor and query dispatch switches.
+const (
+	opPutMetricData       = "PutMetricData"
+	opGetMetricStatistics = "GetMetricStatistics"
+	opListMetrics         = "ListMetrics"
+	opPutMetricAlarm      = "PutMetricAlarm"
+	opDescribeAlarms      = "DescribeAlarms"
+	opDeleteAlarms        = "DeleteAlarms"
+	opSetAlarmState       = "SetAlarmState"
+)
+
 // Handler serves CloudWatch rpc-v2-cbor requests against a monitoring driver.
 // An optional IPAM metrics source lets the handler surface derived AWS/IPAM
 // metrics that the monitoring store itself doesn't hold.
@@ -88,21 +99,44 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.dispatch(w, r, op, body)
+}
+
+// dispatch routes a decoded rpc-v2-cbor operation to its handler.
+//
+//nolint:gocyclo // first-match dispatch over many CloudWatch operations.
+func (h *Handler) dispatch(w http.ResponseWriter, r *http.Request, op string, body []byte) {
 	switch op {
-	case "PutMetricData":
+	case opPutMetricData:
 		h.putMetricData(w, r, body)
-	case "GetMetricStatistics":
+	case opGetMetricStatistics:
 		h.getMetricStatistics(w, r, body)
-	case "ListMetrics":
+	case "GetMetricData":
+		h.getMetricData(w, r, body)
+	case opListMetrics:
 		h.listMetrics(w, r, body)
-	case "PutMetricAlarm":
+	case opPutMetricAlarm:
 		h.putMetricAlarm(w, r, body)
-	case "DescribeAlarms":
+	case opDescribeAlarms:
 		h.describeAlarms(w, r, body)
-	case "DeleteAlarms":
+	case "DescribeAlarmsForMetric":
+		h.describeAlarmsForMetric(w, r, body)
+	case "DescribeAlarmHistory":
+		h.describeAlarmHistory(w, r, body)
+	case opDeleteAlarms:
 		h.deleteAlarms(w, r, body)
-	case "SetAlarmState":
+	case opSetAlarmState:
 		h.setAlarmState(w, r, body)
+	case "EnableAlarmActions":
+		h.setAlarmActionsEnabled(w, r, body, true)
+	case "DisableAlarmActions":
+		h.setAlarmActionsEnabled(w, r, body, false)
+	case "TagResource":
+		h.tagResource(w, r, body)
+	case "UntagResource":
+		h.untagResource(w, r, body)
+	case "ListTagsForResource":
+		h.listTagsForResource(w, r, body)
 	default:
 		writeCBORError(w, http.StatusBadRequest,
 			"UnknownOperationException", "unknown operation: "+op)

--- a/server/aws/cloudwatch/metric_data_ops.go
+++ b/server/aws/cloudwatch/metric_data_ops.go
@@ -1,0 +1,384 @@
+package cloudwatch
+
+// This file implements the CloudWatch read/tag operations added for wire
+// fidelity: GetMetricData (the modern primary read API), DescribeAlarmHistory,
+// DescribeAlarmsForMetric, EnableAlarmActions/DisableAlarmActions, and the
+// alarm tagging operations. The alarm-action and tag operations use AWS-local
+// optional interfaces so the shared Monitoring interface is unchanged.
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/fxamacker/cbor/v2"
+
+	mondriver "github.com/stackshy/cloudemu/v2/services/monitoring/driver"
+)
+
+const statusCodeComplete = "Complete"
+
+// alarmActionsToggler is the AWS-local capability behind
+// EnableAlarmActions / DisableAlarmActions.
+type alarmActionsToggler interface {
+	SetAlarmActionsEnabled(ctx context.Context, names []string, enabled bool) error
+}
+
+// alarmTagger is the AWS-local capability behind the alarm tag operations.
+type alarmTagger interface {
+	AddAlarmTags(ctx context.Context, alarmName string, tags map[string]string) error
+	RemoveAlarmTags(ctx context.Context, alarmName string, keys []string) error
+	AlarmTags(ctx context.Context, alarmName string) (map[string]string, error)
+}
+
+type metricCBRRef struct {
+	Namespace  string         `cbor:"Namespace"`
+	MetricName string         `cbor:"MetricName"`
+	Dimensions []dimensionCBR `cbor:"Dimensions,omitempty"`
+}
+
+type metricStatCBR struct {
+	Metric metricCBRRef `cbor:"Metric"`
+	Period int          `cbor:"Period"`
+	Stat   string       `cbor:"Stat"`
+	Unit   string       `cbor:"Unit,omitempty"`
+}
+
+type metricDataQueryCBR struct {
+	ID         string         `cbor:"Id"`
+	Label      string         `cbor:"Label,omitempty"`
+	MetricStat *metricStatCBR `cbor:"MetricStat,omitempty"`
+	ReturnData *bool          `cbor:"ReturnData,omitempty"`
+}
+
+type getMetricDataInput struct {
+	MetricDataQueries []metricDataQueryCBR `cbor:"MetricDataQueries"`
+	StartTime         *time.Time           `cbor:"StartTime,omitempty"`
+	EndTime           *time.Time           `cbor:"EndTime,omitempty"`
+}
+
+type metricDataResultCBR struct {
+	ID         string      `cbor:"Id"`
+	Label      string      `cbor:"Label,omitempty"`
+	Timestamps []time.Time `cbor:"Timestamps,omitempty"`
+	Values     []float64   `cbor:"Values,omitempty"`
+	StatusCode string      `cbor:"StatusCode,omitempty"`
+}
+
+type getMetricDataOutput struct {
+	MetricDataResults []metricDataResultCBR `cbor:"MetricDataResults"`
+}
+
+// getMetricData implements the modern GetMetricData read API used by SDK v2,
+// dashboards, and Grafana.
+func (h *Handler) getMetricData(w http.ResponseWriter, r *http.Request, body []byte) {
+	var in getMetricDataInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	start := timeOrZero(in.StartTime)
+	end := timeOrZero(in.EndTime)
+
+	out := make([]metricDataResultCBR, 0, len(in.MetricDataQueries))
+
+	for _, q := range in.MetricDataQueries {
+		if q.MetricStat == nil {
+			continue // math-expression queries are not modeled
+		}
+
+		res, err := h.monitoring.GetMetricData(r.Context(), mondriver.GetMetricInput{
+			Namespace:  q.MetricStat.Metric.Namespace,
+			MetricName: q.MetricStat.Metric.MetricName,
+			Dimensions: toDimensionMap(q.MetricStat.Metric.Dimensions),
+			StartTime:  start,
+			EndTime:    end,
+			Period:     q.MetricStat.Period,
+			Stat:       q.MetricStat.Stat,
+		})
+		if err != nil {
+			writeDriverErr(w, err)
+			return
+		}
+
+		out = append(out, buildMetricDataResult(q, res))
+	}
+
+	writeCBORResponse(w, getMetricDataOutput{MetricDataResults: out})
+}
+
+func buildMetricDataResult(q metricDataQueryCBR, res *mondriver.MetricDataResult) metricDataResultCBR {
+	label := q.Label
+	if label == "" {
+		label = q.MetricStat.Metric.MetricName
+	}
+
+	row := metricDataResultCBR{ID: q.ID, Label: label, StatusCode: statusCodeComplete}
+
+	if res != nil {
+		row.Timestamps = make([]time.Time, len(res.Timestamps))
+		for i := range res.Timestamps {
+			row.Timestamps[i] = res.Timestamps[i].UTC()
+		}
+
+		row.Values = res.Values
+	}
+
+	return row
+}
+
+type describeAlarmsForMetricInput struct {
+	Namespace  string         `cbor:"Namespace"`
+	MetricName string         `cbor:"MetricName"`
+	Dimensions []dimensionCBR `cbor:"Dimensions,omitempty"`
+	Statistic  string         `cbor:"Statistic,omitempty"`
+	Period     int            `cbor:"Period,omitempty"`
+}
+
+// describeAlarmsForMetric returns the alarms configured against a specific
+// metric, filtered server-side by namespace, metric name, and dimensions.
+func (h *Handler) describeAlarmsForMetric(w http.ResponseWriter, r *http.Request, body []byte) {
+	var in describeAlarmsForMetricInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	alarms, err := h.monitoring.DescribeAlarms(r.Context(), nil)
+	if err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	wantDims := toDimensionMap(in.Dimensions)
+	out := make([]metricAlarmCBR, 0, len(alarms))
+
+	for i := range alarms {
+		if alarmMatchesMetric(&alarms[i], &in, wantDims) {
+			out = append(out, toMetricAlarmCBR(&alarms[i]))
+		}
+	}
+
+	writeCBORResponse(w, describeAlarmsOutput{MetricAlarms: out})
+}
+
+// alarmMatchesMetric reports whether an alarm targets the metric described by a
+// DescribeAlarmsForMetric request.
+func alarmMatchesMetric(a *mondriver.AlarmInfo, in *describeAlarmsForMetricInput, wantDims map[string]string) bool {
+	if a.Namespace != in.Namespace || a.MetricName != in.MetricName {
+		return false
+	}
+
+	if in.Period != 0 && a.Period != in.Period {
+		return false
+	}
+
+	if in.Statistic != "" && a.Statistic != in.Statistic {
+		return false
+	}
+
+	return dimensionsEqual(a.Dimensions, wantDims)
+}
+
+func dimensionsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+type describeAlarmHistoryInput struct {
+	AlarmName       string `cbor:"AlarmName,omitempty"`
+	HistoryItemType string `cbor:"HistoryItemType,omitempty"`
+	MaxRecords      int    `cbor:"MaxRecords,omitempty"`
+}
+
+type alarmHistoryItemCBR struct {
+	AlarmName       string    `cbor:"AlarmName"`
+	Timestamp       time.Time `cbor:"Timestamp"`
+	HistoryItemType string    `cbor:"HistoryItemType"`
+	HistorySummary  string    `cbor:"HistorySummary,omitempty"`
+	HistoryData     string    `cbor:"HistoryData,omitempty"`
+}
+
+type describeAlarmHistoryOutput struct {
+	AlarmHistoryItems []alarmHistoryItemCBR `cbor:"AlarmHistoryItems"`
+}
+
+// describeAlarmHistory surfaces the transition history recorded internally on
+// every alarm state change.
+func (h *Handler) describeAlarmHistory(w http.ResponseWriter, r *http.Request, body []byte) {
+	var in describeAlarmHistoryInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	entries, err := h.monitoring.GetAlarmHistory(r.Context(), in.AlarmName, in.MaxRecords)
+	if err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	out := make([]alarmHistoryItemCBR, 0, len(entries))
+	for i := range entries {
+		out = append(out, alarmHistoryItemCBR{
+			AlarmName:       entries[i].AlarmName,
+			Timestamp:       entries[i].Timestamp.UTC(),
+			HistoryItemType: "StateUpdate",
+			HistorySummary:  entries[i].Reason,
+			HistoryData:     alarmHistoryData(&entries[i]),
+		})
+	}
+
+	writeCBORResponse(w, describeAlarmHistoryOutput{AlarmHistoryItems: out})
+}
+
+func alarmHistoryData(e *mondriver.AlarmHistoryEntry) string {
+	return `{"oldState":{"stateValue":"` + e.OldState + `"},"newState":{"stateValue":"` + e.NewState + `"}}`
+}
+
+type alarmNamesInput struct {
+	AlarmNames []string `cbor:"AlarmNames,omitempty"`
+}
+
+// setAlarmActionsEnabled backs EnableAlarmActions / DisableAlarmActions.
+func (h *Handler) setAlarmActionsEnabled(w http.ResponseWriter, r *http.Request, body []byte, enabled bool) {
+	var in alarmNamesInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	toggler, ok := h.monitoring.(alarmActionsToggler)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "alarm actions toggle not supported")
+		return
+	}
+
+	if err := toggler.SetAlarmActionsEnabled(r.Context(), in.AlarmNames, enabled); err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}
+
+type tagResourceInput struct {
+	ResourceARN string   `cbor:"ResourceARN"`
+	Tags        []tagCBR `cbor:"Tags,omitempty"`
+}
+
+type untagResourceInput struct {
+	ResourceARN string   `cbor:"ResourceARN"`
+	TagKeys     []string `cbor:"TagKeys,omitempty"`
+}
+
+type listTagsForResourceInput struct {
+	ResourceARN string `cbor:"ResourceARN"`
+}
+
+type listTagsForResourceOutput struct {
+	Tags []tagCBR `cbor:"Tags"`
+}
+
+func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request, body []byte) {
+	var in tagResourceInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	tagger, ok := h.monitoring.(alarmTagger)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
+		return
+	}
+
+	if err := tagger.AddAlarmTags(r.Context(), alarmNameFromARN(in.ResourceARN), tagsToMap(in.Tags)); err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}
+
+func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request, body []byte) {
+	var in untagResourceInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	tagger, ok := h.monitoring.(alarmTagger)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
+		return
+	}
+
+	if err := tagger.RemoveAlarmTags(r.Context(), alarmNameFromARN(in.ResourceARN), in.TagKeys); err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, struct{}{})
+}
+
+func (h *Handler) listTagsForResource(w http.ResponseWriter, r *http.Request, body []byte) {
+	var in listTagsForResourceInput
+	if err := cbor.Unmarshal(body, &in); err != nil {
+		writeCBORError(w, http.StatusBadRequest, "SerializationException", err.Error())
+		return
+	}
+
+	tagger, ok := h.monitoring.(alarmTagger)
+	if !ok {
+		writeCBORError(w, http.StatusBadRequest, "UnknownOperationException", "tagging not supported")
+		return
+	}
+
+	tags, err := tagger.AlarmTags(r.Context(), alarmNameFromARN(in.ResourceARN))
+	if err != nil {
+		writeDriverErr(w, err)
+		return
+	}
+
+	writeCBORResponse(w, listTagsForResourceOutput{Tags: mapToTags(tags)})
+}
+
+// alarmNameFromARN extracts the alarm name from a CloudWatch alarm ARN of the
+// form arn:aws:cloudwatch:region:account:alarm:NAME. A bare name is returned
+// unchanged.
+func alarmNameFromARN(arn string) string {
+	if i := strings.Index(arn, ":alarm:"); i >= 0 {
+		return arn[i+len(":alarm:"):]
+	}
+
+	return arn
+}
+
+func mapToTags(tags map[string]string) []tagCBR {
+	out := make([]tagCBR, 0, len(tags))
+	for k, v := range tags {
+		out = append(out, tagCBR{Key: k, Value: v})
+	}
+
+	return out
+}
+
+func timeOrZero(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+
+	return *t
+}

--- a/server/aws/cloudwatch/metric_data_test.go
+++ b/server/aws/cloudwatch/metric_data_test.go
@@ -1,0 +1,260 @@
+package cloudwatch_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	awscw "github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+
+	"github.com/stackshy/cloudemu/v2/config"
+	cwprovider "github.com/stackshy/cloudemu/v2/providers/aws/cloudwatch"
+	cwserver "github.com/stackshy/cloudemu/v2/server/aws/cloudwatch"
+)
+
+// newCWClient wires the real aws-sdk-go-v2 CloudWatch client at an in-process
+// CloudWatch handler backed by the in-memory provider.
+func newCWClient(t *testing.T) (*awscw.Client, context.Context) {
+	t.Helper()
+
+	h := cwserver.New(cwprovider.New(config.NewOptions()))
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+	)
+	if err != nil {
+		t.Fatalf("config: %v", err)
+	}
+
+	client := awscw.NewFromConfig(cfg, func(o *awscw.Options) { o.BaseEndpoint = aws.String(ts.URL) })
+
+	return client, context.Background()
+}
+
+// TestSDKPutMetricDataDefaultTimestamp covers finding 1: a datum with no
+// Timestamp must be stored at request-receipt time (not the Go zero value), so
+// it is queryable immediately afterward.
+func TestSDKPutMetricDataDefaultTimestamp(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("MyApp"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("Requests"),
+			Value:      aws.Float64(42),
+			// No Timestamp on purpose.
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	now := time.Now().UTC()
+	out, err := client.GetMetricStatistics(ctx, &awscw.GetMetricStatisticsInput{
+		Namespace:  aws.String("MyApp"),
+		MetricName: aws.String("Requests"),
+		StartTime:  aws.Time(now.Add(-1 * time.Hour)),
+		EndTime:    aws.Time(now.Add(1 * time.Hour)),
+		Period:     aws.Int32(60),
+		Statistics: []cwtypes.Statistic{cwtypes.StatisticSum},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricStatistics: %v", err)
+	}
+
+	if len(out.Datapoints) != 1 || out.Datapoints[0].Sum == nil || *out.Datapoints[0].Sum != 42 {
+		t.Fatalf("datapoints = %+v, want one datapoint with Sum=42 (default timestamp must be now)", out.Datapoints)
+	}
+}
+
+// TestSDKPutMetricDataFiresAlarm covers finding 1's alarm consequence: without a
+// receipt-time default, alarms stay INSUFFICIENT_DATA forever.
+func TestSDKPutMetricDataFiresAlarm(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	if _, err := client.PutMetricAlarm(ctx, &awscw.PutMetricAlarmInput{
+		AlarmName:          aws.String("high"),
+		Namespace:          aws.String("MyApp"),
+		MetricName:         aws.String("Errors"),
+		ComparisonOperator: cwtypes.ComparisonOperatorGreaterThanThreshold,
+		Threshold:          aws.Float64(10),
+		EvaluationPeriods:  aws.Int32(1),
+		Period:             aws.Int32(60),
+		Statistic:          cwtypes.StatisticAverage,
+	}); err != nil {
+		t.Fatalf("PutMetricAlarm: %v", err)
+	}
+
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("MyApp"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("Errors"),
+			Value:      aws.Float64(99),
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	out, err := client.DescribeAlarms(ctx, &awscw.DescribeAlarmsInput{AlarmNames: []string{"high"}})
+	if err != nil {
+		t.Fatalf("DescribeAlarms: %v", err)
+	}
+
+	if len(out.MetricAlarms) != 1 || out.MetricAlarms[0].StateValue != cwtypes.StateValueAlarm {
+		t.Fatalf("alarm state = %+v, want ALARM", out.MetricAlarms)
+	}
+}
+
+// TestSDKGetMetricData covers finding 3: the modern GetMetricData read API must
+// be dispatched and return the stored series.
+func TestSDKGetMetricData(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	base := time.Now().UTC().Truncate(time.Minute)
+	for i, v := range []float64{10, 20, 30} {
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace: aws.String("MyApp"),
+			MetricData: []cwtypes.MetricDatum{{
+				MetricName: aws.String("Latency"),
+				Value:      aws.Float64(v),
+				Timestamp:  aws.Time(base.Add(time.Duration(i) * time.Minute)),
+			}},
+		}); err != nil {
+			t.Fatalf("PutMetricData: %v", err)
+		}
+	}
+
+	out, err := client.GetMetricData(ctx, &awscw.GetMetricDataInput{
+		StartTime: aws.Time(base.Add(-time.Minute)),
+		EndTime:   aws.Time(base.Add(10 * time.Minute)),
+		MetricDataQueries: []cwtypes.MetricDataQuery{{
+			Id: aws.String("q1"),
+			MetricStat: &cwtypes.MetricStat{
+				Metric: &cwtypes.Metric{
+					Namespace:  aws.String("MyApp"),
+					MetricName: aws.String("Latency"),
+				},
+				Period: aws.Int32(60),
+				Stat:   aws.String("Sum"),
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricData: %v", err)
+	}
+
+	if len(out.MetricDataResults) != 1 {
+		t.Fatalf("results = %+v, want 1", out.MetricDataResults)
+	}
+
+	res := out.MetricDataResults[0]
+	if aws.ToString(res.Id) != "q1" {
+		t.Fatalf("result Id = %q, want q1", aws.ToString(res.Id))
+	}
+
+	var total float64
+	for _, v := range res.Values {
+		total += v
+	}
+
+	if total != 60 {
+		t.Fatalf("summed values = %v, want 60 (10+20+30)", total)
+	}
+}
+
+// TestSDKGetMetricStatisticsUnit covers finding 8: the stored unit must be
+// echoed, not hardcoded to "Count".
+func TestSDKGetMetricStatisticsUnit(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	now := time.Now().UTC()
+	if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+		Namespace: aws.String("AWS/EC2"),
+		MetricData: []cwtypes.MetricDatum{{
+			MetricName: aws.String("CPUUtilization"),
+			Value:      aws.Float64(75),
+			Unit:       cwtypes.StandardUnitPercent,
+			Timestamp:  aws.Time(now),
+		}},
+	}); err != nil {
+		t.Fatalf("PutMetricData: %v", err)
+	}
+
+	out, err := client.GetMetricStatistics(ctx, &awscw.GetMetricStatisticsInput{
+		Namespace:  aws.String("AWS/EC2"),
+		MetricName: aws.String("CPUUtilization"),
+		StartTime:  aws.Time(now.Add(-time.Hour)),
+		EndTime:    aws.Time(now.Add(time.Hour)),
+		Period:     aws.Int32(60),
+		Statistics: []cwtypes.Statistic{cwtypes.StatisticAverage},
+	})
+	if err != nil {
+		t.Fatalf("GetMetricStatistics: %v", err)
+	}
+
+	if len(out.Datapoints) != 1 || out.Datapoints[0].Unit != cwtypes.StandardUnitPercent {
+		t.Fatalf("unit = %+v, want Percent", out.Datapoints)
+	}
+}
+
+// TestSDKListMetricsDimensions covers finding 6: ListMetrics must return each
+// metric's dimensions and honor a DimensionFilter.
+func TestSDKListMetricsDimensions(t *testing.T) {
+	client, ctx := newCWClient(t)
+
+	put := func(instance string) {
+		if _, err := client.PutMetricData(ctx, &awscw.PutMetricDataInput{
+			Namespace: aws.String("AWS/EC2"),
+			MetricData: []cwtypes.MetricDatum{{
+				MetricName: aws.String("CPUUtilization"),
+				Value:      aws.Float64(1),
+				Dimensions: []cwtypes.Dimension{{
+					Name:  aws.String("InstanceId"),
+					Value: aws.String(instance),
+				}},
+			}},
+		}); err != nil {
+			t.Fatalf("PutMetricData: %v", err)
+		}
+	}
+
+	put("i-aaa")
+	put("i-bbb")
+
+	all, err := client.ListMetrics(ctx, &awscw.ListMetricsInput{Namespace: aws.String("AWS/EC2")})
+	if err != nil {
+		t.Fatalf("ListMetrics: %v", err)
+	}
+
+	if len(all.Metrics) != 2 {
+		t.Fatalf("metrics = %+v, want 2 (one per InstanceId)", all.Metrics)
+	}
+
+	for _, m := range all.Metrics {
+		if len(m.Dimensions) != 1 || aws.ToString(m.Dimensions[0].Name) != "InstanceId" {
+			t.Fatalf("metric %+v missing InstanceId dimension", m)
+		}
+	}
+
+	filtered, err := client.ListMetrics(ctx, &awscw.ListMetricsInput{
+		Namespace: aws.String("AWS/EC2"),
+		Dimensions: []cwtypes.DimensionFilter{{
+			Name:  aws.String("InstanceId"),
+			Value: aws.String("i-aaa"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ListMetrics filtered: %v", err)
+	}
+
+	if len(filtered.Metrics) != 1 || aws.ToString(filtered.Metrics[0].Dimensions[0].Value) != "i-aaa" {
+		t.Fatalf("filtered metrics = %+v, want only i-aaa", filtered.Metrics)
+	}
+}

--- a/server/aws/cloudwatch/ops.go
+++ b/server/aws/cloudwatch/ops.go
@@ -3,6 +3,8 @@ package cloudwatch
 import (
 	"context"
 	"net/http"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
@@ -12,10 +14,12 @@ import (
 )
 
 const (
-	statSum         = "Sum"
-	statMinimum     = "Minimum"
-	statMaximum     = "Maximum"
-	statSampleCount = "SampleCount"
+	statSum           = "Sum"
+	statMinimum       = "Minimum"
+	statMaximum       = "Maximum"
+	statSampleCount   = "SampleCount"
+	statAverage       = "Average"
+	defaultMetricUnit = "Count"
 )
 
 // putMetricDataInput mirrors the AWS wire shape for the operation. Field
@@ -49,7 +53,10 @@ func (h *Handler) putMetricData(w http.ResponseWriter, r *http.Request, body []b
 	data := make([]mondriver.MetricDatum, 0, len(in.MetricData))
 
 	for _, d := range in.MetricData {
-		ts := time.Time{}
+		// AWS defaults an omitted timestamp to request-receipt time; storing the
+		// Go zero value instead would make the datapoint unqueryable and leave
+		// alarms stuck in INSUFFICIENT_DATA.
+		ts := time.Now().UTC()
 		if d.Timestamp != nil {
 			ts = *d.Timestamp
 		}
@@ -105,7 +112,7 @@ func (h *Handler) getMetricStatistics(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 
-	stat := "Average"
+	stat := statAverage
 	if len(in.Statistics) > 0 {
 		stat = in.Statistics[0]
 	}
@@ -192,8 +199,15 @@ func setDatapointStat(dp *datapointCBR, stat string, value float64) {
 	}
 }
 
+type dimensionFilterCBR struct {
+	Name  string `cbor:"Name"`
+	Value string `cbor:"Value,omitempty"`
+}
+
 type listMetricsInput struct {
-	Namespace string `cbor:"Namespace,omitempty"`
+	Namespace  string               `cbor:"Namespace,omitempty"`
+	MetricName string               `cbor:"MetricName,omitempty"`
+	Dimensions []dimensionFilterCBR `cbor:"Dimensions,omitempty"`
 }
 
 type metricCBR struct {
@@ -219,37 +233,68 @@ func (h *Handler) listMetrics(w http.ResponseWriter, r *http.Request, body []byt
 		return
 	}
 
-	// A namespace-less "list all" request must return every real metric (with
-	// its true namespace) and, when IPAM is wired, the IPAM metrics merged in —
-	// never one set replacing the other.
-	if in.Namespace == "" {
-		out, err := h.allMetricRows(r)
-		if err != nil {
-			writeDriverErr(w, err)
-			return
-		}
-
-		if h.ipam != nil {
-			out = append(out, h.ipamMetricRows(r)...)
-		}
-
-		writeCBORResponse(w, listMetricsOutput{Metrics: out})
-
-		return
-	}
-
-	names, err := h.monitoring.ListMetrics(r.Context(), in.Namespace)
+	rows, err := h.allMetricRows(r)
 	if err != nil {
 		writeDriverErr(w, err)
 		return
 	}
 
-	out := make([]metricCBR, 0, len(names))
-	for _, name := range names {
-		out = append(out, metricCBR{Namespace: in.Namespace, MetricName: name})
+	if h.ipam != nil && in.Namespace == "" {
+		rows = append(rows, h.ipamMetricRows(r)...)
 	}
 
-	writeCBORResponse(w, listMetricsOutput{Metrics: out})
+	writeCBORResponse(w, listMetricsOutput{Metrics: filterMetricRows(rows, in)})
+}
+
+// filterMetricRows applies the ListMetrics namespace / metric-name / dimension
+// filters AWS honors server-side.
+func filterMetricRows(rows []metricCBR, in listMetricsInput) []metricCBR {
+	out := make([]metricCBR, 0, len(rows))
+
+	for _, row := range rows {
+		if in.Namespace != "" && row.Namespace != in.Namespace {
+			continue
+		}
+
+		if in.MetricName != "" && row.MetricName != in.MetricName {
+			continue
+		}
+
+		if !rowMatchesDimensionFilters(row, in.Dimensions) {
+			continue
+		}
+
+		out = append(out, row)
+	}
+
+	return out
+}
+
+// rowMatchesDimensionFilters reports whether a metric row satisfies every
+// DimensionFilter: a filter with a Value requires an exact match, a filter with
+// only a Name requires that dimension to be present.
+func rowMatchesDimensionFilters(row metricCBR, filters []dimensionFilterCBR) bool {
+	if len(filters) == 0 {
+		return true
+	}
+
+	have := make(map[string]string, len(row.Dimensions))
+	for _, d := range row.Dimensions {
+		have[d.Name] = d.Value
+	}
+
+	for _, f := range filters {
+		v, ok := have[f.Name]
+		if !ok {
+			return false
+		}
+
+		if f.Value != "" && v != f.Value {
+			return false
+		}
+	}
+
+	return true
 }
 
 // detailedMetricLister is the AWS-local capability that enumerates every metric
@@ -271,7 +316,11 @@ func (h *Handler) allMetricRows(r *http.Request) ([]metricCBR, error) {
 
 		out := make([]metricCBR, 0, len(ids))
 		for _, id := range ids {
-			out = append(out, metricCBR{Namespace: id.Namespace, MetricName: id.MetricName})
+			out = append(out, metricCBR{
+				Namespace:  id.Namespace,
+				MetricName: id.MetricName,
+				Dimensions: dimsToCBR(id.Dimensions),
+			})
 		}
 
 		return out, nil
@@ -307,18 +356,27 @@ func (h *Handler) ipamMetricRows(r *http.Request) []metricCBR {
 	return out
 }
 
+type tagCBR struct {
+	Key   string `cbor:"Key"`
+	Value string `cbor:"Value"`
+}
+
 type putMetricAlarmInput struct {
-	AlarmName          string         `cbor:"AlarmName"`
-	Namespace          string         `cbor:"Namespace"`
-	MetricName         string         `cbor:"MetricName"`
-	ComparisonOperator string         `cbor:"ComparisonOperator"`
-	Threshold          float64        `cbor:"Threshold"`
-	Period             int            `cbor:"Period"`
-	EvaluationPeriods  int            `cbor:"EvaluationPeriods"`
-	Statistic          string         `cbor:"Statistic,omitempty"`
-	Dimensions         []dimensionCBR `cbor:"Dimensions,omitempty"`
-	AlarmActions       []string       `cbor:"AlarmActions,omitempty"`
-	OKActions          []string       `cbor:"OKActions,omitempty"`
+	AlarmName               string         `cbor:"AlarmName"`
+	AlarmDescription        string         `cbor:"AlarmDescription,omitempty"`
+	Namespace               string         `cbor:"Namespace"`
+	MetricName              string         `cbor:"MetricName"`
+	ComparisonOperator      string         `cbor:"ComparisonOperator"`
+	Threshold               float64        `cbor:"Threshold"`
+	Period                  int            `cbor:"Period"`
+	EvaluationPeriods       int            `cbor:"EvaluationPeriods"`
+	Statistic               string         `cbor:"Statistic,omitempty"`
+	Dimensions              []dimensionCBR `cbor:"Dimensions,omitempty"`
+	AlarmActions            []string       `cbor:"AlarmActions,omitempty"`
+	OKActions               []string       `cbor:"OKActions,omitempty"`
+	InsufficientDataActions []string       `cbor:"InsufficientDataActions,omitempty"`
+	ActionsEnabled          *bool          `cbor:"ActionsEnabled,omitempty"`
+	Tags                    []tagCBR       `cbor:"Tags,omitempty"`
 }
 
 func (h *Handler) putMetricAlarm(w http.ResponseWriter, r *http.Request, body []byte) {
@@ -329,17 +387,21 @@ func (h *Handler) putMetricAlarm(w http.ResponseWriter, r *http.Request, body []
 	}
 
 	cfg := mondriver.AlarmConfig{
-		Name:               in.AlarmName,
-		Namespace:          in.Namespace,
-		MetricName:         in.MetricName,
-		Dimensions:         toDimensionMap(in.Dimensions),
-		ComparisonOperator: in.ComparisonOperator,
-		Threshold:          in.Threshold,
-		Period:             in.Period,
-		EvaluationPeriods:  in.EvaluationPeriods,
-		Stat:               in.Statistic,
-		AlarmActions:       in.AlarmActions,
-		OKActions:          in.OKActions,
+		Name:                    in.AlarmName,
+		Namespace:               in.Namespace,
+		MetricName:              in.MetricName,
+		Dimensions:              toDimensionMap(in.Dimensions),
+		ComparisonOperator:      in.ComparisonOperator,
+		Threshold:               in.Threshold,
+		Period:                  in.Period,
+		EvaluationPeriods:       in.EvaluationPeriods,
+		Stat:                    in.Statistic,
+		AlarmActions:            in.AlarmActions,
+		OKActions:               in.OKActions,
+		InsufficientDataActions: in.InsufficientDataActions,
+		AlarmDescription:        in.AlarmDescription,
+		ActionsEnabled:          in.ActionsEnabled,
+		Tags:                    tagsToMap(in.Tags),
 	}
 
 	if err := h.monitoring.CreateAlarm(r.Context(), cfg); err != nil {
@@ -350,17 +412,46 @@ func (h *Handler) putMetricAlarm(w http.ResponseWriter, r *http.Request, body []
 	writeCBORResponse(w, struct{}{})
 }
 
+func tagsToMap(tags []tagCBR) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(tags))
+	for _, t := range tags {
+		out[t.Key] = t.Value
+	}
+
+	return out
+}
+
 type describeAlarmsInput struct {
-	AlarmNames []string `cbor:"AlarmNames,omitempty"`
+	AlarmNames      []string `cbor:"AlarmNames,omitempty"`
+	AlarmNamePrefix string   `cbor:"AlarmNamePrefix,omitempty"`
+	StateValue      string   `cbor:"StateValue,omitempty"`
+	ActionPrefix    string   `cbor:"ActionPrefix,omitempty"`
+	MaxRecords      int      `cbor:"MaxRecords,omitempty"`
 }
 
 type metricAlarmCBR struct {
-	AlarmName          string  `cbor:"AlarmName"`
-	Namespace          string  `cbor:"Namespace"`
-	MetricName         string  `cbor:"MetricName"`
-	StateValue         string  `cbor:"StateValue"`
-	ComparisonOperator string  `cbor:"ComparisonOperator"`
-	Threshold          float64 `cbor:"Threshold"`
+	AlarmName               string         `cbor:"AlarmName"`
+	AlarmArn                string         `cbor:"AlarmArn,omitempty"`
+	AlarmDescription        string         `cbor:"AlarmDescription,omitempty"`
+	Namespace               string         `cbor:"Namespace"`
+	MetricName              string         `cbor:"MetricName"`
+	Dimensions              []dimensionCBR `cbor:"Dimensions,omitempty"`
+	StateValue              string         `cbor:"StateValue"`
+	StateReason             string         `cbor:"StateReason,omitempty"`
+	StateUpdatedTimestamp   *time.Time     `cbor:"StateUpdatedTimestamp,omitempty"`
+	ComparisonOperator      string         `cbor:"ComparisonOperator"`
+	Threshold               float64        `cbor:"Threshold"`
+	Period                  int            `cbor:"Period,omitempty"`
+	EvaluationPeriods       int            `cbor:"EvaluationPeriods,omitempty"`
+	Statistic               string         `cbor:"Statistic,omitempty"`
+	ActionsEnabled          bool           `cbor:"ActionsEnabled"`
+	AlarmActions            []string       `cbor:"AlarmActions,omitempty"`
+	OKActions               []string       `cbor:"OKActions,omitempty"`
+	InsufficientDataActions []string       `cbor:"InsufficientDataActions,omitempty"`
 }
 
 type describeAlarmsOutput struct {
@@ -381,18 +472,100 @@ func (h *Handler) describeAlarms(w http.ResponseWriter, r *http.Request, body []
 	}
 
 	out := make([]metricAlarmCBR, 0, len(alarms))
+
 	for i := range alarms {
-		out = append(out, metricAlarmCBR{
-			AlarmName:          alarms[i].Name,
-			Namespace:          alarms[i].Namespace,
-			MetricName:         alarms[i].MetricName,
-			StateValue:         alarms[i].State,
-			ComparisonOperator: alarms[i].ComparisonOperator,
-			Threshold:          alarms[i].Threshold,
-		})
+		if !alarmMatchesFilters(&alarms[i], &in) {
+			continue
+		}
+
+		out = append(out, toMetricAlarmCBR(&alarms[i]))
+
+		if in.MaxRecords > 0 && len(out) >= in.MaxRecords {
+			break
+		}
 	}
 
 	writeCBORResponse(w, describeAlarmsOutput{MetricAlarms: out})
+}
+
+// alarmMatchesFilters applies the DescribeAlarms filter fields (name prefix,
+// state, action prefix) that AWS honors server-side.
+func alarmMatchesFilters(a *mondriver.AlarmInfo, in *describeAlarmsInput) bool {
+	if in.AlarmNamePrefix != "" && !strings.HasPrefix(a.Name, in.AlarmNamePrefix) {
+		return false
+	}
+
+	if in.StateValue != "" && a.State != in.StateValue {
+		return false
+	}
+
+	if in.ActionPrefix != "" && !anyActionHasPrefix(a, in.ActionPrefix) {
+		return false
+	}
+
+	return true
+}
+
+func anyActionHasPrefix(a *mondriver.AlarmInfo, prefix string) bool {
+	for _, actions := range [][]string{a.AlarmActions, a.OKActions, a.InsufficientDataActions} {
+		for _, act := range actions {
+			if strings.HasPrefix(act, prefix) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func toMetricAlarmCBR(a *mondriver.AlarmInfo) metricAlarmCBR {
+	m := metricAlarmCBR{
+		AlarmName:               a.Name,
+		AlarmArn:                a.AlarmArn,
+		AlarmDescription:        a.AlarmDescription,
+		Namespace:               a.Namespace,
+		MetricName:              a.MetricName,
+		Dimensions:              dimsToCBR(a.Dimensions),
+		StateValue:              a.State,
+		StateReason:             a.StateReason,
+		ComparisonOperator:      a.ComparisonOperator,
+		Threshold:               a.Threshold,
+		Period:                  a.Period,
+		EvaluationPeriods:       a.EvaluationPeriods,
+		Statistic:               a.Statistic,
+		ActionsEnabled:          a.ActionsEnabled,
+		AlarmActions:            a.AlarmActions,
+		OKActions:               a.OKActions,
+		InsufficientDataActions: a.InsufficientDataActions,
+	}
+
+	if !a.StateUpdatedTimestamp.IsZero() {
+		ts := a.StateUpdatedTimestamp.UTC()
+		m.StateUpdatedTimestamp = &ts
+	}
+
+	return m
+}
+
+// dimsToCBR renders a dimension map as sorted wire dimensions for stable output.
+func dimsToCBR(dims map[string]string) []dimensionCBR {
+	if len(dims) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(dims))
+	for k := range dims {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	out := make([]dimensionCBR, 0, len(dims))
+	for _, k := range keys {
+		out = append(out, dimensionCBR{Name: k, Value: dims[k]})
+	}
+
+	return out
 }
 
 type deleteAlarmsInput struct {
@@ -460,12 +633,17 @@ func toDatapointsCBR(res *mondriver.MetricDataResult, stat string) []datapointCB
 		return nil
 	}
 
+	unit := res.Unit
+	if unit == "" {
+		unit = defaultMetricUnit
+	}
+
 	out := make([]datapointCBR, 0, len(res.Timestamps))
 
 	for i := range res.Timestamps {
 		dp := datapointCBR{
 			Timestamp: res.Timestamps[i].UTC(),
-			Unit:      "Count",
+			Unit:      unit,
 		}
 
 		v := res.Values[i]

--- a/server/aws/cloudwatch/query.go
+++ b/server/aws/cloudwatch/query.go
@@ -48,19 +48,19 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch r.Form.Get("Action") {
-	case "PutMetricData":
+	case opPutMetricData:
 		h.queryPutMetricData(w, r)
-	case "ListMetrics":
+	case opListMetrics:
 		h.queryListMetrics(w, r)
-	case "GetMetricStatistics":
+	case opGetMetricStatistics:
 		h.queryGetMetricStatistics(w, r)
-	case "PutMetricAlarm":
+	case opPutMetricAlarm:
 		h.queryPutMetricAlarm(w, r)
-	case "DescribeAlarms":
+	case opDescribeAlarms:
 		h.queryDescribeAlarms(w, r)
-	case "DeleteAlarms":
+	case opDeleteAlarms:
 		h.queryDeleteAlarms(w, r)
-	case "SetAlarmState":
+	case opSetAlarmState:
 		h.querySetAlarmState(w, r)
 	default:
 		writeQueryError(w, http.StatusBadRequest, "InvalidAction", "unsupported CloudWatch action: "+r.Form.Get("Action"))
@@ -122,7 +122,7 @@ func (h *Handler) queryListMetrics(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) queryGetMetricStatistics(w http.ResponseWriter, r *http.Request) {
 	stat := r.Form.Get("Statistics.member.1")
 	if stat == "" {
-		stat = "Average"
+		stat = statAverage
 	}
 
 	start, _ := time.Parse(time.RFC3339, r.Form.Get("StartTime"))
@@ -142,8 +142,13 @@ func (h *Handler) queryGetMetricStatistics(w http.ResponseWriter, r *http.Reques
 	var dps []datapointXML
 
 	if res != nil {
+		unit := res.Unit
+		if unit == "" {
+			unit = defaultMetricUnit
+		}
+
 		for i := range res.Timestamps {
-			dp := datapointXML{Timestamp: res.Timestamps[i].UTC().Format(time.RFC3339), Unit: "Count"}
+			dp := datapointXML{Timestamp: res.Timestamps[i].UTC().Format(time.RFC3339), Unit: unit}
 			setQueryStat(&dp, stat, res.Values[i])
 			dps = append(dps, dp)
 		}

--- a/services/monitoring/driver/driver.go
+++ b/services/monitoring/driver/driver.go
@@ -12,6 +12,7 @@ import (
 type MetricIdentifier struct {
 	Namespace  string
 	MetricName string
+	Dimensions map[string]string
 }
 
 // MetricDatum is a single metric data point.
@@ -39,6 +40,7 @@ type GetMetricInput struct {
 type MetricDataResult struct {
 	Timestamps []time.Time
 	Values     []float64
+	Unit       string // the unit stored with the underlying datapoints, if any
 }
 
 // AlarmConfig describes an alarm to create.
@@ -55,16 +57,31 @@ type AlarmConfig struct {
 	AlarmActions            []string // channel IDs to notify on ALARM
 	OKActions               []string // channel IDs to notify on OK
 	InsufficientDataActions []string // channel IDs to notify on INSUFFICIENT_DATA
+	AlarmDescription        string
+	ActionsEnabled          *bool // nil defaults to true (AWS semantics)
+	Tags                    map[string]string
 }
 
 // AlarmInfo describes an alarm.
 type AlarmInfo struct {
-	Name               string
-	Namespace          string
-	MetricName         string
-	State              string // "OK", "ALARM", "INSUFFICIENT_DATA"
-	ComparisonOperator string
-	Threshold          float64
+	Name                    string
+	Namespace               string
+	MetricName              string
+	State                   string // "OK", "ALARM", "INSUFFICIENT_DATA"
+	ComparisonOperator      string
+	Threshold               float64
+	StateReason             string
+	StateUpdatedTimestamp   time.Time
+	Period                  int
+	EvaluationPeriods       int
+	Statistic               string
+	ActionsEnabled          bool
+	AlarmActions            []string
+	OKActions               []string
+	InsufficientDataActions []string
+	AlarmDescription        string
+	AlarmArn                string
+	Dimensions              map[string]string
 }
 
 // NotificationChannelConfig describes a notification channel.


### PR DESCRIPTION
Closes remaining CloudWatch audit findings. Additive driver struct fields only; compat docs clean. SDK round-trip tests per feature.