### PR TITLE
fix(elbv2): target-group attribute store + remaining wire gaps

### DIFF
--- a/providers/aws/elbv2/elb.go
+++ b/providers/aws/elbv2/elb.go
@@ -16,11 +16,12 @@ import (
 // Compile-time checks that Mock implements driver.LoadBalancer and the optional
 // modifier extensions the ELBv2 wire handler dispatches to.
 var (
-	_ driver.LoadBalancer        = (*Mock)(nil)
-	_ driver.TargetGroupModifier = (*Mock)(nil)
-	_ driver.RuleModifier        = (*Mock)(nil)
-	_ driver.LBNetworkModifier   = (*Mock)(nil)
-	_ driver.ListenerGetter      = (*Mock)(nil)
+	_ driver.LoadBalancer              = (*Mock)(nil)
+	_ driver.TargetGroupModifier       = (*Mock)(nil)
+	_ driver.RuleModifier              = (*Mock)(nil)
+	_ driver.LBNetworkModifier         = (*Mock)(nil)
+	_ driver.ListenerGetter            = (*Mock)(nil)
+	_ driver.TargetGroupAttributeStore = (*Mock)(nil)
 )
 
 // defaultIdleTimeoutSec is the default idle timeout for load balancers in seconds.
@@ -39,6 +40,9 @@ type Mock struct {
 
 	attrsMu sync.RWMutex
 	attrs   map[string]driver.LBAttributes // lbARN -> attributes
+
+	tgAttrsMu sync.RWMutex
+	tgAttrs   map[string]map[string]string // tgARN -> attribute overrides
 }
 
 // New creates a new ELB mock with the given configuration options.
@@ -51,6 +55,7 @@ func New(opts *config.Options) *Mock {
 		opts:      opts,
 		health:    make(map[string]map[string]*driver.TargetHealth),
 		attrs:     make(map[string]driver.LBAttributes),
+		tgAttrs:   make(map[string]map[string]string),
 	}
 }
 
@@ -307,6 +312,11 @@ func (m *Mock) DeleteTargetGroup(_ context.Context, arn string) error {
 	m.healthMu.Lock()
 	delete(m.health, arn)
 	m.healthMu.Unlock()
+
+	// Clean up any stored attribute overrides.
+	m.tgAttrsMu.Lock()
+	delete(m.tgAttrs, arn)
+	m.tgAttrsMu.Unlock()
 
 	return nil
 }
@@ -726,6 +736,73 @@ func (m *Mock) UpdateLBAttributes(
 	out.Extra = copyStringMap(attrs.Extra)
 
 	return &out, nil
+}
+
+// defaultTargetGroupAttributes are the attributes real ELBv2 reports for a
+// freshly created target group before any ModifyTargetGroupAttributes call.
+// Modifications overlay these; a Describe returns the merged set.
+//
+//nolint:gochecknoglobals // static table of AWS-published default attribute values.
+var defaultTargetGroupAttributes = map[string]string{
+	"deregistration_delay.timeout_seconds": "300",
+	"stickiness.enabled":                   "false",
+	"stickiness.type":                      "lb_cookie",
+	"load_balancing.algorithm.type":        "round_robin",
+	"slow_start.duration_seconds":          "0",
+}
+
+// GetTargetGroupAttributes returns the full attribute set for a target group:
+// the ELBv2 defaults overlaid with any stored overrides.
+func (m *Mock) GetTargetGroupAttributes(_ context.Context, targetGroupARN string) (map[string]string, error) {
+	if _, ok := m.tgs.Get(targetGroupARN); !ok {
+		return nil, errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
+	}
+
+	m.tgAttrsMu.RLock()
+	defer m.tgAttrsMu.RUnlock()
+
+	return mergedTargetGroupAttributes(m.tgAttrs[targetGroupARN]), nil
+}
+
+// ModifyTargetGroupAttributes merges updates into the target group's stored
+// overrides and returns the resulting full attribute set.
+func (m *Mock) ModifyTargetGroupAttributes(
+	_ context.Context, targetGroupARN string, updates map[string]string,
+) (map[string]string, error) {
+	if _, ok := m.tgs.Get(targetGroupARN); !ok {
+		return nil, errors.Newf(errors.NotFound, "target group %q not found", targetGroupARN)
+	}
+
+	m.tgAttrsMu.Lock()
+	defer m.tgAttrsMu.Unlock()
+
+	overrides := m.tgAttrs[targetGroupARN]
+	if overrides == nil {
+		overrides = make(map[string]string, len(updates))
+	}
+
+	for k, v := range updates {
+		overrides[k] = v
+	}
+
+	m.tgAttrs[targetGroupARN] = overrides
+
+	return mergedTargetGroupAttributes(overrides), nil
+}
+
+// mergedTargetGroupAttributes returns a fresh map of the defaults overlaid with
+// overrides, so the caller never aliases stored state.
+func mergedTargetGroupAttributes(overrides map[string]string) map[string]string {
+	out := make(map[string]string, len(defaultTargetGroupAttributes)+len(overrides))
+	for k, v := range defaultTargetGroupAttributes {
+		out[k] = v
+	}
+
+	for k, v := range overrides {
+		out[k] = v
+	}
+
+	return out
 }
 
 // RegisterTargets registers targets with a target group.

--- a/server/aws/elbv2/attributes.go
+++ b/server/aws/elbv2/attributes.go
@@ -112,6 +112,76 @@ func (h *Handler) describeLoadBalancerAttributes(w http.ResponseWriter, r *http.
 	})
 }
 
+type describeTargetGroupAttributesResponse struct {
+	XMLName  xml.Name           `xml:"DescribeTargetGroupAttributesResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   lbAttributesResult `xml:"DescribeTargetGroupAttributesResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+type modifyTargetGroupAttributesResponse struct {
+	XMLName  xml.Name           `xml:"ModifyTargetGroupAttributesResponse"`
+	Xmlns    string             `xml:"xmlns,attr"`
+	Result   lbAttributesResult `xml:"ModifyTargetGroupAttributesResult"`
+	Metadata responseMetadata   `xml:"ResponseMetadata"`
+}
+
+// describeTargetGroupAttributes returns the target group's attribute set (ELBv2
+// defaults overlaid with any prior modifications).
+func (h *Handler) describeTargetGroupAttributes(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.lb.(lbdriver.TargetGroupAttributeStore)
+	if !ok {
+		writeUnsupported(w, "DescribeTargetGroupAttributes")
+		return
+	}
+
+	attrs, err := store.GetTargetGroupAttributes(r.Context(), r.Form.Get("TargetGroupArn"))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, describeTargetGroupAttributesResponse{
+		Xmlns:    Namespace,
+		Result:   lbAttributesResult{Attributes: attributeMapToXML(attrs)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// modifyTargetGroupAttributes merges the supplied attributes into the target
+// group's set and echoes the merged result, matching ELBv2's partial-update
+// semantics.
+func (h *Handler) modifyTargetGroupAttributes(w http.ResponseWriter, r *http.Request) {
+	store, ok := h.lb.(lbdriver.TargetGroupAttributeStore)
+	if !ok {
+		writeUnsupported(w, "ModifyTargetGroupAttributes")
+		return
+	}
+
+	merged, err := store.ModifyTargetGroupAttributes(
+		r.Context(), r.Form.Get("TargetGroupArn"), parseAttributeMembers(r))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	awsquery.WriteXMLResponse(w, modifyTargetGroupAttributesResponse{
+		Xmlns:    Namespace,
+		Result:   lbAttributesResult{Attributes: attributeMapToXML(merged)},
+		Metadata: responseMetadata{RequestID: awsquery.RequestID},
+	})
+}
+
+// attributeMapToXML renders a flat attribute map as ELBv2 Key/Value members.
+func attributeMapToXML(attrs map[string]string) []lbAttributeXML {
+	out := make([]lbAttributeXML, 0, len(attrs))
+	for k, v := range attrs {
+		out = append(out, lbAttributeXML{Key: k, Value: v})
+	}
+
+	return out
+}
+
 // parseAttributeMembers reads the Attributes.member.N.Key/Value pairs the SDK
 // serializes.
 func parseAttributeMembers(r *http.Request) map[string]string {

--- a/server/aws/elbv2/handler.go
+++ b/server/aws/elbv2/handler.go
@@ -45,6 +45,8 @@ var elbActions = map[string]struct{}{ //nolint:gochecknoglobals // static lookup
 	"DescribeTargetGroups":           {},
 	"DeleteTargetGroup":              {},
 	"ModifyTargetGroup":              {},
+	"DescribeTargetGroupAttributes":  {},
+	"ModifyTargetGroupAttributes":    {},
 	"CreateListener":                 {},
 	"DescribeListeners":              {},
 	"DeleteListener":                 {},
@@ -142,6 +144,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.deleteTargetGroup(w, r)
 	case "ModifyTargetGroup":
 		h.modifyTargetGroup(w, r)
+	case "DescribeTargetGroupAttributes":
+		h.describeTargetGroupAttributes(w, r)
+	case "ModifyTargetGroupAttributes":
+		h.modifyTargetGroupAttributes(w, r)
 	case "CreateListener":
 		h.createListener(w, r)
 	case "DescribeListeners":

--- a/server/aws/elbv2/modify_test.go
+++ b/server/aws/elbv2/modify_test.go
@@ -401,6 +401,85 @@ func TestSDKTargetHealthAdvances(t *testing.T) {
 	}
 }
 
+// TestSDKTargetGroupAttributes proves DescribeTargetGroupAttributes and
+// ModifyTargetGroupAttributes dispatch (instead of returning InvalidAction) and
+// that a modified attribute merges over the ELBv2 defaults and round-trips.
+func TestSDKTargetGroupAttributes(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	tgOut, err := client.CreateTargetGroup(ctx, &elb.CreateTargetGroupInput{
+		Name:     aws.String("attr-tg"),
+		Protocol: elbtypes.ProtocolEnumHttp,
+		Port:     aws.Int32(80),
+		VpcId:    aws.String("vpc-1"),
+	})
+	if err != nil {
+		t.Fatalf("CreateTargetGroup: %v", err)
+	}
+
+	tgARN := aws.ToString(tgOut.TargetGroups[0].TargetGroupArn)
+
+	// Defaults are reported before any modification.
+	desc, err := client.DescribeTargetGroupAttributes(ctx, &elb.DescribeTargetGroupAttributesInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetGroupAttributes: %v", err)
+	}
+
+	if got := attrValue(desc.Attributes, "deregistration_delay.timeout_seconds"); got != "300" {
+		t.Errorf("default deregistration_delay = %q, want 300", got)
+	}
+
+	// A modification merges over the defaults.
+	mod, err := client.ModifyTargetGroupAttributes(ctx, &elb.ModifyTargetGroupAttributesInput{
+		TargetGroupArn: aws.String(tgARN),
+		Attributes: []elbtypes.TargetGroupAttribute{
+			{Key: aws.String("deregistration_delay.timeout_seconds"), Value: aws.String("60")},
+			{Key: aws.String("stickiness.enabled"), Value: aws.String("true")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ModifyTargetGroupAttributes: %v", err)
+	}
+
+	if got := attrValue(mod.Attributes, "deregistration_delay.timeout_seconds"); got != "60" {
+		t.Errorf("modified deregistration_delay = %q, want 60", got)
+	}
+
+	if got := attrValue(mod.Attributes, "stickiness.enabled"); got != "true" {
+		t.Errorf("modified stickiness.enabled = %q, want true", got)
+	}
+
+	// The change persists and an untouched default is still present.
+	after, err := client.DescribeTargetGroupAttributes(ctx, &elb.DescribeTargetGroupAttributesInput{
+		TargetGroupArn: aws.String(tgARN),
+	})
+	if err != nil {
+		t.Fatalf("DescribeTargetGroupAttributes after modify: %v", err)
+	}
+
+	if got := attrValue(after.Attributes, "deregistration_delay.timeout_seconds"); got != "60" {
+		t.Errorf("persisted deregistration_delay = %q, want 60", got)
+	}
+
+	if got := attrValue(after.Attributes, "load_balancing.algorithm.type"); got != "round_robin" {
+		t.Errorf("untouched default load_balancing.algorithm.type = %q, want round_robin", got)
+	}
+}
+
+// attrValue returns the value of the named attribute, or "" if absent.
+func attrValue(attrs []elbtypes.TargetGroupAttribute, key string) string {
+	for _, a := range attrs {
+		if aws.ToString(a.Key) == key {
+			return aws.ToString(a.Value)
+		}
+	}
+
+	return ""
+}
+
 // setupLBAndTG creates a load balancer and target group, returning their ARNs.
 func setupLBAndTG(t *testing.T, client *elb.Client, lbName, tgName string) (string, string) {
 	t.Helper()

--- a/server/aws/elbv2/operations.go
+++ b/server/aws/elbv2/operations.go
@@ -3,6 +3,7 @@ package elbv2
 import (
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 
 	cerrors "github.com/stackshy/cloudemu/v2/errors"
@@ -51,6 +52,17 @@ func (h *Handler) describeLoadBalancers(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Sort for a stable order so the offset-based Marker is meaningful.
+	sort.Slice(lbs, func(i, j int) bool { return lbs[i].ARN < lbs[j].ARN })
+
+	start, end, next, err := pageWindow(r.Form.Get("Marker"), formInt(r.Form.Get("PageSize")), len(lbs))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	lbs = lbs[start:end]
+
 	out := loadBalancersXML{Member: make([]loadBalancerXML, 0, len(lbs))}
 	for i := range lbs {
 		out.Member = append(out.Member, toLoadBalancerXML(&lbs[i]))
@@ -58,7 +70,7 @@ func (h *Handler) describeLoadBalancers(w http.ResponseWriter, r *http.Request) 
 
 	awsquery.WriteXMLResponse(w, describeLoadBalancersResponse{
 		Xmlns:    Namespace,
-		Result:   loadBalancersResult{LoadBalancers: out},
+		Result:   loadBalancersResult{LoadBalancers: out, NextMarker: next},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }
@@ -152,6 +164,16 @@ func (h *Handler) describeTargetGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sort.Slice(tgs, func(i, j int) bool { return tgs[i].ARN < tgs[j].ARN })
+
+	start, end, next, err := pageWindow(r.Form.Get("Marker"), formInt(r.Form.Get("PageSize")), len(tgs))
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+
+	tgs = tgs[start:end]
+
 	out := targetGroupsXML{Member: make([]targetGroupXML, 0, len(tgs))}
 	for i := range tgs {
 		out.Member = append(out.Member, toTargetGroupXML(&tgs[i]))
@@ -159,7 +181,7 @@ func (h *Handler) describeTargetGroups(w http.ResponseWriter, r *http.Request) {
 
 	awsquery.WriteXMLResponse(w, describeTargetGroupsResponse{
 		Xmlns:    Namespace,
-		Result:   targetGroupsResult{TargetGroups: out},
+		Result:   targetGroupsResult{TargetGroups: out, NextMarker: next},
 		Metadata: responseMetadata{RequestID: awsquery.RequestID},
 	})
 }

--- a/server/aws/elbv2/paginate.go
+++ b/server/aws/elbv2/paginate.go
@@ -1,0 +1,62 @@
+package elbv2
+
+import (
+	"encoding/base64"
+	"strconv"
+
+	cerrors "github.com/stackshy/cloudemu/v2/errors"
+)
+
+// defaultPageSize is the page size ELBv2 describe operations use when PageSize
+// is unset; it is also the AWS-documented maximum.
+const defaultPageSize = 400
+
+// pageWindow resolves an opaque Marker + PageSize into a [start,end) slice over
+// a stable result set of length total. It returns the NextMarker to echo ("" on
+// the last page). ELBv2 keys describe pagination on Marker/PageSize; an
+// offset-based marker is stable because each describe returns a
+// deterministically ordered set.
+func pageWindow(marker string, pageSize, total int) (start, end int, nextMarker string, err error) {
+	start, err = decodeMarker(marker)
+	if err != nil {
+		return 0, 0, "", err
+	}
+
+	if start > total {
+		start = total
+	}
+
+	size := pageSize
+	if size <= 0 {
+		size = defaultPageSize
+	}
+
+	end = start + size
+	if end >= total {
+		return start, total, "", nil
+	}
+
+	return start, end, encodeMarker(end), nil
+}
+
+func encodeMarker(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+func decodeMarker(marker string) (int, error) {
+	if marker == "" {
+		return 0, nil
+	}
+
+	b, err := base64.StdEncoding.DecodeString(marker)
+	if err != nil {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid Marker")
+	}
+
+	n, err := strconv.Atoi(string(b))
+	if err != nil || n < 0 {
+		return 0, cerrors.New(cerrors.InvalidArgument, "invalid Marker")
+	}
+
+	return n, nil
+}

--- a/server/aws/elbv2/sdk_roundtrip_test.go
+++ b/server/aws/elbv2/sdk_roundtrip_test.go
@@ -308,3 +308,72 @@ func TestSDKELBListenerLifecycle(t *testing.T) {
 		t.Fatalf("DeleteListener: %v", err)
 	}
 }
+
+// TestSDKDescribeLoadBalancersPagination proves DescribeLoadBalancers honors
+// PageSize and Marker: a PageSize of 1 returns one entry plus a NextMarker, and
+// walking the marker yields every load balancer exactly once.
+func TestSDKDescribeLoadBalancersPagination(t *testing.T) {
+	client := newSDKClient(t)
+	ctx := context.Background()
+
+	names := []string{"page-alb-1", "page-alb-2", "page-alb-3"}
+	for _, n := range names {
+		if _, err := client.CreateLoadBalancer(ctx, &elb.CreateLoadBalancerInput{
+			Name:    aws.String(n),
+			Subnets: []string{"subnet-a"},
+		}); err != nil {
+			t.Fatalf("CreateLoadBalancer(%s): %v", n, err)
+		}
+	}
+
+	seen := map[string]bool{}
+	marker := ""
+	pages := 0
+
+	for {
+		out, err := client.DescribeLoadBalancers(ctx, &elb.DescribeLoadBalancersInput{
+			PageSize: aws.Int32(1),
+			Marker:   markerPtr(marker),
+		})
+		if err != nil {
+			t.Fatalf("DescribeLoadBalancers page %d: %v", pages, err)
+		}
+
+		if len(out.LoadBalancers) != 1 {
+			t.Fatalf("page %d returned %d load balancers, want 1 (PageSize ignored?)",
+				pages, len(out.LoadBalancers))
+		}
+
+		seen[aws.ToString(out.LoadBalancers[0].LoadBalancerName)] = true
+		pages++
+
+		if out.NextMarker == nil || aws.ToString(out.NextMarker) == "" {
+			break
+		}
+
+		marker = aws.ToString(out.NextMarker)
+
+		if pages > len(names) {
+			t.Fatal("pagination did not terminate")
+		}
+	}
+
+	if pages != len(names) {
+		t.Errorf("walked %d pages, want %d", pages, len(names))
+	}
+
+	for _, n := range names {
+		if !seen[n] {
+			t.Errorf("load balancer %q missing from paginated results", n)
+		}
+	}
+}
+
+// markerPtr returns nil for an empty marker so the first page omits Marker.
+func markerPtr(m string) *string {
+	if m == "" {
+		return nil
+	}
+
+	return aws.String(m)
+}

--- a/server/aws/elbv2/types.go
+++ b/server/aws/elbv2/types.go
@@ -67,6 +67,7 @@ type loadBalancersXML struct {
 
 type loadBalancersResult struct {
 	LoadBalancers loadBalancersXML `xml:"LoadBalancers"`
+	NextMarker    string           `xml:"NextMarker,omitempty"`
 }
 
 type createLoadBalancerResponse struct {
@@ -121,6 +122,7 @@ type targetGroupsXML struct {
 
 type targetGroupsResult struct {
 	TargetGroups targetGroupsXML `xml:"TargetGroups"`
+	NextMarker   string          `xml:"NextMarker,omitempty"`
 }
 
 type createTargetGroupResponse struct {

--- a/services/loadbalancer/driver/driver.go
+++ b/services/loadbalancer/driver/driver.go
@@ -263,3 +263,15 @@ type LBNetworkModifier interface {
 	SetSecurityGroups(ctx context.Context, lbARN string, securityGroups []string) error
 	SetSubnets(ctx context.Context, lbARN string, subnets []string) ([]string, error)
 }
+
+// TargetGroupAttributeStore is implemented by drivers that store per-target-group
+// key/value attributes (ELBv2 DescribeTargetGroupAttributes /
+// ModifyTargetGroupAttributes). Both methods return the full attribute set,
+// protocol-derived defaults included, so a caller reads back exactly what real
+// ELBv2 reports. ModifyTargetGroupAttributes merges updates over the stored set.
+type TargetGroupAttributeStore interface {
+	GetTargetGroupAttributes(ctx context.Context, targetGroupARN string) (map[string]string, error)
+	ModifyTargetGroupAttributes(
+		ctx context.Context, targetGroupARN string, updates map[string]string,
+	) (map[string]string, error)
+}


### PR DESCRIPTION
Closes the 2 remaining ELBv2 findings (the rest were already resolved by #462/#467). Adds an optional TargetGroupAttributeStore capability (AWS Mock only; mirrors TargetGroupModifier/RuleModifier), compat docs clean; coverage docs owed to the consolidated regen PR. SDK round-trip tests per fix.