### PR TITLE
fix(s3): MD5 ETags, Range GET (206/416), bucket-config persistence, multipart ETag suffix

### DIFF
--- a/providers/aws/s3/s3.go
+++ b/providers/aws/s3/s3.go
@@ -2,7 +2,9 @@ package s3
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // S3 object ETags are defined as MD5 digests, not a security primitive
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"net/http"
@@ -32,6 +34,7 @@ const (
 var (
 	_ driver.Bucket          = (*Mock)(nil)
 	_ driver.VersionedBucket = (*Mock)(nil)
+	_ driver.RawBucketConfig = (*Mock)(nil)
 )
 
 type s3Object struct {
@@ -93,6 +96,11 @@ type bucketMeta struct {
 	encryption    *driver.EncryptionConfig
 	tags          map[string]string
 	notifications []QueueNotification
+	// rawConfigs holds opaque configuration sub-resource documents (policy, cors,
+	// encryption, lifecycle, website, …) exactly as written, so the wire handler
+	// can echo them back byte-for-byte. Guarded by rawConfigMu.
+	rawConfigMu sync.Mutex
+	rawConfigs  map[string][]byte
 }
 
 // QueueNotification is one S3 bucket-notification target: an SQS queue that
@@ -234,6 +242,29 @@ func (m *Mock) ListBuckets(_ context.Context) ([]driver.BucketInfo, error) {
 	return result, nil
 }
 
+// md5Hex returns the hex-encoded MD5 digest of data. Real S3 reports an object's
+// ETag as its MD5 (32 hex chars); CLIs, transfer managers, and conditional-GET
+// clients compare against this exact shape.
+func md5Hex(data []byte) string {
+	sum := md5.Sum(data) //nolint:gosec // S3 ETag is MD5 by spec, not a security control
+	return hex.EncodeToString(sum[:])
+}
+
+// multipartETag computes the ETag S3 assigns a completed multipart object: the
+// MD5 of the concatenated raw MD5 digests of each part, suffixed with "-N" where
+// N is the part count. Tools detect multipart objects by that "-N" suffix.
+func multipartETag(orderedParts [][]byte) string {
+	var concat []byte
+	for _, p := range orderedParts {
+		sum := md5.Sum(p) //nolint:gosec // S3 ETag is MD5 by spec, not a security control
+		concat = append(concat, sum[:]...)
+	}
+
+	final := md5.Sum(concat) //nolint:gosec // S3 ETag is MD5 by spec, not a security control
+
+	return fmt.Sprintf("%x-%d", final, len(orderedParts))
+}
+
 func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, contentType string, metadata map[string]string) error {
 	bkt, ok := m.buckets.Get(bucket)
 	if !ok {
@@ -247,7 +278,7 @@ func (m *Mock) PutObject(ctx context.Context, bucket, key string, data []byte, c
 		Data:         dataCopy,
 		Size:         int64(len(data)),
 		ContentType:  contentType,
-		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
+		ETag:         md5Hex(data),
 		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata:     maps.Clone(metadata),
 	}
@@ -744,7 +775,7 @@ func (m *Mock) UploadPart(_ context.Context, bucket, _, uploadID string, partNum
 	mp.parts[partNumber] = dataCopy
 	mp.mu.Unlock()
 
-	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+	etag := md5Hex(data)
 
 	return &driver.UploadPart{
 		PartNumber: partNumber, ETag: etag, Size: int64(len(data)),
@@ -779,7 +810,7 @@ func (m *Mock) ListParts(_ context.Context, bucket, _, uploadID string) ([]drive
 		data := mp.parts[n]
 		out = append(out, driver.UploadPart{
 			PartNumber: n,
-			ETag:       fmt.Sprintf("%x", sha256.Sum256(data)),
+			ETag:       md5Hex(data),
 			Size:       int64(len(data)),
 		})
 	}
@@ -805,8 +836,14 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 			return cerrors.Newf(cerrors.InvalidArgument, "part %d not found in upload %q", p.PartNumber, uploadID)
 		}
 	}
-	data := assemblePartsInOrder(mp.parts, parts)
+
+	ordered := orderedPartData(mp.parts, parts)
 	mp.mu.Unlock()
+
+	var data []byte
+	for _, p := range ordered {
+		data = append(data, p...)
+	}
 
 	// storeObject (not a bare objects.Set) so a completed multipart upload is
 	// versioned like a PutObject on a versioning-enabled bucket.
@@ -815,7 +852,7 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 		Data:         data,
 		Size:         int64(len(data)),
 		ContentType:  mp.contentType,
-		ETag:         fmt.Sprintf("%x", sha256.Sum256(data)),
+		ETag:         multipartETag(ordered),
 		LastModified: m.opts.Clock.Now().UTC().Format(s3TimeFormat),
 		Metadata:     make(map[string]string),
 	}
@@ -843,19 +880,20 @@ func (m *Mock) CompleteMultipartUpload(ctx context.Context, bucket, key, uploadI
 	return nil
 }
 
-func assemblePartsInOrder(allParts map[int][]byte, parts []driver.UploadPart) []byte {
-	// S3 assembles parts by ascending PartNumber regardless of the order the
-	// client lists them in CompleteMultipartUpload; sort so an out-of-order
-	// (or unsorted-SDK) Complete doesn't corrupt the object.
+// orderedPartData returns each requested part's bytes in ascending PartNumber
+// order. S3 assembles (and hashes) parts by ascending PartNumber regardless of
+// the order the client lists them in CompleteMultipartUpload; sorting keeps an
+// out-of-order (or unsorted-SDK) Complete from corrupting the object or ETag.
+func orderedPartData(allParts map[int][]byte, parts []driver.UploadPart) [][]byte {
 	ordered := append([]driver.UploadPart(nil), parts...)
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].PartNumber < ordered[j].PartNumber })
 
-	var data []byte
+	out := make([][]byte, 0, len(ordered))
 	for _, p := range ordered {
-		data = append(data, allParts[p.PartNumber]...)
+		out = append(out, allParts[p.PartNumber])
 	}
 
-	return data
+	return out
 }
 
 func (m *Mock) AbortMultipartUpload(_ context.Context, bucket, _, uploadID string) error {
@@ -1345,6 +1383,64 @@ func (m *Mock) DeleteObjectTagging(_ context.Context, bucket, key string) error 
 	}
 
 	obj.Tags = nil
+
+	return nil
+}
+
+// PutBucketConfig stores an opaque bucket-configuration document (policy, cors,
+// encryption, lifecycle, website, …) verbatim so GetBucketConfig can echo it.
+func (m *Mock) PutBucketConfig(_ context.Context, bucket, name string, body []byte) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	stored := make([]byte, len(body))
+	copy(stored, body)
+
+	bkt.rawConfigMu.Lock()
+	if bkt.rawConfigs == nil {
+		bkt.rawConfigs = make(map[string][]byte)
+	}
+
+	bkt.rawConfigs[name] = stored
+	bkt.rawConfigMu.Unlock()
+
+	return nil
+}
+
+// GetBucketConfig returns a stored configuration document, or NotFound when the
+// sub-resource was never configured.
+func (m *Mock) GetBucketConfig(_ context.Context, bucket, name string) ([]byte, error) {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.rawConfigMu.Lock()
+	defer bkt.rawConfigMu.Unlock()
+
+	body, ok := bkt.rawConfigs[name]
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "no %s configuration for bucket %q", name, bucket)
+	}
+
+	out := make([]byte, len(body))
+	copy(out, body)
+
+	return out, nil
+}
+
+// DeleteBucketConfig removes a stored configuration document (idempotent).
+func (m *Mock) DeleteBucketConfig(_ context.Context, bucket, name string) error {
+	bkt, ok := m.buckets.Get(bucket)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "bucket %q not found", bucket)
+	}
+
+	bkt.rawConfigMu.Lock()
+	delete(bkt.rawConfigs, name)
+	bkt.rawConfigMu.Unlock()
 
 	return nil
 }

--- a/providers/aws/s3/s3_lifecycle_test.go
+++ b/providers/aws/s3/s3_lifecycle_test.go
@@ -11,7 +11,6 @@ package s3
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"strings"
 	"testing"
@@ -53,10 +52,6 @@ func e2eRequireCode(t *testing.T, err error, want cerrors.Code, op string) {
 	if got := cerrors.GetCode(err); got != want {
 		t.Fatalf("%s: expected code %v, got %v (err=%v)", op, want, got, err)
 	}
-}
-
-func sha256Hex(data []byte) string {
-	return fmt.Sprintf("%x", sha256.Sum256(data))
 }
 
 // TestFullObjectLifecycle walks a complete user journey:
@@ -102,7 +97,7 @@ func TestFullObjectLifecycle(t *testing.T) {
 		e2eRequireNoErr(t, m.PutObject(ctx, bucket, o.key, o.data, o.contentType, o.metadata), "PutObject "+o.key)
 	}
 
-	// GetObject returns exact bytes, content type and sha256 ETag.
+	// GetObject returns exact bytes, content type and MD5 ETag.
 	for _, o := range objects {
 		got, gerr := m.GetObject(ctx, bucket, o.key)
 		e2eRequireNoErr(t, gerr, "GetObject "+o.key)
@@ -115,8 +110,8 @@ func TestFullObjectLifecycle(t *testing.T) {
 			t.Fatalf("GetObject %s: contentType = %q, want %q", o.key, got.Info.ContentType, o.contentType)
 		}
 
-		if got.Info.ETag != sha256Hex(o.data) {
-			t.Fatalf("GetObject %s: ETag = %q, want sha256 %q", o.key, got.Info.ETag, sha256Hex(o.data))
+		if got.Info.ETag != md5Hex(o.data) {
+			t.Fatalf("GetObject %s: ETag = %q, want md5 %q", o.key, got.Info.ETag, md5Hex(o.data))
 		}
 
 		if got.Info.Size != int64(len(o.data)) {
@@ -220,7 +215,7 @@ func TestFullObjectLifecycle(t *testing.T) {
 	over, err := m.GetObject(ctx, bucket, "docs/readme.txt")
 	e2eRequireNoErr(t, err, "GetObject overwritten")
 
-	if string(over.Data) != "v2" || over.Info.ContentType != "text/markdown" || over.Info.ETag != sha256Hex([]byte("v2")) {
+	if string(over.Data) != "v2" || over.Info.ContentType != "text/markdown" || over.Info.ETag != md5Hex([]byte("v2")) {
 		t.Fatalf("overwrite not fully applied: %+v data=%q", over.Info, over.Data)
 	}
 
@@ -447,8 +442,8 @@ func TestMultipartJourney(t *testing.T) {
 		p, perr := m.UploadPart(ctx, bucket, "assembled/object.bin", up.UploadID, n, partBodies[n])
 		e2eRequireNoErr(t, perr, fmt.Sprintf("UploadPart %d", n))
 
-		if p.ETag != sha256Hex(partBodies[n]) {
-			t.Fatalf("part %d ETag = %q, want sha256 of body", n, p.ETag)
+		if p.ETag != md5Hex(partBodies[n]) {
+			t.Fatalf("part %d ETag = %q, want md5 of body", n, p.ETag)
 		}
 
 		parts = append(parts, *p)
@@ -477,8 +472,11 @@ func TestMultipartJourney(t *testing.T) {
 		t.Fatalf("assembled contentType = %q", obj.Info.ContentType)
 	}
 
-	if obj.Info.ETag != sha256Hex([]byte("AAAABBBBCCCC")) {
-		t.Fatalf("assembled ETag = %q, want fresh sha256 over whole body", obj.Info.ETag)
+	// Multipart ETag is md5(md5(part1)+md5(part2)+md5(part3))-3, parts in
+	// ascending PartNumber order (1=AAAA, 2=BBBB, 3=CCCC).
+	wantETag := multipartETag([][]byte{[]byte("AAAA"), []byte("BBBB"), []byte("CCCC")})
+	if obj.Info.ETag != wantETag {
+		t.Fatalf("assembled ETag = %q, want multipart ETag %q", obj.Info.ETag, wantETag)
 	}
 
 	if obj.Info.Metadata == nil {

--- a/server/aws/aws_test.go
+++ b/server/aws/aws_test.go
@@ -361,7 +361,10 @@ func TestS3SpecialCharactersInKey(t *testing.T) {
 	assert.Equal(t, []byte("data"), got)
 }
 
-func TestS3DuplicateBucketReturnsError(t *testing.T) {
+// TestS3DuplicateBucketIdempotent asserts re-creating a bucket you own in
+// us-east-1 (the emulator's region) is idempotent, matching real S3's
+// global-endpoint behavior rather than returning 409.
+func TestS3DuplicateBucketIdempotent(t *testing.T) {
 	client := newS3Client(t)
 	ctx := context.Background()
 
@@ -373,7 +376,7 @@ func TestS3DuplicateBucketReturnsError(t *testing.T) {
 	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String("dup-bucket"),
 	})
-	require.Error(t, err)
+	require.NoError(t, err, "re-create in us-east-1 must be idempotent")
 }
 
 func TestDDBCreateTableAndListTables(t *testing.T) {

--- a/server/aws/s3/bucket_config.go
+++ b/server/aws/s3/bucket_config.go
@@ -2,11 +2,17 @@ package s3
 
 import (
 	"encoding/xml"
+	"io"
 	"net/http"
 	"net/url"
 
 	"github.com/stackshy/cloudemu/v2/server/wire"
 )
+
+// maxConfigBody caps a bucket-configuration document. Real S3 bucket policies
+// top out at 20 KB; this is a generous ceiling covering cors/lifecycle/website
+// XML as well.
+const maxConfigBody = 2 << 20
 
 // notConfiguredErr maps a read-only bucket configuration sub-resource (query
 // key) to the AWS error code S3 returns when the bucket has no such
@@ -49,24 +55,92 @@ func configSubresourceKey(q url.Values) string {
 	return ""
 }
 
-// bucketConfigOp answers a read-only bucket configuration sub-resource for an
-// existing bucket: GET returns the AWS-correct "not configured"/default
-// response so the base aws_s3_bucket resource's post-create reads round-trip.
+// bucketConfigOp answers a bucket configuration sub-resource. When the driver
+// implements RawBucketConfig (real S3 semantics), PUT persists the document,
+// GET echoes it back, and DELETE removes it — so aws_s3_bucket_policy,
+// _cors_configuration, _server_side_encryption_configuration, _lifecycle_* and
+// _website read back what was written instead of a perpetual "not configured"
+// diff. GET on an unconfigured sub-resource still returns the AWS-correct
+// "not configured"/default response.
 //
-// A write (PUT/DELETE) is accepted as a no-op so it does not fall through to
-// create/delete the bucket. This means these configs are NOT persisted: the
-// standalone config resources (aws_s3_bucket_policy, _public_access_block,
-// _cors_configuration, _server_side_encryption_configuration, _lifecycle_*)
-// would apply but then read back "not configured" — a perpetual diff. Those
-// resources are out of scope for the base fixture; see contrib/terraform's
-// "Known limits". Persisting them (like ?tagging/?versioning already are) is
-// the follow-up when a fixture needs one.
-func (*Handler) bucketConfigOp(w http.ResponseWriter, r *http.Request, sub string) {
-	if r.Method != http.MethodGet {
+// Without the RawBucketConfig capability a write is accepted as a no-op (so it
+// does not fall through to create/delete the bucket) and reads return defaults.
+func (h *Handler) bucketConfigOp(w http.ResponseWriter, r *http.Request, bucket, sub string) {
+	switch r.Method {
+	case http.MethodPut:
+		h.putBucketConfig(w, r, bucket, sub)
+	case http.MethodDelete:
+		h.deleteBucketConfig(w, r, bucket, sub)
+	default:
+		h.getBucketConfig(w, r, bucket, sub)
+	}
+}
+
+// putBucketConfig persists a configuration document when the driver supports it,
+// otherwise accepts the write as a no-op.
+func (h *Handler) putBucketConfig(w http.ResponseWriter, r *http.Request, bucket, sub string) {
+	if h.rawConfig == nil {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxConfigBody))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "MalformedXML", "could not read request body")
+		return
+	}
+
+	if err := h.rawConfig.PutBucketConfig(r.Context(), bucket, sub, body); err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// deleteBucketConfig removes a stored configuration document (204), matching
+// DeleteBucketCors/Policy/Website/Encryption/Lifecycle.
+func (h *Handler) deleteBucketConfig(w http.ResponseWriter, r *http.Request, bucket, sub string) {
+	if h.rawConfig != nil {
+		if err := h.rawConfig.DeleteBucketConfig(r.Context(), bucket, sub); err != nil {
+			writeErr(w, err)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// getBucketConfig echoes a stored document, or returns the AWS "not
+// configured"/default response when the sub-resource was never set.
+func (h *Handler) getBucketConfig(w http.ResponseWriter, r *http.Request, bucket, sub string) {
+	if h.rawConfig != nil {
+		if body, err := h.rawConfig.GetBucketConfig(r.Context(), bucket, sub); err == nil {
+			writeRawBucketConfig(w, sub, body)
+			return
+		}
+	}
+
+	writeConfigDefault(w, sub)
+}
+
+// writeRawBucketConfig echoes a persisted configuration document verbatim with
+// the sub-resource's content type (policy is JSON; the rest are XML).
+func writeRawBucketConfig(w http.ResponseWriter, sub string, body []byte) {
+	contentType := "application/xml"
+	if sub == "policy" {
+		contentType = "application/json"
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body) //nolint:gosec // echoing a stored config document, not HTML
+}
+
+// writeConfigDefault returns the AWS-correct response for an unconfigured
+// sub-resource: a "not configured" error for the persistable ones, or the
+// service default for the always-present ones (location, request payment, …).
+func writeConfigDefault(w http.ResponseWriter, sub string) {
 	if code, ok := notConfiguredErr[sub]; ok {
 		writeError(w, http.StatusNotFound, code, "The "+sub+" configuration does not exist")
 		return

--- a/server/aws/s3/bucket_config_test.go
+++ b/server/aws/s3/bucket_config_test.go
@@ -1,0 +1,201 @@
+package s3_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// TestSDKBucketPolicyRoundTrip covers the config-persistence gap for
+// PutBucketPolicy: the JSON document must read back byte-for-byte (previously a
+// PUT was a no-op and GET returned NoSuchBucketPolicy), and DELETE clears it.
+func TestSDKBucketPolicyRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "policy-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	// Fresh bucket: no policy configured yet.
+	if _, err := client.GetBucketPolicy(ctx, &awss3.GetBucketPolicyInput{Bucket: aws.String(bucket)}); err == nil {
+		t.Fatal("GetBucketPolicy on a fresh bucket: expected NoSuchBucketPolicy, got nil")
+	}
+
+	policy := `{"Version":"2012-10-17","Statement":[{"Sid":"AllowAll","Effect":"Allow",` +
+		`"Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::policy-bucket/*"}]}`
+
+	if _, err := client.PutBucketPolicy(ctx, &awss3.PutBucketPolicyInput{
+		Bucket: aws.String(bucket), Policy: aws.String(policy),
+	}); err != nil {
+		t.Fatalf("PutBucketPolicy: %v", err)
+	}
+
+	got, err := client.GetBucketPolicy(ctx, &awss3.GetBucketPolicyInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("GetBucketPolicy: %v", err)
+	}
+	if aws.ToString(got.Policy) != policy {
+		t.Fatalf("policy round-trip mismatch:\n got %q\nwant %q", aws.ToString(got.Policy), policy)
+	}
+
+	if _, err := client.DeleteBucketPolicy(ctx, &awss3.DeleteBucketPolicyInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("DeleteBucketPolicy: %v", err)
+	}
+	if _, err := client.GetBucketPolicy(ctx, &awss3.GetBucketPolicyInput{Bucket: aws.String(bucket)}); err == nil {
+		t.Fatal("GetBucketPolicy after delete: expected NoSuchBucketPolicy, got nil")
+	}
+}
+
+// TestSDKBucketCorsRoundTrip covers the config-persistence gap for
+// PutBucketCors: the CORS rules must read back instead of NoSuchCORSConfiguration.
+func TestSDKBucketCorsRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "cors-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketCors(ctx, &awss3.PutBucketCorsInput{
+		Bucket: aws.String(bucket),
+		CORSConfiguration: &types.CORSConfiguration{
+			CORSRules: []types.CORSRule{{
+				AllowedMethods: []string{"GET", "PUT"},
+				AllowedOrigins: []string{"https://example.com"},
+				AllowedHeaders: []string{"*"},
+				MaxAgeSeconds:  aws.Int32(3000),
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketCors: %v", err)
+	}
+
+	got, err := client.GetBucketCors(ctx, &awss3.GetBucketCorsInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("GetBucketCors: %v", err)
+	}
+	if len(got.CORSRules) != 1 {
+		t.Fatalf("CORSRules = %d, want 1", len(got.CORSRules))
+	}
+	if got.CORSRules[0].AllowedOrigins[0] != "https://example.com" ||
+		aws.ToInt32(got.CORSRules[0].MaxAgeSeconds) != 3000 {
+		t.Fatalf("CORS rule round-trip mismatch: %+v", got.CORSRules[0])
+	}
+}
+
+// TestSDKBucketEncryptionRoundTrip covers the config-persistence gap for
+// PutBucketEncryption: the SSE rule must read back instead of the
+// ServerSideEncryptionConfigurationNotFoundError.
+func TestSDKBucketEncryptionRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "enc-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketEncryption(ctx, &awss3.PutBucketEncryptionInput{
+		Bucket: aws.String(bucket),
+		ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
+			Rules: []types.ServerSideEncryptionRule{{
+				ApplyServerSideEncryptionByDefault: &types.ServerSideEncryptionByDefault{
+					SSEAlgorithm: types.ServerSideEncryptionAes256,
+				},
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketEncryption: %v", err)
+	}
+
+	got, err := client.GetBucketEncryption(ctx, &awss3.GetBucketEncryptionInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("GetBucketEncryption: %v", err)
+	}
+	if got.ServerSideEncryptionConfiguration == nil || len(got.ServerSideEncryptionConfiguration.Rules) != 1 {
+		t.Fatalf("encryption config = %+v, want 1 rule", got.ServerSideEncryptionConfiguration)
+	}
+	alg := got.ServerSideEncryptionConfiguration.Rules[0].ApplyServerSideEncryptionByDefault.SSEAlgorithm
+	if alg != types.ServerSideEncryptionAes256 {
+		t.Fatalf("SSEAlgorithm = %q, want AES256", alg)
+	}
+}
+
+// TestSDKBucketLifecycleRoundTrip covers the config-persistence gap for
+// PutBucketLifecycleConfiguration: the rule must read back instead of
+// NoSuchLifecycleConfiguration.
+func TestSDKBucketLifecycleRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "lc-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketLifecycleConfiguration(ctx, &awss3.PutBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucket),
+		LifecycleConfiguration: &types.BucketLifecycleConfiguration{
+			Rules: []types.LifecycleRule{{
+				ID:         aws.String("expire-logs"),
+				Status:     types.ExpirationStatusEnabled,
+				Filter:     &types.LifecycleRuleFilter{Prefix: aws.String("logs/")},
+				Expiration: &types.LifecycleExpiration{Days: aws.Int32(30)},
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketLifecycleConfiguration: %v", err)
+	}
+
+	got, err := client.GetBucketLifecycleConfiguration(ctx, &awss3.GetBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		t.Fatalf("GetBucketLifecycleConfiguration: %v", err)
+	}
+	if len(got.Rules) != 1 || aws.ToString(got.Rules[0].ID) != "expire-logs" {
+		t.Fatalf("lifecycle rules = %+v, want one 'expire-logs' rule", got.Rules)
+	}
+	if got.Rules[0].Expiration == nil || aws.ToInt32(got.Rules[0].Expiration.Days) != 30 {
+		t.Fatalf("lifecycle expiration = %+v, want 30 days", got.Rules[0].Expiration)
+	}
+}
+
+// TestSDKBucketWebsiteRoundTrip covers the config-persistence gap for
+// PutBucketWebsite: the website config must read back instead of
+// NoSuchWebsiteConfiguration.
+func TestSDKBucketWebsiteRoundTrip(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "web-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutBucketWebsite(ctx, &awss3.PutBucketWebsiteInput{
+		Bucket: aws.String(bucket),
+		WebsiteConfiguration: &types.WebsiteConfiguration{
+			IndexDocument: &types.IndexDocument{Suffix: aws.String("index.html")},
+			ErrorDocument: &types.ErrorDocument{Key: aws.String("error.html")},
+		},
+	}); err != nil {
+		t.Fatalf("PutBucketWebsite: %v", err)
+	}
+
+	got, err := client.GetBucketWebsite(ctx, &awss3.GetBucketWebsiteInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		t.Fatalf("GetBucketWebsite: %v", err)
+	}
+	if got.IndexDocument == nil || aws.ToString(got.IndexDocument.Suffix) != "index.html" {
+		t.Fatalf("website index = %+v, want index.html", got.IndexDocument)
+	}
+	if got.ErrorDocument == nil || aws.ToString(got.ErrorDocument.Key) != "error.html" {
+		t.Fatalf("website error = %+v, want error.html", got.ErrorDocument)
+	}
+
+	if _, err := client.DeleteBucketWebsite(ctx, &awss3.DeleteBucketWebsiteInput{Bucket: aws.String(bucket)}); err != nil {
+		t.Fatalf("DeleteBucketWebsite: %v", err)
+	}
+	_, err = client.GetBucketWebsite(ctx, &awss3.GetBucketWebsiteInput{Bucket: aws.String(bucket)})
+	if err == nil || !strings.Contains(err.Error(), "NoSuchWebsiteConfiguration") {
+		t.Fatalf("GetBucketWebsite after delete: want NoSuchWebsiteConfiguration, got %v", err)
+	}
+}

--- a/server/aws/s3/fidelity_test.go
+++ b/server/aws/s3/fidelity_test.go
@@ -3,6 +3,9 @@ package s3_test
 import (
 	"bytes"
 	"context"
+	"crypto/md5" //nolint:gosec // S3 ETags are MD5 digests; the test recomputes one to assert the shape
+	"encoding/hex"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +13,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/stackshy/cloudemu/v2"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
@@ -132,5 +136,194 @@ func TestSubResourceMethodNotAllowed(t *testing.T) {
 	// The bucket must NOT have been created by the misrouted PUT above.
 	if code := status(http.MethodGet, "/b"); code == http.StatusOK {
 		t.Fatal("bucket 'b' exists — a ?uploads PUT was misrouted to CreateBucket")
+	}
+}
+
+// TestSDKGetObjectRange covers the Range-header gap: GetObject(Range=bytes=0-4)
+// must return 206 Partial Content with a Content-Range header and just the
+// requested byte slice, not the full body with 200.
+func TestSDKGetObjectRange(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "range-bucket"
+	const key = "obj"
+
+	mustCreateBucket(t, client, bucket)
+
+	if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), Body: bytes.NewReader([]byte("hello world")),
+	}); err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	out, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), Range: aws.String("bytes=0-4"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject(Range): %v", err)
+	}
+	defer out.Body.Close()
+
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	if string(body) != "hello" {
+		t.Fatalf("ranged body = %q, want %q", string(body), "hello")
+	}
+	if aws.ToString(out.ContentRange) != "bytes 0-4/11" {
+		t.Fatalf("ContentRange = %q, want %q", aws.ToString(out.ContentRange), "bytes 0-4/11")
+	}
+	if aws.ToInt64(out.ContentLength) != 5 {
+		t.Fatalf("ContentLength = %d, want 5", aws.ToInt64(out.ContentLength))
+	}
+
+	// A suffix range returns the trailing bytes.
+	suffix, err := client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), Range: aws.String("bytes=-5"),
+	})
+	if err != nil {
+		t.Fatalf("GetObject(suffix range): %v", err)
+	}
+	defer suffix.Body.Close()
+
+	sb, _ := io.ReadAll(suffix.Body)
+	if string(sb) != "world" {
+		t.Fatalf("suffix ranged body = %q, want %q", string(sb), "world")
+	}
+}
+
+// TestSDKObjectETagIsMD5 covers the ETag-algorithm gap: a single-part PutObject
+// ETag must be the 32-char MD5 hex of the body, not a 64-char SHA-256.
+func TestSDKObjectETagIsMD5(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "etag-bucket"
+	const key = "obj"
+
+	mustCreateBucket(t, client, bucket)
+
+	put, err := client.PutObject(ctx, &awss3.PutObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), Body: bytes.NewReader([]byte("hello world")),
+	})
+	if err != nil {
+		t.Fatalf("PutObject: %v", err)
+	}
+
+	sum := md5.Sum([]byte("hello world")) //nolint:gosec // asserting S3's MD5 ETag shape
+	wantETag := hex.EncodeToString(sum[:])
+	if wantETag != "5eb63bbbe01eeed093cb22bb8f5acdc3" {
+		t.Fatalf("test vector wrong: %q", wantETag)
+	}
+
+	gotETag := strings.Trim(aws.ToString(put.ETag), `"`)
+	if gotETag != wantETag {
+		t.Fatalf("PutObject ETag = %q, want MD5 %q", gotETag, wantETag)
+	}
+	if len(gotETag) != 32 {
+		t.Fatalf("ETag length = %d, want 32 (MD5 hex)", len(gotETag))
+	}
+}
+
+// TestSDKMultipartCompleteETagSuffix covers the multipart-ETag gap: a completed
+// multipart object's ETag must carry the "-<numParts>" suffix so tooling can
+// detect it was assembled from parts.
+func TestSDKMultipartCompleteETagSuffix(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "mp-etag-bucket"
+	const key = "obj"
+
+	mustCreateBucket(t, client, bucket)
+
+	created, err := client.CreateMultipartUpload(ctx, &awss3.CreateMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	})
+	if err != nil {
+		t.Fatalf("CreateMultipartUpload: %v", err)
+	}
+	uploadID := aws.ToString(created.UploadId)
+
+	parts := make([]types.CompletedPart, 0, 2)
+	for i, data := range [][]byte{bytes.Repeat([]byte("A"), 1024), bytes.Repeat([]byte("B"), 2048)} {
+		pn := int32(i + 1) //nolint:gosec // small loop index
+		up, upErr := client.UploadPart(ctx, &awss3.UploadPartInput{
+			Bucket: aws.String(bucket), Key: aws.String(key), UploadId: aws.String(uploadID),
+			PartNumber: aws.Int32(pn), Body: bytes.NewReader(data),
+		})
+		if upErr != nil {
+			t.Fatalf("UploadPart %d: %v", pn, upErr)
+		}
+		parts = append(parts, types.CompletedPart{ETag: up.ETag, PartNumber: aws.Int32(pn)})
+	}
+
+	done, err := client.CompleteMultipartUpload(ctx, &awss3.CompleteMultipartUploadInput{
+		Bucket: aws.String(bucket), Key: aws.String(key), UploadId: aws.String(uploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{Parts: parts},
+	})
+	if err != nil {
+		t.Fatalf("CompleteMultipartUpload: %v", err)
+	}
+
+	etag := strings.Trim(aws.ToString(done.ETag), `"`)
+	if !strings.HasSuffix(etag, "-2") {
+		t.Fatalf("multipart ETag = %q, want a %q suffix", etag, "-2")
+	}
+}
+
+// TestSDKListObjectsV2KeyCount covers the KeyCount gap: with a delimiter,
+// KeyCount must count returned keys AND common prefixes, not just Contents.
+func TestSDKListObjectsV2KeyCount(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	const bucket = "kc-bucket"
+	mustCreateBucket(t, client, bucket)
+
+	// Two top-level keys + three keys under two "directory" prefixes.
+	keys := []string{"a.txt", "b.txt", "docs/1", "docs/2", "img/1"}
+	for _, k := range keys {
+		if _, err := client.PutObject(ctx, &awss3.PutObjectInput{
+			Bucket: aws.String(bucket), Key: aws.String(k), Body: bytes.NewReader([]byte("x")),
+		}); err != nil {
+			t.Fatalf("PutObject %s: %v", k, err)
+		}
+	}
+
+	out, err := client.ListObjectsV2(ctx, &awss3.ListObjectsV2Input{
+		Bucket: aws.String(bucket), Delimiter: aws.String("/"),
+	})
+	if err != nil {
+		t.Fatalf("ListObjectsV2: %v", err)
+	}
+
+	// 2 top-level keys (Contents) + 2 common prefixes (docs/, img/) = 4.
+	if len(out.Contents) != 2 || len(out.CommonPrefixes) != 2 {
+		t.Fatalf("Contents=%d CommonPrefixes=%d, want 2 and 2", len(out.Contents), len(out.CommonPrefixes))
+	}
+	if aws.ToInt32(out.KeyCount) != 4 {
+		t.Fatalf("KeyCount = %d, want 4 (Contents + CommonPrefixes)", aws.ToInt32(out.KeyCount))
+	}
+}
+
+// TestSDKListBucketsOwner covers the missing-Owner gap: ListBuckets must carry
+// an <Owner> element so clients that read the bucket owner don't see nil.
+func TestSDKListBucketsOwner(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	mustCreateBucket(t, client, "owned-bucket")
+
+	out, err := client.ListBuckets(ctx, &awss3.ListBucketsInput{})
+	if err != nil {
+		t.Fatalf("ListBuckets: %v", err)
+	}
+
+	if out.Owner == nil || aws.ToString(out.Owner.ID) == "" {
+		t.Fatalf("ListBuckets Owner = %+v, want a non-empty owner", out.Owner)
 	}
 }

--- a/server/aws/s3/handler.go
+++ b/server/aws/s3/handler.go
@@ -5,7 +5,8 @@ package s3
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/md5" //nolint:gosec // S3 object ETags are defined as MD5 digests, not a security primitive
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -35,6 +36,11 @@ type Handler struct {
 	// versioned is set when the driver retains per-object version history; the
 	// handler then honors versioning status, ?versionId, and ListObjectVersions.
 	versioned driver.VersionedBucket
+	// rawConfig is set when the driver can persist opaque bucket-configuration
+	// sub-resource documents (policy, cors, encryption, lifecycle, website, …);
+	// the handler then round-trips PUT/GET/DELETE on them instead of treating a
+	// write as a no-op.
+	rawConfig driver.RawBucketConfig
 }
 
 // New returns an S3 handler backed by b.
@@ -44,7 +50,17 @@ func New(b driver.Bucket) *Handler {
 		h.versioned = vb
 	}
 
+	if rc, ok := b.(driver.RawBucketConfig); ok {
+		h.rawConfig = rc
+	}
+
 	return h
+}
+
+// md5Sum returns the raw MD5 digest of data. S3 object ETags are MD5 digests.
+func md5Sum(data []byte) []byte {
+	sum := md5.Sum(data) //nolint:gosec // S3 ETag is MD5 by spec, not a security control
+	return sum[:]
 }
 
 // Matches returns true for requests that look like S3 REST calls: no
@@ -113,7 +129,10 @@ func (h *Handler) listBuckets(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := listAllMyBucketsResult{Xmlns: xmlns}
+	result := listAllMyBucketsResult{
+		Xmlns: xmlns,
+		Owner: aclOwnerXML{ID: cannedOwnerID, DisplayName: "cloudemu"},
+	}
 	for _, b := range buckets {
 		result.Buckets = append(result.Buckets, bucketXML{
 			Name: b.Name, CreationDate: b.CreatedAt,
@@ -171,7 +190,7 @@ func (h *Handler) bucketOp(w http.ResponseWriter, r *http.Request, bucket string
 	// location, …) that IaC clients read after create; without these the request
 	// would fall through to ListObjects and the client fails to parse it.
 	if sub := configSubresourceKey(q); sub != "" {
-		h.bucketConfigOp(w, r, sub)
+		h.bucketConfigOp(w, r, bucket, sub)
 		return
 	}
 
@@ -264,14 +283,46 @@ func (h *Handler) bucketTaggingOp(w http.ResponseWriter, r *http.Request, bucket
 	}
 }
 
+// usEast1 is the region where CreateBucket is idempotent for the owner.
+const usEast1 = "us-east-1"
+
 func (h *Handler) createBucket(w http.ResponseWriter, r *http.Request, bucket string) {
 	if err := h.bucket.CreateBucket(r.Context(), bucket); err != nil {
+		// In us-east-1 (the global endpoint) re-creating a bucket you already own
+		// is idempotent and returns 200; every other region returns 409
+		// BucketAlreadyOwnedByYou. cloudemu models a single account, so an existing
+		// bucket is always same-owner — the region alone decides.
+		if cerrors.IsAlreadyExists(err) && h.bucketRegion(r.Context(), bucket) == usEast1 {
+			w.Header().Set("Location", "/"+bucket)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
 		writeErr(w, err)
 		return
 	}
 
 	w.Header().Set("Location", "/"+bucket)
 	w.WriteHeader(http.StatusOK)
+}
+
+// bucketRegion returns the region of an existing bucket, or "" if it can't be
+// determined. An empty LocationConstraint is equivalent to us-east-1.
+func (h *Handler) bucketRegion(ctx context.Context, bucket string) string {
+	buckets, err := h.bucket.ListBuckets(ctx)
+	if err != nil {
+		return ""
+	}
+
+	for _, b := range buckets {
+		if b.Name == bucket {
+			if b.Region == "" {
+				return usEast1
+			}
+			return b.Region
+		}
+	}
+
+	return ""
 }
 
 func (h *Handler) deleteBucket(w http.ResponseWriter, r *http.Request, bucket string) {
@@ -322,7 +373,9 @@ func (h *Handler) listObjects(w http.ResponseWriter, r *http.Request, bucket str
 		Delimiter:   opts.Delimiter,
 		MaxKeys:     maxKeys,
 		IsTruncated: result.IsTruncated,
-		KeyCount:    len(result.Objects),
+		// KeyCount counts returned keys AND rolled-up common prefixes, matching
+		// real S3 (a delimited listing reports both under KeyCount).
+		KeyCount: len(result.Objects) + len(result.CommonPrefixes),
 	}
 
 	if result.NextPageToken != "" {
@@ -416,7 +469,7 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 	// algorithm; if a concurrent delete races the read-back, fall back to
 	// computing it from the body we just stored — a successful PUT must
 	// never answer 404.
-	etag := fmt.Sprintf("%x", sha256.Sum256(data))
+	etag := hex.EncodeToString(md5Sum(data))
 
 	var versionID string
 	if info, err := h.bucket.HeadObject(r.Context(), bucket, key); err == nil {
@@ -425,7 +478,7 @@ func (h *Handler) putObject(w http.ResponseWriter, r *http.Request, bucket, key 
 	}
 	w.Header().Set("ETag", fmt.Sprintf("%q", etag))
 	if versionID != "" {
-		w.Header().Set("x-amz-version-id", versionID)
+		w.Header().Set("X-Amz-Version-Id", versionID)
 	}
 	w.WriteHeader(http.StatusOK)
 }
@@ -445,9 +498,123 @@ func (h *Handler) getObject(w http.ResponseWriter, r *http.Request, bucket, key 
 		return
 	}
 
+	if rangeHeader := r.Header.Get("Range"); rangeHeader != "" {
+		h.writeRangedObject(w, obj, rangeHeader)
+		return
+	}
+
 	writeObjectHeaders(w, &obj.Info, int64(len(obj.Data)))
+	w.Header().Set("Accept-Ranges", "bytes")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(obj.Data) //nolint:gosec // writing raw object bytes, not HTML
+}
+
+// rangeOutcome classifies a Range header against an object.
+type rangeOutcome int
+
+const (
+	rangeIgnore        rangeOutcome = iota // unparseable header → serve full body (200)
+	rangeUnsatisfiable                     // valid syntax but out of bounds → 416
+	rangeOK                                // satisfiable → 206
+)
+
+// writeRangedObject serves a GetObject carrying a Range header: 206 with a
+// Content-Range slice when satisfiable, 416 when the range is out of bounds, and
+// a full 200 body when the header is unparseable (matching real S3).
+func (*Handler) writeRangedObject(w http.ResponseWriter, obj *driver.Object, header string) {
+	total := int64(len(obj.Data))
+	start, end, outcome := parseByteRange(header, total)
+
+	switch outcome {
+	case rangeUnsatisfiable:
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", total))
+		writeError(w, http.StatusRequestedRangeNotSatisfiable, "InvalidRange",
+			"The requested range is not satisfiable")
+	case rangeOK:
+		writeObjectHeaders(w, &obj.Info, end-start+1)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write(obj.Data[start : end+1]) //nolint:gosec // writing raw object bytes, not HTML
+	case rangeIgnore: // unparseable header → serve the full body
+		writeObjectHeaders(w, &obj.Info, total)
+		w.Header().Set("Accept-Ranges", "bytes")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(obj.Data) //nolint:gosec // writing raw object bytes, not HTML
+	}
+}
+
+// parseByteRange parses a single HTTP byte range ("bytes=0-4", "bytes=5-",
+// "bytes=-5") against an object of size total, returning the inclusive
+// [start,end] offsets and an outcome. Only the first range of a multi-range
+// header is honored (the common single-range download path).
+func parseByteRange(header string, total int64) (start, end int64, outcome rangeOutcome) {
+	const prefix = "bytes="
+	if !strings.HasPrefix(header, prefix) {
+		return 0, 0, rangeIgnore
+	}
+
+	spec := strings.TrimPrefix(header, prefix)
+	if idx := strings.IndexByte(spec, ','); idx >= 0 {
+		spec = spec[:idx]
+	}
+
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return 0, 0, rangeIgnore
+	}
+
+	startStr, endStr := spec[:dash], spec[dash+1:]
+
+	if startStr == "" {
+		return suffixRange(endStr, total)
+	}
+
+	return boundedRange(startStr, endStr, total)
+}
+
+// suffixRange handles "bytes=-N": the last N bytes of the object.
+func suffixRange(endStr string, total int64) (start, end int64, outcome rangeOutcome) {
+	n, err := strconv.ParseInt(endStr, 10, 64)
+	if err != nil {
+		return 0, 0, rangeIgnore
+	}
+
+	if n <= 0 || total == 0 {
+		return 0, 0, rangeUnsatisfiable
+	}
+
+	if n > total {
+		n = total
+	}
+
+	return total - n, total - 1, rangeOK
+}
+
+// boundedRange handles "bytes=start-" and "bytes=start-end".
+func boundedRange(startStr, endStr string, total int64) (start, end int64, outcome rangeOutcome) {
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil {
+		return 0, 0, rangeIgnore
+	}
+
+	if start >= total {
+		return 0, 0, rangeUnsatisfiable
+	}
+
+	end = total - 1
+	if endStr != "" {
+		end, err = strconv.ParseInt(endStr, 10, 64)
+		if err != nil || start > end {
+			return 0, 0, rangeIgnore
+		}
+
+		if end >= total {
+			end = total - 1
+		}
+	}
+
+	return start, end, rangeOK
 }
 
 func (h *Handler) headObject(w http.ResponseWriter, r *http.Request, bucket, key string) {
@@ -476,11 +643,11 @@ func writeObjectHeaders(w http.ResponseWriter, info *driver.ObjectInfo, size int
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
 
 	if info.VersionID != "" {
-		w.Header().Set("x-amz-version-id", info.VersionID)
+		w.Header().Set("X-Amz-Version-Id", info.VersionID)
 	}
 
 	if info.DeleteMarker {
-		w.Header().Set("x-amz-delete-marker", "true")
+		w.Header().Set("X-Amz-Delete-Marker", "true")
 	}
 
 	for k, v := range info.Metadata {
@@ -500,10 +667,10 @@ func (h *Handler) deleteObject(w http.ResponseWriter, r *http.Request, bucket, k
 			return
 		}
 		if vid != "" {
-			w.Header().Set("x-amz-version-id", vid)
+			w.Header().Set("X-Amz-Version-Id", vid)
 		}
 		if marker {
-			w.Header().Set("x-amz-delete-marker", "true")
+			w.Header().Set("X-Amz-Delete-Marker", "true")
 		}
 		w.WriteHeader(http.StatusNoContent)
 		return

--- a/server/aws/s3/s3_lifecycle_test.go
+++ b/server/aws/s3/s3_lifecycle_test.go
@@ -7,7 +7,7 @@ package s3_test
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
+	"crypto/md5" //nolint:gosec // S3 ETags are MD5 digests; this mirrors that in test assertions
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -143,8 +143,8 @@ func suiteGetBody(t *testing.T, client *s3.Client, bucket, key string) ([]byte, 
 	return data, out
 }
 
-func quotedSHA256(data []byte) string {
-	sum := sha256.Sum256(data)
+func quotedMD5(data []byte) string {
+	sum := md5.Sum(data) //nolint:gosec // S3 ETag is MD5 by spec, not a security control
 	return `"` + hex.EncodeToString(sum[:]) + `"`
 }
 
@@ -179,13 +179,13 @@ func TestS3ObjectJourney(t *testing.T) {
 		suitePut(t, client, bucket, obj.key, obj.body, obj.contentType)
 	}
 
-	// Get: bodies, content types, and the emulator's sha256-hex ETag (note:
-	// real S3 uses MD5-based ETags; the emulator documents sha256).
+	// Get: bodies, content types, and the MD5-hex ETag S3 reports for a
+	// single-part PutObject.
 	for _, obj := range objects {
 		data, out := suiteGetBody(t, client, bucket, obj.key)
 		assert.Equal(t, obj.body, data, "body %s", obj.key)
 		assert.Equal(t, obj.contentType, aws.ToString(out.ContentType), "content-type %s", obj.key)
-		assert.Equal(t, quotedSHA256(obj.body), aws.ToString(out.ETag), "etag %s", obj.key)
+		assert.Equal(t, quotedMD5(obj.body), aws.ToString(out.ETag), "etag %s", obj.key)
 		assert.Equal(t, int64(len(obj.body)), aws.ToInt64(out.ContentLength), "content-length %s", obj.key)
 	}
 
@@ -196,7 +196,7 @@ func TestS3ObjectJourney(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1<<20), aws.ToInt64(head.ContentLength))
-	assert.Equal(t, quotedSHA256(oneMB), aws.ToString(head.ETag))
+	assert.Equal(t, quotedMD5(oneMB), aws.ToString(head.ETag))
 	assert.NotNil(t, head.LastModified)
 
 	// List everything: keys come back lexically sorted.
@@ -461,9 +461,10 @@ func TestS3MissingBucketError(t *testing.T) {
 	assert.Equal(t, "NoSuchBucket", apiErr.ErrorCode())
 }
 
-// TestS3DuplicateBucketTypedError asserts the second CreateBucket
-// for the same name surfaces *types.BucketAlreadyOwnedByYou.
-func TestS3DuplicateBucketTypedError(t *testing.T) {
+// TestS3DuplicateBucketIdempotentUSEast1 asserts that re-creating a bucket you
+// already own in us-east-1 (the emulator's region) is idempotent and succeeds,
+// matching real S3's global-endpoint behavior rather than returning 409.
+func TestS3DuplicateBucketIdempotentUSEast1(t *testing.T) {
 	client := newSuiteS3Client(t)
 	ctx := context.Background()
 
@@ -473,11 +474,7 @@ func TestS3DuplicateBucketTypedError(t *testing.T) {
 	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
 	})
-	require.Error(t, err)
-
-	var owned *types.BucketAlreadyOwnedByYou
-	assert.True(t, errors.As(err, &owned),
-		"want *types.BucketAlreadyOwnedByYou, got %T: %v", err, err)
+	require.NoError(t, err, "re-create in us-east-1 must be idempotent (200), not 409")
 }
 
 // TestS3DeleteNonEmptyBucketError asserts deleting a non-empty
@@ -660,7 +657,7 @@ func TestS3CopyObjectSemantics(t *testing.T) {
 
 	gotBody, get := suiteGetBody(t, client, dstBucket, "dst.txt")
 	assert.Equal(t, body, gotBody)
-	assert.Equal(t, quotedSHA256(body), aws.ToString(get.ETag), "copy preserves ETag")
+	assert.Equal(t, quotedMD5(body), aws.ToString(get.ETag), "copy preserves ETag")
 	assert.Equal(t, "text/plain", aws.ToString(get.ContentType), "copy preserves content type")
 	assert.Equal(t, map[string]string{"origin": "src"}, get.Metadata, "copy preserves metadata")
 
@@ -706,7 +703,7 @@ func TestS3OverwriteResetsTags(t *testing.T) {
 	body, get := suiteGetBody(t, client, bucket, key)
 	assert.Equal(t, []byte("v2 body is longer"), body)
 	assert.Equal(t, "application/json", aws.ToString(get.ContentType))
-	assert.Equal(t, quotedSHA256([]byte("v2 body is longer")), aws.ToString(get.ETag))
+	assert.Equal(t, quotedMD5([]byte("v2 body is longer")), aws.ToString(get.ETag))
 
 	tags, err := client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
 		Bucket: aws.String(bucket), Key: aws.String(key),
@@ -868,6 +865,6 @@ func TestS3PutObjectReturnsETag(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, quotedSHA256(body), aws.ToString(put.ETag),
+	assert.Equal(t, quotedMD5(body), aws.ToString(put.ETag),
 		"real S3 returns the object ETag on PutObject; the emulator omits it")
 }

--- a/server/aws/s3/xml.go
+++ b/server/aws/s3/xml.go
@@ -13,6 +13,7 @@ type errorXML struct {
 type listAllMyBucketsResult struct {
 	XMLName xml.Name    `xml:"ListAllMyBucketsResult"`
 	Xmlns   string      `xml:"xmlns,attr"`
+	Owner   aclOwnerXML `xml:"Owner"`
 	Buckets []bucketXML `xml:"Buckets>Bucket"`
 }
 

--- a/services/storage/driver/driver.go
+++ b/services/storage/driver/driver.go
@@ -119,6 +119,22 @@ type VersionedBucket interface {
 	ListObjectVersions(ctx context.Context, bucket string, opts ListOptions) (*VersionListResult, error)
 }
 
+// RawBucketConfig is an OPTIONAL capability (discovered by type assertion, like
+// VersionedBucket) a storage provider implements to persist and echo back opaque
+// bucket-configuration sub-resource documents — policy (JSON), cors, encryption,
+// lifecycle, website, and the like (XML) — byte-for-byte. The S3 handler uses it
+// to make PutBucketX/GetBucketX/DeleteBucketX round-trip; providers that don't
+// implement it fall back to the read-only "not configured" responses.
+type RawBucketConfig interface {
+	// PutBucketConfig stores document body under the sub-resource name (e.g.
+	// "policy", "cors") for bucket, replacing any previous document.
+	PutBucketConfig(ctx context.Context, bucket, name string, body []byte) error
+	// GetBucketConfig returns the stored document, or NotFound when none was set.
+	GetBucketConfig(ctx context.Context, bucket, name string) ([]byte, error)
+	// DeleteBucketConfig removes the stored document (idempotent).
+	DeleteBucketConfig(ctx context.Context, bucket, name string) error
+}
+
 // CopySource identifies the source for a copy operation.
 type CopySource struct {
 	Bucket string


### PR DESCRIPTION
Closes the remaining S3 audit findings.

- Range header honored (206 + Content-Range, 416 unsatisfiable); ETag is now MD5 hex (was SHA-256) across Put/Get/Head/List/UploadPart
- PutBucketPolicy/Cors/Encryption/Lifecycle/Website persist + round-trip (new optional RawBucketConfig capability, AWS Mock only)
- CompleteMultipartUpload ETag carries -N part-count suffix; ListObjectsV2 KeyCount includes CommonPrefixes; ListBuckets emits Owner; CreateBucket idempotent in us-east-1 for owner

New capability is an interface ADDITION (Azure/GCP/OCI compile unchanged); compat docs clean. Coverage docs for the new capability are owed and will land in a consolidated coverage-regen PR. SDK round-trip tests per fix.