### PR TITLE
fix(sns): subscription attributes, confirm/publish-batch, permissions, pending counts

### DIFF
--- a/cloudemu_test.go
+++ b/cloudemu_test.go
@@ -2339,11 +2339,12 @@ func testNotificationWithDriver(t *testing.T, ctx context.Context, d notifdriver
 		t.Errorf("expected 'order-events', got %q", got.Name)
 	}
 
-	// Subscribe
+	// Subscribe. SMS auto-confirms across all three providers (AWS SNS email/
+	// http/https start pending), so the confirmed assertion holds portably.
 	sub, err := d.Subscribe(ctx, notifdriver.SubscriptionConfig{
 		TopicID:  "order-events",
-		Protocol: "email",
-		Endpoint: "admin@example.com",
+		Protocol: "sms",
+		Endpoint: "+15551234567",
 	})
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)

--- a/compat/aws/notification_compat_test.go
+++ b/compat/aws/notification_compat_test.go
@@ -77,6 +77,9 @@ func TestSNSCompat(t *testing.T) {
 			TopicArn: aws.String(topicArn),
 			Protocol: aws.String(snsProtocol),
 			Endpoint: aws.String(snsEndpoint),
+			// email requires confirmation, so real SNS returns "pending confirmation"
+			// unless the caller opts in to the ARN being returned immediately.
+			ReturnSubscriptionArn: true,
 		})
 		if err != nil {
 			return err

--- a/providers/aws/sns/sns.go
+++ b/providers/aws/sns/sns.go
@@ -20,6 +20,12 @@ import (
 // Compile-time check that Mock implements driver.Notification.
 var _ driver.Notification = (*Mock)(nil)
 
+// Subscription lifecycle states.
+const (
+	statusConfirmed = "confirmed"
+	statusPending   = "pending"
+)
+
 type publishedMessage struct {
 	ID         string
 	TopicID    string
@@ -32,7 +38,23 @@ type topicData struct {
 	info          driver.TopicInfo
 	subscriptions *memstore.Store[driver.SubscriptionInfo]
 	messages      []publishedMessage
+	deleted       int // monotonic count of unsubscribed endpoints
 	mu            sync.RWMutex
+}
+
+// confirmationProtocols is the set of SNS protocols whose subscriptions start
+// out pending until ConfirmSubscription is called. sqs/lambda/sms/application/
+// firehose auto-confirm.
+var confirmationProtocols = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"http":       {},
+	"https":      {},
+	"email":      {},
+	"email-json": {},
+}
+
+func requiresConfirmation(protocol string) bool {
+	_, ok := confirmationProtocols[protocol]
+	return ok
 }
 
 // SQSDeliverer delivers an SNS notification into an SQS queue identified by
@@ -133,10 +155,36 @@ func (m *Mock) GetTopic(_ context.Context, id string) (*driver.TopicInfo, error)
 		return nil, errors.Newf(errors.NotFound, "topic %q not found", id)
 	}
 
-	result := td.info
-	result.SubscriptionCount = td.subscriptions.Len()
+	result := td.withCounts()
 
 	return &result, nil
+}
+
+// withCounts returns a copy of the topic info with the confirmed/pending/deleted
+// subscription counters populated from live subscription state.
+func (td *topicData) withCounts() driver.TopicInfo {
+	info := td.info
+
+	var confirmed, pending int
+
+	for _, s := range td.subscriptions.All() {
+		if s.Status == statusPending {
+			pending++
+		} else {
+			confirmed++
+		}
+	}
+
+	info.SubscriptionsConfirmed = confirmed
+	info.SubscriptionsPending = pending
+
+	td.mu.RLock()
+	info.SubscriptionsDeleted = td.deleted
+	td.mu.RUnlock()
+
+	info.SubscriptionCount = confirmed + pending
+
+	return info
 }
 
 // ListTopics lists all SNS topics visible under the given scope filter.
@@ -150,9 +198,7 @@ func (m *Mock) ListTopics(_ context.Context, filter scope.Scope) ([]driver.Topic
 			continue
 		}
 
-		info := td.info
-		info.SubscriptionCount = td.subscriptions.Len()
-		topics = append(topics, info)
+		topics = append(topics, td.withCounts())
 	}
 
 	return topics, nil
@@ -170,17 +216,22 @@ func (m *Mock) UpdateTopic(_ context.Context, cfg driver.TopicConfig) (*driver.T
 	if cfg.DisplayName != "" {
 		td.info.DisplayName = cfg.DisplayName
 	}
+
 	if cfg.Tags != nil {
 		td.info.Tags = maps.Clone(cfg.Tags)
 	}
+
+	if cfg.Policy != "" {
+		td.info.Policy = cfg.Policy
+	}
+
 	if !cfg.Scope.IsZero() {
 		td.info.Scope = cfg.Scope
 	}
 
 	m.topics.Set(cfg.Name, td)
 
-	result := td.info
-	result.SubscriptionCount = td.subscriptions.Len()
+	result := td.withCounts()
 
 	return &result, nil
 }
@@ -201,14 +252,25 @@ func (m *Mock) Subscribe(_ context.Context, cfg driver.SubscriptionConfig) (*dri
 	}
 
 	subID := idgen.GenerateID("sub-")
-	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, "subscription/"+subID)
+	arn := idgen.AWSARN("sns", m.opts.Region, m.opts.AccountID, cfg.TopicID+":"+subID)
+
+	attrs := make(map[string]string, len(cfg.Attributes))
+	for k, v := range cfg.Attributes {
+		attrs[k] = v
+	}
 
 	sub := driver.SubscriptionInfo{
-		ID:       arn,
-		TopicID:  cfg.TopicID,
-		Protocol: cfg.Protocol,
-		Endpoint: cfg.Endpoint,
-		Status:   "confirmed",
+		ID:         arn,
+		TopicID:    cfg.TopicID,
+		Protocol:   cfg.Protocol,
+		Endpoint:   cfg.Endpoint,
+		Status:     statusConfirmed,
+		Attributes: attrs,
+	}
+
+	if requiresConfirmation(cfg.Protocol) {
+		sub.Status = statusPending
+		sub.ConfirmationToken = idgen.GenerateID("")
 	}
 
 	td.subscriptions.Set(arn, sub)
@@ -224,6 +286,10 @@ func (m *Mock) Unsubscribe(_ context.Context, subscriptionID string) error {
 
 	for _, td := range all {
 		if td.subscriptions.Delete(subscriptionID) {
+			td.mu.Lock()
+			td.deleted++
+			td.mu.Unlock()
+
 			return nil
 		}
 	}

--- a/providers/aws/sns/sns_test.go
+++ b/providers/aws/sns/sns_test.go
@@ -304,10 +304,11 @@ func TestListTopics(t *testing.T) {
 
 func TestSubscribe(t *testing.T) {
 	tests := []struct {
-		name      string
-		cfg       driver.SubscriptionConfig
-		setup     func(*Mock) driver.SubscriptionConfig
-		expectErr bool
+		name       string
+		cfg        driver.SubscriptionConfig
+		setup      func(*Mock) driver.SubscriptionConfig
+		wantStatus string
+		expectErr  bool
 	}{
 		{
 			name: "email subscription",
@@ -317,6 +318,8 @@ func TestSubscribe(t *testing.T) {
 					TopicID: info.Name, Protocol: "email", Endpoint: "user@example.com",
 				}
 			},
+			// email requires out-of-band confirmation, so it starts pending.
+			wantStatus: "pending",
 		},
 		{
 			name: "sms subscription",
@@ -326,6 +329,8 @@ func TestSubscribe(t *testing.T) {
 					TopicID: info.Name, Protocol: "sms", Endpoint: "+1234567890",
 				}
 			},
+			// SMS auto-confirms.
+			wantStatus: "confirmed",
 		},
 		{
 			name: "nonexistent topic",
@@ -376,7 +381,7 @@ func TestSubscribe(t *testing.T) {
 			assert.NotEmpty(t, sub.ID)
 			assert.Equal(t, cfg.Protocol, sub.Protocol)
 			assert.Equal(t, cfg.Endpoint, sub.Endpoint)
-			assert.Equal(t, "confirmed", sub.Status)
+			assert.Equal(t, tc.wantStatus, sub.Status)
 		})
 	}
 }

--- a/providers/aws/sns/subscription_attributes.go
+++ b/providers/aws/sns/subscription_attributes.go
@@ -1,0 +1,221 @@
+package sns
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// mutableSubAttributes is the set of subscription attributes a caller may set via
+// SetSubscriptionAttributes. Real SNS rejects unknown attribute names.
+var mutableSubAttributes = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
+	"DeliveryPolicy":      {},
+	"FilterPolicy":        {},
+	"FilterPolicyScope":   {},
+	"RawMessageDelivery":  {},
+	"RedrivePolicy":       {},
+	"SubscriptionRoleArn": {},
+}
+
+// findSubscription locates a subscription by its ARN across every topic and
+// returns its owning topic plus a copy of the subscription.
+func (m *Mock) findSubscription(subscriptionARN string) (*topicData, driver.SubscriptionInfo, bool) {
+	for _, td := range m.topics.All() {
+		if sub, ok := td.subscriptions.Get(subscriptionARN); ok {
+			return td, sub, true
+		}
+	}
+
+	return nil, driver.SubscriptionInfo{}, false
+}
+
+// GetSubscription returns a copy of the subscription identified by its ARN.
+func (m *Mock) GetSubscription(_ context.Context, subscriptionARN string) (*driver.SubscriptionInfo, error) {
+	_, sub, ok := m.findSubscription(subscriptionARN)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "subscription %q not found", subscriptionARN)
+	}
+
+	result := sub
+
+	return &result, nil
+}
+
+// SetSubscriptionAttribute sets a single subscription attribute to value,
+// mirroring SNS SetSubscriptionAttributes (one attribute per call).
+func (m *Mock) SetSubscriptionAttribute(_ context.Context, subscriptionARN, name, value string) error {
+	if _, ok := mutableSubAttributes[name]; !ok {
+		return errors.Newf(errors.InvalidArgument, "AttributeName %q is not a valid subscription attribute", name)
+	}
+
+	td, sub, ok := m.findSubscription(subscriptionARN)
+	if !ok {
+		return errors.Newf(errors.NotFound, "subscription %q not found", subscriptionARN)
+	}
+
+	if sub.Attributes == nil {
+		sub.Attributes = make(map[string]string, 1)
+	}
+
+	if value == "" {
+		delete(sub.Attributes, name)
+	} else {
+		sub.Attributes[name] = value
+	}
+
+	td.subscriptions.Set(subscriptionARN, sub)
+
+	return nil
+}
+
+// ConfirmSubscription confirms a pending subscription on the topic. The token
+// must match the pending subscription's confirmation token. It returns the
+// confirmed subscription's ARN.
+func (m *Mock) ConfirmSubscription(_ context.Context, topicID, token string) (*driver.SubscriptionInfo, error) {
+	if token == "" {
+		return nil, errors.New(errors.InvalidArgument, "confirmation token is required")
+	}
+
+	td, ok := m.topics.Get(topicID)
+	if !ok {
+		return nil, errors.Newf(errors.NotFound, "topic %q not found", topicID)
+	}
+
+	for _, sub := range td.subscriptions.All() {
+		if sub.Status != statusPending || sub.ConfirmationToken != token {
+			continue
+		}
+
+		sub.Status = statusConfirmed
+		sub.ConfirmationToken = ""
+		td.subscriptions.Set(sub.ID, sub)
+
+		result := sub
+
+		return &result, nil
+	}
+
+	return nil, errors.New(errors.InvalidArgument, "Invalid token")
+}
+
+// AddTopicPermission adds an Allow statement (Sid=label) granting the given
+// accounts the given SNS actions on the topic, mutating the stored policy.
+func (m *Mock) AddTopicPermission(_ context.Context, topicID, label string, accountIDs, actions []string) error {
+	td, ok := m.topics.Get(topicID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "topic %q not found", topicID)
+	}
+
+	doc, err := topicPolicyDoc(td)
+	if err != nil {
+		return errors.Newf(errors.InvalidArgument, "topic policy is not valid JSON: %v", err)
+	}
+
+	principals := make([]string, 0, len(accountIDs))
+	for _, acct := range accountIDs {
+		principals = append(principals, "arn:aws:iam::"+acct+":root")
+	}
+
+	qualified := make([]string, 0, len(actions))
+	for _, a := range actions {
+		qualified = append(qualified, "SNS:"+a)
+	}
+
+	doc.Statement = append(doc.Statement, policyStatement{
+		Sid:       label,
+		Effect:    "Allow",
+		Principal: map[string]any{"AWS": principals},
+		Action:    qualified,
+		Resource:  td.info.ResourceID,
+	})
+
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return errors.Newf(errors.Internal, "encode policy: %v", err)
+	}
+
+	td.info.Policy = string(encoded)
+	m.topics.Set(topicID, td)
+
+	return nil
+}
+
+// RemoveTopicPermission removes the statement whose Sid equals label.
+func (m *Mock) RemoveTopicPermission(_ context.Context, topicID, label string) error {
+	td, ok := m.topics.Get(topicID)
+	if !ok {
+		return errors.Newf(errors.NotFound, "topic %q not found", topicID)
+	}
+
+	policy := td.info.Policy
+	if policy == "" {
+		return nil
+	}
+
+	doc, err := decodePolicy(policy)
+	if err != nil {
+		return errors.Newf(errors.InvalidArgument, "topic policy is not valid JSON: %v", err)
+	}
+
+	kept := doc.Statement[:0]
+
+	for _, st := range doc.Statement {
+		if st.Sid != label {
+			kept = append(kept, st)
+		}
+	}
+
+	doc.Statement = kept
+
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return errors.Newf(errors.Internal, "encode policy: %v", err)
+	}
+
+	td.info.Policy = string(encoded)
+	m.topics.Set(topicID, td)
+
+	return nil
+}
+
+// policyDoc / policyStatement model just enough of an SNS access policy to add
+// and remove statements while round-tripping unknown fields verbatim.
+type policyDoc struct {
+	Version   string            `json:"Version"`
+	ID        string            `json:"Id,omitempty"`
+	Statement []policyStatement `json:"Statement"`
+}
+
+type policyStatement struct {
+	Sid       string         `json:"Sid,omitempty"`
+	Effect    string         `json:"Effect"`
+	Principal any            `json:"Principal,omitempty"`
+	Action    any            `json:"Action,omitempty"`
+	Resource  any            `json:"Resource,omitempty"`
+	Condition map[string]any `json:"Condition,omitempty"`
+}
+
+func decodePolicy(s string) (*policyDoc, error) {
+	var doc policyDoc
+	if err := json.Unmarshal([]byte(s), &doc); err != nil {
+		return nil, err
+	}
+
+	return &doc, nil
+}
+
+// topicPolicyDoc returns the topic's stored policy as a decoded document, or a
+// fresh default document (matching the SNS-seeded default) when none is stored.
+func topicPolicyDoc(td *topicData) (*policyDoc, error) {
+	if td.info.Policy != "" {
+		return decodePolicy(td.info.Policy)
+	}
+
+	return &policyDoc{
+		Version:   "2008-10-17",
+		ID:        "__default_policy_ID",
+		Statement: []policyStatement{},
+	}, nil
+}

--- a/server/aws/sns/handler.go
+++ b/server/aws/sns/handler.go
@@ -18,9 +18,15 @@
 //	ListTopics                  — Notification.ListTopics
 //	Subscribe                   — Notification.Subscribe
 //	Unsubscribe                 — Notification.Unsubscribe
+//	ConfirmSubscription         — snsExtras.ConfirmSubscription
+//	GetSubscriptionAttributes   — snsExtras.GetSubscription
+//	SetSubscriptionAttributes   — snsExtras.SetSubscriptionAttribute
 //	ListSubscriptions           — Notification.ListSubscriptions across all topics
 //	ListSubscriptionsByTopic    — Notification.ListSubscriptions for one topic
 //	Publish                     — Notification.Publish
+//	PublishBatch                — Notification.Publish per entry
+//	AddPermission               — snsExtras.AddTopicPermission
+//	RemovePermission            — snsExtras.RemoveTopicPermission
 package sns
 
 import (
@@ -41,23 +47,36 @@ const (
 	maxFormBodyBytes = 1 << 20
 )
 
+// SNS attribute-value literals and the pending subscription state.
+const (
+	statusPending = "pending"
+	attrTrue      = "true"
+	attrFalse     = "false"
+)
+
 // snsActions is the set of Action values this handler recognizes. Matches uses
 // it to decide whether to claim a request. Disjoint from RDS / Redshift / IAM /
 // EC2 / ElastiCache action sets.
 var snsActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup table
-	"CreateTopic":              {},
-	"DeleteTopic":              {},
-	"GetTopicAttributes":       {},
-	"SetTopicAttributes":       {},
-	"ListTopics":               {},
-	"Subscribe":                {},
-	"Unsubscribe":              {},
-	"ListSubscriptions":        {},
-	"ListSubscriptionsByTopic": {},
-	"Publish":                  {},
-	"TagResource":              {},
-	"UntagResource":            {},
-	actionListTagsForResource:  {},
+	"CreateTopic":               {},
+	"DeleteTopic":               {},
+	"GetTopicAttributes":        {},
+	"SetTopicAttributes":        {},
+	"ListTopics":                {},
+	"Subscribe":                 {},
+	"Unsubscribe":               {},
+	"ConfirmSubscription":       {},
+	"GetSubscriptionAttributes": {},
+	"SetSubscriptionAttributes": {},
+	"ListSubscriptions":         {},
+	"ListSubscriptionsByTopic":  {},
+	"Publish":                   {},
+	"PublishBatch":              {},
+	"AddPermission":             {},
+	"RemovePermission":          {},
+	"TagResource":               {},
+	"UntagResource":             {},
+	actionListTagsForResource:   {},
 }
 
 // actionListTagsForResource is the generic tag-read verb SNS shares with other
@@ -74,6 +93,18 @@ const actionListTagsForResource = "ListTagsForResource"
 type topicTagger interface {
 	TagTopic(ctx context.Context, topicName string, tags map[string]string) error
 	UntagTopic(ctx context.Context, topicName string, keys []string) error
+}
+
+// snsExtras is the AWS-only surface (subscription attributes, confirmation, and
+// topic access-policy permissions) that isn't part of the portable Notification
+// driver — Azure Notification Hubs and GCP FCM don't model it. The AWS SNS mock
+// implements it; handlers type-assert for it and return NotSupported otherwise.
+type snsExtras interface {
+	GetSubscription(ctx context.Context, subscriptionARN string) (*notifdriver.SubscriptionInfo, error)
+	SetSubscriptionAttribute(ctx context.Context, subscriptionARN, name, value string) error
+	ConfirmSubscription(ctx context.Context, topicName, token string) (*notifdriver.SubscriptionInfo, error)
+	AddTopicPermission(ctx context.Context, topicName, label string, accountIDs, actions []string) error
+	RemoveTopicPermission(ctx context.Context, topicName, label string) error
 }
 
 // Handler serves SNS query-protocol requests against a notification driver.
@@ -126,6 +157,8 @@ func (*Handler) Matches(r *http.Request) bool {
 }
 
 // ServeHTTP dispatches on Action. The form has already been parsed by Matches.
+//
+//nolint:gocyclo // flat dispatch switch over the SNS action set
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	action := r.Form.Get("Action")
 
@@ -144,12 +177,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.subscribe(w, r)
 	case "Unsubscribe":
 		h.unsubscribe(w, r)
+	case "ConfirmSubscription":
+		h.confirmSubscription(w, r)
+	case "GetSubscriptionAttributes":
+		h.getSubscriptionAttributes(w, r)
+	case "SetSubscriptionAttributes":
+		h.setSubscriptionAttributes(w, r)
 	case "ListSubscriptions":
 		h.listSubscriptions(w, r)
 	case "ListSubscriptionsByTopic":
 		h.listSubscriptionsByTopic(w, r)
 	case "Publish":
 		h.publish(w, r)
+	case "PublishBatch":
+		h.publishBatch(w, r)
+	case "AddPermission":
+		h.addPermission(w, r)
+	case "RemovePermission":
+		h.removePermission(w, r)
 	case "TagResource":
 		h.tagResource(w, r)
 	case "UntagResource":
@@ -202,6 +247,12 @@ func accountFromARN(arn string) string {
 
 	return ""
 }
+
+// defaultEffectiveDeliveryPolicy is the delivery policy SNS reports for a topic
+// that hasn't overridden the account defaults.
+const defaultEffectiveDeliveryPolicy = `{"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,` +
+	`"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,"numNoDelayRetries":0,` +
+	`"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}}`
 
 // defaultTopicPolicy mirrors the access policy real SNS attaches to a new topic,
 // so a client that reads Policy back gets valid JSON.

--- a/server/aws/sns/operations.go
+++ b/server/aws/sns/operations.go
@@ -1,6 +1,7 @@
 package sns
 
 import (
+	"encoding/base64"
 	"net/http"
 	"net/url"
 	"sort"
@@ -11,6 +12,48 @@ import (
 	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
 	"github.com/stackshy/cloudemu/v2/services/scope"
 )
+
+// listPageSize is the fixed number of items SNS returns per ListTopics /
+// ListSubscriptions page; callers walk further with the returned NextToken.
+const listPageSize = 100
+
+// pageWindow returns the [start,end) slice bounds for the page requested by
+// token, plus the NextToken to fetch the following page ("" when exhausted).
+func pageWindow(total int, token string) (start, end int, next string) {
+	start = decodePageToken(token)
+	if start > total {
+		start = total
+	}
+
+	end = start + listPageSize
+	if end >= total {
+		return start, total, ""
+	}
+
+	return start, end, encodePageToken(end)
+}
+
+func decodePageToken(token string) int {
+	if token == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+func encodePageToken(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
 
 func (h *Handler) tagResource(w http.ResponseWriter, r *http.Request) {
 	tagger, ok := h.notif.(topicTagger)
@@ -54,7 +97,17 @@ func (h *Handler) untagResource(w http.ResponseWriter, r *http.Request) {
 // .Value.StringValue form parameters into a flat name->value map. Only string
 // values are modeled (the common case); binary values are ignored.
 func parseMessageAttributes(form url.Values) map[string]string {
-	idx := awsquery.CollectIndices(form, "MessageAttributes.entry")
+	return parseMessageAttributesAt(form, "MessageAttributes.entry")
+}
+
+// parseBatchMessageAttributes reads a PublishBatch entry's MessageAttributes,
+// which are nested under the entry's form prefix.
+func parseBatchMessageAttributes(form url.Values, entryPrefix string) map[string]string {
+	return parseMessageAttributesAt(form, entryPrefix+".MessageAttributes.entry")
+}
+
+func parseMessageAttributesAt(form url.Values, prefix string) map[string]string {
+	idx := awsquery.CollectIndices(form, prefix)
 	if len(idx) == 0 {
 		return nil
 	}
@@ -62,7 +115,7 @@ func parseMessageAttributes(form url.Values) map[string]string {
 	out := make(map[string]string, len(idx))
 
 	for _, i := range idx {
-		base := "MessageAttributes.entry." + strconv.Itoa(i)
+		base := prefix + "." + strconv.Itoa(i)
 
 		name := form.Get(base + ".Name")
 		if name == "" {
@@ -127,18 +180,23 @@ func (h *Handler) deleteTopic(w http.ResponseWriter, r *http.Request) {
 // getTopicAttributes maps GetTopicAttributes to Notification.GetTopic and
 // exposes the topic's ARN, display name, and subscription count as the standard
 // SNS attribute map.
-// setTopicAttributes maps SetTopicAttributes to Notification.UpdateTopic, but
-// persists only DisplayName today. A Policy (or DeliveryPolicy) write is accepted
-// and dropped, and GetTopicAttributes returns the synthesized default — so a
-// topic that declares a custom `policy` would drift. Tracked as a follow-up;
-// topics without a policy (the common case) round-trip cleanly.
+// setTopicAttributes maps SetTopicAttributes to Notification.UpdateTopic,
+// persisting DisplayName and Policy. Other attributes (DeliveryPolicy) are
+// accepted and dropped.
 func (h *Handler) setTopicAttributes(w http.ResponseWriter, r *http.Request) {
 	name := topicNameFromARN(r.Form.Get("TopicArn"))
 
-	if r.Form.Get("AttributeName") == "DisplayName" {
-		if _, err := h.notif.UpdateTopic(r.Context(), notifdriver.TopicConfig{
-			Name: name, DisplayName: r.Form.Get("AttributeValue"),
-		}); err != nil {
+	cfg := notifdriver.TopicConfig{Name: name}
+
+	switch r.Form.Get("AttributeName") {
+	case "DisplayName":
+		cfg.DisplayName = r.Form.Get("AttributeValue")
+	case "Policy":
+		cfg.Policy = r.Form.Get("AttributeValue")
+	}
+
+	if cfg.DisplayName != "" || cfg.Policy != "" {
+		if _, err := h.notif.UpdateTopic(r.Context(), cfg); err != nil {
 			writeErr(w, err)
 			return
 		}
@@ -184,14 +242,22 @@ func (h *Handler) getTopicAttributes(w http.ResponseWriter, r *http.Request) {
 
 	owner := accountFromARN(info.ResourceID)
 
-	entries := []attributeEntry{
-		{Key: "TopicArn", Value: info.ResourceID},
-		{Key: "SubscriptionsConfirmed", Value: strconv.Itoa(info.SubscriptionCount)},
-		{Key: "Owner", Value: owner},
+	policy := info.Policy
+	if policy == "" {
 		// Real SNS seeds a default access policy. The aws_sns_topic resource
 		// reads Policy back and parses it as JSON, so an absent value fails
 		// with "unexpected end of JSON input".
-		{Key: "Policy", Value: defaultTopicPolicy(info.ResourceID, owner)},
+		policy = defaultTopicPolicy(info.ResourceID, owner)
+	}
+
+	entries := []attributeEntry{
+		{Key: "TopicArn", Value: info.ResourceID},
+		{Key: "SubscriptionsConfirmed", Value: strconv.Itoa(info.SubscriptionsConfirmed)},
+		{Key: "SubscriptionsPending", Value: strconv.Itoa(info.SubscriptionsPending)},
+		{Key: "SubscriptionsDeleted", Value: strconv.Itoa(info.SubscriptionsDeleted)},
+		{Key: "Owner", Value: owner},
+		{Key: "Policy", Value: policy},
+		{Key: "EffectiveDeliveryPolicy", Value: defaultEffectiveDeliveryPolicy},
 	}
 	if info.DisplayName != "" {
 		entries = append(entries, attributeEntry{Key: "DisplayName", Value: info.DisplayName})
@@ -211,34 +277,72 @@ func (h *Handler) listTopics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	members := make([]topicMember, 0, len(topics))
-	for i := range topics {
+	start, end, next := pageWindow(len(topics), r.Form.Get("NextToken"))
+
+	members := make([]topicMember, 0, end-start)
+	for i := start; i < end; i++ {
 		members = append(members, topicMember{TopicArn: topics[i].ResourceID})
 	}
 
 	awsquery.WriteXMLResponse(w, listTopicsResponse{
 		Xmlns:    Namespace,
-		Result:   listTopicsResult{Topics: topicsList{Members: members}},
+		Result:   listTopicsResult{Topics: topicsList{Members: members}, NextToken: next},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
 
+// pendingConfirmationARN is the literal SNS returns from Subscribe for a
+// subscription that still needs confirmation (unless ReturnSubscriptionArn=true).
+const pendingConfirmationARN = "pending confirmation"
+
 func (h *Handler) subscribe(w http.ResponseWriter, r *http.Request) {
 	sub, err := h.notif.Subscribe(r.Context(), notifdriver.SubscriptionConfig{
-		TopicID:  topicNameFromARN(r.Form.Get("TopicArn")),
-		Protocol: r.Form.Get("Protocol"),
-		Endpoint: r.Form.Get("Endpoint"),
+		TopicID:    topicNameFromARN(r.Form.Get("TopicArn")),
+		Protocol:   r.Form.Get("Protocol"),
+		Endpoint:   r.Form.Get("Endpoint"),
+		Attributes: parseSubscriptionAttributes(r.Form),
 	})
 	if err != nil {
 		writeErr(w, err)
 		return
 	}
 
+	// A subscription awaiting confirmation reports the literal "pending
+	// confirmation" ARN unless the caller asked for the real ARN.
+	arn := sub.ID
+	if sub.Status == statusPending && r.Form.Get("ReturnSubscriptionArn") != attrTrue {
+		arn = pendingConfirmationARN
+	}
+
 	awsquery.WriteXMLResponse(w, subscribeResponse{
 		Xmlns:    Namespace,
-		Result:   subscribeResult{SubscriptionArn: sub.ID},
+		Result:   subscribeResult{SubscriptionArn: arn},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
+}
+
+// parseSubscriptionAttributes reads the Attributes.entry.N.key / .value form
+// parameters SNS Subscribe/SetSubscriptionAttributes serialize into a flat map.
+func parseSubscriptionAttributes(form url.Values) map[string]string {
+	idx := awsquery.CollectIndices(form, "Attributes.entry")
+	if len(idx) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(idx))
+
+	for _, i := range idx {
+		base := "Attributes.entry." + strconv.Itoa(i)
+
+		key := form.Get(base + ".key")
+		if key == "" {
+			continue
+		}
+
+		out[key] = form.Get(base + ".value")
+	}
+
+	return out
 }
 
 func (h *Handler) unsubscribe(w http.ResponseWriter, r *http.Request) {
@@ -275,9 +379,12 @@ func (h *Handler) listSubscriptions(w http.ResponseWriter, r *http.Request) {
 		members = append(members, subscriptionMembers(topics[i].ResourceID, subs)...)
 	}
 
+	start, end, next := pageWindow(len(members), r.Form.Get("NextToken"))
+	members = members[start:end]
+
 	awsquery.WriteXMLResponse(w, listSubscriptionsResponse{
 		Xmlns:    Namespace,
-		Result:   listSubscriptionsResult{Subscriptions: subscriptionsList{Members: members}},
+		Result:   listSubscriptionsResult{Subscriptions: subscriptionsList{Members: members}, NextToken: next},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/sns/sdk_roundtrip_test.go
+++ b/server/aws/sns/sdk_roundtrip_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,11 +17,23 @@ import (
 	snstypes "github.com/aws/aws-sdk-go-v2/service/sns/types"
 
 	"github.com/stackshy/cloudemu/v2"
+	snsprovider "github.com/stackshy/cloudemu/v2/providers/aws/sns"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 	snspkg "github.com/stackshy/cloudemu/v2/server/aws/sns"
 )
 
 func newSDKClient(t *testing.T) *awssns.Client {
+	t.Helper()
+
+	client, _ := newSDKServer(t)
+
+	return client
+}
+
+// newSDKServer stands up an in-process SNS wire server and returns both the SDK
+// client and the backing provider mock (so tests can read internal state such as
+// a pending subscription's confirmation token).
+func newSDKServer(t *testing.T) (*awssns.Client, *snsprovider.Mock) {
 	t.Helper()
 
 	cloud := cloudemu.NewAWS()
@@ -46,9 +59,11 @@ func newSDKClient(t *testing.T) *awssns.Client {
 		t.Fatalf("aws config: %v", err)
 	}
 
-	return awssns.NewFromConfig(cfg, func(o *awssns.Options) {
+	client := awssns.NewFromConfig(cfg, func(o *awssns.Options) {
 		o.BaseEndpoint = aws.String(ts.URL)
 	})
+
+	return client, cloud.SNS
 }
 
 func TestSDKSNSTopicLifecycle(t *testing.T) {
@@ -91,9 +106,10 @@ func TestSDKSNSTopicLifecycle(t *testing.T) {
 	}
 
 	sub, err := client.Subscribe(ctx, &awssns.SubscribeInput{
-		TopicArn: aws.String(topicArn),
-		Protocol: aws.String("email"),
-		Endpoint: aws.String("ops@example.com"),
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("email"),
+		Endpoint:              aws.String("ops@example.com"),
+		ReturnSubscriptionArn: true,
 	})
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
@@ -268,5 +284,332 @@ func TestSNSMatchesScopeGatesListTags(t *testing.T) {
 
 	if h.Matches(req("rds")) {
 		t.Error("rds-scoped ListTagsForResource must NOT be claimed by SNS")
+	}
+}
+
+// TestSDKSNSSubscriptionAttributes covers Subscribe carrying FilterPolicy /
+// RawMessageDelivery, GetSubscriptionAttributes surfacing them, and
+// SetSubscriptionAttributes mutating one — none of which the handler modeled
+// before (both attribute ops were undispatched → InvalidAction).
+func TestSDKSNSSubscriptionAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("attr-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	sub, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("sqs"),
+		Endpoint:              aws.String("arn:aws:sqs:us-east-1:000000000000:q"),
+		ReturnSubscriptionArn: true,
+		Attributes: map[string]string{
+			"FilterPolicy":       `{"color":["red"]}`,
+			"RawMessageDelivery": "true",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	subArn := aws.ToString(sub.SubscriptionArn)
+
+	got, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: aws.String(subArn),
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes: %v", err)
+	}
+
+	if got.Attributes["FilterPolicy"] != `{"color":["red"]}` {
+		t.Fatalf("FilterPolicy = %q, want the subscribe-time policy", got.Attributes["FilterPolicy"])
+	}
+
+	if got.Attributes["RawMessageDelivery"] != "true" {
+		t.Fatalf("RawMessageDelivery = %q, want true", got.Attributes["RawMessageDelivery"])
+	}
+
+	if got.Attributes["PendingConfirmation"] != "false" {
+		t.Fatalf("PendingConfirmation = %q, want false (sqs auto-confirms)", got.Attributes["PendingConfirmation"])
+	}
+
+	if got.Attributes["TopicArn"] != topicArn || got.Attributes["Protocol"] != "sqs" {
+		t.Fatalf("attrs TopicArn/Protocol = %q/%q", got.Attributes["TopicArn"], got.Attributes["Protocol"])
+	}
+
+	if _, err := client.SetSubscriptionAttributes(ctx, &awssns.SetSubscriptionAttributesInput{
+		SubscriptionArn: aws.String(subArn),
+		AttributeName:   aws.String("FilterPolicy"),
+		AttributeValue:  aws.String(`{"color":["blue"]}`),
+	}); err != nil {
+		t.Fatalf("SetSubscriptionAttributes: %v", err)
+	}
+
+	got2, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: aws.String(subArn),
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes (after set): %v", err)
+	}
+
+	if got2.Attributes["FilterPolicy"] != `{"color":["blue"]}` {
+		t.Fatalf("FilterPolicy after set = %q, want the updated policy", got2.Attributes["FilterPolicy"])
+	}
+}
+
+// TestSDKSNSPendingConfirmationCounts asserts that confirmation-required
+// protocols return the literal "pending confirmation" ARN and are counted as
+// pending (not confirmed) by GetTopicAttributes.
+func TestSDKSNSPendingConfirmationCounts(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("pending-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	emailSub, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: aws.String(topicArn),
+		Protocol: aws.String("email"),
+		Endpoint: aws.String("ops@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("Subscribe(email): %v", err)
+	}
+
+	if aws.ToString(emailSub.SubscriptionArn) != "pending confirmation" {
+		t.Fatalf("email SubscriptionArn = %q, want \"pending confirmation\"", aws.ToString(emailSub.SubscriptionArn))
+	}
+
+	if _, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn: aws.String(topicArn),
+		Protocol: aws.String("sqs"),
+		Endpoint: aws.String("arn:aws:sqs:us-east-1:000000000000:q"),
+	}); err != nil {
+		t.Fatalf("Subscribe(sqs): %v", err)
+	}
+
+	attrs, err := client.GetTopicAttributes(ctx, &awssns.GetTopicAttributesInput{TopicArn: aws.String(topicArn)})
+	if err != nil {
+		t.Fatalf("GetTopicAttributes: %v", err)
+	}
+
+	if attrs.Attributes["SubscriptionsPending"] != "1" {
+		t.Fatalf("SubscriptionsPending = %q, want 1", attrs.Attributes["SubscriptionsPending"])
+	}
+
+	if attrs.Attributes["SubscriptionsConfirmed"] != "1" {
+		t.Fatalf("SubscriptionsConfirmed = %q, want 1 (only the sqs sub)", attrs.Attributes["SubscriptionsConfirmed"])
+	}
+
+	if attrs.Attributes["EffectiveDeliveryPolicy"] == "" {
+		t.Fatal("EffectiveDeliveryPolicy is absent")
+	}
+
+	var edp map[string]any
+	if err := json.Unmarshal([]byte(attrs.Attributes["EffectiveDeliveryPolicy"]), &edp); err != nil {
+		t.Fatalf("EffectiveDeliveryPolicy is not valid JSON: %v", err)
+	}
+}
+
+// TestSDKSNSConfirmSubscription drives a pending email subscription through
+// ConfirmSubscription (previously undispatched → InvalidAction) using the token
+// the mock generated, and asserts the subscription flips to confirmed.
+func TestSDKSNSConfirmSubscription(t *testing.T) {
+	client, mock := newSDKServer(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("confirm-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	sub, err := client.Subscribe(ctx, &awssns.SubscribeInput{
+		TopicArn:              aws.String(topicArn),
+		Protocol:              aws.String("email"),
+		Endpoint:              aws.String("ops@example.com"),
+		ReturnSubscriptionArn: true,
+	})
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	subArn := aws.ToString(sub.SubscriptionArn)
+
+	// The confirmation token is delivered out-of-band by real SNS; read it from
+	// the mock to complete the round trip.
+	pending, err := mock.GetSubscription(ctx, subArn)
+	if err != nil {
+		t.Fatalf("GetSubscription: %v", err)
+	}
+
+	if pending.ConfirmationToken == "" {
+		t.Fatal("pending subscription has no confirmation token")
+	}
+
+	confirmed, err := client.ConfirmSubscription(ctx, &awssns.ConfirmSubscriptionInput{
+		TopicArn: aws.String(topicArn),
+		Token:    aws.String(pending.ConfirmationToken),
+	})
+	if err != nil {
+		t.Fatalf("ConfirmSubscription: %v", err)
+	}
+
+	if aws.ToString(confirmed.SubscriptionArn) != subArn {
+		t.Fatalf("ConfirmSubscription arn = %q, want %q", aws.ToString(confirmed.SubscriptionArn), subArn)
+	}
+
+	attrs, err := client.GetSubscriptionAttributes(ctx, &awssns.GetSubscriptionAttributesInput{
+		SubscriptionArn: aws.String(subArn),
+	})
+	if err != nil {
+		t.Fatalf("GetSubscriptionAttributes: %v", err)
+	}
+
+	if attrs.Attributes["PendingConfirmation"] != "false" {
+		t.Fatalf("PendingConfirmation = %q, want false after confirm", attrs.Attributes["PendingConfirmation"])
+	}
+}
+
+// TestSDKSNSPublishBatch asserts PublishBatch (previously undispatched) fans out
+// to per-entry results with distinct message ids.
+func TestSDKSNSPublishBatch(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("batch-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	out, err := client.PublishBatch(ctx, &awssns.PublishBatchInput{
+		TopicArn: aws.String(topicArn),
+		PublishBatchRequestEntries: []snstypes.PublishBatchRequestEntry{
+			{Id: aws.String("a"), Message: aws.String("one")},
+			{Id: aws.String("b"), Message: aws.String("two")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PublishBatch: %v", err)
+	}
+
+	if len(out.Successful) != 2 {
+		t.Fatalf("got %d successful, want 2 (failed=%v)", len(out.Successful), out.Failed)
+	}
+
+	ids := map[string]string{}
+	for _, s := range out.Successful {
+		if aws.ToString(s.MessageId) == "" {
+			t.Fatalf("entry %q has empty MessageId", aws.ToString(s.Id))
+		}
+
+		ids[aws.ToString(s.Id)] = aws.ToString(s.MessageId)
+	}
+
+	if ids["a"] == "" || ids["b"] == "" || ids["a"] == ids["b"] {
+		t.Fatalf("batch message ids = %v, want two distinct ids for a and b", ids)
+	}
+}
+
+// TestSDKSNSAddRemovePermission asserts AddPermission / RemovePermission
+// (previously undispatched) mutate the topic access policy.
+func TestSDKSNSAddRemovePermission(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	created, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{Name: aws.String("perm-topic")})
+	if err != nil {
+		t.Fatalf("CreateTopic: %v", err)
+	}
+
+	topicArn := aws.ToString(created.TopicArn)
+
+	if _, err := client.AddPermission(ctx, &awssns.AddPermissionInput{
+		TopicArn:     aws.String(topicArn),
+		Label:        aws.String("share-publish"),
+		AWSAccountId: []string{"111122223333"},
+		ActionName:   []string{"Publish"},
+	}); err != nil {
+		t.Fatalf("AddPermission: %v", err)
+	}
+
+	attrs, err := client.GetTopicAttributes(ctx, &awssns.GetTopicAttributesInput{TopicArn: aws.String(topicArn)})
+	if err != nil {
+		t.Fatalf("GetTopicAttributes: %v", err)
+	}
+
+	if !strings.Contains(attrs.Attributes["Policy"], "share-publish") ||
+		!strings.Contains(attrs.Attributes["Policy"], "111122223333") {
+		t.Fatalf("policy after AddPermission missing statement: %s", attrs.Attributes["Policy"])
+	}
+
+	if _, err := client.RemovePermission(ctx, &awssns.RemovePermissionInput{
+		TopicArn: aws.String(topicArn),
+		Label:    aws.String("share-publish"),
+	}); err != nil {
+		t.Fatalf("RemovePermission: %v", err)
+	}
+
+	attrs2, err := client.GetTopicAttributes(ctx, &awssns.GetTopicAttributesInput{TopicArn: aws.String(topicArn)})
+	if err != nil {
+		t.Fatalf("GetTopicAttributes (after remove): %v", err)
+	}
+
+	if strings.Contains(attrs2.Attributes["Policy"], "share-publish") {
+		t.Fatalf("policy still has removed statement: %s", attrs2.Attributes["Policy"])
+	}
+}
+
+// TestSDKSNSListTopicsPagination asserts ListTopics returns a NextToken and
+// pages through results once the topic count exceeds one page.
+func TestSDKSNSListTopicsPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const total = 101
+
+	for i := 0; i < total; i++ {
+		if _, err := client.CreateTopic(ctx, &awssns.CreateTopicInput{
+			Name: aws.String("page-topic-" + strconv.Itoa(i)),
+		}); err != nil {
+			t.Fatalf("CreateTopic %d: %v", i, err)
+		}
+	}
+
+	first, err := client.ListTopics(ctx, &awssns.ListTopicsInput{})
+	if err != nil {
+		t.Fatalf("ListTopics: %v", err)
+	}
+
+	if len(first.Topics) != 100 {
+		t.Fatalf("first page = %d topics, want 100", len(first.Topics))
+	}
+
+	if aws.ToString(first.NextToken) == "" {
+		t.Fatal("first page returned no NextToken")
+	}
+
+	second, err := client.ListTopics(ctx, &awssns.ListTopicsInput{NextToken: first.NextToken})
+	if err != nil {
+		t.Fatalf("ListTopics (page 2): %v", err)
+	}
+
+	if len(second.Topics) != total-100 {
+		t.Fatalf("second page = %d topics, want %d", len(second.Topics), total-100)
+	}
+
+	if aws.ToString(second.NextToken) != "" {
+		t.Fatalf("second page NextToken = %q, want empty", aws.ToString(second.NextToken))
 	}
 }

--- a/server/aws/sns/subscription_attributes.go
+++ b/server/aws/sns/subscription_attributes.go
@@ -1,0 +1,250 @@
+package sns
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/server/wire/awsquery"
+	notifdriver "github.com/stackshy/cloudemu/v2/services/notification/driver"
+)
+
+// baseSubAttributeCount is the number of always-present subscription attributes
+// emitted before any caller-set attributes.
+const baseSubAttributeCount = 8
+
+// extras returns the AWS-only SNS surface, or writes NotSupported and returns
+// false if the wired driver doesn't implement it.
+func (h *Handler) extras(w http.ResponseWriter) (snsExtras, bool) {
+	ex, ok := h.notif.(snsExtras)
+	if !ok {
+		writeErr(w, cerrors.New(cerrors.Unimplemented, "operation not supported"))
+		return nil, false
+	}
+
+	return ex, true
+}
+
+func (h *Handler) confirmSubscription(w http.ResponseWriter, r *http.Request) {
+	ex, ok := h.extras(w)
+	if !ok {
+		return
+	}
+
+	sub, err := ex.ConfirmSubscription(r.Context(),
+		topicNameFromARN(r.Form.Get("TopicArn")), r.Form.Get("Token"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, confirmSubscriptionResponse{
+		Xmlns:    Namespace,
+		Result:   confirmSubscriptionResult{SubscriptionArn: sub.ID},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) getSubscriptionAttributes(w http.ResponseWriter, r *http.Request) {
+	ex, ok := h.extras(w)
+	if !ok {
+		return
+	}
+
+	sub, err := ex.GetSubscription(r.Context(), r.Form.Get("SubscriptionArn"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, getSubscriptionAttributesResponse{
+		Xmlns: Namespace,
+		Result: getSubscriptionAttributesResult{
+			Attributes: attributesMap{Entries: subscriptionAttributeEntries(sub)},
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// subscriptionAttributeEntries assembles the SNS attribute map a subscription
+// exposes, mirroring GetSubscriptionAttributes.
+func subscriptionAttributeEntries(sub *notifdriver.SubscriptionInfo) []attributeEntry {
+	pending := attrFalse
+	if sub.Status == statusPending {
+		pending = attrTrue
+	}
+
+	entries := make([]attributeEntry, 0, baseSubAttributeCount+len(sub.Attributes))
+	entries = append(entries,
+		attributeEntry{Key: "SubscriptionArn", Value: sub.ID},
+		attributeEntry{Key: "TopicArn", Value: idgenTopicARN(sub)},
+		attributeEntry{Key: "Protocol", Value: sub.Protocol},
+		attributeEntry{Key: "Endpoint", Value: sub.Endpoint},
+		attributeEntry{Key: "Owner", Value: accountFromARN(sub.ID)},
+		attributeEntry{Key: "PendingConfirmation", Value: pending},
+		attributeEntry{Key: "ConfirmationWasAuthenticated", Value: attrFalse},
+		attributeEntry{Key: "RawMessageDelivery", Value: rawMessageDelivery(sub)},
+	)
+
+	// Emit caller-set attributes (FilterPolicy, RedrivePolicy, ...) in a stable
+	// order so successive reads don't churn.
+	keys := make([]string, 0, len(sub.Attributes))
+
+	for k := range sub.Attributes {
+		if k == "RawMessageDelivery" {
+			continue // already surfaced above
+		}
+
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		entries = append(entries, attributeEntry{Key: k, Value: sub.Attributes[k]})
+	}
+
+	return entries
+}
+
+// idgenTopicARN reconstructs the topic ARN from the subscription ARN, which SNS
+// forms as <topic-arn>:<sub-uuid>.
+func idgenTopicARN(sub *notifdriver.SubscriptionInfo) string {
+	arn := sub.ID
+	if i := lastColon(arn); i >= 0 {
+		return arn[:i]
+	}
+
+	return arn
+}
+
+func lastColon(s string) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == ':' {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func rawMessageDelivery(sub *notifdriver.SubscriptionInfo) string {
+	if v, ok := sub.Attributes["RawMessageDelivery"]; ok && v == attrTrue {
+		return attrTrue
+	}
+
+	return attrFalse
+}
+
+func (h *Handler) setSubscriptionAttributes(w http.ResponseWriter, r *http.Request) {
+	ex, ok := h.extras(w)
+	if !ok {
+		return
+	}
+
+	err := ex.SetSubscriptionAttribute(r.Context(), r.Form.Get("SubscriptionArn"),
+		r.Form.Get("AttributeName"), r.Form.Get("AttributeValue"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, setSubscriptionAttributesResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) addPermission(w http.ResponseWriter, r *http.Request) {
+	ex, ok := h.extras(w)
+	if !ok {
+		return
+	}
+
+	err := ex.AddTopicPermission(r.Context(), topicNameFromARN(r.Form.Get("TopicArn")),
+		r.Form.Get("Label"),
+		awsquery.ListStrings(r.Form, "AWSAccountId.member"),
+		awsquery.ListStrings(r.Form, "ActionName.member"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, addPermissionResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func (h *Handler) removePermission(w http.ResponseWriter, r *http.Request) {
+	ex, ok := h.extras(w)
+	if !ok {
+		return
+	}
+
+	err := ex.RemoveTopicPermission(r.Context(),
+		topicNameFromARN(r.Form.Get("TopicArn")), r.Form.Get("Label"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, removePermissionResponse{
+		Xmlns: Namespace, Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// publishBatch fans PublishBatchRequestEntries out to individual driver
+// Publish calls, collecting per-entry success/failure results.
+func (h *Handler) publishBatch(w http.ResponseWriter, r *http.Request) {
+	arn := r.Form.Get("TopicArn")
+	if arn == "" {
+		arn = r.Form.Get("TargetArn")
+	}
+
+	topicID := topicNameFromARN(arn)
+
+	idx := awsquery.CollectIndices(r.Form, "PublishBatchRequestEntries.member")
+
+	var (
+		successes []batchResultEntry
+		failures  []batchErrorEntry
+	)
+
+	for _, i := range idx {
+		base := "PublishBatchRequestEntries.member." + strconv.Itoa(i)
+		entryID := r.Form.Get(base + ".Id")
+
+		out, err := h.notif.Publish(r.Context(), notifdriver.PublishInput{
+			TopicID:    topicID,
+			Subject:    r.Form.Get(base + ".Subject"),
+			Message:    r.Form.Get(base + ".Message"),
+			Attributes: parseBatchMessageAttributes(r.Form, base),
+		})
+		if err != nil {
+			failures = append(failures, batchErrorEntry{
+				ID: entryID, Code: batchErrorCode(err), Message: err.Error(), SenderFault: true,
+			})
+
+			continue
+		}
+
+		successes = append(successes, batchResultEntry{ID: entryID, MessageID: out.MessageID})
+	}
+
+	awsquery.WriteXMLResponse(w, publishBatchResponse{
+		Xmlns: Namespace,
+		Result: publishBatchResult{
+			Successful: successes,
+			Failed:     failures,
+		},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+func batchErrorCode(err error) string {
+	if cerrors.IsNotFound(err) {
+		return "NotFound"
+	}
+
+	return "InvalidParameter"
+}

--- a/server/aws/sns/types.go
+++ b/server/aws/sns/types.go
@@ -114,7 +114,8 @@ type topicsList struct {
 }
 
 type listTopicsResult struct {
-	Topics topicsList `xml:"Topics"`
+	Topics    topicsList `xml:"Topics"`
+	NextToken string     `xml:"NextToken,omitempty"`
 }
 
 type listTopicsResponse struct {
@@ -153,6 +154,7 @@ type subscriptionsList struct {
 
 type listSubscriptionsResult struct {
 	Subscriptions subscriptionsList `xml:"Subscriptions"`
+	NextToken     string            `xml:"NextToken,omitempty"`
 }
 
 type listSubscriptionsResponse struct {
@@ -183,5 +185,77 @@ type publishResponse struct {
 	XMLName  xml.Name         `xml:"PublishResponse"`
 	Xmlns    string           `xml:"xmlns,attr"`
 	Result   publishResult    `xml:"PublishResult"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// --- PublishBatch ---
+
+type batchResultEntry struct {
+	ID        string `xml:"Id"`
+	MessageID string `xml:"MessageId"`
+}
+
+type batchErrorEntry struct {
+	ID          string `xml:"Id"`
+	Code        string `xml:"Code"`
+	Message     string `xml:"Message"`
+	SenderFault bool   `xml:"SenderFault"`
+}
+
+type publishBatchResult struct {
+	Successful []batchResultEntry `xml:"Successful>member"`
+	Failed     []batchErrorEntry  `xml:"Failed>member"`
+}
+
+type publishBatchResponse struct {
+	XMLName  xml.Name           `xml:"PublishBatchResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   publishBatchResult `xml:"PublishBatchResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+// --- ConfirmSubscription ---
+
+type confirmSubscriptionResult struct {
+	SubscriptionArn string `xml:"SubscriptionArn"`
+}
+
+type confirmSubscriptionResponse struct {
+	XMLName  xml.Name                  `xml:"ConfirmSubscriptionResponse"`
+	Xmlns    string                    `xml:"xmlns,attr"`
+	Result   confirmSubscriptionResult `xml:"ConfirmSubscriptionResult"`
+	Metadata responseMetadata          `xml:"ResponseMetadata"`
+}
+
+// --- GetSubscriptionAttributes / SetSubscriptionAttributes ---
+
+type getSubscriptionAttributesResult struct {
+	Attributes attributesMap `xml:"Attributes"`
+}
+
+type getSubscriptionAttributesResponse struct {
+	XMLName  xml.Name                        `xml:"GetSubscriptionAttributesResponse"`
+	Xmlns    string                          `xml:"xmlns,attr"`
+	Result   getSubscriptionAttributesResult `xml:"GetSubscriptionAttributesResult"`
+	Metadata responseMetadata                `xml:"ResponseMetadata"`
+}
+
+type setSubscriptionAttributesResponse struct {
+	XMLName  xml.Name         `xml:"SetSubscriptionAttributesResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+// --- AddPermission / RemovePermission (empty results) ---
+
+type addPermissionResponse struct {
+	XMLName  xml.Name         `xml:"AddPermissionResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
+	Metadata responseMetadata `xml:"ResponseMetadata"`
+}
+
+type removePermissionResponse struct {
+	XMLName  xml.Name         `xml:"RemovePermissionResponse"`
+	Xmlns    string           `xml:"xmlns,attr"`
 	Metadata responseMetadata `xml:"ResponseMetadata"`
 }

--- a/services/notification/driver/driver.go
+++ b/services/notification/driver/driver.go
@@ -13,6 +13,10 @@ type TopicConfig struct {
 	DisplayName string
 	Tags        map[string]string
 
+	// Policy is the JSON access policy (AWS SNS). Empty leaves the topic on
+	// its synthesized default policy.
+	Policy string
+
 	// Scope records where the resource lives (Azure subscription/resource
 	// group, GCP project). Zero for AWS and unscoped portable callers.
 	Scope scope.Scope
@@ -20,13 +24,23 @@ type TopicConfig struct {
 
 // TopicInfo describes a notification topic.
 type TopicInfo struct {
-	ID                string
-	Name              string
-	ResourceID        string
-	DisplayName       string
+	ID          string
+	Name        string
+	ResourceID  string
+	DisplayName string
+	// SubscriptionCount is the total number of subscriptions on the topic
+	// (confirmed + pending). AWS SNS reports the breakdown separately.
 	SubscriptionCount int
-	Tags              map[string]string
-	Scope             scope.Scope
+	// SubscriptionsConfirmed / SubscriptionsPending / SubscriptionsDeleted mirror
+	// the SNS GetTopicAttributes counters. Deleted is a monotonic tally of
+	// unsubscribed endpoints.
+	SubscriptionsConfirmed int
+	SubscriptionsPending   int
+	SubscriptionsDeleted   int
+	// Policy is the JSON access policy (AWS SNS); empty means the default.
+	Policy string
+	Tags   map[string]string
+	Scope  scope.Scope
 }
 
 // SubscriptionConfig describes a subscription to create.
@@ -34,6 +48,9 @@ type SubscriptionConfig struct {
 	TopicID  string
 	Protocol string // "email", "sms", "http", "https", "sqs", "lambda"
 	Endpoint string
+	// Attributes carries subscription attributes accepted at Subscribe time
+	// (FilterPolicy, RawMessageDelivery, RedrivePolicy, DeliveryPolicy, ...).
+	Attributes map[string]string
 }
 
 // SubscriptionInfo describes a subscription.
@@ -43,6 +60,12 @@ type SubscriptionInfo struct {
 	Protocol string
 	Endpoint string
 	Status   string // "confirmed", "pending"
+	// Attributes holds the subscription's mutable attributes (FilterPolicy,
+	// RawMessageDelivery, RedrivePolicy, DeliveryPolicy, ...).
+	Attributes map[string]string
+	// ConfirmationToken is the opaque token an AWS SNS pending subscription is
+	// confirmed with via ConfirmSubscription. Empty for auto-confirmed subs.
+	ConfirmationToken string
 }
 
 // PublishInput configures a message publish operation.

--- a/services/notification/notification_test.go
+++ b/services/notification/notification_test.go
@@ -117,7 +117,9 @@ func TestSubscribePortable(t *testing.T) {
 
 	assert.NotEmpty(t, sub.ID)
 	assert.Equal(t, "email", sub.Protocol)
-	assert.Equal(t, "confirmed", sub.Status)
+	// AWS SNS email subscriptions require out-of-band confirmation, so they
+	// start out pending.
+	assert.Equal(t, "pending", sub.Status)
 }
 
 func TestSubscribePortableError(t *testing.T) {


### PR DESCRIPTION
Closes the remaining SNS audit findings, wire+provider (no cross-cloud interface method change).

- GetSubscriptionAttributes/SetSubscriptionAttributes dispatched; Subscribe persists FilterPolicy/RawMessageDelivery/etc (was silently dropped)
- ConfirmSubscription + PublishBatch dispatched; confirmation-required protocols (http/https/email/email-json) return 'pending confirmation' unless ReturnSubscriptionArn=true
- GetTopicAttributes SubscriptionsConfirmed counts only confirmed; adds SubscriptionsPending/Deleted + EffectiveDeliveryPolicy; AddPermission/RemovePermission mutate the access policy; ListTopics/ListSubscriptions pagination
- Subscription ARN now AWS-real shape (arn:...:<Topic>:<uuid>)

AWS-only ops exposed via an optional server-side interface (snsExtras), same pattern as topicTagger — Azure/GCP/OCI untouched. compat docs clean. SDK round-trip tests per fix.