### PR TITLE
fix(lambda): Function URL API, function attributes, wire fidelity

### DIFF
--- a/providers/aws/lambda/aliases.go
+++ b/providers/aws/lambda/aliases.go
@@ -37,6 +37,7 @@ func (m *Mock) CreateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 		RoutingConfig:   copyRoutingConfig(cfg.RoutingConfig),
 		AliasARN:        aliasARN,
 		CreatedAt:       m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		RevisionID:      newRevisionID(),
 	}
 
 	fd.aliases.Set(cfg.Name, &aliasData{alias: a})
@@ -73,6 +74,8 @@ func (m *Mock) UpdateAlias(_ context.Context, cfg driver.AliasConfig) (*driver.A
 	if cfg.RoutingConfig != nil {
 		ad.alias.RoutingConfig = copyRoutingConfig(cfg.RoutingConfig)
 	}
+
+	ad.alias.RevisionID = newRevisionID()
 
 	fd.aliases.Set(cfg.Name, ad)
 

--- a/providers/aws/lambda/esm.go
+++ b/providers/aws/lambda/esm.go
@@ -3,9 +3,11 @@ package lambda
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/internal/idgen"
 	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
 )
 
@@ -43,6 +45,7 @@ func (m *Mock) CreateEventSourceMapping(
 		UUID:             uuid,
 		EventSourceArn:   cfg.EventSourceArn,
 		FunctionName:     cfg.FunctionName,
+		FunctionArn:      m.functionARN(cfg.FunctionName),
 		BatchSize:        batchSize,
 		Enabled:          cfg.Enabled,
 		StartingPosition: cfg.StartingPosition,
@@ -55,6 +58,23 @@ func (m *Mock) CreateEventSourceMapping(
 	result := *info
 
 	return &result, nil
+}
+
+// functionARN resolves an event-source-mapping target to a full function ARN.
+// A value already shaped like an ARN is returned unchanged; a bare name is
+// looked up (falling back to a synthesized ARN if the function isn't tracked,
+// e.g. it was referenced before creation) so the wire layer always returns a
+// FunctionArn, never the bare name.
+func (m *Mock) functionARN(nameOrARN string) string {
+	if strings.HasPrefix(nameOrARN, "arn:") {
+		return nameOrARN
+	}
+
+	if fd, ok := m.funcs.Get(nameOrARN); ok {
+		return fd.info.ARN
+	}
+
+	return idgen.AWSARN("lambda", m.opts.Region, m.opts.AccountID, "function:"+nameOrARN)
 }
 
 // DeleteEventSourceMapping deletes an event source mapping by UUID.
@@ -110,6 +130,7 @@ func (m *Mock) UpdateEventSourceMapping(
 
 	if cfg.FunctionName != "" {
 		updated.FunctionName = cfg.FunctionName
+		updated.FunctionArn = m.functionARN(cfg.FunctionName)
 	}
 
 	if cfg.EventSourceArn != "" {

--- a/providers/aws/lambda/functionurl.go
+++ b/providers/aws/lambda/functionurl.go
@@ -1,0 +1,165 @@
+package lambda
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+	"github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// Function URL defaults applied when the request omits them, matching real
+// Lambda.
+const (
+	defaultInvokeMode = "BUFFERED"
+	defaultAuthType   = "NONE"
+)
+
+// CreateFunctionURLConfig provisions the (single) Function URL for a function.
+//
+//nolint:gocritic // hugeParam: matches the functionURLManager interface signature.
+func (m *Mock) CreateFunctionURLConfig(_ context.Context, cfg driver.FunctionURLConfig) (*driver.FunctionURLConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if fd.urlConfig != nil {
+		return nil, cerrors.Newf(cerrors.AlreadyExists, "function url config for %s already exists", cfg.FunctionName)
+	}
+
+	now := m.opts.Clock.Now().UTC().Format(timeFormat)
+
+	authType := cfg.AuthType
+	if authType == "" {
+		authType = defaultAuthType
+	}
+
+	invokeMode := cfg.InvokeMode
+	if invokeMode == "" {
+		invokeMode = defaultInvokeMode
+	}
+
+	url := &driver.FunctionURLConfig{
+		FunctionName: cfg.FunctionName,
+		FunctionArn:  fd.info.ARN,
+		FunctionURL:  m.functionURL(),
+		AuthType:     authType,
+		InvokeMode:   invokeMode,
+		Cors:         cfg.Cors,
+		CreationTime: now,
+		LastModified: now,
+	}
+	fd.urlConfig = url
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	result := *url
+
+	return &result, nil
+}
+
+// GetFunctionURLConfig returns the Function URL for a function.
+func (m *Mock) GetFunctionURLConfig(_ context.Context, functionName string) (*driver.FunctionURLConfig, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if fd.urlConfig == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "function url config for %s not found", functionName)
+	}
+
+	result := *fd.urlConfig
+
+	return &result, nil
+}
+
+// UpdateFunctionURLConfig mutates AuthType/InvokeMode/Cors on an existing URL.
+//
+//nolint:gocritic // hugeParam: matches the functionURLManager interface signature.
+func (m *Mock) UpdateFunctionURLConfig(_ context.Context, cfg driver.FunctionURLConfig) (*driver.FunctionURLConfig, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(cfg.FunctionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", cfg.FunctionName)
+	}
+
+	if fd.urlConfig == nil {
+		return nil, cerrors.Newf(cerrors.NotFound, "function url config for %s not found", cfg.FunctionName)
+	}
+
+	updated := *fd.urlConfig
+
+	if cfg.AuthType != "" {
+		updated.AuthType = cfg.AuthType
+	}
+
+	if cfg.InvokeMode != "" {
+		updated.InvokeMode = cfg.InvokeMode
+	}
+
+	if cfg.Cors != nil {
+		updated.Cors = cfg.Cors
+	}
+
+	updated.LastModified = m.opts.Clock.Now().UTC().Format(timeFormat)
+	fd.urlConfig = &updated
+	m.funcs.Set(cfg.FunctionName, fd)
+
+	result := updated
+
+	return &result, nil
+}
+
+// DeleteFunctionURLConfig removes a function's URL.
+func (m *Mock) DeleteFunctionURLConfig(_ context.Context, functionName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if fd.urlConfig == nil {
+		return cerrors.Newf(cerrors.NotFound, "function url config for %s not found", functionName)
+	}
+
+	fd.urlConfig = nil
+	m.funcs.Set(functionName, fd)
+
+	return nil
+}
+
+// ListFunctionURLConfigs returns the Function URL configs for a function (zero
+// or one, since a function has at most one URL for the $LATEST qualifier).
+func (m *Mock) ListFunctionURLConfigs(_ context.Context, functionName string) ([]driver.FunctionURLConfig, error) {
+	fd, ok := m.funcs.Get(functionName)
+	if !ok {
+		return nil, cerrors.Newf(cerrors.NotFound, "function %s not found", functionName)
+	}
+
+	if fd.urlConfig == nil {
+		return []driver.FunctionURLConfig{}, nil
+	}
+
+	return []driver.FunctionURLConfig{*fd.urlConfig}, nil
+}
+
+// functionURL synthesizes a Lambda Function URL of the real shape
+// https://<url-id>.lambda-url.<region>.on.aws/.
+func (m *Mock) functionURL() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("https://cloudemu.lambda-url.%s.on.aws/", m.opts.Region)
+	}
+
+	return fmt.Sprintf("https://%s.lambda-url.%s.on.aws/", hex.EncodeToString(b[:8])+hex.EncodeToString(b[8:]), m.opts.Region)
+}

--- a/providers/aws/lambda/lambda.go
+++ b/providers/aws/lambda/lambda.go
@@ -2,7 +2,10 @@ package lambda
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"sync"
@@ -30,10 +33,11 @@ const (
 )
 
 type versionData struct {
-	config    driver.FunctionConfig
-	version   string
-	codeSHA   string
-	createdAt string
+	config     driver.FunctionConfig
+	version    string
+	codeSHA    string
+	revisionID string
+	createdAt  string
 }
 
 type aliasData struct {
@@ -54,6 +58,7 @@ type funcData struct {
 	aliases      *memstore.Store[*aliasData]
 	concurrency  *driver.ConcurrencyConfig
 	policy       map[string]driver.PermissionStatement
+	urlConfig    *driver.FunctionURLConfig // Lambda Function URL, nil until created
 }
 
 // Mock is an in-memory mock implementation of AWS Lambda.
@@ -105,9 +110,12 @@ func (m *Mock) CreateFunction(ctx context.Context, cfg driver.FunctionConfig) (*
 	arn := idgen.AWSARN("lambda", m.opts.Region, m.opts.AccountID, "function:"+cfg.Name)
 	info := driver.FunctionInfo{
 		Name: cfg.Name, ARN: arn, Runtime: cfg.Runtime, Handler: cfg.Handler,
+		Role: cfg.Role, Description: cfg.Description,
 		Memory: cfg.Memory, Timeout: cfg.Timeout, State: "Active",
 		Environment: maps.Clone(cfg.Environment), Tags: maps.Clone(cfg.Tags),
 		LastModified: m.opts.Clock.Now().UTC().Format(time.RFC3339),
+		CodeSHA256:   codeHash(cfg.Code), CodeSize: int64(len(cfg.Code)),
+		Version: latestVersion, RevisionID: newRevisionID(),
 	}
 
 	m.handlersMu.RLock()
@@ -181,6 +189,15 @@ func (m *Mock) UpdateFunction(ctx context.Context, name string, cfg driver.Funct
 	info := fd.info
 	applyConfigUpdates(&info, cfg)
 	info.LastModified = m.opts.Clock.Now().UTC().Format(time.RFC3339)
+	// Every update — configuration or code — mints a new revision, matching the
+	// RevisionId Terraform reads to detect drift.
+	info.RevisionID = newRevisionID()
+
+	if len(cfg.Code) > 0 {
+		info.CodeSHA256 = codeHash(cfg.Code)
+		info.CodeSize = int64(len(cfg.Code))
+	}
+
 	fd.info = info
 
 	// A code update re-deploys to the engine using the post-merge runtime/handler
@@ -303,6 +320,14 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 		info.Handler = cfg.Handler
 	}
 
+	if cfg.Role != "" {
+		info.Role = cfg.Role
+	}
+
+	if cfg.Description != "" {
+		info.Description = cfg.Description
+	}
+
 	if cfg.Memory != 0 {
 		info.Memory = cfg.Memory
 	}
@@ -320,9 +345,29 @@ func applyConfigUpdates(info *driver.FunctionInfo, cfg driver.FunctionConfig) {
 	}
 }
 
-func codeSHA(info *driver.FunctionInfo) string {
-	data := fmt.Sprintf("%s:%s:%s", info.Name, info.Handler, info.Runtime)
-	hash := sha256.Sum256([]byte(data))
+// codeHash returns the base64-encoded SHA-256 of the deployment package, the
+// same CodeSha256 shape real Lambda returns and Terraform compares against its
+// locally computed source_code_hash.
+func codeHash(code []byte) string {
+	hash := sha256.Sum256(code)
 
-	return fmt.Sprintf("%x", hash)
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+// newRevisionID mints a random UUID-shaped revision identifier. Lambda changes
+// the RevisionId on every configuration or code mutation.
+func newRevisionID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failure is not expected; fall back to a zero-value UUID so
+		// callers still get a well-formed (if non-unique) revision id.
+		return "00000000-0000-4000-8000-000000000000"
+	}
+
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+
+	h := hex.EncodeToString(b[:])
+
+	return fmt.Sprintf("%s-%s-%s-%s-%s", h[0:8], h[8:12], h[12:16], h[16:20], h[20:32])
 }

--- a/providers/aws/lambda/lambda_test.go
+++ b/providers/aws/lambda/lambda_test.go
@@ -277,10 +277,12 @@ func TestVersionImmutability(t *testing.T) {
 	requireNoError(t, err)
 	origSHA := ver1.CodeSHA256
 
-	// Update the function config
+	// Update the function code (CodeSha256 tracks the deployment package, not
+	// configuration, matching real Lambda).
 	_, err = m.UpdateFunction(ctx, "my-func", driver.FunctionConfig{
 		Runtime: "python3.9",
 		Handler: "new_handler",
+		Code:    []byte("new-deployment-package"),
 	})
 	requireNoError(t, err)
 
@@ -288,7 +290,7 @@ func TestVersionImmutability(t *testing.T) {
 	ver2, err := m.PublishVersion(ctx, "my-func", "v2")
 	requireNoError(t, err)
 
-	// The two versions should have different code SHAs since config changed
+	// The two versions should have different code SHAs since the code changed
 	assertEqual(t, true, origSHA != ver2.CodeSHA256)
 
 	// Verify that version list still has original version

--- a/providers/aws/lambda/versions.go
+++ b/providers/aws/lambda/versions.go
@@ -26,14 +26,16 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 	fd.nextVersion++
 
 	verStr := strconv.Itoa(verNum)
-	sha := codeSHA(&fd.info)
+	sha := fd.info.CodeSHA256
+	rev := fd.info.RevisionID
 	now := m.opts.Clock.Now().UTC().Format(time.RFC3339)
 
 	vd := &versionData{
-		config:    snapshotConfig(&fd.info),
-		version:   verStr,
-		codeSHA:   sha,
-		createdAt: now,
+		config:     snapshotConfig(&fd.info),
+		version:    verStr,
+		codeSHA:    sha,
+		revisionID: rev,
+		createdAt:  now,
 	}
 	fd.versions = append(fd.versions, vd)
 	m.funcs.Set(functionName, fd)
@@ -43,7 +45,13 @@ func (m *Mock) PublishVersion(_ context.Context, functionName, description strin
 		Version:      verStr,
 		Description:  description,
 		CodeSHA256:   sha,
+		RevisionID:   rev,
 		CreatedAt:    now,
+		Runtime:      fd.info.Runtime,
+		Handler:      fd.info.Handler,
+		Memory:       fd.info.Memory,
+		Timeout:      fd.info.Timeout,
+		Role:         fd.info.Role,
 	}, nil
 }
 
@@ -59,7 +67,13 @@ func (m *Mock) ListVersions(_ context.Context, functionName string) ([]driver.Fu
 	result = append(result, driver.FunctionVersion{
 		FunctionName: functionName,
 		Version:      latestVersion,
-		CodeSHA256:   codeSHA(&fd.info),
+		CodeSHA256:   fd.info.CodeSHA256,
+		RevisionID:   fd.info.RevisionID,
+		Runtime:      fd.info.Runtime,
+		Handler:      fd.info.Handler,
+		Memory:       fd.info.Memory,
+		Timeout:      fd.info.Timeout,
+		Role:         fd.info.Role,
 	})
 
 	for _, v := range fd.versions {
@@ -67,7 +81,13 @@ func (m *Mock) ListVersions(_ context.Context, functionName string) ([]driver.Fu
 			FunctionName: functionName,
 			Version:      v.version,
 			CodeSHA256:   v.codeSHA,
+			RevisionID:   v.revisionID,
 			CreatedAt:    v.createdAt,
+			Runtime:      v.config.Runtime,
+			Handler:      v.config.Handler,
+			Memory:       v.config.Memory,
+			Timeout:      v.config.Timeout,
+			Role:         v.config.Role,
 		})
 	}
 
@@ -90,6 +110,8 @@ func snapshotConfig(info *driver.FunctionInfo) driver.FunctionConfig {
 		Name:        info.Name,
 		Runtime:     info.Runtime,
 		Handler:     info.Handler,
+		Role:        info.Role,
+		Description: info.Description,
 		Memory:      info.Memory,
 		Timeout:     info.Timeout,
 		Environment: env,

--- a/server/aws/lambda/esm.go
+++ b/server/aws/lambda/esm.go
@@ -18,10 +18,15 @@ type eventSourceMappingJSON struct {
 }
 
 func toESMJSON(info *sdrv.EventSourceMappingInfo) eventSourceMappingJSON {
+	functionArn := info.FunctionArn
+	if functionArn == "" {
+		functionArn = info.FunctionName
+	}
+
 	return eventSourceMappingJSON{
 		UUID:             info.UUID,
 		EventSourceArn:   info.EventSourceArn,
-		FunctionArn:      info.FunctionName,
+		FunctionArn:      functionArn,
 		BatchSize:        info.BatchSize,
 		State:            info.State,
 		StartingPosition: info.StartingPosition,

--- a/server/aws/lambda/functionurl.go
+++ b/server/aws/lambda/functionurl.go
@@ -1,0 +1,200 @@
+package lambda
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	sdrv "github.com/stackshy/cloudemu/v2/services/serverless/driver"
+)
+
+// functionURLManager is the AWS-specific Lambda Function URL surface. Function
+// URLs aren't part of the portable Serverless driver, so the handler
+// type-asserts for it rather than requiring every cloud to implement it.
+type functionURLManager interface {
+	CreateFunctionURLConfig(ctx context.Context, cfg sdrv.FunctionURLConfig) (*sdrv.FunctionURLConfig, error)
+	GetFunctionURLConfig(ctx context.Context, functionName string) (*sdrv.FunctionURLConfig, error)
+	UpdateFunctionURLConfig(ctx context.Context, cfg sdrv.FunctionURLConfig) (*sdrv.FunctionURLConfig, error)
+	DeleteFunctionURLConfig(ctx context.Context, functionName string) error
+	ListFunctionURLConfigs(ctx context.Context, functionName string) ([]sdrv.FunctionURLConfig, error)
+}
+
+// corsJSON is the AWS Cors shape shared by the Function URL request and response.
+type corsJSON struct {
+	AllowCredentials bool     `json:"AllowCredentials,omitempty"`
+	AllowHeaders     []string `json:"AllowHeaders,omitempty"`
+	AllowMethods     []string `json:"AllowMethods,omitempty"`
+	AllowOrigins     []string `json:"AllowOrigins,omitempty"`
+	ExposeHeaders    []string `json:"ExposeHeaders,omitempty"`
+	MaxAge           int      `json:"MaxAge,omitempty"`
+}
+
+// functionURLRequest is the body of Create/UpdateFunctionUrlConfig.
+type functionURLRequest struct {
+	AuthType   string    `json:"AuthType"`
+	InvokeMode string    `json:"InvokeMode"`
+	Cors       *corsJSON `json:"Cors"`
+}
+
+// functionURLResponse is the AWS FunctionUrlConfig shape.
+type functionURLResponse struct {
+	FunctionArn      string    `json:"FunctionArn"`
+	FunctionURL      string    `json:"FunctionUrl"`
+	AuthType         string    `json:"AuthType"`
+	InvokeMode       string    `json:"InvokeMode,omitempty"`
+	Cors             *corsJSON `json:"Cors,omitempty"`
+	CreationTime     string    `json:"CreationTime,omitempty"`
+	LastModifiedTime string    `json:"LastModifiedTime,omitempty"`
+}
+
+// listFunctionURLConfigsResponse is the ListFunctionUrlConfigs envelope.
+type listFunctionURLConfigsResponse struct {
+	FunctionURLConfigs []functionURLResponse `json:"FunctionUrlConfigs"`
+}
+
+func toCorsJSON(c *sdrv.FunctionURLCors) *corsJSON {
+	if c == nil {
+		return nil
+	}
+
+	return &corsJSON{
+		AllowCredentials: c.AllowCredentials,
+		AllowHeaders:     c.AllowHeaders,
+		AllowMethods:     c.AllowMethods,
+		AllowOrigins:     c.AllowOrigins,
+		ExposeHeaders:    c.ExposeHeaders,
+		MaxAge:           c.MaxAge,
+	}
+}
+
+func toCorsDriver(c *corsJSON) *sdrv.FunctionURLCors {
+	if c == nil {
+		return nil
+	}
+
+	return &sdrv.FunctionURLCors{
+		AllowCredentials: c.AllowCredentials,
+		AllowHeaders:     c.AllowHeaders,
+		AllowMethods:     c.AllowMethods,
+		AllowOrigins:     c.AllowOrigins,
+		ExposeHeaders:    c.ExposeHeaders,
+		MaxAge:           c.MaxAge,
+	}
+}
+
+func toFunctionURLResponse(u *sdrv.FunctionURLConfig) functionURLResponse {
+	return functionURLResponse{
+		FunctionArn:      u.FunctionArn,
+		FunctionURL:      u.FunctionURL,
+		AuthType:         u.AuthType,
+		InvokeMode:       u.InvokeMode,
+		Cors:             toCorsJSON(u.Cors),
+		CreationTime:     u.CreationTime,
+		LastModifiedTime: u.LastModified,
+	}
+}
+
+// serveFunctionURL dispatches the Lambda Function URL API under
+// /2021-10-31/functions/{name}/url (create/get/update/delete) and
+// /2021-10-31/functions/{name}/urls (list).
+func (h *Handler) serveFunctionURL(w http.ResponseWriter, r *http.Request) {
+	mgr, ok := h.fn.(functionURLManager)
+	if !ok {
+		writeError(w, http.StatusNotImplemented, "InvalidRequestException", "function urls not supported")
+		return
+	}
+
+	rest := strings.TrimPrefix(r.URL.Path, functionURLPrefix)
+	rest = strings.TrimPrefix(rest, "/")
+	parts := strings.Split(rest, "/")
+
+	const wantParts = 2 // {name}/url or {name}/urls
+	if len(parts) != wantParts || parts[0] == "" {
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+		return
+	}
+
+	name := parts[0]
+
+	switch parts[1] {
+	case "url":
+		serveFunctionURLItem(w, r, mgr, name)
+	case "urls":
+		listFunctionURLConfigs(w, r, mgr, name)
+	default:
+		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
+	}
+}
+
+// serveFunctionURLItem handles POST/GET/PUT/DELETE on .../{name}/url.
+func serveFunctionURLItem(w http.ResponseWriter, r *http.Request, mgr functionURLManager, name string) {
+	switch r.Method {
+	case http.MethodPost:
+		writeFunctionURL(w, r, mgr.CreateFunctionURLConfig, name, http.StatusCreated)
+	case http.MethodPut:
+		writeFunctionURL(w, r, mgr.UpdateFunctionURLConfig, name, http.StatusOK)
+	case http.MethodGet:
+		u, err := mgr.GetFunctionURLConfig(r.Context(), name)
+		if err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, toFunctionURLResponse(u))
+	case http.MethodDelete:
+		if err := mgr.DeleteFunctionURLConfig(r.Context(), name); err != nil {
+			writeErr(w, err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+	}
+}
+
+// writeFunctionURL decodes a create/update body and writes the result. The op
+// (create vs update) is supplied as fn so both share the decode/encode path.
+func writeFunctionURL(
+	w http.ResponseWriter, r *http.Request,
+	fn func(context.Context, sdrv.FunctionURLConfig) (*sdrv.FunctionURLConfig, error),
+	name string, status int,
+) {
+	var req functionURLRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	u, err := fn(r.Context(), sdrv.FunctionURLConfig{
+		FunctionName: name,
+		AuthType:     req.AuthType,
+		InvokeMode:   req.InvokeMode,
+		Cors:         toCorsDriver(req.Cors),
+	})
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	writeJSON(w, status, toFunctionURLResponse(u))
+}
+
+func listFunctionURLConfigs(w http.ResponseWriter, r *http.Request, mgr functionURLManager, name string) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "InvalidRequestException", "method not allowed")
+		return
+	}
+
+	urls, err := mgr.ListFunctionURLConfigs(r.Context(), name)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	out := listFunctionURLConfigsResponse{FunctionURLConfigs: make([]functionURLResponse, 0, len(urls))}
+	for i := range urls {
+		out.FunctionURLConfigs = append(out.FunctionURLConfigs, toFunctionURLResponse(&urls[i]))
+	}
+
+	writeJSON(w, http.StatusOK, out)
+}

--- a/server/aws/lambda/handler.go
+++ b/server/aws/lambda/handler.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 
@@ -54,9 +55,24 @@ const (
 // functions (not a function sub-resource), so they route on their own prefix.
 const layersPrefix = "/2018-10-31/layers"
 
+// functionURLPrefix is the Lambda Function URL API prefix. The URL config is a
+// function sub-resource (.../{name}/url and .../{name}/urls) but versioned under
+// 2021-10-31, so it needs its own Matches clause.
+const functionURLPrefix = "/2021-10-31/functions"
+
 // subVersions is the "versions" path segment shared by the function-versions
 // route (/functions/{name}/versions) and the layer-versions routes.
 const subVersions = "versions"
+
+// Function sub-resource path segments that route both a collection/item verb
+// (serveSubresource) and a sub-item verb (the partsSubItem switch).
+const (
+	subAliases = "aliases"
+	subPolicy  = "policy"
+)
+
+// latestVersion is the symbolic version for a function's mutable current code.
+const latestVersion = "$LATEST"
 
 const (
 	contentTypeJSON = "application/json"
@@ -130,7 +146,8 @@ func (*Handler) Matches(r *http.Request) bool {
 		strings.HasPrefix(r.URL.Path, esmPrefix) ||
 		strings.HasPrefix(r.URL.Path, concurrencyWritePrefix) ||
 		strings.HasPrefix(r.URL.Path, concurrencyReadPrefix) ||
-		strings.HasPrefix(r.URL.Path, layersPrefix)
+		strings.HasPrefix(r.URL.Path, layersPrefix) ||
+		strings.HasPrefix(r.URL.Path, functionURLPrefix)
 }
 
 // ServeHTTP dispatches Lambda operations based on path shape and method.
@@ -167,9 +184,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.serveSubresource(w, r, name, parts[1])
 	case partsSubItem:
 		switch parts[1] {
-		case "aliases":
+		case subAliases:
 			h.serveAlias(w, r, name, parts[2])
-		case "policy":
+		case subPolicy:
 			h.serveRemovePermission(w, r, name, parts[2])
 		default:
 			writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
@@ -193,6 +210,8 @@ func (h *Handler) routePrefixed(w http.ResponseWriter, r *http.Request) bool {
 		h.serveEventSourceMappings(w, r, uuid)
 	case strings.HasPrefix(r.URL.Path, layersPrefix):
 		h.serveLayers(w, r)
+	case strings.HasPrefix(r.URL.Path, functionURLPrefix):
+		h.serveFunctionURL(w, r)
 	default:
 		name, ok := concurrencyFunctionName(r.URL.Path)
 		if !ok {
@@ -216,9 +235,9 @@ func (h *Handler) serveSubresource(w http.ResponseWriter, r *http.Request, name,
 		h.serveCode(w, r, name)
 	case subVersions:
 		h.serveVersions(w, r, name)
-	case "aliases":
+	case subAliases:
 		h.serveAliases(w, r, name)
-	case "policy":
+	case subPolicy:
 		h.servePolicy(w, r, name)
 	default:
 		writeError(w, http.StatusNotFound, "ResourceNotFoundException", "unsupported Lambda path")
@@ -384,11 +403,13 @@ func (h *Handler) serveConfiguration(w http.ResponseWriter, r *http.Request, nam
 	}
 
 	cfg := sdrv.FunctionConfig{
-		Name:    name,
-		Runtime: req.Runtime,
-		Handler: req.Handler,
-		Memory:  req.MemorySize,
-		Timeout: req.Timeout,
+		Name:        name,
+		Runtime:     req.Runtime,
+		Handler:     req.Handler,
+		Role:        req.Role,
+		Description: req.Description,
+		Memory:      req.MemorySize,
+		Timeout:     req.Timeout,
 	}
 	if req.Environment != nil {
 		cfg.Environment = req.Environment.Variables
@@ -471,10 +492,7 @@ func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, name str
 			return
 		}
 
-		cfg := toConfiguration(info)
-		cfg.Version = ver.Version
-		cfg.Description = ver.Description
-		writeJSON(w, http.StatusCreated, cfg)
+		writeJSON(w, http.StatusCreated, toVersionConfiguration(info, ver))
 	case http.MethodGet:
 		vers, err := h.fn.ListVersions(r.Context(), name)
 		if err != nil {
@@ -490,10 +508,7 @@ func (h *Handler) serveVersions(w http.ResponseWriter, r *http.Request, name str
 
 		out := listVersionsResponse{Versions: make([]functionConfiguration, 0, len(vers))}
 		for i := range vers {
-			cfg := toConfiguration(info)
-			cfg.Version = vers[i].Version
-			cfg.Description = vers[i].Description
-			out.Versions = append(out.Versions, cfg)
+			out.Versions = append(out.Versions, toVersionConfiguration(info, &vers[i]))
 		}
 
 		writeJSON(w, http.StatusOK, out)
@@ -515,6 +530,7 @@ func (h *Handler) serveAliases(w http.ResponseWriter, r *http.Request, name stri
 		a, err := h.fn.CreateAlias(r.Context(), sdrv.AliasConfig{
 			FunctionName: name, Name: req.Name,
 			FunctionVersion: req.FunctionVersion, Description: req.Description,
+			RoutingConfig: toRoutingConfig(req.RoutingConfig),
 		})
 		if err != nil {
 			writeErr(w, err)
@@ -560,6 +576,7 @@ func (h *Handler) serveAlias(w http.ResponseWriter, r *http.Request, name, alias
 		a, err := h.fn.UpdateAlias(r.Context(), sdrv.AliasConfig{
 			FunctionName: name, Name: aliasName,
 			FunctionVersion: req.FunctionVersion, Description: req.Description,
+			RoutingConfig: toRoutingConfig(req.RoutingConfig),
 		})
 		if err != nil {
 			writeErr(w, err)
@@ -579,13 +596,39 @@ func (h *Handler) serveAlias(w http.ResponseWriter, r *http.Request, name, alias
 	}
 }
 
+// toRoutingConfig maps the wire AliasRoutingConfiguration (a map of additional
+// version -> weight) to the single-additional-version driver shape. Only the
+// first entry is honored, which matches the driver's model.
+func toRoutingConfig(rc *aliasRoutingConfig) *sdrv.AliasRoutingConfig {
+	if rc == nil || len(rc.AdditionalVersionWeights) == 0 {
+		return nil
+	}
+
+	for version, weight := range rc.AdditionalVersionWeights {
+		return &sdrv.AliasRoutingConfig{AdditionalVersion: version, Weight: weight}
+	}
+
+	return nil
+}
+
 func toAliasResponse(a *sdrv.Alias) aliasResponse {
-	return aliasResponse{
+	resp := aliasResponse{
 		AliasArn:        a.AliasARN,
 		Name:            a.Name,
 		FunctionVersion: a.FunctionVersion,
 		Description:     a.Description,
+		RevisionID:      a.RevisionID,
 	}
+
+	if a.RoutingConfig != nil {
+		resp.RoutingConfig = &aliasRoutingConfig{
+			AdditionalVersionWeights: map[string]float64{
+				a.RoutingConfig.AdditionalVersion: a.RoutingConfig.Weight,
+			},
+		}
+	}
+
+	return resp
 }
 
 func (h *Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
@@ -626,12 +669,14 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg := sdrv.FunctionConfig{
-		Name:    req.FunctionName,
-		Runtime: req.Runtime,
-		Handler: req.Handler,
-		Memory:  req.MemorySize,
-		Timeout: req.Timeout,
-		Tags:    req.Tags,
+		Name:        req.FunctionName,
+		Runtime:     req.Runtime,
+		Handler:     req.Handler,
+		Role:        req.Role,
+		Description: req.Description,
+		Memory:      req.MemorySize,
+		Timeout:     req.Timeout,
+		Tags:        req.Tags,
 	}
 	if req.Environment != nil {
 		cfg.Environment = req.Environment.Variables
@@ -720,10 +765,18 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out := listFunctionsResponse{Functions: make([]functionConfiguration, 0, len(infos))}
-	for i := range infos {
+	// Sort by name so Marker offsets stay stable across paginated calls (the
+	// driver returns functions in map-iteration order, which is unstable).
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Name < infos[j].Name })
+
+	start, end, nextMarker, _ := pageWindow(len(infos), r.URL.Query())
+
+	out := listFunctionsResponse{Functions: make([]functionConfiguration, 0, end-start)}
+	for i := start; i < end; i++ {
 		out.Functions = append(out.Functions, toConfiguration(&infos[i]))
 	}
+
+	out.NextMarker = nextMarker
 
 	writeJSON(w, http.StatusOK, out)
 }
@@ -781,17 +834,53 @@ func (h *Handler) invoke(w http.ResponseWriter, r *http.Request, name string) {
 	_, _ = w.Write(out.Payload)
 }
 
+// toVersionConfiguration renders a published version's configuration. It starts
+// from the live function (for name/ARN/state/environment) then overlays the
+// immutable per-version fields snapshotted at publish time, so each version
+// reports its own CodeSha256/RevisionId/runtime rather than reusing $LATEST.
+func toVersionConfiguration(info *sdrv.FunctionInfo, ver *sdrv.FunctionVersion) functionConfiguration {
+	cfg := toConfiguration(info)
+	cfg.Version = ver.Version
+	cfg.Description = ver.Description
+	cfg.CodeSha256 = ver.CodeSHA256
+	cfg.RevisionID = ver.RevisionID
+	cfg.Runtime = ver.Runtime
+	cfg.Handler = ver.Handler
+	cfg.Role = ver.Role
+	cfg.MemorySize = ver.Memory
+	cfg.Timeout = ver.Timeout
+
+	// A published version's ARN is qualified with the version number; $LATEST
+	// keeps the unqualified ARN.
+	if ver.Version != "" && ver.Version != latestVersion {
+		cfg.FunctionArn = info.ARN + ":" + ver.Version
+	}
+
+	return cfg
+}
+
 func toConfiguration(info *sdrv.FunctionInfo) functionConfiguration {
+	version := info.Version
+	if version == "" {
+		version = latestVersion
+	}
+
 	cfg := functionConfiguration{
 		FunctionName: info.Name,
 		FunctionArn:  info.ARN,
 		Runtime:      info.Runtime,
+		Role:         info.Role,
 		Handler:      info.Handler,
+		Description:  info.Description,
 		MemorySize:   info.Memory,
 		Timeout:      info.Timeout,
 		LastModified: info.LastModified,
 		State:        info.State,
 		PackageType:  "Zip",
+		CodeSha256:   info.CodeSHA256,
+		CodeSize:     info.CodeSize,
+		Version:      version,
+		RevisionID:   info.RevisionID,
 	}
 
 	if len(info.Environment) > 0 {

--- a/server/aws/lambda/pagination.go
+++ b/server/aws/lambda/pagination.go
@@ -1,0 +1,63 @@
+package lambda
+
+import (
+	"encoding/base64"
+	"net/url"
+	"strconv"
+)
+
+// defaultMaxItems is the page size Lambda applies when ListFunctions omits
+// MaxItems. Real Lambda defaults to 50.
+const defaultMaxItems = 50
+
+// pageWindow computes the [start, end) slice bounds for a ListFunctions request
+// given its Marker/MaxItems parameters and the total number of (already sorted)
+// items. It returns the next Marker and whether the result is truncated. The
+// Marker is an opaque base64-encoded offset into the sorted list, stable as long
+// as the caller sorts deterministically.
+func pageWindow(total int, form url.Values) (start, end int, nextMarker string, truncated bool) {
+	start = decodeMarker(form.Get("Marker"))
+	if start > total {
+		start = total
+	}
+
+	maxItems := defaultMaxItems
+
+	if v := form.Get("MaxItems"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			maxItems = n
+		}
+	}
+
+	end = start + maxItems
+	if end >= total {
+		return start, total, "", false
+	}
+
+	return start, end, encodeMarker(end), true
+}
+
+// decodeMarker parses an opaque Marker back into an offset. A missing or
+// malformed marker resets to the start of the list.
+func decodeMarker(marker string) int {
+	if marker == "" {
+		return 0
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(marker)
+	if err != nil {
+		return 0
+	}
+
+	n, err := strconv.Atoi(string(raw))
+	if err != nil || n < 0 {
+		return 0
+	}
+
+	return n
+}
+
+// encodeMarker turns an offset into an opaque Marker string.
+func encodeMarker(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}

--- a/server/aws/lambda/sdk_roundtrip_test.go
+++ b/server/aws/lambda/sdk_roundtrip_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -16,6 +17,22 @@ import (
 	awsprovider "github.com/stackshy/cloudemu/v2/providers/aws"
 	awsserver "github.com/stackshy/cloudemu/v2/server/aws"
 )
+
+// createBasicFunction creates a minimal function for fidelity tests.
+func createBasicFunction(t *testing.T, client *awslambda.Client, name string) {
+	t.Helper()
+
+	if _, err := client.CreateFunction(context.Background(), &awslambda.CreateFunctionInput{
+		FunctionName: aws.String(name),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/test"),
+		Handler:      aws.String("main"),
+		Description:  aws.String("desc-" + name),
+		Code:         &lambdatypes.FunctionCode{ZipFile: []byte("package-" + name)},
+	}); err != nil {
+		t.Fatalf("CreateFunction(%s): %v", name, err)
+	}
+}
 
 func newSDKClient(t *testing.T) (*awslambda.Client, *awsprovider.Provider) {
 	t.Helper()
@@ -311,5 +328,317 @@ func TestSDKGetFunctionConfiguration(t *testing.T) {
 	}
 	if aws.ToString(out.FunctionName) != "cfg" || aws.ToString(out.Handler) != "main" {
 		t.Fatalf("config = %+v, want FunctionName=cfg Handler=main", out)
+	}
+}
+
+// TestSDKFunctionAttributes covers the fields Terraform reads every plan
+// (Role, CodeSha256, CodeSize, Version, RevisionId, Description). Before the
+// fix these came back empty, causing perpetual drift and broken code-change
+// detection.
+func TestSDKFunctionAttributes(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	code := []byte("package-attrs")
+	if _, err := client.CreateFunction(ctx, &awslambda.CreateFunctionInput{
+		FunctionName: aws.String("attrs"),
+		Runtime:      lambdatypes.RuntimeGo1x,
+		Role:         aws.String("arn:aws:iam::000000000000:role/exec"),
+		Handler:      aws.String("main"),
+		Description:  aws.String("my function"),
+		Code:         &lambdatypes.FunctionCode{ZipFile: code},
+	}); err != nil {
+		t.Fatalf("CreateFunction: %v", err)
+	}
+
+	got, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{FunctionName: aws.String("attrs")})
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+
+	c := got.Configuration
+	if aws.ToString(c.Role) != "arn:aws:iam::000000000000:role/exec" {
+		t.Fatalf("Role = %q, want the exec role", aws.ToString(c.Role))
+	}
+	if aws.ToString(c.Description) != "my function" {
+		t.Fatalf("Description = %q, want 'my function'", aws.ToString(c.Description))
+	}
+	if aws.ToString(c.CodeSha256) == "" {
+		t.Fatal("CodeSha256 empty, want base64 sha of the package")
+	}
+	if c.CodeSize != int64(len(code)) {
+		t.Fatalf("CodeSize = %d, want %d", c.CodeSize, len(code))
+	}
+	if aws.ToString(c.Version) != "$LATEST" {
+		t.Fatalf("Version = %q, want $LATEST", aws.ToString(c.Version))
+	}
+	if aws.ToString(c.RevisionId) == "" {
+		t.Fatal("RevisionId empty, want a revision id")
+	}
+}
+
+// TestSDKUpdateFunctionConfigurationPersists covers UpdateFunctionConfiguration
+// silently dropping Description and Role: the update "succeeded" but never took
+// effect.
+func TestSDKUpdateFunctionConfigurationPersists(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "upd")
+
+	before, err := client.GetFunction(ctx, &awslambda.GetFunctionInput{FunctionName: aws.String("upd")})
+	if err != nil {
+		t.Fatalf("GetFunction: %v", err)
+	}
+	origRevision := aws.ToString(before.Configuration.RevisionId)
+
+	if _, err := client.UpdateFunctionConfiguration(ctx, &awslambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("upd"),
+		Description:  aws.String("updated description"),
+		Role:         aws.String("arn:aws:iam::000000000000:role/newrole"),
+	}); err != nil {
+		t.Fatalf("UpdateFunctionConfiguration: %v", err)
+	}
+
+	got, err := client.GetFunctionConfiguration(ctx, &awslambda.GetFunctionConfigurationInput{
+		FunctionName: aws.String("upd"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionConfiguration: %v", err)
+	}
+	if aws.ToString(got.Description) != "updated description" {
+		t.Fatalf("Description = %q, want 'updated description'", aws.ToString(got.Description))
+	}
+	if aws.ToString(got.Role) != "arn:aws:iam::000000000000:role/newrole" {
+		t.Fatalf("Role = %q, want the new role", aws.ToString(got.Role))
+	}
+	if aws.ToString(got.RevisionId) == origRevision {
+		t.Fatal("RevisionId unchanged after update, want a new revision")
+	}
+}
+
+// TestSDKListFunctionsPagination covers ListFunctions ignoring MaxItems/Marker
+// and never returning a NextMarker.
+func TestSDKListFunctionsPagination(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+
+	for _, n := range []string{"fn-a", "fn-b", "fn-c"} {
+		createBasicFunction(t, client, n)
+	}
+
+	page1, err := client.ListFunctions(ctx, &awslambda.ListFunctionsInput{MaxItems: aws.Int32(2)})
+	if err != nil {
+		t.Fatalf("ListFunctions page1: %v", err)
+	}
+	if len(page1.Functions) != 2 {
+		t.Fatalf("page1 = %d functions, want 2", len(page1.Functions))
+	}
+	if aws.ToString(page1.NextMarker) == "" {
+		t.Fatal("NextMarker empty on truncated page, want a marker")
+	}
+
+	page2, err := client.ListFunctions(ctx, &awslambda.ListFunctionsInput{
+		MaxItems: aws.Int32(2),
+		Marker:   page1.NextMarker,
+	})
+	if err != nil {
+		t.Fatalf("ListFunctions page2: %v", err)
+	}
+	if len(page2.Functions) != 1 {
+		t.Fatalf("page2 = %d functions, want 1", len(page2.Functions))
+	}
+	if aws.ToString(page2.NextMarker) != "" {
+		t.Fatalf("page2 NextMarker = %q, want empty on last page", aws.ToString(page2.NextMarker))
+	}
+}
+
+// TestSDKEventSourceMappingFunctionArn covers Create/Get returning the bare
+// function name in FunctionArn instead of a full ARN.
+func TestSDKEventSourceMappingFunctionArn(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "consumer")
+
+	created, err := client.CreateEventSourceMapping(ctx, &awslambda.CreateEventSourceMappingInput{
+		FunctionName:   aws.String("consumer"),
+		EventSourceArn: aws.String("arn:aws:sqs:us-east-1:000000000000:my-queue"),
+	})
+	if err != nil {
+		t.Fatalf("CreateEventSourceMapping: %v", err)
+	}
+
+	arn := aws.ToString(created.FunctionArn)
+	if !strings.HasPrefix(arn, "arn:aws:lambda:") || !strings.HasSuffix(arn, ":function:consumer") {
+		t.Fatalf("FunctionArn = %q, want a full lambda function ARN", arn)
+	}
+
+	got, err := client.GetEventSourceMapping(ctx, &awslambda.GetEventSourceMappingInput{UUID: created.UUID})
+	if err != nil {
+		t.Fatalf("GetEventSourceMapping: %v", err)
+	}
+	if aws.ToString(got.FunctionArn) != arn {
+		t.Fatalf("Get FunctionArn = %q, want %q", aws.ToString(got.FunctionArn), arn)
+	}
+}
+
+// TestSDKVersionPerVersionAttributes covers PublishVersion/ListVersionsByFunction
+// leaving per-version CodeSha256/RevisionId empty and reusing $LATEST config.
+func TestSDKVersionPerVersionAttributes(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "ver")
+
+	pub, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("ver"),
+		Description:  aws.String("v1"),
+	})
+	if err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+	if aws.ToString(pub.Version) != "1" {
+		t.Fatalf("Version = %q, want 1", aws.ToString(pub.Version))
+	}
+	if aws.ToString(pub.CodeSha256) == "" {
+		t.Fatal("published version CodeSha256 empty")
+	}
+	if aws.ToString(pub.RevisionId) == "" {
+		t.Fatal("published version RevisionId empty")
+	}
+	if !strings.HasSuffix(aws.ToString(pub.FunctionArn), ":function:ver:1") {
+		t.Fatalf("FunctionArn = %q, want qualified with :1", aws.ToString(pub.FunctionArn))
+	}
+
+	list, err := client.ListVersionsByFunction(ctx, &awslambda.ListVersionsByFunctionInput{
+		FunctionName: aws.String("ver"),
+	})
+	if err != nil {
+		t.Fatalf("ListVersionsByFunction: %v", err)
+	}
+	if len(list.Versions) != 2 { // $LATEST + version 1
+		t.Fatalf("Versions = %d, want 2 ($LATEST + 1)", len(list.Versions))
+	}
+	for _, v := range list.Versions {
+		if aws.ToString(v.CodeSha256) == "" {
+			t.Fatalf("version %q CodeSha256 empty", aws.ToString(v.Version))
+		}
+		if v.Runtime != lambdatypes.RuntimeGo1x {
+			t.Fatalf("version %q Runtime = %q, want go1.x", aws.ToString(v.Version), v.Runtime)
+		}
+	}
+}
+
+// TestSDKAliasRevisionAndRouting covers CreateAlias/GetAlias/UpdateAlias missing
+// RevisionId and RoutingConfig.
+func TestSDKAliasRevisionAndRouting(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "aliased")
+
+	if _, err := client.PublishVersion(ctx, &awslambda.PublishVersionInput{
+		FunctionName: aws.String("aliased"),
+	}); err != nil {
+		t.Fatalf("PublishVersion: %v", err)
+	}
+
+	created, err := client.CreateAlias(ctx, &awslambda.CreateAliasInput{
+		FunctionName:    aws.String("aliased"),
+		Name:            aws.String("live"),
+		FunctionVersion: aws.String("1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateAlias: %v", err)
+	}
+	if aws.ToString(created.RevisionId) == "" {
+		t.Fatal("alias RevisionId empty on create")
+	}
+
+	updated, err := client.UpdateAlias(ctx, &awslambda.UpdateAliasInput{
+		FunctionName:    aws.String("aliased"),
+		Name:            aws.String("live"),
+		FunctionVersion: aws.String("1"),
+		RoutingConfig: &lambdatypes.AliasRoutingConfiguration{
+			AdditionalVersionWeights: map[string]float64{"$LATEST": 0.1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdateAlias: %v", err)
+	}
+	if aws.ToString(updated.RevisionId) == aws.ToString(created.RevisionId) {
+		t.Fatal("alias RevisionId unchanged after update")
+	}
+	if updated.RoutingConfig == nil || updated.RoutingConfig.AdditionalVersionWeights["$LATEST"] != 0.1 {
+		t.Fatalf("RoutingConfig = %+v, want $LATEST weight 0.1", updated.RoutingConfig)
+	}
+}
+
+// TestSDKFunctionURLLifecycle covers the Function URL API (Create/Get/Update/
+// List/Delete) previously returning 501 with a non-JSON body because the
+// /2021-10-31/.../url path wasn't matched.
+func TestSDKFunctionURLLifecycle(t *testing.T) {
+	client, _ := newSDKClient(t)
+	ctx := context.Background()
+	createBasicFunction(t, client, "urlfn")
+
+	created, err := client.CreateFunctionUrlConfig(ctx, &awslambda.CreateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlfn"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeNone,
+	})
+	if err != nil {
+		t.Fatalf("CreateFunctionUrlConfig: %v", err)
+	}
+	if !strings.HasPrefix(aws.ToString(created.FunctionUrl), "https://") {
+		t.Fatalf("FunctionUrl = %q, want an https url", aws.ToString(created.FunctionUrl))
+	}
+	if created.AuthType != lambdatypes.FunctionUrlAuthTypeNone {
+		t.Fatalf("AuthType = %q, want NONE", created.AuthType)
+	}
+
+	got, err := client.GetFunctionUrlConfig(ctx, &awslambda.GetFunctionUrlConfigInput{
+		FunctionName: aws.String("urlfn"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionUrlConfig: %v", err)
+	}
+	if aws.ToString(got.FunctionUrl) != aws.ToString(created.FunctionUrl) {
+		t.Fatalf("Get FunctionUrl = %q, want %q", aws.ToString(got.FunctionUrl), aws.ToString(created.FunctionUrl))
+	}
+
+	if _, err := client.UpdateFunctionUrlConfig(ctx, &awslambda.UpdateFunctionUrlConfigInput{
+		FunctionName: aws.String("urlfn"),
+		AuthType:     lambdatypes.FunctionUrlAuthTypeAwsIam,
+	}); err != nil {
+		t.Fatalf("UpdateFunctionUrlConfig: %v", err)
+	}
+
+	afterUpdate, err := client.GetFunctionUrlConfig(ctx, &awslambda.GetFunctionUrlConfigInput{
+		FunctionName: aws.String("urlfn"),
+	})
+	if err != nil {
+		t.Fatalf("GetFunctionUrlConfig after update: %v", err)
+	}
+	if afterUpdate.AuthType != lambdatypes.FunctionUrlAuthTypeAwsIam {
+		t.Fatalf("AuthType = %q, want AWS_IAM after update", afterUpdate.AuthType)
+	}
+
+	list, err := client.ListFunctionUrlConfigs(ctx, &awslambda.ListFunctionUrlConfigsInput{
+		FunctionName: aws.String("urlfn"),
+	})
+	if err != nil {
+		t.Fatalf("ListFunctionUrlConfigs: %v", err)
+	}
+	if len(list.FunctionUrlConfigs) != 1 {
+		t.Fatalf("FunctionUrlConfigs = %d, want 1", len(list.FunctionUrlConfigs))
+	}
+
+	if _, err := client.DeleteFunctionUrlConfig(ctx, &awslambda.DeleteFunctionUrlConfigInput{
+		FunctionName: aws.String("urlfn"),
+	}); err != nil {
+		t.Fatalf("DeleteFunctionUrlConfig: %v", err)
+	}
+
+	if _, err := client.GetFunctionUrlConfig(ctx, &awslambda.GetFunctionUrlConfigInput{
+		FunctionName: aws.String("urlfn"),
+	}); err == nil {
+		t.Fatal("GetFunctionUrlConfig after delete returned nil error, want NotFound")
 	}
 }

--- a/server/aws/lambda/types.go
+++ b/server/aws/lambda/types.go
@@ -19,6 +19,8 @@ type functionConfiguration struct {
 	LastModified string       `json:"LastModified,omitempty"`
 	State        string       `json:"State,omitempty"`
 	CodeSha256   string       `json:"CodeSha256,omitempty"`
+	CodeSize     int64        `json:"CodeSize,omitempty"`
+	RevisionID   string       `json:"RevisionId,omitempty"`
 	Environment  *envEnvelope `json:"Environment,omitempty"`
 	PackageType  string       `json:"PackageType,omitempty"`
 	Version      string       `json:"Version,omitempty"`
@@ -61,17 +63,26 @@ type listVersionsResponse struct {
 
 // aliasRequest is the body of Create/UpdateAlias.
 type aliasRequest struct {
-	Name            string `json:"Name"`
-	FunctionVersion string `json:"FunctionVersion"`
-	Description     string `json:"Description"`
+	Name            string              `json:"Name"`
+	FunctionVersion string              `json:"FunctionVersion"`
+	Description     string              `json:"Description"`
+	RoutingConfig   *aliasRoutingConfig `json:"RoutingConfig"`
 }
 
 // aliasResponse is the AWS AliasConfiguration shape.
 type aliasResponse struct {
-	AliasArn        string `json:"AliasArn"`
-	Name            string `json:"Name"`
-	FunctionVersion string `json:"FunctionVersion"`
-	Description     string `json:"Description,omitempty"`
+	AliasArn        string              `json:"AliasArn"`
+	Name            string              `json:"Name"`
+	FunctionVersion string              `json:"FunctionVersion"`
+	Description     string              `json:"Description,omitempty"`
+	RevisionID      string              `json:"RevisionId,omitempty"`
+	RoutingConfig   *aliasRoutingConfig `json:"RoutingConfig,omitempty"`
+}
+
+// aliasRoutingConfig is the AWS AliasRoutingConfiguration shape: a map of
+// additional version -> weight.
+type aliasRoutingConfig struct {
+	AdditionalVersionWeights map[string]float64 `json:"AdditionalVersionWeights,omitempty"`
 }
 
 // listAliasesResponse is the ListAliases envelope.
@@ -103,11 +114,13 @@ type codeLocation struct {
 
 // listFunctionsResponse is the ListFunctions response envelope.
 type listFunctionsResponse struct {
-	Functions []functionConfiguration `json:"Functions"`
+	Functions  []functionConfiguration `json:"Functions"`
+	NextMarker string                  `json:"NextMarker,omitempty"`
 }
 
 // createFunctionRequest captures the fields we read from a CreateFunction body.
-// We deliberately ignore Role (no IAM evaluation), VPCConfig, etc — the portable
+// Role/Description are stored and echoed back (Terraform reads Role every plan)
+// though IAM is not evaluated; VPCConfig etc are still ignored — the portable
 // driver doesn't model them. Code.ZipFile is read so a configured FunctionEngine
 // can run the real handler; with no engine it is stored only for the invoke stub.
 type createFunctionRequest struct {

--- a/services/serverless/driver/driver.go
+++ b/services/serverless/driver/driver.go
@@ -10,6 +10,16 @@ type FunctionVersion struct {
 	Description  string
 	CodeSHA256   string
 	CreatedAt    string
+	// RevisionID is the revision the version was published from.
+	RevisionID string
+	// Config fields snapshotted at publish time. A published version is
+	// immutable, so these reflect the function state when it was cut, not the
+	// current $LATEST configuration.
+	Runtime string
+	Handler string
+	Memory  int
+	Timeout int
+	Role    string
 }
 
 // PermissionStatement is one statement of a function's resource-based policy,
@@ -19,6 +29,32 @@ type PermissionStatement struct {
 	Action      string
 	Principal   string
 	SourceARN   string
+}
+
+// FunctionURLConfig is a Lambda Function URL configuration. Function URLs are
+// an AWS-specific concept (not part of the portable Serverless interface), so
+// providers expose them through an optional type assertion rather than the
+// shared driver.
+type FunctionURLConfig struct {
+	FunctionName string
+	Qualifier    string
+	FunctionArn  string
+	FunctionURL  string
+	AuthType     string // "NONE" or "AWS_IAM"
+	InvokeMode   string // "BUFFERED" or "RESPONSE_STREAM"
+	Cors         *FunctionURLCors
+	CreationTime string
+	LastModified string
+}
+
+// FunctionURLCors is the CORS configuration of a Function URL.
+type FunctionURLCors struct {
+	AllowCredentials bool
+	AllowHeaders     []string
+	AllowMethods     []string
+	AllowOrigins     []string
+	ExposeHeaders    []string
+	MaxAge           int
 }
 
 // AliasConfig configures a function alias.
@@ -45,6 +81,8 @@ type Alias struct {
 	RoutingConfig   *AliasRoutingConfig
 	AliasARN        string
 	CreatedAt       string
+	// RevisionID changes on every alias mutation (create/update).
+	RevisionID string
 }
 
 // LayerConfig configures a new layer version.
@@ -87,6 +125,8 @@ type FunctionConfig struct {
 	Handler     string
 	Memory      int // MB
 	Timeout     int // seconds
+	Role        string
+	Description string
 	Environment map[string]string
 	Tags        map[string]string
 	Code        []byte // deployment package (.zip); deployed to a FunctionEngine (if configured) on create/update to run real code
@@ -103,12 +143,24 @@ type FunctionInfo struct {
 	ARN          string
 	Runtime      string
 	Handler      string
+	Role         string
+	Description  string
 	Memory       int
 	Timeout      int
 	State        string
 	Environment  map[string]string
 	Tags         map[string]string
 	LastModified string
+	// CodeSHA256 is the base64-encoded SHA-256 of the deployment package, the
+	// value Terraform compares against its locally computed source_code_hash.
+	CodeSHA256 string
+	// CodeSize is the deployment package size in bytes.
+	CodeSize int64
+	// Version is the function's published version ("$LATEST" for the mutable
+	// current code).
+	Version string
+	// RevisionID changes on every configuration or code update.
+	RevisionID string
 }
 
 // InvokeInput configures a function invocation.
@@ -139,9 +191,12 @@ type EventSourceMappingConfig struct {
 
 // EventSourceMappingInfo describes an event source mapping.
 type EventSourceMappingInfo struct {
-	UUID             string
-	EventSourceArn   string
-	FunctionName     string
+	UUID           string
+	EventSourceArn string
+	FunctionName   string
+	// FunctionArn is the full ARN of the target function, resolved at create
+	// time. The Lambda wire protocol returns the ARN, not the bare name.
+	FunctionArn      string
 	BatchSize        int
 	Enabled          bool
 	StartingPosition string


### PR DESCRIPTION
Closes the remaining Lambda audit findings, wire+provider. compat docs clean. SDK round-trip tests per fix.