### PR TITLE
fix(rds): wire fidelity — group-ARN tagging, final snapshot, cluster state

### DIFF
--- a/providers/aws/rds/aurora.go
+++ b/providers/aws/rds/aurora.go
@@ -158,6 +158,13 @@ func (m *Mock) FailoverDBCluster(_ context.Context, clusterID, targetInstanceID 
 		return nil, cerrors.Newf(cerrors.NotFound, "DB cluster %q not found", clusterID)
 	}
 
+	// A failover needs at least one member to promote; real AWS rejects a
+	// failover on a cluster with no available instances as InvalidDBClusterStateFault.
+	if len(cluster.Members) == 0 {
+		return nil, cerrors.Newf(cerrors.FailedPrecondition,
+			"DB cluster %q has no available instances to fail over", clusterID)
+	}
+
 	if targetInstanceID != "" {
 		idx := indexOf(cluster.Members, targetInstanceID)
 		if idx < 0 {

--- a/providers/aws/rds/metadata.go
+++ b/providers/aws/rds/metadata.go
@@ -15,11 +15,15 @@ var (
 
 // ARN resource-kind segments and the fixed RDS ARN field count.
 const (
-	arnKindInstance        = "db"
-	arnKindCluster         = "cluster"
-	arnKindSnapshot        = "snapshot"
-	arnKindClusterSnapshot = "cluster-snapshot"
-	arnFieldCount          = 7
+	arnKindInstance          = "db"
+	arnKindCluster           = "cluster"
+	arnKindSnapshot          = "snapshot"
+	arnKindClusterSnapshot   = "cluster-snapshot"
+	arnKindParamGroup        = "pg"
+	arnKindClusterParamGroup = "cluster-pg"
+	arnKindOptionGroup       = "og"
+	arnKindSubnetGroup       = "subgrp"
+	arnFieldCount            = 7
 )
 
 // engineVersionCatalog is a representative set of supported versions per
@@ -186,26 +190,67 @@ func (m *Mock) ListTagsForResource(_ context.Context, resourceARN string) (map[s
 
 	kind, id := arnResourceKindID(resourceARN)
 
-	switch kind {
-	case arnKindInstance:
-		if r, ok := m.instances.Get(id); ok {
-			return copyTags(r.Tags), nil
-		}
-	case arnKindCluster:
-		if r, ok := m.clusters.Get(id); ok {
-			return copyTags(r.Tags), nil
-		}
-	case arnKindSnapshot:
-		if r, ok := m.snapshots.Get(id); ok {
-			return copyTags(r.Tags), nil
-		}
-	case arnKindClusterSnapshot:
-		if r, ok := m.clusterSnapshots.Get(id); ok {
-			return copyTags(r.Tags), nil
-		}
+	if tags, ok := m.recordTags(kind, id); ok {
+		return tags, nil
+	}
+
+	if isGroupKind(kind) && m.groupExists(kind, id) {
+		return copyTags(m.groupTags[resourceARN]), nil
 	}
 
 	return nil, errUntaggable(resourceARN)
+}
+
+// recordTags returns a copy of the tags on the record named by kind+id, and
+// whether that record exists. Group kinds (parameter/option/subnet groups) are
+// not records and always report false — their tags live in groupTags.
+func (m *Mock) recordTags(kind, id string) (map[string]string, bool) {
+	switch kind {
+	case arnKindInstance:
+		if r, ok := m.instances.Get(id); ok {
+			return copyTags(r.Tags), true
+		}
+	case arnKindCluster:
+		if r, ok := m.clusters.Get(id); ok {
+			return copyTags(r.Tags), true
+		}
+	case arnKindSnapshot:
+		if r, ok := m.snapshots.Get(id); ok {
+			return copyTags(r.Tags), true
+		}
+	case arnKindClusterSnapshot:
+		if r, ok := m.clusterSnapshots.Get(id); ok {
+			return copyTags(r.Tags), true
+		}
+	}
+
+	return nil, false
+}
+
+// isGroupKind reports whether an ARN kind is a parameter/option/subnet group.
+func isGroupKind(kind string) bool {
+	switch kind {
+	case arnKindParamGroup, arnKindClusterParamGroup, arnKindOptionGroup, arnKindSubnetGroup:
+		return true
+	default:
+		return false
+	}
+}
+
+// groupExists reports whether a parameter/option/subnet group named id exists.
+func (m *Mock) groupExists(kind, id string) bool {
+	switch kind {
+	case arnKindParamGroup:
+		return m.paramGroups.Has(id)
+	case arnKindClusterParamGroup:
+		return m.clusterParamGroups.Has(id)
+	case arnKindOptionGroup:
+		return m.optionGroups.Has(id)
+	case arnKindSubnetGroup:
+		return m.subnetGroups.Has(id)
+	default:
+		return false
+	}
 }
 
 // withResourceTags loads the tag map of the resource named by arn, applies fn,
@@ -214,11 +259,31 @@ func (m *Mock) ListTagsForResource(_ context.Context, resourceARN string) (map[s
 func (m *Mock) withResourceTags(arn string, fn func(map[string]string) map[string]string) error {
 	kind, id := arnResourceKindID(arn)
 
+	if isGroupKind(kind) {
+		if !m.groupExists(kind, id) {
+			return errUntaggable(arn)
+		}
+
+		m.setGroupTags(arn, fn(m.groupTags[arn]))
+
+		return nil
+	}
+
+	if !m.setRecordTags(kind, id, fn) {
+		return errUntaggable(arn)
+	}
+
+	return nil
+}
+
+// setRecordTags applies fn to the record named by kind+id and stores it,
+// returning whether the record kind was recognized and the record existed.
+func (m *Mock) setRecordTags(kind, id string, fn func(map[string]string) map[string]string) bool {
 	switch kind {
 	case arnKindInstance:
 		r, ok := m.instances.Get(id)
 		if !ok {
-			return errUntaggable(arn)
+			return false
 		}
 
 		r.Tags = fn(r.Tags)
@@ -226,7 +291,7 @@ func (m *Mock) withResourceTags(arn string, fn func(map[string]string) map[strin
 	case arnKindCluster:
 		r, ok := m.clusters.Get(id)
 		if !ok {
-			return errUntaggable(arn)
+			return false
 		}
 
 		r.Tags = fn(r.Tags)
@@ -234,7 +299,7 @@ func (m *Mock) withResourceTags(arn string, fn func(map[string]string) map[strin
 	case arnKindSnapshot:
 		r, ok := m.snapshots.Get(id)
 		if !ok {
-			return errUntaggable(arn)
+			return false
 		}
 
 		r.Tags = fn(r.Tags)
@@ -242,16 +307,26 @@ func (m *Mock) withResourceTags(arn string, fn func(map[string]string) map[strin
 	case arnKindClusterSnapshot:
 		r, ok := m.clusterSnapshots.Get(id)
 		if !ok {
-			return errUntaggable(arn)
+			return false
 		}
 
 		r.Tags = fn(r.Tags)
 		m.clusterSnapshots.Set(id, r)
 	default:
-		return errUntaggable(arn)
+		return false
 	}
 
-	return nil
+	return true
+}
+
+// setGroupTags stores (or clears) the tags for a group ARN.
+func (m *Mock) setGroupTags(arn string, tags map[string]string) {
+	if len(tags) == 0 {
+		delete(m.groupTags, arn)
+		return
+	}
+
+	m.groupTags[arn] = tags
 }
 
 func errUntaggable(arn string) error {

--- a/providers/aws/rds/option_group.go
+++ b/providers/aws/rds/option_group.go
@@ -87,6 +87,7 @@ func (m *Mock) CreateOptionGroup(_ context.Context, cfg rdsdriver.OptionGroupCon
 		ARN:                optionGroupARN(m.opts.Region, m.opts.AccountID, cfg.Name),
 	}
 	m.optionGroups.Set(cfg.Name, og)
+	m.setGroupTags(og.ARN, copyTags(cfg.Tags))
 
 	out := og
 

--- a/providers/aws/rds/parameter_group.go
+++ b/providers/aws/rds/parameter_group.go
@@ -141,6 +141,7 @@ func (m *Mock) CreateDBParameterGroup(_ context.Context, cfg rdsdriver.Parameter
 		Parameters:  map[string]rdsdriver.Parameter{},
 	}
 	m.paramGroups.Set(cfg.Name, pg)
+	m.setGroupTags(pg.ARN, copyTags(cfg.Tags))
 
 	out := pg
 
@@ -314,6 +315,7 @@ func (m *Mock) CreateDBClusterParameterGroup(
 		Parameters:  map[string]rdsdriver.Parameter{},
 	}
 	m.clusterParamGroups.Set(cfg.Name, pg)
+	m.setGroupTags(pg.ARN, copyTags(cfg.Tags))
 
 	out := pg
 

--- a/providers/aws/rds/rds.go
+++ b/providers/aws/rds/rds.go
@@ -83,6 +83,12 @@ type Mock struct {
 	// mu) so its member instances can provision the cluster's shared database.
 	clusterCreds map[string]clusterCred
 
+	// groupTags holds the tags for parameter/option/subnet groups, keyed by ARN
+	// (guarded by mu). Those resources are taggable in real AWS but carry no tag
+	// field on their records, so the tagging layer tracks them here rather than
+	// answering 404 for a valid group ARN.
+	groupTags map[string]map[string]string
+
 	// rootPasswords remembers each standalone instance's master password (guarded
 	// by mu) so a snapshot restore can re-provision a reachable database with the
 	// original credentials, and a password rotation can be replayed. The emulator
@@ -111,6 +117,7 @@ func New(opts *config.Options) *Mock {
 		clusterEndpoints:   memstore.New[rdsdriver.ClusterEndpoint](),
 		globalClusters:     memstore.New[rdsdriver.GlobalCluster](),
 		clusterCreds:       map[string]clusterCred{},
+		groupTags:          map[string]map[string]string{},
 		rootPasswords:      map[string]string{},
 		opts:               opts,
 	}

--- a/server/aws/rds/aurora_sdk_roundtrip_test.go
+++ b/server/aws/rds/aurora_sdk_roundtrip_test.go
@@ -2,11 +2,37 @@ package rds_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
+
+// TestSDKRDSFailoverEmptyCluster guards that failing a cluster over with no
+// member instances is rejected as InvalidDBClusterStateFault, not silently
+// accepted.
+func TestSDKRDSFailoverEmptyCluster(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBCluster(ctx, &awsrds.CreateDBClusterInput{
+		DBClusterIdentifier: aws.String("empty-cl"),
+		Engine:              aws.String("aurora-mysql"),
+	}); err != nil {
+		t.Fatalf("CreateDBCluster: %v", err)
+	}
+
+	_, err := client.FailoverDBCluster(ctx, &awsrds.FailoverDBClusterInput{
+		DBClusterIdentifier: aws.String("empty-cl"),
+	})
+
+	var state *rdstypes.InvalidDBClusterStateFault
+	if !errors.As(err, &state) {
+		t.Fatalf("failover empty cluster: got %v, want InvalidDBClusterStateFault", err)
+	}
+}
 
 func TestSDKRDSClusterEndpointsAndFailover(t *testing.T) {
 	client := newSDKClient(t)

--- a/server/aws/rds/handler.go
+++ b/server/aws/rds/handler.go
@@ -349,7 +349,7 @@ func writeErr(w http.ResponseWriter, err error) {
 	case cerrors.IsInvalidArgument(err):
 		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterValue", err.Error())
 	case cerrors.IsFailedPrecondition(err):
-		awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidDBInstanceState", err.Error())
+		awsquery.WriteXMLError(w, http.StatusBadRequest, invalidStateCode(err), err.Error())
 	default:
 		awsquery.WriteXMLError(w, http.StatusInternalServerError, "InternalFailure", err.Error())
 	}
@@ -412,9 +412,25 @@ var alreadyExistsFaults = []faultMapping{
 	{"DB snapshot", "DBSnapshotAlreadyExists"},
 }
 
+// invalidStateFaults maps an illegal-state error to the AWS-shaped fault code.
+// Real AWS distinguishes cluster-state faults from instance-state faults, so a
+// message naming a DB cluster gets InvalidDBClusterStateFault; everything else
+// falls back to InvalidDBInstanceState.
+//
+//nolint:gochecknoglobals // ordered static lookup table
+var invalidStateFaults = []faultMapping{
+	{"DB cluster", "InvalidDBClusterStateFault"},
+	{"DB instance", "InvalidDBInstanceState"},
+}
+
 // notFoundCode picks the AWS-shaped NotFound fault from the error message.
 func notFoundCode(err error) string {
 	return matchFault(err.Error(), notFoundFaults, "ResourceNotFoundFault")
+}
+
+// invalidStateCode picks the AWS-shaped illegal-state fault from the message.
+func invalidStateCode(err error) string {
+	return matchFault(err.Error(), invalidStateFaults, "InvalidDBInstanceState")
 }
 
 // alreadyExistsCode picks the AWS-shaped AlreadyExists fault from the message.

--- a/server/aws/rds/operations.go
+++ b/server/aws/rds/operations.go
@@ -139,7 +139,6 @@ func (h *Handler) modifyDBInstance(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // shape mirrors deleteDBCluster but operates on instances.
 func (h *Handler) deleteDBInstance(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("DBInstanceIdentifier")
 
@@ -156,6 +155,26 @@ func (h *Handler) deleteDBInstance(w http.ResponseWriter, r *http.Request) {
 
 	last := insts[0]
 	last.State = rdsdriver.StateDeleting
+
+	// A standalone instance takes a final snapshot unless SkipFinalSnapshot is
+	// set. When a final snapshot is requested, FinalDBSnapshotIdentifier is
+	// mandatory (InvalidParameterCombination otherwise). Cluster members carry no
+	// final-snapshot semantics — that belongs to DeleteDBCluster.
+	if last.ClusterID == "" && !formBool(r.Form.Get("SkipFinalSnapshot")) {
+		finalID := r.Form.Get("FinalDBSnapshotIdentifier")
+		if finalID == "" {
+			awsquery.WriteXMLError(w, http.StatusBadRequest, "InvalidParameterCombination",
+				"FinalDBSnapshotIdentifier is required unless SkipFinalSnapshot is true")
+
+			return
+		}
+
+		if _, err := h.db.CreateSnapshot(r.Context(),
+			rdsdriver.SnapshotConfig{ID: finalID, InstanceID: id}); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
 
 	if err := h.db.DeleteInstance(r.Context(), id); err != nil {
 		writeErr(w, err)
@@ -317,7 +336,6 @@ func (h *Handler) modifyDBCluster(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//nolint:dupl // shape mirrors deleteDBInstance but operates on clusters.
 func (h *Handler) deleteDBCluster(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("DBClusterIdentifier")
 
@@ -452,6 +470,7 @@ func (h *Handler) describeDBSnapshots(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//nolint:dupl // shape mirrors deleteDBClusterSnapshot but operates on instance snapshots.
 func (h *Handler) deleteDBSnapshot(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("DBSnapshotIdentifier")
 
@@ -550,6 +569,7 @@ func (h *Handler) describeDBClusterSnapshots(w http.ResponseWriter, r *http.Requ
 	})
 }
 
+//nolint:dupl // shape mirrors deleteDBSnapshot but operates on cluster snapshots.
 func (h *Handler) deleteDBClusterSnapshot(w http.ResponseWriter, r *http.Request) {
 	id := r.Form.Get("DBClusterSnapshotIdentifier")
 

--- a/server/aws/rds/sdk_roundtrip_test.go
+++ b/server/aws/rds/sdk_roundtrip_test.go
@@ -12,6 +12,7 @@ import (
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	smithy "github.com/aws/smithy-go"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -338,5 +339,160 @@ func TestSDKRDSRoutingDoesNotShadowEC2(t *testing.T) {
 
 	if len(out.Instances) == 0 {
 		t.Fatal("expected at least one EC2 instance")
+	}
+}
+
+// TestSDKRDSDeleteWithFinalSnapshot guards that DeleteDBInstance honors
+// FinalDBSnapshotIdentifier (a final snapshot is created and readable) and
+// rejects the InvalidParameterCombination of no skip + no final id.
+func TestSDKRDSDeleteWithFinalSnapshot(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("finaldb"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	// Neither SkipFinalSnapshot nor FinalDBSnapshotIdentifier is a hard error.
+	_, err := client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String("finaldb"),
+	})
+	if err == nil {
+		t.Fatal("delete without skip or final id: want InvalidParameterCombination, got nil")
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidParameterCombination" {
+		t.Fatalf("delete without skip or final id: got %v, want InvalidParameterCombination", err)
+	}
+
+	// Providing a final snapshot id creates the snapshot before deleting.
+	if _, err := client.DeleteDBInstance(ctx, &awsrds.DeleteDBInstanceInput{
+		DBInstanceIdentifier:      aws.String("finaldb"),
+		FinalDBSnapshotIdentifier: aws.String("finaldb-final"),
+	}); err != nil {
+		t.Fatalf("DeleteDBInstance with final snapshot: %v", err)
+	}
+
+	snaps, err := client.DescribeDBSnapshots(ctx, &awsrds.DescribeDBSnapshotsInput{
+		DBSnapshotIdentifier: aws.String("finaldb-final"),
+	})
+	if err != nil {
+		t.Fatalf("DescribeDBSnapshots for final: %v", err)
+	}
+
+	if len(snaps.DBSnapshots) != 1 {
+		t.Fatalf("got %d final snapshots, want 1", len(snaps.DBSnapshots))
+	}
+}
+
+// TestSDKRDSSnapshotPercentProgress guards that an available snapshot reports
+// PercentProgress=100 (consistent with its Status), not 0.
+func TestSDKRDSSnapshotPercentProgress(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	if _, err := client.CreateDBInstance(ctx, &awsrds.CreateDBInstanceInput{
+		DBInstanceIdentifier: aws.String("progsrc"),
+		Engine:               aws.String("mysql"),
+		DBInstanceClass:      aws.String("db.t3.micro"),
+		AllocatedStorage:     aws.Int32(20),
+	}); err != nil {
+		t.Fatalf("CreateDBInstance: %v", err)
+	}
+
+	out, err := client.CreateDBSnapshot(ctx, &awsrds.CreateDBSnapshotInput{
+		DBSnapshotIdentifier: aws.String("prog-snap"),
+		DBInstanceIdentifier: aws.String("progsrc"),
+	})
+	if err != nil {
+		t.Fatalf("CreateDBSnapshot: %v", err)
+	}
+
+	if aws.ToString(out.DBSnapshot.Status) != "available" {
+		t.Fatalf("snapshot status %q, want available", aws.ToString(out.DBSnapshot.Status))
+	}
+
+	if aws.ToInt32(out.DBSnapshot.PercentProgress) != 100 {
+		t.Fatalf("snapshot PercentProgress=%d, want 100", aws.ToInt32(out.DBSnapshot.PercentProgress))
+	}
+}
+
+// TestSDKRDSListTagsForGroups guards that parameter/option/subnet group ARNs
+// are recognized taggable resources: ListTagsForResource round-trips their tags
+// instead of answering DBInstanceNotFound.
+func TestSDKRDSListTagsForGroups(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	pg, err := client.CreateDBParameterGroup(ctx, &awsrds.CreateDBParameterGroupInput{
+		DBParameterGroupName:   aws.String("pg1"),
+		DBParameterGroupFamily: aws.String("mysql8.0"),
+		Description:            aws.String("pg"),
+		Tags:                   []rdstypes.Tag{{Key: aws.String("team"), Value: aws.String("db")}},
+	})
+	if err != nil {
+		t.Fatalf("CreateDBParameterGroup: %v", err)
+	}
+
+	pgTags, err := client.ListTagsForResource(ctx, &awsrds.ListTagsForResourceInput{
+		ResourceName: pg.DBParameterGroup.DBParameterGroupArn,
+	})
+	if err != nil {
+		t.Fatalf("ListTagsForResource(parameter group): %v", err)
+	}
+
+	if len(pgTags.TagList) != 1 || aws.ToString(pgTags.TagList[0].Key) != "team" {
+		t.Fatalf("parameter-group tags = %+v, want team=db", pgTags.TagList)
+	}
+
+	og, err := client.CreateOptionGroup(ctx, &awsrds.CreateOptionGroupInput{
+		OptionGroupName:        aws.String("og1"),
+		EngineName:             aws.String("mysql"),
+		MajorEngineVersion:     aws.String("8.0"),
+		OptionGroupDescription: aws.String("og"),
+	})
+	if err != nil {
+		t.Fatalf("CreateOptionGroup: %v", err)
+	}
+
+	// Tag an option group after creation, then read it back.
+	if _, err := client.AddTagsToResource(ctx, &awsrds.AddTagsToResourceInput{
+		ResourceName: og.OptionGroup.OptionGroupArn,
+		Tags:         []rdstypes.Tag{{Key: aws.String("env"), Value: aws.String("test")}},
+	}); err != nil {
+		t.Fatalf("AddTagsToResource(option group): %v", err)
+	}
+
+	ogTags, err := client.ListTagsForResource(ctx, &awsrds.ListTagsForResourceInput{
+		ResourceName: og.OptionGroup.OptionGroupArn,
+	})
+	if err != nil {
+		t.Fatalf("ListTagsForResource(option group): %v", err)
+	}
+
+	if len(ogTags.TagList) != 1 || aws.ToString(ogTags.TagList[0].Value) != "test" {
+		t.Fatalf("option-group tags = %+v, want env=test", ogTags.TagList)
+	}
+
+	// A subnet group ARN is also taggable (empty list, not a 404).
+	sg, err := client.CreateDBSubnetGroup(ctx, &awsrds.CreateDBSubnetGroupInput{
+		DBSubnetGroupName:        aws.String("sg1"),
+		DBSubnetGroupDescription: aws.String("sg"),
+		SubnetIds:                []string{"subnet-1", "subnet-2"},
+	})
+	if err != nil {
+		t.Fatalf("CreateDBSubnetGroup: %v", err)
+	}
+
+	if _, err := client.ListTagsForResource(ctx, &awsrds.ListTagsForResourceInput{
+		ResourceName: sg.DBSubnetGroup.DBSubnetGroupArn,
+	}); err != nil {
+		t.Fatalf("ListTagsForResource(subnet group): %v", err)
 	}
 }

--- a/server/aws/rds/xml.go
+++ b/server/aws/rds/xml.go
@@ -8,6 +8,9 @@ import (
 	rdsdriver "github.com/stackshy/cloudemu/v2/services/relationaldb/driver"
 )
 
+// snapshotProgressComplete is the PercentProgress an available snapshot reports.
+const snapshotProgressComplete = 100
+
 // All RDS query-protocol responses are wrapped in <FooResponse> with a
 // <FooResult> child and a trailing <ResponseMetadata>. The structures below
 // mirror the AWS-published XML closely enough that aws-sdk-go-v2's RDS
@@ -103,6 +106,7 @@ type dbSnapshotXML struct {
 	EngineVersion        string      `xml:"EngineVersion,omitempty"`
 	AllocatedStorage     int         `xml:"AllocatedStorage,omitempty"`
 	Status               string      `xml:"Status"`
+	PercentProgress      int         `xml:"PercentProgress"`
 	SnapshotCreateTime   string      `xml:"SnapshotCreateTime,omitempty"`
 	TagList              *tagListXML `xml:"TagList,omitempty"`
 }
@@ -114,6 +118,7 @@ type dbClusterSnapshotXML struct {
 	Engine                      string      `xml:"Engine,omitempty"`
 	EngineVersion               string      `xml:"EngineVersion,omitempty"`
 	Status                      string      `xml:"Status"`
+	PercentProgress             int         `xml:"PercentProgress"`
 	SnapshotCreateTime          string      `xml:"SnapshotCreateTime,omitempty"`
 	TagList                     *tagListXML `xml:"TagList,omitempty"`
 }
@@ -394,9 +399,22 @@ func toSnapshotXML(snap *rdsdriver.Snapshot) dbSnapshotXML {
 		EngineVersion:        snap.EngineVersion,
 		AllocatedStorage:     snap.AllocatedStorage,
 		Status:               snap.State,
+		PercentProgress:      percentProgressForState(snap.State),
 		SnapshotCreateTime:   snap.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		TagList:              toTagListXML(snap.Tags),
 	}
+}
+
+// percentProgressForState reports a snapshot's backup progress: an available
+// snapshot is fully backed up (100), anything still creating is 0. Real AWS
+// reports 100 for an available snapshot, so a caller polling PercentProgress
+// alongside Status sees them agree.
+func percentProgressForState(state string) int {
+	if state == rdsdriver.SnapshotAvailable {
+		return snapshotProgressComplete
+	}
+
+	return 0
 }
 
 func toClusterSnapshotXML(snap *rdsdriver.ClusterSnapshot) dbClusterSnapshotXML {
@@ -407,6 +425,7 @@ func toClusterSnapshotXML(snap *rdsdriver.ClusterSnapshot) dbClusterSnapshotXML 
 		Engine:                      snap.Engine,
 		EngineVersion:               snap.EngineVersion,
 		Status:                      snap.State,
+		PercentProgress:             percentProgressForState(snap.State),
 		SnapshotCreateTime:          snap.CreatedAt.UTC().Format("2006-01-02T15:04:05.000Z"),
 		TagList:                     toTagListXML(snap.Tags),
 	}


### PR DESCRIPTION
Closes the wire-only RDS audit findings. Findings needing driver-struct field additions (ModifyDBInstance param set, CreateDBInstance/Cluster omitted fields, pagination, async waiter states) are deferred for a dedicated driver pass. SDK round-trip tests per fix.