### PR TITLE
fix(route53resolver): HostVPCId + CREATING→OPERATIONAL status

### DIFF
--- a/providers/aws/route53resolver/endpoints.go
+++ b/providers/aws/route53resolver/endpoints.go
@@ -2,6 +2,8 @@ package route53resolver
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
 
 	"github.com/stackshy/cloudemu/v2/errors"
 	"github.com/stackshy/cloudemu/v2/internal/idgen"
@@ -26,6 +28,23 @@ func endpointIDPrefix(direction string) string {
 // minEndpointIPs is the minimum number of IP addresses AWS requires a Resolver
 // endpoint to retain.
 const minEndpointIPs = 2
+
+// hostVPCFor derives the VPC that hosts a Resolver endpoint from its subnets.
+// Real Route 53 Resolver reports HostVPCId as the VPC the endpoint's subnets
+// belong to; we model subnet→VPC with a stable hash so the same subnet always
+// maps to the same VPC id (and a create with no subnet still gets a VPC).
+func hostVPCFor(ips []driver.IPAddress) string {
+	for i := range ips {
+		if ips[i].SubnetID != "" {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(ips[i].SubnetID))
+
+			return fmt.Sprintf("vpc-%08x", h.Sum32())
+		}
+	}
+
+	return idgen.GenerateID("vpc-")
+}
 
 func notFound(id string) error {
 	return errors.Newf(errors.NotFound, "resolver endpoint %q not found", id)
@@ -82,11 +101,12 @@ func (m *Mock) CreateResolverEndpoint(
 		Name:                      in.Name,
 		CreatorRequestID:          in.CreatorRequestID,
 		Direction:                 in.Direction,
+		HostVPCID:                 hostVPCFor(in.IPAddresses),
 		IPAddressCount:            i32(len(ips)),
 		SecurityGroupIDs:          append([]string(nil), in.SecurityGroupIDs...),
 		IPAddresses:               ips,
-		Status:                    statusOperational,
-		StatusMessage:             "This Resolver Endpoint is operational.",
+		Status:                    statusCreating,
+		StatusMessage:             "This Resolver Endpoint is being created.",
 		ResolverEndpointType:      epType,
 		Protocols:                 append([]string(nil), in.Protocols...),
 		OutpostARN:                in.OutpostARN,
@@ -115,6 +135,18 @@ func (m *Mock) GetResolverEndpoint(_ context.Context, id string) (*driver.Resolv
 	e, ok := m.endpoints.Get(id)
 	if !ok {
 		return nil, notFound(id)
+	}
+
+	// Real Route 53 Resolver returns a freshly created endpoint as CREATING and
+	// then transitions it to OPERATIONAL. Advance the status on read so the SDK's
+	// ResolverEndpointCreated waiter (which polls GetResolverEndpoint) completes.
+	if e.Status == statusCreating {
+		updated := cloneEndpoint(e)
+		updated.Status = statusOperational
+		updated.StatusMessage = "This Resolver Endpoint is operational."
+		updated.ModifiedAt = m.now()
+		m.endpoints.Set(id, &updated)
+		e = &updated
 	}
 
 	out := cloneEndpoint(e)

--- a/providers/aws/route53resolver/route53resolver.go
+++ b/providers/aws/route53resolver/route53resolver.go
@@ -19,6 +19,7 @@ import (
 var _ driver.Route53Resolver = (*Mock)(nil)
 
 const (
+	statusCreating    = "CREATING"
 	statusOperational = "OPERATIONAL"
 	statusDeleting    = "DELETING"
 	ipStatusAttached  = "ATTACHED"

--- a/providers/aws/route53resolver/route53resolver_test.go
+++ b/providers/aws/route53resolver/route53resolver_test.go
@@ -38,7 +38,17 @@ func TestEndpointCreateGetUpdateDeleteAndIPs(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, ep.ID, "rslvr-in-")
 	assert.Equal(t, int32(2), ep.IPAddressCount)
-	assert.Equal(t, statusOperational, ep.Status)
+	// A new endpoint is born CREATING with the VPC its subnets belong to.
+	assert.Equal(t, statusCreating, ep.Status)
+	assert.NotEmpty(t, ep.HostVPCID)
+	// The same subnet always maps to the same host VPC.
+	assert.Equal(t, hostVPCFor([]driver.IPAddress{{SubnetID: "subnet-a"}}), ep.HostVPCID)
+
+	// Reading the endpoint advances it to OPERATIONAL (the create waiter's exit).
+	got, err := m.GetResolverEndpoint(ctx, ep.ID)
+	require.NoError(t, err)
+	assert.Equal(t, statusOperational, got.Status)
+	assert.Equal(t, ep.HostVPCID, got.HostVPCID)
 
 	// Tags stored on create are retrievable by ARN.
 	tags, err := m.ListTagsForResource(ctx, ep.ARN)

--- a/server/aws/route53resolver/sdk_roundtrip_test.go
+++ b/server/aws/route53resolver/sdk_roundtrip_test.go
@@ -71,8 +71,14 @@ func TestSDKResolverEndpointLifecycle(t *testing.T) {
 		t.Errorf("ip count = %d, want 2", aws.ToInt32(ep.IpAddressCount))
 	}
 
-	if ep.Status != r53rtypes.ResolverEndpointStatusOperational {
-		t.Errorf("status = %v, want OPERATIONAL", ep.Status)
+	// Real Route 53 Resolver returns a new endpoint as CREATING, not OPERATIONAL.
+	if ep.Status != r53rtypes.ResolverEndpointStatusCreating {
+		t.Errorf("status = %v, want CREATING", ep.Status)
+	}
+
+	// HostVPCId (the VPC the endpoint's subnets belong to) is populated.
+	if aws.ToString(ep.HostVPCId) == "" {
+		t.Errorf("HostVPCId is empty, want a vpc- id")
 	}
 
 	id := aws.ToString(ep.Id)
@@ -81,6 +87,16 @@ func TestSDKResolverEndpointLifecycle(t *testing.T) {
 	got, err := client.GetResolverEndpoint(ctx, &awsr53r.GetResolverEndpointInput{ResolverEndpointId: aws.String(id)})
 	if err != nil || aws.ToString(got.ResolverEndpoint.Name) != "inbound-1" {
 		t.Fatalf("GetResolverEndpoint: %v %+v", err, got)
+	}
+
+	// Reading the endpoint advances it to OPERATIONAL (the create waiter's exit).
+	if got.ResolverEndpoint.Status != r53rtypes.ResolverEndpointStatusOperational {
+		t.Errorf("status after get = %v, want OPERATIONAL", got.ResolverEndpoint.Status)
+	}
+
+	if aws.ToString(got.ResolverEndpoint.HostVPCId) != aws.ToString(ep.HostVPCId) {
+		t.Errorf("HostVPCId changed on get: %q -> %q",
+			aws.ToString(ep.HostVPCId), aws.ToString(got.ResolverEndpoint.HostVPCId))
 	}
 
 	list, err := client.ListResolverEndpoints(ctx, &awsr53r.ListResolverEndpointsInput{})


### PR DESCRIPTION
Sets HostVPCId and the CREATING-on-create → OPERATIONAL-after-get transition for route53resolver endpoints (provider-layer only). The core route53 findings were already resolved on development by #467. SDK + provider tests updated to assert real AWS behavior.